### PR TITLE
fix: address codex review on #493 — handle root dest in LIKE prefix

### DIFF
--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -230,7 +230,7 @@ def ingest(
         # from the raw paths stored in folders.path.
         dest_path = Path(os.path.normpath(destination_dir))
         dest_path_str = str(dest_path)
-        dest_like_prefix = _escape_sql_like(dest_path_str) + "/%"
+        dest_like_prefix = _escape_sql_like(dest_path_str.rstrip("/")) + "/%"
         folder_rows = db.conn.execute(
             """SELECT p.file_hash, f.path AS folder_path
                FROM photos p


### PR DESCRIPTION
Parent PR: #493

Addresses Codex Connect review feedback on #493.

**Issue**: When `destination_dir` is the filesystem root (`"/"`), `os.path.normpath("/")` yields `"/"`, so `dest_like_prefix` became `"//%"`. In SQLite this pattern does not match root children like `/photos/...`, leaving `duplicate_folders` incomplete for root-targeted ingests. This regression was introduced by #493 which removed the prior trailing-slash trim.

**Fix**: Added `.rstrip("/")` before passing `dest_path_str` to `_escape_sql_like`, so the root case produces `"/%"` (matching all absolute paths) instead of `"//%"`.

**Tests**: 427 passed (full test suite).

---
Generated by scheduled PR Agent