### PR TITLE
fix: validate browse_card_fields config type

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -959,7 +959,7 @@ function applyBrowseConfig(cfg) {
       slider.dispatchEvent(new Event('input'));
     }
   }
-  if (cfg.browse_card_fields) cardFields = cfg.browse_card_fields;
+  if (Array.isArray(cfg.browse_card_fields)) cardFields = cfg.browse_card_fields;
 }
 
 function formatFileSize(bytes) {


### PR DESCRIPTION
## Summary
- Add `Array.isArray()` guard before assigning `browse_card_fields` from config, falling back to defaults if the value is not an array

Addresses review feedback from #285.

Parent PR: #285

## Test plan
- [x] All 297 tests pass
- [ ] Manually corrupt `browse_card_fields` in config.json to a string — verify browse grid still renders with defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)