### PR TITLE
fix: run every selected classifier in the pipeline, not just the first

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5622,6 +5622,7 @@ def create_app(db_path, thumb_cache_dir=None):
             labels_file=body.get("labels_file"),
             labels_files=body.get("labels_files"),
             model_id=body.get("model_id"),
+            model_ids=body.get("model_ids"),
             reclassify=body.get("reclassify", False),
             skip_classify=body.get("skip_classify", False),
             download_taxonomy=body.get("download_taxonomy", True),
@@ -5638,13 +5639,27 @@ def create_app(db_path, thumb_cache_dir=None):
         if not params.skip_classify:
             from models import get_active_model, get_models
 
-            _model = None
-            if params.model_id:
-                _all = get_models()
-                _model = next((m for m in _all if m["id"] == params.model_id and m["downloaded"]), None)
-            if not _model:
-                _model = get_active_model()
-            if not _model:
+            # Resolve the set of requested models. Prefer the explicit list,
+            # fall back to the legacy single id, and finally to whatever is
+            # marked active. Any requested id that isn't downloaded fails the
+            # check, so the user sees the "no model available" warning instead
+            # of a mid-run model_loader crash.
+            requested_ids = list(params.model_ids or [])
+            if not requested_ids and params.model_id:
+                requested_ids = [params.model_id]
+
+            all_models = None
+            resolved_any = False
+            if requested_ids:
+                all_models = get_models()
+                by_id = {m["id"]: m for m in all_models}
+                resolved_any = all(
+                    by_id.get(mid, {}).get("downloaded") for mid in requested_ids
+                )
+            else:
+                resolved_any = get_active_model() is not None
+
+            if not resolved_any:
                 params.skip_classify = True
                 params.skip_extract_masks = True
                 params.skip_regroup = True

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -161,7 +161,8 @@ def _load_labels(model_type, model_str, labels_file, labels_files, db=None):
 
 
 def _detect_batch(photos, folders, runner, job, reclassify, db,
-                   det_conf_threshold=None, already_detected_ids=None):
+                   det_conf_threshold=None, already_detected_ids=None,
+                   cached_detections=None):
     """Run MegaDetector on a batch of photos.
 
     Same interface as _detect_subjects but designed to be called with
@@ -174,20 +175,32 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
             loaded from config (fallback for callers that don't pre-load).
         already_detected_ids: Set of photo IDs that already have detections
             in the database. Used for skip-if-already-detected logic.
+        cached_detections: Optional dict {photo_id: [detection_dicts]}
+            produced by a prior model in the same pipeline run. When
+            provided and a photo is in already_detected_ids, the cached
+            entries are used instead of db.get_detections() so that
+            model 2+ binds to the exact detection rows from this run,
+            not stale rows from a previous pipeline pass.
 
     Returns:
-        (detection_map, detected_count) where detection_map is
-        {photo_id: [list_of_detection_dicts]} and detected_count is total
-        photos with at least one detection.
+        (detection_map, detected_count, processed_ids) where detection_map
+        is {photo_id: [list_of_detection_dicts]}, detected_count is total
+        photos with at least one detection, and processed_ids is the set
+        of photo IDs whose per-photo iteration completed without raising
+        (callers use this to distinguish "ran and found nothing" from
+        "never reached because an earlier photo raised mid-loop").
     """
     detected = 0
     detection_map = {}
+    processed_ids: set[int] = set()
     if already_detected_ids is None:
         already_detected_ids = set()
+    if cached_detections is None:
+        cached_detections = {}
 
     try:
         if detect_animals is None or get_primary_detection is None:
-            return detection_map, detected
+            return detection_map, detected, processed_ids
 
         if det_conf_threshold is None:
             import config as cfg
@@ -199,6 +212,18 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
 
             # Skip if already detected (unless reclassifying)
             if not reclassify and photo["id"] in already_detected_ids:
+                # Prefer cached detections from an earlier model in this
+                # same pipeline run so that model 2+ is bound to the
+                # detection rows just produced, not stale rows from a
+                # prior pipeline pass that db.get_detections() would
+                # return when old rows haven't been cleared.
+                if cached_detections is not None and photo["id"] in cached_detections:
+                    det_list = cached_detections[photo["id"]]
+                    if det_list:
+                        detection_map[photo["id"]] = det_list
+                        detected += 1
+                    processed_ids.add(photo["id"])
+                    continue
                 existing_dets = db.get_detections(photo["id"])
                 if existing_dets:
                     det_list = []
@@ -214,6 +239,7 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                         })
                     detection_map[photo["id"]] = det_list
                     detected += 1
+                    processed_ids.add(photo["id"])
                     continue
 
             detections = detect_animals(image_path, confidence_threshold=det_conf_threshold)
@@ -239,6 +265,13 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                         "category": det.get("category", "animal"),
                     })
                 detection_map[photo["id"]] = det_list
+
+                # Mark as processed immediately after detection rows are committed
+                # so that even if the quality-scoring calls below raise, the
+                # reclassify purge in pipeline_job correctly removes the now-stale
+                # pre-run detection rows for this photo rather than leaving them in
+                # place and allowing future non-reclassify runs to reuse them.
+                processed_ids.add(photo["id"])
 
                 # Use highest-confidence detection as primary for quality scoring
                 primary = get_primary_detection(detections)
@@ -286,12 +319,14 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                             photo["id"],
                         )
 
+            processed_ids.add(photo["id"])
+
     except (ImportError, RuntimeError):
         pass
     except Exception:
         log.warning("Detection failed for batch (non-fatal)", exc_info=True)
 
-    return detection_map, detected
+    return detection_map, detected, processed_ids
 
 
 def _detect_subjects(photos, folders, runner, job, reclassify, db):
@@ -361,7 +396,7 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
                 and photo["id"] in already_detected_ids
             )
 
