### PR TITLE
feat: surface skipped model verification instead of silent fallback

### DIFF
--- a/vireo/model_verify.py
+++ b/vireo/model_verify.py
@@ -358,6 +358,12 @@ def _verify_unpinned(model_id: str, model_dir: str, hf_subdir: str) -> None:
         )
         # Cache as checked so we don't re-warn on every pipeline start.
         _verified_this_process.add(model_id)
+        # Clear any stale .verify_skipped: the hash fetch succeeded this
+        # time, so the old "couldn't reach HF" reason no longer reflects
+        # reality. Without this, a previously-unverified model keeps
+        # showing the outdated network-error badge via get_models() even
+        # though lazy verification actually ran.
+        clear_verify_skipped(model_dir)
 
 
 def clear_verified_cache(model_id: str) -> None:

--- a/vireo/model_verify.py
+++ b/vireo/model_verify.py
@@ -435,8 +435,15 @@ def verify_all_models(progress_callback=None) -> dict[str, VerifyResult]:
                 clear_verify_skipped(weights_path)
             else:
                 # Mismatch is ambiguous for unpinned installs — don't
-                # write sentinel, just report to the caller.
+                # write .verify_failed, just report to the caller. But
+                # do clear any stale .verify_skipped: the hash fetch
+                # succeeded this round, so the old "couldn't reach HF"
+                # reason no longer reflects reality. Without this, a
+                # previously-unverified model stays stuck with an
+                # outdated network-error badge and makes Retry look
+                # ineffective even though verification actually ran.
                 _verified_this_process.discard(model_id)
+                clear_verify_skipped(weights_path)
             continue
 
         # --- Pinned install: hard-fail on mismatch ---

--- a/vireo/model_verify.py
+++ b/vireo/model_verify.py
@@ -30,6 +30,49 @@ REVISION_FILE = ".hf_revision"
 
 VERIFY_FAILED_SENTINEL = ".verify_failed"
 
+# Written into a model directory when SHA256 verification could not be run
+# (HuggingFace metadata API unreachable, e.g. TLS / proxy / transient
+# outage). The file contents are the underlying reason string, surfaced in
+# the Settings → Models UI so the skipped-verification state is not silent.
+#
+# Distinct from VERIFY_FAILED_SENTINEL: that one means a file's hash did
+# not match (unambiguous corruption). VERIFY_SKIPPED means the hashes
+# could not be fetched at all — files on disk are probably fine, but
+# could not be cryptographically confirmed.
+VERIFY_SKIPPED_SENTINEL = ".verify_skipped"
+
+
+def write_verify_skipped(model_dir: str, reason: str) -> None:
+    """Write VERIFY_SKIPPED_SENTINEL with the given reason.
+
+    Silently ignores OSError so the outer flow (download/verify) is never
+    blocked by a filesystem hiccup — the worst case is that the Settings
+    UI doesn't show the skipped-verification banner.
+    """
+    try:
+        with open(os.path.join(model_dir, VERIFY_SKIPPED_SENTINEL), "w") as f:
+            f.write(reason)
+    except OSError:
+        pass
+
+
+def clear_verify_skipped(model_dir: str) -> None:
+    """Delete VERIFY_SKIPPED_SENTINEL if present."""
+    path = os.path.join(model_dir, VERIFY_SKIPPED_SENTINEL)
+    if os.path.isfile(path):
+        with contextlib.suppress(OSError):
+            os.unlink(path)
+
+
+def read_verify_skipped_reason(model_dir: str) -> str | None:
+    """Return the reason string from VERIFY_SKIPPED_SENTINEL, or None."""
+    path = os.path.join(model_dir, VERIFY_SKIPPED_SENTINEL)
+    try:
+        with open(path) as f:
+            return f.read().strip() or None
+    except OSError:
+        return None
+
 
 class VerifyError(Exception):
     """Raised when verification can't be performed (network / HTTP error)
@@ -254,8 +297,9 @@ def verify_if_needed(model_id: str, model_dir: str, hf_subdir: str) -> None:
     # --- Pinned install: hard-fail on mismatch ---
     try:
         result = verify_model(model_dir, hf_subdir)
-    except VerifyError:
+    except VerifyError as e:
         _verify_error_cache[model_id] = time.monotonic()
+        write_verify_skipped(model_dir, str(e))
         return
 
     if not result.ok:
@@ -271,6 +315,7 @@ def verify_if_needed(model_id: str, model_dir: str, hf_subdir: str) -> None:
     if os.path.isfile(sentinel):
         with contextlib.suppress(OSError):
             os.unlink(sentinel)
+    clear_verify_skipped(model_dir)
 
 
 def _verify_unpinned(model_id: str, model_dir: str, hf_subdir: str) -> None:
@@ -283,14 +328,16 @@ def _verify_unpinned(model_id: str, model_dir: str, hf_subdir: str) -> None:
     """
     try:
         latest_rev = fetch_latest_revision(ONNX_REPO)
