### PR TITLE
fix: address Codex reviews on #501 — revision in purge and stale-pin clearing

### DIFF
--- a/vireo/models.py
+++ b/vireo/models.py
@@ -521,6 +521,16 @@ def download_model(model_id, progress_callback=None):
                 os.unlink(sentinel_path)
         if pinned_revision is not None:
             model_verify.write_pinned_revision(model_dir, pinned_revision)
+        else:
+            # Verification ran against "main" (model-info API was unavailable
+            # so pinned_revision is None).  Clear any existing .hf_revision so
+            # that future verify_model calls also use "main" instead of reading
+            # a stale SHA from a previous install and fetching expected hashes
+            # for the wrong revision — which would cause false mismatches and
+            # unnecessary Repair prompts.
+            rev_path = os.path.join(model_dir, model_verify.REVISION_FILE)
+            with contextlib.suppress(OSError):
+                os.unlink(rev_path)
     else:
         # Hash fetch was unavailable so verification was skipped. We still
         # need to update (or clear) the revision pin so that a subsequent
@@ -623,10 +633,10 @@ def _download_and_verify_file(
             )
         with contextlib.suppress(OSError):
             os.unlink(local_path)
-        _purge_hf_cache_file(filename, hf_subdir)
+        _purge_hf_cache_file(filename, hf_subdir, revision=revision)
 
 
-def _purge_hf_cache_file(filename, hf_subdir):
+def _purge_hf_cache_file(filename, hf_subdir, revision=None):
     """Delete a cached file from the HuggingFace cache so the next
     hf_hub_download call fetches fresh bytes instead of returning the
     corrupt blob it previously cached.
@@ -640,17 +650,27 @@ def _purge_hf_cache_file(filename, hf_subdir):
     leave the blob intact and hf_hub_download would happily relink to
     the same corrupt bytes on retry. So we resolve the symlink to its
     target and delete both.
+
+    `revision` must match the revision used in the hf_hub_download call
+    that produced the cached file; without it try_to_load_from_cache
+    resolves the entry for the default branch (main) instead of the
+    pinned snapshot, leaving the corrupt blob for the pinned commit
+    untouched and causing repeated hash-mismatch retries.
     """
     try:
         import huggingface_hub
     except ImportError:
         return
 
+    lookup_kwargs: dict = dict(
+        repo_id=ONNX_REPO,
+        filename=f"{hf_subdir}/{filename}" if hf_subdir else filename,
+    )
+    if revision is not None:
+        lookup_kwargs["revision"] = revision
+
     try:
-        cached = huggingface_hub.try_to_load_from_cache(
-            repo_id=ONNX_REPO,
-            filename=f"{hf_subdir}/{filename}" if hf_subdir else filename,
-        )
+        cached = huggingface_hub.try_to_load_from_cache(**lookup_kwargs)
     except Exception as e:
         log.debug("HF cache lookup failed for %s: %s", filename, e)
         return

