### PR TITLE
fix: auto-download fetches DINOv2 .onnx.data sidecar + self-heals stub-only installs

### DIFF
--- a/vireo/dino_embed.py
+++ b/vireo/dino_embed.py
@@ -121,6 +121,21 @@ def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
             )
             shutil.copy2(cached_graph, tmp_path)
 
+            # Pin the sidecar fetch to the same commit that resolved
+            # the graph.  Without this, a repo update between the two
+            # hf_hub_download calls can produce a mismatched pair that
+            # ONNX Runtime refuses to load.  The HF cache path encodes
+            # the resolved SHA as: …/snapshots/{sha}/…
+            # Walk from the end so an ancestor directory named "snapshots"
+            # (e.g. HF_HOME=/mnt/snapshots/cache) can't hijack the match.
+            import pathlib as _pl
+            _parts = list(_pl.Path(cached_graph).parts)
+            try:
+                _idx = len(_parts) - 1 - _parts[::-1].index("snapshots")
+                _pinned_rev = _parts[_idx + 1]
+            except (ValueError, IndexError):
+                _pinned_rev = None  # graceful fallback for mock paths in tests
+
             if progress_callback:
                 progress_callback(
                     f"Downloading DINOv2 {variant} weights sidecar...", 1, 2,
@@ -130,6 +145,7 @@ def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
                 repo_id=ONNX_REPO,
                 filename="model.onnx.data",
                 subfolder=f"dinov2-{variant}",
+                revision=_pinned_rev,
             )
             shutil.copy2(cached_data, tmp_data_path)
 

--- a/vireo/dino_embed.py
+++ b/vireo/dino_embed.py
@@ -108,33 +108,39 @@ def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
 
         tmp_path = model_path + ".download"
         tmp_data_path = data_path + ".download"
+        data_backup_path = data_path + ".prev"
+        had_prior_sidecar = os.path.isfile(data_path)
         try:
+            import contextlib
             import shutil
 
-            from huggingface_hub import hf_hub_download
+            from huggingface_hub import HfApi, hf_hub_download
             from models import ONNX_REPO
+
+            # Resolve a pinned revision upfront so BOTH fetches target the
+            # same commit.  Without this, a push to jss367/vireo-onnx-models
+            # between the graph and sidecar fetches could produce a
+            # mismatched pair that ONNX Runtime refuses to load.  Network
+            # failure here is non-fatal — fall back to the repo's default
+            # branch and accept the (tiny) race window; this is no worse
+            # than the pre-fix behaviour.
+            try:
+                pinned_rev = HfApi().model_info(ONNX_REPO).sha
+            except Exception as e:  # noqa: BLE001
+                log.info(
+                    "Could not resolve HF revision for %s (%s); "
+                    "falling back to default branch",
+                    ONNX_REPO, e,
+                )
+                pinned_rev = None
 
             cached_graph = hf_hub_download(
                 repo_id=ONNX_REPO,
                 filename="model.onnx",
                 subfolder=f"dinov2-{variant}",
+                revision=pinned_rev,
             )
             shutil.copy2(cached_graph, tmp_path)
-
-            # Pin the sidecar fetch to the same commit that resolved
-            # the graph.  Without this, a repo update between the two
-            # hf_hub_download calls can produce a mismatched pair that
-            # ONNX Runtime refuses to load.  The HF cache path encodes
-            # the resolved SHA as: …/snapshots/{sha}/…
-            # Walk from the end so an ancestor directory named "snapshots"
-            # (e.g. HF_HOME=/mnt/snapshots/cache) can't hijack the match.
-            import pathlib as _pl
-            _parts = list(_pl.Path(cached_graph).parts)
-            try:
-                _idx = len(_parts) - 1 - _parts[::-1].index("snapshots")
-                _pinned_rev = _parts[_idx + 1]
-            except (ValueError, IndexError):
-                _pinned_rev = None  # graceful fallback for mock paths in tests
 
             if progress_callback:
                 progress_callback(
@@ -145,15 +151,33 @@ def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
                 repo_id=ONNX_REPO,
                 filename="model.onnx.data",
                 subfolder=f"dinov2-{variant}",
-                revision=_pinned_rev,
+                revision=pinned_rev,
             )
             shutil.copy2(cached_data, tmp_data_path)
 
