### PR TITLE
fix: resolve DMG path once for rebuild and publish

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -87,17 +87,6 @@ else
     echo "==> Ad-hoc signing app bundle..."
     codesign --sign - --force --deep "$APP_PATH"
     codesign --verify --deep --verbose=2 "$APP_PATH"
-
-    # Rebuild the DMG so it contains the signed .app
-    # (cargo tauri build creates .app and .dmg in one step, so the
-    # original DMG contains the unsigned app)
-    OLD_DMG=$(find src-tauri/target/release/bundle/dmg -name "*.dmg" 2>/dev/null | head -1)
-    if [[ -z "$OLD_DMG" ]]; then
-        echo "ERROR: No .dmg found to rebuild"
-        exit 1
-    fi
-    echo "==> Rebuilding DMG with signed app..."
-    hdiutil create -volname "Vireo" -srcfolder "$APP_PATH" -ov -format UDZO "$OLD_DMG"
 fi
 echo ""
 
@@ -106,6 +95,14 @@ DMG=$(find src-tauri/target/release/bundle/dmg -name "*.dmg" 2>/dev/null | head 
 if [[ -z "$DMG" ]]; then
     echo "ERROR: No .dmg found"
     exit 1
+fi
+
+# --- Rebuild DMG after ad-hoc signing ---
+# cargo tauri build creates .app and .dmg in one step, so the original
+# DMG contains the unsigned app. Recreate it with the signed .app.
+if ! $FULL_SIGNING; then
+    echo "==> Rebuilding DMG with signed app..."
+    hdiutil create -volname "Vireo" -srcfolder "$APP_PATH" -ov -format UDZO "$DMG"
 fi
 echo "==> Built: $DMG"
 echo ""


### PR DESCRIPTION
Parent PR: #123

## Summary
- The DMG path is now resolved with a single `find` call right after the build
- That same `$DMG` variable is reused for the `hdiutil` rebuild (ad-hoc path) and the publish/upload step
- Eliminates the risk of two `find` calls selecting different `.dmg` files when stale artifacts exist from prior runs

## Test plan
- [x] 248 tests passing
- [x] Shell syntax check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)