### PR TITLE
fix: don't mark healthy models Incomplete on transient ONNX errors

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -712,24 +712,57 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         except Exception as load_err:
             # ONNXRuntime signals missing external-data with a
             # "model_path must not be empty" / "Initializer" error. Treat
-            # any load failure as an incomplete-model hint for the user.
+            # any load failure as an incomplete-model hint for the user —
+            # but only when we can confirm the on-disk files are actually
+            # bad. A transient ONNX failure (memory pressure, mmap race,
+            # test-suite monkeypatches from another process) should not
+            # permanently mark a healthy install as "Incomplete".
             if _looks_like_missing_external_data(load_err):
-                # Write the .verify_failed sentinel so that
-                # _classify_model_state (used by get_models() / Settings
-                # UI) also reports 'incomplete' and shows the Repair
-                # button.  Without this the pipeline tells the user to
-                # "click Repair" but Settings sees all files present and
-                # no sentinel, so no Repair button appears.
-                if weights_path:
-                    import model_verify
+                import model_verify
+
+                files_ok = False
+                hf_subdir = active_model.get("hf_subdir")
+                if (
+                    weights_path
+                    and hf_subdir
+                    and not model_is_custom
+                ):
                     try:
-                        with open(
-                            os.path.join(
-                                weights_path,
-                                model_verify.VERIFY_FAILED_SENTINEL,
-                            ),
-                            "w",
-                        ) as f:
+                        result = model_verify.verify_model(
+                            weights_path, hf_subdir
+                        )
+                        files_ok = result.ok
+                    except model_verify.VerifyError:
+                        # Network unavailable — can't confirm either way.
+                        # Fall through to the conservative path that writes
+                        # the sentinel so the user sees Repair.
+                        files_ok = False
+
+                if files_ok:
+                    # Files match HF hashes exactly — the ONNX error is
+                    # transient, not corruption. Do NOT write
+                    # .verify_failed; do NOT tell the user to Repair. Just
+                    # re-raise with a retry hint.
+                    log.warning(
+                        "ONNXRuntime load failed for %s but on-disk files "
+                        "pass SHA256 verification — treating as transient.",
+                        active_model.get("id", "<unknown>"),
+                    )
+                    raise RuntimeError(
+                        f"Model '{model_name}' failed to load "
+                        f"(transient ONNXRuntime error). Retry the "
+                        f"pipeline. If this keeps happening, restart Vireo."
+                    ) from load_err
+
+                # Files are bad or unverifiable — write the sentinel so
+                # Settings surfaces the Repair button.
+                if weights_path:
+                    sentinel_path = os.path.join(
+                        weights_path,
+                        model_verify.VERIFY_FAILED_SENTINEL,
+                    )
+                    try:
+                        with open(sentinel_path, "w") as f:
                             f.write(f"onnx-load-failure: {load_err}\n")
                     except OSError:
                         pass

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -2377,6 +2377,15 @@ def test_onnx_load_failure_writes_verify_failed_sentinel(tmp_path, monkeypatch):
         )
 
     monkeypatch.setattr(classifier_mod, "Classifier", boom)