-            # Replace sidecar first, graph second, so ONNX Runtime never
-            # sees a graph file that references a not-yet-written sidecar.
-            # Both replaces are atomic per file.
-            os.replace(tmp_data_path, data_path)
-            os.replace(tmp_path, model_path)
+            # Promote the pair atomically *as a pair*.  Sidecar goes first
+            # so ONNX Runtime never sees a graph that references a
+            # not-yet-written sidecar.  If the graph replace then fails
+            # (e.g. Windows file lock on the existing `model.onnx`),
+            # roll the sidecar back so we don't leave a new-sidecar /
+            # old-graph mismatch on disk that the noop check would
+            # short-circuit on the next run.
+            if had_prior_sidecar:
+                os.replace(data_path, data_backup_path)
+            try:
+                os.replace(tmp_data_path, data_path)
+                os.replace(tmp_path, model_path)
+            except Exception:
+                with contextlib.suppress(OSError):
+                    os.unlink(data_path)
+                if had_prior_sidecar:
+                    with contextlib.suppress(OSError):
+                        os.replace(data_backup_path, data_path)
+                raise
+            else:
+                if had_prior_sidecar:
+                    with contextlib.suppress(OSError):
+                        os.unlink(data_backup_path)
         except Exception as e:
             import contextlib
 
@@ -161,6 +185,8 @@ def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
                 os.unlink(tmp_path)
             with contextlib.suppress(OSError):
                 os.unlink(tmp_data_path)
