### PR TITLE
fix: use exif_data as retry guard to prevent perpetual re-extraction

### DIFF
--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -264,6 +264,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
 
     # Build existing photo lookup for incremental mode
     existing_photos = {}
+    exif_extracted = set()  # photo IDs where ExifTool has already run
     if incremental:
         all_photos = db.get_photos(per_page=999999)
         for p in all_photos:
@@ -276,6 +277,10 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             folder_path = folders.get(p["folder_id"], "")
             full_path = os.path.join(folder_path, p["filename"])
             existing_by_path[full_path] = p
+        # Track which photos have had ExifTool metadata extracted (exif_data
+        # is non-NULL). Photos with NULL exif_data need re-extraction.
+        for row in db.conn.execute("SELECT id FROM photos WHERE exif_data IS NOT NULL"):
+            exif_extracted.add(row["id"])
 
     # Build folder cache: path -> folder_id
     folder_cache = {}
@@ -314,9 +319,14 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             if existing:
                 file_unchanged = existing["file_mtime"] == file_mtime
                 xmp_unchanged = existing["xmp_mtime"] == xmp_mtime
-                # Re-process if critical metadata is missing (e.g. ExifTool
-                # was unavailable during the original scan)
-                metadata_missing = existing["timestamp"] is None
+                # Re-process if ExifTool never ran for this photo (both
+                # timestamp and exif_data are NULL). Photos with genuinely
+                # missing timestamps (screenshots, exports) will have
+                # exif_data set after one extraction attempt.
+                metadata_missing = (
+                    existing["timestamp"] is None
+                    and existing["id"] not in exif_extracted
+                )
 
                 if file_unchanged and xmp_unchanged and not metadata_missing:
                     processed_count += 1
@@ -469,6 +479,11 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         if file_meta and extract_full_metadata:
             updates.append("exif_data=?")
             update_params.append(json.dumps(file_meta))
+        elif file_meta:
+            # Store minimal marker so we know ExifTool ran (even when
+            # extract_full_metadata is off) — prevents perpetual retry
+            updates.append("exif_data=COALESCE(exif_data, ?)")
+            update_params.append("{}")
         if updates:
             update_params.append(photo_id)
             db.conn.execute(

--- a/vireo/tests/test_scanner_callback.py
+++ b/vireo/tests/test_scanner_callback.py
@@ -68,8 +68,8 @@ def test_scan_photo_callback_fires_for_incremental_skip(tmp_path):
         assert path.endswith(".jpg")
 
 
-def test_incremental_scan_reprocesses_photos_missing_timestamp(tmp_path):
-    """Photos with NULL timestamp should be re-processed on incremental scan.
+def test_incremental_scan_reprocesses_photos_missing_metadata(tmp_path):
+    """Photos with NULL timestamp AND NULL exif_data are re-processed.
 
     Covers the case where ExifTool was unavailable during the original scan,
     leaving critical metadata NULL. The scanner should retry extraction rather
@@ -87,21 +87,53 @@ def test_incremental_scan_reprocesses_photos_missing_timestamp(tmp_path):
     assert len(photos) == 1
     photo_id = photos[0]["id"]
 
-    # Simulate a failed initial scan: NULL out metadata
+    # Simulate a failed initial scan: NULL out metadata AND exif_data
     db.conn.execute(
-        "UPDATE photos SET timestamp = NULL, width = NULL, height = NULL WHERE id = ?",
+        "UPDATE photos SET timestamp = NULL, width = NULL, height = NULL, exif_data = NULL WHERE id = ?",
         (photo_id,),
     )
     db.conn.commit()
 
     # Verify it's really NULL
-    row = db.conn.execute("SELECT width, timestamp FROM photos WHERE id = ?", (photo_id,)).fetchone()
+    row = db.conn.execute("SELECT width, exif_data FROM photos WHERE id = ?", (photo_id,)).fetchone()
     assert row["width"] is None
+    assert row["exif_data"] is None
 
-    # Incremental re-scan should re-process because timestamp is NULL
+    # Incremental re-scan should re-process because timestamp AND exif_data are NULL
     scan(tmp_path, db, incremental=True)
 
     # Width should be restored by the re-scan
     row = db.conn.execute("SELECT width, height FROM photos WHERE id = ?", (photo_id,)).fetchone()
     assert row["width"] is not None, "Width should be restored after re-scan of metadata-missing photo"
     assert row["height"] is not None, "Height should be restored after re-scan of metadata-missing photo"
+
+
+def test_incremental_scan_skips_photos_with_exif_data_but_no_timestamp(tmp_path):
+    """Photos with NULL timestamp but non-NULL exif_data should be skipped.
+
+    If ExifTool ran but the file genuinely has no timestamp (e.g. screenshots),
+    the photo should not be perpetually re-processed.
+    """
+    img = Image.new("RGB", (200, 150), "blue")
+    img.save(str(tmp_path / "screenshot.jpg"))
+
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db._active_workspace_id)
+
+    scan(tmp_path, db, incremental=False)
+    photos = db.get_photos(per_page=999)
+    photo_id = photos[0]["id"]
+
+    # Simulate: ExifTool ran (exif_data present) but no timestamp in EXIF
+    db.conn.execute(
+        "UPDATE photos SET timestamp = NULL, width = 999, exif_data = '{}' WHERE id = ?",
+        (photo_id,),
+    )
+    db.conn.commit()
+
+    # Incremental scan should SKIP this file (exif_data proves ExifTool ran)
+    scan(tmp_path, db, incremental=True)
+
+    # Width should still be 999 (not overwritten by re-processing)
+    row = db.conn.execute("SELECT width FROM photos WHERE id = ?", (photo_id,)).fetchone()
+    assert row["width"] == 999, "Photo with exif_data should not be re-processed"


### PR DESCRIPTION
Parent PR: #309

## Summary

- Addresses [review feedback](https://github.com/jss367/vireo/pull/309#discussion_r3017934450): photos genuinely lacking EXIF timestamps (screenshots, exports) were being re-processed on every incremental scan
- Now uses `exif_data IS NOT NULL` as the "ExifTool was attempted" marker — retry only fires when **both** `timestamp` and `exif_data` are NULL
- Stores a minimal `'{}'` marker in `exif_data` when `extract_full_metadata` is off, ensuring one extraction attempt stops retries

## Test plan

- [x] New test: `test_incremental_scan_skips_photos_with_exif_data_but_no_timestamp` — verifies photos with exif_data set are not perpetually re-processed
- [x] Updated `test_incremental_scan_reprocesses_photos_missing_metadata` — NULLs out exif_data too to trigger retry
- [x] Full suite: 316 passed in 7.84s

🤖 Generated with [Claude Code](https://claude.com/claude-code)