### PR TITLE
fix: avoid duplicate job polling when panel starts open

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2246,13 +2246,15 @@ function formatDuration(seconds) {
         });
     }
 
-    // Always poll once for navbar badge; slow background poll keeps it current
+    // Always poll once for navbar badge
     pollJobs();
-    _navJobPollTimer = setInterval(pollJobs, 15000);
 
-    // Fast poll when panel is open
     if (panelOpen) {
+      // Fast poll when panel is open; no slow poll needed
       _jobPollTimer = setInterval(pollJobs, 2000);
+    } else {
+      // Slow background poll keeps navbar badge current
+      _navJobPollTimer = setInterval(pollJobs, 15000);
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixes duplicate polling when the bottom panel is already open at page load
- Previously both the 15s navbar poll and 2s panel poll ran simultaneously
- Now only one poll timer runs at a time: fast (2s) when panel is open, slow (15s) when closed

Parent PR: #303

## Test plan
- [x] All 309 tests pass
- [ ] Open app with panel open (localStorage `vireo_panel_open` = true), verify no duplicate `/api/jobs` requests in Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)