### PR TITLE
Move classification overrides to settings page

### DIFF
--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -129,6 +129,18 @@
         <span style="font-size:13px;color:var(--text-primary);min-width:36px;" id="cfgThresholdVal">40%</span>
       </div>
     </div>
+    <div class="setting-row" style="padding:0 0 8px 16px;">
+      <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:12px;color:var(--text-dim);">
+        <input type="checkbox" id="wsOverride_classification_threshold" onchange="toggleWsOverride('classification_threshold')" style="accent-color:var(--accent);">
+        Override for "<span class="ws-override-name">…</span>"
+      </label>
+      <div id="wsOverrideCtrl_classification_threshold" style="display:none;align-items:center;gap:8px;margin-left:24px;margin-top:4px;">
+        <input type="range" id="wsVal_classification_threshold" min="1" max="99"
+               style="width:120px;accent-color:var(--accent);"
+               oninput="document.getElementById('wsThresholdVal').textContent=this.value+'%'; saveWsConfig()">
+        <span id="wsThresholdVal" style="font-size:12px;color:var(--text-dim);min-width:30px;">-</span>
+      </div>
+    </div>
     <div class="setting-row">
       <div class="setting-label">
         Grouping window
@@ -138,6 +150,18 @@
         <input type="number" id="cfgGroupingWindow" min="1" max="120" value="10"
                style="width:60px;background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:4px 8px;font-size:13px;text-align:center;"
                onchange="saveConfig()">
+        <span style="font-size:13px;color:var(--text-dim);">seconds</span>
+      </div>
+    </div>
+    <div class="setting-row" style="padding:0 0 8px 16px;">
+      <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:12px;color:var(--text-dim);">
+        <input type="checkbox" id="wsOverride_grouping_window_seconds" onchange="toggleWsOverride('grouping_window_seconds')" style="accent-color:var(--accent);">
+        Override for "<span class="ws-override-name">…</span>"
+      </label>
+      <div id="wsOverrideCtrl_grouping_window_seconds" style="display:none;align-items:center;gap:8px;margin-left:24px;margin-top:4px;">
+        <input type="number" id="wsVal_grouping_window_seconds" min="1" max="120"
+               style="width:60px;background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:4px 8px;font-size:13px;text-align:center;"
+               onchange="saveWsConfig()">
         <span style="font-size:13px;color:var(--text-dim);">seconds</span>
       </div>
     </div>
@@ -152,6 +176,18 @@
                oninput="document.getElementById('cfgSimilarityVal').textContent=this.value+'%'"
                onchange="saveConfig()">
         <span id="cfgSimilarityVal" style="font-size:13px;color:var(--text-primary);min-width:30px;">85%</span>
+      </div>
+    </div>
+    <div class="setting-row" style="padding:0 0 8px 16px;">
+      <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:12px;color:var(--text-dim);">
+        <input type="checkbox" id="wsOverride_similarity_threshold" onchange="toggleWsOverride('similarity_threshold')" style="accent-color:var(--accent);">
+        Override for "<span class="ws-override-name">…</span>"
+      </label>
+      <div id="wsOverrideCtrl_similarity_threshold" style="display:none;align-items:center;gap:8px;margin-left:24px;margin-top:4px;">
+        <input type="range" id="wsVal_similarity_threshold" min="50" max="99"
+               style="width:120px;accent-color:var(--accent);"
+               oninput="document.getElementById('wsSimilarityVal').textContent=this.value+'%'; saveWsConfig()">
+        <span id="wsSimilarityVal" style="font-size:12px;color:var(--text-dim);min-width:30px;">-</span>
       </div>
     </div>
     <div class="setting-row" style="display:flex;justify-content:space-between;align-items:center;padding:8px 0;">
@@ -820,6 +856,7 @@ loadModels();
 loadTaxonomy();
 loadSystemInfo();
 loadConfig();
+loadWsOverrides();
 loadEmbeddingMatrix();
 loadScanRoots();
 loadVersion();
