### PR TITLE
feat: add thumbnail size slider to pipeline review panel

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -161,7 +161,7 @@ body { padding-bottom: 36px; }
 /* Photo cards */
 .photo-card {
   flex-shrink: 0;
-  width: 160px;
+  width: var(--photo-card-size, 160px);
   border-radius: 6px;
   overflow: hidden;
   border: 2px solid transparent;
@@ -949,6 +949,11 @@ input[type="range"]::-moz-range-thumb {
       <button class="filter-btn" data-filter="KEEP" onclick="setFilter('KEEP')">Keep<span class="count" id="countKeep"></span></button>
       <button class="filter-btn" data-filter="REVIEW" onclick="setFilter('REVIEW')">Review<span class="count" id="countReview"></span></button>
       <button class="filter-btn" data-filter="REJECT" onclick="setFilter('REJECT')">Reject<span class="count" id="countReject"></span></button>
+      <div class="confidence-slider-wrap" title="Thumbnail size">
+        <span>&#9638;</span>
+        <input type="range" id="thumbSizeSlider" min="100" max="320" step="20" value="160"
+               oninput="updateThumbSize(this.value)">
+      </div>
       <div class="confidence-slider-wrap">
         <label for="confSlider">Min confidence:</label>
         <input type="range" id="confSlider" min="0" max="100" value="40" oninput="setMinConfidence(this.value)">
@@ -1152,6 +1157,10 @@ function setFilter(f) {
 }
 
 var _confTimer = null;
+
+function updateThumbSize(val) {
+  document.getElementById('encountersContainer').style.setProperty('--photo-card-size', val + 'px');
+}
 
 function setMinConfidence(val) {
   minConfidence = parseInt(val, 10);


### PR DESCRIPTION
## Summary
- Adds an image size slider to the pipeline review filter bar, matching the one in the browse panel
- Photo card width now uses a CSS variable (`--photo-card-size`) instead of a hardcoded `160px`
- Slider range: 100px–320px in 20px steps

## Test plan
- [x] All 297 tests pass
- [ ] Open pipeline review page, verify slider appears in filter bar next to confidence slider
- [ ] Drag slider and confirm photo cards resize smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)