### PR TITLE
Partial releases + fix macOS x86 and Windows builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -62,8 +62,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          # Python 3.14 + PyInstaller --onefile fails on Windows (DLL loading bug)
-          python-version: ${{ runner.os == 'Windows' && '3.13' || env.PYTHON_VERSION }}
+          # Windows: PyInstaller --onefile DLL loading bug with 3.14
+          # macOS x86: no PyTorch CPU wheels for x86_64 + 3.14
+          python-version: ${{ (runner.os == 'Windows' || matrix.label == 'macos-x86_64') && '3.13' || env.PYTHON_VERSION }}
           cache: pip
 
       - name: Install PyTorch (CPU only)
@@ -214,14 +215,15 @@ jobs:
             src-tauri/target/${{ matrix.rust-target }}/release/bundle/**/*.exe
             src-tauri/target/${{ matrix.rust-target }}/release/bundle/**/*.AppImage
             src-tauri/target/${{ matrix.rust-target }}/release/bundle/**/*.deb
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 7
 
   # ── Release job ─────────────────────────────────────────
   release:
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag_name != ''
+    # Run even if some builds failed — release whatever succeeded
+    if: always() && (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag_name != '')
 
     steps:
       - name: Download all artifacts

--- a/scripts/build_sidecar.py
+++ b/scripts/build_sidecar.py
@@ -124,8 +124,11 @@ def main():
             "--exclude-module", "notebook",
             "--exclude-module", "jupyter",
             "--exclude-module", "IPython",
-            "--strip",
         ]
+        # --strip corrupts Windows system DLLs (api-ms-win-core-*.dll),
+        # causing "Invalid access to memory location" at runtime
+        if platform.system() != "Windows":
+            pyinstaller_args.append("--strip")
 
     pyinstaller_args.append(os.path.join(repo_root, "vireo", "app.py"))
 


### PR DESCRIPTION
## Summary
Four fixes to get releases shipping:

- **Partial releases**: Release job now runs with `if: always()` — whatever platforms succeed get released instead of blocking on all 4. Upload uses `warn` instead of `error` for missing files.
- **macOS x86**: Use Python 3.13 (PyTorch CPU index has no x86_64 wheels for 3.14)
- **Windows**: Skip `--strip` in `build_sidecar.py` on Windows — it was stripping `api-ms-win-core-*.dll` system DLLs, causing the `LoadLibrary: Invalid access to memory location` error at runtime
- **Python version logic**: `(runner.os == 'Windows' || matrix.label == 'macos-x86_64') && '3.13'`

## Test plan
- [x] All 271 tests pass locally
- [ ] Trigger build — macOS ARM64 should succeed and create a draft release even if other platforms fail
- [ ] macOS x86 should get past PyTorch install (now on 3.13)
- [ ] Windows sidecar should pass smoke test (no more --strip on DLLs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)