### PR TITLE
feat: show job progress on dock/taskbar icon

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,10 +4,35 @@ mod tray;
 mod updater;
 use sidecar::SidecarState;
 use tauri::{Manager, RunEvent};
+use tauri::window::{ProgressBarState, ProgressBarStatus};
 
 #[tauri::command]
 fn get_server_port(state: tauri::State<'_, SidecarState>) -> u16 {
     state.port
+}
+
+// Update the OS-level progress indicator on the dock/taskbar icon.
+// `progress` is 0-100 (None = clear). When `indeterminate` is true the bar
+// pulses instead of filling — used for phases without a known total.
+#[tauri::command]
+fn set_job_progress(
+    window: tauri::WebviewWindow,
+    progress: Option<u64>,
+    indeterminate: bool,
+) -> Result<(), String> {
+    let (status, progress) = if indeterminate {
+        (ProgressBarStatus::Indeterminate, Some(0))
+    } else if let Some(p) = progress {
+        (ProgressBarStatus::Normal, Some(p.min(100)))
+    } else {
+        (ProgressBarStatus::None, None)
+    };
+    window
+        .set_progress_bar(ProgressBarState {
+            status: Some(status),
+            progress,
+        })
+        .map_err(|e| e.to_string())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -114,11 +139,18 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             get_server_port,
+            set_job_progress,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app_handle, event| {
             if let RunEvent::Exit = event {
+                if let Some(window) = app_handle.get_webview_window("main") {
+                    let _ = window.set_progress_bar(ProgressBarState {
+                        status: Some(ProgressBarStatus::None),
+                        progress: None,
+                    });
+                }
                 if let Some(state) = app_handle.try_state::<SidecarState>() {
                     sidecar::stop_sidecar(&state);
                 }

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2992,6 +2992,7 @@ function formatDuration(seconds) {
       renderJobs();
       updateSummary();
       updateActivityDot();
+      updateDockProgress();
     }
   });
 
@@ -3004,8 +3005,46 @@ function formatDuration(seconds) {
         renderJobs();
         updateSummary();
         updateActivityDot();
+        updateDockProgress();
       })
       .catch(function() {});
+  }
+
+  // Show OS-level progress on the dock/taskbar icon for the longest-running
+  // job so users can see progress when the window is minimized. No-op outside
+  // Tauri. With multiple concurrent jobs we pick the one that started first
+  // (earliest started_at); phases without a known total pulse instead.
+  var _lastDockProgress = { state: null, value: -1 };
+  function updateDockProgress() {
+    if (!window.__TAURI_INTERNALS__) return;
+    var running = activeJobs.filter(function(j) { return j.status === 'running'; });
+    var state, value;
+    if (running.length === 0) {
+      state = 'none'; value = null;
+    } else {
+      var longest = running[0];
+      for (var i = 1; i < running.length; i++) {
+        var a = running[i].started_at || '';
+        var b = longest.started_at || '';
+        if (a && (!b || a < b)) longest = running[i];
+      }
+      var total = longest.progress && longest.progress.total;
+      var current = longest.progress && longest.progress.current;
+      if (total && total > 0) {
+        var pct = Math.max(0, Math.min(100, Math.round((current / total) * 100)));
+        state = 'normal'; value = pct;
+      } else {
+        state = 'indeterminate'; value = null;
+      }
+    }
+    if (_lastDockProgress.state === state && _lastDockProgress.value === value) return;
+    _lastDockProgress = { state: state, value: value };
+    try {
+      window.__TAURI_INTERNALS__.invoke('set_job_progress', {
+        progress: value,
+        indeterminate: state === 'indeterminate',
+      }).catch(function() {});
+    } catch (e) { /* ignore */ }
   }
 
   function renderJobs() {


### PR DESCRIPTION
## Summary
- New Tauri command `set_job_progress` calls `WebviewWindow::set_progress_bar`, rendering a native progress indicator on the macOS dock, Windows taskbar, or Linux Unity launcher.
- `_navbar.html`'s existing `pollJobs` now also picks the longest-running job (earliest `started_at`) and pushes its progress to the OS icon. Phases without a known total show an indeterminate pulse; with zero running jobs the bar is cleared.
- Runs on every poll but skips redundant invokes so the icon isn't churned.
- No-op outside Tauri (browser, dev server without the shell) because it gates on `window.__TAURI_INTERNALS__`.

## Notes
- Poll cadence is inherited from the existing jobs poller: 2s while the bottom panel is open, 15s while closed. Good enough for "is it still crunching" without adding a new timer.
- Progress bar is also explicitly cleared on `RunEvent::Exit`.

## Test plan
- [x] `cargo check` on `src-tauri/` (passes; required a placeholder sidecar binary to satisfy `tauri-build` in the worktree — not needed in normal dev/CI builds)
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` → 439 passed
- [ ] Manual: kick off a long job (scan/classify), minimize the window, confirm dock icon shows a filling progress bar; confirm it clears when the job finishes
- [ ] Manual: start a phase with unknown total (e.g. early scan) and confirm the bar pulses (indeterminate) instead of sitting at 0%