### PR TITLE
Fix repeated macOS network volume permission prompt

### DIFF
--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -18,8 +18,12 @@
     <key>com.apple.security.network.server</key>
     <true/>
 
-    <!-- Allow read access to user-selected files (photo folders) -->
-    <key>com.apple.security.files.user-selected.read-only</key>
+    <!-- Allow read access to all files (sidecar reads photo paths directly, not via NSOpenPanel) -->
+    <key>com.apple.security.files.all</key>
+    <true/>
+
+    <!-- Allow access to network volumes (NAS, SMB shares with photos) -->
+    <key>com.apple.security.files.network.volumes.read-only</key>
     <true/>
 </dict>
 </plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSNetworkVolumesUsageDescription</key>
+    <string>Vireo needs access to network volumes to read and organize your wildlife photos stored on NAS or shared drives.</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Replace `com.apple.security.files.user-selected.read-only` entitlement with `com.apple.security.files.all` — the sidecar reads photo paths directly (not via NSOpenPanel), so user-selected doesn't apply
- Add explicit `com.apple.security.files.network.volumes.read-only` entitlement for NAS/SMB access
- Add `NSNetworkVolumesUsageDescription` to `Info.plist` so macOS can display a proper prompt and persist the user's choice

## Why this fixes it
The `user-selected.read-only` entitlement only covers files chosen through a native macOS file picker dialog. Since Vireo's sidecar accesses paths configured through the web UI, macOS couldn't associate a persistent permission grant with the app, causing the "access files on a network volume" prompt to reappear on every access.

## Test plan
- [ ] Build the app (`cargo tauri build`)
- [ ] Open Vireo with photos on a network volume
- [ ] Confirm the permission prompt appears once and does not reappear on subsequent launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)