### PR TITLE
fix: DISTINCT in get_photos for keyword queries

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -996,8 +996,9 @@ class Database:
         params.extend([per_page, offset])
 
         pcols = ", ".join(f"p.{c.strip()}" for c in self.PHOTO_COLS.split(","))
+        distinct = "DISTINCT " if keyword is not None else ""
         query = f"""
-            SELECT {pcols} FROM photos p
+            SELECT {distinct}{pcols} FROM photos p
             {join_clause}
             {where}
             ORDER BY {order}


### PR DESCRIPTION
## Summary

- Addresses review feedback on #176: keyword search joins can produce duplicate photo rows when a photo matches multiple keywords (e.g., searching "bird" matches both "bird" and "blackbird" keywords on the same photo).
- `count_filtered_photos()` correctly uses `COUNT(DISTINCT p.id)`, but `get_photos()` lacked `DISTINCT`, so paged results could contain duplicates while the total was lower — breaking pagination.
- Adds `DISTINCT` to the `SELECT` in `get_photos()` when keyword filter is active, so both queries agree on unique photos.

Parent PR: #176

## Test plan

- [x] All 271 tests pass
- [x] Fix is scoped: DISTINCT only applied when keyword join is active (no performance impact for non-keyword queries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)