### PR TITLE
feat: user-first testing harness (PR #1: safety + sweep mode)

### DIFF
--- a/scripts/build_test_photos.py
+++ b/scripts/build_test_photos.py
@@ -69,10 +69,28 @@ def has_gps(path):
 
 
 def find_duplicates(files):
-    """Return a list of (hash, [paths]) groups where len(paths) > 1."""
-    groups = defaultdict(list)
+    """Return a list of (hash, [paths]) groups where len(paths) > 1.
+
+    Hashes only files that share a size with at least one other file, so this
+    stays fast across full libraries (tens of thousands of photos) while still
+    surfacing duplicate pairs that would otherwise be missed by a leading-prefix
+    scan.
+    """
+    by_size = defaultdict(list)
     for f in files:
-        groups[content_hash(f)].append(f)
+        try:
+            by_size[f.stat().st_size].append(f)
+        except OSError:
+            continue
+    groups = defaultdict(list)
+    for same_size in by_size.values():
+        if len(same_size) < 2:
+            continue
+        for f in same_size:
+            try:
+                groups[content_hash(f)].append(f)
+            except OSError:
+                continue
     return [(h, paths) for h, paths in groups.items() if len(paths) > 1]
 
 
@@ -165,8 +183,12 @@ def sample(source, dest, counts=None, dry_run=False):
             elif gps is False:
                 gps_no.append(f)
 
-    burst = find_burst(all_files[:500])[:5]
-    dups = find_duplicates(all_files[:500])
+    # Scan the full set (not a leading 500-file slice) so burst runs and
+    # duplicate pairs later in a large library aren't silently dropped —
+    # otherwise `duplicates=0` can appear even when the library has obvious
+    # dup pairs, and the burst pick becomes unrepresentative.
+    burst = find_burst(all_files)[:5]
+    dups = find_duplicates(all_files)
     dup_pair = dups[0][1][:2] if dups else []
 
     picks = {

--- a/scripts/build_test_photos.py
+++ b/scripts/build_test_photos.py
@@ -165,6 +165,14 @@ def sample(source, dest, counts=None, dry_run=False):
             copied[category] = []
             for src in files:
                 tgt = cat_dir / src.name
+                # If something's already at the base name, only treat it as the
+                # same file when the contents actually match — otherwise two
+                # distinct sources with the same basename (e.g. repeated
+                # IMG_0001.jpg) would collapse into one destination and be
+                # miscounted in the manifest. Disambiguate with a content-hash
+                # suffix so each source gets its own deterministic target.
+                if tgt.exists() and content_hash(tgt) != content_hash(src):
+                    tgt = cat_dir / f"{src.stem}-{content_hash(src)[:8]}{src.suffix}"
                 if tgt.exists():
                     copied[category].append(tgt)
                     continue

--- a/scripts/build_test_photos.py
+++ b/scripts/build_test_photos.py
@@ -127,6 +127,11 @@ def sample(source, dest, counts=None, dry_run=False):
             p = Path(root) / name
             if classify_ext(p) != "skip":
                 all_files.append(p)
+    # Sort so downstream category slicing and the copy loop see the same order
+    # on every run. Without this, os.walk's order variance would flip which
+    # same-basename source gets the original name vs. the hashed one, so a
+    # second run would create a third file and break idempotency.
+    all_files.sort()
 
     gps_yes, gps_no, raws, jpegs = [], [], [], []
     for f in all_files:

--- a/scripts/build_test_photos.py
+++ b/scripts/build_test_photos.py
@@ -117,6 +117,12 @@ def sample(source, dest, counts=None, dry_run=False):
     source = Path(source).expanduser().resolve()
     dest = _safe_dest(dest)
 
+    # dest == source would make every category subdir a child of the walk root,
+    # so the dirs[:]-filter below would never exclude them and a rerun would
+    # re-ingest its own outputs into the real source library. Reject up front.
+    if dest == source:
+        sys.exit(f"refusing to use source as destination: {dest}")
+
     counts = counts or {
         "gps_yes": 10, "gps_no": 10, "raws": 10, "jpegs": 10, "random": 50,
     }

--- a/scripts/build_test_photos.py
+++ b/scripts/build_test_photos.py
@@ -115,6 +115,11 @@ def sample(source, dest, counts=None, dry_run=False):
     Returns a dict summarizing what was copied.
     """
     source = Path(source).expanduser().resolve()
+    # os.walk on a missing path yields no entries, so without this guard a typo
+    # in --source looks like a successful run with all-zero counts and an empty
+    # dataset — which quietly invalidates every downstream user-first test.
+    if not source.is_dir():
+        sys.exit(f"source does not exist or is not a directory: {source}")
     dest = _safe_dest(dest)
 
     # dest == source would make every category subdir a child of the walk root,

--- a/scripts/build_test_photos.py
+++ b/scripts/build_test_photos.py
@@ -163,21 +163,28 @@ def sample(source, dest, counts=None, dry_run=False):
             cat_dir = dest / category
             cat_dir.mkdir(exist_ok=True)
             copied[category] = []
+            # Track basenames already claimed by another source in this run so
+            # two sources with the same name never collapse into one physical
+            # file — including when contents are identical (which is exactly
+            # what the "duplicates" scenario needs: two real files on disk).
+            claimed = set()
             for src in files:
                 tgt = cat_dir / src.name
-                # If something's already at the base name, only treat it as the
-                # same file when the contents actually match — otherwise two
-                # distinct sources with the same basename (e.g. repeated
-                # IMG_0001.jpg) would collapse into one destination and be
-                # miscounted in the manifest. Disambiguate with a content-hash
-                # suffix so each source gets its own deterministic target.
-                if tgt.exists() and content_hash(tgt) != content_hash(src):
-                    tgt = cat_dir / f"{src.stem}-{content_hash(src)[:8]}{src.suffix}"
+                src_path_hash = hashlib.md5(str(src).encode()).hexdigest()[:8]
+                disambiguated = cat_dir / f"{src.stem}-{src_path_hash}{src.suffix}"
+                if tgt in claimed:
+                    # Another source already took this basename this run.
+                    tgt = disambiguated
+                elif tgt.exists() and content_hash(tgt) != content_hash(src):
+                    # A prior run wrote a different source to this basename.
+                    tgt = disambiguated
                 if tgt.exists():
                     copied[category].append(tgt)
+                    claimed.add(tgt)
                     continue
                 shutil.copy2(src, tgt)
                 copied[category].append(tgt)
+                claimed.add(tgt)
 
         manifest = dest / "MANIFEST.md"
         lines = [

--- a/scripts/build_test_photos.py
+++ b/scripts/build_test_photos.py
@@ -1,0 +1,203 @@
+"""Sample a small test photo set from the user's real library.
+
+Usage:
+    python scripts/build_test_photos.py --source /path/to/real/photos \\
+        --dest ~/vireo-test-photos
+
+Writes ~100 photos into `dest` with a mix intended to exercise the 9 first-cut
+user-first scenarios: GPS/no-GPS for map, burst for cull, duplicates for
+resolver, mix of RAW/JPEG, variety for pagination.
+
+Only ever *reads* the source and only ever *writes* under the destination.
+Idempotent: re-running skips files already present.
+"""
+import argparse
+import hashlib
+import os
+import shutil
+import sys
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+RAW_EXTS = {".cr2", ".cr3", ".nef", ".arw", ".dng", ".raf", ".orf", ".rw2"}
+JPEG_EXTS = {".jpg", ".jpeg"}
+IMAGE_EXTS = RAW_EXTS | JPEG_EXTS | {".tif", ".tiff", ".png"}
+
+
+def classify_ext(path):
+    ext = path.suffix.lower()
+    if ext in RAW_EXTS:
+        return "raw"
+    if ext in JPEG_EXTS:
+        return "jpeg"
+    return "other" if ext in IMAGE_EXTS else "skip"
+
+
+def content_hash(path, chunk_size=65536):
+    h = hashlib.md5()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def has_gps(path):
+    """Best-effort GPS-EXIF check. Returns None when we can't tell."""
+    try:
+        from PIL import ExifTags, Image
+    except ImportError:
+        return None
+    try:
+        with Image.open(path) as im:
+            exif = im.getexif()
+            if not exif:
+                return False
+            # GPSInfo tag is 34853
+            gps_tag = next(
+                (k for k, v in ExifTags.TAGS.items() if v == "GPSInfo"), 34853
+            )
+            gps = exif.get_ifd(gps_tag) if hasattr(exif, "get_ifd") else exif.get(gps_tag)
+            if not gps:
+                return False
+            return 2 in gps and 4 in gps
+    except Exception:
+        return None
+
+
+def find_duplicates(files):
+    """Return a list of (hash, [paths]) groups where len(paths) > 1."""
+    groups = defaultdict(list)
+    for f in files:
+        groups[content_hash(f)].append(f)
+    return [(h, paths) for h, paths in groups.items() if len(paths) > 1]
+
+
+def find_burst(files, window_seconds=2):
+    """Return the longest run of files whose mtimes are within `window_seconds`."""
+    sorted_files = sorted(files, key=lambda p: p.stat().st_mtime)
+    best_run = []
+    current = []
+    last_mtime = None
+    for f in sorted_files:
+        m = f.stat().st_mtime
+        if last_mtime is not None and m - last_mtime <= window_seconds:
+            current.append(f)
+        else:
+            current = [f]
+        if len(current) > len(best_run):
+            best_run = current[:]
+        last_mtime = m
+    return best_run
+
+
+def _safe_dest(dest):
+    """Validate destination is not inside ~/.vireo/ or $HOME."""
+    dest = Path(dest).expanduser().resolve()
+    home = Path.home().resolve()
+    if dest == home:
+        sys.exit(f"refusing to write to $HOME: {dest}")
+    real_vireo = (home / ".vireo").resolve()
+    try:
+        dest.relative_to(real_vireo)
+        sys.exit(f"refusing to write under ~/.vireo/: {dest}")
+    except ValueError:
+        pass
+    return dest
+
+
+def sample(source, dest, counts=None, dry_run=False):
+    """Walk `source`, pick a representative subset, copy to `dest`.
+
+    Returns a dict summarizing what was copied.
+    """
+    source = Path(source).expanduser().resolve()
+    dest = _safe_dest(dest)
+
+    counts = counts or {
+        "gps_yes": 10, "gps_no": 10, "raws": 10, "jpegs": 10, "random": 50,
+    }
+
+    all_files = []
+    for root, _, filenames in os.walk(source):
+        for name in filenames:
+            p = Path(root) / name
+            if classify_ext(p) != "skip":
+                all_files.append(p)
+
+    gps_yes, gps_no, raws, jpegs = [], [], [], []
+    for f in all_files:
+        cls = classify_ext(f)
+        if cls == "raw":
+            raws.append(f)
+        elif cls == "jpeg":
+            jpegs.append(f)
+        if cls == "jpeg":
+            gps = has_gps(f)
+            if gps is True:
+                gps_yes.append(f)
+            elif gps is False:
+                gps_no.append(f)
+
+    burst = find_burst(all_files[:500])[:5]
+    dups = find_duplicates(all_files[:500])
+    dup_pair = dups[0][1][:2] if dups else []
+
+    picks = {
+        "gps_yes": gps_yes[: counts["gps_yes"]],
+        "gps_no": gps_no[: counts["gps_no"]],
+        "raws": raws[: counts["raws"]],
+        "jpegs": jpegs[: counts["jpegs"]],
+        "burst": burst,
+        "duplicates": dup_pair,
+        "random": all_files[: counts["random"]],
+    }
+
+    copied = {}
+    if not dry_run:
+        dest.mkdir(parents=True, exist_ok=True)
+        for category, files in picks.items():
+            cat_dir = dest / category
+            cat_dir.mkdir(exist_ok=True)
+            copied[category] = []
+            for src in files:
+                tgt = cat_dir / src.name
+                if tgt.exists():
+                    copied[category].append(tgt)
+                    continue
+                shutil.copy2(src, tgt)
+                copied[category].append(tgt)
+
+        manifest = dest / "MANIFEST.md"
+        lines = [
+            f"# Vireo test photo set — built {datetime.now().isoformat()}",
+            f"Source: `{source}`",
+            "",
+        ]
+        for category, files in copied.items():
+            lines.append(f"## {category} ({len(files)} files)")
+            for f in files:
+                lines.append(f"- {f.relative_to(dest)}")
+            lines.append("")
+        manifest.write_text("\n".join(lines))
+
+    return {k: len(v) for k, v in picks.items()}
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--source", required=True, help="Real photo library root")
+    p.add_argument("--dest", default="~/vireo-test-photos", help="Destination directory")
+    p.add_argument("--dry-run", action="store_true", help="Report picks without copying")
+    args = p.parse_args()
+    result = sample(args.source, args.dest, dry_run=args.dry_run)
+    print("Picks:")
+    for k, v in result.items():
+        print(f"  {k}: {v}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_test_photos.py
+++ b/scripts/build_test_photos.py
@@ -122,7 +122,14 @@ def sample(source, dest, counts=None, dry_run=False):
     }
 
     all_files = []
-    for root, _, filenames in os.walk(source):
+    for root, dirs, filenames in os.walk(source):
+        # If dest lives inside source (e.g. `--dest <source>/vireo-test-photos`),
+        # skip it so a second run doesn't re-ingest its own outputs and grow
+        # the sampled set unboundedly — breaking idempotency.
+        root_path = Path(root).resolve()
+        dirs[:] = [
+            d for d in dirs if (root_path / d).resolve() != dest
+        ]
         for name in filenames:
             p = Path(root) / name
             if classify_ext(p) != "skip":

--- a/vireo/testing/userfirst/__init__.py
+++ b/vireo/testing/userfirst/__init__.py
@@ -1,0 +1,6 @@
+"""User-first testing harness.
+
+Drives a running Vireo instance via Playwright and reports observed
+behavior (console errors, failed requests, visible DOM state) rather
+than inferring behavior from code.
+"""

--- a/vireo/testing/userfirst/harness.py
+++ b/vireo/testing/userfirst/harness.py
@@ -215,7 +215,10 @@ def vireo_session(name="session", startup_timeout=30.0, keep_runs=20):
     run_dir.mkdir(parents=True)
 
     port = _free_port()
-    base_url = f"http://localhost:{port}"
+    # Flask binds to 127.0.0.1 (see app.py); using the literal IPv4 address
+    # instead of `localhost` avoids environments where `localhost` resolves to
+    # IPv6 (`::1`) first and the health probe/navigation hits the wrong stack.
+    base_url = f"http://127.0.0.1:{port}"
     log_file = run_dir / "app.log"
 
     # Subprocess gets a fake HOME inside the profile so all ~/.vireo/* paths

--- a/vireo/testing/userfirst/harness.py
+++ b/vireo/testing/userfirst/harness.py
@@ -18,6 +18,7 @@ from .profile import (
     resolve_photos_root,
     resolve_profile,
     validate_db_folders,
+    validate_profile_tree,
 )
 from .report import Finding, Report
 
@@ -201,6 +202,10 @@ def vireo_session(name="session", startup_timeout=30.0, keep_runs=20):
       - `playwright` installed with Chromium browsers
     """
     profile = resolve_profile()
+    # Reject any pre-existing symlink inside the profile that points outside
+    # it (e.g. `<profile>/vireo.db -> ~/.vireo/vireo.db`) before creating any
+    # subdirectories — otherwise the mkdir below would write through the link.
+    validate_profile_tree(profile)
     photos_root = resolve_photos_root()
     paths = profile_paths(profile)
 
@@ -266,5 +271,10 @@ def vireo_session(name="session", startup_timeout=30.0, keep_runs=20):
                 proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 proc.kill()
+                # Reap the killed child so it doesn't linger as a zombie —
+                # repeated timeouts across sessions would otherwise leak
+                # defunct processes.
+                with contextlib.suppress(subprocess.TimeoutExpired, OSError):
+                    proc.wait(timeout=5)
         log_fh.close()
         _prune_runs(paths["runs"], keep=keep_runs)

--- a/vireo/testing/userfirst/harness.py
+++ b/vireo/testing/userfirst/harness.py
@@ -1,0 +1,262 @@
+"""User-first testing harness — runs Vireo in a subprocess, drives it via Playwright."""
+import contextlib
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+from .profile import (
+    profile_paths,
+    resolve_photos_root,
+    resolve_profile,
+    validate_db_folders,
+)
+from .report import Finding, Report
+
+_APP_PY = (Path(__file__).parent.parent.parent / "app.py").resolve()
+
+
+def _free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _new_run_id():
+    return datetime.now().strftime("%Y%m%d-%H%M%S-%f-") + uuid.uuid4().hex[:4]
+
+
+def _prune_runs(runs_dir, keep):
+    runs_dir = Path(runs_dir)
+    if not runs_dir.exists():
+        return
+    entries = sorted(p for p in runs_dir.iterdir() if p.is_dir())
+    for old in entries[:-keep]:
+        shutil.rmtree(old, ignore_errors=True)
+
+
+def _relative_url_same_origin(url, origin):
+    """Return the path+query of `url` if it shares origin with `origin`, else None."""
+    u, o = urlparse(url), urlparse(origin)
+    if (u.scheme, u.hostname, u.port) != (o.scheme, o.hostname, o.port):
+        return None
+    path = u.path
+    if u.query:
+        path += "?" + u.query
+    return path
+
+
+def _wait_for_health(base_url, timeout=30.0):
+    deadline = time.time() + timeout
+    last_err = None
+    while time.time() < deadline:
+        try:
+            with urlopen(f"{base_url}/api/health", timeout=1) as r:
+                if r.status == 200:
+                    return
+        except Exception as e:
+            last_err = e
+        time.sleep(0.1)
+    raise RuntimeError(f"server at {base_url} not healthy in {timeout}s (last: {last_err})")
+
+
+def _start_app(paths, port, log_file, fake_home):
+    env = os.environ.copy()
+    # Isolate the subprocess from the user's real ~/.vireo/ — this redirects
+    # config, logs, models, masks, and any other ~/.vireo/* reads/writes.
+    env["HOME"] = str(fake_home)
+    cmd = [
+        sys.executable,
+        str(_APP_PY),
+        "--db", str(paths["db"]),
+        "--thumb-dir", str(paths["thumbnails"]),
+        "--port", str(port),
+        "--no-browser",
+    ]
+    # The log handle must outlive this function — it's closed on session exit.
+    log = open(log_file, "wb")  # noqa: SIM115 — closed in vireo_session()
+    return subprocess.Popen(cmd, env=env, stdout=log, stderr=subprocess.STDOUT), log
+
+
+class VireoSession:
+    """User-first testing session — wraps a Playwright page with instrumentation."""
+
+    def __init__(self, base_url, page, report, run_dir):
+        self.base_url = base_url
+        self.page = page
+        self.report = report
+        self.run_dir = Path(run_dir)
+        (self.run_dir / "screens").mkdir(parents=True, exist_ok=True)
+        self._screen_counter = 0
+        self._wire_listeners()
+
+    def _wire_listeners(self):
+        def on_console(msg):
+            if msg.type in ("error", "warning"):
+                kind = Finding.bug if msg.type == "error" else Finding.warn
+                text = msg.text
+                # Filter out resource-load 404s — those are captured via requestfailed/response
+                if "Failed to load resource" in text:
+                    return
+                self.report.add(kind(f"console.{msg.type}: {text}"))
+
+        def on_response(resp):
+            rel = _relative_url_same_origin(resp.url, self.base_url)
+            if rel is None:
+                return
+            if resp.status >= 400:
+                self.report.add(
+                    Finding.bug(
+                        f"HTTP {resp.status} on same-origin request",
+                        url=rel,
+                        method=resp.request.method,
+                    )
+                )
+
+        def on_requestfailed(req):
+            rel = _relative_url_same_origin(req.url, self.base_url)
+            if rel is None:
+                return
+            self.report.add(
+                Finding.bug(
+                    f"request failed: {req.failure}",
+                    url=rel,
+                    method=req.method,
+                )
+            )
+
+        self.page.on("console", on_console)
+        self.page.on("response", on_response)
+        self.page.on("requestfailed", on_requestfailed)
+
+    def goto(self, path, wait_until="networkidle", timeout=20000):
+        url = self.base_url + path
+        t0 = time.time()
+        try:
+            resp = self.page.goto(url, wait_until=wait_until, timeout=timeout)
+        except Exception as e:
+            self.report.record_step(f"goto {path}", status=None, elapsed_ms=None, error=str(e))
+            self.report.add(Finding.bug(f"goto failed: {e}", url=path))
+            return None
+        elapsed_ms = int((time.time() - t0) * 1000)
+        status = resp.status if resp else None
+        self.report.record_step(f"goto {path}", status=status, elapsed_ms=elapsed_ms)
+        if elapsed_ms > 5000:
+            self.report.add(Finding.perf(f"slow page load: {elapsed_ms}ms", url=path))
+        return resp
+
+    def click(self, selector, timeout=5000):
+        try:
+            self.page.click(selector, timeout=timeout)
+            self.report.record_step(f"click {selector}")
+        except Exception as e:
+            self.report.record_step(f"click {selector}", error=str(e))
+            self.report.add(Finding.bug(f"click failed: {e}", selector=selector))
+
+    def fill(self, selector, text, timeout=5000):
+        try:
+            self.page.fill(selector, text, timeout=timeout)
+            self.report.record_step(f"fill {selector!r}")
+        except Exception as e:
+            self.report.record_step(f"fill {selector}", error=str(e))
+            self.report.add(Finding.bug(f"fill failed: {e}", selector=selector))
+
+    def eval(self, js):
+        return self.page.evaluate(js)
+
+    def screenshot(self, label):
+        self._screen_counter += 1
+        name = f"{self._screen_counter:02d}-{label}.png"
+        path = self.run_dir / "screens" / name
+        try:
+            self.page.screenshot(path=str(path), full_page=False)
+            self.report.add_screenshot(path)
+        except Exception as e:
+            self.report.record_step(f"screenshot {label}", error=str(e))
+
+    def assert_that(self, cond, msg, **ctx):
+        """Soft assert — records a BUG finding, does not abort."""
+        if not cond:
+            self.report.add(Finding.bug(f"assertion failed: {msg}", **ctx))
+
+    def flag_suspect(self, message, **ctx):
+        self.report.add(Finding.suspect(message, **ctx))
+
+
+@contextmanager
+def vireo_session(name="session", startup_timeout=30.0, keep_runs=20):
+    """Start Vireo against the test profile + launch Playwright; yield a session.
+
+    Requires:
+      - VIREO_PROFILE env var set to a safe test directory
+      - optionally, VIREO_TEST_PHOTOS set for photo-folder validation
+      - `playwright` installed with Chromium browsers
+    """
+    profile = resolve_profile()
+    photos_root = resolve_photos_root()
+    paths = profile_paths(profile)
+
+    profile.mkdir(parents=True, exist_ok=True)
+    paths["thumbnails"].mkdir(parents=True, exist_ok=True)
+    paths["runs"].mkdir(parents=True, exist_ok=True)
+
+    validate_db_folders(paths["db"], photos_root)
+
+    run_id = _new_run_id()
+    run_dir = paths["runs"] / run_id
+    run_dir.mkdir(parents=True)
+
+    port = _free_port()
+    base_url = f"http://localhost:{port}"
+    log_file = run_dir / "app.log"
+
+    # Subprocess gets a fake HOME inside the profile so all ~/.vireo/* paths
+    # resolve to <profile>/fake_home/.vireo/* — isolated from real data.
+    fake_home = profile / "fake_home"
+    (fake_home / ".vireo").mkdir(parents=True, exist_ok=True)
+
+    proc, log_fh = _start_app(paths, port, log_file, fake_home)
+    print(f"USER-FIRST TEST MODE — profile={profile}, photos={photos_root}, port={port}")
+    started = time.time()
+
+    browser = pw = ctx = page = None
+    try:
+        _wait_for_health(base_url, timeout=startup_timeout)
+
+        from playwright.sync_api import sync_playwright
+        pw = sync_playwright().start()
+        browser = pw.chromium.launch()
+        ctx = browser.new_context(viewport={"width": 1440, "height": 900})
+        page = ctx.new_page()
+
+        report = Report(name=name)
+        session = VireoSession(base_url, page, report, run_dir)
+        yield session
+
+        report.duration_s = time.time() - started
+        report.write_json(run_dir / "findings.json")
+        report.write_markdown(run_dir / "report.md")
+    finally:
+        for close in (
+            lambda: ctx and ctx.close(),
+            lambda: browser and browser.close(),
+            lambda: pw and pw.stop(),
+        ):
+            with contextlib.suppress(Exception):
+                close()
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        log_fh.close()
+        _prune_runs(paths["runs"], keep=keep_runs)

--- a/vireo/testing/userfirst/harness.py
+++ b/vireo/testing/userfirst/harness.py
@@ -228,6 +228,7 @@ def vireo_session(name="session", startup_timeout=30.0, keep_runs=20):
     started = time.time()
 
     browser = pw = ctx = page = None
+    report = None
     try:
         _wait_for_health(base_url, timeout=startup_timeout)
 
@@ -240,11 +241,15 @@ def vireo_session(name="session", startup_timeout=30.0, keep_runs=20):
         report = Report(name=name)
         session = VireoSession(base_url, page, report, run_dir)
         yield session
-
-        report.duration_s = time.time() - started
-        report.write_json(run_dir / "findings.json")
-        report.write_markdown(run_dir / "report.md")
     finally:
+        # Persist the report even when the session body raises — otherwise
+        # findings and screenshots from a crashed scenario are silently lost.
+        if report is not None:
+            report.duration_s = time.time() - started
+            with contextlib.suppress(Exception):
+                report.write_json(run_dir / "findings.json")
+            with contextlib.suppress(Exception):
+                report.write_markdown(run_dir / "report.md")
         for close in (
             lambda: ctx and ctx.close(),
             lambda: browser and browser.close(),

--- a/vireo/testing/userfirst/profile.py
+++ b/vireo/testing/userfirst/profile.py
@@ -1,0 +1,97 @@
+"""Test-profile path resolution and safety guard.
+
+The guard refuses to start the harness against real data. Violations
+are hard errors (`UnsafeProfileError`), never warnings.
+"""
+import os
+import sqlite3
+from pathlib import Path
+
+
+class UnsafeProfileError(RuntimeError):
+    """The configured profile would touch real data."""
+
+
+def _reject_if_unsafe(path, env_name):
+    home = Path.home().resolve()
+    if path == home:
+        raise UnsafeProfileError(f"{env_name} cannot be $HOME: {path}")
+    real_vireo = (home / ".vireo").resolve()
+    if path == real_vireo:
+        raise UnsafeProfileError(f"{env_name} cannot be ~/.vireo/: {path}")
+    try:
+        path.relative_to(real_vireo)
+    except ValueError:
+        return
+    raise UnsafeProfileError(f"{env_name} cannot be under ~/.vireo/: {path}")
+
+
+def resolve_profile():
+    """Resolve and validate the test profile path from VIREO_PROFILE.
+
+    Raises UnsafeProfileError if the env var is unset or points at real data.
+    """
+    raw = os.environ.get("VIREO_PROFILE")
+    if not raw:
+        raise UnsafeProfileError(
+            "VIREO_PROFILE is not set — the harness refuses to start without "
+            "an explicit test profile directory"
+        )
+    path = Path(raw).expanduser().resolve()
+    _reject_if_unsafe(path, "VIREO_PROFILE")
+    return path
+
+
+def resolve_photos_root():
+    """Resolve and validate the test photos root from VIREO_TEST_PHOTOS.
+
+    Returns None if unset (photo-folder validation is skipped).
+    Raises UnsafeProfileError if set but unsafe.
+    """
+    raw = os.environ.get("VIREO_TEST_PHOTOS")
+    if not raw:
+        return None
+    path = Path(raw).expanduser().resolve()
+    _reject_if_unsafe(path, "VIREO_TEST_PHOTOS")
+    return path
+
+
+def profile_paths(profile_dir):
+    """Standard paths under a profile directory."""
+    p = Path(profile_dir)
+    return {
+        "db": p / "vireo.db",
+        "thumbnails": p / "thumbnails",
+        "labels": p / "labels",
+        "config": p / "config.json",
+        "runs": p / "runs",
+    }
+
+
+def validate_db_folders(db_path, photos_root):
+    """Ensure every folder in the DB lives under `photos_root`.
+
+    No-op if `photos_root` is None. Raises UnsafeProfileError on violation.
+    """
+    if photos_root is None:
+        return
+    photos_root = Path(photos_root).resolve()
+    conn = sqlite3.connect(str(db_path))
+    try:
+        try:
+            cur = conn.execute("SELECT path FROM folders")
+        except sqlite3.OperationalError:
+            return
+        for (path_str,) in cur:
+            if not path_str:
+                continue
+            folder = Path(path_str).expanduser().resolve()
+            try:
+                folder.relative_to(photos_root)
+            except ValueError as err:
+                raise UnsafeProfileError(
+                    f"DB references folder outside photos root: {folder} "
+                    f"(allowed root: {photos_root})"
+                ) from err
+    finally:
+        conn.close()

--- a/vireo/testing/userfirst/profile.py
+++ b/vireo/testing/userfirst/profile.py
@@ -68,6 +68,33 @@ def profile_paths(profile_dir):
     }
 
 
+def validate_profile_tree(profile_dir):
+    """Reject any entry under `profile_dir` that symlinks outside it.
+
+    `resolve_profile()` only checks the profile directory path itself. Without
+    this walk, a child like `<profile>/vireo.db -> ~/.vireo/vireo.db` would
+    still pass the outer guard and let the harness read/write real data via
+    the symlink. Every symlink in the tree must resolve to a target inside
+    the profile, or the harness refuses to start.
+    """
+    profile = Path(profile_dir).resolve()
+    if not profile.exists():
+        return
+    for root, dirs, files in os.walk(profile, followlinks=False):
+        root_path = Path(root)
+        for name in list(dirs) + list(files):
+            entry = root_path / name
+            if not entry.is_symlink():
+                continue
+            target = Path(os.path.realpath(entry))
+            try:
+                target.relative_to(profile)
+            except ValueError as err:
+                raise UnsafeProfileError(
+                    f"symlink inside profile escapes it: {entry} -> {target}"
+                ) from err
+
+
 def validate_db_folders(db_path, photos_root):
     """Ensure every folder in the DB lives under `photos_root`.
 

--- a/vireo/testing/userfirst/report.py
+++ b/vireo/testing/userfirst/report.py
@@ -1,0 +1,118 @@
+"""Findings and report formatting for user-first testing runs."""
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+FINDING_KINDS = ("BUG", "SUSPECT", "PERF", "WARN")
+
+
+@dataclass
+class Finding:
+    kind: str
+    message: str
+    context: dict = field(default_factory=dict)
+
+    @classmethod
+    def bug(cls, message, **ctx):
+        return cls("BUG", message, ctx)
+
+    @classmethod
+    def suspect(cls, message, **ctx):
+        return cls("SUSPECT", message, ctx)
+
+    @classmethod
+    def perf(cls, message, **ctx):
+        return cls("PERF", message, ctx)
+
+    @classmethod
+    def warn(cls, message, **ctx):
+        return cls("WARN", message, ctx)
+
+    def to_dict(self):
+        return {"kind": self.kind, "message": self.message, "context": self.context}
+
+
+class Report:
+    def __init__(self, name):
+        self.name = name
+        self.findings: list[Finding] = []
+        self.steps: list[dict[str, Any]] = []
+        self.screenshots: list[Path] = []
+        self.duration_s: float = 0.0
+
+    def add(self, finding):
+        self.findings.append(finding)
+
+    def record_step(self, action, status=None, elapsed_ms=None, **extra):
+        step = {"action": action, "status": status, "elapsed_ms": elapsed_ms}
+        step.update(extra)
+        self.steps.append(step)
+
+    def add_screenshot(self, path):
+        self.screenshots.append(Path(path))
+
+    def counts(self):
+        c = {k: 0 for k in FINDING_KINDS}
+        for f in self.findings:
+            c[f.kind] = c.get(f.kind, 0) + 1
+        return c
+
+    def has_bugs(self):
+        return any(f.kind == "BUG" for f in self.findings)
+
+    def to_markdown(self):
+        counts = self.counts()
+        header = (
+            f"## User-first run — {self.name}\n"
+            f"**Result:** "
+            + ", ".join(f"{counts[k]} {k}" for k in FINDING_KINDS)
+            + f"\n**Duration:** {self.duration_s:.1f}s\n"
+        )
+
+        lines = [header]
+
+        if self.findings:
+            lines.append("### Findings\n")
+            for f in self.findings:
+                ctx = (
+                    " (" + ", ".join(f"{k}={v}" for k, v in f.context.items()) + ")"
+                    if f.context
+                    else ""
+                )
+                lines.append(f"- [{f.kind}] {f.message}{ctx}")
+            lines.append("")
+
+        if self.steps:
+            lines.append("### Steps")
+            for i, s in enumerate(self.steps, 1):
+                status = f" → {s['status']}" if s.get("status") is not None else ""
+                elapsed = (
+                    f" ({s['elapsed_ms']}ms)" if s.get("elapsed_ms") is not None else ""
+                )
+                lines.append(f"{i}. {s['action']}{status}{elapsed}")
+            lines.append("")
+
+        if self.screenshots:
+            lines.append("### Screenshots")
+            for s in self.screenshots:
+                lines.append(f"- {s.name}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def to_dict(self):
+        return {
+            "name": self.name,
+            "duration_s": self.duration_s,
+            "counts": self.counts(),
+            "findings": [f.to_dict() for f in self.findings],
+            "steps": self.steps,
+            "screenshots": [str(s) for s in self.screenshots],
+        }
+
+    def write_json(self, path):
+        Path(path).write_text(json.dumps(self.to_dict(), indent=2, default=str))
+
+    def write_markdown(self, path):
+        Path(path).write_text(self.to_markdown())

--- a/vireo/testing/userfirst/sweep.py
+++ b/vireo/testing/userfirst/sweep.py
@@ -36,11 +36,16 @@ def run_sweep(session, pages=None):
     """Visit each page in `pages`, capture findings on every one.
 
     Returns the session's report (same one that's mutated during the run).
+
+    Uses `wait_until="load"` instead of the default `networkidle`: some pages
+    (e.g. `/logs`) open a long-lived `EventSource` on load, which means the
+    network never goes idle and `networkidle` would time out and record a
+    false BUG finding for an otherwise-healthy page.
     """
     if pages is None:
         pages = DEFAULT_PAGES
     for path in pages:
         label = path.strip("/").replace("/", "_") or "root"
-        session.goto(path)
+        session.goto(path, wait_until="load")
         session.screenshot(f"sweep-{label}")
     return session.report

--- a/vireo/testing/userfirst/sweep.py
+++ b/vireo/testing/userfirst/sweep.py
@@ -1,0 +1,44 @@
+"""Generic route-walker for user-first testing.
+
+Visits every registered page route, captures console/network errors and a
+screenshot per page. Finds the "missing static asset" / "broken wire"
+class of bug that code review can't see.
+"""
+
+# Ordered page routes — only user-facing pages, no /api/* or /<int:id>.
+DEFAULT_PAGES = [
+    "/",
+    "/welcome",
+    "/browse",
+    "/review",
+    "/lightroom",
+    "/audit",
+    "/cull",
+    "/pipeline",
+    "/pipeline/review",
+    "/variants",
+    "/workspace",
+    "/compare",
+    "/settings",
+    "/shortcuts",
+    "/keywords",
+    "/jobs",
+    "/duplicates",
+    "/move",
+    "/highlights",
+    "/map",
+]
+
+
+def run_sweep(session, pages=None):
+    """Visit each page in `pages`, capture findings on every one.
+
+    Returns the session's report (same one that's mutated during the run).
+    """
+    if pages is None:
+        pages = DEFAULT_PAGES
+    for path in pages:
+        label = path.strip("/").replace("/", "_") or "root"
+        session.goto(path)
+        session.screenshot(f"sweep-{label}")
+    return session.report

--- a/vireo/testing/userfirst/sweep.py
+++ b/vireo/testing/userfirst/sweep.py
@@ -28,6 +28,7 @@ DEFAULT_PAGES = [
     "/move",
     "/highlights",
     "/map",
+    "/logs",
 ]
 
 

--- a/vireo/testing/userfirst/sweep.py
+++ b/vireo/testing/userfirst/sweep.py
@@ -9,6 +9,7 @@ class of bug that code review can't see.
 DEFAULT_PAGES = [
     "/",
     "/welcome",
+    "/dashboard",
     "/browse",
     "/review",
     "/lightroom",

--- a/vireo/tests/test_build_test_photos.py
+++ b/vireo/tests/test_build_test_photos.py
@@ -213,6 +213,21 @@ def test_sample_idempotent_under_reversed_walk_order(tmp_path, monkeypatch):
     )
 
 
+def test_sample_rejects_source_equals_dest(tmp_path):
+    # If dest is the source directory itself, the walk-filter can't exclude
+    # category subdirs (they become children of the walk root) and a rerun
+    # would re-ingest its own outputs into the real source library.
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "a.jpg").write_bytes(b"A")
+    with pytest.raises(SystemExit, match="source as destination"):
+        build_test_photos.sample(
+            source,
+            source,
+            counts={"gps_yes": 0, "gps_no": 0, "raws": 0, "jpegs": 1, "random": 0},
+        )
+
+
 def test_sample_idempotent_when_dest_is_inside_source(tmp_path):
     # If the user picks a dest path inside source (e.g.
     # `--dest <source>/vireo-test-photos`), a naive walk re-ingests prior

--- a/vireo/tests/test_build_test_photos.py
+++ b/vireo/tests/test_build_test_photos.py
@@ -211,3 +211,26 @@ def test_sample_idempotent_under_reversed_walk_order(tmp_path, monkeypatch):
     assert files_after_second == files_after_first, (
         f"reversed walk order created extra files: {files_after_second}"
     )
+
+
+def test_sample_idempotent_when_dest_is_inside_source(tmp_path):
+    # If the user picks a dest path inside source (e.g.
+    # `--dest <source>/vireo-test-photos`), a naive walk re-ingests prior
+    # outputs on every rerun and silently grows the sampled set. Verify the
+    # walk skips the dest subtree, so a second run produces no new files.
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "a.jpg").write_bytes(b"A")
+    (source / "b.jpg").write_bytes(b"B")
+    dest = source / "vireo-test-photos"
+    counts = {"gps_yes": 0, "gps_no": 0, "raws": 0, "jpegs": 2, "random": 0}
+
+    build_test_photos.sample(source, dest, counts=counts)
+    first = sorted(p.name for p in (dest / "jpegs").iterdir())
+    assert len(first) == 2
+
+    build_test_photos.sample(source, dest, counts=counts)
+    second = sorted(p.name for p in (dest / "jpegs").iterdir())
+    assert second == first, (
+        f"dest-inside-source re-ingested outputs: {second} vs {first}"
+    )

--- a/vireo/tests/test_build_test_photos.py
+++ b/vireo/tests/test_build_test_photos.py
@@ -117,6 +117,26 @@ def test_sample_copies_and_writes_manifest(tmp_path):
     assert "jpegs" in content
 
 
+def test_sample_disambiguates_same_basename_different_content(tmp_path):
+    # Two different files with the same basename (common when libraries have
+    # repeated IMG_0001.jpg names across folders) must both land in dest.
+    source = tmp_path / "src"
+    (source / "dir1").mkdir(parents=True)
+    (source / "dir2").mkdir(parents=True)
+    (source / "dir1" / "IMG_0001.jpg").write_bytes(b"AAA")
+    (source / "dir2" / "IMG_0001.jpg").write_bytes(b"BBB")
+    dest = tmp_path / "dest"
+    build_test_photos.sample(
+        source,
+        dest,
+        counts={"gps_yes": 0, "gps_no": 0, "raws": 0, "jpegs": 2, "random": 0},
+    )
+    copied = list((dest / "jpegs").iterdir())
+    assert len(copied) == 2, f"expected 2 files, got {[p.name for p in copied]}"
+    contents = sorted(p.read_bytes() for p in copied)
+    assert contents == [b"AAA", b"BBB"]
+
+
 def test_sample_is_idempotent(tmp_path):
     source = tmp_path / "src"
     source.mkdir()

--- a/vireo/tests/test_build_test_photos.py
+++ b/vireo/tests/test_build_test_photos.py
@@ -213,6 +213,24 @@ def test_sample_idempotent_under_reversed_walk_order(tmp_path, monkeypatch):
     )
 
 
