### PR TITLE
Auto-download MegaDetector weights on first pipeline run

### DIFF
--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -341,22 +341,32 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
     """
     total = len(photos)
 
+    # Resolve cached-detection state before running MegaDetector so we can skip
+    # the weight download entirely when every photo already has a detection row.
+    already_detected_ids = (
+        db.get_existing_detection_photo_ids() if not reclassify else set()
+    )
+
     if detect_animals is not None and get_primary_detection is not None:
-        from detector import ensure_megadetector_weights
+        needs_fresh_detection = reclassify or any(
+            p["id"] not in already_detected_ids for p in photos
+        )
+        if needs_fresh_detection:
+            from detector import ensure_megadetector_weights
 
-        def _dl_progress(phase, current, total_steps):
-            runner.push_event(
-                job["id"],
-                "progress",
-                {
-                    "current": current,
-                    "total": total_steps,
-                    "current_file": "",
-                    "phase": f"Step 4/5: {phase}",
-                },
-            )
+            def _dl_progress(phase, current, total_steps):
+                runner.push_event(
+                    job["id"],
+                    "progress",
+                    {
+                        "current": current,
+                        "total": total_steps,
+                        "current_file": "",
+                        "phase": f"Step 4/5: {phase}",
+                    },
+                )
 
-        ensure_megadetector_weights(progress_callback=_dl_progress)
+            ensure_megadetector_weights(progress_callback=_dl_progress)
 
     try:
         if detect_animals is None or get_primary_detection is None:
@@ -379,9 +389,6 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
         # Load config once for the entire detection loop
         import config as cfg
         det_conf_threshold = cfg.load().get("detector_confidence", 0.2)
-
-        # Get set of photo IDs that already have detections in the database
-        already_detected_ids = db.get_existing_detection_photo_ids() if not reclassify else set()
 
         # Process one photo at a time so we can report per-photo progress
         detection_map = {}

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -348,8 +348,12 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
     )
 
     if detect_animals is not None and get_primary_detection is not None:
-        needs_fresh_detection = reclassify or any(
-            p["id"] not in already_detected_ids for p in photos
+        # Require at least one photo — a no-op reclassify over 0 photos should
+        # not trigger a ~300 MB MegaDetector download.
+        needs_fresh_detection = bool(photos) and (
+            reclassify or any(
+                p["id"] not in already_detected_ids for p in photos
+            )
         )
         if needs_fresh_detection:
             from detector import ensure_megadetector_weights

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -341,6 +341,23 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
     """
     total = len(photos)
 
