### PR TITLE
fix: download DINOv2 weights sidecar so models actually load

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3782,11 +3782,18 @@ def create_app(db_path, thumb_cache_dir=None):
         for variant_id, name, dims, size_est in dinov2_variants:
             variant_dir = os.path.join(models_dir, f"dinov2-{variant_id}")
             model_path = os.path.join(variant_dir, "model.onnx")
+            data_path = model_path + ".data"
             status = "not downloaded"
             size = None
-            if os.path.isfile(model_path):
-                size = round(os.path.getsize(model_path) / 1024 / 1024, 1)
+            # DINOv2 uses external-data ONNX: model.onnx is just the ~1 MB graph;
+            # the real weights live in a model.onnx.data sidecar. Both must be
+            # present for the model to load.
+            if os.path.isfile(model_path) and os.path.isfile(data_path):
+                total_bytes = os.path.getsize(model_path) + os.path.getsize(data_path)
+                size = round(total_bytes / 1024 / 1024, 1)
                 status = "downloaded"
+            elif os.path.isfile(model_path) or os.path.isfile(data_path):
+                status = "incomplete"
             models.append({
                 "id": variant_id,
                 "name": name,
@@ -3834,15 +3841,15 @@ def create_app(db_path, thumb_cache_dir=None):
             },
             "vit-s14": {
                 "subfolder": "dinov2-vit-s14",
-                "files": ["model.onnx"],
+                "files": ["model.onnx", "model.onnx.data"],
             },
             "vit-b14": {
                 "subfolder": "dinov2-vit-b14",
-                "files": ["model.onnx"],
+                "files": ["model.onnx", "model.onnx.data"],
             },
             "vit-l14": {
                 "subfolder": "dinov2-vit-l14",
-                "files": ["model.onnx"],
+                "files": ["model.onnx", "model.onnx.data"],
             },
         }
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1882,3 +1882,46 @@ def test_system_info_megadetector_installed_when_weights_present(app_and_db, mon
 
     assert data["megadetector"] == "installed"
     assert data["megadetector_weights"] == "downloaded"
+
+
+def test_pipeline_models_dinov2_incomplete_without_data_sidecar(
+    app_and_db, monkeypatch, tmp_path,
+):
+    """DINOv2 reports 'incomplete' when only model.onnx is on disk.
+
+    DINOv2 uses external-data ONNX: the ~1 MB model.onnx graph is useless
+    without the companion model.onnx.data weights file. Without this check
+    the status endpoint used to report "downloaded 1.0 MB" for a broken
+    install that couldn't actually run.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    variant_dir = tmp_path / ".vireo" / "models" / "dinov2-vit-b14"
+    variant_dir.mkdir(parents=True)
+    (variant_dir / "model.onnx").write_bytes(b"\x00" * 1024)  # graph only
+
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/models/pipeline")
+    assert resp.status_code == 200
+    entry = next(m for m in resp.get_json()["models"] if m["id"] == "vit-b14")
+    assert entry["status"] == "incomplete"
+    assert entry["size"] is None
+
+
+def test_pipeline_models_dinov2_downloaded_sums_graph_and_data(
+    app_and_db, monkeypatch, tmp_path,
+):
+    """DINOv2 reports 'downloaded' with total size once both files exist."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    variant_dir = tmp_path / ".vireo" / "models" / "dinov2-vit-b14"
+    variant_dir.mkdir(parents=True)
+    (variant_dir / "model.onnx").write_bytes(b"\x00" * (1 * 1024 * 1024))
+    (variant_dir / "model.onnx.data").write_bytes(b"\x00" * (10 * 1024 * 1024))
+
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/models/pipeline")
+    assert resp.status_code == 200
+    entry = next(m for m in resp.get_json()["models"] if m["id"] == "vit-b14")
+    assert entry["status"] == "downloaded"
+    assert entry["size"] == "11.0 MB"


### PR DESCRIPTION
## Summary

- Found while investigating a user report: the pipeline models UI showed "DINOv2 ViT-B/14 — Downloaded 1.0 MB" despite the variant being ~347 MB
- Root cause: DINOv2 ONNX on HF (jss367/vireo-onnx-models) uses external-data layout — `model.onnx` is just the ~1 MB graph, and the weights live in a companion `model.onnx.data` (~85 MB / 346 MB / 1.2 GB for S/B/L). The pipeline download spec only fetched `model.onnx`, so the real weights were never downloaded and the model wouldn't actually load
- The status endpoint compounded this by measuring only `model.onnx`, making a broken install look successful

## Changes

- `vireo/app.py` — add `model.onnx.data` to the download spec for `vit-s14`, `vit-b14`, `vit-l14`
- `vireo/app.py` — require both files before reporting `downloaded`; sum their sizes; report `incomplete` when only one is on disk (mirrors SAM2's two-file check)
- `vireo/tests/test_app.py` — two new tests covering the incomplete and downloaded cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)