### PR TITLE
fix: address codex review on #520 — restrict size floor to .onnx.data sidecars only

### DIFF
--- a/vireo/models.py
+++ b/vireo/models.py
@@ -553,11 +553,15 @@ def download_model(model_id, progress_callback=None):
                 os.unlink(rev_path)
 
         # SHA256 verification was unavailable (HF tree API unreachable).
-        # Apply a minimal size floor to binary model files so that a
-        # truncated or stub download is surfaced immediately rather than
-        # being registered as a healthy model that later fails at runtime.
+        # Apply a minimal size floor to weight sidecar files (.onnx.data) so
+        # that a truncated download is surfaced immediately rather than being
+        # registered as a healthy model that later fails at runtime.
+        # Plain .onnx graph files are deliberately excluded: in external-data
+        # layouts the graph file is legitimately small (the weights live in the
+        # .onnx.data sidecar), so applying the floor there would falsely reject
+        # valid installs whenever the HF tree API is unavailable.
         for filename in files:
-            if not filename.endswith((".onnx", ".onnx.data")):
+            if not filename.endswith(".onnx.data"):
                 continue
             local_path = os.path.join(model_dir, filename)
             actual_size = os.path.getsize(local_path) if os.path.isfile(local_path) else 0
@@ -595,9 +599,11 @@ def download_model(model_id, progress_callback=None):
 
 _MAX_HASH_RETRIES = 2  # 1 initial attempt + 2 retries = 3 total per file
 
-# Minimum size for binary model files (.onnx, .onnx.data) when post-download
+# Minimum size for weight sidecar files (.onnx.data) when post-download
 # SHA256 verification is unavailable (HF tree API unreachable).  Guards against
 # truncated or stub downloads being silently registered as healthy models.
+# Plain .onnx graph files are not checked — they are legitimately small in
+# external-data ONNX layouts.
 _MIN_BINARY_MODEL_BYTES = 10 * 1024 * 1024  # 10 MB
 
 

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -1140,11 +1140,13 @@ def test_download_model_raises_when_binary_file_too_small_and_hash_fetch_fails(
     tmp_path, monkeypatch
 ):
     """When hash verification is unavailable (HF tree API offline) and a
-    downloaded binary model file is below the 10 MB floor, download_model must
-    raise immediately rather than silently registering a truncated/stub file
-    as a healthy model.
+    downloaded .onnx.data weight sidecar is below the 10 MB floor,
+    download_model must raise immediately rather than silently registering a
+    truncated/stub file as a healthy model.
 
     Regression for Codex P2 review on #501 (vireo/models.py line 487).
+    Plain .onnx graph files are excluded from the floor check because they are
+    legitimately small in external-data ONNX layouts (Codex P1 on #520).
     """
     import model_verify
     models, model_dir = _patch_download_model_env(tmp_path, monkeypatch)
@@ -1169,3 +1171,51 @@ def test_download_model_raises_when_binary_file_too_small_and_hash_fetch_fails(
     import pytest as _pytest
     with _pytest.raises(RuntimeError, match="truncated"):
         models.download_model("bioclip-vit-b-16")
+
+
+def test_download_model_small_onnx_graph_does_not_trigger_size_floor(
+    tmp_path, monkeypatch
+):
+    """Plain .onnx graph files must NOT be rejected by the size-floor check
+    even when they are smaller than _MIN_BINARY_MODEL_BYTES.  In external-data
+    ONNX layouts the graph file is legitimately tiny; the weights live in the
+    .onnx.data sidecar.  Applying the floor to .onnx files would falsely reject
+    valid installs whenever the HF tree API is down.
+
+    Regression for Codex P1 review on #520 (vireo/models.py line 560).
+    """
+    import model_verify
+    models, model_dir = _patch_download_model_env(tmp_path, monkeypatch)
+
+    # _MIN_BINARY_MODEL_BYTES is 10 MB; write a large-enough .onnx.data sidecar
+    # but a tiny stub .onnx graph to confirm the floor only fires on .onnx.data.
+    def fake_download(repo_id, filename, local_dir, subfolder=None,
+                      progress_callback=None, revision=None):
+        os.makedirs(local_dir, exist_ok=True)
+        dest = os.path.join(local_dir, filename)
+        with open(dest, "wb") as f:
+            if filename.endswith(".onnx.data"):
+                # large enough to pass the floor
+                f.write(b"\x00" * (models._MIN_BINARY_MODEL_BYTES + 1))
+            else:
+                f.write(b"stub-tiny-graph")
+        return dest
+
+    def fetch_raises(subdir, revision="main"):
+        raise model_verify.VerifyError("tree API offline")
+
+    monkeypatch.setattr(
+        models, "_purge_hf_cache_file", lambda filename, subdir, revision=None: None
+    )
+    monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
+    monkeypatch.setattr(model_verify, "fetch_expected_hashes", fetch_raises)
+
+    # Must NOT raise "truncated" — the .onnx graph is tiny but that is
+    # allowed; only the .onnx.data sidecars are subject to the floor.
+    try:
+        models.download_model("bioclip-vit-b-16")
+    except RuntimeError as exc:
+        assert "truncated" not in str(exc), (
+            "Size-floor check must not fire on plain .onnx graph files — "
+            "they are legitimately small in external-data ONNX layouts"
+        )


### PR DESCRIPTION
Parent PR: #520

Addresses Codex Connect P1 review feedback on #520 (`vireo/models.py` line 560).

## Problem

The fallback size-floor check (used when the HF tree API is unavailable) applied the 10 MB floor to **both** `.onnx` and `.onnx.data` files. In external-data ONNX layouts the graph `.onnx` file is legitimately much smaller than 10 MB — the weights live in the `.onnx.data` sidecar. This caused healthy installs to be incorrectly rejected as "truncated" whenever the HF tree API was down, turning a safety fallback into a hard failure for valid models.

## Fix (`vireo/models.py`)

- Changed the file filter from `.endswith((".onnx", ".onnx.data"))` to `.endswith(".onnx.data")` so the size floor only applies to the weight sidecar files.
- Updated the `_MIN_BINARY_MODEL_BYTES` constant comment and the inline comment to clarify that plain `.onnx` graph files are deliberately excluded.

## Test changes (`vireo/tests/test_models.py`)

- Updated docstring of the existing `test_download_model_raises_when_binary_file_too_small_and_hash_fetch_fails` to note it specifically tests `.onnx.data` sidecars.
- Added `test_download_model_small_onnx_graph_does_not_trigger_size_floor` — confirms that a tiny `.onnx` graph file does not raise "truncated" when the `.onnx.data` sidecar is large enough, pinning the new scoped behavior.

## Test results

**430 passed** (full canonical suite) + **65 passed** (`test_models` + `test_model_verify`)

---
Generated by scheduled PR Agent