### PR TITLE
feat: auto-detach burst when confirmed species differs from encounter

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -94,6 +94,127 @@ def _trash_via_finder(filepath):
         raise OSError(result.stderr.strip() or f"Finder trash failed ({result.returncode})")
 
 
+def _compute_time_range(photos_by_id, photo_ids):
+    """Return [min_ts, max_ts] ISO strings for photo_ids, or [None, None]."""
+    timestamps = [
+        photos_by_id[pid]["timestamp"]
+        for pid in photo_ids
+        if pid in photos_by_id and photos_by_id[pid].get("timestamp")
+    ]
+    if not timestamps:
+        return [None, None]
+    return [min(timestamps), max(timestamps)]
+
+
+def _find_merge_target(encounters, detached_range, target_species):
+    """Find an encounter index whose confirmed species matches target_species and
+    whose time range is adjacent to detached_range (no other encounter sits in
+    the gap between them). Returns None if none found.
+    """
+    d_min, d_max = detached_range
+    if d_min is None or d_max is None:
+        return None
+
+    other_ranges = []
+    for i, e in enumerate(encounters):
+        tr = e.get("time_range") or [None, None]
+        if tr[0] is not None and tr[1] is not None:
+            other_ranges.append((i, tr[0], tr[1]))
+
+    for i, e in enumerate(encounters):
+        if not e.get("species_confirmed"):
+            continue
+        if e.get("confirmed_species") != target_species:
+            continue
+        tr = e.get("time_range") or [None, None]
+        if tr[0] is None or tr[1] is None:
+            continue
+        c_min, c_max = tr[0], tr[1]
+        if c_max < d_min:
+            gap_start, gap_end = c_max, d_min
+        elif d_max < c_min:
+            gap_start, gap_end = d_max, c_min
+        else:
+            return i  # overlapping — treat as adjacent
+        intervening = False
+        for j, o_min, o_max in other_ranges:
+            if j == i:
+                continue
+            if o_max > gap_start and o_min < gap_end:
+                intervening = True
+                break
+        if not intervening:
+            return i
+    return None
+
+
+def _auto_detach_burst_for_species(results, enc_idx, burst_idx, new_species):
+    """Detach the burst at (enc_idx, burst_idx) from its encounter. If an adjacent
+    encounter already has new_species as its confirmed species, merge the burst
+    into that encounter; otherwise create a new single-burst encounter with
+    new_species confirmed. Mutates results in place.
+    """
+    from pipeline import rebuild_species_predictions
+
+    encounters = results["encounters"]
+    enc = encounters[enc_idx]
+    bursts = enc["bursts"]
+    detached = bursts.pop(burst_idx)
+    detached_ids = detached["photo_ids"]
+
+    photos_by_id = {p["id"]: p for p in results.get("photos", [])}
+    detached_range = _compute_time_range(photos_by_id, detached_ids)
+
+    if len(bursts) == 0:
+        encounters.pop(enc_idx)
+    else:
+        remaining = [pid for pid in enc["photo_ids"] if pid not in set(detached_ids)]
+        enc["photo_ids"] = remaining
+        enc["photo_count"] = len(remaining)
+        enc["burst_count"] = len(bursts)
+        enc["species_predictions"] = rebuild_species_predictions(results, remaining)
+        for b in bursts:
+            b["species_predictions"] = rebuild_species_predictions(results, b["photo_ids"])
+        enc["time_range"] = _compute_time_range(photos_by_id, remaining)
+
+    detached["species_predictions"] = rebuild_species_predictions(results, detached_ids)
+
+    merge_idx = _find_merge_target(encounters, detached_range, new_species)
+    if merge_idx is not None:
+        target = encounters[merge_idx]
+        target["bursts"].append(detached)
+        target["photo_ids"] = list(target["photo_ids"]) + list(detached_ids)
+        target["photo_count"] = len(target["photo_ids"])
+        target["burst_count"] = len(target["bursts"])
+        target["species_predictions"] = rebuild_species_predictions(
+            results, target["photo_ids"]
+        )
+        t_min, t_max = target.get("time_range") or [None, None]
+        d_min, d_max = detached_range
+        mins = [x for x in (t_min, d_min) if x is not None]
+        maxs = [x for x in (t_max, d_max) if x is not None]
+        target["time_range"] = [
+            min(mins) if mins else None,
+            max(maxs) if maxs else None,
+        ]
+    else:
+        encounters.append({
+            "species": enc.get("species"),
+            "confirmed_species": new_species,
+            "species_predictions": detached["species_predictions"],
+            "species_confirmed": True,
+            "photo_count": len(detached_ids),
+            "burst_count": 1,
+            "time_range": detached_range,
+            "photo_ids": list(detached_ids),
+            "bursts": [detached],
+        })
+
+    summary = results.setdefault("summary", {})
+    summary["encounter_count"] = len(encounters)
+    summary["burst_count"] = sum(e.get("burst_count", 0) for e in encounters)
+
+
 def create_app(db_path, thumb_cache_dir=None):
     """Create the Flask app for the Vireo photo browser.
 
@@ -6021,7 +6142,7 @@ def create_app(db_path, thumb_cache_dir=None):
         if cached:
             photo_id_set = set(photo_ids)
             burst_index = body.get("burst_index")
-            for enc in cached.get("encounters", []):
+            for enc_idx, enc in enumerate(cached.get("encounters", [])):
                 enc_ids = set(enc.get("photo_ids", []))
                 if not photo_id_set.issubset(enc_ids):
                     continue
@@ -6033,6 +6154,20 @@ def create_app(db_path, thumb_cache_dir=None):
                             "species": species,
                             "confirmed": True,
                         }
+                        # Auto-detach if burst's confirmed species differs from its
+                        # encounter — splits it out and merges into an adjacent
+                        # encounter of the same confirmed species when one exists.
+                        enc_species = enc.get("confirmed_species") or (
+                            enc["species"][0] if enc.get("species") else None
+                        )
+                        if (
+                            enc_species is not None
+                            and enc_species != species
+                            and len(enc["bursts"]) > 1
+                        ):
+                            _auto_detach_burst_for_species(
+                                cached, enc_idx, burst_index, species
+                            )
                 else:
                     # Encounter-level confirmation
                     enc["species_confirmed"] = True

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6175,12 +6175,16 @@ def create_app(db_path, thumb_cache_dir=None):
                 break
             save_results_raw(cached, cache_dir, db._active_workspace_id)
 
-        return jsonify({
+        response = {
             "ok": True,
             "species": species,
             "keyword_id": kid,
             "photo_count": len(photo_ids),
-        })
+        }
+        if cached:
+            response["encounters"] = cached.get("encounters", [])
+            response["summary"] = cached.get("summary", {})
+        return jsonify(response)
 
     @app.route("/api/species/search")
     def api_species_search():

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1806,8 +1806,17 @@ async function confirmSpecies(event, encIdx, burstIdx, speciesName) {
   });
   if (!resp || !resp.ok) return;
 
-  // Update local state optimistically
-  if (burstIdx != null && enc.bursts && enc.bursts[burstIdx]) {
+  // Prefer the server's encounter list — the endpoint may auto-detach a burst
+  // into a new or adjacent encounter when its confirmed species differs from
+  // the encounter's, and a stale local list would lose that change on the
+  // next save-cache POST.
+  if (resp.encounters) {
+    pipelineResults.encounters = resp.encounters;
+    if (resp.summary) {
+      pipelineResults.summary = resp.summary;
+      updateSummaryBar(pipelineResults.summary);
+    }
+  } else if (burstIdx != null && enc.bursts && enc.bursts[burstIdx]) {
     enc.bursts[burstIdx].species_override = { species: speciesName, confirmed: true };
   } else {
     enc.species_confirmed = true;

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -791,6 +791,181 @@ def test_pipeline_detach_photo(app_and_db):
     assert "Eagle" in new_species
 
 
+def test_encounter_species_auto_detaches_mixed_burst(app_and_db):
+    """Confirming a burst to a species different from its encounter auto-detaches it."""
+    import json as _json
+    app, db = app_and_db
+    client = app.test_client()
+
+    cache_dir = os.path.dirname(app.config["DB_PATH"])
+    ws_id = db._active_workspace_id
+    results = {
+        "encounters": [
+            {
+                "species": ["Bald Eagle", 0.9],
+                "confirmed_species": None,
+                "species_predictions": [{"species": "Bald Eagle", "count": 3, "models": []}],
+                "species_confirmed": False,
+                "photo_count": 3,
+                "burst_count": 2,
+                "time_range": ["2024-06-10T09:00:00", "2024-06-10T09:05:00"],
+                "photo_ids": [1, 2, 3],
+                "bursts": [
+                    {"photo_ids": [1, 2], "species_predictions": [], "species_override": None},
+                    {"photo_ids": [3], "species_predictions": [], "species_override": None},
+                ],
+            }
+        ],
+        "photos": [
+            {"id": 1, "label": "KEEP", "filename": "a.jpg", "timestamp": "2024-06-10T09:00:00", "species_top5": [["Bald Eagle", 0.9, "m1"]]},
+            {"id": 2, "label": "KEEP", "filename": "b.jpg", "timestamp": "2024-06-10T09:00:02", "species_top5": [["Bald Eagle", 0.9, "m1"]]},
+            {"id": 3, "label": "REVIEW", "filename": "c.jpg", "timestamp": "2024-06-10T09:05:00", "species_top5": [["Golden Eagle", 0.6, "m1"]]},
+        ],
+        "summary": {"total_photos": 3, "encounter_count": 1, "burst_count": 2,
+                     "keep_count": 2, "review_count": 1, "reject_count": 0, "rarity_protected": 0},
+    }
+    path = os.path.join(cache_dir, f"pipeline_results_ws{ws_id}.json")
+    with open(path, "w") as f:
+        _json.dump(results, f)
+
+    # Confirm burst 1 (photo 3) as Golden Eagle — differs from encounter's Bald Eagle
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Golden Eagle", "photo_ids": [3], "burst_index": 1})
+    assert resp.status_code == 200
+
+    with open(path) as f:
+        updated = _json.load(f)
+    encounters = updated["encounters"]
+    # Original encounter should no longer contain burst with photo 3
+    assert len(encounters) == 2
+    bald_enc = next(e for e in encounters if 1 in e["photo_ids"])
+    eagle_enc = next(e for e in encounters if 3 in e["photo_ids"])
+    assert bald_enc is not eagle_enc
+    assert bald_enc["photo_ids"] == [1, 2]
+    assert eagle_enc["photo_ids"] == [3]
+    assert eagle_enc["species_confirmed"] is True
+    assert eagle_enc["confirmed_species"] == "Golden Eagle"
+
+
+def test_encounter_species_confirm_single_burst_does_not_detach(app_and_db):
+    """Confirming the only burst in an encounter does not detach (nothing to split from)."""
+    import json as _json
+    app, db = app_and_db
+    client = app.test_client()
+
+    cache_dir = os.path.dirname(app.config["DB_PATH"])
+    ws_id = db._active_workspace_id
+    results = {
+        "encounters": [
+            {
+                "species": ["Bald Eagle", 0.9],
+                "confirmed_species": None,
+                "species_predictions": [],
+                "species_confirmed": False,
+                "photo_count": 2,
+                "burst_count": 1,
+                "time_range": ["2024-06-10T09:00:00", "2024-06-10T09:00:02"],
+                "photo_ids": [1, 2],
+                "bursts": [
+                    {"photo_ids": [1, 2], "species_predictions": [], "species_override": None},
+                ],
+            }
+        ],
+        "photos": [
+            {"id": 1, "label": "KEEP", "filename": "a.jpg", "timestamp": "2024-06-10T09:00:00"},
+            {"id": 2, "label": "KEEP", "filename": "b.jpg", "timestamp": "2024-06-10T09:00:02"},
+        ],
+        "summary": {"total_photos": 2, "encounter_count": 1, "burst_count": 1,
+                     "keep_count": 2, "review_count": 0, "reject_count": 0, "rarity_protected": 0},
+    }
+    path = os.path.join(cache_dir, f"pipeline_results_ws{ws_id}.json")
+    with open(path, "w") as f:
+        _json.dump(results, f)
+
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Golden Eagle", "photo_ids": [1, 2], "burst_index": 0})
+    assert resp.status_code == 200
+
+    with open(path) as f:
+        updated = _json.load(f)
+    # Still one encounter, burst stays put, override recorded
+    assert len(updated["encounters"]) == 1
+    enc = updated["encounters"][0]
+    assert len(enc["bursts"]) == 1
+    assert enc["bursts"][0]["species_override"] == {"species": "Golden Eagle", "confirmed": True}
+
+
+def test_encounter_species_detach_merges_into_adjacent_encounter(app_and_db):
+    """Detaching a second burst merges it into an adjacent encounter with matching confirmed species."""
+    import json as _json
+    app, db = app_and_db
+    client = app.test_client()
+
+    cache_dir = os.path.dirname(app.config["DB_PATH"])
+    ws_id = db._active_workspace_id
+    # Original encounter has 3 bursts, all "Bald Eagle" predictions.
+    # After first burst confirmed Golden Eagle and auto-detached, confirming another
+    # burst to Golden Eagle should merge into the detached encounter (adjacent in time).
+    results = {
+        "encounters": [
+            {
+                "species": ["Bald Eagle", 0.9],
+                "confirmed_species": None,
+                "species_predictions": [],
+                "species_confirmed": False,
+                "photo_count": 3,
+                "burst_count": 3,
+                "time_range": ["2024-06-10T09:00:00", "2024-06-10T09:10:00"],
+                "photo_ids": [1, 2, 3],
+                "bursts": [
+                    {"photo_ids": [1], "species_predictions": [], "species_override": None},
+                    {"photo_ids": [2], "species_predictions": [], "species_override": None},
+                    {"photo_ids": [3], "species_predictions": [], "species_override": None},
+                ],
+            }
+        ],
+        "photos": [
+            {"id": 1, "label": "KEEP", "filename": "a.jpg", "timestamp": "2024-06-10T09:00:00"},
+            {"id": 2, "label": "KEEP", "filename": "b.jpg", "timestamp": "2024-06-10T09:05:00"},
+            {"id": 3, "label": "KEEP", "filename": "c.jpg", "timestamp": "2024-06-10T09:10:00"},
+        ],
+        "summary": {"total_photos": 3, "encounter_count": 1, "burst_count": 3,
+                     "keep_count": 3, "review_count": 0, "reject_count": 0, "rarity_protected": 0},
+    }
+    path = os.path.join(cache_dir, f"pipeline_results_ws{ws_id}.json")
+    with open(path, "w") as f:
+        _json.dump(results, f)
+
+    # Confirm burst 2 (photo 3) as Golden Eagle -> detaches to new Golden Eagle encounter
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Golden Eagle", "photo_ids": [3], "burst_index": 2})
+    assert resp.status_code == 200
+
+    # Now confirm burst (photo 2, still in original encounter) as Golden Eagle.
+    # Its burst_index in the original encounter is now 1 (after photo 3 detached).
+    with open(path) as f:
+        mid = _json.load(f)
+    bald_idx = next(i for i, e in enumerate(mid["encounters"]) if 1 in e["photo_ids"])
+    burst_idx_in_bald = next(
+        i for i, b in enumerate(mid["encounters"][bald_idx]["bursts"]) if 2 in b["photo_ids"]
+    )
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Golden Eagle", "photo_ids": [2],
+                             "burst_index": burst_idx_in_bald,
+                             "encounter_index": bald_idx})
+    assert resp.status_code == 200
+
+    with open(path) as f:
+        final = _json.load(f)
+    # Expect 2 encounters: original Bald Eagle (photo 1), one Golden Eagle with photos 2 & 3
+    assert len(final["encounters"]) == 2
+    golden = next(e for e in final["encounters"] if e.get("confirmed_species") == "Golden Eagle")
+    assert set(golden["photo_ids"]) == {2, 3}
+    assert len(golden["bursts"]) == 2
+    bald = next(e for e in final["encounters"] if e is not golden)
+    assert bald["photo_ids"] == [1]
+
+
 def test_keyword_duplicates_scoped_by_workspace(app_and_db):
     """Keyword duplicates endpoint only reports duplicates within the active workspace."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -833,6 +833,13 @@ def test_encounter_species_auto_detaches_mixed_burst(app_and_db):
                        json={"species": "Golden Eagle", "photo_ids": [3], "burst_index": 1})
     assert resp.status_code == 200
 
