### PR TITLE
fix: stop pipeline crashing when DB has mixed DINOv2 variants

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5703,6 +5703,7 @@ def create_app(db_path, thumb_cache_dir=None):
                         photo_id,
                         dino_subject_embedding=subj_emb_blob,
                         dino_global_embedding=global_emb_blob,
+                        variant=dinov2_variant,
                     )
                     masked += 1
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -357,6 +357,15 @@ class Database:
             self.conn.execute("SELECT noise_estimate FROM photos LIMIT 0")
         except sqlite3.OperationalError:
             self.conn.execute("ALTER TABLE photos ADD COLUMN noise_estimate REAL")
+        # DINOv2 variant that produced the embeddings. NULL for legacy rows
+        # written before this column existed; pipeline treats those as "unknown"
+        # and drops them when the dim doesn't match the configured variant.
+        try:
+            self.conn.execute("SELECT dino_embedding_variant FROM photos LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute(
+                "ALTER TABLE photos ADD COLUMN dino_embedding_variant TEXT"
+            )
         # Enhanced EXIF metadata columns
         try:
             self.conn.execute("SELECT focal_length FROM photos LIMIT 0")
@@ -2640,7 +2649,8 @@ class Database:
         return result
 
     def update_photo_embeddings(
-        self, photo_id, dino_subject_embedding=None, dino_global_embedding=None
+        self, photo_id, dino_subject_embedding=None, dino_global_embedding=None,
+        variant=None,
     ):
         """Store DINOv2 embedding BLOBs for a photo.
 
@@ -2648,10 +2658,15 @@ class Database:
             photo_id: photo ID
             dino_subject_embedding: bytes (float32 numpy array .tobytes())
             dino_global_embedding: bytes (float32 numpy array .tobytes())
+            variant: DINOv2 variant name that produced the embeddings
+                (e.g. "vit-b14"). Stored so the pipeline can detect stale
+                embeddings after a variant switch and drop them instead of
+                feeding mismatched-dim vectors to cosine similarity.
         """
         self.conn.execute(
-            "UPDATE photos SET dino_subject_embedding=?, dino_global_embedding=? WHERE id=?",
-            (dino_subject_embedding, dino_global_embedding, photo_id),
+            "UPDATE photos SET dino_subject_embedding=?, dino_global_embedding=?, "
+            "dino_embedding_variant=? WHERE id=?",
+            (dino_subject_embedding, dino_global_embedding, variant, photo_id),
         )
         self.conn.commit()
 

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -28,9 +28,34 @@ _PIPELINE_PHOTO_COLS = """
     p.subject_clip_high, p.subject_clip_low, p.subject_y_median,
     p.phash_crop,
     p.dino_subject_embedding, p.dino_global_embedding,
+    p.dino_embedding_variant,
     p.focal_length, p.burst_id, p.noise_estimate,
     p.flag, p.rating
 """
+
+
+def _embedding_usable(stored_variant, expected_variant, emb_bytes):
+    """Decide whether a stored embedding blob can be used under expected_variant.
+
+    - No configured variant → accept whatever is stored (back-compat for tests).
+    - stored_variant matches expected → accept.
+    - stored_variant is NULL (pre-migration) → accept only when the blob's
+      byte-length matches the expected variant's dim × 4 (float32).
+    - Otherwise drop. Feeding mismatched-dim vectors to cosine sim raises
+      "shapes not aligned" in encounters.sim_embedding.
+    """
+    if expected_variant is None:
+        return True
+    if stored_variant == expected_variant:
+        return True
+    if stored_variant is None:
+        try:
+            from dino_embed import get_embedding_dim
+            expected_dim = get_embedding_dim(expected_variant)
+        except Exception:
+            return False
+        return emb_bytes is not None and (len(emb_bytes) // 4) == expected_dim
+    return False
 
 
 def _resolve_collection_photo_ids(db, collection_id):
@@ -154,18 +179,30 @@ def load_photo_features(db, collection_id=None, config=None):
     for row in species_kw_rows:
         confirmed_by_photo.setdefault(row["photo_id"], row["name"])
 
+    # Only accept embeddings written with the currently configured DINOv2
+    # variant. Without this check, switching variants leaves stale embeddings
+    # of the old dim in place and the regroup stage crashes with
+    # "shapes (1024,) and (768,) not aligned" in encounters.sim_embedding.
+    expected_variant = (config or {}).get("pipeline", {}).get("dinov2_variant")
+    variant_mismatches = 0
+
     photos = []
     for row in rows:
         pid = row["id"]
 
-        # Decode embeddings from BLOBs
-        subj_emb = None
-        if row["dino_subject_embedding"]:
-            subj_emb = np.frombuffer(row["dino_subject_embedding"], dtype=np.float32)
+        stored_variant = row["dino_embedding_variant"]
 
+        subj_bytes = row["dino_subject_embedding"]
+        subj_emb = None
+        if subj_bytes and _embedding_usable(stored_variant, expected_variant, subj_bytes):
+            subj_emb = np.frombuffer(subj_bytes, dtype=np.float32)
+        elif subj_bytes:
+            variant_mismatches += 1
+
+        glob_bytes = row["dino_global_embedding"]
         global_emb = None
-        if row["dino_global_embedding"]:
-            global_emb = np.frombuffer(row["dino_global_embedding"], dtype=np.float32)
+        if glob_bytes and _embedding_usable(stored_variant, expected_variant, glob_bytes):
+            global_emb = np.frombuffer(glob_bytes, dtype=np.float32)
 
         det = primary_det_by_photo.get(pid)
         det_box = None
@@ -208,6 +245,14 @@ def load_photo_features(db, collection_id=None, config=None):
         })
 
     log.info("Loaded %d photos with pipeline features", len(photos))
