### PR TITLE
fix: use certifi CA bundle in model_verify HF API calls

### DIFF
--- a/vireo/model_verify.py
+++ b/vireo/model_verify.py
@@ -11,9 +11,12 @@ import hashlib
 import json
 import logging
 import os
+import ssl
 import time
 import urllib.request
 from dataclasses import dataclass, field
+
+import certifi
 
 log = logging.getLogger(__name__)
 
@@ -21,6 +24,9 @@ ONNX_REPO = "jss367/vireo-onnx-models"
 _TREE_API = "https://huggingface.co/api/models/{repo}/tree/{revision}/{subdir}"
 _MODEL_INFO_API = "https://huggingface.co/api/models/{repo}"
 _FETCH_TIMEOUT = 30  # seconds
+
+# Use certifi's CA bundle so HTTPS works on macOS without Install Certificates.command
+_ssl_ctx = ssl.create_default_context(cafile=certifi.where())
 
 # Filename (inside each model directory) that pins the HF commit SHA the
 # model was downloaded from. Read by verify_if_needed so that upstream
@@ -97,7 +103,9 @@ def fetch_latest_revision(repo_id: str) -> str:
     """
     url = _MODEL_INFO_API.format(repo=repo_id)
     try:
-        with urllib.request.urlopen(url, timeout=_FETCH_TIMEOUT) as resp:
+        with urllib.request.urlopen(
+            url, timeout=_FETCH_TIMEOUT, context=_ssl_ctx
+        ) as resp:
             payload = json.loads(resp.read())
     except Exception as e:
         raise VerifyError(
@@ -132,7 +140,9 @@ def fetch_expected_hashes(
         repo=ONNX_REPO, revision=revision, subdir=hf_subdir
     )
     try:
-        with urllib.request.urlopen(url, timeout=_FETCH_TIMEOUT) as resp:
+        with urllib.request.urlopen(
+            url, timeout=_FETCH_TIMEOUT, context=_ssl_ctx
+        ) as resp:
             payload = json.loads(resp.read())
     except Exception as e:
         raise VerifyError(

--- a/vireo/tests/test_model_verify.py
+++ b/vireo/tests/test_model_verify.py
@@ -95,7 +95,7 @@ def test_fetch_expected_hashes_returns_lfs_files_only(monkeypatch):
 
     captured_url = {}
 
-    def fake_urlopen(url, timeout=None):
+    def fake_urlopen(url, timeout=None, context=None):
         captured_url["url"] = url
         return _FakeResponse(_CANNED_TREE)
 
@@ -120,7 +120,7 @@ def test_fetch_expected_hashes_raises_verify_error_on_network_failure(monkeypatc
     exception type to handle rather than urllib/http internals."""
     import model_verify
 
-    def fake_urlopen(url, timeout=None):
+    def fake_urlopen(url, timeout=None, context=None):
         raise OSError("connection refused")
 
     monkeypatch.setattr(model_verify.urllib.request, "urlopen", fake_urlopen)
@@ -138,7 +138,7 @@ def test_fetch_expected_hashes_uses_pinned_revision(monkeypatch):
 
     captured_url = {}
 
-    def fake_urlopen(url, timeout=None):
+    def fake_urlopen(url, timeout=None, context=None):
         captured_url["url"] = url
         return _FakeResponse(_CANNED_TREE)
 
@@ -157,7 +157,7 @@ def test_fetch_latest_revision_returns_sha(monkeypatch):
     the HF model-info API. Used by download_model to pin new downloads."""
     import model_verify
 
-    def fake_urlopen(url, timeout=None):
+    def fake_urlopen(url, timeout=None, context=None):
         # HF /api/models/{repo} returns a dict with a `sha` field that is
         # the latest commit on main.
         return _FakeResponse(
@@ -177,7 +177,7 @@ def test_fetch_latest_revision_network_error_raises_verify_error(monkeypatch):
     """Same error wrapping contract as fetch_expected_hashes."""
     import model_verify
 
-    def fake_urlopen(url, timeout=None):
+    def fake_urlopen(url, timeout=None, context=None):
         raise OSError("dns failure")
 
     monkeypatch.setattr(model_verify.urllib.request, "urlopen", fake_urlopen)


### PR DESCRIPTION
## Summary

- `model_verify.fetch_latest_revision` and `fetch_expected_hashes` called `urllib.request.urlopen` without an SSL context, so on macOS (packaged app / Python without `Install Certificates.command`) the TLS handshake to `huggingface.co/api` fails with `CERTIFICATE_VERIFY_FAILED`.
- The file downloads themselves succeeded (httpx bundles certifi), so a model would "finish" in seconds, but the post-download SHA256 verification was silently skipped, and clicking **Verify all models** then reported the model as broken.
- Mirror the certifi-backed SSL context already used in `vireo/taxonomy.py` (commit 6189e32) so both `urllib` callers use the same CA bundle.

## Symptoms observed in `~/.vireo/vireo.log`
```
models: Download complete: .../timm-inat21-eva02-l/model.onnx
models: Download complete: .../timm-inat21-eva02-l/model.onnx.data
...
WARNING models: Could not fetch latest revision for jss367/vireo-onnx-models:
  <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED]>
WARNING models: Could not fetch expected hashes for timm-eva02-large-inat21@main:
  <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED]>
  Proceeding without post-download verification.
```

## Test plan
- [x] `python -m pytest vireo/tests/test_model_verify.py` — 28 passed
- [x] Full batch from CLAUDE.md — 460 passed, 1 unrelated flake (`test_pipeline_auto_skips_classify_when_no_model`) that also fails on `main` when `test_model_verify.py` runs before it; pre-existing test-ordering pollution, not caused by this change.
- [ ] Manual: delete and re-download a model from Settings → Models, then click Verify all models — should verify cleanly without SSL warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)