+    if detect_animals is not None and get_primary_detection is not None:
+        from detector import ensure_megadetector_weights
+
+        def _dl_progress(phase, current, total_steps):
+            runner.push_event(
+                job["id"],
+                "progress",
+                {
+                    "current": current,
+                    "total": total_steps,
+                    "current_file": "",
+                    "phase": f"Step 4/5: {phase}",
+                },
+            )
+
+        ensure_megadetector_weights(progress_callback=_dl_progress)
+
     try:
         if detect_animals is None or get_primary_detection is None:
             raise ImportError(

--- a/vireo/detector.py
+++ b/vireo/detector.py
@@ -13,6 +13,7 @@ log = logging.getLogger(__name__)
 
 _session = None
 _lock = threading.Lock()
+_download_lock = threading.Lock()
 
 # MegaDetector ONNX model path — downloaded to ~/.vireo/models/megadetector-v6/
 MEGADETECTOR_ONNX_DIR = os.path.expanduser("~/.vireo/models/megadetector-v6")
@@ -39,48 +40,64 @@ def ensure_megadetector_weights(progress_callback=None):
     if os.path.isfile(MEGADETECTOR_ONNX_PATH):
         return MEGADETECTOR_ONNX_PATH
 
-    os.makedirs(MEGADETECTOR_ONNX_DIR, exist_ok=True)
+    # Serialize concurrent first-run downloads. Without the lock, two parallel
+    # jobs would both start a ~300 MB download; without the atomic replace
+    # below, a second caller could also observe a half-copied file at the
+    # final path and try to load it as ONNX.
+    with _download_lock:
+        if os.path.isfile(MEGADETECTOR_ONNX_PATH):
+            return MEGADETECTOR_ONNX_PATH
 
-    if progress_callback:
-        progress_callback(
-            "Downloading MegaDetector V6 (~300 MB, first run only)...", 0, 1
-        )
-    log.info("MegaDetector weights missing — downloading from Hugging Face")
+        os.makedirs(MEGADETECTOR_ONNX_DIR, exist_ok=True)
 
-    try:
-        import shutil
+        if progress_callback:
+            progress_callback(
+                "Downloading MegaDetector V6 (~300 MB, first run only)...", 0, 1
+            )
+        log.info("MegaDetector weights missing — downloading from Hugging Face")
 
-        from huggingface_hub import hf_hub_download
-        from models import ONNX_REPO
+        tmp_path = MEGADETECTOR_ONNX_PATH + ".download"
+        try:
+            import shutil
 
-        cached_path = hf_hub_download(
-            repo_id=ONNX_REPO,
-            filename="model.onnx",
-            subfolder="megadetector-v6",
-        )
-        if cached_path != MEGADETECTOR_ONNX_PATH:
-            shutil.copy2(cached_path, MEGADETECTOR_ONNX_PATH)
-    except Exception as e:
-        raise RuntimeError(
-            f"Failed to download MegaDetector V6 weights: {e}. "
-            "Check your network connection and retry, or download manually "
-            "from the pipeline models page."
-        ) from e
+            from huggingface_hub import hf_hub_download
+            from models import ONNX_REPO
 
-    if not os.path.isfile(MEGADETECTOR_ONNX_PATH):
-        raise RuntimeError(
-            "MegaDetector download completed but weights file is missing at "
-            f"{MEGADETECTOR_ONNX_PATH}."
-        )
+            cached_path = hf_hub_download(
+                repo_id=ONNX_REPO,
+                filename="model.onnx",
+                subfolder="megadetector-v6",
+            )
+            # Copy to a sibling temp path then atomically replace so other
+            # threads only ever observe either the old (missing) state or a
+            # fully written weights file — never a partial copy.
+            shutil.copy2(cached_path, tmp_path)
+            os.replace(tmp_path, MEGADETECTOR_ONNX_PATH)
+        except Exception as e:
+            import contextlib
 
-    size_mb = round(os.path.getsize(MEGADETECTOR_ONNX_PATH) / 1024 / 1024, 1)
-    log.info("MegaDetector weights downloaded (%s MB)", size_mb)
-    if progress_callback:
-        progress_callback(
-            f"MegaDetector V6 ready ({size_mb} MB)", 1, 1
-        )
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+            raise RuntimeError(
+                f"Failed to download MegaDetector V6 weights: {e}. "
+                "Check your network connection and retry, or download manually "
+                "from the pipeline models page."
+            ) from e
 
-    return MEGADETECTOR_ONNX_PATH
+        if not os.path.isfile(MEGADETECTOR_ONNX_PATH):
+            raise RuntimeError(
+                "MegaDetector download completed but weights file is missing at "
+                f"{MEGADETECTOR_ONNX_PATH}."
+            )
+
+        size_mb = round(os.path.getsize(MEGADETECTOR_ONNX_PATH) / 1024 / 1024, 1)
+        log.info("MegaDetector weights downloaded (%s MB)", size_mb)
+        if progress_callback:
+            progress_callback(
+                f"MegaDetector V6 ready ({size_mb} MB)", 1, 1
+            )
+
+        return MEGADETECTOR_ONNX_PATH
 
 
 def _get_session():

--- a/vireo/detector.py
+++ b/vireo/detector.py
@@ -25,6 +25,64 @@ INPUT_SIZE = 640
 CLASS_NAMES = {0: "animal", 1: "person", 2: "vehicle"}
 
 
+def ensure_megadetector_weights(progress_callback=None):
+    """Ensure MegaDetector V6 ONNX weights are present on disk.
+
+    Returns the weights path if already downloaded. Otherwise downloads from
+    Hugging Face and copies into MEGADETECTOR_ONNX_DIR. Raises RuntimeError
+    on failure so callers can abort rather than silently run without detection.
+
+    Args:
+        progress_callback: optional callable(phase: str, current: int, total: int)
+            invoked before the download starts and after it completes.
+    """
+    if os.path.isfile(MEGADETECTOR_ONNX_PATH):
+        return MEGADETECTOR_ONNX_PATH
+
+    os.makedirs(MEGADETECTOR_ONNX_DIR, exist_ok=True)
+
+    if progress_callback:
+        progress_callback(
+            "Downloading MegaDetector V6 (~300 MB, first run only)...", 0, 1
+        )
+    log.info("MegaDetector weights missing — downloading from Hugging Face")
+
+    try:
+        import shutil
+
+        from huggingface_hub import hf_hub_download
+        from models import ONNX_REPO
+
+        cached_path = hf_hub_download(
+            repo_id=ONNX_REPO,
+            filename="model.onnx",
+            subfolder="megadetector-v6",
+        )
+        if cached_path != MEGADETECTOR_ONNX_PATH:
+            shutil.copy2(cached_path, MEGADETECTOR_ONNX_PATH)
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to download MegaDetector V6 weights: {e}. "
+            "Check your network connection and retry, or download manually "
+            "from the pipeline models page."
+        ) from e
+
+    if not os.path.isfile(MEGADETECTOR_ONNX_PATH):
+        raise RuntimeError(
+            "MegaDetector download completed but weights file is missing at "
+            f"{MEGADETECTOR_ONNX_PATH}."
+        )
+
+    size_mb = round(os.path.getsize(MEGADETECTOR_ONNX_PATH) / 1024 / 1024, 1)
+    log.info("MegaDetector weights downloaded (%s MB)", size_mb)
+    if progress_callback:
+        progress_callback(
+            f"MegaDetector V6 ready ({size_mb} MB)", 1, 1
+        )
+
+    return MEGADETECTOR_ONNX_PATH
+
+
 def _get_session():
     """Load MegaDetector ONNX session (cached singleton).
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -963,20 +963,25 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
             from datetime import datetime as dt
 
-            # Ensure MegaDetector weights are on disk before any detection runs.
-            # Failure here aborts the stage rather than falling back to full-image
-            # classification, which produces unusable triage results downstream.
-            from detector import ensure_megadetector_weights
+            # Ensure MegaDetector weights are on disk before any fresh detection
+            # runs. Skip when every photo already has cached detections and we're
+            # not reclassifying — _detect_batch will reuse DB rows and never call
+            # MegaDetector, so an offline rerun should not abort on missing weights.
+            needs_fresh_detection = params.reclassify or any(
+                p["id"] not in already_detected for p in photos
+            )
+            if needs_fresh_detection:
+                from detector import ensure_megadetector_weights
 
-            def _dl_progress(phase, current, total_steps):
-                runner.push_event(job["id"], "progress", {
-                    "phase": phase,
-                    "stage_id": "classify",
-                    "current": current, "total": total_steps,
-                    "stages": {k: dict(v) for k, v in stages.items()},
-                })
+                def _dl_progress(phase, current, total_steps):
+                    runner.push_event(job["id"], "progress", {
+                        "phase": phase,
+                        "stage_id": "classify",
+                        "current": current, "total": total_steps,
+                        "stages": {k: dict(v) for k, v in stages.items()},
+                    })
 
-            ensure_megadetector_weights(progress_callback=_dl_progress)
+                ensure_megadetector_weights(progress_callback=_dl_progress)
 
             for spec_idx, active_spec in enumerate(resolved_specs):
                 if _should_abort(abort):

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -963,6 +963,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
             from datetime import datetime as dt
 
+            # Ensure MegaDetector weights are on disk before any detection runs.
+            # Failure here aborts the stage rather than falling back to full-image
+            # classification, which produces unusable triage results downstream.
+            from detector import ensure_megadetector_weights
+
+            def _dl_progress(phase, current, total_steps):
+                runner.push_event(job["id"], "progress", {
+                    "phase": phase,
+                    "stage_id": "classify",
+                    "current": current, "total": total_steps,
+                    "stages": {k: dict(v) for k, v in stages.items()},
+                })
+
+            ensure_megadetector_weights(progress_callback=_dl_progress)
+
             for spec_idx, active_spec in enumerate(resolved_specs):
                 if _should_abort(abort):
                     break

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -967,8 +967,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             # runs. Skip when every photo already has cached detections and we're
             # not reclassifying — _detect_batch will reuse DB rows and never call
             # MegaDetector, so an offline rerun should not abort on missing weights.
-            needs_fresh_detection = params.reclassify or any(
-                p["id"] not in already_detected for p in photos
+            # Also skip for empty photo sets — a no-op reclassify over 0 photos
+            # should not trigger a ~300 MB download.
+            needs_fresh_detection = bool(photos) and (
+                params.reclassify or any(
+                    p["id"] not in already_detected for p in photos
+                )
             )
             if needs_fresh_detection:
                 from detector import ensure_megadetector_weights

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -284,6 +284,32 @@ def test_detect_subjects_skips_weight_download_when_all_cached(tmp_path):
     mock_ensure.assert_not_called()
 
 
+def test_detect_subjects_skips_weight_download_for_empty_reclassify(tmp_path):
+    """An empty photo list with reclassify=True should not trigger the
+    MegaDetector download. No photos = no detection pass, so the
+    ~300 MB fetch would be pure waste and would also make offline no-op
+    reclassifies fatally dependent on the network.
+
+    Regression for Codex P2 review on #535."""
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _detect_subjects
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    mock_db = MagicMock()
+    mock_db.get_existing_detection_photo_ids.return_value = set()
+
+    with patch("detector.ensure_megadetector_weights") as mock_ensure:
+        _detect_subjects(
+            photos=[], folders={}, runner=runner, job=job,
+            reclassify=True, db=mock_db,
+        )
+
+    mock_ensure.assert_not_called()
+
+
 def test_detect_subjects_graceful_on_import_error():
     """Phase 5: returns empty map if PytorchWildlife not installed."""
     from unittest.mock import MagicMock

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -254,6 +254,36 @@ def test_detect_subjects_skips_existing_detections(tmp_path):
     assert detection_map[1][0]["id"] == 101
 
 
