### PR TITLE
fix: replace window.prompt() with modals for batch buttons

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1750,6 +1750,7 @@ async function addToCollection() {
   document.getElementById('batchCollectionList').innerHTML = listHtml;
   document.getElementById('batchCollectionNewName').value = '';
   document.getElementById('batchCollectionModal').classList.add('open');
+  setTimeout(function() { document.getElementById('batchCollectionNewName').focus(); }, 50);
 }
 
 function pickBatchCollection(id) {
@@ -2168,6 +2169,13 @@ document.addEventListener('click', function(e) {
 
 /* ---------- Keyboard Shortcuts ---------- */
 document.addEventListener('keydown', function(e) {
+  // Suppress browse shortcuts while any modal is open
+  var openModal = document.querySelector('.modal-overlay.open');
+  if (openModal) {
+    if (e.key === 'Escape') { openModal.classList.remove('open'); }
+    return;
+  }
+
   if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
 
   if (e.key === 'Escape') {


### PR DESCRIPTION
## Summary
- **Root cause**: `window.prompt()` silently returns `null` in Tauri's webview (WKWebView), causing the "+ Keyword" and "+ Collection" batch action buttons to do nothing when clicked after selecting photos
- **Fix**: Replaced both `prompt()` calls with custom modals using the app's existing modal system (`.modal-overlay` / `.modal` CSS classes)
- The keyword modal has a text input with Enter-to-submit support
- The collection modal shows a clickable list of existing collections with an option to create a new one

## Test plan
- [x] All 274 existing tests pass
- [ ] Select multiple photos with Ctrl+A, click "+ Keyword" — modal appears, enter keyword, click Add
- [ ] Select multiple photos, click "+ Collection" — modal shows existing collections, can pick one or create new
- [ ] Both modals dismiss with Cancel button
- [ ] Enter key submits in both modals

🤖 Generated with [Claude Code](https://claude.com/claude-code)