### PR TITLE
fix: queue sidecar changes for all affected workspaces

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -587,19 +587,19 @@ def create_app(db_path, thumb_cache_dir=None):
         log.info("Keyword cleanup: merged %d duplicates", merged)
         return jsonify({"ok": True, "merged": merged})
 
-    def _queue_keyword_add(photo_id, keyword_name):
+    def _queue_keyword_add(photo_id, keyword_name, workspace_id=None):
         """Queue a keyword add unless it cancels a pending removal."""
         db = _get_db()
-        removed = db.remove_pending_changes(photo_id, "keyword_remove", keyword_name)
+        removed = db.remove_pending_changes(photo_id, "keyword_remove", keyword_name, workspace_id=workspace_id)
         if removed == 0:
-            db.queue_change(photo_id, "keyword_add", keyword_name)
+            db.queue_change(photo_id, "keyword_add", keyword_name, workspace_id=workspace_id)
 
-    def _queue_keyword_remove(photo_id, keyword_name):
+    def _queue_keyword_remove(photo_id, keyword_name, workspace_id=None):
         """Queue a keyword removal unless it cancels a pending add."""
         db = _get_db()
-        removed = db.remove_pending_changes(photo_id, "keyword_add", keyword_name)
+        removed = db.remove_pending_changes(photo_id, "keyword_add", keyword_name, workspace_id=workspace_id)
         if removed == 0:
-            db.queue_change(photo_id, "keyword_remove", keyword_name)
+            db.queue_change(photo_id, "keyword_remove", keyword_name, workspace_id=workspace_id)
 
     # -- Edit API routes --
 
@@ -682,37 +682,39 @@ def create_app(db_path, thumb_cache_dir=None):
             db.update_keyword(keyword_id, **body)
         except ValueError as e:
             return json_error(str(e), 400)
-        # Queue sidecar updates only after successful DB update, scoped to active workspace
+        # Queue sidecar updates only after successful DB update, for all affected workspaces
         if old_name:
-            photo_ids = db.conn.execute(
-                """SELECT pk.photo_id FROM photo_keywords pk
+            affected = db.conn.execute(
+                """SELECT pk.photo_id, wf.workspace_id
+                   FROM photo_keywords pk
                    JOIN photos p ON p.id = pk.photo_id
                    JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-                   WHERE pk.keyword_id = ? AND wf.workspace_id = ?""",
-                (keyword_id, db._ws_id()),
+                   WHERE pk.keyword_id = ?""",
+                (keyword_id,),
             ).fetchall()
-            for row in photo_ids:
-                _queue_keyword_remove(row["photo_id"], old_name)
-                _queue_keyword_add(row["photo_id"], new_name)
+            for row in affected:
+                _queue_keyword_remove(row["photo_id"], old_name, workspace_id=row["workspace_id"])
+                _queue_keyword_add(row["photo_id"], new_name, workspace_id=row["workspace_id"])
         return jsonify({"ok": True})
 
     @app.route("/api/keywords/<int:keyword_id>", methods=["DELETE"])
     def api_delete_keyword(keyword_id):
         db = _get_db()
-        # Queue sidecar removals scoped to the active workspace
+        # Queue sidecar removals for all affected workspaces
         kw_row = db.conn.execute(
             "SELECT name FROM keywords WHERE id = ?", (keyword_id,)
         ).fetchone()
         if kw_row:
-            photo_ids = db.conn.execute(
-                """SELECT pk.photo_id FROM photo_keywords pk
+            affected = db.conn.execute(
+                """SELECT pk.photo_id, wf.workspace_id
+                   FROM photo_keywords pk
                    JOIN photos p ON p.id = pk.photo_id
                    JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-                   WHERE pk.keyword_id = ? AND wf.workspace_id = ?""",
-                (keyword_id, db._ws_id()),
+                   WHERE pk.keyword_id = ?""",
+                (keyword_id,),
             ).fetchall()
-            for row in photo_ids:
-                _queue_keyword_remove(row["photo_id"], kw_row["name"])
+            for row in affected:
+                _queue_keyword_remove(row["photo_id"], kw_row["name"], workspace_id=row["workspace_id"])
         db.conn.execute("UPDATE keywords SET parent_id = NULL WHERE parent_id = ?", (keyword_id,))
         db.conn.execute("DELETE FROM photo_keywords WHERE keyword_id = ?", (keyword_id,))
         db.conn.execute("DELETE FROM keywords WHERE id = ?", (keyword_id,))

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1709,21 +1709,23 @@ class Database:
 
     # -- Pending Changes --
 
-    def queue_change(self, photo_id, change_type, value):
+    def queue_change(self, photo_id, change_type, value, workspace_id=None):
         """Add a change to the sync queue (skips if already queued).
 
         Returns the inserted pending change token, or None if an identical row already exists.
+        If workspace_id is not provided, uses the active workspace.
         """
+        ws_id = workspace_id if workspace_id is not None else self._ws_id()
         existing = self.conn.execute(
             "SELECT id FROM pending_changes WHERE photo_id = ? AND change_type = ? AND value = ? AND workspace_id = ?",
-            (photo_id, change_type, value, self._ws_id()),
+            (photo_id, change_type, value, ws_id),
         ).fetchone()
         if existing:
             return None
         change_token = str(uuid.uuid4())
         self.conn.execute(
             "INSERT INTO pending_changes (photo_id, change_type, value, change_token, workspace_id) VALUES (?, ?, ?, ?, ?)",
-            (photo_id, change_type, value, change_token, self._ws_id()),
+            (photo_id, change_type, value, change_token, ws_id),
         )
         self.conn.commit()
         return change_token
@@ -1735,10 +1737,11 @@ class Database:
             (self._ws_id(),),
         ).fetchall()
 
