### PR TITLE
fix: address codex review on #501 — revision pinning and blob purge

### DIFF
--- a/vireo/model_verify.py
+++ b/vireo/model_verify.py
@@ -14,11 +14,16 @@ import urllib.request
 from dataclasses import dataclass, field
 
 ONNX_REPO = "jss367/vireo-onnx-models"
-_TREE_API = "https://huggingface.co/api/models/{repo}/tree/main/{subdir}"
+_TREE_API = "https://huggingface.co/api/models/{repo}/tree/{revision}/{subdir}"
+_REPO_API = "https://huggingface.co/api/models/{repo}"
 _FETCH_TIMEOUT = 30  # seconds
 
 
 VERIFY_FAILED_SENTINEL = ".verify_failed"
+# Written by download_model to pin verification to the exact HF commit
+# that was downloaded. verify_model reads this to avoid false failures
+# when upstream later updates model files at the same branch tip.
+REVISION_FILE = ".hf_revision"
 
 
 class VerifyError(Exception):
@@ -69,18 +74,44 @@ def sha256_file(path: str) -> str:
     return h.hexdigest()
 
 
-def fetch_expected_hashes(hf_subdir: str) -> dict[str, str]:
-    """Fetch expected SHA256 hashes from the HuggingFace tree API.
+def fetch_repo_revision(repo: str) -> str:
+    """Return the current HEAD commit SHA for the given HuggingFace repo.
 
-    Returns a dict mapping basename -> hex SHA256 for every LFS file under
-    the given subdirectory of ONNX_REPO. Non-LFS files (config.json,
-    tokenizer.json) are omitted — their integrity is covered by
-    _classify_model_state's file-presence check plus the clear parse
-    errors they produce at load time.
+    Used by download_model to record the exact revision that was present
+    when files were downloaded, so that verify_model can compare against
+    that immutable snapshot rather than the moving 'main' tip.
 
     Raises VerifyError on any network or HTTP failure.
     """
-    url = _TREE_API.format(repo=ONNX_REPO, subdir=hf_subdir)
+    url = _REPO_API.format(repo=repo)
+    try:
+        with urllib.request.urlopen(url, timeout=_FETCH_TIMEOUT) as resp:
+            data = json.loads(resp.read())
+        sha = data.get("sha")
+        if not sha:
+            raise VerifyError(f"no sha field in repo info for {repo}")
+        return sha
+    except VerifyError:
+        raise
+    except Exception as e:
+        raise VerifyError(f"failed to fetch revision for {repo}: {e}") from e
+
+
+def fetch_expected_hashes(hf_subdir: str, revision: str = "main") -> dict[str, str]:
+    """Fetch expected SHA256 hashes from the HuggingFace tree API.
+
+    Returns a dict mapping basename -> hex SHA256 for every LFS file under
+    the given subdirectory of ONNX_REPO at the given revision. Non-LFS
+    files (config.json, tokenizer.json) are omitted — their integrity is
+    covered by _classify_model_state's file-presence check plus the clear
+    parse errors they produce at load time.
+
+    Pass an immutable commit SHA as revision to avoid false failures when
+    upstream later updates files at the same branch tip.
+
+    Raises VerifyError on any network or HTTP failure.
+    """
+    url = _TREE_API.format(repo=ONNX_REPO, revision=revision, subdir=hf_subdir)
     try:
         with urllib.request.urlopen(url, timeout=_FETCH_TIMEOUT) as resp:
             payload = json.loads(resp.read())
@@ -102,11 +133,25 @@ def fetch_expected_hashes(hf_subdir: str) -> dict[str, str]:
 def verify_model(model_dir: str, hf_subdir: str) -> VerifyResult:
     """Verify that LFS files in model_dir match the hashes HF reports.
 
