### PR TITLE
fix: SAM2 coordinate space, MegaDetector status, box clamping

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2557,7 +2557,7 @@ def create_app(db_path, thumb_cache_dir=None):
         # MegaDetector status — just check for the ONNX file
         from detector import MEGADETECTOR_ONNX_PATH
 
-        info["megadetector"] = "available"
+        info["megadetector"] = "installed"
         info["megadetector_detail"] = "MegaDetector V6 (YOLOv9-c) — subject detection for crop-based classification"
 
         if os.path.isfile(MEGADETECTOR_ONNX_PATH):

--- a/vireo/detector.py
+++ b/vireo/detector.py
@@ -168,8 +168,12 @@ def _postprocess(outputs, preprocess_info, confidence_threshold):
         # Clip to image bounds and normalize to 0-1
         x1 = max(0, x1) / orig_w
         y1 = max(0, y1) / orig_h
-        x2 = min(orig_w, x2) / orig_w
-        y2 = min(orig_h, y2) / orig_h
+        x2 = max(0, min(orig_w, x2)) / orig_w
+        y2 = max(0, min(orig_h, y2)) / orig_h
+
+        # Drop invalid boxes where width or height would be non-positive
+        if x2 <= x1 or y2 <= y1:
+            continue
 
         category = CLASS_NAMES.get(int(class_ids[i]), "animal")
         detections.append(

--- a/vireo/masking.py
+++ b/vireo/masking.py
@@ -122,14 +122,21 @@ def generate_mask(image, detection_box, variant="sam2-small"):
         image_embeddings = enc_outputs[0]  # (1, C, H', W')
 
         # Step 2: Encode box prompt as numpy arrays
+        # The image encoder resizes to SAM2_INPUT_SIZE x SAM2_INPUT_SIZE,
+        # so the decoder expects prompt coordinates in that same space.
+        # Scale the original-pixel box into encoder input coordinates.
+        scale_x = SAM2_INPUT_SIZE / orig_w
+        scale_y = SAM2_INPUT_SIZE / orig_h
+        enc_x1 = bx * scale_x
+        enc_y1 = by * scale_y
+        enc_x2 = (bx + bw) * scale_x
+        enc_y2 = (by + bh) * scale_y
+
         # For box prompts: point_coords has shape (1, 2, 2) with top-left
         # and bottom-right corners; point_labels has shape (1, 2) with
         # values [2, 3] (SAM2 box prompt markers)
-        # TODO(export-script): Verify coordinate space matches ONNX export.
-        # These are original pixel coords; may need rescaling to 1024x1024
-        # if the decoder doesn't use orig_im_size for internal rescaling.
         point_coords = np.array(
-            [[[bx, by], [bx + bw, by + bh]]], dtype=np.float32
+            [[[enc_x1, enc_y1], [enc_x2, enc_y2]]], dtype=np.float32
         )  # (1, 2, 2)
         point_labels = np.array([[2, 3]], dtype=np.float32)  # (1, 2)
 


### PR DESCRIPTION
Parent PR: #184

## Summary
- **P1: SAM2 prompt coordinates** — Transform box prompt from original pixel space into encoder input space (1024×1024). Without this, masks are misaligned for any non-square image.
- **P2: MegaDetector status enum** — Change `"available"` → `"installed"` in system-info API to match frontend template checks (`settings.html`, `stats.html`).
- **P2: Negative box clamping** — Clamp x2/y2 to non-negative in detector postprocessing and drop boxes with non-positive width/height to prevent negative dimensions reaching downstream code.

## Test plan
- [x] 304 tests pass (271 integration + 33 module), 2 skipped (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)