### PR TITLE
fix: self-heal broken model downloads instead of silently failing

### DIFF
--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -148,11 +148,20 @@ class JobRunner:
                     job["status"] = "completed"
                 job["result"] = result
         except Exception as e:
-            job["status"] = "failed"
-            job["errors"].append(str(e))
-            log.exception("Job %s failed", job["id"])
+            # Cancellation takes precedence over failure: if the user cancelled
+            # while the work function was raising (e.g. a stage crash happened
+            # during shutdown), honor the cancel rather than recording a
+            # misleading "failed" status.
             with self._lock:
-                self._cancelled.discard(job["id"])
+                job_id = job["id"]
+                if job_id in self._cancelled:
+                    job["status"] = "cancelled"
+                    self._cancelled.discard(job_id)
+                else:
+                    job["status"] = "failed"
+                    job["errors"].append(str(e))
+            if job["status"] == "failed":
+                log.exception("Job %s failed", job["id"])
         finally:
             elapsed = time.time() - start_time
             job["finished_at"] = datetime.now().isoformat()

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -199,10 +199,15 @@ class JobRunner:
             # when the work function stashed one before raising. Otherwise
             # fall back to a minimal {"error": ...} payload so the history
             # row still carries something useful.
+            # Use the pre-selected fatal error when available (pipeline jobs
+            # set _fatal_error to a "[stage] Fatal: …" message, which is the
+            # true failure cause). Fall back to errors[0] for non-pipeline
+            # jobs or edge cases where _fatal_error wasn't set.
+            primary_error = job.get("_fatal_error") or job["errors"][0]
             if isinstance(result_data, dict):
-                result_data = {**result_data, "error": job["errors"][0]}
+                result_data = {**result_data, "error": primary_error}
             else:
-                result_data = {"error": job["errors"][0]}
+                result_data = {"error": primary_error}
 
         tree_json = json.dumps(job.get("steps", []))
         summary = self._build_summary(job)

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -195,7 +195,14 @@ class JobRunner:
 
         result_data = job["result"]
         if job["status"] == "failed" and job["errors"]:
-            result_data = {"error": job["errors"][0]}
+            # Preserve a structured result (e.g. the pipeline's stages dict)
+            # when the work function stashed one before raising. Otherwise
+            # fall back to a minimal {"error": ...} payload so the history
+            # row still carries something useful.
+            if isinstance(result_data, dict):
+                result_data = {**result_data, "error": job["errors"][0]}
+            else:
+                result_data = {"error": job["errors"][0]}
 
         tree_json = json.dumps(job.get("steps", []))
         summary = self._build_summary(job)

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -159,7 +159,14 @@ class JobRunner:
                     self._cancelled.discard(job_id)
                 else:
                     job["status"] = "failed"
-                    job["errors"].append(str(e))
+                    # Avoid duplicating an error the work function already
+                    # recorded. Pipelines capture stage errors directly into
+                    # job["errors"] and then re-raise with the same message,
+                    # so a naive append here would double-count them and
+                    # inflate error_count in the persisted history.
+                    err_str = str(e)
+                    if err_str not in job["errors"]:
+                        job["errors"].append(err_str)
             if job["status"] == "failed":
                 log.exception("Job %s failed", job["id"])
         finally:

--- a/vireo/models.py
+++ b/vireo/models.py
@@ -17,6 +17,13 @@ CONFIG_PATH = os.path.expanduser("~/.vireo/models.json")
 # HuggingFace repo containing all ONNX models
 ONNX_REPO = "jss367/vireo-onnx-models"
 
+# Minimum size for an ONNX external-data sidecar file (.onnx.data). Real weights
+# are always hundreds of MB; anything smaller means the download was truncated
+# or the .data file was never fetched. 10 MB is a generous floor that catches
+# the observed failure mode (graph stub with no weights) without risking any
+# legitimate file.
+_ONNX_DATA_MIN_BYTES = 10 * 1024 * 1024
+
 # Known models that can be downloaded.
 # Each entry specifies which ONNX files are needed and the subdirectory
 # within the HF repo where they live.
@@ -122,51 +129,86 @@ def _save_config(config):
 
 
 def _check_onnx_downloaded(model_dir, files):
-    """Check if all required model files exist in a model directory.
+    """Check if all required model files exist and look usable.
 
-    Args:
-        model_dir: path to the model directory
-        files: list of filenames that must be present
+    Requires each listed file to exist, and requires any ONNX external-data
+    sidecar (*.onnx.data) to be at least _ONNX_DATA_MIN_BYTES so that graph
+    stubs without weights are detected as incomplete.
 
     Returns:
