### PR TITLE
fix: CASCADE on detections FK, eliminate NULL detection_id

### DIFF
--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -651,7 +651,11 @@ def _classify_photos(
                     failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results)
                     batch = []
         else:
-            # No detections — classify full image
+            # No detections — create a full-image detection and classify it
+            full_image_det = [{"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+                               "confidence": 0, "category": "animal"}]
+            full_det_ids = db.save_detections(photo["id"], full_image_det,
+                                              detector_model="full-image")
             img, folder_path, image_path = _prepare_image(photo, folders, None)
             if img is None:
                 failed += 1
@@ -659,7 +663,7 @@ def _classify_photos(
 
             batch.append({
                 "photo": photo,
-                "detection_id": None,
+                "detection_id": full_det_ids[0],
                 "folder_path": folder_path,
                 "image_path": image_path,
                 "img": img,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -123,7 +123,7 @@ class Database:
 
             CREATE TABLE IF NOT EXISTS detections (
                 id                INTEGER PRIMARY KEY,
-                photo_id          INTEGER REFERENCES photos(id),
+                photo_id          INTEGER REFERENCES photos(id) ON DELETE CASCADE,
                 workspace_id      INTEGER REFERENCES workspaces(id) ON DELETE CASCADE,
                 box_x             REAL,
                 box_y             REAL,


### PR DESCRIPTION
Parent PR: #263

## Summary

Fixes two issues from Codex code review on #263:

- **Add `ON DELETE CASCADE` to `detections.photo_id` FK** — deleting a photo now cascades through detections→predictions instead of raising FK constraint errors
- **Eliminate NULL `detection_id` predictions** — when MegaDetector is unavailable or finds no animals, the pipeline now creates a synthetic full-image detection (box: 0,0,1,1) so every prediction has a valid detection_id. Previously these would fail the FK constraint or become orphaned from all JOIN-based queries.

## Test Plan

- [x] 309 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)