+def test_detect_subjects_skips_weight_download_when_all_cached(tmp_path):
+    """When every photo is already detected and reclassify=False, no fresh
+    MegaDetector pass runs, so the auto-download should be skipped entirely.
+    Prevents offline reruns from aborting on missing weights."""
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _detect_subjects
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    photos = [{"id": 1, "filename": "bird.jpg", "folder_id": 10}]
+    folders = {10: str(tmp_path)}
+
+    mock_db = MagicMock()
+    mock_db.get_existing_detection_photo_ids.return_value = {1}
+    mock_db.get_detections.return_value = [
+        {"id": 101, "box_x": 0.1, "box_y": 0.1, "box_w": 0.5, "box_h": 0.5,
+         "detector_confidence": 0.9, "category": "animal"},
+    ]
+
+    with patch("detector.ensure_megadetector_weights") as mock_ensure:
+        _detect_subjects(
+            photos=photos, folders=folders, runner=runner, job=job,
+            reclassify=False, db=mock_db,
+        )
+
+    mock_ensure.assert_not_called()
+
+
 def test_detect_subjects_graceful_on_import_error():
     """Phase 5: returns empty map if PytorchWildlife not installed."""
     from unittest.mock import MagicMock

--- a/vireo/tests/test_detector.py
+++ b/vireo/tests/test_detector.py
@@ -208,6 +208,103 @@ def test_get_primary_detection_no_animals():
     assert get_primary_detection([]) is None
 
 
