### PR TITLE
fix: address Codex review on #255

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1649,6 +1649,8 @@ def create_app(db_path, thumb_cache_dir=None):
         photo_ids = body.get("photo_ids")
         if not photo_ids:
             return jsonify({"error": "photo_ids required"}), 400
+        if not isinstance(photo_ids, list):
+            return jsonify({"error": "photo_ids must be a list"}), 400
 
         db = _get_db()
         folders = {f["id"]: f["path"] for f in db.get_folder_tree()}

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1799,6 +1799,21 @@ async function safeFetch(url, opts, options) {
   return JSON.parse(text);
 }
 
+/* ---------- Open in External Editor ---------- */
+async function openInEditor(photoIds) {
+  if (!photoIds || !photoIds.length) return;
+  try {
+    var data = await safeFetch('/api/photos/open-external', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: photoIds}),
+    });
+    showToast('Opened ' + data.opened + ' photo(s) in editor', 'success');
+  } catch(e) {
+    showToast(e.message || 'Failed to open in editor');
+  }
+}
+
 /* ---------- Safe EventSource ---------- */
 function safeEventSource(url, callbacks) {
   callbacks = callbacks || {};

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2305,20 +2305,6 @@ async function developSelected() {
   }
 }
 
-async function openInEditor(photoIds) {
-  if (!photoIds || !photoIds.length) return;
-  try {
-    var data = await safeFetch('/api/photos/open-external', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({photo_ids: photoIds}),
-    });
-    showToast('Opened ' + data.opened + ' photo(s) in editor');
-  } catch(e) {
-    showToast(e.message || 'Failed to open in editor');
-  }
-}
-
 function openInEditorBatch() {
   var ids = Array.from(selectedPhotos);
   if (!ids.length) return;


### PR DESCRIPTION
Parent PR: #255

Addresses Codex Connect review feedback on #255.

## Changes

**P1 (`_navbar.html`):** Move `openInEditor` from `browse.html` into `_navbar.html` so the lightbox "Open in Editor" button works on all pages (review, cull, variants, etc.) without throwing a `ReferenceError` when the browse-specific scripts are absent.

**P2 (`app.py`):** Add `isinstance(photo_ids, list)` check after the truthiness guard so malformed payloads like `{"photo_ids": 1}` are rejected with a 400 instead of propagating a `TypeError` that returns 500.

## Test results

280 passed, 0 failed.

---
Generated by scheduled PR Agent