### PR TITLE
feat: show SAM2/DINOv2 download status on Extract Features card

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2016,6 +2016,28 @@ def create_app(db_path, thumb_cache_dir=None):
             }
         )
 
+    @app.route("/api/pipeline/extract-readiness")
+    def api_extract_readiness():
+        """Report SAM2/DINOv2 download status for the Extract Features card."""
+        from dino_embed import DINOV2_VARIANTS, dinov2_status
+        from masking import SAM2_VARIANTS, sam2_status
+
+        db = _get_db()
+        pipeline_cfg = db.get_effective_config(cfg.load()).get("pipeline", {})
+        sam2_variant = request.args.get("sam2_variant") or pipeline_cfg.get(
+            "sam2_variant", "sam2-small"
+        )
+        dinov2_variant = request.args.get("dinov2_variant") or pipeline_cfg.get(
+            "dinov2_variant", "vit-b14"
+        )
+
+        return jsonify({
+            "sam2": sam2_status(sam2_variant),
+            "sam2_known": sam2_variant in SAM2_VARIANTS,
+            "dinov2": dinov2_status(dinov2_variant),
+            "dinov2_known": dinov2_variant in DINOV2_VARIANTS,
+        })
+
     @app.route("/api/system/install-exiftool", methods=["POST"])
     def api_install_exiftool():
         """Install exiftool via Homebrew."""

--- a/vireo/dino_embed.py
+++ b/vireo/dino_embed.py
@@ -50,6 +50,23 @@ def _dinov2_model_path(variant):
     return model_dir, os.path.join(model_dir, "model.onnx")
 
 
+def dinov2_status(variant):
+    """Report whether DINOv2 weights for ``variant`` are already on disk.
+
+    Both the graph stub (``model.onnx``) and external-data sidecar
+    (``model.onnx.data``) must be present — a graph-only state is treated
+    as not-ready so the readiness UI matches what the loader actually
+    requires (see ``ensure_dinov2_weights``).
+    """
+    _, model_path = _dinov2_model_path(variant)
+    data_path = model_path + ".data"
+    return {
+        "variant": variant,
+        "ready": os.path.isfile(model_path) and os.path.isfile(data_path),
+        "size_hint": _DINOV2_SIZE_HINT.get(variant, ""),
+    }
+
+
 def ensure_dinov2_weights(variant="vit-b14", progress_callback=None):
     """Ensure DINOv2 ONNX weights for ``variant`` are on disk.
 

--- a/vireo/masking.py
+++ b/vireo/masking.py
@@ -52,6 +52,23 @@ def _sam2_model_dir(variant):
     )
 
 
+def sam2_status(variant):
+    """Report whether SAM2 weights for ``variant`` are already on disk.
+
+    Returns a dict with ``variant``, ``ready`` (bool), and ``size_hint`` (str).
+    Unknown variants come back as not-ready with an empty size hint so callers
+    can render a generic "not downloaded" state without raising.
+    """
+    model_dir = _sam2_model_dir(variant)
+    encoder_path = os.path.join(model_dir, "image_encoder.onnx")
+    decoder_path = os.path.join(model_dir, "mask_decoder.onnx")
+    return {
+        "variant": variant,
+        "ready": os.path.isfile(encoder_path) and os.path.isfile(decoder_path),
+        "size_hint": _SAM2_SIZE_HINT.get(variant, ""),
+    }
+
+
 def ensure_sam2_weights(variant="sam2-small", progress_callback=None):
     """Ensure SAM2 ONNX encoder + decoder weights for ``variant`` are on disk.
 

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -827,6 +827,7 @@ body { padding-bottom: 36px; }
           </div>
         </div>
       </div>
+      <div class="readiness-panel" id="extractReadinessPanel" style="display:none;"></div>
       <span class="status-msg" id="statusExtract"></span>
       <div class="progress-wrap" id="progressExtract" style="display:none;">
         <div class="progress-bar-track"><div class="progress-bar-fill" id="fillExtract"></div></div>
