### PR TITLE
fix: handle root path in folder prefix LIKE query

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3422,7 +3422,7 @@ def create_app(db_path, thumb_cache_dir=None):
                     """SELECT p.id FROM photos p
                        JOIN folders f ON p.folder_id = f.id
                        WHERE f.path = ? OR f.path LIKE ?""",
-                    (scan_target, scan_target + "/%"),
+                    (scan_target, scan_target.rstrip("/") + "/%"),
                 ).fetchall()
                 photo_ids = [r["id"] for r in rows]
 


### PR DESCRIPTION
Parent PR: #203\n\n## Summary\n- When `scan_target` is `/` (filesystem root), `scan_target + \"/%\"` produced `//%` which doesn't match any subfolders\n- Use `scan_target.rstrip(\"/\") + \"/%\"` so root becomes `/%` (matches all paths)\n\n## Test plan\n- [x] 259 tests pass (12 pre-existing failures unrelated to this change)\n\nhttps://claude.ai/code/session_01U7BkNZS2M7FGK72ZNAqYQX