### PR TITLE
fix: lazy-load collection counts to avoid N+1 on browse init

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -343,11 +343,6 @@ def create_app(db_path, thumb_cache_dir=None):
         folders = db.get_folder_tree()
         keywords = db.get_keyword_tree()
         collections = db.get_collections()
-        coll_list = []
-        for c in collections:
-            d = dict(c)
-            d["photo_count"] = db.count_collection_photos(c["id"])
-            coll_list.append(d)
 
         return jsonify(
             {
@@ -357,7 +352,7 @@ def create_app(db_path, thumb_cache_dir=None):
                 "per_page": per_page,
                 "folders": [dict(f) for f in folders],
                 "keywords": [dict(k) for k in keywords],
-                "collections": coll_list,
+                "collections": [dict(c) for c in collections],
             }
         )
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -895,10 +895,13 @@ async function bootstrapBrowse() {
     renderFolderTree(data.folders || []);
     renderKeywordTree(data.keywords || []);
     renderCollectionList(data.collections || []);
+    loadCollectionCounts();
     renderGrid();
     updateFilterSummary();
 
     document.getElementById('loadingState').style.display = 'none';
+    // Lazy-load collection photo counts to avoid N+1 on init
+    loadCollectionCounts();
   } catch(e) {
     document.getElementById('loadingState').textContent = 'Error loading.';
   }
@@ -1039,6 +1042,25 @@ async function loadCollections() {
   try {
     var data = await safeFetch('/api/collections', {}, { toast: false });
     renderCollectionList(data);
+  } catch(e) {}
+}
+
+async function loadCollectionCounts() {
+  try {
+    var data = await safeFetch('/api/collections', {}, { toast: false });
+    if (!data) return;
+    var items = document.querySelectorAll('#collectionList .tree-item');
+    var countsById = {};
+    data.forEach(function(c) { countsById[c.id] = c.photo_count; });
+    items.forEach(function(el) {
+      var onclick = el.getAttribute('onclick') || '';
+      var m = onclick.match(/filterByCollection\((\d+)\)/);
+      if (m) {
+        var id = parseInt(m[1], 10);
+        var span = el.querySelector('.count');
+        if (span && countsById[id] != null) span.textContent = countsById[id];
+      }
+    });
   } catch(e) {}
 }
 
@@ -2243,6 +2265,7 @@ async function developSelected() {
       renderFolderTree(initData.folders || []);
       renderKeywordTree(initData.keywords || []);
       renderCollectionList(initData.collections || []);
+      loadCollectionCounts();
       photos = initData.photos || [];
       totalPhotos = initData.total || 0;
       currentPage = 2;


### PR DESCRIPTION
Parent PR: #231

## Summary
- Removes the N+1 `count_collection_photos()` loop from `api_browse_init` so the initial browse page load stays fast regardless of collection count.
- Collections render immediately without counts, then `loadCollectionCounts()` fetches `/api/collections` asynchronously and backfills the count `<span>` elements.
- The `/api/collections` endpoint still computes counts (acceptable for a dedicated collections call), so `loadCollections()` continues to work as before.

## Test plan
- [x] All 274 existing tests pass
- [ ] Open browse page — sidebar loads instantly, collection counts appear shortly after
- [ ] Verify counts match when clicking into a collection
- [ ] Test with many collections to confirm no init latency regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)