@@ -955,6 +956,7 @@ function initPipelinePage() {
 
       updateCardStates();
       if (typeof updateReadiness === 'function') updateReadiness();
+      if (typeof updateExtractReadiness === 'function') updateExtractReadiness();
 
       // Populate recent destinations
       var recents = data.recent_destinations || [];
@@ -2579,6 +2581,41 @@ function onModelConfigChange() {
       _savedModelConfig = newCfg;
     }
   }).catch(function() {});
+
+  updateExtractReadiness();
+}
+
+async function updateExtractReadiness() {
+  var panel = document.getElementById('extractReadinessPanel');
+  if (!panel) return;
+  var sam2 = document.getElementById('cfgSam2').value;
+  var dinov2 = document.getElementById('cfgDinov2').value;
+  try {
+    var r = await safeFetch(
+      '/api/pipeline/extract-readiness'
+        + '?sam2_variant=' + encodeURIComponent(sam2)
+        + '&dinov2_variant=' + encodeURIComponent(dinov2),
+      {}, { toast: false }
+    );
+    var items = [];
+    items.push(renderModelReadiness('SAM2', r.sam2));
+    items.push(renderModelReadiness('DINOv2', r.dinov2));
+    panel.innerHTML = items.join('<br>');
+    panel.style.display = '';
+  } catch(e) {
+    panel.style.display = 'none';
+  }
+}
+
+function renderModelReadiness(label, info) {
+  if (info && info.ready) {
+    return '<span style="color:var(--accent,#24E5CA);">&#10003;</span> '
+      + label + ': <b>' + info.variant + '</b> &mdash; ready';
+  }
+  var size = info && info.size_hint ? ' (' + info.size_hint + ')' : '';
+  return '<span style="color:var(--warning,#f0c040);">&#9679;</span> '
+    + label + ': <b>' + (info ? info.variant : '?')
+    + '</b> &mdash; will download' + size + ' on first run';
 }
 
 async function runExtractStep(collectionId) {

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2597,35 +2597,60 @@ async function updateExtractReadiness() {
         + '&dinov2_variant=' + encodeURIComponent(dinov2),
       {}, { toast: false }
     );
-    var items = [];
-    items.push(renderModelReadiness('SAM2', r.sam2, r.sam2_known));
-    items.push(renderModelReadiness('DINOv2', r.dinov2, r.dinov2_known));
-    panel.innerHTML = items.join('<br>');
+    panel.textContent = '';
+    panel.appendChild(renderModelReadiness('SAM2', r.sam2, r.sam2_known));
+    panel.appendChild(document.createElement('br'));
+    panel.appendChild(renderModelReadiness('DINOv2', r.dinov2, r.dinov2_known));
     panel.style.display = '';
   } catch(e) {
     panel.style.display = 'none';
   }
 }
 
