### PR TITLE
fix: address codex review on #515

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -585,13 +585,13 @@ jobs:
             head=$(gh pr view "$pr" --repo "$REPO" --json headRefName -q .headRefName)
 
             if [[ "$base" != "main" ]]; then
-              gh pr comment "$pr" --repo "$REPO" --body "🤖 Auto-merge skipped: PR targets \`$base\` instead of \`main\`. Legacy stacked PRs must be merged manually from leaf to root."
+              echo "PR #${pr}: targets '${base}' not 'main' — skipping (no comment posted by scheduled poll)."
               continue
             fi
 
             children=$(gh pr list --repo "$REPO" --base "$head" --label claude-agent --state open --json number -q 'length')
             if [[ "$children" -gt 0 ]]; then
-              gh pr comment "$pr" --repo "$REPO" --body "🤖 Auto-merge skipped: open child PRs still target \`$head\`. Resolve or close children first, then re-react with 👍."
+              echo "PR #${pr}: ${children} open child PR(s) target '${head}' — skipping (no comment posted by scheduled poll)."
               continue
             fi
 


### PR DESCRIPTION
Parent PR: #515

Addresses Codex Connect P2 review feedback on #515 (line 588).

## Problem

`merge-on-reaction` runs every 15 minutes via cron and re-selects any PR whose trusted 👍 reaction is newer than its last push. When a PR is intentionally non-mergeable (`base != main`, or open child PRs exist), the previous code called `gh pr comment` on **every** cron cycle — posting repeated identical skip messages that create unbounded noise in the PR thread without changing state.

## Fix

Replace the two `gh pr comment` calls inside the `merge-on-reaction` polling loop with silent `echo` log statements. The skip logic is unchanged — ineligible PRs are still skipped cleanly — but no comment is posted by the scheduled poll.

The `merge-on-approval` and `merge-on-thumbsup` jobs are event-driven (triggered once by a real approval/👍) and still post skip comments exactly once when an interactive merge attempt is blocked, so users remain informed when they actually trigger a merge.

## Test results

**430 passed** in 22.68s

---
Generated by scheduled PR Agent