### PR TITLE
fix: cull analyze backfills phash from working copy, warns when missing

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5621,6 +5621,7 @@ def create_app(db_path, thumb_cache_dir=None):
                 phash_threshold=phash_threshold,
                 cross_bucket_merge=cross_bucket_merge,
                 progress_callback=progress_cb,
+                vireo_dir=os.path.dirname(db_path),
             )
 
             # Store culling results in a temporary cache for the UI
@@ -5637,6 +5638,7 @@ def create_app(db_path, thumb_cache_dir=None):
                 "suggested_keepers": result["suggested_keepers"],
                 "suggested_rejects": result["suggested_rejects"],
                 "species_count": len(result["species_groups"]),
+                "photos_missing_phash": result.get("photos_missing_phash", 0),
             }
 
         job_id = runner.start(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5621,7 +5621,7 @@ def create_app(db_path, thumb_cache_dir=None):
                 phash_threshold=phash_threshold,
                 cross_bucket_merge=cross_bucket_merge,
                 progress_callback=progress_cb,
-                vireo_dir=os.path.dirname(db_path),
+                vireo_dir=os.path.dirname(app.config["THUMB_CACHE_DIR"]),
             )
 
             # Store culling results in a temporary cache for the UI

--- a/vireo/culling.py
+++ b/vireo/culling.py
@@ -142,11 +142,14 @@ def analyze_for_culling(
             if not row:
                 continue
             try:
+                img = None
                 if vireo_dir:
                     img = load_working_image(
                         dict(row), vireo_dir, max_size=None, folders=folders_map
                     )
-                else:
+                if img is None:
+                    # Working copy absent/corrupt, or vireo_dir not provided —
+                    # try the original source (handles RAW via rawpy).
                     folder_path = folders_map.get(row["folder_id"], "")
                     img = load_image(os.path.join(folder_path, row["filename"]))
                 if img is None:

--- a/vireo/culling.py
+++ b/vireo/culling.py
@@ -9,11 +9,12 @@ The culling pipeline:
 """
 
 import logging
+import os
 from datetime import datetime
 
 import imagehash
 import numpy as np
-from PIL import Image
+from image_loader import load_image, load_working_image
 
 log = logging.getLogger(__name__)
 
@@ -27,6 +28,7 @@ def analyze_for_culling(
     phash_threshold=None,
     cross_bucket_merge=False,
     progress_callback=None,
+    vireo_dir=None,
 ):
     """Run full culling analysis on a set of photos.
 
@@ -39,6 +41,9 @@ def analyze_for_culling(
         phash_threshold: max Hamming distance for "same scene" (None = read from config)
         cross_bucket_merge: whether to merge time buckets by pHash similarity
         progress_callback: optional callable(message) for status updates
+        vireo_dir: path to ~/.vireo/ — when provided, missing pHashes are
+            backfilled from the working-copy JPEG (required for RAW formats
+            PIL can't open directly). When None, the source file is used.
 
     Returns:
         dict with:
@@ -46,6 +51,7 @@ def analyze_for_culling(
             total_photos: int
             suggested_keepers: int
             suggested_rejects: int
+            photos_missing_phash: count of photos that couldn't be hashed
     """
     import config as cfg
     user_cfg = cfg.load()
@@ -64,7 +70,13 @@ def analyze_for_culling(
 
     photo_ids = [p["id"] for p in photos]
     if not photo_ids:
-        return {"species_groups": [], "total_photos": 0, "suggested_keepers": 0, "suggested_rejects": 0}
+        return {
+            "species_groups": [],
+            "total_photos": 0,
+            "suggested_keepers": 0,
+            "suggested_rejects": 0,
+            "photos_missing_phash": 0,
+        }
 
     # Load predictions (highest confidence per photo via detections)
     predictions = {}
@@ -118,29 +130,35 @@ def analyze_for_culling(
     if missing_phash:
         if progress_callback:
             progress_callback("Computing scene hashes...")
+        folders_map = {
+            r["id"]: r["path"]
+            for r in db.conn.execute("SELECT id, path FROM folders").fetchall()
+        }
         for pid in missing_phash:
             row = db.conn.execute(
-                "SELECT folder_id, filename FROM photos WHERE id = ?", (pid,)
+                "SELECT folder_id, filename, working_copy_path FROM photos WHERE id = ?",
+                (pid,),
             ).fetchone()
             if not row:
                 continue
-            folder = db.conn.execute(
-                "SELECT path FROM folders WHERE id = ?", (row["folder_id"],)
-            ).fetchone()
-            if not folder:
-                continue
-            import os
-            image_path = os.path.join(folder["path"], row["filename"])
             try:
-                with Image.open(image_path) as img:
-                    h = imagehash.phash(img)
-                    phashes[pid] = h
-                    db.conn.execute(
-                        "UPDATE photos SET phash = ? WHERE id = ?",
-                        (str(h), pid),
+                if vireo_dir:
+                    img = load_working_image(
+                        dict(row), vireo_dir, max_size=None, folders=folders_map
                     )
+                else:
+                    folder_path = folders_map.get(row["folder_id"], "")
+                    img = load_image(os.path.join(folder_path, row["filename"]))
+                if img is None:
+                    continue
+                h = imagehash.phash(img)
+                phashes[pid] = h
+                db.conn.execute(
+                    "UPDATE photos SET phash = ? WHERE id = ?",
+                    (str(h), pid),
+                )
             except Exception:
-                log.debug("Could not compute pHash for photo %d", pid)
+                log.debug("Could not compute pHash for photo %d", pid, exc_info=True)
         db.conn.commit()
 
     # Classify extensions as RAW or non-RAW
@@ -225,11 +243,14 @@ def analyze_for_culling(
         total_keepers += sp_keepers
         total_rejects += sp_rejects
 
+    photos_missing_phash = sum(1 for pid in photo_ids if pid not in phashes)
+
     return {
         "species_groups": species_groups,
         "total_photos": len(photo_ids),
         "suggested_keepers": total_keepers,
         "suggested_rejects": total_rejects,
+        "photos_missing_phash": photos_missing_phash,
     }
 
 

--- a/vireo/templates/cull.html
+++ b/vireo/templates/cull.html
@@ -599,6 +599,16 @@ function renderCulling() {
     '<div class="summary-stat"><div class="num" style="color:var(--danger);">' + cullData.suggested_rejects + '</div><div class="label">Reject Candidates</div></div>' +
     '<div class="summary-stat"><div class="num">' + cullData.species_groups.length + '</div><div class="label">Species</div></div>' +
   '</div>';
+  var missing = cullData.photos_missing_phash || 0;
+  if (missing > 0) {
+    summaryHtml += '<div style="margin-top:12px;padding:10px 14px;border:1px solid var(--danger);' +
+      'border-radius:6px;background:rgba(255,100,100,0.08);color:var(--text);font-size:14px;">' +
+      '\u26A0 ' + missing + ' photo' + (missing === 1 ? '' : 's') + ' couldn\'t be hashed. ' +
+      'Scene grouping will treat each as unique, so time-window and pHash thresholds ' +
+      'won\'t merge them. Usually means the working-copy JPEG is missing — ' +
+      're-run thumbnail/working-copy extraction, then re-analyze.' +
+      '</div>';
+  }
   document.getElementById('cullSummary').innerHTML = summaryHtml;
   document.getElementById('cullSummary').style.display = '';
   document.getElementById('applyBtn').style.display = '';

--- a/vireo/tests/test_culling.py
+++ b/vireo/tests/test_culling.py
@@ -587,3 +587,85 @@ def test_analyze_for_culling_progress_callback(tmp_path):
     analyze_for_culling(db, progress_callback=lambda msg: messages.append(msg))
     # Should have called with pHash backfill message
     assert any("hash" in m.lower() for m in messages)
+
+
+def test_analyze_for_culling_backfills_phash_from_working_copy(tmp_path):
+    """When the source file can't be opened (e.g. RAW), the phash backfill
+    should use the working-copy JPEG if available."""
+    from culling import analyze_for_culling
+    from db import Database
+    from PIL import Image
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    vireo_dir = tmp_path
+    folder_path = str(tmp_path / "raws")
+    os.makedirs(folder_path, exist_ok=True)
+    fid = db.add_folder(folder_path, name="raws")
+
+    # Simulate a RAW: register the photo with a .NEF extension, but don't
+    # write a real NEF — PIL can't open it. The working copy IS available.
+    fname = "bird.NEF"
+    with open(os.path.join(folder_path, fname), "wb") as f:
+        f.write(b"not a real raw file")
+
+    wc_rel = "working/bird.jpg"
+    wc_abs = os.path.join(vireo_dir, wc_rel)
+    os.makedirs(os.path.dirname(wc_abs), exist_ok=True)
+    Image.new("RGB", (100, 100), color=(50, 120, 80)).save(wc_abs)
+
+    pid = db.add_photo(fid, fname, ".NEF", 1000, 1.0, timestamp="2024-01-01T10:00:00")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path = ? WHERE id = ?", (wc_rel, pid)
+    )
+    det_ids = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")
+    db.add_prediction(det_ids[0], "Robin", 0.95, "test-model")
+    db.conn.commit()
+
+    analyze_for_culling(db, vireo_dir=str(vireo_dir))
+
+    row = db.conn.execute("SELECT phash FROM photos WHERE id = ?", (pid,)).fetchone()
+    assert row["phash"], "phash should be backfilled from working-copy JPEG"
+
+
+def test_analyze_for_culling_reports_missing_phash_count(tmp_path):
+    """Photos that can't be hashed (no working copy, unreadable original)
+    should be counted in result['photos_missing_phash']."""
+    from culling import analyze_for_culling
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    folder_path = str(tmp_path / "raws")
+    os.makedirs(folder_path, exist_ok=True)
+    fid = db.add_folder(folder_path, name="raws")
+
+    # Unreadable "RAW": junk bytes, no working copy
+    fname = "broken.NEF"
+    with open(os.path.join(folder_path, fname), "wb") as f:
+        f.write(b"not a real raw file")
+
+    pid = db.add_photo(fid, fname, ".NEF", 1000, 1.0, timestamp="2024-01-01T10:00:00")
+    det_ids = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")
+    db.add_prediction(det_ids[0], "Robin", 0.95, "test-model")
+    db.conn.commit()
+
+    result = analyze_for_culling(db, vireo_dir=str(tmp_path))
+    assert result["photos_missing_phash"] == 1
+
+
+def test_analyze_for_culling_missing_phash_zero_when_all_hashed(tmp_path):
+    """When every photo gets a phash, the missing count is zero."""
+    from culling import analyze_for_culling
+
+    db, _ = _setup_culling_db(tmp_path, with_embeddings=False)
+    result = analyze_for_culling(db)
+    assert result["photos_missing_phash"] == 0

--- a/vireo/tests/test_culling.py
+++ b/vireo/tests/test_culling.py
@@ -669,3 +669,49 @@ def test_analyze_for_culling_missing_phash_zero_when_all_hashed(tmp_path):
     db, _ = _setup_culling_db(tmp_path, with_embeddings=False)
     result = analyze_for_culling(db)
     assert result["photos_missing_phash"] == 0
+
+
+def test_analyze_for_culling_falls_back_to_source_when_working_copy_corrupt(tmp_path):
+    """If the working-copy JPEG can't be decoded, the backfill should still
+    try the original source file instead of giving up."""
+    from culling import analyze_for_culling
+    from db import Database
+    from PIL import Image
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    vireo_dir = tmp_path
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    fid = db.add_folder(folder_path, name="photos")
+
+    # Valid JPEG at the source path — can be opened.
+    fname = "bird.jpg"
+    Image.new("RGB", (100, 100), color=(20, 140, 90)).save(
+        os.path.join(folder_path, fname)
+    )
+
+    # Working-copy path points to a file that exists but is junk bytes —
+    # _load_standard will return None.
+    wc_rel = "working/broken.jpg"
+    wc_abs = os.path.join(vireo_dir, wc_rel)
+    os.makedirs(os.path.dirname(wc_abs), exist_ok=True)
+    with open(wc_abs, "wb") as f:
+        f.write(b"not a real jpeg")
+
+    pid = db.add_photo(fid, fname, ".jpg", 1000, 1.0, timestamp="2024-01-01T10:00:00")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path = ? WHERE id = ?", (wc_rel, pid)
+    )
+    det_ids = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")
+    db.add_prediction(det_ids[0], "Robin", 0.95, "test-model")
+    db.conn.commit()
+
+    result = analyze_for_culling(db, vireo_dir=str(vireo_dir))
+    assert result["photos_missing_phash"] == 0
+    row = db.conn.execute("SELECT phash FROM photos WHERE id = ?", (pid,)).fetchone()
+    assert row["phash"], "phash should fall back to the valid source JPEG"

--- a/vireo/tests/test_job_submission_api.py
+++ b/vireo/tests/test_job_submission_api.py
@@ -28,6 +28,62 @@ def test_job_cull_returns_job_id(app_and_db):
     assert data["job_id"].startswith("cull-")
 
 
+def test_job_cull_passes_thumb_cache_parent_as_vireo_dir(tmp_path, monkeypatch):
+    """api_job_cull must derive vireo_dir from THUMB_CACHE_DIR's parent,
+    matching scan/classify — not from db_path's parent. Users who pass a
+    custom --thumb-dir on a filesystem separate from the DB must still
+    have culling find their working copies in the right place."""
+    import config as cfg
+    import culling as culling_module
+    from app import create_app
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    # DB and thumbnails live under DIFFERENT parents — the bug case.
+    db_dir = tmp_path / "db_root"
+    db_dir.mkdir()
+    db_path = str(db_dir / "app.db")
+
+    thumb_parent = tmp_path / "thumb_root"
+    thumb_parent.mkdir()
+    thumb_dir = str(thumb_parent / "thumbnails")
+    os.makedirs(thumb_dir)
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir)
+
+    captured = {}
+
+    def spy(db, **kwargs):
+        captured.update(kwargs)
+        return {
+            "species_groups": [],
+            "total_photos": 0,
+            "suggested_keepers": 0,
+            "suggested_rejects": 0,
+            "photos_missing_phash": 0,
+        }
+
+    monkeypatch.setattr(culling_module, "analyze_for_culling", spy)
+
+    client = app.test_client()
+    resp = client.post("/api/jobs/cull", json={})
+    assert resp.status_code == 200
+
+    deadline = time.time() + 5.0
+    while "vireo_dir" not in captured and time.time() < deadline:
+        time.sleep(0.02)
+
+    assert "vireo_dir" in captured, "analyze_for_culling was never called"
+    assert captured["vireo_dir"] == str(thumb_parent), (
+        f"expected {thumb_parent!r}, got {captured['vireo_dir']!r}"
+    )
+
+
 def test_job_classify_requires_collection_id(app_and_db):
     """POST /api/jobs/classify with empty json returns 400 with 'collection_id' in error."""
     app, _ = app_and_db


### PR DESCRIPTION
## Summary

- Culling on RAW-only workspaces silently produced one-scene-per-photo results because the pHash backfill called `PIL.Image.open` directly on `.NEF` files, which fails. The exception was swallowed, leaving every photo with `phash=None`. `_phash_merge` then pushed each hash-less photo into its own cluster, undoing the time bucketing — so `time_window` and `phash_threshold` sliders had no effect.
- `analyze_for_culling` now takes `vireo_dir` and uses `load_working_image` for the backfill, reading the working-copy JPEG (with `load_image` → rawpy fallback for RAWs).
- Result payload now includes `photos_missing_phash`; the cull page shows a warning banner when any photos couldn't be hashed, so users aren't left wondering why the sliders do nothing.

## Investigation that led here

Analyzed the 707-photo grosbeak workspace that produced 0 reject candidates. All 457 photos in the cached result had `phash: null` (confirmed in `culling_results_ws8.json` and DB: 914/914 NULL). All were `.NEF` RAWs; the backfill at `culling.py:117-144` opened source paths with `Image.open(...)`, failed silently via `except Exception: log.debug(...)`, and left phashes missing. Because `_phash_merge` pushes hash-less photos into their own cluster, the time-bucketing step was undone — every photo became a scene of 1, every photo was marked `keep`.

## Test plan

- [x] 3 new TDD tests in `vireo/tests/test_culling.py`:
  - `test_analyze_for_culling_backfills_phash_from_working_copy` — .NEF with unopenable source but a real working-copy JPEG gets hashed.
  - `test_analyze_for_culling_reports_missing_phash_count` — unhashable photo counted in `photos_missing_phash`.
  - `test_analyze_for_culling_missing_phash_zero_when_all_hashed` — zero when everything succeeds.
- [x] Full culling suite: 41/41 pass
- [x] Required CLAUDE.md test battery: 514/514 pass
- [x] Full suite minus pre-existing unrelated failures (`test_models.py` InternalError, `test_find_darktable`, `test_pipeline_auto_skips_classify_when_no_model`, `test_welcome_page_renders`): 1378 passing
- [ ] Manual: re-run cull on grosbeak workspace, confirm phashes populate and sliders produce reject candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)