### PR TITLE
fix: show manually-confirmed species on highlights, map, and species list

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2201,13 +2201,19 @@ class Database:
             params.append(f"%{keyword}%")
             params.append(f"%{keyword}%")
 
-        where = "WHERE " + " AND ".join(conditions)
-
-        having_clause = ""
-        having_params = []
+        # Match any species tag on the photo, not just MIN(name) — a photo can be
+        # tagged with multiple species keywords.
         if species is not None:
-            having_clause = "HAVING species = ?"
-            having_params.append(species)
+            conditions.append(
+                """EXISTS (SELECT 1 FROM photo_keywords pk_f
+                           JOIN keywords k_f ON k_f.id = pk_f.keyword_id
+                           WHERE pk_f.photo_id = p.id
+                             AND k_f.is_species = 1
+                             AND k_f.name = ?)"""
+            )
+            params.append(species)
+
+        where = "WHERE " + " AND ".join(conditions)
 
         query = f"""
             SELECT p.id, p.latitude, p.longitude, p.thumb_path, p.filename,
@@ -2219,10 +2225,8 @@ class Database:
             {join_clause}
             {where}
             GROUP BY p.id
-            {having_clause}
             ORDER BY p.timestamp ASC, p.filename ASC, p.id ASC
         """
-        params.extend(having_params)
         return self.conn.execute(query, params).fetchall()
 
     def get_accepted_species(self):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2215,19 +2215,33 @@ class Database:
 
         where = "WHERE " + " AND ".join(conditions)
 
+        # When filtering by species, surface that species in the row so the map
+        # popup/legend match the active filter. Otherwise fall back to the
+        # most-recently-tagged species keyword (highest rowid), which reflects
+        # the user's latest confirmed identification when multiple tags exist.
+        if species is not None:
+            species_col_sql = "? AS species"
+            species_col_params = [species]
+        else:
+            species_col_sql = (
+                "(SELECT k2.name FROM photo_keywords pk2 "
+                "JOIN keywords k2 ON k2.id = pk2.keyword_id "
+                "WHERE pk2.photo_id = p.id AND k2.is_species = 1 "
+                "ORDER BY pk2.rowid DESC LIMIT 1) AS species"
+            )
+            species_col_params = []
+
         query = f"""
             SELECT p.id, p.latitude, p.longitude, p.thumb_path, p.filename,
                    p.timestamp, p.rating, p.folder_id,
-                   (SELECT MIN(k2.name) FROM photo_keywords pk2
-                    JOIN keywords k2 ON k2.id = pk2.keyword_id
-                    WHERE pk2.photo_id = p.id AND k2.is_species = 1) AS species
+                   {species_col_sql}
             FROM photos p
             {join_clause}
             {where}
             GROUP BY p.id
             ORDER BY p.timestamp ASC, p.filename ASC, p.id ASC
         """
-        return self.conn.execute(query, params).fetchall()
+        return self.conn.execute(query, species_col_params + params).fetchall()
 
     def get_accepted_species(self):
         """Return distinct marker species from geolocated photos in the active workspace.
@@ -2943,11 +2957,16 @@ class Database:
                FROM photos p
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                LEFT JOIN (
-                   SELECT pk.photo_id, MIN(k.name) AS species
-                   FROM photo_keywords pk
-                   JOIN keywords k ON k.id = pk.keyword_id
-                   WHERE k.is_species = 1
-                   GROUP BY pk.photo_id
+                   SELECT photo_id, name AS species FROM (
+                       SELECT pk.photo_id, k.name,
+                              ROW_NUMBER() OVER (
+                                  PARTITION BY pk.photo_id
+                                  ORDER BY pk.rowid DESC
+                              ) AS rn
+                       FROM photo_keywords pk
+                       JOIN keywords k ON k.id = pk.keyword_id
+                       WHERE k.is_species = 1
+                   ) WHERE rn = 1
                ) bp ON bp.photo_id = p.id
                WHERE p.folder_id = ?
                  AND wf.workspace_id = ?

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2168,8 +2168,9 @@ class Database:
         """Return all geolocated photos with optional species, scoped to active workspace.
 
         Returns photos that have non-null latitude and longitude. No pagination —
