### PR TITLE
feat: auto-download SAM2 + DINOv2 weights on first pipeline run

### DIFF
--- a/vireo/dino_embed.py
+++ b/vireo/dino_embed.py
@@ -9,6 +9,7 @@ Models are loaded as ONNX sessions from ~/.vireo/models/dinov2-{variant}/.
 
 import logging
 import os
+import threading
 
 import numpy as np
 import onnx_runtime
@@ -22,6 +23,13 @@ DINOV2_VARIANTS = {
     "vit-l14": 1024,
 }
 
+# Rough size estimate surfaced in the download progress message, per variant.
+_DINOV2_SIZE_HINT = {
+    "vit-s14": "~85 MB",
+    "vit-b14": "~350 MB",
+    "vit-l14": "~1.2 GB",
+}
+
 # DINOv2 native input size
 DINOV2_INPUT_SIZE = 518
 
@@ -31,6 +39,100 @@ _IMAGENET_STD = [0.229, 0.224, 0.225]
 
 _session = None
 _variant_loaded = None
+
+_dinov2_download_lock = threading.Lock()
+
+
+def _dinov2_model_path(variant):
+    model_dir = os.path.join(
+        os.path.expanduser("~"), ".vireo", "models", f"dinov2-{variant}"
+    )
+    return model_dir, os.path.join(model_dir, "model.onnx")
+
+
+def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
+    """Ensure DINOv2 ONNX weights for ``variant`` are on disk.
+
+    Returns the weights path when already downloaded.  Otherwise fetches
+    ``dinov2-{variant}/model.onnx`` from Hugging Face and copies it into
+    ``~/.vireo/models/dinov2-{variant}/``.  Raises RuntimeError on failure
+    so callers can abort rather than silently run without embeddings.
+
+    Args:
+        variant: one of vit-s14, vit-b14, vit-l14
+        progress_callback: optional callable(phase: str, current: int,
+            total: int) invoked once before the download starts and once
+            after it completes.
+    """
+    if variant not in DINOV2_VARIANTS:
+        raise ValueError(
+            f"Unknown DINOv2 variant: {variant}. "
+            f"Choose from: {list(DINOV2_VARIANTS.keys())}"
+        )
+
+    model_dir, model_path = _dinov2_model_path(variant)
+    if os.path.isfile(model_path):
+        return model_path
+
+    with _dinov2_download_lock:
+        if os.path.isfile(model_path):
+            return model_path
+
+        os.makedirs(model_dir, exist_ok=True)
+
+        size_hint = _DINOV2_SIZE_HINT.get(variant, "")
+        if progress_callback:
+            progress_callback(
+                f"Downloading DINOv2 {variant} ({size_hint}, first run only)...",
+                0, 1,
+            )
+        log.info(
+            "DINOv2 weights missing for %s — downloading from Hugging Face",
+            variant,
+        )
+
+        tmp_path = model_path + ".download"
+        try:
+            import shutil
+
+            from huggingface_hub import hf_hub_download
+            from models import ONNX_REPO
+
+            cached_path = hf_hub_download(
+                repo_id=ONNX_REPO,
+                filename="model.onnx",
+                subfolder=f"dinov2-{variant}",
+            )
+            # Copy to a sibling temp path then atomically replace so other
+            # threads only ever observe either the missing state or a
+            # fully written weights file — never a partial copy.
+            shutil.copy2(cached_path, tmp_path)
+            os.replace(tmp_path, model_path)
+        except Exception as e:
+            import contextlib
+
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+            raise RuntimeError(
+                f"Failed to download DINOv2 weights ({variant}): {e}. "
+                "Check your network connection and retry, or download "
+                "manually from the pipeline models page."
+            ) from e
+
+        if not os.path.isfile(model_path):
+            raise RuntimeError(
+                "DINOv2 download completed but weights file is missing at "
+                f"{model_path}."
+            )
+
+        size_mb = round(os.path.getsize(model_path) / 1024 / 1024, 1)
+        log.info("DINOv2 weights downloaded (%s, %s MB)", variant, size_mb)
+        if progress_callback:
+            progress_callback(
+                f"DINOv2 {variant} ready ({size_mb} MB)", 1, 1,
+            )
+
+        return model_path
 
 
 def get_embedding_dim(variant="vit-b14"):

--- a/vireo/masking.py
+++ b/vireo/masking.py
@@ -8,6 +8,7 @@ Masks are saved as single-channel PNGs in ~/.vireo/masks/{photo_id}.png.
 
 import logging
 import os
