### PR TITLE
feat: "new images detected" workspace banner

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4285,16 +4285,20 @@ def create_app(db_path, thumb_cache_dir=None):
                 })
 
             vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
-            do_scan(
-                root, thread_db, progress_callback=progress_cb, incremental=incremental,
-                extract_full_metadata=pipeline_cfg.get("extract_full_metadata", True),
-                status_callback=status_cb,
-                vireo_dir=vireo_dir,
-            )
+            try:
+                do_scan(
+                    root, thread_db, progress_callback=progress_cb, incremental=incremental,
+                    extract_full_metadata=pipeline_cfg.get("extract_full_metadata", True),
+                    status_callback=status_cb,
+                    vireo_dir=vireo_dir,
+                )
+            finally:
+                # scanner.scan commits photo rows incrementally, so even a mid-scan
+                # failure can leave DB state that invalidates cached new-image counts.
+                _invalidate_new_images_after_scan(thread_db, root)
             photo_count = job["progress"].get("total", 0)
             runner.update_step(job["id"], "scan", status="completed",
                                summary=f"{photo_count} photos")
-            _invalidate_new_images_after_scan(thread_db, root)
             runner.update_step(job["id"], "thumbnails", status="running")
 
             # Auto-generate thumbnails for new photos only
@@ -4879,11 +4883,15 @@ def create_app(db_path, thumb_cache_dir=None):
                 })
 
             vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
-            do_scan(scan_target, thread_db, progress_callback=scan_cb, skip_paths=exclude_paths or None, vireo_dir=vireo_dir)
+            try:
+                do_scan(scan_target, thread_db, progress_callback=scan_cb, skip_paths=exclude_paths or None, vireo_dir=vireo_dir)
+            finally:
+                # scanner.scan commits photo rows incrementally, so even a mid-scan
+                # failure can leave DB state that invalidates cached new-image counts.
+                _invalidate_new_images_after_scan(thread_db, scan_target)
             scan_count = job["progress"].get("total", 0)
             runner.update_step(job["id"], "scan", status="completed",
                                summary=f"{scan_count} photos")
-            _invalidate_new_images_after_scan(thread_db, scan_target)
 
             # Phase 3: Generate thumbnails
             runner.update_step(job["id"], "thumbnails", status="running")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -231,10 +231,12 @@ def _invalidate_new_images_after_scan(db, root):
     # fail to match the stored ``/Volumes/shoot`` in the ``path = ?`` arm.
     root = os.path.normpath(root)
     # LIKE wildcards (%, _) in `root` are not escaped. Worst case is a harmless
-    # over-invalidation that triggers a re-walk. Path separators assume POSIX.
+    # over-invalidation that triggers a re-walk. The descendant pattern uses
+    # os.sep so it matches what the scanner stores via str(Path(...)) on both
+    # POSIX and Windows.
     touched_ids = [r["id"] for r in db.conn.execute(
         "SELECT id FROM folders WHERE path = ? OR path LIKE ?",
-        (root, root.rstrip("/") + "/%"),
+        (root, root.rstrip("/\\") + os.sep + "%"),
     ).fetchall()]
     db.invalidate_new_images_cache_for_folders(touched_ids)
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -215,30 +215,11 @@ def _auto_detach_burst_for_species(results, enc_idx, burst_idx, new_species):
     summary["burst_count"] = sum(e.get("burst_count", 0) for e in encounters)
 
 
-def _invalidate_new_images_after_scan(db, root):
-    """Invalidate the new-images cache for every workspace linked to any folder
-    touched by a scan of ``root``.
-
-    Uses a LIKE query because ``scanner.scan`` auto-registers subfolders as
-    their own ``folders`` rows (see ``vireo/db.py`` ``add_folder``), so we
-    need to invalidate caches for all workspaces that reference any of those
-    descendant folders, not just the explicit scan root.
-    """
-    # Canonicalize the root to match what the scanner stores. The scanner
-    # passes folder paths through ``str(Path(...))`` which (like normpath)
-    # strips a trailing slash and collapses duplicate separators. Without
-    # this, a caller-supplied trailing slash like ``/Volumes/shoot/`` would
-    # fail to match the stored ``/Volumes/shoot`` in the ``path = ?`` arm.
-    root = os.path.normpath(root)
-    # LIKE wildcards (%, _) in `root` are not escaped. Worst case is a harmless
-    # over-invalidation that triggers a re-walk. The descendant pattern uses
-    # os.sep so it matches what the scanner stores via str(Path(...)) on both
-    # POSIX and Windows.
-    touched_ids = [r["id"] for r in db.conn.execute(
-        "SELECT id FROM folders WHERE path = ? OR path LIKE ?",
-        (root, root.rstrip("/\\") + os.sep + "%"),
-    ).fetchall()]
-    db.invalidate_new_images_cache_for_folders(touched_ids)
+# The canonical implementation lives in ``new_images.py`` so non-Flask
+# modules (e.g. ``pipeline_job.py``) can import it without pulling in the
+# app module. Kept aliased here under the original private name for
+# backward-compatibility with existing call sites and tests.
+from new_images import invalidate_new_images_after_scan as _invalidate_new_images_after_scan  # noqa: E402
 
 
 def create_app(db_path, thumb_cache_dir=None):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -224,6 +224,8 @@ def _invalidate_new_images_after_scan(db, root):
     need to invalidate caches for all workspaces that reference any of those
     descendant folders, not just the explicit scan root.
     """
+    # LIKE wildcards (%, _) in `root` are not escaped. Worst case is a harmless
+    # over-invalidation that triggers a re-walk. Path separators assume POSIX.
     touched_ids = [r["id"] for r in db.conn.execute(
         "SELECT id FROM folders WHERE path = ? OR path LIKE ?",
         (root, root.rstrip("/") + "/%"),

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1817,7 +1817,7 @@ def create_app(db_path, thumb_cache_dir=None):
         db.update_workspace(db._active_workspace_id, config_overrides=existing)
         return jsonify({"ok": True, "nav_order": nav_order})
 
-    @app.route("/api/workspace/new-images")
+    @app.route("/api/workspaces/active/new-images")
     def api_workspace_new_images():
         db = _get_db()
         ws_id = db._active_workspace_id

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -215,6 +215,22 @@ def _auto_detach_burst_for_species(results, enc_idx, burst_idx, new_species):
     summary["burst_count"] = sum(e.get("burst_count", 0) for e in encounters)
 
 
+def _invalidate_new_images_after_scan(db, root):
+    """Invalidate the new-images cache for every workspace linked to any folder
+    touched by a scan of ``root``.
+
+    Uses a LIKE query because ``scanner.scan`` auto-registers subfolders as
+    their own ``folders`` rows (see ``vireo/db.py`` ``add_folder``), so we
+    need to invalidate caches for all workspaces that reference any of those
+    descendant folders, not just the explicit scan root.
+    """
+    touched_ids = [r["id"] for r in db.conn.execute(
+        "SELECT id FROM folders WHERE path = ? OR path LIKE ?",
+        (root, root.rstrip("/") + "/%"),
+    ).fetchall()]
+    db.invalidate_new_images_cache_for_folders(touched_ids)
+
+
 def create_app(db_path, thumb_cache_dir=None):
     """Create the Flask app for the Vireo photo browser.
 
@@ -4257,6 +4273,7 @@ def create_app(db_path, thumb_cache_dir=None):
             photo_count = job["progress"].get("total", 0)
             runner.update_step(job["id"], "scan", status="completed",
                                summary=f"{photo_count} photos")
+            _invalidate_new_images_after_scan(thread_db, root)
             runner.update_step(job["id"], "thumbnails", status="running")
 
             # Auto-generate thumbnails for new photos only
@@ -4845,6 +4862,7 @@ def create_app(db_path, thumb_cache_dir=None):
             scan_count = job["progress"].get("total", 0)
             runner.update_step(job["id"], "scan", status="completed",
                                summary=f"{scan_count} photos")
+            _invalidate_new_images_after_scan(thread_db, scan_target)
 
             # Phase 3: Generate thumbnails
             runner.update_step(job["id"], "thumbnails", status="running")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1822,8 +1822,11 @@ def create_app(db_path, thumb_cache_dir=None):
         db = _get_db()
         ws_id = db._active_workspace_id
         if ws_id is None:
-            return jsonify({"new_count": 0, "per_root": [], "sample": []})
-        return jsonify(db.get_new_images_for_workspace(ws_id))
+            return jsonify({"workspace_id": None, "new_count": 0, "per_root": [], "sample": []})
+        payload = db.get_new_images_for_workspace(ws_id)
+        payload = dict(payload)
+        payload["workspace_id"] = ws_id
+        return jsonify(payload)
 
     # -- Prediction API routes --
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1817,6 +1817,14 @@ def create_app(db_path, thumb_cache_dir=None):
         db.update_workspace(db._active_workspace_id, config_overrides=existing)
         return jsonify({"ok": True, "nav_order": nav_order})
 
+    @app.route("/api/workspace/new-images")
+    def api_workspace_new_images():
+        db = _get_db()
+        ws_id = db._active_workspace_id
+        if ws_id is None:
+            return jsonify({"new_count": 0, "per_root": [], "sample": []})
+        return jsonify(db.get_new_images_for_workspace(ws_id))
+
     # -- Prediction API routes --
 
     @app.route("/api/predictions")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -224,6 +224,12 @@ def _invalidate_new_images_after_scan(db, root):
     need to invalidate caches for all workspaces that reference any of those
     descendant folders, not just the explicit scan root.
     """
+    # Canonicalize the root to match what the scanner stores. The scanner
+    # passes folder paths through ``str(Path(...))`` which (like normpath)
+    # strips a trailing slash and collapses duplicate separators. Without
+    # this, a caller-supplied trailing slash like ``/Volumes/shoot/`` would
+    # fail to match the stored ``/Volumes/shoot`` in the ``path = ?`` arm.
+    root = os.path.normpath(root)
     # LIKE wildcards (%, _) in `root` are not escaped. Worst case is a harmless
     # over-invalidation that triggers a re-walk. Path separators assume POSIX.
     touched_ids = [r["id"] for r in db.conn.execute(

--- a/vireo/audit.py
+++ b/vireo/audit.py
@@ -192,9 +192,22 @@ def import_untracked(db, paths):
         db: Database instance
         paths: list of file paths to import
     """
+    from new_images import invalidate_new_images_after_scan
     from scanner import scan
 
     # Group by parent directory
     dirs = set(os.path.dirname(p) for p in paths)
     for d in dirs:
-        scan(d, db, incremental=True)
+        try:
+            scan(d, db, incremental=True)
+        finally:
+            # scanner.scan commits photo rows incrementally, so even a
+            # mid-scan failure can leave DB state that invalidates cached
+            # new-image counts. Mirrors the try/finally in pipeline_job
+            # and the api_job_scan / api_job_import_full handlers.
+            try:
+                invalidate_new_images_after_scan(db, d)
+            except Exception:
+                log.exception(
+                    "Failed to invalidate new-images cache for %s", d
+                )

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -6,6 +6,8 @@ import os
 import sqlite3
 import uuid
 
+from new_images import NewImagesCache
+
 log = logging.getLogger(__name__)
 
 _UNSET = object()  # sentinel for "not provided" vs explicit None
@@ -58,6 +60,7 @@ class Database:
         self.conn.execute("PRAGMA temp_store=MEMORY")
         self.conn.execute("PRAGMA mmap_size=30000000")  # 30 MB
         self._active_workspace_id = None
+        self._new_images_cache = NewImagesCache()
         self._create_tables()
         self.ensure_default_workspace()
         # Restore last-used workspace, or fall back to Default
@@ -717,6 +720,29 @@ class Database:
         if self._active_workspace_id is None:
             raise RuntimeError("No active workspace set")
         return self._active_workspace_id
+
+    def get_new_images_for_workspace(self, workspace_id):
+        """Return new-images result for workspace, using cache when fresh."""
+        import new_images
+        cached = self._new_images_cache.get(workspace_id)
+        if cached is not None:
+            return cached
+        result = new_images.count_new_images_for_workspace(self, workspace_id)
+        self._new_images_cache.set(workspace_id, result)
+        return result
+
+    def invalidate_new_images_cache_for_folders(self, folder_ids):
+        """Clear cache for every workspace linked to any of the given folder_ids."""
+        if not folder_ids:
+            return
+        placeholders = ",".join("?" * len(folder_ids))
+        rows = self.conn.execute(
+            f"SELECT DISTINCT workspace_id FROM workspace_folders "
+            f"WHERE folder_id IN ({placeholders})",
+            tuple(folder_ids),
+        ).fetchall()
+        ws_ids = [r["workspace_id"] for r in rows]
+        self._new_images_cache.invalidate_workspaces(ws_ids)
 
     def _photo_in_workspace(self, photo_id):
         """Return True if the photo belongs to a folder visible in the active workspace."""

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -51,6 +51,11 @@ class Database:
         db_dir = os.path.dirname(db_path)
         if db_path != ":memory:" and db_dir:
             os.makedirs(db_dir, exist_ok=True)
+        # Preserved for the new-images cache key, which compounds
+        # (db_path, workspace_id) so instances against different SQLite files
+        # don't cross-read each other's cached results (workspace_id=1 is
+        # reused across every database as the default workspace).
+        self._db_path = db_path
         self.conn = sqlite3.connect(db_path, check_same_thread=False)
         self.conn.row_factory = sqlite3.Row
         self.conn.execute("PRAGMA journal_mode=WAL")
