### PR TITLE
Roll up folder photo counts and filter by subtree

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3020,11 +3020,14 @@ class Database:
         is ``'ok'``) — matching the subtree scope of
         :meth:`get_highlights_candidates`.
         """
+        ws = self._ws_id()
         return self.conn.execute(
             """WITH RECURSIVE ancestors(photo_id, folder_id, timestamp) AS (
                    SELECT p.id, p.folder_id, p.timestamp
                    FROM photos p
                    JOIN folders f0 ON f0.id = p.folder_id AND f0.status = 'ok'
+                   JOIN workspace_folders wf0
+                     ON wf0.folder_id = p.folder_id AND wf0.workspace_id = ?
                    WHERE p.quality_score IS NOT NULL
                    UNION ALL
                    SELECT a.photo_id, f.parent_id, a.timestamp
@@ -3042,7 +3045,7 @@ class Database:
                  AND f.status = 'ok'
                GROUP BY f.id
                ORDER BY latest_photo DESC""",
-            (self._ws_id(),),
+            (ws, ws),
         ).fetchall()
 
     VALID_KEYWORD_TYPES = ('general', 'taxonomy', 'location', 'descriptive', 'people', 'event')

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2988,6 +2988,7 @@ class Database:
                       bp.species
                FROM photos p
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
                LEFT JOIN (
                    SELECT photo_id, name AS species FROM (
                        SELECT pk.photo_id, k.name,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3033,6 +3033,10 @@ class Database:
         :meth:`get_highlights_candidates`.
         """
         ws = self._ws_id()
+        # The recursive step also joins workspace_folders on the current
+        # folder: propagation stops at any ancestor that is not in the active
+        # workspace, which matches get_folder_subtree_ids and keeps the
+        # dropdown counts aligned with get_highlights_candidates.
         return self.conn.execute(
             """WITH RECURSIVE ancestors(photo_id, folder_id, timestamp) AS (
                    SELECT p.id, p.folder_id, p.timestamp
@@ -3045,6 +3049,8 @@ class Database:
                    SELECT a.photo_id, f.parent_id, a.timestamp
                    FROM ancestors a
                    JOIN folders f ON f.id = a.folder_id
+                   JOIN workspace_folders wf_step
+                     ON wf_step.folder_id = f.id AND wf_step.workspace_id = ?
                    WHERE f.parent_id IS NOT NULL
                )
                SELECT f.id, f.path, f.name,
@@ -3057,7 +3063,7 @@ class Database:
                  AND f.status = 'ok'
                GROUP BY f.id
                ORDER BY latest_photo DESC""",
-            (ws, ws),
+            (ws, ws, ws),
         ).fetchall()
 
     VALID_KEYWORD_TYPES = ('general', 'taxonomy', 'location', 'descriptive', 'people', 'event')

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -979,25 +979,28 @@ class Database:
     def get_folder_subtree_ids(self, folder_id):
         """Return [folder_id, ...descendant_ids] restricted to the active workspace.
 
-        The root is always included as-is. Descendants are walked through
-        ``folders.parent_id`` but only via intermediate folders that are linked
-        to the active workspace, so branches that pass through folders removed
-        from the active workspace do not propagate. This matches the browse
-        tree (which only shows active-workspace folders) and ensures that
-        folder-scoped filters don't reach across workspaces through the shared
-        global folder hierarchy.
+        The root is always included as-is so callers' own workspace filter on
+        photos still applies. Descendants are walked through
+        ``folders.parent_id`` only when both the parent (the current node)
+        AND the child are linked to the active workspace, so branches that
+        pass through detached folders never propagate. In particular, a stale
+        or crafted ``folder_id`` for a folder that is no longer in the active
+        workspace will not expand into its active descendants.
         """
+        ws = self._ws_id()
         rows = self.conn.execute(
             """WITH RECURSIVE tree(id) AS (
                    SELECT ?
                    UNION ALL
                    SELECT f.id FROM folders f
                    JOIN tree t ON f.parent_id = t.id
-                   JOIN workspace_folders wf
-                     ON wf.folder_id = f.id AND wf.workspace_id = ?
+                   JOIN workspace_folders wf_t
+                     ON wf_t.folder_id = t.id AND wf_t.workspace_id = ?
+                   JOIN workspace_folders wf_f
+                     ON wf_f.folder_id = f.id AND wf_f.workspace_id = ?
                )
                SELECT id FROM tree""",
-            (folder_id, self._ws_id()),
+            (folder_id, ws, ws),
         ).fetchall()
         return [r["id"] for r in rows]
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3012,21 +3012,34 @@ class Database:
         return rows
 
     def get_folders_with_quality_data(self):
-        """Return folders that have at least one photo with a quality_score.
+        """Return folders with at least one scored photo in their subtree.
 
         Used to populate the folder dropdown on the highlights page.
-        Returns id, path, name, and count of scored photos, ordered by most recent photo first.
+        ``photo_count`` is the count of scored photos across the folder and
+        all of its descendant folders (restricted to folders whose ``status``
+        is ``'ok'``) — matching the subtree scope of
+        :meth:`get_highlights_candidates`.
         """
         return self.conn.execute(
-            """SELECT f.id, f.path, f.name,
-                      COUNT(p.id) as photo_count,
-                      MAX(p.timestamp) as latest_photo
+            """WITH RECURSIVE ancestors(photo_id, folder_id, timestamp) AS (
+                   SELECT p.id, p.folder_id, p.timestamp
+                   FROM photos p
+                   JOIN folders f0 ON f0.id = p.folder_id AND f0.status = 'ok'
+                   WHERE p.quality_score IS NOT NULL
+                   UNION ALL
+                   SELECT a.photo_id, f.parent_id, a.timestamp
+                   FROM ancestors a
+                   JOIN folders f ON f.id = a.folder_id
+                   WHERE f.parent_id IS NOT NULL
+               )
+               SELECT f.id, f.path, f.name,
+                      COUNT(a.photo_id) as photo_count,
+                      MAX(a.timestamp) as latest_photo
                FROM folders f
                JOIN workspace_folders wf ON wf.folder_id = f.id
-               JOIN photos p ON p.folder_id = f.id
+               JOIN ancestors a ON a.folder_id = f.id
                WHERE wf.workspace_id = ?
                  AND f.status = 'ok'
-                 AND p.quality_score IS NOT NULL
                GROUP BY f.id
                ORDER BY latest_photo DESC""",
             (self._ws_id(),),

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -977,15 +977,27 @@ class Database:
         ).fetchall()
 
     def get_folder_subtree_ids(self, folder_id):
