### PR TITLE
fix: batch-agnostic text encoder export + jobs ETA

### DIFF
--- a/scripts/export_onnx.py
+++ b/scripts/export_onnx.py
@@ -128,6 +128,58 @@ def _validate_onnx(onnx_path, input_dict, pytorch_outputs, tolerance=0.01):
     return all_ok
 
 
+def _verify_text_encoder_batched(onnx_path, txt_wrapper, batch_size=8):
+    """Sanity-check that the exported text encoder accepts batches > 1.
+
+    Earlier exports baked batch=1 into a downstream Reshape (see
+    _TextEncoderWrapper docstring), so any batched call failed at runtime.
+    Run a batch_size inference and compare each row against per-row PyTorch
+    outputs to catch regressions at export time, not first-cold-start time.
+    """
+    import onnxruntime as ort
+
+    log.info("  Verifying text encoder accepts batch=%d...", batch_size)
+    rng = np.random.default_rng(0)
+    # Use realistic token IDs (49407 is CLIP's EOT token; surround with random
+    # in-vocab IDs). Vocab size for open_clip CLIP tokenizers is 49408.
+    tokens_np = rng.integers(low=1, high=49407, size=(batch_size, 77), dtype=np.int64)
+    tokens_np[:, 0] = 49406  # SOT
+    eot_positions = rng.integers(low=5, high=76, size=(batch_size,))
+    for i, pos in enumerate(eot_positions):
+        tokens_np[i, pos] = 49407
+        tokens_np[i, pos + 1 :] = 0
+
+    session = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+    input_name = session.get_inputs()[0].name
+    try:
+        ort_batch = session.run(None, {input_name: tokens_np})[0]
+    except Exception as e:
+        raise RuntimeError(
+            "Text encoder ONNX rejected batched input — export still has a "
+            f"hardcoded batch dimension. Original error: {e!r}"
+        ) from e
+
+    # Compare against per-row PyTorch outputs
+    tokens_pt = torch.from_numpy(tokens_np)
+    with torch.no_grad():
+        pt_rows = [
+            txt_wrapper(tokens_pt[i : i + 1]).numpy() for i in range(batch_size)
+        ]
+    pt_batch = np.concatenate(pt_rows, axis=0)
+
+    abs_diff = np.abs(pt_batch.astype(np.float32) - ort_batch.astype(np.float32))
+    max_diff = float(abs_diff.max())
+    if max_diff > 0.05:
+        raise RuntimeError(
+            f"Batched ONNX output diverges from PyTorch per-row reference "
+            f"(max abs diff {max_diff:.4f})"
+        )
+    log.info(
+        "  Text encoder batched verification OK (max diff vs per-row PT: %.6f)",
+        max_diff,
+    )
+
+
 # ---------------------------------------------------------------------------
 # MegaDetector (YOLOv9)
 # ---------------------------------------------------------------------------
@@ -248,14 +300,64 @@ class _ImageEncoderWrapper(torch.nn.Module):
 
 
 class _TextEncoderWrapper(torch.nn.Module):
-    """Wrapper to export only the text encoder of an open_clip model."""
+    """Wrapper to export only the text encoder of an open_clip model.
+
+    open_clip's CLIP.encode_text uses text_global_pool, which contains:
+
+        x[torch.arange(x.shape[0], device=x.device), text.argmax(dim=-1)]
+
+    When traced by torch.onnx.export with a dummy batch of 1, ``x.shape[0]``
+    is captured as the constant ``1`` and propagates downstream as a
+    hardcoded Reshape target, so the resulting graph rejects any batch != 1
+    at runtime. We re-implement encode_text here, replacing that gather
+    with ``torch.gather`` (which exports cleanly with dynamic batch) and
+    keeping pool-type semantics consistent with open_clip.
+    """
 
     def __init__(self, clip_model):
         super().__init__()
         self.clip_model = clip_model
+        # Resolve pool config once so forward() avoids attribute lookups
+        # that the tracer might fold into constants.
+        self._pool_type = getattr(clip_model, "text_pool_type", "argmax")
+        self._eos_token_id = getattr(clip_model, "text_eos_id", None)
 
     def forward(self, text):
