### PR TITLE
feat: add retry/resume to taxonomy downloads

### DIFF
--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -76,10 +76,10 @@ def _download_with_resume(url, dest_path, progress_callback=None,
 
             with urllib.request.urlopen(req, timeout=120) as resp:
                 # If server returned 200 (not 206), it doesn't support Range —
-                # start from scratch.
+                # start from scratch.  Don't reset downloaded_before: it's the
+                # stall-detection baseline (did we get further than last time?).
                 if resp.status == 200 and downloaded_before > 0:
                     log.info("Server does not support Range; restarting download")
-                    downloaded_before = 0
 
                 # Determine expected size so we can detect truncated responses
                 content_length = resp.headers.get("Content-Length")

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -741,3 +741,32 @@ def test_download_with_resume_server_ignores_range(tmp_path):
         assert open(dest, "rb").read() == content
     finally:
         server.shutdown()
+
+
+def test_download_with_resume_no_range_stalls_correctly(tmp_path):
+    """Server ignoring Range + repeated partial writes must still trigger stall."""
+    from taxonomy import _download_with_resume
+
+    content = b"D" * 2000
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            # Always return 200 (ignore Range), always deliver only 500 bytes
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content[:500])
+
+        def log_message(self, *args):
+            pass
+
+    server, port = _start_test_server(Handler)
+    try:
+        dest = str(tmp_path / "taxa.csv.gz")
+        import pytest
+        with pytest.raises(RuntimeError, match="stalled"):
+            _download_with_resume(
+                f"http://127.0.0.1:{port}/taxa.csv.gz", dest, max_stalled=2,
+            )
+    finally:
+        server.shutdown()


### PR DESCRIPTION
## Summary
- Added `_download_with_resume()` helper that streams to a `.partial` file, resumes via HTTP `Range` headers on failure, and retries as long as progress is being made (gives up after 3 consecutive stalls with no new bytes)
- `download_taxa()` (AWS taxa.csv.gz) now uses resumable download instead of one-shot `urlretrieve`
- `download_taxonomy()` (DWCA zip) now streams to disk instead of holding the entire zip in memory, then processes from the file — reduces peak RAM and enables resume
- Added 6 tests covering: success, retry after mid-transfer failure, stall detection, progress resetting stall counter, callback invocation, and server-ignores-Range fallback

## Test plan
- [x] All 6 new `test_download_with_resume_*` tests pass
- [x] All 337 tests pass (full suite including existing taxonomy, app, db, workspace tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)