### PR TITLE
Pipeline auto-repairs broken photo metadata

### DIFF
--- a/docs/plans/2026-04-16-pipeline-metadata-repair-design.md
+++ b/docs/plans/2026-04-16-pipeline-metadata-repair-design.md
@@ -1,0 +1,271 @@
+# Pipeline auto-repair for broken photo metadata
+
+## Problem
+
+Pipeline runs against a collection silently skip the scan stage
+(`pipeline_job.py:248`, `skip_scan = collection_id is not None`). Any photo
+whose EXIF metadata never got extracted — i.e. `timestamp IS NULL`, and for
+RAW files often `width, height = 160, 120` (the embedded JPEG thumbnail
+dimensions) — stays broken across every subsequent pipeline run.
+
+Broken timestamps poison encounter segmentation. `encounters.py:82-86` treats
+a NULL timestamp as `dt = inf`, which trips the hard-cut rule at
+`encounters.py:274` (`dt > 180`) for every adjacent pair, so each affected
+photo becomes its own single-photo encounter. Broken dimensions separately
+break thumbnails, crops, subject boxes, and working-copy extraction.
+
+The San Elijo Lagoon workspace (id 4) currently shows this: 14,160 photos,
+1,510 with `timestamp IS NULL` (1,403 in `/Raw Files/USA/2026/2026-03-28`,
+100 in `2026-04-04`), and 1,680 single-photo encounters of which 1,510
+trace directly to the NULL-timestamp bug.
+
+## Goal
+
+When the pipeline is about to process photos with broken metadata, silently
+re-extract that metadata before the rest of the pipeline runs, so encounter
+segmentation and downstream stages see correct data. No new user-visible
+action. Runs with no broken data are unchanged.
+
+## Non-goals
+
+- Defining a policy for "what is a photo's canonical timestamp?" when EXIF
+  has none (screenshots, exports). Those photos (7 rows in ws4) have
+  `exif_data IS NOT NULL` and the scanner already correctly skips them —
+  they'd remain singletons. Fallback to `file_mtime` is a separate
+  discussion; `file_mtime` drifts when files are copied or restored from
+  backup and is not a trustworthy substitute for EXIF `DateTimeOriginal`.
+- A user-visible "repair metadata" button. The self-healing framing calls
+  for automatic detection and repair.
+- Migration of existing broken rows outside a pipeline run.
+
+## Detection rule
+
+A photo needs metadata re-extraction if:
+
+```sql
+p.timestamp IS NULL
+OR (p.extension IN ('.nef','.cr2','.cr3','.arw','.raf','.dng','.rw2','.orf')
+    AND p.width IS NOT NULL
+    AND p.width < 1000)
+```
+
+The RAW-dimension clause is defense in depth. On ws4 it adds zero new
+detections (every dim-suspect row is also `timestamp IS NULL`), but it
+catches future failure modes where ExifTool partially succeeds —
+timestamp populated, dimensions still 160×120.
+
+Cross-tab from ws4 confirms the buckets:
+
+| timestamp | dims_suspect | exif_data | count |
+|-----------|-------------|-----------|-------|
+| not NULL | fine | populated | 12,647 |
+| NULL | yes (RAW<1000px) | NULL | 1,403 |
+| NULL | fine | NULL | 95 |
+| NULL | fine | populated | 7 (skipped by exif_extracted guard) |
+| NULL (NULL ext) | — | NULL | 5 |
+| not NULL | fine | NULL | 3 |
+
+## Architecture
+
+The repair lives inside `scanner_stage()` in `pipeline_job.py`, replacing
+the current `if skip_scan: return` early-exit. Flow in collection mode:
+
+1. Pipeline receives `collection_id`; resolve to photo ID set.
+2. New helper `_find_broken_metadata_folders(db, photo_ids)` runs one
+   indexed SQL query against the detection rule, groups by `folder_id`,
+   returns `[(folder_path, broken_count), ...]`.
+3. If empty, scan stage reports "Skipped (using collection)" exactly as
+   today — no behavior change.
+4. If non-empty, scan stage runs `do_scan(folder_path, incremental=True,
+   restrict_dirs=[folder_path])` per affected folder. Scanner's existing
+   incremental logic re-extracts metadata for broken photos and skips
+   healthy ones in the same folder.
+5. Control passes to the rest of the pipeline (thumbnails, classify,
+   encounters, ...) with fresh data.
+
+The scan stage progress label flips to "Repair metadata (N photos)" when
+repair happens, so the user can see where time went when it isn't a no-op.
+
+## Scanner change
+
+`vireo/scanner.py:423-426`. Extend the `metadata_missing` check with a
+RAW-dimension-suspect clause.
+
+```python
+# Before
+metadata_missing = (
+    existing["timestamp"] is None
+    and existing["id"] not in exif_extracted
+)
+
+# After
+dims_suspect = (
+    existing.get("extension") in RAW_EXTENSIONS
+    and existing.get("width") is not None
+    and existing["width"] < 1000
+)
+metadata_missing = (
+    (existing["timestamp"] is None or dims_suspect)
+    and existing["id"] not in exif_extracted
+)
+```
+
+`exif_extracted` (populated at `scanner.py:378-380` from
+`SELECT id FROM photos WHERE exif_data IS NOT NULL`) is unchanged. It
+guards against retry loops: once ExifTool has stored output, we don't
+retry regardless of signal. This keeps genuine EXIF-less photos from
+being pounded on every run.
+
+`RAW_EXTENSIONS` is already imported in `scanner.py:12`. `get_photos()`
+already returns `extension` and `width`, so no DB or loader change.
+
+## Pipeline change
+
+`vireo/pipeline_job.py`. Replace the `if skip_scan:` block inside
+`scanner_stage()`:
+
+```python
+if skip_scan:
+    collection_photo_ids = thread_db.get_collection_photo_ids(collection_id)
+    broken = _find_broken_metadata_folders(thread_db, collection_photo_ids)
+    if not broken:
+        stages["scan"]["status"] = "skipped"
+        runner.update_step(job["id"], "scan", status="completed",
+                           summary="Skipped (using collection)")
+        _update_stages(runner, job["id"], stages)
+        scan_to_thumb.put(_SENTINEL)
+        return
+
+    total_broken = sum(n for _, n in broken)
+    stages["scan"]["label"] = f"Repair metadata ({total_broken} photos)"
+    stages["scan"]["status"] = "running"
+    runner.update_step(job["id"], "scan", status="running",
+                       summary=f"Repairing {total_broken} photos in {len(broken)} folders")
+    _update_stages(runner, job["id"], stages)
+
+    unreachable = 0
+    for folder_path, _ in broken:
+        try:
+            do_scan(
+                folder_path, thread_db,
+                progress_callback=progress_cb,
+                incremental=True,
+                extract_full_metadata=pipeline_cfg.get("extract_full_metadata", True),
+                photo_callback=photo_cb,
+                status_callback=status_cb,
+                restrict_dirs=[folder_path],
+            )
+        except (FileNotFoundError, NotADirectoryError, PermissionError) as e:
+            log.warning("Repair scan failed for %s: %s", folder_path, e)
+            unreachable += 1
+
+    summary = f"{total_broken} photos repaired"
+    if unreachable:
+        summary += f", {unreachable} folders unreachable"
+    stages["scan"]["status"] = "completed"
+    runner.update_step(job["id"], "scan", status="completed", summary=summary)
+    scan_to_thumb.put(_SENTINEL)
+    return
+```
+
+New helper at module level:
+
+```python
+def _find_broken_metadata_folders(db, photo_ids):
+    """Return [(folder_path, broken_count), ...] for folders containing
+    any photo in photo_ids that fails the detection rule. Empty list when
+    nothing is broken."""
+    if not photo_ids:
+        return []
+    raw_exts = ",".join(f"'{e}'" for e in (
+        ".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf"))
+    placeholders = ",".join("?" * len(photo_ids))
+    rows = db.conn.execute(
+        f"""SELECT f.path, COUNT(*) AS n
+            FROM photos p
+            JOIN folders f ON p.folder_id = f.id
+            WHERE p.id IN ({placeholders})
+              AND (p.timestamp IS NULL
+                   OR (p.extension IN ({raw_exts})
+                       AND p.width IS NOT NULL AND p.width < 1000))
+            GROUP BY f.id
+            ORDER BY f.path""",
+        tuple(photo_ids),
+    ).fetchall()
+    return [(r["path"], r["n"]) for r in rows]
+```
+
+`Database.get_collection_photo_ids(collection_id)` — add if missing.
+Existing `get_collection_photos()` returns full rows; a lighter
+ID-only variant avoids loading unused columns for this check.
+
+## Edge cases
+
+- **Folder path unreachable (external drive disconnected).** Each
+  per-folder `do_scan` is wrapped in try/except. A failed folder logs a
+  warning, increments `unreachable`, and the stage summary records it.
+  Pipeline continues; encounter segmentation on those photos still
+  produces singletons — unchanged from today.
+- **Photo file missing from disk.** Scanner's file iteration doesn't see
+  it, so it isn't re-extracted. Harmless.
+- **ExifTool binary missing.** `extract_metadata` returns empty; broken
+  rows stay broken; pipeline continues. Tested via mock.
+- **Very large broken set.** Progress callback reports incrementally.
+  No cap needed.
+- **Concurrent scans.** Existing job queue serializes. Not a new concern.
+
+## Testing
+
+`vireo/tests/test_scanner.py` — new tests for the extended detection:
+
+1. Incremental rescan re-processes a photo where `timestamp IS NULL`
+   (regression guard for existing behavior).
+2. Incremental rescan re-processes a RAW row with `width=160, height=120`
+   and populated timestamp.
+3. Incremental rescan does not re-process a JPEG row with
+   `width=160, height=120` (RAW-specific rule).
+4. Incremental rescan does not re-process a RAW row with `width=160`
+   when `exif_data IS NOT NULL` (guard holds — prevents retry loop).
+
+`vireo/tests/test_jobs_api.py` — pipeline integration:
+
+5. Pipeline with a collection of healthy photos → scan stage
+   `"skipped"`, summary "Skipped (using collection)".
+6. Pipeline with a collection containing broken-metadata photos →
+   scan stage `"completed"`, summary mentions repair, broken rows end
+   with populated `timestamp` and corrected dimensions.
+7. Pipeline where a broken photo's folder is unreachable → stage
+   completes, summary mentions unreachable, other folders repaired.
+
+## End-to-end verification on real data
+
+After landing, on ws4 (San Elijo Lagoon):
+
+Before:
+- 1,510 rows match the detection rule
+- 2,535 encounters, 1,680 single-photo (1,510 of those from NULL timestamps)
+
+After running pipeline against the same collection used previously:
+- ≤7 rows match the detection rule (only the genuinely EXIF-less)
+- RAW rows with `width < 1000` → 0
+- Encounter count drops significantly; single-photo encounters with
+  `time_range=[None,None]` drop to ≤7
+- Singleton ratio moves into the range seen in other workspaces
+
+## Rollout
+
+- One branch: `claude/pipeline-auto-repair-metadata`.
+- One PR against `main`.
+- No migration, no config flag. Behavior is strictly additive:
+  previously-skipped scans stay skipped when nothing's broken.
+- Self-clearing: after repair, broken rows are no longer broken, so
+  subsequent runs see an empty broken set and take the fast path.
+
+## Files touched
+
+- `vireo/scanner.py` — 5-line heuristic extension in `metadata_missing`.
+- `vireo/pipeline_job.py` — new helper + replacement of `skip_scan`
+  early-return block.
+- `vireo/db.py` — `get_collection_photo_ids` helper if not already present.
+- `vireo/tests/test_scanner.py` — 4 new tests.
+- `vireo/tests/test_jobs_api.py` — 3 new tests.

