### PR TITLE
fix: sort imports in app.py to pass ruff lint

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11,8 +11,8 @@ import logging.handlers
 import os
 import queue
 import time
-from pathlib import Path
 import webbrowser
+from pathlib import Path
 
 from db import Database
 from flask import (


### PR DESCRIPTION
## Summary
- `import webbrowser` was before `from pathlib import Path`, violating ruff's import sorting rule (I001).
- Swapped the two lines so stdlib imports are properly sorted.

## Test plan
- [x] `ruff check vireo/app.py` passes
- [x] Full test suite passes (271 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)