-            batch_map, batch_detected = _detect_batch(
+            batch_map, batch_detected, _batch_processed = _detect_batch(
                 [photo], folders, runner, job, reclassify, db,
                 det_conf_threshold=det_conf_threshold,
                 already_detected_ids=already_detected_ids,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3218,6 +3218,61 @@ class Database:
         ).fetchall()
         return {r["photo_id"] for r in rows}
 
+    def get_detection_ids_for_photos(self, photo_ids):
+        """Return {photo_id: set(detection_id, ...)} for the given photo IDs.
+
+        Only returns rows from the active workspace.  Used to snapshot
+        pre-run detection IDs so that a reclassify pass can delete only
+        the *stale* rows after fresh ones have been inserted, avoiding the
+        cascade-delete that would destroy other-model predictions.
+
+        IDs are queried in chunks of at most 900 to stay safely under
+        SQLite's default bound-parameter limit (SQLITE_LIMIT_VARIABLE_NUMBER,
+        typically 999 in production builds).
+        """
+        if not photo_ids:
+            return {}
+        ws_id = self._ws_id()
+        result: dict = {}
+        ids = list(photo_ids)
+        _CHUNK = 900
+        for i in range(0, len(ids), _CHUNK):
+            chunk = ids[i : i + _CHUNK]
+            placeholders = ",".join("?" * len(chunk))
+            rows = self.conn.execute(
+                f"SELECT id, photo_id FROM detections "
+                f"WHERE photo_id IN ({placeholders}) AND workspace_id = ?",
+                (*chunk, ws_id),
+            ).fetchall()
+            for row in rows:
+                result.setdefault(row["photo_id"], set()).add(row["id"])
+        return result
+
+    def delete_detections_by_ids(self, detection_ids):
+        """Delete specific detection rows by primary key.
+
+        Cascades to predictions via the FK constraint.  Does nothing if
+        the list is empty.  Used by reclassify to purge only the stale
+        rows for photos that have just been re-detected, without touching
+        detection rows that belong to models not included in the current run.
+
+        IDs are deleted in chunks of at most 900 to stay safely under
+        SQLite's default bound-parameter limit (SQLITE_LIMIT_VARIABLE_NUMBER,
+        typically 999 in production builds).
+        """
+        if not detection_ids:
+            return
+        ids = list(detection_ids)
+        _CHUNK = 900
+        for i in range(0, len(ids), _CHUNK):
+            chunk = ids[i : i + _CHUNK]
+            placeholders = ",".join("?" * len(chunk))
+            self.conn.execute(
+                f"DELETE FROM detections WHERE id IN ({placeholders})",
+                chunk,
+            )
+        self.conn.commit()
+
     # -- Pending Changes --
 
     def queue_change(self, photo_id, change_type, value, workspace_id=None, _commit=True):

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -38,6 +38,7 @@ class PipelineParams:
     labels_file: str | None = None
     labels_files: list | None = None
     model_id: str | None = None
+    model_ids: list | None = None
     reclassify: bool = False
     skip_extract_masks: bool = False
     skip_regroup: bool = False
@@ -165,6 +166,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
     collection_ready = threading.Event()
     models_ready = threading.Event()
     loaded_models = {}  # populated by model_loader thread
+
+    # Normalize model_ids: prefer the explicit list, fall back to the legacy
+    # single `model_id`, and finally to `[]` which means "use the active model
+    # from config." This is the knob the multi-model fix hangs off of.
+    if params.model_ids:
+        effective_model_ids = list(params.model_ids)
+    elif params.model_id:
+        effective_model_ids = [params.model_id]
+    else:
+        effective_model_ids = []
 
     skip_scan = collection_id is not None
 
@@ -593,6 +604,95 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
         _update_stages(runner, job["id"], stages)
 
+    def _resolve_model_spec(model_id_arg):
+        """Look up a model by id and require it to be fully downloaded."""
+        from models import get_active_model, get_models
+
+        if model_id_arg:
+            all_models = get_models()
+            spec = next(
+                (m for m in all_models if m["id"] == model_id_arg and m["downloaded"]),
+                None,
+            )
+            if not spec:
+                raise RuntimeError(
+                    f"Model '{model_id_arg}' not found or not downloaded."
+                )
+            return spec
+        spec = get_active_model()
+        if not spec:
+            raise RuntimeError("No model available. Download one in Settings.")
+        return spec
+
+    def _load_model_bundle(active_model, tax, thread_db):
+        """Turn a resolved model spec into a ready-to-use classifier bundle.
+
+        Loads labels for the model and constructs the Classifier/TimmClassifier,
+        translating ONNXRuntime's cryptic missing-weights errors into an
+        actionable "Repair" hint. Called by both the model_loader stage (for
+        the first model) and the classify stage (for each subsequent model in
+        a multi-model run).
+        """
+        from classify_job import _load_labels
+        from models import _classify_model_state
+
+        model_str = active_model["model_str"]
+        weights_path = active_model["weights_path"]
+        model_type = active_model.get("model_type", "bioclip")
+        model_name = active_model["name"]
+        model_is_custom = active_model.get("source") == "custom"
+
+        labels, use_tol = _load_labels(
+            model_type=model_type,
+            model_str=model_str,
+            labels_file=params.labels_file,
+            labels_files=params.labels_files,
+            db=thread_db,
+        )
+
+        # Preflight: validate the on-disk model before handing it to
+        # ONNXRuntime. A stale _check_onnx_downloaded result (e.g. after
+        # the user deleted a .onnx.data file, or the download manifest
+        # changed) would otherwise surface as an opaque ONNXRuntime crash.
+        files = active_model.get("files", [])
+        if files and weights_path:
+            state = _classify_model_state(weights_path, files)
+            if state != "ok":
+                raise RuntimeError(
+                    _incomplete_model_message(model_name, model_is_custom)
+                )
+
+        try:
+            if model_type == "timm":
+                from timm_classifier import TimmClassifier
+                clf = TimmClassifier(model_str, taxonomy=tax)
+            else:
+                from classifier import Classifier
+                clf = Classifier(
+                    labels=None if use_tol else labels,
+                    model_str=model_str,
+                    pretrained_str=weights_path,
+                )
+        except Exception as load_err:
+            # ONNXRuntime signals missing external-data with a
+            # "model_path must not be empty" / "Initializer" error. Treat
+            # any load failure as an incomplete-model hint for the user.
+            if _looks_like_missing_external_data(load_err):
+                raise RuntimeError(
+                    _incomplete_model_message(model_name, model_is_custom)
+                ) from load_err
+            raise
+
+        return {
+            "clf": clf,
+            "model_type": model_type,
+            "model_name": model_name,
+            "model_str": model_str,
+            "labels": labels,
+            "use_tol": use_tol,
+            "active_model": active_model,
+        }
+
     def model_loader_stage():
         if params.skip_classify:
             stages["model_loader"]["status"] = "skipped"
@@ -606,32 +706,23 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                            current_file="Resolving model...")
         _update_stages(runner, job["id"], stages)
         try:
-            from classify_job import _load_labels, _load_taxonomy
-            from models import get_active_model, get_models
+            from classify_job import _load_taxonomy
 
             thread_db = Database(db_path)
             thread_db.set_active_workspace(workspace_id)
 
-            # Resolve model
-            if params.model_id:
-                all_models = get_models()
-                active_model = next(
-                    (m for m in all_models if m["id"] == params.model_id and m["downloaded"]),
-                    None,
-                )
-                if not active_model:
-                    raise RuntimeError(f"Model '{params.model_id}' not found or not downloaded.")
+            # Resolve every requested model upfront so a bad id fails fast
+            # BEFORE taxonomy download, rather than mid-run after the user
+            # has already watched one classifier finish.
+            if effective_model_ids:
+                resolved_specs = [
+                    _resolve_model_spec(mid) for mid in effective_model_ids
+                ]
             else:
-                active_model = get_active_model()
-            if not active_model:
-                raise RuntimeError("No model available. Download one in Settings.")
+                resolved_specs = [_resolve_model_spec(None)]
 
-            model_str = active_model["model_str"]
-            weights_path = active_model["weights_path"]
-            model_type = active_model.get("model_type", "bioclip")
-            model_name = active_model["name"]
-            model_is_custom = active_model.get("source") == "custom"
-            runner.update_step(job["id"], "model_loader", current_file=model_name)
+            first_name = resolved_specs[0]["name"]
+            runner.update_step(job["id"], "model_loader", current_file=first_name)
 
             # Download taxonomy if missing and requested
             taxonomy_path = os.path.join(os.path.dirname(__file__), "taxonomy.json")
@@ -655,70 +746,29 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 except Exception as e:
                     log.warning("Taxonomy download failed, continuing without: %s", e)
 
-            # Load taxonomy
+            # Taxonomy is shared across every classifier in the run.
             tax = _load_taxonomy(taxonomy_path)
+            loaded_models["tax"] = tax
+            loaded_models["resolved_specs"] = resolved_specs
 
-            # Load labels
-            labels, use_tol = _load_labels(
-                model_type=model_type,
-                model_str=model_str,
-                labels_file=params.labels_file,
-                labels_files=params.labels_files,
-                db=thread_db,
-            )
-
-            # Load classifier
+            # Load the first classifier so classify_stage can start as soon
+            # as scan completes; any remaining specs are loaded inside
+            # classify_stage so we never hold more than one model in memory.
             runner.push_event(job["id"], "progress", {
-                "phase": f"Loading {model_name}...",
+                "phase": f"Loading {first_name}...",
                 "stage_id": "model_loader",
                 "current": 0, "total": 0,
                 "stages": {k: dict(v) for k, v in stages.items()},
             })
 
