### PR TITLE
fix: add codex connector to allowed_bots in PR Agent

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -63,6 +63,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: "chatgpt-codex-connector[bot]"
           prompt: |
             You are a PR fix agent for the Vireo repository.
 
@@ -143,6 +144,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: "chatgpt-codex-connector[bot]"
           prompt: |
             You are a PR fix agent for the Vireo repository.
 
@@ -224,6 +226,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: "chatgpt-codex-connector[bot]"
           prompt: |
             You are a PR fix agent for the Vireo repository.
 
@@ -337,6 +340,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: "chatgpt-codex-connector[bot]"
           prompt: |
             You are a PR fix agent for the Vireo repository.
 


### PR DESCRIPTION
## Summary
- The `codex-review`, `fix-comments`, `activate`, and `fix-comment-feedback` jobs in the PR Agent workflow were failing with: `Workflow initiated by non-human actor: chatgpt-codex-connector (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.`
- Added `allowed_bots: "chatgpt-codex-connector[bot]"` to all four `claude-code-action` steps that can be triggered by the Codex Connect bot
- Affected PRs: #229, #231, #232 (and any future PRs reviewed by Codex Connect)

## Test plan
- [x] All 274 tests pass locally
- [ ] Verify the `codex-review` job succeeds on the next Codex Connect review

🤖 Generated with [Claude Code](https://claude.com/claude-code)