--- a/vireo/tests/test_model_verify.py
+++ b/vireo/tests/test_model_verify.py
@@ -684,7 +684,7 @@ def test_download_model_writes_revision_when_hash_fetch_fails(tmp_path, monkeypa
             f.write(b"stub")
         return dest
 
-    monkeypatch.setattr(models_mod, "_purge_hf_cache_file", lambda f, s: None)
+    monkeypatch.setattr(models_mod, "_purge_hf_cache_file", lambda f, s, revision=None: None)
     monkeypatch.setattr(models_mod, "_hf_download_with_retry", fake_download)
 
     model_dir = tmp_path / "models" / "bioclip-vit-b-16"
@@ -734,7 +734,7 @@ def test_download_model_clears_stale_revision_when_both_apis_fail(tmp_path, monk
             f.write(b"stub")
         return dest
 
-    monkeypatch.setattr(models_mod, "_purge_hf_cache_file", lambda f, s: None)
+    monkeypatch.setattr(models_mod, "_purge_hf_cache_file", lambda f, s, revision=None: None)
     monkeypatch.setattr(models_mod, "_hf_download_with_retry", fake_download)
 
     # download_model raises because state check sees no sentinel but files

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -680,7 +680,7 @@ def test_download_model_raises_after_max_retries(tmp_path, monkeypatch):
         return dest
 
     monkeypatch.setattr(
-        models, "_purge_hf_cache_file", lambda filename, subdir: None
+        models, "_purge_hf_cache_file", lambda filename, subdir, revision=None: None
     )
     monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
     monkeypatch.setattr(
@@ -722,7 +722,7 @@ def test_download_model_clears_verify_cache_on_success(tmp_path, monkeypatch):
         return dest
 
     monkeypatch.setattr(
-        models, "_purge_hf_cache_file", lambda filename, subdir: None
+        models, "_purge_hf_cache_file", lambda filename, subdir, revision=None: None
     )
     monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
     monkeypatch.setattr(
@@ -767,7 +767,7 @@ def test_download_model_writes_pinned_revision(tmp_path, monkeypatch):
         return expected
 
     monkeypatch.setattr(
-        models, "_purge_hf_cache_file", lambda filename, subdir: None
+        models, "_purge_hf_cache_file", lambda filename, subdir, revision=None: None
     )
     monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
     monkeypatch.setattr(
@@ -827,7 +827,7 @@ def test_download_model_falls_back_to_main_when_revision_lookup_fails(
         return expected
 
     monkeypatch.setattr(
-        models, "_purge_hf_cache_file", lambda filename, subdir: None
+        models, "_purge_hf_cache_file", lambda filename, subdir, revision=None: None
     )
     monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
     monkeypatch.setattr(
@@ -873,7 +873,7 @@ def test_download_model_skips_verification_only_when_tree_api_also_fails(
         raise model_verify.VerifyError("tree api offline")
 
     monkeypatch.setattr(
-        models, "_purge_hf_cache_file", lambda filename, subdir: None
+        models, "_purge_hf_cache_file", lambda filename, subdir, revision=None: None
     )
     monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
     monkeypatch.setattr(
@@ -912,7 +912,7 @@ def test_purge_hf_cache_file_deletes_blob_target(tmp_path, monkeypatch):
     symlink_path = snapshots / "image_encoder.onnx.data"
     os.symlink(blob_path, symlink_path)
 
-    def fake_try_to_load_from_cache(repo_id, filename):
+    def fake_try_to_load_from_cache(repo_id, filename, revision=None):
         return str(symlink_path)
 
     import huggingface_hub
@@ -959,7 +959,7 @@ def test_download_model_preserves_sentinel_when_fetch_hashes_fails(
         raise model_verify.VerifyError("tree API offline")
 
     monkeypatch.setattr(
-        models, "_purge_hf_cache_file", lambda filename, subdir: None
+        models, "_purge_hf_cache_file", lambda filename, subdir, revision=None: None
     )
     monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
     monkeypatch.setattr(model_verify, "fetch_expected_hashes", fetch_raises)
@@ -973,3 +973,142 @@ def test_download_model_preserves_sentinel_when_fetch_hashes_fails(
     # Sentinel must still be on disk so a future pipeline run (or a retry
     # after HF is back up) keeps the model flagged as corrupt.
     assert sentinel.is_file()
+
+
+def test_purge_hf_cache_file_passes_revision_to_cache_lookup(tmp_path, monkeypatch):
+    """_purge_hf_cache_file must pass the revision parameter to
+    try_to_load_from_cache so the lookup resolves the pinned snapshot entry
+    rather than the default-branch entry.
+
+    Without revision= the HF cache lookup targets 'main', leaving the
+    corrupt blob for the pinned commit untouched; every retry then
+    relinks to the same bad bytes and hash-mismatch retries are exhausted
+    without ever fetching fresh bytes.
+
+    Regression for Codex P1 review on #501, models.py line 653.
+    """
+    import sys
+    import types
+
+    import models
+
+    captured: dict = {}
+
+    blobs = tmp_path / "blobs"
+    snapshots = tmp_path / "snapshots" / "abc123" / "bioclip-vit-b-16"
+    blobs.mkdir(parents=True)
+    snapshots.mkdir(parents=True)
+    blob_path = blobs / "corruptblob"
+    blob_path.write_bytes(b"corrupt")
+    symlink_path = snapshots / "image_encoder.onnx.data"
+    os.symlink(blob_path, symlink_path)
+
+    def fake_try_to_load_from_cache(repo_id, filename, revision=None):
+        captured["revision"] = revision
+        return str(symlink_path)
+
+    # Stub huggingface_hub in sys.modules so the test passes in environments
+    # where the library is not installed.
+    hf_stub = types.ModuleType("huggingface_hub")
+    hf_stub.try_to_load_from_cache = fake_try_to_load_from_cache
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hf_stub)
+
+    models._purge_hf_cache_file(
+        "image_encoder.onnx.data", "bioclip-vit-b-16", revision="abc123"
+    )
+
+    assert captured.get("revision") == "abc123", (
+        "try_to_load_from_cache must receive the pinned revision so the "
+        "correct snapshot entry is purged — regression for Codex P1 on "
+        "#501 models.py line 653"
+    )
+    # Both the symlink and blob should be deleted
+    assert not symlink_path.exists()
+    assert not blob_path.exists()
+
+
+def test_download_model_clears_stale_revision_when_verification_runs_against_main(
+    tmp_path, monkeypatch
+):
+    """When verification runs against 'main' (because fetch_latest_revision
+    failed so pinned_revision is None), any pre-existing .hf_revision must
+    be deleted.
+
+    If a stale .hf_revision remains from a previous install, the next
+    verify_model call reads that old SHA and fetches expected hashes for
+    the wrong revision, causing false mismatches and unnecessary Repair
+    prompts even though the downloaded files are correct.
+
+    Regression for Codex P2 review on #501, models.py line 523.
+    """
+    import hashlib
+    import sys
+    import types
+
+    import model_verify
+
+    # Stub out huggingface_hub so the import guard in download_model passes
+    # even when the library is not installed in this environment.
+    hf_stub = types.ModuleType("huggingface_hub")
+    hf_stub.hf_hub_download = lambda *a, **kw: None
+    hf_stub.try_to_load_from_cache = lambda *a, **kw: None
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hf_stub)
+
+    models, model_dir = _patch_download_model_env(tmp_path, monkeypatch)
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    # Simulate a stale revision pin left by a previous install.
+    stale_rev_path = model_dir / model_verify.REVISION_FILE
+    stale_rev_path.write_text("old_sha_from_previous_install\n")
+
+    # fetch_latest_revision will raise (model-info API offline), so
+    # pinned_revision will be None but the tree API still works (returns
+    # expected hashes against "main").
+    monkeypatch.setattr(
+        model_verify,
+        "fetch_latest_revision",
+        lambda repo: (_ for _ in ()).throw(
+            model_verify.VerifyError("model-info offline")
+        ),
+    )
+
+    lfs_contents = {
+        "image_encoder.onnx": b"graph-i" * 100,
+        "image_encoder.onnx.data": b"weights-i" * 1000,
+        "text_encoder.onnx": b"graph-t" * 100,
+        "text_encoder.onnx.data": b"weights-t" * 1000,
+    }
+    expected = {
+        fn: hashlib.sha256(data).hexdigest()
+        for fn, data in lfs_contents.items()
+    }
+
+    def fake_download(repo_id, filename, local_dir, subfolder=None,
+                      progress_callback=None, revision=None):
+        os.makedirs(local_dir, exist_ok=True)
+        base = os.path.basename(filename)
+        dest = os.path.join(local_dir, base)
+        with open(dest, "wb") as f:
+            f.write(lfs_contents.get(base, b"stub"))
+        return dest
+
+    monkeypatch.setattr(
+        models, "_purge_hf_cache_file", lambda filename, subdir, revision=None: None
+    )
+    monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
+    monkeypatch.setattr(
+        model_verify,
+        "fetch_expected_hashes",
+        lambda subdir, revision="main": expected,
+    )
+
+    models.download_model("bioclip-vit-b-16")
+
+    # The stale .hf_revision must have been deleted so that verify_model
+    # uses "main" (matching the revision used for hash verification) rather
+    # than the old SHA, which would produce false mismatches.
+    assert not stale_rev_path.exists(), (
+        ".hf_revision must be deleted when verification runs against 'main' "
+        "(pinned_revision=None) to prevent false mismatch errors on the "
+        "next verify_model call — regression for Codex P2 on #501 line 523"
+    )


### PR DESCRIPTION
Parent PR: #501

Addresses two Codex Connect review comments on #501 that were not outdated and had not been addressed by prior fix PRs (#502, #504, #512).

---

## Fix 1 (P1) — Pass pinned revision when purging HuggingFace cache (`vireo/models.py` line 653)

**Problem:** `_download_and_verify_file` called `_purge_hf_cache_file(filename, hf_subdir)` without the `revision` parameter. Inside `_purge_hf_cache_file`, `try_to_load_from_cache` resolved the cache entry for the default branch (`main`) instead of the pinned snapshot. In the hash-mismatch retry path, the corrupt blob for the pinned commit was therefore never found and deleted — subsequent retries relinked to the same bad bytes and all `_MAX_HASH_RETRIES` attempts could fail without ever fetching fresh bytes.

**Fix:**
- Added `revision=None` parameter to `_purge_hf_cache_file`.
- Passes `revision=` to `try_to_load_from_cache` so the lookup targets the correct pinned snapshot entry.
- Updated `_download_and_verify_file` call site to pass `revision=revision`.
- Updated all lambda stubs in tests to accept the new keyword argument.

**New test:** `test_purge_hf_cache_file_passes_revision_to_cache_lookup` — asserts that `try_to_load_from_cache` receives the exact revision passed to `_purge_hf_cache_file`, and that both the snapshot symlink and the underlying blob are deleted.

---

## Fix 2 (P2) — Clear stale `.hf_revision` when verification runs against `main` (`vireo/models.py` line 523)

**Problem:** When the model-info API was unavailable (`pinned_revision=None`) but the HF tree API succeeded and verification ran against `main` (`verification_ran=True`), any pre-existing `.hf_revision` from a previous install was left untouched. The next `verify_model` call would read that stale SHA and fetch expected hashes for the wrong revision, causing false mismatches and unnecessary Repair prompts even though the downloaded files were correct.

**Fix:** In the `if verification_ran:` branch, added an `else` clause: when `pinned_revision is None`, delete any existing `.hf_revision` so that `verify_model` falls back to `"main"` (which matches the revision used for actual hash verification).

**New test:** `test_download_model_clears_stale_revision_when_verification_runs_against_main` — pre-seeds a stale `.hf_revision`, runs `download_model` with `fetch_latest_revision` raising (model-info offline) but `fetch_expected_hashes` succeeding, and asserts the stale pin is deleted.

---

## Test results

**52 passed** (test_models + test_model_verify suites). The 11 pre-existing failures are all due to `huggingface_hub` not being installed in this environment and were present before these changes.

---
Generated by scheduled PR Agent