+import threading
 
 import numpy as np
 import onnx_runtime
@@ -23,6 +24,14 @@ SAM2_VARIANTS = {
     "sam2-large": "sam2-large",
 }
 
+# Rough size estimate surfaced in the download progress message, per variant.
+_SAM2_SIZE_HINT = {
+    "sam2-tiny": "~40 MB",
+    "sam2-small": "~150 MB",
+    "sam2-base-plus": "~320 MB",
+    "sam2-large": "~900 MB",
+}
+
 # SAM2 image encoder native input size
 SAM2_INPUT_SIZE = 1024
 
@@ -33,6 +42,115 @@ _IMAGENET_STD = [0.229, 0.224, 0.225]
 _encoder_session = None
 _decoder_session = None
 _sam2_variant_loaded = None
+
+_sam2_download_lock = threading.Lock()
+
+
+def _sam2_model_dir(variant):
+    return os.path.join(
+        os.path.expanduser("~"), ".vireo", "models", variant
+    )
+
+
+def ensure_sam2_weights(variant="sam2-small", progress_callback=None):
+    """Ensure SAM2 ONNX encoder + decoder weights for ``variant`` are on disk.
+
+    Returns the variant's model directory when both files are already present.
+    Otherwise downloads whichever file is missing from Hugging Face and copies
+    them into ``~/.vireo/models/{variant}/``. Raises RuntimeError on failure
+    so callers can abort rather than silently run without masks.
+
+    Args:
+        variant: one of sam2-tiny, sam2-small, sam2-base-plus, sam2-large
+        progress_callback: optional callable(phase: str, current: int,
+            total: int) invoked once before the download starts and once per
+            downloaded file.
+    """
+    if variant not in SAM2_VARIANTS:
+        raise ValueError(
+            f"Unknown SAM2 variant: {variant}. "
+            f"Choose from: {list(SAM2_VARIANTS.keys())}"
+        )
+
+    model_dir = _sam2_model_dir(variant)
+    encoder_path = os.path.join(model_dir, "image_encoder.onnx")
+    decoder_path = os.path.join(model_dir, "mask_decoder.onnx")
+
+    if os.path.isfile(encoder_path) and os.path.isfile(decoder_path):
+        return model_dir
+
+    # Serialize concurrent first-run downloads so two parallel jobs don't
+    # both start a ~hundreds-of-MB download, and so a second caller never
+    # observes a half-copied file at the final path and tries to load it
+    # as ONNX.
+    with _sam2_download_lock:
+        if os.path.isfile(encoder_path) and os.path.isfile(decoder_path):
+            return model_dir
+
+        os.makedirs(model_dir, exist_ok=True)
+
+        size_hint = _SAM2_SIZE_HINT.get(variant, "")
+        files = [("image_encoder.onnx", encoder_path),
+                 ("mask_decoder.onnx", decoder_path)]
+        missing = [(name, path) for name, path in files if not os.path.isfile(path)]
+        total_files = len(missing)
+
+        if progress_callback:
+            progress_callback(
+                f"Downloading {variant} ({size_hint}, first run only)...",
+                0, total_files,
+            )
+        log.info(
+            "SAM2 weights missing for %s — downloading %d file(s) from Hugging Face",
+            variant, total_files,
+        )
+
+        try:
+            import contextlib
+            import shutil
+
+            from huggingface_hub import hf_hub_download
+            from models import ONNX_REPO
+
+            for idx, (filename, final_path) in enumerate(missing):
+                tmp_path = final_path + ".download"
+                try:
+                    cached_path = hf_hub_download(
+                        repo_id=ONNX_REPO,
+                        filename=filename,
+                        subfolder=variant,
+                    )
+                    # Copy to a sibling temp path then atomically replace so
+                    # other threads only ever observe either the missing
+                    # state or a fully written weights file — never a
+                    # partial copy.
+                    shutil.copy2(cached_path, tmp_path)
+                    os.replace(tmp_path, final_path)
+                except Exception:
+                    with contextlib.suppress(OSError):
+                        os.unlink(tmp_path)
+                    raise
+
+                if progress_callback:
+                    progress_callback(
+                        f"Downloaded {filename} ({idx + 1}/{total_files})",
+                        idx + 1, total_files,
+                    )
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to download SAM2 weights ({variant}): {e}. "
+                "Check your network connection and retry, or download "
+                "manually from the pipeline models page."
+            ) from e
+
+        if not (os.path.isfile(encoder_path) and os.path.isfile(decoder_path)):
+            raise RuntimeError(
+                f"SAM2 download completed but weights are missing at "
+                f"{model_dir}."
+            )
+
+        log.info("SAM2 weights downloaded (%s)", variant)
+        return model_dir
 
 
 def _get_sam2_sessions(variant="sam2-small"):

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1408,6 +1408,33 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 _update_stages(runner, job["id"], stages)
                 return
 
