### PR TITLE
ci: auto-publish releases instead of drafts

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -268,7 +268,7 @@ jobs:
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: Vireo ${{ steps.tag.outputs.tag }}
-          draft: true
+          draft: false
           prerelease: false
           generate_release_notes: true
           files: release-files/*


### PR DESCRIPTION
## Summary
- Change `draft: true` to `draft: false` in the release job
- Draft releases cause download links to 404 since the website updates before manual publication
- CI already smoke-tests the sidecar, so manual review adds friction without safety benefit

Parent PR: #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)