+def test_sample_rejects_missing_source(tmp_path):
+    # A typo in --source would otherwise produce an empty dataset with all-zero
+    # counts and silently invalidate downstream tests. Fail loudly instead.
+    missing = tmp_path / "does-not-exist"
+    dest = tmp_path / "dest"
+    with pytest.raises(SystemExit, match="source does not exist"):
+        build_test_photos.sample(missing, dest)
+
+
+def test_sample_rejects_source_that_is_a_file(tmp_path):
+    # is_dir() also covers the case where --source points at a regular file.
+    not_a_dir = tmp_path / "a.jpg"
+    not_a_dir.write_bytes(b"A")
+    dest = tmp_path / "dest"
+    with pytest.raises(SystemExit, match="source does not exist"):
+        build_test_photos.sample(not_a_dir, dest)
+
+
 def test_sample_rejects_source_equals_dest(tmp_path):
     # If dest is the source directory itself, the walk-filter can't exclude
     # category subdirs (they become children of the walk root) and a rerun

--- a/vireo/tests/test_build_test_photos.py
+++ b/vireo/tests/test_build_test_photos.py
@@ -168,3 +168,46 @@ def test_sample_is_idempotent(tmp_path):
     build_test_photos.sample(source, dest, counts=counts)
     mtime2 = (dest / "jpegs" / "a.jpg").stat().st_mtime
     assert mtime1 == mtime2
