### PR TITLE
fix: address codex review on #501

### DIFF
--- a/vireo/model_verify.py
+++ b/vireo/model_verify.py
@@ -189,12 +189,14 @@ def verify_all_models(progress_callback=None) -> dict[str, VerifyResult]:
         try:
             result = verify_model(weights_path, m["hf_subdir"])
         except VerifyError as e:
-            # Network or HTTP failure — can't verify, but don't mark
-            # the model as corrupt either. Surface to caller via a
-            # VerifyResult with ok=False and a synthetic "missing" entry.
-            result = VerifyResult(
+            # Network or HTTP failure — can't verify, but don't mark the
+            # model as corrupt. Record the result for the caller and skip
+            # sentinel writing so a transient outage doesn't flip healthy
+            # models to 'incomplete' and break pipelines.
+            results[model_id] = VerifyResult(
                 ok=False, missing=[f"<hash fetch failed: {e}>"]
             )
+            continue
         results[model_id] = result
         if not result.ok:
             sentinel = os.path.join(weights_path, VERIFY_FAILED_SENTINEL)

--- a/vireo/tests/test_model_verify.py
+++ b/vireo/tests/test_model_verify.py
@@ -397,6 +397,40 @@ def test_verify_all_models_reports_per_model_results(tmp_path, monkeypatch):
     assert any("bad-model" in m for m in progress_messages)
 
 
+def test_verify_all_models_skips_sentinel_on_verify_error(tmp_path, monkeypatch):
+    """A VerifyError (network/HTTP failure) must NOT write .verify_failed.
+    A transient connectivity issue should not permanently reclassify a
+    healthy model as 'incomplete' and break pipelines."""
+    import model_verify
+
+    good_dir = tmp_path / "good-model"
+    good_dir.mkdir()
+    fake_models = [{
+        "id": "good-model",
+        "state": "ok",
+        "downloaded": True,
+        "weights_path": str(good_dir),
+        "hf_subdir": "good-model",
+        "source": "hf-hub:test",
+    }]
+
+    def raise_verify_error(d, s):
+        raise model_verify.VerifyError("connection refused")
+
+    monkeypatch.setattr(model_verify, "verify_model", raise_verify_error)
+    import models
+    monkeypatch.setattr(models, "get_models", lambda: fake_models)
+
+    results = model_verify.verify_all_models()
+
+    # Result is reported to caller (ok=False with synthetic entry).
+    assert "good-model" in results
+    assert results["good-model"].ok is False
+    assert any("hash fetch failed" in m for m in results["good-model"].missing)
+    # No sentinel written — model stays in its current 'ok' state on disk.
+    assert not (good_dir / model_verify.VERIFY_FAILED_SENTINEL).exists()
+
+
 def test_verify_all_models_writes_sentinel_on_mismatch(tmp_path, monkeypatch):
     """A bad model gets a .verify_failed sentinel written so the Settings UI
     surfaces the Repair state after the sweep completes."""


### PR DESCRIPTION
Parent PR: #501

Addresses Codex Connect review feedback on #501 (P1: "Avoid flagging models corrupt on hash-fetch failures").

## What changed

`verify_all_models` caught `VerifyError` (network/HTTP outage) and built a `VerifyResult(ok=False)`, but then **fell through** to the shared `if not result.ok:` block that writes `.verify_failed`. The comment even said "don't mark the model as corrupt either" — but the code did exactly that, turning a transient connectivity issue into a permanent `incomplete` state that blocked pipelines until a full Repair download.

**Fix** (`vireo/model_verify.py`):
- Use `continue` immediately after recording the `VerifyError` result so the sentinel-writing block is bypassed for network failures.
- Real hash mismatches (where `verify_model` returns `ok=False`) still write `.verify_failed` as intended.

**New test** (`vireo/tests/test_model_verify.py`):
- `test_verify_all_models_skips_sentinel_on_verify_error` — verifies that a `VerifyError` populates the return dict with `ok=False` but does **not** write `.verify_failed` on disk.

## Test results

443 passed in 25.17s

---
Generated by scheduled PR Agent