### PR TITLE
fix: escape error messages in innerHTML to prevent XSS

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1427,7 +1427,7 @@ function openPipeline(photoId) {
 
   safeFetch('/api/photos/' + photoId + '/pipeline', {}, { toast: false })
     .then(function(data) { renderPipeline(data, photoId); })
-    .catch(function(e) { content.innerHTML = '<p style="color:#e74c3c;">Failed to load: ' + e.message + '</p>'; });
+    .catch(function(e) { content.innerHTML = '<p style="color:#e74c3c;">Failed to load: ' + escapeHtml(e.message) + '</p>'; });
 }
 
 function closePipeline() {
@@ -1575,7 +1575,7 @@ function findSimilar(photoId) {
   safeFetch('/api/photos/' + photoId + '/similar?limit=40', {}, { toast: false })
     .then(function(data) {
       if (data.error) {
-        content.innerHTML = '<p style="color:var(--warning,#f0c040);">' + data.error + '</p>';
+        content.innerHTML = '<p style="color:var(--warning,#f0c040);">' + escapeHtml(data.error) + '</p>';
         return;
       }
       var html = '<p style="font-size:12px;color:var(--text-dim,#888);margin-bottom:12px;">Compared against ' +
@@ -1601,7 +1601,7 @@ function findSimilar(photoId) {
       content.innerHTML = html;
     })
     .catch(function(e) {
-      content.innerHTML = '<p style="color:var(--danger,#e74c3c);">Failed: ' + e.message + '</p>';
+      content.innerHTML = '<p style="color:var(--danger,#e74c3c);">Failed: ' + escapeHtml(e.message) + '</p>';
     });
 }
 

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -101,7 +101,7 @@ async function openSyncPreview() {
     _syncPreviewData = await safeFetch('/api/sync/preview', {}, { toast: false });
     renderSyncPreview();
   } catch(e) {
-    content.innerHTML = '<p style="color:var(--danger,#e74c3c);padding:20px;">Failed to load: ' + e.message + '</p>';
+    content.innerHTML = '<p style="color:var(--danger,#e74c3c);padding:20px;">Failed to load: ' + escapeHtml(e.message) + '</p>';
   }
 }
 

--- a/vireo/templates/variants.html
+++ b/vireo/templates/variants.html
@@ -289,7 +289,7 @@ async function selectSpecies(name) {
     var data = await safeFetch('/api/species/' + encodeURIComponent(name) + '/clusters?threshold=' + threshold, {}, { toast: false });
     renderClusters(data);
   } catch(e) {
-    area.innerHTML = '<div class="cluster-empty" style="color:var(--danger,#e74c3c);">Failed to analyze: ' + e.message + '</div>';
+    area.innerHTML = '<div class="cluster-empty" style="color:var(--danger,#e74c3c);">Failed to analyze: ' + escapeHtml(e.message) + '</div>';
   }
 }
 
@@ -356,7 +356,7 @@ async function recluster(species, threshold) {
     var data = await safeFetch('/api/species/' + encodeURIComponent(species) + '/clusters?threshold=' + threshold, {}, { toast: false });
     renderClusters(data);
   } catch(e) {
-    area.innerHTML = '<div class="cluster-empty" style="color:var(--danger,#e74c3c);">Failed: ' + e.message + '</div>';
+    area.innerHTML = '<div class="cluster-empty" style="color:var(--danger,#e74c3c);">Failed: ' + escapeHtml(e.message) + '</div>';
   }
 }
 


### PR DESCRIPTION
## Summary
- Wrapped `e.message` and `data.error` with `escapeHtml()` in 6 locations across `variants.html`, `_navbar.html`, and `_sync_panel.html` where error text was being injected directly into `innerHTML` without escaping.
- The global `escapeHtml()` function from `vireo/static/vireo-utils.js` is already available on all pages.
- Prevents potential XSS if error messages contain user-controlled HTML content.

## Changes
| File | Lines | What changed |
|------|-------|-------------|
| `vireo/templates/variants.html` | 292, 359 | `e.message` -> `escapeHtml(e.message)` in cluster analysis error handlers |
| `vireo/templates/_navbar.html` | 1430, 1578, 1604 | `e.message`/`data.error` -> `escapeHtml(...)` in pipeline and similar-photos error handlers |
| `vireo/templates/_sync_panel.html` | 104 | `e.message` -> `escapeHtml(e.message)` in sync preview error handler |

## Test plan
- [x] `python -m pytest tests/ vireo/tests/ -v --tb=short -q` — 763 passed, 11 failed (all pre-existing failures unrelated to this change: missing BioCLIP model, darktable path, welcome redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)