+            # Auto-download SAM2 + DINOv2 weights on first pipeline run.
+            # Mirrors the MegaDetector auto-download pattern (commit 90cd0f9):
+            # without this, first-time users hit 1 FileNotFoundError per
+            # photo (e.g. 124 identical tracebacks) instead of either
+            # getting the weights automatically or seeing one actionable
+            # message.  Only fire when there is actually work to do — a
+            # no-op rerun over 0 photos should not trigger a multi-hundred
+            # MB download.
+            if total > 0:
+                from dino_embed import ensure_dinov2_weights
+                from masking import ensure_sam2_weights
+
+                def _dl_progress(phase, current, total_steps):
+                    runner.push_event(job["id"], "progress", {
+                        "phase": phase,
+                        "stage_id": "extract_masks",
+                        "current": current, "total": total_steps,
+                        "stages": {k: dict(v) for k, v in stages.items()},
+                    })
+
+                ensure_sam2_weights(
+                    variant=sam2_variant, progress_callback=_dl_progress,
+                )
+                ensure_dinov2_weights(
+                    variant=dinov2_variant, progress_callback=_dl_progress,
+                )
+
             for i, entry in enumerate(photos_to_process):
                 if _should_abort(abort):
                     break

--- a/vireo/tests/test_dinov2.py
+++ b/vireo/tests/test_dinov2.py
@@ -373,3 +373,120 @@ def test_input_size_constant():
     from dino_embed import DINOV2_INPUT_SIZE
 
     assert DINOV2_INPUT_SIZE == 518
+
+
+# -- ensure_dinov2_weights (auto-download on first pipeline run) --
+
+
+def test_ensure_dinov2_weights_noop_when_present(tmp_path, monkeypatch):
+    """ensure_dinov2_weights() returns path without downloading when file
+    is already on disk."""
+    import sys
+    import types
+
+    import dino_embed
+
+    model_dir = tmp_path / "dinov2-vit-b14"
+    model_dir.mkdir()
+    model_path = model_dir / "model.onnx"
+    model_path.write_bytes(b"x" * 1024)
+
+    monkeypatch.setattr(
+        dino_embed, "_dinov2_model_path",
+        lambda variant: (str(model_dir), str(model_path)),
+    )
+
+    def fake_hf_hub_download(**kwargs):
+        raise AssertionError("must not download when file already exists")
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = fake_hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    progress = []
+    result = dino_embed.ensure_dinov2_weights(
+        "vit-b14", progress_callback=lambda p, c, t: progress.append((p, c, t))
+    )
+
+    assert result == str(model_path)
+    assert progress == []
+
+
+def test_ensure_dinov2_weights_downloads_when_missing(tmp_path, monkeypatch):
+    """ensure_dinov2_weights() fetches model.onnx and surfaces progress."""
+    import sys
+    import types
+
+    import dino_embed
+
+    model_dir = tmp_path / "dinov2-vit-b14"
+    model_path = model_dir / "model.onnx"
+
+    monkeypatch.setattr(
+        dino_embed, "_dinov2_model_path",
+        lambda variant: (str(model_dir), str(model_path)),
+    )
+
+    cache_path = tmp_path / "hf-cache" / "model.onnx"
+    cache_path.parent.mkdir()
+    cache_path.write_bytes(b"m" * 4096)
+
+    seen_requests = []
+
+    def fake_hf_hub_download(**kwargs):
+        seen_requests.append((kwargs["filename"], kwargs["subfolder"]))
+        return str(cache_path)
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = fake_hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    progress = []
+    result = dino_embed.ensure_dinov2_weights(
+        "vit-b14",
+        progress_callback=lambda p, c, t: progress.append((p, c, t)),
+    )
+
+    assert result == str(model_path)
+    assert model_path.read_bytes() == b"m" * 4096
+    assert seen_requests == [("model.onnx", "dinov2-vit-b14")]
+    assert progress[0] == (progress[0][0], 0, 1)
+    assert progress[-1][1] == 1 and progress[-1][2] == 1
+
+
+def test_ensure_dinov2_weights_raises_on_download_failure(tmp_path, monkeypatch):
+    """A failed download must raise RuntimeError and leave no partial file
+    at the final path."""
+    import sys
+    import types
+
+    import dino_embed
+    import pytest
+
+    model_dir = tmp_path / "dinov2-vit-b14"
+    model_path = model_dir / "model.onnx"
+    monkeypatch.setattr(
+        dino_embed, "_dinov2_model_path",
+        lambda variant: (str(model_dir), str(model_path)),
+    )
+
+    def fake_hf_hub_download(**kwargs):
+        raise ConnectionError("network unreachable")
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = fake_hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    with pytest.raises(RuntimeError, match="Failed to download DINOv2"):
+        dino_embed.ensure_dinov2_weights("vit-b14")
+
+    assert not model_path.exists()
+
+
+def test_ensure_dinov2_weights_rejects_unknown_variant():
+    """Guard against typos that would otherwise fetch from a wrong repo path."""
+    import dino_embed
+    import pytest
+
+    with pytest.raises(ValueError, match="Unknown DINOv2 variant"):
+        dino_embed.ensure_dinov2_weights("vit-xxl")

