### PR TITLE
feat: add resolution slider to Review Burst Group

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6800,6 +6800,65 @@ def create_app(db_path, thumb_cache_dir=None):
         img.save(cache_path, format="JPEG", quality=preview_quality)
         return send_file(cache_path, mimetype="image/jpeg")
 
+    PREVIEW_SIZE_ALLOWLIST = (1920, 2560, 3840)
+
+    @app.route("/photos/<int:photo_id>/preview")
+    def serve_photo_preview(photo_id):
+        """Serve a JPEG preview at a chosen max-size, cached per size.
+
+        Query params:
+          size: int — max dimension (longest side). Must be in PREVIEW_SIZE_ALLOWLIST
+                to avoid unbounded cache growth.
+        """
+        import config as cfg
+        from flask import request, send_file
+
+        try:
+            size = int(request.args.get("size", "1920"))
+        except ValueError:
+            return "Invalid size", 400
+        if size not in PREVIEW_SIZE_ALLOWLIST:
+            return "Unsupported size", 400
+
+        preview_dir = os.path.join(
+            os.path.dirname(app.config["THUMB_CACHE_DIR"]), "previews"
+        )
+        cache_path = os.path.join(preview_dir, f"{photo_id}_{size}.jpg")
+
+        if os.path.exists(cache_path):
+            return send_file(cache_path, mimetype="image/jpeg")
+
+        from image_loader import load_image
+
+        db = _get_db()
+        photo = db.get_photo(photo_id)
+        if not photo:
+            return "Not found", 404
+
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        image_path = None
+        if photo["working_copy_path"]:
+            wc = os.path.join(vireo_dir, photo["working_copy_path"])
+            if os.path.exists(wc):
+                image_path = wc
+
+        if image_path is None:
+            folder = db.conn.execute(
+                "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
+            ).fetchone()
+            if not folder:
+                return "Not found", 404
+            image_path = os.path.join(folder["path"], photo["filename"])
+
+        img = load_image(image_path, max_size=size)
+        if img is None:
+            return "Could not load image", 500
+
+        os.makedirs(preview_dir, exist_ok=True)
+        preview_quality = cfg.load().get("preview_quality", 90)
+        img.save(cache_path, format="JPEG", quality=preview_quality)
+        return send_file(cache_path, mimetype="image/jpeg")
+
     @app.route("/photos/<int:photo_id>/original")
     def serve_original_photo(photo_id):
         """Serve full-resolution image for 1:1 zoom."""

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1067,7 +1067,10 @@ def create_app(db_path, thumb_cache_dir=None):
 
         result = db.delete_photos(photo_ids, include_companions=include_companions)
 
-        # Clean up cached files (thumbnails, previews, working copies)
+        # Clean up cached files (thumbnails, previews, working copies).
+        # The preview dir also holds per-size variants named <id>_<size>.jpg,
+        # which must be removed so SQLite id reuse can't surface stale images.
+        import glob as _glob
         thumb_dir = app.config["THUMB_CACHE_DIR"]
         vireo_dir = os.path.dirname(thumb_dir)
         preview_dir = os.path.join(vireo_dir, "previews")
@@ -1078,6 +1081,11 @@ def create_app(db_path, thumb_cache_dir=None):
                 cached = os.path.join(d, f"{pid}.jpg")
                 if os.path.isfile(cached):
                     os.remove(cached)
+            for variant in _glob.glob(os.path.join(preview_dir, f"{pid}_*.jpg")):
+                try:
+                    os.remove(variant)
+                except OSError:
+                    pass
 
         trashed = 0
         trash_failed = []
@@ -6820,6 +6828,14 @@ def create_app(db_path, thumb_cache_dir=None):
         if size not in PREVIEW_SIZE_ALLOWLIST:
             return "Unsupported size", 400
 
