### PR TITLE
fix: address codex review on #483

### DIFF
--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1246,7 +1246,13 @@ function checkForDuplicates() {
     .filter(function(f) { return _previewSelected[f.path] !== false; })
     .map(function(f) { return f.path; });
 
-  if (!paths.length) return;
+  if (!paths.length) {
+    applyDuplicateVisuals();
+    var summary = document.getElementById('previewSummary');
+    var ds = summary ? summary.querySelector('.dup-status') : null;
+    if (ds) ds.remove();
+    return;
+  }
 
   fetch('/api/import/check-duplicates', {
     method: 'POST',

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1246,6 +1246,8 @@ function checkForDuplicates() {
     .filter(function(f) { return _previewSelected[f.path] !== false; })
     .map(function(f) { return f.path; });
 
+  if (!paths.length) return;
+
   fetch('/api/import/check-duplicates', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1238,7 +1238,13 @@ function checkForDuplicates() {
   _duplicateResults = {};
   _duplicateCheckAbort = new AbortController();
 
-  var paths = _previewData.files.map(function(f) { return f.path; });
+  // Only send selected files: deselected files are excluded from import and
+  // should not influence which other files are flagged as run-duplicates,
+  // matching the behaviour of the actual import step (exclude_paths applied
+  // before duplicate filtering).
+  var paths = _previewData.files
+    .filter(function(f) { return _previewSelected[f.path] !== false; })
+    .map(function(f) { return f.path; });
 
   fetch('/api/import/check-duplicates', {
     method: 'POST',
@@ -1437,6 +1443,7 @@ function onCopyModeChange() {
 
   if (_copyMode) {
     copyFields.style.display = '';
+    if (_previewData) checkForDuplicates();
   } else {
     copyFields.style.display = 'none';
     _folderPreviewShown = false;


### PR DESCRIPTION
Parent PR: #483

Addresses Codex Connect review feedback on #483 (fix: address codex review on #482).

## What changed

### `vireo/templates/pipeline.html`

- **Re-run duplicate scan when copy mode is enabled** (Codex comment at line 1110): `onCopyModeChange()` now calls `checkForDuplicates()` when `_copyMode` is set to `true` and preview data is already loaded. This ensures duplicate badges and the summary appear in the common flow where a user loads the preview first, then enables "Copy photos".

- **Exclude deselected files from seen-hash duplicate checks** (Codex comment at app.py line 2818): `checkForDuplicates()` now filters `_previewData.files` to only selected files before sending `paths` to the `check-duplicates` endpoint. Deselected files are excluded from import and must not influence `seen_hashes`, matching actual import behaviour where `exclude_paths` is applied before duplicate filtering. This prevents false-duplicate flags when a later same-hash file would actually be imported.

## Test results

420 passed (3 pre-existing failures unrelated to this change: missing `certifi` module in test env)

---
Generated by scheduled PR Agent

https://claude.ai/code/session_01CpYQAJ2eEXwjCRBaN9JUw1