-        return self.clip_model.encode_text(text)
+        m = self.clip_model
+        cast_dtype = m.transformer.get_cast_dtype()
+
+        x = m.token_embedding(text).to(cast_dtype)         # (B, L, D)
+        x = x + m.positional_embedding.to(cast_dtype)
+        x = m.transformer(x, attn_mask=m.attn_mask)
+        x = m.ln_final(x)                                   # (B, L, D)
+
+        # Trace-friendly EOS pooling. Avoids torch.arange(x.shape[0]).
+        pool = self._pool_type
+        if pool == "first":
+            x = x[:, 0]
+        elif pool == "last":
+            x = x[:, -1]
+        elif pool in ("argmax", "eos"):
+            if pool == "argmax":
+                idx = text.argmax(dim=-1)                   # (B,)
+            else:
+                if self._eos_token_id is None:
+                    raise ValueError(
+                        "text_pool_type='eos' requires clip_model.text_eos_id"
+                    )
+                idx = (text == self._eos_token_id).int().argmax(dim=-1)  # (B,)
+            # gather along seq dim: index shape (B, 1, D) → output (B, 1, D)
+            idx = idx.unsqueeze(-1).unsqueeze(-1).expand(-1, 1, x.size(-1))
+            x = x.gather(1, idx).squeeze(1)                 # (B, D)
+        # else: pool == 'none' or unknown — leave x as (B, L, D)
+
+        if m.text_projection is not None:
+            if isinstance(m.text_projection, torch.nn.Linear):
+                x = m.text_projection(x)
+            else:
+                x = x @ m.text_projection
+
+        return x
 
 
 def _export_bioclip_variant(model_id, output_dir, opset, validate=False):
@@ -315,7 +417,11 @@ def _export_bioclip_variant(model_id, output_dir, opset, validate=False):
 
     txt_wrapper = _TextEncoderWrapper(model)
     txt_wrapper.eval()
-    dummy_tokens = torch.zeros(1, 77, dtype=torch.long)
+    # Use a multi-row dummy so the tracer cannot fold batch into a constant.
+    # If anything in the model still bakes in a fixed batch size, the export
+    # itself will produce a graph that fails at runtime for other batch sizes
+    # — caught by the batched validation below.
+    dummy_tokens = torch.zeros(2, 77, dtype=torch.long)
 
     with torch.no_grad():
         pt_txt_out = txt_wrapper(dummy_tokens).numpy()
@@ -333,6 +439,11 @@ def _export_bioclip_variant(model_id, output_dir, opset, validate=False):
         },
     )
     log.info("  Text encoder: %s (output shape: %s)", text_encoder_path, pt_txt_out.shape)
+
+    # Verify the exported text encoder accepts batches != the dummy size.
+    # Catches any remaining hardcoded-batch reshape regressions before users
+    # hit them at inference time.
+    _verify_text_encoder_batched(text_encoder_path, txt_wrapper)
 
     # --- Save tokenizer ---
     tokenizer_path = os.path.join(out_dir, "tokenizer.json")

--- a/vireo/classifier.py
+++ b/vireo/classifier.py
@@ -215,36 +215,24 @@ def _normalize(vec):
     return vec / norm
 
 
-def _make_text_runner(text_session, text_input_name):
-    """Return a callable that runs the text encoder on a (N, seq_len) token batch.
+def _run_text_batched(text_session, text_input_name, tokens):
+    """Run the text encoder on a (N, seq_len) token batch.
 
