### PR TITLE
feat: add in-app Report Issue feature

### DIFF
--- a/docs/google-apps-script-issue-report.js
+++ b/docs/google-apps-script-issue-report.js
@@ -1,0 +1,46 @@
+/**
+ * Google Apps Script for receiving Vireo issue reports.
+ *
+ * Setup:
+ * 1. Go to https://script.google.com and create a new project.
+ * 2. Paste this code into Code.gs.
+ * 3. Replace YOUR_EMAIL@gmail.com with your email address.
+ * 4. Click Deploy > New deployment > Web app.
+ *    - Execute as: Me
+ *    - Who has access: Anyone
+ * 5. Copy the deployment URL and set it as "report_url" in Vireo's
+ *    Settings page or in ~/.vireo/config.json.
+ */
+
+function doPost(e) {
+  var data = JSON.parse(e.postData.contents);
+  var desc = (data.description || '').substring(0, 80);
+  var subject = 'Vireo Issue Report: ' + desc;
+
+  // Format body as readable text
+  var lines = [
+    'DESCRIPTION',
+    data.description || '(none)',
+    '',
+    'VIREO VERSION: ' + (data.vireo_version || 'unknown'),
+    'TIMESTAMP: ' + (data.timestamp || 'unknown'),
+    '',
+    'SYSTEM',
+    JSON.stringify(data.system || {}, null, 2),
+    '',
+    'APP STATE',
+    JSON.stringify(data.app_state || {}, null, 2),
+    '',
+    'RECENT JOBS',
+    JSON.stringify(data.recent_jobs || [], null, 2),
+    '',
+    'CONFIG',
+    JSON.stringify(data.config || {}, null, 2),
+    '',
+    'RECENT LOGS (last 200 entries)',
+    JSON.stringify(data.logs || [], null, 2),
+  ];
+
+  GmailApp.sendEmail('YOUR_EMAIL@gmail.com', subject, lines.join('\n'));
+  return ContentService.createTextOutput('ok');
+}

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5103,7 +5103,14 @@ def create_app(db_path, thumb_cache_dir=None):
         }
 
         # --- Send or download ---
-        effective = db.get_effective_config(cfg.load()) if db else cfg.load()
+        # Fall back to plain cfg.load() if the DB is degraded (e.g. schema or
+        # connection errors) so the download path still works when users are
+        # reporting DB problems.
+        try:
+            effective = db.get_effective_config(cfg.load()) if db else cfg.load()
+        except Exception:
+            log.exception("Failed to load effective config for issue report")
+            effective = cfg.load()
         report_url = effective.get("report_url", "")
 
         if report_url:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5042,6 +5042,7 @@ def create_app(db_path, thumb_cache_dir=None):
                 vireo_version = "unknown"
 
         # --- App state ---
+        db = None
         try:
             db = _get_db()
             ws = db.get_active_workspace()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13,6 +13,7 @@ import queue
 import subprocess
 import time
 import webbrowser
+from datetime import UTC
 from pathlib import Path
 from urllib.parse import quote
 
@@ -5015,6 +5016,114 @@ def create_app(db_path, thumb_cache_dir=None):
         db = _get_db()
         limit = min(max(1, request.args.get("limit", 10, type=int)), 1000)
         return jsonify(app._job_runner.get_history(db, limit=limit))
