### PR TITLE
Fix XMP sync missing module in sidecar build

### DIFF
--- a/scripts/build_sidecar.py
+++ b/scripts/build_sidecar.py
@@ -72,11 +72,14 @@ def main():
     sep = ";" if platform.system() == "Windows" else ":"
     vireo_dir = os.path.join(repo_root, "vireo")
 
+    lr_migration_dir = os.path.join(repo_root, "lr-migration")
+
     pyinstaller_args = [
         sys.executable, "-m", "PyInstaller",
         "--onefile",
         "--name", "vireo-server",
         "--paths", vireo_dir,
+        "--paths", lr_migration_dir,
         # Bundle Flask templates and static assets — destinations are
         # relative to _MEIPASS, and Flask resolves them relative to
         # os.path.dirname(__file__) which is _MEIPASS for the entry script.
@@ -112,6 +115,8 @@ def main():
         "--hidden-import", "bursts",
         "--hidden-import", "detector",
         "--hidden-import", "timm_classifier",
+        "--hidden-import", "xmp_writer",
+        "--hidden-import", "catalog_reader",
     ]
 
     if args.ci:

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1842,7 +1842,7 @@ function formatDuration(seconds) {
       // Use saved logs and merge with any newer server logs
       savedLogs.forEach(function(l) { addLpLine(l, true); });
       var lastTime = savedLogs[savedLogs.length - 1].time || 0;
-      fetch('/api/logs/recent?count=50')
+      fetch('/api/logs/recent?count=200')
         .then(function(r) { return r.json(); })
         .then(function(logs) {
           logs.forEach(function(l) {
@@ -1851,7 +1851,7 @@ function formatDuration(seconds) {
           lpApplyFilter();
         });
     } else {
-      fetch('/api/logs/recent?count=50')
+      fetch('/api/logs/recent?count=200')
         .then(function(r) { return r.json(); })
         .then(function(logs) {
           logs.forEach(function(l) { addLpLine(l, true); });


### PR DESCRIPTION
## Summary
- **XMP sync broken in Tauri build**: The PyInstaller sidecar was missing `lr-migration/` from `--paths` and `xmp_writer`/`catalog_reader` from `--hidden-import`. This caused `ModuleNotFoundError: No module named 'xmp_writer'` when running XMP sync.
- **Errors not visible in Logs panel**: The bottom panel fetched only the last 50 log entries on load. Errors from jobs that failed minutes ago were pushed out by routine log traffic. Increased to 200 entries (matching more of the 500-entry ring buffer).

## Test plan
- [x] All 202 tests pass
- [ ] Rebuild sidecar (`python scripts/build_sidecar.py`) and verify XMP sync works
- [ ] Trigger a job error and confirm it remains visible in the Logs panel after navigating pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)