### PR TITLE
Show current version in "up to date" dialog

### DIFF
--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -76,7 +76,10 @@ async fn do_update_check(
             log::info!("No update available");
             if user_initiated {
                 app.dialog()
-                    .message("You're running the latest version of Vireo.")
+                    .message(format!(
+                        "You're running the latest version of Vireo (v{}).",
+                        env!("CARGO_PKG_VERSION")
+                    ))
                     .title("Up to Date")
                     .kind(MessageDialogKind::Info)
                     .show(|_| {});


### PR DESCRIPTION
## Summary

The updater's "Up to Date" dialog previously just said "You're running the latest version of Vireo." It now includes the installed version number, e.g. **"You're running the latest version of Vireo (v0.8.8)."** so users can see at a glance which build they're on.

Uses `env!("CARGO_PKG_VERSION")` at compile time, matching the existing pattern in `src-tauri/src/menu.rs:50`.

## Note on the logo

The original request also asked to put the Vireo logo in that dialog. This dialog is rendered by `tauri-plugin-dialog`, which uses native OS dialogs (NSAlert on macOS, MessageBox on Windows, GTK on Linux). The plugin's `MessageDialogBuilder` API exposes only `title`, `message`, `kind`, `buttons`, and `parent` — there is no way to embed a custom image in the dialog body.

On macOS, NSAlert automatically shows the app's bundle icon (`icons/icon.icns`), so the Vireo logo already appears in the dialog on release builds. On Windows/Linux only the generic info glyph is available. A custom webview-based dialog would be needed to force a logo on all platforms, which is a significantly larger change and sacrifices the native look; we opted against it.

## Test plan

- [x] `cargo check` in `src-tauri/` — clean build
- [x] Python test suite passes (`test_workspaces.py`, `test_db.py`, `test_app.py`, `test_photos_api.py`, `test_edits_api.py`, `test_jobs_api.py`, `test_darktable_api.py`, `test_config.py`) — 427 passed
- [ ] Manual: run the app, trigger "Check for Updates" from the menu when on the latest release, confirm the dialog reads `You're running the latest version of Vireo (v<current>).`