### PR TITLE
Only update website when all builds succeed

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -266,10 +266,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ── Update website download links ───────────────────────
+  # Only update when ALL platforms built — partial releases leave some
+  # download links as 404s, so the website stays on the last full version.
   update-website:
-    needs: release
+    needs: [build, release]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag_name != ''
+    if: needs.build.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag_name != '')
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Parent PR: #191

## Summary
- `update-website` now checks `needs.build.result == 'success'` — it only runs when ALL platform builds pass
- Partial releases still create a GitHub Release with whatever artifacts exist, but the download page stays on the last fully successful version

🤖 Generated with [Claude Code](https://claude.com/claude-code)