### PR TITLE
fix: restore continue-on-error for Windows/Linux, guard find under pipefail

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -211,7 +211,8 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           APP="src-tauri/target/${{ matrix.rust-target }}/release/bundle/macos/Vireo.app"
-          DMG=$(find src-tauri/target/${{ matrix.rust-target }}/release/bundle/dmg -name "*.dmg" 2>/dev/null | head -1)
+          DMG_DIR="src-tauri/target/${{ matrix.rust-target }}/release/bundle/dmg"
+          DMG=$(find "$DMG_DIR" -name "*.dmg" 2>/dev/null | head -1 || true)
 
           echo "::group::Build artifacts"
           echo "--- .app bundle ---"
@@ -256,9 +257,10 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          DMG=$(find src-tauri/target/${{ matrix.rust-target }}/release/bundle/dmg -name "*.dmg" | head -1)
+          DMG_DIR="src-tauri/target/${{ matrix.rust-target }}/release/bundle/dmg"
+          DMG=$(find "$DMG_DIR" -name "*.dmg" 2>/dev/null | head -1 || true)
           if [ -z "$DMG" ]; then
-            echo "::error::No DMG found after build"
+            echo "::error::No DMG found in $DMG_DIR"
             exit 1
           fi
           echo "Submitting for notarization: $DMG"
@@ -282,7 +284,8 @@ jobs:
       - name: Verify macOS code signing
         if: runner.os == 'macOS'
         run: |
-          DMG=$(find src-tauri/target/${{ matrix.rust-target }}/release/bundle/dmg -name "*.dmg" | head -1)
+          DMG_DIR="src-tauri/target/${{ matrix.rust-target }}/release/bundle/dmg"
+          DMG=$(find "$DMG_DIR" -name "*.dmg" 2>/dev/null | head -1 || true)
           APP="src-tauri/target/${{ matrix.rust-target }}/release/bundle/macos/Vireo.app"
 
           echo "::group::Final .app verification"
@@ -300,9 +303,13 @@ jobs:
           echo ""
           echo "=== All verifications passed ==="
 
-      # Windows/Linux: no signing needed
+      # Windows/Linux: no signing needed.
+      # continue-on-error because Tauri can exit non-zero after producing
+      # valid installers (e.g. post-bundle steps fail). The upload step
+      # must still run to capture .msi/.AppImage/.deb artifacts.
       - name: Build Tauri app (Windows/Linux)
         if: runner.os != 'macOS'
+        continue-on-error: true
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Addresses review feedback on #294 and #296.

Parent PR: #296

**P1 from #294 — Windows/Linux artifact loss:**
The new `Build Tauri app (Windows/Linux)` step had no `continue-on-error`, so if Tauri exits non-zero after producing valid installers (known behavior with post-bundle steps), the upload step wouldn't run and artifacts would be lost. Added `continue-on-error: true` back for this step only. macOS intentionally has no fallback.

**P2 from #296 — find fails silently under pipefail:**
`find .../dmg -name "*.dmg" | head -1` exits non-zero under `bash -eo pipefail` when the `dmg/` directory doesn't exist, killing the step before it can print the error message. Added `2>/dev/null` and `|| true` guards to all DMG discovery commands.

## Test plan
- [ ] Verify YAML is valid (done locally)
- [ ] Windows/Linux builds should still upload artifacts even if tauri-action exits non-zero
- [ ] If DMG directory is missing, diagnostic step should print error instead of dying silently

Generated with [Claude Code](https://claude.com/claude-code)