### PR TITLE
fix: drop old species keyword when encounter species is changed

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6004,27 +6004,46 @@ def create_app(db_path, thumb_cache_dir=None):
                 if not photo_id_set.issubset(enc_ids):
                     continue
                 target_enc = enc
-                if burst_index is not None and "bursts" in enc \
-                        and 0 <= burst_index < len(enc["bursts"]):
-                    ovr = enc["bursts"][burst_index].get("species_override")
-                    if ovr and ovr.get("species"):
-                        previous_species = ovr["species"]
-                    else:
-                        # No burst override yet — inherit the encounter's
-                        # confirmed species, which is what those photos were
-                        # actually tagged with.
-                        previous_species = enc.get("confirmed_species")
-                else:
-                    previous_species = enc.get("confirmed_species")
                 break
+
+        # If this is a burst-scoped request, the burst must actually exist in
+        # the cached encounter. A stale client (e.g. submitting after a burst
+        # regrouping) could otherwise fall through to an encounter-level cache
+        # update even though only the submitted photo_ids were retagged.
+        if burst_index is not None:
+            bursts = target_enc.get("bursts") if target_enc else None
+            if not bursts or not (0 <= burst_index < len(bursts)):
+                return json_error(
+                    f"Unknown burst_index {burst_index} for submitted photos",
+                )
+
+        if target_enc is not None:
+            if burst_index is not None:
+                ovr = target_enc["bursts"][burst_index].get("species_override")
+                if ovr and ovr.get("species"):
+                    previous_species = ovr["species"]
+                else:
+                    # No burst override yet — inherit the encounter's confirmed
+                    # species, which is what those photos were actually tagged
+                    # with.
+                    previous_species = target_enc.get("confirmed_species")
+            else:
+                previous_species = target_enc.get("confirmed_species")
 
         ws_id = db._ws_id()
 
         # If the species is changing, untag the old keyword from these photos
         # and cancel/queue a sidecar remove so the XMP stays in sync.
         if previous_species and previous_species.strip().lower() != species.lower():
+            # Match add_keyword's write path: species keywords live as root
+            # keywords (parent_id IS NULL) with is_species=1. Looking up by
+            # name alone could collide with a non-species homonym nested under
+            # another keyword (schema allows UNIQUE(name, parent_id)).
             old_kid_row = db.conn.execute(
-                "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE",
+                """SELECT id FROM keywords
+                   WHERE name = ? COLLATE NOCASE
+                     AND parent_id IS NULL
+                     AND is_species = 1""",
                 (previous_species,),
             ).fetchone()
             if old_kid_row:
@@ -6063,10 +6082,11 @@ def create_app(db_path, thumb_cache_dir=None):
             is_batch=len(photo_ids) > 1,
         )
 
-        # Update pipeline cache
+        # Update pipeline cache. burst_index was validated above, so the
+        # branch here is unambiguous: burst-scoped requests only touch the
+        # burst override, encounter-scoped requests only touch the encounter.
         if cached and target_enc is not None:
