### PR TITLE
fix: address codex review on #482

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2803,13 +2803,19 @@ def create_app(db_path, thumb_cache_dir=None):
             total = len(paths)
             duplicate_count = 0
             batch_duplicates = []
+            # Also track hashes seen in this run so identical source files
+            # (not yet in DB) are reported as duplicates of each other,
+            # matching the behaviour of the actual import step.
+            seen_hashes = set()
 
             for checked, path in enumerate(paths, 1):
                 try:
                     file_hash = compute_file_hash(path)
-                    if file_hash in known_hashes:
+                    if file_hash in known_hashes or file_hash in seen_hashes:
                         batch_duplicates.append(path)
                         duplicate_count += 1
+                    else:
+                        seen_hashes.add(file_hash)
                 except OSError:
                     pass  # Skip unreadable/missing files
 

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1107,7 +1107,7 @@ function fetchFolderPreview() {
         _previewSelected[f.path] = !f.duplicate;
       });
       renderPreview();
-      checkForDuplicates();
+      if (_copyMode) checkForDuplicates();
     })
     .catch(function(err) {
       if (err.name === 'AbortError') return;
@@ -1265,9 +1265,12 @@ function checkForDuplicates() {
             data.duplicates.forEach(function(p) {
               _duplicateResults[p] = true;
             });
-            applyDuplicateVisuals();
           }
-          updateDuplicateSummary(data);
+          // Only update UI if the user still wants to skip duplicates
+          if (document.getElementById('chkSkipDuplicates').checked) {
+            if (data.duplicates) applyDuplicateVisuals();
+            updateDuplicateSummary(data);
+          }
         });
         read();
       }).catch(function() {});
@@ -1323,21 +1326,15 @@ function onSkipDuplicatesToggle() {
   if (!checked) {
     // Abort any in-flight check so SSE callbacks stop updating the UI
     if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
-  }
-  if (Object.keys(_duplicateResults).length > 0) {
+    // Remove duplicate visuals and summary
     applyDuplicateVisuals();
-    // Update summary: re-show or remove duplicate count
-    var dupCount = Object.keys(_duplicateResults).length;
     var summary = document.getElementById('previewSummary');
     var existing = summary.querySelector('.dup-status');
     if (existing) existing.remove();
-    if (checked && dupCount > 0) {
-      var span = document.createElement('span');
-      span.className = 'stat dup-status';
-      span.innerHTML = '<span class="stat-value">' + dupCount + '</span> already imported';
-      summary.appendChild(span);
-    }
-  } else if (checked) {
+  } else {
+    // Re-check: if a prior scan was aborted partway, _duplicateCheckAbort was cleared
+    // to null but _duplicateResults may be partial. Always re-run for a fresh result.
+    _duplicateResults = {};
     checkForDuplicates();
   }
 }
@@ -1560,6 +1557,8 @@ function markFolderPreviewStale() {
 }
 
 function selectSourceMode(mode) {
+  // Cancel any in-flight duplicate scan before switching context
+  if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
   _sourceMode = mode;
   document.getElementById('radioImport').checked = (mode === 'import');
   document.getElementById('radioCollection').checked = (mode === 'collection');

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1238,7 +1238,21 @@ function checkForDuplicates() {
   _duplicateResults = {};
   _duplicateCheckAbort = new AbortController();
 
-  var paths = _previewData.files.map(function(f) { return f.path; });
+  // Only send selected files: deselected files are excluded from import and
+  // should not influence which other files are flagged as run-duplicates,
+  // matching the behaviour of the actual import step (exclude_paths applied
+  // before duplicate filtering).
+  var paths = _previewData.files
+    .filter(function(f) { return _previewSelected[f.path] !== false; })
+    .map(function(f) { return f.path; });
+
+  if (!paths.length) {
+    applyDuplicateVisuals();
+    var summary = document.getElementById('previewSummary');
+    var ds = summary ? summary.querySelector('.dup-status') : null;
+    if (ds) ds.remove();
+    return;
+  }
 
   fetch('/api/import/check-duplicates', {
     method: 'POST',
@@ -1437,6 +1451,7 @@ function onCopyModeChange() {
 
   if (_copyMode) {
     copyFields.style.display = '';
+    if (_previewData) checkForDuplicates();
   } else {
     copyFields.style.display = 'none';
     _folderPreviewShown = false;


### PR DESCRIPTION
Parent PR: #482

Addresses all unaddressed Codex Connect P2 review comments on #482 (Show duplicate photos in import preview).

## What changed

### `vireo/templates/pipeline.html`

- **Skip duplicate scanning when copy mode is disabled** (Codex comment at line 1110): `checkForDuplicates()` is now only called from the preview load callback when `_copyMode` is true, since the "Skip duplicates" control is hidden when copy mode is off.

- **Stop applying duplicate SSE updates after skip is disabled** (Codex comment at line 1270): SSE data is still accumulated into `_duplicateResults` unconditionally (so the cache stays fresh if re-enabled), but `applyDuplicateVisuals()` and `updateDuplicateSummary()` are only called when the skip checkbox is still checked. This prevents in-flight SSE events from re-adding duplicate UI after the user unchecks the option mid-stream.

- **Re-run duplicate check after aborting a partial scan** (Codex comment at line 1331): `onSkipDuplicatesToggle()` now always clears `_duplicateResults` and calls `checkForDuplicates()` when re-enabling, instead of reusing a potentially incomplete cache from an aborted scan.

- **Cancel duplicate scan when leaving import preview** (Codex comment at line 1233): `selectSourceMode()` now aborts `_duplicateCheckAbort` before switching source mode, preventing stale SSE events from a prior import scan from corrupting the new preview context.

### `vireo/app.py`

- **Include current-run hashes in duplicate preview checks** (Codex comment at line 2811): The `check-duplicates` endpoint now maintains a `seen_hashes` set during streaming. The second occurrence of an identical source file (not yet in the DB) is reported as a duplicate, matching the actual import-time behaviour where `ingest.py` tracks `known_hashes` across the run.

## Test results

423 passed in 20.74s

---
Generated by scheduled PR Agent

https://claude.ai/code/session_01J5qYP9Dd5oTEfhyX8kZMXu