### PR TITLE
Fix ingest test assertions for new folder template

### DIFF
--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -12,7 +12,7 @@ from PIL import Image
 
 def test_build_destination_path_default_template():
     dt = datetime(2026, 3, 28, 14, 30, 0)
-    assert build_destination_path(dt) == "2026/03/28"
+    assert build_destination_path(dt) == "2026/03-28"
 
 
 def test_build_destination_path_custom_template():
@@ -109,7 +109,7 @@ def test_ingest_copies_files_to_date_folders(tmp_path):
 
     assert result["copied"] == 1
     assert result["total"] == 1
-    assert (dst / "2026" / "03" / "28" / "photo.jpg").exists()
+    assert (dst / "2026" / "03-28" / "photo.jpg").exists()
 
 
 def test_ingest_unsorted_fallback(tmp_path):
@@ -195,7 +195,7 @@ def test_ingest_filename_collision(tmp_path):
     ingest(str(src1), str(dst), db=db)
     ingest(str(src2), str(dst), db=db)
 
-    date_folder = dst / "2026" / "03" / "28"
+    date_folder = dst / "2026" / "03-28"
     files = sorted(f.name for f in date_folder.iterdir())
     assert "IMG_001.jpg" in files
     assert "IMG_001_1.jpg" in files
@@ -296,9 +296,9 @@ def test_ingest_then_scan_end_to_end(tmp_path):
     assert result["failed"] == 0
 
     # Verify folder structure
-    assert (dst / "2026" / "03" / "25").exists()
-    assert (dst / "2026" / "03" / "26").exists()
-    assert (dst / "2026" / "03" / "27").exists()
+    assert (dst / "2026" / "03-25").exists()
+    assert (dst / "2026" / "03-26").exists()
+    assert (dst / "2026" / "03-27").exists()
 
     # Step 2: Scan the destination
     scan(str(dst), db)


### PR DESCRIPTION
## Summary
- Update 4 test assertions in `test_ingest.py` to expect `%Y/%m-%d` folder structure instead of old `%Y/%m/%d`

Parent PR: #171

## Test plan
- [x] All 18 ingest tests pass
- [x] All 271 core tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)