### PR TITLE
Reorder navbar to match photographer workflow

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -731,17 +731,17 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
       <button class="ws-menu-action" onclick="showCreateWorkspaceModal()">+ New Workspace</button>
     </div>
   </div>
-  <a href="/browse">Browse</a>
+  <a href="/import">Import</a>
+  <a href="/pipeline">Pipeline</a>
   <a href="/pipeline/review">Pipeline Review</a>
   <a href="/review">Review</a>
-  <a href="/import">Import</a>
   <a href="/cull">Cull</a>
-  <a href="/pipeline">Pipeline</a>
+  <a href="/browse">Browse</a>
+  <a href="/map">Map</a>
+  <a href="/variants">Variants</a>
+  <a href="/dashboard">Dashboard</a>
   <a href="/audit">Audit</a>
   <a href="/compare">Compare</a>
-  <a href="/variants">Variants</a>
-  <a href="/map">Map</a>
-  <a href="/dashboard">Dashboard</a>
   <a href="/workspace">Workspace</a>
   <a href="/settings">Settings</a>
   <span class="nav-spacer"></span>


### PR DESCRIPTION
## Summary
- Reorders navbar links to follow the natural workflow: Import → Pipeline → Pipeline Review → Review → Cull → Browse → Map → Variants → Dashboard → Audit → Compare → Workspace → Settings
- Previously the order was arbitrary (Browse first, Import buried in the middle), which made it unclear where to start
- Less-used pages (Audit, Compare, Workspace, Settings) moved to the right

## Test plan
- [x] All 154 tests pass
- [ ] Visually verify navbar order in browser
- [ ] Confirm active-page highlighting still works on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)