### PR TITLE
fix: use definite height for logs page flex layout

### DIFF
--- a/vireo/templates/logs.html
+++ b/vireo/templates/logs.html
@@ -11,7 +11,7 @@
 body {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  height: 100vh;
 }
 .content {
   flex: 1;


### PR DESCRIPTION
Parent PR: #236

## Summary
- Replace no-op `min-height: 100vh` with `height: 100vh` on the logs page body
- `min-height` was already set globally in `vireo-base.css`, so the previous commit was effectively a no-op
- Root cause: `flex: 1` on `.content` requires a **definite height** on the parent to distribute remaining space — `min-height` alone doesn't provide one, so the layout collapsed when filtering reduced visible log lines (WARNING/ERROR)

## Test plan
- [x] All 274 tests pass
- [ ] Open logs page, set filter to WARNING+ or ERROR+ — log container should fill the full viewport height
- [ ] Verify INFO+/DEBUG+ still works (content scrolls within the container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)