### PR TITLE
fix: address Codex review on #504 — preserve hash verification when revision lookup fails

### DIFF
--- a/vireo/models.py
+++ b/vireo/models.py
@@ -454,9 +454,31 @@ def download_model(model_id, progress_callback=None):
     # a genuinely corrupt model as healthy.
     verification_ran = False
     hf_revision = None
+
+    # Step 1: Try to resolve the pinned HF revision for this download.
+    # Failure (repo-info API unreachable) falls back to "main" so that
+    # SHA256 verification can still run against the tree API — the two
+    # APIs are independent and the tree API may be healthy even when the
+    # model-info endpoint is not.
     try:
         hf_revision = model_verify.fetch_repo_revision(ONNX_REPO)
-        expected_hashes = model_verify.fetch_expected_hashes(hf_subdir, revision=hf_revision)
+    except model_verify.VerifyError as e:
+        log.warning(
+            "Could not resolve HF revision for %s: %s. "
+            "Will verify hashes against 'main'.",
+            ONNX_REPO, e,
+        )
+        hf_revision = None  # will fall back to "main" below
+
+    # Step 2: Fetch expected hashes using the resolved revision (or "main"
+    # if the revision lookup above failed). Only if this step also fails do
+    # we skip SHA256 verification entirely — and we must NOT clear any
+    # preexisting .verify_failed sentinel in that case.
+    revision_for_hashes = hf_revision or "main"
+    try:
+        expected_hashes = model_verify.fetch_expected_hashes(
+            hf_subdir, revision=revision_for_hashes
+        )
         verification_ran = True
     except model_verify.VerifyError as e:
         log.warning(
@@ -465,7 +487,7 @@ def download_model(model_id, progress_callback=None):
             hf_subdir, e,
         )
         expected_hashes = {}
-        hf_revision = None
+        hf_revision = None  # no verified revision to pin against
 
     for fi, filename in enumerate(files):
         if progress_callback:

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -843,3 +843,56 @@ def test_download_model_writes_revision_file(tmp_path, monkeypatch):
     rev_file = model_dir / model_verify.REVISION_FILE
     assert rev_file.is_file()
     assert rev_file.read_text().strip() == "pinned_sha_abc123"
+
+
+def test_download_model_still_verifies_when_revision_lookup_fails(tmp_path, monkeypatch):
+    """When fetch_repo_revision fails (repo-info API down) but fetch_expected_hashes
+    succeeds against 'main', SHA256 verification must still run — the two API
+    endpoints are independent and a revision-lookup failure must not silently
+    disable integrity checking.
+
+    Regression test for the Codex P1 comment on #504 ('Preserve hash
+    verification when revision lookup fails').
+    """
+    import hashlib
+
+    import model_verify
+    models, model_dir = _patch_download_model_env(tmp_path, monkeypatch)
+
+    contents = b"verifyok" * 100
+    expected = {
+        "image_encoder.onnx": hashlib.sha256(contents).hexdigest(),
+        "image_encoder.onnx.data": hashlib.sha256(contents).hexdigest(),
+        "text_encoder.onnx": hashlib.sha256(contents).hexdigest(),
+        "text_encoder.onnx.data": hashlib.sha256(contents).hexdigest(),
+    }
+    fetch_hashes_call_count = {"n": 0}
+
+    def fake_download(repo_id, filename, local_dir, subfolder=None, progress_callback=None):
+        os.makedirs(local_dir, exist_ok=True)
+        dest = os.path.join(local_dir, filename)
+        with open(dest, "wb") as f:
+            f.write(contents if filename in expected else b"{}")
+        return dest
+
+    def fetch_raises_verify_error(repo):
+        raise model_verify.VerifyError("repo-info API offline")
+
+    def fake_fetch_hashes(subdir, revision="main"):
+        fetch_hashes_call_count["n"] += 1
+        # Verify that we fall back to "main" when revision is unknown
+        assert revision == "main", f"Expected 'main' fallback, got {revision!r}"
+        return expected
+
+    monkeypatch.setattr(models, "_purge_hf_cache_file", lambda filename, subdir: None)
+    monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
+    monkeypatch.setattr(model_verify, "fetch_repo_revision", fetch_raises_verify_error)
+    monkeypatch.setattr(model_verify, "fetch_expected_hashes", fake_fetch_hashes)
+
+    models.download_model("bioclip-vit-b-16")
+
+    # Verification must have run even though revision lookup failed.
+    assert fetch_hashes_call_count["n"] == 1, (
+        "fetch_expected_hashes should have been called once (against 'main') "
+        "even when fetch_repo_revision raises VerifyError"
+    )


### PR DESCRIPTION
Parent PR: #504

Addresses the Codex Connect P1 review comment on #504 at `vireo/models.py` line 459.

## Problem

`download_model` wrapped both `fetch_repo_revision` and `fetch_expected_hashes` in a single `try/except`. If `fetch_repo_revision` raised `VerifyError` (repo-info API unreachable), the handler immediately set `expected_hashes = {}` and `verification_ran = False` — silently disabling SHA256 verification even though the tree API might be perfectly healthy and reachable independently. A corrupted or stale cached blob would then be accepted as a successful install with no integrity check.

## Fix (`vireo/models.py`)

Split the single `try` into two independent steps:

1. **Try `fetch_repo_revision`** — on failure, log a warning and fall back to `revision = "main"`. The HuggingFace repo-info API and tree API are separate endpoints; a failure of one does not imply a failure of the other.
2. **Try `fetch_expected_hashes(hf_subdir, revision=revision_for_hashes)`** — only if this also fails do we skip verification entirely (and we still preserve any preexisting `.verify_failed` sentinel in that case, as before).

## New test (`vireo/tests/test_models.py`)

`test_download_model_still_verifies_when_revision_lookup_fails` — asserts that `fetch_expected_hashes` is called with `revision="main"` (the correct fallback) even when `fetch_repo_revision` raises `VerifyError`.

## Test results

**482 passed** in 23.87s

---
Generated by scheduled PR Agent