-        True if the directory exists and contains all required files
+        True only if the directory exists, every file in `files` is present,
+        and every *.onnx.data file meets the size floor.
+    """
+    return _classify_model_state(model_dir, files) == "ok"
+
+
+def _classify_model_state(model_dir, files):
+    """Return 'ok', 'missing', or 'incomplete' for a model directory.
+
+    - 'missing':    directory doesn't exist, or no required file is present.
+    - 'incomplete': directory exists with some but not all required files,
+                    OR an .onnx.data sidecar exists but is below the size
+                    floor (indicating a truncated / stubs-only download).
+    - 'ok':         all files present and sidecars meet the size floor.
     """
     if not os.path.isdir(model_dir):
-        return False
-    return all(
-        os.path.isfile(os.path.join(model_dir, f))
-        for f in files
-    )
+        return "missing"
+
+    present = [
+        f for f in files if os.path.isfile(os.path.join(model_dir, f))
+    ]
+    if not present:
+        return "missing"
+    if len(present) < len(files):
+        return "incomplete"
+
+    for f in files:
+        if f.endswith(".onnx.data"):
+            size = os.path.getsize(os.path.join(model_dir, f))
+            if size < _ONNX_DATA_MIN_BYTES:
+                return "incomplete"
+
+    return "ok"
 
 
 def get_models():
-    """Return list of all models (known + custom) with download status."""
+    """Return list of all models (known + custom) with download status.
+
+    Each entry includes a `state` field with one of:
+      - "ok":         model files are all present and pass validation
+      - "incomplete": model directory exists but some files are missing or
+                      an .onnx.data sidecar is below the size floor
+      - "missing":    model directory doesn't exist or has no files
+
+    The legacy `downloaded` boolean is True only for state == "ok".
+    """
     config = _load_config()
     registered = {m["id"]: m for m in config.get("models", [])}
 
     result = []
     for km in KNOWN_MODELS:
         model_dir = os.path.join(DEFAULT_MODELS_DIR, km["id"])
-        downloaded = _check_onnx_downloaded(model_dir, km.get("files", []))
+        files = km.get("files", [])
+        state = _classify_model_state(model_dir, files)
 
+        # If the default dir doesn't have the model, check any custom
+        # registered path before giving up.
+        if state != "ok" and km["id"] in registered:
+            reg_path = registered[km["id"]].get("weights_path", "")
+            if reg_path and reg_path != model_dir:
+                reg_state = _classify_model_state(reg_path, files)
+                if reg_state == "ok":
+                    model_dir = reg_path
+                    state = "ok"
+
+        downloaded = state == "ok"
         entry = {
             **km,
             "downloaded": downloaded,
+            "state": state,
             "weights_path": model_dir if downloaded else None,
             "model_type": km.get("model_type", "bioclip"),
         }
-
-        # Also check registered path if different
-        if not downloaded and km["id"] in registered:
-            reg = registered[km["id"]]
-            reg_path = reg.get("weights_path", "")
-            if reg_path and os.path.isdir(reg_path) and all(
-                os.path.isfile(os.path.join(reg_path, f))
-                for f in km.get("files", [])
-            ):
-                entry["downloaded"] = True
-                entry["weights_path"] = reg_path
-
         result.append(entry)
 
     # Add custom models
@@ -194,6 +236,7 @@ def get_models():
                     "description": m.get("description", "Custom model"),
                     "weights_path": path,
                     "downloaded": downloaded,
+                    "state": "ok" if downloaded else "missing",
                 }
             )
 
@@ -427,6 +470,18 @@ def download_model(model_id, progress_callback=None):
             model_dir,
             subfolder=hf_subdir,
             progress_callback=progress_callback,
+        )
+
+    # Validate that what landed on disk is actually usable before we register
+    # the model. This catches truncated downloads (e.g. ONNX graph stubs with
+    # no external data sidecar) so the download-model job surfaces the
+    # failure instead of silently registering a broken model.
+    state = _classify_model_state(model_dir, files)
+    if state != "ok":
+        raise RuntimeError(
+            f"Downloaded {km['name']} failed validation ({state}). "
+            f"Some files may be missing or truncated in {model_dir}. "
+            f"Try the download again — it will resume from the cache."
         )
 
     if progress_callback:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -54,7 +54,12 @@ def _should_abort(abort_event):
     return abort_event.is_set()
 
 
-def _incomplete_model_message(model_name):
+def _incomplete_model_message(model_name, is_custom=False):
+    if is_custom:
+        return (
+            f"Model '{model_name}' appears to be missing required files. "
+            f"Ensure all model files are present in the model directory."
+        )
     return (
         f"Model '{model_name}' is incomplete. "
         f"Open Settings → Models and click Repair to finish the download."
@@ -587,6 +592,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             weights_path = active_model["weights_path"]
             model_type = active_model.get("model_type", "bioclip")
             model_name = active_model["name"]
+            model_is_custom = active_model.get("source") == "custom"
             runner.update_step(job["id"], "model_loader", current_file=model_name)
 
             # Download taxonomy if missing and requested
@@ -640,7 +646,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             if files and weights_path:
                 state = _classify_model_state(weights_path, files)
                 if state != "ok":
-                    raise RuntimeError(_incomplete_model_message(model_name))
+                    raise RuntimeError(_incomplete_model_message(model_name, model_is_custom))
 
             try:
                 if model_type == "timm":
@@ -659,7 +665,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 # any load failure as an incomplete-model hint for the user.
                 if _looks_like_missing_external_data(load_err):
                     raise RuntimeError(
-                        _incomplete_model_message(model_name)
+                        _incomplete_model_message(model_name, model_is_custom)
                     ) from load_err
                 raise
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1082,6 +1082,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         name for name, s in stages.items() if s.get("status") == "failed"
     ]
     if failed_stages and not runner.is_cancelled(job["id"]):
+        # Stash the structured result on the job BEFORE raising so the
+        # completion event and job_history still carry per-stage details
+        # (stages dict, errors list). Without this, the pipeline UI loses
+        # the "Failed: [stage_name]" mapping on the card that owned the
+        # failure because it reads result.result.stages / .errors.
+        job["result"] = result
         first_error = errors[0] if errors else f"stage '{failed_stages[0]}' failed"
         raise RuntimeError(first_error)
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1094,12 +1094,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         # the "Failed: [stage_name]" mapping on the card that owned the
         # failure because it reads result.result.stages / .errors.
         job["result"] = result
-        first_error = errors[0] if errors else f"stage '{failed_stages[0]}' failed"
-        # Preserve the structured stage/error data on the job before raising so
-        # the completion event and frontend (which reads result.result.errors and
-        # result.result.stages) still has the per-stage breakdown even though the
-        # job is marked as failed.
-        job["result"] = result
+        # Prefer a "[stage] Fatal: …" error from one of the failed stages
+        # rather than blindly using errors[0], which may be a non-fatal
+        # per-photo warning (e.g. "Photo <id>: mask extraction failed")
+        # logged before the stage-level failure. Falling back to errors[0]
+        # when no stage-fatal entry exists keeps backward compatibility for
+        # any edge case where a stage marks itself failed without appending a
+        # Fatal error; the final fallback covers an empty errors list.
+        first_error = next(
+            (e for e in errors if any(e.startswith(f"[{s}] Fatal:") for s in failed_stages)),
+            errors[0] if errors else f"stage '{failed_stages[0]}' failed",
+        )
         raise RuntimeError(first_error)
 
     return result

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1122,6 +1122,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             (e for e in errors if any(e.startswith(f"[{s}] Fatal:") for s in failed_stages)),
             errors[0] if errors else f"stage '{failed_stages[0]}' failed",
         )
+        # Record the fatal error for _persist_job so it can store the stage
+        # failure message rather than job["errors"][0], which may be a
+        # non-fatal per-photo warning that was logged before this failure.
+        job["_fatal_error"] = first_error
         raise RuntimeError(first_error)
 
     return result

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1089,6 +1089,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         # failure because it reads result.result.stages / .errors.
         job["result"] = result
         first_error = errors[0] if errors else f"stage '{failed_stages[0]}' failed"
+        # Preserve the structured stage/error data on the job before raising so
+        # the completion event and frontend (which reads result.result.errors and
+        # result.result.stages) still has the per-stage breakdown even though the
+        # job is marked as failed.
+        job["result"] = result
         raise RuntimeError(first_error)
 
     return result

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -54,6 +54,24 @@ def _should_abort(abort_event):
     return abort_event.is_set()
 
 
+def _incomplete_model_message(model_name):
+    return (
+        f"Model '{model_name}' is incomplete. "
+        f"Open Settings → Models and click Repair to finish the download."
+    )
+
+
+def _looks_like_missing_external_data(err):
+    """Heuristic: does this exception look like ONNXRuntime failing to find
+    an external-data sidecar? Matches the specific message the runtime
+    raises when a graph references external weights that aren't on disk."""
+    msg = str(err).lower()
+    return (
+        "model_path must not be empty" in msg
+        or "external data" in msg
+    )
+
+
 def _update_stages(runner, job_id, stages):
     """Push a stages progress update."""
     runner.push_event(job_id, "progress", {
@@ -613,16 +631,37 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 "stages": {k: dict(v) for k, v in stages.items()},
             })
 
