### PR TITLE
fix: cascade encounter species confirmation to burst widgets

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1667,8 +1667,15 @@ function renderSpeciesWidget(enc, encIdx, level, burstIdx) {
   if (level === 'burst') {
     var burst = enc.bursts[burstIdx];
     var ovr = burst.species_override;
-    isConfirmed = ovr && ovr.confirmed;
-    displayName = (ovr && ovr.species) || (enc.species ? enc.species[0] : 'Unknown');
+    if (ovr) {
+      isConfirmed = !!ovr.confirmed;
+      displayName = ovr.species || (enc.species ? enc.species[0] : 'Unknown');
+    } else {
+      // No per-burst override: inherit from the encounter so confirming the
+      // encounter visibly cascades to every burst.
+      isConfirmed = !!enc.species_confirmed;
+      displayName = enc.confirmed_species || (enc.species ? enc.species[0] : 'Unknown');
+    }
     predictions = burst.species_predictions || [];
   } else {
     isConfirmed = enc.species_confirmed;


### PR DESCRIPTION
## Summary
- When a user clicked the ✓ next to an encounter's species on the pipeline review page, the encounter badge flipped to confirmed but each burst's widget (\`B1\`, \`B2\`…) kept showing the \`?\` badge and its own ✓ button — even though \`/api/encounters/species\` had already tagged every photo in the encounter.
- \`renderSpeciesWidget\` decided a burst's confirmed-ness purely from \`burst.species_override\`, and encounter-level \`confirmSpecies\` only mutates \`enc.species_confirmed\` / \`enc.confirmed_species\`. So the visual state never caught up.
- Fix: when a burst has no \`species_override\`, inherit the encounter's confirmation and confirmed species. Bursts with their own override (different species, or independently confirmed) keep their own state — and clearing an override via "Use encounter label" now correctly falls back to the encounter's confirmed species rather than the raw prediction.

## Test plan
- [x] \`python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py\` — 442 passed
- [ ] Manual: on the pipeline review page, click the ✓ next to an encounter with multiple bursts; verify every burst flips to the confirmed style with the encounter's species label.
- [ ] Manual: override one burst to a different species, then confirm the encounter; verify the overridden burst retains its own species/badge while other bursts follow the encounter.
- [ ] Manual: after an encounter is confirmed, open a burst dropdown and pick "Use encounter label" — burst should revert to showing the encounter's confirmed species, still in the confirmed style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)