### PR TITLE
Fix preferred common name priority over alternates

### DIFF
--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -653,11 +653,13 @@ def download_taxonomy(output_path, progress_callback=None):
         sci_key = taxon["scientific_name"].lower()
         taxa_by_scientific[sci_key] = entry
 
-    # Index preferred common names first so they always win
+    # Index preferred common names first so they always win.
+    # Keep the first mapping when two taxa share a preferred name.
     for taxon_id, cn in common_names.items():
         entry = entries_by_taxon.get(taxon_id)
-        if entry:
-            taxa_by_common[cn.lower()] = entry
+        cn_key = cn.lower()
+        if entry and cn_key not in taxa_by_common:
+            taxa_by_common[cn_key] = entry
 
     # Then index alternate names only for still-unmapped keys
     for taxon_id, names in alt_names.items():


### PR DESCRIPTION
Parent PR: #144

## Summary
- Index preferred common names in a first pass so they always take priority
- Add alternate names only for keys not already mapped by a preferred name
- Prevents incorrect species resolution when an alternate name for one taxon collides with the preferred name of another

## Test plan
- [x] All 270 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)