### PR TITLE
fix: keep folder picker Select button on screen with long paths

### DIFF
--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -305,7 +305,7 @@ body { padding-bottom: 36px; }
   padding: 12px 20px; border-top: 1px solid var(--border-color);
 }
 .folder-browser-path {
-  font-size: 11px; color: var(--text-muted); flex: 1;
+  font-size: 11px; color: var(--text-muted); flex: 1; min-width: 0;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   margin-right: 12px;
 }
@@ -2971,11 +2971,11 @@ var _fbHomePath = '';
     </div>
     <div class="folder-browser-list" id="fbList"></div>
     <div class="folder-browser-footer">
-      <button class="btn btn-secondary" onclick="showNewFolderInput()" style="font-size:12px;">New Folder</button>
-      <div style="display:flex;align-items:center;">
+      <button class="btn btn-secondary" onclick="showNewFolderInput()" style="font-size:12px;flex-shrink:0;">New Folder</button>
+      <div style="display:flex;align-items:center;flex:1;min-width:0;margin-left:12px;">
         <span class="folder-browser-path" id="fbSelectedPath"></span>
-        <button class="btn btn-secondary" onclick="closeFolderBrowser()" style="font-size:12px;">Cancel</button>
-        <button class="btn btn-primary" id="fbSelectBtn" onclick="selectFolder()" style="font-size:12px;">Select</button>
+        <button class="btn btn-secondary" onclick="closeFolderBrowser()" style="font-size:12px;flex-shrink:0;">Cancel</button>
+        <button class="btn btn-primary" id="fbSelectBtn" onclick="selectFolder()" style="font-size:12px;flex-shrink:0;">Select</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
When a folder with a long absolute path was selected in the Select Source Folder dialog, the Select button slid off the right edge of the modal (see reproduction screenshot).

The footer used a nested flex container without `min-width: 0`, so the long path stretched the inner container past the panel's 540px width, pushing Cancel/Select off screen.

## Fix
- Give the inner footer container `flex:1; min-width:0` so it takes remaining space and allows its children to shrink.
- Add `min-width: 0` to `.folder-browser-path` so `text-overflow: ellipsis` actually kicks in inside the flex context.
- Mark New Folder / Cancel / Select as `flex-shrink:0` so they never collapse.

## Test plan
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` — 430 passed
- [ ] Manually: open pipeline page → Select Source Folder → browse into a deeply nested path (e.g. `/Volumes/Photography/Raw Files/USA/2026/2026-04-08`) → confirm Select button stays inside the modal and the path ellipsizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)