-    Some BioCLIP ONNX exports (notably bioclip-2.5-vith14) contain an internal
-    Reshape node with a hardcoded single-prompt shape, so inference fails for
-    any batch size > 1 even though the model's declared input is dynamic.
-    The returned runner tries the batched call first and, on failure, falls
-    back to per-row inference and remembers the choice for subsequent calls.
+    Vireo's text encoder ONNX exports are batch-agnostic (see
+    ``scripts/export_onnx.py:_TextEncoderWrapper``). If a session rejects a
+    batched input, the model file is from an older export with a hardcoded
+    batch dimension — fail loudly so the user re-downloads via the Models
+    page rather than silently falling back to a 50× slower per-row path.
     """
-    state = {"batched_ok": True}
-
-    def run(tokens):
-        if state["batched_ok"]:
-            try:
-                return text_session.run(None, {text_input_name: tokens})[0]
-            except Exception as e:
-                log.warning(
-                    "Text encoder rejected batched input (%s: %s); "
-                    "falling back to per-row inference",
-                    type(e).__name__,
-                    e,
-                )
-                state["batched_ok"] = False
-        rows = [
-            text_session.run(None, {text_input_name: tokens[i : i + 1]})[0]
-            for i in range(tokens.shape[0])
-        ]
-        return np.concatenate(rows, axis=0)
-
-    return run
+    try:
+        return text_session.run(None, {text_input_name: tokens})[0]
+    except Exception as e:
+        raise RuntimeError(
+            "Text encoder ONNX rejected batched input — the local model "
+            "file is from a stale export with a hardcoded batch dimension. "
+            "Re-download the model from the Models page in Settings. "
+            f"Underlying error: {type(e).__name__}: {e}"
+        ) from e
 
 
 def _compute_embeddings_with_progress(
@@ -271,13 +259,11 @@ def _compute_embeddings_with_progress(
     if progress_callback:
         progress_callback(0, total)
 
-    run_text = _make_text_runner(text_session, text_input_name)
-
     all_features = []
     for i, classname in enumerate(labels):
         txts = [template(classname) for template in OPENAI_IMAGENET_TEMPLATE]
         tokens = _tokenize(tokenizer, txts)
-        txt_features = run_text(tokens)
+        txt_features = _run_text_batched(text_session, text_input_name, tokens)
         txt_features = txt_features.astype(np.float32)
         # Normalize each template's output, then average
         txt_features = _normalize(txt_features)

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -429,7 +429,7 @@
 
     // Expanded content
     if (isExpanded) {
-      // 8: Throughput for running steps
+      // 8: Throughput + ETA for running steps
       if (isRunning && step.progress && step.progress.current > 0 && step.started_at) {
         var stepSecs = (Date.now() - new Date(step.started_at).getTime()) / 1000;
         if (stepSecs > 0) {
@@ -441,7 +441,15 @@
           } else {
             throughput = '~' + (1 / perSec).toFixed(1) + 's each';
           }
-          html += '<div class="tree-step-throughput">' + throughput + '</div>';
+          var statusLine = throughput;
+          // ETA only when we know the total and have a non-zero rate
+          if (step.progress.total > 0 && perSec > 0) {
+            var remaining = step.progress.total - step.progress.current;
+            if (remaining > 0) {
+              statusLine += ' &middot; ETA ' + formatElapsed(remaining / perSec);
+            }
+          }
+          html += '<div class="tree-step-throughput">' + statusLine + '</div>';
         }
       }
 

--- a/vireo/tests/test_classifier.py
+++ b/vireo/tests/test_classifier.py
@@ -446,16 +446,20 @@ class TestTreeOfLifeMode:
             assert isinstance(emb, np.ndarray)
 
 
-class TestTextEncoderBatchFallback:
-    """Tests for the per-row fallback when the text encoder's ONNX graph
-    rejects batched inputs (a known issue with bioclip-2.5-vith14 where an
-    internal Reshape node has a hardcoded batch=1 shape)."""
+class TestTextEncoderBatchRejection:
+    """Tests for the strict batched-only text encoder path.
+
+    Old BioCLIP ONNX exports baked batch=1 into a downstream Reshape node
+    (see scripts/export_onnx.py:_TextEncoderWrapper). The classifier used
+    to silently fall back to per-row inference (~50× slower); now it
+    raises a clear error that tells the user to re-download the model.
+    """
 
     def _make_batch1_only_text_session(self, embedding_dim=512):
         """Mock text session that raises for batch > 1, succeeds for batch == 1.
 
