### PR TITLE
fix: suppress browse shortcuts while modals are open

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1750,6 +1750,7 @@ async function addToCollection() {
   document.getElementById('batchCollectionList').innerHTML = listHtml;
   document.getElementById('batchCollectionNewName').value = '';
   document.getElementById('batchCollectionModal').classList.add('open');
+  setTimeout(function() { document.getElementById('batchCollectionNewName').focus(); }, 50);
 }
 
 function pickBatchCollection(id) {
@@ -2168,6 +2169,13 @@ document.addEventListener('click', function(e) {
 
 /* ---------- Keyboard Shortcuts ---------- */
 document.addEventListener('keydown', function(e) {
+  // Suppress browse shortcuts while any modal is open
+  var openModal = document.querySelector('.modal-overlay.open');
+  if (openModal) {
+    if (e.key === 'Escape') { openModal.classList.remove('open'); }
+    return;
+  }
+
   if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
 
   if (e.key === 'Escape') {


### PR DESCRIPTION
Parent PR: #232

## Summary
- Focus `#batchCollectionNewName` when the collection modal opens (matching the keyword modal behavior)
- Add a modal guard at the top of the document keydown handler: when any `.modal-overlay.open` exists, all browse shortcuts are suppressed and Escape closes the modal instead of clearing selection
- Prevents `x`/`p`/`u`/arrow keys from unintentionally modifying photo state while typing in a modal

## Test plan
- [x] 274 tests pass
- [ ] Open "+ Collection" modal, type a name — no browse shortcuts fire (e.g. `x` doesn't reject, `p` doesn't flag)
- [ ] Open "+ Keyword" modal, same behavior — shortcuts suppressed
- [ ] Press Escape while modal is open — modal closes, selection is preserved
- [ ] With no modal open, shortcuts work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)