### PR TITLE
fix: use actual RAW dimensions instead of embedded thumbnail

### DIFF
--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from pathlib import Path
 
 import imagehash
-from image_loader import SUPPORTED_EXTENSIONS
+from image_loader import RAW_EXTENSIONS, SUPPORTED_EXTENSIONS
 from metadata import extract_metadata
 from PIL import Image
 from xmp import read_hierarchical_keywords, read_keywords
@@ -53,24 +53,41 @@ def _import_keywords_for_photo(db, photo_id, xmp_path_str):
             db.tag_photo(photo_id, kid)
 
 
-def _extract_dimensions(exif_group, file_group):
+def _extract_dimensions(exif_group, file_group, extension=None):
     """Extract width and height from ExifTool metadata groups.
 
-    Priority:
-    1. EXIF:ExifImageWidth / EXIF:ExifImageHeight (actual image dimensions for JPEGs)
+    For standard images (JPEG, PNG, etc.):
+    1. EXIF:ExifImageWidth / EXIF:ExifImageHeight
     2. EXIF:ImageWidth / EXIF:ImageHeight
     3. File:ImageWidth / File:ImageHeight
+
+    For RAW files (NEF, CR2, ARW, etc.), ExifImageWidth/Height contains the
+    embedded JPEG thumbnail dimensions (e.g. 160x120), not the actual image.
+    Priority for RAW:
+    1. File:ImageWidth / File:ImageHeight (actual decoded dimensions)
+    2. EXIF:ImageWidth / EXIF:ImageHeight
     """
-    width = exif_group.get("ExifImageWidth")
-    if width is None:
-        width = exif_group.get("ImageWidth")
-    if width is None:
+    is_raw = extension and extension.lower() in RAW_EXTENSIONS
+
+    if is_raw:
         width = file_group.get("ImageWidth")
-    height = exif_group.get("ExifImageHeight")
-    if height is None:
-        height = exif_group.get("ImageHeight")
-    if height is None:
+        if width is None:
+            width = exif_group.get("ImageWidth")
         height = file_group.get("ImageHeight")
+        if height is None:
+            height = exif_group.get("ImageHeight")
+    else:
+        width = exif_group.get("ExifImageWidth")
+        if width is None:
+            width = exif_group.get("ImageWidth")
+        if width is None:
+            width = file_group.get("ImageWidth")
+        height = exif_group.get("ExifImageHeight")
+        if height is None:
+            height = exif_group.get("ImageHeight")
+        if height is None:
+            height = file_group.get("ImageHeight")
+
     if width is not None:
         width = int(width)
     if height is not None:
@@ -350,15 +367,26 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         composite = file_meta.get("Composite", {})
 
         # Dimensions from ExifTool (works for all file types including RAW)
-        width, height = _extract_dimensions(exif_group, file_group)
+        width, height = _extract_dimensions(exif_group, file_group, extension=image_path.suffix.lower())
 
-        # Fallback to Pillow if ExifTool didn't provide dimensions
+        # Fallback if ExifTool didn't provide dimensions
         if width is None or height is None:
-            try:
-                with Image.open(str(image_path)) as img:
-                    width, height = img.size
-            except Exception:
-                log.debug("Could not read dimensions from %s", image_path)
+            ext = image_path.suffix.lower()
+            if ext in RAW_EXTENSIONS:
+                try:
+                    import rawpy
+
+                    with rawpy.imread(str(image_path)) as raw:
+                        width = raw.sizes.width
+                        height = raw.sizes.height
+                except Exception:
+                    log.debug("Could not read RAW dimensions from %s", image_path)
+            else:
+                try:
+                    with Image.open(str(image_path)) as img:
+                        width, height = img.size
+                except Exception:
+                    log.debug("Could not read dimensions from %s", image_path)
 
         # Timestamp from ExifTool
         timestamp = _extract_timestamp(exif_group)

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -586,3 +586,82 @@ def test_scan_stores_file_hash(tmp_path):
     photo = db.conn.execute("SELECT file_hash FROM photos LIMIT 1").fetchone()
     assert photo["file_hash"] is not None
     assert len(photo["file_hash"]) == 64  # SHA-256 hex digest length
