### PR TITLE
fix: address codex review on #488 — preserve pipeline result on stage failure

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1083,6 +1083,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
     ]
     if failed_stages and not runner.is_cancelled(job["id"]):
         first_error = errors[0] if errors else f"stage '{failed_stages[0]}' failed"
+        # Preserve the structured stage/error data on the job before raising so
+        # the completion event and frontend (which reads result.result.errors and
+        # result.result.stages) still has the per-stage breakdown even though the
+        # job is marked as failed.
+        job["result"] = result
         raise RuntimeError(first_error)
 
     return result


### PR DESCRIPTION
Parent PR: #488

Addresses Codex Connect review feedback on #488.

## What changed

`vireo/pipeline_job.py` — When a pipeline stage fails, `run_pipeline_job` raises `RuntimeError` after building the structured `result` dict. Previously `job["result"]` was never set in this failure path, so the completion SSE event delivered `result = null` to the frontend. `templates/pipeline.html` reads `result.result.errors` and `result.result.stages` to display per-stage error details, so users lost the actionable failure breakdown.

Fix: `job["result"] = result` is now set before raising, so `JobRunner`'s `finally` block includes the full structured stage data in the completion event even for failed jobs.

Note: the duplicate-error issue (Codex comment on `jobs.py:170`) was already addressed in the previous commit on this branch (`9fbbec8`).

## Test results

427 passed in 22.50s

---
Generated by scheduled PR Agent