+        # Confirm the photo still exists before any cache return so that a
+        # deleted photo can't be served from a stale per-size cache (and so
+        # SQLite id reuse can't surface the wrong image).
+        db = _get_db()
+        photo = db.get_photo(photo_id)
+        if not photo:
+            return "Not found", 404
+
         preview_dir = os.path.join(
             os.path.dirname(app.config["THUMB_CACHE_DIR"]), "previews"
         )
@@ -6829,11 +6845,6 @@ def create_app(db_path, thumb_cache_dir=None):
             return send_file(cache_path, mimetype="image/jpeg")
 
         from image_loader import load_image
-
-        db = _get_db()
-        photo = db.get_photo(photo_id)
-        if not photo:
-            return "Not found", 404
 
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
         image_path = None

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -759,6 +759,8 @@ input[type="range"]::-moz-range-thumb {
   flex-shrink: 0;
 }
 .grm-footer .grm-hint { font-size: 11px; color: var(--text-ghost); flex: 1; }
+.grm-res-control { display: flex; align-items: center; gap: 8px; }
+.grm-res-control input[type="range"] { width: 100px; }
 
 /* Loupe mode — split layout with preview on right */
 .grm-body {
@@ -1057,6 +1059,11 @@ input[type="range"]::-moz-range-thumb {
     <label style="font-size:12px;color:var(--text-muted);">Species:</label>
     <input type="text" id="grmSpecies" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:13px;width:200px;">
     <button onclick="grmRemoveFromGroup()" style="background:var(--bg-tertiary);color:var(--text-muted);border:none;border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;">Remove from group</button>
+    <div class="grm-res-control" title="Image resolution — higher = slower but better for pixel-peeping">
+      <label style="font-size:12px;color:var(--text-muted);">Res:</label>
+      <input type="range" id="grmResSlider" min="0" max="3" step="1" value="0" oninput="grmSetResolution(this.value)">
+      <span id="grmResLabel" style="font-size:11px;color:var(--text-dim);min-width:140px;">1920 · preview</span>
+    </div>
     <span class="grm-hint">↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom</span>
     <button onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);">Apply & Close</button>
   </div>
@@ -1067,6 +1074,54 @@ var pipelineResults = null;
 var activeFilter = 'all';
 var minConfidence = 40;
 var speciesFilter = '';
+
+// GRM resolution slider — index into GRM_RES_STOPS. Persists across photos within a session.
+var GRM_RES_STOPS = [
+  {size: 1920, label: '1920', kind: 'preview'},
+  {size: 2560, label: '2560', kind: 'preview'},
+  {size: 3840, label: '4K',   kind: 'preview'},
+  {size: 0,    label: 'Original', kind: 'original'}
+];
+var grmResolutionIdx = 0;
+
+function grmPhotoUrl(photoId) {
+  var stop = GRM_RES_STOPS[grmResolutionIdx];
+  if (stop.kind === 'original') return '/photos/' + photoId + '/original';
+  return '/photos/' + photoId + '/preview?size=' + stop.size;
+}
+
+function grmUpdateResLabel() {
+  var el = document.getElementById('grmResLabel');
+  if (!el) return;
+  var stop = GRM_RES_STOPS[grmResolutionIdx];
+  var dims = '';
+  var photo = grmState && grmState.selected
+    ? grmState.items.find(function(p) { return p.id === grmState.selected; })
+    : (grmState && grmState.items[0]);
+  if (photo && photo.width && photo.height) {
+    if (stop.kind === 'original') {
+      dims = photo.width + '×' + photo.height;
+    } else {
+      var longest = Math.max(photo.width, photo.height);
+      var scale = longest > stop.size ? stop.size / longest : 1;
+      var w = Math.round(photo.width * scale);
+      var h = Math.round(photo.height * scale);
+      dims = w + '×' + h;
+    }
+  }
+  el.textContent = (dims ? dims + ' · ' : stop.label + ' · ') + stop.kind;
+}
+
+function grmSetResolution(idx) {
+  grmResolutionIdx = parseInt(idx, 10) || 0;
+  renderGroupModal();
+  // If a photo is selected, reload the loupe at the new resolution
+  if (grmState && grmState.selected) {
+    var img = document.getElementById('grmLoupePhoto');
+    if (img) img.src = grmPhotoUrl(grmState.selected);
+  }
+  grmUpdateResLabel();
+}
 
 function setSpeciesFilter(val) {
   speciesFilter = val.toLowerCase();
@@ -1991,6 +2046,11 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
 
   document.getElementById('grmOverlay').classList.add('open');
 
+  // Sync slider DOM with persisted resolution choice
+  var slider = document.getElementById('grmResSlider');
+  if (slider) slider.value = grmResolutionIdx;
+  grmUpdateResLabel();
+
   // Auto-select the requested photo (or the best)
   var initSelect = selectPhotoId || (best ? best.id : null);
   if (initSelect) {
@@ -2027,7 +2087,7 @@ function renderGroupModal() {
 
     return '<div class="' + cls + '" data-photo-id="' + p.id + '" onclick="grmSelect(' + p.id + ')">' +
       '<div style="position:relative;">' +
-        '<img src="/thumbnails/' + p.id + '.jpg" loading="lazy">' +
+        '<img src="' + grmPhotoUrl(p.id) + '" loading="lazy">' +
         flagHtml +
       '</div>' +
       '<div class="grm-card-info">' +
@@ -2065,7 +2125,7 @@ function grmSelect(photoId) {
   var detailEl = document.getElementById('grmLoupeDetail');
 
   if (grmState.selected) {
-    loupeImg.src = '/photos/' + grmState.selected + '/full';
+    loupeImg.src = grmPhotoUrl(grmState.selected);
     var photo = grmState.items.find(function(p) { return p.id === grmState.selected; });
     if (photo) {
       var sharp = photo.subject_tenengrad != null ? Math.round(photo.subject_tenengrad) : '?';
@@ -2074,6 +2134,7 @@ function grmSelect(photoId) {
       // Render pipeline metadata in detail panel
       detailEl.innerHTML = buildPipelineMetadataHtml(photo);
     }
+    grmUpdateResLabel();
   } else {
     loupeImg.src = '';
     loupeInfo.textContent = 'Select a photo to preview. Hover to compare sharpness across all frames.';

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -191,6 +191,38 @@ def test_api_batch_delete_vireo_mode(app_and_db):
     assert db.get_photo(pid) is None
 
 
+def test_api_batch_delete_purges_sized_preview_variants(app_and_db):
+    """Delete removes every <id>_<size>.jpg preview variant, not just <id>.jpg.
+
+    Without this, SQLite id reuse could cause a newly inserted photo to be
+    served stale bytes from a previous photo's cached preview.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+    pid = db.get_photos()[0]["id"]
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    preview_dir = os.path.join(vireo_dir, "previews")
+    os.makedirs(preview_dir, exist_ok=True)
+
+    # Seed cache with both legacy <id>.jpg and sized variants
+    legacy = os.path.join(preview_dir, f"{pid}.jpg")
+    v1920 = os.path.join(preview_dir, f"{pid}_1920.jpg")
+    v2560 = os.path.join(preview_dir, f"{pid}_2560.jpg")
+    for p in (legacy, v1920, v2560):
+        Image.new("RGB", (10, 10)).save(p, "JPEG")
+
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": [pid],
+        "mode": "vireo",
+    })
+    assert resp.status_code == 200
+
+    assert not os.path.exists(legacy)
+    assert not os.path.exists(v1920)
+    assert not os.path.exists(v2560)
+
+
 def test_api_batch_delete_disk_mode(app_and_db, tmp_path):
     """API endpoint in disk mode moves files to trash (or deletes them)."""
     app, db = app_and_db

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -393,6 +393,53 @@ def test_preview_falls_back_to_original(app_and_db, tmp_path):
     assert resp.status_code == 200
 
 
+def test_preview_sized_caches_per_size(app_and_db):
+    """Preview endpoint caches each requested size separately."""
+    app, db = app_and_db
+    client = app.test_client()
+
+    photos = db.get_photos()
+    pid = photos[0]["id"]
+
+    from PIL import Image
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_path = os.path.join(working_dir, f"{pid}.jpg")
+    Image.new("RGB", (4096, 2731), color=(0, 255, 0)).save(wc_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (f"working/{pid}.jpg", pid),
+    )
+    db.conn.commit()
+
+    resp = client.get(f"/photos/{pid}/preview?size=1920")
+    assert resp.status_code == 200
+    resp = client.get(f"/photos/{pid}/preview?size=2560")
+    assert resp.status_code == 200
+
+    preview_dir = os.path.join(vireo_dir, "previews")
+    assert os.path.exists(os.path.join(preview_dir, f"{pid}_1920.jpg"))
+    assert os.path.exists(os.path.join(preview_dir, f"{pid}_2560.jpg"))
+
+    # The 2560 variant should actually be larger on disk than the 1920 variant
+    size_1920 = os.path.getsize(os.path.join(preview_dir, f"{pid}_1920.jpg"))
+    size_2560 = os.path.getsize(os.path.join(preview_dir, f"{pid}_2560.jpg"))
+    assert size_2560 > size_1920
+
+
+def test_preview_rejects_unsupported_size(app_and_db):
+    """Preview endpoint rejects sizes outside the allowlist to prevent cache-bombing."""
+    app, db = app_and_db
+    client = app.test_client()
+
+    pid = db.get_photos()[0]["id"]
+    resp = client.get(f"/photos/{pid}/preview?size=9999")
+    assert resp.status_code == 400
+    resp = client.get(f"/photos/{pid}/preview?size=abc")
+    assert resp.status_code == 400
+
+
 def test_original_serves_full_res_working_copy(app_and_db):
     """Original endpoint serves working copy directly when it is full-res."""
     app, db = app_and_db

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -428,6 +428,29 @@ def test_preview_sized_caches_per_size(app_and_db):
     assert size_2560 > size_1920
 
 
+def test_preview_returns_404_for_deleted_photo_even_with_stale_cache(app_and_db):
+    """Defense against SQLite id reuse: don't serve a cached image for a row
+    that no longer exists.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+    pid = db.get_photos()[0]["id"]
+
+    from PIL import Image
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    preview_dir = os.path.join(vireo_dir, "previews")
+    os.makedirs(preview_dir, exist_ok=True)
+
+    # Delete the photo (cascades FK-dependent rows) then simulate a leftover
+    # cache file, e.g. crash-after-commit-before-cleanup.
+    db.delete_photos([pid])
+    stale = os.path.join(preview_dir, f"{pid}_1920.jpg")
+    Image.new("RGB", (10, 10)).save(stale, "JPEG")
+
+    resp = client.get(f"/photos/{pid}/preview?size=1920")
+    assert resp.status_code == 404
+
+
 def test_preview_rejects_unsupported_size(app_and_db):
     """Preview endpoint rejects sizes outside the allowlist to prevent cache-bombing."""
     app, db = app_and_db


### PR DESCRIPTION
## Summary
- Pixel-peeping in the GRM used a 1920px preview with no resolution indicator, and scroll-wheel "zoom" just CSS-scaled that preview rather than loading a higher-res source.
- Adds a 4-stop snapping slider (1920 · 2560 · 4K · Original) in the GRM footer that controls both the loupe and all strip card `<img>` srcs, so CSS scroll-wheel zoom can actually pixel-peep.
- Adds `/photos/<id>/preview?size=N` with per-size caching (`previews/<id>_<size>.jpg`) and a size allowlist (1920/2560/3840) to prevent unbounded cache growth.
- A `W×H · preview|original` label next to the slider tells users exactly what resolution they're looking at; slider choice persists across photos within a GRM session.

## Test plan
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` → 444 passed
- [x] New tests: per-size caching produces distinct `<id>_1920.jpg` / `<id>_2560.jpg` files, and sizes outside the allowlist return 400.
- [ ] Manual browser verification of the slider + loupe reload — not performed in this session; please spot-check in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)