### PR TITLE
fix: address codex review on #259

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1084,9 +1084,12 @@ class Database:
             parts = self._build_collection_query(collection_id)
             if parts is not None:
                 coll_folder_join, coll_join_clause, coll_where, coll_params = parts
-                # Build a subquery that returns the photo IDs in this collection
+                # Build a subquery that returns the photo IDs in this collection.
+                # Use alias "p" to match the alias expected by _build_collection_query;
+                # the subquery is wrapped in parentheses so "p" is scoped to it and
+                # does not conflict with the outer query's "p" alias.
                 coll_subquery = (
-                    f"SELECT DISTINCT p2.id FROM photos p2 "
+                    f"SELECT DISTINCT p.id FROM photos p "
                     f"{coll_folder_join} {coll_join_clause} {coll_where}"
                 )
                 conditions.append(f"p.id IN ({coll_subquery})")

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1240,6 +1240,9 @@ function resetAndLoad() {
   allLoaded = false;
   selectedPhotoId = null;
   selectedIndex = -1;
+  // Leaving collection mode when applying non-collection filters (sort, rating,
+  // date, keyword, folder) so the summary stays in sync with the visible grid.
+  activeCollectionId = null;
   closeDetail();
   document.getElementById('grid').innerHTML = '';
   loadPhotos();


### PR DESCRIPTION
Parent PR: #259

Addresses two Codex Connect review comments on #259.

## Changes

### P1: Fix alias mismatch in collection subquery (`db.py`, line 1090)
`_build_collection_query()` emits all JOIN/WHERE clauses using alias `p` for the photos table. The subquery in `get_browse_summary` used `FROM photos p2`, so the injected conditions (e.g. `p.id IN (...)`, `p.rating >= ?`) bound to the **outer** query's `p` alias rather than the inner subquery's table — turning a simple `IN` filter into a correlated subquery that rescans the photos table on every outer row.

Fixed by using `FROM photos p` in the subquery. SQLite scopes aliases to their enclosing parenthesised expression, so the inner `p` does not conflict with the outer `p`.

### P2: Clear stale collection scope in `resetAndLoad()` (`browse.html`)
When sort, rating, date, or keyword filters changed they called `resetAndLoad()`, which loads photos via `/api/photos` (no collection scope). However `activeCollectionId` was left set, so `loadSummary()` still sent `collection_id` and the summary panel showed collection-scoped stats while the grid showed workspace-wide photos.

Fixed by setting `activeCollectionId = null` at the start of `resetAndLoad()`. This aligns summary scope with the grid for all non-collection filter changes. `filterByCollection()` does not call `resetAndLoad()`, so collection mode is unaffected.

## Tests
284 passed, 0 failed

---
Generated by scheduled PR Agent