### PR TITLE
feat: add folder browser for source folder selection

### DIFF
--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -317,7 +317,7 @@ body { padding-bottom: 36px; }
                          placeholder="/path/to/photos" style="font-family:inherit;flex:1;"
                          onkeydown="if(event.key==='Enter'){event.preventDefault();addSourceFolder();}">
                   <datalist id="volumeDatalist"></datalist>
-                  <button onclick="browseForFolder()" class="btn btn-secondary tauri-only" style="display:none;white-space:nowrap;">Browse&hellip;</button>
+                  <button onclick="browseForFolder()" class="btn btn-secondary" style="white-space:nowrap;">Browse&hellip;</button>
                   <button onclick="addSourceFolder()" class="btn btn-secondary" style="white-space:nowrap;">Add</button>
                 </div>
                 <div id="sourceFolderList" style="margin-top:6px;"></div>
@@ -1547,12 +1547,16 @@ function updateCardStates() {
 })();
 
 async function browseForFolder() {
-  var path = await pickDirectory('Select photo folder');
-  if (path && _sourceFolders.indexOf(path) === -1) {
-    _sourceFolders.push(path);
-    renderSourceFolders();
-    updateStartButton();
+  if (typeof pickDirectory === 'function') {
+    var path = await pickDirectory('Select photo folder');
+    if (path && _sourceFolders.indexOf(path) === -1) {
+      _sourceFolders.push(path);
+      renderSourceFolders();
+      updateStartButton();
+      return;
+    }
   }
+  openFolderBrowser('source');
 }
 
 async function browseForDestination() {
@@ -1564,14 +1568,17 @@ async function browseForDestination() {
       return;
     }
   }
-  openFolderBrowser();
+  openFolderBrowser('destination');
 }
 
 // ---------- Folder Browser ----------
 var _fbCurrentPath = '';
 var _fbSelectedDir = '';
+var _fbMode = 'destination'; // 'source' or 'destination'
 
-function openFolderBrowser() {
+function openFolderBrowser(mode) {
+  _fbMode = mode || 'destination';
+  document.getElementById('fbTitle').textContent = _fbMode === 'source' ? 'Select Source Folder' : 'Select Destination Folder';
   var overlay = document.getElementById('folderBrowserOverlay');
   overlay.classList.add('active');
   document.body.style.overflow = 'hidden';
@@ -1681,7 +1688,14 @@ function renderFolderList(dirs) {
 
 function selectFolder() {
   if (!_fbSelectedDir) return;
-  document.getElementById('cfgDestination').value = _fbSelectedDir;
+  if (_fbMode === 'source') {
+    if (_sourceFolders.indexOf(_fbSelectedDir) === -1) {
+      _sourceFolders.push(_fbSelectedDir);
+      renderSourceFolders();
+    }
+  } else {
+    document.getElementById('cfgDestination').value = _fbSelectedDir;
+  }
   updateStartButton();
   closeFolderBrowser();
 }
@@ -1724,7 +1738,7 @@ var _fbHomePath = '';
 <div class="folder-browser-overlay" id="folderBrowserOverlay">
   <div class="folder-browser-panel">
     <div class="folder-browser-header">
-      <h3>Select Destination Folder</h3>
+      <h3 id="fbTitle">Select Destination Folder</h3>
       <button class="folder-browser-close" onclick="closeFolderBrowser()">&times;</button>
     </div>
     <div class="folder-browser-shortcuts">


### PR DESCRIPTION
## Summary
- The source folder "Browse..." button on the pipeline page was previously hidden in the web browser (Tauri-only). Now it's always visible and opens the existing folder browser modal.
- The folder browser modal now supports both source and destination modes — the title updates dynamically and selecting a folder either adds it to the source list or sets the destination input.
- In Tauri, the native OS picker is still tried first, with the web modal as fallback.

## Test plan
- [x] All 312 existing tests pass
- [ ] Open pipeline page in browser — verify "Browse..." button appears next to source folder input
- [ ] Click Browse on source — modal title says "Select Source Folder", selecting a folder adds it to the source list
- [ ] Click Browse on destination — modal title says "Select Destination Folder", selecting a folder sets the destination input
- [ ] Verify duplicate source folders are not added

🤖 Generated with [Claude Code](https://claude.com/claude-code)