-            # Preflight: validate the on-disk model before handing it to
-            # ONNXRuntime. A stale _check_onnx_downloaded result (e.g. after
-            # the user deleted a .onnx.data file, or the download manifest
-            # changed) would otherwise surface as an opaque ONNXRuntime crash.
-            from models import _classify_model_state
-            files = active_model.get("files", [])
-            if files and weights_path:
-                state = _classify_model_state(weights_path, files)
-                if state != "ok":
-                    raise RuntimeError(_incomplete_model_message(model_name, model_is_custom))
-
-            try:
-                if model_type == "timm":
-                    from timm_classifier import TimmClassifier
-                    clf = TimmClassifier(model_str, taxonomy=tax)
-                else:
-                    from classifier import Classifier
-                    clf = Classifier(
-                        labels=None if use_tol else labels,
-                        model_str=model_str,
-                        pretrained_str=weights_path,
-                    )
-            except Exception as load_err:
-                # ONNXRuntime signals missing external-data with a
-                # "model_path must not be empty" / "Initializer" error. Treat
-                # any load failure as an incomplete-model hint for the user.
-                if _looks_like_missing_external_data(load_err):
-                    raise RuntimeError(
-                        _incomplete_model_message(model_name, model_is_custom)
-                    ) from load_err
-                raise
-
-            loaded_models["clf"] = clf
-            loaded_models["model_type"] = model_type
-            loaded_models["model_name"] = model_name
-            loaded_models["model_str"] = model_str
-            loaded_models["tax"] = tax
-            loaded_models["labels"] = labels
-            loaded_models["use_tol"] = use_tol
-            loaded_models["active_model"] = active_model
+            bundle = _load_model_bundle(resolved_specs[0], tax, thread_db)
+            loaded_models.update(bundle)
+            loaded_models["pending_specs"] = resolved_specs[1:]
 
             stages["model_loader"]["status"] = "completed"
+            summary = ", ".join(s["name"] for s in resolved_specs)
             runner.update_step(job["id"], "model_loader", status="completed",
-                               summary=model_name)
+                               summary=summary)
         except Exception as e:
             errors.append(f"[model_loader] Fatal: {e}")
             log.exception("Pipeline model loader stage failed")
@@ -759,118 +809,181 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             thread_db.set_active_workspace(workspace_id)
 
             user_cfg = thread_db.get_effective_config(cfg.load())
+            grouping_window = user_cfg.get("grouping_window_seconds", 5)
+            similarity_threshold = user_cfg.get("similarity_threshold", 0.85)
 
-            clf = loaded_models["clf"]
-            model_type = loaded_models["model_type"]
-            model_name = loaded_models["model_name"]
             tax = loaded_models["tax"]
+            resolved_specs = loaded_models.get("resolved_specs") or [
+                loaded_models["active_model"]
+            ]
 
             photos = _filter_excluded(thread_db.get_collection_photos(collection_id, per_page=999999))
             folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
             total = len(photos)
 
-            if params.reclassify:
-                photo_ids = [p["id"] for p in photos]
-                thread_db.clear_predictions(model=model_name, collection_photo_ids=photo_ids)
+            # Aggregate counters across every model run. The UI reads a single
+            # stages.classify dict, so we sum across models rather than emit
+            # per-model rows.
+            total_predictions_stored = 0
+            total_detected = 0
+            total_failed = 0
+            total_skipped_existing = 0
 
-            existing_preds = set()
-            if not params.reclassify:
-                existing_preds = thread_db.get_existing_prediction_photo_ids(model_name)
-
-            # Interleaved detect + classify in batches
-            raw_results = []
-            failed = 0
-            detected = 0
-            skipped_existing = 0
-            start_time = time.time()
+            # Seed with detections that already exist in the DB so the first
+            # model iteration doesn't re-run MegaDetector on photos that were
+            # detected in a prior pipeline pass. Also lets model #2..N reuse
+            # detections that model #1 just produced.
+            already_detected = set(
+                getattr(thread_db, "get_existing_detection_photo_ids", lambda: set())()
+            )
 
             from datetime import datetime as dt
 
-            for batch_start in range(0, total, _BATCH_SIZE):
+            for spec_idx, active_spec in enumerate(resolved_specs):
                 if _should_abort(abort):
                     break
 
-                batch = photos[batch_start:batch_start + _BATCH_SIZE]
-                batch_idx = batch_start + len(batch)
+                if spec_idx == 0:
+                    # First model was preloaded by model_loader_stage.
+                    clf = loaded_models["clf"]
+                    model_type = loaded_models["model_type"]
+                    model_name = loaded_models["model_name"]
+                else:
+                    # Load the next classifier. Release the previous bundle
+                    # first so we don't hold two large ONNX graphs in memory
+                    # at once.
+                    runner.push_event(job["id"], "progress", {
+                        "phase": f"Loading {active_spec['name']}...",
+                        "stage_id": "classify",
+                        "current": 0, "total": total,
+                        "stages": {k: dict(v) for k, v in stages.items()},
+                    })
+                    for k in ("clf", "model_type", "model_name", "model_str",
+                              "labels", "use_tol", "active_model"):
+                        loaded_models.pop(k, None)
+                    bundle = _load_model_bundle(active_spec, tax, thread_db)
+                    loaded_models.update(bundle)
+                    clf = bundle["clf"]
+                    model_type = bundle["model_type"]
+                    model_name = bundle["model_name"]
 
-                runner.push_event(job["id"], "progress", {
-                    "phase": "Classifying species",
-                    "stage_id": "classify",
-                    "current": batch_idx,
-                    "total": total,
-                    "rate": round(batch_idx / max(time.time() - start_time, 0.01) * 60, 1),
-                    "stages": {k: dict(v) for k, v in stages.items()},
-                })
-                stages["classify"]["count"] = batch_idx
-                runner.update_step(job["id"], "classify",
-                                   progress={"current": batch_idx, "total": total})
+                if params.reclassify:
+                    photo_ids = [p["id"] for p in photos]
+                    thread_db.clear_predictions(
+                        model=model_name, collection_photo_ids=photo_ids
+                    )
 
