### PR TITLE
fix: stall detection when server ignores Range headers

### DIFF
--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -76,10 +76,10 @@ def _download_with_resume(url, dest_path, progress_callback=None,
 
             with urllib.request.urlopen(req, timeout=120) as resp:
                 # If server returned 200 (not 206), it doesn't support Range —
-                # start from scratch.
+                # start from scratch.  Don't reset downloaded_before: it's the
+                # stall-detection baseline (did we get further than last time?).
                 if resp.status == 200 and downloaded_before > 0:
                     log.info("Server does not support Range; restarting download")
-                    downloaded_before = 0
 
                 # Determine expected size so we can detect truncated responses
                 content_length = resp.headers.get("Content-Length")

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -741,3 +741,32 @@ def test_download_with_resume_server_ignores_range(tmp_path):
         assert open(dest, "rb").read() == content
     finally:
         server.shutdown()
+
+
+def test_download_with_resume_no_range_stalls_correctly(tmp_path):
+    """Server ignoring Range + repeated partial writes must still trigger stall."""
+    from taxonomy import _download_with_resume
+
+    content = b"D" * 2000
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            # Always return 200 (ignore Range), always deliver only 500 bytes
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content[:500])
+
+        def log_message(self, *args):
+            pass
+
+    server, port = _start_test_server(Handler)
+    try:
+        dest = str(tmp_path / "taxa.csv.gz")
+        import pytest
+        with pytest.raises(RuntimeError, match="stalled"):
+            _download_with_resume(
+                f"http://127.0.0.1:{port}/taxa.csv.gz", dest, max_stalled=2,
+            )
+    finally:
+        server.shutdown()


### PR DESCRIPTION
Parent PR: #321

## Summary
- Removed `downloaded_before = 0` reset when server returns 200 instead of 206. This was causing stall detection to never fire when the server doesn't support Range — repeated partial writes looked like fresh progress.
- Added regression test: server always ignores Range and delivers the same partial data, verifying the stall counter increments and `RuntimeError` is raised.

## Test plan
- [x] New `test_download_with_resume_no_range_stalls_correctly` passes
- [x] All 7 `download_with_resume` tests pass
- [x] Existing `server_ignores_range` test still passes (successful full retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)