### PR TITLE
fix: upsert taxonomy rows on reload and fix lint

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4826,7 +4826,7 @@ def main():
         ig_stats = seed_informal_groups(db)
         print(f"  Informal groups: {ig_stats['groups_created']} groups created")
         print("Done.")
-        sys.exit(0)
+        raise SystemExit(0)
 
     # Resolve port: --port 0 means pick a random free port
     port = args.port

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -347,8 +347,10 @@ def load_taxa_from_file(db, gz_path):
     inat_to_local = {}
     for inat_id, t in filtered.items():
         db.conn.execute(
-            "INSERT OR IGNORE INTO taxa (inat_id, name, rank, kingdom) "
-            "VALUES (?, ?, ?, ?)",
+            "INSERT INTO taxa (inat_id, name, rank, kingdom) "
+            "VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(inat_id) DO UPDATE SET "
+            "name = excluded.name, rank = excluded.rank, kingdom = excluded.kingdom",
             (inat_id, t['name'], t['rank'], t['kingdom']),
         )
         row = db.conn.execute(

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -371,6 +371,28 @@ def test_load_taxa_idempotent(tmp_path):
     assert count1 == count2
 
 
+def test_load_taxa_updates_on_reload(tmp_path):
+    """Reloading taxa updates changed names/ranks instead of ignoring them."""
+    from taxonomy import load_taxa_from_file
+
+    db = Database(str(tmp_path / "test.db"))
+    tsv_path = _make_taxa_tsv(tmp_path)
+
+    load_taxa_from_file(db, tsv_path)
+
+    # Manually corrupt a taxon name to simulate stale data
+    db.conn.execute("UPDATE taxa SET name = 'OldName' WHERE inat_id = 3")
+    db.conn.commit()
+    assert db.conn.execute(
+        "SELECT name FROM taxa WHERE inat_id = 3"
+    ).fetchone()["name"] == "OldName"
+
+    # Reload should fix it
+    load_taxa_from_file(db, tsv_path)
+    row = db.conn.execute("SELECT name FROM taxa WHERE inat_id = 3").fetchone()
+    assert row["name"] == "Aves"
+
+
 from unittest.mock import MagicMock, patch
 
 


### PR DESCRIPTION
Parent PR: #91

## Summary

- **Upsert taxonomy rows** — Changed `INSERT OR IGNORE` to `INSERT ... ON CONFLICT(inat_id) DO UPDATE SET name, rank, kingdom` in `load_taxa_from_file()`. Previously, reloading the taxonomy after iNaturalist updated a taxon's name or rank would silently keep stale values. Now reloads apply upstream changes.
- **Fix lint failure** — `sys.exit(0)` in the `--load-taxonomy` handler failed because `sys` wasn't imported. Replaced with `raise SystemExit(0)`.

## Test plan

- [x] New test: `test_load_taxa_updates_on_reload` — corrupts a taxon name, reloads, verifies it's corrected
- [x] Existing `test_load_taxa_idempotent` still passes (count unchanged)
- [x] 19 taxonomy tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)