### PR TITLE
fix: align species dropdown and GPS stats semantics

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -514,11 +514,13 @@ def create_app(db_path, thumb_cache_dir=None):
 
         total_photos = db.count_photos()
         total_without_gps = db.count_photos_without_gps()
+        total_with_gps = total_photos - total_without_gps
 
         return jsonify({
             "photos": [dict(p) for p in photos],
-            "total_geo": len(photos),
+            "total_filtered": len(photos),
             "total_photos": total_photos,
+            "total_with_gps": total_with_gps,
             "total_without_gps": total_without_gps,
         })
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -972,20 +972,33 @@ class Database:
         return self.conn.execute(query, params).fetchall()
 
     def get_accepted_species(self):
-        """Return distinct accepted species names in the active workspace."""
+        """Return distinct marker species from geolocated photos in the active workspace.
+
+        Uses the same derivation as get_geolocated_photos: the highest-confidence
+        accepted prediction per photo.  Only considers photos that have GPS
+        coordinates, so every returned species can actually produce a map marker.
+        """
+        ws = self._ws_id()
         return [
             row[0]
             for row in self.conn.execute(
                 """
-                SELECT DISTINCT pr.species
-                FROM predictions pr
-                JOIN photos p ON p.id = pr.photo_id
-                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-                WHERE pr.workspace_id = ? AND pr.status = 'accepted'
-                  AND wf.workspace_id = ?
-                ORDER BY pr.species ASC
+                SELECT DISTINCT top_species FROM (
+                    SELECT (SELECT pr.species FROM predictions pr
+                            WHERE pr.photo_id = p.id
+                              AND pr.workspace_id = ?
+                              AND pr.status = 'accepted'
+                            ORDER BY pr.confidence DESC LIMIT 1) AS top_species
+                    FROM photos p
+                    JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                    WHERE wf.workspace_id = ?
+                      AND p.latitude IS NOT NULL
+                      AND p.longitude IS NOT NULL
+                )
+                WHERE top_species IS NOT NULL
+                ORDER BY top_species ASC
                 """,
-                (self._ws_id(), self._ws_id()),
+                (ws, ws),
             ).fetchall()
         ]
 

--- a/vireo/templates/map.html
+++ b/vireo/templates/map.html
@@ -598,18 +598,20 @@ async function loadPhotos() {
     map.fitBounds(markers.getBounds(), { padding: [30, 30] });
     renderSidebar(data.photos);
 
-    /* GPS coverage stats */
-    var totalGeo = data.total_geo;
+    /* GPS coverage stats — global (unfiltered) for consistency */
+    var totalFiltered = data.total_filtered;
+    var totalWithGps = data.total_with_gps;
     var totalPhotos = data.total_photos;
     var missingGps = data.total_without_gps;
-    var pct = totalPhotos > 0 ? Math.round((totalGeo / totalPhotos) * 100) : 0;
+    var pct = totalPhotos > 0 ? Math.round((totalWithGps / totalPhotos) * 100) : 0;
 
     var statusEl = document.getElementById('mapStatus');
-    statusEl.innerHTML = 'Showing ' + totalGeo + ' geolocated photos &mdash; '
-      + pct + '% GPS coverage'
-      + (missingGps > 0
-          ? ' &mdash; <a href="/browse?missing_gps=1">' + missingGps + ' missing GPS</a>'
-          : '');
+    var parts = ['Showing ' + totalFiltered + ' of ' + totalWithGps + ' geolocated photos'];
+    parts.push(pct + '% GPS coverage');
+    if (missingGps > 0) {
+      parts.push('<a href="/browse?missing_gps=1">' + missingGps + ' missing GPS</a>');
+    }
+    statusEl.innerHTML = parts.join(' &mdash; ');
   } catch (e) {
     document.getElementById('mapStatus').textContent = 'Failed to load photos.';
   }

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -926,7 +926,7 @@ def test_get_geolocated_photos_species_filter(tmp_path):
 
 
 def test_get_accepted_species(tmp_path):
-    """get_accepted_species returns distinct species from accepted predictions."""
+    """get_accepted_species returns distinct marker species from geolocated photos."""
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     fid = db.add_folder('/photos', name='photos')
@@ -934,6 +934,9 @@ def test_get_accepted_species(tmp_path):
                       file_size=100, file_mtime=1.0)
     p2 = db.add_photo(folder_id=fid, filename='heron.jpg', extension='.jpg',
                       file_size=100, file_mtime=1.0)
+    # Both photos need GPS to appear in species list
+    db.conn.execute("UPDATE photos SET latitude=37.0, longitude=-122.0 WHERE id IN (?,?)", (p1, p2))
+    db.conn.commit()
     db.add_prediction(p1, 'Red-tailed Hawk', 0.95, 'bioclip')
     db.add_prediction(p2, 'Great Blue Heron', 0.90, 'bioclip')
     preds = db.get_predictions(photo_ids=[p1, p2])
@@ -947,6 +950,23 @@ def test_get_accepted_species(tmp_path):
     assert len(species) == 2
 
 
