### PR TITLE
fix: address ONNX migration review findings

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1732,7 +1732,7 @@ def create_app(db_path, thumb_cache_dir=None):
         entries = []
         total_size = 0
         for f in sorted(os.listdir(CACHE_DIR)):
-            if f.endswith(".npy"):
+            if f.endswith(".npy") or f.endswith(".pt"):
                 fp = os.path.join(CACHE_DIR, f)
                 size = os.path.getsize(fp)
                 total_size += size
@@ -2555,20 +2555,24 @@ def create_app(db_path, thumb_cache_dir=None):
             info["device_detail"] = "onnxruntime not installed"
 
         # MegaDetector status — just check for the ONNX file
-        from detector import MEGADETECTOR_ONNX_PATH
+        try:
+            from detector import MEGADETECTOR_ONNX_PATH
 
-        info["megadetector"] = "installed"
-        info["megadetector_detail"] = "MegaDetector V6 (YOLOv9-c) — subject detection for crop-based classification"
+            info["megadetector"] = "installed"
+            info["megadetector_detail"] = "MegaDetector V6 (YOLOv9-c) — subject detection for crop-based classification"
 
-        if os.path.isfile(MEGADETECTOR_ONNX_PATH):
-            size_mb = round(os.path.getsize(MEGADETECTOR_ONNX_PATH) / 1024 / 1024, 1)
-            info["megadetector_weights"] = "downloaded"
-            info["megadetector_weights_path"] = MEGADETECTOR_ONNX_PATH
-            info["megadetector_weights_size"] = f"{size_mb} MB"
-        else:
-            info["megadetector_weights"] = "not downloaded"
-            info["megadetector_weights_path"] = None
-            info["megadetector_weights_size"] = None
+            if os.path.isfile(MEGADETECTOR_ONNX_PATH):
+                size_mb = round(os.path.getsize(MEGADETECTOR_ONNX_PATH) / 1024 / 1024, 1)
+                info["megadetector_weights"] = "downloaded"
+                info["megadetector_weights_path"] = MEGADETECTOR_ONNX_PATH
+                info["megadetector_weights_size"] = f"{size_mb} MB"
+            else:
+                info["megadetector_weights"] = "not downloaded"
+                info["megadetector_weights_path"] = None
+                info["megadetector_weights_size"] = None
+        except ImportError:
+            info["megadetector"] = "unavailable"
+            info["megadetector_detail"] = "detector module not available"
 
         return jsonify(info)
 

--- a/vireo/classifier.py
+++ b/vireo/classifier.py
@@ -29,14 +29,90 @@ _MODELS_ROOT = os.path.expanduser("~/.vireo/models")
 # Context length for CLIP-style tokenizers (pad/truncate to this length)
 _CONTEXT_LENGTH = 77
 
