### PR TITLE
fix: release raw_results before loading next classifier in multi-model pipeline

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -913,6 +913,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     # Without this, two large model graphs can be resident
                     # simultaneously during the handoff.
                     clf = None
+                    # Also release the previous iteration's output list so
+                    # embeddings/image metadata for all photos don't stay
+                    # alive during the model-load handoff.
+                    raw_results = None
                     bundle = _load_model_bundle(active_spec, tax, thread_db)
                     loaded_models.update(bundle)
                     clf = bundle["clf"]


### PR DESCRIPTION
Parent PR: #505

Addresses Codex Connect P1 review comment on #505: "Release prior model outputs before loading next classifier".

## Problem

In the multi-model `classify_stage` loop, `raw_results` from the previous model iteration stayed strongly referenced when `_load_model_bundle(...)` was called for the next model. This meant the process could briefly hold the prior model's full output list (embeddings and image metadata for every classified photo) alongside the next model's weights simultaneously — enough to trigger OOMs on large collections and defeating the memory-safety goal of the unload-before-load sequence introduced in this PR.

## Fix

Set `raw_results = None` immediately after `clf = None` in the non-first-model `else` branch (`pipeline_job.py`), so both the classifier graph and its output buffer are eligible for GC before `_load_model_bundle` allocates the next bundle.

## Test results

- **430 passed** (full CLAUDE.md canonical suite)
- **59 passed** (`test_pipeline_job.py` + `test_pipeline_api.py`)

---
Generated by scheduled PR Agent