### PR TITLE
Add Report an Issue to Help menu

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,6 +81,13 @@ pub fn run() {
         .on_menu_event(|app, event| {
             let id = event.id().0.as_str();
 
+            // "Report an Issue" — open GitHub issues in the default browser
+            if id == menu::ids::REPORT_ISSUE {
+                use tauri_plugin_shell::ShellExt;
+                let _ = app.shell().open("https://github.com/jss367/vireo/issues", None::<&str>);
+                return;
+            }
+
             // Navigation items — evaluate JS in the main webview
             if let Some(route) = menu::route_for_id(id) {
                 if let Some(window) = app.get_webview_window("main") {

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -19,6 +19,7 @@ pub mod ids {
     pub const NAV_WORKSPACE: &str = "nav_workspace";
     pub const NAV_SETTINGS: &str = "nav_settings";
     pub const NAV_LOGS: &str = "nav_logs";
+    pub const REPORT_ISSUE: &str = "report_issue";
 }
 
 /// Map a menu item ID to its Flask route path.
@@ -193,10 +194,14 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
     #[allow(unused_mut)]
     let mut help_builder = SubmenuBuilder::new(app, "Help");
 
+    let report_issue = MenuItemBuilder::with_id(ids::REPORT_ISSUE, "Report an Issue...")
+        .build(app)?;
+    help_builder = help_builder.item(&report_issue);
+
     #[cfg(not(target_os = "macos"))]
     {
         let about = PredefinedMenuItem::about(app, Some("About Vireo"), Some(build_about_metadata()))?;
-        help_builder = help_builder.item(&about);
+        help_builder = help_builder.separator().item(&about);
     }
 
     let help_menu = help_builder.build()?;


### PR DESCRIPTION
## Summary
- Adds a "Report an Issue..." item to the Help menu in the Tauri desktop app
- Clicking it opens https://github.com/jss367/vireo/issues in the default browser via `tauri-plugin-shell`
- Available on both macOS and non-macOS (appears above "About Vireo" on non-macOS)

## Test plan
- [x] Rust compiles with no errors
- [x] All 202 Python tests pass
- [ ] Verify menu item appears under Help menu in desktop app
- [ ] Verify clicking it opens the GitHub issues page in default browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)