### PR TITLE
fix: scan destination once after all ingests, short-circuit empty previews, use u.folder in audit

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -175,9 +175,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         "stages": {k: dict(v) for k, v in stages.items()},
                     })
 
-            for src_folder in sources:
-                root = src_folder
-                if params.destination:
+            if params.destination:
+                # Copy mode: ingest all sources first, then scan destination once.
+                # Scanning inside the loop would rescan the entire destination on
+                # each iteration, re-queuing unchanged files and inflating counts.
+                for src_folder in sources:
                     do_ingest(
                         source_dir=src_folder,
                         destination_dir=params.destination,
@@ -187,15 +189,23 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         skip_duplicates=params.skip_duplicates,
                         progress_callback=ingest_cb,
                     )
-                    root = params.destination
-
                 do_scan(
-                    root, thread_db,
+                    params.destination, thread_db,
                     progress_callback=progress_cb,
                     incremental=True,
                     extract_full_metadata=pipeline_cfg.get("extract_full_metadata", True),
                     photo_callback=photo_cb,
                 )
+            else:
+                # Scan-in-place: scan each source folder independently.
+                for src_folder in sources:
+                    do_scan(
+                        src_folder, thread_db,
+                        progress_callback=progress_cb,
+                        incremental=True,
+                        extract_full_metadata=pipeline_cfg.get("extract_full_metadata", True),
+                        photo_callback=photo_cb,
+                    )
             stages["scan"]["status"] = "completed"
             runner.update_step(job["id"], "scan", status="completed",
                                summary=f"{stages['scan']['count']} photos")
@@ -319,6 +329,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
             if collection_id:
                 photos = thread_db.get_collection_photos(collection_id, per_page=999999)
+            elif not skip_scan:
+                # Scan ran but produced no photos — skip previews to avoid
+                # unexpectedly processing the entire workspace.
+                runner.update_step(job["id"], "previews", status="completed",
+                                   summary="Skipped (no photos scanned)")
+                stages["previews"]["status"] = "completed"
+                return
             else:
                 photos = thread_db.get_photos(per_page=999999)
 

--- a/vireo/templates/audit.html
+++ b/vireo/templates/audit.html
@@ -312,7 +312,7 @@ async function importAllUntracked() {
 function sendToPipeline() {
   var folders = [];
   untrackedData.forEach(function(u) {
-    var dir = u.path.substring(0, u.path.lastIndexOf('/'));
+    var dir = u.folder;
     if (dir && folders.indexOf(dir) === -1) folders.push(dir);
   });
   var params = folders.map(function(f) { return 'folder=' + encodeURIComponent(f); }).join('&');


### PR DESCRIPTION
Parent PR: #267

## Summary

Addresses all three Codex review comments on #267 (Merge Import page into Pipeline):

### P1: Scan destination once after ingesting all sources (`pipeline_job.py:194`)

In copy mode (`destination` set), `do_scan()` was inside the per-source loop, causing the entire destination folder to be rescanned after every source ingest. Because incremental scans still invoke `photo_callback` for unchanged files, previously processed photos were re-queued and recounted on each pass — inflating runtime and stage counts for multi-folder imports.

Fixed by restructuring the loop: all sources are ingested first, then a single `do_scan()` runs on the destination. Scan-in-place mode (no destination) is unchanged and still scans each source folder independently.

### P2: Skip previews when pipeline produced no collection (`pipeline_job.py:323`)

When a source scan yielded zero photos, `collection_id` remained `None` and the previews stage fell back to `get_photos(per_page=999999)` for the entire workspace — unexpectedly generating previews for unrelated existing photos.

Fixed by adding a short-circuit: when the scan ran but produced no photos (i.e. no collection was created from this run), previews stage completes immediately with `"Skipped (no photos scanned)"`. The pre-existing `collection_id` passthrough path (when a collection is supplied directly) is unaffected.

### P2: Use normalized folder paths for Send to Pipeline (`audit.html:316`)

`sendToPipeline()` derived the directory by splitting `u.path` on `'/'`, which breaks on Windows-style backslash paths and could send empty `folder=` query params. Changed to use `u.folder` directly, which is already present in every untracked-file API response item.

## Test results

284 passed, 0 failed

https://claude.ai/code/session_01JnoSyBX5A43VYdifWgUrhj