### PR TITLE
fix: resolve macOS .app bundle when editor is set to a parent folder

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2362,13 +2362,22 @@ def create_app(db_path, thumb_cache_dir=None):
                 app_bundle = editor_path
             elif os.path.isdir(editor_path):
                 try:
-                    for entry in sorted(os.listdir(editor_path)):
-                        if entry.endswith(".app"):
-                            app_bundle = os.path.join(editor_path, entry)
-                            break
+                    bundles = [
+                        entry for entry in sorted(os.listdir(editor_path))
+                        if entry.endswith(".app")
+                    ]
                 except OSError:
-                    pass
-                if app_bundle is None:
+                    bundles = []
+                if len(bundles) == 1:
+                    app_bundle = os.path.join(editor_path, bundles[0])
+                elif len(bundles) > 1:
+                    return json_error(
+                        f"Multiple .app bundles found in {editor_path} "
+                        f"({', '.join(bundles)}). "
+                        "Set the editor to a specific .app bundle.",
+                        500,
+                    )
+                else:
                     return json_error(
                         f"No .app bundle found in {editor_path}. "
                         "Set the editor to the .app bundle directly.",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2347,21 +2347,59 @@ def create_app(db_path, thumb_cache_dir=None):
             return json_error("No photos found", 404)
 
         editor = cfg.get("external_editor")
+        editor_path = os.path.expanduser(editor) if editor else ""
+
+        # On macOS, an .app bundle is a directory — execing it raises EACCES.
+        # Resolve the bundle when the user gives the parent folder (e.g.
+        # /Applications/Adobe Lightroom Classic/) and route through `open -a`.
+        app_bundle = None
+        if sys.platform == "darwin" and editor_path:
+            if editor_path.endswith(".app"):
+                app_bundle = editor_path
+            elif os.path.isdir(editor_path):
+                try:
+                    for entry in sorted(os.listdir(editor_path)):
+                        if entry.endswith(".app"):
+                            app_bundle = os.path.join(editor_path, entry)
+                            break
+                except OSError:
+                    pass
+                if app_bundle is None:
+                    return json_error(
+                        f"No .app bundle found in {editor_path}. "
+                        "Set the editor to the .app bundle directly.",
+                        500,
+                    )
+
         try:
-            if editor:
-                if sys.platform == "darwin" and editor.endswith(".app"):
-                    subprocess.Popen(["open", "-a", editor] + file_paths)
-                else:
-                    subprocess.Popen([editor] + file_paths)
+            if app_bundle:
+                # `open -a` returns quickly after launching; capture the exit
+                # so launch failures surface instead of disappearing silently.
+                result = subprocess.run(
+                    ["open", "-a", app_bundle] + file_paths,
+                    capture_output=True, text=True, timeout=30,
+                )
+                if result.returncode != 0:
+                    err = (result.stderr or result.stdout or "open failed").strip()
+                    log.warning("open -a %s failed: %s", app_bundle, err)
+                    return json_error(err, 500)
+            elif editor_path:
+                subprocess.Popen([editor_path] + file_paths)
+            elif sys.platform == "darwin":
+                result = subprocess.run(
+                    ["open"] + file_paths,
+                    capture_output=True, text=True, timeout=30,
+                )
+                if result.returncode != 0:
+                    err = (result.stderr or result.stdout or "open failed").strip()
+                    log.warning("open %s failed: %s", file_paths, err)
+                    return json_error(err, 500)
+            elif sys.platform == "win32":
+                for fp in file_paths:
+                    os.startfile(fp)
             else:
-                if sys.platform == "darwin":
-                    subprocess.Popen(["open"] + file_paths)
-                elif sys.platform == "win32":
-                    for fp in file_paths:
-                        os.startfile(fp)
-                else:
-                    for fp in file_paths:
-                        subprocess.Popen(["xdg-open", fp])
+                for fp in file_paths:
+                    subprocess.Popen(["xdg-open", fp])
         except Exception as e:
             log.warning("Failed to open external editor: %s", e)
             return json_error(str(e), 500)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2347,6 +2347,10 @@ def create_app(db_path, thumb_cache_dir=None):
             return json_error("No photos found", 404)
 
         editor = cfg.get("external_editor")
+        if editor and not isinstance(editor, str):
+            return json_error(
+                "external_editor config must be a string path", 500
+            )
         editor_path = os.path.expanduser(editor) if editor else ""
 
         # On macOS, an .app bundle is a directory — execing it raises EACCES.

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -668,7 +668,7 @@
     <div class="setting-row">
       <div class="setting-label">
         Editor path
-        <small>Full path to the editor executable (e.g. /usr/bin/darktable, /Applications/RawTherapee.app). Leave empty to open with your OS default application.</small>
+        <small>Full path to the editor executable or .app bundle (e.g. /usr/bin/darktable, /Applications/RawTherapee.app, /Applications/Adobe Lightroom Classic/Adobe Lightroom Classic.app). Leave empty to open with your OS default application.</small>
       </div>
       <input type="text" id="cfgExternalEditor" placeholder="OS default"
              style="width:280px;background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:12px;font-family:monospace;"

--- a/vireo/tests/test_open_external.py
+++ b/vireo/tests/test_open_external.py
@@ -223,6 +223,35 @@ def test_open_external_directory_without_app_bundle_errors(app_and_db, monkeypat
     assert ".app" in body["error"]
 
 
+def test_open_external_directory_with_multiple_app_bundles_errors(app_and_db, monkeypatch, tmp_path):
+    """Directory containing multiple .app bundles reports a clear error instead of
+    silently picking the first one alphabetically."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    monkeypatch.setattr(sys, 'platform', 'darwin')
+
+    container = tmp_path / "AmbiguousApps"
+    (container / "Alpha.app").mkdir(parents=True)
+    (container / "Beta.app").mkdir()
+
+    client.post('/api/config',
+                data=json.dumps({"external_editor": str(container)}),
+                content_type='application/json')
+
+    launched = _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [1]}),
+                       content_type='application/json')
+    assert resp.status_code == 500
+    body = resp.get_json()
+    assert "Multiple" in body["error"]
+    assert "Alpha.app" in body["error"]
+    assert "Beta.app" in body["error"]
+    assert launched == []
+
+
 def test_open_external_rejects_non_string_editor(app_and_db, monkeypatch):
     """Non-string external_editor values return a structured 500, not an uncaught TypeError.
 

--- a/vireo/tests/test_open_external.py
+++ b/vireo/tests/test_open_external.py
@@ -223,6 +223,30 @@ def test_open_external_directory_without_app_bundle_errors(app_and_db, monkeypat
     assert ".app" in body["error"]
 
 
+def test_open_external_rejects_non_string_editor(app_and_db, monkeypatch):
+    """Non-string external_editor values return a structured 500, not an uncaught TypeError.
+
+    /api/config doesn't type-validate writes, so the persisted value can be any
+    JSON type. The endpoint must guard expanduser() to keep returning the
+    documented JSON error envelope.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+
+    import config as cfg
+    cfg.set("external_editor", 12345)
+
+    _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [1]}),
+                       content_type='application/json')
+    assert resp.status_code == 500
+    body = resp.get_json()
+    assert "error" in body
+    assert "string" in body["error"].lower()
+
+
 def test_open_external_expands_user_in_editor_path(app_and_db, monkeypatch, tmp_path):
     """`~`-prefixed editor paths are expanded before use."""
     app, _ = app_and_db

--- a/vireo/tests/test_open_external.py
+++ b/vireo/tests/test_open_external.py
@@ -1,4 +1,33 @@
 import json
+import subprocess
+import sys
+
+
+class _FakeCompleted:
+    def __init__(self, returncode=0, stderr=""):
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = ""
+
+
+def _patch_launchers(monkeypatch, run_returncode=0, run_stderr=""):
+    """Capture both subprocess.Popen and subprocess.run invocations.
+
+    Returns a list of recorded calls. Each entry is (kind, cmd) where kind is
+    either 'popen' or 'run'.
+    """
+    launched = []
+
+    def fake_popen(cmd, **kwargs):
+        launched.append(('popen', cmd))
+
+    def fake_run(cmd, **kwargs):
+        launched.append(('run', cmd))
+        return _FakeCompleted(returncode=run_returncode, stderr=run_stderr)
+
+    monkeypatch.setattr(subprocess, 'Popen', fake_popen)
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    return launched
 
 
 def test_open_external_requires_photo_ids(app_and_db):
@@ -25,13 +54,7 @@ def test_open_external_success(app_and_db, monkeypatch):
     """POST /api/photos/open-external opens photos and returns count."""
     app, db = app_and_db
     client = app.test_client()
-
-    launched = []
-    def fake_popen(cmd, **kwargs):
-        launched.append(cmd)
-
-    import subprocess
-    monkeypatch.setattr(subprocess, 'Popen', fake_popen)
+    launched = _patch_launchers(monkeypatch)
 
     resp = client.post('/api/photos/open-external',
                        data=json.dumps({"photo_ids": [1]}),
@@ -43,38 +66,35 @@ def test_open_external_success(app_and_db, monkeypatch):
 
 
 def test_open_external_uses_configured_editor(app_and_db, monkeypatch):
-    """Uses external_editor from config when set."""
+    """Uses external_editor from config when set to a plain executable."""
     app, db = app_and_db
     client = app.test_client()
 
-    # Set configured editor
     client.post('/api/config',
                 data=json.dumps({"external_editor": "/usr/bin/gimp"}),
                 content_type='application/json')
 
-    launched = []
-    def fake_popen(cmd, **kwargs):
-        launched.append(cmd)
-
-    import subprocess
-    monkeypatch.setattr(subprocess, 'Popen', fake_popen)
+    launched = _patch_launchers(monkeypatch)
 
     resp = client.post('/api/photos/open-external',
                        data=json.dumps({"photo_ids": [1]}),
                        content_type='application/json')
     assert resp.status_code == 200
-    assert launched[0][0] == '/usr/bin/gimp'
+    # Plain executable: launched via Popen, not `open -a`
+    assert launched[0][1][0] == '/usr/bin/gimp'
 
 
 def test_open_external_returns_500_on_launch_failure(app_and_db, monkeypatch):
-    """POST /api/photos/open-external returns 500 when editor fails to launch."""
+    """POST /api/photos/open-external returns 500 when launcher raises."""
     app, _ = app_and_db
     client = app.test_client()
 
-    import subprocess
     def failing_popen(cmd, **kwargs):
         raise FileNotFoundError("No such file: /bad/editor")
+    def failing_run(cmd, **kwargs):
+        raise FileNotFoundError("No such file: /bad/editor")
     monkeypatch.setattr(subprocess, 'Popen', failing_popen)
+    monkeypatch.setattr(subprocess, 'run', failing_run)
 
     resp = client.post('/api/photos/open-external',
                        data=json.dumps({"photo_ids": [1]}),
@@ -94,3 +114,135 @@ def test_config_saves_external_editor(app_and_db):
     resp2 = client.get('/api/config')
     cfg = resp2.get_json()
     assert cfg["external_editor"] == "/usr/bin/rawtherapee"
+
+
+def test_open_external_resolves_app_bundle_inside_directory(app_and_db, monkeypatch, tmp_path):
+    """A directory containing a .app bundle is resolved to that bundle.
+
+    Adobe Lightroom Classic installs to /Applications/Adobe Lightroom Classic/
+    (a folder) containing Adobe Lightroom Classic.app. Setting the folder as
+    the editor must still launch the bundled app.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+
+    monkeypatch.setattr(sys, 'platform', 'darwin')
+
+    # Build a fake app structure: <tmp>/MyEditor/MyEditor.app/
+    container = tmp_path / "MyEditor"
+    bundle = container / "MyEditor.app"
+    bundle.mkdir(parents=True)
+
+    client.post('/api/config',
+                data=json.dumps({"external_editor": str(container)}),
+                content_type='application/json')
+
+    launched = _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [1]}),
+                       content_type='application/json')
+    assert resp.status_code == 200, resp.get_json()
+    # Should be `open -a <bundle>` via subprocess.run
+    assert launched[0][0] == 'run'
+    assert launched[0][1][0] == 'open'
+    assert launched[0][1][1] == '-a'
+    assert launched[0][1][2] == str(bundle)
+
+
+def test_open_external_app_bundle_path_uses_open_a(app_and_db, monkeypatch, tmp_path):
+    """A direct .app path is launched with `open -a`."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    monkeypatch.setattr(sys, 'platform', 'darwin')
+
+    bundle = tmp_path / "Foo.app"
+    bundle.mkdir()
+
+    client.post('/api/config',
+                data=json.dumps({"external_editor": str(bundle)}),
+                content_type='application/json')
+
+    launched = _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [1]}),
+                       content_type='application/json')
+    assert resp.status_code == 200
+    assert launched[0][0] == 'run'
+    assert launched[0][1][:3] == ['open', '-a', str(bundle)]
+
+
+def test_open_external_surfaces_open_command_failure(app_and_db, monkeypatch, tmp_path):
+    """Non-zero exit from `open` is reported as 500 with stderr in the body."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    monkeypatch.setattr(sys, 'platform', 'darwin')
+
+    bundle = tmp_path / "Broken.app"
+    bundle.mkdir()
+
+    client.post('/api/config',
+                data=json.dumps({"external_editor": str(bundle)}),
+                content_type='application/json')
+
+    _patch_launchers(monkeypatch, run_returncode=1,
+                     run_stderr="The application cannot be opened.")
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [1]}),
+                       content_type='application/json')
+    assert resp.status_code == 500
+    body = resp.get_json()
+    assert "cannot be opened" in body["error"]
+
+
+def test_open_external_directory_without_app_bundle_errors(app_and_db, monkeypatch, tmp_path):
+    """Directory with no .app inside reports a clear error instead of execing it."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    monkeypatch.setattr(sys, 'platform', 'darwin')
+
+    container = tmp_path / "NotAnApp"
+    container.mkdir()
+
+    client.post('/api/config',
+                data=json.dumps({"external_editor": str(container)}),
+                content_type='application/json')
+
+    _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [1]}),
+                       content_type='application/json')
+    assert resp.status_code == 500
+    body = resp.get_json()
+    assert ".app" in body["error"]
+
+
+def test_open_external_expands_user_in_editor_path(app_and_db, monkeypatch, tmp_path):
+    """`~`-prefixed editor paths are expanded before use."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    monkeypatch.setattr(sys, 'platform', 'darwin')
+    monkeypatch.setenv('HOME', str(tmp_path))
+
+    bundle_dir = tmp_path / "Apps"
+    bundle = bundle_dir / "Tilde.app"
+    bundle.mkdir(parents=True)
+
+    client.post('/api/config',
+                data=json.dumps({"external_editor": "~/Apps/Tilde.app"}),
+                content_type='application/json')
+
+    launched = _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [1]}),
+                       content_type='application/json')
+    assert resp.status_code == 200
+    assert launched[0][1][2] == str(bundle)


