### PR TITLE
fix: address codex review on #538

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -657,7 +657,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         files = active_model.get("files", [])
         if files and weights_path:
             state = _classify_model_state(weights_path, files)
-            if state != "ok":
+            if state not in ("ok", "unverified"):
                 raise RuntimeError(
                     _incomplete_model_message(model_name, model_is_custom)
                 )


### PR DESCRIPTION
Parent PR: #538

Addresses Codex Connect review feedback on #538.

## What changed

`_load_model_bundle` in `vireo/pipeline_job.py` contained a preflight check that raised a "model incomplete" error for any model state other than `"ok"`. This included the new `"unverified"` state introduced in #538, which represents a model whose files are all present but whose SHA256 hashes could not be confirmed against HuggingFace's API (e.g. due to a transient network outage).

The result: users who downloaded a model during an HF API outage would see the Settings UI show an amber "Unverified" badge with a "Use This" button (correctly, per the PR's intent), but clicking "Use This" and starting the pipeline would immediately fail with an "incomplete model" error — the very runtime failure the new state was meant to avoid.

**Fix:** change the preflight condition from `state != "ok"` to `state not in ("ok", "unverified")`. Models in the `"unverified"` state have all required files present; the only missing piece is the cryptographic hash confirmation. If the files are actually corrupt, the lazy `verify_if_needed` step (which runs immediately after preflight) or ONNXRuntime's own load will catch it. This is consistent with `models.py`, where `"unverified"` is already treated as `downloaded=True`.

## Test results

415 passed (18 pre-existing failures on the base branch, unchanged by this fix).

---
Generated by scheduled PR Agent