### PR TITLE
fix(ci): add actions:write permission for deploy workflow trigger

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 env:
   PYTHON_VERSION: "3.14"


### PR DESCRIPTION
## Summary
- The `update-website` job in `build-release.yml` calls `gh workflow run deploy-website.yml --ref main` to trigger a website deploy after updating download links
- This API requires `actions: write` permission, but the workflow only had `contents: write`, causing `HTTP 403: Resource not accessible by integration`
- Added `actions: write` to the workflow's permissions block

## Test plan
- [ ] Trigger a release build and verify the "Trigger website deploy" step no longer fails with 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)