+
+
+def test_sample_idempotent_under_reversed_walk_order(tmp_path, monkeypatch):
+    # os.walk() order isn't guaranteed stable across runs. For same-basename +
+    # identical-content sources, the file that's encountered second gets the
+    # hashed filename. If walk order flips, the *other* source becomes second
+    # and a fresh hashed copy is created — breaking idempotency. Verified fix:
+    # sample() sorts its file list, so the decision is stable regardless of
+    # walk order.
+    import os as real_os
+
+    source = tmp_path / "src"
+    (source / "dir1").mkdir(parents=True)
+    (source / "dir2").mkdir(parents=True)
+    (source / "dir1" / "IMG_0001.jpg").write_bytes(b"SAME")
+    (source / "dir2" / "IMG_0001.jpg").write_bytes(b"SAME")
+    dest = tmp_path / "dest"
+    counts = {"gps_yes": 0, "gps_no": 0, "raws": 0, "jpegs": 2, "random": 0}
+
+    build_test_photos.sample(source, dest, counts=counts)
+    files_after_first = sorted(p.name for p in (dest / "jpegs").iterdir())
+    assert len(files_after_first) == 2
+
+    # Second run: flip os.walk's output order to simulate filesystem order drift.
+    # Must reverse both the sequence of yielded (root, dirs, files) tuples AND
+    # the files within each tuple — otherwise the iteration that builds
+    # `all_files` sees the same order as the first run and the bug is hidden.
+    original_walk = real_os.walk
+
+    def reversed_walk(top, *args, **kwargs):
+        entries = [
+            (root, dirs, list(reversed(files)))
+            for root, dirs, files in original_walk(top, *args, **kwargs)
+        ]
+        yield from reversed(entries)
+
+    monkeypatch.setattr(build_test_photos.os, "walk", reversed_walk)
+    build_test_photos.sample(source, dest, counts=counts)
+
+    files_after_second = sorted(p.name for p in (dest / "jpegs").iterdir())
+    assert files_after_second == files_after_first, (
+        f"reversed walk order created extra files: {files_after_second}"
+    )