+
+
+def test_extract_dimensions_raw_skips_exif_thumbnail_size():
+    """For RAW files, ExifImageWidth/Height is the embedded JPEG thumbnail (e.g. 160x120),
+    not the actual image. _extract_dimensions should return the real dimensions from
+    File:ImageWidth/Height instead."""
+    from scanner import _extract_dimensions
+
+    # Simulate ExifTool output for a Nikon NEF file:
+    # EXIF:ExifImageWidth/Height = 160x120 (embedded thumbnail)
+    # File:ImageWidth/Height = 8256x5504 (actual RAW image)
+    exif_group = {
+        "ExifImageWidth": 160,
+        "ExifImageHeight": 120,
+        "ImageWidth": 160,
+        "ImageHeight": 120,
+    }
+    file_group = {
+        "ImageWidth": 8256,
+        "ImageHeight": 5504,
+    }
+
+    width, height = _extract_dimensions(exif_group, file_group, extension=".nef")
+
+    assert width == 8256, f"Expected actual RAW width 8256, got {width} (embedded thumbnail)"
+    assert height == 5504, f"Expected actual RAW height 5504, got {height} (embedded thumbnail)"
+
+
+def test_extract_dimensions_jpeg_still_uses_exif():
+    """For JPEG files, ExifImageWidth/Height should still be the first priority."""
+    from scanner import _extract_dimensions
+
+    exif_group = {
+        "ExifImageWidth": 6000,
+        "ExifImageHeight": 4000,
+    }
+    file_group = {
+        "ImageWidth": 6000,
+        "ImageHeight": 4000,
+    }
+
+    width, height = _extract_dimensions(exif_group, file_group, extension=".jpg")
+
+    assert width == 6000
+    assert height == 4000
+
+
+def test_extract_dimensions_raw_falls_back_to_exif_imagewidth():
+    """For RAW files without File dimensions, EXIF:ImageWidth (non-ExifImageWidth) is used."""
+    from scanner import _extract_dimensions
+
+    exif_group = {
+        "ExifImageWidth": 160,
+        "ExifImageHeight": 120,
+        "ImageWidth": 8256,
+        "ImageHeight": 5504,
+    }
+    file_group = {}
+
+    width, height = _extract_dimensions(exif_group, file_group, extension=".nef")
+
+    # Should skip ExifImageWidth (thumbnail) but still find ImageWidth
+    assert width == 8256
+    assert height == 5504
+
+
+def test_extract_dimensions_all_raw_extensions():
+    """All supported RAW extensions should skip ExifImageWidth/Height."""
+    from scanner import _extract_dimensions
+
+    raw_exts = [".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf"]
+
+    for ext in raw_exts:
+        exif_group = {"ExifImageWidth": 160, "ExifImageHeight": 120}
+        file_group = {"ImageWidth": 8256, "ImageHeight": 5504}
+
+        width, height = _extract_dimensions(exif_group, file_group, extension=ext)
+        assert width == 8256, f"Failed for {ext}: got width {width}"
+        assert height == 5504, f"Failed for {ext}: got height {height}"


### PR DESCRIPTION
## Summary
- For RAW files (NEF, CR2, ARW, etc.), `EXIF:ExifImageWidth`/`ExifImageHeight` contains the embedded JPEG thumbnail dimensions (e.g. 160×120), not the actual sensor resolution. This caused RAW photos to display as 160×120 in the pipeline.
- Updated `_extract_dimensions()` to prefer `File:ImageWidth`/`File:ImageHeight` for RAW formats, which contains the correct decoded dimensions.
- Fixed the Pillow fallback path to use `rawpy` for RAW files, since `Image.open()` also reads only the embedded thumbnail.

## Test plan
- [x] 4 new unit tests covering NEF dimension extraction, JPEG non-regression, fallback chain, and all 8 RAW extensions
- [x] Full test suite passes (294 tests, 0 failures)
- [ ] Manual verification: rescan a folder with NEF files and confirm dimensions are correct (e.g. 8256×5504 instead of 160×120)

🤖 Generated with [Claude Code](https://claude.com/claude-code)