+
+    @app.route("/api/report-issue", methods=["POST"])
+    def api_report_issue():
+        """Collect diagnostics and optionally send to a configured report URL."""
+        import platform
+        import sys
+        import urllib.request
+
+        data = request.get_json(force=True, silent=True) or {}
+        description = (data.get("description") or "").strip()
+        if not description:
+            return json_error("A description is required")
+
+        # --- Version (same logic as api_version) ---
+        try:
+            from importlib.metadata import version as pkg_version
+            vireo_version = pkg_version("vireo")
+        except Exception:
+            import tomllib
+            try:
+                with open(os.path.join(os.path.dirname(__file__), "..", "pyproject.toml"), "rb") as f:
+                    vireo_version = tomllib.load(f)["project"]["version"]
+            except Exception:
+                vireo_version = "unknown"
+
+        # --- App state ---
+        try:
+            db = _get_db()
+            ws = db.get_active_workspace()
+            ws_name = ws["name"] if ws else "unknown"
+            folder_count = db.conn.execute("SELECT COUNT(*) FROM folders").fetchone()[0]
+            photo_count = db.conn.execute("SELECT COUNT(*) FROM photos").fetchone()[0]
+            pred_count = db.conn.execute(
+                "SELECT COUNT(*) FROM predictions WHERE workspace_id = ?",
+                (db._ws_id(),)
+            ).fetchone()[0]
+        except Exception:
+            ws_name = "unknown"
+            folder_count = photo_count = pred_count = 0
+
+        # --- Recent jobs ---
+        try:
+            recent_jobs = app._job_runner.get_history(db, limit=10)
+        except Exception:
+            recent_jobs = []
+
+        # --- Config (sanitized) ---
+        import config as cfg
+
+        def _redact(obj):
+            if isinstance(obj, dict):
+                out = {}
+                for k, v in obj.items():
+                    if any(s in k.lower() for s in ("token", "key", "secret", "password")):
+                        out[k] = "[REDACTED]"
+                    else:
+                        out[k] = _redact(v)
+                return out
+            return obj
+
+        sanitized_config = _redact(cfg.load())
+
+        # --- Build the bundle ---
+        from datetime import datetime
+
+        bundle = {
+            "description": description,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "vireo_version": vireo_version,
+            "system": {
+                "platform": platform.platform(),
+                "python": sys.version,
+                "architecture": platform.machine(),
+            },
+            "logs": app._log_broadcaster.get_recent(200),
+            "app_state": {
+                "workspace": ws_name,
+                "folders": folder_count,
+                "photos": photo_count,
+                "predictions": pred_count,
+            },
+            "recent_jobs": recent_jobs,
+            "config": sanitized_config,
+        }
+
+        # --- Send or download ---
+        effective = db.get_effective_config(cfg.load()) if db else cfg.load()
+        report_url = effective.get("report_url", "")
+
+        if report_url:
+            try:
+                payload = json.dumps(bundle).encode("utf-8")
+                req = urllib.request.Request(
+                    report_url,
+                    data=payload,
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                resp = urllib.request.urlopen(req, timeout=10)
+                if 200 <= resp.status < 300:
+                    return jsonify({"status": "sent"})
+                else:
+                    return jsonify({"status": "download", "diagnostics": bundle})
+            except Exception:
+                log.exception("Failed to send report to %s", report_url)
+                return jsonify({"status": "download", "diagnostics": bundle})
+
+        return jsonify({"status": "download", "diagnostics": bundle})
 
     # -- Image serving --
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5075,6 +5075,8 @@ def create_app(db_path, thumb_cache_dir=None):
                     else:
                         out[k] = _redact(v)
                 return out
+            if isinstance(obj, list):
+                return [_redact(item) for item in obj]
             return obj
 
         sanitized_config = _redact(cfg.load())

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -27,6 +27,7 @@ DEFAULTS = {
     "setup_complete": False,
     "darktable_bin": "",
     "external_editor": "",
+    "report_url": "",
     "darktable_style": "",
     "darktable_output_format": "jpg",
     "darktable_output_dir": "",

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -193,6 +193,65 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   font-size: 13px;
 }
 
+/* ---------- Report Issue Modal ---------- */
+.report-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: rgba(0,0,0,0.5);
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 10vh;
+}
+.report-overlay.active { display: flex; }
+.report-modal {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  width: 480px;
+  padding: 24px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+}
+.report-modal h3 { margin: 0 0 12px; color: var(--text-primary); }
+.report-modal textarea {
+  width: 100%;
+  min-height: 120px;
+  padding: 10px 12px;
+  font-size: 14px;
+  font-family: inherit;
+  border: 1px solid var(--border-secondary);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  resize: vertical;
+  box-sizing: border-box;
+}
+.report-modal textarea:focus { border-color: var(--accent); outline: none; }
+.report-modal .report-hint {
+  font-size: 12px;
+  color: var(--text-ghost);
+  margin: 8px 0 16px;
+}
+.report-modal .report-actions { display: flex; gap: 8px; justify-content: flex-end; }
+.report-modal .report-status {
+  font-size: 13px;
+  margin-top: 12px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  display: none;
+}
+.report-modal .report-status.success {
+  background: rgba(76, 175, 80, 0.15);
+  color: #4caf50;
+  display: block;
+}
+.report-modal .report-status.error {
+  background: rgba(244, 67, 54, 0.15);
+  color: #f44336;
+  display: block;
+}
+
 /* ---------- Bottom Panel ---------- */
 .bottom-toggle {
   background: var(--bg-panel);
@@ -931,6 +990,7 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   <a href="/shortcuts" data-nav-id="shortcuts">Shortcuts</a>
   <a href="/settings" data-nav-id="settings">Settings</a>
   <span class="nav-spacer"></span>
+  <span class="nav-icon" onclick="openReportModal()" title="Report Issue" id="reportToggle">&#9888;</span>
   <span class="nav-icon" onclick="openHelpModal()" title="Help (F1)" id="helpToggle">&#63;</span>
   <span class="nav-icon" onclick="toggleDevMode()" title="Toggle developer mode" id="devModeToggle" style="opacity:0.4;">&#9881;</span>
   <span class="nav-icon" onclick="toggleTheme()" title="Toggle light/dark mode" id="themeToggle">&#9788;</span>
@@ -950,6 +1010,82 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
     <div class="help-results" id="helpResults"></div>
   </div>
 </div>
+
+<!-- Report Issue Modal -->
+<div class="report-overlay" id="reportModal" onclick="if(event.target===this)closeReportModal()">
+  <div class="report-modal">
+    <h3>Report Issue</h3>
+    <textarea id="reportDescription" placeholder="What happened? What did you expect?"></textarea>
+    <div class="report-hint">This report includes recent logs and system info to help diagnose the issue.</div>
+    <div class="report-actions">
+      <button class="modal-btn modal-btn-cancel" onclick="closeReportModal()">Cancel</button>
+      <button class="modal-btn modal-btn-primary" id="reportSendBtn" onclick="sendReport()">Send Report</button>
+    </div>
+    <div class="report-status" id="reportStatus"></div>
+  </div>
+</div>
+<script>
+function openReportModal() {
+  document.getElementById('reportModal').classList.add('active');
+  document.getElementById('reportDescription').value = '';
+  document.getElementById('reportStatus').className = 'report-status';
+  document.getElementById('reportStatus').textContent = '';
+  document.getElementById('reportSendBtn').disabled = false;
+  document.getElementById('reportDescription').focus();
+}
+function closeReportModal() {
+  document.getElementById('reportModal').classList.remove('active');
+}
+function sendReport() {
+  var desc = document.getElementById('reportDescription').value.trim();
+  if (!desc) {
+    document.getElementById('reportDescription').style.borderColor = 'var(--danger)';
+    document.getElementById('reportDescription').focus();
+    return;
+  }
+  var btn = document.getElementById('reportSendBtn');
+  var status = document.getElementById('reportStatus');
+  btn.disabled = true;
+  btn.textContent = 'Sending...';
+  status.className = 'report-status';
+  status.textContent = '';
+
+  fetch('/api/report-issue', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({description: desc})
+  })
+  .then(function(r) { return r.json(); })
+  .then(function(data) {
+    if (data.status === 'sent') {
+      status.className = 'report-status success';
+      status.textContent = 'Report sent — thanks!';
+      setTimeout(closeReportModal, 2000);
+    } else if (data.status === 'download') {
+      var blob = new Blob([JSON.stringify(data.diagnostics, null, 2)], {type: 'application/json'});
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement('a');
+      a.href = url;
+      a.download = 'vireo-issue-report.json';
+      a.click();
+      URL.revokeObjectURL(url);
+      status.className = 'report-status error';
+      status.textContent = 'Could not send automatically. Please email the downloaded file.';
+    } else if (data.error) {
+      status.className = 'report-status error';
+      status.textContent = data.error;
+    }
+    btn.disabled = false;
+    btn.textContent = 'Send Report';
+  })
+  .catch(function(err) {
+    status.className = 'report-status error';
+    status.textContent = 'Failed to send report: ' + err.message;
+    btn.disabled = false;
+    btn.textContent = 'Send Report';
+  });
+}
+</script>
 
 <!-- Missing Folders Banner -->
 <div class="missing-folders-banner" id="missingFoldersBanner" style="display:none;">