--- a/vireo/tests/test_build_test_photos.py
+++ b/vireo/tests/test_build_test_photos.py
@@ -246,6 +246,28 @@ def test_sample_rejects_source_equals_dest(tmp_path):
         )
 
 
+def test_sample_finds_duplicates_beyond_first_500_files(tmp_path):
+    # A leading-prefix scan (all_files[:500]) would silently miss duplicate
+    # pairs that sort after the first 500 files in a large library, so the
+    # "duplicates" category would report 0 picks even when the library has
+    # obvious dup pairs. Seed a library with 520 unique files plus one dup
+    # pair that sorts last and confirm it's still picked up.
+    source = tmp_path / "src"
+    source.mkdir()
+    for i in range(520):
+        (source / f"a{i:04d}.jpg").write_bytes(f"unique{i}".encode())
+    # Pair sorts after all the a-prefixed files.
+    (source / "z_dup_1.jpg").write_bytes(b"DUPLICATE")
+    (source / "z_dup_2.jpg").write_bytes(b"DUPLICATE")
+    dest = tmp_path / "dest"
+    result = build_test_photos.sample(
+        source,
+        dest,
+        counts={"gps_yes": 0, "gps_no": 0, "raws": 0, "jpegs": 0, "random": 0},
+    )
+    assert result["duplicates"] == 2, f"expected 2 dup picks, got {result}"
+
+
 def test_sample_idempotent_when_dest_is_inside_source(tmp_path):
     # If the user picks a dest path inside source (e.g.
     # `--dest <source>/vireo-test-photos`), a naive walk re-ingests prior

