### PR TITLE
fix: check generate_thumbnail return value for silent failures

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -310,8 +310,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 try:
                     thumb_path = os.path.join(cache_dir, f"{photo_id}.jpg")
                     already_exists = os.path.exists(thumb_path)
-                    generate_thumbnail(photo_id, photo_path, cache_dir, size=thumb_size)
-                    if already_exists:
+                    result_path = generate_thumbnail(photo_id, photo_path, cache_dir, size=thumb_size)
+                    if result_path is None:
+                        failed += 1
+                    elif already_exists:
                         skipped += 1
                     else:
                         generated += 1


### PR DESCRIPTION
## Summary
- `generate_thumbnail` returns `None` when `load_image` fails on corrupt/unreadable images without raising an exception
- The pipeline code was only checking `os.path.exists` before the call, so these silent failures were miscounted as "generated"
- Now checks the return value and counts `None` results as `failed`

Parent PR: #307

## Test plan
- [x] All 332 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)