### PR TITLE
fix: address codex review on #488 — raise pipeline failure with fatal stage error

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1094,12 +1094,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         # the "Failed: [stage_name]" mapping on the card that owned the
         # failure because it reads result.result.stages / .errors.
         job["result"] = result
-        first_error = errors[0] if errors else f"stage '{failed_stages[0]}' failed"
-        # Preserve the structured stage/error data on the job before raising so
-        # the completion event and frontend (which reads result.result.errors and
-        # result.result.stages) still has the per-stage breakdown even though the
-        # job is marked as failed.
-        job["result"] = result
+        # Prefer a "[stage] Fatal: …" error from one of the failed stages
+        # rather than blindly using errors[0], which may be a non-fatal
+        # per-photo warning (e.g. "Photo <id>: mask extraction failed")
+        # logged before the stage-level failure. Falling back to errors[0]
+        # when no stage-fatal entry exists keeps backward compatibility for
+        # any edge case where a stage marks itself failed without appending a
+        # Fatal error; the final fallback covers an empty errors list.
+        first_error = next(
+            (e for e in errors if any(e.startswith(f"[{s}] Fatal:") for s in failed_stages)),
+            errors[0] if errors else f"stage '{failed_stages[0]}' failed",
+        )
         raise RuntimeError(first_error)
 
     return result


### PR DESCRIPTION
Parent PR: #488

Addresses Codex Connect review feedback on #488 (comment #4, the only unaddressed one):

**Comment 4 — `pipeline_job.py` line 1097: Raise pipeline failures with a fatal stage error**

`errors[0]` blindly picks the first entry in the shared `errors` list, which may be a non-fatal per-photo warning (e.g. `"Photo <id>: mask extraction failed"`) logged before the stage that actually caused the pipeline to fail. This misreports the real failure cause in job history and makes diagnosis harder.

Fix: search `errors` for a `"[stage] Fatal: …"` entry matching one of the `failed_stages` before falling back to `errors[0]` (if no fatal entry exists) or `"stage 'X' failed"` (if the list is empty). Also removes the duplicate `job["result"] = result` assignment that was present in the block.

All 427 tests pass.

---
Generated by scheduled PR Agent