### PR TITLE
ci: skip RPM bundling on Linux to fix build timeout

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -323,13 +323,15 @@ jobs:
 
       # Linux: build directly so cargo output streams to logs in real time.
       # The tauri-action is a black box — if it hangs we get no diagnostics.
+      # Skip RPM — the Tauri RPM bundler hangs indefinitely on large sidecar
+      # binaries (PyInstaller + PyTorch). deb + AppImage cover Linux users.
       - name: Build Tauri app (Linux direct)
         if: runner.os == 'Linux'
         shell: bash
         run: |
           echo "=== Starting Tauri build at $(date -u) ==="
           cd src-tauri
-          npx tauri build --target ${{ matrix.rust-target }} 2>&1
+          npx tauri build --target ${{ matrix.rust-target }} --bundles deb,appimage 2>&1
           echo "=== Tauri build finished at $(date -u) ==="
 
       # Windows: no signing needed, use tauri-action.


### PR DESCRIPTION
## Summary
- Skip RPM bundle target on Linux builds (`--bundles deb,appimage`) to fix the 90-minute timeout
- The Tauri RPM bundler hangs indefinitely on large sidecar binaries (PyInstaller + PyTorch ~1.6GB)
- Linux has never shipped a successful build — deb completed in ~34s but RPM hung every time (v0.6.15, v0.6.16)
- deb + AppImage cover essentially all Linux desktop users

## Test plan
- [ ] Verify the next tagged release produces Linux artifacts (`.deb` + `.AppImage`) in the GitHub release
- [ ] Confirm Linux build completes within a reasonable time (~30-40 min)
- [ ] Verify macOS and Windows builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)