+    # Force hash check to report the files as bad, so the ONNX failure
+    # handler commits the sentinel write (the "real corruption" path).
+    monkeypatch.setattr(
+        model_verify,
+        "verify_model",
+        lambda *a, **k: model_verify.VerifyResult(
+            ok=False, mismatches=["image_encoder.onnx.data"]
+        ),
+    )
 
     params = PipelineParams(
         collection_id=col_id,
@@ -2409,6 +2418,75 @@ def test_onnx_load_failure_writes_verify_failed_sentinel(tmp_path, monkeypatch):
     assert state == "incomplete", (
         f"_classify_model_state should return 'incomplete' after the "
         f"sentinel is written, but got '{state}'"
+    )
+
+
+def test_onnx_load_failure_skips_sentinel_when_files_verify_ok(
+    tmp_path, monkeypatch
+):
+    """If ONNX Runtime fails to load but SHA256 verification reports the
+    files are intact, the .verify_failed sentinel must NOT be written.
+
+    This is the guard against a transient ONNXRuntime hiccup (memory
+    pressure, mmap race, a pytest monkeypatch from a worktree running
+    against the same $HOME) permanently marking a healthy model as
+    'Incomplete — repair available'. Left unchecked, every subsequent
+    pipeline run told the user to click Repair, and Repair succeeded
+    but the sentinel came back on the next transient failure.
+    """
+    import classifier as classifier_mod
+    import config as cfg
+    import model_verify
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    model_id = _setup_fake_downloaded_model(tmp_path, monkeypatch)
+    model_dir = tmp_path / "models" / model_id
+
+    def boom(*args, **kwargs):
+        raise RuntimeError(
+            "[ONNXRuntimeError] model_path must not be empty. Ensure that "
+            "a path is provided when the model is created or loaded."
+        )
+
+    monkeypatch.setattr(classifier_mod, "Classifier", boom)
+    # Files hash-check clean — the ONNX error is transient, not corruption.
+    monkeypatch.setattr(
+        model_verify,
+        "verify_model",
+        lambda *a, **k: model_verify.VerifyResult(ok=True),
+    )
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    import pytest
+    with pytest.raises(RuntimeError) as exc:
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    sentinel = model_dir / model_verify.VERIFY_FAILED_SENTINEL
+    assert not sentinel.exists(), (
+        "verified-clean files must not get a .verify_failed sentinel "
+        "from a transient ONNXRuntime error — that's what traps users "
+        "in the 'Repair never sticks' loop."
+    )
+    # And the user-facing error should NOT say "click Repair" since the
+    # files are fine; it should suggest a retry instead.
+    assert "Repair" not in str(exc.value), (
+        f"Expected transient-failure message, got: {exc.value}"
     )
 
 


### PR DESCRIPTION
## Summary

Your BioCLIP-2.5 (and any other external-data ONNX model) keeps showing "Incomplete — repair available" even after repeated Repairs. I checked your installed files directly: every SHA256 matches HuggingFace at the pinned revision exactly, and ONNX Runtime loads the model cleanly. The files are fine — the state machine is the bug.

`pipeline_job._load_model_bundle` writes `.verify_failed` whenever the Classifier constructor raises anything matching `_looks_like_missing_external_data` ("model_path must not be empty" / "external data"). That fires on legitimate corruption, but it also fires on transient causes: memory pressure, an mmap race, or — as in your `~/.vireo/vireo.log` around 2026-04-13 19:51 — a pytest running from `.claude/worktrees/prediction-orphans` that monkeypatches `Classifier`/`verify_if_needed` to raise the same string. Because every subprocess writes to the shared log file and, in that run, wound up resolving `weights_path` to the real `~/.vireo/models/bioclip-2.5-vith14/`, the sentinel landed in the real user dir. Repair clears it, the next run re-writes it → the loop you've been hitting.

**Fix:** before writing the sentinel, re-verify the on-disk files against HuggingFace's pinned SHA256s. If they all match, the ONNX failure is not corruption — do not write the sentinel, and surface a "transient, retry" error instead of the "click Repair" message. If the hash fetch fails (offline), keep the old conservative behaviour so Repair is still shown.

- `vireo/pipeline_job.py`: guarded sentinel write (model_verify.verify_model first; only persist on `!result.ok` or `VerifyError`).
- `vireo/tests/test_pipeline_job.py`: existing regression test now explicitly simulates the "files bad" path; new test pins the "files good" path (sentinel absent, error string does not contain "Repair").

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_pipeline_job.py vireo/tests/test_models.py vireo/tests/test_model_verify.py -q` — 573 passed.
- [ ] Manual: delete `~/.vireo/models/bioclip-2.5-vith14/.verify_failed`, run a pipeline with BioCLIP-2.5 active, confirm Settings no longer shows "Incomplete" after completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)