### PR TITLE
fix: address codex review on #538

### DIFF
--- a/vireo/model_verify.py
+++ b/vireo/model_verify.py
@@ -358,6 +358,12 @@ def _verify_unpinned(model_id: str, model_dir: str, hf_subdir: str) -> None:
         )
         # Cache as checked so we don't re-warn on every pipeline start.
         _verified_this_process.add(model_id)
+        # Clear any stale .verify_skipped: the hash fetch succeeded this
+        # time, so the old "couldn't reach HF" reason no longer reflects
+        # reality. Without this, a previously-unverified model keeps
+        # showing the outdated network-error badge via get_models() even
+        # though lazy verification actually ran.
+        clear_verify_skipped(model_dir)
 
 
 def clear_verified_cache(model_id: str) -> None:

--- a/vireo/tests/test_model_verify.py
+++ b/vireo/tests/test_model_verify.py
@@ -521,6 +521,51 @@ def test_unpinned_install_fails_open_on_network_error(tmp_path, monkeypatch):
     assert "bioclip-vit-b-16" in model_verify._verify_error_cache
 
 
+def test_verify_if_needed_unpinned_mismatch_clears_stale_verify_skipped(
+    tmp_path, monkeypatch
+):
+    """_verify_unpinned: if a previous transient outage wrote .verify_skipped
+    and a later verify_if_needed run actually reaches HF (but returns a
+    mismatch), the stale sentinel must be cleared. Without this, get_models()
+    keeps reporting state='unverified' with the outdated network-error reason
+    even though lazy verification has already run."""
+    import model_verify
+
+    # Legacy install — no .hf_revision.
+    p = tmp_path / "image_encoder.onnx.data"
+    p.write_bytes(b"old version bytes")
+
+    # Simulate a previous outage that left .verify_skipped on disk.
+    (tmp_path / model_verify.VERIFY_SKIPPED_SENTINEL).write_text(
+        "Could not reach HuggingFace (prior outage)"
+    )
+
+    # Now HF is reachable but the files don't match (hash mismatch).
+    monkeypatch.setattr(
+        model_verify,
+        "fetch_expected_hashes",
+        lambda subdir, revision="main": {"image_encoder.onnx.data": "0" * 64},
+    )
+    monkeypatch.setattr(
+        model_verify, "fetch_latest_revision", lambda repo: "latestsha123"
+    )
+
+    # Must not raise — soft-fail semantics for unpinned installs.
+    model_verify.verify_if_needed(
+        "bioclip-vit-b-16", str(tmp_path), "bioclip-vit-b-16"
+    )
+
+    # .verify_skipped must be gone: the hash fetch succeeded, so the old
+    # "couldn't reach HF" reason is now stale and misleading.
+    assert not (tmp_path / model_verify.VERIFY_SKIPPED_SENTINEL).is_file(), (
+        "_verify_unpinned must clear .verify_skipped on mismatch path"
+    )
+    # .verify_failed must NOT have been written (ambiguous mismatch).
+    assert not (tmp_path / model_verify.VERIFY_FAILED_SENTINEL).is_file()
+    # Model is cached as checked (to avoid re-warning on every pipeline start).
+    assert "bioclip-vit-b-16" in model_verify._verified_this_process
+
+
 # ---------------------------------------------------------------------------
 # verify_all_models — iterate installed models for the "Verify all" button
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Parent PR: #538

Addresses Codex Connect review feedback on #538.

## What changed

`_verify_unpinned` in `vireo/model_verify.py` writes `.verify_skipped` when HuggingFace's metadata API is unreachable (transient outage), but only cleared that sentinel in the `result.ok` branch. If a previously-unverified legacy install later reached HF during a lazy `verify_if_needed()` call but got a hash mismatch against current `main`, the old network-error sentinel was left on disk. `get_models()` would keep reporting `state="unverified"` with the stale "couldn't reach HF" reason indefinitely — making the Settings amber badge sticky and making "Retry verification" look ineffective even though lazy verification had actually run.

**Fix:** add `clear_verify_skipped(model_dir)` in the mismatch (`else`) branch of `_verify_unpinned`, mirroring the fix already applied to `verify_all_models` in the prior commit (`84cd99b`). The hash fetch succeeded this round, so the "couldn't reach HF" reason no longer reflects reality regardless of whether the hash comparison passed or failed. The soft-fail semantics for unpinned installs (no `.verify_failed` written, pipeline not blocked) are unchanged.

## Test results

433 passed.

---
Generated by scheduled PR Agent