### PR TITLE
Fix PyTorch install on macOS x86

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -68,7 +68,14 @@ jobs:
           cache: pip
 
       - name: Install PyTorch (CPU only)
-        run: pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            # PyTorch CPU index has no macOS wheels; default PyPI serves CPU-only builds for Mac
+            pip install torch torchvision
+          else
+            pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          fi
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
## Summary
- The PyTorch CPU wheel index (`download.pytorch.org/whl/cpu`) has no macOS wheels at all — not x86_64, not ARM64
- macOS doesn't have CUDA, so the default PyPI index is correct — it serves CPU-only builds for Mac
- Linux/Windows continue using the CPU index to avoid downloading massive CUDA builds

## Test plan
- [ ] macOS x86 build gets past the PyTorch install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)