### PR TITLE
fix: surface MegaDetector weight-missing state instead of silent fallback

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3635,19 +3635,21 @@ def create_app(db_path, thumb_cache_dir=None):
         except ImportError:
             info["device_detail"] = "onnxruntime not installed"
 
-        # MegaDetector status — just check for the ONNX file
+        # "installed" requires both module AND weights — module-only
+        # lets classify silently fall back to full-image classification.
         try:
             from detector import MEGADETECTOR_ONNX_PATH
 
-            info["megadetector"] = "installed"
-            info["megadetector_detail"] = "MegaDetector V6 (YOLOv9-c) — subject detection for crop-based classification"
-
             if os.path.isfile(MEGADETECTOR_ONNX_PATH):
                 size_mb = round(os.path.getsize(MEGADETECTOR_ONNX_PATH) / 1024 / 1024, 1)
+                info["megadetector"] = "installed"
+                info["megadetector_detail"] = "MegaDetector V6 (YOLOv9-c) — subject detection for crop-based classification"
                 info["megadetector_weights"] = "downloaded"
                 info["megadetector_weights_path"] = MEGADETECTOR_ONNX_PATH
                 info["megadetector_weights_size"] = f"{size_mb} MB"
             else:
+                info["megadetector"] = "weights_missing"
+                info["megadetector_detail"] = "Weights not downloaded — subject detection disabled until the MegaDetector V6 ONNX model is downloaded from the pipeline models page."
                 info["megadetector_weights"] = "not downloaded"
                 info["megadetector_weights_path"] = None
                 info["megadetector_weights_size"] = None

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -416,8 +416,16 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
     except (ImportError, RuntimeError) as e:
         msg = str(e)
         if "ONNX model not available" in msg or "not found" in msg:
-            log.info(
-                "MegaDetector not available — skipping detection (classifying full images)"
+            log.warning(
+                "MegaDetector weights not available — detection skipped; classifying full images. "
+                "Download the MegaDetector V6 ONNX model from the pipeline models page to enable "
+                "subject detection, cropped classification, and mask extraction."
+            )
+            job["errors"].append(
+                "MegaDetector weights not downloaded — detection skipped. Classification ran on full "
+                "images (less accurate) and no detections were stored, which also prevents the mask "
+                "extraction stage from producing subject masks. Download MegaDetector V6 from the "
+                "pipeline models page to fix."
             )
             runner.push_event(
                 job["id"],
@@ -426,7 +434,7 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
                     "current": 0,
                     "total": total,
                     "current_file": "",
-                    "phase": "Step 4/5: Detection skipped (MegaDetector not available)",
+                    "phase": "Step 4/5: Detection skipped — MegaDetector weights not downloaded",
                 },
             )
         else:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1320,7 +1320,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             #   (a) weights missing → actionable remediation
             #   (b) weights present → legitimate outcome (empty scenes,
             #       strict confidence threshold, non-wildlife photos)
-            if photos_with_detections == 0 and len(photos) > 0:
+            # Only fire this diagnostic when classify actually ran in this
+            # invocation.  If classify was skipped (skip_classify=True, no
+            # models available, abort, etc.) zero detections is expected and
+            # appending an extract_masks error would be factually incorrect.
+            classify_ran = stages["classify"]["status"] not in ("skipped", "pending")
+            if photos_with_detections == 0 and len(photos) > 0 and classify_ran:
                 weights_present = False
                 try:
                     from detector import MEGADETECTOR_ONNX_PATH

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1313,27 +1313,51 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             start_time = time.time()
 
             # If the input collection has photos but none carry detections,
-            # fail loudly instead of silently completing with masked=0. The
-            # pipeline would otherwise reject every photo with no_subject_mask
-            # without explaining why the masks were never produced.
+            # surface a clear status instead of silently completing with
+            # masked=0 — otherwise the pipeline rejects every photo with
+            # no_subject_mask without explaining why masks were never made.
+            # Distinguish two cases:
+            #   (a) weights missing → actionable remediation
+            #   (b) weights present → legitimate outcome (empty scenes,
+            #       strict confidence threshold, non-wildlife photos)
             if photos_with_detections == 0 and len(photos) > 0:
