### PR TITLE
fix: roll up per-file failures into pipeline stage status and error_count

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -518,13 +518,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             # but status surfaces the problem on the job history list.
             final_status = "failed" if failed > 0 else "completed"
             stages["thumbnails"]["status"] = final_status
-            if failed > 0:
-                errors.append(
-                    f"[thumbnails] {failed} of {processed} thumbnails failed to generate"
-                )
+            thumb_rollup = (
+                f"[thumbnails] {failed} of {processed} thumbnails failed to generate"
+                if failed > 0 else None
+            )
+            if thumb_rollup:
+                errors.append(thumb_rollup)
             runner.update_step(job["id"], "thumbnails", status=final_status,
                                summary=thumb_summary(thumb_result),
                                error_count=failed,
+                               error=thumb_rollup,
                                progress={"current": processed, "total": processed})
             result["stages"]["thumbnails"] = thumb_result
         except Exception as e:
@@ -612,10 +615,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             }
             final_status = "failed" if failed > 0 else "completed"
             stages["previews"]["status"] = final_status
-            if failed > 0:
-                errors.append(
-                    f"[previews] {failed} of {total} previews failed to generate"
-                )
+            previews_rollup = (
+                f"[previews] {failed} of {total} previews failed to generate"
+                if failed > 0 else None
+            )
+            if previews_rollup:
+                errors.append(previews_rollup)
             summary_parts = [f"{generated} generated"]
             if skipped:
                 summary_parts.append(f"{skipped} cached")
@@ -623,7 +628,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 summary_parts.append(f"{failed} failed")
             runner.update_step(job["id"], "previews", status=final_status,
                                summary=", ".join(summary_parts),
-                               error_count=failed)
+                               error_count=failed,
+                               error=previews_rollup)
         except Exception as e:
             errors.append(f"[previews] Fatal: {e}")
             log.exception("Pipeline previews stage failed")
@@ -1350,15 +1356,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
             # Any per-photo classify failure flips the stage to 'failed'.
             # Summary still shows both counts; status surfaces the problem.
+            # error_count uses unique failed photo IDs (not per-model attempt
+            # count) so the badge can never exceed total photos.
+            n_failed_photos = len(failed_photo_ids)
             final_status = "failed" if total_failed > 0 else "completed"
             stages["classify"]["status"] = final_status
-            if total_failed > 0:
-                errors.append(
-                    f"[classify] {len(failed_photo_ids)} of {total} photos failed to classify"
-                )
+            classify_rollup = (
+                f"[classify] {n_failed_photos} of {total} photos failed to classify"
+                if total_failed > 0 else None
+            )
+            if classify_rollup:
+                errors.append(classify_rollup)
             runner.update_step(job["id"], "classify", status=final_status,
                                summary="; ".join(summary_parts),
-                               error_count=total_failed)
+                               error_count=n_failed_photos,
+                               error=classify_rollup)
             result["stages"]["classify"] = {
                 "total": total,
                 "predictions_stored": total_predictions_stored,
@@ -1608,16 +1620,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
             final_status = "failed" if em_failed > 0 else "completed"
             stages["extract_masks"]["status"] = final_status
-            if em_failed > 0:
-                errors.append(
-                    f"[extract_masks] {em_failed} of {total} photos failed mask extraction"
-                )
+            em_rollup = (
+                f"[extract_masks] {em_failed} of {total} photos failed mask extraction"
+                if em_failed > 0 else None
+            )
+            if em_rollup:
+                errors.append(em_rollup)
             em_summary_parts = [f"{masked} masked", f"{skipped} skipped"]
             if em_failed:
                 em_summary_parts.append(f"{em_failed} failed")
             runner.update_step(job["id"], "extract_masks", status=final_status,
                                summary=", ".join(em_summary_parts),
-                               error_count=em_failed)
+                               error_count=em_failed,
+                               error=em_rollup)
             result["stages"]["extract_masks"] = {
                 "masked": masked, "skipped": skipped, "failed": em_failed, "total": total,
             }

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -524,6 +524,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 )
             runner.update_step(job["id"], "thumbnails", status=final_status,
                                summary=thumb_summary(thumb_result),
+                               error_count=failed,
                                progress={"current": processed, "total": processed})
             result["stages"]["thumbnails"] = thumb_result
         except Exception as e:
