### PR TITLE
fix: generate thumbnails for collection photos in pipeline replay

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -578,6 +578,56 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     "stages": {k: dict(v) for k, v in stages.items()},
                 })
 
+            # Collection mode: the scanner is skipped so the queue above was
+            # empty. Iterate the collection's photos directly — mirrors the
+            # pattern used by previews_stage — so replays against an existing
+            # collection still regenerate any missing thumbs.
+            if skip_scan and collection_id:
+                coll_photos = _filter_excluded(
+                    thread_db.get_collection_photos(collection_id, per_page=999999)
+                )
+                folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
+                total = len(coll_photos)
+                for photo in coll_photos:
+                    if _should_abort(abort):
+                        break
+                    photo_id = photo["id"]
+                    folder_path = folders.get(photo["folder_id"], "")
+                    photo_path = os.path.join(folder_path, photo["filename"])
+                    thumb_path = os.path.join(cache_dir, f"{photo_id}.jpg")
+                    already_exists = os.path.exists(thumb_path)
+                    try:
+                        result_path = generate_thumbnail(
+                            photo_id, photo_path, cache_dir, size=thumb_size,
+                        )
+                        if result_path is None:
+                            failed += 1
+                        elif already_exists:
+                            skipped += 1
+                        else:
+                            generated += 1
+                    except Exception:
+                        failed += 1
+                        log.debug("Thumbnail failed for photo %s", photo_id)
+                    stages["thumbnails"]["count"] = generated + skipped + failed
+                    processed = generated + skipped + failed
+                    runner.update_step(
+                        job["id"], "thumbnails",
+                        current_file=os.path.basename(photo_path),
+                        progress={"current": processed, "total": total},
+                    )
+                    elapsed = time.time() - job["_start_time"]
+                    rate = round(processed / max(elapsed, 0.01) * 60, 1)
+                    runner.push_event(job["id"], "progress", {
+                        "phase": "Generating thumbnails",
+                        "stage_id": "thumbnails",
+                        "current": processed,
+                        "total": total,
+                        "current_file": os.path.basename(photo_path),
+                        "rate": rate,
+                        "stages": {k: dict(v) for k, v in stages.items()},
+                    })
+
             from thumbnails import format_summary as thumb_summary
             thumb_result = {"generated": generated, "skipped": skipped, "failed": failed}
             processed = generated + skipped + failed

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -1265,6 +1265,64 @@ def test_pipeline_collection_mode_marks_scan_skipped(tmp_path, monkeypatch):
         f"scan should be 'skipped' in collection mode, saw: {scan_statuses}"
 
 
+def test_pipeline_collection_mode_generates_missing_thumbnails(tmp_path, monkeypatch):
+    """In collection mode the thumbnail stage must still process the collection's
+    photos. Previously it drained an empty queue (only fed by the scanner) and
+    completed with '0 thumbnails' even when photos were missing thumbs."""
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    for name in ["a.jpg", "b.jpg", "c.jpg"]:
+        Image.new("RGB", (100, 100), "red").save(str(photo_dir / name))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # First pipeline run: scan + build collection + generate thumbnails.
+    runner = FakeRunner()
+    job = _make_job()
+    result = run_pipeline_job(
+        job, runner, db_path, ws_id,
+        PipelineParams(
+            source=str(photo_dir),
+            skip_classify=True, skip_extract_masks=True, skip_regroup=True,
+        ),
+    )
+    coll_id = result["collection_id"]
+
+    # Wipe the thumbnail cache to simulate thumbs that were lost or never built.
+    thumb_dir = os.path.join(os.path.dirname(db_path), "thumbnails")
+    for f in os.listdir(thumb_dir):
+        os.remove(os.path.join(thumb_dir, f))
+
+    # Second run: replay the pipeline against the existing collection
+    # (skip_scan path). Thumbnails must be regenerated for all 3 photos.
+    runner2 = FakeRunner()
+    job2 = _make_job()
+    result2 = run_pipeline_job(
+        job2, runner2, db_path, ws_id,
+        PipelineParams(
+            collection_id=coll_id,
+            skip_classify=True, skip_extract_masks=True, skip_regroup=True,
+        ),
+    )
+
+    thumb_result = result2["stages"].get("thumbnails", {})
+    assert thumb_result.get("generated", 0) == 3, (
+        f"Expected 3 thumbnails regenerated in collection mode, "
+        f"got {thumb_result}"
+    )
+    thumb_files = [f for f in os.listdir(thumb_dir) if not f.startswith(".")]
+    assert len(thumb_files) == 3
+
+
 # ---------------------------------------------------------------------------
 # Stage failure propagation (fixes the silent model-loader failure incident)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Pipeline replay against an existing collection (`collection_id` set, `skip_scan=True`) was reporting **\"0 thumbnails\"** in the Generate thumbnails step even when photos in the collection had no thumbnail on disk.
- `thumbnail_stage()` only consumed from the `scan_to_thumb` queue, which the scanner feeds. In collection mode the scanner returns immediately after pushing `_SENTINEL`, so the loop exited in a few ms with `generated=skipped=failed=0`.
- `previews_stage()` already handles this case by iterating `thread_db.get_collection_photos(collection_id, ...)`. This change mirrors that pattern in `thumbnail_stage` — after the queue drains, if `skip_scan and collection_id`, walk the collection's photos and call `generate_thumbnail` for each, counting generated / skipped / failed using the same existing-thumb check.

## Test plan

- [x] New test `test_pipeline_collection_mode_generates_missing_thumbnails` — runs the pipeline with `source=...` to build a collection, wipes the thumbnail cache, reruns with `collection_id=...`, asserts 3 thumbnails are regenerated. Fails before the fix (`generated: 0`), passes after.
- [x] Full prescribed suite: `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_pipeline_job.py -q` → **523 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)