### PR TITLE
fix: distinguish HF cache hits from network downloads in model fetch logs

### DIFF
--- a/vireo/models.py
+++ b/vireo/models.py
@@ -375,7 +375,7 @@ def _hf_download_with_retry(repo_id, filename, local_dir,
     """
     import time as _time
 
-    from huggingface_hub import hf_hub_download
+    from huggingface_hub import hf_hub_download, try_to_load_from_cache
 
     os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "300")
 
@@ -386,20 +386,6 @@ def _hf_download_with_retry(repo_id, filename, local_dir,
     while True:
         attempt += 1
         try:
-            if progress_callback:
-                if attempt == 1:
-                    progress_callback(f"Downloading {filename}...")
-                else:
-                    progress_callback(f"Resuming download (attempt {attempt})...")
-
-            log.info(
-                "Downloading %s/%s%s (attempt %d)",
-                repo_id,
-                f"{subfolder}/" if subfolder else "",
-                filename,
-                attempt,
-            )
-
             kwargs = {
                 "repo_id": repo_id,
                 "filename": filename,
@@ -409,15 +395,74 @@ def _hf_download_with_retry(repo_id, filename, local_dir,
             if revision:
                 kwargs["revision"] = revision
 
+            # Detect cache hit before triggering any network activity, so the
+            # log + UI can distinguish "1.2 GB came over the wire" from
+            # "the blob was already in the HF cache and we just cloned it
+            # into the model dir" (a few hundred ms on APFS even for huge
+            # files). Without this distinction a sub-second 'download' of
+            # a multi-GB model looks suspicious instead of correct.
+            from_cache = False
+            if attempt == 1:
+                try:
+                    pre_cached = try_to_load_from_cache(
+                        repo_id=repo_id,
+                        filename=(f"{subfolder}/{filename}"
+                                  if subfolder else filename),
+                        revision=revision,
+                    )
+                    from_cache = (
+                        isinstance(pre_cached, str)
+                        and os.path.isfile(pre_cached)
+                    )
+                except Exception as e:
+                    # Cache lookup is best-effort — if it fails, fall through
+                    # to the network path; hf_hub_download will sort it out.
+                    log.debug("Cache lookup failed for %s: %s", filename, e)
+
+            label_path = f"{subfolder}/{filename}" if subfolder else filename
+            if progress_callback:
+                if attempt == 1:
+                    if from_cache:
+                        progress_callback(
+                            f"Found {filename} in HF cache, copying..."
+                        )
+                    else:
+                        progress_callback(
+                            f"Downloading {filename} from Hugging Face..."
+                        )
+                else:
+                    progress_callback(f"Resuming download (attempt {attempt})...")
+
+            if from_cache:
+                log.info(
+                    "%s/%s already in HF cache — no network download needed",
+                    repo_id, label_path,
+                )
+            else:
+                log.info(
+                    "Downloading %s/%s (attempt %d)",
+                    repo_id, label_path, attempt,
+                )
+
             cached_path = hf_hub_download(**kwargs)
 
-            # Copy from cache to our models directory
+            # Copy from cache to our models directory.  On APFS shutil.copy2
+            # uses clonefile() (copy-on-write metadata-only), so cloning a
+            # 1+ GB blob takes milliseconds and shares disk pages with the
+            # cache until either side is modified.
             os.makedirs(local_dir, exist_ok=True)
             dest_path = os.path.join(local_dir, filename)
             if cached_path != dest_path:
                 shutil.copy2(cached_path, dest_path)
 
-            log.info("Download complete: %s", dest_path)
+            if from_cache:
+                size_mb = os.path.getsize(dest_path) / 1024 / 1024
+                log.info(
+                    "Linked from cache: %s (%.1f MB, no network transfer)",
+                    dest_path, size_mb,
+                )
+            else:
+                log.info("Download complete: %s", dest_path)
             return dest_path
 
         except Exception as e:

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -1388,3 +1388,136 @@ def test_download_model_small_onnx_graph_does_not_trigger_size_floor(
     # .onnx.data sidecars are subject to the floor.  Any exception here
     # (including a non-"truncated" RuntimeError) is a test failure.
     models.download_model("bioclip-vit-b-16")
+
+
+# ---------------------------------------------------------------------------
+# _hf_download_with_retry: cache-hit vs network-download messaging
+# ---------------------------------------------------------------------------
+
+def _stub_hf_module(monkeypatch, hf_hub_download_fn, try_to_load_from_cache_fn):
+    """Install a fake huggingface_hub module exposing the two functions
+    _hf_download_with_retry imports."""
+    import sys
+    import types
+
+    stub = types.ModuleType("huggingface_hub")
+    stub.hf_hub_download = hf_hub_download_fn
+    stub.try_to_load_from_cache = try_to_load_from_cache_fn
+    monkeypatch.setitem(sys.modules, "huggingface_hub", stub)
+
+
+def test_hf_download_with_retry_reports_cache_hit(tmp_path, monkeypatch, caplog):
+    """When the file is already in the HF cache, the user-visible message
+    and log say so — no '1.2 GB downloaded in 1 second' confusion."""
+    import logging
+
+    import models
+
+    # Pretend the blob is sitting at this path in the HF cache.
+    cached_blob = tmp_path / "fake-cache" / "blobs" / "abc123"
+    cached_blob.parent.mkdir(parents=True)
+    cached_blob.write_bytes(b"weights" * 100)
+
+    def fake_lookup(repo_id, filename, revision=None):
+        return str(cached_blob)
+
+    def fake_download(repo_id, filename, subfolder=None, revision=None):
+        # Simulate hf_hub_download returning the same cached path it would
+        # normally return when nothing needs to be fetched.
+        return str(cached_blob)
+
+    _stub_hf_module(monkeypatch, fake_download, fake_lookup)
+
+    messages = []
+    dest_dir = tmp_path / "model_dir"
+    with caplog.at_level(logging.INFO, logger="models"):
+        models._hf_download_with_retry(
+            repo_id="acme/foo",
+            filename="model.onnx",
+            local_dir=str(dest_dir),
+            subfolder="sub",
+            progress_callback=messages.append,
+        )
+
+    assert any("HF cache" in m for m in messages), (
+        f"expected a cache-hit message in progress callback, got {messages!r}"
+    )
+    log_text = caplog.text
+    assert "already in HF cache" in log_text
+    assert "Linked from cache" in log_text
+    assert "no network transfer" in log_text
+    # The dest must exist (copied from cache)
+    assert (dest_dir / "model.onnx").exists()
+
+
+def test_hf_download_with_retry_reports_network_download(tmp_path, monkeypatch, caplog):
+    """When the file is not cached, the message says 'Downloading from
+    Hugging Face' — the existing behaviour, kept distinct."""
+    import logging
+
+    import models
+
+    cached_blob = tmp_path / "fake-cache" / "blobs" / "abc123"
+
+    def fake_lookup(repo_id, filename, revision=None):
+        # Cache miss
+        return None
+
+    def fake_download(repo_id, filename, subfolder=None, revision=None):
+        # Pretend the network fetch landed here.
+        cached_blob.parent.mkdir(parents=True, exist_ok=True)
+        cached_blob.write_bytes(b"weights" * 100)
+        return str(cached_blob)
+
+    _stub_hf_module(monkeypatch, fake_download, fake_lookup)
+
+    messages = []
+    dest_dir = tmp_path / "model_dir"
+    with caplog.at_level(logging.INFO, logger="models"):
+        models._hf_download_with_retry(
+            repo_id="acme/foo",
+            filename="model.onnx",
+            local_dir=str(dest_dir),
+            progress_callback=messages.append,
+        )
+
+    assert any("Downloading" in m and "Hugging Face" in m for m in messages), (
+        f"expected a network-download message, got {messages!r}"
+    )
+    log_text = caplog.text
+    assert "already in HF cache" not in log_text
+    assert "Download complete" in log_text
+
+
+def test_hf_download_with_retry_cache_lookup_failure_falls_back(tmp_path, monkeypatch, caplog):
+    """If try_to_load_from_cache raises, we still call hf_hub_download —
+    cache detection is best-effort, not a hard dependency."""
+    import logging
+
+    import models
+
+    cached_blob = tmp_path / "fake-cache" / "blobs" / "abc123"
+
+    def fake_lookup(repo_id, filename, revision=None):
+        raise RuntimeError("HF cache lookup unavailable")
+
+    def fake_download(repo_id, filename, subfolder=None, revision=None):
+        cached_blob.parent.mkdir(parents=True, exist_ok=True)
+        cached_blob.write_bytes(b"weights" * 100)
+        return str(cached_blob)
+
+    _stub_hf_module(monkeypatch, fake_download, fake_lookup)
+
+    messages = []
+    dest_dir = tmp_path / "model_dir"
+    with caplog.at_level(logging.INFO, logger="models"):
+        result = models._hf_download_with_retry(
+            repo_id="acme/foo",
+            filename="model.onnx",
+            local_dir=str(dest_dir),
+            progress_callback=messages.append,
+        )
+
+    # Falls back to network-download messaging since cache state is unknown.
+    assert result == os.path.join(str(dest_dir), "model.onnx")
+    assert any("Downloading" in m and "Hugging Face" in m for m in messages)


### PR DESCRIPTION
## Summary

Today I downloaded the iNat21 (EVA-02 Large) model and it 'completed' in under a second. That's not a bug — the 1.26 GB blob was already in the HuggingFace cache from a prior run, and APFS \`clonefile()\` makes the copy from cache → vireo model dir nearly instantaneous. But the logs gave no hint of any of that:

\`\`\`
Downloading jss367/vireo-onnx-models/timm-eva02-large-inat21/model.onnx.data (attempt 1)
Download complete: /Users/julius/.vireo/models/timm-inat21-eva02-l/model.onnx.data
\`\`\`

Two log lines, same second, looks identical to a mysteriously-fast multi-GB download. Cue the user wondering whether the model is intact.

## Fix

Before calling \`hf_hub_download\`, ask \`try_to_load_from_cache\` whether the file is already cached. If hit, both the progress callback and log say so explicitly:

\`\`\`
Found model.onnx.data in HF cache, copying...
Linked from cache: /Users/julius/.vireo/models/.../model.onnx.data (1199.7 MB, no network transfer)
\`\`\`

Otherwise the existing "Downloading from Hugging Face" / "Download complete" messages are kept. The cache lookup is best-effort — if it raises, the function falls through to the normal network path so a flaky cache API doesn't break downloads.

## Tests

Three new tests covering all three paths:

- \`test_hf_download_with_retry_reports_cache_hit\` — cache present → user-visible "Found in HF cache" + log "no network transfer"
- \`test_hf_download_with_retry_reports_network_download\` — cache miss → existing "Downloading from Hugging Face" + "Download complete"
- \`test_hf_download_with_retry_cache_lookup_failure_falls_back\` — \`try_to_load_from_cache\` raises → silently falls back to network path with the network-download messaging

## Test plan

- [x] \`python -m pytest vireo/tests/test_jobs.py vireo/tests/test_jobs_api.py vireo/tests/test_classify_job.py vireo/tests/test_detector.py vireo/tests/test_classifier.py -q\` → **120 passed**, 1 pre-existing flake (\`test_pipeline_auto_skips_classify_when_no_model\` — passes in isolation, fails in combined runs on \`main\` too)
- [x] New cache-hit/network/fallback tests pass independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)