### PR TITLE
Remove Group & Score card from pipeline page

### DIFF
--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -665,6 +665,7 @@ var _stageToCard = {
   model_loader: 'Classify',
   classify: 'Classify',
   extract_masks: 'Extract',
+  regroup: 'Extract',
 };
 
 // Map pipeline stage names to the progress bar element suffixes


### PR DESCRIPTION
## Summary

- Removed the Group & Score card from the pipeline page — it had no configurable parameters (unlike Source, Classify, and Extract Features), making it dead weight on a configuration form
- Auto-redirects to Pipeline Review (`/pipeline/review`) on successful pipeline completion instead of showing a "View Results" link
- Regroup progress is still visible on the Jobs page via tree-based step visualization

## Changes

All changes are in `vireo/templates/pipeline.html`:
- Removed card HTML, `.view-results-btn` CSS, `runGroupStep()` function
- Removed all JS references: stage maps, reset loop, init block, `_pipelineState.hasResults`, `updateCardStates` check, `_onPipelineComplete` Group block
- Added `window.location.href = '/pipeline/review'` on successful completion (guarded by `succeeded && no errors`)

No backend changes.

## Test plan

- [x] 279 tests pass, 0 failures
- [ ] Run pipeline with import source — verify 3 cards shown (Source, Classify, Extract), no Group card
- [ ] Complete pipeline run — verify auto-redirect to Pipeline Review
- [ ] Pipeline with errors — verify stays on pipeline page showing error

🤖 Generated with [Claude Code](https://claude.com/claude-code)