--- a/docs/plans/2026-04-16-pipeline-metadata-repair-design.md
+++ b/docs/plans/2026-04-16-pipeline-metadata-repair-design.md
@@ -43,16 +43,25 @@ action. Runs with no broken data are unchanged.
 A photo needs metadata re-extraction if:
 
 ```sql
-p.timestamp IS NULL
-OR (p.extension IN ('.nef','.cr2','.cr3','.arw','.raf','.dng','.rw2','.orf')
-    AND p.width IS NOT NULL
-    AND p.width < 1000)
+p.exif_data IS NULL
+AND (p.timestamp IS NULL
+     OR (p.extension IN ('.nef','.cr2','.cr3','.arw','.raf','.dng','.rw2','.orf')
+         AND p.width IS NOT NULL
+         AND p.width < 1000))
 ```
+
+The `exif_data IS NULL` clause mirrors the scanner's `exif_extracted`
+guard: once ExifTool has stored output for a photo, the scanner won't
+retry regardless of signal, so flagging such rows here would cause the
+repair path to fire on every pipeline run without accomplishing anything
+— and the normal fast-path "Skipped (using collection)" summary would
+never return.
 
 The RAW-dimension clause is defense in depth. On ws4 it adds zero new
 detections (every dim-suspect row is also `timestamp IS NULL`), but it
 catches future failure modes where ExifTool partially succeeds —
-timestamp populated, dimensions still 160×120.
+timestamp populated, dimensions still 160×120 — provided exif_data is
+still NULL.
 
 Cross-tab from ws4 confirms the buckets:
 
@@ -71,15 +80,18 @@ The repair lives inside `scanner_stage()` in `pipeline_job.py`, replacing
 the current `if skip_scan: return` early-exit. Flow in collection mode:
 
 1. Pipeline receives `collection_id`; resolve to photo ID set.
