### PR TITLE
fix: address codex review on #553

### DIFF
--- a/vireo/dino_embed.py
+++ b/vireo/dino_embed.py
@@ -109,6 +109,7 @@ def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
         tmp_path = model_path + ".download"
         tmp_data_path = data_path + ".download"
         try:
+            import contextlib
             import shutil
 
             from huggingface_hub import hf_hub_download
@@ -151,12 +152,18 @@ def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
 
             # Replace sidecar first, graph second, so ONNX Runtime never
             # sees a graph file that references a not-yet-written sidecar.
-            # Both replaces are atomic per file.
+            # If the graph replace fails after the sidecar is already in
+            # place (e.g. model.onnx is locked on Windows), roll back the
+            # sidecar so subsequent runs re-download both cleanly — prevents
+            # a mismatched pair from silently passing the existence check.
             os.replace(tmp_data_path, data_path)
-            os.replace(tmp_path, model_path)
+            try:
+                os.replace(tmp_path, model_path)
+            except OSError:
+                with contextlib.suppress(OSError):
+                    os.unlink(data_path)
+                raise
         except Exception as e:
-            import contextlib
-
             with contextlib.suppress(OSError):
                 os.unlink(tmp_path)
             with contextlib.suppress(OSError):

--- a/vireo/tests/test_dinov2.py
+++ b/vireo/tests/test_dinov2.py
@@ -615,6 +615,72 @@ def test_ensure_dinov2_weights_raises_on_sidecar_download_failure(
     assert not data_path.exists()
 
 
+def test_ensure_dinov2_weights_rolls_back_sidecar_if_graph_replace_fails(
+    tmp_path, monkeypatch,
+):
+    """Regression for Codex review: if ``os.replace(tmp_data_path, data_path)``
+    succeeds but ``os.replace(tmp_path, model_path)`` then fails (e.g. the
+    graph file is locked on Windows), the old sidecar must be removed so
+    subsequent runs don't short-circuit on a mismatched pair.
+
+    Without the rollback:
+      1. stub-only install triggers download.
+      2. new sidecar is promoted to ``data_path``.
+      3. graph replace fails, leaving old stub at ``model_path``.
+      4. Both files now exist → short-circuit → ONNX Runtime dies on mismatched
+         external-data layout with the same opaque error we worked hard to fix.
+    """
+    import dino_embed
+
+    model_dir = tmp_path / "dinov2-vit-b14"
+    model_dir.mkdir()
+    model_path = model_dir / "model.onnx"
+    data_path = model_dir / "model.onnx.data"
+
+    # Simulate stub-only install (old graph, no sidecar).
+    model_path.write_bytes(b"old-stub" * 128)
+
+    monkeypatch.setattr(
+        dino_embed, "_dinov2_model_path",
+        lambda variant: (str(model_dir), str(model_path)),
+    )
+
+    cache_dir = tmp_path / "hf-cache"
+    cache_dir.mkdir()
+    (cache_dir / "model.onnx").write_bytes(b"new-graph" * 128)
+    (cache_dir / "model.onnx.data").write_bytes(b"new-sidecar" * 512)
+
+    def fake_hf_hub_download(**kwargs):
+        return str(cache_dir / kwargs["filename"])
+
+    _install_fake_hf(monkeypatch, fake_hf_hub_download)
+
+    # Intercept os.replace: let the sidecar promotion succeed, fail the graph.
+    real_replace = os.replace
+    call_count = [0]
+
+    def patched_replace(src, dst):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            # First call: sidecar → data_path; let it succeed.
+            return real_replace(src, dst)
+        # Second call: graph → model_path; simulate a locked-file error.
+        raise OSError("file is locked")
+
+    monkeypatch.setattr(os, "replace", patched_replace)
+
+    with pytest.raises(RuntimeError, match="Failed to download DINOv2"):
+        dino_embed.ensure_dinov2_weights("vit-b14")
+
+    # After rollback, data_path must NOT exist so the next call re-downloads
+    # both files instead of silently short-circuiting on a mismatched pair.
+    assert not data_path.exists(), (
+        "sidecar was NOT rolled back — subsequent runs will pass the "
+        "existence check with an old graph + new sidecar and ONNX Runtime "
+        "will fail on mismatched external-data layout"
+    )
+
+
 def test_ensure_dinov2_weights_rejects_unknown_variant():
     """Guard against typos that would otherwise fetch from a wrong repo path."""
     import dino_embed


### PR DESCRIPTION
Parent PR: #553

Addresses Codex Connect review feedback on #553 (thread posted 2026-04-14T02:29:33Z — after the previous fix PR #554 was merged).

## What changed

**`vireo/dino_embed.py`** — roll back the promoted sidecar when the graph `os.replace` fails.

After `os.replace(tmp_data_path, data_path)` succeeds, a failure in the next `os.replace(tmp_path, model_path)` (e.g. `model.onnx` is locked on Windows) left the new sidecar at `data_path` while the old graph stub remained at `model_path`. On the next call both files appeared present, so `ensure_dinov2_weights` short-circuited without re-downloading — handing ONNX Runtime a mismatched graph/sidecar pair and reproducing the exact broken state PR #553 was designed to fix.

Fix: wrap the graph replace in an inner `try/except OSError` that removes `data_path` on failure. The next run then sees only the old stub, triggers a fresh download of both files, and reaches a consistent state.

**`vireo/tests/test_dinov2.py`** — adds `test_ensure_dinov2_weights_rolls_back_sidecar_if_graph_replace_fails` to pin this regression.

## Test results

29/29 DINOv2 unit tests pass. 217 pass in the full required suite; the 218 errors are pre-existing `ModuleNotFoundError` issues on this branch unrelated to this change.

---
Generated by scheduled PR Agent