### PR TITLE
Limit Rust parallel jobs to prevent Linux OOM

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,6 +17,8 @@ permissions:
 env:
   PYTHON_VERSION: "3.14"
   NODE_VERSION: "20"
+  # Limit parallel Rust compilation to avoid OOM on 7GB GitHub runners
+  CARGO_BUILD_JOBS: "2"
 
 jobs:
   build:


### PR DESCRIPTION
Parent PR: #188

## Summary
- Sets `CARGO_BUILD_JOBS=2` to limit parallel Rust compilation
- The ubuntu-22.04 runner (7GB RAM) was OOM-killed during the Rust linker phase — the 449MB PyInstaller sidecar + PyTorch + ~200 Rust crates compiling in parallel exhausted memory

## Test plan
- [ ] Linux build completes the Tauri build step (previously cancelled mid-link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)