### PR TITLE
feat: respond to regular PR comments on claude-agent PRs

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -118,6 +118,7 @@ jobs:
     if: >-
       github.event_name == 'issue_comment'
       && github.event.issue.pull_request
+      && github.event.issue.state == 'open'
       && contains(github.event.issue.labels.*.name, 'claude-agent')
       && !contains(github.event.comment.body, '/claude-fix')
       && !contains(github.event.comment.body, '👍')


### PR DESCRIPTION
## Summary
- Adds a `fix-comment-feedback` job to the PR Agent workflow
- Claude now responds to regular PR comments (not just formal reviews) on `claude-agent` PRs
- Closes the gap where Codex could leave feedback as comments that Claude would never see
- Triggers for owners, collaborators, and `chatgpt-codex-connector[bot]`, excluding `/claude-fix` and 👍 (already handled by other jobs)

## Test plan
- [ ] Verify workflow syntax is valid (`act` or push to branch)
- [ ] Leave a regular comment on a `claude-agent` PR from a trusted actor and confirm the job triggers
- [ ] Confirm `/claude-fix` and 👍 comments still route to their existing jobs, not this one

🤖 Generated with [Claude Code](https://claude.com/claude-code)