### PR TITLE
fix: write .verify_failed sentinel on ONNX load failure

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -709,6 +709,25 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             # "model_path must not be empty" / "Initializer" error. Treat
             # any load failure as an incomplete-model hint for the user.
             if _looks_like_missing_external_data(load_err):
+                # Write the .verify_failed sentinel so that
+                # _classify_model_state (used by get_models() / Settings
+                # UI) also reports 'incomplete' and shows the Repair
+                # button.  Without this the pipeline tells the user to
+                # "click Repair" but Settings sees all files present and
+                # no sentinel, so no Repair button appears.
+                if weights_path:
+                    import model_verify
+                    try:
+                        with open(
+                            os.path.join(
+                                weights_path,
+                                model_verify.VERIFY_FAILED_SENTINEL,
+                            ),
+                            "w",
+                        ) as f:
+                            f.write(f"onnx-load-failure: {load_err}\n")
+                    except OSError:
+                        pass
                 raise RuntimeError(
                     _incomplete_model_message(model_name, model_is_custom)
                 ) from load_err

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -2168,3 +2168,77 @@ def test_pipeline_reclassify_partial_batch_exception_preserves_detections(
         "photo that was never re-detected.  "
         "Regression for Codex P1 review on #513 line 981."
     )
+
+
+# ---------------------------------------------------------------------------
+# Sentinel written on ONNX load failure
+# ---------------------------------------------------------------------------
+
+
+def test_onnx_load_failure_writes_verify_failed_sentinel(tmp_path, monkeypatch):
+    """When ONNXRuntime fails with a missing-external-data error, the
+    .verify_failed sentinel must be written so that _classify_model_state
+    reports 'incomplete' and the Settings UI shows a Repair button.
+
+    This is the fix for the bug where the pipeline tells the user
+    "Open Settings -> Models and click Repair" but Settings shows the
+    model as healthy because no sentinel was written.
+    """
+    import classifier as classifier_mod
+    import config as cfg
+    import model_verify
+    import models
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    model_id = _setup_fake_downloaded_model(tmp_path, monkeypatch)
+    model_dir = tmp_path / "models" / model_id
+
+    # Simulate ONNXRuntime raising a missing-external-data error.
+    def boom(*args, **kwargs):
+        raise RuntimeError(
+            "[ONNXRuntimeError] model_path must not be empty. Ensure that "
+            "a path is provided when the model is created or loaded."
+        )
+
+    monkeypatch.setattr(classifier_mod, "Classifier", boom)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    import pytest
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # 1. The .verify_failed sentinel must have been written.
+    sentinel = model_dir / model_verify.VERIFY_FAILED_SENTINEL
+    assert sentinel.exists(), (
+        ".verify_failed sentinel must be written when ONNXRuntime fails "
+        "with a missing-external-data error, otherwise Settings shows the "
+        "model as healthy and no Repair button appears."
+    )
+    assert "onnx-load-failure" in sentinel.read_text()
+
+    # 2. After the sentinel is written, _classify_model_state must return
+    #    'incomplete' so the Settings UI surfaces the Repair button.
+    known = [m for m in models.KNOWN_MODELS if m["id"] == model_id]
+    assert known, f"Expected to find {model_id} in KNOWN_MODELS"
+    files = known[0].get("files", [])
+    state = models._classify_model_state(str(model_dir), files)
+    assert state == "incomplete", (
+        f"_classify_model_state should return 'incomplete' after the "
+        f"sentinel is written, but got '{state}'"
+    )


### PR DESCRIPTION
## Summary

- **Bug**: Pipeline reports model as "incomplete" and tells user "Open Settings → Models and click Repair", but Settings shows the model as healthy with no Repair button.
- **Root cause**: In `_load_model_bundle`, when ONNXRuntime fails with a missing-external-data error (path 3 — corrupted `.onnx.data` file that passes file-existence checks), the `.verify_failed` sentinel was never written. So `_classify_model_state` (used by `get_models()` which powers the Settings UI) sees all files present + no sentinel = "ok". No Repair button.
- **Fix**: Write the `.verify_failed` sentinel in the `_looks_like_missing_external_data` except block before raising the `RuntimeError`, following the same pattern used in `model_verify.py`.

## Test plan

- [x] Added `test_onnx_load_failure_writes_verify_failed_sentinel` verifying that the sentinel is written and `_classify_model_state` returns "incomplete" after an ONNX load failure
- [x] All 514 tests pass (`python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_config.py vireo/tests/test_pipeline_job.py vireo/tests/test_models.py -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)