### PR TITLE
fix: update-website job skipped on build cancellations

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -277,7 +277,7 @@ jobs:
   update-website:
     needs: [build, release]
     runs-on: ubuntu-latest
-    if: needs.release.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag_name != '')
+    if: "!cancelled() && needs.release.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag_name != '')"
 
     steps:
       - name: Checkout repository

--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -6,9 +6,9 @@ const base = import.meta.env.BASE_URL;
 const releaseUrl = (v: string) => `https://github.com/jss367/vireo/releases/download/v${v}`;
 
 // Per-platform versions — updated independently by CI when each platform builds
-const macosArm64Version = '0.6.14';
-const macosX86Version = '0.6.14';
-const windowsVersion = '0.6.14';
+const macosArm64Version = '0.6.15';
+const macosX86Version = '0.6.15';
+const windowsVersion = '0.6.15';
 const linuxVersion = '0.6.4';
 ---
 


### PR DESCRIPTION
## Summary
- Add `!cancelled()` to the `update-website` job's `if` condition in `build-release.yml` so it runs even when one platform build is cancelled (e.g., Linux). Previously, a cancelled matrix entry caused GitHub Actions to skip the job entirely without evaluating the condition.
- Update `download.astro` to v0.6.15 for macOS and Windows — the platforms that built successfully in the v0.6.15 release.

## Test plan
- [ ] Verify the download page at vireo.photo/download shows v0.6.15 after merge and deploy
- [ ] On next release, if a platform build is cancelled, confirm the `update-website` job still runs for successful platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)