### PR TITLE
fix: remove duplicate loadCollectionCounts() call

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -895,7 +895,6 @@ async function bootstrapBrowse() {
     renderFolderTree(data.folders || []);
     renderKeywordTree(data.keywords || []);
     renderCollectionList(data.collections || []);
-    loadCollectionCounts();
     renderGrid();
     updateFilterSummary();
 


### PR DESCRIPTION
Parent PR: #237

## Summary
- Removes the duplicate `loadCollectionCounts()` call in `bootstrapBrowse()` that was sending two `/api/collections` requests on every page load, doubling the count computation work.

## Test plan
- [x] All 274 tests pass
- [ ] Open browse page, verify network tab shows only one `/api/collections` request during init

🤖 Generated with [Claude Code](https://claude.com/claude-code)