### PR TITLE
Default release.sh to patch bump

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 # --- Parse args ---
-BUMP="${1:?Usage: release.sh <patch|minor|major|X.Y.Z> [--publish]}"
+BUMP="${1:-patch}"
 PUBLISH=false
 if [[ "${2:-}" == "--publish" ]]; then
     PUBLISH=true


### PR DESCRIPTION
## Summary
- `./scripts/release.sh` now defaults to `patch` instead of erroring when no argument is given

🤖 Generated with [Claude Code](https://claude.com/claude-code)