### PR TITLE
Sync website download version during releases

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -60,7 +60,7 @@ echo ""
 
 # --- Commit version bump ---
 echo "==> Committing version bump..."
-git add pyproject.toml package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock
+git add pyproject.toml package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock website/src/pages/download.astro
 git commit -m "release: v$NEW_VERSION" || true
 echo ""
 

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -21,6 +21,24 @@ def update_json_file(path, version):
     print(f"  {path}: {old} -> {version}")
 
 
+def update_astro_version(path, version):
+    """Update the version constant in an Astro file."""
+    with open(path) as f:
+        content = f.read()
+    new_content, count = re.subn(
+        r"const version = '[^']*'",
+        f"const version = '{version}'",
+        content,
+        count=1,
+    )
+    if count == 0:
+        print(f"  {path}: WARNING - no version constant found")
+        return
+    with open(path, "w") as f:
+        f.write(new_content)
+    print(f"  {path}: updated to {version}")
+
+
 def update_toml_file(path, version):
     """Update the version in a TOML file (simple regex replacement)."""
     with open(path) as f:
@@ -52,6 +70,7 @@ def main():
     update_json_file("package.json", version)
     update_toml_file("src-tauri/Cargo.toml", version)
     update_toml_file("pyproject.toml", version)
+    update_astro_version("website/src/pages/download.astro", version)
     print("Done.")
 
 

--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -3,7 +3,7 @@ import Base from '../layouts/Base.astro';
 import DownloadButton from '../components/DownloadButton.astro';
 
 const base = import.meta.env.BASE_URL;
-const version = '0.2.1';
+const version = '0.2.4';
 const releaseBase = `https://github.com/jss367/vireo/releases/download/v${version}`;
 ---
 


### PR DESCRIPTION
## Summary
- Adds `website/src/pages/download.astro` to `sync_version.py` so the download page version updates automatically during releases
- Adds the file to `release.sh`'s git staging so it's included in release commits
- Fixes the current stale version (was 0.2.1, now 0.2.4)

Since `release.sh --publish` pushes to main and the website deploy workflow triggers on `website/**` changes, this means the download page will automatically redeploy with the correct version after every release.

## Test plan
- [x] `sync_version.py 0.2.4` correctly updates download.astro
- [x] All 202 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)