@@ -829,6 +866,84 @@ function toggleSection(header) {
   header.classList.toggle('open');
   var body = header.nextElementSibling;
   body.classList.toggle('open');
+}
+
+/* ---------- Workspace Config Overrides ---------- */
+async function loadWsOverrides() {
+  try {
+    var ws = await safeFetch('/api/workspaces/active', {}, { toast: false });
+    if (ws && ws.name) {
+      document.querySelectorAll('.ws-override-name').forEach(function(el) { el.textContent = ws.name; });
+    }
+    var overrides = await safeFetch('/api/workspaces/active/config', {}, { toast: false });
+    ['classification_threshold', 'grouping_window_seconds', 'similarity_threshold'].forEach(function(key) {
+      var checkbox = document.getElementById('wsOverride_' + key);
+      var input = document.getElementById('wsVal_' + key);
+      var ctrl = document.getElementById('wsOverrideCtrl_' + key);
+      if (!checkbox || !input || !ctrl) return;
+      if (overrides[key] !== undefined) {
+        checkbox.checked = true;
+        ctrl.style.display = 'flex';
+        if (key === 'classification_threshold' || key === 'similarity_threshold') {
+          input.value = Math.round(overrides[key] * 100);
+        } else {
+          input.value = overrides[key];
+        }
+        updateWsLabel(key);
+      }
+    });
+  } catch(e) {}
+}
+
+function updateWsLabel(key) {
+  var input = document.getElementById('wsVal_' + key);
+  if (!input) return;
+  if (key === 'classification_threshold') {
+    document.getElementById('wsThresholdVal').textContent = input.value + '%';
+  } else if (key === 'similarity_threshold') {
+    document.getElementById('wsSimilarityVal').textContent = input.value + '%';
+  }
+}
+
+function toggleWsOverride(key) {
+  var checkbox = document.getElementById('wsOverride_' + key);
+  var input = document.getElementById('wsVal_' + key);
+  var ctrl = document.getElementById('wsOverrideCtrl_' + key);
+  if (!checkbox || !input || !ctrl) return;
+  ctrl.style.display = checkbox.checked ? 'flex' : 'none';
+  if (checkbox.checked && !input.value) {
+    if (key === 'classification_threshold') input.value = 40;
+    else if (key === 'grouping_window_seconds') input.value = 10;
+    else if (key === 'similarity_threshold') input.value = 85;
+    updateWsLabel(key);
+  }
+  saveWsConfig();
+}
+
+var _wsSaveTimer = null;
+function saveWsConfig() {
+  clearTimeout(_wsSaveTimer);
+  _wsSaveTimer = setTimeout(async function() {
+    var overrides = {};
+    ['classification_threshold', 'grouping_window_seconds', 'similarity_threshold'].forEach(function(key) {
+      var checkbox = document.getElementById('wsOverride_' + key);
+      var input = document.getElementById('wsVal_' + key);
+      if (checkbox && checkbox.checked && input) {
+        if (key === 'classification_threshold' || key === 'similarity_threshold') {
+          overrides[key] = parseInt(input.value) / 100;
+        } else {
+          overrides[key] = parseInt(input.value);
+        }
+      }
+    });
+    try {
+      await safeFetch('/api/workspaces/active/config', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(overrides)
+      });
+    } catch(e) {}
+  }, 500);
 }
 
 var _saveTimer = null;

--- a/vireo/templates/workspace.html
+++ b/vireo/templates/workspace.html
@@ -35,56 +35,6 @@
     </div>
   </div>
 
-  <!-- Classification Overrides -->
-  <div class="section">
-    <div class="section-title">Classification Overrides</div>
-    <div class="setting-row">
-      <div class="setting-label">
-        <label style="display:flex;align-items:center;gap:6px;cursor:pointer;">
-          <input type="checkbox" id="wsOverride_classification_threshold" onchange="toggleWsOverride('classification_threshold')">
-          Confidence threshold
-        </label>
-        <small>Override the global classification threshold for this workspace</small>
-      </div>
-      <div style="display:flex;align-items:center;gap:8px;">
-        <input type="range" id="wsVal_classification_threshold" min="1" max="99" disabled
-               oninput="document.getElementById('wsThresholdVal').textContent=this.value+'%'; saveWorkspaceConfig()"
-               style="width:120px;">
-        <span id="wsThresholdVal" style="font-size:12px;color:var(--text-dim);min-width:30px;">-</span>
-      </div>
-    </div>
-    <div class="setting-row">
-      <div class="setting-label">
-        <label style="display:flex;align-items:center;gap:6px;cursor:pointer;">
-          <input type="checkbox" id="wsOverride_grouping_window_seconds" onchange="toggleWsOverride('grouping_window_seconds')">
-          Grouping window
-        </label>
-        <small>Override the global grouping window for this workspace</small>
-      </div>
-      <div style="display:flex;align-items:center;gap:8px;">
-        <input type="number" id="wsVal_grouping_window_seconds" min="1" max="120" disabled
-               style="width:60px;background:var(--bg-tertiary);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:4px 8px;font-size:13px;text-align:center;"
-               onchange="saveWorkspaceConfig()">
-        <span style="font-size:13px;color:var(--text-dim);">seconds</span>
-      </div>
-    </div>
-    <div class="setting-row">
-      <div class="setting-label">
-        <label style="display:flex;align-items:center;gap:6px;cursor:pointer;">
-          <input type="checkbox" id="wsOverride_similarity_threshold" onchange="toggleWsOverride('similarity_threshold')">
-          Similarity threshold
-        </label>
-        <small>Override the global similarity threshold for this workspace</small>
-      </div>
-      <div style="display:flex;align-items:center;gap:8px;">
-        <input type="range" id="wsVal_similarity_threshold" min="50" max="99" disabled
-               oninput="document.getElementById('wsSimilarityVal').textContent=this.value+'%'; saveWorkspaceConfig()"
-               style="width:120px;">
-        <span id="wsSimilarityVal" style="font-size:12px;color:var(--text-dim);min-width:30px;">-</span>
-      </div>
-    </div>
-  </div>
-
   <!-- Recent Jobs -->
   <div class="section">
     <div class="section-title">Recent Jobs</div>