@@ -732,12 +737,14 @@ class Database:
         best-effort result.
         """
         import new_images
-        cached = self._new_images_cache.get(workspace_id)
+        cached = self._new_images_cache.get(self._db_path, workspace_id)
         if cached is not None:
             return cached
-        generation = self._new_images_cache.get_generation(workspace_id)
+        generation = self._new_images_cache.get_generation(self._db_path, workspace_id)
         result = new_images.count_new_images_for_workspace(self, workspace_id)
-        self._new_images_cache.set(workspace_id, result, generation=generation)
+        self._new_images_cache.set(
+            self._db_path, workspace_id, result, generation=generation
+        )
         return result
 
     def invalidate_new_images_cache_for_folders(self, folder_ids):
@@ -760,7 +767,7 @@ class Database:
                 tuple(chunk),
             ).fetchall()
             ws_ids.update(r["workspace_id"] for r in rows)
-        self._new_images_cache.invalidate_workspaces(ws_ids)
+        self._new_images_cache.invalidate_workspaces(self._db_path, ws_ids)
 
     def _photo_in_workspace(self, photo_id):
         """Return True if the photo belongs to a folder visible in the active workspace."""
@@ -794,7 +801,7 @@ class Database:
         # rowid, so a freshly created workspace may collide with the stale cache
         # entry of a prior workspace that shared this id. Clear any lingering
         # entry so the new workspace starts clean.
-        self._new_images_cache.invalidate_workspaces([workspace_id])
+        self._new_images_cache.invalidate_workspaces(self._db_path, [workspace_id])
         return workspace_id
 
     def get_workspace(self, workspace_id):
@@ -889,7 +896,7 @@ class Database:
         # if the deleted id is later reused by SQLite for a new workspace,
         # ``get_new_images_for_workspace`` could serve the prior workspace's
         # data until TTL expiry.
-        self._new_images_cache.invalidate_workspaces([workspace_id])
+        self._new_images_cache.invalidate_workspaces(self._db_path, [workspace_id])
 
     def add_workspace_folder(self, workspace_id, folder_id):
         """Link a folder to a workspace."""

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2527,6 +2527,14 @@ class Database:
         for row in rows:
             folder_counts[row["folder_id"]] = folder_counts.get(row["folder_id"], 0) + 1
 
+        # Collect affected folder ids BEFORE the delete so we can invalidate the
+        # new-images cache even if the delete raises. In "Remove from Vireo"
+        # mode the on-disk files stay put, so they become eligible for new-image
+        # detection again the moment the photo rows are gone; without an
+        # invalidation here, ``/api/workspaces/active/new-images`` would keep
+        # serving the stale pre-delete ``new_count`` until the TTL expired.
+        affected_folder_ids = list(folder_counts.keys())
+
         try:
             # Delete associated data (non-cascading FKs)
             self.conn.execute(f"DELETE FROM photo_keywords WHERE photo_id IN ({ph})", all_ids)
@@ -2570,6 +2578,12 @@ class Database:
         except Exception:
             self.conn.rollback()
             raise
+        finally:
+            # Always invalidate — even on rollback we may have partially dirtied
+            # state, and on success the removed rows mean untracked on-disk
+            # files should re-surface as "new" on the next read.
+            if affected_folder_ids:
+                self.invalidate_new_images_cache_for_folders(affected_folder_ids)
         return {"deleted": len(all_ids), "files": files}
 
     def update_photo_sharpness(self, photo_id, sharpness):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -744,13 +744,22 @@ class Database:
         """Clear cache for every workspace linked to any of the given folder_ids."""
         if not folder_ids:
             return
-        placeholders = ",".join("?" * len(folder_ids))
-        rows = self.conn.execute(
-            f"SELECT DISTINCT workspace_id FROM workspace_folders "
-            f"WHERE folder_id IN ({placeholders})",
-            tuple(folder_ids),
-        ).fetchall()
-        ws_ids = [r["workspace_id"] for r in rows]
+        # Chunk to stay well under SQLite's SQLITE_MAX_VARIABLE_NUMBER (default 999).
+        # A scan of a deep tree can auto-register thousands of descendant folders;
+        # a single IN (?, ?, ...) across all of them would raise
+        # ``OperationalError: too many SQL variables``.
+        CHUNK = 500
+        ws_ids = set()
+        folder_ids = list(folder_ids)
+        for i in range(0, len(folder_ids), CHUNK):
+            chunk = folder_ids[i:i + CHUNK]
+            placeholders = ",".join("?" * len(chunk))
+            rows = self.conn.execute(
+                f"SELECT DISTINCT workspace_id FROM workspace_folders "
+                f"WHERE folder_id IN ({placeholders})",
+                tuple(chunk),
+            ).fetchall()
+            ws_ids.update(r["workspace_id"] for r in rows)
         self._new_images_cache.invalidate_workspaces(ws_ids)
 
     def _photo_in_workspace(self, photo_id):
@@ -780,7 +789,13 @@ class Database:
              json.dumps(ui_state) if ui_state else None),
         )
         self.conn.commit()
-        return cur.lastrowid
+        workspace_id = cur.lastrowid
+        # SQLite INTEGER PRIMARY KEY (without AUTOINCREMENT) can reuse a deleted
+        # rowid, so a freshly created workspace may collide with the stale cache
+        # entry of a prior workspace that shared this id. Clear any lingering
+        # entry so the new workspace starts clean.
+        self._new_images_cache.invalidate_workspaces([workspace_id])
+        return workspace_id
 
     def get_workspace(self, workspace_id):
         """Return a single workspace by id, or None."""
@@ -870,6 +885,11 @@ class Database:
         """Delete a workspace and all its scoped data (cascade)."""
         self.conn.execute("DELETE FROM workspaces WHERE id = ?", (workspace_id,))
         self.conn.commit()
+        # Drop any cached new-images payload for this workspace. Without this,
+        # if the deleted id is later reused by SQLite for a new workspace,
+        # ``get_new_images_for_workspace`` could serve the prior workspace's
+        # data until TTL expiry.
+        self._new_images_cache.invalidate_workspaces([workspace_id])
 
     def add_workspace_folder(self, workspace_id, folder_id):
         """Link a folder to a workspace."""

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -6,7 +6,7 @@ import os
 import sqlite3
 import uuid
 
-from new_images import NewImagesCache
+from new_images import get_shared_cache
 
 log = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ class Database:
         self.conn.execute("PRAGMA temp_store=MEMORY")
         self.conn.execute("PRAGMA mmap_size=30000000")  # 30 MB
         self._active_workspace_id = None
-        self._new_images_cache = NewImagesCache()
+        self._new_images_cache = get_shared_cache()
         self._create_tables()
         self.ensure_default_workspace()
         # Restore last-used workspace, or fall back to Default

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -905,6 +905,10 @@ class Database:
             (workspace_id, folder_id),
         )
         self.conn.commit()
+        # The folder's untracked files now count toward this workspace's
+        # new-images backlog. Drop any stale cached payload so the next read
+        # recomputes against the updated folder set.
+        self._new_images_cache.invalidate_workspaces(self._db_path, [workspace_id])
 
     def remove_workspace_folder(self, workspace_id, folder_id):
         """Unlink a folder from a workspace."""
@@ -913,6 +917,9 @@ class Database:
             (workspace_id, folder_id),
         )
         self.conn.commit()
+        # The folder no longer contributes to this workspace's new-images
+        # backlog. Drop the cached payload so the banner reflects the change.
+        self._new_images_cache.invalidate_workspaces(self._db_path, [workspace_id])
 
     def get_workspace_folders(self, workspace_id):
         """Return all folders linked to a workspace."""
@@ -987,6 +994,12 @@ class Database:
         except Exception:
             self.conn.rollback()
             raise
+
+        # Folders changed membership for BOTH workspaces, so each workspace's
+        # new-images backlog needs to be recomputed on the next read.
+        self._new_images_cache.invalidate_workspaces(
+            self._db_path, [source_ws_id, target_ws_id]
+        )
 
         return {
             "folders_moved": len(folder_ids),

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -722,13 +722,22 @@ class Database:
         return self._active_workspace_id
 
     def get_new_images_for_workspace(self, workspace_id):
-        """Return new-images result for workspace, using cache when fresh."""
+        """Return new-images result for workspace, using cache when fresh.
+
+        Race-safe: we snapshot the cache generation before the (potentially
+        slow) walk and pass it to ``set``. If an invalidation fires during
+        the walk, the generation advances and the stale result is dropped
+        on write — so the next reader recomputes instead of seeing the
+        pre-invalidation value. The current caller still returns its own
+        best-effort result.
+        """
         import new_images
         cached = self._new_images_cache.get(workspace_id)
         if cached is not None:
             return cached
+        generation = self._new_images_cache.get_generation(workspace_id)
         result = new_images.count_new_images_for_workspace(self, workspace_id)
-        self._new_images_cache.set(workspace_id, result)
+        self._new_images_cache.set(workspace_id, result, generation=generation)
         return result
 
     def invalidate_new_images_cache_for_folders(self, folder_ids):

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -1,0 +1,75 @@
+"""Detect image files present on disk but not yet ingested into a workspace."""
+import os
+from pathlib import Path
+
+from image_loader import SUPPORTED_EXTENSIONS
+
+
+def _known_paths_for_workspace(db, workspace_id):
+    """Return the set of absolute paths of photos already ingested into the workspace."""
+    rows = db.conn.execute(
+        """SELECT f.path AS folder_path, p.filename
+           FROM photos p
+           JOIN folders f ON f.id = p.folder_id
+           JOIN workspace_folders wf ON wf.folder_id = f.id
+           WHERE wf.workspace_id = ?""",
+        (workspace_id,),
+    ).fetchall()
+    return {os.path.join(r["folder_path"], r["filename"]) for r in rows}
+
+
+def _mapped_roots(db, workspace_id):
+    """Return the workspace's mapped roots — folders whose parent is not also linked.
+
+    Skips folders marked 'missing'.
+    """
+    rows = db.conn.execute(
+        """SELECT f.id, f.path, f.parent_id, f.status
+           FROM folders f
+           JOIN workspace_folders wf ON wf.folder_id = f.id
+           WHERE wf.workspace_id = ? AND f.status = 'ok'""",
+        (workspace_id,),
+    ).fetchall()
+    linked_ids = {r["id"] for r in rows}
+    return [
+        {"id": r["id"], "path": r["path"]}
+        for r in rows
+        if r["parent_id"] is None or r["parent_id"] not in linked_ids
+    ]
+
+
+def count_new_images_for_workspace(db, workspace_id, sample_limit=5):
+    """Return {'new_count': int, 'per_root': [...], 'sample': [abs_path, ...]}.
+
+    Walks each mapped root recursively, collects image files, and diffs against
+    the set of photo paths already ingested into the workspace.
+    """
+    known = _known_paths_for_workspace(db, workspace_id)
+    roots = _mapped_roots(db, workspace_id)
+
+    per_root = []
+    sample = []
+    total = 0
+    for root in roots:
+        root_path = root["path"]
+        if not os.path.isdir(root_path):
+            per_root.append({"folder_id": root["id"], "path": root_path, "new_count": 0})
+            continue
+
+        root_new = 0
+        for dirpath, _dirnames, filenames in os.walk(root_path):
+            for name in filenames:
+                ext = Path(name).suffix.lower()
+                if ext not in SUPPORTED_EXTENSIONS:
+                    continue
+                full = os.path.join(dirpath, name)
+                if full in known:
+                    continue
+                root_new += 1
+                if len(sample) < sample_limit:
+                    sample.append(full)
+
+        total += root_new
+        per_root.append({"folder_id": root["id"], "path": root_path, "new_count": root_new})
+
+    return {"new_count": total, "per_root": per_root, "sample": sample}

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -156,3 +156,32 @@ def get_shared_cache():
     cache so invalidation from scan workers is visible to API readers.
     """
     return _shared_cache
+
+
+def invalidate_new_images_after_scan(db, root):
+    """Invalidate the new-images cache for every workspace linked to any folder
+    touched by a scan of ``root``.
+
+    Uses a LIKE query because ``scanner.scan`` auto-registers subfolders as
+    their own ``folders`` rows (see ``vireo/db.py`` ``add_folder``), so we
+    need to invalidate caches for all workspaces that reference any of those
+    descendant folders, not just the explicit scan root.
+
+    Lives in this module (not ``app.py``) so non-Flask code paths such as
+    ``pipeline_job.py`` can import it without pulling in the app module.
+    """
+    # Canonicalize the root to match what the scanner stores. The scanner
+    # passes folder paths through ``str(Path(...))`` which (like normpath)
+    # strips a trailing slash and collapses duplicate separators. Without
+    # this, a caller-supplied trailing slash like ``/Volumes/shoot/`` would
+    # fail to match the stored ``/Volumes/shoot`` in the ``path = ?`` arm.
+    root = os.path.normpath(root)
+    # LIKE wildcards (%, _) in `root` are not escaped. Worst case is a harmless
+    # over-invalidation that triggers a re-walk. The descendant pattern uses
+    # os.sep so it matches what the scanner stores via str(Path(...)) on both
+    # POSIX and Windows.
+    touched_ids = [r["id"] for r in db.conn.execute(
+        "SELECT id FROM folders WHERE path = ? OR path LIKE ?",
+        (root, root.rstrip("/\\") + os.sep + "%"),
+    ).fetchall()]
+    db.invalidate_new_images_cache_for_folders(touched_ids)

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -106,12 +106,19 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5):
 
 
 class NewImagesCache:
-    """In-memory per-workspace cache with a TTL ceiling.
+    """In-memory per-``(db_path, workspace_id)`` cache with a TTL ceiling.
 
-    Thread-safe. Invalidation takes a list of workspace_ids (computed by the
-    caller from the set of folder_ids touched by a scan).
+    Thread-safe. Keyed by the compound ``(db_path, workspace_id)`` so that two
+    :class:`Database` instances pointed at different SQLite files cannot read
+    each other's cached results — ``workspace_id=1`` (the default workspace)
+    is reused across databases, and without the db_path scope tests or
+    multi-database embeddings would cross-contaminate.
 
-    A per-workspace generation counter protects against a race between an
+    Invalidation takes a list of workspace_ids (computed by the caller from
+    the set of folder_ids touched by a scan) plus the originating ``db_path``;
+    only entries and generations for that db are affected.
+
+    A per-key generation counter protects against a race between an
     in-flight compute and a concurrent invalidation: a caller snapshots the
     generation before starting the walk and passes it to :meth:`set`; if
     invalidation bumps the generation during the walk, the stale result is
@@ -120,47 +127,53 @@ class NewImagesCache:
 
     def __init__(self, ttl_seconds=300):
         self._ttl = ttl_seconds
-        self._entries = {}  # workspace_id -> (result_dict, set_at_monotonic)
-        self._generations = {}  # workspace_id -> int
+        # key=(db_path, workspace_id) -> (result_dict, set_at_monotonic)
+        self._entries = {}
+        # key=(db_path, workspace_id) -> int
+        self._generations = {}
         self._lock = threading.Lock()
 
-    def get(self, workspace_id):
+    def get(self, db_path, workspace_id):
+        key = (db_path, workspace_id)
         with self._lock:
-            entry = self._entries.get(workspace_id)
+            entry = self._entries.get(key)
             if entry is None:
                 return None
             result, set_at = entry
             if time.monotonic() - set_at > self._ttl:
-                del self._entries[workspace_id]
+                del self._entries[key]
                 return None
             return result
 
-    def get_generation(self, workspace_id):
-        """Return the current generation for a workspace (0 if unseen)."""
+    def get_generation(self, db_path, workspace_id):
+        """Return the current generation for ``(db_path, workspace_id)`` (0 if unseen)."""
+        key = (db_path, workspace_id)
         with self._lock:
-            return self._generations.get(workspace_id, 0)
+            return self._generations.get(key, 0)
 
-    def set(self, workspace_id, result, generation=None):
-        """Store ``result`` for ``workspace_id``.
+    def set(self, db_path, workspace_id, result, generation=None):
+        """Store ``result`` for ``(db_path, workspace_id)``.
 
         If ``generation`` is provided and no longer matches the current
