### PR TITLE
fix: correct redo order and merge shortcut defaults

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -985,7 +985,7 @@ def create_app(db_path, thumb_cache_dir=None):
         placeholders = ",".join("?" for _ in non_undoable)
         latest = db.conn.execute(
             f"SELECT * FROM edit_history WHERE workspace_id = ? AND undone = 1 AND action_type NOT IN ({placeholders}) "
-            "ORDER BY created_at DESC, id DESC LIMIT 1",
+            "ORDER BY created_at ASC, id ASC LIMIT 1",
             (db._ws_id(), *non_undoable),
         ).fetchone()
         if not latest:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2091,11 +2091,14 @@ class Database:
         return entry
 
     def redo_last_undo(self):
-        """Redo the most recently undone edit. Returns the entry dict, or None."""
+        """Redo the most recently undone edit. Returns the entry dict, or None.
+
+        Replays in chronological order (ASC) so sequential undos are redone correctly.
+        """
         placeholders = ",".join("?" for _ in self._NON_UNDOABLE)
         entry = self.conn.execute(
             f"SELECT * FROM edit_history WHERE workspace_id = ? AND undone = 1 AND action_type NOT IN ({placeholders}) "
-            "ORDER BY created_at DESC, id DESC LIMIT 1",
+            "ORDER BY created_at ASC, id ASC LIMIT 1",
             (self._ws_id(), *self._NON_UNDOABLE),
         ).fetchone()
         if not entry:

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -872,17 +872,17 @@ var calendarData = null;
 var clipSearchActive = false;
 
 var _shortcuts = null;
+var _BROWSE_SC_DEFAULTS = {rate_0:'0',rate_1:'1',rate_2:'2',rate_3:'3',rate_4:'4',rate_5:'5',
+  flag:'p',reject:'x',unflag:'u',undo:'ctrl+z',redo:'ctrl+shift+z',select_all:'ctrl+a',zoom:'z'};
 var _cfgPromise = (async function() {
   try {
     var cfg = await safeFetch('/api/config', {}, { toast: false });
-    _shortcuts = (cfg.keyboard_shortcuts || {}).browse || {
-      rate_0:'0',rate_1:'1',rate_2:'2',rate_3:'3',rate_4:'4',rate_5:'5',
-      flag:'p',reject:'x',unflag:'u',undo:'ctrl+z',redo:'ctrl+shift+z',select_all:'ctrl+a',zoom:'z'};
+    var saved = (cfg.keyboard_shortcuts || {}).browse || {};
+    _shortcuts = Object.assign({}, _BROWSE_SC_DEFAULTS, saved);
     window._vireoShortcuts = cfg.keyboard_shortcuts || {};
     return cfg;
   } catch(e) {
-    _shortcuts = {rate_0:'0',rate_1:'1',rate_2:'2',rate_3:'3',rate_4:'4',rate_5:'5',
-      flag:'p',reject:'x',unflag:'u',undo:'ctrl+z',redo:'ctrl+shift+z',select_all:'ctrl+a',zoom:'z'};
+    _shortcuts = Object.assign({}, _BROWSE_SC_DEFAULTS);
     return null;
   }
 })();


### PR DESCRIPTION
Parent PR: #272

## Summary
- **Redo order**: Changed `ORDER BY created_at DESC, id DESC` to `ASC` in `redo_last_undo()` and `/api/redo/status` so sequential undos are redone in chronological order (fixes P1 review comment)
- **Shortcut defaults merge**: Changed browse shortcut loading to `Object.assign({}, defaults, saved)` so new keys like `redo` work even when users have older saved `keyboard_shortcuts` config that doesn't include them (fixes P2 review comment)

## Test plan
- [x] All 284 tests pass
- [ ] Manual: undo two edits in sequence, verify redo replays them in correct chronological order

🤖 Generated with [Claude Code](https://claude.com/claude-code)