-                # Detect this batch
-                det_map, det_count = _detect_batch(
-                    batch, folders, runner, job, params.reclassify, thread_db,
+                existing_preds = set()
+                if not params.reclassify:
+                    existing_preds = thread_db.get_existing_prediction_photo_ids(model_name)
+
+                # Interleaved detect + classify in batches
+                raw_results = []
+                failed = 0
+                detected = 0
+                skipped_existing = 0
+                start_time = time.time()
+
+                for batch_start in range(0, total, _BATCH_SIZE):
+                    if _should_abort(abort):
+                        break
+
+                    batch = photos[batch_start:batch_start + _BATCH_SIZE]
+                    batch_idx = batch_start + len(batch)
+
+                    if len(resolved_specs) > 1:
+                        phase_label = (
+                            f"Classifying species ({model_name}, "
+                            f"{spec_idx + 1}/{len(resolved_specs)})"
+                        )
+                    else:
+                        phase_label = "Classifying species"
+
+                    runner.push_event(job["id"], "progress", {
+                        "phase": phase_label,
+                        "stage_id": "classify",
+                        "current": batch_idx,
+                        "total": total,
+                        "rate": round(batch_idx / max(time.time() - start_time, 0.01) * 60, 1),
+                        "stages": {k: dict(v) for k, v in stages.items()},
+                    })
+                    stages["classify"]["count"] = batch_idx
+                    runner.update_step(job["id"], "classify",
+                                       progress={"current": batch_idx, "total": total})
+
+                    # Detect this batch. Pass already_detected so subsequent
+                    # models (and re-runs) skip MegaDetector on photos that
+                    # already have detections in the DB.
+                    det_map, det_count = _detect_batch(
+                        batch, folders, runner, job, params.reclassify, thread_db,
+                        already_detected_ids=already_detected,
+                    )
+                    detected += det_count
+                    already_detected.update(det_map.keys())
+
+                    # Classify this batch
+                    for photo in batch:
+                        if photo["id"] in existing_preds:
+                            skipped_existing += 1
+                            pred_row = thread_db.get_prediction_for_photo(photo["id"], model_name)
+                            if pred_row:
+                                folder_path = folders.get(photo["folder_id"], "")
+                                image_path = os.path.join(folder_path, photo["filename"])
+                                timestamp = None
+                                if photo["timestamp"]:
+                                    with contextlib.suppress(ValueError, TypeError):
+                                        timestamp = dt.fromisoformat(photo["timestamp"])
+                                embedding = None
+                                if model_type != "timm":
+                                    emb_blob = thread_db.get_photo_embedding(photo["id"])
+                                    if emb_blob:
+                                        import numpy as np
+                                        embedding = np.frombuffer(emb_blob, dtype=np.float32)
+                                raw_results.append({
+                                    "photo": photo,
+                                    "folder_path": folder_path,
+                                    "image_path": image_path,
+                                    "prediction": pred_row["species"],
+                                    "confidence": pred_row["confidence"],
+                                    "timestamp": timestamp,
+                                    "filename": photo["filename"],
+                                    "embedding": embedding,
+                                    "taxonomy": None,
+                                    "_existing": True,
+                                })
+                            continue
+
+                        img, folder_path, image_path = _prepare_image(photo, folders, det_map)
+                        if img is None:
+                            failed += 1
+                            continue
+
+                        img_batch = [{"photo": photo, "folder_path": folder_path,
+                                      "image_path": image_path, "img": img}]
+                        failed += _flush_batch(img_batch, clf, model_type, model_name,
+                                               thread_db, raw_results)
+
+                # Group and store predictions for this model
+                group_result = _store_grouped_predictions(
+                    raw_results, job["id"], model_name,
+                    grouping_window, similarity_threshold, tax, thread_db,
                 )
-                detected += det_count
 
-                # Classify this batch
-                for photo in batch:
-                    if photo["id"] in existing_preds:
-                        skipped_existing += 1
-                        pred_row = thread_db.get_prediction_for_photo(photo["id"], model_name)
-                        if pred_row:
-                            folder_path = folders.get(photo["folder_id"], "")
-                            image_path = os.path.join(folder_path, photo["filename"])
-                            timestamp = None
-                            if photo["timestamp"]:
-                                with contextlib.suppress(ValueError, TypeError):
-                                    timestamp = dt.fromisoformat(photo["timestamp"])
-                            embedding = None
-                            if model_type != "timm":
-                                emb_blob = thread_db.get_photo_embedding(photo["id"])
-                                if emb_blob:
-                                    import numpy as np
-                                    embedding = np.frombuffer(emb_blob, dtype=np.float32)
-                            raw_results.append({
-                                "photo": photo,
-                                "folder_path": folder_path,
-                                "image_path": image_path,
-                                "prediction": pred_row["species"],
-                                "confidence": pred_row["confidence"],
-                                "timestamp": timestamp,
-                                "filename": photo["filename"],
-                                "embedding": embedding,
-                                "taxonomy": None,
-                                "_existing": True,
-                            })
-                        continue
-
-                    img, folder_path, image_path = _prepare_image(photo, folders, det_map)
-                    if img is None:
-                        failed += 1
-                        continue
-
-                    img_batch = [{"photo": photo, "folder_path": folder_path,
-                                  "image_path": image_path, "img": img}]
-                    failed += _flush_batch(img_batch, clf, model_type, model_name,
-                                           thread_db, raw_results)
-
-            # Group and store predictions
-            grouping_window = user_cfg.get("grouping_window_seconds", 5)
-            similarity_threshold = user_cfg.get("similarity_threshold", 0.85)
-
-            group_result = _store_grouped_predictions(
-                raw_results, job["id"], model_name,
-                grouping_window, similarity_threshold, tax, thread_db,
-            )
+                total_predictions_stored += group_result["predictions_stored"]
+                total_detected += detected
+                total_failed += failed
+                total_skipped_existing += skipped_existing
 
             stages["classify"]["status"] = "completed"
             runner.update_step(job["id"], "classify", status="completed",
-                               summary=f"{group_result['predictions_stored']} predictions")
+                               summary=f"{total_predictions_stored} predictions")
             result["stages"]["classify"] = {
                 "total": total,
-                "predictions_stored": group_result["predictions_stored"],
-                "detected": detected,
-                "failed": failed,
-                "already_classified": skipped_existing,
+                "predictions_stored": total_predictions_stored,
+                "detected": total_detected,
+                "failed": total_failed,
+                "already_classified": total_skipped_existing,
+                "model_count": len(resolved_specs),
             }
 
         except Exception as e:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -913,6 +913,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     # Without this, two large model graphs can be resident
                     # simultaneously during the handoff.
                     clf = None
+                    # Also release the previous iteration's output list so
+                    # embeddings/image metadata for all photos don't stay
+                    # alive during the model-load handoff.
+                    raw_results = None
                     bundle = _load_model_bundle(active_spec, tax, thread_db)
                     loaded_models.update(bundle)
                     clf = bundle["clf"]

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -829,13 +829,60 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             total_failed = 0
             total_skipped_existing = 0
 
-            # Seed with detections that already exist in the DB so the first
-            # model iteration doesn't re-run MegaDetector on photos that were
-            # detected in a prior pipeline pass. Also lets model #2..N reuse
-            # detections that model #1 just produced.
-            already_detected = set(
-                getattr(thread_db, "get_existing_detection_photo_ids", lambda: set())()
-            )
+            # For reclassify: start with an empty already_detected so model 1
+            # re-runs MegaDetector on every photo. We intentionally do NOT
+            # clear detection rows from the DB up-front: doing so would
+            # cascade-delete prediction rows from OTHER models (not in this
+            # run's model_ids) via the predictions.detection_id FK, causing
+            # permanent data loss for any model not included in the subset
+            # reclassify. Instead, model 2+ receives the this_run_detections
+            # cache (filled by model 1's detect pass) via _detect_batch's
+            # cached_detections parameter, so later models bind predictions
+            # to the detection rows just produced — not to stale rows from a
+            # prior pass that db.get_detections() would otherwise return.
+            #
+            # After model 1's full detection pass we DELETE the pre-run
+            # detection rows (snapshotted below) for all collection photos.
+            # This prevents stale prior-run boxes from being reused by
+            # subsequent non-reclassify runs via get_existing_detection_photo_ids
+            # + db.get_detections() (the false-positive reuse regression flagged
+            # in the Codex review on #511).  The cascade to predictions is
+            # intentional: any predictions that referenced the OLD detection rows
+            # are now stale (MegaDetector re-ran and produced fresh rows).
+            #
+            # Non-reclassify runs keep existing detections so the cached path
+            # in _detect_batch can reuse them (that's the whole point of the
+            # pre-seed).
+            if params.reclassify:
+                already_detected = set()
+                # Snapshot detection IDs that exist BEFORE this run so we can
+                # delete them after model 1 inserts fresh rows.
+                photo_ids_list = [p["id"] for p in photos]
+                _pre_run_det_ids: dict = getattr(
+                    thread_db, "get_detection_ids_for_photos", lambda _: {}
+                )(photo_ids_list)
+            else:
+                already_detected = set(
+                    getattr(thread_db, "get_existing_detection_photo_ids", lambda: set())()
+                )
+                _pre_run_det_ids = {}
+
+            # Accumulates the detection rows produced by model 1 (spec_idx==0)
+            # so model 2+ can reference exactly those rows rather than calling
+            # db.get_detections() which would include stale rows from prior runs.
+            # Only allocated for multi-model runs; single-model runs never read
+            # the cache, so populating it would just waste memory.
+            _multi_model = len(resolved_specs) > 1
+            this_run_detections: dict = {}
+
+            # Tracks photo IDs whose per-photo iteration in _detect_batch ran
+            # to completion during model 1's pass.  Used to gate the stale
+            # detection purge: only photos that were actually re-processed in
+            # this run should lose their prior-run rows.  Photos whose batch
+            # was never reached (abort) or whose iteration was cut short by a
+            # mid-batch exception keep their old detection rows so a partial
+            # reclassify does not cause data loss.
+            _model1_processed_photo_ids: set = set()
 
             from datetime import datetime as dt
 
