### PR TITLE
Fix XSS: escape error messages in innerHTML

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1427,7 +1427,7 @@ function openPipeline(photoId) {
 
   safeFetch('/api/photos/' + photoId + '/pipeline', {}, { toast: false })
     .then(function(data) { renderPipeline(data, photoId); })
-    .catch(function(e) { content.innerHTML = '<p style="color:#e74c3c;">Failed to load: ' + e.message + '</p>'; });
+    .catch(function(e) { content.innerHTML = '<p style="color:#e74c3c;">Failed to load: ' + escapeHtml(e.message) + '</p>'; });
 }
 
 function closePipeline() {
@@ -1575,7 +1575,7 @@ function findSimilar(photoId) {
   safeFetch('/api/photos/' + photoId + '/similar?limit=40', {}, { toast: false })
     .then(function(data) {
       if (data.error) {
-        content.innerHTML = '<p style="color:var(--warning,#f0c040);">' + data.error + '</p>';
+        content.innerHTML = '<p style="color:var(--warning,#f0c040);">' + escapeHtml(data.error) + '</p>';
         return;
       }
       var html = '<p style="font-size:12px;color:var(--text-dim,#888);margin-bottom:12px;">Compared against ' +
@@ -1601,7 +1601,7 @@ function findSimilar(photoId) {
       content.innerHTML = html;
     })
     .catch(function(e) {
-      content.innerHTML = '<p style="color:var(--danger,#e74c3c);">Failed: ' + e.message + '</p>';
+      content.innerHTML = '<p style="color:var(--danger,#e74c3c);">Failed: ' + escapeHtml(e.message) + '</p>';
     });
 }
 

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -101,7 +101,7 @@ async function openSyncPreview() {
     _syncPreviewData = await safeFetch('/api/sync/preview', {}, { toast: false });
     renderSyncPreview();
   } catch(e) {
-    content.innerHTML = '<p style="color:var(--danger,#e74c3c);padding:20px;">Failed to load: ' + e.message + '</p>';
+    content.innerHTML = '<p style="color:var(--danger,#e74c3c);padding:20px;">Failed to load: ' + escapeHtml(e.message) + '</p>';
   }
 }
 

--- a/vireo/templates/variants.html
+++ b/vireo/templates/variants.html
@@ -289,7 +289,7 @@ async function selectSpecies(name) {
     var data = await safeFetch('/api/species/' + encodeURIComponent(name) + '/clusters?threshold=' + threshold, {}, { toast: false });
     renderClusters(data);
   } catch(e) {
-    area.innerHTML = '<div class="cluster-empty" style="color:var(--danger,#e74c3c);">Failed to analyze: ' + e.message + '</div>';
+    area.innerHTML = '<div class="cluster-empty" style="color:var(--danger,#e74c3c);">Failed to analyze: ' + escapeHtml(e.message) + '</div>';
   }
 }
 
@@ -356,7 +356,7 @@ async function recluster(species, threshold) {
     var data = await safeFetch('/api/species/' + encodeURIComponent(species) + '/clusters?threshold=' + threshold, {}, { toast: false });
     renderClusters(data);
   } catch(e) {
-    area.innerHTML = '<div class="cluster-empty" style="color:var(--danger,#e74c3c);">Failed: ' + e.message + '</div>';
+    area.innerHTML = '<div class="cluster-empty" style="color:var(--danger,#e74c3c);">Failed: ' + escapeHtml(e.message) + '</div>';
   }
 }
 


### PR DESCRIPTION
## Summary

- Wrap `e.message` and `data.error` with `escapeHtml()` in 6 innerHTML assignments across 3 template files to prevent potential XSS from error messages rendered into the DOM.

## Changes

| File | Line | What was escaped |
|------|------|-----------------|
| `vireo/templates/variants.html` | 292 | `e.message` in cluster analysis failure |
| `vireo/templates/variants.html` | 359 | `e.message` in recluster failure |
| `vireo/templates/_navbar.html` | 1430 | `e.message` in pipeline load failure |
| `vireo/templates/_navbar.html` | 1578 | `data.error` in similar photos API error |
| `vireo/templates/_navbar.html` | 1604 | `e.message` in similar photos fetch failure |
| `vireo/templates/_sync_panel.html` | 104 | `e.message` in sync preview load failure |

The global `escapeHtml()` function from `vireo/static/vireo-utils.js` is already available on all pages via the navbar include.

## Test plan

- [ ] Verify pages load without JS errors (variants, navbar pipeline/similar panels, sync panel)
- [ ] Trigger error states and confirm escaped output renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)