### PR TITLE
fix: MegaDetector V6 parser layout + workspace threshold override

### DIFF
--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -202,10 +202,6 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
         if detect_animals is None or get_primary_detection is None:
             return detection_map, detected, processed_ids
 
-        if det_conf_threshold is None:
-            import config as cfg
-            det_conf_threshold = cfg.load().get("detector_confidence", 0.2)
-
         for photo in photos:
             folder_path = folders.get(photo["folder_id"], "")
             image_path = os.path.join(folder_path, photo["filename"])
@@ -241,6 +237,18 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                     detected += 1
                     processed_ids.add(photo["id"])
                     continue
+
+            # Resolve threshold lazily on first actual detection call so a
+            # batch where every photo hits the cached/already-detected
+            # short-circuit doesn't need a working config/db at all (the
+            # cached-detections short-circuit test relies on this).
+            if det_conf_threshold is None:
+                import config as cfg
+                # Use workspace-effective config so per-workspace overrides
+                # (e.g. bird-photography workspaces lowering the threshold)
+                # are honored, not just the bare global default.
+                effective_cfg = db.get_effective_config(cfg.load())
+                det_conf_threshold = effective_cfg.get("detector_confidence", 0.2)
 
             detections = detect_animals(image_path, confidence_threshold=det_conf_threshold)
 
@@ -390,9 +398,11 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
             },
         )
 
-        # Load config once for the entire detection loop
+        # Load config once for the entire detection loop. Use the
+        # workspace-effective config so per-workspace overrides apply.
         import config as cfg
-        det_conf_threshold = cfg.load().get("detector_confidence", 0.2)
+        effective_cfg = db.get_effective_config(cfg.load())
+        det_conf_threshold = effective_cfg.get("detector_confidence", 0.2)
 
         # Process one photo at a time so we can report per-photo progress
         detection_map = {}

