### PR TITLE
fix: block auto-fix on fork PRs

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -219,6 +219,17 @@ jobs:
             exit 0
           fi
 
+          # Security gate: skip fork PRs to avoid running privileged actions on untrusted code
+          pr_repo=$(gh pr view "$pr_number" --repo "${{ github.repository }}" \
+            --json headRepositoryOwner,headRepository \
+            --jq '.headRepositoryOwner.login + "/" + .headRepository.name')
+
+          if [[ "$pr_repo" != "${{ github.repository }}" ]]; then
+            echo "PR #${pr_number} is from fork ${pr_repo} — skipping."
+            echo "should_fix=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # Prevent infinite loops: skip if the failing commit was already a CI fix
           last_msg=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}" \
             --jq '.commit.message' | head -1)


### PR DESCRIPTION
Parent PR: #93

## Summary
- Adds a trust gate that skips fork PRs in the `fix-ci` job
- Compares `headRepositoryOwner/headRepository` against `github.repository` — bails out if they differ
- **P0 (security)**: Prevents running `pytest` on untrusted fork code in the privileged `workflow_run` context (which has write permissions and secret access)
- **P1 (correctness)**: Eliminates impossible `git push origin $HEAD` for fork branches, which would fail or create unrelated branches

## Test plan
- [ ] Open a fork PR with a failing test — verify the fix-ci job logs "from fork — skipping" and exits early
- [ ] Open a same-repo PR with a failing test — verify the fix-ci job proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)