### PR TITLE
Identify imported photos by path, use temp table for lookup

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3257,8 +3257,8 @@ def create_app(db_path, thumb_cache_dir=None):
                 progress_callback=ingest_cb,
             )
 
-            # Track hashes of files actually copied
-            copied_hashes = ingest_result.get("copied_hashes", [])
+            # Track destination paths of files actually copied
+            copied_paths = ingest_result.get("copied_paths", [])
 
             # Phase 2: Scan destination to index into DB
             def scan_cb(current, total):
@@ -3294,14 +3294,26 @@ def create_app(db_path, thumb_cache_dir=None):
             )
 
             # Phase 4: Create collection from files actually copied
+            # Use a temp table to avoid SQLite variable-limit issues
+            # and match by exact path (unique per file, unlike hashes)
             photo_ids = []
-            if copied_hashes:
-                placeholders = ",".join("?" * len(copied_hashes))
+            if copied_paths:
+                thread_db.conn.execute(
+                    "CREATE TEMP TABLE IF NOT EXISTS _imported_paths (dirpath TEXT, fname TEXT)"
+                )
+                thread_db.conn.execute("DELETE FROM _imported_paths")
+                thread_db.conn.executemany(
+                    "INSERT INTO _imported_paths (dirpath, fname) VALUES (?, ?)",
+                    [(os.path.dirname(p), os.path.basename(p)) for p in copied_paths],
+                )
                 rows = thread_db.conn.execute(
-                    f"SELECT id FROM photos WHERE file_hash IN ({placeholders})",
-                    copied_hashes,
+                    """SELECT p.id FROM photos p
+                       JOIN folders f ON p.folder_id = f.id
+                       JOIN _imported_paths ip ON f.path = ip.dirpath
+                                               AND p.filename = ip.fname"""
                 ).fetchall()
                 photo_ids = [r["id"] for r in rows]
+                thread_db.conn.execute("DROP TABLE IF EXISTS _imported_paths")
 
             collection_id = None
             collection_name = None

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -95,7 +95,7 @@ def ingest(
     copied = 0
     skipped_duplicate = 0
     failed = 0
-    copied_hashes = []
+    copied_paths = []
 
     for i, source_file in enumerate(files):
         try:
@@ -143,7 +143,7 @@ def ingest(
 
             shutil.copy2(str(source_file), str(dest_file))
             known_hashes.add(file_hash)
-            copied_hashes.append(file_hash)
+            copied_paths.append(str(dest_file))
             copied += 1
 
         except Exception as e:
@@ -158,5 +158,5 @@ def ingest(
         "skipped_duplicate": skipped_duplicate,
         "failed": failed,
         "total": total,
-        "copied_hashes": copied_hashes,
+        "copied_paths": copied_paths,
     }


### PR DESCRIPTION
Parent PR: #140

## Summary
- **P1:** Track actual destination file paths during ingest (`copied_paths`) instead of file hashes (`copied_hashes`). Paths are unique per copied file — hashes are shared by duplicates, which caused incorrect collection scope when the destination contained duplicate files.
- **P2:** Use a SQLite temp table (`_imported_paths`) for the path lookup instead of `IN (?, ?, ...)` with one placeholder per file. This avoids SQLite's bound-parameter limit (~999) that would fail on large imports.

## How it works
1. `ingest()` now returns `copied_paths` — the absolute path of each successfully copied file
2. After scan, the endpoint creates a temp table with `(dirpath, filename)` pairs
3. Joins `photos` + `folders` against the temp table to find exact matches
4. Drops the temp table after use

## Test plan
- [x] All 252 tests pass
- [ ] Import 1000+ files — verify no SQLite variable-limit error
- [ ] Import into library with existing duplicate files — verify collection only contains newly copied files

🤖 Generated with [Claude Code](https://claude.com/claude-code)