### PR TITLE
fix: include ancestor keywords in scoped listing

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1667,22 +1667,42 @@ class Database:
         self.conn.commit()
 
     def get_all_keywords(self):
-        """Return keywords used in the active workspace with photo counts, type, and taxon info."""
+        """Return keywords used in the active workspace (plus ancestors) with photo counts, type, and taxon info."""
         ws = self._ws_id()
         return self.conn.execute(
-            """SELECT k.id, k.name, k.parent_id, k.type, k.taxon_id,
+            """WITH RECURSIVE
+               ws_kw AS (
+                   SELECT DISTINCT pk.keyword_id AS id
+                   FROM photo_keywords pk
+                   JOIN photos p ON p.id = pk.photo_id
+                   JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                   WHERE wf.workspace_id = ?
+               ),
+               ancestors AS (
+                   SELECT id FROM ws_kw
+                   UNION
+                   SELECT k.parent_id
+                   FROM keywords k
+                   JOIN ancestors a ON a.id = k.id
+                   WHERE k.parent_id IS NOT NULL
+               )
+               SELECT k.id, k.name, k.parent_id, k.type, k.taxon_id,
                       k.latitude, k.longitude,
                       t.name AS taxon_name, t.common_name AS taxon_common_name,
-                      COUNT(pk.photo_id) AS photo_count
+                      COUNT(ws_photo.photo_id) AS photo_count
                FROM keywords k
-               JOIN photo_keywords pk ON pk.keyword_id = k.id
-               JOIN photos p ON p.id = pk.photo_id
-               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               JOIN ancestors a ON a.id = k.id
                LEFT JOIN taxa t ON t.id = k.taxon_id
-               WHERE wf.workspace_id = ?
+               LEFT JOIN (
+                   SELECT pk.keyword_id, pk.photo_id
+                   FROM photo_keywords pk
+                   JOIN photos p ON p.id = pk.photo_id
+                   JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                   WHERE wf.workspace_id = ?
+               ) ws_photo ON ws_photo.keyword_id = k.id
                GROUP BY k.id
                ORDER BY k.name""",
-            (ws,),
+            (ws, ws),
         ).fetchall()
 
     # -- Predictions --

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -679,13 +679,15 @@ def test_keyword_duplicates_scoped_by_workspace(app_and_db):
 
 
 def test_all_keywords_scoped_by_workspace(app_and_db):
-    """GET /api/keywords/all only returns keywords used in the active workspace."""
+    """GET /api/keywords/all only returns keywords used in the active workspace, plus ancestors."""
     app, db = app_and_db
     ws_a = db._active_workspace_id
 
-    # Tag a photo in workspace A with keyword "Hawk"
+    # Create parent keyword "Birds" and child "Hawk" under it
+    k_birds = db.add_keyword("Birds")
+    k_hawk = db.add_keyword("Hawk", parent_id=k_birds)
+    # Tag a photo in workspace A with the child only
     photos_a = db.get_photos()
-    k_hawk = db.add_keyword("Hawk")
     db.tag_photo(photos_a[0]["id"], k_hawk)
 
     # Create workspace B with its own folder, photo, and keyword "Penguin"
@@ -704,7 +706,13 @@ def test_all_keywords_scoped_by_workspace(app_and_db):
         resp = c.get("/api/keywords/all")
         data = resp.get_json()
         names = [k["name"] for k in data]
+        # Child keyword tagged in workspace A — present
         assert "Hawk" in names
+        # Parent keyword not tagged but is ancestor of Hawk — present with photo_count=0
+        assert "Birds" in names
+        birds = next(k for k in data if k["name"] == "Birds")
+        assert birds["photo_count"] == 0
+        # Keyword only in workspace B — absent
         assert "Penguin" not in names
 
 


### PR DESCRIPTION
Parent PR: #247

## Summary
- `get_all_keywords()` was dropping untagged parent/ancestor keywords after the workspace scoping change, which broke parent name resolution in the `/keywords` UI (parent column fell back to raw `#<id>`)
- Added the same recursive CTE pattern used by `get_keyword_tree()` to walk up the `parent_id` chain and include ancestors with `photo_count=0`
- Updated test to verify ancestor inclusion

## Test plan
- [x] `test_all_keywords_scoped_by_workspace` now creates a parent→child hierarchy, tags only the child, and asserts the parent appears with `photo_count=0`
- [x] Full suite: 275 passed in 5.31s

🤖 Generated with [Claude Code](https://claude.com/claude-code)