### PR TITLE
fix: don't offer embedding precompute for timm models

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2393,7 +2393,14 @@ def create_app(db_path, thumb_cache_dir=None):
         from labels import get_saved_labels
         from models import get_models
 
-        models = [m for m in get_models() if m["downloaded"]]
+        # Only BioCLIP-style models use per-label text embeddings. timm models
+        # have a fixed class head and never need embedding precomputation, so
+        # excluding them here prevents the Settings UI from offering a
+        # "Compute" button that would fail with a missing-file error.
+        models = [
+            m for m in get_models()
+            if m["downloaded"] and m.get("model_type", "bioclip") != "timm"
+        ]
         label_sets = get_saved_labels()
 
         matrix = []
@@ -2449,6 +2456,11 @@ def create_app(db_path, thumb_cache_dir=None):
                     break
             if not model or not model["downloaded"]:
                 raise RuntimeError(f"Model {model_id} not found or not downloaded")
+            if model.get("model_type", "bioclip") == "timm":
+                raise RuntimeError(
+                    f"Model {model['name']} has a fixed class head and does "
+                    "not use per-label embeddings — nothing to precompute."
+                )
 
             runner.push_event(
                 job["id"],
@@ -3338,7 +3350,12 @@ def create_app(db_path, thumb_cache_dir=None):
             from models import get_active_model
 
             active_model = get_active_model()
-            if active_model and active_model["downloaded"]:
+            # timm models have a fixed class head — no per-label embeddings.
+            if (
+                active_model
+                and active_model["downloaded"]
+                and active_model.get("model_type", "bioclip") != "timm"
+            ):
                 try:
                     from classifier import _embedding_cache_path, _resolve_model_dir
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1925,3 +1925,85 @@ def test_pipeline_models_dinov2_downloaded_sums_graph_and_data(
     entry = next(m for m in resp.get_json()["models"] if m["id"] == "vit-b14")
     assert entry["status"] == "downloaded"
     assert entry["size"] == "11.0 MB"
+
+
+def test_embedding_matrix_excludes_timm_models(app_and_db, monkeypatch, tmp_path):
+    """Timm models don't use per-label text embeddings, so the matrix should
+    not list them — otherwise Settings renders a 'Compute' button that fails
+    because timm model dirs lack image_encoder.onnx."""
+    labels_file = tmp_path / "birds.txt"
+    labels_file.write_text("robin\nsparrow\n")
+
+    monkeypatch.setattr(
+        "models.get_models",
+        lambda: [
+            {
+                "id": "bioclip-vit-b-16",
+                "name": "BioCLIP",
+                "model_type": "bioclip",
+                "model_str": "ViT-B-16",
+                "weights_path": str(tmp_path),
+                "downloaded": True,
+            },
+            {
+                "id": "timm-inat21-eva02-l",
+                "name": "iNat21 (EVA-02 Large)",
+                "model_type": "timm",
+                "model_str": "hf-hub:timm/eva02",
+                "weights_path": str(tmp_path),
+                "downloaded": True,
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        "labels.get_saved_labels",
+        lambda: [{"name": "Birds", "labels_file": str(labels_file)}],
+    )
+
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/embedding-matrix")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    model_ids = [m["id"] for m in data["models"]]
+    assert "bioclip-vit-b-16" in model_ids
+    assert "timm-inat21-eva02-l" not in model_ids
+
+
+def test_precompute_embeddings_rejects_timm_models(app_and_db, monkeypatch):
+    """Hitting precompute-embeddings for a timm model must fail fast instead
+    of trying to load a non-existent image_encoder.onnx from the timm dir."""
+    monkeypatch.setattr(
+        "models.get_models",
+        lambda: [
+            {
+                "id": "timm-inat21-eva02-l",
+                "name": "iNat21 (EVA-02 Large)",
+                "model_type": "timm",
+                "model_str": "hf-hub:timm/eva02",
+                "weights_path": "/fake",
+                "downloaded": True,
+            },
+        ],
+    )
+
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/jobs/precompute-embeddings",
+        json={"model_id": "timm-inat21-eva02-l", "labels_file": "/tmp/x.txt"},
+    )
+    assert resp.status_code == 200
+    job_id = resp.get_json()["job_id"]
+
+    runner = app._job_runner
+    import time
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        job = runner.get(job_id)
+        if job and job.get("status") in ("completed", "failed"):
+            break
+        time.sleep(0.05)
+    job = runner.get(job_id)
+    assert job["status"] == "failed"
+    assert any("fixed class head" in e for e in (job.get("errors") or []))


### PR DESCRIPTION
## Summary

User clicked "Compute" next to a timm model (\`timm-inat21-eva02-l\`) in Settings → Embeddings and got:

> image encoder ONNX model not found at /Users/julius/.vireo/models/timm-inat21-eva02-l/image_encoder.onnx

Root cause: timm classifiers have a fixed class head and don't use per-label text embeddings — the BioCLIP-only precompute path doesn't apply. But the embedding matrix was still listing timm models, so clicking Compute ran \`Classifier(...)\` against the timm model dir and looked for \`image_encoder.onnx\`, which timm downloads don't contain (they save \`model.onnx\`). Misleading error — the model was correctly downloaded, just not one that uses that file.

Same underlying issue also affected the fetch-labels auto-compute hook (would have silently failed the same way for a timm active model).

## Changes

- \`/api/embedding-matrix\` skips timm models so the Compute button never appears
- \`/api/jobs/precompute-embeddings\` rejects timm model_ids with a clear "fixed class head" error (defense in depth)
- fetch-labels auto-compute skips the \`Classifier()\` call when the active model is timm

## Test plan

- [x] \`python -m pytest vireo/tests/test_app.py -v -k "embedding_matrix or precompute"\` — 2 new tests pass
- [x] Full CLAUDE.md suite — 437 passed
- [ ] Manual: with a timm model downloaded, confirm Settings → Embeddings no longer shows a Compute button for it

🤖 Generated with [Claude Code](https://claude.com/claude-code)