### PR TITLE
Fix macOS x86 and Windows CI builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,6 +17,8 @@ permissions:
 env:
   PYTHON_VERSION: "3.14"
   NODE_VERSION: "20"
+  # Limit parallel Rust compilation to avoid OOM on 7GB GitHub runners
+  CARGO_BUILD_JOBS: "2"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- **macOS x86**: `macos-13` → `macos-15-intel` — the old runner was removed by GitHub in Dec 2025, which is why the job was instantly cancelled with no steps
- **Windows**: Use Python 3.13 instead of 3.14 — PyInstaller `--onefile` has a DLL loading bug with 3.14 on Windows (`LoadLibrary: Invalid access to memory location`). All other platforms stay on 3.14. Drops the PyInstaller develop branch workaround.

## Test plan
- [ ] Trigger a build via `workflow_dispatch` and verify:
  - macOS x86 job actually starts and runs (instead of instant cancellation)
  - Windows sidecar passes the smoke test
  - macOS ARM64 and Linux are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)