-                reason = (
-                    f"No detections found for {len(photos)} photo(s). The classify stage did not "
-                    "produce any detections (most commonly because MegaDetector weights were not "
-                    "downloaded). Without detections the mask extraction stage has nothing to "
-                    "process, and the pipeline will reject every photo with `no_subject_mask`. "
-                    "Download MegaDetector V6 from the pipeline models page and rerun classify."
-                )
+                weights_present = False
+                try:
+                    from detector import MEGADETECTOR_ONNX_PATH
+                    weights_present = os.path.isfile(MEGADETECTOR_ONNX_PATH)
+                except ImportError:
+                    weights_present = False
+
+                if weights_present:
+                    reason = (
+                        f"No detections produced for {len(photos)} photo(s). MegaDetector ran but "
+                        "found no animals meeting the confidence threshold. The pipeline will "
+                        "reject every photo with `no_subject_mask`. Lower `detector_confidence` "
+                        "in settings or rerun classify with a different threshold if detections "
+                        "were expected."
+                    )
+                    summary = "Skipped — MegaDetector produced no detections"
+                else:
+                    reason = (
+                        f"No detections available for {len(photos)} photo(s). MegaDetector "
+                        "weights are not downloaded, so the classify stage ran on full images "
+                        "and stored no detections. Without detections the mask extraction stage "
+                        "has nothing to process, and the pipeline will reject every photo with "
+                        "`no_subject_mask`. Download MegaDetector V6 from the pipeline models "
+                        "page and rerun the pipeline."
+                    )
+                    summary = "Skipped — MegaDetector weights not downloaded"
+
                 log.warning("Pipeline extract-masks: %s", reason)
                 errors.append(f"[extract_masks] {reason}")
                 stages["extract_masks"]["status"] = "skipped"
                 runner.update_step(
                     job["id"], "extract_masks", status="completed",
-                    summary="Skipped — no detections available",
+                    summary=summary,
                 )
                 result["stages"]["extract_masks"] = {
                     "masked": 0, "skipped": 0, "failed": 0, "total": 0,
-                    "reason": "no_detections",
+                    "reason": "weights_missing" if not weights_present else "no_detections",
                 }
                 _update_stages(runner, job["id"], stages)
                 return

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1281,9 +1281,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             # from the detections table. Only photos with detections and without
             # masks need processing.
             photo_det_map = {}
+            photos_with_detections = 0
             for p in photos:
                 dets = thread_db.get_detections(p["id"])
                 if dets:
+                    photos_with_detections += 1
                     primary = dets[0]  # already ordered by confidence DESC
                     has_mask = thread_db.conn.execute(
                         "SELECT mask_path FROM photos WHERE id=?", (p["id"],)
@@ -1309,6 +1311,32 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             skipped = 0
             em_failed = 0
             start_time = time.time()
+
+            # If the input collection has photos but none carry detections,
+            # fail loudly instead of silently completing with masked=0. The
+            # pipeline would otherwise reject every photo with no_subject_mask
+            # without explaining why the masks were never produced.
+            if photos_with_detections == 0 and len(photos) > 0:
+                reason = (
+                    f"No detections found for {len(photos)} photo(s). The classify stage did not "
+                    "produce any detections (most commonly because MegaDetector weights were not "
+                    "downloaded). Without detections the mask extraction stage has nothing to "
+                    "process, and the pipeline will reject every photo with `no_subject_mask`. "
+                    "Download MegaDetector V6 from the pipeline models page and rerun classify."
+                )
+                log.warning("Pipeline extract-masks: %s", reason)
+                errors.append(f"[extract_masks] {reason}")
+                stages["extract_masks"]["status"] = "skipped"
+                runner.update_step(
+                    job["id"], "extract_masks", status="completed",
+                    summary="Skipped — no detections available",
+                )
+                result["stages"]["extract_masks"] = {
+                    "masked": 0, "skipped": 0, "failed": 0, "total": 0,
+                    "reason": "no_detections",
+                }
+                _update_stages(runner, job["id"], stages)
+                return
 
             for i, entry in enumerate(photos_to_process):
                 if _should_abort(abort):

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1256,7 +1256,11 @@ async function loadSystemInfo() {
       mdStatus.textContent = 'Installed';
       mdStatus.style.color = 'var(--accent)';
       mdDetail.textContent = d.megadetector_detail;
-    } else if (d.megadetector === 'not installed') {
+    } else if (d.megadetector === 'weights_missing') {
+      mdStatus.textContent = 'Not ready';
+      mdStatus.style.color = 'var(--warning)';
+      mdDetail.textContent = d.megadetector_detail;
+    } else if (d.megadetector === 'unavailable' || d.megadetector === 'not installed') {
       mdStatus.textContent = 'Not installed';
       mdStatus.style.color = 'var(--warning)';
       mdDetail.textContent = 'Subject detection disabled — ' + d.megadetector_detail;

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1846,3 +1846,39 @@ def test_api_import_full_accepts_exclude_paths(app_and_db, tmp_path):
     assert resp.status_code == 200
     data = resp.get_json()
     assert "job_id" in data
+
+
+def test_system_info_megadetector_weights_missing(app_and_db, monkeypatch, tmp_path):
+    """/api/system/info reports weights_missing (not installed) when only the
+    detector module imports but the ONNX weights file is absent.
+    """
+    import detector
+    missing_path = str(tmp_path / "does_not_exist.onnx")
+    monkeypatch.setattr(detector, "MEGADETECTOR_ONNX_PATH", missing_path)
+
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/system/info")
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    assert data["megadetector"] == "weights_missing"
+    assert data["megadetector_weights"] == "not downloaded"
+    assert "weights not downloaded" in data["megadetector_detail"].lower()
+
+
+def test_system_info_megadetector_installed_when_weights_present(app_and_db, monkeypatch, tmp_path):
+    """/api/system/info reports installed only when weights are on disk."""
+    import detector
+    weights = tmp_path / "model.onnx"
+    weights.write_bytes(b"\x00" * 1024)
+    monkeypatch.setattr(detector, "MEGADETECTOR_ONNX_PATH", str(weights))
+
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/system/info")
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    assert data["megadetector"] == "installed"
+    assert data["megadetector_weights"] == "downloaded"


### PR DESCRIPTION
## Summary

Pipeline was silently producing all-REJECT results (`0 KEEP, 0 REVIEW, N REJECT`) when MegaDetector weights weren't downloaded. From the user's perspective, everything reported success — classify_job logged predictions, pipeline job reported "complete", and the review page just had nothing to show. Three separate layers of silent-failure conspired:

1. **Settings lied.** `/api/system/info` set `megadetector = "installed"` as soon as `from detector import MEGADETECTOR_ONNX_PATH` succeeded — meaning the Python wrapper was importable, not that the ONNX weights were actually on disk. The UI only read this field, so the settings page displayed "Installed" ✅ while the runtime couldn't actually detect anything.
2. **classify_job was too quiet.** When the ONNX load failed, the handler logged `"MegaDetector not available — skipping detection"` at **INFO** level and continued. In a log spammed with one INFO line per classified photo, that single detection-skipped line was trivially lost. No entry was added to `job["errors"]` either.
3. **extract-masks silently no-op'd.** When the `detections` table was empty (no photos had detections because classify fell back), the extract-masks stage iterated zero photos and reported "completed" with `masked=0`. The pipeline then rejected every photo with `no_subject_mask`, which doesn't explain *why* masks were missing.

## Changes

- `vireo/app.py` — `/api/system/info` now reports `megadetector = "installed"` only when **both** module and weights are present. New `"weights_missing"` status covers module-present-but-weights-missing, with a detail message pointing to the pipeline models page.
- `vireo/templates/settings.html` — Renders `"weights_missing"` as "Not ready" (warning color) with the detail message, instead of "Installed".
- `vireo/classify_job.py` — Missing-weights path now logs at **WARNING** and appends a user-visible entry to `job["errors"]` so it surfaces in the jobs UI.
- `vireo/pipeline_job.py` — extract-masks stage detects "photos present but zero detections" and reports `skipped` status with `reason: "no_detections"` and an actionable error message, instead of silently completing.
- `vireo/tests/test_app.py` — Two new tests covering `weights_missing` and `installed` paths through `/api/system/info`.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` → **432 passed** (was 430 baseline + 2 new)
- [x] Adjacent suites: `test_classify_job.py test_pipeline.py test_detector.py test_masking.py test_reflow.py test_scoring.py` → **109 passed, 2 skipped**
- [ ] Manual: open settings with weights absent → shows "Not ready" with weight-download instructions
- [ ] Manual: run pipeline with weights absent → jobs UI shows the detection-skipped warning; extract-masks stage shows "Skipped — no detections available"
- [ ] Manual: download MegaDetector V6, rerun pipeline → photos get detections/masks and land in KEEP/REVIEW buckets

## Note

There is a pre-existing test-ordering issue where `test_classify_job.py` leaks monkeypatches that break `test_jobs_api.py::test_pipeline_auto_skips_classify_when_no_model` when the two files are run in one session. This exists on main, is unrelated to this change, and doesn't affect the project's required test command (which runs the 8 files listed above and passes cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)