-# Simplified set of OpenAI ImageNet templates for zero-shot classification.
-# Averaging across templates smooths out template bias.
+# Full set of 80 OpenAI ImageNet templates for zero-shot classification.
+# Source: openai/CLIP and open_clip. Averaging across all 80 templates
+# produces robust text embeddings that match the original BioCLIP pipeline.
 OPENAI_IMAGENET_TEMPLATE = [
-    lambda c: f"a photo of a {c}.",
     lambda c: f"a bad photo of a {c}.",
     lambda c: f"a photo of many {c}.",
-    lambda c: f"a photo of the large {c}.",
+    lambda c: f"a sculpture of a {c}.",
+    lambda c: f"a photo of the hard to see {c}.",
+    lambda c: f"a low resolution photo of the {c}.",
+    lambda c: f"a rendering of a {c}.",
+    lambda c: f"graffiti of a {c}.",
+    lambda c: f"a bad photo of the {c}.",
+    lambda c: f"a cropped photo of the {c}.",
+    lambda c: f"a tattoo of a {c}.",
+    lambda c: f"the embroidered {c}.",
+    lambda c: f"a photo of a hard to see {c}.",
+    lambda c: f"a bright photo of a {c}.",
+    lambda c: f"a photo of a clean {c}.",
+    lambda c: f"a photo of a dirty {c}.",
+    lambda c: f"a dark photo of the {c}.",
+    lambda c: f"a drawing of a {c}.",
+    lambda c: f"a photo of my {c}.",
+    lambda c: f"the plastic {c}.",
+    lambda c: f"a photo of the cool {c}.",
+    lambda c: f"a close-up photo of a {c}.",
+    lambda c: f"a black and white photo of the {c}.",
+    lambda c: f"a painting of the {c}.",
+    lambda c: f"a painting of a {c}.",
+    lambda c: f"a pixelated photo of the {c}.",
+    lambda c: f"a sculpture of the {c}.",
+    lambda c: f"a bright photo of the {c}.",
+    lambda c: f"a cropped photo of a {c}.",
+    lambda c: f"a plastic {c}.",
+    lambda c: f"a photo of the dirty {c}.",
+    lambda c: f"a jpeg corrupted photo of a {c}.",
+    lambda c: f"a blurry photo of the {c}.",
+    lambda c: f"a photo of the {c}.",
+    lambda c: f"a good photo of the {c}.",
+    lambda c: f"a rendering of the {c}.",
+    lambda c: f"a {c} in a video game.",
+    lambda c: f"a photo of one {c}.",
+    lambda c: f"a doodle of a {c}.",
+    lambda c: f"a close-up photo of the {c}.",
+    lambda c: f"a photo of a {c}.",
+    lambda c: f"the origami {c}.",
+    lambda c: f"the {c} in a video game.",
+    lambda c: f"a sketch of a {c}.",
+    lambda c: f"a doodle of the {c}.",
+    lambda c: f"a origami {c}.",
+    lambda c: f"a low resolution photo of a {c}.",
+    lambda c: f"the toy {c}.",
+    lambda c: f"a rendition of the {c}.",
+    lambda c: f"a photo of the clean {c}.",
+    lambda c: f"a photo of a large {c}.",
+    lambda c: f"a rendition of a {c}.",
+    lambda c: f"a photo of a nice {c}.",
+    lambda c: f"a photo of a weird {c}.",
+    lambda c: f"a blurry photo of a {c}.",
+    lambda c: f"a cartoon {c}.",
+    lambda c: f"art of a {c}.",
+    lambda c: f"a sketch of the {c}.",
+    lambda c: f"a embroidered {c}.",
+    lambda c: f"a pixelated photo of a {c}.",
+    lambda c: f"itap of the {c}.",
+    lambda c: f"a jpeg corrupted photo of the {c}.",
+    lambda c: f"a good photo of a {c}.",
+    lambda c: f"a plushie {c}.",
+    lambda c: f"a photo of the nice {c}.",
     lambda c: f"a photo of the small {c}.",
+    lambda c: f"a photo of the weird {c}.",
+    lambda c: f"the cartoon {c}.",
+    lambda c: f"art of the {c}.",
+    lambda c: f"a drawing of the {c}.",
+    lambda c: f"a photo of the large {c}.",
+    lambda c: f"a black and white photo of a {c}.",
+    lambda c: f"the plushie {c}.",
+    lambda c: f"a dark photo of a {c}.",
+    lambda c: f"itap of a {c}.",
+    lambda c: f"graffiti of the {c}.",
+    lambda c: f"a toy {c}.",
+    lambda c: f"itap of my {c}.",
+    lambda c: f"a photo of a cool {c}.",
+    lambda c: f"a photo of a small {c}.",
+    lambda c: f"a tattoo of the {c}.",
 ]
 
 
@@ -437,6 +513,8 @@ class Classifier:
         """Classify multiple PIL images.
 
         Processes each image individually through the ONNX image encoder.
+        TODO: batch ONNX inference (stack preprocessed arrays along batch dim)
+        would improve throughput for large classification jobs.
 
         Args:
             images: list of PIL Images


### PR DESCRIPTION
## Summary

Fixes critical and important issues found during review of PR #184.

Parent PR: #184

- **Expand OPENAI_IMAGENET_TEMPLATE from 5 to 80 templates** — the reduced set would cause classification accuracy regression vs the original BioCLIP pipeline. Restored the full set from OpenAI/CLIP.
- **Wrap detector import in try/except** in `api_system_info` — bare import could crash the endpoint with a 500 error if the detector module fails to load.
- **Include legacy `.pt` files in embedding cache listing** — after upgrade from PyTorch, old `.pt` cache files were invisible to users but still consumed disk space.
- **Add batch inference TODO** — documents that batch ONNX inference is a future optimization opportunity for `classify_batch_with_embedding`.

## Test plan

- [x] All 271 integration tests pass
- [x] All 26 classifier + onnx_runtime tests pass
- [x] Verified template count is 80 (matches open_clip source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)