### PR TITLE
fix: batch flush ordering and PathLike compatibility

### DIFF
--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -488,6 +488,10 @@ def _classify_photos(
         image_path = os.path.join(folder_path, photo["filename"])
 
         if photo["id"] in existing_preds:
+            # Flush pending batch to preserve photo ordering in raw_results
+            if batch:
+                failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results)
+                batch = []
             skipped_existing += 1
             pred_row = db.get_prediction_for_photo(photo["id"], model_name)
             if pred_row:

--- a/vireo/timm_classifier.py
+++ b/vireo/timm_classifier.py
@@ -126,10 +126,12 @@ class TimmClassifier:
         Returns:
             list of dicts with species, score, auto_tag, confidence_tag, taxonomy
         """
+        import os
+
         import torch
         from PIL import Image as PILImage
 
-        if isinstance(image, str):
+        if isinstance(image, (str, os.PathLike)):
             with PILImage.open(image) as img:
                 input_tensor = self._transform(img.convert("RGB")).unsqueeze(0).to(self._device)
         else:


### PR DESCRIPTION
Parent PR: #166

## Summary

Fixes two review issues on #166:

- **Flush batch before existing predictions** (P1) — When an existing prediction is encountered mid-batch, the pending batch of new images is now flushed first. This preserves photo ordering in `raw_results`, which is critical because `group_by_timestamp` and `refine_groups_by_similarity` are order-sensitive.
- **Accept `os.PathLike` in `TimmClassifier.classify()`** (P2) — The `isinstance(image, str)` check now includes `os.PathLike` so `pathlib.Path` callers don't fall into the PIL branch and crash.

## Test plan

- [x] All 298 tests pass (271 standard + 27 classifier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)