-        generation for the workspace (i.e. an invalidation ran after the
+        generation for the key (i.e. an invalidation ran after the
         caller snapshotted it), the write is silently dropped. Callers that
         don't care about the race can omit ``generation`` and the write is
         unconditional.
         """
+        key = (db_path, workspace_id)
         with self._lock:
             if generation is not None:
-                current = self._generations.get(workspace_id, 0)
+                current = self._generations.get(key, 0)
                 if generation != current:
                     return
-            self._entries[workspace_id] = (result, time.monotonic())
+            self._entries[key] = (result, time.monotonic())
 
-    def invalidate_workspaces(self, workspace_ids):
+    def invalidate_workspaces(self, db_path, workspace_ids):
         with self._lock:
             for wid in workspace_ids:
-                self._entries.pop(wid, None)
-                self._generations[wid] = self._generations.get(wid, 0) + 1
+                key = (db_path, wid)
+                self._entries.pop(key, None)
+                self._generations[key] = self._generations.get(key, 0) + 1
 
     def clear(self):
         with self._lock:

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -61,6 +61,12 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5):
         root_new = 0
         for dirpath, _dirnames, filenames in os.walk(root_path):
             for name in filenames:
+                # Mirror ``vireo/scanner.py``: skip dotfiles (e.g. macOS
+                # AppleDouble sidecars ``._IMG_0001.JPG``) so we don't count
+                # files the scanner will never ingest, which would otherwise
+                # produce a stuck "new images" banner.
+                if name.startswith("."):
+                    continue
                 ext = Path(name).suffix.lower()
                 if ext not in SUPPORTED_EXTENSIONS:
                     continue

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -112,3 +112,15 @@ class NewImagesCache:
     def clear(self):
         with self._lock:
             self._entries.clear()
+
+
+_shared_cache = NewImagesCache()
+
+
+def get_shared_cache():
+    """Return the process-wide shared NewImagesCache.
+
+    Per-thread and per-request Database instances all reference the same
+    cache so invalidation from scan workers is visible to API readers.
+    """
+    return _shared_cache

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -21,22 +21,44 @@ def _known_paths_for_workspace(db, workspace_id):
 
 
 def _mapped_roots(db, workspace_id):
-    """Return the workspace's mapped roots — folders whose parent is not also linked.
+    """Return the workspace's mapped roots — linked folders whose ancestor chain
+    contains no other linked folder. Skips folders marked 'missing'.
 
-    Skips folders marked 'missing'.
+    Checking only the immediate parent would over-include when an intermediate
+    folder was unlinked but a deeper descendant is still linked (e.g. /A linked,
+    /A/B unlinked, /A/B/C linked — both /A and /A/B/C would otherwise be roots
+    and the walk would double-count files under /A/B/C).
     """
     rows = db.conn.execute(
-        """SELECT f.id, f.path, f.parent_id, f.status
+        """SELECT f.id, f.path, f.parent_id
            FROM folders f
            JOIN workspace_folders wf ON wf.folder_id = f.id
            WHERE wf.workspace_id = ? AND f.status = 'ok'""",
         (workspace_id,),
     ).fetchall()
     linked_ids = {r["id"] for r in rows}
+    if not linked_ids:
+        return []
+
+    # Load parent_id for every folder — needed to walk arbitrary-depth ancestor
+    # chains where intermediate folders may not be linked.
+    parent_of = {
+        r["id"]: r["parent_id"]
+        for r in db.conn.execute("SELECT id, parent_id FROM folders").fetchall()
+    }
+
+    def has_linked_ancestor(folder_id):
+        parent = parent_of.get(folder_id)
+        while parent is not None:
+            if parent in linked_ids:
+                return True
+            parent = parent_of.get(parent)
+        return False
+
     return [
         {"id": r["id"], "path": r["path"]}
         for r in rows
-        if r["parent_id"] is None or r["parent_id"] not in linked_ids
+        if not has_linked_ancestor(r["id"])
     ]
 
 

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -170,12 +170,12 @@ def invalidate_new_images_after_scan(db, root):
     Lives in this module (not ``app.py``) so non-Flask code paths such as
     ``pipeline_job.py`` can import it without pulling in the app module.
     """
-    # Canonicalize the root to match what the scanner stores. The scanner
-    # passes folder paths through ``str(Path(...))`` which (like normpath)
-    # strips a trailing slash and collapses duplicate separators. Without
-    # this, a caller-supplied trailing slash like ``/Volumes/shoot/`` would
-    # fail to match the stored ``/Volumes/shoot`` in the ``path = ?`` arm.
-    root = os.path.normpath(root)
+    # Canonicalize the root to match what the scanner stores. scanner.scan passes
+    # folder paths through str(Path(...)), which strips trailing slashes but
+    # preserves `..` segments. Using os.path.normpath here would resolve `..` and
+    # produce a mismatch against the stored path, leaving the cache stale after a
+    # successful scan.
+    root = str(Path(root))
     # LIKE wildcards (%, _) in `root` are not escaped. Worst case is a harmless
     # over-invalidation that triggers a re-walk. The descendant pattern uses
     # os.sep so it matches what the scanner stores via str(Path(...)) on both

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -1,5 +1,7 @@
 """Detect image files present on disk but not yet ingested into a workspace."""
 import os
+import threading
+import time
 from pathlib import Path
 
 from image_loader import SUPPORTED_EXTENSIONS
@@ -73,3 +75,40 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5):
         per_root.append({"folder_id": root["id"], "path": root_path, "new_count": root_new})
 
     return {"new_count": total, "per_root": per_root, "sample": sample}
+
+
+class NewImagesCache:
+    """In-memory per-workspace cache with a TTL ceiling.
+
+    Thread-safe. Invalidation takes a list of workspace_ids (computed by the
+    caller from the set of folder_ids touched by a scan).
+    """
+
+    def __init__(self, ttl_seconds=300):
+        self._ttl = ttl_seconds
+        self._entries = {}  # workspace_id -> (result_dict, set_at_monotonic)
+        self._lock = threading.Lock()
+
+    def get(self, workspace_id):
+        with self._lock:
+            entry = self._entries.get(workspace_id)
+            if entry is None:
+                return None
+            result, set_at = entry
+            if time.monotonic() - set_at > self._ttl:
+                del self._entries[workspace_id]
+                return None
+            return result
+
+    def set(self, workspace_id, result):
+        with self._lock:
+            self._entries[workspace_id] = (result, time.monotonic())
+
+    def invalidate_workspaces(self, workspace_ids):
+        with self._lock:
+            for wid in workspace_ids:
+                self._entries.pop(wid, None)
+
+    def clear(self):
+        with self._lock:
+            self._entries.clear()

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -88,11 +88,18 @@ class NewImagesCache:
 
     Thread-safe. Invalidation takes a list of workspace_ids (computed by the
     caller from the set of folder_ids touched by a scan).
+
+    A per-workspace generation counter protects against a race between an
+    in-flight compute and a concurrent invalidation: a caller snapshots the
+    generation before starting the walk and passes it to :meth:`set`; if
+    invalidation bumps the generation during the walk, the stale result is
+    silently dropped instead of repopulating the cache.
     """
 
     def __init__(self, ttl_seconds=300):
         self._ttl = ttl_seconds
         self._entries = {}  # workspace_id -> (result_dict, set_at_monotonic)
+        self._generations = {}  # workspace_id -> int
         self._lock = threading.Lock()
 
     def get(self, workspace_id):
@@ -106,18 +113,37 @@ class NewImagesCache:
                 return None
             return result
 
-    def set(self, workspace_id, result):
+    def get_generation(self, workspace_id):
+        """Return the current generation for a workspace (0 if unseen)."""
         with self._lock:
+            return self._generations.get(workspace_id, 0)
+
+    def set(self, workspace_id, result, generation=None):
+        """Store ``result`` for ``workspace_id``.
+
+        If ``generation`` is provided and no longer matches the current
+        generation for the workspace (i.e. an invalidation ran after the
+        caller snapshotted it), the write is silently dropped. Callers that
+        don't care about the race can omit ``generation`` and the write is
+        unconditional.
+        """
+        with self._lock:
+            if generation is not None:
+                current = self._generations.get(workspace_id, 0)
+                if generation != current:
+                    return
             self._entries[workspace_id] = (result, time.monotonic())
 
     def invalidate_workspaces(self, workspace_ids):
         with self._lock:
             for wid in workspace_ids:
                 self._entries.pop(wid, None)
+                self._generations[wid] = self._generations.get(wid, 0) + 1
 
     def clear(self):
         with self._lock:
             self._entries.clear()
+            self._generations.clear()
 
 
 _shared_cache = NewImagesCache()

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -273,6 +273,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         # Note: stages["scan"]["status"] is NOT set to "running" here. It is
         # flipped to "running" just before each do_scan() call below, so
         # numScan doesn't pulse during the ingest sub-phase.
+        # Collect the scan roots actually fed to do_scan so the finally clause
+        # can invalidate the new-images cache for each one, matching the
+        # try/finally pattern used by api_job_scan / api_job_import_full in
+        # vireo/app.py. scanner.scan commits photo rows incrementally, so even
+        # a mid-scan failure needs invalidation.
+        scanned_roots: list[str] = []
+        thread_db = None
         try:
             import config as cfg
             from scanner import scan as do_scan
@@ -429,6 +436,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 job["progress"]["current"] = 0
                 job["progress"]["total"] = 0
                 _update_stages(runner, job["id"], stages)
+                scanned_roots.append(params.destination)
                 do_scan(
                     params.destination, thread_db,
                     progress_callback=progress_cb,
@@ -446,6 +454,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 job["progress"]["total"] = 0
                 _update_stages(runner, job["id"], stages)
                 for src_folder in sources:
+                    scanned_roots.append(src_folder)
                     do_scan(
                         src_folder, thread_db,
                         progress_callback=progress_cb,
@@ -466,6 +475,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             stages["scan"]["status"] = "failed"
             runner.update_step(job["id"], "scan", status="failed", error=str(e))
         finally:
+            # Invalidate the new-images cache for every root fed to do_scan,
+            # on both success and exception paths. scanner.scan commits photo
+            # rows incrementally, so even a mid-scan failure can leave DB
+            # state that invalidates cached new-image counts. Mirrors the
+            # try/finally in api_job_scan and api_job_import_full.
+            if thread_db is not None and scanned_roots:
+                from new_images import invalidate_new_images_after_scan
+                for scanned_root in scanned_roots:
+                    try:
+                        invalidate_new_images_after_scan(thread_db, scanned_root)
+                    except Exception:
+                        log.exception(
+                            "Failed to invalidate new-images cache for %s",
+                            scanned_root,
+                        )
             scan_to_thumb.put(_SENTINEL)
             _update_stages(runner, job["id"], stages)
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3277,38 +3277,36 @@ setInterval(checkMissingFolders, 600000);
 
 /* ---------- New Images Banner ---------- */
 const NEW_IMAGES_DISMISS_KEY = 'newImagesDismissedWorkspace';
-let _newImagesActiveWs = null;
 
-async function _getActiveWsIdForBanner() {
-  if (_newImagesActiveWs !== null) return _newImagesActiveWs;
+function _isNewImagesDismissed(wsId, newCount) {
+  if (wsId === null || wsId === undefined || wsId === '') return false;
+  const raw = sessionStorage.getItem(NEW_IMAGES_DISMISS_KEY);
+  if (!raw) return false;
+  let stored;
   try {
-    const resp = await fetch('/api/workspaces/active');
-    if (!resp.ok) return null;
-    const data = await resp.json();
-    _newImagesActiveWs = (data && data.id != null) ? String(data.id) : '';
-    return _newImagesActiveWs;
+    stored = JSON.parse(raw);
   } catch (e) {
-    return null;
+    return false;
   }
-}
-
-function _isNewImagesDismissed(wsId) {
-  const dismissed = sessionStorage.getItem(NEW_IMAGES_DISMISS_KEY) || '';
-  return wsId !== null && wsId !== '' && dismissed === String(wsId);
+  if (!stored || typeof stored !== 'object') return false;
+  if (String(stored.wsId) !== String(wsId)) return false;
+  return newCount <= Number(stored.count);
 }
 
 async function checkNewImages() {
   try {
-    const wsId = await _getActiveWsIdForBanner();
     const resp = await fetch('/api/workspaces/active/new-images');
     if (!resp.ok) return;
     const data = await resp.json();
     const banner = document.getElementById('newImagesBanner');
     const msg = document.getElementById('newImagesMsg');
     if (!banner || !msg) return;
-    if (data.new_count > 0 && !_isNewImagesDismissed(wsId)) {
+    const wsId = (data && data.workspace_id != null) ? String(data.workspace_id) : '';
+    if (data.new_count > 0 && wsId !== '' && !_isNewImagesDismissed(wsId, data.new_count)) {
       const s = data.new_count === 1 ? '' : 's';
       msg.textContent = `${data.new_count} new image${s} detected in your registered folders.`;
+      banner.dataset.count = String(data.new_count);
+      banner.dataset.ws = wsId;
       banner.style.display = 'flex';
     } else {
       banner.style.display = 'none';
@@ -3316,18 +3314,23 @@ async function checkNewImages() {
   } catch (e) { /* ignore */ }
 }
 
-async function dismissNewImagesBanner() {
+function dismissNewImagesBanner() {
   const banner = document.getElementById('newImagesBanner');
-  if (banner) banner.style.display = 'none';
-  const wsId = await _getActiveWsIdForBanner();
-  if (wsId !== null && wsId !== '') {
-    sessionStorage.setItem(NEW_IMAGES_DISMISS_KEY, String(wsId));
+  if (!banner) return;
+  const wsId = banner.dataset.ws || '';
+  const count = Number(banner.dataset.count || 0);
+  banner.style.display = 'none';
+  if (wsId !== '') {
+    sessionStorage.setItem(
+      NEW_IMAGES_DISMISS_KEY,
+      JSON.stringify({ wsId: wsId, count: count })
+    );
   }
 }
 
 // Run on page load and every 60s. Banner dismissal is per-workspace via
-// sessionStorage; a workspace switch triggers a full page reload, which
-// re-reads the dismissal key against the new active workspace id.
+// sessionStorage and re-arms automatically when new_count exceeds the
+// dismissed count (e.g. after importing more images).
 checkNewImages();
 setInterval(checkNewImages, 60000);
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3285,9 +3285,14 @@ setInterval(checkMissingFolders, 600000);
 //     Switch to B -> B's dismissal read from its own key (absent/different).
 //     Switch back to A with count=20 -> still dismissed. Correct.
 //   - Dismiss in A at 20, dismiss in B at 5 -> two independent keys. Correct.
-//   - Dismiss in A at 20, A's count rises to 30 -> 30 !== 20 -> banner shows.
-//   - Dismiss in A at 20, scan clears it to 0, then 5 new imports -> 5 !== 20
-//     -> banner shows. Correct (no decrease-then-increase trap).
+//   - Dismiss in A at 20, count stays at 20 -> banner hidden (dismissal still
+//     active). Correct.
+//   - Dismiss in A at 20, A's count rises to 25 -> 25 !== 20 -> banner shows
+//     (count mismatch). Correct.
+//   - Dismiss in A at 20, scan clears it to 0, then 20 new imports arrive ->
+//     banner shows. Correct: the 0 observation clears the dismissal (see
+//     checkNewImages), so the subsequent 20 is treated as fresh news rather
+//     than being suppressed by the old "20 === 20" exact match.
 const NEW_IMAGES_DISMISS_PREFIX = 'newImagesDismissed_ws_';
 
 function _newImagesDismissKey(wsId) {
@@ -3295,10 +3300,10 @@ function _newImagesDismissKey(wsId) {
 }
 
 // Dismissal suppresses the banner only while the count remains exactly what
-// the user dismissed. Any change — scan reducing it, or new imports
-// increasing it — re-arms the banner. This avoids the decrease-then-increase
-// trap where dismissing at 20, then scanning to 0, then importing 5 would
-// otherwise leave 5 <= 20 satisfied and keep the banner hidden.
+// the user dismissed. A rising/falling count to a *different* non-zero value
+// re-arms the banner via the exact-match check below. The zero-count reset
+// lives in checkNewImages (not here) because it needs to write to storage,
+// not just read it.
 function _isNewImagesDismissed(wsId, newCount) {
   if (wsId === null || wsId === undefined || wsId === '') return false;
   const raw = sessionStorage.getItem(_newImagesDismissKey(wsId));
@@ -3317,6 +3322,17 @@ async function checkNewImages() {
     const msg = document.getElementById('newImagesMsg');
     if (!banner || !msg) return;
     const wsId = (data && data.workspace_id != null) ? String(data.workspace_id) : '';
+
+    // Count dropping to zero means the user resolved the backlog (e.g. ran a
+    // scan / import). Clear any prior dismissal so a future non-zero count is
+    // treated as fresh news — without this, the exact-match suppression
+    // would keep "20 === 20" active through the round-trip dismiss-20 ->
+    // scan-to-0 -> import-20-again, leaving the banner hidden when it
+    // should show.
+    if (data.new_count === 0 && wsId !== '') {
+      sessionStorage.removeItem(_newImagesDismissKey(wsId));
+    }
+
     if (data.new_count > 0 && wsId !== '' && !_isNewImagesDismissed(wsId, data.new_count)) {
       const s = data.new_count === 1 ? '' : 's';
       msg.textContent = `${data.new_count} new image${s} detected in your registered folders.`;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3278,6 +3278,11 @@ setInterval(checkMissingFolders, 600000);
 /* ---------- New Images Banner ---------- */
 const NEW_IMAGES_DISMISS_KEY = 'newImagesDismissedWorkspace';
 
+// Dismissal suppresses the banner only while the count remains exactly what
+// the user dismissed. Any change — scan reducing it, or new imports
+// increasing it — re-arms the banner. This avoids the decrease-then-increase
+// trap where dismissing at 20, then scanning to 0, then importing 5 would
+// otherwise leave 5 <= 20 satisfied and keep the banner hidden.
 function _isNewImagesDismissed(wsId, newCount) {
   if (wsId === null || wsId === undefined || wsId === '') return false;
   const raw = sessionStorage.getItem(NEW_IMAGES_DISMISS_KEY);
@@ -3290,7 +3295,7 @@ function _isNewImagesDismissed(wsId, newCount) {
   }
   if (!stored || typeof stored !== 'object') return false;
   if (String(stored.wsId) !== String(wsId)) return false;
-  return newCount <= Number(stored.count);
+  return Number(stored.count) === Number(newCount);
 }
 
 async function checkNewImages() {
@@ -3329,8 +3334,8 @@ function dismissNewImagesBanner() {
 }
 
 // Run on page load and every 60s. Banner dismissal is per-workspace via
-// sessionStorage and re-arms automatically when new_count exceeds the
-// dismissed count (e.g. after importing more images).
+// sessionStorage and re-arms automatically on any count delta (scan
+// reducing it, or new imports increasing it).
 checkNewImages();
 setInterval(checkNewImages, 60000);
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3276,7 +3276,23 @@ checkMissingFolders();
 setInterval(checkMissingFolders, 600000);
 
 /* ---------- New Images Banner ---------- */
-const NEW_IMAGES_DISMISS_KEY = 'newImagesDismissedWorkspace';
+// Per-workspace dismissal: one sessionStorage key per workspace id so that
+// switching workspaces doesn't clobber other workspaces' dismissal state.
+// Storage value is just the dismissed count (string).
+//
+// Manual trace scenarios (keep in sync with the re-arm semantics below):
+//   - Dismiss in A at count=20 -> key `newImagesDismissed_ws_1 = "20"`.
+//     Switch to B -> B's dismissal read from its own key (absent/different).
+//     Switch back to A with count=20 -> still dismissed. Correct.
+//   - Dismiss in A at 20, dismiss in B at 5 -> two independent keys. Correct.
+//   - Dismiss in A at 20, A's count rises to 30 -> 30 !== 20 -> banner shows.
+//   - Dismiss in A at 20, scan clears it to 0, then 5 new imports -> 5 !== 20
+//     -> banner shows. Correct (no decrease-then-increase trap).
+const NEW_IMAGES_DISMISS_PREFIX = 'newImagesDismissed_ws_';
+
+function _newImagesDismissKey(wsId) {
+  return NEW_IMAGES_DISMISS_PREFIX + String(wsId);
+}
 
 // Dismissal suppresses the banner only while the count remains exactly what
 // the user dismissed. Any change — scan reducing it, or new imports
@@ -3285,17 +3301,11 @@ const NEW_IMAGES_DISMISS_KEY = 'newImagesDismissedWorkspace';
 // otherwise leave 5 <= 20 satisfied and keep the banner hidden.
 function _isNewImagesDismissed(wsId, newCount) {
   if (wsId === null || wsId === undefined || wsId === '') return false;
-  const raw = sessionStorage.getItem(NEW_IMAGES_DISMISS_KEY);
+  const raw = sessionStorage.getItem(_newImagesDismissKey(wsId));
   if (!raw) return false;
-  let stored;
-  try {
-    stored = JSON.parse(raw);
-  } catch (e) {
-    return false;
-  }
-  if (!stored || typeof stored !== 'object') return false;
-  if (String(stored.wsId) !== String(wsId)) return false;
-  return Number(stored.count) === Number(newCount);
+  const stored = Number(raw);
+  if (!Number.isFinite(stored)) return false;
+  return stored === Number(newCount);
 }
 
 async function checkNewImages() {
@@ -3326,10 +3336,9 @@ function dismissNewImagesBanner() {
   const count = Number(banner.dataset.count || 0);
   banner.style.display = 'none';
   if (wsId !== '') {
-    sessionStorage.setItem(
-      NEW_IMAGES_DISMISS_KEY,
-      JSON.stringify({ wsId: wsId, count: count })
-    );
+    // Store the dismissed count under a key scoped to this workspace id so
+    // dismissing in workspace B doesn't overwrite A's entry.
+    sessionStorage.setItem(_newImagesDismissKey(wsId), String(count));
   }
 }
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -956,6 +956,27 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   cursor: pointer;
   padding: 0 4px;
 }
+.new-images-banner {
+  background: var(--bg-tertiary, #153D55);
+  color: var(--text-primary, #E6F1F5);
+  padding: 6px 16px;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid var(--border-primary, #14374E);
+}
+.new-images-banner a {
+  color: var(--accent, #24E5CA);
+  font-weight: 600;
+  text-decoration: underline;
+}
+.new-images-banner a:hover { opacity: 0.85; }
+.new-images-banner .banner-dismiss {
+  color: var(--text-secondary, #9fb3bd);
+}
+/* When the missing-folders banner is visible above, new-images stacks
+   naturally in document flow — both are non-fixed block-level elements. */
 </style>
 
 <nav class="navbar">
@@ -1093,6 +1114,13 @@ function sendReport() {
   <span id="missingFoldersMsg"></span>
   <a href="#" onclick="openMissingFoldersModal(); return false;">Review</a>
   <button class="banner-dismiss" onclick="dismissMissingBanner()">&times;</button>
+</div>
+
+<!-- New Images Banner -->
+<div class="new-images-banner" id="newImagesBanner" style="display:none;">
+  <span id="newImagesMsg"></span>
+  <a href="/pipeline">Create a pipeline</a>
+  <button class="banner-dismiss" onclick="dismissNewImagesBanner()">&times;</button>
 </div>
 
 <!-- Missing Folders Modal -->

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3275,6 +3275,62 @@ function dismissMissingBanner() {
 checkMissingFolders();
 setInterval(checkMissingFolders, 600000);
 
+/* ---------- New Images Banner ---------- */
+const NEW_IMAGES_DISMISS_KEY = 'newImagesDismissedWorkspace';
+let _newImagesActiveWs = null;
+
+async function _getActiveWsIdForBanner() {
+  if (_newImagesActiveWs !== null) return _newImagesActiveWs;
+  try {
+    const resp = await fetch('/api/workspaces/active');
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    _newImagesActiveWs = (data && data.id != null) ? String(data.id) : '';
+    return _newImagesActiveWs;
+  } catch (e) {
+    return null;
+  }
+}
+
+function _isNewImagesDismissed(wsId) {
+  const dismissed = sessionStorage.getItem(NEW_IMAGES_DISMISS_KEY) || '';
+  return wsId !== null && wsId !== '' && dismissed === String(wsId);
+}
+
+async function checkNewImages() {
+  try {
+    const wsId = await _getActiveWsIdForBanner();
+    const resp = await fetch('/api/workspaces/active/new-images');
+    if (!resp.ok) return;
+    const data = await resp.json();
+    const banner = document.getElementById('newImagesBanner');
+    const msg = document.getElementById('newImagesMsg');
+    if (!banner || !msg) return;
+    if (data.new_count > 0 && !_isNewImagesDismissed(wsId)) {
+      const s = data.new_count === 1 ? '' : 's';
+      msg.textContent = `${data.new_count} new image${s} detected in your registered folders.`;
+      banner.style.display = 'flex';
+    } else {
+      banner.style.display = 'none';
+    }
+  } catch (e) { /* ignore */ }
+}
+
+async function dismissNewImagesBanner() {
+  const banner = document.getElementById('newImagesBanner');
+  if (banner) banner.style.display = 'none';
+  const wsId = await _getActiveWsIdForBanner();
+  if (wsId !== null && wsId !== '') {
+    sessionStorage.setItem(NEW_IMAGES_DISMISS_KEY, String(wsId));
+  }
+}
+
+// Run on page load and every 60s. Banner dismissal is per-workspace via
+// sessionStorage; a workspace switch triggers a full page reload, which
+// re-reads the dismissal key against the new active workspace id.
+checkNewImages();
+setInterval(checkNewImages, 60000);
+
 /* ---------- Missing Folders Modal ---------- */
 let _relocatingFolderId = null;
 let _relocateSelectedSub = null; // {name, path} of clicked subfolder, or null for current dir

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -283,3 +283,24 @@ def test_invalidate_new_images_after_scan_clears_shared_cache_across_instances(t
         "Cache for workspace linked only to descendant folder should be cleared "
         "(LIKE query must match auto-registered subfolders)"
     )
+
+
+def test_get_new_images_for_workspace_race_does_not_repopulate_stale(db_with_workspace, monkeypatch):
+    """If invalidation fires during compute, the stale result must not be cached."""
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    root_id = db.add_folder(str(root), name="shoot")
+
+    import new_images
+
+    def racing_compute(db_arg, ws_id_arg, **kwargs):
+        # Simulate an invalidation that fires while we're "walking."
+        db_arg.invalidate_new_images_cache_for_folders([root_id])
+        return {"new_count": 999, "per_root": [], "sample": []}  # stale value
+
+    monkeypatch.setattr(new_images, "count_new_images_for_workspace", racing_compute)
+
+    db.get_new_images_for_workspace(ws_id)
+    # Cache must NOT hold the stale value.
+    assert db._new_images_cache.get(ws_id) is None, "Stale compute leaked into cache"

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -83,3 +83,25 @@ def test_count_new_images_basename_collision_across_subdirs(db_with_workspace):
 
     assert result["new_count"] == 1  # day2's IMG_0001.JPG is the only new one
     assert any("day2" in s for s in result["sample"])
+
+
+def test_db_get_new_images_for_workspace_caches_result(db_with_workspace, monkeypatch):
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG_0001.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    calls = [0]
+    import new_images
+    real = new_images.count_new_images_for_workspace
+
+    def counting_wrapper(*args, **kwargs):
+        calls[0] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(new_images, "count_new_images_for_workspace", counting_wrapper)
+
+    r1 = db.get_new_images_for_workspace(ws_id)
+    r2 = db.get_new_images_for_workspace(ws_id)
+    assert r1 == r2
+    assert calls[0] == 1  # second call served from cache

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -36,3 +36,29 @@ def test_count_new_images_detects_unscanned_files(db_with_workspace):
     assert len(result["per_root"]) == 1
     assert result["per_root"][0]["new_count"] == 2
     assert len(result["sample"]) == 2
+
+
+def test_count_new_images_no_double_counting_with_nested_linked_folders(db_with_workspace):
+    """Nested subfolders auto-linked to workspace_folders must not cause double-counting."""
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "USA2026"
+    nested = root / "day1"
+    deep = nested / "raw"
+    _touch_image(str(deep / "IMG_0001.JPG"))  # one unscanned file, three levels deep
+
+    # Register root AND the intermediate dirs as workspace_folders (mirrors what
+    # the scanner's Database.add_folder does for every discovered subdirectory).
+    root_id = db.add_folder(str(root), name="USA2026")
+    nested_id = db.add_folder(str(nested), name="day1", parent_id=root_id)
+    db.add_folder(str(deep), name="raw", parent_id=nested_id)
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+
+    assert result["new_count"] == 1, (
+        f"Expected 1 new image, got {result['new_count']}. "
+        f"per_root={result['per_root']}"
+    )
+    # Only the top-level root should appear in per_root.
+    assert len(result["per_root"]) == 1
+    assert result["per_root"][0]["path"] == str(root)

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -62,3 +62,24 @@ def test_count_new_images_no_double_counting_with_nested_linked_folders(db_with_
     # Only the top-level root should appear in per_root.
     assert len(result["per_root"]) == 1
     assert result["per_root"][0]["path"] == str(root)
+
+
+def test_count_new_images_basename_collision_across_subdirs(db_with_workspace):
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "day1" / "IMG_0001.JPG"))
+    _touch_image(str(root / "day2" / "IMG_0001.JPG"))
+    root_id = db.add_folder(str(root), name="shoot")
+
+    # Ingest only day1's IMG_0001.JPG.
+    day1_id = db.add_folder(str(root / "day1"), name="day1", parent_id=root_id)
+    db.add_photo(
+        folder_id=day1_id, filename="IMG_0001.JPG", extension=".JPG",
+        file_size=1, file_mtime=0.0,
+    )
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+
+    assert result["new_count"] == 1  # day2's IMG_0001.JPG is the only new one
+    assert any("day2" in s for s in result["sample"])

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -285,6 +285,70 @@ def test_invalidate_new_images_after_scan_clears_shared_cache_across_instances(t
     )
 
 
+class _CapturingConn:
+    """Proxy that forwards every attr to the real sqlite3 connection but
+    captures parameters of ``folders``/``LIKE`` queries for assertions.
+
+    Needed because ``sqlite3.Connection.execute`` is a read-only built-in
+    attribute and cannot be monkeypatched directly.
+    """
+
+    def __init__(self, real_conn, captured):
+        self._real = real_conn
+        self._captured = captured
+
+    def execute(self, sql, params=()):
+        if "folders" in sql and "LIKE" in sql:
+            self._captured["params"] = params
+        return self._real.execute(sql, params)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def test_invalidate_new_images_after_scan_uses_os_sep(db_with_workspace):
+    """The descendant LIKE pattern must end in ``os.sep + '%'`` so it matches
+    folder paths stored by the scanner via ``str(Path(...))`` — which uses
+    ``\\`` on Windows and ``/`` on POSIX."""
+    from app import _invalidate_new_images_after_scan
+
+    db, ws_id, tmp_path = db_with_workspace
+    captured = {}
+    db.conn = _CapturingConn(db.conn, captured)
+
+    _invalidate_new_images_after_scan(db, str(tmp_path / "root"))
+
+    assert "params" in captured, "Expected LIKE query on folders to fire"
+    assert captured["params"][1].endswith(os.sep + "%"), (
+        f"Descendant LIKE pattern must end with os.sep + %, "
+        f"got {captured['params'][1]!r}"
+    )
+
+
+def test_invalidate_new_images_after_scan_windows_separator(db_with_workspace, monkeypatch):
+    """Simulate Windows: the scanner stores folder paths with backslashes via
+    ``str(Path(...))``, so the LIKE descendant pattern must also use
+    backslashes. Verified here by monkeypatching ``os.sep`` to ``\\``."""
+    import app as app_module
+    from app import _invalidate_new_images_after_scan
+
+    db, ws_id, tmp_path = db_with_workspace
+    captured = {}
+    db.conn = _CapturingConn(db.conn, captured)
+
+    # Patch os.sep on the ``os`` module the helper resolves through so it sees
+    # the Windows separator during this call.
+    monkeypatch.setattr(app_module.os, "sep", "\\")
+    # os.path.normpath on POSIX won't rewrite ``C:\shoot``; pass a path that
+    # normpath leaves alone so we can assert on the trailing separator.
+    _invalidate_new_images_after_scan(db, "C:\\shoot")
+
+    assert "params" in captured, "Expected LIKE query on folders to fire"
+    assert captured["params"][1].endswith("\\%"), (
+        f"Windows pattern must end with \\%, got {captured['params'][1]!r}"
+    )
+
+
 def test_get_new_images_for_workspace_race_does_not_repopulate_stale(db_with_workspace, monkeypatch):
     """If invalidation fires during compute, the stale result must not be cached."""
     db, ws_id, tmp_path = db_with_workspace

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -230,6 +230,54 @@ def test_invalidate_new_images_after_scan_normalizes_trailing_slash(tmp_path):
     )
 
 
+def test_invalidate_new_images_after_scan_preserves_dotdot_segments(tmp_path):
+    """Caller-supplied root with ``..`` segments must still match folders stored
+    by the scanner as ``str(Path(...))`` — which preserves ``..`` segments.
+
+    Using ``os.path.normpath`` here would resolve ``..`` to a non-matching
+    canonical path, leaving the cache stale after a successful scan launched
+    against a path like ``/data/shoot/../trip``."""
+    from pathlib import Path
+
+    from app import _invalidate_new_images_after_scan
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    # Build a path containing `..`. Mirror what the scanner would do: store
+    # the folder via str(Path(...)) so the `..` segment survives in
+    # folders.path.
+    dotdot_path = tmp_path / "x" / ".." / "y"
+    # Create the resolved directory on disk with a real image so
+    # count_new_images_for_workspace can walk it (it needs os.path.isdir to
+    # pass).
+    (tmp_path / "y").mkdir()
+    _touch_image(str(tmp_path / "y" / "IMG_0001.JPG"))
+
+    stored = str(Path(dotdot_path))
+    assert ".." in stored, (
+        f"Test precondition: str(Path(...)) must preserve `..` — got {stored!r}. "
+        "If your platform's pathlib collapses `..`, this test is moot."
+    )
+    db.add_folder(stored, name="y")
+
+    # Prime the cache.
+    db.get_new_images_for_workspace(ws_id)
+    assert db._new_images_cache.get(ws_id) is not None
+
+    # Invalidate using the same `..`-bearing path. Canonicalization inside
+    # the helper must use str(Path(...)) (which keeps `..`) rather than
+    # os.path.normpath (which would resolve `..` and produce a mismatch).
+    _invalidate_new_images_after_scan(db, stored)
+
+    assert db._new_images_cache.get(ws_id) is None, (
+        "Root containing `..` must match the canonical form stored by the "
+        "scanner (which also preserves `..` via str(Path(...))). Using "
+        "os.path.normpath here would resolve `..` and leave the cache stale."
+    )
+
+
 def test_invalidate_new_images_after_scan_clears_shared_cache_across_instances(tmp_path):
     """End-to-end coverage of _invalidate_new_images_after_scan:
 

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -719,3 +719,45 @@ def test_create_workspace_clears_stale_cache_on_id_reuse(tmp_path):
         f"New workspace (id={ws_b}) must not inherit deleted workspace's cache "
         f"(id reuse of {ws_a}? {ws_a == ws_b})"
     )
