### PR TITLE
fix: address Codex review on #506 — clear stale already_detected on reclassify

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -889,6 +889,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 skipped_existing = 0
                 start_time = time.time()
 
+                # On the first model of a reclassify run, drop any pre-seeded
+                # already_detected IDs so that later models only reuse
+                # detections that model 1 produced in *this* run.  Without
+                # this, already_detected still contains IDs from
+                # get_existing_detection_photo_ids() that reflect prior
+                # pipeline passes; when model 2 encounters those photo IDs it
+                # calls db.get_detections() and picks up stale rows instead of
+                # the fresh detections model 1 just inserted.
+                if params.reclassify and spec_idx == 0 and len(resolved_specs) > 1:
+                    already_detected = set()
+
                 for batch_start in range(0, total, _BATCH_SIZE):
                     if _should_abort(abort):
                         break

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -1581,3 +1581,102 @@ def test_pipeline_model_ids_back_compat_with_model_id(tmp_path, monkeypatch):
         f"Legacy model_id should load exactly one classifier, "
         f"got {len(construction_calls)}"
     )
+
+
+def test_pipeline_reclassify_multimodel_ignores_stale_detection_ids(
+    tmp_path, monkeypatch
+):
+    """On reclassify with multiple models, already_detected must be cleared
+    before model 1's batch loop so model 2+ only reuse detections produced in
+    this run, not stale rows from a prior pipeline pass.
+
+    Regression: before the fix, already_detected was pre-seeded from
+    get_existing_detection_photo_ids() before the model loop.  When model 1
+    ran with reclassify=True but did NOT produce a detection for a photo that
+    already had a prior-run detection row, model 2 (reclassify=False) still
+    found that photo in already_detected and called db.get_detections(),
+    binding its predictions to outdated detection_ids.
+    """
+    import json
+    import classify_job
+    import classifier as classifier_mod
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # Create a folder + photo and insert a prior-run detection row so that
+    # get_existing_detection_photo_ids() returns this photo's id.
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_id = db.add_photo(folder_id, "test.jpg", ".jpg", 12345, 1_000_000.0)
+    db.save_detections(
+        photo_id,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    # Static collection containing exactly that one photo.
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": [photo_id]}]),
+    )
+
+    model_ids = _setup_two_fake_downloaded_models(tmp_path, monkeypatch)
+
+    # Capture the already_detected_ids set passed to each _detect_batch call.
+    detect_call_ids = []
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None):
+        detect_call_ids.append(frozenset(already_detected_ids or set()))
+        # Model 1 "detects" nothing in this run — empty det_map.
+        return {}, 0
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=model_ids,
+        reclassify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # _detect_batch should have been called at least once (one batch per model).
+    assert len(detect_call_ids) >= 1, (
+        "Expected _detect_batch to be called at least once but it was not."
+    )
+
+    # The stale prior-run photo_id must NOT appear in already_detected_ids for
+    # any _detect_batch invocation.  With the fix, already_detected is wiped
+    # before model 1's loop; model 1 finds nothing → already_detected stays
+    # empty → model 2 receives an empty set, not the pre-seeded stale ID.
+    for call_ids in detect_call_ids:
+        assert photo_id not in call_ids, (
+            f"Prior-run photo_id {photo_id} leaked into already_detected_ids "
+            f"{call_ids!r}. already_detected must be cleared before the first "
+            "model's batch loop so later models do not use stale detection rows "
+            "from prior pipeline passes."
+        )


### PR DESCRIPTION
Parent PR: #506

Addresses the Codex Connect P1 review comment on #506 at `vireo/pipeline_job.py` line 927.

## Problem

`already_detected` was seeded from `get_existing_detection_photo_ids()` **before** the model loop. On a reclassify run with multiple models:

1. Model 1 runs with `reclassify=True` (only the first model re-runs MegaDetector per the PR #506 fix). For any photo that model 1 did **not** re-detect in this run, no new detection row is produced.
2. Model 2 runs with `reclassify=False`. The `already_detected` set still contains the photo's ID from the pre-loop seed. `_detect_batch` calls `db.get_detections(photo_id)` and returns **stale rows from the prior pipeline pass**, binding model 2's predictions to outdated detection_ids.

This regression fires whenever the collection already has detection rows from a previous run before a multi-model reclassify is started.

## Fix (`vireo/pipeline_job.py`)

At the start of the **first model's** batch loop, reset `already_detected = set()` when `params.reclassify=True` and there are multiple models. After model 1 finishes, `already_detected` holds only the photos that model 1 actually detected in this run. Model 2 inherits that clean set and never touches detection rows from prior passes.

## New test (`vireo/tests/test_pipeline_job.py`)

`test_pipeline_reclassify_multimodel_ignores_stale_detection_ids` — seeds the DB with a prior-run detection row for a photo, runs a two-model reclassify where model 1 detects nothing, and asserts that the stale photo_id does **not** appear in `already_detected_ids` for any `_detect_batch` call.

## Test results

**470 passed** in 24.44s

---
Generated by scheduled PR Agent