### PR TITLE
fix: release loading lock before deep-link pagination loop

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2223,6 +2223,9 @@ async function developSelected() {
       document.getElementById('loadingState').style.display = 'none';
     }
 
+    // Release lock so loadPhotos() can paginate inside the loop below
+    loading = false;
+
     // Keep loading pages until we find the photo or run out
     var el = document.querySelector('.grid-card[data-id="' + photoId + '"]');
     while (!el && !allLoaded) {


### PR DESCRIPTION
Parent PR: #211

## Summary
- Releases `loading = false` before the `while (!el && !allLoaded)` deep-link pagination loop, so `loadPhotos()` (which guards with `if (loading) return`) can actually paginate to find the target photo.
- Without this, deep-linking to a photo not on page 1 would spin the loop indefinitely since `loadPhotos()` would always return immediately.

## Test plan
- [x] All 271 existing tests pass
- [ ] Deep-link to a photo beyond page 1 (e.g. `?photo_id=<high_id>`) — verify it scrolls to the photo
- [ ] Normal browse page load still has no duplicate photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)