### PR TITLE
fix: address codex review on #538

### DIFF
--- a/vireo/model_verify.py
+++ b/vireo/model_verify.py
@@ -396,7 +396,7 @@ def verify_all_models(progress_callback=None) -> dict[str, VerifyResult]:
             continue
         if not m.get("hf_subdir"):
             continue
-        if m.get("state") != "ok":
+        if m.get("state") not in ("ok", "unverified"):
             continue
         model_id = m["id"]
         weights_path = m.get("weights_path")


### PR DESCRIPTION
Parent PR: #538

Addresses Codex Connect review feedback on #538.

## What changed

`verify_all_models()` in `vireo/model_verify.py` previously skipped any model whose state was not exactly `"ok"` (`if m.get("state") != "ok": continue`). Models in the new `"unverified"` state (written when HuggingFace's metadata API was unreachable during a prior download) were therefore silently excluded from the retry loop. The Settings UI "Retry verification" button called `verifyAllModels()` → `verify_all_models()`, but because the model was skipped, the `.verify_skipped` sentinel was never cleared and the amber "Unverified" badge remained stuck regardless of network recovery.

**Fix:** broaden the state filter to `not in ("ok", "unverified")` so that models in the `"unverified"` state are included in the retry pass. On a successful re-verification the existing code path already calls `clear_verify_skipped()` and updates `_verified_this_process`, so no other changes are needed.

## Test results

433 passed.

---
Generated by scheduled PR Agent