### PR TITLE
fix: enable lightbox arrow navigation on Review Pending Changes

### DIFF
--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -864,10 +864,15 @@ function renderGrid() {
 document.getElementById('grid').addEventListener('click', function(e) {
   var img = e.target.closest('img[data-photo-id]');
   if (img) {
-    var photoList = Array.prototype.map.call(
-      document.getElementById('grid').querySelectorAll('img[data-photo-id]'),
-      function(el) { return { id: parseInt(el.dataset.photoId, 10), filename: el.dataset.filename || '' }; }
-    );
+    var seen = {};
+    var photoList = [];
+    var thumbs = document.getElementById('grid').querySelectorAll('img[data-photo-id]');
+    for (var i = 0; i < thumbs.length; i++) {
+      var pid = parseInt(thumbs[i].dataset.photoId, 10);
+      if (seen[pid]) continue;
+      seen[pid] = true;
+      photoList.push({ id: pid, filename: thumbs[i].dataset.filename || '' });
+    }
     openLightbox(parseInt(img.dataset.photoId, 10), img.dataset.filename || '', photoList);
     return;
   }

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -864,7 +864,11 @@ function renderGrid() {
 document.getElementById('grid').addEventListener('click', function(e) {
   var img = e.target.closest('img[data-photo-id]');
   if (img) {
-    openLightbox(parseInt(img.dataset.photoId, 10), img.dataset.filename || '');
+    var photoList = Array.prototype.map.call(
+      document.getElementById('grid').querySelectorAll('img[data-photo-id]'),
+      function(el) { return { id: parseInt(el.dataset.photoId, 10), filename: el.dataset.filename || '' }; }
+    );
+    openLightbox(parseInt(img.dataset.photoId, 10), img.dataset.filename || '', photoList);
     return;
   }
   var groupBtn = e.target.closest('button[data-group-id]');


### PR DESCRIPTION
## Summary
- Clicking an image in Review Pending Changes opened the lightbox, but the left/right arrows did nothing because `openLightbox` was called without its third `photoList` argument (see `_navbar.html:1829` — `lightboxNav` bails out when `_lightboxPhotoList.length < 2`).
- Fix: build the photo list from `#grid img[data-photo-id]` at click time, so navigation follows the currently visible order (after filter/sort/group-dedupe).

## Test plan
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` — 442 passed
- [ ] Manual: open Review page, click a thumbnail, verify ← / → arrows walk through the grid