### PR TITLE
fix: address Codex P2 review on #513 — record processed_id before quality scoring

### DIFF
--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -266,6 +266,13 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                     })
                 detection_map[photo["id"]] = det_list
 
+                # Mark as processed immediately after detection rows are committed
+                # so that even if the quality-scoring calls below raise, the
+                # reclassify purge in pipeline_job correctly removes the now-stale
+                # pre-run detection rows for this photo rather than leaving them in
+                # place and allowing future non-reclassify runs to reuse them.
+                processed_ids.add(photo["id"])
+
                 # Use highest-confidence detection as primary for quality scoring
                 primary = get_primary_detection(detections)
                 if primary:

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -279,6 +279,70 @@ def test_detect_subjects_graceful_on_import_error():
 # ── Task 4: Multi-detection pipeline tests ───────────────────────────────────
 
 
+def test_detect_batch_marks_processed_before_quality_scoring(tmp_path):
+    """_detect_batch must add photo_id to processed_ids as soon as detection
+    rows are committed to the DB, before quality-scoring calls.
+
+    If compute_sharpness or update_photo_quality raises after save_detections,
+    the outer except catches the exception and processed_ids.add at the end of
+    the per-photo loop body is never reached.  The photo would be missing from
+    processed_ids, causing the reclassify purge in pipeline_job to skip
+    deleting its stale pre-run detection rows — future non-reclassify runs
+    would then reuse those stale rows indefinitely.
+
+    Regression for Codex P2 review on #513, classify_job.py line 315.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _detect_batch
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    photos = [{"id": 7, "filename": "bird.jpg", "folder_id": 10}]
+    folders = {10: str(tmp_path)}
+
+    img = Image.new("RGB", (100, 100), color="red")
+    img.save(str(tmp_path / "bird.jpg"))
+
+    fake_detections = [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+         "confidence": 0.9, "category": "animal"},
+    ]
+
+    mock_db = MagicMock()
+    mock_db.save_detections.return_value = [42]
+
+    # quality scoring raises — simulates compute_sharpness or
+    # update_photo_quality failing after the detection row is already saved.
+    def raising_sharpness(*args, **kwargs):
+        raise RuntimeError("simulated sharpness failure")
+
+    with patch("classify_job.detect_animals", return_value=fake_detections), \
+         patch("classify_job.get_primary_detection", return_value=fake_detections[0]), \
+         patch("classify_job.compute_sharpness", side_effect=raising_sharpness):
+        detection_map, detected, processed_ids = _detect_batch(
+            photos=photos,
+            folders=folders,
+            runner=runner,
+            job=job,
+            reclassify=True,
+            db=mock_db,
+            already_detected_ids=set(),
+        )
+
+    # The detection was saved to the DB before quality scoring raised.
+    mock_db.save_detections.assert_called_once()
+    # photo 7 must be in processed_ids even though quality scoring raised, so
+    # the reclassify purge correctly removes its stale pre-run detection rows.
+    assert 7 in processed_ids, (
+        "photo_id must be in processed_ids after save_detections even when "
+        "quality-scoring raises — regression for Codex P2 on #513 line 315"
+    )
+    # detection_map should still contain the result from this run
+    assert 7 in detection_map
+
+
 def test_detect_batch_stores_all_detections(tmp_path):
     """_detect_batch should store all detections, not just the primary."""
     from db import Database


### PR DESCRIPTION
Parent PR: #513

Addresses Codex Connect P2 review feedback on #513 (`vireo/classify_job.py` line 315).

## Problem

`processed_ids.add(photo["id"])` appeared at the end of the per-photo loop body in `_detect_batch`, **after** the quality-scoring calls (`compute_sharpness` / `update_photo_quality`). If either raised an unhandled exception, the outer `except Exception:` caught it and the `add` was never executed. The photo would be absent from `processed_ids`, so the reclassify purge in `pipeline_job` would skip deleting its stale pre-run detection rows — future non-reclassify runs would then short-circuit to `db.get_detections()` and reuse those stale bounding boxes indefinitely.

This is a real failure path because `compute_sharpness` involves disk I/O and PIL image loads, and `update_photo_quality` hits SQLite — both can raise in degraded environments.

## Fix (`vireo/classify_job.py`)

Moved `processed_ids.add(photo["id"])` to immediately after `detection_map[photo["id"]] = det_list`, which is after `db.save_detections()` commits the new detection rows but before any quality-scoring work begins. Even if quality scoring raises and is caught by the outer `except`, the photo is already in `processed_ids` and the reclassify purge will correctly remove its stale pre-run rows.

The no-detection case falls through to the existing `processed_ids.add` at the loop level unchanged.

## New test (`vireo/tests/test_classify_job.py`)

`test_detect_batch_marks_processed_before_quality_scoring`:
- Patches `compute_sharpness` to raise `RuntimeError` after `save_detections` is called.
- Asserts that `photo_id` is in `processed_ids` despite the exception.
- Asserts that `detection_map` still contains the result from `save_detections`.

## Test results

**71 passed** (pipeline_job + classify_job suites)

---
Generated by scheduled PR Agent