--- a/vireo/tests/test_build_test_photos.py
+++ b/vireo/tests/test_build_test_photos.py
@@ -137,6 +137,26 @@ def test_sample_disambiguates_same_basename_different_content(tmp_path):
     assert contents == [b"AAA", b"BBB"]
 
 
+def test_sample_disambiguates_same_basename_identical_content(tmp_path):
+    # Two source paths with the same basename AND identical bytes must still
+    # land as two distinct files on disk — otherwise the duplicates category
+    # can't actually populate the duplicate-detection scenarios it exists for.
+    source = tmp_path / "src"
+    (source / "dir1").mkdir(parents=True)
+    (source / "dir2").mkdir(parents=True)
+    (source / "dir1" / "IMG_0001.jpg").write_bytes(b"SAME")
+    (source / "dir2" / "IMG_0001.jpg").write_bytes(b"SAME")
+    dest = tmp_path / "dest"
+    build_test_photos.sample(
+        source,
+        dest,
+        counts={"gps_yes": 0, "gps_no": 0, "raws": 0, "jpegs": 2, "random": 0},
+    )
+    copied = list((dest / "jpegs").iterdir())
+    assert len(copied) == 2, f"expected 2 files, got {[p.name for p in copied]}"
+    assert all(p.read_bytes() == b"SAME" for p in copied)
+
+
 def test_sample_is_idempotent(tmp_path):
     source = tmp_path / "src"
     source.mkdir()

