### PR TITLE
fix: consume all key events while cheat sheet is open

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -956,15 +956,16 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   document.addEventListener('keydown', function(e) {
     if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
     if (document.querySelector('.lightbox-overlay.active, .pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open')) return;
-    // Close if overlay is open
-    if (e.key === 'Escape' && document.getElementById('shortcutsCheatSheet').classList.contains('open')) {
-      closeShortcutsSheet();
-      e.stopPropagation();
+    // When overlay is open, consume ALL key events so page handlers don't fire
+    if (document.getElementById('shortcutsCheatSheet').classList.contains('open')) {
+      if (e.key === 'Escape') {
+        closeShortcutsSheet();
+      }
+      e.preventDefault();
+      e.stopImmediatePropagation();
       return;
     }
     if (e.key === '?' && !e.ctrlKey && !e.metaKey && !e.altKey) {
-      // Don't open if shortcuts sheet is already open
-      if (document.getElementById('shortcutsCheatSheet').classList.contains('open')) return;
       e.preventDefault();
       openShortcutsSheet();
     }


### PR DESCRIPTION
Parent PR: #250

## Summary
- When the `?` shortcuts cheat sheet overlay is open, all keydown events are now consumed with `stopImmediatePropagation` so page-specific handlers (review accept/skip, browse rating/flag) cannot fire behind the modal
- Only Escape is handled (to close the overlay); all other keys are blocked

## Test Plan
- [x] 278 tests pass
- [ ] Open cheat sheet with `?` on the review page, press `a`/`s` — should not accept/skip predictions
- [ ] Open cheat sheet with `?` on the browse page, press `1`-`5` — should not rate photos
- [ ] Escape still closes the overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)