### PR TITLE
fix: address codex review on #498

### DIFF
--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1427,7 +1427,12 @@ function setupThumbnailObserver() {
   }, { root: grid, rootMargin: '200px' });
 
   pendingQueue.forEach(function(t) { observer.observe(t); });
-  pump();
+  // Defer the initial pump so IntersectionObserver has time to fire its initial
+  // callbacks and populate visibleSet before we start dispatching. If pump() is
+  // called synchronously here, visibleSet is always empty on the first pass and
+  // the first CONCURRENCY requests go to top-of-list offscreen thumbs instead of
+  // the currently-visible ones, defeating the visible-first scheduling.
+  setTimeout(function() { if (!cancelled) pump(); }, 0);
 }
 
 function updatePreviewCounts() {


### PR DESCRIPTION
Parent PR: #498

Addresses Codex Connect review feedback on #498.

## What changed

The Codex P2 review (line 1430) flagged that `setupThumbnailObserver()` calls `pump()` synchronously immediately after registering `observe()` calls. Because `IntersectionObserver` reports intersections asynchronously, `visibleSet` is always empty at that point. The first `CONCURRENCY` (4) requests therefore go to the top-of-list thumbs regardless of where the user is scrolled, defeating the visible-first scheduling that the parent PR introduced.

**Fix** (`vireo/templates/pipeline.html`):
- Replace the immediate `pump()` call with `setTimeout(function() { if (!cancelled) pump(); }, 0)`.
- `setTimeout(0)` defers until after the current task queue drains, giving the IntersectionObserver's initial intersection callbacks time to fire and populate `visibleSet`.
- The `!cancelled` guard ensures the deferred call is a no-op if the scheduler was cancelled (e.g., the user navigated away) before it fires.

The P1 comment (line 1376 — cancelling the scheduler when preview is hidden/reset) was already addressed in the previous fix PR (#499): `showPreviewLoading()`, `showPreviewError()`, and `showPreviewPlaceholder()` all invoke `_thumbSchedulerCancel`.

## Test results

430 passed in 21.27s

---
Generated by scheduled PR Agent