### PR TITLE
fix: keep orphan folders visible in browse folder tree

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1041,14 +1041,48 @@ class Database:
         return folder_id
 
     def get_folder_tree(self):
-        """Return folders for the active workspace."""
+        """Return folders for the active workspace.
+
+        ``parent_id`` is rewritten to the nearest ancestor that is also linked
+        to the active workspace AND has ``status='ok'``. If no such ancestor
+        exists, ``parent_id`` is NULL. This keeps the returned set a
+        well-formed tree: callers that group by ``parent_id`` (notably the
+        browse-page folder sidebar) never leave a linked folder dangling under
+        an ancestor that was filtered out of the result.
+        """
+        ws = self._ws_id()
         return self.conn.execute(
-            """SELECT f.id, f.path, f.name, f.parent_id, f.photo_count
+            """WITH RECURSIVE
+               visible(id) AS (
+                   SELECT f.id FROM folders f
+                   JOIN workspace_folders wf ON wf.folder_id = f.id
+                   WHERE wf.workspace_id = ? AND f.status = 'ok'
+               ),
+               walk(start_id, current_id) AS (
+                   SELECT v.id, f.parent_id
+                   FROM visible v
+                   JOIN folders f ON f.id = v.id
+                   UNION ALL
+                   SELECT w.start_id, f.parent_id
+                   FROM walk w
+                   JOIN folders f ON f.id = w.current_id
+                   WHERE w.current_id IS NOT NULL
+                     AND w.current_id NOT IN (SELECT id FROM visible)
+               ),
+               effective AS (
+                   SELECT start_id, current_id AS parent_id
+                   FROM walk
+                   WHERE current_id IS NULL
+                      OR current_id IN (SELECT id FROM visible)
+               )
+               SELECT f.id, f.path, f.name,
+                      e.parent_id AS parent_id,
+                      f.photo_count
                FROM folders f
-               JOIN workspace_folders wf ON wf.folder_id = f.id
-               WHERE wf.workspace_id = ? AND f.status = 'ok'
+               JOIN visible v ON v.id = f.id
+               JOIN effective e ON e.start_id = f.id
                ORDER BY f.path""",
-            (self._ws_id(),),
+            (ws,),
         ).fetchall()
 
     def get_folder_subtree_ids(self, folder_id):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2633,6 +2633,136 @@ def test_missing_folder_hidden_from_folder_tree(tmp_path):
     assert tree[0]["name"] == "ok"
 
 
+def test_folder_tree_orphan_parent_becomes_root(tmp_path):
+    """If a folder's parent_id points to a folder not linked to the active
+    workspace, get_folder_tree returns the folder with parent_id=None so the
+    browse sidebar renders it at root instead of hiding it under an unreachable
+    parent bucket."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    # Parent folder exists in the folders table but is NOT linked to the
+    # active workspace (simulated by detaching it after add_folder auto-links).
+    fid_parent = db.add_folder("/photos", name="photos")
+    db.remove_workspace_folder(ws, fid_parent)
+
+    # Child references the unlinked parent.
+    fid_child = db.add_folder("/photos/2024", name="2024", parent_id=fid_parent)
+
+    tree = db.get_folder_tree()
+    assert len(tree) == 1
+    assert tree[0]["id"] == fid_child
+    assert tree[0]["parent_id"] is None
+
+
+def test_folder_tree_linked_parent_preserved(tmp_path):
+    """When the parent is linked to the workspace, parent_id is unchanged."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    fid_parent = db.add_folder("/photos", name="photos")
+    fid_child = db.add_folder("/photos/2024", name="2024", parent_id=fid_parent)
+
+    tree = db.get_folder_tree()
+    child = [f for f in tree if f["id"] == fid_child][0]
+    assert child["parent_id"] == fid_parent
+
+
+def test_folder_tree_walks_past_unlinked_ancestor(tmp_path):
+    """If a folder's immediate parent is not linked but a grandparent is,
+    parent_id is rewritten to the nearest linked ancestor."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    fid_gp = db.add_folder("/photos", name="photos")
+    fid_mid = db.add_folder("/photos/2024", name="2024", parent_id=fid_gp)
+    # Detach the middle folder from the workspace so it acts as a gap.
+    db.remove_workspace_folder(ws, fid_mid)
+    fid_leaf = db.add_folder("/photos/2024/trip", name="trip", parent_id=fid_mid)
+
+    tree = db.get_folder_tree()
+    paths = {f["id"]: f["parent_id"] for f in tree}
+    assert fid_gp in paths
+    assert fid_mid not in paths  # not linked -> not returned
+    assert paths[fid_leaf] == fid_gp
+
+
+def test_folder_tree_walks_past_missing_ancestor(tmp_path):
+    """A folder whose parent is linked but has status!='ok' should be walked
+    past — the missing ancestor is already filtered from the tree, so the
+    child should reparent to the next linked+ok ancestor instead of dangling."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    fid_gp = db.add_folder("/photos", name="photos")
+    fid_mid = db.add_folder("/photos/2024", name="2024", parent_id=fid_gp)
+    fid_leaf = db.add_folder("/photos/2024/trip", name="trip", parent_id=fid_mid)
+
+    # Mark the middle folder as missing on disk — it stays linked to the
+    # workspace but is filtered out by get_folder_tree's status='ok' clause.
+    db.conn.execute("UPDATE folders SET status = 'missing' WHERE id = ?", (fid_mid,))
+    db.conn.commit()
+
+    tree = db.get_folder_tree()
+    ids = {f["id"] for f in tree}
+    assert fid_mid not in ids
+    leaf_row = [f for f in tree if f["id"] == fid_leaf][0]
+    assert leaf_row["parent_id"] == fid_gp
+
+
+def test_folder_tree_null_parent_stays_null(tmp_path):
+    """A top-level folder (parent_id NULL) stays at root."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    fid = db.add_folder("/photos", name="photos")
+    tree = db.get_folder_tree()
+    assert len(tree) == 1
+    assert tree[0]["id"] == fid
+    assert tree[0]["parent_id"] is None
+
+
+def test_folder_tree_orphan_resolution_is_workspace_scoped(tmp_path):
+    """The parent_id rewrite considers the ACTIVE workspace's links — the
+    same folder linked to two workspaces can have different effective parents
+    depending on which workspace is active."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.create_workspace("A")
+    ws_b = db.create_workspace("B")
+
+    # Build hierarchy in workspace A: parent AND child linked.
+    db.set_active_workspace(ws_a)
+    fid_parent = db.add_folder("/photos", name="photos")
+    fid_child = db.add_folder("/photos/2024", name="2024", parent_id=fid_parent)
+
+    # Link only the child into workspace B (not the parent).
+    db.add_workspace_folder(ws_b, fid_child)
+
+    # In A: parent is linked -> preserved.
+    db.set_active_workspace(ws_a)
+    tree_a = db.get_folder_tree()
+    child_a = [f for f in tree_a if f["id"] == fid_child][0]
+    assert child_a["parent_id"] == fid_parent
+
+    # In B: parent is not linked -> reparented to None.
+    db.set_active_workspace(ws_b)
+    tree_b = db.get_folder_tree()
+    assert len(tree_b) == 1
+    assert tree_b[0]["id"] == fid_child
+    assert tree_b[0]["parent_id"] is None
+
+
 def test_missing_folder_hidden_from_collection(tmp_path):
     """Photos in missing folders don't appear in collection queries."""
     import json


### PR DESCRIPTION
## Summary

- Folders linked to a workspace sometimes disappeared from the browse-page folder sidebar while still showing on the workspace page.
- Root cause: `get_folder_tree` returned `folders.parent_id` verbatim, even when the referenced parent wasn't linked to the active workspace (or had `status != 'ok'`). The browse renderer groups by `parent_id` and only descends from the `'root'` bucket, so those folders got stranded in unreachable buckets — visible in the DB, invisible in the UI.
- Fix: `get_folder_tree` now rewrites `parent_id` to the nearest linked + `status='ok'` ancestor via a recursive CTE, falling back to NULL when no such ancestor exists. The returned column is still called `parent_id` so no client-side change is needed.

## Why server-side

`get_folder_tree` is used in 25+ places (routes, thread jobs, the scanner, export, sync). Fixing it in SQL means every caller automatically gets a well-formed tree for the active workspace, not just the browse sidebar. It also makes the function's contract — "folders for the active workspace" — actually coherent, since `parent_id` now references the scoped result set.

## Test plan

- [x] 6 new unit tests in `vireo/tests/test_db.py`: immediate parent unlinked → root; linked parent preserved; walks past unlinked middle; walks past `status='missing'` middle; NULL parent stays NULL; workspace-scoped resolution.
- [x] Full required suite passes (`test_workspaces.py`, `test_db.py`, `test_app.py`, `test_photos_api.py`, `test_edits_api.py`, `test_jobs_api.py`, `test_darktable_api.py`, `test_config.py` → 499/499 passing).
- [x] Broader `tests/ vireo/tests/` run: 1458 passing. Three unrelated pre-existing failures (`test_find_darktable_returns_none_for_bad_configured_path`, `test_welcome_page_renders`, `test_pipeline_auto_skips_classify_when_no_model`) reproduce on baseline with my changes stashed out, so they are not caused by this PR.
- [x] Smoke test against a copy of the user's real DB: the San Elijo Lagoon workspace's 70 linked folders all become reachable from the root bucket in the browse tree renderer's grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)