### PR TITLE
fix: close file and network handles properly

### DIFF
--- a/vireo/masking.py
+++ b/vireo/masking.py
@@ -152,8 +152,8 @@ def load_mask(masks_dir, photo_id):
     path = os.path.join(masks_dir, f"{photo_id}.png")
     if not os.path.exists(path):
         return None
-    mask_img = Image.open(path).convert("L")
-    return np.array(mask_img) > 127
+    with Image.open(path) as mask_img:
+        return np.array(mask_img.convert("L")) > 127
 
 
 def crop_subject(image, mask, margin=0.15):

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -530,8 +530,8 @@ def download_taxonomy(output_path, progress_callback=None):
             progress_callback(msg)
 
     _status("Downloading iNaturalist taxonomy archive...")
-    response = urllib.request.urlopen(DWCA_URL)
-    zip_data = response.read()
+    with urllib.request.urlopen(DWCA_URL) as response:
+        zip_data = response.read()
     _status(f"Downloaded {len(zip_data) // (1024 * 1024)} MB — parsing...")
 
     # Parse the DWCA zip

--- a/vireo/timm_classifier.py
+++ b/vireo/timm_classifier.py
@@ -93,8 +93,8 @@ class TimmClassifier:
         import torch
         from PIL import Image
 
-        img = Image.open(image_path).convert("RGB")
-        input_tensor = self._transform(img).unsqueeze(0).to(self._device)
+        with Image.open(image_path) as img:
+            input_tensor = self._transform(img.convert("RGB")).unsqueeze(0).to(self._device)
 
         with torch.no_grad():
             output = self._model(input_tensor)


### PR DESCRIPTION
## Summary

- Add context managers (`with` statements) for `Image.open()` in `masking.py` and `timm_classifier.py` to ensure image file handles are closed after use
- Add context manager for `urllib.request.urlopen()` in `taxonomy.py` to ensure the network connection is closed after reading
- Prevents resource leaks (open file descriptors) that could accumulate during batch processing

## Test results

763 passed, 11 failed (all pre-existing failures unrelated to this change — missing BioCLIP model files, darktable path config, welcome page redirect). Key test files covering the changed code all pass:
- `test_masking.py` — 19 passed
- `test_timm_classifier.py` — 10 passed
- `test_taxonomy.py` — 19 passed

## Test plan

- [x] Run full test suite (`python -m pytest tests/ vireo/tests/ -v --tb=short -q`)
- [x] Verify no regressions in masking, timm_classifier, or taxonomy tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)