### PR TITLE
fix: use rowcount instead of lastrowid after INSERT OR IGNORE in add_folder

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -813,7 +813,7 @@ class Database:
             ),
         )
         self.conn.commit()
-        if cur.lastrowid:
+        if cur.rowcount > 0:
             return cur.lastrowid
         row = self.conn.execute(
             "SELECT id FROM photos WHERE folder_id = ? AND filename = ?",


### PR DESCRIPTION
## Summary
- Fixes `sqlite3.IntegrityError: FOREIGN KEY constraint failed` in `test_incremental_scan_detects_xmp_changes` (and in production incremental scans)
- **Root cause**: `db.add_folder()` used `cur.lastrowid` after `INSERT OR IGNORE` to get the folder ID. When the folder already exists and the INSERT is ignored, `lastrowid` returns the rowid from the *most recent successful INSERT on the connection* — which can be from a completely different table (e.g., a keyword ID from `_import_keywords_for_photo`). This wrong ID was then passed to `add_workspace_folder`, causing a FK violation.
- **Fix**: One-line change — `cur.lastrowid` → `cur.rowcount > 0` to check whether a row was actually inserted. When the INSERT is ignored, it falls through to the SELECT lookup which always returns the correct folder ID.

## Test plan
- [x] All 339 tests pass locally, including `test_incremental_scan_detects_xmp_changes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)