+    If model_dir contains a .hf_revision file (written by download_model),
+    verification is pinned to that immutable commit so that upstream updates
+    to the 'main' branch tip do not cause false corruption reports for
+    locally valid files.
+
     Non-LFS files (config.json, tokenizer.json) are not checked here —
     that's _classify_model_state's job (file presence) and the model
     loader's job (parse-time validation).
     """
-    expected = fetch_expected_hashes(hf_subdir)
+    revision = "main"
+    rev_path = os.path.join(model_dir, REVISION_FILE)
+    if os.path.isfile(rev_path):
+        try:
+            stored = open(rev_path).read().strip()
+            if stored:
+                revision = stored
+        except OSError:
+            pass
+    expected = fetch_expected_hashes(hf_subdir, revision=revision)
     mismatches: list[str] = []
     missing: list[str] = []
     for basename, expected_sha in expected.items():

--- a/vireo/models.py
+++ b/vireo/models.py
@@ -444,14 +444,19 @@ def download_model(model_id, progress_callback=None):
     total_files = len(files)
 
     # Fetch expected hashes once up front so we can verify each LFS file
-    # against HF's reported SHA256 as we go. A fetch failure here means
-    # we'll proceed without verification, but we must also NOT clear any
-    # preexisting .verify_failed sentinel — otherwise a Repair attempt
-    # during a transient HF outage could silently reclassify a genuinely
-    # corrupt model as healthy.
+    # against HF's reported SHA256 as we go. We also resolve the HEAD
+    # revision so we can pin future verify_model calls to this exact
+    # commit — preventing false failures when upstream later updates files
+    # at the same branch tip.
+    # A fetch failure here means we'll proceed without verification, but we
+    # must also NOT clear any preexisting .verify_failed sentinel — otherwise
+    # a Repair attempt during a transient HF outage could silently reclassify
+    # a genuinely corrupt model as healthy.
     verification_ran = False
+    hf_revision = None
     try:
-        expected_hashes = model_verify.fetch_expected_hashes(hf_subdir)
+        hf_revision = model_verify.fetch_repo_revision(ONNX_REPO)
+        expected_hashes = model_verify.fetch_expected_hashes(hf_subdir, revision=hf_revision)
         verification_ran = True
     except model_verify.VerifyError as e:
         log.warning(
@@ -460,6 +465,7 @@ def download_model(model_id, progress_callback=None):
             hf_subdir, e,
         )
         expected_hashes = {}
+        hf_revision = None
 
     for fi, filename in enumerate(files):
         if progress_callback:
@@ -484,6 +490,8 @@ def download_model(model_id, progress_callback=None):
     # verification and every file matched its expected hash (a hash
     # mismatch would have raised VerifyError out of the loop above, so
     # reaching here with verification_ran=True means everything passed).
+    # Also write .hf_revision to pin future verify_model calls to this
+    # exact commit, preventing false failures when upstream updates files.
     if verification_ran:
         sentinel_path = os.path.join(
             model_dir, model_verify.VERIFY_FAILED_SENTINEL
@@ -491,6 +499,11 @@ def download_model(model_id, progress_callback=None):
         if os.path.isfile(sentinel_path):
             with contextlib.suppress(OSError):
                 os.unlink(sentinel_path)
+        if hf_revision:
+            rev_path = os.path.join(model_dir, model_verify.REVISION_FILE)
+            with contextlib.suppress(OSError):
+                with open(rev_path, "w") as f:
+                    f.write(hf_revision)
 
     state = _classify_model_state(model_dir, files)
     if state != "ok":
@@ -595,10 +608,22 @@ def _purge_hf_cache_file(filename, hf_subdir):
         log.debug("HF cache lookup failed for %s: %s", filename, e)
         return
 
-    if isinstance(cached, str) and os.path.isfile(cached):
+    if isinstance(cached, str) and os.path.lexists(cached):
         try:
-            os.unlink(cached)
-            log.info("Purged corrupt blob from HF cache: %s", cached)
+            # The HF snapshot path is typically a symlink into blobs/.
+            # Deleting only the symlink leaves the corrupt blob in place and
+            # hf_hub_download can re-link to it on the next attempt.
+            # Resolve to the underlying blob first and remove that, so
+            # subsequent retries must fetch fresh bytes from the network.
+            blob_path = os.path.realpath(cached)
+            if blob_path != cached and os.path.isfile(blob_path):
+                os.unlink(blob_path)
+                log.info("Purged corrupt blob from HF cache: %s", blob_path)
+            # Also remove the snapshot symlink / file so no dangling pointer
+            # is left behind pointing at the now-deleted blob.
+            if os.path.lexists(cached):
+                os.unlink(cached)
+                log.info("Purged corrupt snapshot entry from HF cache: %s", cached)
         except OSError as e:
             log.warning("Could not purge HF cache entry %s: %s", cached, e)
 

--- a/vireo/models.py
+++ b/vireo/models.py
@@ -454,9 +454,31 @@ def download_model(model_id, progress_callback=None):
     # a genuinely corrupt model as healthy.
     verification_ran = False
     hf_revision = None
+
+    # Step 1: Try to resolve the pinned HF revision for this download.
+    # Failure (repo-info API unreachable) falls back to "main" so that
+    # SHA256 verification can still run against the tree API — the two
+    # APIs are independent and the tree API may be healthy even when the
+    # model-info endpoint is not.
     try:
         hf_revision = model_verify.fetch_repo_revision(ONNX_REPO)
-        expected_hashes = model_verify.fetch_expected_hashes(hf_subdir, revision=hf_revision)
+    except model_verify.VerifyError as e:
+        log.warning(
+            "Could not resolve HF revision for %s: %s. "
+            "Will verify hashes against 'main'.",
+            ONNX_REPO, e,
+        )
+        hf_revision = None  # will fall back to "main" below
+
+    # Step 2: Fetch expected hashes using the resolved revision (or "main"
+    # if the revision lookup above failed). Only if this step also fails do
+    # we skip SHA256 verification entirely — and we must NOT clear any
+    # preexisting .verify_failed sentinel in that case.
+    revision_for_hashes = hf_revision or "main"
+    try:
+        expected_hashes = model_verify.fetch_expected_hashes(
+            hf_subdir, revision=revision_for_hashes
+        )
         verification_ran = True
     except model_verify.VerifyError as e:
         log.warning(
@@ -465,7 +487,7 @@ def download_model(model_id, progress_callback=None):
             hf_subdir, e,
         )
         expected_hashes = {}
-        hf_revision = None
+        hf_revision = None  # no verified revision to pin against
 
     for fi, filename in enumerate(files):
         if progress_callback:

--- a/vireo/tests/test_model_verify.py
+++ b/vireo/tests/test_model_verify.py
@@ -1,8 +1,8 @@
 """Tests for vireo/model_verify.py — SHA256 verification of model files.
 
 Covers sha256_file, fetch_expected_hashes (HF tree API parsing),
