### PR TITLE
Simplify New Workspace modal to name-only

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -817,7 +817,7 @@ async function createWorkspace() {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({ current_path: window.location.pathname })
-    }, { toast: false });
+    });
     sessionStorage.setItem('vireo_ws_switched', '1');
     window.location.href = '/pipeline';
   } catch(e) {


### PR DESCRIPTION
## Summary
- Removed folder selection from the "New Workspace" modal — it showed "No folders scanned yet" with no way to add folders, a dead end for new users.
- Modal now collects only a workspace name, creates it, and redirects to `/pipeline` where folder management already exists.
- Single file change in `_navbar.html`: removed folder list HTML, simplified `showCreateWorkspaceModal()` (no longer async), and streamlined `createWorkspace()` to activate + redirect.

## Test plan
- [ ] Create a new workspace from the dropdown — modal should show only name input
- [ ] After clicking Create, should land on `/pipeline` page with the new workspace active
- [ ] Existing workspaces unaffected — switching between them still works normally
- [ ] All 271 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)