### PR TITLE
fix: stop sidecar on app exit to prevent orphaned server processes

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,7 @@ mod menu;
 mod sidecar;
 mod tray;
 use sidecar::SidecarState;
-use tauri::Manager;
+use tauri::{Manager, RunEvent};
 
 #[tauri::command]
 fn get_server_port(state: tauri::State<'_, SidecarState>) -> u16 {
@@ -65,14 +65,6 @@ pub fn run() {
                         let _ = window.hide();
                     }
                 }
-                tauri::WindowEvent::Destroyed => {
-                    if window.label() == "main" {
-                        let app = window.app_handle();
-                        if let Some(state) = app.try_state::<SidecarState>() {
-                            sidecar::stop_sidecar(&state);
-                        }
-                    }
-                }
                 _ => {}
             }
         })
@@ -99,6 +91,13 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             get_server_port,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            if let RunEvent::Exit = event {
+                if let Some(state) = app_handle.try_state::<SidecarState>() {
+                    sidecar::stop_sidecar(&state);
+                }
+            }
+        });
 }


### PR DESCRIPTION
## Summary
- The `Destroyed` window event handler for sidecar cleanup was dead code — `CloseRequested` always calls `prevent_close()` (hide-to-tray behavior), so the window is never actually destroyed
- Each app close left the `vireo-server` process running, accumulating orphaned servers over days (15 instances found, one with 120+ minutes of CPU time)
- Moved sidecar cleanup to `RunEvent::Exit`, which fires on any exit path (Cmd+Q, dock quit, tray quit, etc.)
- The tray "Quit Vireo" path remains safe — `stop_sidecar()` is idempotent

## Test plan
- [x] `cargo check` passes
- [x] 312 Python tests pass
- [ ] Build release app, open and close via Cmd+Q — verify no orphaned `vireo-server` process
- [ ] Build release app, quit via tray menu — verify clean shutdown (no double-kill errors)
- [ ] Hide window, then Cmd+Q — verify sidecar cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)