-        """Return [folder_id, ...descendant_ids] using the folders.parent_id tree."""
+        """Return [folder_id, ...descendant_ids] restricted to the active workspace.
+
+        The root is always included as-is. Descendants are walked through
+        ``folders.parent_id`` but only via intermediate folders that are linked
+        to the active workspace, so branches that pass through folders removed
+        from the active workspace do not propagate. This matches the browse
+        tree (which only shows active-workspace folders) and ensures that
+        folder-scoped filters don't reach across workspaces through the shared
+        global folder hierarchy.
+        """
         rows = self.conn.execute(
             """WITH RECURSIVE tree(id) AS (
                    SELECT ?
                    UNION ALL
-                   SELECT f.id FROM folders f JOIN tree t ON f.parent_id = t.id
+                   SELECT f.id FROM folders f
+                   JOIN tree t ON f.parent_id = t.id
+                   JOIN workspace_folders wf
+                     ON wf.folder_id = f.id AND wf.workspace_id = ?
                )
                SELECT id FROM tree""",
-            (folder_id,),
+            (folder_id, self._ws_id()),
         ).fetchall()
         return [r["id"] for r in rows]
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -976,6 +976,19 @@ class Database:
             (self._ws_id(),),
         ).fetchall()
 
+    def get_folder_subtree_ids(self, folder_id):
+        """Return [folder_id, ...descendant_ids] using the folders.parent_id tree."""
+        rows = self.conn.execute(
+            """WITH RECURSIVE tree(id) AS (
+                   SELECT ?
+                   UNION ALL
+                   SELECT f.id FROM folders f JOIN tree t ON f.parent_id = t.id
+               )
+               SELECT id FROM tree""",
+            (folder_id,),
+        ).fetchall()
+        return [r["id"] for r in rows]
+
     def check_folder_health(self):
         """Check all folders for existence on disk. Update status column.
 
@@ -1828,8 +1841,10 @@ class Database:
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status = 'ok'")
 
         if folder_id is not None:
-            conditions.append("p.folder_id = ?")
-            where_params.append(folder_id)
+            subtree = self.get_folder_subtree_ids(folder_id)
+            placeholders = ",".join("?" for _ in subtree)
+            conditions.append(f"p.folder_id IN ({placeholders})")
+            where_params.extend(subtree)
         if rating_min is not None:
             conditions.append("p.rating >= ?")
             where_params.append(rating_min)
@@ -1896,8 +1911,10 @@ class Database:
         join_params = []
 
         if folder_id is not None:
-            conditions.append("p.folder_id = ?")
-            where_params.append(folder_id)
+            subtree = self.get_folder_subtree_ids(folder_id)
+            placeholders = ",".join("?" for _ in subtree)
+            conditions.append(f"p.folder_id IN ({placeholders})")
+            where_params.extend(subtree)
         if rating_min is not None:
             conditions.append("p.rating >= ?")
             where_params.append(rating_min)
@@ -1973,8 +1990,10 @@ class Database:
         join_params = []
 
         if folder_id is not None:
-            conditions.append("p.folder_id = ?")
-            where_params.append(folder_id)
+            subtree = self.get_folder_subtree_ids(folder_id)
+            placeholders = ",".join("?" for _ in subtree)
+            conditions.append(f"p.folder_id IN ({placeholders})")
+            where_params.extend(subtree)
         if rating_min is not None:
             conditions.append("p.rating >= ?")
             where_params.append(rating_min)
@@ -2033,8 +2052,10 @@ class Database:
         join_params = []
         where_params = [ws]
         if folder_id is not None:
-            conditions.append("p.folder_id = ?")
-            where_params.append(folder_id)
+            subtree = self.get_folder_subtree_ids(folder_id)
+            placeholders = ",".join("?" for _ in subtree)
+            conditions.append(f"p.folder_id IN ({placeholders})")
+            where_params.extend(subtree)
         if rating_min is not None:
             conditions.append("p.rating >= ?")
             where_params.append(rating_min)
@@ -2178,8 +2199,10 @@ class Database:
         params = [self._ws_id()]
 
         if folder_id is not None:
-            conditions.append("p.folder_id = ?")
-            params.append(folder_id)
+            subtree = self.get_folder_subtree_ids(folder_id)
+            placeholders = ",".join("?" for _ in subtree)
+            conditions.append(f"p.folder_id IN ({placeholders})")
+            params.extend(subtree)
         if rating_min is not None:
             conditions.append("p.rating >= ?")
             params.append(rating_min)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2966,9 +2966,10 @@ class Database:
     def get_highlights_candidates(self, folder_id, min_quality=0.0):
         """Return photos eligible for highlights selection.
 
