### PR TITLE
fix: don't auto-run reflow/regroup when opening pipeline review

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1394,8 +1394,8 @@ var GROUPING_DEFAULTS = {
     GROUPING_DEFAULTS.burst_time_gap = p.burst_time_gap != null ? p.burst_time_gap : 3;
     GROUPING_DEFAULTS.burst_phash_threshold = p.burst_phash_threshold != null ? p.burst_phash_threshold : 12;
     GROUPING_DEFAULTS.burst_embedding_threshold = Math.round((p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.80) * 100);
-    resetScoringDefaults();
-    resetGroupingDefaults();
+    applyScoringDefaults();
+    applyGroupingDefaults();
   } catch(e) {
     console.warn('Could not load pipeline config, using built-in defaults:', e);
   }
@@ -1520,7 +1520,7 @@ function updateSummaryBar(summary) {
   }
 }
 
-function resetScoringDefaults() {
+function applyScoringDefaults() {
   document.getElementById('slRejectCrop').value = SCORING_DEFAULTS.reject_crop_complete;
   document.getElementById('slRejectFocus').value = SCORING_DEFAULTS.reject_focus;
   document.getElementById('slRejectClip').value = SCORING_DEFAULTS.reject_clip_high;
@@ -1529,14 +1529,17 @@ function resetScoringDefaults() {
   document.getElementById('slBurstKeep').value = SCORING_DEFAULTS.burst_max_keep;
   document.getElementById('slEncLambda').value = SCORING_DEFAULTS.encounter_lambda;
   document.getElementById('slEncKeep').value = SCORING_DEFAULTS.encounter_max_keep;
-  // Update displays
   document.querySelectorAll('.sidebar-section input[type="range"]').forEach(function(sl) {
     updateSliderDisplay(sl);
   });
+}
+
+function resetScoringDefaults() {
+  applyScoringDefaults();
   doReflow();
 }
 
-function resetGroupingDefaults() {
+function applyGroupingDefaults() {
   document.getElementById('slEncCut').value = GROUPING_DEFAULTS.hard_cut_score;
   document.getElementById('slEncMerge').value = GROUPING_DEFAULTS.merge_score;
   document.getElementById('slBurstTime').value = GROUPING_DEFAULTS.burst_time_gap;
@@ -1545,6 +1548,10 @@ function resetGroupingDefaults() {
   document.querySelectorAll('.sidebar-section input[type="range"]').forEach(function(sl) {
     updateSliderDisplay(sl);
   });
+}
+
+function resetGroupingDefaults() {
+  applyGroupingDefaults();
   doRegroupLive();
 }
 


### PR DESCRIPTION
## Summary

Opening \`/pipeline/review\` fired \`/api/pipeline/reflow\` and \`/api/pipeline/regroup-live\` on every page load. If the pipeline was still running (or hadn't finished \`extract_masks\`), those calls read a partial DB state, rejected every maskless photo with \`no_subject_mask\`, and clobbered the cache the pipeline job was building.

Root cause: the slider-default IIFE in \`pipeline_review.html\` called \`resetScoringDefaults()\` / \`resetGroupingDefaults()\`, each of which did two things — set slider values **and** re-run the pipeline via \`doReflow()\` / \`doRegroupLive()\`.

Fix: split each into \`applyScoringDefaults()\` / \`applyGroupingDefaults()\` (set slider values only) and \`resetScoringDefaults()\` / \`resetGroupingDefaults()\` (apply + re-run). The page-load IIFE now calls \`apply*\`; the Reset buttons still call \`reset*\`.

The cache is now owned by deliberate writes only: (a) the pipeline job's \`regroup_stage\`, or (b) a user-initiated slider move or Reset click.

## Test plan

- [x] \`python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q\` → 465 passed
- [ ] Open \`/pipeline/review\` after running the pipeline — results render from cached JSON, no network POST to reflow/regroup in devtools
- [ ] Move a scoring slider — reflow fires as before
- [ ] Move a grouping slider — regroup-live fires as before
- [ ] Click "Reset defaults" on each panel — slider values reset and pipeline re-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)