@@ -1235,7 +1371,7 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
     document.addEventListener('keydown', function(e) {
       if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
       // Skip if any overlay or modal is open
-      if (document.querySelector('.lightbox-overlay.active, .pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open, .shortcuts-overlay.open, .help-overlay.active')) return;
+      if (document.querySelector('.lightbox-overlay.active, .pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open, .shortcuts-overlay.open, .help-overlay.active, .report-overlay.active')) return;
 
       for (var shortcutStr in keyToHref) {
         if (matchesShortcut(e, shortcutStr)) {
@@ -2061,7 +2197,7 @@ async function inatDoSubmit() {
 // If adding JS-based navigation shortcuts, guard with:
 //   if (window.__TAURI_INTERNALS__) return;
 document.addEventListener('keydown', function(e) {
-  if (e.key === 'Escape') { closeLightbox(); closePipeline(); closeSimilar(); closeInatModal(); if (typeof closeHelpModal === 'function') closeHelpModal(); }
+  if (e.key === 'Escape') { closeLightbox(); closePipeline(); closeSimilar(); closeInatModal(); if (typeof closeHelpModal === 'function') closeHelpModal(); if (typeof closeReportModal === 'function') closeReportModal(); }
   if (!document.getElementById('lightboxOverlay').classList.contains('active')) return;
   if (e.key === 'ArrowRight') { lightboxNav(1); e.preventDefault(); }
   if (e.key === 'ArrowLeft') { lightboxNav(-1); e.preventDefault(); }

--- a/vireo/tests/test_report.py
+++ b/vireo/tests/test_report.py
@@ -107,3 +107,23 @@ class TestReportIssue:
         data = resp.get_json()
         assert data["status"] == "download"
         assert "diagnostics" in data
+
+    def test_report_when_effective_config_raises(self, app_and_db, monkeypatch):
+        """If the DB is degraded and get_effective_config raises, still return
+        a download bundle (don't 500) — this is the path users need when they
+        are reporting DB problems."""
+        app, _ = app_and_db
+
+        from db import Database
+
+        def boom(self, *a, **kw):
+            raise RuntimeError("schema broken")
+
+        monkeypatch.setattr(Database, "get_effective_config", boom)
+
+        with app.test_client() as c:
+            resp = c.post("/api/report-issue", json={"description": "db broken"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "download"
+        assert data["diagnostics"]["description"] == "db broken"

--- a/vireo/tests/test_report.py
+++ b/vireo/tests/test_report.py
@@ -1,0 +1,109 @@
+"""Tests for the issue-reporting endpoint."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from db import Database
+from PIL import Image
+
+
+@pytest.fixture
+def app_and_db(tmp_path, monkeypatch):
+    """Create a test app with sample data and isolated config."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    from app import create_app
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder("/photos/2024", name="2024")
+
+    p1 = db.add_photo(
+        folder_id=fid, filename="bird1.jpg", extension=".jpg",
+        file_size=1000, file_mtime=1.0, timestamp="2024-01-15T10:00:00",
+    )
+    Image.new("RGB", (100, 100)).save(os.path.join(thumb_dir, f"{p1}.jpg"))
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir)
+    app.config["TESTING"] = True
+    return app, db
+
+
+@pytest.fixture
+def client(app_and_db):
+    app, _ = app_and_db
+    with app.test_client() as c:
+        yield c
+
+
+class TestReportIssue:
+    def test_missing_description_returns_400(self, client):
+        resp = client.post("/api/report-issue", json={})
+        assert resp.status_code == 400
+        assert "description" in resp.get_json()["error"].lower()
+
+    def test_empty_description_returns_400(self, client):
+        resp = client.post("/api/report-issue", json={"description": "  "})
+        assert resp.status_code == 400
+
+    def test_report_without_url_returns_download(self, client):
+        resp = client.post("/api/report-issue", json={"description": "Something broke"})
+        data = resp.get_json()
+        assert data["status"] == "download"
+        diag = data["diagnostics"]
+        assert diag["description"] == "Something broke"
+        assert "vireo_version" in diag
+        assert "system" in diag
+        assert "logs" in diag
+        assert "app_state" in diag
+        assert "recent_jobs" in diag
+        assert "config" in diag
+        assert "timestamp" in diag
+
+    def test_diagnostics_system_fields(self, client):
+        """System info should include platform, python, architecture."""
+        resp = client.post("/api/report-issue", json={"description": "check system"})
+        system = resp.get_json()["diagnostics"]["system"]
+        assert "platform" in system
+        assert "python" in system
+        assert "architecture" in system
+
+    def test_sensitive_config_values_are_redacted(self, client):
+        """Tokens and keys must not leak in reports."""
+        import config as cfg
+
+        current = cfg.load()
+        current["hf_token"] = "hf_abc123secret"
+        current["inat_token"] = "my-inat-token"
+        cfg.save(current)
+
+        resp = client.post("/api/report-issue", json={"description": "test redaction"})
+        data = resp.get_json()
+        config_in_report = data["diagnostics"]["config"]
+        assert config_in_report.get("hf_token") == "[REDACTED]"
+        assert config_in_report.get("inat_token") == "[REDACTED]"
+        # Non-sensitive values should not be redacted
+        assert config_in_report.get("classification_threshold") == current["classification_threshold"]
+
+    def test_report_with_bad_url_returns_download_fallback(self, client):
+        """If the report URL is unreachable, fall back to download."""
+        import config as cfg
+
+        current = cfg.load()
+        current["report_url"] = "http://localhost:1/nonexistent"
+        cfg.save(current)
+
+        resp = client.post("/api/report-issue", json={"description": "test fallback"})
+        data = resp.get_json()
+        assert data["status"] == "download"
+        assert "diagnostics" in data


### PR DESCRIPTION
## Summary
- Adds a **Report Issue** button (warning icon) to the navbar that opens a modal for users to describe problems
- New `POST /api/report-issue` endpoint collects diagnostics (version, system info, recent logs, app state, job history, sanitized config) and either POSTs to a configured `report_url` or returns a downloadable JSON file
- Sensitive config values (tokens, keys, secrets, passwords) are recursively redacted
- Adds `report_url` config default, Google Apps Script template for receiving reports, and 6 new tests

## Changes
- `vireo/config.py` — Added `report_url` to DEFAULTS
- `vireo/app.py` — New `POST /api/report-issue` endpoint with diagnostics collection, config redaction, and optional remote submission
- `vireo/templates/_navbar.html` — Report Issue modal CSS, HTML, JS; navbar icon; Escape key handler; overlay guard for keyboard shortcuts
- `docs/google-apps-script-issue-report.js` — Template for deploying a Google Apps Script to receive reports via email
- `vireo/tests/test_report.py` — 6 tests covering validation, diagnostics structure, redaction, and URL fallback

## Test plan
- [x] All 436 tests pass (`python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_report.py -v`)
- [ ] Manual: click Report Issue icon, submit with empty description (should highlight field), submit with text (should download JSON)
- [ ] Manual: configure `report_url` to a test endpoint, verify report is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)