### PR TITLE
fix: don't alarm users when updater manifest is missing their platform

### DIFF
--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -45,7 +45,24 @@ async fn do_update_check(
     app: &AppHandle,
     user_initiated: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let update = app.updater()?.check().await?;
+    let updater = app.updater()?;
+    let update = match updater.check().await {
+        Ok(u) => u,
+        // A missing platform key in the manifest means the release pipeline
+        // didn't publish an artifact for the current OS/arch (e.g. macOS
+        // notarization failed mid-release). That's a broken release for the
+        // developer to fix — not something to alarm end users about. Log
+        // loudly so it shows up in vireo.log, then fall through to the
+        // normal "no update available" path.
+        Err(
+            e @ (tauri_plugin_updater::Error::TargetNotFound(_)
+            | tauri_plugin_updater::Error::TargetsNotFound(_)),
+        ) => {
+            log::error!("Update manifest missing platform entry: {e}");
+            None
+        }
+        Err(e) => return Err(e.into()),
+    };
 
     match update {
         Some(update) => {


### PR DESCRIPTION
## Summary
- When `latest.json` doesn't contain an entry for the running OS/arch, the Tauri updater returns `TargetsNotFound` / `TargetNotFound` and users see an alarming "Update Error" dialog.
- This happened on v0.8.22: the macOS notarization step failed mid-release, so the release published with no `darwin-aarch64` artifacts and Mac users saw the error on their next update check.
- A broken release manifest is a developer problem, not an end-user problem. This PR catches those two error variants in `src-tauri/src/updater.rs`, logs them at `error!` level (so they still show up in `vireo.log`), and falls through to the normal "no update available" path.
- All other updater errors retain existing behavior (log + dialog for user-initiated checks).

## Test plan
- [x] `cargo check` passes in `src-tauri/`
- [ ] Manual: point the updater endpoint at a `latest.json` missing the current platform and confirm no error dialog appears on a user-initiated check (the normal "Up to Date" dialog shows instead)
- [ ] Manual: confirm `vireo.log` contains `Update manifest missing platform entry: ...`