@@ -104,7 +54,6 @@
 
 <script>
 loadWsFolders();
-loadWorkspaceConfig();
 loadHistory();
 loadWorkspaces();
 
@@ -139,88 +88,6 @@ async function loadWsFolders() {
 async function removeFolderFromWs(wsId, folderId) {
   try { await safeFetch('/api/workspaces/' + wsId + '/folders/' + folderId, { method: 'DELETE' }); } catch(e) {}
   loadWsFolders();
-}
-
-/* ---------- Workspace Config Overrides ---------- */
-async function loadWorkspaceConfig() {
-  try {
-    var overrides = await safeFetch('/api/workspaces/active/config', {}, { toast: false });
-    var keys = ['classification_threshold', 'grouping_window_seconds', 'similarity_threshold'];
-    keys.forEach(function(key) {
-      var checkbox = document.getElementById('wsOverride_' + key);
-      var input = document.getElementById('wsVal_' + key);
-      if (checkbox && input) {
-        if (overrides[key] !== undefined) {
-          checkbox.checked = true;
-          input.disabled = false;
-          if (key === 'classification_threshold' || key === 'similarity_threshold') {
-            input.value = Math.round(overrides[key] * 100);
-          } else {
-            input.value = overrides[key];
-          }
-          updateWsLabel(key);
-        } else {
-          checkbox.checked = false;
-          input.disabled = true;
-        }
-      }
-    });
-  } catch(e) {}
-}
-
-function updateWsLabel(key) {
-  var input = document.getElementById('wsVal_' + key);
-  if (!input) return;
-  if (key === 'classification_threshold') {
-    document.getElementById('wsThresholdVal').textContent = input.value + '%';
-  } else if (key === 'similarity_threshold') {
-    document.getElementById('wsSimilarityVal').textContent = input.value + '%';
-  }
-}
-
-function toggleWsOverride(key) {
-  var checkbox = document.getElementById('wsOverride_' + key);
-  var input = document.getElementById('wsVal_' + key);
-  if (!checkbox || !input) return;
-  input.disabled = !checkbox.checked;
-  if (checkbox.checked && !input.value) {
-    // Set a sensible default
-    if (key === 'classification_threshold') {
-      input.value = 40;
-    } else if (key === 'grouping_window_seconds') {
-      input.value = 10;
-    } else if (key === 'similarity_threshold') {
-      input.value = 85;
-    }
-    updateWsLabel(key);
-  }
-  saveWorkspaceConfig();
-}
-
-var _wsSaveTimer = null;
-async function saveWorkspaceConfig() {
-  clearTimeout(_wsSaveTimer);
-  _wsSaveTimer = setTimeout(async function() {
-    var overrides = {};
-    ['classification_threshold', 'grouping_window_seconds', 'similarity_threshold'].forEach(function(key) {
-      var checkbox = document.getElementById('wsOverride_' + key);
-      var input = document.getElementById('wsVal_' + key);
-      if (checkbox && checkbox.checked && input) {
-        if (key === 'classification_threshold' || key === 'similarity_threshold') {
-          overrides[key] = parseInt(input.value) / 100;
-        } else {
-          overrides[key] = parseInt(input.value);
-        }
-      }
-    });
-    try {
-      await safeFetch('/api/workspaces/active/config', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(overrides)
-      });
-    } catch(e) {}
-  }, 500);
 }
 
 /* ---------- Recent Jobs ---------- */


### PR DESCRIPTION
## Summary
- Moved per-workspace classification overrides (confidence threshold, grouping window, similarity threshold) from the Workspace panel to the Settings page
- Each overridable setting now has a subtle inline checkbox beneath it: `Override for "[workspace name]"`. When checked, a second control appears for the workspace-specific value
- Removed the entire "Classification Overrides" section from the Workspace panel, simplifying it to focus on workspace management (folders, jobs, workspace list)
- No backend changes — uses the same `/api/workspaces/active/config` API

## Test plan
- [x] All 329 tests pass
- [ ] Open Settings page — verify override checkboxes appear beneath confidence threshold, grouping window, and similarity threshold
- [ ] Check that the active workspace name appears in each override label
- [ ] Toggle an override on — verify the control appears and saves correctly
- [ ] Toggle an override off — verify it hides and clears the override
- [ ] Open Workspace panel — verify Classification Overrides section is gone
- [ ] Switch workspaces — verify Settings page reflects the new workspace's overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)