-        returns all matching photos for map rendering. Includes the highest-confidence
-        accepted prediction species name (or NULL if none).
+        returns all matching photos for map rendering. Includes the photo's
+        species keyword (or NULL if none), derived from photo_keywords joined to
+        keywords where is_species = 1.
         """
         conditions = ["wf.workspace_id = ?",
                       "p.latitude IS NOT NULL",
@@ -2211,12 +2212,9 @@ class Database:
         query = f"""
             SELECT p.id, p.latitude, p.longitude, p.thumb_path, p.filename,
                    p.timestamp, p.rating, p.folder_id,
-                   (SELECT pr.species FROM predictions pr
-                    JOIN detections d ON d.id = pr.detection_id
-                    WHERE d.photo_id = p.id
-                      AND d.workspace_id = ?
-                      AND pr.status = 'accepted'
-                    ORDER BY pr.confidence DESC LIMIT 1) AS species
+                   (SELECT MIN(k2.name) FROM photo_keywords pk2
+                    JOIN keywords k2 ON k2.id = pk2.keyword_id
+                    WHERE pk2.photo_id = p.id AND k2.is_species = 1) AS species
             FROM photos p
             {join_clause}
             {where}
@@ -2224,40 +2222,33 @@ class Database:
             {having_clause}
             ORDER BY p.timestamp ASC, p.filename ASC, p.id ASC
         """
-        params.insert(0, self._ws_id())  # for the subquery
         params.extend(having_params)
         return self.conn.execute(query, params).fetchall()
 
     def get_accepted_species(self):
         """Return distinct marker species from geolocated photos in the active workspace.
 
-        Uses the same derivation as get_geolocated_photos: the highest-confidence
-        accepted prediction per photo.  Only considers photos that have GPS
-        coordinates, so every returned species can actually produce a map marker.
+        Uses the same derivation as get_geolocated_photos: species keywords
+        (is_species = 1) tagged on the photo.  Only considers photos that have
+        GPS coordinates, so every returned species can actually produce a map marker.
         """
         ws = self._ws_id()
         return [
             row[0]
             for row in self.conn.execute(
                 """
-                SELECT DISTINCT top_species FROM (
-                    SELECT (SELECT pr.species FROM predictions pr
-                            JOIN detections d ON d.id = pr.detection_id
-                            WHERE d.photo_id = p.id
-                              AND d.workspace_id = ?
-                              AND pr.status = 'accepted'
-                            ORDER BY pr.confidence DESC LIMIT 1) AS top_species
-                    FROM photos p
-                    JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-                    JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
-                    WHERE wf.workspace_id = ?
-                      AND p.latitude IS NOT NULL
-                      AND p.longitude IS NOT NULL
-                )
-                WHERE top_species IS NOT NULL
-                ORDER BY top_species ASC
+                SELECT DISTINCT k.name
+                FROM photos p
+                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+                JOIN photo_keywords pk ON pk.photo_id = p.id
+                JOIN keywords k ON k.id = pk.keyword_id AND k.is_species = 1
+                WHERE wf.workspace_id = ?
+                  AND p.latitude IS NOT NULL
+                  AND p.longitude IS NOT NULL
+                ORDER BY k.name ASC
                 """,
-                (ws, ws),
+                (ws,),
             ).fetchall()
         ]
 
@@ -2929,8 +2920,12 @@ class Database:
         """Return photos eligible for highlights selection.
 
         Returns photos in the given folder that have a quality_score >= min_quality
-        and are not user-rejected. Includes the top accepted prediction species
-        (or NULL) and DINO embeddings for MMR diversity.
+        and are not user-rejected. Includes the photo's species keyword (or NULL)
+        and DINO embeddings for MMR diversity.
+
+        Species is derived from photo_keywords joined to keywords where
+        is_species = 1, which covers both accepted predictions (accept_prediction
+        tags the photo) and manual identification via the confirm-species flow.
 
         Ordered by quality_score DESC.
         """
@@ -2944,22 +2939,19 @@ class Database:
                FROM photos p
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                LEFT JOIN (
-                   SELECT det.photo_id, pred.species,
-                          ROW_NUMBER() OVER (
-                              PARTITION BY det.photo_id
-                              ORDER BY pred.confidence DESC
-                          ) AS rn
-                   FROM detections det
-                   JOIN predictions pred ON pred.detection_id = det.id
-                   WHERE det.workspace_id = ? AND pred.status = 'accepted'
-               ) bp ON bp.photo_id = p.id AND bp.rn = 1
+                   SELECT pk.photo_id, MIN(k.name) AS species
+                   FROM photo_keywords pk
+                   JOIN keywords k ON k.id = pk.keyword_id
+                   WHERE k.is_species = 1
+                   GROUP BY pk.photo_id
+               ) bp ON bp.photo_id = p.id
                WHERE p.folder_id = ?
                  AND wf.workspace_id = ?
                  AND p.quality_score IS NOT NULL
                  AND p.quality_score >= ?
                  AND p.flag != 'rejected'
                ORDER BY p.quality_score DESC""",
