### PR TITLE
fix: address codex review on #513 — gate stale-detection purge on processed photos

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -872,6 +872,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             # db.get_detections() which would include stale rows from prior runs.
             this_run_detections: dict = {}
 
+            # Tracks photo IDs whose batches were actually submitted to
+            # _detect_batch during model 1's pass.  Used to gate the stale
+            # detection purge: only photos that were re-processed in this run
+            # should lose their prior-run rows.  Photos in batches that were
+            # never reached (e.g. the run was aborted mid-way) keep their old
+            # detection rows so a partial reclassify does not cause data loss.
+            _model1_attempted_photo_ids: set = set()
+
             from datetime import datetime as dt
 
             for spec_idx, active_spec in enumerate(resolved_specs):
@@ -970,6 +978,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     already_detected.update(det_map.keys())
                     if spec_idx == 0:
                         this_run_detections.update(det_map)
+                        _model1_attempted_photo_ids.update(p["id"] for p in batch)
 
                     # Classify this batch
                     for photo in batch:
@@ -1033,18 +1042,29 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 # are committed before the old ones are removed.
                 # model 2+ already has the new IDs via this_run_detections.
                 if params.reclassify and spec_idx == 0 and _pre_run_det_ids:
+                    # Only purge stale rows for photos whose batches were
+                    # actually submitted to _detect_batch in this run.
+                    # If the run was aborted mid-way, photos in unprocessed
+                    # batches were never re-detected, so deleting their old
+                    # detection rows would be avoidable data loss.
                     stale_ids = [
                         det_id
-                        for id_set in _pre_run_det_ids.values()
+                        for photo_id, id_set in _pre_run_det_ids.items()
                         for det_id in id_set
+                        if photo_id in _model1_attempted_photo_ids
                     ]
                     if stale_ids:
                         getattr(
                             thread_db, "delete_detections_by_ids", lambda _: None
                         )(stale_ids)
                         log.debug(
-                            "reclassify: purged %d stale detection rows for %d photos",
-                            len(stale_ids), len(_pre_run_det_ids),
+                            "reclassify: purged %d stale detection rows for %d "
+                            "photos (%d photos not yet processed, rows preserved)",
+                            len(stale_ids),
+                            len(_model1_attempted_photo_ids & _pre_run_det_ids.keys()),
+                            len(_pre_run_det_ids) - len(
+                                _model1_attempted_photo_ids & _pre_run_det_ids.keys()
+                            ),
                         )
 
             stages["classify"]["status"] = "completed"

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -1777,3 +1777,132 @@ def test_pipeline_reclassify_purges_stale_detection_rows(tmp_path, monkeypatch):
         "causing false-positive detections to persist indefinitely. "
         "Regression for Codex P1 review on #511 line 848."
     )
+
+
+def test_pipeline_reclassify_partial_abort_preserves_unprocessed_detections(
+    tmp_path, monkeypatch
+):
+    """A partial/aborted reclassify must NOT delete detection rows for photos
+    whose batches were never submitted to _detect_batch.
+
+    Scenario: 2 photos each have a prior detection row. Batch size is patched
+    to 1 so each photo is its own batch. After the first batch completes,
+    _should_abort returns True so the second batch is never processed.
+
+    Expected outcome:
+    - photo1's stale detection row is purged (its batch was processed).
+    - photo2's detection row is preserved (its batch was never reached).
+
+    Regression guard for Codex P1 review on #513 line 1040.
+    """
+    import json
+
+    import classify_job
+    import classifier as classifier_mod
+    import config as cfg
+    import pipeline_job as pj
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo1_id = db.add_photo(folder_id, "photo1.jpg", ".jpg", 11111, 1_000_000.0)
+    photo2_id = db.add_photo(folder_id, "photo2.jpg", ".jpg", 22222, 1_000_000.0)
+
+    # Give each photo a prior-run detection row.
+    prior_det1 = db.save_detections(
+        photo1_id,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    prior_det2 = db.save_detections(
+        photo2_id,
+        [{"box": {"x": 0.2, "y": 0.2, "w": 0.3, "h": 0.3},
+          "confidence": 0.8, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    assert prior_det1 and prior_det2, "setup sanity: prior detections inserted"
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": [photo1_id, photo2_id]}]),
+    )
+
+    model_ids = _setup_two_fake_downloaded_models(tmp_path, monkeypatch)
+
+    # Process one photo per batch so we can abort between them.
+    monkeypatch.setattr(classify_job, "_BATCH_SIZE", 1)
+
+    # After the first _detect_batch call, all subsequent _should_abort checks
+    # return True, preventing the second batch from being processed.
+    detect_call_count = [0]
+    original_should_abort = pj._should_abort
+
+    def patched_should_abort(event):
+        if detect_call_count[0] >= 1:
+            return True
+        return original_should_abort(event)
+
+    monkeypatch.setattr(pj, "_should_abort", patched_should_abort)
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        detect_call_count[0] += 1
+        return {}, 0
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=model_ids[:1],
+        reclassify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert detect_call_count[0] == 1, (
+        "Expected exactly one _detect_batch call before abort; "
+        f"got {detect_call_count[0]}"
+    )
+
+    verify_db = Database(db_path)
+    verify_db.set_active_workspace(ws_id)
+
+    remaining1 = verify_db.get_detections(photo1_id)
+    remaining2 = verify_db.get_detections(photo2_id)
+
+    assert remaining1 == [], (
+        f"photo1 was processed in model 1's batch loop; its stale prior-run "
+        f"detection must be purged, but get_detections returned {remaining1!r}. "
+        "Regression for Codex P1 review on #513 line 1040."
+    )
+    assert remaining2 != [], (
+        "photo2's batch was never reached (run was aborted before it). "
+        "Its prior-run detection row must be preserved to avoid data loss "
+        "in partial reclassify runs. "
+        "Regression for Codex P1 review on #513 line 1040."
+    )


### PR DESCRIPTION
Parent PR: #513

Addresses Codex Connect P1 review comment on #513 at `vireo/pipeline_job.py` line 1040.

## Problem

The stale-detection purge introduced in #513 deleted **all** pre-run detection IDs snapshotted before the model loop — even for photos whose batches were never submitted to `_detect_batch` because the run was aborted or cancelled mid-way. Because `predictions.detection_id` has `ON DELETE CASCADE`, this silently deleted prediction rows for photos that were never re-processed, causing avoidable data loss in partial/failed reclassify runs.

## Fix (`vireo/pipeline_job.py`)

- Added `_model1_attempted_photo_ids: set = set()` before the model loop.
- Inside the batch loop (after the abort check, after `_detect_batch` returns), added `_model1_attempted_photo_ids.update(p["id"] for p in batch)` when `spec_idx == 0`.
- The purge now filters `_pre_run_det_ids` to only include entries whose `photo_id` is in `_model1_attempted_photo_ids`. Photos in batches that were never reached (abort, cancellation) keep their old detection rows intact.
- Updated the debug log message to report how many photos were skipped.

## New test (`vireo/tests/test_pipeline_job.py`)

`test_pipeline_reclassify_partial_abort_preserves_unprocessed_detections`:
- 2 photos, each with a prior detection row.
- `_BATCH_SIZE` patched to 1 so each photo is its own batch.
- `_should_abort` intercepted to return `True` after the first `_detect_batch` call (simulating user cancellation mid-run).
- Asserts that photo 1's stale detection is purged (its batch was processed) and photo 2's detection is preserved (its batch was never reached).

## Test results

**27 passed** (full pipeline suite, 16 pre-existing failures unrelated to this change)

---
Generated by scheduled PR Agent