### PR TITLE
feat: always-visible browse detail panel with summary dashboard

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -511,6 +511,7 @@ def create_app(db_path, thumb_cache_dir=None):
         date_from = request.args.get("date_from", None)
         date_to = request.args.get("date_to", None)
         keyword = request.args.get("keyword", None)
+        collection_id = request.args.get("collection_id", None, type=int)
         return jsonify(
             db.get_browse_summary(
                 folder_id=folder_id,
@@ -518,6 +519,7 @@ def create_app(db_path, thumb_cache_dir=None):
                 date_from=date_from,
                 date_to=date_to,
                 keyword=keyword,
+                collection_id=collection_id,
             )
         )
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1057,6 +1057,7 @@ class Database:
         date_from=None,
         date_to=None,
         keyword=None,
+        collection_id=None,
     ):
         """Return summary stats for the browse panel, scoped to active workspace and filters."""
         ws = self._ws_id()
@@ -1076,6 +1077,23 @@ class Database:
         if date_to is not None:
             conditions.append("p.timestamp <= ?")
             params.append(date_to)
+
+        # When browsing a collection, restrict photos to those matching the
+        # collection's rules by using a subquery from _build_collection_query.
+        if collection_id is not None:
+            parts = self._build_collection_query(collection_id)
+            if parts is not None:
+                coll_folder_join, coll_join_clause, coll_where, coll_params = parts
+                # Build a subquery that returns the photo IDs in this collection.
+                # Use alias "p" to match the alias expected by _build_collection_query;
+                # the subquery is wrapped in parentheses so "p" is scoped to it and
+                # does not conflict with the outer query's "p" alias.
+                coll_subquery = (
+                    f"SELECT DISTINCT p.id FROM photos p "
+                    f"{coll_folder_join} {coll_join_clause} {coll_where}"
+                )
+                conditions.append(f"p.id IN ({coll_subquery})")
+                params.extend(coll_params)
 
         join_clause = "JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
         if keyword is not None:
@@ -1113,14 +1131,25 @@ class Database:
         ).fetchone()[0]
 
         # Top species (within filter)
+        # Use a CTE to select the single best prediction per photo (highest confidence,
+        # non-rejected) to avoid inflating species counts when multiple models have
+        # predicted different species for the same photo.
         top_species = self.conn.execute(
-            f"""SELECT pred.species, COUNT(DISTINCT p.id) as count
+            f"""WITH best_pred AS (
+                    SELECT pred.photo_id, pred.species,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY pred.photo_id
+                               ORDER BY pred.confidence DESC
+                           ) AS rn
+                    FROM predictions pred
+                    WHERE pred.workspace_id = ? AND pred.status != 'rejected'
+                )
+                SELECT bp.species, COUNT(DISTINCT p.id) as count
                 FROM photos p
                 {join_clause}
-                JOIN predictions pred ON pred.photo_id = p.id
-                    AND pred.workspace_id = ? AND pred.status != 'rejected'
+                JOIN best_pred bp ON bp.photo_id = p.id AND bp.rn = 1
                 {where}
-                GROUP BY pred.species
+                GROUP BY bp.species
                 ORDER BY count DESC
                 LIMIT 5""",
             [ws] + params,

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -909,6 +909,7 @@ var inatSubmitted = {};  // {photo_id: true}
 var filterRating = 0;
 var activeFolderId = null;
 var activeKeyword = null;
+var activeCollectionId = null;
 var timelineMode = false;
 var calendarYear = new Date().getFullYear();
 var selectedDay = null;
@@ -1045,6 +1046,7 @@ function filterByFolder(folderId) {
     activeFolderId = folderId;
   }
   activeKeyword = null;
+  activeCollectionId = null;
   if (timelineMode) loadCalendarData();
   resetAndLoad();
   // Update active state
@@ -1102,6 +1104,7 @@ function filterByKeyword(name) {
     activeKeyword = name;
   }
   activeFolderId = null;
+  activeCollectionId = null;
   document.getElementById('searchInput').value = activeKeyword || '';
   if (timelineMode) loadCalendarData();
   resetAndLoad();
@@ -1137,6 +1140,7 @@ async function loadCollectionCounts() {
 async function filterByCollection(id) {
   activeFolderId = null;
   activeKeyword = null;
+  activeCollectionId = id;
   photos = [];
   currentPage = 1;
   allLoaded = true;  // collections handle their own pagination
@@ -1240,6 +1244,9 @@ function resetAndLoad() {
   allLoaded = false;
   selectedPhotoId = null;
   selectedIndex = -1;
+  // Leaving collection mode when applying non-collection filters (sort, rating,
+  // date, keyword, folder) so the summary stays in sync with the visible grid.
+  activeCollectionId = null;
   closeDetail();
   document.getElementById('grid').innerHTML = '';
   loadPhotos();
@@ -2158,6 +2165,7 @@ async function loadSummary() {
   var search = document.getElementById('searchInput').value.trim();
   if (search) params.set('keyword', search);
   if (activeKeyword) params.set('keyword', activeKeyword);
+  if (activeCollectionId) params.set('collection_id', activeCollectionId);
 
   try {
     var data = await safeFetch('/api/browse/summary?' + params.toString(), {}, { toast: false });
@@ -2435,6 +2443,7 @@ function openInEditorBatch() {
     // Navigate to the photo's folder
     activeFolderId = photo.folder_id;
     activeKeyword = null;
+    activeCollectionId = null;
     photos = [];
     currentPage = 1;
     allLoaded = false;


### PR DESCRIPTION
## Summary

- **Detail panel is now always visible** in the browse page, eliminating the layout shift that occurred when clicking a photo (the grid no longer reflows)
- When no photo is selected, the panel shows a **summary dashboard** with: photo count (filtered vs total), classification stats, top 5 species, and folder breakdown
- Clicking a photo switches to the existing detail view; the close button returns to the summary dashboard
- New `/api/browse/summary` endpoint and `Database.get_browse_summary()` method power the dashboard, respecting all active filters

## Test plan

- [x] All 284 existing tests pass
- [ ] Load browse page — detail panel is visible immediately with summary stats
- [ ] Click a photo — panel switches to photo detail, no grid layout shift
- [ ] Close detail (×) — panel returns to summary dashboard
- [ ] Apply folder/rating/date/keyword filters — summary updates to reflect filtered counts
- [ ] Verify top species and folder breakdown show correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)