### PR TITLE
ci: temporarily disable Linux build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -35,9 +35,9 @@ jobs:
           - os: windows-latest
             rust-target: x86_64-pc-windows-msvc
             label: windows-x86_64
-          - os: ubuntu-22.04
-            rust-target: x86_64-unknown-linux-gnu
-            label: linux-x86_64
+          # - os: ubuntu-22.04
+          #   rust-target: x86_64-unknown-linux-gnu
+          #   label: linux-x86_64
 
     runs-on: ${{ matrix.os }}
     name: Build (${{ matrix.label }})


### PR DESCRIPTION
## Summary
- Comment out the Linux (ubuntu-22.04) matrix entry in build-release.yml
- Builds will only run for macOS arm64, macOS x86_64, and Windows until re-enabled

## Test plan
- [ ] Next release build should complete with only 3 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)