### PR TITLE
Standardize Python 3.14 across all CI workflows

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,7 +15,7 @@ permissions:
   contents: write
 
 env:
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.14"
   NODE_VERSION: "20"
 
 jobs:

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -54,7 +54,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-          allow-prereleases: true
 
       - name: Install test dependencies
         run: pip install flask Pillow pytest imagehash
@@ -135,7 +134,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-          allow-prereleases: true
 
       - name: Install test dependencies
         run: pip install flask Pillow pytest imagehash
@@ -217,7 +215,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-          allow-prereleases: true
 
       - name: Install test dependencies
         run: pip install flask Pillow pytest imagehash
@@ -342,7 +339,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-          allow-prereleases: true
 
       - name: Install dependencies
         if: steps.pr.outputs.should_fix == 'true'
@@ -437,7 +433,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-          allow-prereleases: true
 
       - name: Install test dependencies
         run: pip install flask Pillow pytest imagehash
@@ -487,7 +482,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-          allow-prereleases: true
 
       - name: Install test dependencies
         run: pip install flask Pillow pytest imagehash
@@ -564,7 +558,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-          allow-prereleases: true
 
       - name: Install test dependencies
         if: steps.approved.outputs.has_approved == 'true'
@@ -640,7 +633,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-          allow-prereleases: true
 
       - name: Install test dependencies
         if: steps.conflicts.outputs.has_conflicts == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-          allow-prereleases: true
 
       - name: Install dependencies
         run: pip install flask Pillow pytest imagehash pytest-cov requests
@@ -33,7 +32,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-          allow-prereleases: true
 
       - name: Install ruff
         run: pip install ruff


### PR DESCRIPTION
## Summary

Python version was inconsistent across CI workflows — `test.yml` and `pr-agent.yml` used 3.14 with `allow-prereleases: true`, `build-release.yml` used 3.11, and `release.yml` used 3.12.

- **build-release.yml**: Updated `PYTHON_VERSION` from `"3.11"` to `"3.14"`
- **release.yml**: Updated `python-version` from `"3.12"` to `"3.14"`
- **test.yml**: Removed `allow-prereleases: true` (2 occurrences) since Python 3.14 is now stable
- **pr-agent.yml**: Removed `allow-prereleases: true` (8 occurrences) since Python 3.14 is now stable

All workflows now use Python 3.14 without the prereleases flag.

## Test plan

- [ ] Verify `test.yml` CI passes with Python 3.14 (no prereleases flag)
- [ ] Verify `build-release.yml` builds successfully with Python 3.14
- [ ] Verify `pr-agent.yml` jobs work with Python 3.14 (no prereleases flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)