### PR TITLE
fix: multi-model pipeline continues when individual models fail to load

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -792,12 +792,27 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 "stages": {k: dict(v) for k, v in stages.items()},
             })
 
-            bundle = _load_model_bundle(resolved_specs[0], tax, thread_db)
-            loaded_models.update(bundle)
+            try:
+                bundle = _load_model_bundle(resolved_specs[0], tax, thread_db)
+                loaded_models.update(bundle)
+            except Exception as preload_err:
+                if len(resolved_specs) > 1:
+                    # Other models remain — don't abort the whole pipeline.
+                    log.warning(
+                        "First model %s failed to load, %d remaining: %s",
+                        first_name, len(resolved_specs) - 1, preload_err,
+                    )
+                    loaded_models["preload_error"] = str(preload_err)
+                else:
+                    # Single model — fatal, let the outer handler abort.
+                    raise
+
             loaded_models["pending_specs"] = resolved_specs[1:]
 
             stages["model_loader"]["status"] = "completed"
             summary = ", ".join(s["name"] for s in resolved_specs)
+            if "preload_error" in loaded_models:
+                summary += f" ({first_name} failed to preload)"
             runner.update_step(job["id"], "model_loader", status="completed",
                                summary=summary)
         except Exception as e:
@@ -815,7 +830,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         collection_ready.wait()
         models_ready.wait()
 
-        if params.skip_classify or abort.is_set() or not collection_id or "clf" not in loaded_models:
+        # Skip classify only when there is truly nothing to run.  When the
+        # first model's preload failed but resolved_specs still contains
+        # other models, we must NOT skip — classify_stage will try each
+        # remaining spec in turn.
+        has_models_to_try = (
+            "clf" in loaded_models
+            or loaded_models.get("resolved_specs")
+        )
+        if params.skip_classify or abort.is_set() or not collection_id or not has_models_to_try:
             stages["classify"]["status"] = "skipped"
             runner.update_step(job["id"], "classify", status="completed",
                                summary="Skipped")
@@ -915,27 +938,33 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             # reclassify does not cause data loss.
             _model1_processed_photo_ids: set = set()
 
+            # Track models that failed to load so we can report them.
+            skipped_model_names: list = []
+            models_succeeded = 0
+
             from datetime import datetime as dt
 
             for spec_idx, active_spec in enumerate(resolved_specs):
                 if _should_abort(abort):
                     break
 
-                if spec_idx == 0:
+                if spec_idx == 0 and "clf" in loaded_models:
                     # First model was preloaded by model_loader_stage.
                     clf = loaded_models["clf"]
                     model_type = loaded_models["model_type"]
                     model_name = loaded_models["model_name"]
                 else:
-                    # Load the next classifier. Release the previous bundle
-                    # first so we don't hold two large ONNX graphs in memory
-                    # at once.
+                    # Either a secondary model (spec_idx > 0), or the first
+                    # model whose preload failed in model_loader_stage.
+                    # Load it now with try/except so one bad model doesn't
+                    # kill the entire multi-model run.
                     runner.push_event(job["id"], "progress", {
                         "phase": f"Loading {active_spec['name']}...",
                         "stage_id": "classify",
                         "current": 0, "total": total,
                         "stages": {k: dict(v) for k, v in stages.items()},
                     })
+                    # Release previous model from memory.
                     for k in ("clf", "model_type", "model_name", "model_str",
                               "labels", "use_tol", "active_model"):
                         loaded_models.pop(k, None)
@@ -948,7 +977,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     # embeddings/image metadata for all photos don't stay
                     # alive during the model-load handoff.
                     raw_results = None
-                    bundle = _load_model_bundle(active_spec, tax, thread_db)
+                    try:
+                        bundle = _load_model_bundle(active_spec, tax, thread_db)
+                    except Exception as model_err:
+                        log.warning(
+                            "Skipping model %s: %s",
+                            active_spec["name"], model_err,
+                        )
+                        runner.push_event(job["id"], "progress", {
+                            "phase": f"Skipping {active_spec['name']}: {model_err}",
+                            "stage_id": "classify",
+                            "current": 0, "total": total,
+                            "stages": {k: dict(v) for k, v in stages.items()},
+                        })
+                        skipped_model_names.append(active_spec["name"])
+                        continue
                     loaded_models.update(bundle)
                     clf = bundle["clf"]
                     model_type = bundle["model_type"]
@@ -1092,6 +1135,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 total_detected += detected
                 total_failed += failed
                 total_skipped_existing += skipped_existing