-    except VerifyError:
+    except VerifyError as e:
         _verify_error_cache[model_id] = time.monotonic()
+        write_verify_skipped(model_dir, str(e))
         return
 
     try:
         result = verify_model(model_dir, hf_subdir, revision=latest_rev)
-    except VerifyError:
+    except VerifyError as e:
         _verify_error_cache[model_id] = time.monotonic()
+        write_verify_skipped(model_dir, str(e))
         return
 
     if result.ok:
@@ -301,6 +348,7 @@ def _verify_unpinned(model_id: str, model_dir: str, hf_subdir: str) -> None:
         if os.path.isfile(sentinel):
             with contextlib.suppress(OSError):
                 os.unlink(sentinel)
+        clear_verify_skipped(model_dir)
     else:
         log.warning(
             "Model %s (no revision pin) does not match current main: "
@@ -365,6 +413,7 @@ def verify_all_models(progress_callback=None) -> dict[str, VerifyResult]:
             try:
                 latest_rev = fetch_latest_revision(ONNX_REPO)
             except VerifyError as e:
+                write_verify_skipped(weights_path, str(e))
                 results[model_id] = VerifyResult(
                     ok=False, missing=[f"<hash fetch failed: {e}>"]
                 )
@@ -374,6 +423,7 @@ def verify_all_models(progress_callback=None) -> dict[str, VerifyResult]:
                     weights_path, m["hf_subdir"], revision=latest_rev
                 )
             except VerifyError as e:
+                write_verify_skipped(weights_path, str(e))
                 results[model_id] = VerifyResult(
                     ok=False, missing=[f"<hash fetch failed: {e}>"]
                 )
@@ -382,6 +432,7 @@ def verify_all_models(progress_callback=None) -> dict[str, VerifyResult]:
             if result.ok:
                 write_pinned_revision(weights_path, latest_rev)
                 _verified_this_process.add(model_id)
+                clear_verify_skipped(weights_path)
             else:
                 # Mismatch is ambiguous for unpinned installs — don't
                 # write sentinel, just report to the caller.
@@ -392,6 +443,7 @@ def verify_all_models(progress_callback=None) -> dict[str, VerifyResult]:
         try:
             result = verify_model(weights_path, m["hf_subdir"])
         except VerifyError as e:
+            write_verify_skipped(weights_path, str(e))
             results[model_id] = VerifyResult(
                 ok=False, missing=[f"<hash fetch failed: {e}>"]
             )
@@ -409,4 +461,5 @@ def verify_all_models(progress_callback=None) -> dict[str, VerifyResult]:
             _verified_this_process.discard(model_id)
         else:
             _verified_this_process.add(model_id)
+            clear_verify_skipped(weights_path)
     return results

--- a/vireo/model_verify.py
+++ b/vireo/model_verify.py
@@ -396,7 +396,7 @@ def verify_all_models(progress_callback=None) -> dict[str, VerifyResult]:
             continue
         if not m.get("hf_subdir"):
             continue
-        if m.get("state") != "ok":
+        if m.get("state") not in ("ok", "unverified"):
             continue
         model_id = m["id"]
         weights_path = m.get("weights_path")

--- a/vireo/models.py
+++ b/vireo/models.py
@@ -133,14 +133,20 @@ def _check_onnx_downloaded(model_dir, files):
 
 
 def _classify_model_state(model_dir, files):
