### PR TITLE
Pin PR agent to existing branch via CLAUDE_BRANCH

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -59,8 +59,23 @@ jobs:
       - name: Install test dependencies
         run: pip install flask Pillow pytest imagehash
 
+      - name: Resolve PR head ref
+        id: head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ref=$(gh pr view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json headRefName -q .headRefName)
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
       - name: Address review comments
         uses: anthropics/claude-code-action@v1
+        env:
+          # Pin the action to the PR's head branch so it doesn't create a new
+          # branch + PR via its default branch_name_template. Undocumented
+          # escape hatch read in src/modes/agent/index.ts in claude-code-action.
+          CLAUDE_BRANCH: ${{ steps.head.outputs.ref }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "chatgpt-codex-connector[bot]"
@@ -124,8 +139,20 @@ jobs:
       - name: Install test dependencies
         run: pip install flask Pillow pytest imagehash
 
+      - name: Resolve PR head ref
+        id: head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ref=$(gh pr view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json headRefName -q .headRefName)
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
       - name: Address comment feedback
         uses: anthropics/claude-code-action@v1
+        env:
+          CLAUDE_BRANCH: ${{ steps.head.outputs.ref }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "chatgpt-codex-connector[bot]"
@@ -192,6 +219,8 @@ jobs:
 
       - name: Address review comments
         uses: anthropics/claude-code-action@v1
+        env:
+          CLAUDE_BRANCH: ${{ github.event.pull_request.head.ref }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "chatgpt-codex-connector[bot]"
@@ -290,6 +319,8 @@ jobs:
       - name: Address codex review
         if: steps.fork-check.outputs.is_fork == 'false'
         uses: anthropics/claude-code-action@v1
+        env:
+          CLAUDE_BRANCH: ${{ github.event.pull_request.head.ref }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "chatgpt-codex-connector[bot]"


### PR DESCRIPTION
## Summary

- PR #515 updated the agent's prompt text to forbid new PR creation, but the three jobs firing on \`pull_request_review\`/\`issue_comment\` events were still opening stray PRs (most recently #537).
- Root cause: \`anthropics/claude-code-action@v1\` wraps Claude's run in its own git plumbing before the prompt ever executes. When \`GITHUB_HEAD_REF\`/\`GITHUB_REF_NAME\` don't identify the PR branch (true for these event types), the action falls through to its \`branch_name_template\` default and creates a new branch + PR. Prompt text can't override behavior that happens outside Claude's scope.
- Fix: pass \`CLAUDE_BRANCH\` as an env var on the action step. The action reads it first when picking its working branch (\`src/modes/agent/index.ts\`, comment: \"useful for auto-fix workflows\"), so it operates directly on the existing PR branch.
- For \`pull_request_review\` jobs, use \`github.event.pull_request.head.ref\` directly. For \`issue_comment\` jobs, add a \`gh pr view\` pre-step to resolve the head ref (only the PR number is in the event payload).
- \`fix-ci\` left unchanged — already works in practice. \`resolve-conflicts\` left unchanged — operates across multiple PRs.

## Test plan

- [ ] YAML validates (\`python -c \"import yaml; yaml.safe_load(open('.github/workflows/pr-agent.yml'))\"\` — already green locally).
- [ ] Live-fire check after merge: submit a Codex review on any PR and confirm the fix-up commit lands on the existing branch instead of a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)