### PR TITLE
fix: resolve duplicate /api/species route on variants page

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4015,7 +4015,7 @@ def create_app(db_path, thumb_cache_dir=None):
         log.info("Labeled %d photos as '%s'", len(photo_ids), label)
         return jsonify({"ok": True, "updated": len(photo_ids), "keyword_id": kid})
 
-    @app.route("/api/species")
+    @app.route("/api/species/summary")
     def api_species_list():
         """List all species with prediction counts, for the variant explorer."""
         db = _get_db()

--- a/vireo/templates/variants.html
+++ b/vireo/templates/variants.html
@@ -233,7 +233,7 @@ var activeSpecies = null;
 
 async function loadSpecies() {
   try {
-    allSpecies = await safeFetch('/api/species', {}, { toast: false });
+    allSpecies = await safeFetch('/api/species/summary', {}, { toast: false });
     renderSpeciesList(allSpecies);
   } catch(e) {
     document.getElementById('speciesList').innerHTML =


### PR DESCRIPTION
## Summary
- Two Flask routes were registered for `/api/species` — the map page's route (returning `{"species": [...]}`) and the variants page's route (returning a flat array). Flask serves the first match, so the variants page always got the wrong format.
- When there are no species, `renderSpeciesList` received an object instead of an array, `.forEach()` threw, and the catch block showed "Failed to load species" — making it look like a bug rather than an empty state.
- Renamed the variants-specific endpoint to `/api/species/summary` to eliminate the conflict.

## Test plan
- [x] All 274 tests pass
- [ ] Open variants page with no classified species — should show "No classified species yet" instead of "Failed to load species"
- [ ] Open variants page with classified species — species list loads normally
- [ ] Map page species filter still works (uses original `/api/species` endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)