### PR TITLE
fix: add missing FakeRunner methods in classify job tests

### DIFF
--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -39,6 +39,12 @@ class FakeRunner:
     def push_event(self, job_id, event_type, data):
         self.events.append((job_id, event_type, data))
 
+    def set_steps(self, job_id, steps):
+        pass
+
+    def update_step(self, job_id, step_id, **kwargs):
+        pass
+
 
 def _make_job(job_id="classify-test"):
     return {


### PR DESCRIPTION
## Summary
- `FakeRunner` in `test_classify_job.py` was missing `set_steps` and `update_step` methods that `classify_job.py` now calls, causing 5 test failures.
- Added no-op stubs matching the pattern already used in `test_pipeline_job.py`.

## Test plan
- [x] All 17 tests in `vireo/tests/test_classify_job.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)