### PR TITLE
Fix slider values not visible in sidebar

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -219,6 +219,7 @@ body { padding-bottom: 36px; }
 }
 input[type="range"] {
   flex: 1;
+  min-width: 0;
   height: 4px;
   -webkit-appearance: none;
   appearance: none;


### PR DESCRIPTION
## Summary
- Range inputs have a default minimum intrinsic width that was pushing the `slider-val` spans off the visible area
- Added `min-width: 0` to `input[type="range"]` so flex can properly shrink the track to make room for the value display

## Test plan
- [ ] Open Pipeline Review and confirm values (e.g., "3", "0.60") appear to the right of each slider
- [ ] Drag a slider and confirm the value updates in real time

🤖 Generated with [Claude Code](https://claude.com/claude-code)