### PR TITLE
fix: add missing ONNX external data files to model configs

### DIFF
--- a/vireo/models.py
+++ b/vireo/models.py
@@ -30,7 +30,9 @@ KNOWN_MODELS = [
         "hf_subdir": "bioclip-vit-b-16",
         "files": [
             "image_encoder.onnx",
+            "image_encoder.onnx.data",
             "text_encoder.onnx",
+            "text_encoder.onnx.data",
             "tokenizer.json",
             "config.json",
         ],
@@ -48,7 +50,9 @@ KNOWN_MODELS = [
         "hf_subdir": "bioclip-2",
         "files": [
             "image_encoder.onnx",
+            "image_encoder.onnx.data",
             "text_encoder.onnx",
+            "text_encoder.onnx.data",
             "tokenizer.json",
             "config.json",
             "tol_embeddings.npy",
@@ -68,7 +72,9 @@ KNOWN_MODELS = [
         "hf_subdir": "bioclip-2.5-vith14",
         "files": [
             "image_encoder.onnx",
+            "image_encoder.onnx.data",
             "text_encoder.onnx",
+            "text_encoder.onnx.data",
             "tokenizer.json",
             "config.json",
         ],
@@ -86,6 +92,7 @@ KNOWN_MODELS = [
         "hf_subdir": "timm-eva02-large-inat21",
         "files": [
             "model.onnx",
+            "model.onnx.data",
             "class_names.json",
             "config.json",
         ],

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -871,7 +871,7 @@ def test_api_route_calls_run_classify_job(app_and_db):
 
     captured = {}
 
-    def fake_run(job, runner, db_path, workspace_id, params):
+    def fake_run(job, runner, db_path, workspace_id, params, vireo_dir=None):
         captured["params"] = params
         captured["workspace_id"] = workspace_id
         return {

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -151,7 +151,9 @@ def test_get_models_downloaded_flag(tmp_path, monkeypatch):
     model_dir = tmp_path / "models" / "bioclip-vit-b-16"
     model_dir.mkdir(parents=True)
     (model_dir / "image_encoder.onnx").write_bytes(b"fake")
+    (model_dir / "image_encoder.onnx.data").write_bytes(b"fake")
     (model_dir / "text_encoder.onnx").write_bytes(b"fake")
+    (model_dir / "text_encoder.onnx.data").write_bytes(b"fake")
     (model_dir / "tokenizer.json").write_text("{}")
     (model_dir / "config.json").write_text("{}")
 
@@ -186,7 +188,9 @@ def test_set_and_get_active_model(tmp_path, monkeypatch):
     model_dir = tmp_path / "models" / "bioclip-vit-b-16"
     model_dir.mkdir(parents=True)
     (model_dir / "image_encoder.onnx").write_bytes(b"fake")
+    (model_dir / "image_encoder.onnx.data").write_bytes(b"fake")
     (model_dir / "text_encoder.onnx").write_bytes(b"fake")
+    (model_dir / "text_encoder.onnx.data").write_bytes(b"fake")
     (model_dir / "tokenizer.json").write_text("{}")
     (model_dir / "config.json").write_text("{}")
 
@@ -208,7 +212,9 @@ def test_get_active_model_fallback(tmp_path, monkeypatch):
     model_dir = tmp_path / "models" / "bioclip-vit-b-16"
     model_dir.mkdir(parents=True)
     (model_dir / "image_encoder.onnx").write_bytes(b"fake")
+    (model_dir / "image_encoder.onnx.data").write_bytes(b"fake")
     (model_dir / "text_encoder.onnx").write_bytes(b"fake")
+    (model_dir / "text_encoder.onnx.data").write_bytes(b"fake")
     (model_dir / "tokenizer.json").write_text("{}")
     (model_dir / "config.json").write_text("{}")
 


### PR DESCRIPTION
## Summary
- Add missing `.onnx.data` external weight files to the download file lists for all four ONNX models (3 BioCLIP + 1 timm). Without these, models download only the graph definition but not the weights, causing `RuntimeException` / `model_path must not be empty` errors at load time.
- Fix `fake_run` mock signature in `test_classify_job.py` to accept the `vireo_dir` kwarg added to `run_classify_job`.

## Test plan
- [x] `test_api_route_calls_run_classify_job` passes
- [x] Full test suite (427 tests) passes
- [ ] Re-download a model (e.g. `timm-inat21-eva02-l`) and verify `.onnx.data` is fetched
- [ ] Run classification pipeline end-to-end to confirm model loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)