+// Build the readiness line as DOM nodes so variant strings (which
+// originate from /api/pipeline/config and may be arbitrary) can never
+// be interpreted as HTML — avoids a stored DOM-XSS sink on /pipeline.
 function renderModelReadiness(label, info, known) {
+  var frag = document.createDocumentFragment();
   var variant = info ? info.variant : '?';
-  // Unknown variant (e.g. stale override pointing at a removed model):
-  // the download-on-first-run path would be misleading because
-  // ensure_sam2_weights / DINOv2 session validation will reject it at
-  // extract time, so flag the bad config up-front instead.
+  var icon = document.createElement('span');
+
   if (known === false) {
-    return '<span style="color:var(--danger,#e74c3c);">&#10007;</span> '
-      + label + ': <b>' + variant + '</b> &mdash; unknown variant; '
-      + 'pick a supported one above';
+    icon.style.color = 'var(--danger,#e74c3c)';
+    icon.textContent = '\u2717';
+    frag.appendChild(icon);
+    frag.appendChild(document.createTextNode(' ' + label + ': '));
+    var nameEl = document.createElement('b');
+    nameEl.textContent = variant;
+    frag.appendChild(nameEl);
+    frag.appendChild(document.createTextNode(
+      ' \u2014 unknown variant; pick a supported one above'));
+    return frag;
   }
+
   if (info && info.ready) {
-    return '<span style="color:var(--accent,#24E5CA);">&#10003;</span> '
-      + label + ': <b>' + variant + '</b> &mdash; ready';
+    icon.style.color = 'var(--accent,#24E5CA)';
+    icon.textContent = '\u2713';
+    frag.appendChild(icon);
+    frag.appendChild(document.createTextNode(' ' + label + ': '));
+    var readyName = document.createElement('b');
+    readyName.textContent = variant;
+    frag.appendChild(readyName);
+    frag.appendChild(document.createTextNode(' \u2014 ready'));
+    return frag;
   }
+
+  icon.style.color = 'var(--warning,#f0c040)';
+  icon.textContent = '\u25CF';
+  frag.appendChild(icon);
+  frag.appendChild(document.createTextNode(' ' + label + ': '));
+  var downloadName = document.createElement('b');
+  downloadName.textContent = variant;
+  frag.appendChild(downloadName);
   var size = info && info.size_hint ? ' (' + info.size_hint + ')' : '';
-  return '<span style="color:var(--warning,#f0c040);">&#9679;</span> '
-    + label + ': <b>' + variant
-    + '</b> &mdash; will download' + size + ' on first run';
+  frag.appendChild(document.createTextNode(
+    ' \u2014 will download' + size + ' on first run'));
+  return frag;
 }
 
 async function runExtractStep(collectionId) {

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2598,8 +2598,8 @@ async function updateExtractReadiness() {
       {}, { toast: false }
     );
     var items = [];
-    items.push(renderModelReadiness('SAM2', r.sam2));
-    items.push(renderModelReadiness('DINOv2', r.dinov2));
+    items.push(renderModelReadiness('SAM2', r.sam2, r.sam2_known));
+    items.push(renderModelReadiness('DINOv2', r.dinov2, r.dinov2_known));
     panel.innerHTML = items.join('<br>');
     panel.style.display = '';
   } catch(e) {
@@ -2607,14 +2607,24 @@ async function updateExtractReadiness() {
   }
 }
 
