### PR TITLE
fix: skip CoreML provider for ONNX models with external data

### DIFF
--- a/vireo/onnx_runtime.py
+++ b/vireo/onnx_runtime.py
@@ -39,9 +39,25 @@ def create_session(model_path):
     Returns:
         ort.InferenceSession
     """
+    import os
+
     import onnxruntime as ort
 
     providers = get_providers()
+
+    # onnxruntime 1.24+ CoreMLExecutionProvider crashes when loading models
+    # that use external data (.onnx.data sidecar files).  Fall back to the
+    # remaining providers for these models.
+    if str(model_path).endswith(".onnx") and os.path.exists(str(model_path) + ".data"):
+        before = list(providers)
+        providers = [p for p in providers if p != "CoreMLExecutionProvider"]
+        if providers != before:
+            log.info(
+                "Model %s uses external data (.onnx.data); "
+                "excluding CoreMLExecutionProvider to avoid crash",
+                model_path,
+            )
+
     log.info("Loading ONNX model: %s (providers: %s)", model_path, providers)
     session = ort.InferenceSession(model_path, providers=providers)
     actual = session.get_providers()

--- a/vireo/tests/test_onnx_runtime.py
+++ b/vireo/tests/test_onnx_runtime.py
@@ -66,3 +66,52 @@ def test_nms_basic():
     assert 0 in keep  # highest score kept
     assert 2 in keep  # non-overlapping kept
     assert 1 not in keep  # suppressed
+
+
+def test_create_session_excludes_coreml_for_external_data(tmp_path):
+    """CoreML should be excluded when a .onnx.data sidecar exists."""
+    from unittest.mock import MagicMock, patch
+
+    model_file = tmp_path / "model.onnx"
+    sidecar = tmp_path / "model.onnx.data"
+    model_file.write_bytes(b"fake")
+    sidecar.write_bytes(b"fake")
+
+    mock_session = MagicMock()
+    mock_session.get_providers.return_value = ["CPUExecutionProvider"]
+
+    with patch("vireo.onnx_runtime.get_providers", return_value=[
+        "CoreMLExecutionProvider", "CPUExecutionProvider",
+    ]), patch("onnxruntime.InferenceSession", return_value=mock_session) as mock_cls:
+        from vireo.onnx_runtime import create_session
+        create_session(str(model_file))
+
+    # CoreML must have been stripped from the providers list
+    _args, kwargs = mock_cls.call_args
+    assert "CoreMLExecutionProvider" not in kwargs.get("providers", _args[1] if len(_args) > 1 else [])
+
+
+def test_create_session_keeps_coreml_without_sidecar(tmp_path):
+    """CoreML should be kept when there is no .onnx.data sidecar."""
+    from unittest.mock import MagicMock, patch
+
+    model_file = tmp_path / "model.onnx"
+    model_file.write_bytes(b"fake")
+    # No sidecar created
+
+    mock_session = MagicMock()
+    mock_session.get_providers.return_value = [
+        "CoreMLExecutionProvider", "CPUExecutionProvider",
+    ]
+
+    with patch("vireo.onnx_runtime.get_providers", return_value=[
+        "CoreMLExecutionProvider", "CPUExecutionProvider",
+    ]), patch("onnxruntime.InferenceSession", return_value=mock_session) as mock_cls:
+        from vireo.onnx_runtime import create_session
+        create_session(str(model_file))
+
+    # CoreML must still be present
+    _args, kwargs = mock_cls.call_args
+    providers_used = kwargs.get("providers", _args[1] if len(_args) > 1 else [])
+    assert "CoreMLExecutionProvider" in providers_used
+    assert "CPUExecutionProvider" in providers_used


### PR DESCRIPTION
## Summary

- **Bug**: onnxruntime 1.24.4's CoreMLExecutionProvider crashes when loading ONNX models that use external data (`.onnx.data` sidecar files) with error `model_path must not be empty`
- **Fix**: In `create_session()`, detect external data models by checking for the `.onnx.data` sidecar file and exclude CoreMLExecutionProvider from the providers list, falling back to CUDA/CPU
- **Tests**: Added two tests to `test_onnx_runtime.py` verifying CoreML is excluded when sidecar exists and kept when it does not

## Test plan

- [x] New unit tests pass (9/9 in `test_onnx_runtime.py`)
- [x] Full test suite passes (517/517)

🤖 Generated with [Claude Code](https://claude.com/claude-code)