### PR TITLE
fix: add id-token permission for claude-code-action OIDC

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -23,6 +23,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   # ═══════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Adds `id-token: write` to the PR Agent workflow permissions
- Fixes the `codex-review` job failing with "Could not fetch an OIDC token" (seen on PR #215)
- `claude-code-action@v1` requires OIDC token support to authenticate

## Test plan
- [ ] Codex Connect review on a PR triggers `codex-review` job successfully (no OIDC error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)