-function renderModelReadiness(label, info) {
+function renderModelReadiness(label, info, known) {
+  var variant = info ? info.variant : '?';
+  // Unknown variant (e.g. stale override pointing at a removed model):
+  // the download-on-first-run path would be misleading because
+  // ensure_sam2_weights / DINOv2 session validation will reject it at
+  // extract time, so flag the bad config up-front instead.
+  if (known === false) {
+    return '<span style="color:var(--danger,#e74c3c);">&#10007;</span> '
+      + label + ': <b>' + variant + '</b> &mdash; unknown variant; '
+      + 'pick a supported one above';
+  }
   if (info && info.ready) {
     return '<span style="color:var(--accent,#24E5CA);">&#10003;</span> '
-      + label + ': <b>' + info.variant + '</b> &mdash; ready';
+      + label + ': <b>' + variant + '</b> &mdash; ready';
   }
   var size = info && info.size_hint ? ' (' + info.size_hint + ')' : '';
   return '<span style="color:var(--warning,#f0c040);">&#9679;</span> '
-    + label + ': <b>' + (info ? info.variant : '?')
+    + label + ': <b>' + variant
     + '</b> &mdash; will download' + size + ' on first run';
 }
 

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -51,6 +51,78 @@ def test_import_full_returns_job_id(setup):
         shutil.rmtree(dest, ignore_errors=True)
 
 
+def test_extract_readiness_reports_missing_models(setup, tmp_path, monkeypatch):
+    """Default state with no weights on disk: both models report not-ready
+    with the variant-specific size hint, so the UI can warn before launch."""
+    app, _ = setup
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    with app.test_client() as c:
+        resp = c.get("/api/pipeline/extract-readiness"
+                     "?sam2_variant=sam2-tiny&dinov2_variant=vit-s14")
+        assert resp.status_code == 200
+        data = resp.get_json()
+
+        assert data["sam2"]["variant"] == "sam2-tiny"
+        assert data["sam2"]["ready"] is False
+        assert "MB" in data["sam2"]["size_hint"]
+        assert data["sam2_known"] is True
+
+        assert data["dinov2"]["variant"] == "vit-s14"
+        assert data["dinov2"]["ready"] is False
+        assert "MB" in data["dinov2"]["size_hint"]
+        assert data["dinov2_known"] is True
+
+
+def test_extract_readiness_reports_ready_when_files_present(
+    setup, tmp_path, monkeypatch
+):
+    """When all required weight files exist on disk, ``ready`` flips true.
+    DINOv2 needs both the graph stub and the external-data sidecar — a
+    graph-only state must NOT report ready, because the loader fails."""
+    app, _ = setup
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    sam2_dir = tmp_path / ".vireo" / "models" / "sam2-tiny"
+    sam2_dir.mkdir(parents=True)
+    (sam2_dir / "image_encoder.onnx").write_bytes(b"x")
+    (sam2_dir / "mask_decoder.onnx").write_bytes(b"x")
+
+    dinov2_dir = tmp_path / ".vireo" / "models" / "dinov2-vit-s14"
+    dinov2_dir.mkdir(parents=True)
+    (dinov2_dir / "model.onnx").write_bytes(b"x")
+    (dinov2_dir / "model.onnx.data").write_bytes(b"x")
+
+    with app.test_client() as c:
+        resp = c.get("/api/pipeline/extract-readiness"
+                     "?sam2_variant=sam2-tiny&dinov2_variant=vit-s14")
+        data = resp.get_json()
+        assert data["sam2"]["ready"] is True
+        assert data["dinov2"]["ready"] is True
+
+
+def test_extract_readiness_dinov2_graph_only_is_not_ready(
+    setup, tmp_path, monkeypatch
+):
+    """Regression guard: a stub-only model.onnx (e.g. lingering from a
+    pre-#550 partial download) must surface as not-ready so the user
+    sees the re-download warning instead of a silent ONNX Runtime
+    crash on first run."""
+    app, _ = setup
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    dinov2_dir = tmp_path / ".vireo" / "models" / "dinov2-vit-b14"
+    dinov2_dir.mkdir(parents=True)
+    (dinov2_dir / "model.onnx").write_bytes(b"x")
+    # Sidecar deliberately missing.
+
+    with app.test_client() as c:
+        resp = c.get("/api/pipeline/extract-readiness"
+                     "?dinov2_variant=vit-b14")
+        data = resp.get_json()
+        assert data["dinov2"]["ready"] is False
+
+
 def test_import_full_requires_source_and_destination(setup):
     app, db_path = setup
     with app.test_client() as c:

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -101,6 +101,25 @@ def test_extract_readiness_reports_ready_when_files_present(
         assert data["dinov2"]["ready"] is True
 
 
+def test_extract_readiness_flags_unknown_variants(setup, tmp_path, monkeypatch):
+    """An unknown variant (possible from a stale workspace override, since
+    /api/pipeline/config accepts any string) must come back with
+    ``*_known=False`` so the UI can flag the bad config instead of
+    falsely promising a download that ``ensure_sam2_weights`` /
+    DINOv2 session validation will reject at extract time."""
+    app, _ = setup
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    with app.test_client() as c:
+        resp = c.get("/api/pipeline/extract-readiness"
+                     "?sam2_variant=sam2-bogus&dinov2_variant=vit-bogus")
+        data = resp.get_json()
+        assert data["sam2_known"] is False
+        assert data["sam2"]["ready"] is False
+        assert data["dinov2_known"] is False
+        assert data["dinov2"]["ready"] is False
+
+
 def test_extract_readiness_dinov2_graph_only_is_not_ready(
     setup, tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- The Extract Features card had SAM2/DINOv2 dropdowns but no readiness indicator — users only saw the download warning *after* clicking Start Pipeline (via the post-launch `modelWarningBanner`).
- Adds a readiness panel under the Extract Features card mirroring the Classify card's pattern: ✓ ready, or ● will download (~size) on first run.
- Backed by a new `GET /api/pipeline/extract-readiness?sam2_variant=…&dinov2_variant=…` endpoint and `sam2_status` / `dinov2_status` helpers in `masking.py` / `dino_embed.py`. The DINOv2 helper requires both the graph stub and the external-data sidecar before reporting ready, matching what the loader actually needs (see #550).

## Test plan
- [x] `python -m pytest vireo/tests/test_pipeline_api.py -v` — 18 passed (3 new)
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` — 442 passed
- [ ] Manual: open `/pipeline`, change SAM2/DINOv2 dropdowns, confirm panel updates