### PR TITLE
Fix sidecar name resolution in bundled app

### DIFF
--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -43,7 +43,7 @@ pub fn start_sidecar(app: &AppHandle) -> Result<SidecarState, String> {
 
     let (mut rx, child) = app
         .shell()
-        .sidecar("binaries/vireo-server")
+        .sidecar("vireo-server")
         .map_err(|e| format!("Failed to create sidecar command: {}", e))?
         .args([
             "--port", &port.to_string(),


### PR DESCRIPTION
## Summary
- Changed sidecar name from `binaries/vireo-server` to `vireo-server` in Rust code
- Tauri resolves sidecars by name (not path) in production bundles — the binary lives at `Contents/MacOS/vireo-server`, not `Contents/MacOS/binaries/vireo-server`
- The old name worked in dev mode but caused "No such file or directory" in the `.app` bundle

## Test plan
- [x] `cargo tauri build` produces working `.dmg`
- [x] `Vireo.app` launches and spawns sidecar successfully
- [x] `cargo tauri dev` still works (dev mode unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)