### PR TITLE
fix: browse summary schema, thread-safe DB, open_clip bundling

### DIFF
--- a/scripts/build_sidecar.py
+++ b/scripts/build_sidecar.py
@@ -72,6 +72,21 @@ def main():
     sep = ";" if platform.system() == "Windows" else ":"
     vireo_dir = os.path.join(repo_root, "vireo")
 
+    # Locate open_clip package directory for bundling its data files
+    open_clip_data_args = []
+    try:
+        import importlib.util
+        spec = importlib.util.find_spec("open_clip")
+        if spec and spec.origin:
+            open_clip_dir = os.path.dirname(spec.origin)
+            bpe_file = os.path.join(open_clip_dir, "bpe_simple_vocab_16e6.txt.gz")
+            if os.path.exists(bpe_file):
+                open_clip_data_args = [
+                    "--add-data", f"{bpe_file}{sep}open_clip",
+                ]
+    except ImportError:
+        pass
+
     pyinstaller_args = [
         sys.executable, "-m", "PyInstaller",
         "--onefile",
@@ -114,7 +129,7 @@ def main():
         "--hidden-import", "timm_classifier",
         "--hidden-import", "xmp",
         "--hidden-import", "catalog",
-    ]
+    ] + open_clip_data_args
 
     if args.ci:
         # Exclude packages that bloat the binary but aren't needed at runtime

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -19,6 +19,7 @@ from db import Database
 from flask import (
     Flask,
     Response,
+    g,
     jsonify,
     make_response,
     redirect,
@@ -178,10 +179,16 @@ def create_app(db_path, thumb_cache_dir=None):
         return jsonify({"error": msg}), status
 
     def _get_db():
-        """Get a Database instance. Creates a new connection per request."""
-        if not hasattr(app, "_db") or app._db is None:
-            app._db = Database(db_path)
-        return app._db
+        """Get a Database instance. One connection per request via Flask g."""
+        if "db" not in g:
+            g.db = Database(db_path)
+        return g.db
+
+    @app.teardown_appcontext
+    def _close_db(exc):
+        db = g.pop("db", None)
+        if db is not None:
+            db.conn.close()
 
     @app.route("/api/health")
     def api_health():

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1258,7 +1258,8 @@ class Database:
         classified = self.conn.execute(
             f"""SELECT COUNT(DISTINCT p.id) FROM photos p
                 {join_clause}
-                JOIN predictions pred ON pred.photo_id = p.id AND pred.workspace_id = ?
+                JOIN detections det ON det.photo_id = p.id AND det.workspace_id = ?
+                JOIN predictions pred ON pred.detection_id = det.id
                 {where}""",
             [ws] + params,
         ).fetchone()[0]
@@ -1269,13 +1270,14 @@ class Database:
         # predicted different species for the same photo.
         top_species = self.conn.execute(
             f"""WITH best_pred AS (
-                    SELECT pred.photo_id, pred.species,
+                    SELECT det.photo_id, pred.species,
                            ROW_NUMBER() OVER (
-                               PARTITION BY pred.photo_id
+                               PARTITION BY det.photo_id
                                ORDER BY pred.confidence DESC
                            ) AS rn
                     FROM predictions pred
-                    WHERE pred.workspace_id = ? AND pred.status != 'rejected'
+                    JOIN detections det ON det.id = pred.detection_id
+                    WHERE det.workspace_id = ? AND pred.status != 'rejected'
                 )
                 SELECT bp.species, COUNT(DISTINCT p.id) as count
                 FROM photos p


### PR DESCRIPTION
## Summary
- Browse summary 500: get_browse_summary referenced pred.photo_id which doesn't exist in the current schema. Fixed to join through detections table.
- Thread-safety 500: _get_db() cached a single Database instance shared across Flask threads. Fixed by using Flask g for per-request connections.
- PyInstaller model loader: open_clip bpe vocab file wasn't bundled. Added --add-data directive to build_sidecar.py.

## Test plan
- [x] All 309 existing tests pass
- [ ] Verify /browse page loads without 500 on /api/browse/summary
- [ ] Verify rapid page navigation doesn't produce InterfaceError 500s
- [ ] Verify packaged build can load classification models