-    """Return 'ok', 'missing', or 'incomplete' for a model directory.
+    """Return 'ok', 'missing', 'incomplete', or 'unverified' for a model dir.
 
     - 'missing':    directory doesn't exist, or no required file is present.
     - 'incomplete': directory exists with some but not all required files,
                     OR model_verify has written a .verify_failed sentinel
                     into the directory (hash mismatch detected at load
                     time or by manual Verify-all).
-    - 'ok':         all files present and no verify-failed sentinel.
+    - 'unverified': all files present, but SHA256 verification could not be
+                    run (HuggingFace metadata API unreachable at download
+                    or verify time). Indicated by .verify_skipped sentinel.
+                    Files are probably fine — they just couldn't be
+                    cryptographically confirmed.
+    - 'ok':         all files present and verification passed (or has never
+                    been attempted because this is an unpinned legacy install).
     """
     if not os.path.isdir(model_dir):
         return "missing"
@@ -157,6 +163,11 @@ def _classify_model_state(model_dir, files):
         return "missing"
     if len(present) < len(files):
         return "incomplete"
+
+    if os.path.isfile(
+        os.path.join(model_dir, model_verify.VERIFY_SKIPPED_SENTINEL)
+    ):
+        return "unverified"
 
     return "ok"
 
@@ -187,11 +198,15 @@ def get_models():
             reg_path = registered[km["id"]].get("weights_path", "")
             if reg_path and reg_path != model_dir:
                 reg_state = _classify_model_state(reg_path, files)
-                if reg_state == "ok":
+                if reg_state in ("ok", "unverified"):
                     model_dir = reg_path
-                    state = "ok"
+                    state = reg_state
 
-        downloaded = state == "ok"
+        # "unverified" means all files are present — the model is usable,
+        # just not cryptographically confirmed. Treat as downloaded so the
+        # pipeline and "Use This" action still work, and surface the
+        # reason so Settings can render the caveat.
+        downloaded = state in ("ok", "unverified")
         entry = {
             **km,
             "downloaded": downloaded,
@@ -199,6 +214,10 @@ def get_models():
             "weights_path": model_dir if downloaded else None,
             "model_type": km.get("model_type", "bioclip"),
         }
+        if state == "unverified":
+            entry["verify_skipped_reason"] = (
+                model_verify.read_verify_skipped_reason(model_dir)
+            )
         result.append(entry)
 
     # Add custom models
@@ -461,6 +480,7 @@ def download_model(model_id, progress_callback=None):
     pinned_revision: str | None = None
     verification_ran = False
     expected_hashes: dict[str, str] = {}
+    skipped_reason: str | None = None
 
     try:
         pinned_revision = model_verify.fetch_latest_revision(ONNX_REPO)
@@ -486,6 +506,9 @@ def download_model(model_id, progress_callback=None):
             "Proceeding without post-download verification.",
             hf_subdir, revision_for_hashes, e,
         )
+        # Remember the reason so Settings → Models can surface "Unverified"
+        # with the underlying cause instead of the failure being invisible.
+        skipped_reason = str(e)
 
     for fi, filename in enumerate(files):
         if progress_callback:
@@ -519,6 +542,9 @@ def download_model(model_id, progress_callback=None):
         if os.path.isfile(sentinel_path):
             with contextlib.suppress(OSError):
                 os.unlink(sentinel_path)
+        # Successful verification also clears any stale .verify_skipped from
+        # a prior download where the HF API was temporarily unreachable.
+        model_verify.clear_verify_skipped(model_dir)
         if pinned_revision is not None:
             model_verify.write_pinned_revision(model_dir, pinned_revision)
         else:
@@ -552,6 +578,12 @@ def download_model(model_id, progress_callback=None):
             with contextlib.suppress(OSError):
                 os.unlink(rev_path)
 
+        # Record the skipped-verification state so Settings → Models can
+        # show "Unverified — could not reach HuggingFace" with the cause,
+        # rather than pretending the download fully succeeded.
+        if skipped_reason:
+            model_verify.write_verify_skipped(model_dir, skipped_reason)
+
         # SHA256 verification was unavailable (HF tree API unreachable).
         # Apply a minimal size floor to weight sidecar files so that a
         # truncated or stub download is surfaced immediately rather than
@@ -581,7 +613,11 @@ def download_model(model_id, progress_callback=None):
                 )
 
     state = _classify_model_state(model_dir, files)
-    if state != "ok":
+    # "unverified" is an acceptable post-download state: every required file
+    # is present, only the cryptographic check was skipped because the HF
+    # metadata API wasn't reachable. The .verify_skipped sentinel makes
+    # that visible in Settings and doesn't block the user.
+    if state not in ("ok", "unverified"):
         raise RuntimeError(
             f"Downloaded {km['name']} failed post-download validation "
             f"({state}). Some files may be missing in {model_dir}."

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -654,10 +654,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         # ONNXRuntime. A stale _check_onnx_downloaded result (e.g. after
         # the user deleted a .onnx.data file, or the download manifest
         # changed) would otherwise surface as an opaque ONNXRuntime crash.
+        # "unverified" is accepted here: all files are present, only the
+        # SHA256 cross-check with HuggingFace was skipped (transient network
+        # issue). The lazy verify_if_needed call below will retry the hash
+        # check, and get_models() already treats these as downloaded, so
+        # rejecting them here turns a warning into a hard pipeline failure.
         files = active_model.get("files", [])
         if files and weights_path:
             state = _classify_model_state(weights_path, files)
-            if state != "ok":
+            if state not in ("ok", "unverified"):
                 raise RuntimeError(
                     _incomplete_model_message(model_name, model_is_custom)
                 )

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1600,6 +1600,8 @@ async function loadModels() {
         statusColor = 'var(--accent)'; statusText = 'Downloaded';
       } else if (state === 'incomplete') {
         statusColor = 'var(--warning)'; statusText = 'Incomplete — repair available';
+      } else if (state === 'unverified') {
+        statusColor = 'var(--warning)'; statusText = 'Unverified — could not reach HuggingFace';
       } else {
         statusColor = 'var(--text-faint)'; statusText = 'Not downloaded';
       }
@@ -1616,21 +1618,26 @@ async function loadModels() {
       html += '<div style="font-size:12px;color:var(--text-dim);margin-bottom:6px;">' + escapeHtml(m.description || '') + '</div>';
       if (state === 'incomplete') {
         html += '<div style="font-size:11px;color:var(--warning);margin-bottom:6px;">Model files are missing or truncated. Click Repair to finish the download — already-downloaded files will not be re-fetched.</div>';
+      } else if (state === 'unverified') {
+        var reason = m.verify_skipped_reason ? ' (' + escapeHtml(m.verify_skipped_reason) + ')' : '';
+        html += '<div style="font-size:11px;color:var(--warning);margin-bottom:6px;">Files are present but SHA256 could not be checked against HuggingFace' + reason + '. The model should work; click Retry verification once the network is reachable.</div>';
       }
       html += '<div style="display:flex;align-items:center;gap:8px;">';
       html += '<span style="font-size:11px;color:' + statusColor + ';">' + statusText + '</span>';
 
-      if (state === 'ok' && m.weights_path) {
+      if ((state === 'ok' || state === 'unverified') && m.weights_path) {
         html += '<span style="font-size:11px;color:var(--text-invisible);">' + escapeHtml(m.weights_path) + '</span>';
       }
 
       html += '<span style="margin-left:auto;display:flex;gap:6px;">';
       if (state === 'incomplete' && m.source !== 'custom') {
         html += '<button onclick="downloadModel(\'' + m.id + '\')" style="background:var(--warning);color:var(--accent-text);border:none;border-radius:4px;padding:4px 12px;font-size:11px;cursor:pointer;font-weight:600;">Repair</button>';
+      } else if (state === 'unverified' && m.source !== 'custom') {
+        html += '<button onclick="verifyAllModels()" style="background:var(--warning);color:var(--accent-text);border:none;border-radius:4px;padding:4px 12px;font-size:11px;cursor:pointer;font-weight:600;">Retry verification</button>';
       } else if (state === 'missing' && m.source !== 'custom') {
         html += '<button onclick="downloadModel(\'' + m.id + '\')" style="background:var(--accent);color:var(--accent-text);border:none;border-radius:4px;padding:4px 12px;font-size:11px;cursor:pointer;">Download</button>';
       }
-      if (!isActive && state === 'ok') {
+      if (!isActive && (state === 'ok' || state === 'unverified')) {
         html += '<button onclick="setActiveModel(\'' + m.id + '\')" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:4px;padding:4px 12px;font-size:11px;cursor:pointer;">Use This</button>';
       }
       if (state !== 'missing') {

--- a/vireo/tests/test_model_verify.py
+++ b/vireo/tests/test_model_verify.py
@@ -705,6 +705,53 @@ def test_verify_all_models_no_sentinel_on_unpinned_mismatch(tmp_path, monkeypatc
     assert not (bad_dir / model_verify.REVISION_FILE).exists()
 
 
+def test_verify_all_models_unpinned_mismatch_clears_stale_verify_skipped(
+    tmp_path, monkeypatch
+):
+    """An unpinned install that was previously marked 'unverified' (transient
+    HF outage wrote .verify_skipped) must have the stale sentinel cleared
+    once a retry actually reaches HuggingFace, even if the retry returns a
+    mismatch. Otherwise get_models() keeps showing the old network-error
+    badge and the 'Retry verification' button looks ineffective."""
+    import model_verify
+
+    bad_dir = tmp_path / "bad-model"
+    bad_dir.mkdir()
+    # Simulate the previous outage: .verify_skipped sentinel is on disk.
+    (bad_dir / model_verify.VERIFY_SKIPPED_SENTINEL).write_text(
+        "Could not reach HuggingFace (prior outage)"
+    )
+    # Previously unverified state is what get_models() would now return.
+    fake_models = [{
+        "id": "bad-model",
+        "state": "unverified",
+        "downloaded": True,
+        "weights_path": str(bad_dir),
+        "hf_subdir": "bad-model",
+        "source": "hf-hub:test",
+    }]
+
+    monkeypatch.setattr(
+        model_verify,
+        "verify_model",
+        lambda d, s, revision=None: model_verify.VerifyResult(
+            ok=False, mismatches=["weights"]
+        ),
+    )
+    monkeypatch.setattr(
+        model_verify, "fetch_latest_revision", lambda repo: "rev999"
+    )
+    import models
+    monkeypatch.setattr(models, "get_models", lambda: fake_models)
+
+    results = model_verify.verify_all_models()
+    assert results["bad-model"].ok is False
+    # Stale .verify_skipped must be gone — verification actually ran.
+    assert not (bad_dir / model_verify.VERIFY_SKIPPED_SENTINEL).exists()
+    # Still no .verify_failed — mismatch for unpinned install stays ambiguous.
+    assert not (bad_dir / model_verify.VERIFY_FAILED_SENTINEL).exists()
+
+
 # ---------------------------------------------------------------------------
 # verify_if_needed — VerifyError failure backoff (Codex P2 on #501 line 207)
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_model_verify.py
+++ b/vireo/tests/test_model_verify.py
@@ -521,6 +521,51 @@ def test_unpinned_install_fails_open_on_network_error(tmp_path, monkeypatch):
     assert "bioclip-vit-b-16" in model_verify._verify_error_cache
 
 
+def test_verify_if_needed_unpinned_mismatch_clears_stale_verify_skipped(
+    tmp_path, monkeypatch
+):
+    """_verify_unpinned: if a previous transient outage wrote .verify_skipped
+    and a later verify_if_needed run actually reaches HF (but returns a
+    mismatch), the stale sentinel must be cleared. Without this, get_models()
+    keeps reporting state='unverified' with the outdated network-error reason
+    even though lazy verification has already run."""
+    import model_verify
+
+    # Legacy install — no .hf_revision.
+    p = tmp_path / "image_encoder.onnx.data"
+    p.write_bytes(b"old version bytes")
+
+    # Simulate a previous outage that left .verify_skipped on disk.
+    (tmp_path / model_verify.VERIFY_SKIPPED_SENTINEL).write_text(
+        "Could not reach HuggingFace (prior outage)"
+    )
+
+    # Now HF is reachable but the files don't match (hash mismatch).
+    monkeypatch.setattr(
+        model_verify,
+        "fetch_expected_hashes",
+        lambda subdir, revision="main": {"image_encoder.onnx.data": "0" * 64},
+    )
+    monkeypatch.setattr(
+        model_verify, "fetch_latest_revision", lambda repo: "latestsha123"
+    )
+
+    # Must not raise — soft-fail semantics for unpinned installs.
+    model_verify.verify_if_needed(
+        "bioclip-vit-b-16", str(tmp_path), "bioclip-vit-b-16"
+    )
+
+    # .verify_skipped must be gone: the hash fetch succeeded, so the old
+    # "couldn't reach HF" reason is now stale and misleading.
+    assert not (tmp_path / model_verify.VERIFY_SKIPPED_SENTINEL).is_file(), (
+        "_verify_unpinned must clear .verify_skipped on mismatch path"
+    )
+    # .verify_failed must NOT have been written (ambiguous mismatch).
+    assert not (tmp_path / model_verify.VERIFY_FAILED_SENTINEL).is_file()
+    # Model is cached as checked (to avoid re-warning on every pipeline start).
+    assert "bioclip-vit-b-16" in model_verify._verified_this_process
+
+
 # ---------------------------------------------------------------------------
 # verify_all_models — iterate installed models for the "Verify all" button
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -504,6 +504,67 @@ def test_classify_state_ok(tmp_path):
     ) == "ok"
 
 
+def test_classify_state_verify_skipped_sentinel_marks_unverified(tmp_path):
+    """All files present plus a .verify_skipped sentinel reports 'unverified'
+    so Settings can distinguish a working-but-unconfirmed download from a
+    fully-verified one."""
+    import models
+    d = tmp_path / "m"
+    d.mkdir()
+    (d / "image_encoder.onnx").write_bytes(b"stub")
+    _make_fake_data_file(d / "image_encoder.onnx.data")
+    (d / ".verify_skipped").write_text("SSL: CERTIFICATE_VERIFY_FAILED")
+    assert models._classify_model_state(
+        str(d), ["image_encoder.onnx", "image_encoder.onnx.data"]
+    ) == "unverified"
+
+
+def test_classify_state_verify_failed_takes_priority_over_skipped(tmp_path):
+    """If both sentinels exist, .verify_failed wins — a known bad hash is
+    more serious than 'could not check'."""
+    import models
+    d = tmp_path / "m"
+    d.mkdir()
+    (d / "image_encoder.onnx").write_bytes(b"stub")
+    _make_fake_data_file(d / "image_encoder.onnx.data")
+    (d / ".verify_failed").write_text("hash mismatch")
+    (d / ".verify_skipped").write_text("hf api unreachable")
+    assert models._classify_model_state(
+        str(d), ["image_encoder.onnx", "image_encoder.onnx.data"]
+    ) == "incomplete"
+
+
+def test_get_models_surfaces_unverified_state_and_reason(tmp_path, monkeypatch):
+    """get_models reports state='unverified', downloaded=True, and surfaces the
+    underlying reason from the sentinel file so the Settings UI can display
+    the cause (e.g. the SSL error text) next to the warning badge."""
+    import models
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
+
+    model_dir = tmp_path / "models" / "bioclip-vit-b-16"
+    model_dir.mkdir(parents=True)
+    (model_dir / "image_encoder.onnx").write_bytes(b"stub")
+    _make_fake_data_file(model_dir / "image_encoder.onnx.data")
+    (model_dir / "text_encoder.onnx").write_bytes(b"stub")
+    _make_fake_data_file(model_dir / "text_encoder.onnx.data")
+    (model_dir / "tokenizer.json").write_text("{}")
+    (model_dir / "config.json").write_text("{}")
+    reason = (
+        "failed to fetch expected hashes for bioclip-vit-b-16@main: "
+        "<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED]>"
+    )
+    (model_dir / ".verify_skipped").write_text(reason)
+
+    result = models.get_models()
+    entry = next(m for m in result if m["id"] == "bioclip-vit-b-16")
+    assert entry["state"] == "unverified"
+    # Unverified models are still usable — pipeline and "Use This" need to work.
+    assert entry["downloaded"] is True
+    assert entry["weights_path"] == str(model_dir)
+    assert entry["verify_skipped_reason"] == reason
+
+
 def test_get_models_surfaces_incomplete_state(tmp_path, monkeypatch):
     """get_models reports state='incomplete' and downloaded=False when a known
     model directory contains a .verify_failed sentinel (written by
@@ -916,6 +977,101 @@ def test_download_model_skips_verification_only_when_tree_api_also_fails(
 
     assert sentinel.is_file()
     assert not (model_dir / model_verify.REVISION_FILE).exists()
+
+
+def test_download_model_writes_verify_skipped_when_hash_fetch_fails(
+    tmp_path, monkeypatch
+):
+    """When the tree API is unreachable at download time, download_model
+    writes .verify_skipped with the underlying reason so the Settings UI
+    can surface why verification was skipped instead of the failure being
+    logged-only."""
+    import hashlib
+
+    import model_verify
+    models, model_dir = _patch_download_model_env(tmp_path, monkeypatch)
+
+    # Files land on disk with real bytes so the size-floor check passes;
+    # verification is blocked by the unreachable tree API, not by bad bytes.
+    large_bytes = b"x" * (20 * 1024 * 1024)  # 20 MB — above _MIN_BINARY_MODEL_BYTES
+
+    def fake_download(repo_id, filename, local_dir, subfolder=None, progress_callback=None, revision=None):
+        os.makedirs(local_dir, exist_ok=True)
+        dest = os.path.join(local_dir, filename)
+        content = large_bytes if filename.endswith(".onnx.data") else b"stub"
+        with open(dest, "wb") as f:
+            f.write(content)
+        return dest
+
+    def fetch_hashes_raises(subdir, revision="main"):
+        raise model_verify.VerifyError(
+            "<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED]>"
+        )
+
+    monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
+    monkeypatch.setattr(
+        model_verify, "fetch_expected_hashes", fetch_hashes_raises
+    )
+
+    models.download_model("bioclip-vit-b-16")
+
+    skipped = model_dir / model_verify.VERIFY_SKIPPED_SENTINEL
+    assert skipped.is_file(), (
+        ".verify_skipped must be written when fetch_expected_hashes fails "
+        "so Settings can show 'Unverified' with the cause"
+    )
+    # The recorded reason must be the actual exception text so the UI can
+    # show the user the real problem (SSL, proxy, etc).
+    assert "CERTIFICATE_VERIFY_FAILED" in skipped.read_text()
+
+    # Sanity: hash-computation just confirms files exist; not asserting a
+    # SHA (verification was skipped by design).
+    assert hashlib.sha256(large_bytes).hexdigest()  # smoke
+
+
+def test_download_model_clears_verify_skipped_on_successful_reverify(
+    tmp_path, monkeypatch
+):
+    """If a previous download left .verify_skipped and a retry now succeeds
+    with working hash fetch, the sentinel must be cleared so the model
+    returns to the 'ok' state."""
+    import hashlib
+
+    import model_verify
+    models, model_dir = _patch_download_model_env(tmp_path, monkeypatch)
+    model_dir.mkdir(parents=True, exist_ok=True)
+    skipped = model_dir / model_verify.VERIFY_SKIPPED_SENTINEL
+    skipped.write_text("earlier SSL failure")
+
+    lfs_contents = {
+        "image_encoder.onnx": b"graph-i" * 100,
+        "image_encoder.onnx.data": b"weights-i" * 1000,
+        "text_encoder.onnx": b"graph-t" * 100,
+        "text_encoder.onnx.data": b"weights-t" * 1000,
+    }
+    expected = {
+        name: hashlib.sha256(data).hexdigest()
+        for name, data in lfs_contents.items()
+    }
+
+    def fake_download(repo_id, filename, local_dir, subfolder=None, progress_callback=None, revision=None):
+        os.makedirs(local_dir, exist_ok=True)
+        dest = os.path.join(local_dir, filename)
+        content = lfs_contents.get(filename, b"{}")
+        with open(dest, "wb") as f:
+            f.write(content)
+        return dest
+
+    monkeypatch.setattr(models, "_hf_download_with_retry", fake_download)
+    monkeypatch.setattr(
+        model_verify, "fetch_expected_hashes", lambda subdir, revision="main": expected
+    )
+
+    models.download_model("bioclip-vit-b-16")
+    assert not skipped.exists(), (
+        ".verify_skipped must be cleared once verification actually runs "
+        "and succeeds"
+    )
 
 
 def test_purge_hf_cache_file_deletes_blob_target(tmp_path, monkeypatch):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -1457,6 +1457,66 @@ def test_pipeline_translates_verify_failure_to_repair_message(tmp_path, monkeypa
         f"Expected a Repair hint in model_loader errors, saw: {model_loader_errors}"
 
 
+def test_pipeline_preflight_accepts_unverified_model(tmp_path, monkeypatch):
+    """Models in 'unverified' state (files present, SHA256 check skipped
+    because HF was unreachable) must pass preflight. get_models() already
+    reports downloaded=True for them, so rejecting them at pipeline start
+    would turn a transient outage into a hard pipeline failure with no way
+    to clear it short of deleting and redownloading the model.
+    """
+    import classifier as classifier_mod
+    import config as cfg
+    import model_verify
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    # Write the verify-skipped sentinel so _classify_model_state returns
+    # "unverified" rather than "ok".
+    model_dir = tmp_path / "models" / "bioclip-vit-b-16"
+    (model_dir / model_verify.VERIFY_SKIPPED_SENTINEL).write_text(
+        "Transient HF outage (test fixture)"
+    )
+
+    # Stub Classifier so the preflight check is the only thing that could
+    # fail on this path. If preflight rejects the unverified state, we'll
+    # see a "Repair" error in model_loader step updates before the stub
+    # is ever invoked.
+    class _StubClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(classifier_mod, "Classifier", _StubClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    model_loader_errors = [
+        kwargs.get("error", "")
+        for (_, step_id, kwargs) in runner.step_updates
+        if step_id == "model_loader" and "error" in kwargs
+    ]
+    assert not any("Repair" in e for e in model_loader_errors), (
+        "Preflight must accept 'unverified' models, but saw Repair error: "
+        f"{model_loader_errors}"
+    )
+
+
 def test_pipeline_translates_incomplete_model_error(tmp_path, monkeypatch):
     """Model loader failures from missing external-data get a friendly message.
 


### PR DESCRIPTION
## Summary

Follow-up to #536. That PR fixed the common cause (missing certifi context) but the failure mode itself was still invisible: when HF's metadata API is unreachable, SHA256 verification silently gets skipped, and the only trace is a WARNING in `vireo.log`. From the user's point of view the download finishes in a second, then Verify reports the model as broken — with no obvious link to the earlier SSL warning.

This PR makes skipped verification a first-class state.

- **`.verify_skipped` sentinel** (new) mirrors the existing `.verify_failed` pattern. Contains the underlying `VerifyError` message as its body so the real cause (SSL cert / proxy / network) surfaces in the UI, not just the log.
- **`model_verify`**: `verify_if_needed` and `verify_all_models` write the sentinel when HF is unreachable, clear it once verification actually runs.
- **`models.py`**: `download_model` writes the sentinel on `VerifyError`, clears it on successful re-verify, accepts `"unverified"` as a valid post-download state.
- **`_classify_model_state`** grows `"unverified"` (distinct from `"ok"` and `"incomplete"`). `get_models()` reports `state="unverified"`, `downloaded=True` (still usable), and exposes `verify_skipped_reason`.
- **Settings UI**: amber "Unverified — could not reach HuggingFace" badge with the reason text; a "Retry verification" button wired to the existing `verifyAllModels()` flow. Unverified models remain selectable ("Use This") so the pipeline isn't blocked on transient HF outages.

## Test plan
- [x] `python -m pytest vireo/tests/test_model_verify.py` — 28 passed
- [x] `python -m pytest vireo/tests/test_models.py` (minus 2 pre-existing env-leak tests that also fail on `main`) — 44 passed, including 5 new tests for:
  - `_classify_model_state` returns `"unverified"` when `.verify_skipped` is present
  - `.verify_failed` takes priority over `.verify_skipped` when both exist
  - `get_models()` surfaces `state="unverified"` + `verify_skipped_reason`
  - `download_model` writes `.verify_skipped` with the `VerifyError` message on `fetch_expected_hashes` failure
  - `download_model` clears `.verify_skipped` on a successful re-verify
- [x] CLAUDE.md full batch — 461 passed
- [ ] Manual: simulate HF API outage (block `huggingface.co/api`), re-download a model, verify Settings shows amber "Unverified" badge with the reason and a working "Retry verification" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)