### PR TITLE
feat: update website to vireo gold palette

### DIFF
--- a/BRAND.md
+++ b/BRAND.md
@@ -8,14 +8,9 @@
 
 | Name              | Hex       | RGB             | Usage                              |
 |-------------------|-----------|-----------------|------------------------------------|
-| Bright Teal       | `#24E5CA` | `36, 229, 202`  | Primary accent, highlights, CTAs   |
-| Teal              | `#12C3B5` | `18, 195, 181`  | Bird head, active states           |
-| Mid Teal          | `#038A96` | `3, 138, 150`   | Bird body, secondary accent        |
-| Slate Blue        | `#0D5B79` | `13, 91, 121`   | Wing, aperture blades              |
-| Navy              | `#0A2F4D` | `10, 47, 77`    | Background gradient mid            |
-| Deep Navy         | `#001B29` | `0, 27, 41`     | Darkest background                 |
-| Warm White        | `#E0F0F0` | `224, 240, 240` | Text on dark backgrounds           |
-
-## Alternate Logo
-
-`logo_teal.png` — Teal gradient on dark navy variant.
+| Gold Bright       | `#E5C233` | `229, 194, 51`  | Primary accent, highlights, CTAs   |
+| Gold              | `#D4A800` | `212, 168, 0`   | Core brand gold, active states     |
+| Gold Hover        | `#B89200` | `184, 146, 0`   | Hover states, secondary accent     |
+| Espresso          | `#2C2618` | `44, 38, 24`    | Warm dark background mid           |
+| Dark Warm         | `#171410` | `23, 20, 16`    | Darkest background                 |
+| Cream             | `#FAF5E6` | `250, 245, 230` | Text on dark backgrounds           |

--- a/website/src/components/DownloadButton.astro
+++ b/website/src/components/DownloadButton.astro
@@ -63,7 +63,7 @@ const platformNames: Record<string, string> = {
 
   .download-btn--highlighted {
     border-color: var(--color-accent);
-    background: rgba(36, 229, 202, 0.1);
+    background: rgba(212, 168, 0, 0.1);
   }
 
   .download-btn__icon {

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -30,7 +30,7 @@ const base = import.meta.env.BASE_URL;
     background: var(--color-bg-dark);
     color: var(--color-text-muted);
     padding: var(--space-3xl) 0;
-    border-top: 1px solid rgba(36, 229, 202, 0.1);
+    border-top: 1px solid rgba(212, 168, 0, 0.15);
   }
 
   .footer__inner {

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -52,9 +52,9 @@ function isActive(href: string): boolean {
     right: 0;
     z-index: 100;
     height: var(--nav-height);
-    background: rgba(0, 27, 41, 0.95);
+    background: rgba(23, 20, 16, 0.95);
     backdrop-filter: blur(12px);
-    border-bottom: 1px solid rgba(36, 229, 202, 0.1);
+    border-bottom: 1px solid rgba(212, 168, 0, 0.15);
   }
 
   .nav__inner {
@@ -136,10 +136,10 @@ function isActive(href: string): boolean {
       left: 0;
       right: 0;
       flex-direction: column;
-      background: rgba(0, 27, 41, 0.98);
+      background: rgba(23, 20, 16, 0.98);
       padding: var(--space-lg);
       gap: var(--space-md);
-      border-bottom: 1px solid rgba(36, 229, 202, 0.1);
+      border-bottom: 1px solid rgba(212, 168, 0, 0.15);
     }
 
     .nav__links--open {

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -18,7 +18,7 @@ const base = import.meta.env.BASE_URL;
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content={description} />
-  <meta name="theme-color" content="#001B29" />
+  <meta name="theme-color" content="#171410" />
 
   <link rel="icon" type="image/png" href={`${base}favicon.png`} />
   <link rel="apple-touch-icon" href={`${base}apple-touch-icon.png`} />

--- a/website/src/pages/features.astro
+++ b/website/src/pages/features.astro
@@ -156,7 +156,7 @@ const base = import.meta.env.BASE_URL;
 
   .ecosystem__card {
     background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(36, 229, 202, 0.15);
+    border: 1px solid rgba(212, 168, 0, 0.15);
     border-radius: var(--border-radius-lg);
     padding: var(--space-xl);
   }

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -5,24 +5,28 @@
 
 :root {
   /* Brand colors */
-  --color-teal-bright: #24E5CA;
-  --color-teal: #12C3B5;
-  --color-teal-mid: #038A96;
-  --color-slate-blue: #0D5B79;
-  --color-navy: #0A2F4D;
-  --color-navy-deep: #001B29;
-  --color-warm-white: #E0F0F0;
+  --color-gold-bright: #E5C233;
+  --color-gold: #D4A800;
+  --color-gold-hover: #B89200;
+  --color-espresso: #2C2618;
+  --color-dark-warm: #171410;
+  --color-cream: #FAF5E6;
+
+  /* Aliases for component references */
+  --color-warm-white: var(--color-cream);
+  --color-navy-deep: var(--color-dark-warm);
+  --color-teal-mid: var(--color-gold-hover);
 
   /* Semantic colors */
-  --color-bg-dark: var(--color-navy-deep);
-  --color-bg-navy: var(--color-navy);
-  --color-bg-light: #F8FAFA;
+  --color-bg-dark: var(--color-dark-warm);
+  --color-bg-navy: var(--color-espresso);
+  --color-bg-light: #FDFAF0;
   --color-bg-white: #FFFFFF;
-  --color-text-on-dark: var(--color-warm-white);
-  --color-text-on-light: #1A2A3A;
-  --color-text-muted: #6B7B8D;
-  --color-accent: var(--color-teal-bright);
-  --color-accent-hover: var(--color-teal);
+  --color-text-on-dark: var(--color-cream);
+  --color-text-on-light: #3A3520;
+  --color-text-muted: #8B7E6A;
+  --color-accent: var(--color-gold);
+  --color-accent-hover: var(--color-gold-hover);
 
   /* Typography */
   --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;


### PR DESCRIPTION
## Summary
- Replaces the teal/navy website color scheme with a warm gold palette matching the app's Vireo Gold theme
- Updates CSS design tokens in `global.css`: teal brand colors → gold (`#D4A800`), navy backgrounds → warm darks (`#171410`, `#2C2618`), cool white → cream (`#FAF5E6`)
- Updates all hardcoded `rgba()` values in Nav, Footer, DownloadButton, and Features components
- Updates `theme-color` meta tag and `BRAND.md` color documentation

## Test plan
- [x] All 271 project tests pass
- [x] Astro website builds successfully
- [ ] Visual review: verify gold accent (#D4A800) renders well on dark warm backgrounds
- [ ] Check nav, footer, download button highlights, and ecosystem cards use gold borders
- [ ] Verify light sections use warm cream (#FDFAF0) background

🤖 Generated with [Claude Code](https://claude.com/claude-code)