### PR TITLE
Fix: surface activation errors via toast

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -817,7 +817,7 @@ async function createWorkspace() {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({ current_path: window.location.pathname })
-    }, { toast: false });
+    });
     sessionStorage.setItem('vireo_ws_switched', '1');
     window.location.href = '/pipeline';
   } catch(e) {


### PR DESCRIPTION
Parent PR: #198

## Summary
- Removed `{ toast: false }` from the workspace activation `safeFetch` call so failures surface via the default toast notification instead of being silently swallowed.

## Test plan
- [ ] If activation fails (e.g. network error), user sees a toast error
- [ ] Happy path unchanged — create workspace still redirects to `/pipeline`
- [ ] All 271 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)