### PR TITLE
fix: resolve stop button and validate destination path

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4340,10 +4340,14 @@ def create_app(db_path, thumb_cache_dir=None):
         if source and not os.path.isdir(source):
             return json_error(f"source directory not found: {source}")
 
+        destination = body.get("destination")
+        if destination and not os.path.isabs(destination):
+            return json_error("destination must be an absolute path")
+
         params = PipelineParams(
             collection_id=collection_id,
             source=source,
-            destination=body.get("destination"),
+            destination=destination,
             file_types=body.get("file_types", "both"),
             folder_template=body.get("folder_template", "%Y/%m-%d"),
             skip_duplicates=body.get("skip_duplicates", True),

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -581,6 +581,7 @@ function updateStartButton() {
 var _pipelineRunning = false;
 var _pipelineAbort = false;
 var _pipelineEventSource = null;
+var _pipelineResolve = null;
 
 async function startPipeline() {
   if (_pipelineRunning) return;
@@ -648,17 +649,20 @@ async function startPipeline() {
     document.getElementById('card-source').classList.add('expanded');
 
     await new Promise(function(resolve) {
+      _pipelineResolve = resolve;
       _pipelineEventSource = safeEventSource('/api/jobs/' + data.job_id + '/stream', {
         onProgress: function(p) {
           if (_pipelineAbort) return;
           _updatePipelineStageUI(p);
         },
         onComplete: function(result) {
+          _pipelineResolve = null;
           window.dispatchEvent(new CustomEvent('vireo-job-done', {detail: {job_id: data.job_id}}));
           _onPipelineComplete(result);
           resolve();
         },
         onError: function() {
+          _pipelineResolve = null;
           document.getElementById('statusSource').textContent = 'Connection lost';
           resolve();
         }
@@ -836,6 +840,11 @@ function stopPipeline() {
   if (_pipelineEventSource) {
     _pipelineEventSource.close();
     _pipelineEventSource = null;
+  }
+  // Resolve the pending stream promise so the finally block runs
+  if (_pipelineResolve) {
+    _pipelineResolve();
+    _pipelineResolve = null;
   }
   var btn = document.getElementById('btnStartPipeline');
   btn.disabled = true;

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -147,6 +147,20 @@ def test_pipeline_job_requires_source_or_collection(app_and_db):
         assert resp.status_code == 400
 
 
+def test_pipeline_job_rejects_relative_destination(app_and_db, tmp_path):
+    """Pipeline endpoint should reject relative destination paths."""
+    app, _ = app_and_db
+    src = tmp_path / "src"
+    src.mkdir()
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "source": str(src),
+            "destination": "relative/path",
+        })
+        assert resp.status_code == 400
+        assert "absolute" in resp.get_json()["error"]
+
+
 def test_pipeline_job_with_collection_returns_job_id(app_and_db):
     """Pipeline with collection_id should start and return job_id."""
     import json


### PR DESCRIPTION
Parent PR: #219

## Summary

Fixes two issues from code review on #219:

- **P1: Stop button leaves UI stuck** — `stopPipeline()` closed the EventSource but the Promise wrapping the SSE stream never resolved, so `_pipelineRunning` never reset in the `finally` block. Fixed by storing the resolve function and calling it from `stopPipeline()`.
- **P2: Missing destination validation** — The pipeline route accepted relative destination paths, unlike the existing import-full route. Added `os.path.isabs()` check with test.

## Test plan

- [x] 291 tests pass (including new `test_pipeline_job_rejects_relative_destination`)
- [x] Verified stopPipeline resolve logic: Promise resolves -> finally block runs -> button resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)