### PR TITLE
fix: address codex review on #535

### DIFF
--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -348,8 +348,10 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
     )
 
     if detect_animals is not None and get_primary_detection is not None:
-        needs_fresh_detection = reclassify or any(
-            p["id"] not in already_detected_ids for p in photos
+        needs_fresh_detection = bool(photos) and (
+            reclassify or any(
+                p["id"] not in already_detected_ids for p in photos
+            )
         )
         if needs_fresh_detection:
             from detector import ensure_megadetector_weights

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -967,8 +967,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             # runs. Skip when every photo already has cached detections and we're
             # not reclassifying — _detect_batch will reuse DB rows and never call
             # MegaDetector, so an offline rerun should not abort on missing weights.
-            needs_fresh_detection = params.reclassify or any(
-                p["id"] not in already_detected for p in photos
+            # Also skip when photos is empty: a no-op reclassify on an empty
+            # collection should not trigger a weight download.
+            needs_fresh_detection = bool(photos) and (
+                params.reclassify or any(
+                    p["id"] not in already_detected for p in photos
+                )
             )
             if needs_fresh_detection:
                 from detector import ensure_megadetector_weights


### PR DESCRIPTION
Parent PR: #535

Addresses Codex Connect review feedback on #535.

## What changed

`needs_fresh_detection` in both `pipeline_job.py` (`classify_stage`) and `classify_job.py` (`_detect_subjects`) was computed as:

```python
needs_fresh_detection = reclassify or any(p["id"] not in already_detected for p in photos)
```

When `photos` is empty and `reclassify=True`, this evaluates to `True` and triggers `ensure_megadetector_weights()` even though no detection pass will run (the loop body is never entered). This turned a no-op reclassify on an empty collection into a fatal network dependency — offline/air-gapped reruns would abort at startup rather than completing instantly with 0 photos processed.

**Fix:** prepend `bool(photos) and` to the predicate in both call sites so that the weight download is skipped entirely when the photo list is empty.

## Test results

432 passed.

---
Generated by scheduled PR Agent