+    # Response must include updated encounters so the client can refresh its
+    # local state and avoid overwriting the detach via a later save-cache POST.
+    body = resp.get_json()
+    assert "encounters" in body
+    assert "summary" in body
+    assert len(body["encounters"]) == 2
+
     with open(path) as f:
         updated = _json.load(f)
     encounters = updated["encounters"]


### PR DESCRIPTION
## Summary
- In the pipeline review, confirming a species on a burst that differs from its encounter's species now splits the burst into its own encounter instead of leaving a mixed-species encounter behind.
- If an existing encounter already has the newly confirmed species and is temporally adjacent (no other encounter sits in the gap), the detached burst merges into it. So confirming a second burst to the same species rejoins it with the first one.
- Skipped when the encounter has only one burst (nothing to split from) or when the confirmed species matches the encounter's existing species.

## Implementation
- New helpers in `vireo/app.py`: `_compute_time_range`, `_find_merge_target`, `_auto_detach_burst_for_species`.
- `/api/encounters/species` invokes the auto-detach after setting `species_override` on the burst.
- Adjacency uses encounter `time_range` from photo timestamps; a candidate is adjacent if no other encounter's range falls in the gap between it and the detached burst (overlapping ranges also count).
- Existing `/api/pipeline/detach-burst` endpoint is unchanged — this is only wired into the species-confirm path.

## Test plan
- [x] `test_encounter_species_auto_detaches_mixed_burst` — new Golden Eagle encounter created
- [x] `test_encounter_species_confirm_single_burst_does_not_detach` — single-burst encounter stays put
- [x] `test_encounter_species_detach_merges_into_adjacent_encounter` — second Golden-Eagle confirm merges into the first detached encounter
- [x] Full project test suite (445 tests) passes