### PR TITLE
fix: enable navigation hotkeys in Tauri desktop app

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -777,7 +777,6 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 
       for (var shortcutStr in keyToHref) {
         if (matchesShortcut(e, shortcutStr)) {
-          if (window.__TAURI_INTERNALS__) return;
           // Live check: does the current page claim this key?
           if (pageCtx && window._vireoShortcuts && window._vireoShortcuts[pageCtx]) {
             var pageShortcuts = window._vireoShortcuts[pageCtx];


### PR DESCRIPTION
## Summary
- Removed the overly broad `window.__TAURI_INTERNALS__` guard in the navigation keydown handler (`_navbar.html:780`)
- This guard was silently blocking all single-letter navigation hotkeys (a, v, b, d, i, p, etc.) when running as a Tauri desktop app
- The guard was unnecessary — bare letter keys don't conflict with the native `Cmd+1..0` menu accelerators

## Test plan
- [ ] Launch Vireo desktop app, navigate to dashboard
- [ ] Press `b` — should navigate to Browse
- [ ] Press `a` — should navigate to Audit
- [ ] Press `v` — should navigate to Variants
- [ ] Verify `Cmd+1..0` native menu shortcuts still work
- [ ] Verify hotkeys are ignored when typing in input fields
- [ ] All 274 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)