### PR TITLE
fix: guard all overlay types in nav hotkey handler

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -777,16 +777,8 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 
     document.addEventListener('keydown', function(e) {
       if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
-      var lightbox = document.getElementById('lightboxOverlay');
-      if (lightbox && lightbox.classList.contains('active')) return;
-      var pipeline = document.getElementById('pipelineOverlay');
-      if (pipeline && pipeline.classList.contains('active')) return;
-      var similar = document.getElementById('similarOverlay');
-      if (similar && similar.classList.contains('active')) return;
-      var inat = document.getElementById('inatModal');
-      if (inat && inat.classList.contains('open')) return;
-      var createWs = document.getElementById('createWsModal');
-      if (createWs && createWs.classList.contains('open')) return;
+      // Skip if any overlay or modal is open
+      if (document.querySelector('.lightbox-overlay.active, .pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open')) return;
 
       for (var shortcutStr in keyToHref) {
         if (matchesShortcut(e, shortcutStr)) {


### PR DESCRIPTION
Parent PR: #205

## Summary
- Replace five hardcoded overlay ID checks with a single CSS selector query
- Now catches all overlay types: `.lightbox-overlay.active`, `.pipeline-overlay.active`, `.similar-overlay.active`, `.modal-overlay.open`, `.grm-overlay.open`, `.inspect-overlay.open`
- Fixes: nav hotkeys could fire while `grmOverlay` (group review) or `inspect-overlay` (pipeline review) were open, potentially navigating away and losing in-progress modal work

## Test plan
- [ ] Open group review modal on Review page, press `d` — should NOT navigate to Dashboard
- [ ] Open pipeline inspector overlay, press `b` — should NOT navigate to Browse
- [ ] Verify normal nav hotkeys still work when no overlay is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)