### PR TITLE
fix: re-render species filter on confidence slider change

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1245,6 +1245,7 @@ function updateThumbSize(val) {
 function setMinConfidence(val) {
   minConfidence = parseInt(val, 10);
   document.getElementById('confSliderVal').textContent = minConfidence + '%';
+  if (speciesFilter) renderResults();
   clearTimeout(_confTimer);
   _confTimer = setTimeout(function() {
     fetch('/api/workspaces/active/config')


### PR DESCRIPTION
Parent PR: #282

## Summary
- When a species filter is active, moving the confidence slider now triggers `renderResults()` so encounter visibility updates in real time
- Addresses Codex review feedback on #282: `setMinConfidence` didn't re-render when species filter was active

## Test plan
- [ ] Set a species filter (e.g. "sparrow"), then move the confidence slider — encounters should update immediately
- [ ] Without a species filter active, verify the confidence slider still works as before (no unnecessary re-renders)
- [ ] `python -m pytest` — all 297 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)