-            if model_type == "timm":
-                from timm_classifier import TimmClassifier
-                clf = TimmClassifier(model_str, taxonomy=tax)
-            else:
-                from classifier import Classifier
-                clf = Classifier(
-                    labels=None if use_tol else labels,
-                    model_str=model_str,
-                    pretrained_str=weights_path,
-                )
+            # Preflight: validate the on-disk model before handing it to
+            # ONNXRuntime. A stale _check_onnx_downloaded result (e.g. after
+            # the user deleted a .onnx.data file, or the download manifest
+            # changed) would otherwise surface as an opaque ONNXRuntime crash.
+            from models import _classify_model_state
+            files = active_model.get("files", [])
+            if files and weights_path:
+                state = _classify_model_state(weights_path, files)
+                if state != "ok":
+                    raise RuntimeError(_incomplete_model_message(model_name))
+
+            try:
+                if model_type == "timm":
+                    from timm_classifier import TimmClassifier
+                    clf = TimmClassifier(model_str, taxonomy=tax)
+                else:
+                    from classifier import Classifier
+                    clf = Classifier(
+                        labels=None if use_tol else labels,
+                        model_str=model_str,
+                        pretrained_str=weights_path,
+                    )
+            except Exception as load_err:
+                # ONNXRuntime signals missing external-data with a
+                # "model_path must not be empty" / "Initializer" error. Treat
+                # any load failure as an incomplete-model hint for the user.
+                if _looks_like_missing_external_data(load_err):
+                    raise RuntimeError(
+                        _incomplete_model_message(model_name)
+                    ) from load_err
+                raise
 
             loaded_models["clf"] = clf
             loaded_models["model_type"] = model_type
@@ -1034,5 +1073,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
     elapsed = time.time() - job["_start_time"]
     result["duration"] = round(elapsed, 1)
     result["errors"] = list(errors)
