### PR TITLE
fix: apply same rowcount fix to add_photo

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -813,7 +813,7 @@ class Database:
             ),
         )
         self.conn.commit()
-        if cur.lastrowid:
+        if cur.rowcount > 0:
             return cur.lastrowid
         row = self.conn.execute(
             "SELECT id FROM photos WHERE folder_id = ? AND filename = ?",


### PR DESCRIPTION
## Summary
- `add_photo` has the same `INSERT OR IGNORE` + `lastrowid` bug as `add_folder`
- When a photo already exists during incremental scan, `lastrowid` returns a stale ID (e.g. a keyword ID from `_import_keywords_for_photo`), causing `tag_photo` to fail with `FOREIGN KEY constraint failed`
- Same one-line fix: `cur.lastrowid` → `cur.rowcount > 0`

Parent PR: #314

## Test plan
- [x] All 339 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)