### PR TITLE
fix: bottom panel logs tab only using lower half of panel

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2095,7 +2095,7 @@ function closeSimilar() {
     </div>
     <!-- History Pane -->
     <div class="bp-pane" id="bpHistory">
-      <div class="bp-history-list" id="bpHistoryList" style="overflow-y:auto;flex:1;"
+      <div class="bp-history-list" id="bpHistoryList" style="overflow-y:auto;flex:1;">
         <div class="bp-history-empty" style="color:var(--text-muted);padding:12px;font-size:12px;">No edits yet</div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- The history list `<div>` in the bottom panel was missing its closing `>` on line 2098 of `_navbar.html`
- This caused the browser's HTML parser to swallow the next div's attributes, creating one fewer DOM node than expected
- The extra `</div>` then prematurely closed `bp-content`, placing the Logs pane (`bpLogs`) as a sibling of `bp-content` instead of inside it
- Both `bp-content` and `bpLogs` had `flex: 1`, splitting the panel height 50/50 — the top half was empty, the bottom half showed the logs

## Test plan
- [x] All 312 tests pass
- [ ] Open the bottom panel, switch to the Logs tab, and verify logs fill the entire panel height
- [ ] Switch to History tab and verify it still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)