### PR TITLE
Add browse button for custom model weights path

### DIFF
--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -56,6 +56,7 @@
                style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:12px;flex:1;">
         <input type="text" id="customModelPath" placeholder="/path/to/weights.bin"
                style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:12px;flex:2;">
+        <button onclick="browseForWeights()" class="tauri-only" style="display:none;background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:4px;padding:6px 14px;font-size:12px;cursor:pointer;white-space:nowrap;">Browse&hellip;</button>
         <button onclick="addCustomModel()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:4px;padding:6px 14px;font-size:12px;cursor:pointer;">Add</button>
       </div>
     </div>
@@ -1897,6 +1898,13 @@ async function browseForOutputDir() {
   if (path) {
     document.getElementById('cfgDarktableOutputDir').value = path;
     saveConfig();
+  }
+}
+
+async function browseForWeights() {
+  var path = await pickFile({ title: 'Select model weights file' });
+  if (path) {
+    document.getElementById('customModelPath').value = path;
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds a Tauri-only "Browse…" file picker button next to the custom model weights input on the Settings page
- Follows the existing pattern used by `browseForDarktable` and `browseForOutputDir` on the same page
- The button is hidden in web mode and only appears in the Tauri desktop app

## Test plan
- [x] All 307 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)