-            if burst_index is not None and "bursts" in target_enc \
-                    and 0 <= burst_index < len(target_enc["bursts"]):
+            if burst_index is not None:
                 target_enc["bursts"][burst_index]["species_override"] = {
                     "species": species,
                     "confirmed": True,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6034,7 +6034,12 @@ def create_app(db_path, thumb_cache_dir=None):
 
         # If the species is changing, untag the old keyword from these photos
         # and cancel/queue a sidecar remove so the XMP stays in sync.
-        if previous_species and previous_species.strip().lower() != species.lower():
+        old_kid = None
+        is_replacement = (
+            previous_species is not None
+            and previous_species.strip().lower() != species.lower()
+        )
+        if is_replacement:
             # Match add_keyword's write path: species keywords live as root
             # keywords (parent_id IS NULL) with is_species=1. Looking up by
             # name alone could collide with a non-species homonym nested under
@@ -6051,17 +6056,6 @@ def create_app(db_path, thumb_cache_dir=None):
                 for pid in photo_ids:
                     db.untag_photo(pid, old_kid)
                     _queue_keyword_remove(pid, previous_species, workspace_id=ws_id)
-                old_items = [
-                    {"photo_id": pid, "old_value": str(old_kid), "new_value": ""}
-                    for pid in photo_ids
-                ]
-                db.record_edit(
-                    "keyword_remove",
-                    f'Replaced species "{previous_species}" with "{species}" on {len(photo_ids)} photos',
-                    str(old_kid),
-                    old_items,
-                    is_batch=len(photo_ids) > 1,
-                )
 
         # Create or find the new species keyword (commits on its own)
         kid = db.add_keyword(species, is_species=True)
@@ -6070,17 +6064,33 @@ def create_app(db_path, thumb_cache_dir=None):
             db.tag_photo(pid, kid)
             _queue_keyword_add(pid, species, workspace_id=ws_id)
 
-        items = [
-            {"photo_id": pid, "old_value": "", "new_value": str(kid)}
-            for pid in photo_ids
-        ]
-        db.record_edit(
-            "keyword_add",
-            f'Confirmed species "{species}" on {len(photo_ids)} photos',
-            str(kid),
-            items,
-            is_batch=len(photo_ids) > 1,
-        )
+        # Record the full action as a single undoable edit so one undo
+        # restores the previous confirmed species rather than leaving the
+        # photos with neither keyword.
+        if is_replacement and old_kid is not None:
+            items = [
+                {"photo_id": pid, "old_value": str(old_kid), "new_value": str(kid)}
+                for pid in photo_ids
+            ]
+            db.record_edit(
+                "species_replace",
+                f'Replaced species "{previous_species}" with "{species}" on {len(photo_ids)} photos',
+                str(kid),
+                items,
+                is_batch=len(photo_ids) > 1,
+            )
+        else:
+            items = [
+                {"photo_id": pid, "old_value": "", "new_value": str(kid)}
+                for pid in photo_ids
+            ]
+            db.record_edit(
+                "keyword_add",
+                f'Confirmed species "{species}" on {len(photo_ids)} photos',
+                str(kid),
+                items,
+                is_batch=len(photo_ids) > 1,
+            )
 
         # Update pipeline cache. burst_index was validated above, so the
         # branch here is unambiguous: burst-scoped requests only touch the

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -902,19 +902,31 @@ def create_app(db_path, thumb_cache_dir=None):
         log.info("Keyword cleanup: merged %d duplicates", merged)
         return jsonify({"ok": True, "merged": merged})
 
-    def _queue_keyword_add(photo_id, keyword_name, workspace_id=None):
+    def _queue_keyword_add(photo_id, keyword_name, workspace_id=None, _commit=True):
         """Queue a keyword add unless it cancels a pending removal."""
         db = _get_db()
-        removed = db.remove_pending_changes(photo_id, "keyword_remove", keyword_name, workspace_id=workspace_id)
+        removed = db.remove_pending_changes(
+            photo_id, "keyword_remove", keyword_name,
+            workspace_id=workspace_id, _commit=_commit,
+        )
         if removed == 0:
-            db.queue_change(photo_id, "keyword_add", keyword_name, workspace_id=workspace_id)
+            db.queue_change(
+                photo_id, "keyword_add", keyword_name,
+                workspace_id=workspace_id, _commit=_commit,
+            )
 
-    def _queue_keyword_remove(photo_id, keyword_name, workspace_id=None):
+    def _queue_keyword_remove(photo_id, keyword_name, workspace_id=None, _commit=True):
         """Queue a keyword removal unless it cancels a pending add."""
         db = _get_db()
-        removed = db.remove_pending_changes(photo_id, "keyword_add", keyword_name, workspace_id=workspace_id)
+        removed = db.remove_pending_changes(
+            photo_id, "keyword_add", keyword_name,
+            workspace_id=workspace_id, _commit=_commit,
+        )
         if removed == 0:
-            db.queue_change(photo_id, "keyword_remove", keyword_name, workspace_id=workspace_id)
+            db.queue_change(
+                photo_id, "keyword_remove", keyword_name,
+                workspace_id=workspace_id, _commit=_commit,
+            )
 
     # -- Edit API routes --
 
@@ -6143,14 +6155,21 @@ def create_app(db_path, thumb_cache_dir=None):
                 break
 
         # If this is a burst-scoped request, the burst must actually exist in
-        # the cached encounter. A stale client (e.g. submitting after a burst
-        # regrouping) could otherwise fall through to an encounter-level cache
-        # update even though only the submitted photo_ids were retagged.
+        # the cached encounter AND the submitted photo_ids must be a subset of
+        # that burst's photos. Otherwise a stale client (e.g. one that still
+        # holds a burst index from before a regrouping) could retag photos
+        # that don't belong to this burst while the cache update below touches
+        # the wrong override.
         if burst_index is not None:
             bursts = target_enc.get("bursts") if target_enc else None
             if not bursts or not (0 <= burst_index < len(bursts)):
                 return json_error(
                     f"Unknown burst_index {burst_index} for submitted photos",
+                )
+            burst_photo_ids = set(bursts[burst_index].get("photo_ids", []))
+            if not set(photo_ids).issubset(burst_photo_ids):
+                return json_error(
+                    f"photo_ids are not members of bursts[{burst_index}]",
                 )
 
         if target_enc is not None:
@@ -6168,8 +6187,6 @@ def create_app(db_path, thumb_cache_dir=None):
 
         ws_id = db._ws_id()
 
-        # If the species is changing, untag the old keyword from these photos
-        # and cancel/queue a sidecar remove so the XMP stays in sync.
         old_kid = None
         is_replacement = (
             previous_species is not None
@@ -6189,44 +6206,59 @@ def create_app(db_path, thumb_cache_dir=None):
             ).fetchone()
             if old_kid_row:
                 old_kid = old_kid_row["id"]
+
+        # Run all mutations in a single transaction so that a mid-loop failure
+        # (SQLite lock, disk error, etc.) can't leave half the photos retagged
+        # while the other half still carry the old species.
+        try:
+            if is_replacement and old_kid is not None:
                 for pid in photo_ids:
-                    db.untag_photo(pid, old_kid)
-                    _queue_keyword_remove(pid, previous_species, workspace_id=ws_id)
+                    db.untag_photo(pid, old_kid, _commit=False)
+                    _queue_keyword_remove(
+                        pid, previous_species,
+                        workspace_id=ws_id, _commit=False,
+                    )
 
-        # Create or find the new species keyword (commits on its own)
-        kid = db.add_keyword(species, is_species=True)
+            kid = db.add_keyword(species, is_species=True, _commit=False)
 
-        for pid in photo_ids:
-            db.tag_photo(pid, kid)
-            _queue_keyword_add(pid, species, workspace_id=ws_id)
+            for pid in photo_ids:
+                db.tag_photo(pid, kid, _commit=False)
+                _queue_keyword_add(
+                    pid, species, workspace_id=ws_id, _commit=False,
+                )
 
-        # Record the full action as a single undoable edit so one undo
-        # restores the previous confirmed species rather than leaving the
-        # photos with neither keyword.
-        if is_replacement and old_kid is not None:
-            items = [
-                {"photo_id": pid, "old_value": str(old_kid), "new_value": str(kid)}
-                for pid in photo_ids
-            ]
-            db.record_edit(
-                "species_replace",
-                f'Replaced species "{previous_species}" with "{species}" on {len(photo_ids)} photos',
-                str(kid),
-                items,
-                is_batch=len(photo_ids) > 1,
-            )
-        else:
-            items = [
-                {"photo_id": pid, "old_value": "", "new_value": str(kid)}
-                for pid in photo_ids
-            ]
-            db.record_edit(
-                "keyword_add",
-                f'Confirmed species "{species}" on {len(photo_ids)} photos',
-                str(kid),
-                items,
-                is_batch=len(photo_ids) > 1,
-            )
+            if is_replacement and old_kid is not None:
+                items = [
+                    {"photo_id": pid, "old_value": str(old_kid), "new_value": str(kid)}
+                    for pid in photo_ids
+                ]
+                db.record_edit(
+                    "species_replace",
+                    f'Replaced species "{previous_species}" with "{species}" on {len(photo_ids)} photos',
+                    str(kid),
+                    items,
+                    is_batch=len(photo_ids) > 1,
+                    _commit=False,
+                )
+            else:
+                items = [
+                    {"photo_id": pid, "old_value": "", "new_value": str(kid)}
+                    for pid in photo_ids
+                ]
+                db.record_edit(
+                    "keyword_add",
+                    f'Confirmed species "{species}" on {len(photo_ids)} photos',
+                    str(kid),
+                    items,
+                    is_batch=len(photo_ids) > 1,
+                    _commit=False,
+                )
+            db.conn.commit()
+        except Exception:
+            db.conn.rollback()
+            raise
+        # Prune oldest edit-history rows now that the transaction has landed.
+        db._prune_edit_history()
 
         # Update pipeline cache. burst_index was validated above, so the
         # branch here is unambiguous: burst-scoped requests only touch the

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5957,15 +5957,22 @@ def create_app(db_path, thumb_cache_dir=None):
 
     @app.route("/api/encounters/species", methods=["POST"])
     def api_encounter_species():
-        """Confirm species for all photos in an encounter.
+        """Confirm species for all photos in an encounter or a single burst.
 
-        Expects JSON: {"species": "Blue Jay", "photo_ids": [1, 2, 3]}
-        Creates species keyword, tags photos, queues pending changes.
+        Expects JSON: {"species": "Blue Jay", "photo_ids": [1, 2, 3],
+                       "burst_index": <int|null>}
+
+        Creates the species keyword, tags photos, and queues a sidecar add.
+        If the encounter (or burst) was previously confirmed as a different
+        species, also untags that species and queues a sidecar remove — or
+        cancels the still-pending add if it hadn't synced yet — so the XMP
+        doesn't accumulate stale species keywords.
         """
         db = _get_db()
         body = request.get_json(silent=True) or {}
         species = body.get("species", "").strip()
         photo_ids = body.get("photo_ids", [])
+        burst_index = body.get("burst_index")
 
         if not species:
             return json_error("species is required")
@@ -5982,69 +5989,104 @@ def create_app(db_path, thumb_cache_dir=None):
         if missing:
             return json_error(f"Unknown photo_ids: {missing}")
 
-        # Create or find the species keyword (commits on its own)
-        kid = db.add_keyword(species, is_species=True)
-
-        # Tag all photos and queue pending changes in a single transaction
-        ws_id = db._ws_id()
-        try:
-            for pid in photo_ids:
-                db.conn.execute(
-                    "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
-                    (pid, kid),
-                )
-                existing = db.conn.execute(
-                    "SELECT id FROM pending_changes WHERE photo_id = ? AND change_type = ? AND value = ? AND workspace_id = ?",
-                    (pid, "keyword_add", species, ws_id),
-                ).fetchone()
-                if not existing:
-                    db.conn.execute(
-                        "INSERT INTO pending_changes (photo_id, change_type, value, workspace_id) VALUES (?, ?, ?, ?)",
-                        (pid, "keyword_add", species, ws_id),
-                    )
-            db.conn.commit()
-        except Exception:
-            db.conn.rollback()
-            raise
-
-        # Record edit history
-        items = [{'photo_id': pid, 'old_value': '', 'new_value': str(kid)} for pid in photo_ids]
-        db.record_edit('keyword_add',
-                       f'Confirmed species "{species}" on {len(photo_ids)} photos',
-                       str(kid), items, is_batch=len(photo_ids) > 1)
-
-        # Update pipeline cache if it exists
+        # Look up the previous species (if any) from the pipeline cache before
+        # mutating. We reuse the same cached dict to write the update below.
         from pipeline import load_results_raw, save_results_raw
 
         cache_dir = os.path.dirname(db_path)
         cached = load_results_raw(cache_dir, db._active_workspace_id)
+        previous_species = None
+        target_enc = None
         if cached:
             photo_id_set = set(photo_ids)
-            burst_index = body.get("burst_index")
             for enc in cached.get("encounters", []):
                 enc_ids = set(enc.get("photo_ids", []))
                 if not photo_id_set.issubset(enc_ids):
                     continue
-                if burst_index is not None and "bursts" in enc:
-                    # Burst-level confirmation
-                    if 0 <= burst_index < len(enc["bursts"]):
-                        burst = enc["bursts"][burst_index]
-                        burst["species_override"] = {
-                            "species": species,
-                            "confirmed": True,
-                        }
+                target_enc = enc
+                if burst_index is not None and "bursts" in enc \
+                        and 0 <= burst_index < len(enc["bursts"]):
+                    ovr = enc["bursts"][burst_index].get("species_override")
+                    if ovr and ovr.get("species"):
+                        previous_species = ovr["species"]
+                    else:
+                        # No burst override yet — inherit the encounter's
+                        # confirmed species, which is what those photos were
+                        # actually tagged with.
+                        previous_species = enc.get("confirmed_species")
                 else:
-                    # Encounter-level confirmation
-                    enc["species_confirmed"] = True
-                    enc["confirmed_species"] = species
+                    previous_species = enc.get("confirmed_species")
                 break
+
+        ws_id = db._ws_id()
+
+        # If the species is changing, untag the old keyword from these photos
+        # and cancel/queue a sidecar remove so the XMP stays in sync.
+        if previous_species and previous_species.strip().lower() != species.lower():
+            old_kid_row = db.conn.execute(
+                "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE",
+                (previous_species,),
+            ).fetchone()
+            if old_kid_row:
+                old_kid = old_kid_row["id"]
+                for pid in photo_ids:
+                    db.untag_photo(pid, old_kid)
+                    _queue_keyword_remove(pid, previous_species, workspace_id=ws_id)
+                old_items = [
+                    {"photo_id": pid, "old_value": str(old_kid), "new_value": ""}
+                    for pid in photo_ids
+                ]
+                db.record_edit(
+                    "keyword_remove",
+                    f'Replaced species "{previous_species}" with "{species}" on {len(photo_ids)} photos',
+                    str(old_kid),
+                    old_items,
+                    is_batch=len(photo_ids) > 1,
+                )
+
+        # Create or find the new species keyword (commits on its own)
+        kid = db.add_keyword(species, is_species=True)
+
+        for pid in photo_ids:
+            db.tag_photo(pid, kid)
+            _queue_keyword_add(pid, species, workspace_id=ws_id)
+
+        items = [
+            {"photo_id": pid, "old_value": "", "new_value": str(kid)}
+            for pid in photo_ids
+        ]
+        db.record_edit(
+            "keyword_add",
+            f'Confirmed species "{species}" on {len(photo_ids)} photos',
+            str(kid),
+            items,
+            is_batch=len(photo_ids) > 1,
+        )
+
+        # Update pipeline cache
+        if cached and target_enc is not None:
+            if burst_index is not None and "bursts" in target_enc \
+                    and 0 <= burst_index < len(target_enc["bursts"]):
+                target_enc["bursts"][burst_index]["species_override"] = {
+                    "species": species,
+                    "confirmed": True,
+                }
+            else:
+                target_enc["species_confirmed"] = True
+                target_enc["confirmed_species"] = species
             save_results_raw(cached, cache_dir, db._active_workspace_id)
 
+        replaced = (
+            previous_species
+            if previous_species and previous_species.strip().lower() != species.lower()
+            else None
+        )
         return jsonify({
             "ok": True,
             "species": species,
             "keyword_id": kid,
             "photo_count": len(photo_ids),
+            "previous_species": replaced,
         })
 
     @app.route("/api/species/search")

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2893,13 +2893,19 @@ class Database:
         if _commit:
             self.conn.commit()
 
-    def untag_photo(self, photo_id, keyword_id):
-        """Remove a keyword association from a photo."""
+    def untag_photo(self, photo_id, keyword_id, _commit=True):
+        """Remove a keyword association from a photo.
+
+        Args:
+            _commit: If False, skip the internal commit (caller is responsible
+                     for committing the transaction).
+        """
         self.conn.execute(
             "DELETE FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
             (photo_id, keyword_id),
         )
-        self.conn.commit()
+        if _commit:
+            self.conn.commit()
 
     def get_photo_keywords(self, photo_id):
         """Return all keywords for a photo."""
@@ -3568,8 +3574,13 @@ class Database:
             (self._ws_id(),),
         ).fetchall()
 
-    def remove_pending_changes(self, photo_id, change_type=None, value=None, workspace_id=None):
-        """Delete matching pending changes. Returns rows removed."""
+    def remove_pending_changes(self, photo_id, change_type=None, value=None, workspace_id=None, _commit=True):
+        """Delete matching pending changes. Returns rows removed.
+
+        Args:
+            _commit: If False, skip the internal commit (caller is responsible
+                     for committing the transaction).
+        """
         ws_id = workspace_id if workspace_id is not None else self._ws_id()
         clauses = ["photo_id = ?", "workspace_id = ?"]
         params = [photo_id, ws_id]
@@ -3584,7 +3595,8 @@ class Database:
             f"DELETE FROM pending_changes WHERE {' AND '.join(clauses)}",
             params,
         )
-        self.conn.commit()
+        if _commit:
+            self.conn.commit()
         return cur.rowcount
 
     def remove_pending_change_token(self, change_token):
@@ -3611,10 +3623,15 @@ class Database:
 
     # -- Edit History --
 
-    def record_edit(self, action_type, description, new_value, items, is_batch=False):
+    def record_edit(self, action_type, description, new_value, items, is_batch=False, _commit=True):
         """Record an edit action with per-photo before/after values.
 
         Clears the redo stack (any undone entries) since a new action invalidates them.
+
+        Args:
+            _commit: If False, skip the internal commit and the history prune
+                     (caller is responsible for committing the transaction;
+                     prune can be run later).
         """
         # Clear redo stack — new edit invalidates undone entries
         self.conn.execute(
@@ -3631,8 +3648,9 @@ class Database:
                 "INSERT INTO edit_history_items (edit_id, photo_id, old_value, new_value) VALUES (?, ?, ?, ?)",
                 (edit_id, item['photo_id'], item['old_value'], item['new_value']),
             )
-        self.conn.commit()
-        self._prune_edit_history()
+        if _commit:
+            self.conn.commit()
+            self._prune_edit_history()
         return edit_id
 
     def get_edit_history(self, limit=50, offset=0):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3706,6 +3706,34 @@ class Database:
                                        (int(entry['new_value']),)).fetchone()
                 if kw:
                     self.remove_pending_changes(pid, 'keyword_remove', kw['name'])
+            elif entry['action_type'] == 'species_replace':
+                # Atomic swap: the edit replaced old_value's species with
+                # new_value's. Undo untags the new species and retags the
+                # old one, symmetrically reversing the pending-change queue.
+                new_kid = int(item['new_value']) if item['new_value'] else None
+                old_kid = int(old_val) if old_val else None
+                if new_kid:
+                    self.untag_photo(pid, new_kid)
+                    new_kw = self.conn.execute(
+                        "SELECT name FROM keywords WHERE id = ?", (new_kid,)
+                    ).fetchone()
+                    if new_kw:
+                        cancelled = self.remove_pending_changes(
+                            pid, 'keyword_add', new_kw['name']
+                        )
+                        if cancelled == 0:
+                            self.queue_change(pid, 'keyword_remove', new_kw['name'])
+                if old_kid:
+                    self.tag_photo(pid, old_kid)
+                    old_kw = self.conn.execute(
+                        "SELECT name FROM keywords WHERE id = ?", (old_kid,)
+                    ).fetchone()
+                    if old_kw:
+                        cancelled = self.remove_pending_changes(
+                            pid, 'keyword_remove', old_kw['name']
+                        )
+                        if cancelled == 0:
+                            self.queue_change(pid, 'keyword_add', old_kw['name'])
 
     def _apply_redo(self, entry, items):
         """Re-apply the effects of an undone edit entry."""
@@ -3754,6 +3782,32 @@ class Database:
                                        (int(entry['new_value']),)).fetchone()
                 if kw:
                     self.queue_change(pid, 'keyword_remove', kw['name'])
+            elif entry['action_type'] == 'species_replace':
+                # Re-apply the swap: untag old, retag new, mirror pending queue.
+                new_kid = int(new_val) if new_val else None
+                old_kid = int(item['old_value']) if item['old_value'] else None
+                if old_kid:
+                    self.untag_photo(pid, old_kid)
+                    old_kw = self.conn.execute(
+                        "SELECT name FROM keywords WHERE id = ?", (old_kid,)
+                    ).fetchone()
+                    if old_kw:
+                        cancelled = self.remove_pending_changes(
+                            pid, 'keyword_add', old_kw['name']
+                        )
+                        if cancelled == 0:
+                            self.queue_change(pid, 'keyword_remove', old_kw['name'])
+                if new_kid:
+                    self.tag_photo(pid, new_kid)
+                    new_kw = self.conn.execute(
+                        "SELECT name FROM keywords WHERE id = ?", (new_kid,)
+                    ).fetchone()
+                    if new_kw:
+                        cancelled = self.remove_pending_changes(
+                            pid, 'keyword_remove', new_kw['name']
+                        )
+                        if cancelled == 0:
+                            self.queue_change(pid, 'keyword_add', new_kw['name'])
 
     def _prune_edit_history(self):
         """Delete oldest entries beyond the configured max (excludes undone entries awaiting redo)."""

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -182,6 +182,166 @@ def test_encounter_species_updates_pipeline_cache(app_and_db):
     assert enc["confirmed_species"] == "Blue Jay"
 
 
+def _seed_encounter_cache(app, db, photo_ids, *, confirmed_species=None, bursts=None):
+    """Write a pipeline cache with one encounter for the given photos."""
+    import json as _json
+    cache_dir = os.path.dirname(app.config["DB_PATH"])
+    ws_id = db._active_workspace_id
+    enc = {
+        "species": ["Sparrow", 0.8],
+        "confirmed_species": confirmed_species,
+        "species_predictions": [],
+        "species_confirmed": confirmed_species is not None,
+        "photo_count": len(photo_ids),
+        "burst_count": len(bursts) if bursts else 0,
+        "time_range": [None, None],
+        "photo_ids": photo_ids,
+    }
+    if bursts is not None:
+        enc["bursts"] = bursts
+    results = {
+        "encounters": [enc],
+        "photos": [{"id": pid, "label": "KEEP", "filename": f"{pid}.jpg"} for pid in photo_ids],
+        "summary": {"total_photos": len(photo_ids), "encounter_count": 1,
+                    "burst_count": enc["burst_count"],
+                    "keep_count": len(photo_ids), "review_count": 0,
+                    "reject_count": 0, "rarity_protected": 0},
+    }
+    path = os.path.join(cache_dir, f"pipeline_results_ws{ws_id}.json")
+    with open(path, "w") as f:
+        _json.dump(results, f)
+    return path
+
+
+def test_encounter_species_change_cancels_pending_add(app_and_db):
+    """Changing the confirmed species before sync cancels the stale add."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+
+    _seed_encounter_cache(app, db, photo_ids)
+
+    # First confirm as Sparrow
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Sparrow", "photo_ids": photo_ids})
+    assert resp.status_code == 200
+
+    # Still pending (not synced yet) — change to Blue Jay
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Blue Jay", "photo_ids": photo_ids})
+    assert resp.status_code == 200
+    assert resp.get_json()["previous_species"] == "Sparrow"
+
+    # Photos should now have Blue Jay but not Sparrow
+    for pid in photo_ids:
+        names = {k["name"] for k in db.get_photo_keywords(pid)}
+        assert "Blue Jay" in names
+        assert "Sparrow" not in names
+
+    # Pending changes should contain keyword_add:Blue Jay only.
+    # The Sparrow add had not synced, so it should be cancelled, not followed
+    # by a keyword_remove (otherwise the sidecar would see a remove for a
+    # keyword that was never written).
+    changes = [dict(c) for c in db.get_pending_changes()]
+    values_by_type = {(c["change_type"], c["value"]) for c in changes}
+    assert ("keyword_add", "Blue Jay") in values_by_type
+    assert ("keyword_add", "Sparrow") not in values_by_type
+    assert ("keyword_remove", "Sparrow") not in values_by_type
+
+
+def test_encounter_species_change_queues_remove_after_sync(app_and_db):
+    """If the previous species was already synced, changing it queues a remove."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+
+    _seed_encounter_cache(app, db, photo_ids)
+
+    # Confirm as Sparrow, then simulate a completed sync by clearing pending.
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Sparrow", "photo_ids": photo_ids})
+    assert resp.status_code == 200
+    db.conn.execute("DELETE FROM pending_changes")
+    db.conn.commit()
+
+    # Change to Blue Jay
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Blue Jay", "photo_ids": photo_ids})
+    assert resp.status_code == 200
+
+    # Photos have Blue Jay, not Sparrow
+    for pid in photo_ids:
+        names = {k["name"] for k in db.get_photo_keywords(pid)}
+        assert "Blue Jay" in names
+        assert "Sparrow" not in names
+
+    # Now a keyword_remove:Sparrow must be queued so the XMP drops the
+    # already-written Sparrow tag.
+    values_by_type = {(c["change_type"], c["value"]) for c in db.get_pending_changes()}
+    assert ("keyword_remove", "Sparrow") in values_by_type
+    assert ("keyword_add", "Blue Jay") in values_by_type
+
+
+def test_burst_override_change_untags_previous(app_and_db):
+    """Changing a burst override removes the previously overridden species."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+    burst_ids = photo_ids[:1]
+
+    bursts = [{
+        "photo_ids": burst_ids,
+        "species_predictions": [],
+        "species_override": None,
+    }]
+    _seed_encounter_cache(app, db, photo_ids, bursts=bursts)
+
+    # Override burst 0 to Sparrow
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Sparrow", "photo_ids": burst_ids,
+                             "burst_index": 0})
+    assert resp.status_code == 200
+    db.conn.execute("DELETE FROM pending_changes")
+    db.conn.commit()
+
+    # Now change the burst override to Junco
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Junco", "photo_ids": burst_ids,
+                             "burst_index": 0})
+    assert resp.status_code == 200
+    assert resp.get_json()["previous_species"] == "Sparrow"
+
+    for pid in burst_ids:
+        names = {k["name"] for k in db.get_photo_keywords(pid)}
+        assert "Junco" in names
+        assert "Sparrow" not in names
+
+    values = {(c["change_type"], c["value"]) for c in db.get_pending_changes()}
+    assert ("keyword_remove", "Sparrow") in values
+    assert ("keyword_add", "Junco") in values
+
+
+def test_encounter_species_confirm_same_species_noop_on_keywords(app_and_db):
+    """Re-confirming the same species doesn't queue a remove."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+
+    _seed_encounter_cache(app, db, photo_ids)
+    client.post("/api/encounters/species",
+                json={"species": "Sparrow", "photo_ids": photo_ids})
+    db.conn.execute("DELETE FROM pending_changes")
+    db.conn.commit()
+
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Sparrow", "photo_ids": photo_ids})
+    assert resp.status_code == 200
+    assert resp.get_json()["previous_species"] is None
+
+    values = {c["change_type"] for c in db.get_pending_changes()}
+    assert "keyword_remove" not in values
+
+
 def test_species_search(app_and_db):
     """GET /api/species/search returns matching species from keywords."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -342,6 +342,70 @@ def test_encounter_species_confirm_same_species_noop_on_keywords(app_and_db):
     assert "keyword_remove" not in values
 
 
