### PR TITLE
Fix progress tracking for XET model downloads

### DIFF
--- a/vireo/models.py
+++ b/vireo/models.py
@@ -422,6 +422,12 @@ def _download_with_byte_progress(repo_id, filename, file_size,
         done.wait(2.0)
 
     if error[0]:
+        # Preserve tqdm-reported progress so the retry loop can tell
+        # whether data was flowing before the error (e.g. connection reset
+        # after partial XET transfer).
+        if not hasattr(error[0], "bytes_downloaded"):
+            with lock:
+                error[0].bytes_downloaded = state["bytes"]
         raise error[0]
     return result[0]
 


### PR DESCRIPTION
## Summary
- The blob-polling approach in `_download_with_byte_progress` couldn't see XET download progress — XET writes to its own chunk-cache (`~/.cache/huggingface/xet/.../chunk-cache/`), not HF's `blobs/` dir
- This caused two bugs: (1) UI always showed "1 MB" instead of real progress, (2) stall detection fired as a fixed 120s timeout regardless of whether data was flowing
- Replaced blob polling with `hf_hub_download`'s `tqdm_class` parameter to intercept real progress directly from the download backend (works with both HTTP and XET)
- Added `_DownloadStalled` exception that carries `bytes_downloaded` so the retry loop can distinguish "stalled after real progress" (reset counter) from "zero progress" (increment stall counter)
- Removed unused `_get_total_cache_size` function

## Root cause investigation
- XET logs showed data was being downloaded via `transfer.xethub.hf.co` with adaptive concurrency (27-28 connections)
- Data goes through XET's content-addressed chunk-cache, with the final blob only materializing in `blobs/` when all chunks are assembled
- tqdm (from HF's download code) tracked real progress, but our blob polling saw nothing

## Test plan
- [x] 129 tests pass
- [ ] Trigger EVA-02 model download — verify real-time MB progress in the Jobs panel
- [ ] If download stalls, verify stall detection reports correct MB count and retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)