### PR TITLE
fix: strict assertion for duplicate prediction merge test

### DIFF
--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -445,7 +445,7 @@ def test_pairing_merges_predictions_without_unique_violation(tmp_path):
 
 
 def test_pairing_merges_duplicate_predictions_keeps_higher_confidence(tmp_path):
-    """When both raw and JPEG have predictions for the same model, keep higher confidence."""
+    """When both raw and JPEG have predictions, both detections transfer to primary."""
     from db import Database
 
     img_dir = tmp_path / "photos"
@@ -492,10 +492,11 @@ def test_pairing_merges_duplicate_predictions_keeps_higher_confidence(tmp_path):
            WHERE d.photo_id = ?""",
         (photos[0]["id"],),
     ).fetchall()
-    # Should keep the higher-confidence prediction
-    assert len(preds) >= 1
-    best = max(p["confidence"] for p in preds)
-    assert best == 0.95
+    # Both detections (and their predictions) transfer to the primary photo.
+    # UNIQUE(detection_id, model) doesn't conflict since detection IDs differ.
+    assert len(preds) == 2
+    confidences = sorted(p["confidence"] for p in preds)
+    assert confidences == [0.70, 0.95]
 
 
 def test_pairing_transfers_inat_submissions(tmp_path):


### PR DESCRIPTION
Parent PR: #288

## Summary
- Addresses Codex review feedback: restores strict assertion in `test_pairing_merges_duplicate_predictions_keeps_higher_confidence`
- In the detection-based schema, pairing transfers both detections to the primary photo — `UNIQUE(detection_id, model)` doesn't conflict since detection IDs differ
- Changed `assert len(preds) >= 1` to `assert len(preds) == 2` with exact confidence values checked

## Test plan
- [x] Updated test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)