### PR TITLE
fix: undo/redo sibling restoration and group info scoping

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2232,11 +2232,11 @@ class Database:
         return [(row["id"], row["embedding"]) for row in rows]
 
     def update_prediction_group_info(self, detection_id, model, group_id, vote_count, total_votes, individual):
-        """Update group info on an existing prediction."""
+        """Update group info on an existing prediction (primary only, not alternatives)."""
         self.conn.execute(
             """UPDATE predictions
                SET group_id=?, vote_count=?, total_votes=?, individual=?
-               WHERE detection_id=? AND model=?""",
+               WHERE detection_id=? AND model=? AND status != 'alternative'""",
             (group_id, vote_count, total_votes, individual, detection_id, model),
         )
         self.conn.commit()
@@ -2549,7 +2549,33 @@ class Database:
                 if kw:
                     self.remove_pending_changes(pid, 'keyword_add', kw['name'])
                 if entry['action_type'] == 'prediction_accept' and old_val:
-                    self.update_prediction_status(int(old_val), 'pending')
+                    pred_id = int(old_val)
+                    # Restore the accepted prediction and its siblings
+                    pred_row = self.conn.execute(
+                        "SELECT detection_id, model FROM predictions WHERE id = ?",
+                        (pred_id,),
+                    ).fetchone()
+                    if pred_row:
+                        # Set all siblings to 'alternative' first
+                        self.conn.execute(
+                            """UPDATE predictions SET status = 'alternative'
+                               WHERE detection_id = ? AND model = ?
+                               AND status IN ('accepted', 'rejected')""",
+                            (pred_row["detection_id"], pred_row["model"]),
+                        )
+                        # Promote highest-confidence one to 'pending'
+                        top = self.conn.execute(
+                            """SELECT id FROM predictions
+                               WHERE detection_id = ? AND model = ?
+                               ORDER BY confidence DESC LIMIT 1""",
+                            (pred_row["detection_id"], pred_row["model"]),
+                        ).fetchone()
+                        if top:
+                            self.conn.execute(
+                                "UPDATE predictions SET status = 'pending' WHERE id = ?",
+                                (top["id"],),
+                            )
+                        self.conn.commit()
             elif entry['action_type'] == 'keyword_remove':
                 self.tag_photo(pid, int(entry['new_value']))
                 kw = self.conn.execute("SELECT name FROM keywords WHERE id = ?",
@@ -2577,7 +2603,21 @@ class Database:
                 if kw:
                     self.queue_change(pid, 'keyword_add', kw['name'])
                 if entry['action_type'] == 'prediction_accept' and item['old_value']:
-                    self.update_prediction_status(int(item['old_value']), 'accepted')
+                    pred_id = int(item['old_value'])
+                    self.update_prediction_status(pred_id, 'accepted')
+                    # Re-reject siblings (mirrors accept_prediction behavior)
+                    pred_row = self.conn.execute(
+                        "SELECT detection_id, model FROM predictions WHERE id = ?",
+                        (pred_id,),
+                    ).fetchone()
+                    if pred_row:
+                        self.conn.execute(
+                            """UPDATE predictions SET status = 'rejected'
+                               WHERE detection_id = ? AND model = ? AND id != ?
+                               AND status IN ('pending', 'alternative')""",
+                            (pred_row["detection_id"], pred_row["model"], pred_id),
+                        )
+                        self.conn.commit()
             elif entry['action_type'] == 'keyword_remove':
                 self.untag_photo(pid, int(entry['new_value']))
                 kw = self.conn.execute("SELECT name FROM keywords WHERE id = ?",


### PR DESCRIPTION
Parent PR: #284

## Summary

- **P1 fix**: Undo/redo prediction acceptance now properly restores sibling predictions. Undo sets all siblings to `alternative`, then promotes the highest-confidence one to `pending`. Redo re-rejects siblings to match the original accept behavior.
- **P2 fix**: `update_prediction_group_info` now filters by `status != 'alternative'` so group metadata only applies to the primary prediction, not alternatives.

## Test Plan

- [x] All 332 tests pass
- [ ] Manual: accept a prediction with alternatives, undo, verify alternatives are restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)