### PR TITLE
feat: show active job count in navbar Jobs link

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2246,13 +2246,15 @@ function formatDuration(seconds) {
         });
     }
 
-    // Always poll once for navbar badge; slow background poll keeps it current
+    // Always poll once for navbar badge
     pollJobs();
-    _navJobPollTimer = setInterval(pollJobs, 15000);
 
-    // Fast poll when panel is open
     if (panelOpen) {
+      // Fast poll when panel is open; no slow poll needed
       _jobPollTimer = setInterval(pollJobs, 2000);
+    } else {
+      // Slow background poll keeps navbar badge current
+      _navJobPollTimer = setInterval(pollJobs, 15000);
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds a running job count badge to the navbar "Jobs" link, showing e.g. "Jobs (3)" when jobs are active
- Adds a slow background poll (every 15s) so the badge stays current even when the bottom panel is closed
- When the bottom panel is open, the existing fast 2s poll updates the badge; the slow poll pauses to avoid double-polling
- Badge disappears when no jobs are running (just shows "Jobs")

## Test plan
- [x] All 309 existing tests pass
- [ ] Start a job (scan, classify, etc.) and verify the navbar shows "Jobs (N)"
- [ ] Verify the count updates when jobs start/complete
- [ ] Verify badge disappears when all jobs finish
- [ ] Verify toggling the bottom panel doesn't cause duplicate polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)