### PR TITLE
fix: restrict pipeline scan to duplicate folders when nothing is copied

### DIFF
--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -13,6 +13,17 @@ from scanner import compute_file_hash
 log = logging.getLogger(__name__)
 
 
+def _escape_sql_like(s):
+    """Escape SQL LIKE wildcard metacharacters in a literal string.
+
+    SQLite's LIKE treats ``%`` and ``_`` as wildcards unconditionally. The
+    ESCAPE clause lets us declare an escape character so a literal ``%``
+    or ``_`` in the pattern is matched literally. We pair this helper with
+    ``... LIKE ? ESCAPE '\\'`` at the call site.
+    """
+    return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 def _is_unsafe_path(s):
     """Check if a path string could escape the destination directory."""
     if not s:
@@ -182,7 +193,7 @@ def ingest(
     # Load known hashes from database for duplicate detection and merge with
     # any hashes accumulated by previous ingest() calls in the same session.
     known_hashes = set()
-    known_hash_folder: dict[str, str] = {}
+    known_hash_folders: dict[str, set[str]] = {}
     if skip_duplicates:
         # Global hash set for dedup decisions. A source file matching any
         # existing photo in the DB (even in another library root) is skipped
@@ -191,44 +202,47 @@ def ingest(
             "SELECT file_hash FROM photos WHERE file_hash IS NOT NULL"
         ).fetchall()
         known_hashes = {r["file_hash"] for r in rows}
-        # Destination-scoped hash -> folder-path map for populating the
-        # caller's post-ingest scan restrict_dirs. Four guards, layered:
+        # Destination-scoped hash -> set-of-folder-paths map for populating
+        # the caller's post-ingest scan restrict_dirs. The same hash can
+        # legitimately appear in more than one destination subfolder (e.g.,
+        # the user copied the same photo into multiple date folders), and
+        # every matching folder needs to be walked so all of them get
+        # linked to the active workspace. Four guards, layered:
         #   1. SQL ``f.status = 'ok'`` — exclude folders the DB already
         #      knows are missing (cheap and visible to static analysis).
-        #   2. SQL prefix match on ``f.path`` — rough subtree cut so we
-        #      don't haul the whole library into memory on large DBs.
+        #   2. SQL prefix match on ``f.path`` with an explicit ``ESCAPE``
+        #      clause — rough subtree cut so we don't haul the whole
+        #      library into memory on large DBs. Escaping is required
+        #      because destination paths may legally contain SQL LIKE
+        #      wildcard characters (``_`` and ``%``).
         #   3. Python ``Path.is_relative_to`` — strict path-component
-        #      comparison that catches LIKE wildcard leaks (``_``/``%``
-        #      in destination_dir can otherwise match sibling subtrees).
+        #      comparison that catches any residual LIKE wildcard leaks.
         #   4. Python ``Path.is_dir`` — catches stale ``status='ok'``
         #      rows when the folder was deleted since the last scan and
         #      the caller didn't refresh folder health first.
-        # A folder passes only if all four guards agree. Without this,
-        # restrict_dirs can end up with out-of-tree, wildcard-aliased, or
-        # non-existent paths, any of which breaks the post-ingest scan.
+        # A folder passes only if all four guards agree.
         dest_path = Path(destination_dir)
         dest_path_str = str(dest_path)
-        dest_like_prefix = dest_path_str.rstrip("/") + "/%"
+        dest_like_prefix = (
+            _escape_sql_like(dest_path_str.rstrip("/")) + "/%"
+        )
         folder_rows = db.conn.execute(
             """SELECT p.file_hash, f.path AS folder_path
                FROM photos p
                JOIN folders f ON p.folder_id = f.id
                WHERE p.file_hash IS NOT NULL
                  AND f.status = 'ok'
-                 AND (f.path = ? OR f.path LIKE ?)""",
+                 AND (f.path = ? OR f.path LIKE ? ESCAPE '\\')""",
             (dest_path_str, dest_like_prefix),
         ).fetchall()
         for r in folder_rows:
-            fh = r["file_hash"]
-            if fh in known_hash_folder:
-                continue
             folder_path = r["folder_path"]
             candidate = Path(folder_path)
             if not candidate.is_relative_to(dest_path):
                 continue
             if not candidate.is_dir():
                 continue
-            known_hash_folder[fh] = folder_path
+            known_hash_folders.setdefault(r["file_hash"], set()).add(folder_path)
         if extra_known_hashes:
             known_hashes |= extra_known_hashes
 
@@ -245,9 +259,14 @@ def ingest(
 
             if skip_duplicates and file_hash in known_hashes:
                 skipped_duplicate += 1
-                existing_folder = known_hash_folder.get(file_hash)
-                if existing_folder:
-                    duplicate_folders.add(existing_folder)
+                # Record every destination folder that holds a copy of
+                # this file, not just one. The pipeline uses this set
+                # verbatim as restrict_dirs, so if we only report one
+                # folder the others never get linked to the active
+                # workspace.
+                duplicate_folders.update(
+                    known_hash_folders.get(file_hash, ())
+                )
                 if progress_callback:
                     progress_callback(i + 1, total, source_file.name)
                 continue

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -181,12 +181,22 @@ def ingest(
 
     # Load known hashes from database for duplicate detection and merge with
     # any hashes accumulated by previous ingest() calls in the same session.
+    # Also build a hash -> folder-path map so we can tell the caller where
+    # the existing duplicates live; the pipeline uses this to restrict the
+    # post-ingest scan to just the relevant subdirectories instead of
+    # walking the entire destination tree.
     known_hashes = set()
+    known_hash_folder = {}
     if skip_duplicates:
         rows = db.conn.execute(
-            "SELECT file_hash FROM photos WHERE file_hash IS NOT NULL"
+            """SELECT p.file_hash, f.path AS folder_path
+               FROM photos p
+               JOIN folders f ON p.folder_id = f.id
+               WHERE p.file_hash IS NOT NULL"""
         ).fetchall()
-        known_hashes = {r["file_hash"] for r in rows}
+        for r in rows:
+            known_hashes.add(r["file_hash"])
+            known_hash_folder.setdefault(r["file_hash"], r["folder_path"])
         if extra_known_hashes:
             known_hashes |= extra_known_hashes
 
@@ -194,6 +204,7 @@ def ingest(
     skipped_duplicate = 0
     failed = 0
     copied_paths = []
+    duplicate_folders: set[str] = set()
 
     for i, source_file in enumerate(files):
         try:
@@ -202,6 +213,9 @@ def ingest(
 
             if skip_duplicates and file_hash in known_hashes:
                 skipped_duplicate += 1
+                existing_folder = known_hash_folder.get(file_hash)
+                if existing_folder:
+                    duplicate_folders.add(existing_folder)
                 if progress_callback:
                     progress_callback(i + 1, total, source_file.name)
                 continue
@@ -230,6 +244,7 @@ def ingest(
                     # Exact same file already there
                     skipped_duplicate += 1
                     known_hashes.add(file_hash)
+                    duplicate_folders.add(str(dest_folder))
                     if progress_callback:
                         progress_callback(i + 1, total, source_file.name)
                     continue
@@ -259,4 +274,5 @@ def ingest(
         "failed": failed,
         "total": total,
         "copied_paths": copied_paths,
+        "duplicate_folders": sorted(duplicate_folders),
     }

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -192,14 +192,22 @@ def ingest(
         ).fetchall()
         known_hashes = {r["file_hash"] for r in rows}
         # Destination-scoped hash -> folder-path map for populating the
-        # caller's post-ingest scan restrict_dirs. Constrain at the SQL
-        # level to folders that are (a) descendants of destination_dir and
-        # (b) live on disk (status='ok'). This prevents restrict_dirs from
-        # leaking out-of-tree paths (which would make scanner._ensure_folder
-        # recurse parents all the way to '/') or stale paths (which would
-        # make scanner.scan() warn on a missing root and fail to link the
-        # real duplicate folder to the active workspace).
-        dest_path_str = str(Path(destination_dir))
+        # caller's post-ingest scan restrict_dirs. Four guards, layered:
+        #   1. SQL ``f.status = 'ok'`` — exclude folders the DB already
+        #      knows are missing (cheap and visible to static analysis).
+        #   2. SQL prefix match on ``f.path`` — rough subtree cut so we
+        #      don't haul the whole library into memory on large DBs.
+        #   3. Python ``Path.is_relative_to`` — strict path-component
+        #      comparison that catches LIKE wildcard leaks (``_``/``%``
+        #      in destination_dir can otherwise match sibling subtrees).
+        #   4. Python ``Path.is_dir`` — catches stale ``status='ok'``
+        #      rows when the folder was deleted since the last scan and
+        #      the caller didn't refresh folder health first.
+        # A folder passes only if all four guards agree. Without this,
+        # restrict_dirs can end up with out-of-tree, wildcard-aliased, or
+        # non-existent paths, any of which breaks the post-ingest scan.
+        dest_path = Path(destination_dir)
+        dest_path_str = str(dest_path)
         dest_like_prefix = dest_path_str.rstrip("/") + "/%"
         folder_rows = db.conn.execute(
             """SELECT p.file_hash, f.path AS folder_path
@@ -211,7 +219,16 @@ def ingest(
             (dest_path_str, dest_like_prefix),
         ).fetchall()
         for r in folder_rows:
-            known_hash_folder.setdefault(r["file_hash"], r["folder_path"])
+            fh = r["file_hash"]
+            if fh in known_hash_folder:
+                continue
+            folder_path = r["folder_path"]
+            candidate = Path(folder_path)
+            if not candidate.is_relative_to(dest_path):
+                continue
+            if not candidate.is_dir():
+                continue
+            known_hash_folder[fh] = folder_path
         if extra_known_hashes:
             known_hashes |= extra_known_hashes
 

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -184,9 +184,14 @@ def ingest(
     # Also build a hash -> folder-path map so we can tell the caller where
     # the existing duplicates live; the pipeline uses this to restrict the
     # post-ingest scan to just the relevant subdirectories instead of
-    # walking the entire destination tree.
+    # walking the entire destination tree. Only folders that are descendants
+    # of ``destination_dir`` are tracked here — cross-library duplicates are
+    # still skipped via ``known_hashes`` but must NOT leak out-of-tree paths
+    # into the caller's scan restrict_dirs (that would make the scanner
+    # recurse parents all the way up to '/').
+    dest_path_for_filter = Path(destination_dir)
     known_hashes = set()
-    known_hash_folder = {}
+    known_hash_folder: dict[str, str] = {}
     if skip_duplicates:
         rows = db.conn.execute(
             """SELECT p.file_hash, f.path AS folder_path
@@ -195,8 +200,13 @@ def ingest(
                WHERE p.file_hash IS NOT NULL"""
         ).fetchall()
         for r in rows:
-            known_hashes.add(r["file_hash"])
-            known_hash_folder.setdefault(r["file_hash"], r["folder_path"])
+            fh = r["file_hash"]
+            known_hashes.add(fh)
+            if fh in known_hash_folder:
+                continue
+            folder_path = r["folder_path"]
+            if Path(folder_path).is_relative_to(dest_path_for_filter):
+                known_hash_folder[fh] = folder_path
         if extra_known_hashes:
             known_hashes |= extra_known_hashes
 

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import logging
+import os
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -215,14 +216,19 @@ def ingest(
         #      library into memory on large DBs. Escaping is required
         #      because destination paths may legally contain SQL LIKE
         #      wildcard characters (``_`` and ``%``).
-        #   3. Python ``Path.is_relative_to`` — strict path-component
-        #      comparison that catches any residual LIKE wildcard leaks.
-        #   4. Python ``Path.is_dir`` — catches stale ``status='ok'``
-        #      rows when the folder was deleted since the last scan and
-        #      the caller didn't refresh folder health first.
+        #   3. Python ``Path.is_relative_to`` on lexically-normalized
+        #      paths — strict path-component comparison that catches any
+        #      residual LIKE wildcard leaks. ``os.path.normpath`` is
+        #      applied to both sides first so ``..`` segments in a
+        #      stored folder path can't lexically appear to be under
+        #      the destination while actually resolving outside it.
+        #   4. Python ``Path.is_dir`` on the raw stored path — catches
+        #      stale ``status='ok'`` rows when the folder was deleted
+        #      since the last scan and the caller didn't refresh folder
+        #      health first.
         # A folder passes only if all four guards agree.
-        dest_path = Path(destination_dir)
-        dest_path_str = str(dest_path)
+        dest_path_str = str(Path(destination_dir))
+        dest_path_normalized = Path(os.path.normpath(dest_path_str))
         dest_like_prefix = (
             _escape_sql_like(dest_path_str.rstrip("/")) + "/%"
         )
@@ -237,10 +243,10 @@ def ingest(
         ).fetchall()
         for r in folder_rows:
             folder_path = r["folder_path"]
-            candidate = Path(folder_path)
-            if not candidate.is_relative_to(dest_path):
+            candidate_normalized = Path(os.path.normpath(folder_path))
+            if not candidate_normalized.is_relative_to(dest_path_normalized):
                 continue
-            if not candidate.is_dir():
+            if not Path(folder_path).is_dir():
                 continue
             known_hash_folders.setdefault(r["file_hash"], set()).add(folder_path)
         if extra_known_hashes:

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -181,32 +181,37 @@ def ingest(
 
     # Load known hashes from database for duplicate detection and merge with
     # any hashes accumulated by previous ingest() calls in the same session.
-    # Also build a hash -> folder-path map so we can tell the caller where
-    # the existing duplicates live; the pipeline uses this to restrict the
-    # post-ingest scan to just the relevant subdirectories instead of
-    # walking the entire destination tree. Only folders that are descendants
-    # of ``destination_dir`` are tracked here — cross-library duplicates are
-    # still skipped via ``known_hashes`` but must NOT leak out-of-tree paths
-    # into the caller's scan restrict_dirs (that would make the scanner
-    # recurse parents all the way up to '/').
-    dest_path_for_filter = Path(destination_dir)
     known_hashes = set()
     known_hash_folder: dict[str, str] = {}
     if skip_duplicates:
+        # Global hash set for dedup decisions. A source file matching any
+        # existing photo in the DB (even in another library root) is skipped
+        # so we don't silently duplicate bytes on disk.
         rows = db.conn.execute(
+            "SELECT file_hash FROM photos WHERE file_hash IS NOT NULL"
+        ).fetchall()
+        known_hashes = {r["file_hash"] for r in rows}
+        # Destination-scoped hash -> folder-path map for populating the
+        # caller's post-ingest scan restrict_dirs. Constrain at the SQL
+        # level to folders that are (a) descendants of destination_dir and
+        # (b) live on disk (status='ok'). This prevents restrict_dirs from
+        # leaking out-of-tree paths (which would make scanner._ensure_folder
+        # recurse parents all the way to '/') or stale paths (which would
+        # make scanner.scan() warn on a missing root and fail to link the
+        # real duplicate folder to the active workspace).
+        dest_path_str = str(Path(destination_dir))
+        dest_like_prefix = dest_path_str.rstrip("/") + "/%"
+        folder_rows = db.conn.execute(
             """SELECT p.file_hash, f.path AS folder_path
                FROM photos p
                JOIN folders f ON p.folder_id = f.id
-               WHERE p.file_hash IS NOT NULL"""
+               WHERE p.file_hash IS NOT NULL
+                 AND f.status = 'ok'
+                 AND (f.path = ? OR f.path LIKE ?)""",
+            (dest_path_str, dest_like_prefix),
         ).fetchall()
-        for r in rows:
-            fh = r["file_hash"]
-            known_hashes.add(fh)
-            if fh in known_hash_folder:
-                continue
-            folder_path = r["folder_path"]
-            if Path(folder_path).is_relative_to(dest_path_for_filter):
-                known_hash_folder[fh] = folder_path
+        for r in folder_rows:
+            known_hash_folder.setdefault(r["file_hash"], r["folder_path"])
         if extra_known_hashes:
             known_hashes |= extra_known_hashes
 

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -227,11 +227,29 @@ def ingest(
         #      since the last scan and the caller didn't refresh folder
         #      health first.
         # A folder passes only if all four guards agree.
+        #
+        # The SQL prefilter compares against ``dest_path_str`` (derived
+        # from ``str(Path(destination_dir))``, i.e. raw lexical form minus
+        # the trailing slash that ``Path`` already strips). We deliberately
+        # do NOT apply ``os.path.normpath`` before querying: scanner.scan
+        # persists folder paths via ``str(Path(...))``, which keeps ``..``
+        # segments intact, so a library that was previously scanned with
+        # an unnormalized root (e.g. ``/mnt/photos/../library``) stores
+        # rows with those ``..`` segments in place. A pre-normalized query
+        # string would silently drop those rows from the prefilter and
+        # leave ``known_hash_folders`` empty for duplicate-only ingests
+        # into such destinations. ``rstrip("/")`` is kept so the root
+        # destination (``"/"``) produces LIKE prefix ``"/%"`` rather than
+        # ``"//%"``.
+        #
+        # ``dest_path_normalized`` is a separate ``Path`` used ONLY by the
+        # Python ``is_relative_to`` guard below. ``os.path.normpath`` is
+        # used instead of ``Path.resolve()`` to avoid filesystem access
+        # and symlink expansion, which could diverge from the raw paths
+        # stored in ``folders.path``.
         dest_path_str = str(Path(destination_dir))
         dest_path_normalized = Path(os.path.normpath(dest_path_str))
-        dest_like_prefix = (
-            _escape_sql_like(dest_path_str.rstrip("/")) + "/%"
-        )
+        dest_like_prefix = _escape_sql_like(dest_path_str.rstrip("/")) + "/%"
         folder_rows = db.conn.execute(
             """SELECT p.file_hash, f.path AS folder_path
                FROM photos p
@@ -243,6 +261,11 @@ def ingest(
         ).fetchall()
         for r in folder_rows:
             folder_path = r["folder_path"]
+            # Normalise both sides before the subtree check: a stored path
+            # like "/dest/sub/../other" is lexically NOT relative to
+            # "/dest/sub" but IS relative to "/dest". Without normpath,
+            # is_relative_to gives the wrong answer for paths with ".."
+            # segments that happen to share a prefix with dest.
             candidate_normalized = Path(os.path.normpath(folder_path))
             if not candidate_normalized.is_relative_to(dest_path_normalized):
                 continue

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -234,6 +234,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
                 accumulated_hashes: set = set()
                 all_copied_paths: list = []
+                all_duplicate_folders: set = set()
                 total_copied = 0
                 total_skipped = 0
                 for src_folder in sources:
@@ -250,6 +251,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         recursive=params.recursive,
                     )
                     all_copied_paths.extend(result_info.get("copied_paths", []))
+                    all_duplicate_folders.update(result_info.get("duplicate_folders", []))
                     total_copied += result_info.get("copied", 0)
                     total_skipped += result_info.get("skipped_duplicate", 0)
                     # Collect hashes of files just copied so the next source
@@ -273,15 +275,20 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                                    summary=", ".join(parts) or "0 files")
                 _update_stages(runner, job["id"], stages)
 
-                # Scan only the destination subfolders that received files,
-                # not the entire destination tree. We use restrict_dirs so the
-                # scanner still roots the folder hierarchy at the destination,
-                # preserving parent folder links.
-                restrict = None
+                # Scan only the destination subfolders that actually contain
+                # files we care about, not the entire destination tree. Use
+                # restrict_dirs so the scanner still roots the folder hierarchy
+                # at the destination, preserving parent folder links. Include
+                # folders that received copies AND folders that already hold
+                # duplicates of the source files — both need to be linked to
+                # the active workspace.
+                restrict_set: set[str] = set()
                 if all_copied_paths:
-                    restrict = sorted({
+                    restrict_set.update(
                         str(Path(p).parent) for p in all_copied_paths
-                    })
+                    )
+                restrict_set.update(all_duplicate_folders)
+                restrict = sorted(restrict_set) if restrict_set else None
                 # Flip scan to running and reset job progress so status
                 # events during enumeration don't carry ingest's numbers.
                 stages["scan"]["status"] = "running"

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -287,10 +287,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 # to '/', so restrict_dirs must contain only descendants of
                 # params.destination. ingest() already enforces this, but
                 # we re-check here to keep the invariant local and obvious.
-                dest_p = Path(params.destination)
+                # Both sides are lexically normalized via os.path.normpath so
+                # a stored path containing ``..`` can't defeat the check.
+                import os as _os
+                dest_p = Path(_os.path.normpath(params.destination))
 
                 def _under_destination(path: str) -> bool:
-                    return Path(path).is_relative_to(dest_p)
+                    return Path(_os.path.normpath(path)).is_relative_to(dest_p)
 
                 restrict_set: set[str] = set()
                 if all_copied_paths:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -281,13 +281,26 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 # at the destination, preserving parent folder links. Include
                 # folders that received copies AND folders that already hold
                 # duplicates of the source files — both need to be linked to
-                # the active workspace.
+                # the active workspace. Guard every candidate at this seam:
+                # scanner._ensure_folder recurses parents until it equals the
+                # scan root; a non-descendant path would recurse all the way
+                # to '/', so restrict_dirs must contain only descendants of
+                # params.destination. ingest() already enforces this, but
+                # we re-check here to keep the invariant local and obvious.
+                dest_p = Path(params.destination)
+
+                def _under_destination(path: str) -> bool:
+                    return Path(path).is_relative_to(dest_p)
+
                 restrict_set: set[str] = set()
                 if all_copied_paths:
                     restrict_set.update(
                         str(Path(p).parent) for p in all_copied_paths
+                        if _under_destination(str(Path(p).parent))
                     )
-                restrict_set.update(all_duplicate_folders)
+                restrict_set.update(
+                    f for f in all_duplicate_folders if _under_destination(f)
+                )
                 restrict = sorted(restrict_set) if restrict_set else None
                 # Flip scan to running and reset job progress so status
                 # events during enumeration don't carry ingest's numbers.

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -395,6 +395,107 @@ def test_ingest_duplicate_folders_prefers_live_folder_over_stale(tmp_path):
     )
 
 
+def test_ingest_duplicate_folders_rejects_sql_like_wildcard_siblings(tmp_path):
+    """duplicate_folders must not leak siblings that only match because of
+    SQL LIKE wildcard characters in the destination path.
+
+    Regression: the subtree filter was expressed as ``f.path LIKE ?`` with
+    the destination path spliced in directly. SQLite's LIKE treats ``_`` as
+    a single-char wildcard, so a destination like ``.../dest_x`` combined
+    with the ``.../dest_x/%`` pattern can match ``.../destXx/sub``, leaking
+    a sibling subtree into duplicate_folders and reopening the out-of-tree
+    scan problem on destinations whose names contain ``_`` or ``%``.
+    """
+    src = tmp_path / "sd_card"
+    dest_under = tmp_path / "dest_x"
+    # Sibling matches the SQL LIKE pattern ``dest_x/%`` because ``_`` is a
+    # single-char wildcard. A nested subfolder is required because the
+    # pattern demands a literal ``/`` after the wildcard-matched char.
+    sibling_nested = tmp_path / "destXx" / "photos"
+    for d in [src, dest_under, sibling_nested]:
+        d.mkdir(parents=True)
+
+    img = Image.new("RGB", (100, 100), color="teal")
+    img.save(str(sibling_nested / "shot.jpg"))
+
+    db = Database(str(tmp_path / "test.db"))
+    from scanner import scan
+    scan(str(tmp_path), db)
+
+    import shutil
+    shutil.copy2(str(sibling_nested / "shot.jpg"), str(src / "shot.jpg"))
+
+    result = ingest(str(src), str(dest_under), db=db, skip_duplicates=True)
+
+    assert result["skipped_duplicate"] == 1
+    assert result["copied"] == 0
+    dup_folders = result.get("duplicate_folders", [])
+    assert str(sibling_nested) not in dup_folders, (
+        f"duplicate_folders leaked LIKE-wildcard sibling {str(sibling_nested)!r}; "
+        f"got {dup_folders!r}"
+    )
+    # Also verify no path that's not under the destination slipped in.
+    for f in dup_folders:
+        assert f == str(dest_under) or f.startswith(str(dest_under) + "/"), (
+            f"duplicate_folders contains {f!r} which is not under "
+            f"destination {str(dest_under)!r}"
+        )
+
+
+def test_ingest_duplicate_folders_excludes_folder_deleted_from_disk(tmp_path):
+    """duplicate_folders must not contain folders that no longer exist on
+    disk, even if their DB status is stale ('ok').
+
+    Regression: the pipeline path does not refresh folder health before
+    ingest, so a folder deleted since the last scan can still be marked
+    ``status='ok'`` in the DB. If such a folder is returned first and
+    recorded in duplicate_folders, the post-ingest scan walks a missing
+    root and logs a warning without touching anything — the still-existing
+    live duplicate folder never gets linked to the active workspace.
+    """
+    import shutil
+
+    src = tmp_path / "sd_card"
+    dst = tmp_path / "library"
+    gone_dir = dst / "2024" / "2024-01-01"
+    live_dir = dst / "2024" / "2024-02-02"
+    for d in [src, gone_dir, live_dir]:
+        d.mkdir(parents=True)
+
+    img = Image.new("RGB", (100, 100), color="magenta")
+    img.save(str(gone_dir / "shot.jpg"))
+    img.save(str(live_dir / "shot.jpg"))
+
+    db = Database(str(tmp_path / "test.db"))
+    from scanner import scan
+    scan(str(dst), db)
+
+    # Simulate the filesystem disappearing since the last scan, without
+    # refreshing DB folder health. gone_dir's row keeps status='ok'.
+    shutil.rmtree(str(gone_dir))
+    assert not gone_dir.exists()
+    row = db.conn.execute(
+        "SELECT status FROM folders WHERE path = ?", (str(gone_dir),)
+    ).fetchone()
+    assert row and row["status"] == "ok", \
+        "precondition: DB status must still be stale-ok"
+
+    shutil.copy2(str(live_dir / "shot.jpg"), str(src / "shot.jpg"))
+    result = ingest(str(src), str(dst), db=db, skip_duplicates=True)
+
+    assert result["skipped_duplicate"] == 1
+    assert result["copied"] == 0
+    dup_folders = result.get("duplicate_folders", [])
+    assert str(gone_dir) not in dup_folders, (
+        f"duplicate_folders contained deleted folder {str(gone_dir)!r}; "
+        f"got {dup_folders!r}"
+    )
+    assert str(live_dir) in dup_folders, (
+        f"duplicate_folders should contain the live folder {str(live_dir)!r}; "
+        f"got {dup_folders!r}"
+    )
+
+
 def test_ingest_file_types_filter(tmp_path):
     """Only selected file types are copied."""
     src = tmp_path / "sd_card"

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -496,6 +496,49 @@ def test_ingest_duplicate_folders_excludes_folder_deleted_from_disk(tmp_path):
     )
 
 
+def test_ingest_duplicate_folders_tracks_all_destination_matches(tmp_path):
+    """When the same hash lives in multiple destination subfolders, every
+    one of them must appear in duplicate_folders.
+
+    Regression: the hash→folder map kept only the first row per hash
+    (``if fh in known_hash_folder: continue``). In the all-duplicates
+    pipeline path, that reduced list was used as restrict_dirs, so the
+    other matching folders were never scanned and therefore never linked
+    into the active workspace. The user would see one of the duplicate's
+    locations but not the others.
+    """
+    import shutil
+
+    src = tmp_path / "sd_card"
+    dst = tmp_path / "library"
+    folder_a = dst / "2024" / "2024-03-10"
+    folder_b = dst / "2024" / "2024-05-20"
+    for d in [src, folder_a, folder_b]:
+        d.mkdir(parents=True)
+
+    # Byte-identical file in both destination subfolders — same hash twice.
+    img = Image.new("RGB", (100, 100), color="olive")
+    img.save(str(folder_a / "shot.jpg"))
+    shutil.copy2(str(folder_a / "shot.jpg"), str(folder_b / "shot.jpg"))
+
+    db = Database(str(tmp_path / "test.db"))
+    from scanner import scan
+    scan(str(dst), db)
+
+    shutil.copy2(str(folder_a / "shot.jpg"), str(src / "shot.jpg"))
+    result = ingest(str(src), str(dst), db=db, skip_duplicates=True)
+
+    assert result["skipped_duplicate"] == 1
+    assert result["copied"] == 0
+    dup_folders = set(result.get("duplicate_folders", []))
+    assert str(folder_a) in dup_folders, (
+        f"duplicate_folders missing {str(folder_a)!r}; got {dup_folders!r}"
+    )
+    assert str(folder_b) in dup_folders, (
+        f"duplicate_folders missing {str(folder_b)!r}; got {dup_folders!r}"
+    )
+
+
 def test_ingest_file_types_filter(tmp_path):
     """Only selected file types are copied."""
     src = tmp_path / "sd_card"

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -341,6 +341,60 @@ def test_ingest_duplicate_folders_only_under_destination(tmp_path):
         )
 
 
+def test_ingest_duplicate_folders_prefers_live_folder_over_stale(tmp_path):
+    """When a hash exists in multiple destination subfolders, duplicate_folders
+    must not select one whose DB status is not 'ok'.
+
+    Regression: ingest's hash→folder map kept the first row returned by the
+    query, which has no ordering or health filter. If a stale/missing folder
+    was returned first, restrict_dirs pointed the post-ingest scan at a
+    non-existent directory, which the scanner warns on and skips — so the
+    live duplicate folder never got linked to the active workspace.
+    """
+    src = tmp_path / "sd_card"
+    dst = tmp_path / "library"
+    stale_dir = dst / "2024" / "2024-01-01"
+    live_dir = dst / "2024" / "2024-02-02"
+    for d in [src, stale_dir, live_dir]:
+        d.mkdir(parents=True)
+
+    # Two byte-identical files, one in each destination subfolder.
+    img = Image.new("RGB", (100, 100), color="orange")
+    img.save(str(stale_dir / "shot.jpg"))
+    img.save(str(live_dir / "shot.jpg"))
+
+    db = Database(str(tmp_path / "test.db"))
+    from scanner import scan
+    scan(str(dst), db)
+
+    # Mark one of the folders as stale at the DB level, as check_folder_health
+    # would if the directory had disappeared between scans.
+    db.conn.execute(
+        "UPDATE folders SET status = 'missing' WHERE path = ?",
+        (str(stale_dir),),
+    )
+    db.conn.commit()
+
+    # Source file with the same hash.
+    import shutil
+    shutil.copy2(str(live_dir / "shot.jpg"), str(src / "shot.jpg"))
+
+    result = ingest(str(src), str(dst), db=db, skip_duplicates=True)
+
+    assert result["skipped_duplicate"] == 1
+    assert result["copied"] == 0
+
+    dup_folders = result.get("duplicate_folders", [])
+    assert str(stale_dir) not in dup_folders, (
+        f"duplicate_folders picked the stale folder {str(stale_dir)!r}; "
+        f"got {dup_folders!r}"
+    )
+    assert str(live_dir) in dup_folders, (
+        f"duplicate_folders should contain the live folder {str(live_dir)!r}; "
+        f"got {dup_folders!r}"
+    )
+
+
 def test_ingest_file_types_filter(tmp_path):
     """Only selected file types are copied."""
     src = tmp_path / "sd_card"

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -614,6 +614,65 @@ def test_ingest_duplicate_folders_flat_import_root_duplicate(tmp_path):
     )
 
 
