### PR TITLE
Fix: keep flag/rating in photo dicts during pipeline recompute

### DIFF
--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -168,6 +168,8 @@ def load_photo_features(db, collection_id=None, config=None):
             "focal_length": row["focal_length"],
             "burst_id": row["burst_id"],
             "noise_estimate": row["noise_estimate"],
+            "flag": row["flag"],
+            "rating": row["rating"],
         })
 
     log.info("Loaded %d photos with pipeline features", len(photos))


### PR DESCRIPTION
Parent PR: #200

## Summary
- `load_photo_features` builds each photo dict with an explicit field list — the new `flag` and `rating` SQL columns were selected but never copied into the dict
- After reflow or regroup, `serialize_results` returned photos without `flag`/`rating`, so P/X badges disappeared

## Fix
Add `"flag": row["flag"]` and `"rating": row["rating"]` to the photo dict in `load_photo_features`.

## Test plan
- [x] All 271 tests pass
- [ ] Open pipeline review, adjust a scoring slider to trigger reflow — verify P/X badges remain visible
- [ ] Click regroup — verify badges persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)