+                models_succeeded += 1
 
                 # After model 1 has inserted all fresh detection rows, delete
                 # the pre-run stale rows we snapshotted before the loop.
@@ -1129,9 +1173,24 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                             len(_pre_run_det_ids) - len(processed_with_priors),
                         )
 
+            # If every model failed to load, mark classify as failed.
+            if models_succeeded == 0 and skipped_model_names:
+                fail_msg = (
+                    f"All {len(skipped_model_names)} model(s) failed to load: "
+                    + ", ".join(skipped_model_names)
+                )
+                raise RuntimeError(fail_msg)
+
+            summary_parts = [f"{total_predictions_stored} predictions"]
+            if skipped_model_names:
+                skipped_str = ", ".join(skipped_model_names)
+                summary_parts.append(
+                    f"{len(skipped_model_names)} model(s) skipped: {skipped_str}"
+                )
+
             stages["classify"]["status"] = "completed"
             runner.update_step(job["id"], "classify", status="completed",
-                               summary=f"{total_predictions_stored} predictions")
+                               summary="; ".join(summary_parts))
             result["stages"]["classify"] = {
                 "total": total,
                 "predictions_stored": total_predictions_stored,
@@ -1139,6 +1198,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 "failed": total_failed,
                 "already_classified": total_skipped_existing,
                 "model_count": len(resolved_specs),
+                "models_succeeded": models_succeeded,
+                "models_skipped": len(skipped_model_names),
+                "skipped_model_names": skipped_model_names,
             }
 
         except Exception as e:

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -2168,3 +2168,220 @@ def test_pipeline_reclassify_partial_batch_exception_preserves_detections(
         "photo that was never re-detected.  "
         "Regression for Codex P1 review on #513 line 981."
     )
+
+
+# ---------------------------------------------------------------------------
+# Multi-model pipeline resilience to individual model failures
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_continues_when_first_model_fails(tmp_path, monkeypatch):
+    """When the first model in a multi-model run fails to load, the pipeline
+    must NOT abort.  The second model should still classify photos and the
+    pipeline should complete successfully.
+
+    This is the fix for the multi-model pipeline abort bug: previously
+    model_loader_stage set abort on ANY preload failure, which killed the
+    entire pipeline even when other models were available.
+    """
+    import classifier as classifier_mod
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    model_ids = _setup_two_fake_downloaded_models(tmp_path, monkeypatch)
+
+    # The first model ("bioclip-vit-b-16") always fails; the second
+    # ("bioclip-2") always succeeds. Use the pretrained_str kwarg to
+    # distinguish which model is being loaded.
+    construction_calls = []
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pretrained = kwargs.get("pretrained_str", "") or ""
+            if "bioclip-vit-b-16" in pretrained:
+                raise RuntimeError("simulated first model failure")
+            construction_calls.append(kwargs)
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=model_ids,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    # Should NOT raise — second model should succeed.
+    result = run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # The second model must have been constructed successfully.
+    assert len(construction_calls) >= 1, (
+        "Expected at least one successful Classifier construction (second model), "
+        f"got {len(construction_calls)}"
+    )
+
+    # model_loader summary should note the preload failure.
+    model_loader_summaries = [
+        kwargs.get("summary", "")
+        for (_, step_id, kwargs) in runner.step_updates
+        if step_id == "model_loader" and kwargs.get("status") == "completed"
+    ]
+    assert model_loader_summaries, "model_loader should complete (not fail)"
+    assert "failed to preload" in " ".join(model_loader_summaries)
+
+    # classify summary should mention the skipped model.
+    classify_summaries = [
+        kwargs.get("summary", "")
+        for (_, step_id, kwargs) in runner.step_updates
+        if step_id == "classify" and kwargs.get("status") == "completed"
+    ]
+    assert classify_summaries, "classify stage should complete"
+    joined_classify = " ".join(classify_summaries)
+    assert "skipped" in joined_classify.lower(), (
+        f"classify summary should mention skipped model, got: {classify_summaries}"
+    )
+
+    # The returned result must record the skipped model info.
+    assert isinstance(result, dict)
+    classify_result = result.get("stages", {}).get("classify", {})
+    assert classify_result.get("models_skipped", 0) >= 1
+    assert classify_result.get("models_succeeded", 0) >= 1
+
+
+def test_pipeline_continues_when_secondary_model_fails(tmp_path, monkeypatch):
+    """When the second model in a multi-model run fails to load, the first
+    model's results are kept and the pipeline completes with a partial success.
+    """
+    import classifier as classifier_mod
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    model_ids = _setup_two_fake_downloaded_models(tmp_path, monkeypatch)
+
+    # The second model ("bioclip-2") always fails; the first succeeds.
+    construction_calls = []
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pretrained = kwargs.get("pretrained_str", "") or ""
+            if "bioclip-2" in pretrained:
+                raise RuntimeError("simulated second model failure")
+            construction_calls.append(kwargs)
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=model_ids,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    # Should NOT raise — first model succeeded.
+    result = run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # The first model must have been constructed.
+    assert len(construction_calls) >= 1, (
+        f"Expected at least 1 construction call, got {len(construction_calls)}"
+    )
+
+    # classify summary should mention the skipped model.
+    classify_summaries = [
+        kwargs.get("summary", "")
+        for (_, step_id, kwargs) in runner.step_updates
+        if step_id == "classify" and kwargs.get("status") == "completed"
+    ]
+    assert classify_summaries, "classify stage should complete"
+    joined_classify = " ".join(classify_summaries)
+    assert "skipped" in joined_classify.lower(), (
+        f"classify summary should mention skipped model, got: {classify_summaries}"
+    )
+
+    assert isinstance(result, dict)
+    classify_result = result.get("stages", {}).get("classify", {})
+    assert classify_result.get("models_skipped", 0) >= 1
+    assert classify_result.get("models_succeeded", 0) >= 1
+
+
+def test_pipeline_single_model_still_aborts_on_failure(tmp_path, monkeypatch):
+    """When there is only one model and it fails to load, the pipeline must
+    still abort — the resilience logic should NOT swallow single-model errors.
+    This preserves the existing behavior tested by
+    test_pipeline_raises_when_stage_fails.
+    """
+    import classifier as classifier_mod
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated single model failure")
+
+    monkeypatch.setattr(classifier_mod, "Classifier", boom)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=["bioclip-vit-b-16"],
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    import pytest
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # model_loader should be marked as failed.
+    model_loader_failures = [
+        kwargs
+        for (_, step_id, kwargs) in runner.step_updates
+        if step_id == "model_loader" and kwargs.get("status") == "failed"
+    ]
+    assert model_loader_failures, (
+        "Single-model pipeline must mark model_loader as failed"
+    )
+    assert isinstance(job["result"], dict)
+    assert any(
+        "model_loader" in e for e in job["result"]["errors"]
+    ), f"Expected a model_loader error, got: {job['result']['errors']}"


