### PR TITLE
ci: grant actions:write for workflow dispatch

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 env:
   PYTHON_VERSION: "3.14"


### PR DESCRIPTION
## Summary
- Add `actions: write` permission so `gh workflow run deploy-website.yml` can dispatch the workflow
- Without it, the step fails with "Resource not accessible by integration" since unspecified scopes default to `none`

Parent PR: #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)