### PR TITLE
Fix: route regroup errors to Extract card

### DIFF
--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -665,6 +665,7 @@ var _stageToCard = {
   model_loader: 'Classify',
   classify: 'Classify',
   extract_masks: 'Extract',
+  regroup: 'Extract',
 };
 
 // Map pipeline stage names to the progress bar element suffixes


### PR DESCRIPTION
## Summary

- Maps `regroup` to `'Extract'` in `_stageToCard` so regroup failures surface on the Extract Features card instead of being silently dropped

Addresses review feedback on #261: regroup errors tagged `[regroup]` were lost after removing the Group card since `_onPipelineComplete` only renders errors for stages found in `_stageToCard`.

Parent PR: #261

## Test plan

- [x] 279 tests pass, 0 failures
- [ ] Simulate regroup failure — verify error message appears on Extract card

🤖 Generated with [Claude Code](https://claude.com/claude-code)