+    if variant_mismatches:
+        log.warning(
+            "Dropped %d stale subject embeddings that don't match configured "
+            "DINOv2 variant %s; those photos will need re-embedding for "
+            "grouping to use their embeddings",
+            variant_mismatches,
+            expected_variant,
+        )
     return photos
 
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1541,6 +1541,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         photo_id,
                         dino_subject_embedding=subj_emb_blob,
                         dino_global_embedding=global_emb_blob,
+                        variant=dinov2_variant,
                     )
                     masked += 1
                 except Exception:

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2802,3 +2802,57 @@ def test_redo_color_label(tmp_path):
 
     db.redo_last_undo()
     assert db.get_color_label(pid) == 'red'
+
+
+def test_dino_embedding_variant_column_exists(tmp_path):
+    """The photos table has a dino_embedding_variant column."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.conn.execute("SELECT dino_embedding_variant FROM photos LIMIT 0")
+
+
+def test_update_photo_embeddings_stores_variant(tmp_path):
+    """update_photo_embeddings persists the DINOv2 variant alongside the blobs."""
+    import numpy as np
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+    pid = db.add_photo(fid, "a.jpg", ".jpg", 100, 1.0)
+
+    blob = np.ones(1024, dtype=np.float32).tobytes()
+    db.update_photo_embeddings(
+        pid,
+        dino_subject_embedding=blob,
+        dino_global_embedding=blob,
+        variant="vit-l14",
+    )
+    row = db.conn.execute(
+        "SELECT dino_embedding_variant FROM photos WHERE id = ?", (pid,)
+    ).fetchone()
+    assert row["dino_embedding_variant"] == "vit-l14"
+
+
+def test_update_photo_embeddings_rewrite_updates_variant(tmp_path):
+    """Re-embedding a photo with a new variant overwrites the stored variant."""
+    import numpy as np
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+    pid = db.add_photo(fid, "a.jpg", ".jpg", 100, 1.0)
+
+    db.update_photo_embeddings(
+        pid,
+        dino_subject_embedding=np.ones(768, dtype=np.float32).tobytes(),
+        dino_global_embedding=np.ones(768, dtype=np.float32).tobytes(),
+        variant="vit-b14",
+    )
+    db.update_photo_embeddings(
+        pid,
+        dino_subject_embedding=np.ones(1024, dtype=np.float32).tobytes(),
+        dino_global_embedding=np.ones(1024, dtype=np.float32).tobytes(),
+        variant="vit-l14",
+    )
+    row = db.conn.execute(
+        "SELECT dino_embedding_variant FROM photos WHERE id = ?", (pid,)
+    ).fetchone()
+    assert row["dino_embedding_variant"] == "vit-l14"

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -463,3 +463,90 @@ def test_serialize_results_has_burst_species_predictions(tmp_path):
             assert "photo_ids" in burst
             assert "species_predictions" in burst
             assert "species_override" in burst
+
+
+# -- DINOv2 variant filtering --
+
+
+def _add_photo_with_embedding(db, fid, filename, emb, variant=None, ts=None):
+    """Helper: insert a photo and attach a subject+global embedding."""
+    from dino_embed import embedding_to_blob
+    pid = db.add_photo(
+        fid, filename, ".jpg", 1000, 1.0,
+        timestamp=(ts or datetime(2026, 3, 20, 10, 0, 0)).isoformat(),
+        width=4000, height=3000,
+    )
+    db.update_photo_embeddings(
+        pid,
+        dino_subject_embedding=embedding_to_blob(emb),
+        dino_global_embedding=embedding_to_blob(emb),
+        variant=variant,
+    )
+    return pid
+
+
+def test_load_photo_features_filters_variant_mismatch(tmp_path):
+    """load_photo_features drops embeddings whose stored variant differs from configured variant."""
+    from db import Database
+    from pipeline import load_photo_features
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+
+    # Photo A: stored as vit-b14 (768-dim)
+    emb_b = np.ones(768, dtype=np.float32) / np.sqrt(768)
+    pid_b = _add_photo_with_embedding(db, fid, "b.jpg", emb_b, variant="vit-b14")
+
+    # Photo L: stored as vit-l14 (1024-dim)
+    emb_l = np.ones(1024, dtype=np.float32) / np.sqrt(1024)
+    pid_l = _add_photo_with_embedding(db, fid, "l.jpg", emb_l, variant="vit-l14")
+
+    # Configure pipeline to use vit-b14
+    cfg = {"pipeline": {"dinov2_variant": "vit-b14"}}
+    photos = load_photo_features(db, config=cfg)
+    by_id = {p["id"]: p for p in photos}
+
+    assert by_id[pid_b]["dino_subject_embedding"] is not None
+    assert len(by_id[pid_b]["dino_subject_embedding"]) == 768
+    # Mismatched variant must be dropped so it can't feed a dot product of wrong dim
+    assert by_id[pid_l]["dino_subject_embedding"] is None
+    assert by_id[pid_l]["dino_global_embedding"] is None
+
+
+def test_load_photo_features_legacy_null_variant_dim_fallback(tmp_path):
+    """Photos with NULL variant (pre-migration) are kept only if embedding dim matches."""
+    from db import Database
+    from pipeline import load_photo_features
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+
+    # Legacy 768-dim embedding, NULL variant
+    emb_768 = np.ones(768, dtype=np.float32) / np.sqrt(768)
+    pid_match = _add_photo_with_embedding(db, fid, "m.jpg", emb_768, variant=None)
+    # Legacy 1024-dim embedding, NULL variant
+    emb_1024 = np.ones(1024, dtype=np.float32) / np.sqrt(1024)
+    pid_mismatch = _add_photo_with_embedding(db, fid, "x.jpg", emb_1024, variant=None)
+
+    cfg = {"pipeline": {"dinov2_variant": "vit-b14"}}
+    photos = load_photo_features(db, config=cfg)
+    by_id = {p["id"]: p for p in photos}
+
+    assert by_id[pid_match]["dino_subject_embedding"] is not None
+    assert by_id[pid_mismatch]["dino_subject_embedding"] is None
+
+
+def test_load_photo_features_no_variant_configured_keeps_embeddings(tmp_path):
+    """If config doesn't specify a variant, behavior is unchanged (backward compat for tests)."""
+    from db import Database
+    from pipeline import load_photo_features
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+
+    emb = np.ones(768, dtype=np.float32) / np.sqrt(768)
+    pid = _add_photo_with_embedding(db, fid, "a.jpg", emb, variant=None)
+
+    photos = load_photo_features(db)  # no config
+    assert len(photos) == 1
+    assert photos[0]["dino_subject_embedding"] is not None