-        Returns photos in the given folder that have a quality_score >= min_quality
-        and are not user-rejected. Includes the photo's species keyword (or NULL)
-        and DINO embeddings for MMR diversity.
+        Returns photos in the given folder (and its descendant folders) that
+        have a quality_score >= min_quality and are not user-rejected. Includes
+        the photo's species keyword (or NULL) and DINO embeddings for MMR
+        diversity.
 
         Species is derived from photo_keywords joined to keywords where
         is_species = 1, which covers both accepted predictions (accept_prediction
@@ -2976,8 +2977,10 @@ class Database:
 
         Ordered by quality_score DESC.
         """
+        subtree = self.get_folder_subtree_ids(folder_id)
+        placeholders = ",".join("?" for _ in subtree)
         rows = self.conn.execute(
-            """SELECT p.id, p.folder_id, p.filename, p.extension,
+            f"""SELECT p.id, p.folder_id, p.filename, p.extension,
                       p.timestamp, p.width, p.height, p.rating, p.flag,
                       p.thumb_path, p.quality_score, p.subject_sharpness,
                       p.subject_size, p.sharpness, p.phash_crop,
@@ -2997,13 +3000,13 @@ class Database:
                        WHERE k.is_species = 1
                    ) WHERE rn = 1
                ) bp ON bp.photo_id = p.id
-               WHERE p.folder_id = ?
+               WHERE p.folder_id IN ({placeholders})
                  AND wf.workspace_id = ?
                  AND p.quality_score IS NOT NULL
                  AND p.quality_score >= ?
                  AND p.flag != 'rejected'
                ORDER BY p.quality_score DESC""",
-            (folder_id, self._ws_id(), min_quality),
+            (*subtree, self._ws_id(), min_quality),
         ).fetchall()
         return rows
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1195,6 +1195,12 @@ function renderFolderTree(folders) {
     byParent[pid].push(f);
   });
 
