### PR TITLE
fix: move About info to native dialog, fix version fallback

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -48,6 +48,8 @@ fn build_about_metadata() -> tauri::menu::AboutMetadata<'static> {
         .name(Some("Vireo"))
         .version(Some(env!("CARGO_PKG_VERSION")))
         .comments(Some("AI-powered wildlife photo organizer"))
+        .website(Some("https://github.com/jss367/vireo"))
+        .website_label(Some("GitHub"))
         .license(Some("MIT"))
         .build()
 }

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1977,7 +1977,12 @@ def create_app(db_path, thumb_cache_dir=None):
             from importlib.metadata import version as pkg_version
             ver = pkg_version("vireo")
         except Exception:
-            ver = "0.1.0"
+            import tomllib
+            try:
+                with open(os.path.join(os.path.dirname(__file__), "..", "pyproject.toml"), "rb") as f:
+                    ver = tomllib.load(f)["project"]["version"]
+            except Exception:
+                ver = "0.0.0"
         return jsonify({"version": ver})
 
     @app.route("/api/volumes", methods=["GET"])

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -803,24 +803,11 @@
     </div>
   </div>
 
-  <!-- About -->
-  <div class="section">
-    <div class="section-title">About</div>
-    <div class="setting-row">
-      <div class="setting-label">Vireo</div>
-      <span class="setting-value" id="appVersion">-</span>
-    </div>
-    <div style="font-size:12px;color:var(--text-faint);margin-top:8px;">
-      AI-powered wildlife photo organizer.
-      <a href="https://github.com/jss367/vireo" style="color:var(--accent);text-decoration:none;">GitHub</a>
-    </div>
-  </div>
-
   <!-- About & Updates -->
   <div class="section" id="updateSection" style="display:none;">
     <div class="section-title">About & Updates</div>
     <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px;">
-      <span style="font-size:13px;color:var(--text-secondary);">Vireo v<span id="currentVersion">0.1.0</span></span>
+      <span style="font-size:13px;color:var(--text-secondary);">Vireo v<span id="currentVersion">-</span></span>
       <button class="btn-sm" id="checkUpdateBtn" onclick="doCheckForUpdate()">Check for Updates</button>
       <span id="updateStatus" style="font-size:12px;color:var(--text-dim);"></span>
     </div>
@@ -2007,8 +1994,6 @@ async function cleanKeywords() {
 async function loadVersion() {
   try {
     var d = await safeFetch('/api/version', {}, { toast: false });
-    var ver = 'v' + d.version;
-    document.getElementById('appVersion').textContent = ver;
     var cv = document.getElementById('currentVersion');
     if (cv) cv.textContent = d.version;
   } catch(e) {}


### PR DESCRIPTION
## Summary
- Remove the "About" section from the settings page (it showed a hardcoded v0.1.0 fallback)
- Add GitHub link and website label to the native Vireo > About Vireo dialog
- Fix the `/api/version` fallback to read from `pyproject.toml` instead of hardcoding `0.1.0`
- Clean up the `currentVersion` HTML fallback and dead `appVersion` JS reference

## Test plan
- [x] All 274 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)