### PR DESCRIPTION
## Summary

Fix `shapes (1024,) and (768,) not aligned` crash in the regroup stage when the database contains embeddings produced by different DINOv2 variants. Previously, switching `pipeline.dinov2_variant` left the old-dim embeddings in place and `encounters.sim_embedding` fed mismatched vectors into `np.dot`.

- Add `dino_embedding_variant` TEXT column to `photos` (migration in `Database.__init__`).
- `update_photo_embeddings(..., variant=...)` writes the variant atomically with the blobs; callers in `pipeline_job.py` and `app.py` now pass `variant=dinov2_variant`.
- `load_photo_features` reads the expected variant from `config["pipeline"]["dinov2_variant"]` and drops any embedding whose stored variant doesn't match. Legacy NULL-variant rows (pre-migration) fall back to a byte-length dim check so they aren't dropped when they actually match.
- `_cosine_sim` already returns 0.0 for `None`, so dropped embeddings degrade grouping gracefully.

## Test plan

- [x] New RED→GREEN tests:
  - `test_dino_embedding_variant_column_exists` / `test_update_photo_embeddings_stores_variant` / `test_update_photo_embeddings_rewrite_updates_variant`
  - `test_load_photo_features_filters_variant_mismatch`
  - `test_load_photo_features_legacy_null_variant_dim_fallback`
  - `test_load_photo_features_no_variant_configured_keeps_embeddings` (back-compat for tests that don't pass a variant)
- [x] Project test suite per CLAUDE.md: **500 passed**
  ```
  python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py \
    vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py \
    vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_pipeline.py \
    vireo/tests/test_reflow.py vireo/tests/test_dinov2.py
  ```

## Follow-ups (not in this PR)

- A self-healing path that re-embeds stale photos in the background after a variant switch, instead of leaving grouping permanently degraded. Fits the "app self-heals broken state" pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)