@@ -621,7 +622,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             if failed:
                 summary_parts.append(f"{failed} failed")
             runner.update_step(job["id"], "previews", status=final_status,
-                               summary=", ".join(summary_parts))
+                               summary=", ".join(summary_parts),
+                               error_count=failed)
         except Exception as e:
             errors.append(f"[previews] Fatal: {e}")
             log.exception("Pipeline previews stage failed")
@@ -965,6 +967,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             total_detected = 0
             total_failed = 0
             total_skipped_existing = 0
+            # Track unique photo IDs that failed in any model so the rollup
+            # message always produces a valid X-of-N ratio. total_failed sums
+            # per-model failures and can exceed total in multi-model runs.
+            failed_photo_ids: set = set()
 
             # For reclassify: start with an empty already_detected so model 1
             # re-runs MegaDetector on every photo. We intentionally do NOT
@@ -1257,6 +1263,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         )
                         if img is None:
                             failed += 1
+                            failed_photo_ids.add(photo["id"])
                             continue
 
                         img_batch = [{
@@ -1266,8 +1273,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                             "image_path": image_path,
                             "img": img,
                         }]
-                        failed += _flush_batch(img_batch, clf, model_type, model_name,
-                                               thread_db, raw_results)
+                        n_batch_failed = _flush_batch(img_batch, clf, model_type, model_name,
+                                                      thread_db, raw_results)
+                        if n_batch_failed:
+                            failed_photo_ids.add(photo["id"])
+                        failed += n_batch_failed
 
                 # Group and store predictions for this model
                 group_result = _store_grouped_predictions(
@@ -1344,10 +1354,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             stages["classify"]["status"] = final_status
             if total_failed > 0:
                 errors.append(
-                    f"[classify] {total_failed} of {total} photos failed to classify"
+                    f"[classify] {len(failed_photo_ids)} of {total} photos failed to classify"
                 )
             runner.update_step(job["id"], "classify", status=final_status,
-                               summary="; ".join(summary_parts))
+                               summary="; ".join(summary_parts),
+                               error_count=total_failed)
             result["stages"]["classify"] = {
                 "total": total,
                 "predictions_stored": total_predictions_stored,
@@ -1605,7 +1616,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             if em_failed:
                 em_summary_parts.append(f"{em_failed} failed")
             runner.update_step(job["id"], "extract_masks", status=final_status,
-                               summary=", ".join(em_summary_parts))
+                               summary=", ".join(em_summary_parts),
+                               error_count=em_failed)
             result["stages"]["extract_masks"] = {
                 "masked": masked, "skipped": skipped, "failed": em_failed, "total": total,
             }

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -482,10 +482,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         skipped += 1
                     else:
                         generated += 1
-                    stages["thumbnails"]["count"] = generated + skipped
                 except Exception:
                     failed += 1
                     log.debug("Thumbnail failed for photo %s", photo_id)
+                # Include failed in the progress counter so the dashboard
+                # reflects all work attempted, not just successes. Mixed
+                # success/failure must not hide behind a 0/N progress bar.
+                stages["thumbnails"]["count"] = generated + skipped + failed
                 processed = generated + skipped + failed
                 # Use scan count directly regardless of whether scan has
                 # completed yet — this avoids the total staying at 0/? when
@@ -507,11 +510,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     "stages": {k: dict(v) for k, v in stages.items()},
                 })
 
-            stages["thumbnails"]["status"] = "completed"
             from thumbnails import format_summary as thumb_summary
             thumb_result = {"generated": generated, "skipped": skipped, "failed": failed}
             processed = generated + skipped + failed
-            runner.update_step(job["id"], "thumbnails", status="completed",
+            # Mixed-outcome rollup: any failure flips status to 'failed'.
+            # The summary still shows both counts so partial success is visible,
+            # but status surfaces the problem on the job history list.
+            final_status = "failed" if failed > 0 else "completed"
+            stages["thumbnails"]["status"] = final_status
+            if failed > 0:
+                errors.append(
+                    f"[thumbnails] {failed} of {processed} thumbnails failed to generate"
+                )
+            runner.update_step(job["id"], "thumbnails", status=final_status,
                                summary=thumb_summary(thumb_result),
                                progress={"current": processed, "total": processed})
             result["stages"]["thumbnails"] = thumb_result
@@ -559,6 +570,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             total = len(photos)
             generated = 0
             skipped = 0
+            failed = 0
 
             for i, photo in enumerate(photos):
                 if _should_abort(abort):
@@ -573,6 +585,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     if img:
                         img.save(cache_path, format="JPEG", quality=preview_quality)
                         generated += 1
+                    else:
+                        # image_loader already logged the failure at WARNING;
+                        # count it here so it surfaces in the rollup.
+                        failed += 1
 
                 stages["previews"]["count"] = i + 1
                 runner.update_step(job["id"], "previews",
@@ -591,11 +607,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 })
 
             result["stages"]["previews"] = {
-                "generated": generated, "skipped": skipped, "total": total
+                "generated": generated, "skipped": skipped, "failed": failed, "total": total
             }