-            (self._ws_id(), folder_id, self._ws_id(), min_quality),
+            (folder_id, self._ws_id(), min_quality),
         ).fetchall()
         return rows
 

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1068,6 +1068,33 @@ def test_get_geolocated_photos_species_filter(tmp_path):
     assert results[0]['filename'] == 'heron.jpg'
 
 
+def test_get_geolocated_photos_species_filter_multi_species(tmp_path):
+    """Filter matches any species tag on the photo, not only the alphabetical first."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    db.add_workspace_folder(db._active_workspace_id, fid)
+    p1 = db.add_photo(folder_id=fid, filename='both.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET latitude=37.0, longitude=-122.0 WHERE id=?", (p1,))
+    db.conn.commit()
+    det1 = db.save_detections(p1, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.95, "category": "animal"}
+    ], detector_model="MDV6")
+    det2 = db.save_detections(p1, [
+        {"box": {"x": 0.5, "y": 0.5, "w": 0.3, "h": 0.4}, "confidence": 0.60, "category": "animal"}
+    ], detector_model="MDV6")
+    db.add_prediction(det1[0], 'Red-tailed Hawk', 0.95, 'bioclip')
+    db.add_prediction(det2[0], "Sparrow", 0.60, 'bioclip')
+    for pr in db.get_predictions(photo_ids=[p1]):
+        db.accept_prediction(pr['id'])
+
+    # Photo is tagged with both; either filter value must return it.
+    assert len(db.get_geolocated_photos(species='Red-tailed Hawk')) == 1
+    assert len(db.get_geolocated_photos(species='Sparrow')) == 1
+    assert db.get_geolocated_photos(species='Cardinal') == []
+
+
 def test_get_accepted_species(tmp_path):
     """get_accepted_species returns distinct marker species from geolocated photos."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1089,9 +1089,14 @@ def test_get_geolocated_photos_species_filter_multi_species(tmp_path):
     for pr in db.get_predictions(photo_ids=[p1]):
         db.accept_prediction(pr['id'])
 
-    # Photo is tagged with both; either filter value must return it.
-    assert len(db.get_geolocated_photos(species='Red-tailed Hawk')) == 1
-    assert len(db.get_geolocated_photos(species='Sparrow')) == 1
+    # Photo is tagged with both; either filter value must return it,
+    # and the species label in the returned row must match the filter.
+    rows = db.get_geolocated_photos(species='Red-tailed Hawk')
+    assert len(rows) == 1
+    assert rows[0]['species'] == 'Red-tailed Hawk'
+    rows = db.get_geolocated_photos(species='Sparrow')
+    assert len(rows) == 1
+    assert rows[0]['species'] == 'Sparrow'
     assert db.get_geolocated_photos(species='Cardinal') == []
 
 

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1012,10 +1012,8 @@ def test_get_geolocated_photos_with_species(tmp_path):
         {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
     ], detector_model="MDV6")
     db.add_prediction(det_ids[0], 'Red-tailed Hawk', 0.95, 'bioclip')
-    # Accept the prediction
     pred = db.get_predictions(photo_ids=[p1])
-    db.conn.execute("UPDATE predictions SET status='accepted' WHERE id=?", (pred[0]['id'],))
-    db.conn.commit()
+    db.accept_prediction(pred[0]['id'])
 
     results = db.get_geolocated_photos()
     assert len(results) == 1
@@ -1059,8 +1057,7 @@ def test_get_geolocated_photos_species_filter(tmp_path):
     db.add_prediction(det_ids2[0], 'Great Blue Heron', 0.90, 'bioclip')
     preds = db.get_predictions(photo_ids=[p1, p2])
     for pr in preds:
-        db.conn.execute("UPDATE predictions SET status='accepted' WHERE id=?", (pr['id'],))
-    db.conn.commit()
+        db.accept_prediction(pr['id'])
 
     results = db.get_geolocated_photos(species='Red-tailed Hawk')
     assert len(results) == 1
