### PR TITLE
fix: lightbox arrows navigate between photos opened from browse

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -1,0 +1,36 @@
+from playwright.sync_api import expect
+
+
+def test_browse_lightbox_arrows_navigate(live_server, page):
+    """On-screen ◄/► arrows in the lightbox navigate between photos opened from /browse.
+
+    Regression: previously browse.html called openLightbox() without the photo-list
+    argument, so _lightboxPhotoList stayed empty and lightboxNav() silently no-op'd.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_filename = first_card.get_attribute("data-filename")
+
+    first_card.dblclick()
+
+    overlay = page.locator("#lightboxOverlay")
+    expect(overlay).to_have_class("lightbox-overlay active")
+
+    filename_display = page.locator("#lightboxFilename")
+    expect(filename_display).to_have_text(first_filename)
+
+    counter = page.locator("#lightboxCounter")
+    expect(counter).to_be_visible()
+    expect(counter).to_contain_text("1 /")
+
+    page.locator("[title='Next (→)']").click()
+
+    expect(filename_display).not_to_have_text(first_filename)
+    expect(counter).to_contain_text("2 /")
+
+    page.locator("[title='Previous (←)']").click()
+    expect(filename_display).to_have_text(first_filename)
+    expect(counter).to_contain_text("1 /")

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -898,7 +898,7 @@ body {
     <!-- Photo Detail (shown when a photo is selected) -->
     <div class="detail-content" id="detailContent">
       <button class="detail-close" onclick="closeDetail()">&times;</button>
-      <img class="detail-preview" id="detailImg" src="" alt="" style="cursor:pointer;" onclick="openLightbox(window._detailPhotoId, document.getElementById('detailFilename').textContent)">
+      <img class="detail-preview" id="detailImg" src="" alt="" style="cursor:pointer;" onclick="openLightbox(window._detailPhotoId, document.getElementById('detailFilename').textContent, photos)">
       <div class="detail-filename" id="detailFilename"></div>
 
       <div class="detail-section">
@@ -1932,7 +1932,7 @@ document.getElementById('grid').addEventListener('dblclick', function(e) {
   if (!card) return;
   var id = parseInt(card.dataset.id, 10);
   var filename = card.dataset.filename || '';
-  openLightbox(id, filename);
+  openLightbox(id, filename, photos);
 });
 
 /* ---------- Infinite Scroll ---------- */


### PR DESCRIPTION
## Summary

The on-screen ◄/► arrows inside the full-screen lightbox silently did nothing when the lightbox was opened from `/browse`. `lightboxNav()` bails when `_lightboxPhotoList.length < 2`, and that list is only populated when `openLightbox()` receives a 3rd `photoList` argument.

`review.html`, `highlights.html`, and `cull.html` all pass the list — `browse.html` was the outlier. This PR passes the current `photos` array in both call sites (detail preview click + grid dblclick).

## Changes

- `vireo/templates/browse.html` — pass `photos` as the 3rd arg in the two `openLightbox(...)` call sites.
- `tests/e2e/test_browse_lightbox.py` — new Playwright regression test that dblclicks a grid card, clicks the Next arrow, verifies the filename + counter update, then clicks Previous and verifies it returns.

## Test plan

- [x] RED/GREEN check: `test_browse_lightbox_arrows_navigate` fails on `main` without the fix, passes with it.
- [x] Full e2e suite: `python -m pytest tests/e2e/ -q` → 43 passed.
- [x] Project test sweep: `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` → 499 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)