### PR TITLE
Fix missing GPS, metadata, and file size in RAW+JPEG pairing

### DIFF
--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -147,12 +147,13 @@ def _pair_raw_jpeg_companions(db):
         companion = jpegs[0]
 
         # Transfer metadata from companion to primary if primary lacks it
+        transfer_cols = "timestamp, rating, flag, latitude, longitude, exif_data, focal_length, width, height"
         primary_full = db.conn.execute(
-            "SELECT timestamp, rating, flag FROM photos WHERE id = ?",
+            f"SELECT {transfer_cols} FROM photos WHERE id = ?",
             (primary["id"],),
         ).fetchone()
         companion_full = db.conn.execute(
-            "SELECT timestamp, rating, flag FROM photos WHERE id = ?",
+            f"SELECT {transfer_cols} FROM photos WHERE id = ?",
             (companion["id"],),
         ).fetchone()
 
@@ -167,6 +168,18 @@ def _pair_raw_jpeg_companions(db):
         if primary_full["flag"] == "none" and companion_full["flag"] != "none":
             updates.append("flag = ?")
             params.append(companion_full["flag"])
+        if not primary_full["latitude"] and companion_full["latitude"]:
+            updates.extend(["latitude = ?", "longitude = ?"])
+            params.extend([companion_full["latitude"], companion_full["longitude"]])
+        if not primary_full["exif_data"] and companion_full["exif_data"]:
+            updates.append("exif_data = ?")
+            params.append(companion_full["exif_data"])
+        if not primary_full["focal_length"] and companion_full["focal_length"]:
+            updates.append("focal_length = ?")
+            params.append(companion_full["focal_length"])
+        if not primary_full["width"] and companion_full["width"]:
+            updates.extend(["width = ?", "height = ?"])
+            params.extend([companion_full["width"], companion_full["height"]])
         if updates:
             params.append(primary["id"])
             db.conn.execute(

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1974,7 +1974,10 @@ function renderDetail(photo) {
   // Date, dimensions, file size (always from photo fields)
   if (photo.timestamp) summary += 'Date: ' + photo.timestamp + '<br>';
   if (photo.width && photo.height) summary += 'Size: ' + photo.width + ' x ' + photo.height + '<br>';
-  if (photo.file_size) summary += 'File: ' + Math.round(photo.file_size / 1024) + ' KB<br>';
+  if (photo.file_size) {
+    var sz = photo.file_size;
+    summary += 'File: ' + (sz >= 1048576 ? (sz / 1048576).toFixed(1) + ' MB' : Math.round(sz / 1024) + ' KB') + '<br>';
+  }
   document.getElementById('detailSummary').innerHTML = summary;
 
   // Path

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -665,3 +665,66 @@ def test_extract_dimensions_all_raw_extensions():
         width, height = _extract_dimensions(exif_group, file_group, extension=ext)
         assert width == 8256, f"Failed for {ext}: got width {width}"
         assert height == 5504, f"Failed for {ext}: got height {height}"
+
+
+def test_pair_raw_jpeg_transfers_gps_and_metadata(tmp_path):
+    """Pairing raw+JPEG transfers GPS, exif_data, and focal_length from companion."""
+    import json
+
+    from db import Database
+    from scanner import _pair_raw_jpeg_companions
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+
+    # JPEG has GPS and metadata, RAW does not
+    jpeg_id = db.add_photo(folder_id=fid, filename="IMG.jpg", extension=".jpg",
+                           file_size=1000, file_mtime=1.0)
+    raw_id = db.add_photo(folder_id=fid, filename="IMG.nef", extension=".nef",
+                          file_size=25000000, file_mtime=1.0)
+
+    exif_json = json.dumps({"EXIF": {"Make": "Nikon", "Model": "Z9", "ISO": 400}})
+    db.conn.execute(
+        "UPDATE photos SET latitude=32.88, longitude=-117.25, exif_data=?, focal_length=400.0 WHERE id=?",
+        (exif_json, jpeg_id),
+    )
+    db.conn.commit()
+
+    _pair_raw_jpeg_companions(db)
+
+    photo = db.conn.execute(
+        "SELECT filename, latitude, longitude, exif_data, focal_length FROM photos"
+    ).fetchone()
+    assert photo["filename"] == "IMG.nef"
+    assert photo["latitude"] == 32.88
+    assert photo["longitude"] == -117.25
+    assert photo["focal_length"] == 400.0
+    meta = json.loads(photo["exif_data"])
+    assert meta["EXIF"]["Make"] == "Nikon"
+
+
+def test_pair_raw_jpeg_keeps_primary_gps_when_present(tmp_path):
+    """If RAW already has GPS, companion GPS is not overwritten."""
+    from db import Database
+    from scanner import _pair_raw_jpeg_companions
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+
+    jpeg_id = db.add_photo(folder_id=fid, filename="IMG.jpg", extension=".jpg",
+                           file_size=1000, file_mtime=1.0)
+    raw_id = db.add_photo(folder_id=fid, filename="IMG.cr3", extension=".cr3",
+                          file_size=20000000, file_mtime=1.0)
+
+    # Both have GPS but different coords — primary should keep its own
+    db.conn.execute(
+        "UPDATE photos SET latitude=40.0, longitude=-74.0 WHERE id=?", (jpeg_id,))
+    db.conn.execute(
+        "UPDATE photos SET latitude=32.0, longitude=-117.0 WHERE id=?", (raw_id,))
+    db.conn.commit()
+
+    _pair_raw_jpeg_companions(db)
+
+    photo = db.conn.execute("SELECT latitude, longitude FROM photos").fetchone()
+    assert photo["latitude"] == 32.0
+    assert photo["longitude"] == -117.0


### PR DESCRIPTION
## Summary

- **Fix companion pairing**: `_pair_raw_jpeg_companions()` now transfers GPS coordinates, full EXIF metadata (`exif_data`), focal length, and dimensions from the JPEG companion to the RAW primary when the primary lacks them. Previously these fields were lost when the JPEG record was deleted, causing missing map pins and sparse browse panel info.
- **Fix file size display**: Browse panel now shows MB for files >= 1MB (e.g., "24.5 MB") instead of always using KB (e.g., "25088 KB").

## Test plan

- [x] All 284 existing tests pass
- [x] All 25 scanner tests pass (including 2 new)
- [x] New test: GPS/exif_data/focal_length transferred from JPEG companion to RAW primary
- [x] New test: RAW's own GPS is preserved when both files have coordinates
- [ ] Manual: rescan a folder with RAW+JPEG pairs where JPEG has GPS → verify map shows pins
- [ ] Manual: check browse panel shows camera/lens/exposure info for paired RAW files

🤖 Generated with [Claude Code](https://claude.com/claude-code)