### PR TITLE
fix: copy DMG contents not mountpoint directory

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -107,7 +107,7 @@ if ! $FULL_SIGNING; then
     DMG_MOUNT=$(mktemp -d)
     DMG_STAGING=$(mktemp -d)
     hdiutil attach "$DMG" -mountpoint "$DMG_MOUNT" -nobrowse -readonly -noverify
-    cp -a "$DMG_MOUNT"/ "$DMG_STAGING"/
+    cp -a "$DMG_MOUNT"/. "$DMG_STAGING"/
     hdiutil detach "$DMG_MOUNT"
     rm -rf "$DMG_STAGING/Vireo.app"
     cp -a "$APP_PATH" "$DMG_STAGING/"


### PR DESCRIPTION
Parent PR: #126

## Summary
- `cp -a "$DMG_MOUNT"/` copies the mountpoint directory itself into staging, not its contents — the rebuilt DMG would contain a nested temp directory instead of the expected top-level layout
- Changed to `cp -a "$DMG_MOUNT"/.` which reliably copies directory contents (including hidden files like `.DS_Store`, `.background/`) on macOS BSD cp

## Test plan
- [x] 248 tests passing
- [x] Shell syntax check passes
- [ ] Run `./scripts/release.sh patch`, mount the resulting DMG, verify top-level contains `Vireo.app` + `Applications` symlink (no nested temp directory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)