### PR TITLE
Add Vireo Gold theme for yellow logo variant

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -99,7 +99,7 @@
   --accent: #D4A800;
   --accent-hover: #B89200;
   --accent-dim: #FFF8D0;
-  --accent-text: #FFFEF8;
+  --accent-text: #3A3A3A;
   --warning: #C87A00;
   --danger: #C0392B;
   --info: #7A7A7A;


### PR DESCRIPTION
## Summary
- Adds a **Vireo Gold** theme with warm yellow/cream backgrounds and grey text, derived from the `logo_yellow.png` color palette
- Automatically appears in both the navbar theme toggle (cycles through all themes) and the Settings page theme picker
- No changes to existing themes — just one new `data-theme="vireo-gold"` CSS block and a JS theme list entry

## Test plan
- [x] All 248 existing tests pass
- [ ] Click the theme toggle (sun icon in navbar) to cycle through themes — Vireo Gold should appear between Classic Dark and High Contrast
- [ ] Open Settings and verify the Vireo Gold button appears in the theme picker
- [ ] Verify the gold theme looks good across different pages (browse, settings, collections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)