### PR TITLE
feat: ship issue reporting URL as config default

### DIFF
--- a/docs/google-apps-script-issue-report.js
+++ b/docs/google-apps-script-issue-report.js
@@ -1,15 +1,21 @@
 /**
  * Google Apps Script for receiving Vireo issue reports.
  *
- * Setup:
+ * NOTE: This script is already wired up for the maintainer's deployment —
+ * the corresponding deployment URL ships as the default value of
+ * `report_url` in `vireo/config.py`, so issue reporting works out of the
+ * box for end users with no extra configuration.
+ *
+ * Forkers who want to collect their own reports should:
  * 1. Go to https://script.google.com and create a new project.
  * 2. Paste this code into Code.gs.
  * 3. Replace YOUR_EMAIL@gmail.com with your email address.
  * 4. Click Deploy > New deployment > Web app.
  *    - Execute as: Me
  *    - Who has access: Anyone
- * 5. Copy the deployment URL and set it as "report_url" in Vireo's
- *    Settings page or in ~/.vireo/config.json.
+ * 5. Copy the deployment URL and replace the `report_url` default in
+ *    `vireo/config.py` with your own URL (or override it per-install via
+ *    Vireo's Settings page / ~/.vireo/config.json).
  */
 
 function doPost(e) {

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -27,7 +27,7 @@ DEFAULTS = {
     "setup_complete": False,
     "darktable_bin": "",
     "external_editor": "",
-    "report_url": "",
+    "report_url": "https://script.google.com/macros/s/AKfycbwqjy8KaB0X04b9R614PWkikRmEsbarXXdarl0S0QC6thT9Uoyn8F74Gku-5z9h-TTf/exec",
     "darktable_style": "",
     "darktable_output_format": "jpg",
     "darktable_output_dir": "",

--- a/vireo/tests/test_report.py
+++ b/vireo/tests/test_report.py
@@ -57,6 +57,14 @@ class TestReportIssue:
         assert resp.status_code == 400
 
     def test_report_without_url_returns_download(self, client):
+        """With report_url explicitly cleared, the endpoint returns the
+        download bundle directly."""
+        import config as cfg
+
+        current = cfg.load()
+        current["report_url"] = ""
+        cfg.save(current)
+
         resp = client.post("/api/report-issue", json={"description": "Something broke"})
         data = resp.get_json()
         assert data["status"] == "download"
@@ -70,8 +78,24 @@ class TestReportIssue:
         assert "config" in diag
         assert "timestamp" in diag
 
+    def test_default_config_ships_report_url(self):
+        """The shipped default includes a working report URL so issue
+        reporting works out of the box without user configuration."""
+        import config as cfg
+
+        assert cfg.DEFAULTS["report_url"].startswith("https://script.google.com/")
+
     def test_diagnostics_system_fields(self, client):
-        """System info should include platform, python, architecture."""
+        """System info should include platform, python, architecture.
+
+        Uses an unreachable URL to force the download fallback so we get
+        diagnostics back regardless of network conditions in the test env."""
+        import config as cfg
+
+        current = cfg.load()
+        current["report_url"] = "http://localhost:1/nonexistent"
+        cfg.save(current)
+
         resp = client.post("/api/report-issue", json={"description": "check system"})
         system = resp.get_json()["diagnostics"]["system"]
         assert "platform" in system
@@ -85,6 +109,9 @@ class TestReportIssue:
         current = cfg.load()
         current["hf_token"] = "hf_abc123secret"
         current["inat_token"] = "my-inat-token"
+        # Force download path so we can inspect the diagnostics payload
+        # without depending on network reachability.
+        current["report_url"] = "http://localhost:1/nonexistent"
         cfg.save(current)
 
         resp = client.post("/api/report-issue", json={"description": "test redaction"})
@@ -114,7 +141,14 @@ class TestReportIssue:
         are reporting DB problems."""
         app, _ = app_and_db
 
+        import config as cfg
         from db import Database
+
+        # Force an unreachable URL so this test doesn't depend on the
+        # network reachability of the default Apps Script endpoint.
+        current = cfg.load()
+        current["report_url"] = "http://localhost:1/nonexistent"
+        cfg.save(current)
 
         def boom(self, *a, **kw):
             raise RuntimeError("schema broken")


### PR DESCRIPTION
## Summary

Makes the built-in issue reporter work out of the box for every Vireo user — no config required. Previously `report_url` defaulted to `""`, so fresh installs silently fell back to the download-bundle path and reports never reached the maintainer.

This change bakes the maintainer's Google Apps Script deployment URL into `config.DEFAULTS["report_url"]`. Users (and per-workspace overrides) can still replace it via Settings or `~/.vireo/config.json`.

## Security trade-off

The deployment URL is now public in the source tree. Mitigations:
- Google Apps Script enforces a daily invocation quota per deployment, capping abuse volume.
- If the URL is abused, the maintainer can rotate by redeploying the script with a new URL and shipping a point release that updates the default.
- The endpoint only accepts POSTs and its only side effect is sending an email to the maintainer — no credentials or user data are exposed by leaking the URL.

## Changes

- `vireo/config.py`: set `report_url` default to the live Apps Script URL.
- `vireo/tests/test_report.py`:
  - `test_report_without_url_returns_download` now explicitly clears `report_url` before asserting the download path.
  - Added `test_default_config_ships_report_url` to lock in the behavior.
  - Pinned an unreachable URL in `test_diagnostics_system_fields`, `test_sensitive_config_values_are_redacted`, and `test_report_when_effective_config_raises` so the download-fallback assertions don't depend on network reachability of the live endpoint.
- `docs/google-apps-script-issue-report.js`: updated the header comment to note the script is already deployed and wired up for the maintainer; forkers need to redeploy and update `vireo/config.py` if they want their own collection point.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_report.py -v` → 447 passed
- [ ] Manual: fresh install with no `~/.vireo/config.json` → submit a test report from the Settings page → maintainer inbox receives the email
- [ ] Manual: override `report_url` to `""` in config → submit report → client receives the download-bundle JSON as before

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>