### PR TITLE
fix: address codex review on #528

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5042,6 +5042,7 @@ def create_app(db_path, thumb_cache_dir=None):
                 vireo_version = "unknown"
 
         # --- App state ---
+        db = None
         try:
             db = _get_db()
             ws = db.get_active_workspace()


### PR DESCRIPTION
Parent PR: #528

Addresses Codex Connect review feedback on #528.

## What changed

In `api_report_issue`, `db` was only assigned inside a `try` block (`db = _get_db()`). If `_get_db()` raised an exception, `db` was never bound, but the subsequent line:

```python
effective = db.get_effective_config(cfg.load()) if db else cfg.load()
```

would raise `UnboundLocalError` rather than falling through to the `cfg.load()` fallback — returning a 500 instead of the intended download response.

**Fix:** initialize `db = None` before the `try` block so the ternary guard works as intended and the endpoint degrades gracefully when the database is inaccessible.

## Test results

All 436 tests pass.

---
Generated by scheduled PR Agent