### PR TITLE
fix: address codex review on #553

### DIFF
--- a/vireo/dino_embed.py
+++ b/vireo/dino_embed.py
@@ -126,10 +126,13 @@ def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
             # hf_hub_download calls can produce a mismatched pair that
             # ONNX Runtime refuses to load.  The HF cache path encodes
             # the resolved SHA as: …/snapshots/{sha}/…
+            # Walk from the end so an ancestor directory named "snapshots"
+            # (e.g. HF_HOME=/mnt/snapshots/cache) can't hijack the match.
             import pathlib as _pl
-            _parts = _pl.Path(cached_graph).parts
+            _parts = list(_pl.Path(cached_graph).parts)
             try:
-                _pinned_rev = _parts[list(_parts).index("snapshots") + 1]
+                _idx = len(_parts) - 1 - _parts[::-1].index("snapshots")
+                _pinned_rev = _parts[_idx + 1]
             except (ValueError, IndexError):
                 _pinned_rev = None  # graceful fallback for mock paths in tests
 

--- a/vireo/dino_embed.py
+++ b/vireo/dino_embed.py
@@ -121,6 +121,18 @@ def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
             )
             shutil.copy2(cached_graph, tmp_path)
 
+            # Pin the sidecar fetch to the same commit that resolved
+            # the graph.  Without this, a repo update between the two
+            # hf_hub_download calls can produce a mismatched pair that
+            # ONNX Runtime refuses to load.  The HF cache path encodes
+            # the resolved SHA as: …/snapshots/{sha}/…
+            import pathlib as _pl
+            _parts = _pl.Path(cached_graph).parts
+            try:
+                _pinned_rev = _parts[list(_parts).index("snapshots") + 1]
+            except (ValueError, IndexError):
+                _pinned_rev = None  # graceful fallback for mock paths in tests
+
             if progress_callback:
                 progress_callback(
                     f"Downloading DINOv2 {variant} weights sidecar...", 1, 2,
@@ -130,6 +142,7 @@ def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
                 repo_id=ONNX_REPO,
                 filename="model.onnx.data",
                 subfolder=f"dinov2-{variant}",
+                revision=_pinned_rev,
             )
             shutil.copy2(cached_data, tmp_data_path)
 

--- a/vireo/tests/test_dinov2.py
+++ b/vireo/tests/test_dinov2.py
@@ -622,3 +622,51 @@ def test_ensure_dinov2_weights_rejects_unknown_variant():
 
     with pytest.raises(ValueError, match="Unknown DINOv2 variant"):
         dino_embed.ensure_dinov2_weights("vit-xxl")
+
+
+def test_ensure_dinov2_weights_pins_revision_when_cache_root_contains_snapshots(
+    tmp_path, monkeypatch,
+):
+    """The HF cache may itself live under a directory named 'snapshots'
+    (e.g. HF_HOME=/mnt/snapshots/cache). The revision extraction must pin
+    the sidecar fetch to the commit SHA from the HF cache layout's
+    trailing '.../snapshots/<sha>/...' segment, not to an ancestor
+    directory that happens to share the name."""
+    import dino_embed
+
+    model_dir = tmp_path / "dinov2-vit-b14"
+    model_path = model_dir / "model.onnx"
+    data_path = model_dir / "model.onnx.data"
+
+    monkeypatch.setattr(
+        dino_embed, "_dinov2_model_path",
+        lambda variant: (str(model_dir), str(model_path)),
+    )
+
+    real_sha = "a" * 40
+    # Simulate HF_HOME=/.../snapshots/hub/... — the first 'snapshots' in
+    # the path is NOT the one that precedes the SHA.
+    cache_root = tmp_path / "snapshots" / "hub" / "models--jss367--vireo-onnx-models"
+    graph_cached = cache_root / "snapshots" / real_sha / "dinov2-vit-b14" / "model.onnx"
+    data_cached = cache_root / "snapshots" / real_sha / "dinov2-vit-b14" / "model.onnx.data"
+    graph_cached.parent.mkdir(parents=True)
+    graph_cached.write_bytes(b"m" * 1024)
+    data_cached.write_bytes(b"d" * 8192)
+
+    seen_revisions = []
+
+    def fake_hf_hub_download(**kwargs):
+        seen_revisions.append(kwargs.get("revision"))
+        if kwargs["filename"] == "model.onnx":
+            return str(graph_cached)
+        return str(data_cached)
+
+    _install_fake_hf(monkeypatch, fake_hf_hub_download)
+
+    dino_embed.ensure_dinov2_weights("vit-b14")
+
+    # First call (graph) has no pinned revision; second (sidecar) must
+    # pin to the SHA from the LAST 'snapshots' segment, not "hub".
+    assert seen_revisions == [None, real_sha]
+    assert model_path.read_bytes() == b"m" * 1024
+    assert data_path.read_bytes() == b"d" * 8192


### PR DESCRIPTION
Parent PR: #553

Addresses Codex Connect review feedback on #553.

## What changed

Both `hf_hub_download` calls in `ensure_dinov2_weights` tracked `main` independently (no `revision` parameter). If `jss367/vireo-onnx-models` receives a push between the two fetches, the local `model.onnx` + `model.onnx.data` pair can come from different commits, producing a graph/sidecar mismatch that ONNX Runtime refuses to load.

**Fix:** after the first `hf_hub_download` resolves the graph, extract the commit SHA from the HF cache path (`…/snapshots/{sha}/…`) and pass it as `revision` to the second download, guaranteeing both files come from the same commit. When the path doesn't contain `"snapshots"` (e.g. in test mocks), `revision=None` falls back to the default branch — identical behaviour to before.

## Test results

All 27 DINOv2 unit tests pass. The 18 failures in the broader suite are pre-existing on the parent branch and unrelated to this change.

---
Generated by scheduled PR Agent