### PR TITLE
feat: duplicate detection and auto-rejection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Tests use temp databases. `vireo/tests/test_app.py` isolates config via `cfg.CON
 
 - `vireo/app.py` — Flask app with all routes. Created via `create_app(db_path, thumb_cache_dir)`.
 - `vireo/db.py` — `Database` class. SQLite with workspace support. Auto-creates Default workspace and restores last-used workspace on init.
+- `vireo/duplicates.py` — Pure exact-duplicate resolver (winner/loser decision + metadata merge). Consumed by `db.apply_duplicate_resolution` and the scan job.
 - `vireo/jobs.py` — `JobRunner` for background tasks (scan, classify, thumbnails, etc.) with SSE progress streaming.
 - `vireo/config.py` — Global config read/write from `~/.vireo/config.json`.
 - `vireo/templates/_navbar.html` — Shared navbar included by all pages. Contains workspace switcher, bottom panel, lightbox, theme system.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -384,6 +384,10 @@ def create_app(db_path, thumb_cache_dir=None):
     def jobs_page():
         return render_template("jobs.html")
 
+    @app.route("/duplicates")
+    def duplicates_page():
+        return render_template("duplicates.html")
+
     @app.route("/move")
     def move_page():
         return render_template("move.html")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4190,11 +4190,13 @@ def create_app(db_path, thumb_cache_dir=None):
         if not isinstance(hashes, list) or not hashes:
             return json_error("hashes required")
 
+        for h in hashes:
+            if not isinstance(h, str) or not h:
+                return json_error("hashes must be a list of non-empty strings")
+
         db = _get_db()
         total_rejected = 0
         for h in hashes:
-            if not isinstance(h, str) or not h:
-                continue
             rows = db.conn.execute(
                 "SELECT id FROM photos "
                 "WHERE file_hash = ? AND flag != 'rejected'",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4147,6 +4147,65 @@ def create_app(db_path, thumb_cache_dir=None):
         job_id = runner.start("thumbnails", work, workspace_id=active_ws)
         return jsonify({"job_id": job_id})
 
+    @app.route("/api/duplicates/scan", methods=["POST"])
+    def api_duplicates_scan():
+        """Start a background duplicate-detection job.
+
+        Returns immediately with the job id. The job walks every file_hash
+        group with >=2 non-rejected rows and proposes a winner/losers per
+        group (without applying). The UI polls /api/jobs/<id> to fetch the
+        proposals from job.result and lets the user apply them via
+        /api/duplicates/apply.
+        """
+        runner = app._job_runner
+        active_ws = _get_db()._active_workspace_id
+
+        def work(job):
+            from duplicate_scan import run_duplicate_scan
+            thread_db = Database(db_path)
+            if active_ws is not None:
+                thread_db.set_active_workspace(active_ws)
+            try:
+                return run_duplicate_scan(job, thread_db)
+            finally:
+                thread_db.conn.close()
+
+        job_id = runner.start("duplicate-scan", work, workspace_id=active_ws)
+        return jsonify({"job_id": job_id})
+
+    @app.route("/api/duplicates/apply", methods=["POST"])
+    def api_duplicates_apply():
+        """Apply resolver decisions for the given list of file hashes.
+
+        Body: {"hashes": ["<hash>", ...]}. For each hash we look up every
+        non-rejected photo sharing it and hand that set to
+        apply_duplicate_resolution, which picks a winner via the pure
+        resolver and flags the losers as rejected. Returns the total number
+        of photos rejected across all hashes.
+        """
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return json_error("hashes required")
+        hashes = body.get("hashes")
+        if not isinstance(hashes, list) or not hashes:
+            return json_error("hashes required")
+
+        db = _get_db()
+        total_rejected = 0
+        for h in hashes:
+            if not isinstance(h, str) or not h:
+                continue
+            rows = db.conn.execute(
+                "SELECT id FROM photos "
+                "WHERE file_hash = ? AND flag != 'rejected'",
+                (h,),
+            ).fetchall()
+            if len(rows) < 2:
+                continue
+            result = db.apply_duplicate_resolution([r["id"] for r in rows])
+            total_rejected += result.get("rejected", 0)
+        return jsonify({"rejected_count": total_rejected})
+
     @app.route("/api/jobs/previews", methods=["POST"])
     def api_job_previews():
         body = request.get_json(silent=True) or {}

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1507,7 +1507,8 @@ class Database:
             )
             for r in rows
         ]
-        winner_id, loser_ids = resolve_duplicates(candidates)
+        winner_id, losers_with_reasons = resolve_duplicates(candidates)
+        loser_ids = [lid for lid, _reason in losers_with_reasons]
 
         def _meta(photo_id):
             r = self.conn.execute(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1372,13 +1372,21 @@ class Database:
         width=None,
         height=None,
         xmp_mtime=None,
+        file_hash=None,
     ):
-        """Insert a photo. Returns the photo id."""
+        """Insert a photo. Returns the photo id.
+
+        If ``file_hash`` is provided and the insert creates a new row that
+        collides with an existing non-rejected photo sharing the same hash,
+        the duplicate auto-resolver runs and flags the loser(s) as rejected.
+        The hook is wrapped in try/except so resolver bugs never break
+        inserts.
+        """
         cur = self.conn.execute(
             """INSERT OR IGNORE INTO photos
                (folder_id, filename, extension, file_size, file_mtime, xmp_mtime,
-                timestamp, width, height)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                timestamp, width, height, file_hash)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 folder_id,
                 filename,
@@ -1389,16 +1397,36 @@ class Database:
                 timestamp,
                 width,
                 height,
+                file_hash,
             ),
         )
         self.conn.commit()
         if cur.rowcount > 0:
-            return cur.lastrowid
-        row = self.conn.execute(
-            "SELECT id FROM photos WHERE folder_id = ? AND filename = ?",
-            (folder_id, filename),
-        ).fetchone()
-        return row["id"]
+            photo_id = cur.lastrowid
+        else:
+            row = self.conn.execute(
+                "SELECT id FROM photos WHERE folder_id = ? AND filename = ?",
+                (folder_id, filename),
+            ).fetchone()
+            photo_id = row["id"]
+
+        # Auto-resolve duplicates when we have a file_hash and >1 non-rejected
+        # rows share it. Disabled via env var for tests that exercise
+        # apply_duplicate_resolution directly.
+        if file_hash and not os.environ.get("VIREO_DISABLE_AUTO_DUP_RESOLVE"):
+            try:
+                dup_rows = self.conn.execute(
+                    "SELECT id FROM photos WHERE file_hash = ? AND flag != 'rejected'",
+                    (file_hash,),
+                ).fetchall()
+                if len(dup_rows) > 1:
+                    self.apply_duplicate_resolution([r["id"] for r in dup_rows])
+            except Exception as e:
+                logging.getLogger(__name__).warning(
+                    "Duplicate auto-resolve failed for hash %s: %s", file_hash, e,
+                )
+
+        return photo_id
 
     def apply_duplicate_resolution(self, photo_ids):
         """Resolve a group of photos sharing a file_hash.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1441,6 +1441,28 @@ class Database:
             )
         return None
 
+    def find_duplicate_groups(self):
+        """Return [{file_hash, photo_ids: [...]}] for every hash with 2+ non-rejected rows.
+
+        Used by the duplicate-scan job to preview groups without applying.
+        """
+        rows = self.conn.execute(
+            """
+            SELECT file_hash, GROUP_CONCAT(id) AS ids
+            FROM photos
+            WHERE file_hash IS NOT NULL AND flag != 'rejected'
+            GROUP BY file_hash
+            HAVING COUNT(*) > 1
+            """
+        ).fetchall()
+        return [
+            {
+                "file_hash": r["file_hash"],
+                "photo_ids": [int(x) for x in r["ids"].split(",")],
+            }
+            for r in rows
+        ]
+
     def apply_duplicate_resolution(self, photo_ids):
         """Resolve a group of photos sharing a file_hash.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1400,6 +1400,112 @@ class Database:
         ).fetchone()
         return row["id"]
 
+    def apply_duplicate_resolution(self, photo_ids):
+        """Resolve a group of photos sharing a file_hash.
+
+        Picks a winner using :func:`vireo.duplicates.resolve_duplicates`,
+        merges metadata (rating/keywords) from losers onto the winner, and
+        flags the losers as rejected. Runs in a single transaction.
+
+        Photos whose ``flag`` is already ``'rejected'`` are filtered out
+        before resolving — we never un-reject previously handled losers.
+
+        Returns ``{"winner_id": int|None, "loser_ids": [int], "rejected": int}``.
+        If fewer than 2 non-rejected candidates remain, returns the no-op
+        shape with ``winner_id=None``.
+        """
+        from duplicates import (
+            DupCandidate,
+            PhotoMetadata,
+            merge_metadata,
+            resolve_duplicates,
+        )
+
+        if not photo_ids or len(photo_ids) < 2:
+            return {"winner_id": None, "loser_ids": [], "rejected": 0}
+
+        placeholders = ",".join("?" * len(photo_ids))
+        rows = self.conn.execute(
+            f"""SELECT p.id, p.filename, p.file_mtime, p.rating, p.flag,
+                       f.path AS folder_path
+                FROM photos p
+                LEFT JOIN folders f ON f.id = p.folder_id
+                WHERE p.id IN ({placeholders}) AND p.flag != 'rejected'""",
+            list(photo_ids),
+        ).fetchall()
+        if len(rows) < 2:
+            return {"winner_id": None, "loser_ids": [], "rejected": 0}
+
+        candidates = [
+            DupCandidate(
+                id=r["id"],
+                path=os.path.join(r["folder_path"] or "", r["filename"] or ""),
+                mtime=r["file_mtime"] or 0.0,
+            )
+            for r in rows
+        ]
+        winner_id, loser_ids = resolve_duplicates(candidates)
+
+        def _meta(photo_id):
+            r = self.conn.execute(
+                "SELECT rating FROM photos WHERE id = ?", (photo_id,)
+            ).fetchone()
+            kw_rows = self.conn.execute(
+                "SELECT keyword_id FROM photo_keywords WHERE photo_id = ?",
+                (photo_id,),
+            ).fetchall()
+            pend = self.conn.execute(
+                "SELECT 1 FROM pending_changes WHERE photo_id = ? LIMIT 1",
+                (photo_id,),
+            ).fetchone()
+            return PhotoMetadata(
+                id=photo_id,
+                rating=(r["rating"] if r and r["rating"] is not None else 0),
+                keyword_ids={kr["keyword_id"] for kr in kw_rows},
+                # Collections in Vireo are rule-based (no junction table); skip.
+                collection_ids=set(),
+                has_pending_edit=pend is not None,
+            )
+
+        winner_meta = _meta(winner_id)
+        loser_metas = [_meta(lid) for lid in loser_ids]
+        merge = merge_metadata(winner_meta, loser_metas)
+
+        with self.conn:  # transaction
+            if merge.new_rating != winner_meta.rating:
+                self.conn.execute(
+                    "UPDATE photos SET rating = ? WHERE id = ?",
+                    (merge.new_rating, winner_id),
+                )
+            for kw_id in merge.keyword_ids_to_add:
+                self.conn.execute(
+                    "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) "
+                    "VALUES (?, ?)",
+                    (winner_id, kw_id),
+                )
+            # TODO: pending-edit copy for duplicate merge — see plan Task 7.
+            # Skipped because pending_changes is workspace-scoped and its
+            # value/change_token columns are non-trivial to copy safely in
+            # this transaction. Rare edge case; revisit if product needs it.
+            # Collections are rule-based (no junction table) so
+            # merge.collection_ids_to_add has nothing to write either.
+            loser_placeholders = ",".join("?" * len(loser_ids))
+            self.conn.execute(
+                f"UPDATE photos SET flag = 'rejected' WHERE id IN ({loser_placeholders})",
+                loser_ids,
+            )
+
+        logging.getLogger(__name__).info(
+            "Duplicate resolved: kept id=%s, rejected id(s)=%s",
+            winner_id,
+            loser_ids,
+        )
+        return {
+            "winner_id": winner_id,
+            "loser_ids": list(loser_ids),
+            "rejected": len(loser_ids),
+        }
+
     # Columns to return in photo list queries (excludes large fields)
     PHOTO_COLS = """id, folder_id, filename, extension, file_size, file_mtime, xmp_mtime,
                     timestamp, width, height, rating, flag, thumb_path, sharpness,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1411,22 +1411,35 @@ class Database:
             photo_id = row["id"]
 
         # Auto-resolve duplicates when we have a file_hash and >1 non-rejected
-        # rows share it. Disabled via env var for tests that exercise
-        # apply_duplicate_resolution directly.
-        if file_hash and not os.environ.get("VIREO_DISABLE_AUTO_DUP_RESOLVE"):
-            try:
-                dup_rows = self.conn.execute(
-                    "SELECT id FROM photos WHERE file_hash = ? AND flag != 'rejected'",
-                    (file_hash,),
-                ).fetchall()
-                if len(dup_rows) > 1:
-                    self.apply_duplicate_resolution([r["id"] for r in dup_rows])
-            except Exception as e:
-                logging.getLogger(__name__).warning(
-                    "Duplicate auto-resolve failed for hash %s: %s", file_hash, e,
-                )
+        # rows share it. Most scanner-path callers leave file_hash=None here
+        # and set it later via an UPDATE; those callers must invoke
+        # check_and_resolve_duplicates_for_hash themselves after the UPDATE.
+        if file_hash:
+            self.check_and_resolve_duplicates_for_hash(file_hash)
 
         return photo_id
+
+    def check_and_resolve_duplicates_for_hash(self, file_hash: str) -> dict | None:
+        """Look up non-rejected photos sharing this hash; if >=2, resolve.
+
+        Returns the result dict from apply_duplicate_resolution when resolution
+        ran, or None when no resolution was needed. Failures are logged and
+        swallowed — this is a best-effort hook, not a correctness guarantee.
+        """
+        if not file_hash:
+            return None
+        try:
+            dup_rows = self.conn.execute(
+                "SELECT id FROM photos WHERE file_hash = ? AND flag != 'rejected'",
+                (file_hash,),
+            ).fetchall()
+            if len(dup_rows) > 1:
+                return self.apply_duplicate_resolution([r["id"] for r in dup_rows])
+        except sqlite3.Error as e:
+            logging.getLogger(__name__).warning(
+                "Duplicate auto-resolve failed for hash %s: %s", file_hash, e,
+            )
+        return None
 
     def apply_duplicate_resolution(self, photo_ids):
         """Resolve a group of photos sharing a file_hash.

--- a/vireo/duplicate_scan.py
+++ b/vireo/duplicate_scan.py
@@ -3,12 +3,9 @@
 Read-only. Does not apply — the UI shows the preview and a user action (the
 ``/api/duplicates/apply`` endpoint) actually flags the losers as rejected.
 """
-import logging
 import os
 
 from duplicates import DupCandidate, resolve_duplicates
-
-log = logging.getLogger(__name__)
 
 
 def _row_to_info(row, folder_path):

--- a/vireo/duplicate_scan.py
+++ b/vireo/duplicate_scan.py
@@ -44,7 +44,7 @@ def run_duplicate_scan(job, db):
                        f.path AS folder_path
                 FROM photos p
                 LEFT JOIN folders f ON f.id = p.folder_id
-                WHERE p.id IN ({placeholders})""",
+                WHERE p.id IN ({placeholders}) AND p.flag != 'rejected'""",
             photo_ids,
         ).fetchall()
 

--- a/vireo/duplicate_scan.py
+++ b/vireo/duplicate_scan.py
@@ -1,0 +1,99 @@
+"""Background job: scan the DB for duplicate groups and propose a resolution.
+
+Read-only. Does not apply — the UI shows the preview and a user action (the
+``/api/duplicates/apply`` endpoint) actually flags the losers as rejected.
+"""
+import logging
+import os
+
+from duplicates import DupCandidate, _has_dup_suffix, resolve_duplicates
+
+log = logging.getLogger(__name__)
+
+
+def _row_to_info(row, folder_path):
+    """Shape a photos row into the dict the UI consumes for a proposal entry."""
+    filename = row["filename"] or ""
+    full_path = os.path.join(folder_path or "", filename)
+    return {
+        "id": row["id"],
+        "filename": filename,
+        "path": full_path,
+        "mtime": row["file_mtime"] or 0.0,
+        "rating": row["rating"] if row["rating"] is not None else 0,
+    }
+
+
+def _loser_reason(winner_info, loser_info):
+    """Return a short string describing why this loser was picked.
+
+    Matches the tiebreaker cascade in ``duplicates.resolve_duplicates``.
+    """
+    w_dirty = _has_dup_suffix(winner_info["path"])
+    l_dirty = _has_dup_suffix(loser_info["path"])
+    if l_dirty and not w_dirty:
+        return "filename has dup suffix"
+    w_len = len(winner_info["path"])
+    l_len = len(loser_info["path"])
+    if l_len > w_len:
+        return "longer path"
+    if loser_info["mtime"] > winner_info["mtime"]:
+        return "later mtime"
+    return "higher id"
+
+
+def run_duplicate_scan(job, db):
+    """Work function for ``JobRunner.start('duplicate-scan', ...)``.
+
+    Updates ``job['progress']`` as it walks groups. Returns a dict with a
+    ``proposals`` list the UI can render; each proposal contains the
+    winner/losers with full paths, mtimes, ratings, and a per-loser reason.
+    """
+    groups = db.find_duplicate_groups()
+    total = len(groups)
+    job["progress"] = {"current": 0, "total": total, "current_file": ""}
+
+    proposals = []
+    for i, g in enumerate(groups):
+        photo_ids = g["photo_ids"]
+        placeholders = ",".join("?" * len(photo_ids))
+        rows = db.conn.execute(
+            f"""SELECT p.id, p.filename, p.file_mtime, p.rating,
+                       f.path AS folder_path
+                FROM photos p
+                LEFT JOIN folders f ON f.id = p.folder_id
+                WHERE p.id IN ({placeholders})""",
+            photo_ids,
+        ).fetchall()
+
+        info_by_id = {r["id"]: _row_to_info(r, r["folder_path"]) for r in rows}
+        candidates = [
+            DupCandidate(id=r["id"], path=info_by_id[r["id"]]["path"],
+                         mtime=r["file_mtime"] or 0.0)
+            for r in rows
+        ]
+        if len(candidates) < 2:
+            # Race: rows could have been rejected between the group query and
+            # this lookup. Skip silently.
+            continue
+        winner_id, loser_ids = resolve_duplicates(candidates)
+        winner_info = info_by_id[winner_id]
+        losers = []
+        for lid in loser_ids:
+            linfo = dict(info_by_id[lid])
+            linfo["reason"] = _loser_reason(winner_info, linfo)
+            losers.append(linfo)
+
+        proposals.append({
+            "file_hash": g["file_hash"],
+            "winner": winner_info,
+            "losers": losers,
+        })
+        job["progress"]["current"] = i + 1
+        job["progress"]["current_file"] = g["file_hash"]
+
+    return {
+        "proposals": proposals,
+        "group_count": total,
+        "loser_count": sum(len(p["losers"]) for p in proposals),
+    }

--- a/vireo/duplicate_scan.py
+++ b/vireo/duplicate_scan.py
@@ -6,7 +6,7 @@ Read-only. Does not apply — the UI shows the preview and a user action (the
 import logging
 import os
 
-from duplicates import DupCandidate, _has_dup_suffix, resolve_duplicates
+from duplicates import DupCandidate, resolve_duplicates
 
 log = logging.getLogger(__name__)
 
@@ -21,25 +21,8 @@ def _row_to_info(row, folder_path):
         "path": full_path,
         "mtime": row["file_mtime"] or 0.0,
         "rating": row["rating"] if row["rating"] is not None else 0,
+        "file_size": row["file_size"] if row["file_size"] is not None else 0,
     }
-
-
-def _loser_reason(winner_info, loser_info):
-    """Return a short string describing why this loser was picked.
-
-    Matches the tiebreaker cascade in ``duplicates.resolve_duplicates``.
-    """
-    w_dirty = _has_dup_suffix(winner_info["path"])
-    l_dirty = _has_dup_suffix(loser_info["path"])
-    if l_dirty and not w_dirty:
-        return "filename has dup suffix"
-    w_len = len(winner_info["path"])
-    l_len = len(loser_info["path"])
-    if l_len > w_len:
-        return "longer path"
-    if loser_info["mtime"] > winner_info["mtime"]:
-        return "later mtime"
-    return "higher id"
 
 
 def run_duplicate_scan(job, db):
@@ -47,7 +30,9 @@ def run_duplicate_scan(job, db):
 
     Updates ``job['progress']`` as it walks groups. Returns a dict with a
     ``proposals`` list the UI can render; each proposal contains the
-    winner/losers with full paths, mtimes, ratings, and a per-loser reason.
+    winner/losers with full paths, mtimes, ratings, file sizes, and a
+    per-loser reason supplied by :func:`duplicates.resolve_duplicates` (the
+    single source of truth for tiebreaker reasons).
     """
     groups = db.find_duplicate_groups()
     total = len(groups)
@@ -58,7 +43,7 @@ def run_duplicate_scan(job, db):
         photo_ids = g["photo_ids"]
         placeholders = ",".join("?" * len(photo_ids))
         rows = db.conn.execute(
-            f"""SELECT p.id, p.filename, p.file_mtime, p.rating,
+            f"""SELECT p.id, p.filename, p.file_mtime, p.rating, p.file_size,
                        f.path AS folder_path
                 FROM photos p
                 LEFT JOIN folders f ON f.id = p.folder_id
@@ -76,12 +61,12 @@ def run_duplicate_scan(job, db):
             # Race: rows could have been rejected between the group query and
             # this lookup. Skip silently.
             continue
-        winner_id, loser_ids = resolve_duplicates(candidates)
+        winner_id, losers_with_reasons = resolve_duplicates(candidates)
         winner_info = info_by_id[winner_id]
         losers = []
-        for lid in loser_ids:
+        for lid, reason in losers_with_reasons:
             linfo = dict(info_by_id[lid])
-            linfo["reason"] = _loser_reason(winner_info, linfo)
+            linfo["reason"] = reason
             losers.append(linfo)
 
         proposals.append({
@@ -90,7 +75,8 @@ def run_duplicate_scan(job, db):
             "losers": losers,
         })
         job["progress"]["current"] = i + 1
-        job["progress"]["current_file"] = g["file_hash"]
+        # Show the winner's path (human-readable) rather than an opaque hash.
+        job["progress"]["current_file"] = winner_info["path"]
 
     return {
         "proposals": proposals,

--- a/vireo/duplicates.py
+++ b/vireo/duplicates.py
@@ -55,4 +55,12 @@ def resolve_duplicates(candidates):
         losers = [c for c in candidates if c.id != winner.id]
         return winner.id, [l.id for l in losers]
 
-    raise NotImplementedError("rules 3-4 not yet")
+    # Rule 3: older mtime wins
+    min_mtime = min(c.mtime for c in pool)
+    oldest = [c for c in pool if c.mtime == min_mtime]
+    if len(oldest) == 1:
+        winner = oldest[0]
+        losers = [c for c in candidates if c.id != winner.id]
+        return winner.id, [l.id for l in losers]
+
+    raise NotImplementedError("rule 4 not yet")

--- a/vireo/duplicates.py
+++ b/vireo/duplicates.py
@@ -63,4 +63,7 @@ def resolve_duplicates(candidates):
         losers = [c for c in candidates if c.id != winner.id]
         return winner.id, [l.id for l in losers]
 
-    raise NotImplementedError("rule 4 not yet")
+    # Rule 4: lower id wins (deterministic)
+    winner = min(pool, key=lambda c: c.id)
+    losers = [c for c in candidates if c.id != winner.id]
+    return winner.id, [l.id for l in losers]

--- a/vireo/duplicates.py
+++ b/vireo/duplicates.py
@@ -28,22 +28,35 @@ def _has_dup_suffix(path: str) -> bool:
 
 
 def resolve_duplicates(candidates):
-    """Return (winner_id, [loser_ids]) for a group sharing a file_hash.
+    """Return ``(winner_id, [(loser_id, reason), ...])`` for a duplicate group.
 
-    Tiebreakers applied in order until decisive:
+    The resolver itself is the single source of truth for *why* each candidate
+    lost — callers (UI, DB) should never replay the rules to reconstruct a
+    reason.
+
+    Tiebreakers applied in order until decisive. Candidates eliminated at an
+    earlier rule keep the earlier-rule reason; later rules operate only on the
+    still-tied pool:
+
     1. If at least one candidate has a clean filename, all dirty candidates
-       lose and tiebreaking continues among the clean ones. If all candidates
-       are dirty (or all are clean), this rule is a no-op.
-    2. Shorter path wins.
-    3. Older mtime wins.
-    4. Lower id wins.
+       lose with reason ``"filename has dup suffix"`` and tiebreaking
+       continues among the clean ones. If all candidates are dirty (or all
+       are clean), this rule is a no-op.
+    2. Shorter path wins. Longer-path losers get reason ``"longer path"``.
+    3. Older mtime wins. Later-mtime losers get reason ``"later mtime"``.
+    4. Lower id wins. Higher-id losers get reason ``"higher id"``.
     """
     assert len(candidates) >= 2, "resolver called with <2 candidates"
 
+    losers_with_reasons = []
+
+    # Rule 1: clean filename beats dirty (dup-suffix) filename
     clean = [c for c in candidates if not _has_dup_suffix(c.path)]
     dirty = [c for c in candidates if _has_dup_suffix(c.path)]
     if clean and dirty:
-        # rule 1 eliminated dirty; now run rules 2-4 on clean only
+        losers_with_reasons.extend(
+            (c.id, "filename has dup suffix") for c in dirty
+        )
         pool = clean
     else:
         pool = candidates
@@ -53,21 +66,29 @@ def resolve_duplicates(candidates):
     shortest = [c for c in pool if len(c.path) == min_len]
     if len(shortest) == 1:
         winner = shortest[0]
-        losers = [c.id for c in candidates if c.id != winner.id]
-        return winner.id, losers
+        losers_with_reasons.extend(
+            (c.id, "longer path") for c in pool if c.id != winner.id
+        )
+        return winner.id, losers_with_reasons
 
-    # Rule 3: older mtime wins
+    # Rule 3: older mtime wins — operate on `shortest` (still tied at rule 2)
+    pool = shortest
     min_mtime = min(c.mtime for c in pool)
     oldest = [c for c in pool if c.mtime == min_mtime]
     if len(oldest) == 1:
         winner = oldest[0]
-        losers = [c.id for c in candidates if c.id != winner.id]
-        return winner.id, losers
+        losers_with_reasons.extend(
+            (c.id, "later mtime") for c in pool if c.id != winner.id
+        )
+        return winner.id, losers_with_reasons
 
-    # Rule 4: lower id wins (deterministic)
+    # Rule 4: lower id wins (deterministic) — operate on `oldest`
+    pool = oldest
     winner = min(pool, key=lambda c: c.id)
-    losers = [c.id for c in candidates if c.id != winner.id]
-    return winner.id, losers
+    losers_with_reasons.extend(
+        (c.id, "higher id") for c in pool if c.id != winner.id
+    )
+    return winner.id, losers_with_reasons
 
 
 @dataclass

--- a/vireo/duplicates.py
+++ b/vireo/duplicates.py
@@ -2,7 +2,9 @@
 
 Pure functions — no DB access. See docs/plans/2026-04-12-duplicate-detection-design.md.
 """
+import re
 from dataclasses import dataclass
+from pathlib import Path
 
 
 @dataclass
@@ -12,5 +14,37 @@ class DupCandidate:
     mtime: float
 
 
+_DUP_SUFFIX_RES = [
+    re.compile(r" \(\d+\)$", re.IGNORECASE),
+    re.compile(r" copy( \d+)?$", re.IGNORECASE),
+    re.compile(r"-\d+$"),
+    re.compile(r"_\d+$"),
+]
+
+
+def _has_dup_suffix(path: str) -> bool:
+    stem = Path(path).stem
+    return any(r.search(stem) for r in _DUP_SUFFIX_RES)
+
+
 def resolve_duplicates(candidates):
-    raise NotImplementedError
+    """Return (winner_id, [loser_ids]) for a group sharing a file_hash.
+
+    Tiebreakers applied in order until decisive:
+    1. Prefer filenames without dup-ish suffixes (case-insensitive).
+    2. (TODO) shorter path wins.
+    3. (TODO) older mtime wins.
+    4. (TODO) lower id wins.
+    """
+    assert len(candidates) >= 2, "resolver called with <2 candidates"
+
+    clean = [c for c in candidates if not _has_dup_suffix(c.path)]
+    dirty = [c for c in candidates if _has_dup_suffix(c.path)]
+    if clean and dirty:
+        # rule 1 decisive: all dirty are losers; among clean, arbitrary for now
+        winner = clean[0]
+        losers = [c for c in candidates if c.id != winner.id]
+        return winner.id, [l.id for l in losers]
+
+    # No decisive split yet — fall through to later rules (raise for now)
+    raise NotImplementedError("later tiebreakers not yet implemented")

--- a/vireo/duplicates.py
+++ b/vireo/duplicates.py
@@ -1,0 +1,16 @@
+"""Exact-duplicate resolution for photos sharing a file_hash.
+
+Pure functions — no DB access. See docs/plans/2026-04-12-duplicate-detection-design.md.
+"""
+from dataclasses import dataclass
+
+
+@dataclass
+class DupCandidate:
+    id: int
+    path: str
+    mtime: float
+
+
+def resolve_duplicates(candidates):
+    raise NotImplementedError

--- a/vireo/duplicates.py
+++ b/vireo/duplicates.py
@@ -71,7 +71,13 @@ def resolve_duplicates(candidates):
         )
         return winner.id, losers_with_reasons
 
-    # Rule 3: older mtime wins — operate on `shortest` (still tied at rule 2)
+    # Rule 3: older mtime wins — operate on `shortest` (still tied at rule 2).
+    # Record the longer-path candidates being dropped from the pool as losers
+    # now; the later rules only see `shortest`, so without this the longer-path
+    # rows would never appear in losers_with_reasons and stay unrejected.
+    losers_with_reasons.extend(
+        (c.id, "longer path") for c in pool if len(c.path) != min_len
+    )
     pool = shortest
     min_mtime = min(c.mtime for c in pool)
     oldest = [c for c in pool if c.mtime == min_mtime]
@@ -82,7 +88,12 @@ def resolve_duplicates(candidates):
         )
         return winner.id, losers_with_reasons
 
-    # Rule 4: lower id wins (deterministic) — operate on `oldest`
+    # Rule 4: lower id wins (deterministic) — operate on `oldest`.
+    # Same as above: record the later-mtime candidates being dropped so the
+    # rule-4 sub-pool isn't the only source of losers.
+    losers_with_reasons.extend(
+        (c.id, "later mtime") for c in pool if c.mtime != min_mtime
+    )
     pool = oldest
     winner = min(pool, key=lambda c: c.id)
     losers_with_reasons.extend(

--- a/vireo/duplicates.py
+++ b/vireo/duplicates.py
@@ -31,42 +31,43 @@ def resolve_duplicates(candidates):
     """Return (winner_id, [loser_ids]) for a group sharing a file_hash.
 
     Tiebreakers applied in order until decisive:
-    1. Prefer filenames without dup-ish suffixes (case-insensitive).
-    2. (TODO) shorter path wins.
-    3. (TODO) older mtime wins.
-    4. (TODO) lower id wins.
+    1. If at least one candidate has a clean filename, all dirty candidates
+       lose and tiebreaking continues among the clean ones. If all candidates
+       are dirty (or all are clean), this rule is a no-op.
+    2. Shorter path wins.
+    3. Older mtime wins.
+    4. Lower id wins.
     """
     assert len(candidates) >= 2, "resolver called with <2 candidates"
 
     clean = [c for c in candidates if not _has_dup_suffix(c.path)]
     dirty = [c for c in candidates if _has_dup_suffix(c.path)]
     if clean and dirty:
-        # rule 1 decisive: all dirty are losers; among clean, arbitrary for now
-        winner = clean[0]
-        losers = [c for c in candidates if c.id != winner.id]
-        return winner.id, [l.id for l in losers]
+        # rule 1 eliminated dirty; now run rules 2-4 on clean only
+        pool = clean
+    else:
+        pool = candidates
 
-    # All same on rule 1 — try rule 2 (shorter path wins)
-    pool = candidates
+    # Rule 2: shorter path wins
     min_len = min(len(c.path) for c in pool)
     shortest = [c for c in pool if len(c.path) == min_len]
     if len(shortest) == 1:
         winner = shortest[0]
-        losers = [c for c in candidates if c.id != winner.id]
-        return winner.id, [l.id for l in losers]
+        losers = [c.id for c in candidates if c.id != winner.id]
+        return winner.id, losers
 
     # Rule 3: older mtime wins
     min_mtime = min(c.mtime for c in pool)
     oldest = [c for c in pool if c.mtime == min_mtime]
     if len(oldest) == 1:
         winner = oldest[0]
-        losers = [c for c in candidates if c.id != winner.id]
-        return winner.id, [l.id for l in losers]
+        losers = [c.id for c in candidates if c.id != winner.id]
+        return winner.id, losers
 
     # Rule 4: lower id wins (deterministic)
     winner = min(pool, key=lambda c: c.id)
-    losers = [c for c in candidates if c.id != winner.id]
-    return winner.id, [l.id for l in losers]
+    losers = [c.id for c in candidates if c.id != winner.id]
+    return winner.id, losers
 
 
 @dataclass

--- a/vireo/duplicates.py
+++ b/vireo/duplicates.py
@@ -67,3 +67,48 @@ def resolve_duplicates(candidates):
     winner = min(pool, key=lambda c: c.id)
     losers = [c for c in candidates if c.id != winner.id]
     return winner.id, [l.id for l in losers]
+
+
+@dataclass
+class PhotoMetadata:
+    id: int
+    rating: int
+    keyword_ids: set
+    collection_ids: set
+    has_pending_edit: bool
+
+
+@dataclass
+class MergeResult:
+    winner_id: int
+    new_rating: int
+    keyword_ids_to_add: set
+    collection_ids_to_add: set
+    pending_from_loser_id: int | None
+    loser_ids: list
+
+
+def merge_metadata(winner: PhotoMetadata, losers: list) -> MergeResult:
+    new_rating = max([winner.rating] + [l.rating for l in losers])
+
+    all_loser_kws = set().union(*(l.keyword_ids for l in losers)) if losers else set()
+    kws_to_add = all_loser_kws - winner.keyword_ids
+
+    all_loser_cols = set().union(*(l.collection_ids for l in losers)) if losers else set()
+    cols_to_add = all_loser_cols - winner.collection_ids
+
+    pending_from = None
+    if not winner.has_pending_edit:
+        for l in losers:
+            if l.has_pending_edit:
+                pending_from = l.id
+                break
+
+    return MergeResult(
+        winner_id=winner.id,
+        new_rating=new_rating,
+        keyword_ids_to_add=kws_to_add,
+        collection_ids_to_add=cols_to_add,
+        pending_from_loser_id=pending_from,
+        loser_ids=[l.id for l in losers],
+    )

--- a/vireo/duplicates.py
+++ b/vireo/duplicates.py
@@ -46,5 +46,13 @@ def resolve_duplicates(candidates):
         losers = [c for c in candidates if c.id != winner.id]
         return winner.id, [l.id for l in losers]
 
-    # No decisive split yet — fall through to later rules (raise for now)
-    raise NotImplementedError("later tiebreakers not yet implemented")
+    # All same on rule 1 — try rule 2 (shorter path wins)
+    pool = candidates
+    min_len = min(len(c.path) for c in pool)
+    shortest = [c for c in pool if len(c.path) == min_len]
+    if len(shortest) == 1:
+        winner = shortest[0]
+        losers = [c for c in candidates if c.id != winner.id]
+        return winner.id, [l.id for l in losers]
+
+    raise NotImplementedError("rules 3-4 not yet")

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -590,15 +590,20 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 update_params,
             )
             db.conn.commit()
-            # Trigger duplicate auto-resolve now that file_hash is committed.
-            # add_photo was called without the hash, so the hook there was a
-            # no-op — we own firing it here.
-            if file_hash is not None:
-                db.check_and_resolve_duplicates_for_hash(file_hash)
 
-        # Import XMP keywords if sidecar exists
+        # Import XMP keywords if sidecar exists — must land BEFORE the
+        # duplicate auto-resolve hook below, so if this row turns out to be
+        # the loser its keywords are visible to apply_duplicate_resolution's
+        # metadata query and get merged onto the winner. Otherwise the
+        # keywords would be stranded on the rejected row.
         if xmp_path.exists():
             _import_keywords_for_photo(db, photo_id, str(xmp_path))
+
+        # Trigger duplicate auto-resolve now that file_hash AND XMP keywords
+        # are committed. add_photo was called without the hash, so the hook
+        # there was a no-op — we own firing it here.
+        if file_hash is not None:
+            db.check_and_resolve_duplicates_for_hash(file_hash)
 
         if photo_callback:
             photo_callback(photo_id, str(image_path))

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -590,6 +590,11 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 update_params,
             )
             db.conn.commit()
+            # Trigger duplicate auto-resolve now that file_hash is committed.
+            # add_photo was called without the hash, so the hook there was a
+            # no-op — we own firing it here.
+            if file_hash is not None:
+                db.check_and_resolve_duplicates_for_hash(file_hash)
 
         # Import XMP keywords if sidecar exists
         if xmp_path.exists():

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -929,6 +929,7 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   <a href="/workspace" data-nav-id="workspace">Workspace</a>
   <a href="/keywords" data-nav-id="keywords">Keywords</a>
   <a href="/shortcuts" data-nav-id="shortcuts">Shortcuts</a>
+  <a href="/duplicates" data-nav-id="duplicates">Duplicates</a>
   <a href="/settings" data-nav-id="settings">Settings</a>
   <span class="nav-spacer"></span>
   <span class="nav-icon" onclick="openHelpModal()" title="Help (F1)" id="helpToggle">&#63;</span>

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -389,6 +389,7 @@
       showToast('Rejected ' + n + ' duplicate' + (n === 1 ? '' : 's'), 'success');
       clearResults();
     } catch (e) {
+      showToast(e.message || 'Apply failed', 'error');
       status.textContent = '';
       btn.disabled = false;
       // safeFetch already shows a toast on failure.

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -1,0 +1,409 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" type="image/png" href="/favicon.ico">
+<link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
+<link rel="stylesheet" href="/static/vireo-base.css">
+<title>Vireo - Duplicates</title>
+<style>
+  body { padding-bottom: 36px; }
+  .content { max-width: 1200px; }
+
+  .page-header {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 16px;
+  }
+  .page-header h1 { margin: 0; font-size: 20px; font-weight: 600; color: var(--text-primary); }
+  .page-header .sub { font-size: 12px; color: var(--text-dim); margin-top: 4px; }
+
+  .btn-primary {
+    background: var(--accent); color: var(--accent-text); border: none;
+    border-radius: 4px; padding: 8px 16px; font-size: 13px; cursor: pointer;
+    font-weight: 500;
+  }
+  .btn-primary:hover { filter: brightness(1.1); }
+  .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .btn-secondary {
+    background: var(--bg-tertiary); color: var(--text-secondary);
+    border: 1px solid var(--border-secondary); border-radius: 4px;
+    padding: 6px 14px; font-size: 12px; cursor: pointer;
+  }
+  .btn-secondary:hover { background: var(--border-secondary); }
+
+  .empty-state, .no-results {
+    text-align: center; padding: 48px 20px; color: var(--text-dim);
+    border: 1px dashed var(--border-primary); border-radius: 8px;
+  }
+  .empty-state .label { margin-bottom: 16px; font-size: 14px; }
+
+  .progress-box {
+    padding: 16px; border: 1px solid var(--border-primary); border-radius: 8px;
+    background: var(--bg-secondary); margin-bottom: 16px;
+  }
+  .progress-box .status { font-size: 13px; color: var(--text-secondary); }
+  .progress-box .spinner {
+    display: inline-block; width: 10px; height: 10px; margin-right: 8px;
+    border: 2px solid var(--border-secondary); border-top-color: var(--accent);
+    border-radius: 50%; animation: spin 1s linear infinite;
+    vertical-align: middle;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  .summary-bar {
+    display: flex; gap: 24px; padding: 12px 16px; margin-bottom: 16px;
+    background: var(--bg-secondary); border: 1px solid var(--border-primary);
+    border-radius: 6px; align-items: center;
+  }
+  .summary-stat .num {
+    font-size: 20px; font-weight: 600; color: var(--text-primary);
+  }
+  .summary-stat .label {
+    font-size: 11px; color: var(--text-dim); text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .dup-group {
+    border: 1px solid var(--border-primary); border-radius: 8px;
+    padding: 12px; margin-bottom: 12px; background: var(--bg-secondary);
+  }
+  .dup-group-header {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 10px; padding-bottom: 8px;
+    border-bottom: 1px solid var(--border-primary);
+  }
+  .dup-group-header label {
+    display: flex; align-items: center; gap: 8px;
+    font-size: 13px; color: var(--text-secondary); cursor: pointer;
+    user-select: none;
+  }
+  .dup-group-header .hash {
+    font-family: monospace; font-size: 11px; color: var(--text-ghost);
+    margin-left: auto;
+  }
+
+  .dup-row { display: flex; flex-wrap: wrap; gap: 12px; }
+
+  .dup-card {
+    width: 180px; display: flex; flex-direction: column;
+    border: 2px solid transparent; border-radius: 6px;
+    padding: 6px; background: var(--bg-tertiary);
+  }
+  .dup-card.winner { border-color: var(--accent); }
+  .dup-card.loser { opacity: 0.65; }
+  .dup-card .thumb {
+    width: 100%; aspect-ratio: 4/3; object-fit: cover;
+    border-radius: 4px; background: var(--bg-primary);
+    display: block;
+  }
+  .dup-card .thumb-placeholder {
+    width: 100%; aspect-ratio: 4/3; border-radius: 4px;
+    background: var(--bg-primary); display: flex;
+    align-items: center; justify-content: center;
+    color: var(--text-ghost); font-size: 11px;
+  }
+  .dup-card .badge {
+    display: inline-block; margin-top: 6px;
+    padding: 2px 8px; border-radius: 3px;
+    font-size: 10px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.5px;
+    align-self: flex-start;
+  }
+  .dup-card.winner .badge {
+    background: var(--accent); color: var(--accent-text);
+  }
+  .dup-card.loser .badge {
+    background: var(--danger); color: var(--text-primary);
+  }
+  .dup-card .filename {
+    margin-top: 4px; font-size: 12px; color: var(--text-primary);
+    word-break: break-all; font-weight: 500;
+  }
+  .dup-card .path {
+    font-size: 10px; color: var(--text-dim); word-break: break-all;
+    margin-top: 2px;
+  }
+  .dup-card .reason {
+    font-size: 11px; color: var(--danger); margin-top: 4px;
+    font-style: italic;
+  }
+  .dup-card .meta {
+    font-size: 10px; color: var(--text-ghost); margin-top: 4px;
+  }
+
+  .apply-bar {
+    position: sticky; bottom: 0; background: var(--bg-primary);
+    padding: 12px 0; border-top: 1px solid var(--border-primary);
+    margin-top: 16px; display: flex; gap: 12px; align-items: center;
+  }
+</style>
+</head>
+<body>
+
+{% include '_navbar.html' %}
+
+<div class="content">
+
+  <div class="page-header">
+    <div>
+      <h1>Duplicate Files</h1>
+      <div class="sub">Find exact-byte duplicate photos and reject the inferior copy.</div>
+    </div>
+    <div>
+      <button id="scanBtn" class="btn-primary" onclick="startScan()">Scan for duplicate files</button>
+    </div>
+  </div>
+
+  <div id="progress" class="progress-box" style="display:none;">
+    <span class="spinner"></span>
+    <span class="status" id="progressStatus">Starting scan...</span>
+  </div>
+
+  <div id="summary" style="display:none;"></div>
+
+  <div id="results"></div>
+
+  <div id="emptyState" class="empty-state">
+    <div class="label">Click <b>Scan for duplicate files</b> to find exact-byte duplicates in your library.</div>
+  </div>
+
+  <div id="applyBar" class="apply-bar" style="display:none;">
+    <button id="applyBtn" class="btn-primary" onclick="applyRejections()">Reject 0 losers</button>
+    <button class="btn-secondary" onclick="clearResults()">Clear results</button>
+    <span id="applyStatus" style="font-size:12px;color:var(--text-dim);"></span>
+  </div>
+
+</div>
+
+<script>
+  var _proposals = [];
+  var _currentJobId = null;
+
+  function escapeHtml(s) {
+    if (s == null) return '';
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function showProgress(msg) {
+    var pg = document.getElementById('progress');
+    pg.style.display = '';
+    document.getElementById('progressStatus').textContent = msg || 'Scanning...';
+  }
+
+  function hideProgress() {
+    document.getElementById('progress').style.display = 'none';
+  }
+
+  function setEmptyVisible(visible) {
+    document.getElementById('emptyState').style.display = visible ? '' : 'none';
+  }
+
+  async function startScan() {
+    var scanBtn = document.getElementById('scanBtn');
+    scanBtn.disabled = true;
+    setEmptyVisible(false);
+    document.getElementById('results').innerHTML = '';
+    document.getElementById('summary').style.display = 'none';
+    document.getElementById('applyBar').style.display = 'none';
+    showProgress('Starting scan...');
+
+    try {
+      var data = await safeFetch('/api/duplicates/scan', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: '{}',
+      }, { toast: false });
+      _currentJobId = data.job_id;
+
+      safeEventSource('/api/jobs/' + data.job_id + '/stream', {
+        onProgress: function(p) {
+          var msg = p.phase || p.current_file || 'Scanning...';
+          if (p.total && p.current != null) {
+            msg += ' (' + p.current + '/' + p.total + ')';
+          }
+          showProgress(msg);
+        },
+        onComplete: function(evt) {
+          if (evt.status === 'completed') {
+            renderResults(evt.result || {});
+          } else if (evt.status === 'cancelled') {
+            hideProgress();
+            scanBtn.disabled = false;
+            setEmptyVisible(true);
+            showToast('Scan cancelled', 'error');
+          } else {
+            hideProgress();
+            scanBtn.disabled = false;
+            setEmptyVisible(true);
+            var err = (evt.errors || []).join(', ') || 'Scan failed';
+            showToast(err, 'error');
+          }
+        },
+        onError: function() {
+          hideProgress();
+          scanBtn.disabled = false;
+          setEmptyVisible(true);
+        },
+      });
+    } catch (e) {
+      hideProgress();
+      scanBtn.disabled = false;
+      setEmptyVisible(true);
+      showToast(e.message || 'Failed to start scan', 'error');
+    }
+  }
+
+  function renderResults(result) {
+    hideProgress();
+    document.getElementById('scanBtn').disabled = false;
+
+    _proposals = result.proposals || [];
+    var groupCount = result.group_count != null ? result.group_count : _proposals.length;
+    var loserCount = result.loser_count || 0;
+
+    if (_proposals.length === 0) {
+      setEmptyVisible(false);
+      document.getElementById('results').innerHTML =
+        '<div class="no-results">No duplicates found. Your library is clean.</div>';
+      return;
+    }
+
+    setEmptyVisible(false);
+
+    // Summary
+    var summary = document.getElementById('summary');
+    summary.style.display = '';
+    summary.innerHTML =
+      '<div class="summary-bar">' +
+        '<div class="summary-stat"><div class="num">' + groupCount + '</div>' +
+          '<div class="label">Duplicate groups</div></div>' +
+        '<div class="summary-stat"><div class="num" style="color:var(--danger);">' + loserCount + '</div>' +
+          '<div class="label">Losers to reject</div></div>' +
+      '</div>';
+
+    // Groups
+    var html = '';
+    _proposals.forEach(function(group, gi) {
+      var winner = group.winner || {};
+      var losers = group.losers || [];
+      var hash = group.file_hash || '';
+
+      html += '<div class="dup-group" data-hash="' + escapeHtml(hash) + '">';
+      html += '<div class="dup-group-header">';
+      html += '<label><input type="checkbox" class="group-check" data-gi="' + gi + '" checked onchange="updateApplyCount()"> ' +
+              'Include this group (' + losers.length + ' to reject)</label>';
+      html += '<span class="hash">' + escapeHtml(hash.substring(0, 16)) + '...</span>';
+      html += '</div>';
+
+      html += '<div class="dup-row">';
+      html += renderCard(winner, true, null);
+      losers.forEach(function(loser) {
+        html += renderCard(loser, false, loser.reason);
+      });
+      html += '</div>';
+      html += '</div>';
+    });
+    document.getElementById('results').innerHTML = html;
+
+    document.getElementById('applyBar').style.display = '';
+    updateApplyCount();
+  }
+
+  function renderCard(photo, isWinner, reason) {
+    var cls = isWinner ? 'winner' : 'loser';
+    var badge = isWinner ? 'KEEP' : 'WILL REJECT';
+    var thumbUrl = photo.id != null ? ('/thumbnails/' + photo.id + '.jpg') : null;
+    var html = '<div class="dup-card ' + cls + '">';
+    if (thumbUrl) {
+      html += '<img class="thumb" src="' + escapeHtml(thumbUrl) +
+              '" alt="' + escapeHtml(photo.filename || '') +
+              '" onerror="this.outerHTML=\'<div class=\\\'thumb-placeholder\\\'>No thumbnail</div>\'">';
+    } else {
+      html += '<div class="thumb-placeholder">No thumbnail</div>';
+    }
+    html += '<span class="badge">' + badge + '</span>';
+    html += '<div class="filename">' + escapeHtml(photo.filename || '') + '</div>';
+    html += '<div class="path">' + escapeHtml(photo.path || '') + '</div>';
+    var meta = [];
+    if (photo.rating != null && photo.rating > 0) meta.push(photo.rating + '\u2605');
+    if (photo.file_size != null) meta.push(formatBytes(photo.file_size));
+    if (meta.length) html += '<div class="meta">' + meta.join(' \u00b7 ') + '</div>';
+    if (reason) html += '<div class="reason">' + escapeHtml(reason) + '</div>';
+    html += '</div>';
+    return html;
+  }
+
+  function formatBytes(n) {
+    if (n == null) return '';
+    if (n < 1024) return n + ' B';
+    if (n < 1024 * 1024) return (n / 1024).toFixed(1) + ' KB';
+    if (n < 1024 * 1024 * 1024) return (n / 1024 / 1024).toFixed(1) + ' MB';
+    return (n / 1024 / 1024 / 1024).toFixed(2) + ' GB';
+  }
+
+  function getCheckedGroups() {
+    var checked = [];
+    document.querySelectorAll('.group-check').forEach(function(cb) {
+      if (cb.checked) {
+        var gi = parseInt(cb.getAttribute('data-gi'), 10);
+        if (!isNaN(gi) && _proposals[gi]) checked.push(_proposals[gi]);
+      }
+    });
+    return checked;
+  }
+
+  function updateApplyCount() {
+    var checked = getCheckedGroups();
+    var loserCount = 0;
+    checked.forEach(function(g) { loserCount += (g.losers || []).length; });
+    var btn = document.getElementById('applyBtn');
+    btn.textContent = 'Reject ' + loserCount + ' loser' + (loserCount === 1 ? '' : 's');
+    btn.disabled = loserCount === 0;
+  }
+
+  async function applyRejections() {
+    var checked = getCheckedGroups();
+    if (checked.length === 0) return;
+    var hashes = checked.map(function(g) { return g.file_hash; }).filter(Boolean);
+    if (hashes.length === 0) return;
+
+    var btn = document.getElementById('applyBtn');
+    var status = document.getElementById('applyStatus');
+    btn.disabled = true;
+    status.textContent = 'Applying...';
+
+    try {
+      var data = await safeFetch('/api/duplicates/apply', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ hashes: hashes }),
+      });
+      var n = data.rejected_count || 0;
+      showToast('Rejected ' + n + ' duplicate' + (n === 1 ? '' : 's'), 'success');
+      clearResults();
+    } catch (e) {
+      status.textContent = '';
+      btn.disabled = false;
+      // safeFetch already shows a toast on failure.
+    }
+  }
+
+  function clearResults() {
+    _proposals = [];
+    _currentJobId = null;
+    document.getElementById('results').innerHTML = '';
+    document.getElementById('summary').style.display = 'none';
+    document.getElementById('applyBar').style.display = 'none';
+    document.getElementById('applyStatus').textContent = '';
+    setEmptyVisible(true);
+  }
+</script>
+</body>
+</html>

--- a/vireo/tests/test_duplicates.py
+++ b/vireo/tests/test_duplicates.py
@@ -14,6 +14,11 @@ def test_module_exports_exist():
     assert callable(resolve_duplicates)
 
 
+def _loser_ids(losers):
+    """resolve_duplicates now returns [(loser_id, reason), ...] — strip reasons."""
+    return [lid for lid, _ in losers]
+
+
 @pytest.mark.parametrize("clean_name, dup_name", [
     ("owl.jpg", "owl (2).jpg"),
     ("owl.jpg", "owl (10).jpg"),
@@ -28,7 +33,7 @@ def test_resolve_prefers_clean_filename(clean_name, dup_name):
     dup = DupCandidate(id=2, path=f"/a/{dup_name}", mtime=100.0)
     winner, losers = resolve_duplicates([dup, clean])  # order shouldn't matter
     assert winner == 1
-    assert losers == [2]
+    assert _loser_ids(losers) == [2]
 
 
 def test_resolve_prefers_shorter_path():
@@ -36,7 +41,7 @@ def test_resolve_prefers_shorter_path():
     deep = DupCandidate(id=2, path="/pics/archive/2024/owl.jpg", mtime=100.0)
     winner, losers = resolve_duplicates([deep, shallow])
     assert winner == 1
-    assert losers == [2]
+    assert _loser_ids(losers) == [2]
 
 
 def test_resolve_prefers_older_mtime():
@@ -44,7 +49,7 @@ def test_resolve_prefers_older_mtime():
     newer = DupCandidate(id=2, path="/b/owl.jpg", mtime=200.0)  # same-length path
     winner, losers = resolve_duplicates([newer, older])
     assert winner == 1
-    assert losers == [2]
+    assert _loser_ids(losers) == [2]
 
 
 def test_resolve_falls_back_to_lower_id():
@@ -52,7 +57,7 @@ def test_resolve_falls_back_to_lower_id():
     b = DupCandidate(id=3, path="/b/owl.jpg", mtime=100.0)  # same everything
     winner, losers = resolve_duplicates([a, b])
     assert winner == 3
-    assert losers == [5]
+    assert _loser_ids(losers) == [5]
 
 
 def test_resolve_three_way_middle_wins():
@@ -61,7 +66,7 @@ def test_resolve_three_way_middle_wins():
     c = DupCandidate(id=3, path="/archive/deep/owl.jpg", mtime=100.0)  # clean, long
     winner, losers = resolve_duplicates([a, b, c])
     assert winner == 2
-    assert sorted(losers) == [1, 3]
+    assert sorted(_loser_ids(losers)) == [1, 3]
 
 
 def test_resolve_rule1_cascades_to_rule2_among_clean():
@@ -71,7 +76,7 @@ def test_resolve_rule1_cascades_to_rule2_among_clean():
     # Pass in an order that would tempt the old buggy code to pick id=1:
     winner, losers = resolve_duplicates([long_clean, short_clean, dirty])
     assert winner == 2                    # rule 2 (shorter path) decides among clean
-    assert sorted(losers) == [1, 3]        # both the long-clean and the dirty one lose
+    assert sorted(_loser_ids(losers)) == [1, 3]  # long-clean and dirty both lose
 
 
 def test_resolve_all_dirty_falls_through_to_rules_2_through_4():
@@ -79,7 +84,66 @@ def test_resolve_all_dirty_falls_through_to_rules_2_through_4():
     b = DupCandidate(id=2, path="/a/owl (3).jpg",         mtime=100.0)
     winner, losers = resolve_duplicates([a, b])
     assert winner == 2  # rule 2 — shorter path wins among all-dirty
-    assert losers == [1]
+    assert _loser_ids(losers) == [1]
+
+
+# -----------------------------------------------------------------------------
+# Reason strings — resolver is the single source of truth for *why* each
+# loser was picked. Locked in so callers don't replay the rules.
+# -----------------------------------------------------------------------------
+
+def test_resolve_returns_reason_rule1():
+    """Rule 1: a dirty-suffix loser gets reason 'filename has dup suffix'."""
+    clean = DupCandidate(id=1, path="/a/owl.jpg", mtime=100.0)
+    dirty = DupCandidate(id=2, path="/a/owl (2).jpg", mtime=100.0)
+    winner, losers = resolve_duplicates([clean, dirty])
+    assert winner == 1
+    assert losers == [(2, "filename has dup suffix")]
+
+
+def test_resolve_returns_reason_rule2():
+    """Rule 2: longer-path clean loser gets reason 'longer path'."""
+    short = DupCandidate(id=1, path="/a/owl.jpg", mtime=100.0)
+    long_ = DupCandidate(id=2, path="/archive/deep/owl.jpg", mtime=100.0)
+    winner, losers = resolve_duplicates([short, long_])
+    assert winner == 1
+    assert losers == [(2, "longer path")]
+
+
+def test_resolve_returns_reason_rule3():
+    """Rule 3: same-length paths, later mtime loses with reason 'later mtime'."""
+    older = DupCandidate(id=1, path="/a/owl.jpg", mtime=100.0)
+    newer = DupCandidate(id=2, path="/b/owl.jpg", mtime=200.0)
+    winner, losers = resolve_duplicates([older, newer])
+    assert winner == 1
+    assert losers == [(2, "later mtime")]
+
+
+def test_resolve_returns_reason_rule4():
+    """Rule 4: everything tied, higher-id loses with reason 'higher id'."""
+    a = DupCandidate(id=3, path="/a/owl.jpg", mtime=100.0)
+    b = DupCandidate(id=5, path="/b/owl.jpg", mtime=100.0)
+    winner, losers = resolve_duplicates([a, b])
+    assert winner == 3
+    assert losers == [(5, "higher id")]
+
+
+def test_resolve_mixed_reasons_in_three_way():
+    """3-way: one rule-1 loser (dirty), one rule-2 loser (long clean).
+
+    The dirty candidate is eliminated at rule 1 and keeps that reason; rule 2
+    only sees the two clean candidates and tags the longer one.
+    """
+    short_clean = DupCandidate(id=1, path="/a/owl.jpg", mtime=100.0)
+    long_clean  = DupCandidate(id=2, path="/archive/deep/owl.jpg", mtime=100.0)
+    dirty       = DupCandidate(id=3, path="/a/owl (2).jpg", mtime=100.0)
+    winner, losers = resolve_duplicates([short_clean, long_clean, dirty])
+    assert winner == 1
+    reasons = dict(losers)
+    assert reasons == {
+        2: "longer path",
+        3: "filename has dup suffix",
+    }
 
 
 def test_merge_rating_takes_max():

--- a/vireo/tests/test_duplicates.py
+++ b/vireo/tests/test_duplicates.py
@@ -24,3 +24,11 @@ def test_resolve_prefers_clean_filename(clean_name, dup_name):
     winner, losers = resolve_duplicates([dup, clean])  # order shouldn't matter
     assert winner == 1
     assert losers == [2]
+
+
+def test_resolve_prefers_shorter_path():
+    shallow = DupCandidate(id=1, path="/pics/owl.jpg", mtime=100.0)
+    deep = DupCandidate(id=2, path="/pics/archive/2024/owl.jpg", mtime=100.0)
+    winner, losers = resolve_duplicates([deep, shallow])
+    assert winner == 1
+    assert losers == [2]

--- a/vireo/tests/test_duplicates.py
+++ b/vireo/tests/test_duplicates.py
@@ -1,0 +1,7 @@
+from vireo.duplicates import DupCandidate, resolve_duplicates
+
+
+def test_module_exports_exist():
+    c = DupCandidate(id=1, path="/a/owl.jpg", mtime=100.0)
+    assert c.id == 1
+    assert callable(resolve_duplicates)

--- a/vireo/tests/test_duplicates.py
+++ b/vireo/tests/test_duplicates.py
@@ -1,3 +1,5 @@
+import pytest
+
 from vireo.duplicates import DupCandidate, resolve_duplicates
 
 
@@ -5,3 +7,20 @@ def test_module_exports_exist():
     c = DupCandidate(id=1, path="/a/owl.jpg", mtime=100.0)
     assert c.id == 1
     assert callable(resolve_duplicates)
+
+
+@pytest.mark.parametrize("clean_name, dup_name", [
+    ("owl.jpg", "owl (2).jpg"),
+    ("owl.jpg", "owl (10).jpg"),
+    ("owl.jpg", "owl copy.jpg"),
+    ("owl.jpg", "owl copy 3.jpg"),
+    ("owl.jpg", "owl-1.jpg"),
+    ("owl.jpg", "owl_1.jpg"),
+    ("owl.jpg", "owl COPY.jpg"),  # case-insensitive
+])
+def test_resolve_prefers_clean_filename(clean_name, dup_name):
+    clean = DupCandidate(id=1, path=f"/a/{clean_name}", mtime=100.0)
+    dup = DupCandidate(id=2, path=f"/a/{dup_name}", mtime=100.0)
+    winner, losers = resolve_duplicates([dup, clean])  # order shouldn't matter
+    assert winner == 1
+    assert losers == [2]

--- a/vireo/tests/test_duplicates.py
+++ b/vireo/tests/test_duplicates.py
@@ -1,6 +1,11 @@
 import pytest
 
-from vireo.duplicates import DupCandidate, resolve_duplicates
+from vireo.duplicates import (
+    DupCandidate,
+    PhotoMetadata,
+    merge_metadata,
+    resolve_duplicates,
+)
 
 
 def test_module_exports_exist():
@@ -57,3 +62,38 @@ def test_resolve_three_way_middle_wins():
     winner, losers = resolve_duplicates([a, b, c])
     assert winner == 2
     assert sorted(losers) == [1, 3]
+
+
+def test_merge_rating_takes_max():
+    winner = PhotoMetadata(id=1, rating=0, keyword_ids=set(), collection_ids=set(), has_pending_edit=False)
+    losers = [PhotoMetadata(id=2, rating=5, keyword_ids=set(), collection_ids=set(), has_pending_edit=False)]
+    result = merge_metadata(winner, losers)
+    assert result.new_rating == 5
+
+
+def test_merge_keywords_union():
+    winner = PhotoMetadata(id=1, rating=0, keyword_ids={10}, collection_ids=set(), has_pending_edit=False)
+    losers = [PhotoMetadata(id=2, rating=0, keyword_ids={20, 30}, collection_ids=set(), has_pending_edit=False)]
+    result = merge_metadata(winner, losers)
+    assert result.keyword_ids_to_add == {20, 30}  # only new ones
+
+
+def test_merge_collections_union():
+    winner = PhotoMetadata(id=1, rating=0, keyword_ids=set(), collection_ids={100}, has_pending_edit=False)
+    losers = [PhotoMetadata(id=2, rating=0, keyword_ids=set(), collection_ids={100, 200}, has_pending_edit=False)]
+    result = merge_metadata(winner, losers)
+    assert result.collection_ids_to_add == {200}
+
+
+def test_merge_pending_copy_when_winner_has_none():
+    winner = PhotoMetadata(id=1, rating=0, keyword_ids=set(), collection_ids=set(), has_pending_edit=False)
+    losers = [PhotoMetadata(id=2, rating=0, keyword_ids=set(), collection_ids=set(), has_pending_edit=True)]
+    result = merge_metadata(winner, losers)
+    assert result.pending_from_loser_id == 2
+
+
+def test_merge_pending_skip_when_both_have():
+    winner = PhotoMetadata(id=1, rating=0, keyword_ids=set(), collection_ids=set(), has_pending_edit=True)
+    losers = [PhotoMetadata(id=2, rating=0, keyword_ids=set(), collection_ids=set(), has_pending_edit=True)]
+    result = merge_metadata(winner, losers)
+    assert result.pending_from_loser_id is None

--- a/vireo/tests/test_duplicates.py
+++ b/vireo/tests/test_duplicates.py
@@ -32,3 +32,11 @@ def test_resolve_prefers_shorter_path():
     winner, losers = resolve_duplicates([deep, shallow])
     assert winner == 1
     assert losers == [2]
+
+
+def test_resolve_prefers_older_mtime():
+    older = DupCandidate(id=1, path="/a/owl.jpg", mtime=100.0)
+    newer = DupCandidate(id=2, path="/b/owl.jpg", mtime=200.0)  # same-length path
+    winner, losers = resolve_duplicates([newer, older])
+    assert winner == 1
+    assert losers == [2]

--- a/vireo/tests/test_duplicates.py
+++ b/vireo/tests/test_duplicates.py
@@ -146,6 +146,54 @@ def test_resolve_mixed_reasons_in_three_way():
     }
 
 
+def test_resolve_preserves_longer_path_losers_when_rule2_still_tied():
+    """Rule 2 (shorter-path wins) may leave multiple candidates tied on the
+    shortest length. The longer-path candidates being dropped from the pool
+    must still be recorded as 'longer path' losers — otherwise the DB layer
+    only rejects losers from the rule-3/4 sub-pool and leaves rows with the
+    same file_hash unflagged.
+    """
+    # Two short-path candidates tied, two longer-path candidates dropped.
+    # Rule 3 breaks the short-path tie (a < b by mtime).
+    a = DupCandidate(id=1, path="/x/owl.jpg", mtime=100.0)
+    b = DupCandidate(id=2, path="/x/owl.jpg", mtime=200.0)
+    c = DupCandidate(id=3, path="/archive/deep/owl.jpg", mtime=100.0)
+    d = DupCandidate(id=4, path="/archive/deep/owl.jpg", mtime=200.0)
+    winner, losers = resolve_duplicates([a, b, c, d])
+    assert winner == 1
+    reasons = dict(losers)
+    assert reasons == {
+        2: "later mtime",
+        3: "longer path",
+        4: "longer path",
+    }
+    # Sanity: every non-winner candidate must appear in losers.
+    assert {c.id for c in [a, b, c, d] if c.id != winner} == set(reasons)
+
+
+def test_resolve_preserves_later_mtime_losers_when_rule3_still_tied():
+    """Rule 3 (oldest-mtime wins) may leave multiple candidates tied on the
+    oldest mtime. Later-mtime candidates being dropped from the pool must
+    still be recorded as 'later mtime' losers so the DB layer rejects the
+    full duplicate set, not just the rule-4 sub-pool.
+    """
+    # All four share the shortest path (rule 2 no-op). Two share oldest mtime
+    # (rule 3 leaves pool=[a,b]); rule 4 picks lowest id among those.
+    a = DupCandidate(id=1, path="/x/owl.jpg", mtime=100.0)
+    b = DupCandidate(id=2, path="/x/owl.jpg", mtime=100.0)
+    c = DupCandidate(id=3, path="/x/owl.jpg", mtime=200.0)
+    d = DupCandidate(id=4, path="/x/owl.jpg", mtime=200.0)
+    winner, losers = resolve_duplicates([a, b, c, d])
+    assert winner == 1
+    reasons = dict(losers)
+    assert reasons == {
+        2: "higher id",
+        3: "later mtime",
+        4: "later mtime",
+    }
+    assert {c.id for c in [a, b, c, d] if c.id != winner} == set(reasons)
+
+
 def test_merge_rating_takes_max():
     winner = PhotoMetadata(id=1, rating=0, keyword_ids=set(), collection_ids=set(), has_pending_edit=False)
     losers = [PhotoMetadata(id=2, rating=5, keyword_ids=set(), collection_ids=set(), has_pending_edit=False)]

--- a/vireo/tests/test_duplicates.py
+++ b/vireo/tests/test_duplicates.py
@@ -64,6 +64,24 @@ def test_resolve_three_way_middle_wins():
     assert sorted(losers) == [1, 3]
 
 
+def test_resolve_rule1_cascades_to_rule2_among_clean():
+    long_clean  = DupCandidate(id=1, path="/archive/deep/owl.jpg", mtime=100.0)
+    short_clean = DupCandidate(id=2, path="/a/owl.jpg",           mtime=100.0)
+    dirty       = DupCandidate(id=3, path="/a/owl (2).jpg",       mtime=100.0)
+    # Pass in an order that would tempt the old buggy code to pick id=1:
+    winner, losers = resolve_duplicates([long_clean, short_clean, dirty])
+    assert winner == 2                    # rule 2 (shorter path) decides among clean
+    assert sorted(losers) == [1, 3]        # both the long-clean and the dirty one lose
+
+
+def test_resolve_all_dirty_falls_through_to_rules_2_through_4():
+    a = DupCandidate(id=1, path="/a/archive/owl (2).jpg", mtime=100.0)
+    b = DupCandidate(id=2, path="/a/owl (3).jpg",         mtime=100.0)
+    winner, losers = resolve_duplicates([a, b])
+    assert winner == 2  # rule 2 — shorter path wins among all-dirty
+    assert losers == [1]
+
+
 def test_merge_rating_takes_max():
     winner = PhotoMetadata(id=1, rating=0, keyword_ids=set(), collection_ids=set(), has_pending_edit=False)
     losers = [PhotoMetadata(id=2, rating=5, keyword_ids=set(), collection_ids=set(), has_pending_edit=False)]

--- a/vireo/tests/test_duplicates.py
+++ b/vireo/tests/test_duplicates.py
@@ -40,3 +40,20 @@ def test_resolve_prefers_older_mtime():
     winner, losers = resolve_duplicates([newer, older])
     assert winner == 1
     assert losers == [2]
+
+
+def test_resolve_falls_back_to_lower_id():
+    a = DupCandidate(id=5, path="/a/owl.jpg", mtime=100.0)
+    b = DupCandidate(id=3, path="/b/owl.jpg", mtime=100.0)  # same everything
+    winner, losers = resolve_duplicates([a, b])
+    assert winner == 3
+    assert losers == [5]
+
+
+def test_resolve_three_way_middle_wins():
+    a = DupCandidate(id=1, path="/a/owl (2).jpg", mtime=100.0)  # dup suffix
+    b = DupCandidate(id=2, path="/a/owl.jpg", mtime=100.0)       # clean, short
+    c = DupCandidate(id=3, path="/archive/deep/owl.jpg", mtime=100.0)  # clean, long
+    winner, losers = resolve_duplicates([a, b, c])
+    assert winner == 2
+    assert sorted(losers) == [1, 3]

--- a/vireo/tests/test_duplicates_api.py
+++ b/vireo/tests/test_duplicates_api.py
@@ -1,0 +1,164 @@
+"""API tests for /api/duplicates/scan and /api/duplicates/apply."""
+import time
+
+
+def _seed_pair(db, file_hash, fid, name_a="x.jpg", name_b="x (2).jpg"):
+    """Seed two dup photos sharing a hash, then undo the hook's auto-reject."""
+    p1 = db.add_photo(
+        folder_id=fid, filename=name_a, extension=".jpg",
+        file_size=1000, file_mtime=100.0, file_hash=file_hash,
+    )
+    p2 = db.add_photo(
+        folder_id=fid, filename=name_b, extension=".jpg",
+        file_size=1000, file_mtime=200.0, file_hash=file_hash,
+    )
+    db.conn.execute(
+        "UPDATE photos SET flag='none' WHERE file_hash=?", (file_hash,)
+    )
+    db.conn.commit()
+    return p1, p2
+
+
+def test_scan_endpoint_starts_job(app_and_db):
+    """POST /api/duplicates/scan kicks off a background job and returns job_id."""
+    app, db = app_and_db
+    fid = db.add_folder("/tmp/dupscan1")
+    _seed_pair(db, "H1", fid)
+
+    client = app.test_client()
+    resp = client.post("/api/duplicates/scan")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "job_id" in body
+    assert body["job_id"].startswith("duplicate-scan-")
+
+
+def test_scan_endpoint_job_completes_with_proposals(app_and_db):
+    """The spawned job completes and stores proposals in its result."""
+    app, db = app_and_db
+    fid = db.add_folder("/tmp/dupscan2")
+    _seed_pair(db, "HSCAN", fid)
+
+    client = app.test_client()
+    resp = client.post("/api/duplicates/scan")
+    job_id = resp.get_json()["job_id"]
+
+    for _ in range(50):
+        resp = client.get(f"/api/jobs/{job_id}")
+        data = resp.get_json()
+        if data["status"] in ("completed", "failed"):
+            break
+        time.sleep(0.1)
+
+    assert data["status"] == "completed"
+    result = data["result"]
+    assert result["group_count"] >= 1
+    hashes = [p["file_hash"] for p in result["proposals"]]
+    assert "HSCAN" in hashes
+
+
+def test_apply_endpoint_rejects_losers(app_and_db):
+    """POST /api/duplicates/apply flags the losers as rejected."""
+    app, db = app_and_db
+    fid = db.add_folder("/tmp/dupapply1")
+    p1, p2 = _seed_pair(db, "H2", fid, name_a="y.jpg", name_b="y (2).jpg")
+
+    client = app.test_client()
+    resp = client.post("/api/duplicates/apply", json={"hashes": ["H2"]})
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["rejected_count"] == 1
+
+    flag1 = db.conn.execute("SELECT flag FROM photos WHERE id=?", (p1,)).fetchone()["flag"]
+    flag2 = db.conn.execute("SELECT flag FROM photos WHERE id=?", (p2,)).fetchone()["flag"]
+    assert flag1 != "rejected"
+    assert flag2 == "rejected"
+
+
+def test_apply_endpoint_rejects_only_losers_not_all_but_one(app_and_db):
+    """With a 3-way dup, exactly the resolver-picked losers are rejected."""
+    app, db = app_and_db
+    fid = db.add_folder("/tmp/dupapply2")
+    p1 = db.add_photo(
+        folder_id=fid, filename="z.jpg", extension=".jpg",
+        file_size=1000, file_mtime=100.0,
+    )
+    p2 = db.add_photo(
+        folder_id=fid, filename="z (2).jpg", extension=".jpg",
+        file_size=1000, file_mtime=100.0,
+    )
+    p3 = db.add_photo(
+        folder_id=fid, filename="z copy.jpg", extension=".jpg",
+        file_size=1000, file_mtime=100.0,
+    )
+    db.conn.execute(
+        "UPDATE photos SET file_hash='H3', flag='none' WHERE id IN (?, ?, ?)",
+        (p1, p2, p3),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.post("/api/duplicates/apply", json={"hashes": ["H3"]})
+    assert resp.status_code == 200
+    assert resp.get_json()["rejected_count"] == 2
+
+    # Clean filename p1 wins; the two dirty ones get rejected.
+    flag1 = db.conn.execute("SELECT flag FROM photos WHERE id=?", (p1,)).fetchone()["flag"]
+    flag2 = db.conn.execute("SELECT flag FROM photos WHERE id=?", (p2,)).fetchone()["flag"]
+    flag3 = db.conn.execute("SELECT flag FROM photos WHERE id=?", (p3,)).fetchone()["flag"]
+    assert flag1 != "rejected"
+    assert flag2 == "rejected"
+    assert flag3 == "rejected"
+
+
+def test_apply_endpoint_skips_already_resolved_hash(app_and_db):
+    """If only one non-rejected row remains, skip — return 0 rejects."""
+    app, db = app_and_db
+    fid = db.add_folder("/tmp/dupapply3")
+    # Hook auto-rejects one; leave as-is so only 1 non-rejected row remains.
+    db.add_photo(
+        folder_id=fid, filename="w.jpg", extension=".jpg",
+        file_size=1000, file_mtime=100.0, file_hash="H4",
+    )
+    db.add_photo(
+        folder_id=fid, filename="w (2).jpg", extension=".jpg",
+        file_size=1000, file_mtime=100.0, file_hash="H4",
+    )
+
+    client = app.test_client()
+    resp = client.post("/api/duplicates/apply", json={"hashes": ["H4"]})
+    assert resp.status_code == 200
+    assert resp.get_json()["rejected_count"] == 0
+
+
+def test_apply_endpoint_missing_hashes_returns_400(app_and_db):
+    """Missing 'hashes' key -> 400."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/duplicates/apply", json={})
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_apply_endpoint_empty_hashes_returns_400(app_and_db):
+    """Empty list -> 400."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/duplicates/apply", json={"hashes": []})
+    assert resp.status_code == 400
+
+
+def test_apply_endpoint_non_list_hashes_returns_400(app_and_db):
+    """Non-list 'hashes' value -> 400."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/duplicates/apply", json={"hashes": "H1"})
+    assert resp.status_code == 400
+
+
+def test_apply_endpoint_no_json_body_returns_400(app_and_db):
+    """Missing body entirely -> 400."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/duplicates/apply")
+    assert resp.status_code == 400

--- a/vireo/tests/test_duplicates_api.py
+++ b/vireo/tests/test_duplicates_api.py
@@ -162,3 +162,15 @@ def test_apply_endpoint_no_json_body_returns_400(app_and_db):
     client = app.test_client()
     resp = client.post("/api/duplicates/apply")
     assert resp.status_code == 400
+
+
+def test_apply_endpoint_bad_entry_in_list_returns_400(app_and_db):
+    """Any non-string or empty-string entry in the list -> 400 (no silent skip)."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/duplicates/apply",
+        json={"hashes": ["H1", 42, "", "H2"]},
+    )
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()

--- a/vireo/tests/test_duplicates_db.py
+++ b/vireo/tests/test_duplicates_db.py
@@ -1,4 +1,4 @@
-"""DB integration tests for duplicate resolution (Task 7)."""
+"""DB integration tests for duplicate resolution (Tasks 7 & 8)."""
 import os
 import sys
 
@@ -7,31 +7,30 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from db import Database
 
 
-def _add(db, folder_id, filename, file_mtime=100.0, rating=0, file_hash=None):
-    """Helper: add_photo + optionally set file_hash + rating in-place.
-
-    file_hash is applied via UPDATE because the Task-7 add_photo signature
-    does not accept it yet — Task 8 will add the kwarg.
-    """
+def _add(db, folder_id, filename, file_hash=None, file_mtime=100.0, rating=0):
+    """Helper: add_photo + optionally set file_hash + rating in-place."""
     pid = db.add_photo(
         folder_id=folder_id,
         filename=filename,
         extension=os.path.splitext(filename)[1] or ".jpg",
         file_size=1000,
         file_mtime=file_mtime,
+        file_hash=file_hash,
     )
-    if file_hash is not None:
-        db.conn.execute(
-            "UPDATE photos SET file_hash = ? WHERE id = ?", (file_hash, pid)
-        )
     if rating:
         db.conn.execute("UPDATE photos SET rating = ? WHERE id = ?", (rating, pid))
-    db.conn.commit()
+        db.conn.commit()
     return pid
 
 
-def test_apply_resolution_rejects_loser_and_merges_rating(tmp_path):
+# -----------------------------------------------------------------------------
+# Task 7: apply_duplicate_resolution
+# -----------------------------------------------------------------------------
+
+def test_apply_resolution_rejects_loser_and_merges_rating(tmp_path, monkeypatch):
     """The resolver picks a winner, merges max rating, rejects losers."""
+    # Disable the auto-resolve hook so we can test apply_duplicate_resolution directly.
+    monkeypatch.setenv("VIREO_DISABLE_AUTO_DUP_RESOLVE", "1")
     db = Database(str(tmp_path / "t.db"))
     fid = db.add_folder(str(tmp_path))
     p1 = _add(db, fid, "owl.jpg", file_hash="HASH1", rating=0)
@@ -53,8 +52,9 @@ def test_apply_resolution_rejects_loser_and_merges_rating(tmp_path):
     assert row["flag"] == "rejected"
 
 
-def test_apply_resolution_skips_already_rejected(tmp_path):
+def test_apply_resolution_skips_already_rejected(tmp_path, monkeypatch):
     """If fewer than 2 non-rejected candidates remain, resolver is a no-op."""
+    monkeypatch.setenv("VIREO_DISABLE_AUTO_DUP_RESOLVE", "1")
     db = Database(str(tmp_path / "t.db"))
     fid = db.add_folder(str(tmp_path))
     p1 = _add(db, fid, "a.jpg", file_hash="H")
@@ -66,12 +66,14 @@ def test_apply_resolution_skips_already_rejected(tmp_path):
     assert result["winner_id"] is None
     assert result["loser_ids"] == []
     assert result["rejected"] == 0
+    # p2 stays rejected, p1 stays unflagged
     r1 = db.conn.execute("SELECT flag FROM photos WHERE id = ?", (p1,)).fetchone()
     assert r1["flag"] != "rejected"
 
 
-def test_apply_resolution_merges_keywords(tmp_path):
+def test_apply_resolution_merges_keywords(tmp_path, monkeypatch):
     """Winner gains loser's keywords (union)."""
+    monkeypatch.setenv("VIREO_DISABLE_AUTO_DUP_RESOLVE", "1")
     db = Database(str(tmp_path / "t.db"))
     fid = db.add_folder(str(tmp_path))
     p1 = _add(db, fid, "owl.jpg", file_hash="H")
@@ -90,11 +92,67 @@ def test_apply_resolution_merges_keywords(tmp_path):
     assert any(r["keyword_id"] == kw_id for r in rows)
 
 
-def test_apply_resolution_single_candidate_noop(tmp_path):
+def test_apply_resolution_single_candidate_noop(tmp_path, monkeypatch):
     """With <2 candidates we return an empty result with no changes."""
+    monkeypatch.setenv("VIREO_DISABLE_AUTO_DUP_RESOLVE", "1")
     db = Database(str(tmp_path / "t.db"))
     fid = db.add_folder(str(tmp_path))
     p1 = _add(db, fid, "a.jpg", file_hash="H")
     result = db.apply_duplicate_resolution([p1])
     assert result["winner_id"] is None
     assert result["rejected"] == 0
+
+
+# -----------------------------------------------------------------------------
+# Task 8: Auto-resolve hook in add_photo
+# -----------------------------------------------------------------------------
+
+def test_add_photo_auto_rejects_duplicate(tmp_path):
+    """Adding a second photo with a duplicate file_hash auto-rejects the loser."""
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    p1 = _add(db, fid, "owl.jpg", file_hash="HDUP")
+    p2 = _add(db, fid, "owl (2).jpg", file_hash="HDUP")
+
+    # Dirty-suffix filename loses to clean filename (rule 1).
+    row2 = db.conn.execute("SELECT flag FROM photos WHERE id = ?", (p2,)).fetchone()
+    assert row2["flag"] == "rejected"
+    row1 = db.conn.execute("SELECT flag FROM photos WHERE id = ?", (p1,)).fetchone()
+    assert row1["flag"] != "rejected"
+
+
+def test_add_photo_no_hash_no_hook(tmp_path):
+    """add_photo without file_hash does not trigger the hook."""
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    p1 = _add(db, fid, "a.jpg")
+    p2 = _add(db, fid, "b.jpg")
+    for pid in (p1, p2):
+        row = db.conn.execute("SELECT flag FROM photos WHERE id = ?", (pid,)).fetchone()
+        assert row["flag"] == "none"
+
+
+def test_add_photo_hook_does_not_break_on_resolver_error(tmp_path, monkeypatch):
+    """If the resolver raises, the insert still succeeds and returns the id."""
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    p1 = _add(db, fid, "owl.jpg", file_hash="HBOOM")
+
+    # Monkeypatch the resolver to raise — the hook should swallow and log.
+    import duplicates as dup_mod
+    def _boom(*a, **kw):
+        raise RuntimeError("synthetic resolver failure")
+    monkeypatch.setattr(dup_mod, "resolve_duplicates", _boom)
+
+    p2 = db.add_photo(
+        folder_id=fid,
+        filename="owl (2).jpg",
+        extension=".jpg",
+        file_size=1000,
+        file_mtime=100.0,
+        file_hash="HBOOM",
+    )
+    assert p2 is not None
+    # Neither photo is rejected because the hook failed gracefully.
+    r2 = db.conn.execute("SELECT flag FROM photos WHERE id = ?", (p2,)).fetchone()
+    assert r2["flag"] != "rejected"

--- a/vireo/tests/test_duplicates_db.py
+++ b/vireo/tests/test_duplicates_db.py
@@ -1,0 +1,100 @@
+"""DB integration tests for duplicate resolution (Task 7)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from db import Database
+
+
+def _add(db, folder_id, filename, file_mtime=100.0, rating=0, file_hash=None):
+    """Helper: add_photo + optionally set file_hash + rating in-place.
+
+    file_hash is applied via UPDATE because the Task-7 add_photo signature
+    does not accept it yet — Task 8 will add the kwarg.
+    """
+    pid = db.add_photo(
+        folder_id=folder_id,
+        filename=filename,
+        extension=os.path.splitext(filename)[1] or ".jpg",
+        file_size=1000,
+        file_mtime=file_mtime,
+    )
+    if file_hash is not None:
+        db.conn.execute(
+            "UPDATE photos SET file_hash = ? WHERE id = ?", (file_hash, pid)
+        )
+    if rating:
+        db.conn.execute("UPDATE photos SET rating = ? WHERE id = ?", (rating, pid))
+    db.conn.commit()
+    return pid
+
+
+def test_apply_resolution_rejects_loser_and_merges_rating(tmp_path):
+    """The resolver picks a winner, merges max rating, rejects losers."""
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    p1 = _add(db, fid, "owl.jpg", file_hash="HASH1", rating=0)
+    p2 = _add(db, fid, "owl (2).jpg", file_hash="HASH1", rating=5)
+
+    result = db.apply_duplicate_resolution([p1, p2])
+    assert result["winner_id"] == p1
+    assert result["loser_ids"] == [p2]
+    assert result["rejected"] == 1
+
+    row = db.conn.execute(
+        "SELECT rating, flag FROM photos WHERE id = ?", (p1,)
+    ).fetchone()
+    assert row["rating"] == 5
+    assert row["flag"] != "rejected"
+    row = db.conn.execute(
+        "SELECT flag FROM photos WHERE id = ?", (p2,)
+    ).fetchone()
+    assert row["flag"] == "rejected"
+
+
+def test_apply_resolution_skips_already_rejected(tmp_path):
+    """If fewer than 2 non-rejected candidates remain, resolver is a no-op."""
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    p1 = _add(db, fid, "a.jpg", file_hash="H")
+    p2 = _add(db, fid, "b.jpg", file_hash="H")
+    db.conn.execute("UPDATE photos SET flag = 'rejected' WHERE id = ?", (p2,))
+    db.conn.commit()
+
+    result = db.apply_duplicate_resolution([p1, p2])
+    assert result["winner_id"] is None
+    assert result["loser_ids"] == []
+    assert result["rejected"] == 0
+    r1 = db.conn.execute("SELECT flag FROM photos WHERE id = ?", (p1,)).fetchone()
+    assert r1["flag"] != "rejected"
+
+
+def test_apply_resolution_merges_keywords(tmp_path):
+    """Winner gains loser's keywords (union)."""
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    p1 = _add(db, fid, "owl.jpg", file_hash="H")
+    p2 = _add(db, fid, "owl (2).jpg", file_hash="H")
+    kw_id = db.add_keyword("bird")
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p2, kw_id),
+    )
+    db.conn.commit()
+
+    db.apply_duplicate_resolution([p1, p2])
+    rows = db.conn.execute(
+        "SELECT keyword_id FROM photo_keywords WHERE photo_id = ?", (p1,)
+    ).fetchall()
+    assert any(r["keyword_id"] == kw_id for r in rows)
+
+
+def test_apply_resolution_single_candidate_noop(tmp_path):
+    """With <2 candidates we return an empty result with no changes."""
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    p1 = _add(db, fid, "a.jpg", file_hash="H")
+    result = db.apply_duplicate_resolution([p1])
+    assert result["winner_id"] is None
+    assert result["rejected"] == 0

--- a/vireo/tests/test_duplicates_db.py
+++ b/vireo/tests/test_duplicates_db.py
@@ -309,3 +309,160 @@ def test_find_duplicate_groups_empty(tmp_path):
     fid = db.add_folder(str(tmp_path))
     _add(db, fid, "solo.jpg", file_hash="SOLO")
     assert db.find_duplicate_groups() == []
+
+
+# -----------------------------------------------------------------------------
+# Scanner-order regression: XMP import must land BEFORE auto-resolve so a
+# loser's keywords are merged onto the winner (Codex review fix #1).
+# -----------------------------------------------------------------------------
+
+def test_auto_resolve_after_xmp_import_merges_loser_keywords(tmp_path):
+    """The loser's keywords must end up on the winner when auto-resolve fires.
+
+    Scanner flow: add_photo (no hash) -> UPDATE file_hash -> import XMP
+    keywords -> check_and_resolve_duplicates_for_hash. If XMP import ran
+    AFTER the hook, the loser's keywords would be stranded on the rejected
+    row. This test locks in the merge contract by simulating that order at
+    the DB layer: keywords linked to the loser BEFORE the hook fires, then
+    assert they are carried over to the winner.
+    """
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+
+    # Raw inserts so the auto-hook does not fire prematurely.
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size, "
+        "file_mtime, file_hash, flag) VALUES (?, ?, ?, ?, ?, ?, 'none')",
+        (fid, "winner.jpg", ".jpg", 1000, 100.0, "HASH"),
+    )
+    winner_id = db.conn.execute(
+        "SELECT id FROM photos WHERE filename = ?", ("winner.jpg",)
+    ).fetchone()["id"]
+    # Dirty-suffix filename loses to clean (tiebreaker rule 1).
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size, "
+        "file_mtime, file_hash, flag) VALUES (?, ?, ?, ?, ?, ?, 'none')",
+        (fid, "winner (2).jpg", ".jpg", 1000, 100.0, "HASH"),
+    )
+    loser_id = db.conn.execute(
+        "SELECT id FROM photos WHERE filename = ?", ("winner (2).jpg",)
+    ).fetchone()["id"]
+    db.conn.commit()
+
+    # Simulate XMP import: link a keyword to the loser ONLY.
+    kw_id = db.add_keyword("bird")
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (loser_id, kw_id),
+    )
+    db.conn.commit()
+
+    # Now fire the auto-resolve hook (as scanner does after XMP import).
+    result = db.check_and_resolve_duplicates_for_hash("HASH")
+    assert result is not None
+    assert result["winner_id"] == winner_id
+    assert result["loser_ids"] == [loser_id]
+
+    # Winner must have the loser's keyword merged onto it.
+    winner_kws = db.conn.execute(
+        "SELECT keyword_id FROM photo_keywords WHERE photo_id = ?", (winner_id,)
+    ).fetchall()
+    assert any(r["keyword_id"] == kw_id for r in winner_kws), (
+        "Loser's XMP keyword was not merged onto the winner — the scanner "
+        "order (XMP import before auto-resolve) is broken."
+    )
+
+    # Loser flagged rejected.
+    row = db.conn.execute(
+        "SELECT flag FROM photos WHERE id = ?", (loser_id,)
+    ).fetchone()
+    assert row["flag"] == "rejected"
+
+
+# -----------------------------------------------------------------------------
+# run_duplicate_scan must filter rows rejected after find_duplicate_groups
+# returns (race with concurrent ingest). (Codex review fix #2).
+# -----------------------------------------------------------------------------
+
+def test_run_duplicate_scan_skips_rows_rejected_after_find_groups(
+    tmp_path, monkeypatch
+):
+    """If rows are rejected between find_duplicate_groups and the per-group
+    SELECT inside the loop, the per-group SELECT must filter them out. If the
+    survivors fall below 2, the group is skipped.
+
+    We monkeypatch ``find_duplicate_groups`` to simulate the race: it returns
+    3 candidate IDs, but 2 are already rejected at the moment the per-group
+    SELECT runs — exactly the state a concurrent ingest + auto-hook would
+    leave behind between the two queries.
+    """
+    from duplicate_scan import run_duplicate_scan
+
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    ids = []
+    for name in ("a.jpg", "b.jpg", "c.jpg"):
+        db.conn.execute(
+            "INSERT INTO photos (folder_id, filename, extension, file_size, "
+            "file_mtime, file_hash, flag) VALUES (?, ?, ?, ?, ?, ?, 'none')",
+            (fid, name, ".jpg", 1000, 100.0, "HRACE"),
+        )
+        ids.append(
+            db.conn.execute(
+                "SELECT id FROM photos WHERE filename = ?", (name,)
+            ).fetchone()["id"]
+        )
+    # Reject two BEFORE the scan; then spoof find_duplicate_groups to still
+    # report all three (the race window).
+    db.conn.execute(
+        "UPDATE photos SET flag = 'rejected' WHERE filename IN (?, ?)",
+        ("a.jpg", "b.jpg"),
+    )
+    db.conn.commit()
+
+    def _stale_find_groups():
+        return [{"file_hash": "HRACE", "photo_ids": ids}]
+
+    monkeypatch.setattr(db, "find_duplicate_groups", _stale_find_groups)
+
+    result = run_duplicate_scan({"progress": {}}, db)
+    # Only one non-rejected row; the per-group SELECT must filter to 1 and
+    # the `< 2` guard must drop it.
+    assert result["proposals"] == []
+
+
+def test_run_duplicate_scan_positive_case_with_one_rejected(
+    tmp_path, monkeypatch
+):
+    """Race-window variant: 3 reported, 1 rejected; scan proposes group of 2."""
+    from duplicate_scan import run_duplicate_scan
+
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    ids = []
+    for name in ("x.jpg", "x (2).jpg", "x (3).jpg"):
+        db.conn.execute(
+            "INSERT INTO photos (folder_id, filename, extension, file_size, "
+            "file_mtime, file_hash, flag) VALUES (?, ?, ?, ?, ?, ?, 'none')",
+            (fid, name, ".jpg", 1000, 100.0, "HPOS"),
+        )
+        ids.append(
+            db.conn.execute(
+                "SELECT id FROM photos WHERE filename = ?", (name,)
+            ).fetchone()["id"]
+        )
+    db.conn.execute(
+        "UPDATE photos SET flag = 'rejected' WHERE filename = ?", ("x (3).jpg",)
+    )
+    db.conn.commit()
+
+    def _stale_find_groups():
+        return [{"file_hash": "HPOS", "photo_ids": ids}]
+
+    monkeypatch.setattr(db, "find_duplicate_groups", _stale_find_groups)
+
+    result = run_duplicate_scan({"progress": {}}, db)
+    assert len(result["proposals"]) == 1
+    prop = result["proposals"][0]
+    # 1 winner + 1 loser after filtering the rejected row.
+    assert 1 + len(prop["losers"]) == 2

--- a/vireo/tests/test_duplicates_db.py
+++ b/vireo/tests/test_duplicates_db.py
@@ -224,3 +224,43 @@ def test_check_and_resolve_for_hash_covers_scanner_flow(tmp_path):
     r2 = db.conn.execute("SELECT flag FROM photos WHERE id = ?", (p2,)).fetchone()
     assert r1["flag"] != "rejected"
     assert r2["flag"] == "rejected"
+
+
+# -----------------------------------------------------------------------------
+# Task 9: find_duplicate_groups
+# -----------------------------------------------------------------------------
+
+def test_find_duplicate_groups_returns_only_multi_groups(tmp_path):
+    """Returns hashes with 2+ non-rejected rows; skips singletons."""
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    # Group A: 2 dups — hook auto-rejects one, reset so scan sees both again.
+    a1 = _add(db, fid, "a.jpg", file_hash="HA")
+    a2 = _add(db, fid, "a copy.jpg", file_hash="HA")
+    _reset_flags(db, "HA")
+    # Group B: singleton
+    _add(db, fid, "b.jpg", file_hash="HB")
+    # Group C: two rows but one rejected -> should not appear
+    c1 = _add(db, fid, "c.jpg", file_hash="HC")
+    c2 = _add(db, fid, "c (2).jpg", file_hash="HC")
+    # Hook already rejected one of c1/c2; leave as-is so only 1 non-rejected row.
+    # Group D: NULL hash -> should not appear
+    _add(db, fid, "d.jpg")
+
+    groups = db.find_duplicate_groups()
+    hashes = [g["file_hash"] for g in groups]
+    assert "HA" in hashes
+    assert "HB" not in hashes
+    assert "HC" not in hashes  # only one non-rejected row
+    assert None not in hashes
+
+    ha = next(g for g in groups if g["file_hash"] == "HA")
+    assert sorted(ha["photo_ids"]) == sorted([a1, a2])
+
+
+def test_find_duplicate_groups_empty(tmp_path):
+    """No dup groups -> empty list."""
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    _add(db, fid, "solo.jpg", file_hash="SOLO")
+    assert db.find_duplicate_groups() == []

--- a/vireo/tests/test_duplicates_db.py
+++ b/vireo/tests/test_duplicates_db.py
@@ -23,18 +23,29 @@ def _add(db, folder_id, filename, file_hash=None, file_mtime=100.0, rating=0):
     return pid
 
 
+def _reset_flags(db, file_hash):
+    """Clear auto-rejection so tests can exercise apply_duplicate_resolution directly."""
+    db.conn.execute(
+        "UPDATE photos SET flag = 'none' WHERE file_hash = ?", (file_hash,)
+    )
+    db.conn.commit()
+
+
 # -----------------------------------------------------------------------------
 # Task 7: apply_duplicate_resolution
 # -----------------------------------------------------------------------------
 
-def test_apply_resolution_rejects_loser_and_merges_rating(tmp_path, monkeypatch):
+def test_apply_resolution_rejects_loser_and_merges_rating(tmp_path):
     """The resolver picks a winner, merges max rating, rejects losers."""
-    # Disable the auto-resolve hook so we can test apply_duplicate_resolution directly.
-    monkeypatch.setenv("VIREO_DISABLE_AUTO_DUP_RESOLVE", "1")
     db = Database(str(tmp_path / "t.db"))
     fid = db.add_folder(str(tmp_path))
     p1 = _add(db, fid, "owl.jpg", file_hash="HASH1", rating=0)
-    p2 = _add(db, fid, "owl (2).jpg", file_hash="HASH1", rating=5)
+    p2 = _add(db, fid, "owl (2).jpg", file_hash="HASH1")
+    # The add_photo hook auto-rejected one already; reset so we can test
+    # apply_duplicate_resolution directly. Also set p2's rating via raw SQL.
+    _reset_flags(db, "HASH1")
+    db.conn.execute("UPDATE photos SET rating = ? WHERE id = ?", (5, p2))
+    db.conn.commit()
 
     result = db.apply_duplicate_resolution([p1, p2])
     assert result["winner_id"] == p1
@@ -52,32 +63,50 @@ def test_apply_resolution_rejects_loser_and_merges_rating(tmp_path, monkeypatch)
     assert row["flag"] == "rejected"
 
 
-def test_apply_resolution_skips_already_rejected(tmp_path, monkeypatch):
-    """If fewer than 2 non-rejected candidates remain, resolver is a no-op."""
-    monkeypatch.setenv("VIREO_DISABLE_AUTO_DUP_RESOLVE", "1")
+def test_apply_resolution_skips_already_rejected(tmp_path):
+    """If fewer than 2 non-rejected candidates remain, resolver is a no-op.
+
+    After two add_photo calls with a shared hash, the hook has already
+    rejected one of them. Calling apply_duplicate_resolution on the same
+    pair should be a no-op.
+    """
     db = Database(str(tmp_path / "t.db"))
     fid = db.add_folder(str(tmp_path))
     p1 = _add(db, fid, "a.jpg", file_hash="H")
     p2 = _add(db, fid, "b.jpg", file_hash="H")
-    db.conn.execute("UPDATE photos SET flag = 'rejected' WHERE id = ?", (p2,))
-    db.conn.commit()
+
+    # Exactly one of p1/p2 is rejected by the hook; identify the survivor.
+    flags = {
+        r["id"]: r["flag"]
+        for r in db.conn.execute(
+            "SELECT id, flag FROM photos WHERE id IN (?, ?)", (p1, p2)
+        ).fetchall()
+    }
+    rejected = [pid for pid, f in flags.items() if f == "rejected"]
+    assert len(rejected) == 1
 
     result = db.apply_duplicate_resolution([p1, p2])
     assert result["winner_id"] is None
     assert result["loser_ids"] == []
     assert result["rejected"] == 0
-    # p2 stays rejected, p1 stays unflagged
-    r1 = db.conn.execute("SELECT flag FROM photos WHERE id = ?", (p1,)).fetchone()
-    assert r1["flag"] != "rejected"
+    # Flags unchanged.
+    flags_after = {
+        r["id"]: r["flag"]
+        for r in db.conn.execute(
+            "SELECT id, flag FROM photos WHERE id IN (?, ?)", (p1, p2)
+        ).fetchall()
+    }
+    assert flags_after == flags
 
 
-def test_apply_resolution_merges_keywords(tmp_path, monkeypatch):
+def test_apply_resolution_merges_keywords(tmp_path):
     """Winner gains loser's keywords (union)."""
-    monkeypatch.setenv("VIREO_DISABLE_AUTO_DUP_RESOLVE", "1")
     db = Database(str(tmp_path / "t.db"))
     fid = db.add_folder(str(tmp_path))
     p1 = _add(db, fid, "owl.jpg", file_hash="H")
     p2 = _add(db, fid, "owl (2).jpg", file_hash="H")
+    # Reset hook's auto-rejection so apply_duplicate_resolution sees both.
+    _reset_flags(db, "H")
     kw_id = db.add_keyword("bird")
     db.conn.execute(
         "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
@@ -92,9 +121,8 @@ def test_apply_resolution_merges_keywords(tmp_path, monkeypatch):
     assert any(r["keyword_id"] == kw_id for r in rows)
 
 
-def test_apply_resolution_single_candidate_noop(tmp_path, monkeypatch):
+def test_apply_resolution_single_candidate_noop(tmp_path):
     """With <2 candidates we return an empty result with no changes."""
-    monkeypatch.setenv("VIREO_DISABLE_AUTO_DUP_RESOLVE", "1")
     db = Database(str(tmp_path / "t.db"))
     fid = db.add_folder(str(tmp_path))
     p1 = _add(db, fid, "a.jpg", file_hash="H")
@@ -132,17 +160,19 @@ def test_add_photo_no_hash_no_hook(tmp_path):
         assert row["flag"] == "none"
 
 
-def test_add_photo_hook_does_not_break_on_resolver_error(tmp_path, monkeypatch):
-    """If the resolver raises, the insert still succeeds and returns the id."""
+def test_add_photo_hook_swallows_sqlite_error(tmp_path, monkeypatch):
+    """sqlite3.Error raised inside the hook is logged and swallowed."""
+    import sqlite3
+
     db = Database(str(tmp_path / "t.db"))
     fid = db.add_folder(str(tmp_path))
     p1 = _add(db, fid, "owl.jpg", file_hash="HBOOM")
 
-    # Monkeypatch the resolver to raise — the hook should swallow and log.
-    import duplicates as dup_mod
-    def _boom(*a, **kw):
-        raise RuntimeError("synthetic resolver failure")
-    monkeypatch.setattr(dup_mod, "resolve_duplicates", _boom)
+    # Patch apply_duplicate_resolution on the instance so the hook's
+    # execute() succeeds but the resolver call raises sqlite3.Error.
+    def _boom(ids):
+        raise sqlite3.OperationalError("synthetic")
+    monkeypatch.setattr(db, "apply_duplicate_resolution", _boom)
 
     p2 = db.add_photo(
         folder_id=fid,
@@ -156,3 +186,41 @@ def test_add_photo_hook_does_not_break_on_resolver_error(tmp_path, monkeypatch):
     # Neither photo is rejected because the hook failed gracefully.
     r2 = db.conn.execute("SELECT flag FROM photos WHERE id = ?", (p2,)).fetchone()
     assert r2["flag"] != "rejected"
+
+
+# -----------------------------------------------------------------------------
+# Scanner-style flow: add_photo (no hash) + UPDATE hash + explicit hook call.
+# -----------------------------------------------------------------------------
+
+def test_check_and_resolve_for_hash_covers_scanner_flow(tmp_path):
+    """Mimic scanner.py: insert without file_hash, UPDATE it, then call the hook."""
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+
+    # Scanner path: add_photo with no hash, then UPDATE photos SET file_hash=?
+    p1 = db.add_photo(
+        folder_id=fid, filename="owl.jpg", extension=".jpg",
+        file_size=1000, file_mtime=100.0,
+    )
+    p2 = db.add_photo(
+        folder_id=fid, filename="owl (2).jpg", extension=".jpg",
+        file_size=1000, file_mtime=100.0,
+    )
+    db.conn.execute("UPDATE photos SET file_hash = ? WHERE id = ?", ("SCANHASH", p1))
+    db.conn.commit()
+    # First call: only one row has the hash — no-op.
+    result = db.check_and_resolve_duplicates_for_hash("SCANHASH")
+    assert result is None
+
+    db.conn.execute("UPDATE photos SET file_hash = ? WHERE id = ?", ("SCANHASH", p2))
+    db.conn.commit()
+    # Second call: two rows share the hash — resolve.
+    result = db.check_and_resolve_duplicates_for_hash("SCANHASH")
+    assert result is not None
+    assert result["winner_id"] == p1
+    assert result["loser_ids"] == [p2]
+
+    r1 = db.conn.execute("SELECT flag FROM photos WHERE id = ?", (p1,)).fetchone()
+    r2 = db.conn.execute("SELECT flag FROM photos WHERE id = ?", (p2,)).fetchone()
+    assert r1["flag"] != "rejected"
+    assert r2["flag"] == "rejected"

--- a/vireo/tests/test_duplicates_db.py
+++ b/vireo/tests/test_duplicates_db.py
@@ -149,6 +149,51 @@ def test_add_photo_auto_rejects_duplicate(tmp_path):
     assert row1["flag"] != "rejected"
 
 
+def test_auto_resolve_does_not_unreject_existing_loser(tmp_path):
+    """Adding a new dup must not un-reject a previously rejected loser.
+
+    Design decision: the hook filters ``flag != 'rejected'`` before resolving,
+    so rows already rejected on a past pass stay rejected even if a newer
+    candidate with a "better" name arrives later.
+    """
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    # Step 1 & 2: insert two photos sharing a hash; the hook rejects one.
+    old = _add(db, fid, "old.jpg", file_hash="HX")
+    loser = _add(db, fid, "loser (2).jpg", file_hash="HX")
+
+    # Step 3: force the state we want to test — `loser` is the pre-existing
+    # rejected row, `old` is clean. (The hook probably already did this given
+    # the filenames, but set it explicitly so the test does not depend on
+    # tiebreaker rules.)
+    db.conn.execute("UPDATE photos SET flag = 'rejected' WHERE id = ?", (loser,))
+    db.conn.execute("UPDATE photos SET flag = 'none' WHERE id = ?", (old,))
+    db.conn.commit()
+
+    # Step 4: a NEW photo arrives with a clean filename and the same hash.
+    newcomer = _add(db, fid, "newcomer.jpg", file_hash="HX")
+
+    # Step 5: the previously rejected loser stays rejected.
+    row_loser = db.conn.execute(
+        "SELECT flag FROM photos WHERE id = ?", (loser,)
+    ).fetchone()
+    assert row_loser["flag"] == "rejected", (
+        "Hook un-rejected a previously rejected duplicate — regression."
+    )
+
+    # Step 6: among {old, newcomer}, exactly one is rejected (the hook
+    # resolved the pair); which one depends on tiebreakers but both must
+    # not be rejected simultaneously, and at least one must survive.
+    row_old = db.conn.execute(
+        "SELECT flag FROM photos WHERE id = ?", (old,)
+    ).fetchone()
+    row_new = db.conn.execute(
+        "SELECT flag FROM photos WHERE id = ?", (newcomer,)
+    ).fetchone()
+    survivors = [f for f in (row_old["flag"], row_new["flag"]) if f != "rejected"]
+    assert len(survivors) >= 1
+
+
 def test_add_photo_no_hash_no_hook(tmp_path):
     """add_photo without file_hash does not trigger the hook."""
     db = Database(str(tmp_path / "t.db"))


### PR DESCRIPTION
## Summary

Adds exact-byte duplicate detection to Vireo. When the scanner finds a file whose hash matches an existing photo, the inferior copy is auto-rejected and its metadata (rating, keywords) merged onto the winner. A new `/duplicates` page lets you preview and apply a one-shot sweep over existing duplicates already in the library.

## How it works

- **Pure resolver** (`vireo/duplicates.py`) picks the winner via a four-rule cascade: clean filename (no ` (2)`, ` copy`, `-N`, `_N` suffixes) → shorter path → older mtime → lower id. Each loser gets a human-readable reason string.
- **Auto-resolve on scan** — the scanner now calls `db.check_and_resolve_duplicates_for_hash()` right after setting `file_hash`, so duplicates are silently flagged as they're discovered. Reversible via the existing Rejected filter + unflag.
- **Manual sweep** — `/duplicates` page (linked from navbar) kicks off a scan job, renders proposed winner/loser pairs with thumbnails and reason strings, and applies only the groups you check.

Rejection uses `photos.flag = 'rejected'` globally — no disk deletion, no workspace scoping. See the design doc at `docs/plans/2026-04-12-duplicate-detection-design.md` (local, gitignored).

## Test plan

- [x] Resolver unit tests — 21 tests covering every tiebreaker rule, cascade, N-way, and reason strings
- [x] DB integration — 12 tests for `apply_duplicate_resolution`, `find_duplicate_groups`, auto-resolve hook, scanner flow, no-unrejecting-pre-existing-losers regression
- [x] API — 9 tests for `/api/duplicates/scan` (job lifecycle) and `/api/duplicates/apply` (strict input validation, no-op on resolved hash, n-way)
- [x] Full project test suite: **551 passed** (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_duplicates.py vireo/tests/test_duplicates_db.py vireo/tests/test_duplicates_api.py vireo/tests/test_scanner.py vireo/tests/test_ingest.py`)
- [ ] Manual browser testing of `/duplicates` page (visual layout across themes, thumbnail rendering, apply + toast flow)

## Deferred (intentional YAGNI)

- **Pending-edit copy across duplicate merge** — the pure `merge_metadata` function computes this, but the DB layer currently skips it with a TODO. `pending_changes` is workspace-scoped and copying values safely is a whole separate concern.
- **Perceptual / near-duplicate detection** — this PR is exact-byte only. `phash` columns exist but are not used here.
- **Undo / restore** — rely on the existing "Rejected" filter + unflag UI.

## First-run note

The first time a library is rescanned with this code, any pre-existing byte-identical duplicates will be silently auto-rejected as the scanner revisits their files. Users can review them at any time via the Rejected filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)