### PR TITLE
Restore updater signing keys in fallback build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -178,13 +178,32 @@ jobs:
         run: echo "::warning::macOS code signing failed — building unsigned. Users will need to right-click > Open on first launch."
 
       - name: Build Tauri app (unsigned fallback)
+        id: tauri-unsigned
         if: steps.tauri-signed.outcome == 'failure' || steps.tauri-signed.outcome == 'skipped'
+        continue-on-error: true
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tauriScript: npx tauri
           args: --target ${{ matrix.rust-target }}
+
+      # Verify that the main artifacts were produced even if updater
+      # signing failed (DMG/MSI/AppImage/deb are built before signing).
+      - name: Verify build artifacts exist
+        if: steps.tauri-unsigned.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Tauri build exited non-zero (likely updater signing failure). Checking if main artifacts were still produced..."
+          FOUND=$(find src-tauri/target/${{ matrix.rust-target }}/release/bundle -type f \( -name "*.dmg" -o -name "*.msi" -o -name "*.AppImage" -o -name "*.deb" \) 2>/dev/null | head -5)
+          if [ -z "$FOUND" ]; then
+            echo "::error::No build artifacts found — build genuinely failed."
+            exit 1
+          fi
+          echo "Artifacts found despite build error (updater signing likely failed):"
+          echo "$FOUND"
 
       # ── Upload artifacts ──────────────────────────────────
       - name: Upload build artifacts


### PR DESCRIPTION
Parent PR: #183

## Summary
- Restores `TAURI_SIGNING_PRIVATE_KEY` env vars to the unsigned fallback step — this is the only build path for Linux/Windows, and missing keys can hard-fail `cargo tauri build` when updater artifacts are configured
- Adds `continue-on-error: true` so invalid keys don't block the build (DMG/MSI/deb are produced before updater signing runs)
- Adds a verification step that checks artifacts exist and only fails if the build genuinely produced nothing

## Test plan
- [ ] Trigger build — all platforms should succeed even with invalid/missing updater signing keys
- [ ] If updater signing fails, the warning annotation should appear but artifacts should still be uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)