### PR TITLE
fix: surface job phase/current_file to polling clients

### DIFF
--- a/vireo/classifier.py
+++ b/vireo/classifier.py
@@ -287,10 +287,10 @@ def _compute_embeddings_with_progress(
         all_features.append(mean_feature)
 
         done = i + 1
+        if progress_callback:
+            progress_callback(done, total)
         if done % 50 == 0 or done == total:
             log.info("Computing label embeddings: %d/%d", done, total)
-            if progress_callback:
-                progress_callback(done, total)
 
     # Stack into (num_labels, embedding_dim) then transpose to (embedding_dim, num_labels)
     stacked = np.stack(all_features, axis=0)  # (num_labels, embedding_dim)

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -337,6 +337,18 @@ class JobRunner:
         with self._lock:
             if event_type == "progress":
                 job = self._jobs.get(job_id)
+                if job is not None:
+                    # Mirror latest progress fields onto job["progress"] so
+                    # clients polling /api/jobs or /api/jobs/history see the
+                    # current phase/current_file without needing SSE.
+                    prog = job.setdefault(
+                        "progress",
+                        {"current": 0, "total": 0, "current_file": ""},
+                    )
+                    for key, value in data.items():
+                        if key == "steps":
+                            continue
+                        prog[key] = value
                 if job and job.get("steps"):
                     data = dict(data)
                     data["steps"] = [dict(s) for s in job["steps"]]

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -498,3 +498,50 @@ def test_progress_events_include_steps(tmp_path):
     assert "steps" in last_progress["data"]
     assert len(last_progress["data"]["steps"]) == 2
     assert last_progress["data"]["steps"][0]["status"] == "running"
+
+
+def test_push_event_mirrors_progress_onto_job(tmp_path):
+    """push_event('progress', ...) merges fields onto job['progress'] so
+    polling clients (which don't subscribe to SSE) see the latest phase
+    and current_file."""
+    import threading
+    import time
+
+    from db import Database
+    from jobs import JobRunner
+
+    db = Database(str(tmp_path / "test.db"))
+    runner = JobRunner(db=db)
+
+    gate = threading.Event()
+
+    def work(job):
+        runner.push_event(job["id"], "progress", {
+            "phase": "Step 3/5: Computing embeddings",
+            "current": 150,
+            "total": 843,
+            "current_file": "Computing label embeddings (150/843)...",
+        })
+        gate.wait(timeout=2)
+        return {}
+
+    job_id = runner.start("test", work, workspace_id=1)
+
+    # Read progress while the job is still running — this is what the UI does.
+    deadline = time.time() + 2
+    while time.time() < deadline:
+        j = runner.get(job_id)
+        if j and j["progress"].get("phase"):
+            break
+        time.sleep(0.02)
+
+    j = runner.get(job_id)
+    assert j["progress"]["phase"] == "Step 3/5: Computing embeddings"
+    assert j["progress"]["current"] == 150
+    assert j["progress"]["total"] == 843
+    assert j["progress"]["current_file"] == "Computing label embeddings (150/843)..."
+    # 'steps' must not leak into the stored progress (it is injected only
+    # onto the outbound event payload).
+    assert "steps" not in j["progress"]
+
+    gate.set()


### PR DESCRIPTION
## Summary

While the classifier was spending ~60 min computing label embeddings on a cold start, the jobs page showed nothing about it. The backend was actually emitting the right progress events — they just weren't reaching polling clients.

**Root cause:** `JobRunner.push_event("progress", ...)` only delivered events to live SSE subscribers and the buffered event log. It never updated `job["progress"]`. So `/api/jobs` and `/api/jobs/history` (what the page polls/reloads from) kept returning the stale `{current:0, total:0, current_file:""}` initialized at job start, even though `classify_job.py` was pushing `"Step 3/5: Computing embeddings (N/843)"` updates.

## Changes

- **`vireo/jobs.py`** — `push_event` now merges progress fields onto `job["progress"]` under the lock, so polling clients see the latest phase/current/total/current_file. `steps` is filtered out so it doesn't leak into the stored snapshot (it's still injected onto the outbound event payload as before).
- **`vireo/classifier.py`** — embedding progress callback now fires every iteration instead of every 50. Each iteration takes ~5s in the per-row fallback path, so the callback overhead is negligible but the UI now ticks forward visibly. Logging is still gated to every 50 to avoid log spam.
- **`vireo/tests/test_jobs.py`** — new `test_push_event_mirrors_progress_onto_job` covers the fix.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_jobs.py -q` → **450 passed**
- [x] New `test_push_event_mirrors_progress_onto_job` passes and verifies phase/current/total/current_file are readable via `runner.get(job_id)` mid-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)