+def test_ingest_duplicate_folders_matches_unnormalized_stored_path(tmp_path):
+    """When the DB holds a folder row whose path contains ``..`` segments
+    because a previous scan was run with an unnormalized root, ingesting
+    into that same unnormalized destination must still find the row via
+    the SQL prefilter.
+
+    Regression: pre-normalizing ``destination_dir`` before building the
+    SQL query (with ``os.path.normpath``) turns ``/.../other/../library``
+    into ``/.../library`` and queries ``/.../library`` / ``/.../library/%``,
+    neither of which matches the raw stored ``/.../other/../library/...``
+    string that scanner.scan persists (``Path`` does not collapse ``..``
+    segments). ``known_hash_folders`` stays empty and the caller's scan
+    then walks the full destination subtree unnecessarily.
+    """
+    import shutil
+
+    from scanner import scan
+
+    src = tmp_path / "sd_card"
+    real_dst = tmp_path / "library"
+    sibling = tmp_path / "other"
+    for d in [src, real_dst, sibling]:
+        d.mkdir()
+
+    # Seed the destination library with a photo and scan it so a folder
+    # row exists in the DB.
+    Image.new("RGB", (64, 64), color="teal").save(str(real_dst / "keeper.jpg"))
+    db = Database(str(tmp_path / "test.db"))
+    scan(str(real_dst), db)
+
+    # Rewrite the folder row to an equivalent path that routes through a
+    # ``..`` segment. This mimics the state left behind by a prior scan
+    # started with an unnormalized root like ``{tmp}/other/../library``.
+    unnorm_path = f"{sibling}/../library"
+    assert os.path.isdir(unnorm_path)
+    db.conn.execute(
+        "UPDATE folders SET path = ? WHERE path = ?",
+        (unnorm_path, str(real_dst)),
+    )
+    db.conn.commit()
+
+    # Stage the same file on the "SD card" so it's a byte-for-byte
+    # duplicate of the one already in the destination library.
+    shutil.copy2(str(real_dst / "keeper.jpg"), str(src / "keeper.jpg"))
+
+    # Ingest into the SAME unnormalized form the DB holds. skip_duplicates
+    # should recognise the duplicate AND record the stored folder in
+    # duplicate_folders so the post-ingest restrict scan can link it.
+    result = ingest(str(src), unnorm_path, db=db, skip_duplicates=True)
+
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 1
+    dup_folders = result.get("duplicate_folders", [])
+    assert unnorm_path in dup_folders, (
+        f"expected unnormalized stored path {unnorm_path!r} in "
+        f"duplicate_folders; got {dup_folders!r}"
+    )
+
+
 def test_ingest_duplicate_folders_rejects_dot_dot_escape(tmp_path):
     """A DB folder path containing ``..`` segments that lexically starts
     with destination_dir but resolves outside it must not leak into

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -539,6 +539,81 @@ def test_ingest_duplicate_folders_tracks_all_destination_matches(tmp_path):
     )
 
 
+def test_ingest_duplicate_folders_matches_dest_root_with_trailing_slash(tmp_path):
+    """When destination_dir has a trailing slash and the duplicate lives
+    directly at the destination root, duplicate_folders must still contain
+    that root.
+
+    Regression guard: path normalization between destination_dir (the
+    caller's input) and folder paths stored in the DB (which are
+    str(Path(...)) without trailing slashes) must agree. If they disagree,
+    the ``f.path = ?`` branch of the subtree guard misses duplicates at
+    the destination root, duplicate_folders stays empty, and the pipeline
+    falls back to a full-tree scan.
+    """
+    import shutil
+
+    src = tmp_path / "sd_card"
+    dst = tmp_path / "library"
+    for d in [src, dst]:
+        d.mkdir()
+
+    img = Image.new("RGB", (100, 100), color="cyan")
+    img.save(str(dst / "root_shot.jpg"))
+
+    db = Database(str(tmp_path / "test.db"))
+    from scanner import scan
+    scan(str(dst), db)
+
+    shutil.copy2(str(dst / "root_shot.jpg"), str(src / "root_shot.jpg"))
+
+    # Call ingest with a trailing slash on destination_dir.
+    result = ingest(str(src), str(dst) + "/", db=db, skip_duplicates=True)
+
+    assert result["skipped_duplicate"] == 1
+    assert result["copied"] == 0
+    dup_folders = result.get("duplicate_folders", [])
+    assert str(dst) in dup_folders, (
+        f"duplicate_folders should contain destination root {str(dst)!r} "
+        f"even when destination_dir has a trailing slash; got {dup_folders!r}"
+    )
+
+
+def test_ingest_duplicate_folders_flat_import_root_duplicate(tmp_path):
+    """Flat imports (folder_template='') put every file directly in the
+    destination root. A matching duplicate at the root must show up in
+    duplicate_folders so the pipeline scan targets it.
+    """
+    import shutil
+
+    src = tmp_path / "sd_card"
+    dst = tmp_path / "flat_lib"
+    for d in [src, dst]:
+        d.mkdir()
+
+    img = Image.new("RGB", (100, 100), color="magenta")
+    img.save(str(dst / "at_root.jpg"))
+
+    db = Database(str(tmp_path / "test.db"))
+    from scanner import scan
+    scan(str(dst), db)
+
+    shutil.copy2(str(dst / "at_root.jpg"), str(src / "at_root.jpg"))
+
+    result = ingest(
+        str(src), str(dst), db=db,
+        skip_duplicates=True, folder_template="",
+    )
+
+    assert result["skipped_duplicate"] == 1
+    assert result["copied"] == 0
+    dup_folders = result.get("duplicate_folders", [])
+    assert str(dst) in dup_folders, (
+        f"flat-import root duplicate should be tracked; "
+        f"got duplicate_folders={dup_folders!r}"
+    )
+
+
 def test_ingest_file_types_filter(tmp_path):
     """Only selected file types are copied."""
     src = tmp_path / "sd_card"

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -614,6 +614,67 @@ def test_ingest_duplicate_folders_flat_import_root_duplicate(tmp_path):
     )
 
 
+def test_ingest_duplicate_folders_rejects_dot_dot_escape(tmp_path):
+    """A DB folder path containing ``..`` segments that lexically starts
+    with destination_dir but resolves outside it must not leak into
+    duplicate_folders.
+
+    Regression: ``Path.is_relative_to`` is a lexical check on path parts,
+    so a stored path like ``/library/../other/photos`` passes
+    ``is_relative_to(Path("/library"))`` even though ``os.path.normpath``
+    would resolve it to ``/other/photos``. Scanner stores raw strings, so
+    a previous scan with an unnormalized root (or any manual DB edit)
+    could persist such paths, and without normalization they would end
+    up in restrict_dirs and get walked as if under destination.
+    """
+    import shutil
+
+    src = tmp_path / "sd_card"
+    dst = tmp_path / "library"
+    escape_target = tmp_path / "other"
+    for d in [src, dst, escape_target]:
+        d.mkdir()
+
+    img = Image.new("RGB", (100, 100), color="navy")
+    img.save(str(escape_target / "shot.jpg"))
+
+    db = Database(str(tmp_path / "test.db"))
+    from scanner import scan
+    scan(str(escape_target), db)
+
+    # Rewrite the folder row to use a lexical escape that still resolves
+    # to the same real directory on disk. The ``..`` leg pretends to be
+    # anchored at dst, so is_relative_to(dst) lexically succeeds, but the
+    # actual resolution points outside dst.
+    escape_path = f"{dst}/../other"
+    db.conn.execute(
+        "UPDATE folders SET path = ? WHERE path = ?",
+        (escape_path, str(escape_target)),
+    )
+    db.conn.commit()
+
+    shutil.copy2(str(escape_target / "shot.jpg"), str(src / "shot.jpg"))
+
+    result = ingest(str(src), str(dst), db=db, skip_duplicates=True)
+
+    assert result["skipped_duplicate"] == 1
+    assert result["copied"] == 0
+    dup_folders = result.get("duplicate_folders", [])
+    assert escape_path not in dup_folders, (
+        f"duplicate_folders accepted lexical .. escape {escape_path!r}; "
+        f"got {dup_folders!r}"
+    )
+    # And make sure nothing outside dst slipped through under a different
+    # disguise.
+    import os
+    for f in dup_folders:
+        resolved = os.path.normpath(f)
+        assert resolved == str(dst) or resolved.startswith(str(dst) + os.sep), (
+            f"duplicate_folders contains {f!r} (normpath={resolved!r}) "
+            f"which is not under destination {str(dst)!r}"
+        )
+
+
 def test_ingest_file_types_filter(tmp_path):
     """Only selected file types are copied."""
     src = tmp_path / "sd_card"

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -290,6 +290,57 @@ def test_ingest_skip_duplicates_via_db_hash(tmp_path):
     assert not list(dst.rglob("new_copy.jpg"))
 
 
+def test_ingest_duplicate_folders_only_under_destination(tmp_path):
+    """duplicate_folders must only contain paths under destination_dir.
+
+    Regression test: ingest() globally joins photos+folders to find where
+    existing duplicates live. If the match is in a library root other than
+    the current destination, returning that out-of-tree path causes the
+    pipeline to feed scanner.scan() restrict_dirs that aren't descendants
+    of its root, making scanner._ensure_folder() recurse parents all the
+    way up to '/' — polluting the active workspace with folders from an
+    unrelated library.
+    """
+    src = tmp_path / "sd_card"
+    dst = tmp_path / "new_library"
+    old_library = tmp_path / "old_library" / "2023" / "2023-05-10"
+    for d in [src, dst, old_library]:
+        d.mkdir(parents=True)
+
+    # A photo already lives in an unrelated library root.
+    img = Image.new("RGB", (100, 100), color="purple")
+    img.save(str(old_library / "old_shot.jpg"))
+    # And a byte-identical copy is on the card, about to be ingested into
+    # the new library.
+    import shutil
+    shutil.copy2(str(old_library / "old_shot.jpg"), str(src / "old_shot.jpg"))
+
+    db = Database(str(tmp_path / "test.db"))
+    # Scan the old library so its photo ends up in the DB with a file_hash.
+    from scanner import scan
+    scan(str(old_library.parent.parent), db)
+
+    result = ingest(str(src), str(dst), db=db, skip_duplicates=True)
+
+    # File should still be skipped (cross-library dedup behavior preserved).
+    assert result["skipped_duplicate"] == 1
+    assert result["copied"] == 0
+
+    # But duplicate_folders must NOT leak the old library's path — it is
+    # not a descendant of the destination and must never end up in the
+    # pipeline's scan restrict_dirs.
+    dup_folders = result.get("duplicate_folders", [])
+    assert str(old_library) not in dup_folders, (
+        f"duplicate_folders leaked out-of-tree path {str(old_library)!r}; "
+        f"got {dup_folders!r}"
+    )
+    for d in dup_folders:
+        assert d.startswith(str(dst)), (
+            f"duplicate_folders contains {d!r} which is not under "
+            f"destination {str(dst)!r}"
+        )
+
+
 def test_ingest_file_types_filter(tmp_path):
     """Only selected file types are copied."""
     src = tmp_path / "sd_card"

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -823,6 +823,169 @@ def test_pipeline_ingest_step_present_only_with_destination(tmp_path, monkeypatc
         "ingest step should come before scan"
 
 
+def test_pipeline_all_duplicates_restricts_scan_to_existing_folders(tmp_path, monkeypatch):
+    """When every source file is a duplicate of an existing photo in the DB,
+    the scan phase must be restricted to just the folders that hold those
+    existing duplicates — not left with restrict_dirs=None, which makes the
+    scanner walk the entire destination tree.
+
+    Regression test: user selects N photos from an SD card that have already
+    been imported, clicks pipeline, and expects those photos to become linked
+    to their current workspace. With restrict_dirs=None the scan either takes
+    far too long (17+ minutes for a 50k-file library) or skips folder linking
+    entirely for the workspaces the user cares about.
+    """
+    import shutil
+
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    # Destination tree with two populated date folders plus an unrelated
+    # folder that should NOT be walked by the restricted scan.
+    dest = tmp_path / "dest"
+    duplicate_home = dest / "2024" / "2024-06-15"
+    duplicate_home.mkdir(parents=True)
+    unrelated = dest / "2023" / "2023-01-01"
+    unrelated.mkdir(parents=True)
+    for i in range(2):
+        Image.new("RGB", (100, 100), (i * 80, 50, 50)).save(
+            str(duplicate_home / f"dup_{i}.jpg")
+        )
+    Image.new("RGB", (100, 100), "blue").save(str(unrelated / "unrelated.jpg"))
+
+    # Scan so the existing photos land in the DB with their hashes.
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    from scanner import scan as do_scan
+    do_scan(str(dest), db)
+
+    # Source is a fresh directory containing byte-identical copies of the
+    # duplicates (same hashes), simulating an SD card that still has the
+    # already-imported photos on it.
+    src = tmp_path / "source"
+    src.mkdir()
+    for i in range(2):
+        shutil.copy2(
+            str(duplicate_home / f"dup_{i}.jpg"),
+            str(src / f"dup_{i}.jpg"),
+        )
+
+    params = PipelineParams(
+        source=str(src),
+        destination=str(dest),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+
+    scan_calls = []
+    from unittest.mock import patch
+
+    import scanner as scanner_mod
+    original_scan = scanner_mod.scan
+
+    def tracking_scan(root, *args, **kwargs):
+        scan_calls.append({
+            "root": str(root),
+            "restrict_dirs": kwargs.get("restrict_dirs"),
+        })
+        return original_scan(root, *args, **kwargs)
+
+    with patch.object(scanner_mod, "scan", tracking_scan):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # Find the pipeline's scan-stage call (root == destination).
+    pipeline_scans = [c for c in scan_calls if c["root"] == str(dest)]
+    assert pipeline_scans, \
+        f"Pipeline did not call scan on destination; calls={scan_calls}"
+    call = pipeline_scans[-1]
+
+    restrict = call["restrict_dirs"]
+    assert restrict is not None, (
+        "When every file is a duplicate, pipeline should restrict the scan "
+        "to the existing-duplicates' folders instead of walking the entire "
+        "destination tree (restrict_dirs=None)."
+    )
+    restrict_set = set(restrict)
+    assert str(duplicate_home) in restrict_set, (
+        f"Expected {duplicate_home!r} in restrict_dirs; got {restrict_set!r}"
+    )
+    assert str(unrelated) not in restrict_set, (
+        f"Unrelated folder {unrelated!r} must not be in restrict_dirs; "
+        f"got {restrict_set!r}"
+    )
+
+
+def test_pipeline_all_duplicates_links_existing_folders_to_workspace(tmp_path, monkeypatch):
+    """When every source file is a duplicate, the folders holding those
+    existing duplicates should end up linked to the active workspace after
+    the pipeline runs — even if the workspace had no folders linked before.
+    """
+    import shutil
+
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    dest = tmp_path / "dest"
+    dup_folder = dest / "2024" / "2024-06-15"
+    dup_folder.mkdir(parents=True)
+    for i in range(2):
+        Image.new("RGB", (100, 100), (i * 80, 40, 40)).save(
+            str(dup_folder / f"dup_{i}.jpg")
+        )
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    default_ws = db._active_workspace_id
+
+    from scanner import scan as do_scan
+    do_scan(str(dest), db)
+
+    # Switch to a fresh workspace that has no folders.
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+    assert db.get_folder_tree() == []
+
+    src = tmp_path / "source"
+    src.mkdir()
+    for i in range(2):
+        shutil.copy2(
+            str(dup_folder / f"dup_{i}.jpg"),
+            str(src / f"dup_{i}.jpg"),
+        )
+
+    params = PipelineParams(
+        source=str(src),
+        destination=str(dest),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(job, runner, db_path, other_ws, params)
+
+    # Re-open DB to pick up writes made on the worker thread's own connection.
+    db2 = Database(db_path)
+    db2.set_active_workspace(other_ws)
+    other_folders = {f["path"] for f in db2.get_folder_tree()}
+    assert str(dup_folder) in other_folders, (
+        f"Expected {dup_folder!r} to be linked to Other workspace after "
+        f"pipeline dedupped all source files; got {other_folders!r}"
+    )
+
+
 def test_pipeline_copy_mode_scans_subfolders(tmp_path, monkeypatch):
     """After ingest, scan should use restrict_dirs to target only subfolders
     that received files, while keeping the destination as root for folder hierarchy."""


### PR DESCRIPTION
## Summary

- **Bug:** When a user imports photos via the pipeline and every source file is already a duplicate in the DB, `all_copied_paths` is empty, so `restrict_dirs` is `None`, and the scanner walks the entire destination tree. For a 50k-file library this took 17+ minutes of churn for what should have been an instant "link these folders to my current workspace" operation.
- **Fix:** `ingest()` now looks up the folder each skipped duplicate lives in (via a single upfront `photos JOIN folders` query instead of per-file lookups) and returns them as `duplicate_folders`. `pipeline_job` unions those folder paths with the copied-file parent dirs when building `restrict_dirs`, so the scan stays targeted regardless of dedup outcome.
- **Also handled:** the filename-collision branch in `ingest()` where the destination already holds a byte-identical file now adds `dest_folder` to `duplicate_folders` too.

## How the bug was found

User imported 10 photos from an SD card into a workspace where those photos were already present (from an earlier import that had landed in a different workspace). Clicking "start pipeline" showed the ingest step complete instantly with "10 skipped," then the scan step sat in "Discovering files..." for 16+ minutes walking the full USA library tree. The eventual workspace-linking outcome did still happen as a side effect of the full walk — but the wait was so long the user assumed it wasn't working.

## Test plan

- [x] `python -m pytest vireo/tests/test_pipeline_job.py vireo/tests/test_ingest.py vireo/tests/test_scanner.py tests/test_workspaces.py vireo/tests/test_db.py -q` — 302 passed
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` — 427 passed
- [x] Full suite (excluding e2e): 1175 passed, 1 pre-existing environmental failure in `test_find_darktable_returns_none_for_bad_configured_path` unrelated to these changes
- [x] New regression tests:
  - `test_pipeline_all_duplicates_restricts_scan_to_existing_folders` — asserts `restrict_dirs` contains the duplicate's folder and excludes unrelated folders when all files dedup
  - `test_pipeline_all_duplicates_links_existing_folders_to_workspace` — end-to-end: after pipeline dedup, the existing duplicate's folder is linked to the active workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)