### PR TITLE
Fix layout shift when reflow indicator appears

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -25,7 +25,7 @@ body { padding-bottom: 36px; }
   padding: 20px 16px;
   overflow-y: auto;
 }
-.sidebar-section { margin-bottom: 24px; }
+.sidebar-section { margin-bottom: 24px; position: relative; }
 .sidebar-title {
   font-size: 11px;
   font-weight: 700;
@@ -260,9 +260,11 @@ input[type="range"]::-moz-range-thumb {
 }
 .reflow-indicator {
   display: none;
+  position: absolute;
+  top: 0;
+  right: 0;
   font-size: 10px;
   color: var(--info, #12C3B5);
-  margin-top: 4px;
   animation: pulse 0.8s infinite;
 }
 .reset-btn {


### PR DESCRIPTION
## Summary
- The "Recomputing..."/"Regrouping..." indicator was `display: none` → `display: block`, inserting into the flow and pushing all sliders down mid-drag
- Now absolutely positioned in the top-right corner of the section header — appears without affecting layout

## Test plan
- [ ] Drag any scoring slider — "Recomputing..." should appear next to "Scoring Thresholds" without shifting sliders
- [ ] Drag any grouping slider — "Regrouping..." should appear in the same spot without shifting sliders
- [ ] Confirm the indicator text doesn't overlap the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)