### PR TITLE
Add confidence threshold slider to Review panel

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1025,10 +1025,22 @@ def create_app(db_path, thumb_cache_dir=None):
         body = request.get_json(silent=True) or {}
         # Only allow workspace-overridable keys
         allowed = {"classification_threshold", "grouping_window_seconds", "similarity_threshold", "review_min_confidence"}
-        overrides = {k: v for k, v in body.items() if k in allowed and v is not None}
-        # Remove keys set to null (revert to global)
-        db.update_workspace(db._active_workspace_id, config_overrides=overrides if overrides else None)
-        return jsonify({"ok": True, "overrides": overrides})
+        # Merge into existing overrides to preserve non-whitelisted keys
+        ws = db.get_workspace(db._active_workspace_id)
+        existing = {}
+        if ws and ws["config_overrides"]:
+            try:
+                existing = json.loads(ws["config_overrides"]) if isinstance(ws["config_overrides"], str) else ws["config_overrides"]
+            except Exception:
+                pass
+        for k, v in body.items():
+            if k in allowed:
+                if v is None:
+                    existing.pop(k, None)
+                else:
+                    existing[k] = v
+        db.update_workspace(db._active_workspace_id, config_overrides=existing if existing else None)
+        return jsonify({"ok": True, "overrides": existing})
 
     # -- Prediction API routes --
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1209,7 +1209,7 @@ function openInspect(photoId) {
   if (enc && enc.species_predictions && enc.species_predictions.length > 0) {
     var threshold = minConfidence / 100;
     var filtered = enc.species_predictions.filter(function(sp) {
-      return sp.models.some(function(m) { return m.confidence >= threshold; });
+      return (sp.models || []).some(function(m) { return m.confidence >= threshold; });
     });
     if (filtered.length > 0) {
       html += '<div class="inspect-species-predictions">';

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -759,3 +759,26 @@ def test_review_min_confidence_persists_in_workspace(app_and_db):
         resp = c.get("/api/workspaces/active/config")
         assert resp.status_code == 200
         assert resp.get_json()["review_min_confidence"] == 40
+
+
+def test_workspace_config_post_preserves_non_whitelisted_keys(app_and_db):
+    """POST /api/workspaces/active/config merges into existing overrides,
+    preserving keys not in the whitelist (e.g. active_labels)."""
+    app, db = app_and_db
+    # Pre-set overrides with a non-whitelisted key
+    db.update_workspace(db._active_workspace_id,
+                        config_overrides={"active_labels": ["/path/to/birds.txt"],
+                                          "classification_threshold": 0.5})
+    with app.test_client() as c:
+        # POST only review_min_confidence
+        resp = c.post("/api/workspaces/active/config",
+                       json={"review_min_confidence": 30},
+                       content_type="application/json")
+        assert resp.status_code == 200
+        overrides = resp.get_json()["overrides"]
+        # New key saved
+        assert overrides["review_min_confidence"] == 30
+        # Whitelisted key preserved
+        assert overrides["classification_threshold"] == 0.5
+        # Non-whitelisted key preserved
+        assert overrides["active_labels"] == ["/path/to/birds.txt"]


### PR DESCRIPTION
## Summary
- Adds a "Min confidence" slider (0-100%, default 40%) to the pipeline Review filter bar, to the right of the All/Keep/Review/Reject buttons
- Predictions below the threshold are hidden in the inspect panel when clicking on a photo
- The threshold is persisted per-workspace via `config_overrides` so it survives page reloads
- Slider uses debounced read-merge-write to avoid flooding the server and preserve other workspace overrides

## Changes
- `vireo/app.py`: Added `review_min_confidence` to allowed workspace config keys; added `workspace_overrides` to page-init response
- `vireo/templates/pipeline_review.html`: Slider HTML/CSS in filter bar; JS for filtering predictions, persisting threshold, and loading saved value
- `vireo/tests/test_app.py`: Two new tests for config persistence and page-init response

## Test plan
- [x] All 204 tests pass (`python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -v`)
- [ ] Manual: Open Review page, verify slider appears right of Reject button
- [ ] Manual: Click a photo, verify low-confidence predictions are hidden
- [ ] Manual: Change slider, reload page, verify value persists
- [ ] Manual: Switch workspaces, verify each workspace has its own threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)