+
+
+def test_delete_photos_invalidates_cache(db_with_workspace):
+    """Deleting photos must invalidate the new-images cache.
+
+    In "Remove from Vireo" mode the on-disk files stay put; the photo rows
+    go away. Those files immediately become eligible for new-image detection
+    again. Without an invalidation, ``/api/workspaces/active/new-images``
+    keeps serving the cached pre-delete ``new_count`` for up to the TTL.
+    """
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "a.JPG"))
+    _touch_image(str(root / "b.JPG"))
+    root_id = db.add_folder(str(root), name="shoot")
+
+    # Ingest both so they're not "new".
+    a_id = db.add_photo(
+        folder_id=root_id, filename="a.JPG", extension=".JPG",
+        file_size=1, file_mtime=0.0,
+    )
+    db.add_photo(
+        folder_id=root_id, filename="b.JPG", extension=".JPG",
+        file_size=1, file_mtime=0.0,
+    )
+
+    # Prime the cache: nothing should be new yet.
+    r1 = db.get_new_images_for_workspace(ws_id)
+    assert r1["new_count"] == 0
+    assert db._new_images_cache.get(ws_id) is not None
+
+    # Remove a.JPG's photo row but leave the file on disk (mimics
+    # "Remove from Vireo" semantics — delete_photos does not touch files).
+    db.delete_photos([a_id])
+
+    # a.JPG on disk is now untracked: it should re-appear as "new" on the
+    # next read. If the cache was not invalidated, this would still be 0.
+    r2 = db.get_new_images_for_workspace(ws_id)
+    assert r2["new_count"] == 1, (
+        f"Expected a.JPG to re-surface as new after delete_photos removed "
+        f"its row; got new_count={r2['new_count']}. per_root={r2['per_root']}"
+    )

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -572,6 +572,36 @@ def test_pipeline_job_scan_invalidates_cache(tmp_path, monkeypatch):
     )
 
 
