### PR TITLE
pipeline: add explanation for proxy resolution setting

### DIFF
--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -343,6 +343,10 @@ body { padding-bottom: 36px; }
         </div>
         <div class="setting-item">
           <div class="setting-label">Proxy res.</div>
+          <div style="font-size:11px;color:var(--text-faint,#5A8890);margin-bottom:4px;line-height:1.4;">
+            Working resolution for masking and embeddings. Higher values improve detail
+            but use more memory and run slower. 1536 is a good default for most photos.
+          </div>
           <div style="display:flex;align-items:center;gap:8px;">
             <input type="range" min="1024" max="2048" value="1536" step="64"
                    id="cfgProxy" oninput="onModelConfigChange()"


### PR DESCRIPTION
## Summary
- Adds a brief description below the "Proxy res." label on the pipeline page explaining what it controls (working resolution for masking and embeddings) and the tradeoff (higher = more detail but more memory/slower)

## Test plan
- [ ] Open the pipeline page and verify the explanation text appears below the "Proxy res." label in the Extract Features card
- [ ] Confirm styling matches the existing label color/size

All 274 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)