### PR TITLE
Add Ctrl+Tab / Ctrl+Shift+Tab to cycle navbar tabs

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1330,7 +1330,7 @@ document.addEventListener('keydown', function(e) {
   if (e.key !== 'Tab' || !e.ctrlKey || e.altKey || e.metaKey) return;
   e.preventDefault();
   var navLinks = Array.prototype.slice.call(
-    document.querySelectorAll('.navbar > a[href]:not(.brand)')
+    document.querySelectorAll('.navbar > a[href]:not(.brand):not(.nav-icon)')
   );
   if (!navLinks.length) return;
   var activeIdx = -1;


### PR DESCRIPTION
## Summary
- Adds Chrome-style tab cycling hotkeys: **Ctrl+Tab** (next tab) and **Ctrl+Shift+Tab** (previous tab)
- Wraps around at both ends of the navbar
- Works alongside existing Tauri menu shortcuts (Cmd+1-0)

## Test plan
- [ ] Open any page, press Ctrl+Tab — navigates to the next tab in the navbar
- [ ] Press Ctrl+Shift+Tab — navigates to the previous tab
- [ ] On the last tab (Settings), Ctrl+Tab wraps to the first tab (Import)
- [ ] On the first tab (Import), Ctrl+Shift+Tab wraps to the last tab (Settings)
- All 202 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)