+def test_audit_import_untracked_invalidates_cache(db_with_workspace):
+    """audit.import_untracked() calls scanner.scan internally (once per unique
+    parent directory of the untracked paths). Each scan must invalidate the
+    new-images cache for workspaces that reference the scanned folder so the
+    banner updates immediately rather than waiting for TTL expiry.
+
+    Mirrors the try/finally pattern in pipeline_job.scanner_stage and the
+    api_job_scan / api_job_import_full handlers.
+    """
+    from audit import import_untracked
+
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    img_path = root / "IMG_0001.JPG"
+    _touch_image(str(img_path))
+    db.add_folder(str(root), name="shoot")
+
+    # Prime the cache: one file present, none ingested -> new_count=1.
+    primed = db.get_new_images_for_workspace(ws_id)
+    assert primed["new_count"] == 1
+    assert db._new_images_cache.get(ws_id) is not None
+
+    import_untracked(db, [str(img_path)])
+
+    assert db._new_images_cache.get(ws_id) is None, (
+        "audit.import_untracked must invalidate the new-images cache for "
+        "every scanned parent directory (try/finally mirrors pipeline_job)"
+    )
+
+
 def test_invalidate_new_images_cache_for_folders_handles_thousands_of_ids(
     db_with_workspace,
 ):

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -825,3 +825,91 @@ def test_delete_photos_invalidates_cache(db_with_workspace):
         f"Expected a.JPG to re-surface as new after delete_photos removed "
         f"its row; got new_count={r2['new_count']}. per_root={r2['per_root']}"
     )
+
+
+def test_add_workspace_folder_invalidates_cache(tmp_path):
+    """Linking a folder to a workspace must clear the workspace's cached
+    new-images payload. Otherwise the banner keeps showing the pre-link
+    ``new_count`` (e.g. ``0``) until TTL expiry even though the newly-linked
+    folder's untracked files are now in scope.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.ensure_default_workspace()
+    ws_b = db.create_workspace("B")
+
+    # Add a folder under workspace B only. ``add_folder`` auto-links to the
+    # active workspace, so set ws_b active first.
+    db.set_active_workspace(ws_b)
+    root = tmp_path / "unattached"
+    _touch_image(str(root / "IMG.JPG"))
+    folder_id = db.add_folder(str(root), name="unattached")
+
+    # Prime the cache for ws_a — it has no linked folders yet, so new_count=0.
+    db.set_active_workspace(ws_a)
+    r1 = db.get_new_images_for_workspace(ws_a)
+    assert r1["new_count"] == 0
+    assert db._new_images_cache.get(db._db_path, ws_a) is not None
+
+    # Link the folder to ws_a. This must invalidate ws_a's cache so the
+    # banner reflects the newly-visible untracked file.
+    db.add_workspace_folder(ws_a, folder_id)
+
+    assert db._new_images_cache.get(db._db_path, ws_a) is None, (
+        "add_workspace_folder must invalidate the workspace's new-images cache"
+    )
+
+
+def test_remove_workspace_folder_invalidates_cache(db_with_workspace):
+    """Unlinking a folder from a workspace must clear the cached new-images
+    payload so the banner stops crediting the removed folder's untracked
+    files to this workspace.
+    """
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    folder_id = db.add_folder(str(root), name="shoot")
+
+    # Prime the cache: one untracked file in this workspace.
+    r1 = db.get_new_images_for_workspace(ws_id)
+    assert r1["new_count"] == 1
+    assert db._new_images_cache.get(db._db_path, ws_id) is not None
+
+    db.remove_workspace_folder(ws_id, folder_id)
+
+    assert db._new_images_cache.get(db._db_path, ws_id) is None, (
+        "remove_workspace_folder must invalidate the workspace's "
+        "new-images cache"
+    )
+
+
+def test_move_folders_to_workspace_invalidates_both_workspaces(tmp_path):
+    """``move_folders_to_workspace`` changes folder membership for BOTH the
+    source and target workspaces, so each workspace's cached new-images
+    payload must be dropped.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.ensure_default_workspace()
+    ws_b = db.create_workspace("B")
+
+    # Add a folder to ws_a (auto-linked via add_folder).
+    db.set_active_workspace(ws_a)
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    folder_id = db.add_folder(str(root), name="shoot")
+
+    # Prime both caches.
+    db.get_new_images_for_workspace(ws_a)
+    db.get_new_images_for_workspace(ws_b)
+    assert db._new_images_cache.get(db._db_path, ws_a) is not None
+    assert db._new_images_cache.get(db._db_path, ws_b) is not None
+
+    # Move folder from ws_a to ws_b.
+    result = db.move_folders_to_workspace(ws_a, ws_b, [folder_id])
+    assert result["folders_moved"] == 1
+
+    assert db._new_images_cache.get(db._db_path, ws_a) is None, (
+        "move_folders_to_workspace must invalidate the source workspace's cache"
+    )
+    assert db._new_images_cache.get(db._db_path, ws_b) is None, (
+        "move_folders_to_workspace must invalidate the target workspace's cache"
+    )

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -174,14 +174,14 @@ def test_invalidate_cache_for_shared_folder_across_workspaces(tmp_path):
     db.set_active_workspace(ws_a)
     db.get_new_images_for_workspace(ws_a)
     db.get_new_images_for_workspace(ws_b)
-    assert db._new_images_cache.get(ws_a) is not None
-    assert db._new_images_cache.get(ws_b) is not None
+    assert db._new_images_cache.get(db._db_path, ws_a) is not None
+    assert db._new_images_cache.get(db._db_path, ws_b) is not None
 
     # Scan completes for folder root_id.
     db.invalidate_new_images_cache_for_folders([root_id])
 
-    assert db._new_images_cache.get(ws_a) is None
-    assert db._new_images_cache.get(ws_b) is None
+    assert db._new_images_cache.get(db._db_path, ws_a) is None
+    assert db._new_images_cache.get(db._db_path, ws_b) is None
 
 
 def test_scan_job_invalidates_cache(db_with_workspace):
@@ -216,8 +216,72 @@ def test_two_database_instances_share_cache(tmp_path):
 
     # A second Database instance (simulating a different thread / request)
     db_b = Database(str(tmp_path / "test.db"))