+def test_encounter_species_rejects_out_of_range_burst_index(app_and_db):
+    """A stale burst_index must not silently fall through to an encounter update."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+
+    # Encounter has exactly one burst.
+    bursts = [{
+        "photo_ids": photo_ids[:1],
+        "species_predictions": [],
+        "species_override": None,
+    }]
+    _seed_encounter_cache(app, db, photo_ids, bursts=bursts)
+
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Blue Jay",
+                             "photo_ids": photo_ids[:1],
+                             "burst_index": 99})
+    assert resp.status_code == 400
+    assert "burst_index" in resp.get_json()["error"]
+
+    # Nothing should have been written.
+    for pid in photo_ids[:1]:
+        names = {k["name"] for k in db.get_photo_keywords(pid)}
+        assert "Blue Jay" not in names
+    assert not db.get_pending_changes()
+
+
+def test_encounter_species_replacement_ignores_nested_homonym(app_and_db):
+    """Old-species lookup must be scoped to root species keywords only."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+
+    _seed_encounter_cache(app, db, photo_ids)
+
+    # Confirm as Sparrow (creates root species keyword).
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Sparrow", "photo_ids": photo_ids})
+    assert resp.status_code == 200
+    root_sparrow_id = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = 'Sparrow' AND parent_id IS NULL"
+    ).fetchone()["id"]
+
+    # Create a non-species homonym "Sparrow" nested under another keyword. If
+    # the replacement lookup were scoped by name only, it could resolve here
+    # and leave the real species tag intact.
+    parent = db.add_keyword("Birds")
+    db.conn.execute(
+        "INSERT INTO keywords (name, parent_id, is_species) VALUES ('Sparrow', ?, 0)",
+        (parent,),
+    )
+    db.conn.commit()
+
+    # Change species — the root Sparrow tag must still be removed.
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Blue Jay", "photo_ids": photo_ids})
+    assert resp.status_code == 200
+
+    for pid in photo_ids:
+        kw_ids = {k["id"] for k in db.get_photo_keywords(pid)}
+        assert root_sparrow_id not in kw_ids
+
+
 def test_species_search(app_and_db):
     """GET /api/species/search returns matching species from keywords."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -342,6 +342,117 @@ def test_encounter_species_confirm_same_species_noop_on_keywords(app_and_db):
     assert "keyword_remove" not in values
 
 
+def test_encounter_species_replacement_is_atomic_in_history(app_and_db):
+    """Replacing the encounter species records one history entry, not two."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+
+    _seed_encounter_cache(app, db, photo_ids)
+    client.post("/api/encounters/species",
+                json={"species": "Sparrow", "photo_ids": photo_ids})
+    # Clear history from the initial confirm so we're only looking at the
+    # replacement.
+    db.conn.execute("DELETE FROM edit_history")
+    db.conn.commit()
+
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Blue Jay", "photo_ids": photo_ids})
+    assert resp.status_code == 200
+
+    history = db.get_edit_history()
+    assert len(history) == 1
+    assert history[0]['action_type'] == 'species_replace'
+    assert 'Sparrow' in history[0]['description']
+    assert 'Blue Jay' in history[0]['description']
+
+
+def test_encounter_species_replacement_undo_restores_previous(app_and_db):
+    """One undo after a replacement restores the previous species, not neither."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+
+    _seed_encounter_cache(app, db, photo_ids)
+    client.post("/api/encounters/species",
+                json={"species": "Sparrow", "photo_ids": photo_ids})
+    client.post("/api/encounters/species",
+                json={"species": "Blue Jay", "photo_ids": photo_ids})
+
+    # One undo should swap the photos back to Sparrow.
+    undone = db.undo_last_edit()
+    assert undone is not None
+    assert undone['action_type'] == 'species_replace'
+
+    for pid in photo_ids:
+        names = {k["name"] for k in db.get_photo_keywords(pid)}
+        assert "Sparrow" in names
+        assert "Blue Jay" not in names
+
+    # Neither species was synced, so undo should cancel the pending swap
+    # outright rather than queue a keyword_remove for a never-written tag.
+    values = {(c["change_type"], c["value"]) for c in db.get_pending_changes()}
+    assert ("keyword_remove", "Blue Jay") not in values
+    assert ("keyword_remove", "Sparrow") not in values
+    # Original keyword_add:Sparrow is back in the queue because the replace
+    # had cancelled it — and undoing the replace's own add (Blue Jay) means
+    # the sidecar state matches what was there before Blue Jay was confirmed.
+    assert ("keyword_add", "Sparrow") in values
+    assert ("keyword_add", "Blue Jay") not in values
+
+
+def test_encounter_species_replacement_undo_after_sync_queues_swap(app_and_db):
+    """If the replacement already synced, undo queues the reverse XMP ops."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+
+    _seed_encounter_cache(app, db, photo_ids)
+    client.post("/api/encounters/species",
+                json={"species": "Sparrow", "photo_ids": photo_ids})
+    client.post("/api/encounters/species",
+                json={"species": "Blue Jay", "photo_ids": photo_ids})
+    # Pretend the replacement has synced: drop all pending changes.
+    db.conn.execute("DELETE FROM pending_changes")
+    db.conn.commit()
+
+    undone = db.undo_last_edit()
+    assert undone is not None
+    assert undone['action_type'] == 'species_replace'
+
+    for pid in photo_ids:
+        names = {k["name"] for k in db.get_photo_keywords(pid)}
+        assert "Sparrow" in names
+        assert "Blue Jay" not in names
+
+    values = {(c["change_type"], c["value"]) for c in db.get_pending_changes()}
+    assert ("keyword_remove", "Blue Jay") in values
+    assert ("keyword_add", "Sparrow") in values
+
+
+def test_encounter_species_replacement_redo_reapplies(app_and_db):
+    """Redo after undo re-applies the replacement."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+
+    _seed_encounter_cache(app, db, photo_ids)
+    client.post("/api/encounters/species",
+                json={"species": "Sparrow", "photo_ids": photo_ids})
+    client.post("/api/encounters/species",
+                json={"species": "Blue Jay", "photo_ids": photo_ids})
+
+    db.undo_last_edit()
+    redone = db.redo_last_undo()
+    assert redone is not None
+    assert redone['action_type'] == 'species_replace'
+
+    for pid in photo_ids:
+        names = {k["name"] for k in db.get_photo_keywords(pid)}
+        assert "Blue Jay" in names
+        assert "Sparrow" not in names
+
+
 def test_encounter_species_rejects_out_of_range_burst_index(app_and_db):
     """A stale burst_index must not silently fall through to an encounter update."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -453,6 +453,35 @@ def test_encounter_species_replacement_redo_reapplies(app_and_db):
         assert "Sparrow" not in names
 
 
