### PR TITLE
fix: monotonic progress, Pillow fallback, CI skip for exiftool tests

### DIFF
--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -289,8 +289,9 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
 
     # First pass: determine which files need full processing (for incremental mode).
     # Handle XMP-only changes inline; collect files needing metadata extraction.
-    files_to_process = []  # list of (index, image_path) tuples
-    for i, image_path in enumerate(image_files):
+    files_to_process = []
+    processed_count = 0
+    for image_path in image_files:
         stat = image_path.stat()
         file_mtime = stat.st_mtime
         xmp_path = image_path.with_suffix(".xmp")
@@ -304,8 +305,9 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 xmp_unchanged = existing["xmp_mtime"] == xmp_mtime
 
                 if file_unchanged and xmp_unchanged:
+                    processed_count += 1
                     if progress_callback:
-                        progress_callback(i + 1, total)
+                        progress_callback(processed_count, total)
                     continue
 
                 # XMP changed: re-import keywords
@@ -318,17 +320,18 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     db.conn.commit()
 
                 if file_unchanged:
+                    processed_count += 1
                     if progress_callback:
-                        progress_callback(i + 1, total)
+                        progress_callback(processed_count, total)
                     continue
 
-        files_to_process.append((i, image_path))
+        files_to_process.append(image_path)
 
     # Batch extract metadata via ExifTool only for files that need processing
-    paths_to_extract = [str(ip) for _, ip in files_to_process]
+    paths_to_extract = [str(ip) for ip in files_to_process]
     metadata_map = extract_metadata(paths_to_extract) if paths_to_extract else {}
 
-    for i, image_path in files_to_process:
+    for image_path in files_to_process:
         folder_id = _ensure_folder(image_path.parent)
 
         # File stats
@@ -348,6 +351,14 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
 
         # Dimensions from ExifTool (works for all file types including RAW)
         width, height = _extract_dimensions(exif_group, file_group)
+
+        # Fallback to Pillow if ExifTool didn't provide dimensions
+        if width is None or height is None:
+            try:
+                with Image.open(str(image_path)) as img:
+                    width, height = img.size
+            except Exception:
+                log.debug("Could not read dimensions from %s", image_path)
 
         # Timestamp from ExifTool
         timestamp = _extract_timestamp(exif_group)
@@ -431,8 +442,9 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         if xmp_path.exists():
             _import_keywords_for_photo(db, photo_id, str(xmp_path))
 
+        processed_count += 1
         if progress_callback:
-            progress_callback(i + 1, total)
+            progress_callback(processed_count, total)
 
     # Pair raw+JPEG companions: raw is primary, JPEG becomes companion_path
     _pair_raw_jpeg_companions(db)

--- a/vireo/tests/test_metadata.py
+++ b/vireo/tests/test_metadata.py
@@ -1,12 +1,20 @@
 """Tests for vireo/metadata.py — ExifTool wrapper."""
 
 import os
+import shutil
 import sys
+
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from PIL import Image
 from PIL.ExifTags import IFD, Base
+
+requires_exiftool = pytest.mark.skipif(
+    shutil.which("exiftool") is None,
+    reason="exiftool not installed",
+)
 
 
 def _create_jpg_with_exif(path):
@@ -32,6 +40,7 @@ def _create_plain_jpg(path):
     img.save(path)
 
 
+@requires_exiftool
 def test_extract_metadata_single_file(tmp_path):
     """extract_metadata returns grouped tag dict for a single file."""
     from metadata import extract_metadata
@@ -60,6 +69,7 @@ def test_extract_metadata_single_file(tmp_path):
     assert meta["File"]["ImageHeight"] == 100
 
 
+@requires_exiftool
 def test_extract_metadata_returns_empty_for_missing_file(tmp_path):
     """extract_metadata returns empty dict for nonexistent file."""
     from metadata import extract_metadata
@@ -71,6 +81,7 @@ def test_extract_metadata_returns_empty_for_missing_file(tmp_path):
     assert results.get(missing) is None or results == {}
 
 
+@requires_exiftool
 def test_extract_metadata_batch(tmp_path):
     """extract_metadata handles multiple files in one call."""
     from metadata import extract_metadata
@@ -94,6 +105,7 @@ def test_extract_metadata_empty_list():
     assert extract_metadata([]) == {}
 
 
+@requires_exiftool
 def test_extract_metadata_with_restricted_tags(tmp_path):
     """extract_metadata can restrict which tags are returned."""
     from metadata import extract_metadata
@@ -214,6 +226,7 @@ def test_group_tags_ungrouped_keys_go_to_meta():
     assert grouped["EXIF"]["Make"] == "Canon"
 
 
+@requires_exiftool
 def test_extract_metadata_integration_with_summary(tmp_path):
     """End-to-end: extract_metadata then extract_summary_fields."""
     from metadata import extract_metadata, extract_summary_fields

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1,12 +1,20 @@
 # vireo/tests/test_scanner.py
 import json
 import os
+import shutil
 import sys
 import time
+
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from PIL import Image
+
+requires_exiftool = pytest.mark.skipif(
+    shutil.which("exiftool") is None,
+    reason="exiftool not installed",
+)
 
 
 def _create_test_images(root, structure):
@@ -285,6 +293,7 @@ def test_incremental_scan_detects_xmp_changes(tmp_path):
     assert 'Cardinal' in kw_names
 
 
+@requires_exiftool
 def test_scan_populates_exif_data(tmp_path):
     """scan() populates the exif_data JSON column when extract_full_metadata is on."""
     from db import Database


### PR DESCRIPTION
Parent PR: #120

## Summary
- Fix progress regression in incremental scans: use a single monotonic counter across both passes instead of storing original indices
- Add Pillow fallback for image dimensions when ExifTool is unavailable (CI environments)
- Skip ExifTool-dependent tests with `@requires_exiftool` marker so CI passes without it installed

## Test plan
- [x] 282 tests pass locally (exiftool available)
- [x] Tests that need exiftool are marked with skipif
- [x] Dimension reading falls back to Pillow when ExifTool returns nothing
- [x] Progress callbacks are monotonically increasing in incremental mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)