### PR TITLE
feat: show per-photo top-5 predictions in burst group loupe

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3202,31 +3202,31 @@ class Database:
         rows = [dict(r) for r in primaries]
         if not rows:
             return rows
-        # Each detection's alternatives must match that detection's primary
-        # model — a detection may have been classified by multiple models, and
-        # we only want to show alternatives from the model that produced the
-        # group's primary prediction.
+        # Alternatives are correlated by (detection_id, model): a detection may
+        # have been classified by multiple models (and those may even share a
+        # group), so we must not merge alternatives across models.
         det_model_pairs = [
             (r['detection_id'], r.get('model'))
             for r in rows if r.get('detection_id') is not None
         ]
-        alts_by_det = {did: [] for did, _ in det_model_pairs}
+        alts_by_key = {pair: [] for pair in det_model_pairs}
         if det_model_pairs:
             clauses = ' OR '.join(['(detection_id = ? AND model = ?)'] * len(det_model_pairs))
             params = [v for pair in det_model_pairs for v in pair]
             alt_rows = self.conn.execute(
-                f"""SELECT detection_id, species, confidence
+                f"""SELECT detection_id, model, species, confidence
                     FROM predictions
                     WHERE status = 'alternative' AND ({clauses})
                     ORDER BY confidence DESC""",
                 params,
             ).fetchall()
             for a in alt_rows:
-                alts_by_det.setdefault(a['detection_id'], []).append(
+                key = (a['detection_id'], a['model'])
+                alts_by_key.setdefault(key, []).append(
                     {'species': a['species'], 'confidence': a['confidence']}
                 )
         for r in rows:
-            r['alternatives'] = alts_by_det.get(r.get('detection_id'), [])
+            r['alternatives'] = alts_by_key.get((r.get('detection_id'), r.get('model')), [])
         return rows
 
     def update_predictions_status_by_photo(self, photo_id, status):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3205,26 +3205,32 @@ class Database:
         # Alternatives are correlated by (detection_id, model): a detection may
         # have been classified by multiple models (and those may even share a
         # group), so we must not merge alternatives across models.
-        det_model_pairs = [
+        #
+        # Fetch all alternatives for the distinct detection_ids in one IN(...)
+        # query, then filter by model in Python. This keeps the SQL expression
+        # depth bounded even for very large burst groups (SQLite's default
+        # expression-depth limit breaks with one OR branch per row).
+        det_model_pairs = {
             (r['detection_id'], r.get('model'))
             for r in rows if r.get('detection_id') is not None
-        ]
+        }
         alts_by_key = {pair: [] for pair in det_model_pairs}
-        if det_model_pairs:
-            clauses = ' OR '.join(['(detection_id = ? AND model = ?)'] * len(det_model_pairs))
-            params = [v for pair in det_model_pairs for v in pair]
+        det_ids = list({did for did, _ in det_model_pairs})
+        if det_ids:
+            placeholders = ','.join('?' * len(det_ids))
             alt_rows = self.conn.execute(
                 f"""SELECT detection_id, model, species, confidence
                     FROM predictions
-                    WHERE status = 'alternative' AND ({clauses})
+                    WHERE status = 'alternative' AND detection_id IN ({placeholders})
                     ORDER BY confidence DESC""",
-                params,
+                det_ids,
             ).fetchall()
             for a in alt_rows:
                 key = (a['detection_id'], a['model'])
-                alts_by_key.setdefault(key, []).append(
-                    {'species': a['species'], 'confidence': a['confidence']}
-                )
+                if key in alts_by_key:
+                    alts_by_key[key].append(
+                        {'species': a['species'], 'confidence': a['confidence']}
+                    )
         for r in rows:
             r['alternatives'] = alts_by_key.get((r.get('detection_id'), r.get('model')), [])
         return rows

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3202,16 +3202,24 @@ class Database:
         rows = [dict(r) for r in primaries]
         if not rows:
             return rows
-        det_ids = [r['detection_id'] for r in rows if r.get('detection_id') is not None]
-        alts_by_det = {did: [] for did in det_ids}
-        if det_ids:
-            placeholders = ','.join('?' * len(det_ids))
+        # Each detection's alternatives must match that detection's primary
+        # model — a detection may have been classified by multiple models, and
+        # we only want to show alternatives from the model that produced the
+        # group's primary prediction.
+        det_model_pairs = [
+            (r['detection_id'], r.get('model'))
+            for r in rows if r.get('detection_id') is not None
+        ]
+        alts_by_det = {did: [] for did, _ in det_model_pairs}
+        if det_model_pairs:
+            clauses = ' OR '.join(['(detection_id = ? AND model = ?)'] * len(det_model_pairs))
+            params = [v for pair in det_model_pairs for v in pair]
             alt_rows = self.conn.execute(
                 f"""SELECT detection_id, species, confidence
                     FROM predictions
-                    WHERE status = 'alternative' AND detection_id IN ({placeholders})
+                    WHERE status = 'alternative' AND ({clauses})
                     ORDER BY confidence DESC""",
-                det_ids,
+                params,
             ).fetchall()
             for a in alt_rows:
                 alts_by_det.setdefault(a['detection_id'], []).append(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3181,8 +3181,13 @@ class Database:
             self.conn.commit()
 
     def get_group_predictions(self, group_id):
-        """Get all predictions and photo data for a burst group."""
-        return self.conn.execute(
+        """Get all predictions and photo data for a burst group.
+
+        Each returned row is a dict with an ``alternatives`` list containing
+        the per-detection alternative species predictions (status='alternative'),
+        sorted by confidence descending.
+        """
+        primaries = self.conn.execute(
             """SELECT pr.*, d.photo_id, d.box_x, d.box_y, d.box_w, d.box_h,
                       d.detector_confidence, p.filename, p.timestamp, p.sharpness,
                       p.quality_score, p.subject_sharpness, p.subject_size,
@@ -3194,6 +3199,27 @@ class Database:
                ORDER BY p.quality_score DESC""",
             (group_id, self._ws_id()),
         ).fetchall()
+        rows = [dict(r) for r in primaries]
+        if not rows:
+            return rows
+        det_ids = [r['detection_id'] for r in rows if r.get('detection_id') is not None]
+        alts_by_det = {did: [] for did in det_ids}
+        if det_ids:
+            placeholders = ','.join('?' * len(det_ids))
+            alt_rows = self.conn.execute(
+                f"""SELECT detection_id, species, confidence
+                    FROM predictions
+                    WHERE status = 'alternative' AND detection_id IN ({placeholders})
+                    ORDER BY confidence DESC""",
+                det_ids,
+            ).fetchall()
+            for a in alt_rows:
+                alts_by_det.setdefault(a['detection_id'], []).append(
+                    {'species': a['species'], 'confidence': a['confidence']}
+                )
+        for r in rows:
+            r['alternatives'] = alts_by_det.get(r.get('detection_id'), [])
+        return rows
 
     def update_predictions_status_by_photo(self, photo_id, status):
         """Update status for all predictions of a photo in the active workspace."""

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -475,6 +475,35 @@
     border-top: 1px solid var(--border-primary, #14374E);
     text-align: center;
   }
+  .grm-loupe-preds {
+    padding: 8px 12px 10px;
+    border-top: 1px solid var(--border-primary, #14374E);
+    font-size: 11px;
+  }
+  .grm-loupe-preds-title {
+    color: var(--text-dim, #888);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 4px;
+    font-size: 10px;
+  }
+  .grm-loupe-preds-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 2px 0;
+    color: var(--text-primary, #E0F0F0);
+  }
+  .grm-loupe-preds-row.top {
+    font-weight: 600;
+  }
+  .grm-loupe-preds-row .conf {
+    color: var(--text-dim, #888);
+    font-variant-numeric: tabular-nums;
+  }
+  .grm-loupe-preds-empty {
+    color: var(--text-ghost, #555);
+    font-style: italic;
+  }
   .grm-loupe-crosshair {
     position: absolute;
     pointer-events: none;
@@ -1208,18 +1237,42 @@ function grmSelect(photoId) {
   // Update loupe preview
   var loupeImg = document.getElementById('grmLoupePhoto');
   var loupeInfo = document.getElementById('grmLoupeInfo');
+  var loupePreds = document.getElementById('grmLoupePreds');
   if (grmState.selected) {
     loupeImg.src = '/photos/' + grmState.selected + '/full';
     var item = grmState.items.find(function(it) { return it.photo_id === grmState.selected; });
     if (item) {
       var sharp = item.subject_sharpness != null ? Math.round(item.subject_sharpness) : (item.sharpness != null ? Math.round(item.sharpness) : '?');
       loupeInfo.textContent = (item.filename || '') + ' — sharpness: ' + sharp + ' — move cursor to compare';
+      loupePreds.innerHTML = renderLoupePreds(item);
     }
   } else {
     loupeImg.src = '';
     loupeInfo.textContent = 'Select a photo to preview. Hover to compare sharpness across all frames.';
+    loupePreds.innerHTML = '';
     grmLoupeReset();
   }
+}
+
+function renderLoupePreds(item) {
+  var preds = [];
+  if (item.species) {
+    preds.push({ species: item.species, confidence: item.confidence || 0, top: true });
+  }
+  (item.alternatives || []).forEach(function(a) {
+    preds.push({ species: a.species, confidence: a.confidence || 0, top: false });
+  });
+  preds = preds.slice(0, 5);
+  var header = '<div class="grm-loupe-preds-title">This photo\u2019s top predictions</div>';
+  if (!preds.length) {
+    return header + '<div class="grm-loupe-preds-empty">No predictions available.</div>';
+  }
+  return header + preds.map(function(p) {
+    return '<div class="grm-loupe-preds-row' + (p.top ? ' top' : '') + '">' +
+      '<span>' + escapeHtml(p.species) + '</span>' +
+      '<span class="conf">' + Math.round((p.confidence || 0) * 100) + '%</span>' +
+    '</div>';
+  }).join('');
 }
 
 var _grmZoomLevel = 4;
@@ -1438,10 +1491,11 @@ document.addEventListener('keydown', function(e) {
         <div class="grm-loupe-crosshair-v" id="grmCrosshairV"></div>
       </div>
       <div class="grm-loupe-info" id="grmLoupeInfo">Select a photo to preview. Hover to compare sharpness across all frames.</div>
+      <div class="grm-loupe-preds" id="grmLoupePreds"></div>
     </div>
   </div>
   <div class="grm-footer">
-    <label style="font-size:12px;color:var(--text-muted,#888);">Species:</label>
+    <label style="font-size:12px;color:var(--text-muted,#888);">Consensus species:</label>
     <input type="text" id="grmSpecies" style="background:var(--bg-input,#14374E);color:var(--text-primary,#E0F0F0);border:1px solid var(--border-secondary,#1A4560);border-radius:4px;padding:6px 10px;font-size:13px;width:200px;">
     <button onclick="grmRemoveFromGroup()" style="background:var(--bg-tertiary,#14374E);color:var(--text-muted,#888);border:none;border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;">Remove from group</button>
     <span class="grm-hint">↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom</span>

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1222,9 +1222,28 @@ function renderGroupModal() {
   document.getElementById('grmCandidates').innerHTML = candidateItems.map(renderCard).join('') || '<span style="font-size:12px;color:var(--text-ghost,#555);">All sorted</span>';
   document.getElementById('grmRejects').innerHTML = rejectItems.map(renderCard).join('') || '<span style="font-size:12px;color:var(--text-ghost,#555);">Drag or press ↓ to reject</span>';
 
-  // Species input — use the consensus
+  // Species input — prefill with the group consensus. Matches the backend
+  // consensus_prediction algorithm: pick the species with the highest sum of
+  // per-frame confidence (== count × avg_confidence), tie-broken by vote count.
   if (!document.getElementById('grmSpecies').value && items.length > 0) {
-    document.getElementById('grmSpecies').value = items[0].species || '';
+    var votes = {};
+    items.forEach(function(it) {
+      if (!it.species) return;
+      if (!votes[it.species]) votes[it.species] = { count: 0, confSum: 0 };
+      votes[it.species].count += 1;
+      votes[it.species].confSum += (it.confidence || 0);
+    });
+    var consensus = '';
+    var bestConf = -1, bestCount = -1;
+    Object.keys(votes).forEach(function(sp) {
+      var v = votes[sp];
+      if (v.confSum > bestConf || (v.confSum === bestConf && v.count > bestCount)) {
+        bestConf = v.confSum;
+        bestCount = v.count;
+        consensus = sp;
+      }
+    });
+    document.getElementById('grmSpecies').value = consensus;
   }
 
   document.getElementById('grmCount').textContent = pickItems.length + ' picks, ' + rejectItems.length + ' rejects, ' + candidateItems.length + ' unsorted';

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -822,6 +822,22 @@ def test_get_group_predictions_alternatives_filtered_by_model(tmp_path):
     assert alts == ['Sparrow']
 
 
+def test_get_group_predictions_handles_large_group(tmp_path):
+    """Very large burst groups must not blow up SQLite's expression depth."""
+    size = 1005
+    photos = [{'quality_score': 0.5} for _ in range(size)]
+    db, pids = _make_workspace_with_photos(tmp_path, photos)
+    for pid in pids:
+        det = db.save_detections(pid, [
+            {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
+        ], detector_model="MDV6")
+        db.add_prediction(det[0], species='Robin', confidence=0.9, model='test', group_id='g1')
+
+    results = db.get_group_predictions('g1')
+    assert len(results) == size
+    assert all(dict(r)['alternatives'] == [] for r in results)
+
+
 def test_get_group_predictions_alternatives_keyed_by_detection_and_model(tmp_path):
     """If the same detection has primaries from multiple models in one group,
     each primary gets only its own model's alternatives."""

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -822,6 +822,23 @@ def test_get_group_predictions_alternatives_filtered_by_model(tmp_path):
     assert alts == ['Sparrow']
 
 
+def test_get_group_predictions_alternatives_keyed_by_detection_and_model(tmp_path):
+    """If the same detection has primaries from multiple models in one group,
+    each primary gets only its own model's alternatives."""
+    db, pids = _make_workspace_with_photos(tmp_path, [{'quality_score': 0.9}])
+    det = db.save_detections(pids[0], [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")
+    db.add_prediction(det[0], species='Robin', confidence=0.95, model='modelA', group_id='g1')
+    db.add_prediction(det[0], species='Sparrow', confidence=0.4, model='modelA', status='alternative')
+    db.add_prediction(det[0], species='Eagle', confidence=0.90, model='modelB', group_id='g1')
+    db.add_prediction(det[0], species='Hawk', confidence=0.3, model='modelB', status='alternative')
+
+    results = [dict(r) for r in db.get_group_predictions('g1')]
+    by_model = {r['model']: [a['species'] for a in r['alternatives']] for r in results}
+    assert by_model == {'modelA': ['Sparrow'], 'modelB': ['Hawk']}
+
+
 def test_update_predictions_status_by_photo(tmp_path):
     """Updates prediction status for all predictions of a photo."""
     db, pids = _make_workspace_with_photos(tmp_path, [{}])

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -779,6 +779,33 @@ def test_get_group_predictions(tmp_path):
     assert 'filename' in dict(results[0])
 
 
+def test_get_group_predictions_includes_alternatives(tmp_path):
+    """Each primary row includes per-detection alternatives sorted by confidence."""
+    db, pids = _make_workspace_with_photos(tmp_path, [
+        {'quality_score': 0.9}, {'quality_score': 0.5},
+    ])
+    det0 = db.save_detections(pids[0], [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")
+    det1 = db.save_detections(pids[1], [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.8, "category": "animal"}
+    ], detector_model="MDV6")
+    db.add_prediction(det0[0], species='Robin', confidence=0.95, model='test', group_id='g1')
+    db.add_prediction(det0[0], species='Sparrow', confidence=0.30, model='test', status='alternative')
+    db.add_prediction(det0[0], species='Wren', confidence=0.10, model='test', status='alternative')
+    db.add_prediction(det1[0], species='Robin', confidence=0.80, model='test', group_id='g1')
+    db.add_prediction(det1[0], species='Finch', confidence=0.25, model='test', status='alternative')
+
+    results = db.get_group_predictions('g1')
+    assert len(results) == 2
+    row0 = dict(results[0])
+    row1 = dict(results[1])
+    # Alternatives attached per detection, sorted desc by confidence
+    assert [a['species'] for a in row0['alternatives']] == ['Sparrow', 'Wren']
+    assert [a['species'] for a in row1['alternatives']] == ['Finch']
+    assert row0['alternatives'][0]['confidence'] == 0.30
+
+
 def test_update_predictions_status_by_photo(tmp_path):
     """Updates prediction status for all predictions of a photo."""
     db, pids = _make_workspace_with_photos(tmp_path, [{}])

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -806,6 +806,22 @@ def test_get_group_predictions_includes_alternatives(tmp_path):
     assert row0['alternatives'][0]['confidence'] == 0.30
 
 
+def test_get_group_predictions_alternatives_filtered_by_model(tmp_path):
+    """Alternatives from a different classifier model must not leak in."""
+    db, pids = _make_workspace_with_photos(tmp_path, [{'quality_score': 0.9}])
+    det = db.save_detections(pids[0], [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")
+    db.add_prediction(det[0], species='Robin', confidence=0.95, model='modelA', group_id='g1')
+    db.add_prediction(det[0], species='Sparrow', confidence=0.4, model='modelA', status='alternative')
+    # Alternative from a different model on the same detection — must be excluded
+    db.add_prediction(det[0], species='Eagle', confidence=0.9, model='modelB', status='alternative')
+
+    results = db.get_group_predictions('g1')
+    alts = [a['species'] for a in dict(results[0])['alternatives']]
+    assert alts == ['Sparrow']
+
+
 def test_update_predictions_status_by_photo(tmp_path):
     """Updates prediction status for all predictions of a photo."""
     db, pids = _make_workspace_with_photos(tmp_path, [{}])


### PR DESCRIPTION
## Summary

In the burst group review modal, the per-card species label is the per-photo top-1 prediction and the footer input is the group consensus — but in practice the classifier often agrees on top-1 across all burst frames, so clicking through photos looked like species never changed (while quality score did). This PR makes the relationship explicit and surfaces the per-photo top-5 so the underlying variation is visible.

- Rename footer input label from \"Species:\" to \"Consensus species:\" to clarify that field is the label applied to picks.
- Add a predictions panel to the loupe pane that renders the selected photo's top-5 species predictions (primary + up-to-4 alternatives).
- Extend \`Database.get_group_predictions\` to attach an \`alternatives\` list to each primary row, sorted by confidence descending. Per-detection alternatives were already stored by the classify job (\`status='alternative'\`) but weren't returned by this query.

## Test plan

- [x] \`python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py\` — 443 passed
- [x] New regression test \`test_get_group_predictions_includes_alternatives\` verifies alternatives are attached per detection and sorted by confidence
- [ ] UI: open a burst group in review, click each member, confirm the loupe pane now shows a \"This photo's top predictions\" list of up to 5 entries with per-photo confidences, and the footer label reads \"Consensus species:\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)