--- a/vireo/detector.py
+++ b/vireo/detector.py
@@ -168,12 +168,22 @@ def _preprocess(image_array):
 def _postprocess(outputs, preprocess_info, confidence_threshold):
     """Post-process ONNX model outputs to detection list.
 
-    Handles common YOLOv9 ONNX output formats flexibly:
-    - (1, N, 4+1+num_classes): N candidate boxes with
-      [x1, y1, x2, y2, obj_conf, cls0, cls1, ...]
-    - (1, 4+1+num_classes, N): transposed variant
-    - (1, N, 4+num_classes): no separate objectness score,
-      [cx, cy, w, h, cls0, cls1, ...]
+    Supports two YOLO output layouts (after squeezing the batch dim and
+    transposing to (N, C) where N = number of anchor proposals):
+
+    - C == 4 + num_classes (YOLOv8/v9 — no objectness):
+        [cx, cy, w, h, cls0, cls1, ...]
+        For MegaDetector V6 (YOLOv9c, 3 classes) this is C == 7.
+    - C == 5 + num_classes (legacy YOLOv5/v7 with objectness):
+        [x1, y1, x2, y2, obj_conf, cls0, cls1, ...]
+        With 3 classes that's C == 8.
+
+    The two layouts are distinguished by an exact column count keyed off
+    ``CLASS_NAMES``. Earlier code keyed on ``num_cols >= 7``, which sent
+    the YOLOv9 7-column output down the with-objectness path and silently
+    corrupted both the confidence (animal × max(person, vehicle) ≈ 0)
+    and the category labels (off-by-one) on every MegaDetector V6
+    detection.
 
     Args:
         outputs: list of numpy arrays from ONNX session.run()
@@ -202,18 +212,10 @@ def _postprocess(outputs, preprocess_info, confidence_threshold):
             output = output.T  # transpose (C, N) -> (N, C)
 
     num_cols = output.shape[1]
+    num_classes = len(CLASS_NAMES)
 
-    if num_cols >= 7:
-        # Format: [x1, y1, x2, y2, obj_conf, cls0, cls1, cls2, ...]
-        # Separate objectness score multiplied by class score
-        boxes_raw = output[:, :4]
-        obj_conf = output[:, 4]
-        class_scores = output[:, 5:]
-        class_ids = class_scores.argmax(axis=1)
-        confidences = obj_conf * class_scores[np.arange(len(class_scores)), class_ids]
-    elif num_cols >= 5:
-        # Format: [cx, cy, w, h, cls0, cls1, ...] (no separate obj_conf)
-        # Box coords are center-x, center-y, width, height
+    if num_cols == 4 + num_classes:
+        # YOLOv8/v9 layout: [cx, cy, w, h, cls0, cls1, ...]
         cx, cy, bw, bh = output[:, 0], output[:, 1], output[:, 2], output[:, 3]
         boxes_raw = np.stack(
             [cx - bw / 2, cy - bh / 2, cx + bw / 2, cy + bh / 2], axis=1
@@ -221,8 +223,20 @@ def _postprocess(outputs, preprocess_info, confidence_threshold):
         class_scores = output[:, 4:]
         class_ids = class_scores.argmax(axis=1)
         confidences = class_scores[np.arange(len(class_scores)), class_ids]
+    elif num_cols == 5 + num_classes:
+        # Legacy YOLOv5/v7 layout with objectness:
+        # [x1, y1, x2, y2, obj_conf, cls0, cls1, ...]
+        boxes_raw = output[:, :4]
+        obj_conf = output[:, 4]
+        class_scores = output[:, 5:]
+        class_ids = class_scores.argmax(axis=1)
+        confidences = obj_conf * class_scores[np.arange(len(class_scores)), class_ids]
     else:
-        log.warning("Unexpected ONNX output shape: %s", output.shape)
+        log.warning(
+            "Unexpected ONNX output shape: %s (expected %d or %d columns "
+            "for %d classes)",
+            output.shape, 4 + num_classes, 5 + num_classes, num_classes,
+        )
         return []
 
     # Filter by confidence

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -399,6 +399,67 @@ def test_detect_batch_marks_processed_before_quality_scoring(tmp_path):
     assert 7 in detection_map
 
 
+def test_detect_batch_uses_workspace_effective_threshold(tmp_path, monkeypatch):
+    """When det_conf_threshold is unset, _detect_batch must read the
+    workspace-effective config (so per-workspace overrides apply), not
+    the bare global config.
+
+    Regression: the old code called cfg.load() directly, which dropped
+    workspace overrides on the floor. A bird-photography workspace
+    setting detector_confidence=0.05 was silently ignored — every call
+    used the 0.2 global default.
+    """
+    from unittest.mock import patch
+
+    import config as cfg
+    from classify_job import _detect_batch
+    from db import Database
+
+    # Real DB with a workspace that overrides detector_confidence
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.create_workspace(
+        "Birds", config_overrides={"detector_confidence": 0.05}
+    )
+    db.set_active_workspace(ws_id)
+
+    # Isolate global config so we don't read ~/.vireo/config.json
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    img = Image.new("RGB", (100, 100), color="red")
+    img_path = str(tmp_path / "bird.jpg")
+    img.save(img_path)
+
+    photos = [{"id": 1, "filename": "bird.jpg", "folder_id": 10}]
+    folders = {10: str(tmp_path)}
+
+    captured = {}
+
+    def fake_detect(image_path, confidence_threshold):
+        captured["threshold"] = confidence_threshold
+        return []
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    with patch("classify_job.detect_animals", side_effect=fake_detect), \
+         patch("classify_job.get_primary_detection", return_value=None), \
+         patch("classify_job.compute_sharpness", return_value=50.0):
+        _detect_batch(
+            photos=photos,
+            folders=folders,
+            runner=runner,
+            job=job,
+            reclassify=True,
+            db=db,
+            already_detected_ids=set(),
+        )
+
+    assert captured["threshold"] == 0.05, (
+        "workspace override detector_confidence=0.05 was dropped; "
+        f"detect_animals was called with {captured.get('threshold')!r}"
+    )
+
+
 def test_detect_batch_stores_all_detections(tmp_path):
     """_detect_batch should store all detections, not just the primary."""
     from db import Database

--- a/vireo/tests/test_detector.py
+++ b/vireo/tests/test_detector.py
@@ -131,19 +131,23 @@ def test_postprocess_with_detections():
     assert all(k in det["box"] for k in ("x", "y", "w", "h"))
 
 
-def test_postprocess_cxcywh_format():
-    """_postprocess must handle cx/cy/w/h format (no objectness score)."""
+def test_postprocess_cxcywh_format_yolov9():
+    """7-column YOLOv9 output (no objectness) parses as cxcywh + 3 classes.
+
+    MegaDetector V6 (YOLOv9c) produces (1, 7, 8400) output with the
+    layout [cx, cy, w, h, animal_score, person_score, vehicle_score].
+    A previous version of the parser keyed on ``num_cols >= 7`` and
+    sent this through the with-objectness branch, multiplying the
+    animal score by max(person, vehicle) — yielding near-zero on bird
+    photos and corrupting category labels off-by-one.
+    """
     import detector
 
-    # Simulate (1, N, 7) format: [cx, cy, w, h, cls0, cls1, cls2]
-    # This is 7 columns which hits the num_cols >= 7 branch differently,
-    # but let's test the 5-6 column format with (1, N, 6)
-    # Actually, 7 columns hits the >= 7 branch. Let's test exactly the
-    # >= 5 branch by using 5 columns: [cx, cy, w, h, cls0]
+    # (1, N, 7) — single detection, animal class strong, person/vehicle ~0
     output = np.array(
         [
             [
-                [320, 320, 200, 200, 0.9],
+                [320, 320, 200, 200, 0.9, 0.02, 0.01],
             ]
         ],
         dtype=np.float32,
@@ -153,8 +157,39 @@ def test_postprocess_cxcywh_format():
 
     assert len(result) == 1
     det = result[0]
-    assert det["category"] == "animal"  # class 0
-    assert det["confidence"] > 0.5
+    assert det["category"] == "animal"
+    # Confidence must be the raw animal score (0.9), not animal × max(other)
+    assert det["confidence"] == pytest.approx(0.9, abs=1e-5)
+    # Box must be derived from cxcywh, not interpreted as xyxy
+    # cx=320, cy=320, w=200, h=200 → x1=220, y1=220, x2=420, y2=420
+    # Normalized to 640: x=220/640=0.34375, w=200/640=0.3125
+    assert det["box"]["x"] == pytest.approx(220 / 640, abs=1e-4)
+    assert det["box"]["y"] == pytest.approx(220 / 640, abs=1e-4)
+    assert det["box"]["w"] == pytest.approx(200 / 640, abs=1e-4)
+    assert det["box"]["h"] == pytest.approx(200 / 640, abs=1e-4)
+
+
+def test_postprocess_yolov9_category_labels_correct():
+    """7-column YOLOv9 output assigns categories from the class index in
+    cols 4-6, not via the off-by-one shifted lookup the old parser did."""
+    import detector
+
+    # Three detections, one strong in each class
+    output = np.array(
+        [
+            [
+                [100, 100, 50, 50, 0.9, 0.0, 0.0],   # animal
+                [200, 200, 50, 50, 0.0, 0.85, 0.0],  # person
+                [300, 300, 50, 50, 0.0, 0.0, 0.8],   # vehicle
+            ]
+        ],
+        dtype=np.float32,
+    )
+    preprocess_info = (1.0, 0, 0, 640, 640)
+    result = detector._postprocess([output], preprocess_info, 0.2)
+
+    cats = sorted(d["category"] for d in result)
+    assert cats == ["animal", "person", "vehicle"]
 
 
 def test_postprocess_transposed_format():


### PR DESCRIPTION
## Summary

Two related bugs were silently corrupting wildlife detection across the entire pipeline. Together they explain why a recent run produced **0 KEEP / 0 REVIEW / 124 REJECT** on a batch of clear bird photos.

## Bug 1: parser misinterpreted YOLOv9 layout (`vireo/detector.py`)

`detector._postprocess` keyed on `if num_cols >= 7:` and assumed the legacy YOLOv5/v7 layout `[x1, y1, x2, y2, obj_conf, cls0, cls1, cls2]` (8 cols). MegaDetector V6 is YOLOv9c with 3 classes, so its output is `(1, 7, 8400)` → `[cx, cy, w, h, animal, person, vehicle]` (7 cols, no objectness). With exactly 7 cols the parser:

- treated col 4 (animal probability) as `obj_conf`
- treated cols 5–6 (person, vehicle) as `class_scores` (only 2 of them)
- emitted `confidence = animal × max(person, vehicle)` → near-zero on real wildlife
- assigned categories from a `class_id` space of `{0, 1}` — labels off-by-one (an "animal" detection was actually scoring person; "person" was actually vehicle; "vehicle" never appeared)
- interpreted boxes as `xyxy` when they were really `cxcywh`

**Diagnosed** by running ultralytics' own `YOLO(MDV6-yolov9-c.pt)(photo)` on the same image as a reference — confirmed both that the output layout is YOLOv9 (no objectness) and that real animal scores on these photos are in the 0.04–0.10 range (small distant birds at 600mm, not MegaDetector's strong suit). The buggy parser was multiplying that already-low score by ~0.01 (max(person, vehicle)) → effectively zero everywhere.

**Fix:** strict layout detection keyed on column count vs `len(CLASS_NAMES)`:

| layout | columns | branch |
|---|---|---|
| YOLOv8/v9 (no objectness) | `4 + num_classes` (= 7 for MD V6) | `[cx, cy, w, h, cls0, cls1, …]` |
| YOLOv5/v7 (with objectness) | `5 + num_classes` (= 8 for MD V6) | `[x1, y1, x2, y2, obj_conf, cls0, …]` |
| anything else | — | warn and return `[]` |

## Bug 2: workspace `detector_confidence` override silently ignored (`vireo/classify_job.py`)

`_detect_batch` and `_detect_subjects` read `detector_confidence` from `cfg.load()` directly, so any per-workspace `config_overrides` were dropped. A bird-photography workspace setting `detector_confidence: 0.05` was silently using the global 0.2 default.

**Fix:** read via `thread_db.get_effective_config(cfg.load())` so workspace overrides apply. Threshold lookup is now deferred until the first non-cached photo so all-cached batches still don't need a working config/db (preserves the existing `test_detect_batch_prefers_cached_detections_over_db` short-circuit).

## Tests

Three new tests:

- `test_postprocess_cxcywh_format_yolov9`: 7-col input parses as cxcywh + 3 classes, confidence is the raw animal score (not `animal × max(person, vehicle)`), box coords derived from cxcywh.
- `test_postprocess_yolov9_category_labels_correct`: each class column maps to the correct `CLASS_NAMES` label end-to-end (no off-by-one).
- `test_detect_batch_uses_workspace_effective_threshold`: workspace override flows through to `detect_animals(confidence_threshold=...)`.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_jobs.py vireo/tests/test_classifier.py vireo/tests/test_text_encoder.py vireo/tests/test_detector.py vireo/tests/test_classify_job.py vireo/tests/test_pipeline_job.py -q` → **571 passed**
- [x] One pre-existing flake (`test_pipeline_auto_skips_classify_when_no_model`) — passes in isolation, fails in combined runs on `main` too.

## Follow-up (not in this PR)

Even with the parser fix, MegaDetector's animal scores on the rejected photos peak around 0.05–0.10. The existing 0.2 default threshold will still reject them. Workspaces doing bird photography should set a workspace-level `detector_confidence: 0.05` (now actually honored). Longer-term we may want a "no detection → use full frame" fallback in `extract_masks_stage` so the pipeline doesn't reject every photo when the detector underperforms — separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)