-verify_model (on-disk vs expected), verify_if_needed (lazy + cached),
-and the .verify_failed sentinel file.
+fetch_repo_revision, verify_model (on-disk vs expected, revision pinning),
+verify_if_needed (lazy + cached), and the .verify_failed sentinel file.
 """
 import hashlib
 import json
@@ -129,6 +129,53 @@ def test_fetch_expected_hashes_raises_verify_error_on_network_failure(monkeypatc
     assert "connection refused" in str(excinfo.value)
 
 
+def test_fetch_expected_hashes_uses_revision_in_url(monkeypatch):
+    """When a revision is provided, the tree API URL uses that revision
+    instead of 'main', so verification is pinned to an immutable commit."""
+    import model_verify
+
+    captured_url = {}
+
+    def fake_urlopen(url, timeout=None):
+        captured_url["url"] = url
+        return _FakeResponse(_CANNED_TREE)
+
+    monkeypatch.setattr(model_verify.urllib.request, "urlopen", fake_urlopen)
+    model_verify.fetch_expected_hashes("bioclip-vit-b-16", revision="abc123def456")
+
+    assert "abc123def456" in captured_url["url"]
+    assert "main" not in captured_url["url"]
+
+
+# ---------------------------------------------------------------------------
+# fetch_repo_revision — HuggingFace repo info API
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_repo_revision_returns_sha(monkeypatch):
+    """fetch_repo_revision parses the sha field from the HF model info API."""
+    import model_verify
+
+    def fake_urlopen(url, timeout=None):
+        return _FakeResponse({"sha": "deadbeef1234567890abcdef", "modelId": "jss367/vireo-onnx-models"})
+
+    monkeypatch.setattr(model_verify.urllib.request, "urlopen", fake_urlopen)
+    sha = model_verify.fetch_repo_revision("jss367/vireo-onnx-models")
+    assert sha == "deadbeef1234567890abcdef"
+
+
+def test_fetch_repo_revision_raises_on_network_failure(monkeypatch):
+    """Network errors from fetch_repo_revision are wrapped in VerifyError."""
+    import model_verify
+
+    def fake_urlopen(url, timeout=None):
+        raise OSError("timeout")
+
+    monkeypatch.setattr(model_verify.urllib.request, "urlopen", fake_urlopen)
+    with pytest.raises(model_verify.VerifyError):
+        model_verify.fetch_repo_revision("jss367/vireo-onnx-models")
+
+
 # ---------------------------------------------------------------------------
 # verify_model
 # ---------------------------------------------------------------------------
@@ -153,7 +200,7 @@ def test_verify_model_ok(tmp_path, monkeypatch):
     monkeypatch.setattr(
         model_verify,
         "fetch_expected_hashes",
-        lambda subdir: {
+        lambda subdir, revision="main": {
             "image_encoder.onnx": h1,
             "image_encoder.onnx.data": h2,
         },
@@ -163,6 +210,27 @@ def test_verify_model_ok(tmp_path, monkeypatch):
     assert result.ok is True
     assert result.mismatches == []
     assert result.missing == []
+
+
+def test_verify_model_uses_stored_revision(tmp_path, monkeypatch):
+    """When .hf_revision exists, verify_model passes it to fetch_expected_hashes
+    so verification is pinned to the commit the files were downloaded from."""
+    import model_verify
+
+    h1 = _write_with_hash(tmp_path, "image_encoder.onnx", b"graph1" * 1000)
+    pinned_rev = "abc123def456pinned"
+    (tmp_path / model_verify.REVISION_FILE).write_text(pinned_rev)
+
+    captured_rev = {}
+
+    def fake_fetch(subdir, revision="main"):
+        captured_rev["revision"] = revision
+        return {"image_encoder.onnx": h1}
+
+    monkeypatch.setattr(model_verify, "fetch_expected_hashes", fake_fetch)
+
+    model_verify.verify_model(str(tmp_path), "bioclip-vit-b-16")
+    assert captured_rev["revision"] == pinned_rev
 
 
 def test_verify_model_detects_mismatch(tmp_path, monkeypatch):
@@ -178,7 +246,7 @@ def test_verify_model_detects_mismatch(tmp_path, monkeypatch):
     monkeypatch.setattr(
         model_verify,
         "fetch_expected_hashes",
-        lambda subdir: {
+        lambda subdir, revision="main": {
             "image_encoder.onnx": h1,
             "image_encoder.onnx.data": bad_expected,
         },
@@ -200,7 +268,7 @@ def test_verify_model_detects_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(
         model_verify,
         "fetch_expected_hashes",
-        lambda subdir: {
+        lambda subdir, revision="main": {
             "image_encoder.onnx": h1,
             "image_encoder.onnx.data": "a" * 64,
         },
@@ -237,7 +305,7 @@ def test_verify_if_needed_calls_verify_model_once_per_process(
     monkeypatch.setattr(
         model_verify,
         "fetch_expected_hashes",
-        lambda subdir: {"image_encoder.onnx": h},
+        lambda subdir, revision="main": {"image_encoder.onnx": h},
     )
 
     call_count = {"n": 0}
@@ -268,7 +336,7 @@ def test_verify_if_needed_raises_and_writes_sentinel_on_mismatch(
     monkeypatch.setattr(
         model_verify,
         "fetch_expected_hashes",
-        lambda subdir: {"image_encoder.onnx.data": "0" * 64},
+        lambda subdir, revision="main": {"image_encoder.onnx.data": "0" * 64},
     )
 
     with pytest.raises(model_verify.ModelCorruptError) as excinfo:
@@ -291,7 +359,7 @@ def test_verify_if_needed_mismatch_does_not_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(
         model_verify,
         "fetch_expected_hashes",
-        lambda subdir: {"image_encoder.onnx.data": "0" * 64},
+        lambda subdir, revision="main": {"image_encoder.onnx.data": "0" * 64},
     )
 
     with pytest.raises(model_verify.ModelCorruptError):
@@ -314,7 +382,7 @@ def test_clear_verified_cache_forces_re_verification(tmp_path, monkeypatch):
     monkeypatch.setattr(
         model_verify,
         "fetch_expected_hashes",
-        lambda subdir: {"image_encoder.onnx": h},
+        lambda subdir, revision="main": {"image_encoder.onnx": h},
     )
 
     model_verify.verify_if_needed("bioclip-vit-b-16", str(tmp_path), "bioclip-vit-b-16")

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -843,3 +843,56 @@ def test_download_model_writes_revision_file(tmp_path, monkeypatch):
     rev_file = model_dir / model_verify.REVISION_FILE
     assert rev_file.is_file()
     assert rev_file.read_text().strip() == "pinned_sha_abc123"
+
+
+def test_download_model_still_verifies_when_revision_lookup_fails(tmp_path, monkeypatch):
+    """When fetch_repo_revision fails (repo-info API down) but fetch_expected_hashes
+    succeeds against 'main', SHA256 verification must still run — the two API
+    endpoints are independent and a revision-lookup failure must not silently
+    disable integrity checking.
+
+    Regression test for the Codex P1 comment on #504 ('Preserve hash
+    verification when revision lookup fails').
+    """
+    import hashlib
+
+    import model_verify
+    models, model_dir = _patch_download_model_env(tmp_path, monkeypatch)
+
+    contents = b"verifyok" * 100
+    expected = {
+        "image_encoder.onnx": hashlib.sha256(contents).hexdigest(),
+        "image_encoder.onnx.data": hashlib.sha256(contents).hexdigest(),
+        "text_encoder.onnx": hashlib.sha256(contents).hexdigest(),
+        "text_encoder.onnx.data": hashlib.sha256(contents).hexdigest(),
+    }
+    fetch_hashes_call_count = {"n": 0}
+
+    def fake_download(repo_id, filename, local_dir, subfolder=None, progress_callback=None):
+        os.makedirs(local_dir, exist_ok=True)
+        dest = os.path.join(local_dir, filename)
+        with open(dest, "wb") as f:
+            f.write(contents if filename in expected else b"{}")
+        return dest
+
+    def fetch_raises_verify_error(repo):
+        raise model_verify.VerifyError("repo-info API offline")
+
+    def fake_fetch_hashes(subdir, revision="main"):
+        fetch_hashes_call_count["n"] += 1
+        # Verify that we fall back to "main" when revision is unknown
+        assert revision == "main", f"Expected 'main' fallback, got {revision!r}"
+        return expected
+
+    monkeypatch.setattr(models, "_purge_hf_cache_file", lambda filename, subdir: None)
+    monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
+    monkeypatch.setattr(model_verify, "fetch_repo_revision", fetch_raises_verify_error)
+    monkeypatch.setattr(model_verify, "fetch_expected_hashes", fake_fetch_hashes)
+
+    models.download_model("bioclip-vit-b-16")
+
+    # Verification must have run even though revision lookup failed.
+    assert fetch_hashes_call_count["n"] == 1, (
+        "fetch_expected_hashes should have been called once (against 'main') "
+        "even when fetch_repo_revision raises VerifyError"
+    )

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -535,8 +535,25 @@ def test_get_models_surfaces_incomplete_state(tmp_path, monkeypatch):
 
 
 def _patch_download_model_env(tmp_path, monkeypatch):
-    """Shared setup: isolate config/models dir and return the model dir path."""
+    """Shared setup: isolate config/models dir and return the model dir path.
+
+    Also stubs huggingface_hub so download_model's import guard succeeds
+    even in environments where the library isn't installed (CI uses the
+    real library; local dev uses this stub).
+    """
+    import sys
+    import types
+
     import models
+
+    # Stub huggingface_hub so the `from huggingface_hub import hf_hub_download`
+    # guard at the top of download_model doesn't raise ImportError.
+    if "huggingface_hub" not in sys.modules:
+        hf_stub = types.ModuleType("huggingface_hub")
+        hf_stub.hf_hub_download = lambda **kwargs: None
+        hf_stub.try_to_load_from_cache = lambda **kwargs: None
+        monkeypatch.setitem(sys.modules, "huggingface_hub", hf_stub)
+
     monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
     monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
     return models, tmp_path / "models" / "bioclip-vit-b-16"
@@ -576,7 +593,10 @@ def test_download_model_accepts_valid_result(tmp_path, monkeypatch):
 
     monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
     monkeypatch.setattr(
-        model_verify, "fetch_expected_hashes", lambda subdir: expected
+        model_verify, "fetch_repo_revision", lambda repo: "testsha123abc"
+    )
+    monkeypatch.setattr(
+        model_verify, "fetch_expected_hashes", lambda subdir, revision="main": expected
     )
 
     result = models.download_model("bioclip-vit-b-16")
@@ -636,7 +656,10 @@ def test_download_model_retries_on_hash_mismatch_then_succeeds(
     )
     monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
     monkeypatch.setattr(
-        model_verify, "fetch_expected_hashes", lambda subdir: expected
+        model_verify, "fetch_repo_revision", lambda repo: "testsha123abc"
+    )
+    monkeypatch.setattr(
+        model_verify, "fetch_expected_hashes", lambda subdir, revision="main": expected
     )
 
     result = models.download_model("bioclip-vit-b-16")
@@ -676,7 +699,10 @@ def test_download_model_raises_after_max_retries(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
     monkeypatch.setattr(
-        model_verify, "fetch_expected_hashes", lambda subdir: expected
+        model_verify, "fetch_repo_revision", lambda repo: "testsha123abc"
+    )
+    monkeypatch.setattr(
+        model_verify, "fetch_expected_hashes", lambda subdir, revision="main": expected
     )
 
     import pytest as _pytest
@@ -718,7 +744,10 @@ def test_download_model_clears_verify_cache_on_success(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
     monkeypatch.setattr(
-        model_verify, "fetch_expected_hashes", lambda subdir: expected
+        model_verify, "fetch_repo_revision", lambda repo: "testsha123abc"
+    )
+    monkeypatch.setattr(
+        model_verify, "fetch_expected_hashes", lambda subdir, revision="main": expected
     )
 
     model_verify._verified_this_process.add("bioclip-vit-b-16")
@@ -750,13 +779,16 @@ def test_download_model_preserves_sentinel_when_fetch_hashes_fails(
             f.write(b"stub")
         return dest
 
-    def fetch_raises(subdir):
+    def fetch_raises(subdir, revision="main"):
         raise model_verify.VerifyError("tree API offline")
 
     monkeypatch.setattr(
         models, "_purge_hf_cache_file", lambda filename, subdir: None
     )
     monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
+    monkeypatch.setattr(
+        model_verify, "fetch_repo_revision", lambda repo: "testsha123abc"
+    )
     monkeypatch.setattr(model_verify, "fetch_expected_hashes", fetch_raises)
 
     # download_model should raise because _classify_model_state will still
@@ -768,3 +800,46 @@ def test_download_model_preserves_sentinel_when_fetch_hashes_fails(
     # Sentinel must still be on disk so a future pipeline run (or a retry
     # after HF is back up) keeps the model flagged as corrupt.
     assert sentinel.is_file()
+
+
+def test_download_model_writes_revision_file(tmp_path, monkeypatch):
+    """After a successful download with SHA256 verification, download_model
+    writes .hf_revision with the resolved HF commit SHA so that future
+    verify_model calls hash against that immutable revision instead of the
+    moving 'main' tip."""
+    import hashlib
+
+    import model_verify
+    models, model_dir = _patch_download_model_env(tmp_path, monkeypatch)
+
+    contents = b"realbytes" * 100
+    expected = {
+        "image_encoder.onnx": hashlib.sha256(contents).hexdigest(),
+        "image_encoder.onnx.data": hashlib.sha256(contents).hexdigest(),
+        "text_encoder.onnx": hashlib.sha256(contents).hexdigest(),
+        "text_encoder.onnx.data": hashlib.sha256(contents).hexdigest(),
+    }
+
+    def fake_download(repo_id, filename, local_dir, subfolder=None, progress_callback=None):
+        os.makedirs(local_dir, exist_ok=True)
+        dest = os.path.join(local_dir, filename)
+        with open(dest, "wb") as f:
+            f.write(contents if filename in expected else b"{}")
+        return dest
+
+    monkeypatch.setattr(
+        models, "_purge_hf_cache_file", lambda filename, subdir: None
+    )
+    monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
+    monkeypatch.setattr(
+        model_verify, "fetch_repo_revision", lambda repo: "pinned_sha_abc123"
+    )
+    monkeypatch.setattr(
+        model_verify, "fetch_expected_hashes", lambda subdir, revision="main": expected
+    )
+
+    models.download_model("bioclip-vit-b-16")
+
+    rev_file = model_dir / model_verify.REVISION_FILE
+    assert rev_file.is_file()
+    assert rev_file.read_text().strip() == "pinned_sha_abc123"


### PR DESCRIPTION
Parent PR: #501

Addresses two Codex Connect P1 review comments on #501 that arrived after the earlier fix PR (#502) was merged.

## What changed

### Fix 1: Pin verification hashes to an immutable HF revision (`vireo/model_verify.py`, `vireo/models.py`)

**Problem:** `_TREE_API` always fetched hashes from `main`. When upstream updates model files, previously-downloaded local files would start failing hash verification, writing `.verify_failed` and blocking pipelines as "incomplete" — even though the local files are not corrupt.

**Fix:**
- Added `fetch_repo_revision(repo)` — fetches the current HEAD commit SHA from `https://huggingface.co/api/models/{repo}`.
- `fetch_expected_hashes` now accepts an optional `revision` parameter (default `"main"`); the tree API URL uses `{revision}` instead of the literal `main`.
- `download_model` resolves the HEAD SHA before downloading and, on success, writes it to `.hf_revision` in the model directory.
- `verify_model` reads `.hf_revision` if present and passes the pinned SHA to `fetch_expected_hashes`, anchoring all future verifications to the exact commit the files were downloaded from. If network outage prevents SHA resolution, falls back to `"main"` (no `.hf_revision` written), preserving existing behavior.

### Fix 2: Purge the blob target, not only the cached snapshot path (`vireo/models.py::_purge_hf_cache_file`)

**Problem:** `try_to_load_from_cache` returns the snapshot path, which in HF's cache layout is a symlink into `blobs/`. Unlinking only the symlink left the corrupt blob on disk; `hf_hub_download` would re-link to the same bad bytes on the next retry, so all three retry attempts could fail identically.

**Fix:** Resolve the symlink with `os.path.realpath`, delete the underlying blob first, then remove the now-dangling snapshot symlink.

## Tests

- **`test_model_verify.py`**: Updated all `lambda subdir:` mock patches to also accept the new `revision` kwarg; added `test_fetch_expected_hashes_uses_revision_in_url`, `test_fetch_repo_revision_returns_sha`, `test_fetch_repo_revision_raises_on_network_failure`, `test_verify_model_uses_stored_revision`.
- **`test_models.py`**: Added `fetch_repo_revision` stubs to all download tests; added `test_download_model_writes_revision_file`; added `huggingface_hub` `sys.modules` stub to `_patch_download_model_env` so tests pass in environments without the library installed.

## Test results

**481 passed** in 22.87s

---
Generated by scheduled PR Agent