### PR TITLE
fix: address codex review on #530

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1320,7 +1320,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             #   (a) weights missing → actionable remediation
             #   (b) weights present → legitimate outcome (empty scenes,
             #       strict confidence threshold, non-wildlife photos)
-            if photos_with_detections == 0 and len(photos) > 0:
+            # Only fire this diagnostic when classify actually ran in this
+            # invocation.  If classify was skipped (skip_classify=True, no
+            # models available, abort, etc.) zero detections is expected and
+            # appending an extract_masks error would be factually incorrect.
+            classify_ran = stages["classify"]["status"] not in ("skipped", "pending")
+            if photos_with_detections == 0 and len(photos) > 0 and classify_ran:
                 weights_present = False
                 try:
                     from detector import MEGADETECTOR_ONNX_PATH


### PR DESCRIPTION
Parent PR: #530

Addresses Codex Connect review feedback on #530.

## What changed

`extract_masks_stage` in `vireo/pipeline_job.py` fired an `[extract_masks]` error whenever a collection had photos but zero detections — even when `skip_classify=True` or classify was otherwise skipped (no models, abort). In those cases zero detections is expected, but the stage was still emitting a misleading error and a remediation hint claiming MegaDetector ran (or that classify ran full-image fallback), which caused the pipeline run to be marked as errored in the UI despite an intentional skip.

**Fix:** check `stages["classify"]["status"]` before emitting the diagnostic. The no-detection warning and error entry now only fire when classify actually ran in the current job invocation.

## Test results

432 passed.

---
Generated by scheduled PR Agent