--- a/vireo/tests/test_build_test_photos.py
+++ b/vireo/tests/test_build_test_photos.py
@@ -1,0 +1,130 @@
+"""Tests for scripts/build_test_photos.py helpers."""
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).parent.parent.parent / "scripts" / "build_test_photos.py"
+spec = importlib.util.spec_from_file_location("build_test_photos", _SCRIPT)
+build_test_photos = importlib.util.module_from_spec(spec)
+sys.modules["build_test_photos"] = build_test_photos
+spec.loader.exec_module(build_test_photos)
+
+
+def test_classify_ext_raws(tmp_path):
+    assert build_test_photos.classify_ext(tmp_path / "x.cr2") == "raw"
+    assert build_test_photos.classify_ext(tmp_path / "x.NEF") == "raw"
+    assert build_test_photos.classify_ext(tmp_path / "x.dng") == "raw"
+
+
+def test_classify_ext_jpegs(tmp_path):
+    assert build_test_photos.classify_ext(tmp_path / "x.jpg") == "jpeg"
+    assert build_test_photos.classify_ext(tmp_path / "x.JPEG") == "jpeg"
+
+
+def test_classify_ext_skip(tmp_path):
+    assert build_test_photos.classify_ext(tmp_path / "notes.txt") == "skip"
+    assert build_test_photos.classify_ext(tmp_path / "video.mp4") == "skip"
+
+
+def test_content_hash_matches_for_identical_content(tmp_path):
+    a = tmp_path / "a.bin"
+    b = tmp_path / "b.bin"
+    a.write_bytes(b"same content")
+    b.write_bytes(b"same content")
+    assert build_test_photos.content_hash(a) == build_test_photos.content_hash(b)
+
+
+def test_content_hash_differs_for_different_content(tmp_path):
+    a = tmp_path / "a.bin"
+    b = tmp_path / "b.bin"
+    a.write_bytes(b"one")
+    b.write_bytes(b"two")
+    assert build_test_photos.content_hash(a) != build_test_photos.content_hash(b)
+
+
+def test_find_duplicates(tmp_path):
+    files = [tmp_path / f"f{i}.jpg" for i in range(4)]
+    files[0].write_bytes(b"A")
+    files[1].write_bytes(b"A")
+    files[2].write_bytes(b"B")
+    files[3].write_bytes(b"C")
+    groups = build_test_photos.find_duplicates(files)
+    assert len(groups) == 1
+    assert len(groups[0][1]) == 2
+
+
+def test_find_burst(tmp_path):
+    import os
+    files = []
+    base_time = 1_700_000_000
+    # Burst of 4 within 2 seconds
+    for i in range(4):
+        f = tmp_path / f"burst{i}.jpg"
+        f.write_bytes(b"x")
+        os.utime(f, (base_time + i * 0.5, base_time + i * 0.5))
+        files.append(f)
+    # A singleton far away
+    singleton = tmp_path / "singleton.jpg"
+    singleton.write_bytes(b"x")
+    os.utime(singleton, (base_time + 1000, base_time + 1000))
+    files.append(singleton)
+
+    burst = build_test_photos.find_burst(files, window_seconds=2)
+    assert len(burst) == 4
+
+
+def test_safe_dest_rejects_home(monkeypatch):
+    with pytest.raises(SystemExit, match="HOME"):
+        build_test_photos._safe_dest(str(Path.home()))
+
+
+def test_safe_dest_rejects_under_vireo(monkeypatch):
+    with pytest.raises(SystemExit, match=r"\.vireo"):
+        build_test_photos._safe_dest(str(Path.home() / ".vireo" / "photos"))
+
+
+def test_safe_dest_accepts_tmp(tmp_path):
+    result = build_test_photos._safe_dest(str(tmp_path / "photos"))
+    assert result == (tmp_path / "photos").resolve()
+
+
+def test_sample_dry_run(tmp_path):
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "a.jpg").write_bytes(b"A")
+    (source / "b.cr2").write_bytes(b"B")
+    (source / "c.nef").write_bytes(b"C")
+    dest = tmp_path / "dest"
+    result = build_test_photos.sample(source, dest, dry_run=True)
+    assert "raws" in result
+    assert "jpegs" in result
+    assert not dest.exists()
+
+
+def test_sample_copies_and_writes_manifest(tmp_path):
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "a.jpg").write_bytes(b"A")
+    (source / "b.cr2").write_bytes(b"B")
+    dest = tmp_path / "dest"
+    build_test_photos.sample(source, dest, counts={"gps_yes":0,"gps_no":0,"raws":1,"jpegs":1,"random":0})
+    manifest = dest / "MANIFEST.md"
+    assert manifest.exists()
+    content = manifest.read_text()
+    assert "raws" in content
+    assert "jpegs" in content
+
+
+def test_sample_is_idempotent(tmp_path):
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "a.jpg").write_bytes(b"A")
+    dest = tmp_path / "dest"
+    counts = {"gps_yes":0,"gps_no":0,"raws":0,"jpegs":1,"random":0}
+    build_test_photos.sample(source, dest, counts=counts)
+    mtime1 = (dest / "jpegs" / "a.jpg").stat().st_mtime
+    build_test_photos.sample(source, dest, counts=counts)
+    mtime2 = (dest / "jpegs" / "a.jpg").stat().st_mtime
+    assert mtime1 == mtime2