-        Simulates the bioclip-2.5-vith14 text_encoder.onnx behaviour where
-        the internal 'gemm_input_reshape' node fails whenever batch > 1.
+        Simulates the legacy text_encoder.onnx behaviour where the internal
+        'gemm_input_reshape' node fails whenever batch > 1.
         """
         session = MagicMock()
         mock_input = MagicMock()
@@ -476,9 +480,10 @@ class TestTextEncoderBatchFallback:
         session.run = fake_run
         return session
 
-    def test_falls_back_to_per_row_when_batch_rejected(self, tmp_path):
-        """If the text encoder raises on batched inputs, embeddings are still
-        computed via per-row inference."""
+    def test_raises_clear_error_when_batch_rejected(self, tmp_path):
+        """A stale text encoder ONNX must surface a re-download instruction
+        rather than silently falling back to slow per-row inference."""
+        import pytest
         from classifier import Classifier
 
         _make_model_dir(tmp_path)
@@ -498,11 +503,9 @@ class TestTextEncoderBatchFallback:
                 side_effect=[fake_image_session, fake_text_session],
             ),
             patch("classifier._load_tokenizer", return_value=fake_tokenizer),
+            pytest.raises(RuntimeError, match="Re-download"),
         ):
-            clf = Classifier(labels=["bird", "cat"], model_str="ViT-B-16")
-
-        assert clf._txt_embeddings.shape == (512, 2)
-        assert clf._txt_embeddings.dtype == np.float32
+            Classifier(labels=["bird", "cat"], model_str="ViT-B-16")
 
 
 class TestEmbeddingCache:


### PR DESCRIPTION
## Summary

Restores fast cold-start for BioCLIP classification (was ~60 min per-row, now seconds batched) and exposes ETA on the jobs page.

## Root cause

`open_clip.transformer.text_global_pool` does:

```python
pooled = x[torch.arange(x.shape[0], device=x.device), text.argmax(dim=-1)]
```

When `torch.onnx.export` traces this with `dummy_tokens = torch.zeros(1, 77)`, `x.shape[0]` becomes the constant `1`. That propagates downstream as a hardcoded Reshape target (`gemm_input_reshape`), so the exported graph rejects any batch ≠ 1 at runtime — even though `dynamic_axes={"input_ids": {0: "batch"}}` is set.

The classifier had a silent per-row fallback for this, which is what kept things working but ~50× slower.

## Changes

- **`scripts/export_onnx.py`**
  - Replace `_TextEncoderWrapper.forward` with an inlined, trace-friendly version of `encode_text` that uses `torch.gather` for EOS/argmax/eos pooling instead of `torch.arange`-indexed lookup.
  - Use a multi-row dummy input (`torch.zeros(2, 77)`) so any remaining baked-in `batch=1` would surface during export rather than at first cold-start.
  - Add `_verify_text_encoder_batched` helper that runs a batch-8 inference at export time against per-row PyTorch reference. Catches regressions before users hit them.
- **`vireo/classifier.py`** — remove the silent per-row fallback. If a session rejects batched input, raise a clear `RuntimeError` telling the user to re-download the model. No more silent slow path.
- **`vireo/templates/jobs.html`** — running steps now show ETA next to throughput (\`~120/min · ETA 5m 12s\`).
- **`vireo/tests/test_classifier.py`** — updated batch-rejection test to assert the new strict-error behaviour rather than the removed fallback.

## Migration

Locally-installed BioCLIP models will need to be re-downloaded from the Models page. The existing `model_verify` system already flags exports with mismatched SHAs, so users will see the prompt automatically.

## Verification

Re-exported both BioCLIP variants locally with the new wrapper:

| model | batched verification (max abs diff vs PT per-row) |
|---|---|
| bioclip-vit-b-16 | 4e-6 |
| bioclip-2 | 1.2e-5 |

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_jobs.py vireo/tests/test_classifier.py vireo/tests/test_text_encoder.py -q` → **474 passed**
- [x] Local re-export of bioclip-vit-b-16 and bioclip-2 succeeds with batched verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)