### PR TITLE
fix: disk_permanent with photo_ids and companion flag gating

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -861,13 +861,13 @@ def create_app(db_path, thumb_cache_dir=None):
 
         trashed = 0
         trash_failed = []
-        if mode == "disk":
+        if mode in ("disk", "disk_permanent"):
             for f in result["files"]:
                 # Collect all files to delete: primary + companion
                 file_paths = []
                 primary = os.path.join(f["folder_path"], f["filename"])
                 file_paths.append(primary)
-                if f.get("companion_path"):
+                if include_companions and f.get("companion_path"):
                     companion = os.path.join(f["folder_path"], f["companion_path"])
                     file_paths.append(companion)
 
@@ -875,13 +875,21 @@ def create_app(db_path, thumb_cache_dir=None):
                     if not os.path.isfile(filepath):
                         log.warning("File already missing: %s", filepath)
                         continue
-                    try:
-                        from send2trash import send2trash as _trash
-                        _trash(filepath)
-                        trashed += 1
-                    except Exception:
-                        log.warning("Trash failed for %s", filepath, exc_info=True)
-                        trash_failed.append({"path": filepath})
+                    if mode == "disk":
+                        try:
+                            from send2trash import send2trash as _trash
+                            _trash(filepath)
+                            trashed += 1
+                        except Exception:
+                            log.warning("Trash failed for %s", filepath, exc_info=True)
+                            trash_failed.append({"path": filepath})
+                    else:  # disk_permanent
+                        try:
+                            os.remove(filepath)
+                            trashed += 1
+                        except OSError:
+                            log.warning("Permanent delete failed for %s", filepath, exc_info=True)
+                            trash_failed.append({"path": filepath})
 
         return jsonify({
             "ok": True,

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -291,7 +291,7 @@ def test_api_batch_delete_disk_permanent_retry_with_paths(app_and_db, tmp_path):
 
 
 def test_api_batch_delete_disk_deletes_companion_file(app_and_db, tmp_path):
-    """Disk mode deletes companion files alongside the primary file."""
+    """Disk mode deletes companion files when include_companions is true."""
     app, db = app_and_db
     client = app.test_client()
     photos = db.get_photos()
@@ -319,6 +319,7 @@ def test_api_batch_delete_disk_deletes_companion_file(app_and_db, tmp_path):
     resp = client.post("/api/batch/delete", json={
         "photo_ids": [pid],
         "mode": "disk",
+        "include_companions": True,
     })
 
     assert resp.status_code == 200
@@ -328,3 +329,72 @@ def test_api_batch_delete_disk_deletes_companion_file(app_and_db, tmp_path):
     assert data["trashed"] == 2
     assert not os.path.exists(primary_file)
     assert not os.path.exists(companion_file)
+
+
+def test_api_batch_delete_disk_skips_companion_when_unchecked(app_and_db, tmp_path):
+    """Disk mode leaves companion files when include_companions is false."""
+    app, db = app_and_db
+    client = app.test_client()
+    photos = db.get_photos()
+    pid = photos[0]["id"]
+
+    db.conn.execute(
+        "UPDATE photos SET companion_path = 'companion.jpg' WHERE id = ?",
+        (pid,),
+    )
+    folder_path = str(tmp_path / "disk_photos")
+    db.conn.execute(
+        "UPDATE folders SET path = ? WHERE id = ?",
+        (folder_path, photos[0]["folder_id"]),
+    )
+    db.conn.commit()
+
+    os.makedirs(folder_path, exist_ok=True)
+    primary_file = os.path.join(folder_path, photos[0]["filename"])
+    companion_file = os.path.join(folder_path, "companion.jpg")
+    Image.new("RGB", (10, 10)).save(primary_file)
+    Image.new("RGB", (10, 10)).save(companion_file)
+
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": [pid],
+        "mode": "disk",
+        "include_companions": False,
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["trashed"] == 1
+    assert not os.path.exists(primary_file)
+    assert os.path.exists(companion_file)
+
+
+def test_api_batch_delete_disk_permanent_with_photo_ids(app_and_db, tmp_path):
+    """disk_permanent mode with photo_ids permanently deletes files."""
+    app, db = app_and_db
+    client = app.test_client()
+    photos = db.get_photos()
+    pid = photos[0]["id"]
+
+    folder_path = str(tmp_path / "disk_photos")
+    db.conn.execute(
+        "UPDATE folders SET path = ? WHERE id = ?",
+        (folder_path, photos[0]["folder_id"]),
+    )
+    db.conn.commit()
+
+    os.makedirs(folder_path, exist_ok=True)
+    real_file = os.path.join(folder_path, photos[0]["filename"])
+    Image.new("RGB", (10, 10)).save(real_file)
+
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": [pid],
+        "mode": "disk_permanent",
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["deleted"] == 1
+    assert data["trashed"] == 1
+    assert not os.path.exists(real_file)
+    assert db.get_photo(pid) is None


### PR DESCRIPTION
Parent PR: #217

## Summary
- **P1 fix**: Restored `disk_permanent` mode with `photo_ids` — the previous fix accidentally narrowed file deletion to `disk` mode only, leaving `disk_permanent` as a no-op when called with photo IDs directly
- **P2 fix**: Companion file deletion now gated by `include_companions` flag — previously deleted companion files even when the user unchecked "Also delete companion files"
- Added 2 new tests (20 total delete tests, 291 total passing)

## Test plan
- [x] `test_api_batch_delete_disk_permanent_with_photo_ids` — verifies disk_permanent with photo_ids deletes files
- [x] `test_api_batch_delete_disk_skips_companion_when_unchecked` — verifies companions are left alone when flag is false
- [x] Full suite: 291 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)