+  function rollupCount(f) {
+    var total = f.photo_count || 0;
+    (byParent[f.id] || []).forEach(function(c) { total += rollupCount(c); });
+    return total;
+  }
+
   function buildTree(parentId, depth) {
     var children = byParent[parentId] || [];
     var html = '';
@@ -1207,7 +1213,7 @@ function renderFolderTree(folders) {
       html += '<div class="tree-item' + activeClass + '" onclick="filterByFolder(' + f.id + ')" data-folder-id="' + f.id + '">' +
         indent + toggle +
         '<span>' + escapeHtml(f.name) + '</span>' +
-        '<span class="count">' + f.photo_count + '</span>' +
+        '<span class="count">' + rollupCount(f) + '</span>' +
       '</div>';
       if (hasChildren) {
         html += '<div class="tree-children">' + buildTree(f.id, depth + 1) + '</div>';

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1195,11 +1195,16 @@ function renderFolderTree(folders) {
     byParent[pid].push(f);
   });
 
-  function rollupCount(f) {
+  // Single post-order pass: each subtree's rollup is computed once and cached.
+  // (Per-node recomputation during render would be O(n^2) on deep trees.)
+  var rolledUp = {};
+  function computeRollup(f) {
     var total = f.photo_count || 0;
-    (byParent[f.id] || []).forEach(function(c) { total += rollupCount(c); });
+    (byParent[f.id] || []).forEach(function(c) { total += computeRollup(c); });
+    rolledUp[f.id] = total;
     return total;
   }
+  (byParent['root'] || []).forEach(computeRollup);
 
   function buildTree(parentId, depth) {
     var children = byParent[parentId] || [];
@@ -1213,7 +1218,7 @@ function renderFolderTree(folders) {
       html += '<div class="tree-item' + activeClass + '" onclick="filterByFolder(' + f.id + ')" data-folder-id="' + f.id + '">' +
         indent + toggle +
         '<span>' + escapeHtml(f.name) + '</span>' +
-        '<span class="count">' + rollupCount(f) + '</span>' +
+        '<span class="count">' + rolledUp[f.id] + '</span>' +
       '</div>';
       if (hasChildren) {
         html += '<div class="tree-children">' + buildTree(f.id, depth + 1) + '</div>';

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2894,6 +2894,38 @@ def test_get_folders_with_quality_data_scopes_to_active_workspace(tmp_path):
     assert db.get_highlights_candidates(folder_id=root, min_quality=0.0) == []
 
 
+def test_get_folders_with_quality_data_stops_at_inactive_ancestor(tmp_path):
+    """Rollup cannot propagate across an inactive intermediate folder.
+
+    Tree: A(active) -> B(inactive) -> C(active with scored photo). A must
+    NOT show a rolled-up count sourced from C, since get_folder_subtree_ids
+    stops at B and get_highlights_candidates(A) returns nothing.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    active_ws = db._ws_id()
+    other_ws = db.create_workspace('Other')
+    a = db.add_folder('/a', name='a')
+    b = db.add_folder('/a/b', name='b', parent_id=a)
+    c = db.add_folder('/a/b/c', name='c', parent_id=b)
+    pid = db.add_photo(folder_id=c, filename='x.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET quality_score = 0.8 WHERE id = ?", (pid,))
+    # Detach B from the active workspace.
+    db.remove_workspace_folder(active_ws, b)
+    db.add_workspace_folder(other_ws, b)
+    db.conn.commit()
+
+    folders = db.get_folders_with_quality_data()
+    by_name = {f["name"]: f for f in folders}
+    # C still shows up (its own photo counts).
+    assert by_name["c"]["photo_count"] == 1
+    # A must NOT inherit C's count through the inactive B.
+    assert "a" not in by_name
+    # Sanity: candidate API agrees.
+    assert db.get_highlights_candidates(folder_id=a, min_quality=0.0) == []
+
+
 def test_get_folders_with_quality_data_skips_missing_descendants(tmp_path):
     """A parent folder does not count photos in descendant folders marked 'missing'."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -133,6 +133,35 @@ def test_get_photos_filter_by_folder(tmp_path):
     assert all(r['folder_id'] == f2 for r in results)
 
 
+def test_folder_subtree_does_not_cross_workspace_boundary(tmp_path):
+    """Expansion stops at folders removed from the active workspace.
+
+    Tree: A (active) -> B (not active) -> C (active). Filtering by A should
+    NOT include C even though C is in the active workspace, because the
+    intermediate B is detached from A in the active workspace's tree.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    active_ws = db._ws_id()
+    other_ws = db.create_workspace('Other')
+    a = db.add_folder('/a', name='a')
+    b = db.add_folder('/a/b', name='b', parent_id=a)
+    c = db.add_folder('/a/b/c', name='c', parent_id=b)
+    # Move B out of the active workspace; A and C stay.
+    db.remove_workspace_folder(active_ws, b)
+    db.add_workspace_folder(other_ws, b)
+
+    db.add_photo(folder_id=a, filename='a.jpg', extension='.jpg',
+                 file_size=100, file_mtime=1.0)
+    db.add_photo(folder_id=c, filename='c.jpg', extension='.jpg',
+                 file_size=100, file_mtime=2.0)
+
+    assert db.get_folder_subtree_ids(a) == [a]
+    results = db.get_photos(folder_id=a)
+    assert len(results) == 1
+    assert results[0]['filename'] == 'a.jpg'
+
+
 def test_get_photos_folder_filter_includes_descendants(tmp_path):
     """get_photos(folder_id=parent) includes photos from descendant folders."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2748,6 +2748,28 @@ def test_get_highlights_candidates_includes_descendants(tmp_path):
     assert len(results) == 2
 
 
+def test_get_highlights_candidates_skips_missing_descendants(tmp_path):
+    """Photos in descendant folders marked 'missing' are excluded (match count_filtered_photos)."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    root = db.add_folder('/p', name='p')
+    ok_child = db.add_folder('/p/ok', name='ok', parent_id=root)
+    missing_child = db.add_folder('/p/gone', name='gone', parent_id=root)
+    p_ok = db.add_photo(folder_id=ok_child, filename='a.jpg', extension='.jpg',
+                        file_size=100, file_mtime=1.0)
+    p_gone = db.add_photo(folder_id=missing_child, filename='b.jpg', extension='.jpg',
+                          file_size=100, file_mtime=2.0)
+    db.conn.execute("UPDATE photos SET quality_score = 0.8 WHERE id IN (?, ?)", (p_ok, p_gone))
+    db.conn.execute("UPDATE folders SET status = 'missing' WHERE id = ?", (missing_child,))
+    db.conn.commit()
+
+    candidates = db.get_highlights_candidates(folder_id=root, min_quality=0.0)
+    assert len(candidates) == 1
+    assert candidates[0]["filename"] == 'a.jpg'
+    # Consistent with count_filtered_photos
+    assert db.count_filtered_photos(folder_id=root) == 1
+
+
 def test_get_highlights_candidates_excludes_rejected(tmp_path):
     """Flagged-rejected photos are excluded."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -133,6 +133,32 @@ def test_get_photos_filter_by_folder(tmp_path):
     assert all(r['folder_id'] == f2 for r in results)
 
 
+def test_folder_subtree_does_not_expand_when_root_is_inactive(tmp_path):
+    """A stale/crafted folder_id for an out-of-workspace root must not expand.
+
+    Tree: A(inactive) -> B(active). Passing A should not pull B in — otherwise
+    a stale request could surface photos from active descendants of a folder
+    that no longer belongs to the current workspace.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    active_ws = db._ws_id()
+    other_ws = db.create_workspace('Other')
+    a = db.add_folder('/a', name='a')
+    b = db.add_folder('/a/b', name='b', parent_id=a)
+    # Detach A from the active workspace; B stays.
+    db.remove_workspace_folder(active_ws, a)
+    db.add_workspace_folder(other_ws, a)
+
+    db.add_photo(folder_id=b, filename='b.jpg', extension='.jpg',
+                 file_size=100, file_mtime=1.0)
+
+    # Only A itself comes back (no expansion into B).
+    assert db.get_folder_subtree_ids(a) == [a]
+    # And since A itself isn't in the active workspace, the photo query returns nothing.
+    assert db.get_photos(folder_id=a) == []
+
+
 def test_folder_subtree_does_not_cross_workspace_boundary(tmp_path):
     """Expansion stops at folders removed from the active workspace.
 

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2839,6 +2839,32 @@ def test_get_folders_with_quality_data_rolls_up_subtree(tmp_path):
     assert by_name["c"]["photo_count"] == 1
 
 
+def test_get_folders_with_quality_data_scopes_to_active_workspace(tmp_path):
+    """When a descendant belongs to another workspace, its scored photos are excluded."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    # Parent lives in the active (Default) workspace; child is moved to a second workspace.
+    active_ws = db._ws_id()
+    other_ws = db.create_workspace('Other')
+    root = db.add_folder('/p', name='p')
+    child = db.add_folder('/p/c', name='c', parent_id=root)
+    pid = db.add_photo(folder_id=child, filename='a.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET quality_score = 0.8 WHERE id = ?", (pid,))
+    # Move the child folder to the other workspace only.
+    db.remove_workspace_folder(active_ws, child)
+    db.add_workspace_folder(other_ws, child)
+    db.conn.commit()
+
+    folders = db.get_folders_with_quality_data()
+    by_name = {f["name"]: f for f in folders}
+    # Parent should NOT inherit the child's scored photo, since the child is
+    # no longer in the active workspace. get_highlights_candidates would
+    # return 0 candidates for the parent, so the dropdown count must match.
+    assert "p" not in by_name
+    assert db.get_highlights_candidates(folder_id=root, min_quality=0.0) == []
+
+
 def test_get_folders_with_quality_data_skips_missing_descendants(tmp_path):
     """A parent folder does not count photos in descendant folders marked 'missing'."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -133,6 +133,85 @@ def test_get_photos_filter_by_folder(tmp_path):
     assert all(r['folder_id'] == f2 for r in results)
 
 
+def test_get_photos_folder_filter_includes_descendants(tmp_path):
+    """get_photos(folder_id=parent) includes photos from descendant folders."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    root = db.add_folder('/photos', name='photos')
+    year = db.add_folder('/photos/2024', name='2024', parent_id=root)
+    leaf = db.add_folder('/photos/2024/01-15', name='01-15', parent_id=year)
+    sibling = db.add_folder('/other', name='other')
+
+    db.add_photo(folder_id=root, filename='top.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+    db.add_photo(folder_id=year, filename='mid.jpg', extension='.jpg', file_size=100, file_mtime=2.0)
+    db.add_photo(folder_id=leaf, filename='deep.jpg', extension='.jpg', file_size=100, file_mtime=3.0)
+    db.add_photo(folder_id=sibling, filename='other.jpg', extension='.jpg', file_size=100, file_mtime=4.0)
+
+    assert len(db.get_photos(folder_id=root)) == 3
+    assert len(db.get_photos(folder_id=year)) == 2
+    assert len(db.get_photos(folder_id=leaf)) == 1
+    assert len(db.get_photos(folder_id=sibling)) == 1
+
+
+def test_count_filtered_photos_folder_includes_descendants(tmp_path):
+    """count_filtered_photos(folder_id=parent) counts descendant photos."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    root = db.add_folder('/p', name='p')
+    child = db.add_folder('/p/c', name='c', parent_id=root)
+    db.add_photo(folder_id=child, filename='x.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+    db.add_photo(folder_id=child, filename='y.jpg', extension='.jpg', file_size=100, file_mtime=2.0)
+
+    assert db.count_filtered_photos(folder_id=root) == 2
+    assert db.count_filtered_photos(folder_id=child) == 2
+
+
+def test_browse_summary_folder_includes_descendants(tmp_path):
+    """get_browse_summary(folder_id=parent) counts descendants in filtered_total."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    root = db.add_folder('/p', name='p')
+    child = db.add_folder('/p/c', name='c', parent_id=root)
+    db.add_photo(folder_id=child, filename='x.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+    db.add_photo(folder_id=root, filename='y.jpg', extension='.jpg', file_size=100, file_mtime=2.0)
+
+    summary = db.get_browse_summary(folder_id=root)
+    assert summary['filtered_total'] == 2
+
+
+def test_calendar_data_folder_includes_descendants(tmp_path):
+    """get_calendar_data(folder_id=parent) counts descendants."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    root = db.add_folder('/p', name='p')
+    child = db.add_folder('/p/c', name='c', parent_id=root)
+    db.add_photo(folder_id=child, filename='x.jpg', extension='.jpg', file_size=100,
+                 file_mtime=1.0, timestamp='2024-06-15T00:00:00')
+    db.add_photo(folder_id=child, filename='y.jpg', extension='.jpg', file_size=100,
+                 file_mtime=2.0, timestamp='2024-06-15T00:01:00')
+
+    data = db.get_calendar_data(year=2024, folder_id=root)
+    assert data['days'].get('2024-06-15') == 2
+
+
+def test_geolocated_photos_folder_includes_descendants(tmp_path):
+    """get_geolocated_photos(folder_id=parent) includes descendant-folder photos."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    root = db.add_folder('/p', name='p')
+    child = db.add_folder('/p/c', name='c', parent_id=root)
+    pid1 = db.add_photo(folder_id=child, filename='x.jpg', extension='.jpg',
+                        file_size=100, file_mtime=1.0)
+    pid2 = db.add_photo(folder_id=root, filename='y.jpg', extension='.jpg',
+                        file_size=100, file_mtime=2.0)
+    db.conn.execute("UPDATE photos SET latitude = 10.0, longitude = 20.0 WHERE id = ?", (pid1,))
+    db.conn.execute("UPDATE photos SET latitude = 11.0, longitude = 21.0 WHERE id = ?", (pid2,))
+    db.conn.commit()
+
+    photos = db.get_geolocated_photos(folder_id=root)
+    assert len(photos) == 2
+
+
 def test_get_photos_filter_by_rating(tmp_path):
     """get_photos can filter by minimum rating."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2731,6 +2731,23 @@ def test_get_highlights_candidates(tmp_path):
     assert all("species" in dict(r) for r in results)
 
 
+def test_get_highlights_candidates_includes_descendants(tmp_path):
+    """get_highlights_candidates(folder_id=parent) includes photos from descendant folders."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    root = db.add_folder('/p', name='p')
+    child = db.add_folder('/p/c', name='c', parent_id=root)
+    p1 = db.add_photo(folder_id=root, filename='top.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=child, filename='deep.jpg', extension='.jpg',
+                      file_size=100, file_mtime=2.0)
+    db.conn.execute("UPDATE photos SET quality_score = 0.8 WHERE id IN (?, ?)", (p1, p2))
+    db.conn.commit()
+
+    results = db.get_highlights_candidates(folder_id=root, min_quality=0.0)
+    assert len(results) == 2
+
+
 def test_get_highlights_candidates_excludes_rejected(tmp_path):
     """Flagged-rejected photos are excluded."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2820,6 +2820,46 @@ def test_get_folders_with_quality_data(tmp_path):
     assert folders[0]["photo_count"] > 0
 
 
+def test_get_folders_with_quality_data_rolls_up_subtree(tmp_path):
+    """Parent folder's photo_count reflects scored photos in descendant folders."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    root = db.add_folder('/p', name='p')
+    child = db.add_folder('/p/c', name='c', parent_id=root)
+    # Scored photo lives only in the child
+    pid = db.add_photo(folder_id=child, filename='a.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET quality_score = 0.8 WHERE id = ?", (pid,))
+    db.conn.commit()
+
+    folders = db.get_folders_with_quality_data()
+    # Both the parent and the child appear; each counts the single scored photo
+    by_name = {f["name"]: f for f in folders}
+    assert by_name["p"]["photo_count"] == 1
+    assert by_name["c"]["photo_count"] == 1
+
+
+def test_get_folders_with_quality_data_skips_missing_descendants(tmp_path):
+    """A parent folder does not count photos in descendant folders marked 'missing'."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    root = db.add_folder('/p', name='p')
+    ok_child = db.add_folder('/p/ok', name='ok', parent_id=root)
+    missing_child = db.add_folder('/p/gone', name='gone', parent_id=root)
+    p_ok = db.add_photo(folder_id=ok_child, filename='a.jpg', extension='.jpg',
+                        file_size=100, file_mtime=1.0)
+    p_gone = db.add_photo(folder_id=missing_child, filename='b.jpg', extension='.jpg',
+                          file_size=100, file_mtime=2.0)
+    db.conn.execute("UPDATE photos SET quality_score = 0.8 WHERE id IN (?, ?)", (p_ok, p_gone))
+    db.conn.execute("UPDATE folders SET status = 'missing' WHERE id = ?", (missing_child,))
+    db.conn.commit()
+
+    folders = db.get_folders_with_quality_data()
+    by_name = {f["name"]: f for f in folders}
+    assert by_name["p"]["photo_count"] == 1  # only the ok-child photo
+    assert "gone" not in by_name
+
+
 def test_color_labels_table_exists(tmp_path):
     """photo_color_labels table is created on init."""
     from db import Database


### PR DESCRIPTION
## Summary

The folder tree in the browse view showed direct photo counts only, so parent folders like `USA` or `2022` displayed `0` when all their photos lived in date-named leaf subfolders. Clicking such a parent also loaded 0 photos because the filter used `p.folder_id = ?` (exact match).

This PR makes both the **count** and the **filter** subtree-aware, matching Finder/Lightroom behavior.

- New `Database.get_folder_subtree_ids(folder_id)` helper (recursive CTE over `folders.parent_id`).
- `get_photos`, `count_filtered_photos`, `get_browse_summary`, `get_calendar_data`, and `get_geolocated_photos` expand `folder_id` to its subtree when filtering.
- `renderFolderTree` in `browse.html` sums each node's own `photo_count` plus its descendants' rolled-up totals before rendering.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -v` — 470 passed
- [x] Added 5 new DB tests covering each of the updated filter methods
- [ ] Manual: open browse view, confirm parent folders show rolled-up counts and clicking a parent loads photos from its entire subtree

🤖 Generated with [Claude Code](https://claude.com/claude-code)