### PR TITLE
feat: add burst group review mode to pipeline review

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2142,7 +2142,7 @@ document.addEventListener('keydown', function(e) {
 function grmApply() {
   var species = document.getElementById('grmSpecies').value.trim();
 
-  // Update local pipelineResults with pick/reject decisions
+  // Update local pipelineResults with pick/reject/candidate decisions
   var photoMap = {};
   pipelineResults.photos.forEach(function(p) { photoMap[p.id] = p; });
 
@@ -2155,6 +2155,32 @@ function grmApply() {
     var p = photoMap[pid];
     if (p) p.label = 'REJECT';
   });
+
+  // Candidates (not picked, not rejected, not removed) → REVIEW
+  grmState.items.forEach(function(item) {
+    if (!grmState.picks.has(item.id) && !grmState.rejects.has(item.id) && !grmState.removed.has(item.id)) {
+      var p = photoMap[item.id];
+      if (p) p.label = 'REVIEW';
+    }
+  });
+
+  // Detach removed photos from the burst into new single-photo bursts
+  if (grmState.removed.size > 0) {
+    var enc = pipelineResults.encounters[grmState.encIdx];
+    var burst = enc.bursts[grmState.burstIdx];
+    var burstIds = burst.photo_ids || burst;
+    grmState.removed.forEach(function(pid) {
+      var idx = burstIds.indexOf(pid);
+      if (idx >= 0) burstIds.splice(idx, 1);
+      // Add as a new single-photo burst in the same encounter
+      enc.bursts.push({ photo_ids: [pid], species_predictions: burst.species_predictions || [], species_override: null });
+    });
+    // Clean up empty burst
+    if (burstIds.length === 0) {
+      enc.bursts.splice(grmState.burstIdx, 1);
+    }
+    enc.burst_count = enc.bursts.length;
+  }
 
   // Update species if changed
   if (species) {


### PR DESCRIPTION
## Summary
- When clicking a photo in pipeline review that belongs to a burst with 2+ photos, opens the full burst group review modal (GRM) instead of the single-photo inspect panel
- GRM shows all burst photos in picks/candidates/rejects zones with zoom/pan sync across all thumbnails (1-12x)
- Full pipeline metadata (triage badge, reject reasons, species predictions, score waterfall, feature table) displayed below the loupe for the selected photo
- Single-photo bursts continue to use the existing inspect panel
- Apply & Close saves pick/reject decisions back to pipeline results and updates summary counts

## Test plan
- [x] All 202 existing tests pass
- [x] Template renders with all GRM elements present
- [ ] Manual: click a photo in a multi-photo burst → GRM opens with all burst photos
- [ ] Manual: click a photo in a single-photo burst → existing inspect panel opens
- [ ] Manual: verify zoom/pan sync across thumbnails in GRM
- [ ] Manual: verify pipeline metadata (scores, species, features) appears below loupe
- [ ] Manual: verify pick/reject zone movement with arrow keys
- [ ] Manual: verify Apply & Close updates photo labels and summary counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)