### PR TITLE
feat: add reaction-polling merge trigger for Codex +1 reactions

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -321,13 +321,18 @@ jobs:
 
           approved_prs=""
           for pr in $prs; do
-            # Check for +1 reactions from trusted actors
-            reactions=$(gh api "repos/${{ github.repository }}/issues/${pr}/reactions" \
-              --jq '[.[] | select(.content == "+1") | .user.login]')
+            # Get the timestamp of the PR's latest push (most recent commit)
+            last_push=$(gh pr view "$pr" --repo "${{ github.repository }}" \
+              --json commits --jq '.commits[-1].committedDate')
+
+            # Check for +1 reactions from trusted actors that are newer than the last push
+            reaction_match=$(gh api "repos/${{ github.repository }}/issues/${pr}/reactions" \
+              --jq --arg cutoff "$last_push" \
+              '[.[] | select(.content == "+1" and .created_at > $cutoff) | .user.login]')
 
             for actor in $TRUSTED_ACTORS; do
-              if echo "$reactions" | jq -e "index(\"$actor\")" > /dev/null 2>&1; then
-                echo "PR #${pr} has +1 from trusted actor: ${actor}"
+              if echo "$reaction_match" | jq -e "index(\"$actor\")" > /dev/null 2>&1; then
+                echo "PR #${pr} has +1 from ${actor} after latest push (${last_push})"
                 approved_prs="${approved_prs} ${pr}"
                 break
               fi


### PR DESCRIPTION
## Summary
- Adds `merge-on-reaction` job that polls every 15 minutes (and on `workflow_dispatch`) for +1 reactions from trusted actors on `claude-agent` PRs
- Needed because Codex leaves +1 reactions (not comments), and GitHub Actions can't trigger on reaction events
- Trusted actors: `jss367`, `chatgpt-codex-connector[bot]`

## Test plan
- [ ] Add `claude-agent` label to a test PR, leave a +1 reaction
- [ ] Run workflow manually (`gh workflow run pr-agent.yml`) and verify merge triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)