### PR TITLE
fix: prevent duplicate photos in browse grid

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -879,6 +879,8 @@ bootstrapBrowse();
 async function bootstrapBrowse() {
   // If deep-linking to a specific photo, skip normal bootstrap — the deep-link handler takes over
   if (new URLSearchParams(window.location.search).get('photo_id')) return;
+  // Prevent the IntersectionObserver from triggering loadPhotos() while bootstrap is in flight
+  loading = true;
   try {
     applyBrowseConfig(await _cfgPromise);
     var data = await safeFetch('/api/browse/init?per_page=' + perPage + '&sort=' + document.getElementById('sortSelect').value);
@@ -899,6 +901,7 @@ async function bootstrapBrowse() {
   } catch(e) {
     document.getElementById('loadingState').textContent = 'Error loading.';
   }
+  loading = false;
 }
 
 function renderCollectionList(collections) {
@@ -2187,10 +2190,12 @@ async function developSelected() {
   photoId = parseInt(photoId, 10);
   if (isNaN(photoId)) return;
 
+  // Prevent the IntersectionObserver from triggering loadPhotos() while deep-link is loading
+  loading = true;
   try {
     applyBrowseConfig(await _cfgPromise);
     var photo = await safeFetch('/api/photos/' + photoId, {}, { toast: false });
-    if (!photo || !photo.folder_id) return;
+    if (!photo || !photo.folder_id) { loading = false; return; }
 
     // Navigate to the photo's folder
     activeFolderId = photo.folder_id;
@@ -2241,6 +2246,7 @@ async function developSelected() {
       }, 2000);
     }
   } catch(e) { /* ignore deep-link errors silently */ }
+  loading = false;
 })();
 </script>
 


### PR DESCRIPTION
## Summary
- Fixed a race condition where `bootstrapBrowse()` and the `IntersectionObserver` could both fetch page 1 of photos concurrently, causing every photo on the first page to appear twice in the grid.
- The same race existed in the deep-link handler — fixed there too.
- Root cause: both `bootstrapBrowse()` and the deep-link IIFE are `async` but neither set `loading = true` before their fetch. The `IntersectionObserver` fires `loadPhotos()` while the bootstrap fetch is in flight (the grid is empty so the sentinel is visible), and since `loading` is still `false`, `loadPhotos()` proceeds to also fetch page 1. When both resolve, page 1 data ends up in the `photos` array twice.

## Test plan
- [x] All 271 existing tests pass
- [ ] Open browse page with San Elijo Lagoon workspace — verify no duplicate photos
- [ ] Open browse page with `?photo_id=X` deep-link — verify no duplicate photos
- [ ] Verify infinite scroll still loads subsequent pages correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)