+
+    # If any stage ended in 'failed' and the job wasn't cancelled, propagate
+    # the failure so JobRunner marks the whole job as failed rather than
+    # silently recording it as completed. Cancellation takes precedence:
+    # a cancelled job stays cancelled even if stages crashed on the way down.
+    failed_stages = [
+        name for name, s in stages.items() if s.get("status") == "failed"
+    ]
+    if failed_stages and not runner.is_cancelled(job["id"]):
+        first_error = errors[0] if errors else f"stage '{failed_stages[0]}' failed"
+        raise RuntimeError(first_error)
 
     return result

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1583,8 +1583,15 @@ async function loadModels() {
     var html = '';
     models.forEach(function(m) {
       var isActive = m.id === activeId;
-      var statusColor = m.downloaded ? 'var(--accent)' : 'var(--text-faint)';
-      var statusText = m.downloaded ? 'Downloaded' : 'Not downloaded';
+      var state = m.state || (m.downloaded ? 'ok' : 'missing');
+      var statusColor, statusText;
+      if (state === 'ok') {
+        statusColor = 'var(--accent)'; statusText = 'Downloaded';
+      } else if (state === 'incomplete') {
+        statusColor = 'var(--warning)'; statusText = 'Incomplete — repair available';
+      } else {
+        statusColor = 'var(--text-faint)'; statusText = 'Not downloaded';
+      }
       var activeTag = isActive ? ' <span style="color:var(--accent);font-size:10px;font-weight:600;">ACTIVE</span>' : '';
 
       html += '<div style="padding:10px 0;border-bottom:1px solid var(--border-subtle);">';
@@ -1596,21 +1603,26 @@ async function loadModels() {
       html += activeTag;
       html += '</div>';
       html += '<div style="font-size:12px;color:var(--text-dim);margin-bottom:6px;">' + escapeHtml(m.description || '') + '</div>';
+      if (state === 'incomplete') {
+        html += '<div style="font-size:11px;color:var(--warning);margin-bottom:6px;">Model files are missing or truncated. Click Repair to finish the download — already-downloaded files will not be re-fetched.</div>';
+      }
       html += '<div style="display:flex;align-items:center;gap:8px;">';
       html += '<span style="font-size:11px;color:' + statusColor + ';">' + statusText + '</span>';
 
-      if (m.downloaded && m.weights_path) {
+      if (state === 'ok' && m.weights_path) {
         html += '<span style="font-size:11px;color:var(--text-invisible);">' + escapeHtml(m.weights_path) + '</span>';
       }
 
       html += '<span style="margin-left:auto;display:flex;gap:6px;">';
-      if (!m.downloaded && m.source !== 'custom') {
+      if (state === 'incomplete' && m.source !== 'custom') {
+        html += '<button onclick="downloadModel(\'' + m.id + '\')" style="background:var(--warning);color:var(--accent-text);border:none;border-radius:4px;padding:4px 12px;font-size:11px;cursor:pointer;font-weight:600;">Repair</button>';
+      } else if (state === 'missing' && m.source !== 'custom') {
         html += '<button onclick="downloadModel(\'' + m.id + '\')" style="background:var(--accent);color:var(--accent-text);border:none;border-radius:4px;padding:4px 12px;font-size:11px;cursor:pointer;">Download</button>';
       }
-      if (!isActive) {
+      if (!isActive && state === 'ok') {
         html += '<button onclick="setActiveModel(\'' + m.id + '\')" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:4px;padding:4px 12px;font-size:11px;cursor:pointer;">Use This</button>';
       }
-      if (m.downloaded) {
+      if (state !== 'missing') {
         html += '<button onclick="removeModel(\'' + m.id + '\')" style="background:none;color:var(--danger);border:1px solid var(--danger);border-radius:4px;padding:4px 12px;font-size:11px;cursor:pointer;">Remove</button>';
       }
       html += '</span>';

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -59,6 +59,65 @@ def test_job_runner_tracks_failure(tmp_path):
     assert 'something broke' in job['errors'][0]
 
 
+def test_job_runner_does_not_duplicate_preexisting_errors():
+    """When work_fn records its own errors into job['errors'] and then raises
+    with the same message, the failure handler must not double-count it.
+
+    Pipelines do exactly this: stages append to job['errors'] directly, and
+    run_pipeline_job re-raises with errors[0]. Without the dedupe, the error
+    shows up twice and inflates error_count in job_history.
+    """
+    from jobs import JobRunner
+
+    runner = JobRunner()
+
+    def failing_work(job):
+        job['errors'].append("[model_loader] Fatal: model_path must not be empty")
+        raise RuntimeError("[model_loader] Fatal: model_path must not be empty")
+
+    job_id = runner.start('test', failing_work)
+
+    for _ in range(50):
+        job = runner.get(job_id)
+        if job['status'] == 'failed':
+            break
+        time.sleep(0.05)
+
+    job = runner.get(job_id)
+    assert job['status'] == 'failed'
+    # Exactly one error entry — the one the work function already recorded.
+    assert job['errors'] == [
+        "[model_loader] Fatal: model_path must not be empty"
+    ], f"Expected single error entry, got: {job['errors']}"
+
+
+def test_job_runner_still_records_novel_exception_text():
+    """If the exception from work_fn is *different* from any pre-recorded
+    error, it should still be appended (the dedupe is targeted, not blanket).
+    """
+    from jobs import JobRunner
+
+    runner = JobRunner()
+
+    def failing_work(job):
+        job['errors'].append("stage warning: something odd")
+        raise RuntimeError("orchestrator failure: unexpected state")
+
+    job_id = runner.start('test', failing_work)
+
+    for _ in range(50):
+        job = runner.get(job_id)
+        if job['status'] == 'failed':
+            break
+        time.sleep(0.05)
+
+    job = runner.get(job_id)
+    assert job['status'] == 'failed'
+    assert len(job['errors']) == 2
+    assert "stage warning: something odd" in job['errors']
+    assert "orchestrator failure: unexpected state" in job['errors']
+
+
 def test_job_runner_list_jobs():
     """JobRunner.list_jobs returns all jobs."""
     from jobs import JobRunner

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -118,6 +118,93 @@ def test_job_runner_still_records_novel_exception_text():
     assert "orchestrator failure: unexpected state" in job['errors']
 
 
+def test_failed_job_history_preserves_structured_result(tmp_path):
+    """When a work function stashes a structured result on job['result']
+    before raising, _persist_job must preserve that structure in history
+    (merging the error into it) rather than replacing it with {"error": ...}.
+
+    This is what lets the pipeline UI render per-stage details on a failed
+    run — it reads result.result.stages and result.result.errors.
+    """
+    import json as _json
+
+    from db import Database
+    from jobs import JobRunner
+
+    db = Database(str(tmp_path / "test.db"))
+    runner = JobRunner(db=db)
+
+    def failing_pipeline_like(job):
+        # Simulate pipeline_job's behavior: build a result dict, attach it to
+        # the job, and raise with the first error message.
+        job['result'] = {
+            "stages": {
+                "scan": {"status": "completed", "count": 10},
+                "model_loader": {"status": "failed"},
+            },
+            "errors": ["[model_loader] Fatal: model_path must not be empty"],
+            "duration": 1.2,
+        }
+        job['errors'].append("[model_loader] Fatal: model_path must not be empty")
+        raise RuntimeError("[model_loader] Fatal: model_path must not be empty")
+
+    job_id = runner.start('pipeline', failing_pipeline_like)
+
+    for _ in range(50):
+        job = runner.get(job_id)
+        if job['status'] == 'failed':
+            break
+        time.sleep(0.05)
+
+    # Let the finally block persist
+    time.sleep(0.15)
+
+    row = db.conn.execute(
+        "SELECT result, error_count FROM job_history WHERE id = ?", (job_id,)
+    ).fetchone()
+    assert row is not None
+
+    stored = _json.loads(row["result"])
+    # Structured result must survive — the stages dict is what the UI needs.
+    assert "stages" in stored, f"expected stages in stored result, got: {stored}"
+    assert stored["stages"]["model_loader"]["status"] == "failed"
+    # The error must be merged in, not replacing the structure.
+    assert stored.get("error") == "[model_loader] Fatal: model_path must not be empty"
+    # Exactly one error entry (dedupe is working) → error_count == 1.
+    assert row["error_count"] == 1, f"expected error_count=1, got {row['error_count']}"
+
+
+def test_failed_job_history_falls_back_when_no_structured_result(tmp_path):
+    """When work_fn raises without stashing a result, persist the minimal
+    {"error": ...} payload as before — the fallback path still works."""
+    import json as _json
+
+    from db import Database
+    from jobs import JobRunner
+
+    db = Database(str(tmp_path / "test.db"))
+    runner = JobRunner(db=db)
+
+    def failing_work(job):
+        raise RuntimeError("boom")
+
+    job_id = runner.start('test', failing_work)
+
+    for _ in range(50):
+        job = runner.get(job_id)
+        if job['status'] == 'failed':
+            break
+        time.sleep(0.05)
+
+    time.sleep(0.15)
+
+    row = db.conn.execute(
+        "SELECT result FROM job_history WHERE id = ?", (job_id,)
+    ).fetchone()
+    stored = _json.loads(row["result"])
+    assert stored == {"error": "boom"}
+
+
 def test_job_runner_list_jobs():
     """JobRunner.list_jobs returns all jobs."""
     from jobs import JobRunner

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -12,6 +12,18 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
+def _make_fake_data_file(path, size_bytes=None):
+    """Create a sparse file of the given size for .onnx.data stubs in tests.
+
+    Defaults to a size that clears the _ONNX_DATA_MIN_BYTES floor in models.py.
+    """
+    import models as _models
+    if size_bytes is None:
+        size_bytes = _models._ONNX_DATA_MIN_BYTES + 1024
+    with open(path, "wb") as f:
+        f.truncate(size_bytes)
+
+
 # ---------------------------------------------------------------------------
 # Config load / save
 # ---------------------------------------------------------------------------
@@ -151,9 +163,9 @@ def test_get_models_downloaded_flag(tmp_path, monkeypatch):
     model_dir = tmp_path / "models" / "bioclip-vit-b-16"
     model_dir.mkdir(parents=True)
     (model_dir / "image_encoder.onnx").write_bytes(b"fake")
-    (model_dir / "image_encoder.onnx.data").write_bytes(b"fake")
+    _make_fake_data_file(model_dir / "image_encoder.onnx.data")
     (model_dir / "text_encoder.onnx").write_bytes(b"fake")
-    (model_dir / "text_encoder.onnx.data").write_bytes(b"fake")
+    _make_fake_data_file(model_dir / "text_encoder.onnx.data")
     (model_dir / "tokenizer.json").write_text("{}")
     (model_dir / "config.json").write_text("{}")
 
@@ -188,9 +200,9 @@ def test_set_and_get_active_model(tmp_path, monkeypatch):
     model_dir = tmp_path / "models" / "bioclip-vit-b-16"
     model_dir.mkdir(parents=True)
     (model_dir / "image_encoder.onnx").write_bytes(b"fake")
-    (model_dir / "image_encoder.onnx.data").write_bytes(b"fake")
+    _make_fake_data_file(model_dir / "image_encoder.onnx.data")
     (model_dir / "text_encoder.onnx").write_bytes(b"fake")
-    (model_dir / "text_encoder.onnx.data").write_bytes(b"fake")
+    _make_fake_data_file(model_dir / "text_encoder.onnx.data")
     (model_dir / "tokenizer.json").write_text("{}")
     (model_dir / "config.json").write_text("{}")
 
@@ -212,9 +224,9 @@ def test_get_active_model_fallback(tmp_path, monkeypatch):
     model_dir = tmp_path / "models" / "bioclip-vit-b-16"
     model_dir.mkdir(parents=True)
     (model_dir / "image_encoder.onnx").write_bytes(b"fake")
-    (model_dir / "image_encoder.onnx.data").write_bytes(b"fake")
+    _make_fake_data_file(model_dir / "image_encoder.onnx.data")
     (model_dir / "text_encoder.onnx").write_bytes(b"fake")
-    (model_dir / "text_encoder.onnx.data").write_bytes(b"fake")
+    _make_fake_data_file(model_dir / "text_encoder.onnx.data")
     (model_dir / "tokenizer.json").write_text("{}")
     (model_dir / "config.json").write_text("{}")
 
@@ -411,3 +423,161 @@ def test_download_model_unknown_id(tmp_path, monkeypatch):
         assert False, "Should have raised ValueError"
     except ValueError as e:
         assert "Unknown model" in str(e)
+
+
+# ---------------------------------------------------------------------------
+# Model state classification (self-heal detection)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_state_missing_directory(tmp_path):
+    """Nonexistent directory reports 'missing'."""
+    import models
+    assert models._classify_model_state(
+        str(tmp_path / "nope"), ["a.onnx", "a.onnx.data"]
+    ) == "missing"
+
+
+def test_classify_state_empty_directory(tmp_path):
+    """Directory with no required files reports 'missing'."""
+    import models
+    d = tmp_path / "m"
+    d.mkdir()
+    assert models._classify_model_state(
+        str(d), ["image_encoder.onnx", "image_encoder.onnx.data"]
+    ) == "missing"
+
+
+def test_classify_state_partial_files(tmp_path):
+    """Directory with some but not all required files reports 'incomplete'."""
+    import models
+    d = tmp_path / "m"
+    d.mkdir()
+    (d / "image_encoder.onnx").write_bytes(b"stub")
+    _make_fake_data_file(d / "image_encoder.onnx.data")
+    # missing text_encoder files
+    assert models._classify_model_state(
+        str(d),
+        [
+            "image_encoder.onnx", "image_encoder.onnx.data",
+            "text_encoder.onnx", "text_encoder.onnx.data",
+        ],
+    ) == "incomplete"
+
+
+def test_classify_state_truncated_data_file(tmp_path):
+    """An .onnx.data file below the size floor reports 'incomplete'."""
+    import models
+    d = tmp_path / "m"
+    d.mkdir()
+    (d / "image_encoder.onnx").write_bytes(b"stub")
+    # Sub-threshold data file — the exact failure mode from the incident.
+    _make_fake_data_file(d / "image_encoder.onnx.data", size_bytes=1024)
+    assert models._classify_model_state(
+        str(d), ["image_encoder.onnx", "image_encoder.onnx.data"]
+    ) == "incomplete"
+
+
+def test_classify_state_ok(tmp_path):
+    """All files present and data file meets floor reports 'ok'."""
+    import models
+    d = tmp_path / "m"
+    d.mkdir()
+    (d / "image_encoder.onnx").write_bytes(b"stub")
+    _make_fake_data_file(d / "image_encoder.onnx.data")
+    assert models._classify_model_state(
+        str(d), ["image_encoder.onnx", "image_encoder.onnx.data"]
+    ) == "ok"
+
+
+def test_get_models_surfaces_incomplete_state(tmp_path, monkeypatch):
+    """get_models reports state='incomplete' and downloaded=False when a known
+    model directory exists but the .onnx.data sidecar is under the size floor.
+
+    This is the exact disk state that caused the incident: graph stubs were
+    downloaded before the manifest learned about external-data files.
+    """
+    import models
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
+
+    model_dir = tmp_path / "models" / "bioclip-vit-b-16"
+    model_dir.mkdir(parents=True)
+    (model_dir / "image_encoder.onnx").write_bytes(b"stub")
+    _make_fake_data_file(model_dir / "image_encoder.onnx.data", size_bytes=2048)
+    (model_dir / "text_encoder.onnx").write_bytes(b"stub")
+    _make_fake_data_file(model_dir / "text_encoder.onnx.data", size_bytes=2048)
+    (model_dir / "tokenizer.json").write_text("{}")
+    (model_dir / "config.json").write_text("{}")
+
+    result = models.get_models()
+    entry = next(m for m in result if m["id"] == "bioclip-vit-b-16")
+    assert entry["state"] == "incomplete"
+    assert entry["downloaded"] is False
+
+
+# ---------------------------------------------------------------------------
+# download_model post-download validation
+# ---------------------------------------------------------------------------
+
+
+def test_download_model_rejects_truncated_result(tmp_path, monkeypatch):
+    """download_model raises if the downloaded files fail validation.
+
+    Simulates the regression window where the downloader would fetch ONNX
+    graph stubs but the .onnx.data file was missing/truncated. The fix: fail
+    the job instead of registering a broken model.
+    """
+    import models
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
+
+    model_dir = tmp_path / "models" / "bioclip-vit-b-16"
+
+    def fake_download(repo_id, filename, local_dir, subfolder=None, progress_callback=None):
+        os.makedirs(local_dir, exist_ok=True)
+        dest = os.path.join(local_dir, filename)
+        if filename.endswith(".onnx.data"):
+            # Truncated sidecar — below the size floor.
+            with open(dest, "wb") as f:
+                f.truncate(1024)
+        else:
+            with open(dest, "wb") as f:
+                f.write(b"stub")
+        return dest
+
+    monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
+
+    import pytest
+    with pytest.raises(RuntimeError, match="failed validation"):
+        models.download_model("bioclip-vit-b-16")
+
+    # The broken model must not have been registered.
+    cfg = models._load_config()
+    assert not any(m["id"] == "bioclip-vit-b-16" for m in cfg.get("models", []))
+
+
+def test_download_model_accepts_valid_result(tmp_path, monkeypatch):
+    """download_model registers the model when validation passes."""
+    import models
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
+
+    def fake_download(repo_id, filename, local_dir, subfolder=None, progress_callback=None):
+        os.makedirs(local_dir, exist_ok=True)
+        dest = os.path.join(local_dir, filename)
+        if filename.endswith(".onnx.data"):
+            with open(dest, "wb") as f:
+                f.truncate(models._ONNX_DATA_MIN_BYTES + 1024)
+        else:
+            with open(dest, "wb") as f:
+                f.write(b"stub")
+        return dest
+
+    monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
+
+    result = models.download_model("bioclip-vit-b-16")
+    assert result.endswith("bioclip-vit-b-16")
+
+    cfg = models._load_config()
+    assert any(m["id"] == "bioclip-vit-b-16" for m in cfg.get("models", []))

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -1131,6 +1131,20 @@ def test_pipeline_raises_when_stage_fails(tmp_path, monkeypatch):
     with pytest.raises(RuntimeError):
         run_pipeline_job(job, runner, db_path, ws_id, params)
 
+    # The pipeline must stash its structured result on the job before raising,
+    # so the pipeline UI's _onPipelineComplete handler can still read
+    # result.result.errors and map the "[model_loader] Fatal: ..." prefix to
+    # the right stage card. Without this, users on a failed run lose the
+    # actionable "Failed: <stage error>" label on the card that broke.
+    assert isinstance(job["result"], dict), \
+        "Failed pipeline must leave a dict result on the job for UI rendering"
+    assert "errors" in job["result"]
+    assert any(
+        "model_loader" in e for e in job["result"]["errors"]
+    ), f"Expected a [model_loader]-prefixed error, got: {job['result']['errors']}"
+    assert "duration" in job["result"]
+    assert "stages" in job["result"]
+
 
 def test_pipeline_translates_incomplete_model_error(tmp_path, monkeypatch):
     """Model loader failures from missing external-data get a friendly message.

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -29,6 +29,7 @@ class FakeRunner:
     def __init__(self):
         self.events = []
         self.step_updates = []
+        self._cancelled_ids = set()
 
     def push_event(self, job_id, event_type, data):
         self.events.append((job_id, event_type, data))
@@ -38,6 +39,12 @@ class FakeRunner:
 
     def update_step(self, job_id, step_id, **kwargs):
         self.step_updates.append((job_id, step_id, kwargs))
+
+    def is_cancelled(self, job_id):
+        return job_id in self._cancelled_ids
+
+    def mark_cancelled(self, job_id):
+        self._cancelled_ids.add(job_id)
 
 
 def test_pipeline_params_has_skip_classify():
@@ -140,6 +147,7 @@ def test_pipeline_job_with_collection_skips_scan(tmp_path, monkeypatch):
 
     params = PipelineParams(
         collection_id=col_id,
+        skip_classify=True,
         skip_extract_masks=True,
         skip_regroup=True,
     )
@@ -194,6 +202,7 @@ def test_pipeline_abort_on_nonexistent_source(tmp_path, monkeypatch):
     params = PipelineParams(
         source=str(tmp_path / "nonexistent_dir"),
         destination=str(tmp_path / "dest"),
+        skip_classify=True,
         skip_extract_masks=True,
         skip_regroup=True,
     )
@@ -205,8 +214,9 @@ def test_pipeline_abort_on_nonexistent_source(tmp_path, monkeypatch):
 
     assert isinstance(result, dict)
     assert "duration" in result
-    # Should have errors (model_loader will fail in test env without models)
-    assert len(result["errors"]) > 0
+    # With skip_classify set, the scanner should handle the missing source
+    # gracefully and end without error. If this regresses — i.e. a real stage
+    # failure creeps in — the pipeline now raises, which also fails the test.
 
 
 def test_pipeline_scan_thumbnail_collection_stages(tmp_path, monkeypatch):
@@ -231,6 +241,7 @@ def test_pipeline_scan_thumbnail_collection_stages(tmp_path, monkeypatch):
 
     params = PipelineParams(
         source=str(photo_dir),
+        skip_classify=True,
         skip_extract_masks=True,
         skip_regroup=True,
     )
@@ -279,6 +290,7 @@ def test_pipeline_stages_dict_in_progress_events(tmp_path, monkeypatch):
 
     params = PipelineParams(
         source=str(photo_dir),
+        skip_classify=True,
         skip_extract_masks=True,
         skip_regroup=True,
     )
@@ -328,6 +340,7 @@ def test_pipeline_scan_and_thumbnail_overlap(tmp_path, monkeypatch):
 
     params = PipelineParams(
         source=str(photo_dir),
+        skip_classify=True,
         skip_extract_masks=True,
         skip_regroup=True,
     )
@@ -373,6 +386,7 @@ def test_pipeline_skips_scan_with_collection_id(tmp_path, monkeypatch):
 
     params = PipelineParams(
         collection_id=col_id,
+        skip_classify=True,
         skip_extract_masks=True,
         skip_regroup=True,
     )
@@ -405,6 +419,7 @@ def test_pipeline_nonexistent_source_scans_nothing(tmp_path, monkeypatch):
 
     params = PipelineParams(
         source="/nonexistent/path/that/does/not/exist",
+        skip_classify=True,
         skip_extract_masks=True,
         skip_regroup=True,
     )
@@ -434,6 +449,7 @@ def test_pipeline_result_has_duration(tmp_path, monkeypatch):
 
     params = PipelineParams(
         collection_id=col_id,
+        skip_classify=True,
         skip_extract_masks=True,
         skip_regroup=True,
     )
@@ -470,6 +486,7 @@ def test_pipeline_collection_created_after_scan(tmp_path, monkeypatch):
 
     params = PipelineParams(
         source=str(photo_dir),
+        skip_classify=True,
         skip_extract_masks=True,
         skip_regroup=True,
     )
@@ -1022,3 +1039,187 @@ def test_pipeline_collection_mode_marks_scan_skipped(tmp_path, monkeypatch):
     }
     assert "skipped" in scan_statuses, \
         f"scan should be 'skipped' in collection mode, saw: {scan_statuses}"
+
+
+# ---------------------------------------------------------------------------
+# Stage failure propagation (fixes the silent model-loader failure incident)
+# ---------------------------------------------------------------------------
+
+
+def _make_stage_failer(monkeypatch, stage_name, err_message):
+    """Monkeypatch a specific pipeline stage to raise when invoked."""
+    import pipeline_job
+
+    real_run = pipeline_job.run_pipeline_job
+
+    def wrapped(job, runner, db_path, ws_id, params):
+        # Replace the stage function inside run_pipeline_job by patching the
+        # classifier module that model_loader_stage imports lazily. We use a
+        # targeted env toggle instead so the test stays hermetic.
+        raise NotImplementedError(
+            "Use direct classifier monkeypatch in the test instead."
+        )
+
+    return real_run
+
+
+def _setup_fake_downloaded_model(tmp_path, monkeypatch):
+    """Put a validation-passing fake model on disk so model_loader_stage can
+    get past the model-lookup / labels / taxonomy steps and into Classifier().
+    Returns the model id that was set active.
+    """
+    import classify_job
+    import models
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
+    model_dir = tmp_path / "models" / "bioclip-vit-b-16"
+    model_dir.mkdir(parents=True)
+    (model_dir / "image_encoder.onnx").write_bytes(b"stub")
+    with open(model_dir / "image_encoder.onnx.data", "wb") as f:
+        f.truncate(models._ONNX_DATA_MIN_BYTES + 1024)
+    (model_dir / "text_encoder.onnx").write_bytes(b"stub")
+    with open(model_dir / "text_encoder.onnx.data", "wb") as f:
+        f.truncate(models._ONNX_DATA_MIN_BYTES + 1024)
+    (model_dir / "tokenizer.json").write_text("{}")
+    (model_dir / "config.json").write_text("{}")
+    models.set_active_model("bioclip-vit-b-16")
+    # Short-circuit taxonomy and label loading so the test stays focused on
+    # model-loading behavior.
+    monkeypatch.setattr(classify_job, "_load_taxonomy", lambda *a, **k: {})
+    monkeypatch.setattr(
+        classify_job, "_load_labels", lambda *a, **k: (["test-label"], False)
+    )
+    return "bioclip-vit-b-16"
+
+
+def test_pipeline_raises_when_stage_fails(tmp_path, monkeypatch):
+    """If any pipeline stage ends in 'failed', run_pipeline_job must raise.
+
+    This is the fix for the silent model-loader crash incident: a stage
+    caught its own exception and returned normally, so jobs.py recorded the
+    run as 'completed' despite the failure. Now stage failures propagate.
+    """
+    import classifier as classifier_mod
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("model_path must not be empty")
+
+    monkeypatch.setattr(classifier_mod, "Classifier", boom)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    import pytest
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+
+def test_pipeline_translates_incomplete_model_error(tmp_path, monkeypatch):
+    """Model loader failures from missing external-data get a friendly message.
+
+    Users should see "open Settings → Models and click Repair" rather than
+    the raw ONNXRuntime stack.
+    """
+    import classifier as classifier_mod
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError(
+            "[ONNXRuntimeError] model_path must not be empty. Ensure that "
+            "a path is provided when the model is created or loaded."
+        )
+
+    monkeypatch.setattr(classifier_mod, "Classifier", boom)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    import pytest
+    with pytest.raises(RuntimeError) as exc:
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # Either the model_loader stage raised with the friendly message directly,
+    # or the pipeline raised its own failure wrapping the original; in either
+    # case the errors list (accessible via the model_loader step update) should
+    # contain the actionable "Repair" hint.
+    model_loader_errors = [
+        kwargs.get("error", "")
+        for (_, step_id, kwargs) in runner.step_updates
+        if step_id == "model_loader" and "error" in kwargs
+    ]
+    assert any("Repair" in e for e in model_loader_errors), \
+        f"Expected a Repair hint in model_loader errors, saw: {model_loader_errors}"
+
+
+def test_pipeline_cancellation_takes_precedence_over_failure(tmp_path, monkeypatch):
+    """A cancelled pipeline must not be recorded as 'failed' even if a stage
+    crashed on the way down. Cancellation intent beats failure.
+    """
+    import classifier as classifier_mod
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("model_path must not be empty")
+
+    monkeypatch.setattr(classifier_mod, "Classifier", boom)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+    # Mark cancelled BEFORE the pipeline starts so the post-stage check sees it.
+    runner.mark_cancelled(job["id"])
+
+    # Should NOT raise — cancellation wins over stage failure.
+    result = run_pipeline_job(job, runner, db_path, ws_id, params)
+    assert isinstance(result, dict)


### PR DESCRIPTION
## Summary

A pipeline run against the BioCLIP-2.5 model was silently succeeding while the model-loader stage crashed. The job was recorded as `completed` with summary `"Skipped (using collection), 0 thumbnails"`, no warning to the user, while ONNXRuntime was actually raising `model_path must not be empty` because the `.onnx.data` sidecar files were never downloaded — the download manifest didn't list them before #486.

Root cause fixed by #486 for future downloads, but existing broken downloads were still unusable, with the only workaround being `rm -rf ~/.vireo/models/<id>` — bad UX for a polished photo organizer. This PR makes the class of failure visible and recoverable without filesystem surgery.

Four changes:

- **Pipeline stage failures propagate** (`pipeline_job.py`, `jobs.py`) — `run_pipeline_job` now raises after all stages run if any stage ended in `failed`, so `JobRunner` records the job as `failed` instead of `completed`. Cancellation takes precedence over failure in both the pipeline (via `runner.is_cancelled(job_id)`) and `JobRunner._run_job`, so a cancel during a crash stays `cancelled`.

- **Model validation** (`models.py`) — new `_classify_model_state()` returns `ok` / `incomplete` / `missing`, requires `.onnx.data` sidecars to be at least 10 MB (catches the graph-stub-without-weights state), and is called both by `get_models()` (now surfaces a `state` field) and by `download_model()` before `register_model()` so a truncated download fails the job instead of silently registering a broken model.

- **Self-heal UI** (`templates/settings.html`) — Settings → Models shows an Incomplete state with a Repair button when a model directory exists but fails validation. Repair reuses the existing `/api/jobs/download-model` endpoint, which is idempotent thanks to the HF cache — completed files are skipped, missing ones are fetched.

- **Friendlier error messages** (`pipeline_job.py`) — `model_loader_stage` preflights the on-disk model before calling `Classifier()`, and catches ONNXRuntime external-data errors during load, translating both into an actionable `"Model '<name>' is incomplete. Open Settings → Models and click Repair to finish the download."` instead of the raw ONNXRuntime stack trace.

## Tangential finding (not fixed in this PR)

While investigating, I noticed `JobRunner.is_cancelled(job_id)` was defined but **never called anywhere in the codebase**. That means `cancel_job` currently adds the id to `_cancelled` but doesn't signal the pipeline's local `abort` event, so pressing Cancel on a running pipeline doesn't actually stop the work — it just relabels the final status when the pipeline finishes naturally. This PR makes `is_cancelled` have at least one caller (the new failure-precedence check) but doesn't fix the stop-mid-run behavior. Worth filing as a separate issue if interactive cancellation matters.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_pipeline_job.py vireo/tests/test_models.py` — 489 passed
- [x] `python -m pytest vireo/tests/test_classify_job.py vireo/tests/test_welcome.py vireo/tests/test_classifier.py` — 63 passed
- [x] New `_classify_model_state` tests cover missing directory, empty directory, partial files, truncated data file, and ok state
- [x] New `test_get_models_surfaces_incomplete_state` reproduces the exact on-disk shape from the incident
- [x] New `test_download_model_rejects_truncated_result` simulates the download regression window and verifies registration does not happen
- [x] New `test_pipeline_raises_when_stage_fails` proves the fix for silent model-loader crashes
- [x] New `test_pipeline_translates_incomplete_model_error` verifies the `Repair` hint reaches the job's error log
- [x] New `test_pipeline_cancellation_takes_precedence_over_failure` verifies cancellation beats failure
- [ ] Manual verification: in the running app, restart with existing broken bioclip-2.5-vith14 download; verify Settings → Models shows "Incomplete — repair available" with a Repair button; click Repair and watch it succeed without `rm -rf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)