### PR TITLE
fix: limit fix-comment-feedback to open PRs only

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -118,6 +118,7 @@ jobs:
     if: >-
       github.event_name == 'issue_comment'
       && github.event.issue.pull_request
+      && github.event.issue.state == 'open'
       && contains(github.event.issue.labels.*.name, 'claude-agent')
       && !contains(github.event.comment.body, '/claude-fix')
       && !contains(github.event.comment.body, '👍')


### PR DESCRIPTION
Parent PR: #141

## Summary
- Adds `github.event.issue.state == 'open'` guard to the `fix-comment-feedback` job condition
- Prevents the agent from triggering on comments left on closed/merged PRs, which would create pointless fix PRs against stale or deleted branches

## Test plan
- [ ] Verify a comment on an open `claude-agent` PR still triggers the job
- [ ] Verify a comment on a closed/merged `claude-agent` PR does not trigger the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)