### PR TITLE
fix: persist fatal stage error in job history instead of first warning

### DIFF
--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -199,10 +199,15 @@ class JobRunner:
             # when the work function stashed one before raising. Otherwise
             # fall back to a minimal {"error": ...} payload so the history
             # row still carries something useful.
+            # Use the pre-selected fatal error when available (pipeline jobs
+            # set _fatal_error to a "[stage] Fatal: …" message, which is the
+            # true failure cause). Fall back to errors[0] for non-pipeline
+            # jobs or edge cases where _fatal_error wasn't set.
+            primary_error = job.get("_fatal_error") or job["errors"][0]
             if isinstance(result_data, dict):
-                result_data = {**result_data, "error": job["errors"][0]}
+                result_data = {**result_data, "error": primary_error}
             else:
-                result_data = {"error": job["errors"][0]}
+                result_data = {"error": primary_error}
 
         tree_json = json.dumps(job.get("steps", []))
         summary = self._build_summary(job)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1122,6 +1122,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             (e for e in errors if any(e.startswith(f"[{s}] Fatal:") for s in failed_stages)),
             errors[0] if errors else f"stage '{failed_stages[0]}' failed",
         )
+        # Record the fatal error for _persist_job so it can store the stage
+        # failure message rather than job["errors"][0], which may be a
+        # non-fatal per-photo warning that was logged before this failure.
+        job["_fatal_error"] = first_error
         raise RuntimeError(first_error)
 
     return result


### PR DESCRIPTION
Parent PR: #488

Addresses Codex Connect review feedback on #488 (comment on jobs.py:203 — persist fatal stage error instead of first warning).

**Issue**: When a pipeline job fails (e.g. model loader stage), `job["errors"]` may contain per-photo warnings logged before the fatal stage error. `_persist_job` was using `job["errors"][0]` as the primary `error` field in the persisted result, which could be a non-fatal per-photo warning (e.g. `"Photo X: mask extraction failed"`) rather than the actual cause of failure (e.g. `"[model_loader] Fatal: …"`), misleading job history.

**Fix**: `pipeline_job.py` now stores the already-computed `first_error` (the fatal stage message, selected by the existing logic that prefers `[stage] Fatal:` over per-photo warnings) in `job["_fatal_error"]` before raising. `_persist_job` prefers `_fatal_error` over `errors[0]` when building the persisted result payload. Non-pipeline jobs are unaffected (`_fatal_error` is absent, so they fall back to `errors[0]`).

**Tests**: 430 passed (full test suite including test_pipeline_job.py and test_jobs_api.py).

---
Generated by scheduled PR Agent
