### PR TITLE
Fix double notarization in build scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,12 +73,11 @@ jobs:
         run: cargo install tauri-cli
 
       # --- Build the Tauri app (signing happens automatically) ---
+      # Only pass APPLE_SIGNING_IDENTITY so Tauri signs but does not notarize.
+      # The separate "Notarize DMG" step handles notarization via xcrun notarytool.
       - name: Build Tauri app
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |

--- a/scripts/build_signed.sh
+++ b/scripts/build_signed.sh
@@ -47,7 +47,10 @@ echo ""
 echo "=== Step 2/4: Build the Tauri app (with code signing) ==="
 cd "$REPO_ROOT"
 BUILD_LOG=$(mktemp)
-if ! cargo tauri build 2>&1 | tee "$BUILD_LOG"; then
+# Unset notarization credentials so Tauri only signs (not notarizes).
+# Step 4 handles notarization via xcrun notarytool which is more reliable.
+if ! env -u APPLE_ID -u APPLE_PASSWORD -u APPLE_TEAM_ID \
+    cargo tauri build 2>&1 | tee "$BUILD_LOG"; then
     # Tolerate updater-signing failure (TAURI_SIGNING_PRIVATE_KEY not configured)
     # but fail on anything else
     if grep -q "TAURI_SIGNING_PRIVATE_KEY" "$BUILD_LOG"; then


### PR DESCRIPTION
## Summary
- Tauri was attempting notarization during `cargo tauri build` (because `APPLE_ID`/`APPLE_PASSWORD` were in the environment), causing an S3 upload timeout that aborted the entire build
- Both `build_signed.sh` step 4 and `release.yml`'s "Notarize DMG" step already handle notarization via `xcrun notarytool`, making Tauri's attempt redundant
- Strip notarization credentials from the `cargo tauri build` invocation so Tauri only signs; the dedicated steps handle notarization reliably

## Test plan
- [x] 271 tests pass
- [ ] Run `./scripts/build_signed.sh` locally — should complete all 4 steps without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)