### PR TITLE
fix: address codex review on #484

### DIFF
--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1186,6 +1186,7 @@ function renderPreview() {
     folderCheck.onchange = function() {
       files.forEach(function(f) { _previewSelected[f.path] = folderCheck.checked; });
       renderPreview();
+      checkForDuplicates();
     };
     header.appendChild(folderCheck);
     header.appendChild(document.createTextNode(' ' + subfolder + ' (' + files.length + ')'));
@@ -1208,6 +1209,7 @@ function renderPreview() {
         e.stopPropagation();
         _previewSelected[f.path] = check.checked;
         updatePreviewCounts();
+        checkForDuplicates();
       };
       thumb.appendChild(check);
 
@@ -1397,6 +1399,7 @@ function toggleSelectAll() {
   if (_previewData) {
     _previewData.files.forEach(function(f) { _previewSelected[f.path] = checked; });
     renderPreview();
+    checkForDuplicates();
   }
 }
 


### PR DESCRIPTION
Parent PR: #484

Addresses Codex Connect review feedback on #484.

The selection handlers (folder checkbox, thumbnail checkbox, and select-all) were updating `_previewSelected` but not triggering `checkForDuplicates()`, leaving stale duplicate badges/summary after selection changes while skip-duplicates is enabled.

Adds `checkForDuplicates()` calls in all three handlers so duplicate results are recomputed based on the current selection.

---
Generated by scheduled PR Agent