-    def remove_pending_changes(self, photo_id, change_type=None, value=None):
+    def remove_pending_changes(self, photo_id, change_type=None, value=None, workspace_id=None):
         """Delete matching pending changes. Returns rows removed."""
+        ws_id = workspace_id if workspace_id is not None else self._ws_id()
         clauses = ["photo_id = ?", "workspace_id = ?"]
-        params = [photo_id, self._ws_id()]
+        params = [photo_id, ws_id]
         if change_type is not None:
             clauses.append("change_type = ?")
             params.append(change_type)

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -904,3 +904,80 @@ def test_rename_with_invalid_type_queues_nothing(app_and_db):
     # Keyword name should be unchanged
     row = db.conn.execute("SELECT name FROM keywords WHERE id = ?", (kid,)).fetchone()
     assert row["name"] == "StableKeyword"
+
+
+def test_rename_keyword_queues_for_all_workspaces(app_and_db):
+    """Renaming a keyword queues sidecar changes for photos in all workspaces."""
+    app, db = app_and_db
+    client = app.test_client()
+
+    # Create a second workspace with its own folder and photo
+    ws2 = db.create_workspace("Second")
+    fid2 = db.add_folder("/photos/ws2", name="ws2")
+    db.add_workspace_folder(ws2, fid2)
+    p_ws2 = db.add_photo(folder_id=fid2, filename="ws2bird.jpg", extension=".jpg",
+                         file_size=100, file_mtime=1.0, timestamp="2024-01-01T00:00:00")
+
+    # Tag photos in both workspaces with the same keyword
+    kid = db.add_keyword("SharedBird")
+    p_ws1 = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    db.tag_photo(p_ws1, kid)
+    db.tag_photo(p_ws2, kid)
+    db.conn.execute("DELETE FROM pending_changes")
+    db.conn.commit()
+
+    # Rename keyword (active workspace is ws1)
+    resp = client.put(f"/api/keywords/{kid}", json={"name": "RenamedBird"})
+    assert resp.status_code == 200
+
+    # Check pending changes for ws1 photo
+    ws1_id = db._ws_id()
+    ws1_changes = db.conn.execute(
+        "SELECT change_type, value FROM pending_changes WHERE photo_id = ? AND workspace_id = ?",
+        (p_ws1, ws1_id),
+    ).fetchall()
+    assert any(c["change_type"] == "keyword_remove" and c["value"] == "SharedBird" for c in ws1_changes)
+    assert any(c["change_type"] == "keyword_add" and c["value"] == "RenamedBird" for c in ws1_changes)
+
+    # Check pending changes for ws2 photo — should also be queued under ws2
+    ws2_changes = db.conn.execute(
+        "SELECT change_type, value FROM pending_changes WHERE photo_id = ? AND workspace_id = ?",
+        (p_ws2, ws2),
+    ).fetchall()
+    assert any(c["change_type"] == "keyword_remove" and c["value"] == "SharedBird" for c in ws2_changes)
+    assert any(c["change_type"] == "keyword_add" and c["value"] == "RenamedBird" for c in ws2_changes)
+
+
+def test_delete_keyword_queues_for_all_workspaces(app_and_db):
+    """Deleting a keyword queues sidecar removals for photos in all workspaces."""
+    app, db = app_and_db
+    client = app.test_client()
+
+    ws2 = db.create_workspace("Second")
+    fid2 = db.add_folder("/photos/ws2del", name="ws2del")
+    db.add_workspace_folder(ws2, fid2)
+    p_ws2 = db.add_photo(folder_id=fid2, filename="ws2del.jpg", extension=".jpg",
+                         file_size=100, file_mtime=1.0, timestamp="2024-01-01T00:00:00")
+
+    kid = db.add_keyword("SharedDelete")
+    p_ws1 = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    db.tag_photo(p_ws1, kid)
+    db.tag_photo(p_ws2, kid)
+    db.conn.execute("DELETE FROM pending_changes")
+    db.conn.commit()
+
+    resp = client.delete(f"/api/keywords/{kid}")
+    assert resp.status_code == 200
+
+    ws1_id = db._ws_id()
+    ws1_changes = db.conn.execute(
+        "SELECT change_type, value FROM pending_changes WHERE photo_id = ? AND workspace_id = ?",
+        (p_ws1, ws1_id),
+    ).fetchall()
+    assert any(c["change_type"] == "keyword_remove" and c["value"] == "SharedDelete" for c in ws1_changes)
+
+    ws2_changes = db.conn.execute(
+        "SELECT change_type, value FROM pending_changes WHERE photo_id = ? AND workspace_id = ?",
+        (p_ws2, ws2),
+    ).fetchall()
+    assert any(c["change_type"] == "keyword_remove" and c["value"] == "SharedDelete" for c in ws2_changes)


### PR DESCRIPTION
## Summary

Fixes two P1 cross-workspace sync issues from review on #134:

- **Rename queues for all workspaces:** Keywords are global but pending_changes are workspace-scoped. The previous fix only queued rename changes for the active workspace. Now queries all `(photo_id, workspace_id)` pairs via `workspace_folders` and passes explicit `workspace_id` to `queue_change`/`remove_pending_changes`.
- **Delete queues for all workspaces:** Same fix for the delete path — queues `keyword_remove` for every workspace that has photos tagged with the keyword.
- **API change:** `queue_change()` and `remove_pending_changes()` now accept an optional `workspace_id` parameter, falling back to `self._ws_id()` when not provided. Existing callers are unaffected.

Parent PR: #134

## Test Plan

- [x] `test_rename_keyword_queues_for_all_workspaces` — verifies pending changes queued under both ws1 and ws2
- [x] `test_delete_keyword_queues_for_all_workspaces` — same for delete
- [x] All 266 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)