### PR TITLE
fix: migrate download.astro from stale --color-teal-mid alias

### DIFF
--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -216,7 +216,7 @@ const linuxVersion = '0.6.4';
 
   .sysreq__card h3 {
     font-size: var(--text-lg);
-    color: var(--color-teal-mid);
+    color: var(--color-accent-hover);
     margin-bottom: var(--space-md);
   }
 


### PR DESCRIPTION
Parent PR: #229

## Summary
- `.sysreq__card h3` in `download.astro` referenced `var(--color-teal-mid)`, which was removed when the alias block was cleaned up in #229
- Migrated to `--color-accent-hover`, the semantic token that `--color-teal-mid` previously aliased

## Test plan
- [x] Website builds successfully
- [ ] Verify system requirements card headings show accent color in both gold and teal themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)