### PR TITLE
ui: make Browse the primary source-folder action

### DIFF
--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -482,13 +482,15 @@ body { padding-bottom: 36px; }
             <div class="setting-row">
               <div class="setting-item" id="folderLabelItem">
                 <div class="setting-label" id="lblFolder">Folders</div>
-                <div style="display:flex;gap:6px;">
-                  <input type="text" class="setting-select" id="cfgSourceInput" list="volumeDatalist"
-                         placeholder="/path/to/photos" style="font-family:inherit;flex:1;"
-                         onkeydown="if(event.key==='Enter'){event.preventDefault();addSourceFolder();}">
-                  <datalist id="volumeDatalist"></datalist>
-                  <button onclick="browseForFolder()" class="btn btn-secondary" style="white-space:nowrap;">Browse&hellip;</button>
-                  <button onclick="addSourceFolder()" class="btn btn-secondary" style="white-space:nowrap;">Add</button>
+                <div style="display:flex;flex-direction:column;gap:6px;">
+                  <button onclick="browseForFolder()" class="btn btn-primary" style="white-space:nowrap;align-self:flex-start;">Browse&hellip;</button>
+                  <div style="display:flex;gap:6px;">
+                    <input type="text" class="setting-select" id="cfgSourceInput" list="volumeDatalist"
+                           placeholder="or type a path" style="font-family:inherit;flex:1;"
+                           onkeydown="if(event.key==='Enter'){event.preventDefault();addSourceFolder();}">
+                    <datalist id="volumeDatalist"></datalist>
+                    <button onclick="addSourceFolder()" class="btn btn-secondary" style="white-space:nowrap;">Add</button>
+                  </div>
                 </div>
                 <div id="sourceFolderList" style="margin-top:6px;"></div>
                 <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;margin-top:6px;display:inline-flex;align-items:center;gap:4px;">


### PR DESCRIPTION
## Summary
- On the pipeline page, the source-folder controls were a flat row of [input] [Browse…] [Add], which made Browse and Add feel equivalent and put Browse between the input and the button that commits the typed path.
- Now Browse is on its own line, promoted to `btn-primary`, with the text input and Add paired directly beneath it. Placeholder reworded to "or type a path" to reinforce the hierarchy.

## Test plan
- [x] `python -m pytest vireo/tests/test_app.py -q` — 108 passed
- [ ] Visual check: open pipeline page, confirm Browse is the prominent button and the input + Add still accept Enter to add a path

🤖 Generated with [Claude Code](https://claude.com/claude-code)