+def test_ensure_weights_noop_when_present(tmp_path, monkeypatch):
+    """ensure_megadetector_weights() returns path without downloading when file exists."""
+    import detector
+
+    fake_path = tmp_path / "model.onnx"
+    fake_path.write_bytes(b"x" * 1024)
+
+    monkeypatch.setattr(detector, "MEGADETECTOR_ONNX_DIR", str(tmp_path))
+    monkeypatch.setattr(detector, "MEGADETECTOR_ONNX_PATH", str(fake_path))
+
+    download_calls = []
+
+    def fake_hf_hub_download(**kwargs):
+        download_calls.append(kwargs)
+        return str(fake_path)
+
+    import sys
+    import types
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = fake_hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    progress_calls = []
+    result = detector.ensure_megadetector_weights(
+        progress_callback=lambda p, c, t: progress_calls.append((p, c, t)),
+    )
+
+    assert result == str(fake_path)
+    assert download_calls == []
+    assert progress_calls == []
+
+
+def test_ensure_weights_downloads_when_missing(tmp_path, monkeypatch):
+    """ensure_megadetector_weights() downloads and copies file when missing; invokes progress callback."""
+    import detector
+
+    dest_dir = tmp_path / "megadetector-v6"
+    dest_path = dest_dir / "model.onnx"
+    monkeypatch.setattr(detector, "MEGADETECTOR_ONNX_DIR", str(dest_dir))
+    monkeypatch.setattr(detector, "MEGADETECTOR_ONNX_PATH", str(dest_path))
+
+    # Simulate HF cache returning a file at a different path (which forces a copy).
+    cache_path = tmp_path / "hf-cache" / "model.onnx"
+    cache_path.parent.mkdir()
+    cache_path.write_bytes(b"m" * 2048)
+
+    def fake_hf_hub_download(**kwargs):
+        assert kwargs["filename"] == "model.onnx"
+        assert kwargs["subfolder"] == "megadetector-v6"
+        return str(cache_path)
+
+    import sys
+    import types
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = fake_hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    progress_calls = []
+    result = detector.ensure_megadetector_weights(
+        progress_callback=lambda p, c, t: progress_calls.append((p, c, t)),
+    )
+
+    assert result == str(dest_path)
+    assert dest_path.is_file()
+    assert dest_path.read_bytes() == b"m" * 2048
+    assert len(progress_calls) >= 2
+    assert progress_calls[0][1] == 0 and progress_calls[0][2] == 1
+    assert progress_calls[-1][1] == 1 and progress_calls[-1][2] == 1
+
+
+def test_ensure_weights_raises_on_download_failure(tmp_path, monkeypatch):
+    """ensure_megadetector_weights() raises RuntimeError with remediation hint when download fails."""
+    import detector
+
+    dest_dir = tmp_path / "megadetector-v6"
+    dest_path = dest_dir / "model.onnx"
+    monkeypatch.setattr(detector, "MEGADETECTOR_ONNX_DIR", str(dest_dir))
+    monkeypatch.setattr(detector, "MEGADETECTOR_ONNX_PATH", str(dest_path))
+
+    def fake_hf_hub_download(**kwargs):
+        raise ConnectionError("network unreachable")
+
+    import sys
+    import types
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = fake_hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    with pytest.raises(RuntimeError, match="Failed to download MegaDetector"):
+        detector.ensure_megadetector_weights()
+
+    assert not dest_path.exists()
+
+
 def test_megadetector_onnx_model_file_valid():
     """Verify MegaDetector ONNX model file exists and is valid."""
     try:

--- a/vireo/tests/test_detector.py
+++ b/vireo/tests/test_detector.py
@@ -305,6 +305,70 @@ def test_ensure_weights_raises_on_download_failure(tmp_path, monkeypatch):
     assert not dest_path.exists()
 
 
+def test_ensure_weights_atomic_and_serialized(tmp_path, monkeypatch):
+    """Concurrent callers download once and never observe a partial file
+    at the final path. Guards against the copy/copy race Codex flagged."""
+    import threading
+
+    import detector
+
+    dest_dir = tmp_path / "megadetector-v6"
+    dest_path = dest_dir / "model.onnx"
+    monkeypatch.setattr(detector, "MEGADETECTOR_ONNX_DIR", str(dest_dir))
+    monkeypatch.setattr(detector, "MEGADETECTOR_ONNX_PATH", str(dest_path))
+
+    cache_path = tmp_path / "hf-cache" / "model.onnx"
+    cache_path.parent.mkdir()
+    cache_path.write_bytes(b"m" * 4096)
+
+    call_count = 0
+    observed_partial = False
+    download_started = threading.Event()
+
+    def fake_hf_hub_download(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        # Release the second thread so it can race the in-progress download.
+        download_started.set()
+        return str(cache_path)
+
+    import sys
+    import types
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = fake_hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    def run():
+        detector.ensure_megadetector_weights()
+
+    def observer():
+        # Wait until thread-A is inside the download block, then repeatedly
+        # probe the final path. With atomic replace + lock it must either
+        # not exist, or be the full 4096 bytes — never anything in between.
+        nonlocal observed_partial
+        download_started.wait(timeout=2.0)
+        for _ in range(100):
+            if dest_path.is_file():
+                size = dest_path.stat().st_size
+                if 0 < size < 4096:
+                    observed_partial = True
+                    return
+
+    t1 = threading.Thread(target=run)
+    t2 = threading.Thread(target=observer)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    # Second caller enters after t1 finished, so exactly one real download occurred.
+    detector.ensure_megadetector_weights()
+    assert call_count == 1
+    assert dest_path.stat().st_size == 4096
+    assert not observed_partial
+
+
 def test_megadetector_onnx_model_file_valid():
     """Verify MegaDetector ONNX model file exists and is valid."""
     try:


### PR DESCRIPTION
## Summary

- Running classify/pipeline without MegaDetector weights silently fell back to full-image classification, wrote zero detections, and then extract-masks rejected every photo with \`no_subject_mask\`. Users had to spot the warning, download manually from the models page, and rerun (with potentially-misclassified species IDs already stored).
- New \`detector.ensure_megadetector_weights(progress_callback)\` downloads the V6 ONNX file (~300 MB) from Hugging Face on first run, with progress surfacing through the job's normal progress events.
- Called from \`classify_job._detect_subjects\` and \`pipeline_job\`'s classify stage before any detection happens. Download failure raises \`RuntimeError\` and aborts the job rather than falling back to degraded classification — keeps the pipeline from producing all-REJECT triage results when detection can't run.

## Behavior after this change

- First pipeline run: job shows \"Step 4/5: Downloading MegaDetector V6 (~300 MB, first run only)...\", then proceeds normally.
- Subsequent runs: \`ensure_megadetector_weights\` is a fast file-existence check and returns immediately.
- No network / HF outage: job aborts with a clear error pointing at the pipeline models page as manual fallback.

## Test plan

- [x] \`python -m pytest vireo/tests/test_detector.py\` — 10 passed (3 new)
- [x] \`python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py\` — 331 passed
- [x] \`python -m pytest vireo/tests/test_app.py\` — 101 passed
- [ ] Manual: delete \`~/.vireo/models/megadetector-v6/model.onnx\`, run a pipeline, confirm download progress appears and pipeline proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)