### PR TITLE
Fix resource leaks: close file and network handles

### DIFF
--- a/vireo/masking.py
+++ b/vireo/masking.py
@@ -152,7 +152,8 @@ def load_mask(masks_dir, photo_id):
     path = os.path.join(masks_dir, f"{photo_id}.png")
     if not os.path.exists(path):
         return None
-    mask_img = Image.open(path).convert("L")
+    with Image.open(path) as f:
+        mask_img = f.convert("L")
     return np.array(mask_img) > 127
 
 

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -530,8 +530,8 @@ def download_taxonomy(output_path, progress_callback=None):
             progress_callback(msg)
 
     _status("Downloading iNaturalist taxonomy archive...")
-    response = urllib.request.urlopen(DWCA_URL)
-    zip_data = response.read()
+    with urllib.request.urlopen(DWCA_URL) as response:
+        zip_data = response.read()
     _status(f"Downloaded {len(zip_data) // (1024 * 1024)} MB — parsing...")
 
     # Parse the DWCA zip

--- a/vireo/timm_classifier.py
+++ b/vireo/timm_classifier.py
@@ -93,7 +93,8 @@ class TimmClassifier:
         import torch
         from PIL import Image
 
-        img = Image.open(image_path).convert("RGB")
+        with Image.open(image_path) as f:
+            img = f.convert("RGB")
         input_tensor = self._transform(img).unsqueeze(0).to(self._device)
 
         with torch.no_grad():


### PR DESCRIPTION
## Summary

- **vireo/masking.py**: Wrap `Image.open()` in a context manager so the file handle is closed after reading the mask image.
- **vireo/timm_classifier.py**: Wrap `Image.open()` in a context manager so the file handle is closed after loading the image for classification.
- **vireo/taxonomy.py**: Wrap `urllib.request.urlopen()` in a context manager so the network connection is closed after downloading the taxonomy archive.

## Test plan

- [x] `test_masking.py` — 19 passed
- [x] `test_timm_classifier.py` — 10 passed
- [x] `test_taxonomy.py` — 19 passed
- [x] Full test suite: 763 passed (11 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)