### PR TITLE
Make slider value display more prominent

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -211,7 +211,8 @@ body { padding-bottom: 36px; }
 }
 .slider-val {
   font-size: 11px;
-  color: var(--text-dim, #5A8890);
+  font-weight: 600;
+  color: var(--text-secondary, #B0CCCC);
   min-width: 32px;
   text-align: right;
   flex-shrink: 0;


### PR DESCRIPTION
## Summary
- Bumped `.slider-val` from dim text color (`#5A8890`) to secondary text color (`#B0CCCC`)
- Added `font-weight: 600` so the current value stands out next to each slider

## Test plan
- [ ] Open Pipeline Review, drag any slider and confirm the value is clearly visible
- [ ] Check that the value styling fits visually with the existing label text

🤖 Generated with [Claude Code](https://claude.com/claude-code)