### PR TITLE
ci: bump CARGO_BUILD_JOBS from 2 to 3

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -18,7 +18,7 @@ env:
   PYTHON_VERSION: "3.14"
   NODE_VERSION: "20"
   # Limit parallel Rust compilation to avoid OOM on 7GB GitHub runners
-  CARGO_BUILD_JOBS: "2"
+  CARGO_BUILD_JOBS: "3"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Increase parallel Rust compilation jobs from 2 to 3 on GitHub runners
- Should speed up Linux builds; need to monitor that it stays within the 7GB RAM limit

## Test plan
- [ ] Watch the next Linux build to confirm it completes without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)