### PR TITLE
fix: hide update UI since updater backend is disabled

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2488,7 +2488,5 @@ function formatDuration(seconds) {
 <script src="/static/vireo-utils.js"></script>
 <script src="/static/tauri-bridge.js"></script>
 <script>
-  if (typeof startupUpdateCheck === 'function') {
-    startupUpdateCheck(24);
-  }
+  /* Updater disabled — startupUpdateCheck skipped until updater is configured */
 </script>

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1826,12 +1826,7 @@ async function browseForOutputDir() {
 }
 
 /* ---------- Auto-Update (Tauri only) ---------- */
-(function() {
-  if (typeof isTauri === 'function' && isTauri()) {
-    var section = document.getElementById('updateSection');
-    if (section) section.style.display = '';
-  }
-})();
+/* Updater disabled — no update commands registered. Section stays hidden. */
 
 async function doCheckForUpdate() {
   var btn = document.getElementById('checkUpdateBtn');


### PR DESCRIPTION
## Summary

- Keep the Settings "About & Updates" section hidden (removed the IIFE that unhides it for Tauri builds)
- Skip the `startupUpdateCheck()` call in `_navbar.html`
- This prevents the frontend from calling the removed `check_for_update` / `install_update` Tauri commands

Parent PR: #273

## Test plan

- [x] 284 tests pass
- [ ] Settings page no longer shows "About & Updates" section in Tauri build
- [ ] No console errors on startup from missing update commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)