### PR TITLE
fix: reject and purge predictions with NULL detection_id

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -625,6 +625,18 @@ class Database:
             """)
             self.conn.commit()
 
+        # Purge orphaned predictions with NULL detection_id.  These are
+        # invisible to every workspace-scoped query (which JOINs through
+        # detections) and accumulated on some installs before the
+        # add_prediction NOT-NULL guard existed.  Regenerable via reclassify.
+        orphan_cnt = self.conn.execute(
+            "SELECT COUNT(*) FROM predictions WHERE detection_id IS NULL"
+        ).fetchone()[0]
+        if orphan_cnt:
+            log.info("Purging %d orphaned predictions (NULL detection_id)", orphan_cnt)
+            self.conn.execute("DELETE FROM predictions WHERE detection_id IS NULL")
+            self.conn.commit()
+
         # Folder health status
         try:
             self.conn.execute("SELECT status FROM folders LIMIT 0")
@@ -3038,6 +3050,12 @@ class Database:
             taxonomy: optional dict with keys kingdom, phylum, class, order,
                       family, genus, scientific_name from taxonomy lookup
         """
+        if detection_id is None:
+            raise ValueError(
+                "add_prediction requires a non-null detection_id; "
+                "predictions without a detection row are orphaned and "
+                "invisible to workspace-scoped queries"
+            )
         tax = taxonomy or {}
         self.conn.execute(
             """INSERT OR IGNORE INTO predictions

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1737,6 +1737,40 @@ def test_add_prediction_with_detection(tmp_path):
     assert preds[0]["confidence"] == 0.92
 
 
+def test_add_prediction_rejects_null_detection_id(tmp_path):
+    """add_prediction must reject None detection_id to prevent orphans
+    that are invisible to workspace-scoped queries."""
+    import pytest
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    with pytest.raises(ValueError, match="non-null detection_id"):
+        db.add_prediction(None, species="Elk", confidence=0.9, model="bioclip")
+
+
+def test_init_purges_orphan_predictions(tmp_path):
+    """Reopening a DB must delete pre-existing predictions with NULL
+    detection_id.  They're invisible to the UI and regenerable via reclassify;
+    purging prevents stale rows from polluting the table forever."""
+    from db import Database
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    # Bypass the add_prediction guard to simulate a legacy orphan row.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, species, confidence, model, status) "
+        "VALUES (NULL, 'Elk', 0.9, 'bioclip', 'pending')"
+    )
+    db.conn.commit()
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM predictions WHERE detection_id IS NULL"
+    ).fetchone()[0] == 1
+    db.conn.close()
+
+    db2 = Database(db_path)
+    assert db2.conn.execute(
+        "SELECT COUNT(*) FROM predictions WHERE detection_id IS NULL"
+    ).fetchone()[0] == 0
+
+
 def test_get_predictions_includes_photo_and_box(tmp_path):
     """get_predictions should include photo filename and bounding box from detection."""
     from db import Database


### PR DESCRIPTION
## Summary

- Predictions with `detection_id = NULL` are orphans: every workspace-scoped query (`get_predictions`, `get_group_predictions`, etc.) joins through `detections`, so a NULL FK silently drops the row. Classification reports `"N predictions stored"` in the log, but pipeline review shows nothing.
- `add_prediction()` now raises `ValueError` when `detection_id is None` — defense-in-depth against whatever historical code path produced the orphans.
- `Database.__init__` deletes any pre-existing NULL-`detection_id` rows at startup. They're regenerable by re-running classify and are invisible to the UI until they're gone.

## Context

Observed in the wild: a user reported that pipeline review mode showed no classifications despite many successful classify runs. Investigation found 2544 rows in `predictions` with `detection_id = NULL` (oldest 2026-04-01, newest 2026-04-13), accumulating across pipeline runs. The original insertion path couldn't be traced definitively from the current code (all production `add_prediction` call sites pass a non-None value), so this PR addresses both the legacy data and any future regression at the API boundary.

## Test plan

- [x] `python -m pytest vireo/tests/test_db.py::test_add_prediction_rejects_null_detection_id vireo/tests/test_db.py::test_init_purges_orphan_predictions` — new coverage
- [x] Full project suite per `CLAUDE.md`: 538 passed, 1 unrelated pre-existing flake (`test_pipeline_auto_skips_classify_when_no_model` in `test_jobs_api.py`, passes in isolation on this branch and fails on `main` when run in the same batch — no logical connection to DB predictions changes)
- [ ] After merge: restart the app to trigger the orphan purge, then re-run classify on any workspace whose predictions weren't showing; verify pipeline review now displays them

🤖 Generated with [Claude Code](https://claude.com/claude-code)