### PR TITLE
fix: address codex review on #557

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1177,6 +1177,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         # produced a detection, aborting classify mid-run.
                         photo_dets = det_map.get(photo["id"], [])
                         primary_det = photo_dets[0] if photo_dets else None
+
+                        # Pipeline classify only processes photos that
+                        # MegaDetector actually detected a subject in.
+                        # Synthesizing a full-image detection to anchor
+                        # the prediction FK corrupts extract_masks_stage:
+                        # get_detections() has no detector_model filter,
+                        # so a synthetic row is treated as a real subject
+                        # candidate, bypassing the photos_with_detections
+                        # == 0 safeguard and triggering mask extraction
+                        # on full-frame boxes for empty-scene photos.
+                        if primary_det is None:
+                            continue
+
                         img, folder_path, image_path = _prepare_image(
                             photo, folders, primary_det
                         )
@@ -1184,28 +1197,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                             failed += 1
                             continue
 
-                        # Every prediction must anchor to a detection row so
-                        # the workspace-scoped skip query
-                        # (predictions ⋈ detections on detection_id) can find
-                        # it. When MegaDetector found nothing, synthesize a
-                        # full-image detection row — matching the standalone
-                        # classify path at classify_job.py ≈ 772-777.
-                        if primary_det is not None:
-                            detection_id = primary_det["id"]
-                        else:
-                            full_image_det = [{
-                                "box": {"x": 0, "y": 0, "w": 1, "h": 1},
-                                "confidence": 0, "category": "animal",
-                            }]
-                            full_det_ids = thread_db.save_detections(
-                                photo["id"], full_image_det,
-                                detector_model="full-image",
-                            )
-                            detection_id = full_det_ids[0]
-
                         img_batch = [{
                             "photo": photo,
-                            "detection_id": detection_id,
+                            "detection_id": primary_det["id"],
                             "folder_path": folder_path,
                             "image_path": image_path,
                             "img": img,

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -2698,6 +2698,13 @@ def test_pipeline_classify_stores_predictions_with_detection_id(
 
     monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
 
+    # Prevent ensure_megadetector_weights from trying to download weights.
+    # photo_without_det has no detection row, so needs_fresh_detection=True
+    # and the pipeline would call ensure_megadetector_weights before
+    # reaching _detect_batch.
+    import detector as detector_mod
+    monkeypatch.setattr(detector_mod, "ensure_megadetector_weights", lambda **_: None)
+
     def fake_prepare_image(photo, folders, detection, vireo_dir=None):
         return (
             Image.new("RGB", (32, 32), "white"),
@@ -2765,14 +2772,37 @@ def test_pipeline_classify_stores_predictions_with_detection_id(
             f"expected {ws_id}."
         )
 
-    # And the skip set must now include both photos on a second run.
+    # The skip set must include photo_with_det (has a real detection + prediction).
     skip_set = db.get_existing_prediction_photo_ids(preds[0]["model"])
     assert photo_with_det in skip_set, (
         f"photo_with_det ({photo_with_det}) missing from skip set {skip_set} — "
         "its prediction is not reachable via the predictions→detections join."
     )
-    assert photo_without_det in skip_set, (
-        f"photo_without_det ({photo_without_det}) missing from skip set "
-        f"{skip_set} — the no-detection path must still anchor its prediction "
-        "to a detection row (e.g. a full-image detection)."
+
+    # photo_without_det has no MegaDetector detection, so the pipeline
+    # classify stage must skip it entirely. No prediction and no synthetic
+    # detection row should have been written for it.
+    assert photo_without_det not in skip_set, (
+        f"photo_without_det ({photo_without_det}) unexpectedly in skip set — "
+        "the pipeline must not classify photos that MegaDetector found no "
+        "detections in, to avoid corrupting extract_masks_stage with "
+        "synthetic full-image detection rows."
+    )
+    no_det_preds = db.conn.execute(
+        """SELECT pr.id FROM predictions pr
+           JOIN detections d ON d.id = pr.detection_id
+           WHERE d.photo_id = ?""",
+        (photo_without_det,),
+    ).fetchall()
+    assert not no_det_preds, (
+        f"Found predictions for photo_without_det via real detections: "
+        f"{[dict(r) for r in no_det_preds]}."
+    )
+    synthetic_dets = db.conn.execute(
+        "SELECT id, detector_model FROM detections WHERE photo_id = ?",
+        (photo_without_det,),
+    ).fetchall()
+    assert not synthetic_dets, (
+        f"Synthetic detection rows were created for photo_without_det: "
+        f"{[dict(r) for r in synthetic_dets]}. These corrupt extract_masks_stage."
     )


### PR DESCRIPTION
Parent PR: #557

Addresses Codex Connect P1 review feedback on #557.

## What changed

**`vireo/pipeline_job.py`** — remove synthetic full-image detection for photos with no MegaDetector result.

The original fix in #557 created a fake detection row (`detector_model="full-image"`) when MegaDetector found no animals, so predictions would have a valid `detection_id` FK. But `extract_masks_stage` calls `get_detections()` with no `detector_model` filter, so these synthetic rows are treated as real subject candidates:

- `photos_with_detections` increments for empty-scene photos
- The `photos_with_detections == 0` safeguard never fires when it should
- Mask extraction runs on a full-frame (0, 0, 1, 1) box, producing misleading quality scores and masking artifacts for photos with no wildlife subject

**Fix:** move the `primary_det is None` guard *before* `_prepare_image`. When MegaDetector found no detections for a photo, the pipeline classify stage skips it entirely — no image load, no synthetic detection, no prediction written. The `extract_masks_stage` diagnostic path fires correctly for all-empty collections.

**`vireo/tests/test_pipeline_job.py`** — correct the test assertions and add missing mock.

- Remove the assertion that `photo_without_det` lands in the skip set (wrong: the pipeline must not classify photos without MegaDetector detections)
- Add assertions that no synthetic detection row and no prediction are written for `photo_without_det`
- Add `ensure_megadetector_weights` mock so the test runs cleanly without `huggingface_hub` installed

## Test results

`test_pipeline_classify_stores_predictions_with_detection_id` passes. 217 tests pass in the CLAUDE.md required suite; the errors are pre-existing `ModuleNotFoundError` failures on this branch (same as reported in #557).

---
Generated by scheduled PR Agent