@@ -861,6 +908,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     for k in ("clf", "model_type", "model_name", "model_str",
                               "labels", "use_tol", "active_model"):
                         loaded_models.pop(k, None)
+                    # Drop the local clf reference so the previous ONNX graph
+                    # is eligible for GC before the next model is loaded.
+                    # Without this, two large model graphs can be resident
+                    # simultaneously during the handoff.
+                    clf = None
                     bundle = _load_model_bundle(active_spec, tax, thread_db)
                     loaded_models.update(bundle)
                     clf = bundle["clf"]
@@ -912,14 +964,46 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                                        progress={"current": batch_idx, "total": total})
 
                     # Detect this batch. Pass already_detected so subsequent
-                    # models (and re-runs) skip MegaDetector on photos that
-                    # already have detections in the DB.
-                    det_map, det_count = _detect_batch(
-                        batch, folders, runner, job, params.reclassify, thread_db,
+                    # models skip MegaDetector on photos that already have
+                    # detections in the DB.  On reclassify runs, only the
+                    # first model iteration re-runs detection (spec_idx == 0);
+                    # subsequent models share those detections rather than
+                    # inserting duplicate rows for the same photos.
+                    # cached_detections gives model 2+ the exact detection
+                    # rows from this run rather than querying the DB (which
+                    # could return stale rows from a prior pipeline pass).
+                    det_map, det_count, det_processed_ids = _detect_batch(
+                        batch, folders, runner, job,
+                        params.reclassify and spec_idx == 0, thread_db,
                         already_detected_ids=already_detected,
+                        cached_detections=this_run_detections if _multi_model else None,
                     )
                     detected += det_count
-                    already_detected.update(det_map.keys())
+                    # Track ALL processed photos — including those where
+                    # MegaDetector found zero detections — so model 2+ skips
+                    # MegaDetector for them instead of re-running detection on
+                    # empty-frame photos each iteration.
+                    already_detected.update(det_processed_ids)
+                    if _multi_model:
+                        # Cache detections from every model iteration so
+                        # later models use this-run rows rather than stale
+                        # rows from db.get_detections().  Only add photos
+                        # not already cached — model 1's results take
+                        # precedence for photos it successfully processed.
+                        for pid, dets in det_map.items():
+                            if pid not in this_run_detections:
+                                this_run_detections[pid] = dets
+                        for pid in det_processed_ids:
+                            if pid not in this_run_detections:
+                                this_run_detections[pid] = []
+                    if spec_idx == 0:
+                        # Key purge eligibility on photos whose per-photo
+                        # iteration in _detect_batch actually completed —
+                        # not the whole submitted batch.  If _detect_batch
+                        # caught an exception mid-loop and returned early,
+                        # unprocessed photos will be absent from this set
+                        # and their stale rows will be preserved.
+                        _model1_processed_photo_ids.update(det_processed_ids)
 
                     # Classify this batch
                     for photo in batch:
@@ -973,6 +1057,42 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 total_detected += detected
                 total_failed += failed
                 total_skipped_existing += skipped_existing
+
+                # After model 1 has inserted all fresh detection rows, delete
+                # the pre-run stale rows we snapshotted before the loop.
+                # This prevents stale prior-run boxes from polluting future
+                # non-reclassify runs (the false-positive reuse regression
+                # flagged by Codex on #511 line 848).  We do this AFTER model
+                # 1's full pass — not batch-by-batch — so that all new rows
+                # are committed before the old ones are removed.
+                # model 2+ already has the new IDs via this_run_detections.
+                if params.reclassify and spec_idx == 0 and _pre_run_det_ids:
+                    # Only purge stale rows for photos whose per-photo
+                    # iteration in _detect_batch actually ran to completion.
+                    # If the run was aborted before a batch was submitted,
+                    # or _detect_batch caught an exception and returned
+                    # mid-batch, unprocessed photos are absent from
+                    # _model1_processed_photo_ids and their old rows stay.
+                    stale_ids = [
+                        det_id
+                        for photo_id, id_set in _pre_run_det_ids.items()
+                        for det_id in id_set
+                        if photo_id in _model1_processed_photo_ids
+                    ]
+                    if stale_ids:
+                        getattr(
+                            thread_db, "delete_detections_by_ids", lambda _: None
+                        )(stale_ids)
+                        processed_with_priors = (
+                            _model1_processed_photo_ids & _pre_run_det_ids.keys()
+                        )
+                        log.debug(
+                            "reclassify: purged %d stale detection rows for %d "
+                            "photos (%d photos not processed, rows preserved)",
+                            len(stale_ids),
+                            len(processed_with_priors),
+                            len(_pre_run_det_ids) - len(processed_with_priors),
+                        )
 
             stages["classify"]["status"] = "completed"
             runner.update_step(job["id"], "classify", status="completed",

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1924,6 +1924,9 @@ async function startPipeline() {
       selectedModels.push({id: cb.value, name: cb.dataset.name});
     });
     if (selectedModels.length > 0) {
+      // Send every checked model. The backend loops over model_ids in the
+      // classify stage; model_id stays for back-compat with older callers.
+      body.model_ids = selectedModels.map(function(m) { return m.id; });
       body.model_id = selectedModels[0].id;
     }
 

--- a/vireo/tests/test_classify_helpers.py
+++ b/vireo/tests/test_classify_helpers.py
@@ -18,12 +18,13 @@ def test_detect_batch_returns_detection_map():
     mock_job = {"id": "test-1", "progress": {}, "errors": [], "_start_time": 1.0}
 
     with patch("classify_job.detect_animals", return_value=[]):
-        detection_map, detected = _detect_batch(
+        detection_map, detected, processed_ids = _detect_batch(
             photos, folders, mock_runner, mock_job, reclassify=False, db=mock_db,
         )
 
     assert isinstance(detection_map, dict)
     assert isinstance(detected, int)
+    assert isinstance(processed_ids, set)
 
 
 def test_detect_batch_uses_cached_detection():
@@ -42,7 +43,7 @@ def test_detect_batch_uses_cached_detection():
     mock_runner = MagicMock()
     mock_job = {"id": "test-1", "progress": {}, "errors": [], "_start_time": 1.0}
 
-    detection_map, detected = _detect_batch(
+    detection_map, detected, processed_ids = _detect_batch(
         photos, folders, mock_runner, mock_job, reclassify=False, db=mock_db,
         already_detected_ids={1},
     )
@@ -51,3 +52,4 @@ def test_detect_batch_uses_cached_detection():
     assert len(detection_map[1]) == 1
     assert detection_map[1][0]["box_x"] == 0.1
     assert detected == 1
+    assert 1 in processed_ids

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -279,6 +279,70 @@ def test_detect_subjects_graceful_on_import_error():
 # ── Task 4: Multi-detection pipeline tests ───────────────────────────────────
 
 
+def test_detect_batch_marks_processed_before_quality_scoring(tmp_path):
+    """_detect_batch must add photo_id to processed_ids as soon as detection
+    rows are committed to the DB, before quality-scoring calls.
+
+    If compute_sharpness or update_photo_quality raises after save_detections,
+    the outer except catches the exception and processed_ids.add at the end of
+    the per-photo loop body is never reached.  The photo would be missing from
+    processed_ids, causing the reclassify purge in pipeline_job to skip
+    deleting its stale pre-run detection rows — future non-reclassify runs
+    would then reuse those stale rows indefinitely.
+
+    Regression for Codex P2 review on #513, classify_job.py line 315.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _detect_batch
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    photos = [{"id": 7, "filename": "bird.jpg", "folder_id": 10}]
+    folders = {10: str(tmp_path)}
+
+    img = Image.new("RGB", (100, 100), color="red")
+    img.save(str(tmp_path / "bird.jpg"))
+
+    fake_detections = [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+         "confidence": 0.9, "category": "animal"},
+    ]
+
+    mock_db = MagicMock()
+    mock_db.save_detections.return_value = [42]
+
+    # quality scoring raises — simulates compute_sharpness or
+    # update_photo_quality failing after the detection row is already saved.
+    def raising_sharpness(*args, **kwargs):
+        raise RuntimeError("simulated sharpness failure")
+
+    with patch("classify_job.detect_animals", return_value=fake_detections), \
+         patch("classify_job.get_primary_detection", return_value=fake_detections[0]), \
+         patch("classify_job.compute_sharpness", side_effect=raising_sharpness):
+        detection_map, detected, processed_ids = _detect_batch(
+            photos=photos,
+            folders=folders,
+            runner=runner,
+            job=job,
+            reclassify=True,
+            db=mock_db,
+            already_detected_ids=set(),
+        )
+
+    # The detection was saved to the DB before quality scoring raised.
+    mock_db.save_detections.assert_called_once()
+    # photo 7 must be in processed_ids even though quality scoring raised, so
+    # the reclassify purge correctly removes its stale pre-run detection rows.
+    assert 7 in processed_ids, (
+        "photo_id must be in processed_ids after save_detections even when "
+        "quality-scoring raises — regression for Codex P2 on #513 line 315"
+    )
+    # detection_map should still contain the result from this run
+    assert 7 in detection_map
+
+
 def test_detect_batch_stores_all_detections(tmp_path):
     """_detect_batch should store all detections, not just the primary."""
     from db import Database
@@ -328,7 +392,7 @@ def test_detect_batch_returns_all_detections(tmp_path):
     with patch("classify_job.detect_animals", return_value=fake_detections), \
          patch("classify_job.get_primary_detection", return_value=fake_detections[0]), \
          patch("classify_job.compute_sharpness", return_value=50.0):
-        detection_map, detected = _detect_batch(
+        detection_map, detected, _processed = _detect_batch(
             photos=photos,
             folders=folders,
             runner=runner,

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -1581,3 +1581,517 @@ def test_pipeline_model_ids_back_compat_with_model_id(tmp_path, monkeypatch):
         f"Legacy model_id should load exactly one classifier, "
         f"got {len(construction_calls)}"
     )
+
+
+def test_pipeline_reclassify_multimodel_ignores_stale_detection_ids(
+    tmp_path, monkeypatch
+):
+    """On reclassify with multiple models, already_detected must be cleared
+    before model 1's batch loop so model 2+ only reuse detections produced in
+    this run, not stale rows from a prior pipeline pass.
+
+    Regression: before the fix, already_detected was pre-seeded from
+    get_existing_detection_photo_ids() before the model loop.  When model 1
+    ran with reclassify=True but did NOT produce a detection for a photo that
+    already had a prior-run detection row, model 2 (reclassify=False) still
+    found that photo in already_detected and called db.get_detections(),
+    binding its predictions to outdated detection_ids.
+    """
+    import json
+
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # Create a folder + photo and insert a prior-run detection row so that
+    # get_existing_detection_photo_ids() returns this photo's id.
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_id = db.add_photo(folder_id, "test.jpg", ".jpg", 12345, 1_000_000.0)
+    db.save_detections(
+        photo_id,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    # Static collection containing exactly that one photo.
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": [photo_id]}]),
+    )
+
+    model_ids = _setup_two_fake_downloaded_models(tmp_path, monkeypatch)
+
+    # Capture the already_detected_ids and cached_detections passed to each
+    # _detect_batch call so we can verify model 2 gets fresh cache entries
+    # from model 1 rather than stale DB rows.
+    detect_calls = []
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        detect_calls.append({
+            "already_detected_ids": frozenset(already_detected_ids or set()),
+            "cached_detections": dict(cached_detections) if cached_detections else {},
+            "reclassify": reclassify,
+        })
+        # Model 1 "detects" nothing in this run — empty det_map, but every
+        # photo in the batch completed its iteration.
+        return {}, 0, {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=model_ids,
+        reclassify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # _detect_batch should have been called twice (one batch per model).
+    assert len(detect_calls) == 2, (
+        f"Expected 2 _detect_batch calls (one per model), got {len(detect_calls)}"
+    )
+
+    # Model 1 (reclassify=True): already_detected must be empty because this
+    # is a fresh reclassify run — no stale prior-run IDs should be seeded.
+    assert photo_id not in detect_calls[0]["already_detected_ids"], (
+        f"Prior-run photo_id {photo_id} leaked into already_detected_ids for "
+        "model 1. already_detected must start empty on reclassify runs."
+    )
+
+    # Model 2: already_detected SHOULD contain photo_id because model 1
+    # processed it (even with zero detections).  This tells model 2 to skip
+    # MegaDetector and use cached_detections from this run instead of falling
+    # back to db.get_detections() which would return stale rows.
+    assert photo_id in detect_calls[1]["already_detected_ids"], (
+        f"photo_id {photo_id} missing from already_detected_ids for model 2. "
+        "Zero-detection photos from model 1 must be tracked so model 2 "
+        "does not redundantly re-run MegaDetector."
+    )
+
+    # Model 2 must receive cached_detections with an empty list for the
+    # zero-detection photo, preventing fallback to db.get_detections().
+    assert photo_id in detect_calls[1]["cached_detections"], (
+        f"photo_id {photo_id} missing from cached_detections for model 2. "
+        "Zero-detection photos must be cached so model 2 uses the fresh "
+        "(empty) result instead of stale DB rows."
+    )
+    assert detect_calls[1]["cached_detections"][photo_id] == [], (
+        "cached_detections entry for a zero-detection photo should be an "
+        "empty list."
+    )
+
+
+def test_detect_batch_prefers_cached_detections_over_db(monkeypatch):
+    """_detect_batch must use cached_detections when provided instead of
+    calling db.get_detections(), so model 2+ in a multi-model reclassify run
+    bind predictions to the detection rows model 1 produced in *this* run
+    rather than stale rows from a prior pipeline pass.
+
+    Regression test for the second Codex P1 comment on #506 ('Restrict model
+    2+ reuse to detections created in this run').
+    """
+    import os
+    import sys
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+    import classify_job
+
+    photo = {"id": 42, "folder_id": 1, "filename": "bird.jpg"}
+
+    cached_det = [{"id": 99, "box_x": 0.1, "box_y": 0.1,
+                   "box_w": 0.5, "box_h": 0.5,
+                   "confidence": 0.95, "category": "animal"}]
+
+    db_called = {"n": 0}
+
+    class FakeDB:
+        def get_detections(self, photo_id):
+            db_called["n"] += 1
+            return []
+
+    det_map, count, processed = classify_job._detect_batch(
+        photos=[photo],
+        folders={1: "/fake"},
+        runner=None,
+        job=None,
+        reclassify=False,
+        db=FakeDB(),
+        already_detected_ids={42},
+        cached_detections={42: cached_det},
+    )
+
+    assert db_called["n"] == 0, (
+        "db.get_detections() must NOT be called when cached_detections "
+        "already has an entry for the photo."
+    )
+    assert det_map.get(42) == cached_det, (
+        "detection_map must contain the cached detection list, not a DB result."
+    )
+    assert count == 1
+    assert 42 in processed
+
+
+def test_pipeline_reclassify_purges_stale_detection_rows(tmp_path, monkeypatch):
+    """On reclassify, prior-run detection rows must be deleted after model 1
+    re-runs MegaDetector so that subsequent non-reclassify runs don't reuse
+    stale bounding boxes via get_existing_detection_photo_ids + get_detections.
+
+    Scenario: a photo had a prior detection (potential false positive). The
+    reclassify run finds NO animals this time (fake_detect_batch returns {}).
+    After reclassify the old detection row must be gone so future runs
+    actually call MegaDetector rather than short-circuiting to the stale box.
+
+    Regression for Codex P1 review on #511 line 848.
+    """
+    import json
+
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_id = db.add_photo(folder_id, "test.jpg", ".jpg", 12345, 1_000_000.0)
+
+    # Prior-run detection row (e.g. a prior false positive).
+    prior_det_ids = db.save_detections(
+        photo_id,
+        [
+            {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+             "confidence": 0.9, "category": "animal"},
+        ],
+        detector_model="MegaDetector",
+    )
+    assert prior_det_ids, "setup sanity: prior detection was inserted"
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": [photo_id]}]),
+    )
+
+    model_ids = _setup_two_fake_downloaded_models(tmp_path, monkeypatch)
+
+    # _detect_batch stub: reclassify finds no animals this time (false pos fixed).
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        return {}, 0, {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=model_ids[:1],
+        reclassify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # The stale prior-run detection must be gone after reclassify so that
+    # future non-reclassify runs don't reuse it via the already-detected path.
+    verify_db = Database(db_path)
+    verify_db.set_active_workspace(ws_id)
+    remaining = verify_db.get_detections(photo_id)
+    assert remaining == [], (
+        f"Stale prior-run detection rows must be purged during reclassify but "
+        f"db.get_detections({photo_id}) returned {remaining!r}. "
+        "Without this cleanup, future non-reclassify runs short-circuit to "
+        "stale boxes via get_existing_detection_photo_ids + get_detections, "
+        "causing false-positive detections to persist indefinitely. "
+        "Regression for Codex P1 review on #511 line 848."
+    )
+
+
+def test_pipeline_reclassify_partial_abort_preserves_unprocessed_detections(
+    tmp_path, monkeypatch
+):
+    """A partial/aborted reclassify must NOT delete detection rows for photos
+    whose batches were never submitted to _detect_batch.
+
+    Scenario: 2 photos each have a prior detection row. Batch size is patched
+    to 1 so each photo is its own batch. After the first batch completes,
+    _should_abort returns True so the second batch is never processed.
+
+    Expected outcome:
+    - photo1's stale detection row is purged (its batch was processed).
+    - photo2's detection row is preserved (its batch was never reached).
+
+    Regression guard for Codex P1 review on #513 line 1040.
+    """
+    import json
+
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    import pipeline_job as pj
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo1_id = db.add_photo(folder_id, "photo1.jpg", ".jpg", 11111, 1_000_000.0)
+    photo2_id = db.add_photo(folder_id, "photo2.jpg", ".jpg", 22222, 1_000_000.0)
+
+    # Give each photo a prior-run detection row.
+    prior_det1 = db.save_detections(
+        photo1_id,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    prior_det2 = db.save_detections(
+        photo2_id,
+        [{"box": {"x": 0.2, "y": 0.2, "w": 0.3, "h": 0.3},
+          "confidence": 0.8, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    assert prior_det1 and prior_det2, "setup sanity: prior detections inserted"
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": [photo1_id, photo2_id]}]),
+    )
+
+    model_ids = _setup_two_fake_downloaded_models(tmp_path, monkeypatch)
+
+    # Process one photo per batch so we can abort between them.
+    monkeypatch.setattr(classify_job, "_BATCH_SIZE", 1)
+
+    # After the first _detect_batch call, all subsequent _should_abort checks
+    # return True, preventing the second batch from being processed.
+    detect_call_count = [0]
+    original_should_abort = pj._should_abort
+
+    def patched_should_abort(event):
+        if detect_call_count[0] >= 1:
+            return True
+        return original_should_abort(event)
+
+    monkeypatch.setattr(pj, "_should_abort", patched_should_abort)
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        detect_call_count[0] += 1
+        return {}, 0, {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=model_ids[:1],
+        reclassify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert detect_call_count[0] == 1, (
+        "Expected exactly one _detect_batch call before abort; "
+        f"got {detect_call_count[0]}"
+    )
+
+    verify_db = Database(db_path)
+    verify_db.set_active_workspace(ws_id)
+
+    remaining1 = verify_db.get_detections(photo1_id)
+    remaining2 = verify_db.get_detections(photo2_id)
+
+    assert remaining1 == [], (
+        f"photo1 was processed in model 1's batch loop; its stale prior-run "
+        f"detection must be purged, but get_detections returned {remaining1!r}. "
+        "Regression for Codex P1 review on #513 line 1040."
+    )
+    assert remaining2 != [], (
+        "photo2's batch was never reached (run was aborted before it). "
+        "Its prior-run detection row must be preserved to avoid data loss "
+        "in partial reclassify runs. "
+        "Regression for Codex P1 review on #513 line 1040."
+    )
+
+
+def test_pipeline_reclassify_partial_batch_exception_preserves_detections(
+    tmp_path, monkeypatch
+):
+    """A reclassify where _detect_batch exits mid-batch on an exception must
+    NOT delete detection rows for the photos that were never actually
+    reached inside that batch.
+
+    Scenario: two photos share a single batch.  _detect_batch only
+    completes the per-photo iteration for the first photo and returns early
+    (simulating detect_animals raising while processing photo2 — the real
+    _detect_batch catches the exception at function level and returns the
+    accumulated detection_map with only the already-processed photos).
+
+    Expected outcome:
+    - photo1 (whose iteration completed) has its stale prior-run row purged.
+    - photo2 (whose iteration never ran) keeps its stale prior-run row.
+
+    Regression for Codex P1 review on #513 line 981 — the purge must be
+    keyed to per-photo processing completion, not the full submitted batch.
+    """
+    import json
+
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo1_id = db.add_photo(folder_id, "photo1.jpg", ".jpg", 11111, 1_000_000.0)
+    photo2_id = db.add_photo(folder_id, "photo2.jpg", ".jpg", 22222, 1_000_000.0)
+
+    prior_det1 = db.save_detections(
+        photo1_id,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    prior_det2 = db.save_detections(
+        photo2_id,
+        [{"box": {"x": 0.2, "y": 0.2, "w": 0.3, "h": 0.3},
+          "confidence": 0.8, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    assert prior_det1 and prior_det2, "setup sanity: prior detections inserted"
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": [photo1_id, photo2_id]}]),
+    )
+
+    model_ids = _setup_two_fake_downloaded_models(tmp_path, monkeypatch)
+
+    # Both photos land in a single batch.  The stub returns a processed_ids
+    # set containing ONLY photo1, mirroring what _detect_batch does when
+    # detect_animals raises while processing photo2: the try/except at the
+    # function level returns the accumulated results and photo2 never makes
+    # it into processed_ids.
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        return {}, 0, {photo1_id}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=model_ids[:1],
+        reclassify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    verify_db = Database(db_path)
+    verify_db.set_active_workspace(ws_id)
+
+    remaining1 = verify_db.get_detections(photo1_id)
+    remaining2 = verify_db.get_detections(photo2_id)
+
+    assert remaining1 == [], (
+        f"photo1's per-photo iteration completed in _detect_batch; its stale "
+        f"prior-run row must be purged, but get_detections returned "
+        f"{remaining1!r}. Regression for Codex P1 review on #513 line 981."
+    )
+    assert remaining2 != [], (
+        "photo2's iteration never ran (simulated mid-batch exception in "
+        "_detect_batch).  Its stale prior-run detection row must be "
+        "preserved — purging it would cascade-delete predictions for a "
+        "photo that was never re-detected.  "
+        "Regression for Codex P1 review on #513 line 981."
+    )

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -110,6 +110,7 @@ def test_pipeline_params_all_fields():
         labels_file="/labels.txt",
         labels_files=["/a.txt", "/b.txt"],
         model_id="bioclip-2",
+        model_ids=["bioclip-2", "timm-inat21-eva02-l"],
         reclassify=True,
         skip_extract_masks=True,
         skip_regroup=True,
@@ -120,11 +121,18 @@ def test_pipeline_params_all_fields():
     assert params.sources == ["/src1", "/src2"]
     assert params.destination == "/dst"
     assert params.file_types == "raw"
+    assert params.model_ids == ["bioclip-2", "timm-inat21-eva02-l"]
     assert params.reclassify is True
     assert params.skip_extract_masks is True
     assert params.skip_regroup is True
     assert params.skip_classify is True
     assert params.preview_max_size == 2560
+
+
+def test_pipeline_params_model_ids_defaults_none():
+    """model_ids defaults to None (single-model / back-compat path)."""
+    params = PipelineParams(collection_id=1)
+    assert params.model_ids is None
 
 
 def test_pipeline_job_with_collection_skips_scan(tmp_path, monkeypatch):
@@ -1267,6 +1275,22 @@ def _make_stage_failer(monkeypatch, stage_name, err_message):
     return real_run
 
 
+def _write_fake_model_files(model_dir, extra_files=()):
+    """Materialize a fake model directory that passes _classify_model_state."""
+    import models
+    model_dir.mkdir(parents=True, exist_ok=True)
+    (model_dir / "image_encoder.onnx").write_bytes(b"stub")
+    with open(model_dir / "image_encoder.onnx.data", "wb") as f:
+        f.truncate(models._ONNX_DATA_MIN_BYTES + 1024)
+    (model_dir / "text_encoder.onnx").write_bytes(b"stub")
+    with open(model_dir / "text_encoder.onnx.data", "wb") as f:
+        f.truncate(models._ONNX_DATA_MIN_BYTES + 1024)
+    (model_dir / "tokenizer.json").write_text("{}")
+    (model_dir / "config.json").write_text("{}")
+    for extra in extra_files:
+        (model_dir / extra).write_text("{}")
+
+
 def _setup_fake_downloaded_model(tmp_path, monkeypatch):
     """Put a validation-passing fake model on disk so model_loader_stage can
     get past the model-lookup / labels / taxonomy steps and into Classifier().
@@ -1276,16 +1300,7 @@ def _setup_fake_downloaded_model(tmp_path, monkeypatch):
     import models
     monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
     monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
-    model_dir = tmp_path / "models" / "bioclip-vit-b-16"
-    model_dir.mkdir(parents=True)
-    (model_dir / "image_encoder.onnx").write_bytes(b"stub")
-    with open(model_dir / "image_encoder.onnx.data", "wb") as f:
-        f.truncate(models._ONNX_DATA_MIN_BYTES + 1024)
-    (model_dir / "text_encoder.onnx").write_bytes(b"stub")
-    with open(model_dir / "text_encoder.onnx.data", "wb") as f:
-        f.truncate(models._ONNX_DATA_MIN_BYTES + 1024)
-    (model_dir / "tokenizer.json").write_text("{}")
-    (model_dir / "config.json").write_text("{}")
+    _write_fake_model_files(tmp_path / "models" / "bioclip-vit-b-16")
     models.set_active_model("bioclip-vit-b-16")
     # Short-circuit taxonomy and label loading so the test stays focused on
     # model-loading behavior.
@@ -1294,6 +1309,25 @@ def _setup_fake_downloaded_model(tmp_path, monkeypatch):
         classify_job, "_load_labels", lambda *a, **k: (["test-label"], False)
     )
     return "bioclip-vit-b-16"
+
+
+def _setup_two_fake_downloaded_models(tmp_path, monkeypatch):
+    """Install two bioclip models side-by-side; both reported as downloaded."""
+    import classify_job
+    import models
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
+    _write_fake_model_files(tmp_path / "models" / "bioclip-vit-b-16")
+    _write_fake_model_files(
+        tmp_path / "models" / "bioclip-2",
+        extra_files=("tol_embeddings.npy", "tol_classes.json"),
+    )
+    models.set_active_model("bioclip-vit-b-16")
+    monkeypatch.setattr(classify_job, "_load_taxonomy", lambda *a, **k: {})
+    monkeypatch.setattr(
+        classify_job, "_load_labels", lambda *a, **k: (["test-label"], False)
+    )
+    return ["bioclip-vit-b-16", "bioclip-2"]
 
 
 def test_pipeline_raises_when_stage_fails(tmp_path, monkeypatch):
@@ -1441,3 +1475,109 @@ def test_pipeline_cancellation_takes_precedence_over_failure(tmp_path, monkeypat
     # Should NOT raise — cancellation wins over stage failure.
     result = run_pipeline_job(job, runner, db_path, ws_id, params)
     assert isinstance(result, dict)
+
+
+def test_pipeline_loops_over_multiple_models(tmp_path, monkeypatch):
+    """When model_ids contains multiple models, each one must be loaded and
+    run through classify. This is the fix for the UI-dropped-multi-select bug:
+    the pipeline page collects multiple checked models but only the first one
+    was forwarded to the backend. The backend now honors model_ids."""
+    import classifier as classifier_mod
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    model_ids = _setup_two_fake_downloaded_models(tmp_path, monkeypatch)
+
+    construction_calls = []
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            construction_calls.append(kwargs)
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=model_ids,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert len(construction_calls) == len(model_ids), (
+        f"Expected Classifier() to be constructed {len(model_ids)} times "
+        f"(one per model_id), got {len(construction_calls)}"
+    )
+    # model_loader must record completion with a summary naming each model.
+    model_loader_summaries = [
+        kwargs.get("summary", "")
+        for (_, step_id, kwargs) in runner.step_updates
+        if step_id == "model_loader" and kwargs.get("status") == "completed"
+    ]
+    joined = " ".join(model_loader_summaries)
+    assert "BioCLIP" in joined and "BioCLIP-2" in joined, (
+        f"model_loader summary should mention both models, saw: {model_loader_summaries}"
+    )
+
+
+def test_pipeline_model_ids_back_compat_with_model_id(tmp_path, monkeypatch):
+    """A job with only the legacy `model_id` field (no `model_ids`) must still
+    load exactly that one model — preserving back-compat with older callers."""
+    import classifier as classifier_mod
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    construction_calls = []
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            construction_calls.append(kwargs)
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_id="bioclip-vit-b-16",
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert len(construction_calls) == 1, (
+        f"Legacy model_id should load exactly one classifier, "
+        f"got {len(construction_calls)}"
+    )


### PR DESCRIPTION
## Summary
- The pipeline page let users check multiple classifier models, but the frontend only forwarded `selectedModels[0]` and the backend's `PipelineParams` accepted a single `model_id`. Any additional models were silently dropped — the user thought they were running two classifiers but only got one.
- Backend now accepts `model_ids: list[str]`, resolves every requested model upfront (so a bad id fails fast), loads the first classifier in `model_loader_stage`, and iterates the rest inside `classify_stage`, unloading each bundle before loading the next so we never hold two large ONNX graphs in memory.
- `_detect_batch` now receives `already_detected_ids` between iterations so MegaDetector doesn't re-run on photos that the first model already processed.
- Frontend sends `body.model_ids = [...all checked...]`; the legacy `model_id` field is still accepted for older callers.
- `api_job_pipeline`'s "no model available" preflight now checks every requested id so users get the warning instead of a mid-run crash.

## Test plan
- [x] `vireo/tests/test_pipeline_job.py::test_pipeline_params_all_fields` — `model_ids` accepted as a list
- [x] `vireo/tests/test_pipeline_job.py::test_pipeline_params_model_ids_defaults_none` — defaults to None
- [x] `vireo/tests/test_pipeline_job.py::test_pipeline_loops_over_multiple_models` — Classifier constructed once per spec, model_loader summary lists both names
- [x] `vireo/tests/test_pipeline_job.py::test_pipeline_model_ids_back_compat_with_model_id` — legacy `model_id` still loads exactly one classifier
- [x] Full CLAUDE.md test suite: `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_pipeline_job.py vireo/tests/test_pipeline_api.py` — **484 passed** in 11m08s

🤖 Generated with [Claude Code](https://claude.com/claude-code)