-            stages["previews"]["status"] = "completed"
-            runner.update_step(job["id"], "previews", status="completed",
-                               summary=f"{generated} generated")
+            final_status = "failed" if failed > 0 else "completed"
+            stages["previews"]["status"] = final_status
+            if failed > 0:
+                errors.append(
+                    f"[previews] {failed} of {total} previews failed to generate"
+                )
+            summary_parts = [f"{generated} generated"]
+            if skipped:
+                summary_parts.append(f"{skipped} cached")
+            if failed:
+                summary_parts.append(f"{failed} failed")
+            runner.update_step(job["id"], "previews", status=final_status,
+                               summary=", ".join(summary_parts))
         except Exception as e:
             errors.append(f"[previews] Fatal: {e}")
             log.exception("Pipeline previews stage failed")
@@ -1304,14 +1330,23 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 raise RuntimeError(fail_msg)
 
             summary_parts = [f"{total_predictions_stored} predictions"]
+            if total_failed:
+                summary_parts.append(f"{total_failed} failed")
             if skipped_model_names:
                 skipped_str = ", ".join(skipped_model_names)
                 summary_parts.append(
                     f"{len(skipped_model_names)} model(s) skipped: {skipped_str}"
                 )
 
-            stages["classify"]["status"] = "completed"
-            runner.update_step(job["id"], "classify", status="completed",
+            # Any per-photo classify failure flips the stage to 'failed'.
+            # Summary still shows both counts; status surfaces the problem.
+            final_status = "failed" if total_failed > 0 else "completed"
+            stages["classify"]["status"] = final_status
+            if total_failed > 0:
+                errors.append(
+                    f"[classify] {total_failed} of {total} photos failed to classify"
+                )
+            runner.update_step(job["id"], "classify", status=final_status,
                                summary="; ".join(summary_parts))
             result["stages"]["classify"] = {
                 "total": total,
@@ -1546,7 +1581,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 except Exception:
                     em_failed += 1
                     log.warning("Mask extraction failed for photo %s", photo_id, exc_info=True)
-                    errors.append(f"Photo {photo_id}: mask extraction failed")
 
                 stages["extract_masks"]["count"] = i + 1
                 runner.update_step(job["id"], "extract_masks",
@@ -1561,9 +1595,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     "stages": {k: dict(v) for k, v in stages.items()},
                 })
 
-            stages["extract_masks"]["status"] = "completed"
-            runner.update_step(job["id"], "extract_masks", status="completed",
-                               summary=f"{masked} masked, {skipped} skipped")
+            final_status = "failed" if em_failed > 0 else "completed"
+            stages["extract_masks"]["status"] = final_status
+            if em_failed > 0:
+                errors.append(
+                    f"[extract_masks] {em_failed} of {total} photos failed mask extraction"
+                )
+            em_summary_parts = [f"{masked} masked", f"{skipped} skipped"]
+            if em_failed:
+                em_summary_parts.append(f"{em_failed} failed")
+            runner.update_step(job["id"], "extract_masks", status=final_status,
+                               summary=", ".join(em_summary_parts))
             result["stages"]["extract_masks"] = {
                 "masked": masked, "skipped": skipped, "failed": em_failed, "total": total,
             }

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -1,5 +1,6 @@
 """Tests for the streaming pipeline job orchestrator."""
 
+import contextlib
 import json
 import os
 import sys
@@ -8,6 +9,18 @@ import threading
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from pipeline_job import PipelineParams, run_pipeline_job
+
+
+def _drop_jpeg(folder_path, filename):
+    """Write a tiny valid JPEG at folder_path/filename so previews/thumbnails
+    can load it. Tests that use db.add_photo need a matching file on disk now
+    that missing files count as stage failures."""
+    import os as _os
+
+    from PIL import Image
+    path = _os.path.join(folder_path, filename)
+    Image.new("RGB", (16, 16), "black").save(path)
+    return path
 
 
 def _make_job():
@@ -689,10 +702,11 @@ def test_pipeline_scan_progress_includes_rate_and_eta(tmp_path, monkeypatch):
     db = Database(db_path)
     ws_id = db._active_workspace_id
 
+    from PIL import Image
     src = tmp_path / "photos"
     src.mkdir()
     for i in range(12):
-        (src / f"img{i:02d}.jpg").write_bytes(b'\xff\xd8\xff\xe0' + b'\x00' * 100)
+        Image.new("RGB", (40, 40), "blue").save(str(src / f"img{i:02d}.jpg"))
 
     runner = JobRunner()
     progress_events = []
@@ -1750,6 +1764,7 @@ def test_pipeline_reclassify_multimodel_ignores_stale_detection_ids(
     os.makedirs(folder_path, exist_ok=True)
     folder_id = db.add_folder(folder_path)
     photo_id = db.add_photo(folder_id, "test.jpg", ".jpg", 12345, 1_000_000.0)
+    _drop_jpeg(folder_path, "test.jpg")
     db.save_detections(
         photo_id,
         [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
@@ -1921,6 +1936,7 @@ def test_pipeline_classify_passes_primary_detection_to_prepare_image(
     os.makedirs(folder_path, exist_ok=True)
     folder_id = db.add_folder(folder_path)
     photo_id = db.add_photo(folder_id, "bird.jpg", ".jpg", 12345, 1_000_000.0)
+    _drop_jpeg(folder_path, "bird.jpg")
     col_id = db.add_collection(
         "Test",
         json.dumps([{"field": "photo_ids", "value": [photo_id]}]),
@@ -1972,7 +1988,12 @@ def test_pipeline_classify_passes_primary_detection_to_prepare_image(
 
     runner = FakeRunner()
     job = _make_job()
-    run_pipeline_job(job, runner, db_path, ws_id, params)
+    # The fake _prepare_image returns None by design to short-circuit before
+    # the classifier runs — we only care about what argument it received.
+    # That now counts as a classify failure, which propagates to a pipeline
+    # RuntimeError; swallow it so we can still inspect `captured`.
+    with contextlib.suppress(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
 
     assert captured, (
         "_prepare_image was never called — test setup no longer exercises "
@@ -2028,6 +2049,7 @@ def test_pipeline_reclassify_purges_stale_detection_rows(tmp_path, monkeypatch):
     os.makedirs(folder_path, exist_ok=True)
     folder_id = db.add_folder(folder_path)
     photo_id = db.add_photo(folder_id, "test.jpg", ".jpg", 12345, 1_000_000.0)
+    _drop_jpeg(folder_path, "test.jpg")
 
     # Prior-run detection row (e.g. a prior false positive).
     prior_det_ids = db.save_detections(
@@ -2129,6 +2151,8 @@ def test_pipeline_reclassify_partial_abort_preserves_unprocessed_detections(
     folder_id = db.add_folder(folder_path)
     photo1_id = db.add_photo(folder_id, "photo1.jpg", ".jpg", 11111, 1_000_000.0)
     photo2_id = db.add_photo(folder_id, "photo2.jpg", ".jpg", 22222, 1_000_000.0)
+    _drop_jpeg(folder_path, "photo1.jpg")
+    _drop_jpeg(folder_path, "photo2.jpg")
 
     # Give each photo a prior-run detection row.
     prior_det1 = db.save_detections(
@@ -2261,6 +2285,8 @@ def test_pipeline_reclassify_partial_batch_exception_preserves_detections(
     folder_id = db.add_folder(folder_path)
     photo1_id = db.add_photo(folder_id, "photo1.jpg", ".jpg", 11111, 1_000_000.0)
     photo2_id = db.add_photo(folder_id, "photo2.jpg", ".jpg", 22222, 1_000_000.0)
+    _drop_jpeg(folder_path, "photo1.jpg")
+    _drop_jpeg(folder_path, "photo2.jpg")
 
     prior_det1 = db.save_detections(
         photo1_id,
@@ -2742,6 +2768,8 @@ def test_pipeline_classify_stores_predictions_with_detection_id(
     photo_without_det = db.add_photo(
         folder_id, "empty.jpg", ".jpg", 12346, 1_000_100.0
     )
+    _drop_jpeg(folder_path, "hawk.jpg")
+    _drop_jpeg(folder_path, "empty.jpg")
     col_id = db.add_collection(
         "Test",
         json.dumps([
@@ -2909,6 +2937,7 @@ def test_extract_masks_stage_ignores_synthetic_full_image_detections(
     os.makedirs(folder_path, exist_ok=True)
     folder_id = db.add_folder(folder_path)
     photo_id = db.add_photo(folder_id, "empty.jpg", ".jpg", 12345, 1_000_000.0)
+    _drop_jpeg(folder_path, "empty.jpg")
     col_id = db.add_collection(
         "Test",
         json.dumps([{"field": "photo_ids", "value": [photo_id]}]),
@@ -3024,6 +3053,8 @@ def test_pipeline_rerun_with_existing_prediction_and_bursts_does_not_crash(
                       timestamp="2026-01-01T12:00:00")
     p2 = db.add_photo(folder_id, "b.jpg", ".jpg", 2, 1_000_001.0,
                       timestamp="2026-01-01T12:00:01")
+    _drop_jpeg(folder_path, "a.jpg")
+    _drop_jpeg(folder_path, "b.jpg")
     col_id = db.add_collection(
         "Test",
         json.dumps([{"field": "photo_ids", "value": [p1, p2]}]),
@@ -3115,4 +3146,174 @@ def test_pipeline_rerun_with_existing_prediction_and_bursts_does_not_crash(
     assert job2["status"] != "failed", (
         f"Second pipeline run status is {job2['status']} (expected not "
         "'failed')"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Failure rollup — per-file failures surface at the stage/job level
+# ---------------------------------------------------------------------------
+
+
+def _make_photo_dir(tmp_path, n):
+    """Drop n tiny JPEGs in a fresh dir and return it."""
+    from PIL import Image
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    for i in range(n):
+        img = Image.new("RGB", (40, 40), "red")
+        img.save(str(photo_dir / f"p_{i}.jpg"))
+    return photo_dir
+
+
+def test_thumbnail_failures_flip_stage_status_to_failed(tmp_path, monkeypatch):
+    """If any thumbnail fails, the stage status must be 'failed' (not 'completed'),
+    even when some thumbnails succeeded. Mixed-outcome rollups are 'failed'."""
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    photo_dir = _make_photo_dir(tmp_path, 4)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # Make every second thumbnail "fail" by returning None.
+    import thumbnails as thumbnails_mod
+    real_gen = thumbnails_mod.generate_thumbnail
+    call_count = {"n": 0}
+
+    def flaky_gen(photo_id, photo_path, cache_dir, size=300):
+        call_count["n"] += 1
+        if call_count["n"] % 2 == 0:
+            return None
+        return real_gen(photo_id, photo_path, cache_dir, size=size)
+
+    monkeypatch.setattr(thumbnails_mod, "generate_thumbnail", flaky_gen)
+
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    job = _make_job()
+    runner = FakeRunner()
+
+    pipeline_result = None
+    try:
+        pipeline_result = run_pipeline_job(job, runner, db_path, ws_id, params)
+    except RuntimeError:
+        # Expected: pipeline raises when a stage ends up in 'failed'.
+        pipeline_result = job.get("result")
+
+    thumb_result = pipeline_result["stages"]["thumbnails"]
+    assert thumb_result["failed"] > 0, (
+        f"Test setup bug: expected thumbnail failures. Result: {thumb_result}"
+    )
+    assert thumb_result["generated"] > 0, (
+        f"Test setup bug: expected some thumbnail successes. Result: {thumb_result}"
+    )
+
+    # Inspect the final stages status as updated on the job runner.
+    final_thumb_updates = [
+        kwargs for (_, step, kwargs) in runner.step_updates
+        if step == "thumbnails" and kwargs.get("status")
+    ]
+    final_status = final_thumb_updates[-1]["status"]
+    assert final_status == "failed", (
+        f"Mixed-outcome rollup must report 'failed', got {final_status!r}. "
+        f"Result: {thumb_result}"
+    )
+
+
+def test_thumbnail_failures_append_rollup_error(tmp_path, monkeypatch):
+    """Per-file thumbnail failures must surface as exactly one rollup entry
+    in the pipeline errors list — not N per-file entries."""
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    photo_dir = _make_photo_dir(tmp_path, 3)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # All thumbnails fail.
+    import thumbnails as thumbnails_mod
+    monkeypatch.setattr(
+        thumbnails_mod, "generate_thumbnail",
+        lambda photo_id, photo_path, cache_dir, size=300: None,
+    )
+
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    job = _make_job()
+
+    with contextlib.suppress(RuntimeError):
+        run_pipeline_job(job, FakeRunner(), db_path, ws_id, params)
+
+    errors = job["errors"]
+    thumb_errors = [e for e in errors if "thumbnail" in e.lower()]
+    assert len(thumb_errors) == 1, (
+        f"Expected exactly one rollup entry for thumbnail failures, got "
+        f"{len(thumb_errors)}: {thumb_errors}"
+    )
+    assert "3" in thumb_errors[0], (
+        f"Rollup should mention the failure count (3), got: {thumb_errors[0]!r}"
+    )
+
+
+def test_thumbnail_progress_counter_includes_failed(tmp_path, monkeypatch):
+    """stages['thumbnails']['count'] must include failed items so the UI
+    progress bar reflects work actually attempted, not just successes."""
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    photo_dir = _make_photo_dir(tmp_path, 2)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    import thumbnails as thumbnails_mod
+    monkeypatch.setattr(
+        thumbnails_mod, "generate_thumbnail",
+        lambda photo_id, photo_path, cache_dir, size=300: None,
+    )
+
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    job = _make_job()
+    runner = FakeRunner()
+
+    with contextlib.suppress(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # stages dict's own counter (shown on the dashboard) must include failed.
+    # Apr 5 bug: scan reported "1472 photos" but stages['thumbnails']['count']
+    # sat at 0 (generated + skipped = 0 + 0) despite all 1472 files processed.
+    thumb_progress_events = [
+        data for (_, evt, data) in runner.events
+        if evt == "progress" and data.get("stage_id") == "thumbnails"
+    ]
+    assert thumb_progress_events, "No thumbnails progress events emitted"
+    last = thumb_progress_events[-1]
+    thumb_stage_count = last["stages"]["thumbnails"].get("count", 0)
+    assert thumb_stage_count > 0, (
+        f"stages['thumbnails']['count'] must include failed items (was {thumb_stage_count}). "
+        f"Last event stages: {last['stages']}"
     )


### PR DESCRIPTION
## Summary

- **Pipeline-level `error_count` now reflects per-file failures.** Previously, a pipeline run where all 1472 thumbnails failed to generate (Apr 5: LibRaw too old for Nikon Z 8 HE\* NEFs) recorded `status: completed` with `error_count: 0`, because per-file image-loader failures were logged as warnings but never rolled up. This PR surfaces them.
- **Mixed success+failure in a stage → `status: failed`.** Per-stage rollup applied to `thumbnails`, `previews`, `classify`, `extract_masks`: any failed items flip the stage status to `failed` while the summary still shows both counts (e.g. `"1470 new, 2 failed"`).
- **Stage progress counters include failed items** so the UI progress bar reflects all attempted work, not just successes (Apr 5 bug: scan said "1472 photos" but thumbnails counter sat at 0/1472).
- **One rollup entry per stage, not one per file.** Each stage with `failed > 0` appends a single readable message like `"[thumbnails] 1472 of 1472 thumbnails failed to generate"` rather than flooding `errors[]` with 1472 per-file entries. Removed the existing per-photo `errors.append` in `extract_masks` for the same reason.
- **`previews` stage now tracks a `failed` counter** (previously `load_image` returning None was silently dropped).

No `rawpy` pin change — the current `rawpy>=0.26.1` already bundles LibRaw 0.22.0, which decodes Nikon Z 8 HE\* NEFs correctly (verified against the original Apr 5 failing files).

## Test plan

- [x] New tests in `vireo/tests/test_pipeline_job.py`:
  - `test_thumbnail_failures_flip_stage_status_to_failed` — mixed outcome → stage status `failed`
  - `test_thumbnail_failures_append_rollup_error` — exactly one rollup entry, not per-file
  - `test_thumbnail_progress_counter_includes_failed` — `stages['thumbnails']['count']` includes failed
- [x] 8 existing tests that registered `db.add_photo` without real files on disk now drop a tiny JPEG alongside — they were previously relying on silent per-file failure, which is exactly the bug this PR fixes.
- [x] Full test battery from `CLAUDE.md` passes: **439 passed in 12m** (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py`).
- [x] `vireo/tests/test_pipeline_job.py` — 58 passed.
- [x] Ruff clean (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)