-2. New helper `_find_broken_metadata_folders(db, photo_ids)` runs one
-   indexed SQL query against the detection rule, groups by `folder_id`,
-   returns `[(folder_path, broken_count), ...]`.
+2. Helper `_find_broken_metadata_folders(db, photo_ids)` runs one
+   indexed SQL query against the detection rule, groups by folder,
+   returns `[(folder_path, [file_paths...]), ...]` — folders mapped to
+   the absolute paths of their broken photos.
 3. If empty, scan stage reports "Skipped (using collection)" exactly as
    today — no behavior change.
 4. If non-empty, scan stage runs `do_scan(folder_path, incremental=True,
-   restrict_dirs=[folder_path])` per affected folder. Scanner's existing
-   incremental logic re-extracts metadata for broken photos and skips
-   healthy ones in the same folder.
+   restrict_dirs=[folder_path], restrict_files=set(paths))` per affected
+   folder. The `restrict_files` argument limits discovery to the known
+   broken photos — new untracked files in the same folder are NOT
+   ingested as a side effect of repair. Scanner's incremental logic
+   then re-extracts metadata for those files.
 5. Control passes to the rest of the pipeline (thumbnails, classify,
    encounters, ...) with fresh data.
 
@@ -263,9 +275,31 @@ After running pipeline against the same collection used previously:
 
 ## Files touched
 
-- `vireo/scanner.py` — 5-line heuristic extension in `metadata_missing`.
-- `vireo/pipeline_job.py` — new helper + replacement of `skip_scan`
-  early-return block.
-- `vireo/db.py` — `get_collection_photo_ids` helper if not already present.
-- `vireo/tests/test_scanner.py` — 4 new tests.
-- `vireo/tests/test_jobs_api.py` — 3 new tests.
+- `vireo/scanner.py` — dims-suspect clause in `metadata_missing`; new
+  `restrict_files` parameter on `scan()` so the repair path can limit
+  discovery to known-broken files (prevents untracked-file ingestion as
+  a side effect of repair).
+- `vireo/pipeline_job.py` — `_find_broken_metadata_folders` helper (returns
+  folders mapped to broken file paths) + replacement of `skip_scan`
+  early-return block, passing `restrict_files=set(paths)` into `do_scan`.
+- `vireo/tests/test_scanner.py` — tests for dims-suspect detection,
+  exif_extracted guard, restrict_files honoring.
+- `vireo/tests/test_jobs_api.py` — unit tests for the helper + integration
+  tests for healthy/broken/unreachable-folder/untracked-file paths.
+
+## Review refinements
+
+Two adjustments made after initial review:
+
+1. **Detection excludes `exif_data IS NOT NULL` rows.** Without this,
+   photos whose source file genuinely has no EXIF timestamp (the
+   scanner's `exif_extracted` guard skips them on re-scan) would stay
+   in the detection set forever, and collection runs would repeatedly
+   enter the repair path instead of returning to the fast-path skip.
+2. **Repair honors `restrict_files`.** The scanner's `restrict_dirs`
+   mode still enumerates every supported file in the listed folders
+   and ingests new ones. For the repair use case that's wrong — a
+   user who adds a new photo to a folder and then runs pipeline
+   against an older collection would see the new photo silently
+   ingested as a side effect. `restrict_files` limits discovery to
+   the specific broken files.

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -78,6 +78,39 @@ def _looks_like_missing_external_data(err):
     )
 
 
+_RAW_EXTENSIONS = (".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf")
+
+
+def _find_broken_metadata_folders(db, photo_ids):
+    """Find folders containing photos with broken metadata in the given scope.
+
+    A photo is considered broken if its EXIF extraction never produced a
+    usable result — ``timestamp IS NULL`` or (for RAW files) dimensions
+    under 1000px, which indicates the embedded JPEG thumbnail leaked
+    through instead of the true sensor size.
+
+    Returns a list of ``(folder_path, broken_count)`` tuples sorted by
+    path, or ``[]`` when nothing needs repair.
+    """
+    if not photo_ids:
+        return []
+    raw_list = ",".join(f"'{e}'" for e in _RAW_EXTENSIONS)
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"""SELECT f.path, COUNT(*) AS n
+            FROM photos p
+            JOIN folders f ON p.folder_id = f.id
+            WHERE p.id IN ({placeholders})
+              AND (p.timestamp IS NULL
+                   OR (p.extension IN ({raw_list})
+                       AND p.width IS NOT NULL AND p.width < 1000))
+            GROUP BY f.id
+            ORDER BY f.path""",
+        tuple(photo_ids),
+    ).fetchall()
+    return [(r["path"], r["n"]) for r in rows]
+
+
 def _update_stages(runner, job_id, stages):
     """Push a stages progress update."""
     runner.push_event(job_id, "progress", {
@@ -263,13 +296,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
     def scanner_stage():
         nonlocal collection_id
 
-        if skip_scan:
-            stages["scan"]["status"] = "skipped"
-            runner.update_step(job["id"], "scan", status="completed",
-                               summary="Skipped (using collection)")
-            _update_stages(runner, job["id"], stages)
-            scan_to_thumb.put(_SENTINEL)
-            return
         # Note: stages["scan"]["status"] is NOT set to "running" here. It is
         # flipped to "running" just before each do_scan() call below, so
         # numScan doesn't pulse during the ingest sub-phase.
@@ -319,6 +345,80 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     "eta_seconds": eta,
                     "stages": {k: dict(v) for k, v in stages.items()},
                 })
+
+            # Collection mode: no scan targets, but check whether any
+            # photos in the collection have broken metadata (NULL timestamp
+            # or RAW thumbnail-sized dimensions) that would poison
+            # downstream stages. If so, run a targeted repair scan on just
+            # the affected folders. This is the self-healing path — when
+            # nothing's broken, we keep the historical "Skipped" summary.
+            if skip_scan:
+                coll_photos = thread_db.get_collection_photos(
+                    collection_id, per_page=999999,
+                )
+                broken = _find_broken_metadata_folders(
+                    thread_db, [p["id"] for p in coll_photos],
+                )
+                if not broken:
+                    stages["scan"]["status"] = "skipped"
+                    runner.update_step(
+                        job["id"], "scan", status="completed",
+                        summary="Skipped (using collection)",
+                    )
+                    _update_stages(runner, job["id"], stages)
+                    scan_to_thumb.put(_SENTINEL)
+                    return
+
+                total_broken = sum(n for _, n in broken)
+                stages["scan"]["label"] = (
+                    f"Repair metadata ({total_broken} photos)"
+                )
+                stages["scan"]["status"] = "running"
+                runner.update_step(
+                    job["id"], "scan", status="running",
+                    summary=(f"Repairing {total_broken} photos in "
+                             f"{len(broken)} folder"
+                             f"{'s' if len(broken) != 1 else ''}"),
+                )
+                _update_stages(runner, job["id"], stages)
+
+                unreachable = 0
+                for folder_path, _ in broken:
+                    if not os.path.isdir(folder_path):
+                        log.warning(
+                            "Repair scan skipped for missing folder: %s",
+                            folder_path,
+                        )
+                        unreachable += 1
+                        continue
+                    try:
+                        do_scan(
+                            folder_path, thread_db,
+                            progress_callback=progress_cb,
+                            incremental=True,
+                            extract_full_metadata=pipeline_cfg.get(
+                                "extract_full_metadata", True,
+                            ),
+                            photo_callback=photo_cb,
+                            status_callback=status_cb,
+                            restrict_dirs=[folder_path],
+                        )
+                    except (OSError, RuntimeError) as e:
+                        log.warning(
+                            "Repair scan failed for %s: %s", folder_path, e,
+                        )
+                        unreachable += 1
+
+                summary = f"{total_broken} photos repaired"
+                if unreachable:
+                    summary += (f", {unreachable} folder"
+                                f"{'s' if unreachable != 1 else ''} unreachable")
+                stages["scan"]["status"] = "completed"
+                runner.update_step(
+                    job["id"], "scan", status="completed", summary=summary,
+                )
+                scan_to_thumb.put(_SENTINEL)
+                return
 
             # Determine source folder(s)
             sources = params.sources or ([params.source] if params.source else [])

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -84,31 +84,42 @@ _RAW_EXTENSIONS = (".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf
 def _find_broken_metadata_folders(db, photo_ids):
     """Find folders containing photos with broken metadata in the given scope.
 
-    A photo is considered broken if its EXIF extraction never produced a
-    usable result — ``timestamp IS NULL`` or (for RAW files) dimensions
-    under 1000px, which indicates the embedded JPEG thumbnail leaked
-    through instead of the true sensor size.
+    A photo is considered broken if EXIF extraction never produced usable
+    output (``exif_data IS NULL``) and either ``timestamp IS NULL`` or,
+    for RAW files, dimensions under 1000px — the latter indicates the
+    embedded JPEG thumbnail leaked through instead of the true sensor
+    size. The ``exif_data IS NULL`` clause mirrors the scanner's
+    ``exif_extracted`` guard: once ExifTool has stored output for a
+    photo, the scanner won't retry regardless of signal, so flagging
+    such rows here would cause the repair path to fire on every pipeline
+    run without accomplishing anything.
 
-    Returns a list of ``(folder_path, broken_count)`` tuples sorted by
-    path, or ``[]`` when nothing needs repair.
+    Returns a list of ``(folder_path, file_paths)`` tuples where
+    ``file_paths`` is a list of absolute image paths in that folder.
+    Empty list when nothing needs repair.
     """
     if not photo_ids:
         return []
     raw_list = ",".join(f"'{e}'" for e in _RAW_EXTENSIONS)
     placeholders = ",".join("?" for _ in photo_ids)
     rows = db.conn.execute(
-        f"""SELECT f.path, COUNT(*) AS n
+        f"""SELECT f.path AS folder_path, p.filename
             FROM photos p
             JOIN folders f ON p.folder_id = f.id
             WHERE p.id IN ({placeholders})
+              AND p.exif_data IS NULL
               AND (p.timestamp IS NULL
                    OR (p.extension IN ({raw_list})
                        AND p.width IS NOT NULL AND p.width < 1000))
-            GROUP BY f.id
-            ORDER BY f.path""",
+            ORDER BY f.path, p.filename""",
         tuple(photo_ids),
     ).fetchall()
-    return [(r["path"], r["n"]) for r in rows]
+    by_folder: dict[str, list[str]] = {}
+    for r in rows:
+        by_folder.setdefault(r["folder_path"], []).append(
+            os.path.join(r["folder_path"], r["filename"])
+        )
+    return [(fp, paths) for fp, paths in by_folder.items()]
 
 
 def _update_stages(runner, job_id, stages):
@@ -369,7 +380,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     scan_to_thumb.put(_SENTINEL)
                     return
 
-                total_broken = sum(n for _, n in broken)
+                total_broken = sum(len(paths) for _, paths in broken)
                 stages["scan"]["label"] = (
                     f"Repair metadata ({total_broken} photos)"
                 )
@@ -383,7 +394,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 _update_stages(runner, job["id"], stages)
 
                 unreachable = 0
-                for folder_path, _ in broken:
+                for folder_path, file_paths in broken:
                     if not os.path.isdir(folder_path):
                         log.warning(
                             "Repair scan skipped for missing folder: %s",
@@ -392,6 +403,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         unreachable += 1
                         continue
                     try:
+                        # restrict_files limits discovery to the known
+                        # broken photos in this folder. Without it, new
+                        # untracked files in the same folder would get
+                        # ingested as a side effect of the repair.
                         do_scan(
                             folder_path, thread_db,
                             progress_callback=progress_cb,
@@ -402,6 +417,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                             photo_callback=photo_cb,
                             status_callback=status_cb,
                             restrict_dirs=[folder_path],
+                            restrict_files=set(file_paths),
                         )
                     except (OSError, RuntimeError) as e:
                         log.warning(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -94,6 +94,12 @@ def _find_broken_metadata_folders(db, photo_ids):
     such rows here would cause the repair path to fire on every pipeline
     run without accomplishing anything.
 
+    IDs are queried in chunks of at most 900 to stay safely under
+    SQLite's default bound-parameter limit (SQLITE_LIMIT_VARIABLE_NUMBER,
+    typically 999 in production builds). Without chunking, large
+    collections would hit ``OperationalError: too many SQL variables``
+    and abort the scan stage.
+
     Returns a list of ``(folder_path, file_paths)`` tuples where
     ``file_paths`` is a list of absolute image paths in that folder.
     Empty list when nothing needs repair.
@@ -101,24 +107,28 @@ def _find_broken_metadata_folders(db, photo_ids):
     if not photo_ids:
         return []
     raw_list = ",".join(f"'{e}'" for e in _RAW_EXTENSIONS)
-    placeholders = ",".join("?" for _ in photo_ids)
-    rows = db.conn.execute(
-        f"""SELECT f.path AS folder_path, p.filename
-            FROM photos p
-            JOIN folders f ON p.folder_id = f.id
-            WHERE p.id IN ({placeholders})
-              AND p.exif_data IS NULL
-              AND (p.timestamp IS NULL
-                   OR (p.extension IN ({raw_list})
-                       AND p.width IS NOT NULL AND p.width < 1000))
-            ORDER BY f.path, p.filename""",
-        tuple(photo_ids),
-    ).fetchall()
+    ids = list(photo_ids)
+    _CHUNK = 900
     by_folder: dict[str, list[str]] = {}
-    for r in rows:
-        by_folder.setdefault(r["folder_path"], []).append(
-            os.path.join(r["folder_path"], r["filename"])
-        )
+    for i in range(0, len(ids), _CHUNK):
+        chunk = ids[i : i + _CHUNK]
+        placeholders = ",".join("?" * len(chunk))
+        rows = db.conn.execute(
+            f"""SELECT f.path AS folder_path, p.filename
+                FROM photos p
+                JOIN folders f ON p.folder_id = f.id
+                WHERE p.id IN ({placeholders})
+                  AND p.exif_data IS NULL
+                  AND (p.timestamp IS NULL
+                       OR (p.extension IN ({raw_list})
+                           AND p.width IS NOT NULL AND p.width < 1000))
+                ORDER BY f.path, p.filename""",
+            tuple(chunk),
+        ).fetchall()
+        for r in rows:
+            by_folder.setdefault(r["folder_path"], []).append(
+                os.path.join(r["folder_path"], r["filename"])
+            )
     return [(fp, paths) for fp, paths in by_folder.items()]
 
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -377,8 +377,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 coll_photos = thread_db.get_collection_photos(
                     collection_id, per_page=999999,
                 )
+                # Respect the user's preview-time exclusions: photos removed
+                # from this run must not be rescanned or have their metadata
+                # rewritten as a side effect of repair.
+                in_scope_photos = _filter_excluded(coll_photos)
                 broken = _find_broken_metadata_folders(
-                    thread_db, [p["id"] for p in coll_photos],
+                    thread_db, [p["id"] for p in in_scope_photos],
                 )
                 if not broken:
                     stages["scan"]["status"] = "skipped"

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -393,6 +393,18 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 )
                 _update_stages(runner, job["id"], stages)
 
+                # Display-only callback for the repair path: updates the
+                # scan step's current_file indicator but does NOT enqueue
+                # into scan_to_thumb. In collection mode thumbnail_stage
+                # already replays the full collection against the thumb
+                # cache, so enqueueing here would double-process every
+                # repaired photo and inflate the thumbnail totals.
+                def repair_photo_cb(photo_id, path):
+                    runner.update_step(
+                        job["id"], "scan",
+                        current_file=os.path.basename(path),
+                    )
+
                 unreachable = 0
                 for folder_path, file_paths in broken:
                     if not os.path.isdir(folder_path):
@@ -414,7 +426,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                             extract_full_metadata=pipeline_cfg.get(
                                 "extract_full_metadata", True,
                             ),
-                            photo_callback=photo_cb,
+                            photo_callback=repair_photo_cb,
                             status_callback=status_cb,
                             restrict_dirs=[folder_path],
                             restrict_files=set(file_paths),

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -94,6 +94,12 @@ def _find_broken_metadata_folders(db, photo_ids):
     such rows here would cause the repair path to fire on every pipeline
     run without accomplishing anything.
 
+    Rows whose file no longer exists on disk are filtered out: the
+    scanner only repairs files it can rediscover via ``Path.iterdir()``,
+    so a missing-file row would stay broken forever and keep the
+    collection stuck in repair mode on every run instead of returning to
+    the fast-path "Skipped (using collection)" summary.
+
     IDs are queried in chunks of at most 900 to stay safely under
     SQLite's default bound-parameter limit (SQLITE_LIMIT_VARIABLE_NUMBER,
     typically 999 in production builds). Without chunking, large
@@ -126,9 +132,10 @@ def _find_broken_metadata_folders(db, photo_ids):
             tuple(chunk),
         ).fetchall()
         for r in rows:
-            by_folder.setdefault(r["folder_path"], []).append(
-                os.path.join(r["folder_path"], r["filename"])
-            )
+            full_path = os.path.join(r["folder_path"], r["filename"])
+            if not os.path.isfile(full_path):
+                continue
+            by_folder.setdefault(r["folder_path"], []).append(full_path)
     return [(fp, paths) for fp, paths in by_folder.items()]
 
 

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -299,7 +299,7 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
     db.conn.commit()
 
 
-def scan(root, db, progress_callback=None, incremental=False, extract_full_metadata=True, photo_callback=None, skip_paths=None, status_callback=None, recursive=True, restrict_dirs=None, vireo_dir=None):
+def scan(root, db, progress_callback=None, incremental=False, extract_full_metadata=True, photo_callback=None, skip_paths=None, status_callback=None, recursive=True, restrict_dirs=None, restrict_files=None, vireo_dir=None):
     """Walk a folder tree, discover photos, read metadata, populate database.
 
     Args:
@@ -316,6 +316,11 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             full tree. When provided, only files in these directories are
             discovered (non-recursively), but ``root`` is still used as the
             folder hierarchy root so parent links are preserved correctly.
+        restrict_files: optional iterable of absolute file paths. When
+            provided alongside ``restrict_dirs``, only files whose path
+            is in this set are discovered — untracked files in the same
+            directory are ignored. Used by the pipeline's repair path to
+            touch only photos already in the DB.
         vireo_dir: optional path to the vireo data directory (e.g. ``~/.vireo``).
             When provided, working copies are extracted for RAW photos after
             companion pairing.
@@ -333,6 +338,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     if restrict_dirs is not None:
         # Only enumerate files in the specified directories (non-recursive).
         # root is still used as the folder hierarchy root for _ensure_folder.
+        restrict_files_set = set(restrict_files) if restrict_files is not None else None
         for d in restrict_dirs:
             dp = Path(d)
             if dp.is_dir():
@@ -340,7 +346,9 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     if (f.is_file()
                             and f.suffix.lower() in SUPPORTED_EXTENSIONS
                             and not f.name.startswith(".")
-                            and (skip_paths is None or str(f) not in skip_paths)):
+                            and (skip_paths is None or str(f) not in skip_paths)
+                            and (restrict_files_set is None
+                                 or str(f) in restrict_files_set)):
                         image_files.append(f)
     else:
         candidates = root_path.rglob("*") if recursive else root_path.iterdir()

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -420,8 +420,17 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 # timestamp and exif_data are NULL). Photos with genuinely
                 # missing timestamps (screenshots, exports) will have
                 # exif_data set after one extraction attempt.
+                # Also flag rows where a RAW file has absurdly small
+                # dimensions (<1000px) — that's the embedded JPEG thumb
+                # leaking through when ExifTool's File group was missing
+                # on the original scan.
+                dims_suspect = (
+                    existing["extension"] in RAW_EXTENSIONS
+                    and existing["width"] is not None
+                    and existing["width"] < 1000
+                )
                 metadata_missing = (
-                    existing["timestamp"] is None
+                    (existing["timestamp"] is None or dims_suspect)
                     and existing["id"] not in exif_extracted
                 )
 

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -794,6 +794,47 @@ def test_find_broken_metadata_folders_groups_by_folder(app_and_db):
     assert sorted(os.path.basename(p) for p in paths) == ['bird1.jpg', 'bird3.jpg']
 
 
+def test_find_broken_metadata_folders_chunks_large_id_lists(app_and_db):
+    """Passing more photo_ids than SQLite's default variable cap (999) must
+    not raise 'too many SQL variables'. The helper chunks internally."""
+    from pipeline_job import _find_broken_metadata_folders
+    _, db = app_and_db
+
+    folder_id = db.conn.execute(
+        "SELECT id FROM folders WHERE path='/photos/2024'"
+    ).fetchone()["id"]
+    # Bulk-insert 1200 photos, all with populated timestamps (none broken).
+    db.conn.executemany(
+        "INSERT INTO photos (folder_id, filename, extension, file_size, "
+        "file_mtime, timestamp) VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            (folder_id, f"bulk_{i}.jpg", ".jpg", 1000, float(i),
+             "2024-01-01T00:00:00")
+            for i in range(1200)
+        ],
+    )
+    db.conn.commit()
+
+    photo_ids = [p["id"] for p in db.conn.execute(
+        "SELECT id FROM photos"
+    ).fetchall()]
+    assert len(photo_ids) > 999
+    # Must not raise OperationalError: too many SQL variables.
+    assert _find_broken_metadata_folders(db, photo_ids) == []
+
+    # Break one of the bulk rows and confirm it's still found across chunks.
+    target = db.conn.execute(
+        "SELECT id, folder_id FROM photos WHERE filename='bulk_1100.jpg'"
+    ).fetchone()
+    db.conn.execute(
+        "UPDATE photos SET timestamp=NULL WHERE id=?", (target["id"],)
+    )
+    db.conn.commit()
+    result = _find_broken_metadata_folders(db, photo_ids)
+    assert len(result) == 1
+    assert any(p.endswith("bulk_1100.jpg") for p in result[0][1])
+
+
 def test_pipeline_with_healthy_collection_skips_scan(app_and_db):
     """A pipeline run against a collection of healthy photos reports the
     scan stage as skipped — preserving existing behavior when nothing's

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -679,11 +679,16 @@ def test_find_broken_metadata_folders_returns_empty_when_healthy(app_and_db):
     assert _find_broken_metadata_folders(db, photo_ids) == []
 
 
-def test_find_broken_metadata_folders_detects_null_timestamp(app_and_db):
+def test_find_broken_metadata_folders_detects_null_timestamp(app_and_db, monkeypatch):
     """_find_broken_metadata_folders flags a photo whose timestamp is NULL
     and returns its file path so the repair path can restrict the scan."""
+    import pipeline_job
     from pipeline_job import _find_broken_metadata_folders
     _, db = app_and_db
+
+    # Fixture rows point at synthetic /photos paths that don't exist on
+    # disk; treat all DB rows as present for the SQL/grouping assertions.
+    monkeypatch.setattr(pipeline_job.os.path, "isfile", lambda _p: True)
 
     # Break one photo's timestamp.
     row = db.conn.execute(
@@ -702,11 +707,14 @@ def test_find_broken_metadata_folders_detects_null_timestamp(app_and_db):
     assert result == [(folder_path, [os.path.join(folder_path, "bird1.jpg")])]
 
 
-def test_find_broken_metadata_folders_detects_raw_thumb_dims(app_and_db):
+def test_find_broken_metadata_folders_detects_raw_thumb_dims(app_and_db, monkeypatch):
     """_find_broken_metadata_folders flags a RAW photo with sub-1000px
     width (the embedded-thumbnail bug) even when timestamp is populated."""
+    import pipeline_job
     from pipeline_job import _find_broken_metadata_folders
     _, db = app_and_db
+
+    monkeypatch.setattr(pipeline_job.os.path, "isfile", lambda _p: True)
 
     row = db.conn.execute(
         "SELECT id, folder_id FROM photos WHERE filename='bird1.jpg'"
@@ -770,11 +778,14 @@ def test_find_broken_metadata_folders_excludes_exif_extracted(app_and_db):
     assert _find_broken_metadata_folders(db, photo_ids) == []
 
 
-def test_find_broken_metadata_folders_groups_by_folder(app_and_db):
+def test_find_broken_metadata_folders_groups_by_folder(app_and_db, monkeypatch):
     """Multiple broken photos in the same folder are returned as one
     folder entry with a count."""
+    import pipeline_job
     from pipeline_job import _find_broken_metadata_folders
     _, db = app_and_db
+
+    monkeypatch.setattr(pipeline_job.os.path, "isfile", lambda _p: True)
 
     # Break both photos in folder '/photos/2024' (bird1 and bird3).
     db.conn.execute(
@@ -794,11 +805,48 @@ def test_find_broken_metadata_folders_groups_by_folder(app_and_db):
     assert sorted(os.path.basename(p) for p in paths) == ['bird1.jpg', 'bird3.jpg']
 
 
-def test_find_broken_metadata_folders_chunks_large_id_lists(app_and_db):
-    """Passing more photo_ids than SQLite's default variable cap (999) must
-    not raise 'too many SQL variables'. The helper chunks internally."""
+def test_find_broken_metadata_folders_filters_missing_files(app_and_db, tmp_path):
+    """Rows whose file no longer exists on disk are filtered out. The
+    scanner can only repair files it rediscovers via Path.iterdir(), so
+    a missing-file row would stay broken forever and keep the collection
+    stuck in repair mode on every pipeline run."""
     from pipeline_job import _find_broken_metadata_folders
     _, db = app_and_db
+
+    # Real folder with one real file (broken) and one DB row pointing at
+    # a deleted file (also broken-looking in the DB).
+    real_dir = tmp_path / "photos"
+    real_dir.mkdir()
+    present = real_dir / "present.jpg"
+    Image.new("RGB", (640, 480)).save(str(present), "JPEG")
+
+    fid = db.add_folder(str(real_dir), name="photos")
+    p_present = db.add_photo(
+        folder_id=fid, filename="present.jpg", extension=".jpg",
+        file_size=present.stat().st_size, file_mtime=present.stat().st_mtime,
+        timestamp=None,
+    )
+    p_missing = db.add_photo(
+        folder_id=fid, filename="ghost.jpg", extension=".jpg",
+        file_size=1, file_mtime=1.0, timestamp=None,
+    )
+    db.conn.commit()
+
+    result = _find_broken_metadata_folders(db, [p_present, p_missing])
+    assert len(result) == 1
+    folder, paths = result[0]
+    assert folder == str(real_dir)
+    assert paths == [str(present)]
+
+
+def test_find_broken_metadata_folders_chunks_large_id_lists(app_and_db, monkeypatch):
+    """Passing more photo_ids than SQLite's default variable cap (999) must
+    not raise 'too many SQL variables'. The helper chunks internally."""
+    import pipeline_job
+    from pipeline_job import _find_broken_metadata_folders
+    _, db = app_and_db
+
+    monkeypatch.setattr(pipeline_job.os.path, "isfile", lambda _p: True)
 
     folder_id = db.conn.execute(
         "SELECT id FROM folders WHERE path='/photos/2024'"
@@ -1034,10 +1082,12 @@ def test_pipeline_repair_does_not_ingest_untracked_files(app_and_db, tmp_path, m
 
 
 def test_pipeline_with_broken_collection_handles_unreachable_folder(app_and_db):
-    """A pipeline run where a broken photo's folder no longer exists on
-    disk handles the missing folder gracefully — the scan stage records
-    the unreachable folder in its summary and doesn't crash. (Downstream
-    stages may still fail because files are missing; that's unrelated.)"""
+    """A pipeline run where a broken photo's underlying file no longer
+    exists on disk handles the missing file gracefully — the broken row
+    is filtered out of the repair scope (since the scanner couldn't
+    repair it anyway), and the scan stage falls through to the normal
+    'Skipped (using collection)' fast path instead of looping forever
+    in repair mode."""
     import json
 
     from db import Database
@@ -1078,12 +1128,14 @@ def test_pipeline_with_broken_collection_handles_unreachable_folder(app_and_db):
                 break
             time.sleep(0.1)
 
-        # The scan step should have completed (not errored) even though
-        # the folder was unreachable. The pipeline's overall status may
-        # be "failed" due to later stages depending on the same missing
-        # files; that's expected and unrelated to the repair logic.
+        # The scan step should have completed without error. With the
+        # broken row's file missing on disk, the repair-target filter
+        # drops it and the scan stage falls through to "Skipped (using
+        # collection)" — this is exactly the behavior we want to keep
+        # the collection from getting stuck in repair mode forever.
         scan_step = next(s for s in data["steps"] if s["id"] == "scan")
         assert scan_step["status"] == "completed"
+        assert scan_step.get("summary") == "Skipped (using collection)"
 
 
 def test_pipeline_repair_does_not_double_process_thumbnails(

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -1172,3 +1172,83 @@ def test_pipeline_repair_does_not_double_process_thumbnails(
 
     # Each repaired photo should be handed to generate_thumbnail exactly once.
     assert calls[pid] == 1, dict(calls)
+
+
+def test_pipeline_repair_respects_excluded_photo_ids(
+    app_and_db, monkeypatch,
+):
+    """Photos excluded from the run via ``exclude_photo_ids`` must not
+    trigger a repair scan — the downstream stages would skip them anyway,
+    so rewriting their metadata would be unexpected out-of-scope work."""
+    import json
+
+    from db import Database
+
+    app, _ = app_and_db
+    db_path = app.config["DB_PATH"]
+    db = Database(db_path)
+    db.set_active_workspace(db._active_workspace_id)
+
+    # The fixture's bird1.jpg doesn't exist on disk, but that's fine —
+    # we only need to verify the scan stage takes the fast-path skip
+    # instead of firing the repair scan. Force it into broken state so
+    # that without the exclusion filter it WOULD be picked up for repair.
+    bird1 = db.conn.execute(
+        "SELECT id FROM photos WHERE filename='bird1.jpg'"
+    ).fetchone()["id"]
+    bird2 = db.conn.execute(
+        "SELECT id FROM photos WHERE filename='bird2.jpg'"
+    ).fetchone()["id"]
+    db.conn.execute(
+        "UPDATE photos SET timestamp=NULL, exif_data=NULL WHERE id=?",
+        (bird1,),
+    )
+    db.conn.commit()
+
+    # If repair ever runs for the excluded photo it would call
+    # extract_metadata; fail loudly if so.
+    import scanner
+    def fail_extract(paths, restricted_tags=None):
+        raise AssertionError(
+            f"extract_metadata must not run for excluded photos: {paths}"
+        )
+    monkeypatch.setattr(scanner, "extract_metadata", fail_extract)
+
+    col_id = db.add_collection(
+        "with_excluded",
+        json.dumps([{"field": "photo_ids", "value": [bird1, bird2]}]),
+    )
+
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id,
+            "exclude_photo_ids": [bird1],
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+            "skip_classify": True,
+        })
+        assert resp.status_code == 200
+        job_id = resp.get_json()["job_id"]
+
+        for _ in range(100):
+            resp = client.get(f"/api/jobs/{job_id}")
+            data = resp.get_json()
+            if data["status"] in ("completed", "failed"):
+                break
+            time.sleep(0.1)
+
+        # The scan step should have reported the "Skipped" fast path
+        # because the only broken photo was excluded from the run.
+        # Downstream stages may still fail on the stub fixture files —
+        # that's unrelated and does not affect the scan-stage assertion.
+        scan_step = next(s for s in data["steps"] if s["id"] == "scan")
+        summary = (scan_step.get("summary") or "").lower()
+        assert "skipped" in summary, scan_step
+        assert "repair" not in summary, scan_step
+
+    # Excluded photo's broken metadata is untouched.
+    row = db.conn.execute(
+        "SELECT timestamp, exif_data FROM photos WHERE id=?", (bird1,)
+    ).fetchone()
+    assert row["timestamp"] is None
+    assert row["exif_data"] is None

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -661,3 +661,278 @@ def test_job_cancel_finished_job_returns_404(app_and_db):
     with app.test_client() as c:
         resp = c.post(f"/api/jobs/{job_id}/cancel")
         assert resp.status_code == 404
+
+
+# --- Pipeline metadata auto-repair tests ---
+
+def test_find_broken_metadata_folders_returns_empty_when_healthy(app_and_db):
+    """_find_broken_metadata_folders returns [] when all photos have good
+    metadata."""
+    from pipeline_job import _find_broken_metadata_folders
+    _, db = app_and_db
+
+    # The fixture's 3 photos all have populated timestamps and .jpg ext,
+    # so none should match the detection rule.
+    photo_ids = [p["id"] for p in db.conn.execute(
+        "SELECT id FROM photos"
+    ).fetchall()]
+    assert _find_broken_metadata_folders(db, photo_ids) == []
+
+
+def test_find_broken_metadata_folders_detects_null_timestamp(app_and_db):
+    """_find_broken_metadata_folders flags a photo whose timestamp is NULL."""
+    from pipeline_job import _find_broken_metadata_folders
+    _, db = app_and_db
+
+    # Break one photo's timestamp.
+    row = db.conn.execute(
+        "SELECT id, folder_id FROM photos WHERE filename='bird1.jpg'"
+    ).fetchone()
+    db.conn.execute("UPDATE photos SET timestamp=NULL WHERE id=?", (row["id"],))
+    db.conn.commit()
+
+    photo_ids = [p["id"] for p in db.conn.execute(
+        "SELECT id FROM photos"
+    ).fetchall()]
+    result = _find_broken_metadata_folders(db, photo_ids)
+    folder_path = db.conn.execute(
+        "SELECT path FROM folders WHERE id=?", (row["folder_id"],)
+    ).fetchone()["path"]
+    assert result == [(folder_path, 1)]
+
+
+def test_find_broken_metadata_folders_detects_raw_thumb_dims(app_and_db):
+    """_find_broken_metadata_folders flags a RAW photo with sub-1000px
+    width (the embedded-thumbnail bug) even when timestamp is populated."""
+    from pipeline_job import _find_broken_metadata_folders
+    _, db = app_and_db
+
+    row = db.conn.execute(
+        "SELECT id, folder_id FROM photos WHERE filename='bird1.jpg'"
+    ).fetchone()
+    db.conn.execute(
+        "UPDATE photos SET extension='.nef', width=160, height=120 "
+        "WHERE id=?", (row["id"],)
+    )
+    db.conn.commit()
+
+    photo_ids = [p["id"] for p in db.conn.execute(
+        "SELECT id FROM photos"
+    ).fetchall()]
+    result = _find_broken_metadata_folders(db, photo_ids)
+    assert len(result) == 1
+    assert result[0][1] == 1
+
+
+def test_find_broken_metadata_folders_ignores_out_of_scope(app_and_db):
+    """Broken photos outside the passed photo_ids list are not returned."""
+    from pipeline_job import _find_broken_metadata_folders
+    _, db = app_and_db
+
+    # Break bird1, but only pass bird2's id in scope.
+    bird1 = db.conn.execute(
+        "SELECT id FROM photos WHERE filename='bird1.jpg'"
+    ).fetchone()["id"]
+    bird2 = db.conn.execute(
+        "SELECT id FROM photos WHERE filename='bird2.jpg'"
+    ).fetchone()["id"]
+    db.conn.execute("UPDATE photos SET timestamp=NULL WHERE id=?", (bird1,))
+    db.conn.commit()
+
+    assert _find_broken_metadata_folders(db, [bird2]) == []
+
+
+def test_find_broken_metadata_folders_groups_by_folder(app_and_db):
+    """Multiple broken photos in the same folder are returned as one
+    folder entry with a count."""
+    from pipeline_job import _find_broken_metadata_folders
+    _, db = app_and_db
+
+    # Break both photos in folder '/photos/2024' (bird1 and bird3).
+    db.conn.execute(
+        "UPDATE photos SET timestamp=NULL "
+        "WHERE filename IN ('bird1.jpg', 'bird3.jpg')"
+    )
+    db.conn.commit()
+
+    photo_ids = [p["id"] for p in db.conn.execute(
+        "SELECT id FROM photos"
+    ).fetchall()]
+    result = _find_broken_metadata_folders(db, photo_ids)
+    assert len(result) == 1
+    assert result[0][0] == '/photos/2024'
+    assert result[0][1] == 2
+
+
+def test_pipeline_with_healthy_collection_skips_scan(app_and_db):
+    """A pipeline run against a collection of healthy photos reports the
+    scan stage as skipped — preserving existing behavior when nothing's
+    broken. The downstream thumbnail stage will fail because the fixture
+    files don't exist on disk; we only care about the scan step."""
+    import json
+
+    from db import Database
+
+    app, _ = app_and_db
+    db_path = app.config["DB_PATH"]
+    db = Database(db_path)
+    db.set_active_workspace(db._active_workspace_id)
+
+    photo_ids = [p["id"] for p in db.conn.execute(
+        "SELECT id FROM photos"
+    ).fetchall()]
+    col_id = db.add_collection(
+        "healthy", json.dumps([{"field": "photo_ids", "value": photo_ids}])
+    )
+
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+            "skip_classify": True,
+        })
+        assert resp.status_code == 200
+        job_id = resp.get_json()["job_id"]
+
+        for _ in range(100):
+            resp = client.get(f"/api/jobs/{job_id}")
+            data = resp.get_json()
+            if data["status"] in ("completed", "failed"):
+                break
+            time.sleep(0.1)
+
+        scan_step = next(s for s in data["steps"] if s["id"] == "scan")
+        assert scan_step.get("summary") == "Skipped (using collection)"
+
+
+def test_pipeline_with_broken_collection_repairs_metadata(app_and_db, tmp_path, monkeypatch):
+    """A pipeline run against a collection with broken-metadata photos
+    triggers a targeted repair scan before downstream stages. Broken
+    rows end with populated timestamp and corrected dimensions."""
+    import json
+
+    from db import Database
+
+    app, _ = app_and_db
+    db_path = app.config["DB_PATH"]
+    db = Database(db_path)
+    db.set_active_workspace(db._active_workspace_id)
+
+    # Create a real image file on disk and register a new folder+photo
+    # pointing at it. The fixture's /photos/... folders don't exist on
+    # disk, so we need our own.
+    photos_root = tmp_path / "real_photos"
+    photos_root.mkdir()
+    image_file = photos_root / "broken.jpg"
+    Image.new("RGB", (640, 480), color="red").save(str(image_file), "JPEG")
+
+    fid = db.add_folder(str(photos_root), name="real_photos")
+    db.add_workspace_folder(db._active_workspace_id, fid)
+    pid = db.add_photo(
+        folder_id=fid, filename="broken.jpg", extension=".jpg",
+        file_size=image_file.stat().st_size,
+        file_mtime=image_file.stat().st_mtime,
+        timestamp=None, width=160, height=120,
+    )
+    # Force broken RAW-thumbnail state so the detection rule fires.
+    db.conn.execute(
+        "UPDATE photos SET extension='.nef', timestamp=NULL, "
+        "exif_data=NULL WHERE id=?", (pid,)
+    )
+    db.conn.commit()
+
+    # Mock ExifTool so the test doesn't depend on the binary.
+    import scanner
+    def fake_extract(paths, restricted_tags=None):
+        return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
+                    "EXIF": {"DateTimeOriginal": "2024:06:15 10:00:00"},
+                    "Composite": {}} for p in paths}
+    monkeypatch.setattr(scanner, "extract_metadata", fake_extract)
+
+    col_id = db.add_collection(
+        "broken", json.dumps([{"field": "photo_ids", "value": [pid]}])
+    )
+
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+            "skip_classify": True,
+        })
+        assert resp.status_code == 200
+        job_id = resp.get_json()["job_id"]
+
+        for _ in range(100):
+            resp = client.get(f"/api/jobs/{job_id}")
+            data = resp.get_json()
+            if data["status"] in ("completed", "failed"):
+                break
+            time.sleep(0.1)
+
+        assert data["status"] == "completed", data
+        scan_step = next(s for s in data["steps"] if s["id"] == "scan")
+        # Scan stage should have run (not been skipped) because of repair.
+        assert "repair" in (scan_step.get("summary") or "").lower()
+
+    # Verify the broken row now has correct metadata.
+    row = db.conn.execute(
+        "SELECT timestamp, width, height FROM photos WHERE id=?", (pid,)
+    ).fetchone()
+    assert row["timestamp"] == "2024-06-15T10:00:00"
+    assert row["width"] == 640
+    assert row["height"] == 480
+
+
+def test_pipeline_with_broken_collection_handles_unreachable_folder(app_and_db):
+    """A pipeline run where a broken photo's folder no longer exists on
+    disk handles the missing folder gracefully — the scan stage records
+    the unreachable folder in its summary and doesn't crash. (Downstream
+    stages may still fail because files are missing; that's unrelated.)"""
+    import json
+
+    from db import Database
+
+    app, _ = app_and_db
+    db_path = app.config["DB_PATH"]
+    db = Database(db_path)
+    db.set_active_workspace(db._active_workspace_id)
+
+    bird1 = db.conn.execute(
+        "SELECT id FROM photos WHERE filename='bird1.jpg'"
+    ).fetchone()["id"]
+    db.conn.execute(
+        "UPDATE photos SET timestamp=NULL, exif_data=NULL WHERE id=?",
+        (bird1,),
+    )
+    db.conn.commit()
+
+    col_id = db.add_collection(
+        "broken_unreachable",
+        json.dumps([{"field": "photo_ids", "value": [bird1]}]),
+    )
+
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+            "skip_classify": True,
+        })
+        assert resp.status_code == 200
+        job_id = resp.get_json()["job_id"]
+
+        for _ in range(100):
+            resp = client.get(f"/api/jobs/{job_id}")
+            data = resp.get_json()
+            if data["status"] in ("completed", "failed"):
+                break
+            time.sleep(0.1)
+
+        # The scan step should have completed (not errored) even though
+        # the folder was unreachable. The pipeline's overall status may
+        # be "failed" due to later stages depending on the same missing
+        # files; that's expected and unrelated to the repair logic.
+        scan_step = next(s for s in data["steps"] if s["id"] == "scan")
+        assert scan_step["status"] == "completed"

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -680,7 +680,8 @@ def test_find_broken_metadata_folders_returns_empty_when_healthy(app_and_db):
 
 
 def test_find_broken_metadata_folders_detects_null_timestamp(app_and_db):
-    """_find_broken_metadata_folders flags a photo whose timestamp is NULL."""
+    """_find_broken_metadata_folders flags a photo whose timestamp is NULL
+    and returns its file path so the repair path can restrict the scan."""
     from pipeline_job import _find_broken_metadata_folders
     _, db = app_and_db
 
@@ -698,7 +699,7 @@ def test_find_broken_metadata_folders_detects_null_timestamp(app_and_db):
     folder_path = db.conn.execute(
         "SELECT path FROM folders WHERE id=?", (row["folder_id"],)
     ).fetchone()["path"]
-    assert result == [(folder_path, 1)]
+    assert result == [(folder_path, [os.path.join(folder_path, "bird1.jpg")])]
 
 
 def test_find_broken_metadata_folders_detects_raw_thumb_dims(app_and_db):
@@ -721,7 +722,9 @@ def test_find_broken_metadata_folders_detects_raw_thumb_dims(app_and_db):
     ).fetchall()]
     result = _find_broken_metadata_folders(db, photo_ids)
     assert len(result) == 1
-    assert result[0][1] == 1
+    # One file in the folder — bird1.jpg with the fake .nef extension.
+    assert len(result[0][1]) == 1
+    assert result[0][1][0].endswith("bird1.jpg")
 
 
 def test_find_broken_metadata_folders_ignores_out_of_scope(app_and_db):
@@ -742,6 +745,31 @@ def test_find_broken_metadata_folders_ignores_out_of_scope(app_and_db):
     assert _find_broken_metadata_folders(db, [bird2]) == []
 
 
+def test_find_broken_metadata_folders_excludes_exif_extracted(app_and_db):
+    """A row whose timestamp is NULL but exif_data is populated is NOT
+    returned. Such rows represent photos where ExifTool already ran and
+    the source file genuinely has no DateTimeOriginal (e.g. screenshots).
+    The scanner's exif_extracted guard would skip them on re-scan anyway,
+    so flagging them as repairable would cause the repair path to fire
+    forever without doing useful work."""
+    from pipeline_job import _find_broken_metadata_folders
+    _, db = app_and_db
+
+    row = db.conn.execute(
+        "SELECT id FROM photos WHERE filename='bird1.jpg'"
+    ).fetchone()
+    db.conn.execute(
+        "UPDATE photos SET timestamp=NULL, exif_data='{\"File\":{}}' "
+        "WHERE id=?", (row["id"],)
+    )
+    db.conn.commit()
+
+    photo_ids = [p["id"] for p in db.conn.execute(
+        "SELECT id FROM photos"
+    ).fetchall()]
+    assert _find_broken_metadata_folders(db, photo_ids) == []
+
+
 def test_find_broken_metadata_folders_groups_by_folder(app_and_db):
     """Multiple broken photos in the same folder are returned as one
     folder entry with a count."""
@@ -760,8 +788,10 @@ def test_find_broken_metadata_folders_groups_by_folder(app_and_db):
     ).fetchall()]
     result = _find_broken_metadata_folders(db, photo_ids)
     assert len(result) == 1
-    assert result[0][0] == '/photos/2024'
-    assert result[0][1] == 2
+    folder, paths = result[0]
+    assert folder == '/photos/2024'
+    assert len(paths) == 2
+    assert sorted(os.path.basename(p) for p in paths) == ['bird1.jpg', 'bird3.jpg']
 
 
 def test_pipeline_with_healthy_collection_skips_scan(app_and_db):
@@ -883,6 +913,83 @@ def test_pipeline_with_broken_collection_repairs_metadata(app_and_db, tmp_path, 
     assert row["timestamp"] == "2024-06-15T10:00:00"
     assert row["width"] == 640
     assert row["height"] == 480
+
+
+def test_pipeline_repair_does_not_ingest_untracked_files(app_and_db, tmp_path, monkeypatch):
+    """When the repair path scans a folder to fix broken metadata, new
+    files that were added to that folder but never scanned do NOT get
+    ingested as a side effect. The repair must touch only the specific
+    photos flagged as broken."""
+    import json
+
+    from db import Database
+
+    app, _ = app_and_db
+    db_path = app.config["DB_PATH"]
+    db = Database(db_path)
+    db.set_active_workspace(db._active_workspace_id)
+
+    # Create a real folder with two files — one in the DB (broken), one
+    # untracked. The repair run should touch the broken one and leave
+    # the untracked one alone.
+    photos_root = tmp_path / "real_photos"
+    photos_root.mkdir()
+    tracked = photos_root / "tracked.jpg"
+    untracked = photos_root / "untracked.jpg"
+    Image.new("RGB", (640, 480), color="red").save(str(tracked), "JPEG")
+    Image.new("RGB", (640, 480), color="blue").save(str(untracked), "JPEG")
+
+    fid = db.add_folder(str(photos_root), name="real_photos")
+    db.add_workspace_folder(db._active_workspace_id, fid)
+    pid = db.add_photo(
+        folder_id=fid, filename="tracked.jpg", extension=".jpg",
+        file_size=tracked.stat().st_size,
+        file_mtime=tracked.stat().st_mtime,
+    )
+    db.conn.execute(
+        "UPDATE photos SET timestamp=NULL, exif_data=NULL WHERE id=?", (pid,)
+    )
+    db.conn.commit()
+
+    import scanner
+    def fake_extract(paths, restricted_tags=None):
+        return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
+                    "EXIF": {"DateTimeOriginal": "2024:06:15 10:00:00"},
+                    "Composite": {}} for p in paths}
+    monkeypatch.setattr(scanner, "extract_metadata", fake_extract)
+
+    col_id = db.add_collection(
+        "broken_tracked",
+        json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+            "skip_classify": True,
+        })
+        assert resp.status_code == 200
+        job_id = resp.get_json()["job_id"]
+
+        for _ in range(100):
+            resp = client.get(f"/api/jobs/{job_id}")
+            data = resp.get_json()
+            if data["status"] in ("completed", "failed"):
+                break
+            time.sleep(0.1)
+
+    # Tracked photo repaired: timestamp populated.
+    tracked_row = db.conn.execute(
+        "SELECT timestamp FROM photos WHERE filename='tracked.jpg'"
+    ).fetchone()
+    assert tracked_row["timestamp"] == "2024-06-15T10:00:00"
+    # Untracked file NOT ingested.
+    untracked_row = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM photos WHERE filename='untracked.jpg'"
+    ).fetchone()
+    assert untracked_row["n"] == 0
 
 
 def test_pipeline_with_broken_collection_handles_unreachable_folder(app_and_db):

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -1043,3 +1043,91 @@ def test_pipeline_with_broken_collection_handles_unreachable_folder(app_and_db):
         # files; that's expected and unrelated to the repair logic.
         scan_step = next(s for s in data["steps"] if s["id"] == "scan")
         assert scan_step["status"] == "completed"
+
+
+def test_pipeline_repair_does_not_double_process_thumbnails(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """Repaired photos must only be processed once by the thumbnail stage.
+    The collection-replay loop in thumbnail_stage() already covers every
+    photo in the collection, so the scan-queue callback must not also
+    enqueue repaired files — doing so would generate the thumbnail twice
+    and inflate the thumbnail totals beyond the collection size."""
+    import json
+
+    from db import Database
+
+    app, _ = app_and_db
+    db_path = app.config["DB_PATH"]
+    db = Database(db_path)
+    db.set_active_workspace(db._active_workspace_id)
+
+    photos_root = tmp_path / "real_photos"
+    photos_root.mkdir()
+    image_file = photos_root / "broken.jpg"
+    Image.new("RGB", (640, 480), color="red").save(str(image_file), "JPEG")
+
+    fid = db.add_folder(str(photos_root), name="real_photos")
+    db.add_workspace_folder(db._active_workspace_id, fid)
+    pid = db.add_photo(
+        folder_id=fid, filename="broken.jpg", extension=".jpg",
+        file_size=image_file.stat().st_size,
+        file_mtime=image_file.stat().st_mtime,
+        timestamp=None, width=160, height=120,
+    )
+    db.conn.execute(
+        "UPDATE photos SET extension='.nef', timestamp=NULL, "
+        "exif_data=NULL WHERE id=?", (pid,)
+    )
+    db.conn.commit()
+
+    import scanner
+    def fake_extract(paths, restricted_tags=None):
+        return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
+                    "EXIF": {"DateTimeOriginal": "2024:06:15 10:00:00"},
+                    "Composite": {}} for p in paths}
+    monkeypatch.setattr(scanner, "extract_metadata", fake_extract)
+
+    # Count generate_thumbnail invocations per photo_id. If the P2 bug
+    # existed the repaired photo would be generated twice (once from the
+    # scan queue, once from the collection replay).
+    from collections import Counter
+    calls = Counter()
+
+    import thumbnails
+    real_generate = thumbnails.generate_thumbnail
+    def counting_generate(photo_id, *args, **kwargs):
+        calls[photo_id] += 1
+        return real_generate(photo_id, *args, **kwargs)
+    monkeypatch.setattr(thumbnails, "generate_thumbnail", counting_generate)
+
+    col_id = db.add_collection(
+        "broken_thumb", json.dumps([{"field": "photo_ids", "value": [pid]}])
+    )
+
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+            "skip_classify": True,
+        })
+        assert resp.status_code == 200
+        job_id = resp.get_json()["job_id"]
+
+        for _ in range(100):
+            resp = client.get(f"/api/jobs/{job_id}")
+            data = resp.get_json()
+            if data["status"] in ("completed", "failed"):
+                break
+            time.sleep(0.1)
+
+        assert data["status"] == "completed", data
+
+        thumb_step = next(s for s in data["steps"] if s["id"] == "thumbnails")
+        # Progress total must match the collection size, not double it.
+        progress = thumb_step.get("progress") or {}
+        assert progress.get("total") == 1, thumb_step
+
+    # Each repaired photo should be handed to generate_thumbnail exactly once.
+    assert calls[pid] == 1, dict(calls)

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1104,6 +1104,54 @@ def test_incremental_rescan_skips_small_jpeg_dims_not_raw(tmp_path, monkeypatch)
     assert all(image_path not in batch for batch in called_with)
 
 
+def test_scan_restrict_files_ignores_files_not_in_list(tmp_path, monkeypatch):
+    """When scan is called with restrict_files, files in restrict_dirs
+    that are not in the list are left untouched — even if they're brand
+    new and not yet in the DB. This prevents the pipeline's repair path
+    from ingesting new files as a side effect of fixing broken metadata."""
+    import scanner
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    existing_file = os.path.join(root, "existing.jpg")
+    Image.new("RGB", (640, 480), color="green").save(existing_file, "JPEG")
+
+    db = Database(str(tmp_path / "test.db"))
+
+    def fake_extract(paths, restricted_tags=None):
+        return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
+                    "EXIF": {}, "Composite": {}} for p in paths}
+    monkeypatch.setattr(scanner, "extract_metadata", fake_extract)
+
+    # Seed the DB with only the existing file, then force broken state.
+    scanner.scan(root, db)
+    pid = db.conn.execute(
+        "SELECT id FROM photos WHERE filename='existing.jpg'"
+    ).fetchone()["id"]
+    db.conn.execute(
+        "UPDATE photos SET timestamp=NULL, exif_data=NULL WHERE id=?", (pid,)
+    )
+    db.conn.commit()
+
+    # NOW add an untracked file to the same folder (after initial scan).
+    new_file = os.path.join(root, "new_untracked.jpg")
+    Image.new("RGB", (640, 480), color="blue").save(new_file, "JPEG")
+
+    # Second scan with restrict_files constrained to the existing file only.
+    scanner.scan(
+        root, db,
+        incremental=True,
+        restrict_dirs=[root],
+        restrict_files={existing_file},
+    )
+
+    # new_untracked.jpg should NOT have been ingested.
+    filenames = [p["filename"] for p in db.get_photos(per_page=999999)]
+    assert "new_untracked.jpg" not in filenames
+    assert "existing.jpg" in filenames
+
+
 def test_incremental_rescan_respects_exif_extracted_guard(tmp_path, monkeypatch):
     """Incremental scan does NOT re-process a row when exif_data is
     populated, even if the row otherwise looks broken. The guard prevents

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -969,3 +969,171 @@ def test_extract_timestamp_subsec_long():
     exif = {"DateTimeOriginal": "2024:06:15 14:30:00", "SubSecTimeOriginal": "12345678"}
     ts = _extract_timestamp(exif)
     assert ts == "2024-06-15T14:30:00.123456"
+
+
+# --- Incremental rescan metadata_missing heuristic tests ---
+
+def _setup_scanned_photo(tmp_path, pil_size=(640, 480)):
+    """Create a JPEG, run a fresh scan, return (db, photo_id, image_path)."""
+    import scanner
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    image_path = os.path.join(root, "photo.jpg")
+    Image.new("RGB", pil_size, color="green").save(image_path, "JPEG")
+
+    db = Database(str(tmp_path / "test.db"))
+    # Mock ExifTool so the first scan populates exif_data with real
+    # dimensions, independent of whether exiftool is installed.
+    def fake_extract(paths, restricted_tags=None):
+        return {
+            p: {"File": {"ImageWidth": pil_size[0], "ImageHeight": pil_size[1]},
+                "EXIF": {}, "Composite": {}}
+            for p in paths
+        }
+    import metadata
+    original = metadata.extract_metadata
+    metadata.extract_metadata = fake_extract
+    scanner.extract_metadata = fake_extract
+    try:
+        scanner.scan(root, db)
+    finally:
+        metadata.extract_metadata = original
+        scanner.extract_metadata = original
+
+    row = db.conn.execute(
+        "SELECT id FROM photos WHERE filename='photo.jpg'"
+    ).fetchone()
+    return db, root, image_path, row["id"]
+
+
+def test_incremental_rescan_reextracts_when_timestamp_null(tmp_path, monkeypatch):
+    """Incremental scan re-processes a photo whose timestamp is NULL
+    and exif_data is NULL (existing behavior — regression guard)."""
+    import scanner
+
+    db, root, image_path, pid = _setup_scanned_photo(tmp_path)
+
+    # Simulate broken state: timestamp lost, dims wrong, exif_data cleared.
+    db.conn.execute(
+        "UPDATE photos SET timestamp=NULL, width=100, height=100, "
+        "exif_data=NULL WHERE id=?", (pid,)
+    )
+    db.conn.commit()
+
+    def fake_extract(paths, restricted_tags=None):
+        return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
+                    "EXIF": {}, "Composite": {}} for p in paths}
+    monkeypatch.setattr(scanner, "extract_metadata", fake_extract)
+
+    scanner.scan(root, db, incremental=True)
+
+    row = db.conn.execute(
+        "SELECT width, height, exif_data FROM photos WHERE id=?", (pid,)
+    ).fetchone()
+    assert row["width"] == 640  # repopulated from fake ExifTool
+    assert row["height"] == 480
+    assert row["exif_data"] is not None
+
+
+def test_incremental_rescan_reextracts_when_raw_dims_suspect(tmp_path, monkeypatch):
+    """Incremental scan re-processes a row where extension is RAW and
+    width < 1000 (the 160x120 embedded-thumb bug), even when timestamp
+    is populated — provided exif_data is NULL so the guard doesn't block."""
+    import scanner
+
+    db, root, image_path, pid = _setup_scanned_photo(tmp_path)
+
+    # Simulate broken state: fake RAW extension with thumbnail dims and
+    # populated timestamp. exif_data=NULL so the exif_extracted guard
+    # doesn't block re-extraction.
+    db.conn.execute(
+        "UPDATE photos SET extension='.nef', width=160, height=120, "
+        "timestamp='2020-01-01T12:00:00', exif_data=NULL WHERE id=?", (pid,)
+    )
+    db.conn.commit()
+
+    def fake_extract(paths, restricted_tags=None):
+        return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
+                    "EXIF": {}, "Composite": {}} for p in paths}
+    monkeypatch.setattr(scanner, "extract_metadata", fake_extract)
+
+    scanner.scan(root, db, incremental=True)
+
+    row = db.conn.execute(
+        "SELECT width, height, exif_data FROM photos WHERE id=?", (pid,)
+    ).fetchone()
+    assert row["width"] == 640
+    assert row["height"] == 480
+    assert row["exif_data"] is not None
+
+
+def test_incremental_rescan_skips_small_jpeg_dims_not_raw(tmp_path, monkeypatch):
+    """Incremental scan does NOT re-process a non-RAW row with suspicious
+    small dimensions. The dims heuristic is RAW-specific so JPEGs, PNGs,
+    etc. that are legitimately tiny aren't re-extracted repeatedly."""
+    import scanner
+
+    db, root, image_path, pid = _setup_scanned_photo(tmp_path)
+
+    # Simulate small-dims on a non-RAW extension; timestamp populated so
+    # the NULL-timestamp branch doesn't fire either.
+    db.conn.execute(
+        "UPDATE photos SET extension='.jpg', width=160, height=120, "
+        "timestamp='2020-01-01T12:00:00', exif_data=NULL WHERE id=?", (pid,)
+    )
+    db.conn.commit()
+
+    called_with = []
+    def fake_extract(paths, restricted_tags=None):
+        called_with.append(list(paths))
+        return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
+                    "EXIF": {}, "Composite": {}} for p in paths}
+    monkeypatch.setattr(scanner, "extract_metadata", fake_extract)
+
+    scanner.scan(root, db, incremental=True)
+
+    # width stays at the synthetic broken value because we didn't reprocess.
+    row = db.conn.execute(
+        "SELECT width, height FROM photos WHERE id=?", (pid,)
+    ).fetchone()
+    assert row["width"] == 160
+    assert row["height"] == 120
+    # And extract_metadata was never called with this file.
+    assert all(image_path not in batch for batch in called_with)
+
+
+def test_incremental_rescan_respects_exif_extracted_guard(tmp_path, monkeypatch):
+    """Incremental scan does NOT re-process a row when exif_data is
+    populated, even if the row otherwise looks broken. The guard prevents
+    retry loops on photos where ExifTool has already produced output
+    (e.g. files with genuinely missing EXIF timestamps)."""
+    import scanner
+
+    db, root, image_path, pid = _setup_scanned_photo(tmp_path)
+
+    # Broken-looking state, but exif_data is populated (ExifTool already
+    # ran once). Scanner must skip this row.
+    db.conn.execute(
+        "UPDATE photos SET extension='.nef', width=160, height=120, "
+        "timestamp='2020-01-01T12:00:00', "
+        "exif_data='{\"File\":{}}' WHERE id=?", (pid,)
+    )
+    db.conn.commit()
+
+    called_with = []
+    def fake_extract(paths, restricted_tags=None):
+        called_with.append(list(paths))
+        return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
+                    "EXIF": {}, "Composite": {}} for p in paths}
+    monkeypatch.setattr(scanner, "extract_metadata", fake_extract)
+
+    scanner.scan(root, db, incremental=True)
+
+    row = db.conn.execute(
+        "SELECT width, height FROM photos WHERE id=?", (pid,)
+    ).fetchone()
+    assert row["width"] == 160
+    assert row["height"] == 120
+    assert all(image_path not in batch for batch in called_with)


### PR DESCRIPTION
## Summary
- Pipeline runs against a collection now detect photos with broken EXIF metadata (NULL timestamp, or RAW photos stuck at the embedded JPEG thumbnail size) and transparently re-extract before downstream stages run. When nothing is broken the stage still reports "Skipped (using collection)" — behaviour is strictly additive.
- Root cause explained: missing timestamps cause `encounters.py` to treat every adjacent pair as `dt=inf`, tripping the hard-cut rule, so each affected photo became its own single-photo encounter. On the San Elijo Lagoon workspace this accounts for 1,510 of the 1,680 one-photo "encounters".
- Scanner's `metadata_missing` heuristic gains a RAW-dimension clause (width<1000px on a RAW extension) so the same repair flow catches the dimension-corruption variant, while the existing `exif_extracted` guard still prevents retry loops on genuinely EXIF-less files.

## Design doc
`docs/plans/2026-04-16-pipeline-metadata-repair-design.md` — captures the approach, detection rule, data flow, edge cases, and verification plan.

## Test plan
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_scanner.py -v` — 514 passed, 0 failed
- [x] New scanner tests (4) cover: NULL-timestamp regression guard, RAW dims-suspect triggers reprocess, non-RAW small dims stay skipped, exif_extracted guard holds
- [x] New pipeline tests (8) cover: helper unit tests (empty/null-timestamp/raw-dims/out-of-scope/grouped-folder), healthy collection still skips scan, broken collection repairs metadata end-to-end, unreachable folder handled gracefully
- [ ] Manual verification on the San Elijo Lagoon workspace (ws4): rerun pipeline, confirm broken-photo count drops from 1,510 to ≤7 and encounter count drops accordingly

## Files touched
- `vireo/scanner.py` — 5-line heuristic extension in `metadata_missing`
- `vireo/pipeline_job.py` — new `_find_broken_metadata_folders` helper, replacement of the `skip_scan` early-return with targeted repair logic
- `vireo/tests/test_scanner.py` — 4 new tests
- `vireo/tests/test_jobs_api.py` — 8 new tests
- `docs/plans/2026-04-16-pipeline-metadata-repair-design.md` — design doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)