+def test_encounter_species_rejects_photo_ids_not_in_burst(app_and_db):
+    """A valid burst_index plus photo_ids from a different burst must be rejected."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+    assert len(photo_ids) >= 2
+
+    # Two bursts: burst 0 holds photo_ids[:1], burst 1 holds photo_ids[1:].
+    bursts = [
+        {"photo_ids": photo_ids[:1], "species_predictions": [], "species_override": None},
+        {"photo_ids": photo_ids[1:], "species_predictions": [], "species_override": None},
+    ]
+    _seed_encounter_cache(app, db, photo_ids, bursts=bursts)
+
+    # burst_index 0 is in range, but we're submitting photos from burst 1.
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Blue Jay",
+                             "photo_ids": photo_ids[1:],
+                             "burst_index": 0})
+    assert resp.status_code == 400
+    assert "bursts[0]" in resp.get_json()["error"]
+
+    # Nothing should have been written.
+    for pid in photo_ids:
+        names = {k["name"] for k in db.get_photo_keywords(pid)}
+        assert "Blue Jay" not in names
+    assert not db.get_pending_changes()
+
+
 def test_encounter_species_rejects_out_of_range_burst_index(app_and_db):
     """A stale burst_index must not silently fall through to an encounter update."""
     app, db = app_and_db


### PR DESCRIPTION
## Summary
- \`/api/encounters/species\` only **added** the new species keyword — it never removed the previously confirmed one. So if a user confirmed an encounter as "Bushtit" and later changed it to "Wrentit", every photo ended up with both keywords, and both got queued as \`keyword_add\` for the XMP sync.
- The endpoint now looks up the previous species (encounter-level \`confirmed_species\`, or burst-level \`species_override\`) from the pipeline cache **before** mutating, and if the species is changing, untags the old keyword and routes through \`_queue_keyword_remove\` — which already knows how to cancel a still-pending \`keyword_add\` (if the old species hadn't synced yet) or queue a \`keyword_remove\` (if it had).
- Replaced the hand-rolled pending-changes inserts with the existing \`_queue_keyword_add\` / \`_queue_keyword_remove\` helpers so the two operations stay symmetric.
- Added a \`previous_species\` field to the response, useful for future UI "changed from X to Y" toasts.
- Companion to #571 which handled the visual cascade from encounter to burst widgets.

### Known remaining edge case (separate from this PR)
When a burst has its own override and the user then changes the encounter-level species, the override-burst photos still keep the old encounter keyword. Fixing that cleanly needs a scope decision on whether encounter-level confirms should also touch override-burst photos (they currently do, which is a separate minor bug). Not addressing here to keep this change focused.

## Test plan
- [x] \`python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py\` — 446 passed (4 new tests)
- [x] New test: changing species before sync cancels the stale \`keyword_add\` instead of leaving a \`keyword_remove\` for an unwritten keyword.
- [x] New test: changing species after sync queues \`keyword_remove\` for the previous species.
- [x] New test: burst-level override replacement removes the previously overridden species.
- [x] New test: re-confirming the same species is a no-op (no stray \`keyword_remove\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)