### PR TITLE
Fix Vireo Gold accent-text contrast

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -99,7 +99,7 @@
   --accent: #D4A800;
   --accent-hover: #B89200;
   --accent-dim: #FFF8D0;
-  --accent-text: #FFFEF8;
+  --accent-text: #3A3A3A;
   --warning: #C87A00;
   --danger: #C0392B;
   --info: #7A7A7A;


### PR DESCRIPTION
## Summary
- Changes `--accent-text` from `#FFFEF8` (white) to `#3A3A3A` (dark grey) in the Vireo Gold theme
- Fixes poor contrast on accent-backed elements like `.btn-batch-accept`, `.badge-new`, and `.modal-btn-primary`

Parent PR: #127

## Test plan
- [x] All 248 tests pass
- [ ] Switch to Vireo Gold theme and verify buttons/badges have readable dark text on gold backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)