+def test_get_accepted_species_excludes_non_geolocated(tmp_path):
+    """get_accepted_species excludes species from photos without GPS."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='hawk.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    # p1 has no GPS coordinates
+    db.add_prediction(p1, 'Red-tailed Hawk', 0.95, 'bioclip')
+    preds = db.get_predictions(photo_ids=[p1])
+    db.conn.execute("UPDATE predictions SET status='accepted' WHERE id=?", (preds[0]['id'],))
+    db.conn.commit()
+
+    species = db.get_accepted_species()
+    assert species == []
+
+
 def test_get_accepted_species_excludes_non_accepted(tmp_path):
     """get_accepted_species only includes accepted predictions, not pending."""
     from db import Database
@@ -954,10 +974,33 @@ def test_get_accepted_species_excludes_non_accepted(tmp_path):
     fid = db.add_folder('/photos', name='photos')
     p1 = db.add_photo(folder_id=fid, filename='hawk.jpg', extension='.jpg',
                       file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET latitude=37.0, longitude=-122.0 WHERE id=?", (p1,))
+    db.conn.commit()
     db.add_prediction(p1, 'Red-tailed Hawk', 0.95, 'bioclip')
 
     species = db.get_accepted_species()
     assert species == []
+
+
+def test_get_accepted_species_uses_top_confidence(tmp_path):
+    """get_accepted_species returns only the highest-confidence species per photo."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='hawk.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET latitude=37.0, longitude=-122.0 WHERE id=?", (p1,))
+    db.conn.commit()
+    db.add_prediction(p1, 'Red-tailed Hawk', 0.95, 'bioclip')
+    db.add_prediction(p1, 'Cooper\'s Hawk', 0.60, 'bioclip')
+    preds = db.get_predictions(photo_ids=[p1])
+    for pr in preds:
+        db.conn.execute("UPDATE predictions SET status='accepted' WHERE id=?", (pr['id'],))
+    db.conn.commit()
+
+    species = db.get_accepted_species()
+    # Only the top-confidence species should appear
+    assert species == ['Red-tailed Hawk']
 
 
 def test_count_photos_without_gps(tmp_path):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -147,9 +147,11 @@ def test_api_photos_geo_returns_geolocated(app_and_db):
     assert resp.status_code == 200
     data = resp.get_json()
     assert 'photos' in data
-    assert 'total_geo' in data
+    assert 'total_filtered' in data
+    assert 'total_with_gps' in data
     assert 'total_photos' in data
-    assert data['total_geo'] == 1
+    assert data['total_filtered'] == 1
+    assert data['total_with_gps'] == 1
     assert data['total_photos'] == 3
     assert len(data['photos']) == 1
     assert data['photos'][0]['latitude'] == 37.77
@@ -179,11 +181,11 @@ def test_api_photos_geo_empty(app_and_db):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data['photos'] == []
-    assert data['total_geo'] == 0
+    assert data['total_filtered'] == 0
 
 
-def test_api_photos_geo_includes_total_without_gps(app_and_db):
-    """GET /api/photos/geo response includes total_without_gps count."""
+def test_api_photos_geo_includes_gps_stats(app_and_db):
+    """GET /api/photos/geo response includes consistent global GPS stats."""
     app, db = app_and_db
     db.conn.execute("UPDATE photos SET latitude=37.77, longitude=-122.42 WHERE filename='bird1.jpg'")
     db.conn.commit()
@@ -191,8 +193,15 @@ def test_api_photos_geo_includes_total_without_gps(app_and_db):
     client = app.test_client()
     resp = client.get('/api/photos/geo')
     data = resp.get_json()
-    assert 'total_without_gps' in data
-    assert data['total_without_gps'] == 2  # bird2 and bird3 have no GPS
+    assert data['total_with_gps'] == 1
+    assert data['total_without_gps'] == 2
+    assert data['total_photos'] == 3
+    # Verify global stats stay consistent even with filters active
+    resp2 = client.get('/api/photos/geo?rating_min=5')
+    data2 = resp2.get_json()
+    assert data2['total_filtered'] == 0  # no rated-5 geo photos
+    assert data2['total_with_gps'] == 1  # global count unchanged
+    assert data2['total_without_gps'] == 2  # global count unchanged
 
 
 def test_api_photos_geo_species_filter(app_and_db):
@@ -216,8 +225,9 @@ def test_api_photos_geo_species_filter(app_and_db):
 
 
 def test_api_species_list(app_and_db):
-    """GET /api/species returns accepted species."""
+    """GET /api/species returns accepted species from geolocated photos."""
     app, db = app_and_db
+    db.conn.execute("UPDATE photos SET latitude=37.0, longitude=-122.0 WHERE id=1")
     db.add_prediction(1, 'Cardinal', 0.9, 'bioclip')
     preds = db.get_predictions(photo_ids=[1])
     db.conn.execute("UPDATE predictions SET status='accepted' WHERE id=?", (preds[0]['id'],))


### PR DESCRIPTION
Parent PR: #85

## Summary

Fixes two review issues from #85:

- **Species dropdown alignment** — `get_accepted_species()` now uses the same derivation as map markers (highest-confidence accepted prediction per geolocated photo). Previously it returned all accepted species including secondary predictions and species on non-geolocated photos, so some dropdown options would produce empty results.
- **Consistent GPS stats** — API response now separates `total_filtered` (filtered count) from `total_with_gps` / `total_without_gps` (workspace-wide). Status bar shows "Showing N of M geolocated photos" to distinguish filtered vs global. Previously mixed filtered and global counts, producing a hybrid percentage when filters were active.

## Test plan

- [x] 2 new DB tests: `test_get_accepted_species_excludes_non_geolocated`, `test_get_accepted_species_uses_top_confidence`
- [x] Updated existing tests for new response field names
- [x] GPS stats test verifies global counts stay consistent with filters active
- [x] 227 passed in ~4s

```
============================= 227 passed in 4.15s ==============================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)