--- a/vireo/tests/test_userfirst_harness_integration.py
+++ b/vireo/tests/test_userfirst_harness_integration.py
@@ -1,0 +1,120 @@
+"""Integration tests — actually start Flask + Playwright + sweep.
+
+Slow (several seconds each). Skipped if playwright or chromium aren't available.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+playwright = pytest.importorskip("playwright.sync_api")
+
+
+@pytest.fixture
+def test_profile(tmp_path, monkeypatch):
+    """Set up an isolated test profile + photos root.
+
+    The harness passes HOME=<profile>/fake_home to the Flask subprocess, so
+    the subprocess's ~/.vireo/* reads/writes are isolated. The parent
+    (pytest) process keeps its real HOME so Playwright finds Chromium.
+    """
+    profile = tmp_path / "vireo-test-profile"
+    photos = tmp_path / "vireo-test-photos"
+    profile.mkdir()
+    photos.mkdir()
+    monkeypatch.setenv("VIREO_PROFILE", str(profile))
+    monkeypatch.setenv("VIREO_TEST_PHOTOS", str(photos))
+    return profile, photos
+
+
+def _chromium_installed():
+    cache = Path.home() / "Library" / "Caches" / "ms-playwright"
+    if not cache.exists():
+        cache = Path.home() / ".cache" / "ms-playwright"
+    return cache.exists() and any(p.name.startswith("chromium") for p in cache.iterdir())
+
+
+pytestmark = pytest.mark.skipif(
+    not _chromium_installed(), reason="Playwright Chromium not installed"
+)
+
+
+def test_harness_starts_and_stops_cleanly(test_profile):
+    profile, _ = test_profile
+    from testing.userfirst.harness import vireo_session
+
+    with vireo_session(name="smoke") as session:
+        resp = session.goto("/api/health")
+        assert resp is not None
+        assert resp.status == 200
+
+    runs = list((profile / "runs").iterdir())
+    assert len(runs) == 1
+    findings_json = runs[0] / "findings.json"
+    assert findings_json.exists()
+    data = json.loads(findings_json.read_text())
+    assert data["name"] == "smoke"
+
+
+def test_sweep_runs_without_crash(test_profile):
+    profile, _ = test_profile
+    from testing.userfirst.harness import vireo_session
+    from testing.userfirst.sweep import run_sweep
+
+    with vireo_session(name="sweep-test") as session:
+        run_sweep(session, pages=["/welcome", "/settings"])
+
+    runs = list((profile / "runs").iterdir())
+    assert len(runs) == 1
+    screens = list((runs[0] / "screens").iterdir())
+    assert len(screens) >= 2
+    report_md = (runs[0] / "report.md").read_text()
+    assert "sweep-test" in report_md
+
+
+def test_sweep_flags_missing_static_asset(test_profile, monkeypatch):
+    """Inject a bogus <script src="/static/does-not-exist.js"> into a template,
+    run sweep, verify the harness surfaces the 404 as a BUG finding. This is
+    the regression guard for the bug that motivated this entire harness.
+    """
+    profile, _ = test_profile
+    from testing.userfirst.harness import vireo_session
+    from testing.userfirst.sweep import run_sweep
+
+    # Find and patch the welcome template
+    template = Path(__file__).parent.parent / "templates" / "welcome.html"
+    original = template.read_text()
+    injected = original.replace(
+        "</body>",
+        '<script src="/static/definitely-missing-12345.js"></script></body>',
+        1,
+    )
+    template.write_text(injected)
+    try:
+        with vireo_session(name="missing-asset") as session:
+            run_sweep(session, pages=["/welcome"])
+
+        runs = sorted((profile / "runs").iterdir())
+        findings = json.loads((runs[-1] / "findings.json").read_text())
+        bug_urls = [
+            f["context"].get("url")
+            for f in findings["findings"]
+            if f["kind"] == "BUG"
+        ]
+        assert any("definitely-missing-12345" in (u or "") for u in bug_urls), (
+            f"expected missing-asset BUG in findings, got: {findings['findings']}"
+        )
+    finally:
+        template.write_text(original)
+
+
+def test_prune_runs_enforces_cap(test_profile):
+    profile, _ = test_profile
+    from testing.userfirst.harness import vireo_session
+
+    for _ in range(3):
+        with vireo_session(name="prune-test", keep_runs=2):
+            pass
+
+    runs = list((profile / "runs").iterdir())
+    assert len(runs) == 2

--- a/vireo/tests/test_userfirst_harness_integration.py
+++ b/vireo/tests/test_userfirst_harness_integration.py
@@ -108,6 +108,28 @@ def test_sweep_flags_missing_static_asset(test_profile, monkeypatch):
         template.write_text(original)
 
 
+def test_report_is_written_when_session_body_raises(test_profile):
+    """Even if the `with` body crashes, findings.json + report.md must be on
+    disk — otherwise the exact failures we most want to diagnose vanish.
+    """
+    profile, _ = test_profile
+    from testing.userfirst.harness import vireo_session
+    from testing.userfirst.report import Finding
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with vireo_session(name="crash-test") as session:
+            session.report.add(Finding.bug("recorded before the crash"))
+            raise RuntimeError("boom")
+
+    runs = list((profile / "runs").iterdir())
+    assert len(runs) == 1
+    findings = json.loads((runs[0] / "findings.json").read_text())
+    assert findings["name"] == "crash-test"
+    messages = [f["message"] for f in findings["findings"]]
+    assert any("recorded before the crash" in m for m in messages)
+    assert (runs[0] / "report.md").exists()
+
+
 def test_prune_runs_enforces_cap(test_profile):
     profile, _ = test_profile
     from testing.userfirst.harness import vireo_session

--- a/vireo/tests/test_userfirst_harness_unit.py
+++ b/vireo/tests/test_userfirst_harness_unit.py
@@ -1,0 +1,68 @@
+"""Unit tests for harness internals that don't need a real Flask server."""
+
+from testing.userfirst.harness import (
+    _free_port,
+    _new_run_id,
+    _prune_runs,
+    _relative_url_same_origin,
+)
+
+
+def test_free_port_returns_integer():
+    port = _free_port()
+    assert isinstance(port, int)
+    assert 1024 < port < 65536
+
+
+def test_free_port_returns_different_ports():
+    # Sanity — two consecutive calls shouldn't collide into the same port
+    # across a fast loop (they might, but rarely; we just check it's callable
+    # repeatedly without error).
+    ports = {_free_port() for _ in range(5)}
+    assert len(ports) >= 1
+
+
+def test_new_run_id_sortable():
+    # Two IDs created in order should sort chronologically.
+    a = _new_run_id()
+    b = _new_run_id()
+    assert a <= b
+    assert len(a) > 10
+
+
+def test_prune_runs_keeps_most_recent(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    for i in range(30):
+        (runs_dir / f"20260416-{i:06d}").mkdir()
+    _prune_runs(runs_dir, keep=20)
+    remaining = sorted(p.name for p in runs_dir.iterdir())
+    assert len(remaining) == 20
+    # The most-recent 20 survive
+    assert remaining[0] == "20260416-000010"
+    assert remaining[-1] == "20260416-000029"
+
+
+def test_prune_runs_noop_when_under_limit(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    for i in range(5):
+        (runs_dir / f"20260416-{i:06d}").mkdir()
+    _prune_runs(runs_dir, keep=20)
+    assert len(list(runs_dir.iterdir())) == 5
+
+
+def test_prune_runs_handles_missing_dir(tmp_path):
+    _prune_runs(tmp_path / "nonexistent", keep=20)
+
+
+def test_relative_url_same_origin_matches():
+    assert _relative_url_same_origin(
+        "http://localhost:8089/static/x.js", "http://localhost:8089"
+    ) == "/static/x.js"
+
+
+def test_relative_url_same_origin_returns_none_for_external():
+    assert _relative_url_same_origin(
+        "https://example.com/x.js", "http://localhost:8089"
+    ) is None

--- a/vireo/tests/test_userfirst_profile.py
+++ b/vireo/tests/test_userfirst_profile.py
@@ -16,6 +16,7 @@ from testing.userfirst.profile import (
     resolve_photos_root,
     resolve_profile,
     validate_db_folders,
+    validate_profile_tree,
 )
 
 
@@ -104,3 +105,46 @@ def test_profile_paths_structure(tmp_path):
     assert paths["labels"] == tmp_path / "labels"
     assert paths["config"] == tmp_path / "config.json"
     assert paths["runs"] == tmp_path / "runs"
+
+
+def test_validate_profile_tree_noop_when_profile_missing(tmp_path):
+    validate_profile_tree(tmp_path / "does-not-exist")
+
+
+def test_validate_profile_tree_allows_internal_symlinks(tmp_path):
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    target = profile / "real"
+    target.mkdir()
+    (profile / "link").symlink_to(target)
+    validate_profile_tree(profile)
+
+
+def test_validate_profile_tree_rejects_file_symlink_escape(tmp_path):
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    outside = tmp_path / "outside.db"
+    outside.write_text("real data")
+    (profile / "vireo.db").symlink_to(outside)
+    with pytest.raises(UnsafeProfileError, match="escapes"):
+        validate_profile_tree(profile)
+
+
+def test_validate_profile_tree_rejects_dir_symlink_escape(tmp_path):
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    outside = tmp_path / "outside-dir"
+    outside.mkdir()
+    (profile / "thumbnails").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(UnsafeProfileError, match="escapes"):
+        validate_profile_tree(profile)
+
+
+def test_validate_profile_tree_rejects_nested_symlink_escape(tmp_path):
+    profile = tmp_path / "profile"
+    (profile / "runs").mkdir(parents=True)
+    outside = tmp_path / "outside.json"
+    outside.write_text("{}")
+    (profile / "runs" / "leak").symlink_to(outside)
+    with pytest.raises(UnsafeProfileError, match="escapes"):
+        validate_profile_tree(profile)

--- a/vireo/tests/test_userfirst_profile.py
+++ b/vireo/tests/test_userfirst_profile.py
@@ -1,0 +1,106 @@
+"""Safety-invariant tests for the user-first testing profile guard.
+
+The guard must refuse to start the harness against real data:
+  - VIREO_PROFILE env var must be set
+  - profile cannot be under ~/.vireo/
+  - profile cannot be $HOME
+  - if VIREO_TEST_PHOTOS is set, no DB folder may live outside it
+"""
+import sqlite3
+from pathlib import Path
+
+import pytest
+from testing.userfirst.profile import (
+    UnsafeProfileError,
+    profile_paths,
+    resolve_photos_root,
+    resolve_profile,
+    validate_db_folders,
+)
+
+
+def test_resolve_profile_requires_env(monkeypatch):
+    monkeypatch.delenv("VIREO_PROFILE", raising=False)
+    with pytest.raises(UnsafeProfileError, match="VIREO_PROFILE"):
+        resolve_profile()
+
+
+def test_resolve_profile_rejects_real_vireo_dir(monkeypatch):
+    real_vireo = Path.home() / ".vireo" / "fake-test-subdir"
+    monkeypatch.setenv("VIREO_PROFILE", str(real_vireo))
+    with pytest.raises(UnsafeProfileError, match=r"\.vireo"):
+        resolve_profile()
+
+
+def test_resolve_profile_rejects_home(monkeypatch):
+    monkeypatch.setenv("VIREO_PROFILE", str(Path.home()))
+    with pytest.raises(UnsafeProfileError, match="HOME"):
+        resolve_profile()
+
+
+def test_resolve_profile_accepts_tmp(monkeypatch, tmp_path):
+    profile = tmp_path / "test-profile"
+    monkeypatch.setenv("VIREO_PROFILE", str(profile))
+    result = resolve_profile()
+    assert result == profile.resolve()
+
+
+def test_resolve_photos_root_returns_none_when_unset(monkeypatch):
+    monkeypatch.delenv("VIREO_TEST_PHOTOS", raising=False)
+    assert resolve_photos_root() is None
+
+
+def test_resolve_photos_root_rejects_real_vireo_dir(monkeypatch):
+    monkeypatch.setenv("VIREO_TEST_PHOTOS", str(Path.home() / ".vireo" / "photos"))
+    with pytest.raises(UnsafeProfileError, match=r"\.vireo"):
+        resolve_photos_root()
+
+
+def test_validate_db_folders_rejects_outside_root(tmp_path):
+    photos_root = tmp_path / "test-photos"
+    photos_root.mkdir()
+
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE folders (path TEXT)")
+    conn.execute("INSERT INTO folders VALUES (?)", ("/Users/julius/real-photos",))
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(UnsafeProfileError, match="outside photos root"):
+        validate_db_folders(db_path, photos_root)
+
+
+def test_validate_db_folders_accepts_inside_root(tmp_path):
+    photos_root = tmp_path / "test-photos"
+    photos_root.mkdir()
+    (photos_root / "2024").mkdir()
+
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE folders (path TEXT)")
+    conn.execute("INSERT INTO folders VALUES (?)", (str(photos_root / "2024"),))
+    conn.commit()
+    conn.close()
+
+    validate_db_folders(db_path, photos_root)
+
+
+def test_validate_db_folders_noop_when_root_is_none(tmp_path):
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE folders (path TEXT)")
+    conn.execute("INSERT INTO folders VALUES (?)", ("/Users/julius/real-photos",))
+    conn.commit()
+    conn.close()
+
+    validate_db_folders(db_path, None)
+
+
+def test_profile_paths_structure(tmp_path):
+    paths = profile_paths(tmp_path)
+    assert paths["db"] == tmp_path / "vireo.db"
+    assert paths["thumbnails"] == tmp_path / "thumbnails"
+    assert paths["labels"] == tmp_path / "labels"
+    assert paths["config"] == tmp_path / "config.json"
+    assert paths["runs"] == tmp_path / "runs"

--- a/vireo/tests/test_userfirst_report.py
+++ b/vireo/tests/test_userfirst_report.py
@@ -1,0 +1,83 @@
+"""Tests for the user-first testing report/findings module."""
+import json
+
+from testing.userfirst.report import Finding, Report
+
+
+def test_finding_types():
+    f = Finding.bug("page not found", url="/missing")
+    assert f.kind == "BUG"
+    assert f.message == "page not found"
+    assert f.context == {"url": "/missing"}
+
+
+def test_report_counts_by_kind():
+    r = Report(name="sweep")
+    r.add(Finding.bug("x"))
+    r.add(Finding.bug("y"))
+    r.add(Finding.warn("z"))
+    r.add(Finding.suspect("q"))
+    counts = r.counts()
+    assert counts["BUG"] == 2
+    assert counts["WARN"] == 1
+    assert counts["SUSPECT"] == 1
+    assert counts["PERF"] == 0
+
+
+def test_report_step_tracking():
+    r = Report(name="scenario")
+    r.record_step("goto /browse", status=200, elapsed_ms=123)
+    r.record_step("click save", status=None, elapsed_ms=5)
+    assert len(r.steps) == 2
+    assert r.steps[0]["action"] == "goto /browse"
+    assert r.steps[0]["status"] == 200
+    assert r.steps[0]["elapsed_ms"] == 123
+
+
+def test_report_markdown_summary():
+    r = Report(name="sweep")
+    r.add(Finding.bug("/static/help.js 404", url="/browse"))
+    r.add(Finding.warn("console deprecation", source="vireo-utils.js"))
+    r.duration_s = 2.5
+    md = r.to_markdown()
+    assert "sweep" in md
+    assert "BUG" in md
+    assert "/static/help.js 404" in md
+    assert "console deprecation" in md
+    assert "2.5" in md
+
+
+def test_report_round_trip_json(tmp_path):
+    r = Report(name="scenario_x")
+    r.add(Finding.bug("boom", url="/x"))
+    r.record_step("goto /x", status=200, elapsed_ms=10)
+    out = tmp_path / "findings.json"
+    r.write_json(out)
+    data = json.loads(out.read_text())
+    assert data["name"] == "scenario_x"
+    assert len(data["findings"]) == 1
+    assert data["findings"][0]["kind"] == "BUG"
+    assert len(data["steps"]) == 1
+
+
+def test_report_screenshots_listed(tmp_path):
+    r = Report(name="scenario")
+    shot1 = tmp_path / "01-initial.png"
+    shot2 = tmp_path / "02-after.png"
+    shot1.write_bytes(b"fake png")
+    shot2.write_bytes(b"fake png")
+    r.add_screenshot(shot1)
+    r.add_screenshot(shot2)
+    assert len(r.screenshots) == 2
+    md = r.to_markdown()
+    assert "01-initial.png" in md
+    assert "02-after.png" in md
+
+
+def test_report_has_bugs_predicate():
+    r = Report(name="x")
+    assert not r.has_bugs()
+    r.add(Finding.warn("x"))
+    assert not r.has_bugs()
+    r.add(Finding.bug("y"))
+    assert r.has_bugs()


### PR DESCRIPTION
## Summary

First of four PRs implementing the user-first testing harness designed in #594. Ships the minimum needed to start finding bugs that code review misses — specifically the class of bug that motivated this whole effort (\`/static/help.js\` 404'ing on every page, invisible to code review, obvious in a browser).

**What's in this PR:**

- \`vireo/testing/userfirst/profile.py\` — safety guard that refuses to start the harness against real data. \`VIREO_PROFILE\` must be set and outside \`~/.vireo/\`; \`VIREO_TEST_PHOTOS\` (if set) scopes allowed DB folders.
- \`vireo/testing/userfirst/harness.py\` — \`vireo_session()\` context manager that starts Flask in a subprocess, redirects its \`HOME\` to \`<profile>/fake_home\` so all \`~/.vireo/*\` reads/writes are isolated, waits for \`/api/health\`, launches Chromium with console/network listeners, yields a \`VireoSession\` with soft-assert semantics, and tears everything down cleanly.
- \`vireo/testing/userfirst/sweep.py\` — generic route walker across all user-facing pages.
- \`vireo/testing/userfirst/report.py\` — \`Finding\` + \`Report\` with \`BUG\`/\`SUSPECT\`/\`PERF\`/\`WARN\` taxonomy, markdown + JSON output.
- \`scripts/build_test_photos.py\` — samples a real photo library into \`~/vireo-test-photos/\` with a mix covering the 9 first-cut scenarios (GPS/no-GPS, burst, duplicates, RAW/JPEG variety). Safe-dest guard refuses writes under \`~/.vireo/\` or \`\$HOME\`. Idempotent.
- 42 new tests. Integration tests actually spin up Flask + Chromium; skipped if Playwright browsers aren't installed.

**Regression guard worth calling out:** \`test_sweep_flags_missing_static_asset\` injects a bogus \`<script src="/static/missing.js">\` into \`welcome.html\`, runs sweep, asserts the harness surfaces the 404 as a \`BUG\` finding. If today's fixed bug ever recurs, this test catches it.

**Not in this PR** (deferred per the rollout plan):
- Scenarios (browse, cull, keywords, etc.) — PR #2 and #3
- Skill doc with activation rules — PR #4

## Test plan

- [x] 42 new tests pass (profile, report, harness unit, harness integration, build_test_photos)
- [x] CLAUDE.md mandated suite still green: 479 tests pass
- [x] Integration tests actually prove end-to-end (Flask subprocess + Playwright + sweep finds injected 404)
- [x] Ruff clean
- [ ] Manual: set \`VIREO_PROFILE=/tmp/vireo-smoke VIREO_TEST_PHOTOS=/tmp/vireo-smoke-photos\`, run sweep from a Python shell, verify report output

🤖 Generated with [Claude Code](https://claude.com/claude-code)