### PR TITLE
fix: CLIP text search bugs — no results and stuck grid

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5349,14 +5349,22 @@ def create_app(db_path, thumb_cache_dir=None):
         from models import get_active_model
         active_model = get_active_model()
         if not active_model:
-            return jsonify({"results": [], "total_matches": 0, "model_used": None})
+            return jsonify({"results": [], "total_matches": 0, "model_used": None,
+                            "reason": "no_model"})
 
         model_name = active_model["name"]
+        model_type = active_model.get("model_type", "bioclip")
+
+        # timm models don't produce CLIP embeddings — text search unsupported
+        if model_type == "timm":
+            return jsonify({"results": [], "total_matches": 0, "model_used": model_name,
+                            "reason": "model_no_text_search"})
 
         # Load embeddings for current model
         emb_pairs = db.get_embeddings_by_model(model_name)
         if not emb_pairs:
-            return jsonify({"results": [], "total_matches": 0, "model_used": model_name})
+            return jsonify({"results": [], "total_matches": 0, "model_used": model_name,
+                            "reason": "no_embeddings"})
 
         # Encode query text
         from text_encoder import encode_text

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1577,7 +1577,10 @@ function toggleDetectionBoxes() {
 
 async function runClipSearch() {
   var query = document.getElementById('clipSearchInput').value.trim();
-  if (!query) return;
+  if (!query) {
+    if (clipSearchActive) clearClipSearch();
+    return;
+  }
 
   photos = [];
   allLoaded = true;
@@ -1597,6 +1600,16 @@ async function runClipSearch() {
     params.set('limit', 100);
     params.set('threshold', 0.15);
     var data = await safeFetch('/api/photos/search?' + params.toString());
+
+    if (data.reason) {
+      var msg = {
+        'model_no_text_search': 'Text search is not supported by ' + (data.model_used || 'this model') + '. Switch to a BioCLIP model in Settings.',
+        'no_embeddings': 'No search index found for ' + (data.model_used || 'this model') + '. Run classification first to enable text search.',
+        'no_model': 'No model available. Download one in Settings.'
+      }[data.reason] || 'Search returned no results.';
+      document.getElementById('loadingState').textContent = msg;
+      return;
+    }
 
     photos = data.results.map(function(r) {
       var p = r.photo;

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -610,6 +610,51 @@ def test_text_search_no_active_model(app_and_db):
     assert data["total_matches"] == 0
 
 
+def test_text_search_timm_model_returns_unsupported(app_and_db, monkeypatch):
+    """Text search returns error when active model is timm (no CLIP embeddings)."""
+    app, _ = app_and_db
+    client = app.test_client()
+    monkeypatch.setattr(
+        "models.get_active_model",
+        lambda: {
+            "name": "iNat21 (EVA-02 Large)",
+            "model_type": "timm",
+            "model_str": "hf-hub:timm/eva02",
+            "downloaded": True,
+        },
+    )
+    resp = client.get("/api/photos/search?q=bird+on+water")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["results"] == []
+    assert data["total_matches"] == 0
+    # Should indicate text search is not supported for this model type
+    assert data.get("reason") == "model_no_text_search"
+
+
+def test_text_search_no_embeddings_returns_reason(app_and_db, monkeypatch):
+    """Text search explains when no embeddings exist for the active model."""
+    app, _ = app_and_db
+    client = app.test_client()
+    monkeypatch.setattr(
+        "models.get_active_model",
+        lambda: {
+            "name": "BioCLIP-2",
+            "model_type": "bioclip",
+            "model_str": "hf-hub:imageomics/bioclip-2",
+            "weights_path": "/fake/path",
+            "downloaded": True,
+        },
+    )
+    resp = client.get("/api/photos/search?q=bird+on+water")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["results"] == []
+    assert data["total_matches"] == 0
+    # Should indicate no embeddings exist for this model
+    assert data.get("reason") == "no_embeddings"
+
+
 def test_settings_has_edit_history_config(app_and_db):
     """Settings page includes the max_edit_history config field."""
     app, _ = app_and_db


### PR DESCRIPTION
## Summary

- **Search with no results gave no explanation**: The `/api/photos/search` endpoint now returns a `reason` field (`model_no_text_search`, `no_embeddings`, `no_model`) so the frontend can display a helpful message — e.g. "Text search is not supported by iNat21. Switch to a BioCLIP model in Settings." or "No search index found. Run classification first."
- **Stuck grid after clearing search text**: Clicking the search button with an empty query while a CLIP search was active silently returned without resetting state, leaving the grid empty with no way to recover. Now clears the search and reloads photos.

## Test plan

- [x] All 309 existing tests pass
- [x] New tests: `test_text_search_timm_model_returns_unsupported`, `test_text_search_no_embeddings_returns_reason`
- [ ] Manual: Search with a timm model active → should show "not supported" message
- [ ] Manual: Search "birds on water", clear the text, click Search → photos should reappear
- [ ] Manual: Search with BioCLIP active but no embeddings → should show "run classification" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)