### PR TITLE
fix: preserve Tauri DMG layout when rebuilding after ad-hoc signing

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -107,7 +107,7 @@ if ! $FULL_SIGNING; then
     DMG_MOUNT=$(mktemp -d)
     DMG_STAGING=$(mktemp -d)
     hdiutil attach "$DMG" -mountpoint "$DMG_MOUNT" -nobrowse -readonly -noverify
-    cp -a "$DMG_MOUNT"/ "$DMG_STAGING"/
+    cp -a "$DMG_MOUNT"/. "$DMG_STAGING"/
     hdiutil detach "$DMG_MOUNT"
     rm -rf "$DMG_STAGING/Vireo.app"
     cp -a "$APP_PATH" "$DMG_STAGING/"


### PR DESCRIPTION
Parent PR: #124

## Summary
- The previous `hdiutil create -srcfolder "$APP_PATH"` created a bare DMG with just the .app, losing the Tauri-generated installer layout (background image, icon positions, Applications symlink)
- Now mounts the original Tauri DMG, copies its full contents to a staging directory (preserving `.DS_Store`, `.background/`, `Applications` symlink), swaps in the signed `.app`, and repackages
- The drag-to-install experience is preserved

## Test plan
- [x] 248 tests passing
- [x] Shell syntax check passes
- [ ] Run `./scripts/release.sh patch`, mount the DMG, verify it shows the background + Applications shortcut layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)