### PR TITLE
Add taxonomy download option to pipeline

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -436,11 +436,15 @@ def create_app(db_path, thumb_cache_dir=None):
             except Exception:
                 pass
 
+        taxonomy_path = os.path.join(os.path.dirname(__file__), "taxonomy.json")
+        taxonomy_available = os.path.exists(taxonomy_path)
+
         return jsonify({
             "total_photos": total_photos,
             "has_detections": pipeline_counts["detections"],
             "has_masks": pipeline_counts["masks"],
             "has_sharpness": pipeline_counts["sharpness"],
+            "taxonomy_available": taxonomy_available,
             "pipeline_config": {
                 "sam2_variant": pipeline_cfg.get("sam2_variant", "sam2-small"),
                 "dinov2_variant": pipeline_cfg.get("dinov2_variant", "vit-b14"),
@@ -4798,6 +4802,7 @@ def create_app(db_path, thumb_cache_dir=None):
             model_id=body.get("model_id"),
             reclassify=body.get("reclassify", False),
             skip_classify=body.get("skip_classify", False),
+            download_taxonomy=body.get("download_taxonomy", True),
             skip_extract_masks=body.get("skip_extract_masks", False),
             skip_regroup=body.get("skip_regroup", False),
             preview_max_size=body.get("preview_max_size", 1920),

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -42,6 +42,7 @@ class PipelineParams:
     skip_extract_masks: bool = False
     skip_regroup: bool = False
     skip_classify: bool = False
+    download_taxonomy: bool = True
     preview_max_size: int = 1920
 
 
@@ -437,8 +438,27 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             model_type = active_model.get("model_type", "bioclip")
             model_name = active_model["name"]
 
-            # Load taxonomy
+            # Download taxonomy if missing and requested
             taxonomy_path = os.path.join(os.path.dirname(__file__), "taxonomy.json")
+            if params.download_taxonomy and not os.path.exists(taxonomy_path):
+                try:
+                    from taxonomy import download_taxonomy
+                    runner.push_event(job["id"], "progress", {
+                        "phase": "Downloading taxonomy...",
+                        "current": 0, "total": 0,
+                        "stages": {k: dict(v) for k, v in stages.items()},
+                    })
+                    download_taxonomy(taxonomy_path, progress_callback=lambda msg:
+                        runner.push_event(job["id"], "progress", {
+                            "phase": msg,
+                            "current": 0, "total": 0,
+                            "stages": {k: dict(v) for k, v in stages.items()},
+                        })
+                    )
+                except Exception as e:
+                    log.warning("Taxonomy download failed, continuing without: %s", e)
+
+            # Load taxonomy
             tax = _load_taxonomy(taxonomy_path)
 
             # Load labels

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -463,6 +463,15 @@ body { padding-bottom: 36px; }
       <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;">
         <input type="checkbox" id="chkReclassify" style="accent-color:var(--accent);"> Re-classify
       </label>
+      <div style="margin-top:8px;">
+        <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;">
+          <input type="checkbox" id="chkDownloadTaxonomy" checked style="accent-color:var(--accent);"> Download taxonomy if missing
+        </label>
+        <div style="font-size:11px;color:var(--text-faint);margin-top:2px;margin-left:20px;">
+          Adds taxonomic hierarchy to predictions (order, family, genus) and enables group filtering.
+          Classification works without it.
+        </div>
+      </div>
       <span class="status-msg" id="statusClassify"></span>
       <div class="progress-wrap" id="progressClassify" style="display:none;">
         <div class="progress-bar-track"><div class="progress-bar-fill" id="fillClassify"></div></div>
@@ -585,6 +594,12 @@ function initPipelinePage() {
         var txt = data.has_masks + ' masks';
         if (data.has_sharpness) txt += ', ' + data.has_sharpness + ' sharpness';
         document.getElementById('txtMasks').textContent = txt;
+      }
+
+      // Hide taxonomy checkbox if already downloaded
+      if (data.taxonomy_available) {
+        var taxWrap = document.getElementById('chkDownloadTaxonomy').closest('div');
+        if (taxWrap) taxWrap.style.display = 'none';
       }
 
       // Config selects and range
@@ -862,6 +877,7 @@ async function startPipeline() {
     if (labelsFiles.length > 0) body.labels_files = labelsFiles;
 
     body.reclassify = !!document.getElementById('chkReclassify').checked;
+    body.download_taxonomy = !!document.getElementById('chkDownloadTaxonomy').checked;
   }
 
   // Reset all stage cards to pending state


### PR DESCRIPTION
## Summary
- Adds a "Download taxonomy if missing" checkbox to the Classify stage in the pipeline, checked by default
- When taxonomy.json doesn't exist and the box is checked, it auto-downloads during model loading before classification
- If taxonomy is already downloaded, the checkbox is hidden on page load
- Download failure is non-fatal — classification continues without taxonomy
- Includes a brief explanation: "Adds taxonomic hierarchy to predictions (order, family, genus) and enables group filtering. Classification works without it."

## Changes
- `vireo/templates/pipeline.html` — checkbox UI + hide logic on page init + sends `download_taxonomy` flag
- `vireo/pipeline_job.py` — new `download_taxonomy` param on `PipelineParams`, download step before `_load_taxonomy`
- `vireo/app.py` — passes `download_taxonomy` to params, adds `taxonomy_available` to page-init response

## Test plan
- [ ] Open Pipeline page without taxonomy downloaded — verify checkbox shows with hint text
- [ ] Run pipeline with checkbox checked — verify taxonomy downloads then classification proceeds
- [ ] Run pipeline with checkbox unchecked — verify classification works without taxonomy
- [ ] Open Pipeline page with taxonomy already downloaded — verify checkbox is hidden
- [x] All 307 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)