### PR TITLE
refactor: move 24 raw SQL queries from route handlers into db.py

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -231,25 +231,7 @@ def create_app(db_path, thumb_cache_dir=None):
     @app.route("/pipeline")
     def pipeline_page():
         db = _get_db()
-        # Check pipeline stage status
-        has_masks = db.conn.execute(
-            """SELECT COUNT(*) FROM photos p
-               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               WHERE wf.workspace_id = ? AND p.mask_path IS NOT NULL""",
-            (db._active_workspace_id,),
-        ).fetchone()[0]
-        has_detections = db.conn.execute(
-            """SELECT COUNT(*) FROM photos p
-               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               WHERE wf.workspace_id = ? AND p.detection_box IS NOT NULL""",
-            (db._active_workspace_id,),
-        ).fetchone()[0]
-        has_sharpness = db.conn.execute(
-            """SELECT COUNT(*) FROM photos p
-               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               WHERE wf.workspace_id = ? AND p.subject_tenengrad IS NOT NULL""",
-            (db._active_workspace_id,),
-        ).fetchone()[0]
+        pipeline_counts = db.get_pipeline_feature_counts()
         total_photos = db.count_photos()
 
         from pipeline import load_results
@@ -262,9 +244,9 @@ def create_app(db_path, thumb_cache_dir=None):
         return render_template(
             "pipeline.html",
             total_photos=total_photos,
-            has_detections=has_detections,
-            has_masks=has_masks,
-            has_sharpness=has_sharpness,
+            has_detections=pipeline_counts["detections"],
+            has_masks=pipeline_counts["masks"],
+            has_sharpness=pipeline_counts["sharpness"],
             results=results,
             pipeline_config={
                 "sam2_variant": pipeline_cfg.get("sam2_variant", "sam2-small"),
@@ -276,18 +258,7 @@ def create_app(db_path, thumb_cache_dir=None):
     @app.route("/pipeline/review")
     def pipeline_review_page():
         db = _get_db()
-        has_masks = db.conn.execute(
-            """SELECT COUNT(*) FROM photos p
-               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               WHERE wf.workspace_id = ? AND p.mask_path IS NOT NULL""",
-            (db._active_workspace_id,),
-        ).fetchone()[0]
-        has_detections = db.conn.execute(
-            """SELECT COUNT(*) FROM photos p
-               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               WHERE wf.workspace_id = ? AND p.detection_box IS NOT NULL""",
-            (db._active_workspace_id,),
-        ).fetchone()[0]
+        pipeline_counts = db.get_pipeline_feature_counts()
         total_photos = db.count_photos()
 
         from pipeline import load_results
@@ -300,8 +271,8 @@ def create_app(db_path, thumb_cache_dir=None):
         return render_template(
             "pipeline_review.html",
             total_photos=total_photos,
-            has_detections=has_detections,
-            has_masks=has_masks,
+            has_detections=pipeline_counts["detections"],
+            has_masks=pipeline_counts["masks"],
             results=results,
             pipeline_config={
                 "sam2_variant": pipeline_cfg.get("sam2_variant", "sam2-small"),
@@ -699,126 +670,9 @@ def create_app(db_path, thumb_cache_dir=None):
     @app.route("/api/stats")
     def api_stats():
         db = _get_db()
-        # Top keywords by photo count
-        top_keywords = db.conn.execute(
-            """
-            SELECT k.name, k.is_species, COUNT(pk.photo_id) as photo_count
-            FROM keywords k
-            JOIN photo_keywords pk ON pk.keyword_id = k.id
-            GROUP BY k.id
-            ORDER BY photo_count DESC
-            LIMIT 30
-        """
-        ).fetchall()
-
-        # Photos by month
-        photos_by_month = db.conn.execute(
-            """
-            SELECT substr(p.timestamp, 1, 7) as month, COUNT(*) as count
-            FROM photos p
-            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            WHERE p.timestamp IS NOT NULL AND wf.workspace_id = ?
-            GROUP BY month
-            ORDER BY month
-        """,
-            (db._active_workspace_id,),
-        ).fetchall()
-
-        # Rating distribution
-        rating_dist = db.conn.execute(
-            """
-            SELECT p.rating, COUNT(*) as count
-            FROM photos p
-            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            WHERE wf.workspace_id = ?
-            GROUP BY p.rating
-            ORDER BY p.rating
-        """,
-            (db._active_workspace_id,),
-        ).fetchall()
-
-        # Flag distribution
-        flag_dist = db.conn.execute(
-            """
-            SELECT p.flag, COUNT(*) as count
-            FROM photos p
-            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            WHERE wf.workspace_id = ?
-            GROUP BY p.flag
-        """,
-            (db._active_workspace_id,),
-        ).fetchall()
-
-        # Classification status breakdown
-        prediction_status = db.conn.execute(
-            """
-            SELECT status, COUNT(*) as count
-            FROM predictions WHERE workspace_id = ?
-            GROUP BY status
-        """,
-            (db._active_workspace_id,),
-        ).fetchall()
-
-        # Unclassified photos (no prediction at all)
-        total_photos = db.count_photos()
-        classified_count = db.conn.execute(
-            "SELECT COUNT(DISTINCT photo_id) FROM predictions WHERE workspace_id = ?",
-            (db._active_workspace_id,),
-        ).fetchone()[0]
-
-        # Photos by hour of day
-        photos_by_hour = db.conn.execute(
-            """
-            SELECT CAST(substr(p.timestamp, 12, 2) AS INTEGER) as hour, COUNT(*) as count
-            FROM photos p
-            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            WHERE p.timestamp IS NOT NULL AND length(p.timestamp) >= 13 AND wf.workspace_id = ?
-            GROUP BY hour
-            ORDER BY hour
-        """,
-            (db._active_workspace_id,),
-        ).fetchall()
-
-        # Quality score distribution (buckets of 0.1)
-        quality_dist = db.conn.execute(
-            """
-            SELECT
-                CASE
-                    WHEN p.quality_score IS NULL THEN -1
-                    ELSE CAST(p.quality_score * 10 AS INTEGER)
-                END as bucket,
-                COUNT(*) as count
-            FROM photos p
-            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            WHERE wf.workspace_id = ?
-            GROUP BY bucket
-            ORDER BY bucket
-        """,
-            (db._active_workspace_id,),
-        ).fetchall()
-
-        # Subject detection coverage
-        detected_count = db.conn.execute(
-            """SELECT COUNT(*) FROM photos p
-            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            WHERE p.detection_conf IS NOT NULL AND p.detection_conf > 0 AND wf.workspace_id = ?""",
-            (db._active_workspace_id,),
-        ).fetchone()[0]
-
-        return jsonify(
-            {
-                "top_keywords": [dict(r) for r in top_keywords],
-                "photos_by_month": [dict(r) for r in photos_by_month],
-                "rating_distribution": [dict(r) for r in rating_dist],
-                "flag_distribution": [dict(r) for r in flag_dist],
-                "prediction_status": [dict(r) for r in prediction_status],
-                "classified_count": classified_count,
-                "total_photos": total_photos,
-                "photos_by_hour": [dict(r) for r in photos_by_hour],
-                "quality_distribution": [dict(r) for r in quality_dist],
-                "detected_count": detected_count,
-            }
-        )
+        stats = db.get_dashboard_stats()
+        stats["total_photos"] = db.count_photos()
+        return jsonify(stats)
 
     @app.route("/api/sync/status")
     def api_sync_status():
@@ -1133,9 +987,7 @@ def create_app(db_path, thumb_cache_dir=None):
                 keywords = db.get_photo_keywords(d["photo_id"])
                 existing_species = [
                     k["name"] for k in keywords
-                    if db.conn.execute(
-                        "SELECT is_species FROM keywords WHERE id = ?", (k["id"],)
-                    ).fetchone()["is_species"]
+                    if db.is_keyword_species(k["id"])
                 ]
                 d["existing_species"] = existing_species
             results.append(d)
@@ -1157,16 +1009,7 @@ def create_app(db_path, thumb_cache_dir=None):
     def api_prediction_group(group_id):
         """Get all predictions and photo data for a burst group."""
         db = _get_db()
-        preds = db.conn.execute(
-            """SELECT pr.*, p.filename, p.timestamp, p.sharpness,
-                      p.quality_score, p.subject_sharpness, p.subject_size,
-                      p.detection_conf, p.rating, p.flag
-               FROM predictions pr
-               JOIN photos p ON p.id = pr.photo_id
-               WHERE pr.group_id = ? AND pr.workspace_id = ?
-               ORDER BY p.quality_score DESC""",
-            (group_id, db._active_workspace_id),
-        ).fetchall()
+        preds = db.get_group_predictions(group_id)
         return jsonify([dict(p) for p in preds])
 
     @app.route("/api/predictions/group/apply", methods=["POST"])
@@ -1191,26 +1034,15 @@ def create_app(db_path, thumb_cache_dir=None):
         for pid in rejects:
             db.update_photo_flag(pid, "rejected")
 
-        # Mark all predictions in this group as accepted
+        # Mark all predictions in this group as accepted/rejected
         for pid in picks:
-            db.conn.execute(
-                "UPDATE predictions SET status = 'accepted' WHERE photo_id = ? AND workspace_id = ?",
-                (pid, db._active_workspace_id),
-            )
+            db.update_predictions_status_by_photo(pid, 'accepted')
         for pid in rejects:
-            db.conn.execute(
-                "UPDATE predictions SET status = 'rejected' WHERE photo_id = ? AND workspace_id = ?",
-                (pid, db._active_workspace_id),
-            )
+            db.update_predictions_status_by_photo(pid, 'rejected')
 
         # Remove predictions from group
         for pred_id in removed:
-            db.conn.execute(
-                "UPDATE predictions SET group_id = NULL WHERE id = ? AND workspace_id = ?",
-                (pred_id, db._active_workspace_id),
-            )
-
-        db.conn.commit()
+            db.ungroup_prediction(pred_id)
         return jsonify({"ok": True})
 
     @app.route("/api/classify/readiness")
@@ -3395,11 +3227,7 @@ def create_app(db_path, thumb_cache_dir=None):
             # Skip photos that already have predictions (unless re-classifying)
             existing_preds = set()
             if not reclassify:
-                rows = thread_db.conn.execute(
-                    "SELECT DISTINCT photo_id FROM predictions WHERE model = ? AND workspace_id = ?",
-                    (model_name, thread_db._active_workspace_id),
-                ).fetchall()
-                existing_preds = {r["photo_id"] for r in rows}
+                existing_preds = thread_db.get_existing_prediction_photo_ids(model_name)
                 if existing_preds:
                     log.info("Skipping %d photos with existing predictions (model=%s)",
                              len(existing_preds), model_name)
@@ -3434,10 +3262,7 @@ def create_app(db_path, thumb_cache_dir=None):
                 if photo["id"] in existing_preds:
                     skipped_existing += 1
                     # Load existing prediction into raw_results for grouping
-                    pred_row = thread_db.conn.execute(
-                        "SELECT species, confidence FROM predictions WHERE photo_id = ? AND model = ? AND workspace_id = ?",
-                        (photo["id"], model_name, thread_db._active_workspace_id),
-                    ).fetchone()
+                    pred_row = thread_db.get_prediction_for_photo(photo["id"], model_name)
                     if pred_row:
                         timestamp = None
                         if photo["timestamp"]:
@@ -3450,13 +3275,10 @@ def create_app(db_path, thumb_cache_dir=None):
                         # stale BioCLIP vectors that would confuse similarity grouping.
                         embedding = None
                         if model_type != "timm":
-                            emb_row = thread_db.conn.execute(
-                                "SELECT embedding FROM photos WHERE id = ?",
-                                (photo["id"],),
-                            ).fetchone()
-                            if emb_row and emb_row["embedding"]:
+                            emb_blob = thread_db.get_photo_embedding(photo["id"])
+                            if emb_blob:
                                 import numpy as np
-                                embedding = np.frombuffer(emb_row["embedding"], dtype=np.float32)
+                                embedding = np.frombuffer(emb_blob, dtype=np.float32)
                         raw_results.append({
                             "photo": photo,
                             "folder_path": folder_path,
@@ -3519,10 +3341,7 @@ def create_app(db_path, thumb_cache_dir=None):
 
                 # Store embedding in DB for grouping (BioCLIP only — timm has no embeddings)
                 if embedding is not None:
-                    thread_db.conn.execute(
-                        "UPDATE photos SET embedding = ? WHERE id = ?",
-                        (embedding.tobytes(), photo["id"]),
-                    )
+                    thread_db.store_photo_embedding(photo["id"], embedding.tobytes())
 
                 if not all_preds:
                     continue
@@ -3653,15 +3472,14 @@ def create_app(db_path, thumb_cache_dir=None):
                     for item in group:
                         if item.get("_existing"):
                             # Update group info only, preserve original species/confidence
-                            thread_db.conn.execute(
-                                """UPDATE predictions
-                                   SET group_id=?, vote_count=?, total_votes=?, individual=?
-                                   WHERE photo_id=? AND model=? AND workspace_id=?""",
-                                (gid, cons["vote_count"], cons["total_votes"],
-                                 individual_json, item["photo"]["id"], model_name,
-                                 thread_db._active_workspace_id),
+                            thread_db.update_prediction_group_info(
+                                photo_id=item["photo"]["id"],
+                                model=model_name,
+                                group_id=gid,
+                                vote_count=cons["vote_count"],
+                                total_votes=cons["total_votes"],
+                                individual=individual_json,
                             )
-                            thread_db.conn.commit()
                         else:
                             # New prediction — store individual species/confidence
                             thread_db.add_prediction(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -567,6 +567,124 @@ class Database:
             (self._ws_id(),),
         ).fetchone()[0]
 
+    def get_pipeline_feature_counts(self):
+        """Return counts of photos with masks, detections, and sharpness data."""
+        ws = self._ws_id()
+        row = self.conn.execute(
+            """SELECT
+                SUM(CASE WHEN p.mask_path IS NOT NULL THEN 1 ELSE 0 END) as masks,
+                SUM(CASE WHEN p.detection_box IS NOT NULL THEN 1 ELSE 0 END) as detections,
+                SUM(CASE WHEN p.subject_tenengrad IS NOT NULL THEN 1 ELSE 0 END) as sharpness
+            FROM photos p
+            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+            WHERE wf.workspace_id = ?""",
+            (ws,),
+        ).fetchone()
+        return {
+            "masks": row["masks"] or 0,
+            "detections": row["detections"] or 0,
+            "sharpness": row["sharpness"] or 0,
+        }
+
+    def get_dashboard_stats(self):
+        """Return aggregate statistics for the dashboard."""
+        ws = self._ws_id()
+
+        top_keywords = self.conn.execute(
+            """SELECT k.name, k.is_species, COUNT(pk.photo_id) as photo_count
+            FROM keywords k
+            JOIN photo_keywords pk ON pk.keyword_id = k.id
+            GROUP BY k.id
+            ORDER BY photo_count DESC
+            LIMIT 30"""
+        ).fetchall()
+
+        photos_by_month = self.conn.execute(
+            """SELECT substr(p.timestamp, 1, 7) as month, COUNT(*) as count
+            FROM photos p
+            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+            WHERE p.timestamp IS NOT NULL AND wf.workspace_id = ?
+            GROUP BY month
+            ORDER BY month""",
+            (ws,),
+        ).fetchall()
+
+        rating_dist = self.conn.execute(
+            """SELECT p.rating, COUNT(*) as count
+            FROM photos p
+            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+            WHERE wf.workspace_id = ?
+            GROUP BY p.rating
+            ORDER BY p.rating""",
+            (ws,),
+        ).fetchall()
+
+        flag_dist = self.conn.execute(
+            """SELECT p.flag, COUNT(*) as count
+            FROM photos p
+            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+            WHERE wf.workspace_id = ?
+            GROUP BY p.flag""",
+            (ws,),
+        ).fetchall()
+
+        prediction_status = self.conn.execute(
+            """SELECT status, COUNT(*) as count
+            FROM predictions WHERE workspace_id = ?
+            GROUP BY status""",
+            (ws,),
+        ).fetchall()
+
+        classified_count = self.conn.execute(
+            "SELECT COUNT(DISTINCT photo_id) FROM predictions WHERE workspace_id = ?",
+            (ws,),
+        ).fetchone()[0]
+
+        photos_by_hour = self.conn.execute(
+            """SELECT CAST(substr(p.timestamp, 12, 2) AS INTEGER) as hour, COUNT(*) as count
+            FROM photos p
+            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+            WHERE p.timestamp IS NOT NULL AND length(p.timestamp) >= 13 AND wf.workspace_id = ?
+            GROUP BY hour
+            ORDER BY hour""",
+            (ws,),
+        ).fetchall()
+
+        quality_dist = self.conn.execute(
+            """SELECT
+                CASE
+                    WHEN p.quality_score IS NULL THEN -1
+                    ELSE CAST(p.quality_score * 10 AS INTEGER)
+                END as bucket,
+                COUNT(*) as count
+            FROM photos p
+            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+            WHERE wf.workspace_id = ?
+            GROUP BY bucket
+            ORDER BY bucket""",
+            (ws,),
+        ).fetchall()
+
+        detected_count = self.conn.execute(
+            """SELECT COUNT(*) FROM photos p
+            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+            WHERE p.detection_conf IS NOT NULL AND p.detection_conf > 0
+            AND wf.workspace_id = ?""",
+            (ws,),
+        ).fetchone()[0]
+
+        return {
+            "top_keywords": [dict(r) for r in top_keywords],
+            "photos_by_month": [dict(r) for r in photos_by_month],
+            "rating_distribution": [dict(r) for r in rating_dist],
+            "flag_distribution": [dict(r) for r in flag_dist],
+            "prediction_status": [dict(r) for r in prediction_status],
+            "classified_count": classified_count,
+            "photos_by_hour": [dict(r) for r in photos_by_hour],
+            "quality_distribution": [dict(r) for r in quality_dist],
+            "detected_count": detected_count,
+        }
+
     def get_photos(
         self,
         folder_id=None,
@@ -1041,6 +1159,82 @@ class Database:
             "UPDATE predictions SET status = ? WHERE id = ?", (status, prediction_id)
         )
         self.conn.commit()
+
+    def get_group_predictions(self, group_id):
+        """Get all predictions and photo data for a burst group, ordered by quality."""
+        return self.conn.execute(
+            """SELECT pr.*, p.filename, p.timestamp, p.sharpness,
+                      p.quality_score, p.subject_sharpness, p.subject_size,
+                      p.detection_conf, p.rating, p.flag
+               FROM predictions pr
+               JOIN photos p ON p.id = pr.photo_id
+               WHERE pr.group_id = ? AND pr.workspace_id = ?
+               ORDER BY p.quality_score DESC""",
+            (group_id, self._ws_id()),
+        ).fetchall()
+
+    def update_predictions_status_by_photo(self, photo_id, status):
+        """Update status for all predictions of a photo in the active workspace."""
+        self.conn.execute(
+            "UPDATE predictions SET status = ? WHERE photo_id = ? AND workspace_id = ?",
+            (status, photo_id, self._ws_id()),
+        )
+        self.conn.commit()
+
+    def ungroup_prediction(self, prediction_id):
+        """Remove a prediction from its group."""
+        self.conn.execute(
+            "UPDATE predictions SET group_id = NULL WHERE id = ? AND workspace_id = ?",
+            (prediction_id, self._ws_id()),
+        )
+        self.conn.commit()
+
+    def get_existing_prediction_photo_ids(self, model):
+        """Return set of photo_ids that have predictions for a model."""
+        rows = self.conn.execute(
+            "SELECT DISTINCT photo_id FROM predictions WHERE model = ? AND workspace_id = ?",
+            (model, self._ws_id()),
+        ).fetchall()
+        return {r["photo_id"] for r in rows}
+
+    def get_prediction_for_photo(self, photo_id, model):
+        """Return species and confidence for a photo's prediction by model, or None."""
+        return self.conn.execute(
+            "SELECT species, confidence FROM predictions WHERE photo_id = ? AND model = ? AND workspace_id = ?",
+            (photo_id, model, self._ws_id()),
+        ).fetchone()
+
+    def get_photo_embedding(self, photo_id):
+        """Return the embedding blob for a photo, or None."""
+        row = self.conn.execute(
+            "SELECT embedding FROM photos WHERE id = ?", (photo_id,),
+        ).fetchone()
+        return row["embedding"] if row else None
+
+    def store_photo_embedding(self, photo_id, embedding_bytes):
+        """Store an embedding blob for a photo."""
+        self.conn.execute(
+            "UPDATE photos SET embedding = ? WHERE id = ?",
+            (embedding_bytes, photo_id),
+        )
+        self.conn.commit()
+
+    def update_prediction_group_info(self, photo_id, model, group_id, vote_count, total_votes, individual):
+        """Update group info on an existing prediction."""
+        self.conn.execute(
+            """UPDATE predictions
+               SET group_id=?, vote_count=?, total_votes=?, individual=?
+               WHERE photo_id=? AND model=? AND workspace_id=?""",
+            (group_id, vote_count, total_votes, individual, photo_id, model, self._ws_id()),
+        )
+        self.conn.commit()
+
+    def is_keyword_species(self, keyword_id):
+        """Return True if the keyword is marked as a species."""
+        row = self.conn.execute(
+            "SELECT is_species FROM keywords WHERE id = ?", (keyword_id,),
+        ).fetchone()
+        return bool(row["is_species"]) if row else False
 
     def accept_prediction(self, prediction_id):
         """Accept a prediction: mark as accepted and add species keyword.

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -461,3 +461,258 @@ def test_default_collections_adds_missing(tmp_path):
     assert 'Untagged' in names
     assert 'Recent Import' in names
     assert len(colls) == 4  # no duplicate Flagged
+
+
+# --- Helper to set up a workspace with photos ---
+
+def _make_workspace_with_photos(tmp_path, photo_overrides=None):
+    """Create a db with a workspace, folder, and photos. Returns (db, photo_ids).
+
+    photo_overrides is a list of dicts with column overrides per photo.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder('/photos', name='photos')
+    db.add_workspace_folder(ws_id, fid)
+    overrides = photo_overrides or [{}]
+    photo_ids = []
+    for i, ov in enumerate(overrides):
+        pid = db.add_photo(
+            folder_id=fid,
+            filename=ov.get('filename', f'IMG_{i:04d}.jpg'),
+            extension='.jpg',
+            file_size=1000,
+            file_mtime=1000.0,
+            timestamp=ov.get('timestamp'),
+        )
+        # Apply column overrides via direct UPDATE
+        for col, val in ov.items():
+            if col not in ('filename', 'timestamp'):
+                db.conn.execute(f"UPDATE photos SET {col} = ? WHERE id = ?", (val, pid))
+        db.conn.commit()
+        photo_ids.append(pid)
+    return db, photo_ids
+
+
+# --- Cluster 1: Pipeline Feature Counts ---
+
+def test_get_pipeline_feature_counts_empty(tmp_path):
+    """Returns zeros when no photos have pipeline features."""
+    db, _ = _make_workspace_with_photos(tmp_path, [{}])
+    counts = db.get_pipeline_feature_counts()
+    assert counts['masks'] == 0
+    assert counts['detections'] == 0
+    assert counts['sharpness'] == 0
+
+
+def test_get_pipeline_feature_counts_with_data(tmp_path):
+    """Returns correct counts for each pipeline feature."""
+    db, _ = _make_workspace_with_photos(tmp_path, [
+        {'mask_path': '/mask/1.png', 'detection_box': '0,0,100,100', 'subject_tenengrad': 42.0},
+        {'mask_path': '/mask/2.png'},
+        {'detection_box': '10,10,50,50'},
+        {},
+    ])
+    counts = db.get_pipeline_feature_counts()
+    assert counts['masks'] == 2
+    assert counts['detections'] == 2
+    assert counts['sharpness'] == 1
+
+
+def test_get_pipeline_feature_counts_workspace_scoped(tmp_path):
+    """Only counts photos in the active workspace's folders."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws1 = db.ensure_default_workspace()
+    db.set_active_workspace(ws1)
+
+    f1 = db.add_folder('/photos1', name='photos1')
+    db.add_workspace_folder(ws1, f1)
+    db.add_photo(folder_id=f1, filename='a.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET mask_path = '/m' WHERE filename = 'a.jpg'")
+    db.conn.commit()
+
+    # Create second workspace with different folder
+    ws2 = db.create_workspace('WS2')
+    f2 = db.add_folder('/photos2', name='photos2')
+    db.add_workspace_folder(ws2, f2)
+    db.set_active_workspace(ws2)
+    db.add_photo(folder_id=f2, filename='b.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+
+    # WS2 should have 0 masks
+    counts = db.get_pipeline_feature_counts()
+    assert counts['masks'] == 0
+
+    # WS1 should have 1 mask
+    db.set_active_workspace(ws1)
+    counts = db.get_pipeline_feature_counts()
+    assert counts['masks'] == 1
+
+
+# --- Cluster 2: Dashboard Stats ---
+
+def test_get_dashboard_stats_empty(tmp_path):
+    """Returns sensible defaults when workspace has photos but no metadata."""
+    db, _ = _make_workspace_with_photos(tmp_path, [{}])
+    stats = db.get_dashboard_stats()
+    assert stats['top_keywords'] == []
+    assert stats['photos_by_month'] == []
+    assert stats['classified_count'] == 0
+    assert stats['detected_count'] == 0
+
+
+def test_get_dashboard_stats_with_data(tmp_path):
+    """Returns correct aggregations across all stat types."""
+    db, pids = _make_workspace_with_photos(tmp_path, [
+        {'timestamp': '2024-06-15T10:30:00', 'rating': 3, 'flag': 'flagged',
+         'quality_score': 0.85, 'detection_conf': 0.9},
+        {'timestamp': '2024-06-20T14:00:00', 'rating': 5, 'flag': 'none',
+         'quality_score': 0.42, 'detection_conf': 0.0},
+        {'timestamp': '2024-07-01T08:00:00', 'rating': 3, 'flag': 'none'},
+    ])
+
+    # Add keywords
+    kid = db.add_keyword('Robin', is_species=True)
+    db.tag_photo(pids[0], kid)
+    db.tag_photo(pids[1], kid)
+
+    # Add a prediction
+    db.add_prediction(photo_id=pids[0], species='Robin', confidence=0.95, model='test')
+
+    stats = db.get_dashboard_stats()
+
+    # top_keywords: Robin with 2 photos
+    assert len(stats['top_keywords']) == 1
+    assert stats['top_keywords'][0]['name'] == 'Robin'
+    assert stats['top_keywords'][0]['photo_count'] == 2
+
+    # photos_by_month: 2 in 2024-06, 1 in 2024-07
+    months = {r['month']: r['count'] for r in stats['photos_by_month']}
+    assert months['2024-06'] == 2
+    assert months['2024-07'] == 1
+
+    # rating_distribution
+    ratings = {r['rating']: r['count'] for r in stats['rating_distribution']}
+    assert ratings[3] == 2
+    assert ratings[5] == 1
+
+    # classified_count
+    assert stats['classified_count'] == 1
+
+    # detected_count (detection_conf > 0)
+    assert stats['detected_count'] == 1
+
+    # photos_by_hour
+    hours = {r['hour']: r['count'] for r in stats['photos_by_hour']}
+    assert hours[10] == 1
+    assert hours[14] == 1
+    assert hours[8] == 1
+
+
+# --- Cluster 3: Prediction Management ---
+
+def test_get_group_predictions(tmp_path):
+    """Returns predictions with photo data for a group."""
+    db, pids = _make_workspace_with_photos(tmp_path, [
+        {'quality_score': 0.9}, {'quality_score': 0.5},
+    ])
+    db.add_prediction(photo_id=pids[0], species='Robin', confidence=0.95,
+                      model='test', group_id='g1')
+    db.add_prediction(photo_id=pids[1], species='Robin', confidence=0.80,
+                      model='test', group_id='g1')
+
+    results = db.get_group_predictions('g1')
+    assert len(results) == 2
+    # Should be ordered by quality_score DESC
+    assert results[0]['quality_score'] == 0.9
+    assert results[1]['quality_score'] == 0.5
+    # Should include photo fields
+    assert 'filename' in dict(results[0])
+
+
+def test_update_predictions_status_by_photo(tmp_path):
+    """Updates prediction status for all predictions of a photo."""
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    db.add_prediction(photo_id=pids[0], species='Robin', confidence=0.95, model='test')
+
+    db.update_predictions_status_by_photo(pids[0], 'accepted')
+
+    preds = db.get_predictions(photo_ids=[pids[0]])
+    assert preds[0]['status'] == 'accepted'
+
+
+def test_ungroup_prediction(tmp_path):
+    """Removes a prediction from its group."""
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    db.add_prediction(photo_id=pids[0], species='Robin', confidence=0.95,
+                      model='test', group_id='g1')
+    pred = db.get_predictions(photo_ids=[pids[0]])[0]
+
+    db.ungroup_prediction(pred['id'])
+
+    updated = db.get_predictions(photo_ids=[pids[0]])[0]
+    assert updated['group_id'] is None
+
+
+def test_get_existing_prediction_photo_ids(tmp_path):
+    """Returns set of photo_ids that have predictions for a model."""
+    db, pids = _make_workspace_with_photos(tmp_path, [{}, {}])
+    db.add_prediction(photo_id=pids[0], species='Robin', confidence=0.9, model='bioclip')
+
+    result = db.get_existing_prediction_photo_ids('bioclip')
+    assert result == {pids[0]}
+
+    result = db.get_existing_prediction_photo_ids('other-model')
+    assert result == set()
+
+
+def test_get_prediction_for_photo(tmp_path):
+    """Returns species and confidence for a photo's prediction by model."""
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    db.add_prediction(photo_id=pids[0], species='Robin', confidence=0.95, model='bioclip')
+
+    row = db.get_prediction_for_photo(pids[0], 'bioclip')
+    assert row['species'] == 'Robin'
+    assert row['confidence'] == 0.95
+
+    assert db.get_prediction_for_photo(pids[0], 'other') is None
+
+
+def test_get_and_store_photo_embedding(tmp_path):
+    """Stores and retrieves a photo embedding."""
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+
+    assert db.get_photo_embedding(pids[0]) is None
+
+    db.store_photo_embedding(pids[0], b'\x01\x02\x03\x04')
+
+    result = db.get_photo_embedding(pids[0])
+    assert result == b'\x01\x02\x03\x04'
+
+
+def test_update_prediction_group_info(tmp_path):
+    """Updates group info on an existing prediction."""
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    db.add_prediction(photo_id=pids[0], species='Robin', confidence=0.95, model='bioclip')
+
+    db.update_prediction_group_info(
+        photo_id=pids[0], model='bioclip',
+        group_id='g1', vote_count=3, total_votes=5, individual='[{"species":"Robin"}]',
+    )
+
+    pred = db.get_predictions(photo_ids=[pids[0]])[0]
+    assert pred['group_id'] == 'g1'
+    assert pred['vote_count'] == 3
+    assert pred['total_votes'] == 5
+
+
+def test_is_keyword_species(tmp_path):
+    """Checks if a keyword is marked as species."""
+    db, _ = _make_workspace_with_photos(tmp_path, [{}])
+    kid_species = db.add_keyword('Robin', is_species=True)
+    kid_location = db.add_keyword('The Park', is_species=False)
+
+    assert db.is_keyword_species(kid_species) is True
+    assert db.is_keyword_species(kid_location) is False


### PR DESCRIPTION
## Summary

- Extract 24 high-value raw `db.conn.execute()` calls from `app.py` route handlers into proper `Database` methods in `db.py`
- Add 11 new methods: `get_pipeline_feature_counts()`, `get_dashboard_stats()`, `get_group_predictions()`, `update_predictions_status_by_photo()`, `ungroup_prediction()`, `get_existing_prediction_photo_ids()`, `get_prediction_for_photo()`, `get_photo_embedding()`, `store_photo_embedding()`, `update_prediction_group_info()`, `is_keyword_species()`
- Reduces raw SQL in route handlers from 44 to 20 (remaining are lower-value one-off queries)
- Net result: `app.py` -211 lines, `db.py` +194 lines, 13 new tests

## Test plan

- [x] 13 new unit tests covering all extracted methods
- [x] Workspace scoping verified (pipeline counts only count active workspace)
- [x] Full test suite passes: 117/117 tests (`python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)