### PR TITLE
fix: address codex review on #528

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5075,6 +5075,8 @@ def create_app(db_path, thumb_cache_dir=None):
                     else:
                         out[k] = _redact(v)
                 return out
+            if isinstance(obj, list):
+                return [_redact(item) for item in obj]
             return obj
 
         sanitized_config = _redact(cfg.load())


### PR DESCRIPTION
Parent PR: #528

Addresses Codex Connect review feedback on #528.

## What changed

`_redact` in `vireo/app.py` only handled dicts and returned any non-dict value unchanged. This meant secrets nested inside lists (e.g. `{"integrations": [{"api_key": "..."}]}`) were not scrubbed from the diagnostics bundle — they could leak in the downloaded JSON or in the payload sent to `report_url`, despite the feature being intended to recursively redact all sensitive values.

**Fix:** add a `list` branch to `_redact` that recurses into each element, so secrets at any nesting depth inside lists are also redacted.

## Test results

437 passed.

---
Generated by scheduled PR Agent