### PR TITLE
Gate website update on successful release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -268,7 +268,7 @@ jobs:
   update-website:
     needs: [build, release]
     runs-on: ubuntu-latest
-    if: always() && (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag_name != '')
+    if: needs.release.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag_name != '')
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Parent PR: #193

## Summary
- Changed `if: always()` to `if: needs.release.result == 'success'` on the update-website job
- Without this, the website updates even when the release job fails or is skipped, pointing download links to a tag with no published assets (404s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)