### PR TITLE
feat: prioritize visible thumbnails in import preview grid

### DIFF
--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1122,6 +1122,7 @@ function showPreviewPlaceholder() {
   document.getElementById('previewLoading').style.display = 'none';
   document.getElementById('previewError').style.display = 'none';
   _previewData = null;
+  if (_thumbSchedulerCancel) { _thumbSchedulerCancel(); _thumbSchedulerCancel = null; }
 }
 
 function showPreviewLoading() {
@@ -1131,6 +1132,7 @@ function showPreviewLoading() {
   document.getElementById('previewError').style.display = 'none';
   // Cancel any in-flight duplicate check when preview context changes
   if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
+  if (_thumbSchedulerCancel) { _thumbSchedulerCancel(); _thumbSchedulerCancel = null; }
 }
 
 function showPreviewError(msg) {
@@ -1140,6 +1142,7 @@ function showPreviewError(msg) {
   var errEl = document.getElementById('previewError');
   errEl.style.display = '';
   errEl.textContent = msg;
+  if (_thumbSchedulerCancel) { _thumbSchedulerCancel(); _thumbSchedulerCancel = null; }
 }
 
 function renderPreview() {

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1041,6 +1041,7 @@ var _previewSelected = {};     // { filePath: true/false }
 var _previewAbort = null;      // AbortController for in-flight request
 var _duplicateResults = {};    // path -> true for duplicates (cache)
 var _duplicateCheckAbort = null;  // AbortController for in-flight check
+var _thumbSchedulerCancel = null; // cancels the current thumbnail pump on re-render
 
 function fetchFolderPreview() {
   if (_previewAbort) _previewAbort.abort();
@@ -1367,11 +1368,24 @@ function onSkipDuplicatesToggle() {
 }
 
 function setupThumbnailObserver() {
+  // Cancel any previous scheduler so its done-callbacks don't keep pumping
+  // on elements that were removed from the DOM by a re-render.
+  if (_thumbSchedulerCancel) { _thumbSchedulerCancel(); _thumbSchedulerCancel = null; }
+
   var grid = document.getElementById('previewGrid');
   var pendingQueue = Array.from(grid.querySelectorAll('.preview-thumb.skeleton'));
   var visibleSet = new Set();
   var inFlight = 0;
   var CONCURRENCY = 4;
+  var cancelled = false;
+
+  // Register a cancel function so the next call to setupThumbnailObserver can
+  // stop this scheduler before it finishes draining its queue.
+  _thumbSchedulerCancel = function() {
+    cancelled = true;
+    pendingQueue.length = 0;
+    observer.disconnect();
+  };
 
   function dispatch(el) {
     var path = el.dataset.path;
@@ -1380,7 +1394,7 @@ function setupThumbnailObserver() {
     var done = function() {
       el.classList.remove('skeleton');
       inFlight--;
-      pump();
+      if (!cancelled) pump();
     };
     img.onload = done;
     img.onerror = done;
@@ -1406,7 +1420,7 @@ function setupThumbnailObserver() {
         visibleSet.delete(entry.target);
       }
     });
-    pump();
+    if (!cancelled) pump();
   }, { root: grid, rootMargin: '200px' });
 
   pendingQueue.forEach(function(t) { observer.observe(t); });

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1368,22 +1368,49 @@ function onSkipDuplicatesToggle() {
 
 function setupThumbnailObserver() {
   var grid = document.getElementById('previewGrid');
-  var thumbs = grid.querySelectorAll('.preview-thumb.skeleton');
+  var pendingQueue = Array.from(grid.querySelectorAll('.preview-thumb.skeleton'));
+  var visibleSet = new Set();
+  var inFlight = 0;
+  var CONCURRENCY = 4;
+
+  function dispatch(el) {
+    var path = el.dataset.path;
+    var img = el.querySelector('img');
+    inFlight++;
+    var done = function() {
+      el.classList.remove('skeleton');
+      inFlight--;
+      pump();
+    };
+    img.onload = done;
+    img.onerror = done;
+    img.src = el.dataset.thumbUrl || ('/api/import/folder-preview/thumbnail?path=' + encodeURIComponent(path));
+  }
+
+  function pump() {
+    while (inFlight < CONCURRENCY && pendingQueue.length > 0) {
+      // Prefer a visible thumb; fall back to the top of the queue.
+      var idx = 0;
+      for (var i = 0; i < pendingQueue.length; i++) {
+        if (visibleSet.has(pendingQueue[i])) { idx = i; break; }
+      }
+      dispatch(pendingQueue.splice(idx, 1)[0]);
+    }
+  }
 
   var observer = new IntersectionObserver(function(entries) {
     entries.forEach(function(entry) {
-      if (!entry.isIntersecting) return;
-      var el = entry.target;
-      var path = el.dataset.path;
-      var img = el.querySelector('img');
-      img.onload = function() { el.classList.remove('skeleton'); };
-      img.onerror = function() { el.classList.remove('skeleton'); };
-      img.src = el.dataset.thumbUrl || ('/api/import/folder-preview/thumbnail?path=' + encodeURIComponent(path));
-      observer.unobserve(el);
+      if (entry.isIntersecting) {
+        visibleSet.add(entry.target);
+      } else {
+        visibleSet.delete(entry.target);
+      }
     });
+    pump();
   }, { root: grid, rootMargin: '200px' });
 
-  thumbs.forEach(function(t) { observer.observe(t); });
+  pendingQueue.forEach(function(t) { observer.observe(t); });
+  pump();
 }
 
 function updatePreviewCounts() {

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1427,7 +1427,12 @@ function setupThumbnailObserver() {
   }, { root: grid, rootMargin: '200px' });
 
   pendingQueue.forEach(function(t) { observer.observe(t); });
-  pump();
+  // Defer the initial pump so IntersectionObserver has time to fire its initial
+  // callbacks and populate visibleSet before we start dispatching. If pump() is
+  // called synchronously here, visibleSet is always empty on the first pass and
+  // the first CONCURRENCY requests go to top-of-list offscreen thumbs instead of
+  // the currently-visible ones, defeating the visible-first scheduling.
+  setTimeout(function() { if (!cancelled) pump(); }, 0);
 }
 
 function updatePreviewCounts() {


### PR DESCRIPTION
## Summary

- Replaces the import preview's fire-and-forget IntersectionObserver with a client-side scheduler that only fetches up to 4 thumbnails at a time and always picks a currently-visible thumb over the top-to-bottom fallback.
- On scroll, thumbs entering the viewport jump ahead of any slots that haven't been dispatched yet. In-flight fetches for rows you scrolled past are left to finish in the background (they're still useful if you scroll back, and aborting them would waste server work).
- Previously, once a thumb entered the viewport its `img.src` was set immediately, so the browser connection pool became the de-facto queue and couldn't be reordered after dispatch. Scrolling fast past unloaded top rows meant waiting for those top-row fetches to free up connection slots before your current viewport would start loading.

## Changes

- `vireo/templates/pipeline.html` — rewrites `setupThumbnailObserver()` (line 1369) to manage `pendingQueue`, `visibleSet`, and an `inFlight` counter with `CONCURRENCY = 4`. Observer callback now only updates `visibleSet` and calls `pump()`; no backend changes.

## Test plan

- [x] Project pytest suite passes (430 passed)
- [ ] **Needs manual UI verification** — JS change wasn't exercised in a running browser. Please open the import pipeline, start a folder preview with a few hundred files, and:
  - [ ] Confirm thumbs still load top-to-bottom when you don't scroll
  - [ ] Scroll down fast and confirm newly visible thumbs start loading before unloaded rows further down the DOM
  - [ ] Confirm skipped top rows eventually finish loading in the background
  - [ ] Watch for any thumbs stuck in `.skeleton` state