### PR TITLE
fix: ad-hoc sign when Apple credentials are absent

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -96,6 +96,14 @@ if [[ -z "$DMG" ]]; then
     echo "ERROR: No .dmg found"
     exit 1
 fi
+
+# --- Rebuild DMG after ad-hoc signing ---
+# cargo tauri build creates .app and .dmg in one step, so the original
+# DMG contains the unsigned app. Recreate it with the signed .app.
+if ! $FULL_SIGNING; then
+    echo "==> Rebuilding DMG with signed app..."
+    hdiutil create -volname "Vireo" -srcfolder "$APP_PATH" -ov -format UDZO "$DMG"
+fi
 echo "==> Built: $DMG"
 echo ""
 


### PR DESCRIPTION
Parent PR: #121

## Summary
- Removed the mandatory env var gate — Apple Developer credentials are no longer required to build a release
- Two paths: if credentials are set → full signing + notarization via `build_signed.sh`; if not → ad-hoc sign with `codesign --sign - --force --deep`
- Ad-hoc signing prevents the "damaged and can't be opened" Gatekeeper error; users see "from an unidentified developer" instead and can right-click → Open to bypass
- The ad-hoc path also uses the targeted updater-signing error handling from #121

## Test plan
- [x] 248 tests passing
- [x] Shell syntax check passes
- [ ] Run `./scripts/release.sh patch` without any Apple env vars — should build and ad-hoc sign
- [ ] Verify the resulting .app opens without "damaged" error
- [ ] Run with all Apple env vars set — should use full signing + notarization

🤖 Generated with [Claude Code](https://claude.com/claude-code)