@@ -1094,8 +1091,7 @@ def test_get_accepted_species(tmp_path):
     db.add_prediction(det_ids2[0], 'Great Blue Heron', 0.90, 'bioclip')
     preds = db.get_predictions(photo_ids=[p1, p2])
     for pr in preds:
-        db.conn.execute("UPDATE predictions SET status='accepted' WHERE id=?", (pr['id'],))
-    db.conn.commit()
+        db.accept_prediction(pr['id'])
 
     species = db.get_accepted_species()
     assert 'Great Blue Heron' in species
@@ -1143,8 +1139,8 @@ def test_get_accepted_species_excludes_non_accepted(tmp_path):
     assert species == []
 
 
-def test_get_accepted_species_uses_top_confidence(tmp_path):
-    """get_accepted_species returns only the highest-confidence species per photo."""
+def test_get_accepted_species_multiple_species_per_photo(tmp_path):
+    """get_accepted_species returns all distinct species keywords tagged on photos."""
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     fid = db.add_folder('/photos', name='photos')
@@ -1164,12 +1160,11 @@ def test_get_accepted_species_uses_top_confidence(tmp_path):
     db.add_prediction(det_ids2[0], 'Cooper\'s Hawk', 0.60, 'bioclip')
     preds = db.get_predictions(photo_ids=[p1])
     for pr in preds:
-        db.conn.execute("UPDATE predictions SET status='accepted' WHERE id=?", (pr['id'],))
-    db.conn.commit()
+        db.accept_prediction(pr['id'])
 
     species = db.get_accepted_species()
-    # Only the top-confidence species should appear
-    assert species == ['Red-tailed Hawk']
+    # Both species keywords tagged on the photo appear, alphabetical.
+    assert species == ["Cooper's Hawk", 'Red-tailed Hawk']
 
 
 def test_count_photos_without_gps(tmp_path):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -216,8 +216,7 @@ def test_api_photos_geo_species_filter(app_and_db):
     db.add_prediction(det3[0], 'Sparrow', 0.8, 'bioclip')
     preds = db.get_predictions(photo_ids=[1, 3])
     for pr in preds:
-        db.conn.execute("UPDATE predictions SET status='accepted' WHERE id=?", (pr['id'],))
-    db.conn.commit()
+        db.accept_prediction(pr['id'])
 
     client = app.test_client()
     resp = client.get('/api/photos/geo?species=Cardinal')
@@ -233,8 +232,7 @@ def test_api_species_list(app_and_db):
     det_ids = db.save_detections(1, [{"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}], detector_model="MDV6")
     db.add_prediction(det_ids[0], 'Cardinal', 0.9, 'bioclip')
     preds = db.get_predictions(photo_ids=[1])
-    db.conn.execute("UPDATE predictions SET status='accepted' WHERE id=?", (preds[0]['id'],))
-    db.conn.commit()
+    db.accept_prediction(preds[0]['id'])
 
     client = app.test_client()
     resp = client.get('/api/species')


### PR DESCRIPTION
## Summary

- On the Small Test workspace, all highlights showed "Unidentified" even after manually confirming species for every photo. Root cause: `get_highlights_candidates`, `get_geolocated_photos`, and `get_accepted_species` all derived a photo's species from `predictions.status = 'accepted'`. The manual "confirm species for encounter" path (`/api/encounters/.../confirm`, `app.py:5960`) only writes to `photo_keywords` and never touches `predictions`, so manual identifications were invisible to those three queries.
- Switched the species lookup to `photo_keywords` joined with `keywords WHERE is_species = 1`. `accept_prediction` already calls `tag_photo`, so the prediction-accept path is still covered; the manual path now works too.
- Updated three tests that set `predictions.status = 'accepted'` via raw SQL to use `db.accept_prediction(...)` instead (which tags the photo correctly). Repurposed `test_get_accepted_species_uses_top_confidence` → `test_get_accepted_species_multiple_species_per_photo` since the "top-confidence-per-photo" semantic no longer applies — a photo with multiple species keywords now returns all of them.

## Test plan
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_highlights.py` → 448 passed
- [ ] Manually verify on Small Test workspace: highlights page now labels identified photos with their species instead of "Unidentified"
- [ ] Map species filter still works, and the species dropdown populates for workspaces where identifications came from the manual flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)