### PR TITLE
website: configure custom domain vireo.photo

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,6 +1,5 @@
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
-  site: 'https://jss367.github.io',
-  base: '/vireo/',
+  site: 'https://vireo.photo',
 });

--- a/website/public/CNAME
+++ b/website/public/CNAME
@@ -1,0 +1,1 @@
+vireo.photo


### PR DESCRIPTION
## Summary
- Update Astro config to use `https://vireo.photo` as the site URL
- Remove `/vireo/` base path (no longer needed with a custom domain)
- Add `CNAME` file so GitHub Pages serves the site on `vireo.photo`

## Steps after merge
1. Configure DNS on Namecheap (A records + CNAME for www)
2. Enable custom domain in GitHub repo Settings → Pages
3. Enable "Enforce HTTPS"

## Test plan
- [x] `npm run build` succeeds
- [x] CNAME file present in build output (`dist/CNAME`)
- [ ] After merge + DNS setup, verify `https://vireo.photo` loads the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)