### PR TITLE
fix: scope missing-folders banner to the active workspace

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -976,15 +976,17 @@ class Database:
         return changed
 
     def get_missing_folders(self):
-        """Return all folders with status='missing' and their photo counts."""
+        """Return missing folders in the active workspace with photo counts."""
         return self.conn.execute(
             """SELECT f.id, f.path, f.name, f.parent_id,
                       COUNT(p.id) as photo_count
                FROM folders f
+               JOIN workspace_folders wf ON wf.folder_id = f.id
                LEFT JOIN photos p ON p.folder_id = f.id
-               WHERE f.status = 'missing'
+               WHERE wf.workspace_id = ? AND f.status = 'missing'
                GROUP BY f.id
-               ORDER BY f.path"""
+               ORDER BY f.path""",
+            (self._ws_id(),),
         ).fetchall()
 
     def relocate_folder(self, folder_id, new_path):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1924,6 +1924,31 @@ def test_get_missing_folders(tmp_path):
     assert missing[0]["photo_count"] == 1
 
 
+def test_get_missing_folders_scoped_to_active_workspace(tmp_path):
+    """Missing folders from other workspaces must not leak into the active one."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.ensure_default_workspace()
+    ws_b = db.create_workspace("Other")
+
+    db.set_active_workspace(ws_a)
+    fid_a = db.add_folder("/gone/in_a", name="in_a")
+
+    db.set_active_workspace(ws_b)
+    fid_b = db.add_folder("/gone/in_b", name="in_b")
+
+    db.conn.execute("UPDATE folders SET status = 'missing'")
+    db.conn.commit()
+
+    db.set_active_workspace(ws_a)
+    missing = db.get_missing_folders()
+    assert [row["path"] for row in missing] == ["/gone/in_a"]
+
+    db.set_active_workspace(ws_b)
+    missing = db.get_missing_folders()
+    assert [row["path"] for row in missing] == ["/gone/in_b"]
+
+
 def test_relocate_folder(tmp_path):
     """relocate_folder updates path and sets status to 'ok'."""
     from db import Database


### PR DESCRIPTION
## Summary
- `Database.get_missing_folders()` scanned the global `folders` table with no workspace filter, so the navbar banner reported every missing folder across every workspace — e.g. "69 folders can't be found on disk" in a workspace that only linked one folder.
- Added the same `workspace_folders` join that `get_folder_tree` already uses, so the banner reflects only the active workspace.
- Added a regression test confirming missing folders from one workspace don't leak into another.

## Test plan
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` — 433 passed
- [ ] Open a workspace with one linked folder where other workspaces have missing folders; confirm the banner shows the correct count (or nothing) instead of the global total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)