### PR TITLE
fix: fall back to per-row text inference for BioCLIP 2.5 reshape error

### DIFF
--- a/vireo/classifier.py
+++ b/vireo/classifier.py
@@ -215,6 +215,38 @@ def _normalize(vec):
     return vec / norm
 
 
+def _make_text_runner(text_session, text_input_name):
+    """Return a callable that runs the text encoder on a (N, seq_len) token batch.
+
+    Some BioCLIP ONNX exports (notably bioclip-2.5-vith14) contain an internal
+    Reshape node with a hardcoded single-prompt shape, so inference fails for
+    any batch size > 1 even though the model's declared input is dynamic.
+    The returned runner tries the batched call first and, on failure, falls
+    back to per-row inference and remembers the choice for subsequent calls.
+    """
+    state = {"batched_ok": True}
+
+    def run(tokens):
+        if state["batched_ok"]:
+            try:
+                return text_session.run(None, {text_input_name: tokens})[0]
+            except Exception as e:
+                log.warning(
+                    "Text encoder rejected batched input (%s: %s); "
+                    "falling back to per-row inference",
+                    type(e).__name__,
+                    e,
+                )
+                state["batched_ok"] = False
+        rows = [
+            text_session.run(None, {text_input_name: tokens[i : i + 1]})[0]
+            for i in range(tokens.shape[0])
+        ]
+        return np.concatenate(rows, axis=0)
+
+    return run
+
+
 def _compute_embeddings_with_progress(
     text_session, text_input_name, tokenizer, labels, progress_callback=None
 ):
@@ -239,11 +271,13 @@ def _compute_embeddings_with_progress(
     if progress_callback:
         progress_callback(0, total)
 
+    run_text = _make_text_runner(text_session, text_input_name)
+
     all_features = []
     for i, classname in enumerate(labels):
         txts = [template(classname) for template in OPENAI_IMAGENET_TEMPLATE]
         tokens = _tokenize(tokenizer, txts)
-        txt_features = text_session.run(None, {text_input_name: tokens})[0]
+        txt_features = run_text(tokens)
         txt_features = txt_features.astype(np.float32)
         # Normalize each template's output, then average
         txt_features = _normalize(txt_features)

--- a/vireo/tests/test_classifier.py
+++ b/vireo/tests/test_classifier.py
@@ -446,6 +446,65 @@ class TestTreeOfLifeMode:
             assert isinstance(emb, np.ndarray)
 
 
+class TestTextEncoderBatchFallback:
+    """Tests for the per-row fallback when the text encoder's ONNX graph
+    rejects batched inputs (a known issue with bioclip-2.5-vith14 where an
+    internal Reshape node has a hardcoded batch=1 shape)."""
+
+    def _make_batch1_only_text_session(self, embedding_dim=512):
+        """Mock text session that raises for batch > 1, succeeds for batch == 1.
+
+        Simulates the bioclip-2.5-vith14 text_encoder.onnx behaviour where
+        the internal 'gemm_input_reshape' node fails whenever batch > 1.
+        """
+        session = MagicMock()
+        mock_input = MagicMock()
+        mock_input.name = "input_ids"
+        session.get_inputs.return_value = [mock_input]
+
+        def fake_run(output_names, input_dict):
+            tokens = list(input_dict.values())[0]
+            if tokens.shape[0] != 1:
+                raise RuntimeError(
+                    "Non-zero status code returned while running Reshape node. "
+                    "Name:'gemm_input_reshape' ... input_shape_size == size was false."
+                )
+            features = np.random.randn(1, embedding_dim).astype(np.float32)
+            norms = np.linalg.norm(features, axis=-1, keepdims=True)
+            return [features / norms]
+
+        session.run = fake_run
+        return session
+
+    def test_falls_back_to_per_row_when_batch_rejected(self, tmp_path):
+        """If the text encoder raises on batched inputs, embeddings are still
+        computed via per-row inference."""
+        from classifier import Classifier
+
+        _make_model_dir(tmp_path)
+        fake_image_session = _make_fake_image_session()
+        fake_text_session = self._make_batch1_only_text_session()
+        fake_tokenizer = _make_fake_tokenizer()
+
+        with (
+            patch("classifier._MODELS_ROOT", str(tmp_path)),
+            patch("classifier.CACHE_DIR", str(tmp_path / "cache")),
+            patch(
+                "classifier._MANIFEST_PATH",
+                str(tmp_path / "cache" / "manifest.json"),
+            ),
+            patch(
+                "classifier.onnx_runtime.create_session",
+                side_effect=[fake_image_session, fake_text_session],
+            ),
+            patch("classifier._load_tokenizer", return_value=fake_tokenizer),
+        ):
+            clf = Classifier(labels=["bird", "cat"], model_str="ViT-B-16")
+
+        assert clf._txt_embeddings.shape == (512, 2)
+        assert clf._txt_embeddings.dtype == np.float32
+
+
 class TestEmbeddingCache:
     """Tests for the embedding cache path utility."""
 


### PR DESCRIPTION
## Summary

- The `bioclip-2.5-vith14/text_encoder.onnx` was exported with an internal `gemm_input_reshape` node that hardcodes a single-prompt shape `{77, 1024}`. Any batch > 1 fails at runtime despite the input's declared batch dim being dynamic, so every custom-labels classify job has been silently skipping BioCLIP 2.5 and falling back to the secondary pipeline model (visible as `WARNING pipeline_job: Skipping model BioCLIP-2.5: ... Input shape:{77,80,1024}, requested shape:{77,1024}` in `~/.vireo/vireo.log`).
- `_compute_embeddings_with_progress` now calls the text encoder through `_make_text_runner`, which tries the batched call first and, on the first exception, logs a warning and switches to per-row inference for the rest of the session. This is a self-healing runtime workaround that preserves the fast path for correctly-exported models (bioclip-2, ViT-B-16) and works around the broken 2.5 export without needing to re-download weights.
- This is distinct from the earlier CoreML fix (#527) — that made the model load on CPU; this fixes a different failure at inference time.

## Test plan

- [x] New unit test `TestTextEncoderBatchFallback` uses a mock session that raises on batch > 1 (same error shape as the real ONNX error) and confirms embeddings are still produced with the correct shape.
- [x] End-to-end smoke test against the real `~/.vireo/models/bioclip-2.5-vith14/text_encoder.onnx`: batched call raises the known Reshape error, fallback produces `(5, 1024)` output.
- [x] Full suite passes: `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_classifier.py -v` — 452 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)