### PR TITLE
fix: address codex review on #557

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1184,28 +1184,20 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                             failed += 1
                             continue
 
-                        # Every prediction must anchor to a detection row so
-                        # the workspace-scoped skip query
-                        # (predictions ⋈ detections on detection_id) can find
-                        # it. When MegaDetector found nothing, synthesize a
-                        # full-image detection row — matching the standalone
-                        # classify path at classify_job.py ≈ 772-777.
-                        if primary_det is not None:
-                            detection_id = primary_det["id"]
-                        else:
-                            full_image_det = [{
-                                "box": {"x": 0, "y": 0, "w": 1, "h": 1},
-                                "confidence": 0, "category": "animal",
-                            }]
-                            full_det_ids = thread_db.save_detections(
-                                photo["id"], full_image_det,
-                                detector_model="full-image",
-                            )
-                            detection_id = full_det_ids[0]
+                        # Pipeline classify is detection-driven: skip photos
+                        # where MegaDetector found no animals.  Synthesizing
+                        # a full-image detection row to anchor the prediction
+                        # is wrong because extract_masks_stage calls
+                        # get_detections() without a detector_model filter and
+                        # would treat the synthetic row as a real subject
+                        # candidate, bypassing the photos_with_detections == 0
+                        # safeguard and running SAM2 on full-frame boxes.
+                        if primary_det is None:
+                            continue
 
                         img_batch = [{
                             "photo": photo,
-                            "detection_id": detection_id,
+                            "detection_id": primary_det["id"],
                             "folder_path": folder_path,
                             "image_path": image_path,
                             "img": img,

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -2641,15 +2641,28 @@ def test_pipeline_classify_stores_predictions_with_detection_id(
     Regression: pipeline_job built img_batch entries without a detection_id
     key, so _flush_batch stored detection_id=None for every pipeline-written
     prediction.
+
+    Pipeline classify is detection-driven: photos with no MegaDetector
+    detection are skipped entirely rather than having a synthetic full-image
+    detection row inserted, which would be mistakenly treated by
+    extract_masks_stage as a real subject candidate.
     """
     import classifier as classifier_mod
     import classify_job
     import config as cfg
+    import detector as detector_mod
     from db import Database
     from PIL import Image
 
     monkeypatch.setenv("HOME", str(tmp_path))
     cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    # Stub out MegaDetector weights so ensure_megadetector_weights
+    # short-circuits without attempting a network download.
+    fake_md = tmp_path / "megadetector" / "model.onnx"
+    fake_md.parent.mkdir(parents=True, exist_ok=True)
+    fake_md.touch()
+    monkeypatch.setattr(detector_mod, "MEGADETECTOR_ONNX_PATH", str(fake_md))
 
     db_path = str(tmp_path / "test.db")
     db = Database(db_path)
@@ -2765,14 +2778,29 @@ def test_pipeline_classify_stores_predictions_with_detection_id(
             f"expected {ws_id}."
         )
 
-    # And the skip set must now include both photos on a second run.
+    # The skip set must include photo_with_det (it has a prediction anchored
+    # to a real detection row).  photo_without_det was skipped by the pipeline
+    # (no detection → no classify → no prediction), so it is NOT in the skip
+    # set — correct pipeline behavior since there is nothing to skip.
     skip_set = db.get_existing_prediction_photo_ids(preds[0]["model"])
     assert photo_with_det in skip_set, (
         f"photo_with_det ({photo_with_det}) missing from skip set {skip_set} — "
         "its prediction is not reachable via the predictions→detections join."
     )
-    assert photo_without_det in skip_set, (
-        f"photo_without_det ({photo_without_det}) missing from skip set "
-        f"{skip_set} — the no-detection path must still anchor its prediction "
-        "to a detection row (e.g. a full-image detection)."
+    assert photo_without_det not in skip_set, (
+        f"photo_without_det ({photo_without_det}) unexpectedly found in skip "
+        f"set {skip_set} — pipeline should not classify photos that had no "
+        "MegaDetector detection."
+    )
+
+    # Confirm no synthetic full-image detections were inserted for the
+    # no-detection photo — those would fool extract_masks_stage.
+    synthetic = db.conn.execute(
+        "SELECT id FROM detections WHERE photo_id = ? AND detector_model = 'full-image'",
+        (photo_without_det,),
+    ).fetchall()
+    assert not synthetic, (
+        f"Pipeline inserted synthetic full-image detection(s) for "
+        f"photo_without_det: {[dict(r) for r in synthetic]}. These are "
+        "picked up by extract_masks_stage as real subject candidates."
     )


### PR DESCRIPTION
Parent PR: #557

Addresses Codex Connect P1 review feedback on #557 (thread posted 2026-04-14T03:19:44Z).

## What changed

**`vireo/pipeline_job.py`** — Remove synthetic full-image detection creation; skip photos with no MegaDetector detection.

PR #557 inserted a `detector_model="full-image"` detection row when MegaDetector found no animals, to anchor the prediction to a detection FK. Codex correctly identified that `extract_masks_stage` calls `get_detections()` without a `detector_model` filter, so that synthetic row is treated as a real subject candidate. This bypasses the `photos_with_detections == 0` safeguard and causes SAM2 to run on full-frame boxes for photos with no detected subjects — producing misleading masks and quality scores, and hiding the "weights missing / no detections" diagnostic path.

Fix: pipeline classify is detection-driven. When `primary_det is None`, `continue` to the next photo. The `detection_id` is taken directly from `primary_det["id"]` with no else branch.

**`vireo/tests/test_pipeline_job.py`** — Update `test_pipeline_classify_stores_predictions_with_detection_id`:
- Replace assertion that `photo_without_det` IS in the skip set → assert it is NOT (correct: no detection → no classify → not in skip set)
- Add assertion that no synthetic `detector_model='full-image'` rows were inserted for the no-detection photo
- Add `MEGADETECTOR_ONNX_PATH` stub so `ensure_megadetector_weights` short-circuits without a network download (makes the test self-contained in CI)

## Test results

- `test_pipeline_classify_stores_predictions_with_detection_id` — passes
- CLAUDE.md required suite (437 tests) — all pass

---
Generated by scheduled PR Agent