### PR TITLE
fix: reject boolean ratings, import bioclip directly in tests

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -620,7 +620,7 @@ def create_app(db_path, thumb_cache_dir=None):
         db = _get_db()
         body = request.get_json(silent=True) or {}
         rating = body.get("rating", 0)
-        if not isinstance(rating, int) or rating < 0 or rating > 5:
+        if isinstance(rating, bool) or not isinstance(rating, int) or rating < 0 or rating > 5:
             return json_error("rating must be an integer 0-5")
         old = db.get_photo(photo_id)
         old_rating = old["rating"] if old else 0
@@ -745,7 +745,7 @@ def create_app(db_path, thumb_cache_dir=None):
         body = request.get_json(silent=True) or {}
         photo_ids = body.get("photo_ids", [])
         rating = body.get("rating", 0)
-        if not isinstance(rating, int) or rating < 0 or rating > 5:
+        if isinstance(rating, bool) or not isinstance(rating, int) or rating < 0 or rating > 5:
             return json_error("rating must be an integer 0-5")
         if not photo_ids:
             return json_error("photo_ids required")

--- a/vireo/tests/test_detector.py
+++ b/vireo/tests/test_detector.py
@@ -32,9 +32,12 @@ def test_megadetector_loads_after_bioclip():
     except ImportError:
         pytest.skip("torch not installed")
 
-    # Phase 1: Import BioCLIP (same as classify job phase 3)
+    # Phase 1: Import BioCLIP/open_clip (same as classify job phase 3)
+    # Must import the actual bioclip package to trigger ultralytics/open_clip
+    # imports that cache references to torch.load. A bare `import classifier`
+    # is not enough because classifier.py defers these imports to __init__().
     try:
-        import classifier  # noqa: F401
+        from bioclip import CustomLabelsClassifier  # noqa: F401
     except Exception:
         pytest.skip("BioCLIP/classifier not available")
 
@@ -72,7 +75,7 @@ def test_megadetector_loads_with_force_weights_only_env():
         pytest.skip("torch not installed")
 
     try:
-        import classifier  # noqa: F401
+        from bioclip import CustomLabelsClassifier  # noqa: F401
     except Exception:
         pytest.skip("BioCLIP/classifier not available")
 


### PR DESCRIPTION
Parent PR: #170

## Summary
- **Reject boolean ratings**: `bool` is a subclass of `int` in Python, so `isinstance(True, int)` is `True`. Added an explicit `isinstance(rating, bool)` check before the int check on both single and batch rating endpoints.
- **Import bioclip directly in detector tests**: `import classifier` only loads the wrapper module — BioCLIP/ultralytics/open_clip imports are deferred to `Classifier.__init__()`. Changed to `from bioclip import CustomLabelsClassifier` which triggers the actual import chain the tests are designed to verify.

## Test plan
- [x] All 271 tests pass
- [ ] Verify `{"rating": true}` is rejected with 400
- [ ] Verify `{"rating": false}` is rejected with 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)