### PR DESCRIPTION
## Summary

- When a user selects multiple models and the first one fails to load, the pipeline now **skips** that model and continues with the remaining ones instead of aborting entirely with zero results.
- When a secondary model fails to load during `classify_stage`, it is skipped and the pipeline continues with whatever models succeeded.
- Single-model failure behavior is preserved (fatal abort, same as before).
- The classify summary and result now include counts of succeeded/skipped models and skipped model names for transparency.

## Root cause

`model_loader_stage` called `abort.set()` on **any** preload failure, even when other `resolved_specs` were available. `classify_stage` then checked `"clf" not in loaded_models` and skipped entirely. Additionally, secondary model loads in the classify loop had no `try/except`, so a single failure there also crashed the entire stage.

## Changes

**`vireo/pipeline_job.py`**:
- `model_loader_stage`: Inner try/except around first-model preload. Only re-raises (triggering abort) when it's the only model. Otherwise stores `preload_error` and lets `classify_stage` handle remaining specs.
- `classify_stage`: Updated skip condition to proceed when `resolved_specs` exist even without a preloaded `clf`. All model loads (including retry of failed preload and secondary models) are wrapped in try/except with `continue`. Tracks `skipped_model_names` and `models_succeeded` for summary reporting.
- If ALL models fail, `classify_stage` raises `RuntimeError` (pipeline fails, same as before).

**`vireo/tests/test_pipeline_job.py`** (3 new tests):
- `test_pipeline_continues_when_first_model_fails` — first model broken, second succeeds
- `test_pipeline_continues_when_secondary_model_fails` — first model succeeds, second broken
- `test_pipeline_single_model_still_aborts_on_failure` — single model, preserves existing abort behavior

## Test results

```
516 passed in 637.19s
```

Full suite: `tests/test_workspaces.py`, `vireo/tests/test_db.py`, `test_app.py`, `test_photos_api.py`, `test_edits_api.py`, `test_jobs_api.py`, `test_config.py`, `test_pipeline_job.py`, `test_models.py` — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)