### PR TITLE
fix: address Codex review on #504 — clear stale .hf_revision when revision lookup fails

### DIFF
--- a/vireo/models.py
+++ b/vireo/models.py
@@ -521,11 +521,18 @@ def download_model(model_id, progress_callback=None):
         if os.path.isfile(sentinel_path):
             with contextlib.suppress(OSError):
                 os.unlink(sentinel_path)
+        rev_path = os.path.join(model_dir, model_verify.REVISION_FILE)
         if hf_revision:
-            rev_path = os.path.join(model_dir, model_verify.REVISION_FILE)
             with contextlib.suppress(OSError):
                 with open(rev_path, "w") as f:
                     f.write(hf_revision)
+        else:
+            # Revision lookup failed but verification ran against "main".
+            # Remove any stale .hf_revision so future verify_model calls
+            # also verify against "main" instead of an outdated commit SHA
+            # that would produce false hash mismatches.
+            with contextlib.suppress(OSError):
+                os.unlink(rev_path)
 
     state = _classify_model_state(model_dir, files)
     if state != "ok":

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -896,3 +896,62 @@ def test_download_model_still_verifies_when_revision_lookup_fails(tmp_path, monk
         "fetch_expected_hashes should have been called once (against 'main') "
         "even when fetch_repo_revision raises VerifyError"
     )
+
+
+def test_download_model_clears_stale_revision_when_revision_lookup_fails(
+    tmp_path, monkeypatch
+):
+    """When fetch_repo_revision fails but fetch_expected_hashes succeeds
+    (verification_ran=True, hf_revision=None), a stale .hf_revision left over
+    from a prior install must be removed.
+
+    Without this, a future verify_model call reads the outdated commit SHA and
+    fetches expected hashes pinned to an older revision.  If the model files
+    on disk are from a newer HEAD, the SHA256s won't match and the model is
+    falsely flagged incomplete.
+
+    Regression test for the second Codex P1 comment on #504 ('Clear stale
+    pinned revision when repo SHA lookup fails').
+    """
+    import hashlib
+    import model_verify
+
+    models, model_dir = _patch_download_model_env(tmp_path, monkeypatch)
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    # Simulate a stale .hf_revision from a prior successful download.
+    stale_rev_path = model_dir / model_verify.REVISION_FILE
+    stale_rev_path.write_text("stalesha123")
+
+    contents = b"freshbytes" * 100
+    expected = {
+        "image_encoder.onnx": hashlib.sha256(contents).hexdigest(),
+        "image_encoder.onnx.data": hashlib.sha256(contents).hexdigest(),
+        "text_encoder.onnx": hashlib.sha256(contents).hexdigest(),
+        "text_encoder.onnx.data": hashlib.sha256(contents).hexdigest(),
+    }
+
+    def fake_download(repo_id, filename, local_dir, subfolder=None, progress_callback=None):
+        os.makedirs(local_dir, exist_ok=True)
+        dest = os.path.join(local_dir, filename)
+        with open(dest, "wb") as f:
+            f.write(contents if filename in expected else b"{}")
+        return dest
+
+    monkeypatch.setattr(models, "_purge_hf_cache_file", lambda filename, subdir: None)
+    monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
+    monkeypatch.setattr(
+        model_verify, "fetch_repo_revision",
+        lambda repo: (_ for _ in ()).throw(model_verify.VerifyError("repo-info offline")),
+    )
+    monkeypatch.setattr(model_verify, "fetch_expected_hashes", lambda subdir, revision="main": expected)
+
+    models.download_model("bioclip-vit-b-16")
+
+    # The stale .hf_revision must be gone so future verify_model calls fall
+    # back to "main" rather than using the outdated commit SHA.
+    assert not stale_rev_path.exists(), (
+        ".hf_revision must be deleted when revision lookup fails but "
+        "verification still ran against 'main', to prevent future "
+        "verify_model from using a stale commit SHA."
+    )


### PR DESCRIPTION
Parent PR: #504

Addresses the second Codex Connect P1 review comment on #504 at `vireo/models.py` line 528.

## Problem

When `fetch_repo_revision` fails (repo-info API offline) but `fetch_expected_hashes` succeeds against `"main"` (`verification_ran=True`, `hf_revision=None`), the old code wrote no revision file — but also **never removed** any pre-existing `.hf_revision` from a prior install. On the next `verify_model` call, the stale commit SHA was read from `.hf_revision`, expected hashes were fetched pinned to that older revision, and SHA256 mismatches were reported for files that are actually correct — falsely marking a healthy model as `incomplete` and forcing unnecessary Repair cycles.

## Fix (`vireo/models.py`)

In the `if verification_ran:` block, moved `rev_path` outside the `if hf_revision:` guard and added an `else` branch: when `hf_revision` is `None` (revision lookup failed), delete any existing `.hf_revision` with `contextlib.suppress(OSError)`. This ensures future `verify_model` calls fall back to `"main"` and avoid false mismatches.

## New test (`vireo/tests/test_models.py`)

`test_download_model_clears_stale_revision_when_revision_lookup_fails` — writes a stale `.hf_revision`, monkeypatches `fetch_repo_revision` to raise `VerifyError`, lets `fetch_expected_hashes` succeed, and asserts the revision file is removed after `download_model`.

## Test results

**53 passed** (model + verify suite) + **430 passed** (full CLAUDE.md suite)

---
Generated by scheduled PR Agent