### PR DESCRIPTION
## Summary
- Setting the external editor to a parent folder like `/Applications/Adobe Lightroom Classic/` (where Adobe puts the `.app`) failed with `[Errno 13] Permission denied` because the code tried to exec the directory as a binary. The macOS branch now expands `~`, searches the directory for a `.app` bundle, and routes it through `open -a`.
- Returns a clear 500 with guidance when a directory has no `.app` inside it.
- macOS `open` invocations switched from fire-and-forget `subprocess.Popen` to `subprocess.run` with captured stderr, so launch failures surface as 500s instead of disappearing silently (the second issue you hit: 200 OK in the log but nothing on screen).
- Settings hint updated to mention `.app` bundles are valid.

## Test plan
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_open_external.py -q` → 510 passed
- [x] New tests cover: directory containing `.app` resolves, direct `.app` uses `open -a`, non-zero `open` exit returns 500 with stderr, directory with no `.app` returns 500, `~`-prefixed paths expand, plain executable still uses Popen
- [ ] Manually set editor to `/Applications/Adobe Lightroom Classic/` and verify Lightroom launches

## Notes on the silent-launch question
With the old code, `subprocess.Popen(["open", "-a", ...])` returned immediately and the request logged 200 — any `open`-level error (app refused to launch, file not found, etc.) was swallowed. The new code captures `open`'s exit and surfaces it. If Lightroom still doesn't show the photo after this fix lands, the response body will now tell us why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)