+            with contextlib.suppress(OSError):
+                os.unlink(data_backup_path)
             raise RuntimeError(
                 f"Failed to download DINOv2 weights ({variant}): {e}. "
                 "Check your network connection and retry, or download "

--- a/vireo/dino_embed.py
+++ b/vireo/dino_embed.py
@@ -53,10 +53,18 @@ def _dinov2_model_path(variant):
 def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
     """Ensure DINOv2 ONNX weights for ``variant`` are on disk.
 
-    Returns the weights path when already downloaded.  Otherwise fetches
-    ``dinov2-{variant}/model.onnx`` from Hugging Face and copies it into
-    ``~/.vireo/models/dinov2-{variant}/``.  Raises RuntimeError on failure
-    so callers can abort rather than silently run without embeddings.
+    DINOv2 ONNX exports use external-data layout: ``model.onnx`` is a
+    ~1 MB graph stub that references the real weights in a sibling
+    ``model.onnx.data`` sidecar (~85 MB / ~346 MB / ~1.2 GB depending on
+    variant).  BOTH files must be on disk — without the sidecar, ONNX
+    Runtime fails with the opaque
+    ``model_path must not be empty`` error on every inference call.
+
+    Returns the graph path when both files are already downloaded.
+    Otherwise fetches whichever is missing from Hugging Face into
+    ``~/.vireo/models/dinov2-{variant}/``.  Raises RuntimeError on
+    failure so callers can abort rather than silently run without
+    embeddings.
 
     Args:
         variant: one of vit-s14, vit-b14, vit-l14
@@ -71,11 +79,18 @@ def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
         )
 
     model_dir, model_path = _dinov2_model_path(variant)
-    if os.path.isfile(model_path):
+    data_path = model_path + ".data"
+
+    # Require BOTH files to short-circuit.  A lingering stub-only
+    # ``model.onnx`` from a pre-#550 UI download (or a past partial
+    # download) must NOT skip the sidecar fetch — otherwise ONNX Runtime
+    # keeps crashing with ``model_path must not be empty`` on every
+    # pipeline run and the broken state never self-heals.
+    if os.path.isfile(model_path) and os.path.isfile(data_path):
         return model_path
 
     with _dinov2_download_lock:
-        if os.path.isfile(model_path):
+        if os.path.isfile(model_path) and os.path.isfile(data_path):
             return model_path
 
         os.makedirs(model_dir, exist_ok=True)
@@ -84,7 +99,7 @@ def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
         if progress_callback:
             progress_callback(
                 f"Downloading DINOv2 {variant} ({size_hint}, first run only)...",
-                0, 1,
+                0, 2,
             )
         log.info(
             "DINOv2 weights missing for %s — downloading from Hugging Face",
@@ -92,44 +107,64 @@ def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
         )
 
         tmp_path = model_path + ".download"
+        tmp_data_path = data_path + ".download"
         try:
             import shutil
 
             from huggingface_hub import hf_hub_download
             from models import ONNX_REPO
 
-            cached_path = hf_hub_download(
+            cached_graph = hf_hub_download(
                 repo_id=ONNX_REPO,
                 filename="model.onnx",
                 subfolder=f"dinov2-{variant}",
             )
-            # Copy to a sibling temp path then atomically replace so other
-            # threads only ever observe either the missing state or a
-            # fully written weights file — never a partial copy.
-            shutil.copy2(cached_path, tmp_path)
+            shutil.copy2(cached_graph, tmp_path)
+
+            if progress_callback:
+                progress_callback(
+                    f"Downloading DINOv2 {variant} weights sidecar...", 1, 2,
+                )
+
+            cached_data = hf_hub_download(
+                repo_id=ONNX_REPO,
+                filename="model.onnx.data",
+                subfolder=f"dinov2-{variant}",
+            )
+            shutil.copy2(cached_data, tmp_data_path)
+
+            # Replace sidecar first, graph second, so ONNX Runtime never
+            # sees a graph file that references a not-yet-written sidecar.
+            # Both replaces are atomic per file.
+            os.replace(tmp_data_path, data_path)
             os.replace(tmp_path, model_path)
         except Exception as e:
             import contextlib
 
             with contextlib.suppress(OSError):
                 os.unlink(tmp_path)
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_data_path)
             raise RuntimeError(
                 f"Failed to download DINOv2 weights ({variant}): {e}. "
                 "Check your network connection and retry, or download "
                 "manually from the pipeline models page."
             ) from e
 
-        if not os.path.isfile(model_path):
+        if not (os.path.isfile(model_path) and os.path.isfile(data_path)):
             raise RuntimeError(
-                "DINOv2 download completed but weights file is missing at "
-                f"{model_path}."
+                "DINOv2 download completed but weights are missing at "
+                f"{model_dir}."
             )
 
-        size_mb = round(os.path.getsize(model_path) / 1024 / 1024, 1)
+        # Size totals both files — reporting just the 1 MB graph makes a
+        # successful install look broken.
+        total_bytes = os.path.getsize(model_path) + os.path.getsize(data_path)
+        size_mb = round(total_bytes / 1024 / 1024, 1)
         log.info("DINOv2 weights downloaded (%s, %s MB)", variant, size_mb)
         if progress_callback:
             progress_callback(
-                f"DINOv2 {variant} ready ({size_mb} MB)", 1, 1,
+                f"DINOv2 {variant} ready ({size_mb} MB)", 2, 2,
             )
 
         return model_path

--- a/vireo/tests/test_dinov2.py
+++ b/vireo/tests/test_dinov2.py
@@ -378,18 +378,30 @@ def test_input_size_constant():
 # -- ensure_dinov2_weights (auto-download on first pipeline run) --
 
 
-def test_ensure_dinov2_weights_noop_when_present(tmp_path, monkeypatch):
-    """ensure_dinov2_weights() returns path without downloading when file
-    is already on disk."""
+def _install_fake_hf(monkeypatch, hf_hub_download):
+    """Install a stub ``huggingface_hub`` module with ``hf_hub_download``."""
     import sys
     import types
 
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = hf_hub_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+
+def test_ensure_dinov2_weights_noop_only_when_stub_and_sidecar_present(
+    tmp_path, monkeypatch,
+):
+    """ensure_dinov2_weights() short-circuits only when BOTH ``model.onnx``
+    and ``model.onnx.data`` are on disk.  A stub-only install must NOT
+    count as complete."""
     import dino_embed
 
     model_dir = tmp_path / "dinov2-vit-b14"
     model_dir.mkdir()
     model_path = model_dir / "model.onnx"
+    data_path = model_dir / "model.onnx.data"
     model_path.write_bytes(b"x" * 1024)
+    data_path.write_bytes(b"X" * 4096)
 
     monkeypatch.setattr(
         dino_embed, "_dinov2_model_path",
@@ -397,11 +409,9 @@ def test_ensure_dinov2_weights_noop_when_present(tmp_path, monkeypatch):
     )
 
     def fake_hf_hub_download(**kwargs):
-        raise AssertionError("must not download when file already exists")
+        raise AssertionError("must not download when both files exist")
 
-    fake_hf = types.ModuleType("huggingface_hub")
-    fake_hf.hf_hub_download = fake_hf_hub_download
-    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+    _install_fake_hf(monkeypatch, fake_hf_hub_download)
 
     progress = []
     result = dino_embed.ensure_dinov2_weights(
@@ -412,54 +422,138 @@ def test_ensure_dinov2_weights_noop_when_present(tmp_path, monkeypatch):
     assert progress == []
 
 
-def test_ensure_dinov2_weights_downloads_when_missing(tmp_path, monkeypatch):
-    """ensure_dinov2_weights() fetches model.onnx and surfaces progress."""
-    import sys
-    import types
+def test_ensure_dinov2_weights_refetches_when_only_stub_present(
+    tmp_path, monkeypatch,
+):
+    """Regression: a previous install that left only the ~1 MB ``model.onnx``
+    graph stub (without the ``model.onnx.data`` sidecar) must trigger a
+    refetch of both files, not persist silently.
 
+    This is the bug users hit after a pre-#550 UI download: the stub
+    passed the noop check, the sidecar never arrived, and every pipeline
+    run died with ``model_path must not be empty`` from ONNX Runtime.
+    """
     import dino_embed
 
     model_dir = tmp_path / "dinov2-vit-b14"
+    model_dir.mkdir()
     model_path = model_dir / "model.onnx"
+    data_path = model_dir / "model.onnx.data"
+    # Stub-only partial install from a prior broken download.
+    model_path.write_bytes(b"stub" * 256)
 
     monkeypatch.setattr(
         dino_embed, "_dinov2_model_path",
         lambda variant: (str(model_dir), str(model_path)),
     )
 
-    cache_path = tmp_path / "hf-cache" / "model.onnx"
-    cache_path.parent.mkdir()
-    cache_path.write_bytes(b"m" * 4096)
+    cache_dir = tmp_path / "hf-cache"
+    cache_dir.mkdir()
+    (cache_dir / "model.onnx").write_bytes(b"M" * 1024)
+    (cache_dir / "model.onnx.data").write_bytes(b"D" * 8192)
+
+    requested = []
+
+    def fake_hf_hub_download(**kwargs):
+        requested.append(kwargs["filename"])
+        return str(cache_dir / kwargs["filename"])
+
+    _install_fake_hf(monkeypatch, fake_hf_hub_download)
+
+    dino_embed.ensure_dinov2_weights("vit-b14")
+
+    assert requested == ["model.onnx", "model.onnx.data"]
+    assert model_path.read_bytes() == b"M" * 1024
+    assert data_path.read_bytes() == b"D" * 8192
+
+
+def test_ensure_dinov2_weights_refetches_when_only_sidecar_present(
+    tmp_path, monkeypatch,
+):
+    """The mirror case: sidecar on disk from a half-finished install but
+    no graph stub.  Both files must be fetched."""
+    import dino_embed
+
+    model_dir = tmp_path / "dinov2-vit-b14"
+    model_dir.mkdir()
+    model_path = model_dir / "model.onnx"
+    data_path = model_dir / "model.onnx.data"
+    data_path.write_bytes(b"sidecar only" * 100)
+
+    monkeypatch.setattr(
+        dino_embed, "_dinov2_model_path",
+        lambda variant: (str(model_dir), str(model_path)),
+    )
+
+    cache_dir = tmp_path / "hf-cache"
+    cache_dir.mkdir()
+    (cache_dir / "model.onnx").write_bytes(b"M" * 1024)
+    (cache_dir / "model.onnx.data").write_bytes(b"D" * 8192)
+
+    requested = []
+
+    def fake_hf_hub_download(**kwargs):
+        requested.append(kwargs["filename"])
+        return str(cache_dir / kwargs["filename"])
+
+    _install_fake_hf(monkeypatch, fake_hf_hub_download)
+
+    dino_embed.ensure_dinov2_weights("vit-b14")
+
+    assert requested == ["model.onnx", "model.onnx.data"]
+    assert model_path.read_bytes() == b"M" * 1024
+    assert data_path.read_bytes() == b"D" * 8192
+
+
+def test_ensure_dinov2_weights_downloads_both_when_missing(tmp_path, monkeypatch):
+    """Fresh install fetches graph + external-data sidecar in order and
+    surfaces progress for each step."""
+    import dino_embed
+
+    model_dir = tmp_path / "dinov2-vit-b14"
+    model_path = model_dir / "model.onnx"
+    data_path = model_dir / "model.onnx.data"
+
+    monkeypatch.setattr(
+        dino_embed, "_dinov2_model_path",
+        lambda variant: (str(model_dir), str(model_path)),
+    )
+
+    cache_dir = tmp_path / "hf-cache"
+    cache_dir.mkdir()
+    (cache_dir / "model.onnx").write_bytes(b"m" * 1024)
+    (cache_dir / "model.onnx.data").write_bytes(b"d" * 8192)
 
     seen_requests = []
 
     def fake_hf_hub_download(**kwargs):
         seen_requests.append((kwargs["filename"], kwargs["subfolder"]))
-        return str(cache_path)
+        return str(cache_dir / kwargs["filename"])
 
-    fake_hf = types.ModuleType("huggingface_hub")
-    fake_hf.hf_hub_download = fake_hf_hub_download
-    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+    _install_fake_hf(monkeypatch, fake_hf_hub_download)
 
     progress = []
-    result = dino_embed.ensure_dinov2_weights(
+    dino_embed.ensure_dinov2_weights(
         "vit-b14",
         progress_callback=lambda p, c, t: progress.append((p, c, t)),
     )
 
-    assert result == str(model_path)
-    assert model_path.read_bytes() == b"m" * 4096
-    assert seen_requests == [("model.onnx", "dinov2-vit-b14")]
-    assert progress[0] == (progress[0][0], 0, 1)
-    assert progress[-1][1] == 1 and progress[-1][2] == 1
+    assert seen_requests == [
+        ("model.onnx", "dinov2-vit-b14"),
+        ("model.onnx.data", "dinov2-vit-b14"),
+    ]
+    assert model_path.read_bytes() == b"m" * 1024
+    assert data_path.read_bytes() == b"d" * 8192
+    # (initial announce, mid-download update, final ready) — total=2.
+    assert progress[0][1] == 0 and progress[0][2] == 2
+    assert progress[-1][1] == 2 and progress[-1][2] == 2
 
 
-def test_ensure_dinov2_weights_raises_on_download_failure(tmp_path, monkeypatch):
-    """A failed download must raise RuntimeError and leave no partial file
-    at the final path."""
-    import sys
-    import types
-
+def test_ensure_dinov2_weights_raises_on_graph_download_failure(
+    tmp_path, monkeypatch,
+):
+    """A failed graph download must raise RuntimeError and leave no
+    partial files at the final paths."""
     import dino_embed
     import pytest
 
@@ -473,14 +567,52 @@ def test_ensure_dinov2_weights_raises_on_download_failure(tmp_path, monkeypatch)
     def fake_hf_hub_download(**kwargs):
         raise ConnectionError("network unreachable")
 
-    fake_hf = types.ModuleType("huggingface_hub")
-    fake_hf.hf_hub_download = fake_hf_hub_download
-    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+    _install_fake_hf(monkeypatch, fake_hf_hub_download)
 
     with pytest.raises(RuntimeError, match="Failed to download DINOv2"):
         dino_embed.ensure_dinov2_weights("vit-b14")
 
     assert not model_path.exists()
+    assert not (model_dir / "model.onnx.data").exists()
+
+
+def test_ensure_dinov2_weights_raises_on_sidecar_download_failure(
+    tmp_path, monkeypatch,
+):
+    """If the graph fetch succeeds but the sidecar fetch fails, NEITHER
+    file should be left at its final path.  Otherwise a future run would
+    see `model.onnx` on disk with no sidecar and reproduce the broken
+    state we're trying to prevent."""
+    import dino_embed
+    import pytest
+
+    model_dir = tmp_path / "dinov2-vit-b14"
+    model_path = model_dir / "model.onnx"
+    data_path = model_dir / "model.onnx.data"
+
+    monkeypatch.setattr(
+        dino_embed, "_dinov2_model_path",
+        lambda variant: (str(model_dir), str(model_path)),
+    )
+
+    cache_dir = tmp_path / "hf-cache"
+    cache_dir.mkdir()
+    (cache_dir / "model.onnx").write_bytes(b"graph" * 200)
+
+    def fake_hf_hub_download(**kwargs):
+        if kwargs["filename"] == "model.onnx.data":
+            raise ConnectionError("sidecar network failed")
+        return str(cache_dir / kwargs["filename"])
+
+    _install_fake_hf(monkeypatch, fake_hf_hub_download)
+
+    with pytest.raises(RuntimeError, match="Failed to download DINOv2"):
+        dino_embed.ensure_dinov2_weights("vit-b14")
+
+    # Neither final file should exist — the graph tmp is cleaned up and
+    # never promoted, so a retry will re-download both.
+    assert not model_path.exists()
+    assert not data_path.exists()
 
 
 def test_ensure_dinov2_weights_rejects_unknown_variant():

--- a/vireo/tests/test_dinov2.py
+++ b/vireo/tests/test_dinov2.py
@@ -622,3 +622,51 @@ def test_ensure_dinov2_weights_rejects_unknown_variant():
 
     with pytest.raises(ValueError, match="Unknown DINOv2 variant"):
         dino_embed.ensure_dinov2_weights("vit-xxl")
+
+
+def test_ensure_dinov2_weights_pins_revision_when_cache_root_contains_snapshots(
+    tmp_path, monkeypatch,
+):
+    """The HF cache may itself live under a directory named 'snapshots'
+    (e.g. HF_HOME=/mnt/snapshots/cache). The revision extraction must pin
+    the sidecar fetch to the commit SHA from the HF cache layout's
+    trailing '.../snapshots/<sha>/...' segment, not to an ancestor
+    directory that happens to share the name."""
+    import dino_embed
+
+    model_dir = tmp_path / "dinov2-vit-b14"
+    model_path = model_dir / "model.onnx"
+    data_path = model_dir / "model.onnx.data"
+
+    monkeypatch.setattr(
+        dino_embed, "_dinov2_model_path",
+        lambda variant: (str(model_dir), str(model_path)),
+    )
+
+    real_sha = "a" * 40
+    # Simulate HF_HOME=/.../snapshots/hub/... — the first 'snapshots' in
+    # the path is NOT the one that precedes the SHA.
+    cache_root = tmp_path / "snapshots" / "hub" / "models--jss367--vireo-onnx-models"
+    graph_cached = cache_root / "snapshots" / real_sha / "dinov2-vit-b14" / "model.onnx"
+    data_cached = cache_root / "snapshots" / real_sha / "dinov2-vit-b14" / "model.onnx.data"
+    graph_cached.parent.mkdir(parents=True)
+    graph_cached.write_bytes(b"m" * 1024)
+    data_cached.write_bytes(b"d" * 8192)
+
+    seen_revisions = []
+
+    def fake_hf_hub_download(**kwargs):
+        seen_revisions.append(kwargs.get("revision"))
+        if kwargs["filename"] == "model.onnx":
+            return str(graph_cached)
+        return str(data_cached)
+
+    _install_fake_hf(monkeypatch, fake_hf_hub_download)
+
+    dino_embed.ensure_dinov2_weights("vit-b14")
+
+    # First call (graph) has no pinned revision; second (sidecar) must
+    # pin to the SHA from the LAST 'snapshots' segment, not "hub".
+    assert seen_revisions == [None, real_sha]
+    assert model_path.read_bytes() == b"m" * 1024
+    assert data_path.read_bytes() == b"d" * 8192

--- a/vireo/tests/test_dinov2.py
+++ b/vireo/tests/test_dinov2.py
@@ -378,14 +378,28 @@ def test_input_size_constant():
 # -- ensure_dinov2_weights (auto-download on first pipeline run) --
 
 
-def _install_fake_hf(monkeypatch, hf_hub_download):
-    """Install a stub ``huggingface_hub`` module with ``hf_hub_download``."""
+def _install_fake_hf(monkeypatch, hf_hub_download, repo_sha="a" * 40):
+    """Install a stub ``huggingface_hub`` module with ``hf_hub_download``
+    and an ``HfApi`` whose ``model_info`` returns a fixed SHA (so the
+    upfront revision-pin call in ``ensure_dinov2_weights`` resolves
+    deterministically).  Returns the SHA that tests can assert against.
+    """
     import sys
     import types
 
+    class _FakeModelInfo:
+        def __init__(self, sha):
+            self.sha = sha
+
+    class _FakeHfApi:
+        def model_info(self, repo_id):
+            return _FakeModelInfo(repo_sha)
+
     fake_hf = types.ModuleType("huggingface_hub")
     fake_hf.hf_hub_download = hf_hub_download
+    fake_hf.HfApi = _FakeHfApi
     monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+    return repo_sha
 
 
 def test_ensure_dinov2_weights_noop_only_when_stub_and_sidecar_present(
@@ -624,49 +638,159 @@ def test_ensure_dinov2_weights_rejects_unknown_variant():
         dino_embed.ensure_dinov2_weights("vit-xxl")
 
 
-def test_ensure_dinov2_weights_pins_revision_when_cache_root_contains_snapshots(
+def test_ensure_dinov2_weights_pins_both_fetches_to_same_revision(
     tmp_path, monkeypatch,
 ):
-    """The HF cache may itself live under a directory named 'snapshots'
-    (e.g. HF_HOME=/mnt/snapshots/cache). The revision extraction must pin
-    the sidecar fetch to the commit SHA from the HF cache layout's
-    trailing '.../snapshots/<sha>/...' segment, not to an ancestor
-    directory that happens to share the name."""
+    """Both ``hf_hub_download`` calls must share the same ``revision`` so
+    a push to the ONNX repo between the graph and sidecar fetches can't
+    produce a mismatched pair that ONNX Runtime refuses to load.
+
+    The revision is resolved upfront via ``HfApi.model_info`` before
+    either fetch runs.
+    """
     import dino_embed
 
     model_dir = tmp_path / "dinov2-vit-b14"
     model_path = model_dir / "model.onnx"
-    data_path = model_dir / "model.onnx.data"
 
     monkeypatch.setattr(
         dino_embed, "_dinov2_model_path",
         lambda variant: (str(model_dir), str(model_path)),
     )
 
-    real_sha = "a" * 40
-    # Simulate HF_HOME=/.../snapshots/hub/... — the first 'snapshots' in
-    # the path is NOT the one that precedes the SHA.
-    cache_root = tmp_path / "snapshots" / "hub" / "models--jss367--vireo-onnx-models"
-    graph_cached = cache_root / "snapshots" / real_sha / "dinov2-vit-b14" / "model.onnx"
-    data_cached = cache_root / "snapshots" / real_sha / "dinov2-vit-b14" / "model.onnx.data"
-    graph_cached.parent.mkdir(parents=True)
-    graph_cached.write_bytes(b"m" * 1024)
-    data_cached.write_bytes(b"d" * 8192)
+    cache_dir = tmp_path / "hf-cache"
+    cache_dir.mkdir()
+    (cache_dir / "model.onnx").write_bytes(b"m" * 1024)
+    (cache_dir / "model.onnx.data").write_bytes(b"d" * 8192)
 
     seen_revisions = []
 
     def fake_hf_hub_download(**kwargs):
         seen_revisions.append(kwargs.get("revision"))
-        if kwargs["filename"] == "model.onnx":
-            return str(graph_cached)
-        return str(data_cached)
+        return str(cache_dir / kwargs["filename"])
 
-    _install_fake_hf(monkeypatch, fake_hf_hub_download)
+    pinned = _install_fake_hf(monkeypatch, fake_hf_hub_download, repo_sha="b" * 40)
 
     dino_embed.ensure_dinov2_weights("vit-b14")
 
-    # First call (graph) has no pinned revision; second (sidecar) must
-    # pin to the SHA from the LAST 'snapshots' segment, not "hub".
-    assert seen_revisions == [None, real_sha]
+    # Both fetches must use the same non-None revision — the SHA
+    # resolved from HfApi.model_info before either download started.
+    assert len(seen_revisions) == 2
+    assert seen_revisions[0] == pinned
+    assert seen_revisions[1] == pinned
+
+
+def test_ensure_dinov2_weights_falls_back_when_model_info_fails(
+    tmp_path, monkeypatch,
+):
+    """If ``HfApi.model_info`` raises (e.g. transient network blip), we
+    must still attempt both fetches with ``revision=None`` rather than
+    fail the whole install.  This is best-effort graceful degradation."""
+    import sys
+    import types
+
+    import dino_embed
+
+    model_dir = tmp_path / "dinov2-vit-b14"
+    model_path = model_dir / "model.onnx"
+    monkeypatch.setattr(
+        dino_embed, "_dinov2_model_path",
+        lambda variant: (str(model_dir), str(model_path)),
+    )
+
+    cache_dir = tmp_path / "hf-cache"
+    cache_dir.mkdir()
+    (cache_dir / "model.onnx").write_bytes(b"m" * 1024)
+    (cache_dir / "model.onnx.data").write_bytes(b"d" * 8192)
+
+    seen_revisions = []
+
+    def fake_hf_hub_download(**kwargs):
+        seen_revisions.append(kwargs.get("revision"))
+        return str(cache_dir / kwargs["filename"])
+
+    class _BrokenHfApi:
+        def model_info(self, repo_id):
+            raise ConnectionError("HfApi network blip")
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = fake_hf_hub_download
+    fake_hf.HfApi = _BrokenHfApi
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    dino_embed.ensure_dinov2_weights("vit-b14")
+
+    # Both fetches fall back to revision=None (HF default branch).
+    assert seen_revisions == [None, None]
     assert model_path.read_bytes() == b"m" * 1024
-    assert data_path.read_bytes() == b"d" * 8192
+
+
+def test_ensure_dinov2_weights_rolls_back_sidecar_if_graph_replace_fails(
+    tmp_path, monkeypatch,
+):
+    """If the graph ``os.replace`` fails after the sidecar has already
+    been promoted (e.g. Windows file lock on the existing ``model.onnx``),
+    the new sidecar must be rolled back to the prior install's sidecar.
+    Otherwise the on-disk pair is mismatched and the noop check on the
+    next run would short-circuit, sticking the user on a broken install
+    forever.
+    """
+    import dino_embed
+    import pytest
+
+    model_dir = tmp_path / "dinov2-vit-b14"
+    model_dir.mkdir()
+    model_path = model_dir / "model.onnx"
+    data_path = model_dir / "model.onnx.data"
+    # Prior partial install: sidecar present, graph missing.  That
+    # combination triggers a refetch (both-files check fails), exercising
+    # the rollback path: new sidecar replaces old sidecar, new graph
+    # replace fails, old sidecar must be restored.
+    data_path.write_bytes(b"OLD_SIDECAR" * 400)
+    prior_sidecar = data_path.read_bytes()
+
+    monkeypatch.setattr(
+        dino_embed, "_dinov2_model_path",
+        lambda variant: (str(model_dir), str(model_path)),
+    )
+
+    cache_dir = tmp_path / "hf-cache"
+    cache_dir.mkdir()
+    (cache_dir / "model.onnx").write_bytes(b"NEW_GRAPH" * 100)
+    (cache_dir / "model.onnx.data").write_bytes(b"NEW_SIDECAR" * 500)
+
+    def fake_hf_hub_download(**kwargs):
+        return str(cache_dir / kwargs["filename"])
+
+    _install_fake_hf(monkeypatch, fake_hf_hub_download)
+
+    # Make the graph replace (second os.replace call) blow up while the
+    # sidecar replace (first call) succeeds.
+    real_replace = os.replace
+    calls = {"n": 0}
+
+    def flaky_replace(src, dst):
+        calls["n"] += 1
+        # Call sequence inside the try block:
+        #   1. backup old sidecar   → allow
+        #   2. promote new sidecar  → allow
+        #   3. promote new graph    → BOOM (simulate Windows lock)
+        if calls["n"] == 3:
+            raise PermissionError("simulated file-lock on model.onnx")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", flaky_replace)
+
+    with pytest.raises(RuntimeError, match="Failed to download DINOv2"):
+        dino_embed.ensure_dinov2_weights("vit-b14")
+
+    # Sidecar must be back to its prior contents — no mismatched
+    # "new sidecar + missing graph" pair left on disk.
+    assert data_path.read_bytes() == prior_sidecar
+    # Graph replace never promoted, so model.onnx stays absent — the
+    # next run will see an incomplete install and refetch cleanly.
+    assert not model_path.exists()
+    # No leftover .prev backup or .download tmps.
+    assert not (model_dir / "model.onnx.data.prev").exists()
+    assert not (model_dir / "model.onnx.download").exists()
+    assert not (model_dir / "model.onnx.data.download").exists()


### PR DESCRIPTION
## Context

Follow-up to #550 (UI download fix) and #551 (auto-download feature).

DINOv2 ONNX exports use ONNX's external-data layout: `model.onnx` is a ~1 MB graph stub that points at `model.onnx.data` holding the real weights (~85 MB / ~346 MB / ~1.2 GB per variant). Without the sidecar, ONNX Runtime fails with the opaque:

```
FAIL : Exception during initialization: ...
Initializer::Initializer(...) !model_path.empty() was false.
model_path must not be empty.
```

on every inference call — this is what produced the 102 identical tracebacks during `extract_masks` in the reported user run.

## Why another PR?

PR #550 fixed the **Settings → Models UI** download path (added `model.onnx.data` to the required file list).  PR #551 introduced the **auto-download** path (`ensure_dinov2_weights`) but didn't learn from #550 — it still fetches only `model.onnx`.

Worse, a stub-only directory (left behind by any pre-#550 UI install, which many users still have on disk) passed `ensure_dinov2_weights`' noop check and prevented the sidecar from ever arriving.  The broken state was sticky.

## Changes (`vireo/dino_embed.py`)

- **Require BOTH files** before short-circuiting.  A stub-only or sidecar-only install triggers a refetch.
- **Fetch both files** on a fresh install.  Atomic replace ordered sidecar-first / graph-second, so ONNX Runtime never sees a graph file that references a not-yet-written sidecar.  If the sidecar fetch fails, neither tmp file is promoted — a retry re-downloads both cleanly.
- Report total size (graph + sidecar) in the log and final progress update.

## Tests

7 tests (4 new, 3 replacing v1 tests):

- Noop only when both files present.
- **Stub-only install refetches** — regression for the reported user bug.
- Sidecar-only install refetches — mirror case.
- Fresh install fetches both files in order.
- Graph download failure raises and leaves no partial files.
- Sidecar download failure raises and leaves no partial files (critical: prevents leaving a new stub-only broken install behind).
- Unknown variant rejected.

## Test plan

- [x] 7 new unit tests pass
- [x] Full required suite: `tests/test_workspaces.py vireo/tests/{test_db,test_app,test_photos_api,test_edits_api,test_jobs_api,test_darktable_api,test_config,test_dinov2,test_masking,test_pipeline_job}.py` → **542 passed**
- [ ] Manually: delete `~/.vireo/models/dinov2-vit-b14/model.onnx` (simulate pre-#550 state) and confirm next pipeline run auto-heals by fetching the sidecar

## Cleanup

I'll delete the stale `claude/auto-download-sam2` branch — its follow-up commit conflicts with #550's approach and is superseded by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)