--- a/vireo/tests/test_masking.py
+++ b/vireo/tests/test_masking.py
@@ -576,3 +576,162 @@ def test_generate_mask_with_mock():
     masking._encoder_session = None
     masking._decoder_session = None
     masking._sam2_variant_loaded = None
+
+
+# -- ensure_sam2_weights (auto-download on first pipeline run) --
+
+
+def test_ensure_sam2_weights_noop_when_present(tmp_path, monkeypatch):
+    """ensure_sam2_weights() returns immediately when both files exist and
+    must never touch Hugging Face."""
+    import sys
+    import types
+
+    import masking
+
+    model_dir = tmp_path / "sam2-small"
+    model_dir.mkdir()
+    (model_dir / "image_encoder.onnx").write_bytes(b"e" * 1024)
+    (model_dir / "mask_decoder.onnx").write_bytes(b"d" * 1024)
+    monkeypatch.setattr(
+        masking, "_sam2_model_dir", lambda variant: str(model_dir)
+    )
+
+    download_calls = []
+
+    def fake_hf_hub_download(**kwargs):
+        download_calls.append(kwargs)
+        raise AssertionError("hf_hub_download must not be called when files exist")
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = fake_hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    progress = []
+    result = masking.ensure_sam2_weights(
+        "sam2-small", progress_callback=lambda p, c, t: progress.append((p, c, t))
+    )
+
+    assert result == str(model_dir)
+    assert download_calls == []
+    assert progress == []
+
+
+def test_ensure_sam2_weights_downloads_both_files(tmp_path, monkeypatch):
+    """ensure_sam2_weights() fetches encoder + decoder and surfaces progress
+    for each file."""
+    import sys
+    import types
+
+    import masking
+
+    model_dir = tmp_path / "sam2-small"
+    monkeypatch.setattr(
+        masking, "_sam2_model_dir", lambda variant: str(model_dir)
+    )
+
+    cache_dir = tmp_path / "hf-cache"
+    cache_dir.mkdir()
+    (cache_dir / "image_encoder.onnx").write_bytes(b"E" * 2048)
+    (cache_dir / "mask_decoder.onnx").write_bytes(b"D" * 512)
+
+    seen_requests = []
+
+    def fake_hf_hub_download(**kwargs):
+        seen_requests.append((kwargs["filename"], kwargs["subfolder"]))
+        return str(cache_dir / kwargs["filename"])
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = fake_hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    progress = []
+    result = masking.ensure_sam2_weights(
+        "sam2-small",
+        progress_callback=lambda p, c, t: progress.append((p, c, t)),
+    )
+
+    assert result == str(model_dir)
+    assert (model_dir / "image_encoder.onnx").read_bytes() == b"E" * 2048
+    assert (model_dir / "mask_decoder.onnx").read_bytes() == b"D" * 512
+    assert seen_requests == [
+        ("image_encoder.onnx", "sam2-small"),
+        ("mask_decoder.onnx", "sam2-small"),
+    ]
+    # Initial announce + once per downloaded file.
+    assert progress[0][1] == 0 and progress[0][2] == 2
+    assert progress[-1][1] == 2 and progress[-1][2] == 2
+
+
+def test_ensure_sam2_weights_downloads_only_missing_file(tmp_path, monkeypatch):
+    """If the encoder is already on disk but the decoder isn't, only fetch
+    the decoder.  Lets a user recover from a partial download without paying
+    for the big encoder again."""
+    import sys
+    import types
+
+    import masking
+
+    model_dir = tmp_path / "sam2-small"
+    model_dir.mkdir()
+    (model_dir / "image_encoder.onnx").write_bytes(b"E" * 2048)
+    monkeypatch.setattr(
+        masking, "_sam2_model_dir", lambda variant: str(model_dir)
+    )
+
+    cache_dir = tmp_path / "hf-cache"
+    cache_dir.mkdir()
+    (cache_dir / "mask_decoder.onnx").write_bytes(b"D" * 512)
+
+    requested = []
+
+    def fake_hf_hub_download(**kwargs):
+        requested.append(kwargs["filename"])
+        return str(cache_dir / kwargs["filename"])
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = fake_hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    masking.ensure_sam2_weights("sam2-small")
+
+    assert requested == ["mask_decoder.onnx"]
+    assert (model_dir / "image_encoder.onnx").read_bytes() == b"E" * 2048
+
+
+def test_ensure_sam2_weights_raises_on_download_failure(tmp_path, monkeypatch):
+    """A failed download must raise RuntimeError with a remediation hint
+    and leave no partial file at the final path."""
+    import sys
+    import types
+
+    import masking
+    import pytest
+
+    model_dir = tmp_path / "sam2-small"
+    monkeypatch.setattr(
+        masking, "_sam2_model_dir", lambda variant: str(model_dir)
+    )
+
+    def fake_hf_hub_download(**kwargs):
+        raise ConnectionError("network unreachable")
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = fake_hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    with pytest.raises(RuntimeError, match="Failed to download SAM2"):
+        masking.ensure_sam2_weights("sam2-small")
+
+    assert not (model_dir / "image_encoder.onnx").exists()
+    assert not (model_dir / "mask_decoder.onnx").exists()
+
+
+def test_ensure_sam2_weights_rejects_unknown_variant():
+    """Guard against typos that would otherwise fetch from a wrong repo
+    path."""
+    import masking
+    import pytest
+
+    with pytest.raises(ValueError, match="Unknown SAM2 variant"):
+        masking.ensure_sam2_weights("sam2-jumbo")