-    assert db_b._new_images_cache.get(ws_id) is not None, (
+    assert db_b._new_images_cache.get(db_b._db_path, ws_id) is not None, (
         "Second Database should see cache populated by the first"
+    )
+
+
+def test_cache_does_not_share_across_different_db_paths(tmp_path):
+    """Two Database instances opened against *different* SQLite files must NOT
+    read each other's cache. Both databases auto-create a Default workspace
+    with workspace_id=1, so a cache keyed only on workspace_id would let the
+    second database serve stale results computed against the first database's
+    folder set.
+
+    Test shape (important):
+      1. Create BOTH Database instances first. This means each DB's
+         ``ensure_default_workspace`` has already run — so the
+         ``create_workspace``'s ``invalidate_workspaces`` call (which, with a
+         workspace_id-only key, would clobber the other DB's cache as a side
+         effect of plain construction) fires *before* we prime anything.
+      2. Then prime db_a's cache.
+      3. Assert db_b cannot see db_a's entry.
+
+    This ordering matters: if we created db_b *after* priming, a broken
+    workspace_id-only cache would still masquerade as "isolated" because
+    ``create_workspace`` wipes the entry. That would give a false positive
+    for this sanity check.
+
+    Removing the db_path dimension from the cache key makes the final
+    ``db_b`` lookup assertion fail.
+    """
+    db_a = Database(str(tmp_path / "a.db"))
+    db_b = Database(str(tmp_path / "b.db"))
+
+    ws_a = db_a._active_workspace_id
+    ws_b = db_b._active_workspace_id
+    assert ws_a == ws_b, (
+        "Test precondition: both fresh databases should reuse workspace_id=1; "
+        f"got ws_a={ws_a} ws_b={ws_b}. If they ever differ this test still "
+        "validates isolation — just for a different reason."
+    )
+
+    # db_a has one image in a linked folder -> new_count == 1.
+    root_a = tmp_path / "shoot_a"
+    _touch_image(str(root_a / "IMG.JPG"))
+    db_a.add_folder(str(root_a), name="shoot_a")
+
+    # Prime db_a's cache AFTER both DBs exist. A cache keyed only on
+    # workspace_id would now publish this entry under key=1 — visible to
+    # any ``get(..., 1)``, including db_b's.
+    result_a = db_a.get_new_images_for_workspace(ws_a)
+    assert result_a["new_count"] == 1
+    assert db_a._new_images_cache.get(db_a._db_path, ws_a) is not None
+
+    # Cache lookup on db_b must NOT find db_a's entry. This is the assertion
+    # that fails when the cache keys by workspace_id only.
+    assert db_b._new_images_cache.get(db_b._db_path, ws_b) is None, (
+        "db_b must not see db_a's cache entry — the shared NewImagesCache "
+        "must key by (db_path, workspace_id), not workspace_id alone."
+    )
+
+    # Full round-trip: fetching via db_b must compute fresh against db_b's
+    # (empty) folder set, not serve db_a's cached value.
+    result_b = db_b.get_new_images_for_workspace(ws_b)
+    assert result_b["new_count"] == 0, (
+        f"db_b (empty folder set) must compute new_count=0, got "
+        f"{result_b['new_count']} — stale data from db_a leaked across the "
+        "shared cache."
     )
 
 
@@ -260,12 +324,12 @@ def test_invalidate_new_images_after_scan_normalizes_trailing_slash(tmp_path):
 
     # Prime the cache.
     db.get_new_images_for_workspace(ws_id)
-    assert db._new_images_cache.get(ws_id) is not None
+    assert db._new_images_cache.get(db._db_path, ws_id) is not None
 
     # Invalidate with a trailing slash. Must still clear the cache.
     _invalidate_new_images_after_scan(db, str(root) + "/")
 
-    assert db._new_images_cache.get(ws_id) is None, (
+    assert db._new_images_cache.get(db._db_path, ws_id) is None, (
         "Trailing-slash root must be normalized so path = ? matches the "
         "canonical form stored in the folders table"
     )
@@ -305,14 +369,14 @@ def test_invalidate_new_images_after_scan_preserves_dotdot_segments(tmp_path):
 
     # Prime the cache.
     db.get_new_images_for_workspace(ws_id)
-    assert db._new_images_cache.get(ws_id) is not None
+    assert db._new_images_cache.get(db._db_path, ws_id) is not None
 
     # Invalidate using the same `..`-bearing path. Canonicalization inside
     # the helper must use str(Path(...)) (which keeps `..`) rather than
     # os.path.normpath (which would resolve `..` and produce a mismatch).
     _invalidate_new_images_after_scan(db, stored)
 
-    assert db._new_images_cache.get(ws_id) is None, (
+    assert db._new_images_cache.get(db._db_path, ws_id) is None, (
         "Root containing `..` must match the canonical form stored by the "
         "scanner (which also preserves `..` via str(Path(...))). Using "
         "os.path.normpath here would resolve `..` and leave the cache stale."
@@ -354,8 +418,8 @@ def test_invalidate_new_images_after_scan_clears_shared_cache_across_instances(t
     # Prime caches for both workspaces via db_a.
     db_a.get_new_images_for_workspace(ws_id)
     db_a.get_new_images_for_workspace(ws_b)
-    assert db_a._new_images_cache.get(ws_id) is not None
-    assert db_a._new_images_cache.get(ws_b) is not None
+    assert db_a._new_images_cache.get(db_a._db_path, ws_id) is not None
+    assert db_a._new_images_cache.get(db_a._db_path, ws_b) is not None
 
     # Invalidate from a DIFFERENT Database instance to exercise the shared
     # cache contract end-to-end.
@@ -365,10 +429,10 @@ def test_invalidate_new_images_after_scan_clears_shared_cache_across_instances(t
     # db_a must observe the cleared caches for both workspaces, including the
     # one that only references the descendant folder (proves the LIKE picked
     # it up).
-    assert db_a._new_images_cache.get(ws_id) is None, (
+    assert db_a._new_images_cache.get(db_a._db_path, ws_id) is None, (
         "Cache for workspace linked to root should be cleared"
     )
-    assert db_a._new_images_cache.get(ws_b) is None, (
+    assert db_a._new_images_cache.get(db_a._db_path, ws_b) is None, (
         "Cache for workspace linked only to descendant folder should be cleared "
         "(LIKE query must match auto-registered subfolders)"
     )
@@ -456,7 +520,7 @@ def test_get_new_images_for_workspace_race_does_not_repopulate_stale(db_with_wor
 
     db.get_new_images_for_workspace(ws_id)
     # Cache must NOT hold the stale value.
-    assert db._new_images_cache.get(ws_id) is None, "Stale compute leaked into cache"
+    assert db._new_images_cache.get(db._db_path, ws_id) is None, "Stale compute leaked into cache"
 
 
 def test_scan_handler_invalidates_cache_when_scan_raises(tmp_path, monkeypatch):
@@ -474,7 +538,7 @@ def test_scan_handler_invalidates_cache_when_scan_raises(tmp_path, monkeypatch):
 
     # Prime the cache.
     db.get_new_images_for_workspace(ws_id)
-    assert db._new_images_cache.get(ws_id) is not None
+    assert db._new_images_cache.get(db._db_path, ws_id) is not None
 
     # Simulate the try/finally pattern used in api_job_scan / api_job_import_full:
     # do_scan raises, invalidation still runs in finally.
@@ -486,7 +550,7 @@ def test_scan_handler_invalidates_cache_when_scan_raises(tmp_path, monkeypatch):
     except RuntimeError:
         pass
 
-    assert db._new_images_cache.get(ws_id) is None, (
+    assert db._new_images_cache.get(db._db_path, ws_id) is None, (
         "Cache must be invalidated even when the scan raises"
     )
 
@@ -526,7 +590,7 @@ def test_pipeline_job_scan_invalidates_cache(tmp_path, monkeypatch):
     # Prime the cache: two files present, none ingested yet -> new_count=2.
     primed = db.get_new_images_for_workspace(ws_id)
     assert primed["new_count"] == 2
-    assert db._new_images_cache.get(ws_id) is not None
+    assert db._new_images_cache.get(db._db_path, ws_id) is not None
 
     # Minimal FakeRunner inline so we don't couple this test to
     # tests/test_pipeline_job.py's helper class.
@@ -560,7 +624,7 @@ def test_pipeline_job_scan_invalidates_cache(tmp_path, monkeypatch):
 
     # After the scan, the cache must be cleared so the next banner fetch
     # recomputes against the updated photos table.
-    assert db._new_images_cache.get(ws_id) is None, (
+    assert db._new_images_cache.get(db._db_path, ws_id) is None, (
         "pipeline_job scanner_stage must invalidate the new-images cache "
         "for roots fed to do_scan (try/finally mirrors api_job_scan)"
     )
@@ -592,11 +656,11 @@ def test_audit_import_untracked_invalidates_cache(db_with_workspace):
     # Prime the cache: one file present, none ingested -> new_count=1.
     primed = db.get_new_images_for_workspace(ws_id)
     assert primed["new_count"] == 1
-    assert db._new_images_cache.get(ws_id) is not None
+    assert db._new_images_cache.get(db._db_path, ws_id) is not None
 
     import_untracked(db, [str(img_path)])
 
-    assert db._new_images_cache.get(ws_id) is None, (
+    assert db._new_images_cache.get(db._db_path, ws_id) is None, (
         "audit.import_untracked must invalidate the new-images cache for "
         "every scanned parent directory (try/finally mirrors pipeline_job)"
     )
@@ -635,11 +699,11 @@ def test_invalidate_new_images_cache_for_folders_handles_thousands_of_ids(
     root_id = db.add_folder(str(root), name="shoot")
 
     db.get_new_images_for_workspace(ws_id)
-    assert db._new_images_cache.get(ws_id) is not None
+    assert db._new_images_cache.get(db._db_path, ws_id) is not None
 
     mixed = unknown_ids + [root_id]
     db.invalidate_new_images_cache_for_folders(mixed)
-    assert db._new_images_cache.get(ws_id) is None, (
+    assert db._new_images_cache.get(db._db_path, ws_id) is None, (
         "Chunked invalidation must still clear the real linked folder's workspace"
     )
 
@@ -655,13 +719,13 @@ def test_delete_workspace_clears_cache(tmp_path):
 
     # Populate the cache directly (avoids needing a real folder / photo setup).
     db._new_images_cache.set(
-        ws_tmp, {"new_count": 7, "per_root": [], "sample": []}
+        db._db_path, ws_tmp, {"new_count": 7, "per_root": [], "sample": []}
     )
-    assert db._new_images_cache.get(ws_tmp) is not None
+    assert db._new_images_cache.get(db._db_path, ws_tmp) is not None
 
     db.delete_workspace(ws_tmp)
 
-    assert db._new_images_cache.get(ws_tmp) is None, (
+    assert db._new_images_cache.get(db._db_path, ws_tmp) is None, (
         "delete_workspace must invalidate the new-images cache entry"
     )
 
@@ -692,8 +756,8 @@ def test_create_workspace_clears_stale_cache_on_id_reuse(tmp_path):
     # was repopulated by a reader racing with delete). Passing ``generation``
     # unconditionally here seeds the entry regardless of the generation
     # invalidate_workspaces bumped.
-    db._new_images_cache.set(ws_a, stale_payload)
-    assert db._new_images_cache.get(ws_a) == stale_payload
+    db._new_images_cache.set(db._db_path, ws_a, stale_payload)
+    assert db._new_images_cache.get(db._db_path, ws_a) == stale_payload
 
     # Create a new workspace. SQLite typically reuses the highest freed rowid,
     # so this usually gets ws_a's old id.
@@ -702,15 +766,15 @@ def test_create_workspace_clears_stale_cache_on_id_reuse(tmp_path):
     if ws_a == ws_b:
         # Id was reused — create_workspace's hook must have cleared the stale
         # entry so the new workspace does NOT inherit the old payload.
-        assert db._new_images_cache.get(ws_b) is None, (
+        assert db._new_images_cache.get(db._db_path, ws_b) is None, (
             f"create_workspace must clear any stale cache entry for the reused "
-            f"id={ws_b}; found {db._new_images_cache.get(ws_b)!r}"
+            f"id={ws_b}; found {db._new_images_cache.get(db._db_path, ws_b)!r}"
         )
     else:  # pragma: no cover — sqlite3 almost always reuses the highest freed rowid
         # No id reuse; verify the new workspace has no stale cache entry under
         # its own id (trivially true) and that the original stale entry is
         # untouched (since it's under a different id now).
-        assert db._new_images_cache.get(ws_b) is None
+        assert db._new_images_cache.get(db._db_path, ws_b) is None
 
     # And a full round-trip: fetching new-images for ws_b must not return the
     # stale payload from ws_a.
@@ -748,7 +812,7 @@ def test_delete_photos_invalidates_cache(db_with_workspace):
     # Prime the cache: nothing should be new yet.
     r1 = db.get_new_images_for_workspace(ws_id)
     assert r1["new_count"] == 0
-    assert db._new_images_cache.get(ws_id) is not None
+    assert db._new_images_cache.get(db._db_path, ws_id) is not None
 
     # Remove a.JPG's photo row but leave the file on disk (mimics
     # "Remove from Vireo" semantics — delete_photos does not touch files).

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -105,3 +105,31 @@ def test_db_get_new_images_for_workspace_caches_result(db_with_workspace, monkey
     r2 = db.get_new_images_for_workspace(ws_id)
     assert r1 == r2
     assert calls[0] == 1  # second call served from cache
+
+
+def test_invalidate_cache_for_shared_folder_across_workspaces(tmp_path):
+    """If workspaces A and B both link folder F, a scan of F must clear both caches."""
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.ensure_default_workspace()
+    ws_b = db.create_workspace("B")
+
+    # Link the same folder into both workspaces.
+    db.set_active_workspace(ws_a)
+    root = tmp_path / "shared"
+    _touch_image(str(root / "IMG.JPG"))
+    root_id = db.add_folder(str(root), name="shared")
+    db.set_active_workspace(ws_b)
+    db.add_workspace_folder(ws_b, root_id)
+
+    # Prime both caches.
+    db.set_active_workspace(ws_a)
+    db.get_new_images_for_workspace(ws_a)
+    db.get_new_images_for_workspace(ws_b)
+    assert db._new_images_cache.get(ws_a) is not None
+    assert db._new_images_cache.get(ws_b) is not None
+
+    # Scan completes for folder root_id.
+    db.invalidate_new_images_cache_for_folders([root_id])
+
+    assert db._new_images_cache.get(ws_a) is None
+    assert db._new_images_cache.get(ws_b) is None

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -16,6 +16,8 @@ def _touch_image(path):
 
 @pytest.fixture
 def db_with_workspace(tmp_path):
+    from new_images import get_shared_cache
+    get_shared_cache().clear()
     db = Database(str(tmp_path / "test.db"))
     ws_id = db.ensure_default_workspace()
     db.set_active_workspace(ws_id)
@@ -109,6 +111,8 @@ def test_db_get_new_images_for_workspace_caches_result(db_with_workspace, monkey
 
 def test_invalidate_cache_for_shared_folder_across_workspaces(tmp_path):
     """If workspaces A and B both link folder F, a scan of F must clear both caches."""
+    from new_images import get_shared_cache
+    get_shared_cache().clear()
     db = Database(str(tmp_path / "test.db"))
     ws_a = db.ensure_default_workspace()
     ws_b = db.create_workspace("B")
@@ -133,3 +137,22 @@ def test_invalidate_cache_for_shared_folder_across_workspaces(tmp_path):
 
     assert db._new_images_cache.get(ws_a) is None
     assert db._new_images_cache.get(ws_b) is None
+
+
+def test_two_database_instances_share_cache(tmp_path):
+    from new_images import get_shared_cache
+    get_shared_cache().clear()
+    db_a = Database(str(tmp_path / "test.db"))
+    ws_id = db_a.ensure_default_workspace()
+    db_a.set_active_workspace(ws_id)
+    root = tmp_path / "shoot"
+    os.makedirs(root, exist_ok=True)
+    Image.new("RGB", (1, 1), "white").save(str(root / "a.JPG"), "JPEG")
+    db_a.add_folder(str(root), name="shoot")
+    db_a.get_new_images_for_workspace(ws_id)  # populates shared cache
+
+    # A second Database instance (simulating a different thread / request)
+    db_b = Database(str(tmp_path / "test.db"))
+    assert db_b._new_images_cache.get(ws_id) is not None, (
+        "Second Database should see cache populated by the first"
+    )

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -180,6 +180,56 @@ def test_two_database_instances_share_cache(tmp_path):
     )
 
 
+def test_count_new_images_skips_dotfiles(db_with_workspace):
+    """Dotfiles (e.g. macOS AppleDouble ``._IMG_0001.JPG`` sidecars) must not be
+    counted as new, since the scanner never ingests them."""
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG_0001.JPG"))
+    # AppleDouble sidecar next to the real file. Use _touch_image so the
+    # suffix matches SUPPORTED_EXTENSIONS; the filter must still reject it
+    # because of the leading dot.
+    _touch_image(str(root / "._IMG_0001.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+
+    assert result["new_count"] == 1, (
+        f"Expected 1 new image (dotfile skipped), got {result['new_count']}. "
+        f"sample={result['sample']}"
+    )
+    assert all(not os.path.basename(s).startswith(".") for s in result["sample"])
+
+
+def test_invalidate_new_images_after_scan_normalizes_trailing_slash(tmp_path):
+    """Caller-supplied root with a trailing slash must still match folders stored
+    by the scanner as ``str(Path(...))`` (no trailing slash)."""
+    from app import _invalidate_new_images_after_scan
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG_0001.JPG"))
+    # Folder stored in canonical form (no trailing slash), matching what the
+    # scanner writes via str(Path(...)).
+    db.add_folder(str(root), name="shoot")
+
+    # Prime the cache.
+    db.get_new_images_for_workspace(ws_id)
+    assert db._new_images_cache.get(ws_id) is not None
+
+    # Invalidate with a trailing slash. Must still clear the cache.
+    _invalidate_new_images_after_scan(db, str(root) + "/")
+
+    assert db._new_images_cache.get(ws_id) is None, (
+        "Trailing-slash root must be normalized so path = ? matches the "
+        "canonical form stored in the folders table"
+    )
+
+
 def test_invalidate_new_images_after_scan_clears_shared_cache_across_instances(tmp_path):
     """End-to-end coverage of _invalidate_new_images_after_scan:
 

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -14,10 +14,16 @@ def _touch_image(path):
     Image.new("RGB", (1, 1), "white").save(path, "JPEG")
 
 
-@pytest.fixture
-def db_with_workspace(tmp_path):
+@pytest.fixture(autouse=True)
+def _clear_shared_new_images_cache():
     from new_images import get_shared_cache
     get_shared_cache().clear()
+    yield
+    get_shared_cache().clear()
+
+
+@pytest.fixture
+def db_with_workspace(tmp_path):
     db = Database(str(tmp_path / "test.db"))
     ws_id = db.ensure_default_workspace()
     db.set_active_workspace(ws_id)
@@ -111,8 +117,6 @@ def test_db_get_new_images_for_workspace_caches_result(db_with_workspace, monkey
 
 def test_invalidate_cache_for_shared_folder_across_workspaces(tmp_path):
     """If workspaces A and B both link folder F, a scan of F must clear both caches."""
-    from new_images import get_shared_cache
-    get_shared_cache().clear()
     db = Database(str(tmp_path / "test.db"))
     ws_a = db.ensure_default_workspace()
     ws_b = db.create_workspace("B")
@@ -160,8 +164,6 @@ def test_scan_job_invalidates_cache(db_with_workspace):
 
 
 def test_two_database_instances_share_cache(tmp_path):
-    from new_images import get_shared_cache
-    get_shared_cache().clear()
     db_a = Database(str(tmp_path / "test.db"))
     ws_id = db_a.ensure_default_workspace()
     db_a.set_active_workspace(ws_id)
@@ -175,4 +177,59 @@ def test_two_database_instances_share_cache(tmp_path):
     db_b = Database(str(tmp_path / "test.db"))
     assert db_b._new_images_cache.get(ws_id) is not None, (
         "Second Database should see cache populated by the first"
+    )
+
+
+def test_invalidate_new_images_after_scan_clears_shared_cache_across_instances(tmp_path):
+    """End-to-end coverage of _invalidate_new_images_after_scan:
+
+    - Includes a descendant folder auto-registered with parent_id so the LIKE
+      query must pick it up to invalidate the workspace that only references
+      the descendant.
+    - Uses two Database instances against the same DB file: populate via
+      db_a, invalidate via db_b, assert db_a sees the cleared cache. This
+      locks in the shared-cache contract.
+    """
+    from app import _invalidate_new_images_after_scan
+
+    # db_a populates the cache for a workspace whose only linked folder is a
+    # descendant of `root`.
+    db_a = Database(str(tmp_path / "test.db"))
+    ws_id = db_a.ensure_default_workspace()
+    db_a.set_active_workspace(ws_id)
+
+    root = tmp_path / "shoot"
+    descendant = root / "day1"
+    _touch_image(str(descendant / "IMG_0001.JPG"))
+
+    root_id = db_a.add_folder(str(root), name="shoot")
+    descendant_id = db_a.add_folder(
+        str(descendant), name="day1", parent_id=root_id
+    )
+
+    # Create a second workspace that only links the descendant folder, so
+    # invalidation via the LIKE query (on the root path) must reach it.
+    ws_b = db_a.create_workspace("B")
+    db_a.add_workspace_folder(ws_b, descendant_id)
+
+    # Prime caches for both workspaces via db_a.
+    db_a.get_new_images_for_workspace(ws_id)
+    db_a.get_new_images_for_workspace(ws_b)
+    assert db_a._new_images_cache.get(ws_id) is not None
+    assert db_a._new_images_cache.get(ws_b) is not None
+
+    # Invalidate from a DIFFERENT Database instance to exercise the shared
+    # cache contract end-to-end.
+    db_b = Database(str(tmp_path / "test.db"))
+    _invalidate_new_images_after_scan(db_b, str(root))
+
+    # db_a must observe the cleared caches for both workspaces, including the
+    # one that only references the descendant folder (proves the LIKE picked
+    # it up).
+    assert db_a._new_images_cache.get(ws_id) is None, (
+        "Cache for workspace linked to root should be cleared"
+    )
+    assert db_a._new_images_cache.get(ws_b) is None, (
+        "Cache for workspace linked only to descendant folder should be cleared "
+        "(LIKE query must match auto-registered subfolders)"
     )

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -139,6 +139,26 @@ def test_invalidate_cache_for_shared_folder_across_workspaces(tmp_path):
     assert db._new_images_cache.get(ws_b) is None
 
 
+def test_scan_job_invalidates_cache(db_with_workspace):
+    """After a successful scan, the cached new_count must be re-computed on next read."""
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "a.JPG"))
+    root_id = db.add_folder(str(root), name="shoot")
+
+    # Prime cache with current state (1 new).
+    r1 = db.get_new_images_for_workspace(ws_id)
+    assert r1["new_count"] == 1
+
+    # Simulate a scan by inserting the photo row and invalidating.
+    db.add_photo(folder_id=root_id, filename="a.JPG", extension=".JPG",
+                 file_size=1, file_mtime=0.0)
+    db.invalidate_new_images_cache_for_folders([root_id])
+
+    r2 = db.get_new_images_for_workspace(ws_id)
+    assert r2["new_count"] == 0
+
+
 def test_two_database_instances_share_cache(tmp_path):
     from new_images import get_shared_cache
     get_shared_cache().clear()

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -368,3 +368,35 @@ def test_get_new_images_for_workspace_race_does_not_repopulate_stale(db_with_wor
     db.get_new_images_for_workspace(ws_id)
     # Cache must NOT hold the stale value.
     assert db._new_images_cache.get(ws_id) is None, "Stale compute leaked into cache"
+
+
+def test_scan_handler_invalidates_cache_when_scan_raises(tmp_path, monkeypatch):
+    """If do_scan raises partway through, invalidation must still run because
+    scanner.scan commits photo rows incrementally. The try/finally in the scan
+    handlers at vireo/app.py guarantees this."""
+    import app as app_module
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    root_id = db.add_folder(str(root), name="shoot")
+
+    # Prime the cache.
+    db.get_new_images_for_workspace(ws_id)
+    assert db._new_images_cache.get(ws_id) is not None
+
+    # Simulate the try/finally pattern used in api_job_scan / api_job_import_full:
+    # do_scan raises, invalidation still runs in finally.
+    try:
+        try:
+            raise RuntimeError("simulated mid-scan failure")
+        finally:
+            app_module._invalidate_new_images_after_scan(db, str(root))
+    except RuntimeError:
+        pass
+
+    assert db._new_images_cache.get(ws_id) is None, (
+        "Cache must be invalidated even when the scan raises"
+    )

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -402,6 +402,87 @@ def test_scan_handler_invalidates_cache_when_scan_raises(tmp_path, monkeypatch):
     )
 
 
+def test_pipeline_job_scan_invalidates_cache(tmp_path, monkeypatch):
+    """The pipeline_job scanner stage (the third scan path alongside
+    api_job_scan and api_job_import_full) must invalidate the new-images
+    cache. Prior to this fix, a pipeline run from templates/pipeline.html
+    would scan photos without clearing the banner's "N new images" count,
+    so the banner stayed stale until TTL.
+
+    Runs the full pipeline job with classify / extract-masks / regroup
+    skipped so the test completes quickly; asserts the cache for the active
+    workspace was cleared by the time the job returns.
+    """
+    import app as app_module  # ensures _invalidate_new_images_after_scan is wired up
+    import config as cfg
+    from PIL import Image
+    from pipeline_job import PipelineParams, run_pipeline_job
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    Image.new("RGB", (100, 100), "red").save(str(photo_dir / "a.jpg"))
+    Image.new("RGB", (100, 100), "red").save(str(photo_dir / "b.jpg"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # Register the source folder against the workspace so
+    # count_new_images_for_workspace has something to enumerate.
+    db.add_folder(str(photo_dir), name="photos")
+
+    # Prime the cache: two files present, none ingested yet -> new_count=2.
+    primed = db.get_new_images_for_workspace(ws_id)
+    assert primed["new_count"] == 2
+    assert db._new_images_cache.get(ws_id) is not None
+
+    # Minimal FakeRunner inline so we don't couple this test to
+    # tests/test_pipeline_job.py's helper class.
+    class _Runner:
+        def push_event(self, *a, **k): pass
+        def set_steps(self, *a, **k): pass
+        def update_step(self, *a, **k): pass
+        def is_cancelled(self, *a, **k): return False
+
+    job = {
+        "id": "test-pipeline-invalidates",
+        "type": "pipeline",
+        "status": "running",
+        "started_at": "2026-01-01T00:00:00",
+        "finished_at": None,
+        "progress": {"current": 0, "total": 0, "current_file": ""},
+        "result": None,
+        "errors": [],
+        "config": {},
+        "workspace_id": ws_id,
+    }
+
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    run_pipeline_job(job, _Runner(), db_path, ws_id, params)
+
+    # After the scan, the cache must be cleared so the next banner fetch
+    # recomputes against the updated photos table.
+    assert db._new_images_cache.get(ws_id) is None, (
+        "pipeline_job scanner_stage must invalidate the new-images cache "
+        "for roots fed to do_scan (try/finally mirrors api_job_scan)"
+    )
+    # Sanity-check that the helper app.py exposes still resolves to the
+    # same canonical implementation used by pipeline_job.
+    import new_images as new_images_mod
+    assert app_module._invalidate_new_images_after_scan is (
+        new_images_mod.invalidate_new_images_after_scan
+    )
+
+
 def test_invalidate_new_images_cache_for_folders_handles_thousands_of_ids(
     db_with_workspace,
 ):

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -400,3 +400,122 @@ def test_scan_handler_invalidates_cache_when_scan_raises(tmp_path, monkeypatch):
     assert db._new_images_cache.get(ws_id) is None, (
         "Cache must be invalidated even when the scan raises"
     )
+
+
+def test_invalidate_new_images_cache_for_folders_handles_thousands_of_ids(
+    db_with_workspace,
+):
+    """A scan of a deep tree can auto-register thousands of descendant folders.
+    Passing them all to ``invalidate_new_images_cache_for_folders`` must not
+    raise ``OperationalError: too many SQL variables``.
+
+    The helper should chunk the ``IN (?, ?, ...)`` query rather than building a
+    single placeholder list whose length exceeds SQLite's
+    ``SQLITE_LIMIT_VARIABLE_NUMBER``. To make this test fast and independent
+    of the host SQLite build (the default cap varies — 999 on old builds,
+    250000 on newer ones), we lower the cap on the connection via
+    ``setlimit`` so a modest list is enough to expose the bug.
+    """
+    import sqlite3
+    db, ws_id, tmp_path = db_with_workspace
+
+    # Lower the variable cap so 2500 ids would blow past it if the helper
+    # did not chunk.
+    db.conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 500)
+
+    # 2500 unknown folder_ids: SQL simply returns no rows, but must execute
+    # without raising.
+    unknown_ids = list(range(100000, 102500))
+    db.invalidate_new_images_cache_for_folders(unknown_ids)  # must not raise
+
+    # Now build a scenario with a real linked folder mixed in with many unknown
+    # ids. Prime the cache, invalidate, and assert it was cleared.
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    root_id = db.add_folder(str(root), name="shoot")
+
+    db.get_new_images_for_workspace(ws_id)
+    assert db._new_images_cache.get(ws_id) is not None
+
+    mixed = unknown_ids + [root_id]
+    db.invalidate_new_images_cache_for_folders(mixed)
+    assert db._new_images_cache.get(ws_id) is None, (
+        "Chunked invalidation must still clear the real linked folder's workspace"
+    )
+
+
+def test_delete_workspace_clears_cache(tmp_path):
+    """Deleting a workspace must drop its cached new-images entry immediately.
+    Otherwise, if SQLite later reuses the rowid for a new workspace, stale
+    data leaks across identities until TTL expiry."""
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    ws_tmp = db.create_workspace("to-delete")
+
+    # Populate the cache directly (avoids needing a real folder / photo setup).
+    db._new_images_cache.set(
+        ws_tmp, {"new_count": 7, "per_root": [], "sample": []}
+    )
+    assert db._new_images_cache.get(ws_tmp) is not None
+
+    db.delete_workspace(ws_tmp)
+
+    assert db._new_images_cache.get(ws_tmp) is None, (
+        "delete_workspace must invalidate the new-images cache entry"
+    )
+
+
+def test_create_workspace_clears_stale_cache_on_id_reuse(tmp_path):
+    """SQLite's ``INTEGER PRIMARY KEY`` (without AUTOINCREMENT) can reuse a
+    deleted rowid. If a cache entry exists under a rowid at the moment a new
+    workspace is created with that id, the new workspace must NOT inherit it.
+
+    We simulate this by seeding the cache *after* the delete (to mimic a race
+    where an in-flight compute from a prior request wrote a stale entry after
+    the delete's invalidation), then creating a new workspace and asserting
+    its ``create_workspace`` hook cleared the stale entry.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    ws_default = db.ensure_default_workspace()
+    db.set_active_workspace(ws_default)
+
+    ws_a = db.create_workspace("A")
+    stale_payload = {"new_count": 42, "per_root": [], "sample": ["/stale.JPG"]}
+
+    db.delete_workspace(ws_a)
+
+    # Simulate a late write landing in the cache AFTER delete_workspace's
+    # invalidation ran. In production this could happen if an in-flight
+    # ``get_new_images_for_workspace`` for ws_a computed a result and called
+    # ``set`` with a stale generation that happened to match (or if the cache
+    # was repopulated by a reader racing with delete). Passing ``generation``
+    # unconditionally here seeds the entry regardless of the generation
+    # invalidate_workspaces bumped.
+    db._new_images_cache.set(ws_a, stale_payload)
+    assert db._new_images_cache.get(ws_a) == stale_payload
+
+    # Create a new workspace. SQLite typically reuses the highest freed rowid,
+    # so this usually gets ws_a's old id.
+    ws_b = db.create_workspace("B")
+
+    if ws_a == ws_b:
+        # Id was reused — create_workspace's hook must have cleared the stale
+        # entry so the new workspace does NOT inherit the old payload.
+        assert db._new_images_cache.get(ws_b) is None, (
+            f"create_workspace must clear any stale cache entry for the reused "
+            f"id={ws_b}; found {db._new_images_cache.get(ws_b)!r}"
+        )
+    else:  # pragma: no cover — sqlite3 almost always reuses the highest freed rowid
+        # No id reuse; verify the new workspace has no stale cache entry under
+        # its own id (trivially true) and that the original stale entry is
+        # untouched (since it's under a different id now).
+        assert db._new_images_cache.get(ws_b) is None
+
+    # And a full round-trip: fetching new-images for ws_b must not return the
+    # stale payload from ws_a.
+    result = db.get_new_images_for_workspace(ws_b)
+    assert result != stale_payload, (
+        f"New workspace (id={ws_b}) must not inherit deleted workspace's cache "
+        f"(id reuse of {ws_a}? {ws_a == ws_b})"
+    )

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from db import Database
+from PIL import Image
+
+
+def _touch_image(path):
+    """Create a real 1x1 JPEG at path."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    Image.new("RGB", (1, 1), "white").save(path, "JPEG")
+
+
+@pytest.fixture
+def db_with_workspace(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    return db, ws_id, tmp_path
+
+
+def test_count_new_images_detects_unscanned_files(db_with_workspace):
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "USA2026"
+    _touch_image(str(root / "IMG_0001.JPG"))
+    _touch_image(str(root / "IMG_0002.JPG"))
+    db.add_folder(str(root), name="USA2026")
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+
+    assert result["new_count"] == 2
+    assert len(result["per_root"]) == 1
+    assert result["per_root"][0]["new_count"] == 2
+    assert len(result["sample"]) == 2

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -72,6 +72,47 @@ def test_count_new_images_no_double_counting_with_nested_linked_folders(db_with_
     assert result["per_root"][0]["path"] == str(root)
 
 
+def test_mapped_roots_excludes_folder_with_any_linked_ancestor(db_with_workspace):
+    """A folder is a root only if *no* ancestor at any depth is linked — not
+    just its immediate parent. Without this, a scenario like:
+
+        /A       linked
+        /A/B     unlinked (intermediate)
+        /A/B/C   linked
+
+    would treat both /A and /A/B/C as roots (because /A/B, C's immediate
+    parent, is not linked) and os.walk'ing both would double-count every file
+    under /A/B/C.
+    """
+    db, ws_id, tmp_path = db_with_workspace
+
+    a = tmp_path / "A"
+    b = a / "B"
+    c = b / "C"
+    _touch_image(str(c / "IMG_0001.JPG"))
+
+    # Register the full chain against the workspace, then unlink the
+    # intermediate /A/B so only /A and /A/B/C remain linked.
+    a_id = db.add_folder(str(a), name="A")
+    b_id = db.add_folder(str(b), name="B", parent_id=a_id)
+    db.add_folder(str(c), name="C", parent_id=b_id)
+    db.remove_workspace_folder(ws_id, b_id)
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+
+    assert result["new_count"] == 1, (
+        f"Expected 1 new image (must not double-count across /A and /A/B/C), "
+        f"got {result['new_count']}. per_root={result['per_root']}"
+    )
+    assert len(result["per_root"]) == 1, (
+        f"Only the true root /A should walk; per_root={result['per_root']}"
+    )
+    assert result["per_root"][0]["path"] == str(a), (
+        f"Root path should be /A, got {result['per_root'][0]['path']!r}"
+    )
+
+
 def test_count_new_images_basename_collision_across_subdirs(db_with_workspace):
     db, ws_id, tmp_path = db_with_workspace
     root = tmp_path / "shoot"

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -1,0 +1,67 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from PIL import Image
+
+
+def _touch_image(path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    Image.new("RGB", (1, 1), "white").save(path, "JPEG")
+
+
+@pytest.fixture(autouse=True)
+def _clear_shared_new_images_cache():
+    from new_images import get_shared_cache
+    get_shared_cache().clear()
+    yield
+    get_shared_cache().clear()
+
+
+@pytest.fixture
+def app_and_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    from app import create_app
+    from db import Database
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir)
+    return app, db, ws_id, tmp_path
+
+
+def test_api_new_images_reports_unscanned_files(app_and_db):
+    app, db, ws_id, tmp_path = app_and_db
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    client = app.test_client()
+    resp = client.get("/api/workspace/new-images")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["new_count"] == 1
+    assert len(data["per_root"]) == 1
+
+
+def test_api_new_images_zero_when_fully_ingested(app_and_db):
+    app, db, ws_id, tmp_path = app_and_db
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    fid = db.add_folder(str(root), name="shoot")
+    db.add_photo(folder_id=fid, filename="IMG.JPG", extension=".JPG",
+                 file_size=1, file_mtime=0.0)
+
+    client = app.test_client()
+    resp = client.get("/api/workspace/new-images")
+    assert resp.get_json()["new_count"] == 0

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -47,7 +47,7 @@ def test_api_new_images_reports_unscanned_files(app_and_db):
     db.add_folder(str(root), name="shoot")
 
     client = app.test_client()
-    resp = client.get("/api/workspace/new-images")
+    resp = client.get("/api/workspaces/active/new-images")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["new_count"] == 1
@@ -63,5 +63,5 @@ def test_api_new_images_zero_when_fully_ingested(app_and_db):
                  file_size=1, file_mtime=0.0)
 
     client = app.test_client()
-    resp = client.get("/api/workspace/new-images")
+    resp = client.get("/api/workspaces/active/new-images")
     assert resp.get_json()["new_count"] == 0

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -52,6 +52,7 @@ def test_api_new_images_reports_unscanned_files(app_and_db):
     data = resp.get_json()
     assert data["new_count"] == 1
     assert len(data["per_root"]) == 1
+    assert data["workspace_id"] == ws_id
 
 
 def test_api_new_images_zero_when_fully_ingested(app_and_db):
@@ -64,4 +65,25 @@ def test_api_new_images_zero_when_fully_ingested(app_and_db):
 
     client = app.test_client()
     resp = client.get("/api/workspaces/active/new-images")
-    assert resp.get_json()["new_count"] == 0
+    data = resp.get_json()
+    assert data["new_count"] == 0
+    assert data["workspace_id"] == ws_id
+
+
+def test_api_new_images_returns_null_workspace_when_none_active(app_and_db, monkeypatch):
+    app, db, ws_id, tmp_path = app_and_db
+    # Each request creates its own Database via _get_db(), which auto-restores
+    # the last-used workspace. To simulate "no active workspace", patch
+    # set_active_workspace to a no-op so the per-request db starts with
+    # _active_workspace_id = None.
+    from db import Database
+    monkeypatch.setattr(Database, "set_active_workspace",
+                        lambda self, ws_id: None)
+
+    client = app.test_client()
+    resp = client.get("/api/workspaces/active/new-images")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["workspace_id"] is None
+    assert data["new_count"] == 0
+    assert data["per_root"] == []

--- a/vireo/tests/test_new_images_cache.py
+++ b/vireo/tests/test_new_images_cache.py
@@ -42,3 +42,38 @@ def test_cache_invalidate_workspace_does_not_clear_others():
     cache.invalidate_workspaces([1])
     assert cache.get(1) is None
     assert cache.get(2) == {"new_count": 7}
+
+
+def test_cache_set_with_stale_generation_is_dropped():
+    cache = NewImagesCache(ttl_seconds=60)
+    gen_before = cache.get_generation(workspace_id=1)
+    cache.invalidate_workspaces([1])
+    # Simulate: compute started before invalidate, tries to write with stale gen
+    cache.set(workspace_id=1, result={"new_count": 5}, generation=gen_before)
+    assert cache.get(1) is None, "Stale set must not repopulate after invalidate"
+
+
+def test_cache_set_with_current_generation_stores():
+    cache = NewImagesCache(ttl_seconds=60)
+    gen = cache.get_generation(workspace_id=1)
+    cache.set(workspace_id=1, result={"new_count": 5}, generation=gen)
+    assert cache.get(1) == {"new_count": 5}
+
+
+def test_cache_set_without_generation_stores_unconditionally():
+    cache = NewImagesCache(ttl_seconds=60)
+    cache.set(workspace_id=1, result={"new_count": 5})
+    assert cache.get(1) == {"new_count": 5}
+
+
+def test_cache_invalidate_then_set_with_stale_gen_is_dropped_then_new_set_works():
+    cache = NewImagesCache(ttl_seconds=60)
+    gen1 = cache.get_generation(1)
+    cache.invalidate_workspaces([1])
+    cache.set(workspace_id=1, result={"new_count": 5}, generation=gen1)  # dropped
+    assert cache.get(1) is None
+    # Fresh compute after invalidation gets the new generation and stores fine.
+    gen2 = cache.get_generation(1)
+    assert gen2 != gen1
+    cache.set(workspace_id=1, result={"new_count": 7}, generation=gen2)
+    assert cache.get(1) == {"new_count": 7}

--- a/vireo/tests/test_new_images_cache.py
+++ b/vireo/tests/test_new_images_cache.py
@@ -6,74 +6,117 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from new_images import NewImagesCache
 
+# Sentinel db_path for the unit tests — the cache keys by
+# (db_path, workspace_id), so every call site must pass one. The exact string
+# doesn't matter here since nothing opens it; what matters is that the same
+# key is used for set and get.
+DB = "/tmp/unit-test.db"
+
 
 def test_cache_returns_cached_value_within_ttl():
     cache = NewImagesCache(ttl_seconds=60)
-    cache.set(workspace_id=1, result={"new_count": 5})
-    assert cache.get(1) == {"new_count": 5}
+    cache.set(DB, workspace_id=1, result={"new_count": 5})
+    assert cache.get(DB, 1) == {"new_count": 5}
 
 
 def test_cache_expires_after_ttl(monkeypatch):
     clock = [1000.0]
     monkeypatch.setattr("new_images.time.monotonic", lambda: clock[0])
     cache = NewImagesCache(ttl_seconds=60)
-    cache.set(workspace_id=1, result={"new_count": 5})
+    cache.set(DB, workspace_id=1, result={"new_count": 5})
     clock[0] += 61
-    assert cache.get(1) is None
+    assert cache.get(DB, 1) is None
 
 
 def test_cache_invalidate_by_folder_ids_clears_all_workspaces_linking_those_folders():
     """When folder F is scanned, every workspace linked to F must have its cache cleared."""
     cache = NewImagesCache(ttl_seconds=60)
-    cache.set(workspace_id=1, result={"new_count": 5})
-    cache.set(workspace_id=2, result={"new_count": 7})
+    cache.set(DB, workspace_id=1, result={"new_count": 5})
+    cache.set(DB, workspace_id=2, result={"new_count": 7})
 
     # Caller supplies the mapping: folder_id -> list of workspace_ids linked to it.
-    cache.invalidate_workspaces([1, 2])
+    cache.invalidate_workspaces(DB, [1, 2])
 
-    assert cache.get(1) is None
-    assert cache.get(2) is None
+    assert cache.get(DB, 1) is None
+    assert cache.get(DB, 2) is None
 
 
 def test_cache_invalidate_workspace_does_not_clear_others():
     cache = NewImagesCache(ttl_seconds=60)
-    cache.set(workspace_id=1, result={"new_count": 5})
-    cache.set(workspace_id=2, result={"new_count": 7})
-    cache.invalidate_workspaces([1])
-    assert cache.get(1) is None
-    assert cache.get(2) == {"new_count": 7}
+    cache.set(DB, workspace_id=1, result={"new_count": 5})
+    cache.set(DB, workspace_id=2, result={"new_count": 7})
+    cache.invalidate_workspaces(DB, [1])
+    assert cache.get(DB, 1) is None
+    assert cache.get(DB, 2) == {"new_count": 7}
 
 
 def test_cache_set_with_stale_generation_is_dropped():
     cache = NewImagesCache(ttl_seconds=60)
-    gen_before = cache.get_generation(workspace_id=1)
-    cache.invalidate_workspaces([1])
+    gen_before = cache.get_generation(DB, workspace_id=1)
+    cache.invalidate_workspaces(DB, [1])
     # Simulate: compute started before invalidate, tries to write with stale gen
-    cache.set(workspace_id=1, result={"new_count": 5}, generation=gen_before)
-    assert cache.get(1) is None, "Stale set must not repopulate after invalidate"
+    cache.set(DB, workspace_id=1, result={"new_count": 5}, generation=gen_before)
+    assert cache.get(DB, 1) is None, "Stale set must not repopulate after invalidate"
 
 
 def test_cache_set_with_current_generation_stores():
     cache = NewImagesCache(ttl_seconds=60)
-    gen = cache.get_generation(workspace_id=1)
-    cache.set(workspace_id=1, result={"new_count": 5}, generation=gen)
-    assert cache.get(1) == {"new_count": 5}
+    gen = cache.get_generation(DB, workspace_id=1)
+    cache.set(DB, workspace_id=1, result={"new_count": 5}, generation=gen)
+    assert cache.get(DB, 1) == {"new_count": 5}
 
 
 def test_cache_set_without_generation_stores_unconditionally():
     cache = NewImagesCache(ttl_seconds=60)
-    cache.set(workspace_id=1, result={"new_count": 5})
-    assert cache.get(1) == {"new_count": 5}
+    cache.set(DB, workspace_id=1, result={"new_count": 5})
+    assert cache.get(DB, 1) == {"new_count": 5}
 
 
 def test_cache_invalidate_then_set_with_stale_gen_is_dropped_then_new_set_works():
     cache = NewImagesCache(ttl_seconds=60)
-    gen1 = cache.get_generation(1)
-    cache.invalidate_workspaces([1])
-    cache.set(workspace_id=1, result={"new_count": 5}, generation=gen1)  # dropped
-    assert cache.get(1) is None
+    gen1 = cache.get_generation(DB, 1)
+    cache.invalidate_workspaces(DB, [1])
+    cache.set(DB, workspace_id=1, result={"new_count": 5}, generation=gen1)  # dropped
+    assert cache.get(DB, 1) is None
     # Fresh compute after invalidation gets the new generation and stores fine.
-    gen2 = cache.get_generation(1)
+    gen2 = cache.get_generation(DB, 1)
     assert gen2 != gen1
-    cache.set(workspace_id=1, result={"new_count": 7}, generation=gen2)
-    assert cache.get(1) == {"new_count": 7}
+    cache.set(DB, workspace_id=1, result={"new_count": 7}, generation=gen2)
+    assert cache.get(DB, 1) == {"new_count": 7}
+
+
+def test_cache_keys_by_db_path_isolates_identical_workspace_ids():
+    """Two databases with identical workspace_ids (typically 1 for Default)
+    must not read each other's cached results. Otherwise switching between two
+    open Vireo instances — or running tests that reuse a shared process-wide
+    cache — would cross-contaminate."""
+    cache = NewImagesCache(ttl_seconds=60)
+    cache.set("/path/a.db", workspace_id=1, result={"new_count": 5, "tag": "A"})
+    cache.set("/path/b.db", workspace_id=1, result={"new_count": 99, "tag": "B"})
+
+    assert cache.get("/path/a.db", 1) == {"new_count": 5, "tag": "A"}
+    assert cache.get("/path/b.db", 1) == {"new_count": 99, "tag": "B"}
+
+    # Invalidating one db must not clear the other.
+    cache.invalidate_workspaces("/path/a.db", [1])
+    assert cache.get("/path/a.db", 1) is None
+    assert cache.get("/path/b.db", 1) == {"new_count": 99, "tag": "B"}
+
+
+def test_cache_generation_is_scoped_by_db_path():
+    """A bump to one db's generation must not race-drop a concurrent write for
+    a different db with the same workspace_id."""
+    cache = NewImagesCache(ttl_seconds=60)
+    gen_a = cache.get_generation("/path/a.db", 1)
+    gen_b = cache.get_generation("/path/b.db", 1)
+    # Advance only A's generation.
+    cache.invalidate_workspaces("/path/a.db", [1])
+    # B's stale-check passes because its generation is still gen_b — the
+    # invalidation on A must not have bumped it.
+    cache.set("/path/b.db", workspace_id=1,
+              result={"new_count": 7}, generation=gen_b)
+    assert cache.get("/path/b.db", 1) == {"new_count": 7}
+    # A's attempted write with the old gen is still dropped.
+    cache.set("/path/a.db", workspace_id=1,
+              result={"new_count": 99}, generation=gen_a)
+    assert cache.get("/path/a.db", 1) is None

--- a/vireo/tests/test_new_images_cache.py
+++ b/vireo/tests/test_new_images_cache.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+from new_images import NewImagesCache
+
+
+def test_cache_returns_cached_value_within_ttl():
+    cache = NewImagesCache(ttl_seconds=60)
+    cache.set(workspace_id=1, result={"new_count": 5})
+    assert cache.get(1) == {"new_count": 5}
+
+
+def test_cache_expires_after_ttl(monkeypatch):
+    clock = [1000.0]
+    monkeypatch.setattr("new_images.time.monotonic", lambda: clock[0])
+    cache = NewImagesCache(ttl_seconds=60)
+    cache.set(workspace_id=1, result={"new_count": 5})
+    clock[0] += 61
+    assert cache.get(1) is None
+
+
+def test_cache_invalidate_by_folder_ids_clears_all_workspaces_linking_those_folders():
+    """When folder F is scanned, every workspace linked to F must have its cache cleared."""
+    cache = NewImagesCache(ttl_seconds=60)
+    cache.set(workspace_id=1, result={"new_count": 5})
+    cache.set(workspace_id=2, result={"new_count": 7})
+
+    # Caller supplies the mapping: folder_id -> list of workspace_ids linked to it.
+    cache.invalidate_workspaces([1, 2])
+
+    assert cache.get(1) is None
+    assert cache.get(2) is None
+
+
+def test_cache_invalidate_workspace_does_not_clear_others():
+    cache = NewImagesCache(ttl_seconds=60)
+    cache.set(workspace_id=1, result={"new_count": 5})
+    cache.set(workspace_id=2, result={"new_count": 7})
+    cache.invalidate_workspaces([1])
+    assert cache.get(1) is None
+    assert cache.get(2) == {"new_count": 7}


### PR DESCRIPTION
## Summary

Implements the design in #583 and plan in #586. Shows a banner — "N new images detected in your registered folders. [Create a pipeline]" — whenever the active workspace's mapped folders contain image files not yet ingested. Click routes to `/pipeline`, whose existing Scan & Import stage handles the ingest; banner auto-hides once `new_count` drops to 0.

**Backend**
- `vireo/new_images.py` — pure helper walks mapped roots (filters `workspace_folders` to roots whose `parent_id` is NULL or not in the workspace), diffs image files on disk against `photos JOIN folders` by absolute path. Uses `image_loader.SUPPORTED_EXTENSIONS` as the canonical extension list.
- `NewImagesCache` — process-wide singleton via `get_shared_cache()`. Keyed by workspace_id, 5-minute TTL, thread-safe. Shared across request-scoped and scan-worker `Database` instances.
- `Database.get_new_images_for_workspace()` + `invalidate_new_images_cache_for_folders()` on `vireo/db.py`.
- Scan-completion hook `_invalidate_new_images_after_scan(db, root)` wired into both scan worker sites in `vireo/app.py` (`api_job_scan` and `api_job_import_full`). Resolves touched folder ids via `path LIKE` and invalidates every workspace linked to any of them.
- `GET /api/workspaces/active/new-images` returns `{new_count, per_root, sample, workspace_id}`.

**Frontend** (`vireo/templates/_navbar.html`)
- Banner DOM + CSS mirrors Missing Folders pattern (in-flow stacking, no position:fixed, themed via existing CSS vars).
- JS polls every 60s, renders aggregate count, links to `/pipeline`.
- Session-scoped dismissal keyed by `{workspaceId, count}`: re-arms when `new_count` later increases (so importing more files after dismissal resurfaces the banner).

## Tests

- 15 new-images tests (8 detection + 4 cache + 3 API) cover: basic detection, no-double-counting across auto-registered subfolders, basename collisions, cross-workspace invalidation, shared cache across `Database` instances, scan hook end-to-end, no-active-workspace.
- Full required sweep green: **480/480 passing**.

```
python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_new_images.py vireo/tests/test_new_images_cache.py vireo/tests/test_new_images_api.py
# 480 passed in ~12s
```

## Known limitation (follow-up)

Cache is not invalidated when `workspace_folders` membership changes directly (a folder unlinked from a workspace, or linked without a scan). Users hit at most 5 minutes of staleness via the TTL. Not in the design doc; filing as a follow-up rather than holding this PR.

## Test plan

- [ ] Open a workspace whose mapped folder has files on disk not in the DB — banner shows with correct count within 60s
- [ ] Click "Create a pipeline" — routes to `/pipeline`, Scan & Import runs, banner disappears on next poll
- [ ] Dismiss banner — stays hidden for the session in that workspace
- [ ] Import more files after dismissal — banner re-appears with the new higher count
- [ ] Switch workspaces — banner state resets per workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)