### PR TITLE
fix: correct updater pubkey typo that broke signature verification

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -54,7 +54,7 @@
       "endpoints": [
         "https://github.com/jss367/vireo/releases/latest/download/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDdCMzUzMEQxQ0NCNEMxNEIKUldSTHdiVE0wVEExZTJsZjQzU3MyTk1oYTlRQ0luN3g5Q2MreGlUU3BnMjJ2NHBEUXZSVW1HWWMK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDdCMzUzMEQxQ0NCNEMxNEIKUldSTHdiVE0wVEExZTJsZjQzU3MyTk1oYTlRQ0luN3g5Q2MreGlUU3BnMjJ2NHBEUXZRVW1HWWMK"
     }
   }
 }


### PR DESCRIPTION
## Summary

The committed minisign public key in `src-tauri/tauri.conf.json` had a **single-character typo** at position 143 of the base64 blob (`S` where it should be `R`), which changed 6 bits of the embedded Ed25519 public key. As a result, **every auto-update attempt since the pubkey was first committed has failed** with `The signature verification failed` — the baked-in pubkey does not correspond to the `TAURI_SIGNING_PRIVATE_KEY` used by CI to sign releases.

The local keypair at `~/.tauri/vireo-updater.key.pub` has the correct value; this PR updates `tauri.conf.json` to match.

## Diff

```diff
-      "pubkey": "...RWRLwbTM0TA1...QvRUmGYc"
+      "pubkey": "...RWRLwbTM0TA1...QvQUmGYc"
```

One character change: `SVW1HWWMK` → `RVW1HWWMK`.

## How the typo slipped through

- PR #453 first set the real pubkey (replacing a placeholder).
- PR #463 restored the same value after v0.8.1 reverted it to the placeholder.
- Neither run actually verified the embedded pubkey against a real signed release — the test plan item "Confirm the updater endpoint and pubkey match the release signing key" in #463 was never checked off.
- The error shows up to users as `Could not check for updates: The signature verification failed`, because `updater.rs:29-37` wraps both `check()` and `download_and_install()` failures under the same "Could not check for updates" prefix.

## Verification

Downloaded the live v0.8.9 artifacts from the GitHub release and verified directly with `minisign`:

```
# Old (committed) pubkey
$ minisign -V -p old.pub -m Vireo_aarch64.app.tar.gz -x <decoded sig>
Signature verification failed

# New (corrected) pubkey
$ minisign -V -p new.pub -m Vireo_aarch64.app.tar.gz -x <decoded sig>
Signature and comment signature verified
Trusted comment: timestamp:1775834550	file:Vireo.app.tar.gz
```

Cross-checked with raw Ed25519 verification via PyNaCl (both prehashed BLAKE2b-512 and legacy modes) — the old pubkey fails both, the new one verifies.

## Known limitation

Users already running any version <= v0.8.9 have the broken pubkey baked into their installed app binary and **cannot auto-update to this fix**. They have to manually download the next release once; from that release forward, auto-update will finally work.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` — 430 passed
- [x] `tauri.conf.json` still parses as valid JSON
- [x] Corrected pubkey verifies live v0.8.9 mac bundle via `minisign -V`
- [x] Corrected pubkey verifies live v0.8.9 mac bundle via raw Ed25519 (PyNaCl, prehashed BLAKE2b-512)
- [ ] After merge: cut a new release and confirm a manual install of that release can subsequently auto-update to the following release

🤖 Generated with [Claude Code](https://claude.com/claude-code)