### PR TITLE
feat: add "Hide confirmed" toggle to pipeline review

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -983,6 +983,7 @@ input[type="range"]::-moz-range-thumb {
       <button class="filter-btn" data-filter="KEEP" onclick="setFilter('KEEP')">Keep<span class="count" id="countKeep"></span></button>
       <button class="filter-btn" data-filter="REVIEW" onclick="setFilter('REVIEW')">Review<span class="count" id="countReview"></span></button>
       <button class="filter-btn" data-filter="REJECT" onclick="setFilter('REJECT')">Reject<span class="count" id="countReject"></span></button>
+      <button class="filter-btn" id="hideConfirmedBtn" onclick="toggleHideConfirmed()" title="Hide encounters/bursts whose species has been confirmed">Hide confirmed</button>
       <div class="species-filter-wrap">
         <input type="text" id="speciesFilterInput" placeholder="Filter by species..." oninput="setSpeciesFilter(this.value)">
         <button class="species-filter-clear" id="speciesFilterClear" onclick="clearSpeciesFilter()" title="Clear filter">&times;</button>
@@ -1067,6 +1068,7 @@ var pipelineResults = null;
 var activeFilter = 'all';
 var minConfidence = 40;
 var speciesFilter = '';
+var hideConfirmed = false;
 
 function setSpeciesFilter(val) {
   speciesFilter = val.toLowerCase();
@@ -1116,10 +1118,28 @@ function renderResults() {
     });
   }
 
-  // Update filter counts (respecting species filter)
+  // Build set of photos hidden because their burst/encounter is confirmed
+  var confirmedHiddenIds = null;
+  if (hideConfirmed) {
+    confirmedHiddenIds = new Set();
+    pipelineResults.encounters.forEach(function(enc) {
+      if (enc.bursts && enc.bursts.length > 0) {
+        enc.bursts.forEach(function(burst) {
+          if (isBurstConfirmed(enc, burst)) {
+            (burst.photo_ids || []).forEach(function(pid) { confirmedHiddenIds.add(pid); });
+          }
+        });
+      } else if (enc.species_confirmed) {
+        (enc.photo_ids || []).forEach(function(pid) { confirmedHiddenIds.add(pid); });
+      }
+    });
+  }
+
+  // Update filter counts (respecting species filter and hide-confirmed)
   var counts = {all: 0, KEEP: 0, REVIEW: 0, REJECT: 0};
   pipelineResults.photos.forEach(function(p) {
     if (speciesVisibleIds && !speciesVisibleIds.has(p.id)) return;
+    if (confirmedHiddenIds && confirmedHiddenIds.has(p.id)) return;
     counts.all++;
     if (p.label) counts[p.label] = (counts[p.label] || 0) + 1;
   });
@@ -1140,11 +1160,21 @@ function renderResults() {
     // Check if encounter passes species filter
     if (!encounterMatchesSpecies(enc)) return;
 
-    // Check if any photo in this encounter passes the label filter
+    // Hide confirmed: skip the whole encounter if every one of its photos is hidden
     var encPhotoIds = enc.photo_ids || [];
+    if (hideConfirmed) {
+      var anyVisible = encPhotoIds.some(function(pid) {
+        return !confirmedHiddenIds.has(pid);
+      });
+      if (!anyVisible) return;
+    }
+
+    // Check if any photo in this encounter passes the label filter
     var hasVisible = encPhotoIds.some(function(pid) {
       var p = photoMap[pid];
-      return p && (activeFilter === 'all' || p.label === activeFilter);
+      if (!p) return false;
+      if (confirmedHiddenIds && confirmedHiddenIds.has(pid)) return false;
+      return activeFilter === 'all' || p.label === activeFilter;
     });
     if (!hasVisible) return;
 
@@ -1161,6 +1191,7 @@ function renderResults() {
 
     if (enc.bursts && enc.bursts.length > 0) {
       enc.bursts.forEach(function(burst, bi) {
+        if (hideConfirmed && isBurstConfirmed(enc, burst)) return;
         var burstIds = burst.photo_ids || burst;
         html += '<div class="burst-strip">';
         html += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:4px;">';
@@ -1230,9 +1261,22 @@ function toggleEncounter(idx) {
 
 function setFilter(f) {
   activeFilter = f;
-  document.querySelectorAll('.filter-btn').forEach(function(btn) {
+  document.querySelectorAll('.filter-btn[data-filter]').forEach(function(btn) {
     btn.classList.toggle('active', btn.getAttribute('data-filter') === f);
   });
+  renderResults();
+}
+
+function isBurstConfirmed(enc, burst) {
+  var ovr = burst && burst.species_override;
+  if (ovr) return !!ovr.confirmed;
+  return !!(enc && enc.species_confirmed);
+}
+
+function toggleHideConfirmed() {
+  hideConfirmed = !hideConfirmed;
+  var btn = document.getElementById('hideConfirmedBtn');
+  if (btn) btn.classList.toggle('active', hideConfirmed);
   renderResults();
 }
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1126,7 +1126,8 @@ function renderResults() {
       if (enc.bursts && enc.bursts.length > 0) {
         enc.bursts.forEach(function(burst) {
           if (isBurstConfirmed(enc, burst)) {
-            (burst.photo_ids || []).forEach(function(pid) { confirmedHiddenIds.add(pid); });
+            var ids = burst.photo_ids || burst || [];
+            ids.forEach(function(pid) { confirmedHiddenIds.add(pid); });
           }
         });
       } else if (enc.species_confirmed) {


### PR DESCRIPTION
## Summary
- Adds a **Hide confirmed** pill to the pipeline review filter bar next to Keep/Review/Reject.
- When active, hides bursts whose species is confirmed (via burst override or cascaded from `enc.species_confirmed`); encounters with no remaining visible bursts/photos drop out entirely.
- Keep/Review/Reject counts also exclude hidden photos so the numbers match what's on screen.

## Implementation notes
- New `hideConfirmed` state + `isBurstConfirmed(enc, burst)` helper that mirrors the widget's cascade logic (burst override wins, otherwise inherits encounter).
- Narrowed `setFilter`'s `.active` toggle to `[data-filter]` buttons so it doesn't clear the new toggle's active state.

## Test plan
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` — 442 passed
- [ ] Manual: load pipeline review, confirm some encounters/bursts, click **Hide confirmed**, verify they disappear and counts update
- [ ] Manual: with Hide confirmed on, switch between Keep/Review/Reject — active state stays on the toggle