### PR DESCRIPTION
## Summary

Mirrors the MegaDetector auto-download pattern (#535 / commit `90cd0f9`) for the `extract_masks` / extract-features stage.

Previously, running the pipeline without `~/.vireo/models/sam2-{variant}/` or `~/.vireo/models/dinov2-{variant}/` produced one `FileNotFoundError` **per photo** from deep inside `masking.py` — e.g. a user just hit **102 identical tracebacks** with zero masks written — and the user had to go download weights manually and rerun.  Matches the self-healing principle: if weights are required, fetch them.

## Changes

- **`masking.ensure_sam2_weights(variant, progress_callback)`** — fetches `image_encoder.onnx` and `mask_decoder.onnx` from `jss367/vireo-onnx-models` (subfolder = variant id) into `~/.vireo/models/{variant}/`. Lock-protected; each file written via temp-path + atomic `os.replace` so a concurrent reader never observes a partial file. If only one of the two files is present (e.g. a partial prior download), only the missing one is fetched.

- **`dino_embed.ensure_dinov2_weights(variant, progress_callback)`** — fetches `model.onnx` into `~/.vireo/models/dinov2-{variant}/` with the same safety model.

- **`pipeline_job.extract_masks_stage`** calls both at the start of the stage when there is work to do (`total > 0`). Progress surfaces as normal stage-level progress events (e.g. `"Downloading sam2-small (~150 MB, first run only)…"`).  Gated on `total > 0` so a no-op rerun over a zero-detection collection does not kick off a multi-hundred-MB download.

## Tests

New unit tests for both functions (9 total):

- `ensure_*` returns immediately when weights already present (no HF call)
- `ensure_*` fetches + atomically copies when missing, surfacing progress events
- `ensure_sam2_weights` fetches **only** the missing file (partial-download recovery)
- Raises `RuntimeError` with remediation hint on download failure, leaves no partial file behind
- Rejects unknown variant names before touching the network

## Test plan

- [x] 9 new unit tests pass
- [x] Full required suite passes: `tests/test_workspaces.py vireo/tests/{test_db,test_app,test_photos_api,test_edits_api,test_jobs_api,test_darktable_api,test_config,test_masking,test_dinov2,test_pipeline_job,test_detector}.py` → 553 passed
- [ ] Manually rerun the pipeline on the dataset that was hitting 102 `FileNotFoundError` to confirm the auto-download kicks in and masks are generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)