### PR TITLE
fix: thumbnail cache and prediction index migration

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3739,8 +3739,7 @@ def create_app(db_path, thumb_cache_dir=None):
         def _send_cached(directory, fname):
             resp = make_response(send_from_directory(directory, fname))
             resp.cache_control.public = True
-            resp.cache_control.max_age = 30 * 24 * 60 * 60  # 30 days
-            resp.cache_control.immutable = True
+            resp.cache_control.max_age = 24 * 60 * 60  # 1 day
             return resp
 
         thumb_path = os.path.join(app.config["THUMB_CACHE_DIR"], filename)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -453,10 +453,19 @@ class Database:
                 "ALTER TABLE keywords ADD COLUMN taxon_id INTEGER REFERENCES taxa(id)"
             )
 
-        # Ensure workspace indexes exist (for fresh DBs that skip migration)
+        # Ensure indexes exist (for fresh DBs that skip migration, and for
+        # legacy DBs where DROP TABLE predictions destroys earlier indexes)
         self.conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_predictions_workspace "
             "ON predictions(workspace_id)"
+        )
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_predictions_photo "
+            "ON predictions(photo_id)"
+        )
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_predictions_status "
+            "ON predictions(status)"
         )
         self.conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_collections_workspace "


### PR DESCRIPTION
Parent PR: #161

## Summary

Addresses two review comments on #161:

- **Drop `immutable` from thumbnail Cache-Control** — Thumbnails can be regenerated under the same URL (e.g., after `/api/storage/clear`), so `immutable` caused browsers to show stale images. Reduced to `max-age=86400` (1 day) without `immutable`.
- **Ensure prediction indexes survive legacy migration** — The `DROP TABLE predictions` in the workspace migration destroyed `idx_predictions_photo` and `idx_predictions_status`. Now recreated after migration alongside existing workspace indexes.

## Test plan

- [x] All 271 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)