### PR TITLE
Eye-focus detection

### DIFF
--- a/docs/plans/2026-04-16-eye-focus-detection-design.md
+++ b/docs/plans/2026-04-16-eye-focus-detection-design.md
@@ -1,0 +1,194 @@
+# Eye-Focus Detection
+
+## Problem
+
+Vireo's current focus signal (`subject_tenengrad` in `vireo/quality.py`) measures sharpness over the entire SAM2 subject mask. For wildlife photography, this is the wrong granularity: a frame with a soft eye and a sharp body reads as "in focus" to the scorer but "garbage" to the photographer. Conversely, a shallow-DOF portrait with a tack-sharp eye and a soft body is scored as if it were out of focus because most of the masked pixels are soft.
+
+The field-standard wildlife-photography rule is "the eye must be sharp." We want a scoring signal that matches that rule, while degrading gracefully on species and poses where we cannot locate an eye.
+
+## Design Decisions
+
+- **Eye focus replaces body focus when we confidently locate the eye.** Not additive, not a blend. When the keypoint model confidently returns an eye coord inside the subject mask, `eye_focus_score` becomes the focus term in `quality_composite`. When we cannot locate an eye, the focus term is `subject_focus` as it is today. The user's score for any given photo is based on the best signal we have for *that* photo.
+- **Same threshold `T` gates two behaviors.** If `eye_conf ≥ T` (and the other gates pass), we *both* use `eye_focus_score` in the composite *and* make the `reject_eye_soft` hard-reject rule eligible. One knob, two effects. Tuning `T` stays coherent.
+- **Best eye wins.** Most wildlife portraits have shallow DOF; the near eye is what the photographer focused on and the far eye being soft is an aesthetic, not a flaw. `eye_focus_score = max` over visible eyes that pass the confidence gate.
+- **Mask containment is a gate.** A keypoint model run on the MegaDetector crop can latch onto the wrong animal in a multi-subject frame. The detected eye coordinate must fall inside the SAM2 subject mask — otherwise we throw it out. Point-in-polygon test, nearly free.
+- **Two models, taxonomy-routed.** SuperAnimal-Quadruped for mammals, SuperAnimal-Bird for birds. Route by `species_top5[0]`'s class lineage (`Mammalia` or `Aves`) via the iNat taxonomy already in the `taxa` table. Everything else (fish, reptiles, insects, unknown) skips keypoint detection and falls back to `subject_focus`.
+- **De-risk the pipeline before exporting SuperAnimal.** First integration uses RTMPose-animal (MMPose, first-party ONNX via `mmdeploy`). This validates ONNX loading, heatmap decoding, window sizing, scoring integration, DB schema, and UI — all the downstream work — against a model with clean tooling. Only then do we wrestle with SuperAnimal's export.
+- **Opt-in weights download, matching SAM2/DINOv2 pattern.** A new "Eye-focus detection" stage appears on the pipeline page. Users who haven't downloaded weights see a download card (mirroring the SAM2/DINOv2 cards added in #579); users who haven't downloaded get `eye_*` columns that stay null and scoring falls back to `subject_focus` — no behavior change.
+- **Null-safe migration.** Adding 4 nullable columns with null defaults means existing photos score identically to today. Scoring changes only take effect on the next pipeline replay.
+
+## Models
+
+**Production (V1):**
+- **SuperAnimal-Quadruped** (DeepLabCut 3.x, HuggingFace). ~90 quadruped species zero-shot. Returns ~39 keypoints including `left_eye` and `right_eye`. Used when `species_top5[0]` lineage contains `Mammalia`.
+- **SuperAnimal-Bird** (DeepLabCut 3.x, HuggingFace). Bird-specific keypoint set including eye. Used when lineage contains `Aves`.
+
+**Integration-spike (ships first, may stay or may be removed):**
+- **RTMPose-animal** (MMPose, trained on AP-10K). Small (~30 MB), transformer-based, first-party ONNX via `mmdeploy`. Returns 17 keypoints including eyes for quadrupeds. Used to prove out ONNX export, decoding, scoring integration, UI, and DB migration before touching SuperAnimal. Decision about whether to keep RTMPose in the shipped app (as a faster alternative or a fallback) deferred until after we have working SuperAnimal integration.
+
+**Export:** add `export_rtmpose_animal()`, `export_superanimal_quadruped()`, and `export_superanimal_bird()` to `scripts/export_onnx.py`, following the existing wrapper + `torch.onnx.export` + `_validate_onnx` pattern. Weights upload to `jss367/vireo-onnx-models`.
+
+**Preprocessing parity is the #1 export risk.** Each model has a specific input size, normalization, and aspect-ratio-preserving resize-with-padding scheme. Mismatch between PyTorch and ONNX at the preprocessing layer manifests as garbage keypoints, not crashes. Validation must compare decoded keypoint coordinates (not raw heatmap tensors) between PyTorch and ONNX Runtime, with tolerance in pixels (±1 px).
+
+## Three-Gate Trust Policy
+
+For a given photo, the eye signal is *trusted* — used in the composite and eligible to trigger `reject_eye_soft` — if and only if **all** of the following hold:
+
+1. `classifier_top1_conf ≥ C` **and** `species_top5[0]` lineage contains `Aves` or `Mammalia`. Default `C = 0.5`. Filters out shaky classifications and non-vertebrate taxa.
+2. The appropriate keypoint model's weights are present on disk (user has completed the download) and the model ran without error.
+3. At least one eye keypoint has `conf ≥ T`. Default `T = 0.5` (tune from SuperAnimal paper's recommended range; validate on real data).
+4. The detected eye coordinate `(x, y)` lies inside the SAM2 subject mask.
+
+If any gate fails, `eye_x`, `eye_y`, `eye_conf`, `eye_focus_score` all stay null. The composite uses `subject_focus` as it does today.
+
+## Scoring Math
+
+For each eye keypoint `(x_k, y_k, conf_k)` where `conf_k ≥ T` and `(x_k, y_k)` is inside the mask:
+
+1. Window side length: `w = round(k * min(bbox_w, bbox_h))`, where `k = 0.08` by default, `bbox` is the MegaDetector bounding box in image-pixel space.
+2. Extract the `w × w` window centered on `(x_k, y_k)`, clamped to image bounds.
+3. Compute multi-scale Tenengrad on the grayscale window using the existing `_multiscale_tenengrad` helper in `vireo/quality.py`.
+
+Then:
+
+- `eye_focus_raw = max_k eye_tenengrad_k`
+- Normalize within encounter using the same percentile normalization that `subject_focus` uses in `vireo/scoring.py` (so `eye_focus_score ∈ [0, 1]` and has the same semantics as `subject_focus`).
+- "Best eye" (for DB storage): the eye whose per-keypoint tenengrad was the maximum. Its `(x, y, conf)` is what lands in the `eye_x`, `eye_y`, `eye_conf` columns.
+
+**Composite change in `score_encounter()`:**
+
+```
+if eye_focus_score is not null and all gates passed:
+    focus_term = eye_focus_score
+else:
+    focus_term = subject_focus
+q = w_focus * focus_term + w_exposure * e + w_composition * c + w_area * a + w_noise * n
+```
+
+All other weights and score components are unchanged.
+
+## Reject Rule
+
+New hard-reject rule parallel to `out_of_focus`:
+
+```
+if gates passed and eye_focus_score < reject_eye_focus:
+    reject_reasons.append(f"eye_soft (E={eye_focus_score:.3f} < {reject_eye_focus})")
+```
+
+Default `reject_eye_focus = 0.35` (mirrors the existing `reject_focus` threshold). Only fires when the eye signal is trusted — never rejects a photo on the basis of a low-confidence or outside-mask eye detection.
+
+## Database Schema
+
+Add four nullable columns to `photos`:
+
+| Column            | Type    | Meaning                                                          |
+|-------------------|---------|------------------------------------------------------------------|
+| `eye_x`           | REAL    | x coord of best eye in image pixels                              |
+| `eye_y`           | REAL    | y coord of best eye in image pixels                              |
+| `eye_conf`        | REAL    | keypoint confidence of the best eye, ∈ [0, 1]                   |
+| `eye_focus_score` | REAL    | normalized focus score around the best eye, ∈ [0, 1]            |
+
+All null when any gate fails. A single "best eye" row per photo rather than storing both eyes separately — the max-over-eyes decision is made at computation time, and we keep only the winner.
+
+Migration: `ALTER TABLE photos ADD COLUMN ...` for each of the four. Safe on existing SQLite because all are nullable with implicit null default.
+
+## Pipeline Staging
+
+New stage in `vireo/pipeline.py` between the existing masking stage and the quality-scoring stage:
+
+```
+... → mask_photos → detect_eye_keypoints → score_quality → score_encounter → MMR triage → ...
+```
+
+`detect_eye_keypoints` is the new stage. For each photo with a subject mask and a species prediction that routes to a supported keypoint model:
+
+1. Crop the image to the MegaDetector bbox (with a modest margin — match whatever margin masking already uses).
+2. Run the routed keypoint model on the crop.
+3. Decode heatmaps to `(x, y, conf)` keypoints (argmax + subpixel refinement, standard MMPose / DLC decoding; ~30 lines of numpy).
+4. Translate eye coords from crop-space back to image-pixel space.
+5. Apply the three-gate policy.
+6. If gated through, compute per-eye tenengrad (raw values), pick the winner, persist `(eye_x, eye_y, eye_conf)`.
+
+Normalization into `eye_focus_score ∈ [0, 1]` happens in the next stage (scoring), where per-encounter statistics are available. This matches how `subject_focus` is computed today.
+
+**Replay:** existing pipeline replay machinery. The stage should be re-runnable independently when model weights appear (e.g., user downloads SuperAnimal weights after first pipeline run), without forcing a full re-score.
+
+## UI
+
+One visible change in V1: the review lightbox draws a small crosshair or ring at `(eye_x, eye_y)` when that column is non-null. Visible at any zoom level; aligns with the photographer workflow of pixel-peeping the eye at 1:1.
+
+No score-panel changes in V1. A badge showing "eye-based focus: 0.62 (replaced body focus 0.54)" is the obvious V1.1 addition once the feature has been dogfooded and we know what framing makes sense to users.
+
+Also needed: a new "Eye-focus detection" stage card on `/pipeline`, mirroring the SAM2/DINOv2 cards that show model-download status. Card states: "Model weights not downloaded → [Download SuperAnimal-Quadruped (~200 MB)]", "Running…", "Ready".
+
+## Configuration
+
+New config keys (global defaults, per-workspace overridable via the existing `config_overrides` JSON column on `workspaces`):
+
+| Key                         | Default | Purpose                                                                 |
+|-----------------------------|---------|-------------------------------------------------------------------------|
+| `eye_detect_enabled`        | `true`  | Master switch for the stage                                             |
+| `eye_classifier_conf_gate`  | `0.5`   | `C` — classifier top-1 confidence required to attempt keypoint detection |
+| `eye_detection_conf_gate`   | `0.5`   | `T` — keypoint-model eye confidence required to trust the signal         |
+| `eye_window_k`              | `0.08`  | Window size as fraction of `min(bbox_w, bbox_h)`                        |
+| `reject_eye_focus`          | `0.35`  | `eye_focus_score` below which `reject_eye_soft` fires                   |
+
+No new composite weights — the existing `w_focus` serves both the old and new focus term.
+
+## Failure Modes Handled
+
+| Failure                                           | Result                                                                    |
+|---------------------------------------------------|---------------------------------------------------------------------------|
+| User hasn't downloaded keypoint weights           | Stage skipped; columns null; scoring uses `subject_focus`                 |
+| Classifier low confidence                         | Gate 1 fails; columns null                                                |
+| Species is fish / reptile / insect / unknown      | Gate 1 fails; columns null                                                |
+| Keypoint model runs but no high-confidence eyes   | Gate 3 fails; columns null                                                |
+| Detected eye keypoint falls outside subject mask  | Gate 4 fails; columns null                                                |
+| Multi-subject frame, wrong eye picked             | Typically caught by gate 4 (mask containment)                             |
+| Photo has no subject mask (masking stage skipped) | Stage skipped for this photo; columns null                                |
+| Back-of-head, occluded, profile shots             | Gate 3 usually fails (low eye conf); columns null                         |
+
+In every failure case, composite math falls back to `subject_focus` — there is no "new scoring regression path" for photos that don't get the eye signal.
+
+## Migration
+
+No rescoring required on upgrade. The migration just adds four nullable columns. Existing photos have null `eye_*` values and score identically to the pre-feature behavior.
+
+First pipeline replay after the user downloads keypoint weights computes `eye_*` for eligible photos and applies the new composite and reject rule.
+
+## Implementation Scope
+
+**New files:**
+- `vireo/keypoints.py` — weights download, ONNX session cache, `detect_keypoints(image, bbox, species_class) → [(name, x, y, conf), ...]`. Mirrors `vireo/detector.py` shape.
+- `scripts/export_onnx.py` additions — three new `export_*` functions (RTMPose-animal, SuperAnimal-Quadruped, SuperAnimal-Bird) following existing patterns.
+
+**Modified:**
+- `scripts/export_onnx.py` — extend `ALL_MODELS` and `_EXPORT_FUNCTIONS`.
+- `vireo/pipeline.py` — new `detect_eye_keypoints` stage between mask + score.
+- `vireo/quality.py` — new `compute_eye_tenengrad(image, eye_xy, bbox, k) → float`.
+- `vireo/scoring.py` — composite now uses `eye_focus_score` when gates pass; new `reject_eye_soft` rule.
+- `vireo/db.py` — migration adding 4 nullable columns; photo CRUD updated.
+- `vireo/taxonomy.py` — helper `classify_to_keypoint_group(top1_taxon_id) → 'Aves' | 'Mammalia' | None`.
+- `vireo/app.py` — new `/api/models/keypoints/status` and download endpoints (mirror SAM2/DINOv2).
+- `vireo/templates/pipeline.html` — new "Eye-focus detection" card.
+- `vireo/templates/_navbar.html` or the specific lightbox container — crosshair overlay at `(eye_x, eye_y)`.
+- `vireo/templates/settings.html` — four new tunable thresholds.
+
+**Tests:**
+- Unit tests for keypoint loading, decoding, coordinate mapping.
+- Scoring tests: gate combinations (each gate failing in isolation, all passing, both-eye case), max-over-eyes, replace-vs-fallback composite behavior, reject-rule firing only when gated through.
+- Quality tests: `compute_eye_tenengrad` window sizing, boundary clamping.
+- Pipeline tests: stage runs when weights present; skipped gracefully when absent; stage is independently replayable.
+- DB tests: migration adds columns; CRUD round-trips all four values including null.
+- Taxonomy tests: `classify_to_keypoint_group` correctly maps Aves/Mammalia lineages and returns None for everything else.
+- UI smoke: crosshair renders when eye_x/eye_y present; hidden when null.
+
+## Open Questions
+
+- **SuperAnimal ONNX export risk.** Export path has been validated in community forks but not first-party. The RTMPose spike de-risks this for the downstream pipeline; the export itself is still work that could turn up surprises (especially in preprocessing parity). If SuperAnimal export turns out to be a real slog, RTMPose-animal alone is a reasonable V1 for mammals — narrower species coverage but proven tooling.
+- **Default thresholds `C` and `T`.** Both defaulted to 0.5 based on common practice; real values come from measuring on a held-out set of Vireo-users' photos. Plan to keep these configurable and iterate after dogfooding.
+- **Multi-bird-in-frame photos** (e.g. a flock). SAM2 picks one subject mask. If the detected eye in the crop belongs to a different bird than the mask, gate 4 catches it. If it belongs to the same species but is in the mask (overlapping birds), the signal is still valid for *a* bird, just maybe not *the* bird. Acceptable edge case.
+- **Cropping margin.** MegaDetector bboxes are tight; some keypoint models work better with a small margin (5–10%). Decide during RTMPose spike based on measured detection rates.
+- **Window size `k`.** 0.08 is a guess informed by eye-to-head ratios in most birds and mammals. Validate on a few hundred real photos; a dynamic `k` based on species class may be needed.
+- **Per-workspace "disable eye-focus" affordance.** The config key is per-workspace overridable, but we don't plan a dedicated toggle in V1. Add if users ask.

--- a/docs/plans/2026-04-16-eye-focus-detection-design.md
+++ b/docs/plans/2026-04-16-eye-focus-detection-design.md
@@ -80,16 +80,18 @@ Default `reject_eye_focus = 0.35` (mirrors the existing `reject_focus` threshold
 
 ## Database Schema
 
-Add four nullable columns to `photos`:
+Add four nullable columns to `photos`. These mirror the persistence pattern of `subject_tenengrad` — raw per-photo values that scoring consumes at query time:
 
-| Column            | Type    | Meaning                                                          |
-|-------------------|---------|------------------------------------------------------------------|
-| `eye_x`           | REAL    | x coord of best eye in image pixels                              |
-| `eye_y`           | REAL    | y coord of best eye in image pixels                              |
-| `eye_conf`        | REAL    | keypoint confidence of the best eye, ∈ [0, 1]                   |
-| `eye_focus_score` | REAL    | normalized focus score around the best eye, ∈ [0, 1]            |
+| Column          | Type | Meaning                                                                              |
+|-----------------|------|--------------------------------------------------------------------------------------|
+| `eye_x`         | REAL | x coord of best eye in image pixels                                                  |
+| `eye_y`         | REAL | y coord of best eye in image pixels                                                  |
+| `eye_conf`      | REAL | keypoint confidence of the best eye, ∈ [0, 1]                                        |
+| `eye_tenengrad` | REAL | raw multi-scale Tenengrad measured in the window around the best eye (parallel to `subject_tenengrad`) |
 
-All null when any gate fails. A single "best eye" row per photo rather than storing both eyes separately — the max-over-eyes decision is made at computation time, and we keep only the winner.
+**What is *not* persisted:** `eye_focus_score` (the per-encounter percentile-normalized version). Computed in-memory at scoring time, same way `focus_score` and `quality_composite` are computed today — Vireo does not persist normalized scores.
+
+All four columns null when any gate fails. A single "best eye" row per photo rather than storing both eyes separately — the max-over-eyes decision is made at computation time, and we keep only the winner.
 
 Migration: `ALTER TABLE photos ADD COLUMN ...` for each of the four. Safe on existing SQLite because all are nullable with implicit null default.
 
@@ -108,9 +110,9 @@ New stage in `vireo/pipeline.py` between the existing masking stage and the qual
 3. Decode heatmaps to `(x, y, conf)` keypoints (argmax + subpixel refinement, standard MMPose / DLC decoding; ~30 lines of numpy).
 4. Translate eye coords from crop-space back to image-pixel space.
 5. Apply the three-gate policy.
-6. If gated through, compute per-eye tenengrad (raw values), pick the winner, persist `(eye_x, eye_y, eye_conf)`.
+6. If gated through, compute per-eye tenengrad (raw values), pick the winner, persist `(eye_x, eye_y, eye_conf, eye_tenengrad)` — the raw tenengrad of the winning eye.
 
-Normalization into `eye_focus_score ∈ [0, 1]` happens in the next stage (scoring), where per-encounter statistics are available. This matches how `subject_focus` is computed today.
+Normalization into `eye_focus_score ∈ [0, 1]` happens in the scoring stage, where per-encounter statistics are available. This matches how `focus_score` is derived from the persisted `subject_tenengrad` today: the raw value is the DB column, the normalized score is ephemeral.
 
 **Replay:** existing pipeline replay machinery. The stage should be re-runnable independently when model weights appear (e.g., user downloads SuperAnimal weights after first pipeline run), without forcing a full re-score.
 

--- a/docs/plans/2026-04-16-eye-focus-detection-plan.md
+++ b/docs/plans/2026-04-16-eye-focus-detection-plan.md
@@ -1,0 +1,1347 @@
+# Eye-Focus Detection Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a per-photo eye-focus signal that replaces body-level sharpness in `quality_composite` when an eye is confidently localized, with a parallel `reject_eye_soft` hard-reject rule. See `docs/plans/2026-04-16-eye-focus-detection-design.md` for validated design.
+
+**Architecture:** Two new ONNX keypoint models (SuperAnimal-Quadruped, SuperAnimal-Bird) taxonomy-routed from `species_top5[0]`. New pipeline stage between masking and scoring. Four new nullable columns on `photos` (`eye_x`, `eye_y`, `eye_conf`, `eye_tenengrad`) — all raw values, normalized `eye_focus_score` computed ephemerally at scoring time (mirrors how `subject_tenengrad` / `focus_score` work today). Ships RTMPose-animal first as an integration spike to de-risk the downstream pipeline before touching SuperAnimal export.
+
+**Tech Stack:** Python 3, SQLite (WAL), ONNX Runtime, Flask, Jinja2, vanilla JS. Models: `mmpose` + `mmdeploy` (RTMPose export), `deeplabcut` (SuperAnimal export), `onnxruntime` (inference). Testing: `pytest`, Playwright for UI.
+
+---
+
+## Important Context for the Implementer
+
+**Workflow rules (non-negotiable, from `CLAUDE.md`):**
+- You are in a worktree (`.worktrees/eye-focus-detection`) on branch `claude/eye-focus-detection`. Do **not** modify files outside this worktree.
+- `docs/plans/` is gitignored. Commit plan/design docs with `git add -f`.
+- Commit after each task passes. Never skip `--no-verify`. Never amend.
+- Before creating a PR, run:
+  ```bash
+  python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py \
+    vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py \
+    vireo/tests/test_darktable_api.py vireo/tests/test_config.py -v
+  ```
+
+**Patterns to mirror (these already exist — read them before writing similar code):**
+- ONNX model loading, download, and session cache: `vireo/detector.py` (MegaDetector), `vireo/masking.py` (SAM2), `vireo/dino_embed.py` (DINOv2). Use the same `_session` / `_lock` / `_download_lock` / `ensure_*_weights` structure.
+- Multi-scale Tenengrad and mask-region sharpness: `vireo/quality.py:53-138`. The helpers `_tenengrad` and `_multiscale_tenengrad` are reusable.
+- DB migration and ALTER TABLE pattern: `vireo/db.py:347` for `subject_tenengrad`. Match.
+- Pipeline stages and progress reporting: `vireo/pipeline.py`. Each stage is a function that iterates photos and reports progress via the `JobRunner` callback.
+- ONNX export script pattern: `scripts/export_onnx.py`. Every model has a `_ModelWrapper` class + `export_*()` function + entry in `_EXPORT_FUNCTIONS` and `ALL_MODELS`.
+- Pipeline UI cards for model-download status: `vireo/templates/pipeline.html` "Extract Features" card (SAM2/DINOv2 download status, from commit `e3eba78`).
+- Settings UI for tunable thresholds: `vireo/templates/settings.html`.
+
+**Test conventions:**
+- DB tests use tmp_path and a fresh `Database(tmp_path/"x.db")`.
+- App tests isolate config via `cfg.CONFIG_PATH = str(tmp_path/"config.json")`.
+- Keypoint-model inference is mocked at the `onnxruntime.InferenceSession.run` level — do not require weights in CI tests.
+- End-to-end tests involving real model weights are dev-only and live under `tests/e2e/`, skipped when weights are absent.
+
+---
+
+## Milestone 1: Database Schema
+
+Add four nullable columns to `photos`. Migration style matches the existing `subject_tenengrad` ALTER at `vireo/db.py:347`.
+
+### Task 1.1: Write failing migration test
+
+**Files:**
+- Modify test: `vireo/tests/test_db.py`
+
+**Step 1: Add test**
+
+```python
+def test_photos_has_eye_focus_columns(tmp_path):
+    db = Database(str(tmp_path / "x.db"))
+    cols = {row[1] for row in db.conn.execute("PRAGMA table_info(photos)")}
+    assert "eye_x" in cols
+    assert "eye_y" in cols
+    assert "eye_conf" in cols
+    assert "eye_tenengrad" in cols
+```
+
+**Step 2: Run test, expect FAIL**
+
+```
+python -m pytest vireo/tests/test_db.py::test_photos_has_eye_focus_columns -v
+```
+
+Expected output: `FAILED` because the columns don't exist.
+
+### Task 1.2: Implement migration
+
+**Files:**
+- Modify: `vireo/db.py` — add ALTER TABLE statements alongside the existing `subject_tenengrad` migration at line ~347.
+
+**Step 1: Add to the migration block**
+
+Find the block containing `ALTER TABLE photos ADD COLUMN subject_tenengrad REAL`. Add four adjacent migrations, each wrapped in the same try/except OperationalError pattern used for existing columns:
+
+```python
+try:
+    self.conn.execute("ALTER TABLE photos ADD COLUMN eye_x REAL")
+except sqlite3.OperationalError:
+    pass
+try:
+    self.conn.execute("ALTER TABLE photos ADD COLUMN eye_y REAL")
+except sqlite3.OperationalError:
+    pass
+try:
+    self.conn.execute("ALTER TABLE photos ADD COLUMN eye_conf REAL")
+except sqlite3.OperationalError:
+    pass
+try:
+    self.conn.execute("ALTER TABLE photos ADD COLUMN eye_tenengrad REAL")
+except sqlite3.OperationalError:
+    pass
+```
+
+**Step 2: Run test, expect PASS**
+
+```
+python -m pytest vireo/tests/test_db.py::test_photos_has_eye_focus_columns -v
+```
+
+**Step 3: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: add eye_x, eye_y, eye_conf, eye_tenengrad columns to photos"
+```
+
+### Task 1.3: Write CRUD test
+
+**Files:**
+- Modify test: `vireo/tests/test_db.py`
+
+**Step 1: Add test**
+
+```python
+def test_update_photo_eye_fields_roundtrip(tmp_path, sample_photo_row):
+    db = Database(str(tmp_path / "x.db"))
+    photo_id = db.insert_photo(sample_photo_row)
+    db.update_photo(photo_id, eye_x=123.4, eye_y=56.7, eye_conf=0.82, eye_tenengrad=18450.2)
+    row = db.conn.execute(
+        "SELECT eye_x, eye_y, eye_conf, eye_tenengrad FROM photos WHERE id=?",
+        (photo_id,),
+    ).fetchone()
+    assert row == (123.4, 56.7, 0.82, 18450.2)
+
+def test_update_photo_eye_fields_accept_null(tmp_path, sample_photo_row):
+    db = Database(str(tmp_path / "x.db"))
+    photo_id = db.insert_photo(sample_photo_row)
+    db.update_photo(photo_id, eye_x=None, eye_y=None, eye_conf=None, eye_tenengrad=None)
+    row = db.conn.execute(
+        "SELECT eye_x, eye_y, eye_conf, eye_tenengrad FROM photos WHERE id=?",
+        (photo_id,),
+    ).fetchone()
+    assert row == (None, None, None, None)
+```
+
+If `sample_photo_row` fixture does not exist, add a conftest fixture that returns a minimal row dict matching the `photos` schema — copy the shape from an existing photo-insert test in the same file.
+
+**Step 2: Run tests, expect FAIL**
+
+Tests fail because `update_photo` doesn't accept these keyword arguments (the method uses a `_UNSET` sentinel pattern — see `db.py:2562`).
+
+### Task 1.4: Implement CRUD
+
+**Files:**
+- Modify: `vireo/db.py` — extend `update_photo` signature and SQL around line 2562–2580.
+
+**Step 1: Add params and SQL fragments**
+
+Add `eye_x=_UNSET`, `eye_y=_UNSET`, `eye_conf=_UNSET`, `eye_tenengrad=_UNSET` to the `update_photo` signature. Add matching entries to the dict that drives SQL generation:
+
+```python
+"eye_x": eye_x,
+"eye_y": eye_y,
+"eye_conf": eye_conf,
+"eye_tenengrad": eye_tenengrad,
+```
+
+**Step 2: Run tests, expect PASS**
+
+```
+python -m pytest vireo/tests/test_db.py::test_update_photo_eye_fields_roundtrip \
+                 vireo/tests/test_db.py::test_update_photo_eye_fields_accept_null -v
+```
+
+**Step 3: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: accept eye_* fields in update_photo"
+```
+
+---
+
+## Milestone 2: Taxonomy Routing Helper
+
+Pure function: given a top-1 iNat taxon ID, return `'Aves'`, `'Mammalia'`, or `None` based on the lineage stored in the `taxa` table.
+
+### Task 2.1: Write failing test
+
+**Files:**
+- Modify test: `vireo/tests/test_taxonomy.py`
+
+**Step 1: Add test**
+
+```python
+def test_classify_to_keypoint_group_bird(tmp_path):
+    db = Database(str(tmp_path / "x.db"))
+    # Insert a minimal Aves lineage: Aves class → Passeriformes order → ... → species
+    db.conn.execute("INSERT INTO taxa (inat_id, name, rank, kingdom) VALUES (3, 'Aves', 'class', 'Animalia')")
+    db.conn.execute("INSERT INTO taxa (inat_id, name, rank, kingdom, parent_id) VALUES (7019, 'Passeriformes', 'order', 'Animalia', 3)")
+    db.conn.execute("INSERT INTO taxa (inat_id, name, rank, kingdom, parent_id) VALUES (12345, 'Cardinalis cardinalis', 'species', 'Animalia', 7019)")
+    db.conn.commit()
+    assert classify_to_keypoint_group(db, 12345) == "Aves"
+
+def test_classify_to_keypoint_group_mammal(tmp_path):
+    db = Database(str(tmp_path / "x.db"))
+    db.conn.execute("INSERT INTO taxa (inat_id, name, rank, kingdom) VALUES (40151, 'Mammalia', 'class', 'Animalia')")
+    db.conn.execute("INSERT INTO taxa (inat_id, name, rank, kingdom, parent_id) VALUES (42158, 'Carnivora', 'order', 'Animalia', 40151)")
+    db.conn.execute("INSERT INTO taxa (inat_id, name, rank, kingdom, parent_id) VALUES (42048, 'Vulpes vulpes', 'species', 'Animalia', 42158)")
+    db.conn.commit()
+    assert classify_to_keypoint_group(db, 42048) == "Mammalia"
+
+def test_classify_to_keypoint_group_fish_returns_none(tmp_path):
+    db = Database(str(tmp_path / "x.db"))
+    db.conn.execute("INSERT INTO taxa (inat_id, name, rank, kingdom) VALUES (47178, 'Actinopterygii', 'class', 'Animalia')")
+    db.conn.execute("INSERT INTO taxa (inat_id, name, rank, kingdom, parent_id) VALUES (47179, 'Perciformes', 'order', 'Animalia', 47178)")
+    db.conn.execute("INSERT INTO taxa (inat_id, name, rank, kingdom, parent_id) VALUES (99999, 'Somefish somefish', 'species', 'Animalia', 47179)")
+    db.conn.commit()
+    assert classify_to_keypoint_group(db, 99999) is None
+
+def test_classify_to_keypoint_group_unknown_returns_none(tmp_path):
+    db = Database(str(tmp_path / "x.db"))
+    assert classify_to_keypoint_group(db, 999999) is None
+```
+
+Inspect `vireo/taxonomy.py` to confirm the actual schema of the `taxa` table (column names for parent, rank). If the table stores `ancestry_ids` as a path instead of `parent_id`, adjust the test fixtures accordingly and the implementation below.
+
+**Step 2: Run, expect FAIL**
+
+### Task 2.2: Implement helper
+
+**Files:**
+- Modify: `vireo/taxonomy.py`
+
+**Step 1: Add function**
+
+```python
+def classify_to_keypoint_group(db, inat_id):
+    """Walk taxon lineage; return 'Aves' or 'Mammalia' if in ancestry, else None.
+
+    Used to route keypoint-model selection. Returns None for fish, reptiles,
+    insects, invertebrates, or if the taxon is absent from the taxonomy.
+    """
+    if inat_id is None:
+        return None
+    seen = set()
+    current = inat_id
+    while current is not None and current not in seen:
+        seen.add(current)
+        row = db.conn.execute(
+            "SELECT name, rank, parent_id FROM taxa WHERE inat_id=?",
+            (current,),
+        ).fetchone()
+        if row is None:
+            return None
+        name, rank, parent_id = row
+        if rank == "class" and name in ("Aves", "Mammalia"):
+            return name
+        current = parent_id
+    return None
+```
+
+Adjust the column names if the actual schema uses `ancestry_ids` or a different parent field — the test fixtures above and this implementation must match whatever `load_taxa_from_file` actually writes.
+
+**Step 2: Run, expect PASS**
+
+```
+python -m pytest vireo/tests/test_taxonomy.py -v -k classify_to_keypoint_group
+```
+
+**Step 3: Commit**
+
+```bash
+git add vireo/taxonomy.py vireo/tests/test_taxonomy.py
+git commit -m "taxonomy: add classify_to_keypoint_group helper"
+```
+
+---
+
+## Milestone 3: RTMPose-animal ONNX Export (Integration Spike)
+
+This is a dev-only operation in `scripts/export_onnx.py`. It produces the first working ONNX keypoint model for Vireo. End-to-end validation is manual — the CI tests in later milestones use mocked ONNX sessions.
+
+### Task 3.1: Add RTMPose export function
+
+**Files:**
+- Modify: `scripts/export_onnx.py`
+
+**Step 1: Add the export function**
+
+Add after the SAM2 section:
+
+```python
+# ---------------------------------------------------------------------------
+# RTMPose-animal (MMPose, AP-10K keypoints)
+# ---------------------------------------------------------------------------
+
+def export_rtmpose_animal(output_dir, opset, validate=False):
+    """Export RTMPose-s trained on AP-10K to ONNX via mmdeploy.
+
+    RTMPose returns heatmaps for 17 keypoints including left_eye (idx 0)
+    and right_eye (idx 1). Top-down: takes a cropped image, returns
+    per-keypoint (x, y, conf) after heatmap decoding (done at inference
+    time, not inside the ONNX graph).
+
+    Input:  (1, 3, 256, 256) float32
+    Output: (1, 17, 64, 64) float32 heatmaps (simcc variant may differ)
+    """
+    import mmpose
+    from mmpose.apis import init_model
+    from mmdeploy.apis import torch2onnx
+
+    model_id = "rtmpose-animal"
+    log.info("Exporting %s...", model_id)
+
+    # Use the official RTMPose-s AP-10K config + checkpoint
+    config = (
+        "https://raw.githubusercontent.com/open-mmlab/mmpose/main/"
+        "configs/animal_2d_keypoint/rtmpose/ap10k/"
+        "rtmpose-s_8xb64-210e_ap10k-256x256.py"
+    )
+    checkpoint = (
+        "https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/"
+        "rtmpose-s_simcc-ap10k_pt-aic-coco_210e-256x256-7a041aa1_20230206.pth"
+    )
+
+    out_dir = _ensure_dir(os.path.join(output_dir, model_id))
+    onnx_path = os.path.join(out_dir, "model.onnx")
+
+    # Use mmdeploy's torch2onnx helper — it handles the simcc head correctly
+    # (RTMPose uses coordinate classification, not pure heatmaps).
+    deploy_cfg = {
+        "onnx_config": {
+            "type": "onnx",
+            "export_params": True,
+            "keep_initializers_as_inputs": False,
+            "opset_version": opset,
+            "save_file": onnx_path,
+            "input_names": ["pixel_values"],
+            "output_names": ["simcc_x", "simcc_y"],
+            "input_shape": [256, 256],
+        },
+        "codebase_config": {"type": "mmpose", "task": "PoseDetection"},
+        "backend_config": {"type": "onnxruntime"},
+    }
+
+    # Download a sample image to use as calibration input
+    import urllib.request
+    sample_path = os.path.join(out_dir, "_sample.jpg")
+    urllib.request.urlretrieve(
+        "https://raw.githubusercontent.com/open-mmlab/mmpose/main/tests/data/ap10k/000000000017.jpg",
+        sample_path,
+    )
+
+    torch2onnx(
+        sample_path,
+        out_dir,
+        "model",
+        deploy_cfg=deploy_cfg,
+        model_cfg=config,
+        model_checkpoint=checkpoint,
+        device="cpu",
+    )
+
+    config_out = {
+        "input_size": [1, 3, 256, 256],
+        "mean": [123.675, 116.28, 103.53],
+        "std": [58.395, 57.12, 57.375],
+        "keypoints": [  # AP-10K keypoint order
+            "left_eye", "right_eye", "nose", "neck", "root_of_tail",
+            "left_shoulder", "left_elbow", "left_front_paw",
+            "right_shoulder", "right_elbow", "right_front_paw",
+            "left_hip", "left_knee", "left_back_paw",
+            "right_hip", "right_knee", "right_back_paw",
+        ],
+        "output_type": "simcc",  # RTMPose uses simcc, not heatmaps
+    }
+    _save_json(os.path.join(out_dir, "config.json"), config_out)
+
+    if os.path.exists(sample_path):
+        os.remove(sample_path)
+
+    log.info("  %s export complete: %s", model_id, out_dir)
+    return onnx_path
+```
+
+**Step 2: Register in ALL_MODELS and dispatcher**
+
+```python
+ALL_MODELS = [
+    # ... existing ...
+    "rtmpose-animal",
+]
+
+_EXPORT_FUNCTIONS = {
+    # ... existing ...
+    "rtmpose-animal": export_rtmpose_animal,
+}
+```
+
+Add the help text entry in `main()`'s epilog string.
+
+**Step 3: Add `[export]` extras if needed**
+
+Check `pyproject.toml`'s `[export]` optional-dependencies group. Add `mmpose`, `mmdeploy`, `mmcv` with appropriate version pins if not already present. RTMPose requires `mmcv>=2.0.0` and `mmengine`.
+
+**Step 4: Commit**
+
+```bash
+git add scripts/export_onnx.py pyproject.toml
+git commit -m "export: add RTMPose-animal ONNX export"
+```
+
+### Task 3.2: Run the export manually and validate
+
+**Step 1:** Install export extras in a throwaway venv:
+
+```bash
+pip install -e ".[export]"
+```
+
+**Step 2:** Run:
+
+```bash
+python scripts/export_onnx.py --model rtmpose-animal --output-dir /tmp/vireo-export
+```
+
+**Step 3:** Verify output:
+
+```bash
+ls /tmp/vireo-export/rtmpose-animal/
+# Expect: model.onnx, config.json
+```
+
+**Step 4:** Manual sanity check — load the ONNX model and a real animal photo, decode keypoints, verify the eye coord lands on the eye visually. Save a Python scratch script under `scripts/validate_rtmpose.py` for this (gitignored, not committed).
+
+**Step 5:** Upload to HF if validation passes:
+
+```bash
+huggingface-cli upload jss367/vireo-onnx-models /tmp/vireo-export/rtmpose-animal rtmpose-animal --repo-type model
+```
+
+No commit — output artifacts don't get checked in.
+
+---
+
+## Milestone 4: `vireo/keypoints.py` — Loading, Running, Decoding
+
+New module. Follows the `detector.py` shape: `ensure_*_weights`, `_load_session`, `detect_keypoints`. Two functions because we have two (eventually three) models.
+
+### Task 4.1: Write failing test for heatmap/simcc decoding
+
+**Files:**
+- Create test: `vireo/tests/test_keypoints.py`
+
+**Step 1: Add decoding test**
+
+```python
+import numpy as np
+from vireo.keypoints import decode_simcc
+
+def test_decode_simcc_picks_argmax():
+    # simcc_x, simcc_y shape: (1, K, size*2) where size is output spatial dim
+    K = 17
+    simcc_x = np.zeros((1, K, 512), dtype=np.float32)
+    simcc_y = np.zeros((1, K, 512), dtype=np.float32)
+    # Eye 0 at (100, 50), input image is 256x256 (simcc splat factor = 2.0)
+    simcc_x[0, 0, 200] = 1.0  # x=200/2 = 100 px
+    simcc_y[0, 0, 100] = 1.0  # y=100/2 = 50 px
+    kps = decode_simcc(simcc_x, simcc_y, input_size=256, simcc_split_ratio=2.0)
+    # kps shape: (K, 3) — x, y, conf
+    assert kps.shape == (K, 3)
+    np.testing.assert_allclose(kps[0, :2], [100.0, 50.0], atol=0.5)
+    assert kps[0, 2] == 1.0  # max confidence
+```
+
+**Step 2: Run, expect FAIL** (`ImportError: vireo.keypoints`).
+
+### Task 4.2: Implement decoding
+
+**Files:**
+- Create: `vireo/keypoints.py`
+
+**Step 1: Write module skeleton**
+
+```python
+"""Animal keypoint detection via ONNX Runtime.
+
+Top-down keypoint models take a cropped image (MegaDetector bbox) and return
+per-keypoint (x, y, conf) in image-pixel coordinates. Used to localize the
+animal's eye for eye-focus scoring.
+
+Models:
+    rtmpose-animal       — AP-10K, integration spike
+    superanimal-quadruped — DLC 3.x, production mammals
+    superanimal-bird      — DLC 3.x, production birds
+
+All models load from ~/.vireo/models/<name>/model.onnx with a sibling
+config.json describing input size, normalization, and keypoint names.
+"""
+import json
+import logging
+import os
+import threading
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+MODELS_DIR = os.path.expanduser("~/.vireo/models")
+
+_sessions = {}
+_locks = {}
+_download_locks = {}
+
+
+def decode_simcc(simcc_x, simcc_y, input_size, simcc_split_ratio=2.0):
+    """Decode RTMPose simcc-format outputs to (K, 3) keypoints.
+
+    Returns array of shape (num_keypoints, 3) with columns (x, y, conf)
+    in input-image pixel space.
+    """
+    # Strip batch dim
+    sx = simcc_x[0]  # (K, size_x)
+    sy = simcc_y[0]  # (K, size_y)
+    idx_x = np.argmax(sx, axis=1)
+    idx_y = np.argmax(sy, axis=1)
+    conf_x = sx[np.arange(sx.shape[0]), idx_x]
+    conf_y = sy[np.arange(sy.shape[0]), idx_y]
+    conf = np.minimum(conf_x, conf_y)
+    x = idx_x / simcc_split_ratio
+    y = idx_y / simcc_split_ratio
+    return np.stack([x, y, conf], axis=1).astype(np.float32)
+```
+
+**Step 2: Run test, expect PASS.**
+
+**Step 3: Commit**
+
+```bash
+git add vireo/keypoints.py vireo/tests/test_keypoints.py
+git commit -m "keypoints: add decode_simcc helper with unit test"
+```
+
+### Task 4.3: Write failing test for `ensure_keypoint_weights`
+
+**Step 1: Add test with mock**
+
+```python
+import os
+from unittest.mock import patch
+
+def test_ensure_keypoint_weights_short_circuits_if_present(tmp_path, monkeypatch):
+    from vireo import keypoints as kp
+    monkeypatch.setattr(kp, "MODELS_DIR", str(tmp_path))
+    model_dir = tmp_path / "rtmpose-animal"
+    model_dir.mkdir()
+    (model_dir / "model.onnx").write_bytes(b"fake")
+    (model_dir / "config.json").write_text("{}")
+    # Should not trigger a download
+    path = kp.ensure_keypoint_weights("rtmpose-animal")
+    assert path == str(model_dir / "model.onnx")
+```
+
+**Step 2: Run, expect FAIL** (function doesn't exist).
+
+### Task 4.4: Implement weights download
+
+**Step 1: Add to `vireo/keypoints.py`**
+
+```python
+def _model_path(model_name):
+    return os.path.join(MODELS_DIR, model_name)
+
+
+def ensure_keypoint_weights(model_name, progress_callback=None):
+    """Ensure ONNX weights for ``model_name`` are on disk.
+
+    Downloads from the Vireo HF repo if absent. Returns path to model.onnx.
+    Raises RuntimeError on download failure.
+    """
+    target = _model_path(model_name)
+    onnx_path = os.path.join(target, "model.onnx")
+    config_path = os.path.join(target, "config.json")
+    if os.path.isfile(onnx_path) and os.path.isfile(config_path):
+        return onnx_path
+
+    lock = _download_locks.setdefault(model_name, threading.Lock())
+    with lock:
+        if os.path.isfile(onnx_path) and os.path.isfile(config_path):
+            return onnx_path
+        os.makedirs(target, exist_ok=True)
+        if progress_callback:
+            progress_callback(
+                f"Downloading {model_name} (first run only)...", 0, 1
+            )
+        log.info("%s weights missing — downloading from Hugging Face", model_name)
+        try:
+            from huggingface_hub import hf_hub_download
+            from models import ONNX_REPO
+            for filename in ("model.onnx", "config.json"):
+                downloaded = hf_hub_download(
+                    repo_id=ONNX_REPO,
+                    filename=filename,
+                    subfolder=model_name,
+                )
+                dest = os.path.join(target, filename)
+                if downloaded != dest:
+                    import shutil
+                    shutil.copy2(downloaded, dest)
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to download {model_name} weights: {e}"
+            ) from e
+        log.info("%s weights downloaded", model_name)
+        if progress_callback:
+            progress_callback(f"{model_name} ready", 1, 1)
+    return onnx_path
+```
+
+**Step 2: Run test, expect PASS.**
+
+**Step 3: Commit**
+
+```bash
+git add vireo/keypoints.py vireo/tests/test_keypoints.py
+git commit -m "keypoints: add ensure_keypoint_weights download helper"
+```
+
+### Task 4.5: Write failing test for `detect_keypoints`
+
+**Step 1: Add test with mocked ONNX session**
+
+```python
+from unittest.mock import MagicMock, patch
+from PIL import Image
+
+def test_detect_keypoints_returns_named_keypoints(tmp_path, monkeypatch):
+    from vireo import keypoints as kp
+    monkeypatch.setattr(kp, "MODELS_DIR", str(tmp_path))
+    model_dir = tmp_path / "rtmpose-animal"
+    model_dir.mkdir()
+    (model_dir / "model.onnx").write_bytes(b"fake")
+    (model_dir / "config.json").write_text(json.dumps({
+        "input_size": [1, 3, 256, 256],
+        "mean": [123.675, 116.28, 103.53],
+        "std": [58.395, 57.12, 57.375],
+        "keypoints": ["left_eye", "right_eye", "nose", "neck", "root_of_tail",
+                      "left_shoulder", "left_elbow", "left_front_paw",
+                      "right_shoulder", "right_elbow", "right_front_paw",
+                      "left_hip", "left_knee", "left_back_paw",
+                      "right_hip", "right_knee", "right_back_paw"],
+        "output_type": "simcc",
+    }))
+
+    # Mock onnxruntime session: return simcc where left_eye is at (128, 128)
+    K = 17
+    simcc_x = np.zeros((1, K, 512), dtype=np.float32)
+    simcc_y = np.zeros((1, K, 512), dtype=np.float32)
+    simcc_x[0, 0, 256] = 0.9  # left_eye x = 128 px
+    simcc_y[0, 0, 256] = 0.9  # left_eye y = 128 px
+    mock_sess = MagicMock()
+    mock_sess.run.return_value = [simcc_x, simcc_y]
+    monkeypatch.setattr(kp, "_load_session", lambda name: mock_sess)
+
+    # Image: 512x512, bbox covering the center (0,0,512,512)
+    img = Image.new("RGB", (512, 512), color=(128, 128, 128))
+    bbox = (0, 0, 512, 512)
+    result = kp.detect_keypoints(img, bbox, "rtmpose-animal")
+    # Eye should land at ~(256, 256) in image coords after reverse-scaling
+    # from 256x256 crop
+    assert any(k["name"] == "left_eye" for k in result)
+    left = [k for k in result if k["name"] == "left_eye"][0]
+    assert abs(left["x"] - 256) < 5
+    assert abs(left["y"] - 256) < 5
+    assert left["conf"] > 0.85
+```
+
+**Step 2: Run, expect FAIL.**
+
+### Task 4.6: Implement `detect_keypoints`
+
+**Step 1: Add to `vireo/keypoints.py`**
+
+```python
+def _load_session(model_name):
+    """Get cached onnxruntime session, loading on first use."""
+    if model_name in _sessions:
+        return _sessions[model_name]
+    lock = _locks.setdefault(model_name, threading.Lock())
+    with lock:
+        if model_name in _sessions:
+            return _sessions[model_name]
+        import onnxruntime as ort
+        onnx_path = os.path.join(MODELS_DIR, model_name, "model.onnx")
+        if not os.path.isfile(onnx_path):
+            raise FileNotFoundError(
+                f"Keypoint model {model_name!r} not found at {onnx_path}. "
+                "Call ensure_keypoint_weights() first."
+            )
+        _sessions[model_name] = ort.InferenceSession(
+            onnx_path, providers=["CPUExecutionProvider"]
+        )
+    return _sessions[model_name]
+
+
+def _load_config(model_name):
+    config_path = os.path.join(MODELS_DIR, model_name, "config.json")
+    with open(config_path) as f:
+        return json.load(f)
+
+
+def detect_keypoints(image, bbox, model_name):
+    """Run a keypoint model on the bbox crop; return per-keypoint (x, y, conf).
+
+    Args:
+        image: PIL.Image (original-resolution RGB).
+        bbox: (x0, y0, x1, y1) in image-pixel space (MegaDetector output).
+        model_name: one of 'rtmpose-animal', 'superanimal-quadruped',
+                    'superanimal-bird'.
+
+    Returns:
+        list of {"name": str, "x": float, "y": float, "conf": float},
+        one entry per keypoint the model produces. Coordinates are in the
+        original image's pixel space.
+    """
+    from PIL import Image
+    cfg = _load_config(model_name)
+    input_h, input_w = cfg["input_size"][2], cfg["input_size"][3]
+    mean = np.array(cfg["mean"], dtype=np.float32).reshape(3, 1, 1)
+    std = np.array(cfg["std"], dtype=np.float32).reshape(3, 1, 1)
+    keypoint_names = cfg["keypoints"]
+
+    x0, y0, x1, y1 = bbox
+    crop = image.crop((x0, y0, x1, y1))
+    crop_w, crop_h = crop.size
+    # Aspect-ratio-preserving resize + pad to input_w x input_h
+    scale = min(input_w / crop_w, input_h / crop_h)
+    new_w = int(round(crop_w * scale))
+    new_h = int(round(crop_h * scale))
+    resized = crop.resize((new_w, new_h), Image.BILINEAR)
+    # Pad (top-left alignment; record offset for inverse map)
+    padded = Image.new("RGB", (input_w, input_h), color=(0, 0, 0))
+    padded.paste(resized, (0, 0))
+
+    arr = np.array(padded, dtype=np.float32).transpose(2, 0, 1)  # CHW
+    arr = (arr - mean) / std
+    arr = arr[np.newaxis, :, :, :]
+
+    session = _load_session(model_name)
+    outputs = session.run(None, {"pixel_values": arr})
+
+    output_type = cfg.get("output_type", "heatmap")
+    if output_type == "simcc":
+        simcc_x, simcc_y = outputs
+        kps_input_space = decode_simcc(
+            simcc_x, simcc_y, input_size=input_w, simcc_split_ratio=2.0
+        )
+    else:
+        heatmaps = outputs[0]  # (1, K, H', W')
+        kps_input_space = decode_heatmaps(heatmaps, input_size=input_w)
+
+    # Inverse map: input-space → crop-space → image-space
+    result = []
+    for i, name in enumerate(keypoint_names):
+        x_in, y_in, conf = kps_input_space[i]
+        x_crop = x_in / scale
+        y_crop = y_in / scale
+        x_img = x_crop + x0
+        y_img = y_crop + y0
+        result.append({
+            "name": name,
+            "x": float(x_img),
+            "y": float(y_img),
+            "conf": float(conf),
+        })
+    return result
+
+
+def decode_heatmaps(heatmaps, input_size):
+    """Decode (1, K, H', W') heatmaps to (K, 3) keypoints in input-image pixels.
+
+    Simple argmax + subpixel quadratic refinement. Suitable for the SuperAnimal
+    heatmap-head output.
+    """
+    hm = heatmaps[0]  # (K, H', W')
+    K, H, W = hm.shape
+    flat = hm.reshape(K, -1)
+    idx = np.argmax(flat, axis=1)
+    ys = (idx // W).astype(np.float32)
+    xs = (idx % W).astype(np.float32)
+    conf = flat[np.arange(K), idx]
+    # Subpixel refinement via quadratic fit — skip here for simplicity; can add later.
+    # Rescale to input-image pixels
+    xs *= input_size / W
+    ys *= input_size / H
+    return np.stack([xs, ys, conf], axis=1).astype(np.float32)
+```
+
+**Step 2: Run test, expect PASS.**
+
+**Step 3: Commit**
+
+```bash
+git add vireo/keypoints.py vireo/tests/test_keypoints.py
+git commit -m "keypoints: add detect_keypoints with inverse coordinate mapping"
+```
+
+---
+
+## Milestone 5: `compute_eye_tenengrad` in `quality.py`
+
+Reuse the existing `_multiscale_tenengrad` over a window around the eye.
+
+### Task 5.1: Write failing test
+
+**Files:**
+- Modify test: `vireo/tests/test_quality.py`
+
+**Step 1: Add test**
+
+```python
+def test_compute_eye_tenengrad_uses_window_around_eye():
+    from vireo.quality import compute_eye_tenengrad
+    from PIL import Image
+    import numpy as np
+
+    img = Image.new("L", (400, 400), color=128)
+    # Draw a sharp edge pattern centered on (200, 200)
+    arr = np.array(img)
+    arr[180:220, 180:220] = np.tile([0, 255] * 20, (40, 1))
+    img = Image.fromarray(arr, mode="L").convert("RGB")
+
+    bbox = (100, 100, 300, 300)  # 200x200 bbox
+    eye_xy = (200.0, 200.0)
+    result = compute_eye_tenengrad(img, eye_xy, bbox, k=0.08)
+    # Window is 0.08 * 200 = 16 px around (200, 200) → fully inside the edge pattern
+    assert result > 1000  # non-trivial sharpness signal
+
+
+def test_compute_eye_tenengrad_clamps_to_image_bounds():
+    from vireo.quality import compute_eye_tenengrad
+    from PIL import Image
+
+    img = Image.new("RGB", (100, 100), color=(128, 128, 128))
+    # Eye at corner — window would extend past the image
+    bbox = (0, 0, 100, 100)
+    result = compute_eye_tenengrad(img, (2.0, 2.0), bbox, k=0.1)
+    # Should not raise; should return a finite float (uniform gray → 0)
+    assert result == 0.0
+```
+
+**Step 2: Run, expect FAIL.**
+
+### Task 5.2: Implement
+
+**Files:**
+- Modify: `vireo/quality.py`
+
+**Step 1: Add function**
+
+```python
+def compute_eye_tenengrad(image, eye_xy, bbox, k=0.08):
+    """Multi-scale Tenengrad in a window around an eye keypoint.
+
+    Window side length = k * min(bbox_w, bbox_h), clamped to image bounds.
+
+    Args:
+        image: PIL.Image (original resolution).
+        eye_xy: (x, y) in image-pixel space.
+        bbox: (x0, y0, x1, y1) MegaDetector bbox, image-pixel space.
+        k: window size as fraction of min(bbox_w, bbox_h). Default 0.08.
+
+    Returns:
+        float — raw multi-scale Tenengrad in the window, 0.0 if window
+        is empty after clamping.
+    """
+    x, y = eye_xy
+    x0, y0, x1, y1 = bbox
+    w_side = max(8, int(round(k * min(x1 - x0, y1 - y0))))
+    half = w_side // 2
+    img_w, img_h = image.size
+    wx0 = max(0, int(x - half))
+    wy0 = max(0, int(y - half))
+    wx1 = min(img_w, int(x + half))
+    wy1 = min(img_h, int(y + half))
+    if wx1 <= wx0 or wy1 <= wy0:
+        return 0.0
+    window = image.crop((wx0, wy0, wx1, wy1))
+    gray = _to_grayscale_array(window)
+    mask = np.ones_like(gray, dtype=bool)
+    return round(_multiscale_tenengrad(gray, mask), 2)
+```
+
+**Step 2: Run tests, expect PASS.**
+
+**Step 3: Commit**
+
+```bash
+git add vireo/quality.py vireo/tests/test_quality.py
+git commit -m "quality: add compute_eye_tenengrad for windowed eye sharpness"
+```
+
+---
+
+## Milestone 6: Pipeline Stage — `detect_eye_keypoints`
+
+Runs between masking and scoring. For each photo: route by species, run model, decode, apply three-gate policy, persist.
+
+### Task 6.1: Write failing test for skip-when-weights-absent
+
+**Files:**
+- Modify test: `vireo/tests/test_pipeline.py`
+
+**Step 1: Add test**
+
+```python
+def test_eye_keypoint_stage_skips_when_weights_absent(tmp_path, monkeypatch):
+    from vireo import keypoints as kp
+    from vireo.pipeline import detect_eye_keypoints_stage
+    monkeypatch.setattr(kp, "MODELS_DIR", str(tmp_path / "empty"))
+    db = Database(str(tmp_path / "x.db"))
+    # insert a photo with species/mask — use fixture or inline
+    pid = db.insert_photo({...})  # fill in
+    detect_eye_keypoints_stage(db, config={"eye_detect_enabled": True})
+    row = db.conn.execute(
+        "SELECT eye_x, eye_y, eye_conf, eye_tenengrad FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert row == (None, None, None, None)
+```
+
+**Step 2: Run, expect FAIL** (function doesn't exist).
+
+### Task 6.2: Implement stage skeleton
+
+**Files:**
+- Modify: `vireo/pipeline.py`
+
+**Step 1: Add the stage function**
+
+```python
+def detect_eye_keypoints_stage(db, config, progress_callback=None):
+    """Pipeline stage: detect eye keypoints and persist raw tenengrad.
+
+    For each photo with a subject mask and an in-scope species, run the
+    routed keypoint model. Apply the three-gate trust policy. Persist
+    (eye_x, eye_y, eye_conf, eye_tenengrad) for gated-through photos.
+    """
+    from vireo import keypoints as kp
+    from vireo.quality import compute_eye_tenengrad
+    from vireo.taxonomy import classify_to_keypoint_group
+    from PIL import Image
+
+    if not config.get("eye_detect_enabled", True):
+        log.info("Eye-focus detection disabled by config; skipping stage")
+        return
+
+    C = config.get("eye_classifier_conf_gate", 0.5)
+    T = config.get("eye_detection_conf_gate", 0.5)
+    k_window = config.get("eye_window_k", 0.08)
+
+    photos = db.list_photos_for_eye_keypoint_stage()  # new helper — see 6.3
+    total = len(photos)
+    for i, photo in enumerate(photos):
+        if progress_callback:
+            progress_callback("Eye keypoints", i, total)
+        try:
+            _process_photo_for_eye(db, photo, config, C=C, T=T, k_window=k_window)
+        except Exception as e:
+            log.warning("Eye keypoint detection failed for photo %s: %s",
+                        photo["id"], e, exc_info=True)
+
+
+def _process_photo_for_eye(db, photo, config, *, C, T, k_window):
+    from vireo import keypoints as kp
+    from vireo.quality import compute_eye_tenengrad
+    from vireo.taxonomy import classify_to_keypoint_group
+    from PIL import Image
+
+    # Gate 1: classifier + class
+    if (photo.get("species_conf") or 0) < C:
+        return
+    group = classify_to_keypoint_group(db, photo.get("species_top1_taxon_id"))
+    if group is None:
+        return
+    model_name = {
+        "Aves": "superanimal-bird",
+        "Mammalia": "superanimal-quadruped",
+    }[group]
+
+    # Gate 2: weights present
+    try:
+        kp.ensure_keypoint_weights(model_name)  # does NOT download here;
+        # at pipeline-run time, user must have already opted in via the
+        # pipeline page card. If the download has not happened, raise a
+        # short-circuit that skips without error.
+    except Exception:
+        return
+    if not os.path.isfile(os.path.join(kp.MODELS_DIR, model_name, "model.onnx")):
+        return
+
+    # Load image + bbox + mask
+    image = Image.open(photo["path"]).convert("RGB")
+    bbox = (photo["bbox_x0"], photo["bbox_y0"], photo["bbox_x1"], photo["bbox_y1"])
+    mask = load_mask(photo["mask_path"])  # bool array (H, W)
+
+    # Run keypoint model
+    kps = kp.detect_keypoints(image, bbox, model_name)
+
+    # Gate 3 + 4: eye conf >= T AND inside mask
+    eye_candidates = []
+    for k_point in kps:
+        if k_point["name"] not in ("left_eye", "right_eye"):
+            continue
+        if k_point["conf"] < T:
+            continue
+        mx, my = int(k_point["x"]), int(k_point["y"])
+        if not (0 <= mx < mask.shape[1] and 0 <= my < mask.shape[0]):
+            continue
+        if not mask[my, mx]:
+            continue
+        eye_candidates.append(k_point)
+
+    if not eye_candidates:
+        return
+
+    # Per-eye tenengrad, max wins
+    best = None
+    best_score = -1.0
+    for eye in eye_candidates:
+        score = compute_eye_tenengrad(image, (eye["x"], eye["y"]), bbox, k=k_window)
+        if score > best_score:
+            best_score = score
+            best = eye
+
+    db.update_photo(
+        photo["id"],
+        eye_x=best["x"],
+        eye_y=best["y"],
+        eye_conf=best["conf"],
+        eye_tenengrad=best_score,
+    )
+```
+
+**Step 2: Run test, expect PASS.**
+
+**Step 3: Commit**
+
+```bash
+git add vireo/pipeline.py vireo/tests/test_pipeline.py
+git commit -m "pipeline: add detect_eye_keypoints_stage with three-gate policy"
+```
+
+### Task 6.3: Add `list_photos_for_eye_keypoint_stage`
+
+**Files:**
+- Modify: `vireo/db.py`
+
+Add a helper that returns photos eligible for the stage — have a subject mask, have a species classification. The exact fields returned should be enough for `_process_photo_for_eye` to do its work without additional DB calls per photo. Match the shape/pattern of similar iteration helpers already in `db.py`.
+
+Commit.
+
+### Task 6.4: Wire stage into pipeline orchestration
+
+**Files:**
+- Modify: `vireo/pipeline.py` — add the stage call after masking, before scoring.
+- Modify: `vireo/pipeline_job.py` — add progress reporting for the new stage.
+
+Commit.
+
+### Task 6.5: Test the full three-gate matrix
+
+Write parameterized pytest cases for each gate:
+- Gate 1 fail: classifier conf below C → stage writes nothing.
+- Gate 1 fail: species is Actinopterygii → stage writes nothing.
+- Gate 2 fail: weights missing → stage writes nothing.
+- Gate 3 fail: both eye keypoints below T → stage writes nothing.
+- Gate 4 fail: eye keypoint outside mask → stage writes nothing.
+- All gates pass → eye_x, eye_y, eye_conf, eye_tenengrad populated.
+- Max-over-eyes: left has higher tenengrad than right → left wins.
+
+Commit.
+
+---
+
+## Milestone 7: Scoring Integration
+
+Composite replacement + `reject_eye_soft` rule, both gated on `eye_tenengrad IS NOT NULL` (which in turn only gets populated when all four gates passed in the pipeline stage — so downstream scoring doesn't re-check gates).
+
+### Task 7.1: Write failing test for composite-replacement
+
+**Files:**
+- Modify test: `vireo/tests/test_scoring.py`
+
+```python
+def test_composite_uses_eye_when_eye_tenengrad_present():
+    from vireo.scoring import score_encounter
+    photos = [
+        # Photo A: has high subject_tenengrad, low eye_tenengrad
+        {..., "subject_tenengrad": 50000, "eye_tenengrad": 5000},
+        # Photo B: low subject_tenengrad, high eye_tenengrad
+        {..., "subject_tenengrad": 5000, "eye_tenengrad": 50000},
+    ]
+    encounter = {"photos": photos}
+    score_encounter(encounter)
+    # When eye_tenengrad is present, it replaces subject_tenengrad in focus term.
+    # So B should score higher than A on focus_score.
+    assert photos[1]["focus_score"] > photos[0]["focus_score"]
+
+
+def test_composite_uses_subject_when_eye_tenengrad_null():
+    # With no eye_tenengrad, scoring matches pre-feature behavior exactly.
+    photos = [
+        {..., "subject_tenengrad": 50000, "eye_tenengrad": None},
+        {..., "subject_tenengrad": 5000, "eye_tenengrad": None},
+    ]
+    encounter = {"photos": photos}
+    score_encounter(encounter)
+    assert photos[0]["focus_score"] > photos[1]["focus_score"]
+```
+
+### Task 7.2: Implement composite branch
+
+**Files:**
+- Modify: `vireo/scoring.py`
+
+Modify the focus-score computation inside `score_encounter` so that when a photo has non-null `eye_tenengrad`, the encounter-percentile focus normalization uses the `eye_tenengrad` value instead of `subject_tenengrad`. Two implementation options:
+
+- **Option A (clean):** compute two separate percentile normalizations — one over `subject_tenengrad`, one over `eye_tenengrad` — and for each photo use whichever corresponds to what's populated.
+- **Option B (single):** build a per-photo `focus_source_value` = `eye_tenengrad if not None else subject_tenengrad`, then normalize that within encounter.
+
+Prefer Option A: keeps `subject_focus_score` semantics unchanged for photos without an eye signal, and means the `eye_focus` percentile is computed against peer photos that *also* have an eye signal, which is the fairer comparison.
+
+Commit.
+
+### Task 7.3: Write failing test for `reject_eye_soft`
+
+```python
+def test_reject_eye_soft_fires_when_eye_present_and_soft():
+    photos = [
+        {..., "subject_tenengrad": 50000, "eye_tenengrad": 1000},  # soft eye
+        {..., "subject_tenengrad": 50000, "eye_tenengrad": 50000},  # sharp eye
+    ]
+    encounter = {"photos": photos}
+    score_encounter(encounter, config={"reject_eye_focus": 0.35})
+    assert any("eye_soft" in r for r in photos[0]["reject_reasons"])
+    assert not any("eye_soft" in r for r in photos[1].get("reject_reasons", []))
+
+
+def test_reject_eye_soft_does_not_fire_when_eye_null():
+    photos = [{..., "subject_tenengrad": 1000, "eye_tenengrad": None}]
+    encounter = {"photos": photos}
+    score_encounter(encounter, config={"reject_eye_focus": 0.35})
+    assert not any("eye_soft" in r for r in photos[0].get("reject_reasons", []))
+```
+
+### Task 7.4: Implement `reject_eye_soft`
+
+**Files:**
+- Modify: `vireo/scoring.py`
+
+In `score_encounter`, after computing `eye_focus_score`, if `eye_tenengrad` is not null AND `eye_focus_score < config["reject_eye_focus"]`, append `f"eye_soft (E={eye_focus_score:.3f} < {cfg['reject_eye_focus']})"` to `reject_reasons`. Ensure `photo["label"] = "REJECT"` logic still works.
+
+Add default `"reject_eye_focus": 0.35` to the `DEFAULTS` dict.
+
+Commit.
+
+---
+
+## Milestone 8: UI — Crosshair Overlay in Lightbox
+
+Small visible signal at `(eye_x, eye_y)` in the review lightbox.
+
+### Task 8.1: Read existing lightbox code
+
+**Step 1: Search for lightbox implementation.**
+
+```
+grep -l "lightbox" vireo/templates/
+```
+
+Open the relevant template(s) and read the coordinate-space conventions in the JS: how it positions markers on zoomed/panned images. The crosshair must transform from image-pixel space `(eye_x, eye_y)` into lightbox-screen coords using the same transform the lightbox already uses.
+
+### Task 8.2–8.5: Implement crosshair
+
+Small SVG circle or CSS-only marker element, positioned via absolute-position + the existing image→screen transform. Visible regardless of zoom level. Hide when `eye_x` or `eye_y` is null.
+
+Playwright test (or a simpler manual verification if Playwright is not already set up for Vireo) that the crosshair element is present and positioned correctly when a photo with `eye_x` is loaded.
+
+Commit.
+
+---
+
+## Milestone 9: UI — Pipeline Page Stage Card
+
+New card on `/pipeline` showing the keypoint-model download status, mirroring SAM2/DINOv2 cards.
+
+### Task 9.1: Read existing card pattern
+
+Open `vireo/templates/pipeline.html` and find the "Extract Features" card (added in commit `e3eba78`). Understand the download-status states and the JS that drives them.
+
+### Task 9.2: Add the card
+
+Two download buttons — one for SuperAnimal-Quadruped, one for SuperAnimal-Bird (each independently downloadable; if one is present and one is not, the card reflects that). Card state "Ready" when both are present.
+
+Add a `GET /api/models/keypoints/status` endpoint in `vireo/app.py` that returns `{"superanimal_quadruped": "ready"|"missing", "superanimal_bird": "ready"|"missing"}`. Add `POST /api/models/keypoints/<name>/download` endpoint that triggers `ensure_keypoint_weights(name)` in a background job, following the SAM2 download pattern.
+
+Commit.
+
+---
+
+## Milestone 10: Settings UI
+
+Surface the four new thresholds.
+
+### Task 10.1: Add fields to `vireo/templates/settings.html`
+
+Following the existing input-with-default pattern:
+
+- `eye_detect_enabled` (boolean toggle)
+- `eye_classifier_conf_gate` (0.0–1.0 float, default 0.5)
+- `eye_detection_conf_gate` (0.0–1.0 float, default 0.5)
+- `eye_window_k` (0.02–0.25 float, default 0.08)
+- `reject_eye_focus` (0.0–1.0 float, default 0.35)
+
+### Task 10.2: Ensure `get_effective_config` passes these through
+
+Config flows from `vireo/config.py` → workspace overrides in `workspaces.config_overrides`. New keys are just new dictionary entries; should flow through without code changes. Verify with an integration test that a workspace override of `reject_eye_focus` affects scoring output.
+
+Commit.
+
+---
+
+## Milestone 11: SuperAnimal-Quadruped Export + Integration
+
+Add the real mammal model. At this point the pipeline, scoring, UI, and DB are proven via RTMPose — we just swap in a more capable model.
+
+### Task 11.1: Add `export_superanimal_quadruped` to `scripts/export_onnx.py`
+
+DeepLabCut 3.x publishes PyTorch weights on HuggingFace. The export needs a wrapper that exposes the raw `forward` producing heatmaps, avoiding DLC's inference wrapper. Use `dlclibrary.load_superanimal_model("superanimal_quadruped")` or equivalent. Match the RTMPose export's structure — input shape, normalization, keypoint-name list, `output_type: "heatmap"`.
+
+**Config fields** specific to SuperAnimal-Quadruped: `"keypoints": [...]` — use the DLC-documented order for this model (contains `left_eye`, `right_eye` among ~39 names).
+
+### Task 11.2: Run export and validate
+
+```bash
+python scripts/export_onnx.py --model superanimal-quadruped --output-dir /tmp/vireo-export --validate
+```
+
+Validation compares decoded keypoint coordinates (not raw heatmaps) between PyTorch reference and ONNX Runtime output on a sample image. Tolerance: ±1 pixel.
+
+### Task 11.3: Upload weights
+
+```bash
+huggingface-cli upload jss367/vireo-onnx-models \
+    /tmp/vireo-export/superanimal-quadruped \
+    superanimal-quadruped --repo-type model
+```
+
+### Task 11.4: Wire routing
+
+In `keypoints.py`'s `detect_keypoints`, ensure the `model_name` path for `"superanimal-quadruped"` works with the heatmap output (not simcc). The `decode_heatmaps` function handles this.
+
+In `pipeline.py`'s `_process_photo_for_eye`, the mapping is already:
+
+```python
+{"Aves": "superanimal-bird", "Mammalia": "superanimal-quadruped"}
+```
+
+Nothing to change unless a bug surfaces.
+
+### Task 11.5: End-to-end test with a real mammal photo
+
+Add a dev-only test under `tests/e2e/test_eye_keypoints.py` (skip when weights absent) that runs the full stage on a real mammal photo shipped under `tests/fixtures/` and asserts the eye was found within a hand-labeled ±5 px region.
+
+Commit.
+
+---
+
+## Milestone 12: SuperAnimal-Bird Export + Integration
+
+Parallel structure to Milestone 11. Model: SuperAnimal-Bird. Output format: heatmaps (same decode path). Real-image e2e test uses a bird photo.
+
+Commit.
+
+---
+
+## Milestone 13: Final Integration and PR
+
+### Task 13.1: Full test suite
+
+```bash
+python -m pytest tests/ vireo/tests/ -q
+```
+
+All tests must pass. Dev-only e2e tests skip cleanly in CI.
+
+### Task 13.2: Manual dogfood run
+
+Start Vireo on a real library, run the pipeline, verify:
+1. Pipeline page shows the new Eye-focus detection card with download buttons.
+2. After downloading SuperAnimal-Quadruped, the stage runs in the pipeline.
+3. A mammal photo in the review lightbox shows the eye crosshair.
+4. A fish photo has no crosshair (fell back to subject_focus).
+5. A back-of-head mammal photo has no crosshair (eye conf below T).
+6. The `eye_soft` reject reason appears on photos with sharp body + soft eye.
+
+Note any issues in PR description.
+
+### Task 13.3: Open PR
+
+```bash
+git push -u origin claude/eye-focus-detection
+gh pr create --title "Eye-focus detection" --body "$(cat <<'EOF'
+## Summary
+- New per-photo eye-focus signal replaces body-level sharpness in the composite when a SuperAnimal keypoint model confidently localizes the eye.
+- New `reject_eye_soft` hard-reject rule catches "sharp body, soft eye" frames — formerly scored as REVIEW.
+- Two new ONNX models (SuperAnimal-Quadruped, SuperAnimal-Bird), opt-in download, taxonomy-routed from `species_top5[0]`.
+- RTMPose-animal shipped as an integration spike; may be removed in a follow-up.
+- Four new nullable columns on `photos` (`eye_x`, `eye_y`, `eye_conf`, `eye_tenengrad`). Safe migration; no rescoring on upgrade.
+
+## Design and plan
+- `docs/plans/2026-04-16-eye-focus-detection-design.md`
+- `docs/plans/2026-04-16-eye-focus-detection-plan.md`
+
+## Test plan
+- [ ] `python -m pytest tests/ vireo/tests/ -q` passes
+- [ ] Dev-only e2e tests pass locally with model weights present
+- [ ] Manual dogfood on real library: crosshair appears on mammal portraits
+- [ ] Manual dogfood: fish photos unchanged (fallback path)
+- [ ] Manual dogfood: back-of-head shots unchanged (gate 3 catches low eye conf)
+- [ ] Manual dogfood: eye_soft reject reason appears correctly on sharp-body soft-eye frames
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### Task 13.4: Respond to review
+
+Push fixes to the same branch (`claude/eye-focus-detection`). The pr-agent handles re-review. Squash-merge when approved.
+
+---
+
+## Open Items Deferred to V1.1
+
+- Score-panel badge showing eye-based vs body-based focus scores with the numerical comparison.
+- Per-workspace toggle UI to disable eye-focus detection (the config key already supports per-workspace override; just not surfaced in settings yet).
+- Subpixel refinement in `decode_heatmaps` (quadratic fit around argmax) — deferred until real-image tests show the need.
+- Decision on whether to keep RTMPose-animal shipped as a smaller/faster alternative or remove it once SuperAnimal integration is proven.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,13 @@ export = [
     "sam2>=1.0",
     "open_clip_torch>=2.0",
     "onnxscript>=0.1",
+    # RTMPose-animal / SuperAnimal keypoint model export (eye-focus detection).
+    # mmpose 1.x depends on mmengine; mmdeploy performs the torch -> ONNX
+    # conversion with simcc-aware graph surgery.
+    "mmengine>=0.10",
+    "mmcv>=2.1",
+    "mmpose>=1.3",
+    "mmdeploy>=1.3",
 ]
 dev = [
     "pytest>=9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,11 @@ export = [
     "mmcv>=2.1",
     "mmpose>=1.3",
     "mmdeploy>=1.3",
+    # SuperAnimal-Quadruped / SuperAnimal-Bird: dlclibrary loads DLC 3.x
+    # PyTorch weights; deeplabcut is pulled for its heatmap decoder utilities
+    # referenced by the export wrapper's validation path.
+    "dlclibrary>=0.0.6",
+    "deeplabcut>=3.0",
 ]
 dev = [
     "pytest>=9.0",

--- a/scripts/export_onnx.py
+++ b/scripts/export_onnx.py
@@ -47,6 +47,8 @@ ALL_MODELS = [
     "sam2-base-plus",
     "sam2-large",
     "rtmpose-animal",
+    "superanimal-quadruped",
+    "superanimal-bird",
 ]
 
 # ---------------------------------------------------------------------------
@@ -1123,6 +1125,174 @@ def export_rtmpose_animal(output_dir, opset, validate=False):
 
 
 # ---------------------------------------------------------------------------
+# SuperAnimal (DeepLabCut 3.x) — production animal keypoint models
+# ---------------------------------------------------------------------------
+#
+# DLC 3.x publishes SuperAnimal-Quadruped and SuperAnimal-Bird under
+# PyTorch state dicts on HuggingFace. dlclibrary.load_superanimal_model
+# returns a torch.nn.Module whose forward produces per-keypoint heatmaps
+# at 1/4 spatial resolution; the ONNX graph exports the raw forward and
+# decoding happens at inference time via keypoints.decode_heatmaps.
+
+# Keypoint orders below come from the DLC model cards. Left/right eye
+# indices are what the eye-focus pipeline stage actually reads; the rest
+# are included so the config.json documents the full model output and the
+# UI could later label them without re-deriving the order.
+_SUPERANIMAL_QUADRUPED_KEYPOINTS = [
+    "nose", "upper_jaw", "lower_jaw", "mouth_end_right", "mouth_end_left",
+    "right_eye", "right_earbase", "right_earend", "right_antler_base",
+    "right_antler_end",
+    "left_eye", "left_earbase", "left_earend", "left_antler_base",
+    "left_antler_end",
+    "neck_base", "neck_end", "throat_base", "throat_end",
+    "back_base", "back_end", "back_middle", "tail_base", "tail_end",
+    "front_left_thai", "front_left_knee", "front_left_paw",
+    "front_right_thai", "front_right_knee", "front_right_paw",
+    "back_left_paw", "back_left_thai", "back_left_knee",
+    "back_right_thai", "back_right_knee", "back_right_paw",
+    "belly_bottom", "body_middle_right", "body_middle_left",
+]
+_SUPERANIMAL_BIRD_KEYPOINTS = [
+    "beak_tip", "left_eye", "right_eye", "crown", "nape",
+    "left_shoulder", "right_shoulder", "left_wing_tip", "right_wing_tip",
+    "back", "tail_base", "tail_tip",
+    "left_leg", "right_leg",
+    "left_foot", "right_foot",
+]
+
+
+class _SuperAnimalWrapper:
+    """Wrap a DLC pose model so ONNX export sees (B,3,H,W) → (B,K,H',W').
+
+    DLC's stock forward can return dataclasses / nested dicts depending on
+    the DLC version; torch.onnx.export needs plain tensors. This wrapper
+    exposes only the heatmap tensor, making the export graph clean and the
+    ONNX output shape predictable for keypoints.decode_heatmaps.
+    """
+
+    def __init__(self, model):
+        import torch.nn as nn
+        if not isinstance(model, nn.Module):
+            raise TypeError(
+                "expected torch.nn.Module from dlclibrary, got "
+                f"{type(model).__name__}"
+            )
+        self.model = model.eval()
+
+    def __call__(self, x):
+        out = self.model(x)
+        # DLC's output structure varies by release; we defensively pull the
+        # heatmap tensor wherever it shows up. Raises early if this layout
+        # changes so a silent wrong-tensor export never lands.
+        if hasattr(out, "heatmap"):
+            return out.heatmap
+        if isinstance(out, dict) and "heatmap" in out:
+            return out["heatmap"]
+        if isinstance(out, (list, tuple)):
+            return out[0]
+        import torch
+        if isinstance(out, torch.Tensor):
+            return out
+        raise RuntimeError(
+            f"Unrecognized DLC model output: {type(out).__name__}. "
+            "Update _SuperAnimalWrapper to match the new DLC forward."
+        )
+
+
+def _export_superanimal_variant(
+    dlc_name, model_id, keypoint_names, output_dir, opset, validate=False,
+):
+    """Shared export path for SuperAnimal-Quadruped and SuperAnimal-Bird.
+
+    Args:
+        dlc_name: the model name accepted by
+            ``dlclibrary.load_superanimal_model`` (e.g. 'superanimal_quadruped').
+        model_id: the Vireo-side id used for directory naming (e.g.
+            'superanimal-quadruped').
+        keypoint_names: ordered list of keypoint names matching the model's
+            output channels.
+    """
+    import torch
+    from dlclibrary import load_superanimal_model
+
+    log.info("Exporting %s...", model_id)
+
+    torch_model = load_superanimal_model(dlc_name)
+    wrapped = _SuperAnimalWrapper(torch_model)
+
+    # 256×256 keeps parity with RTMPose so the pipeline stage's aspect-
+    # preserving resize + top-left pad produces the same crop geometry
+    # regardless of which keypoint model is routed.
+    input_h, input_w = 256, 256
+    dummy = torch.zeros(1, 3, input_h, input_w, dtype=torch.float32)
+
+    out_dir = _ensure_dir(os.path.join(output_dir, model_id))
+    onnx_path = os.path.join(out_dir, "model.onnx")
+
+    torch.onnx.export(
+        lambda x: wrapped(x),
+        dummy,
+        onnx_path,
+        opset_version=opset,
+        do_constant_folding=True,
+        input_names=["pixel_values"],
+        output_names=["heatmaps"],
+        # Fixed batch of 1 keeps the graph simple; the pipeline stage runs
+        # one crop at a time anyway. If batched export is ever needed,
+        # re-add dynamic_axes={"pixel_values": {0: "batch"}} here.
+    )
+
+    config = {
+        "input_size": [1, 3, input_h, input_w],
+        # ImageNet mean/std — DLC SuperAnimal models were fine-tuned from
+        # ImageNet-pretrained backbones and expect the standard normalization.
+        "mean": [123.675, 116.28, 103.53],
+        "std": [58.395, 57.12, 57.375],
+        "keypoints": keypoint_names,
+        "output_type": "heatmap",
+    }
+    _save_json(os.path.join(out_dir, "config.json"), config)
+
+    if validate:
+        # Compare decoded keypoints between PyTorch and ONNX Runtime on the
+        # dummy input — ±1-pixel tolerance is the plan's bar. Real-image
+        # validation lives in tests/e2e/.
+        import onnxruntime as ort
+        sess = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+        with torch.no_grad():
+            torch_hm = wrapped(dummy).numpy()
+        onnx_hm = sess.run(None, {"pixel_values": dummy.numpy()})[0]
+        import numpy as np
+        max_diff = float(np.abs(torch_hm - onnx_hm).max())
+        log.info("  %s ONNX vs PyTorch heatmap max abs diff: %.6f", model_id, max_diff)
+        if max_diff > 1e-3:
+            raise RuntimeError(
+                f"{model_id} ONNX/PyTorch disagreement too large: {max_diff}"
+            )
+
+    log.info("  %s export complete: %s", model_id, out_dir)
+    return onnx_path
+
+
+def export_superanimal_quadruped(output_dir, opset, validate=False):
+    return _export_superanimal_variant(
+        "superanimal_quadruped",
+        "superanimal-quadruped",
+        _SUPERANIMAL_QUADRUPED_KEYPOINTS,
+        output_dir, opset, validate,
+    )
+
+
+def export_superanimal_bird(output_dir, opset, validate=False):
+    return _export_superanimal_variant(
+        "superanimal_bird",
+        "superanimal-bird",
+        _SUPERANIMAL_BIRD_KEYPOINTS,
+        output_dir, opset, validate,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Export dispatcher
 # ---------------------------------------------------------------------------
 
@@ -1140,6 +1310,8 @@ _EXPORT_FUNCTIONS = {
     "sam2-base-plus": export_sam2_base_plus,
     "sam2-large": export_sam2_large,
     "rtmpose-animal": export_rtmpose_animal,
+    "superanimal-quadruped": export_superanimal_quadruped,
+    "superanimal-bird": export_superanimal_bird,
 }
 
 
@@ -1256,6 +1428,8 @@ Available models:
   sam2-base-plus            SAM2 Hiera Base+
   sam2-large                SAM2 Hiera Large
   rtmpose-animal            RTMPose-s AP-10K (animal keypoints, eye-focus spike)
+  superanimal-quadruped     DLC SuperAnimal-Quadruped (39 kp, mammal routing)
+  superanimal-bird          DLC SuperAnimal-Bird (16 kp, bird routing)
 
 Examples:
   %(prog)s --model bioclip-vit-b-16

--- a/scripts/export_onnx.py
+++ b/scripts/export_onnx.py
@@ -46,6 +46,7 @@ ALL_MODELS = [
     "sam2-small",
     "sam2-base-plus",
     "sam2-large",
+    "rtmpose-animal",
 ]
 
 # ---------------------------------------------------------------------------
@@ -1028,6 +1029,100 @@ def export_sam2_large(output_dir, opset, validate=False):
 
 
 # ---------------------------------------------------------------------------
+# RTMPose-animal (MMPose, AP-10K keypoints) — eye-focus detection spike
+# ---------------------------------------------------------------------------
+
+def export_rtmpose_animal(output_dir, opset, validate=False):
+    """Export RTMPose-s trained on AP-10K to ONNX via mmdeploy.
+
+    RTMPose-s is a top-down animal pose estimator. AP-10K provides 17
+    keypoints including left_eye (idx 0) and right_eye (idx 1), which are
+    what the eye-focus pipeline stage consumes. The simcc head emits two
+    1-D classification maps per keypoint; Vireo's keypoints.decode_simcc
+    handles the argmax + rescale.
+
+    Input:  (1, 3, 256, 256) float32, normalized with AP-10K stats.
+    Output: simcc_x (1, 17, 512), simcc_y (1, 17, 512) float32.
+    """
+    from mmdeploy.apis import torch2onnx
+
+    model_id = "rtmpose-animal"
+    log.info("Exporting %s...", model_id)
+
+    # Official RTMPose-s AP-10K config + checkpoint (MMPose v1.x).
+    config = (
+        "https://raw.githubusercontent.com/open-mmlab/mmpose/main/"
+        "configs/animal_2d_keypoint/rtmpose/ap10k/"
+        "rtmpose-s_8xb64-210e_ap10k-256x256.py"
+    )
+    checkpoint = (
+        "https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/"
+        "rtmpose-s_simcc-ap10k_pt-aic-coco_210e-256x256-7a041aa1_20230206.pth"
+    )
+
+    out_dir = _ensure_dir(os.path.join(output_dir, model_id))
+    onnx_path = os.path.join(out_dir, "model.onnx")
+
+    deploy_cfg = {
+        "onnx_config": {
+            "type": "onnx",
+            "export_params": True,
+            "keep_initializers_as_inputs": False,
+            "opset_version": opset,
+            "save_file": "model.onnx",
+            "input_names": ["pixel_values"],
+            "output_names": ["simcc_x", "simcc_y"],
+            "input_shape": [256, 256],
+        },
+        "codebase_config": {"type": "mmpose", "task": "PoseDetection"},
+        "backend_config": {"type": "onnxruntime"},
+    }
+
+    # mmdeploy's torch2onnx wants a sample image for shape inference.
+    import urllib.request
+    sample_path = os.path.join(out_dir, "_sample.jpg")
+    urllib.request.urlretrieve(
+        "https://raw.githubusercontent.com/open-mmlab/mmpose/main/tests/data/"
+        "ap10k/000000000017.jpg",
+        sample_path,
+    )
+
+    try:
+        torch2onnx(
+            sample_path,
+            out_dir,
+            "model",
+            deploy_cfg=deploy_cfg,
+            model_cfg=config,
+            model_checkpoint=checkpoint,
+            device="cpu",
+        )
+    finally:
+        if os.path.exists(sample_path):
+            os.remove(sample_path)
+
+    config_out = {
+        "input_size": [1, 3, 256, 256],
+        "mean": [123.675, 116.28, 103.53],
+        "std": [58.395, 57.12, 57.375],
+        # AP-10K keypoint order. Eye indices (0, 1) are what Vireo reads.
+        "keypoints": [
+            "left_eye", "right_eye", "nose", "neck", "root_of_tail",
+            "left_shoulder", "left_elbow", "left_front_paw",
+            "right_shoulder", "right_elbow", "right_front_paw",
+            "left_hip", "left_knee", "left_back_paw",
+            "right_hip", "right_knee", "right_back_paw",
+        ],
+        "output_type": "simcc",
+        "simcc_split_ratio": 2.0,
+    }
+    _save_json(os.path.join(out_dir, "config.json"), config_out)
+
+    log.info("  %s export complete: %s", model_id, out_dir)
+    return onnx_path
+
+
+# ---------------------------------------------------------------------------
 # Export dispatcher
 # ---------------------------------------------------------------------------
 
@@ -1044,6 +1139,7 @@ _EXPORT_FUNCTIONS = {
     "sam2-small": export_sam2_small,
     "sam2-base-plus": export_sam2_base_plus,
     "sam2-large": export_sam2_large,
+    "rtmpose-animal": export_rtmpose_animal,
 }
 
 
@@ -1159,6 +1255,7 @@ Available models:
   sam2-small                SAM2 Hiera Small
   sam2-base-plus            SAM2 Hiera Base+
   sam2-large                SAM2 Hiera Large
+  rtmpose-animal            RTMPose-s AP-10K (animal keypoints, eye-focus spike)
 
 Examples:
   %(prog)s --model bioclip-vit-b-16

--- a/tests/e2e/test_eye_keypoints.py
+++ b/tests/e2e/test_eye_keypoints.py
@@ -1,0 +1,140 @@
+"""End-to-end eye-keypoint pipeline test with real ONNX weights.
+
+Skipped in CI: ``tests/e2e`` is behind ``--ignore=tests/e2e`` in pyproject.toml
+and each test individually skips when the weights or fixture photo aren't
+present locally. This test exists so an engineer validating the SuperAnimal
+export can run one command and confirm a real mammal frame produces an eye
+coordinate inside the expected region.
+
+How to run (from a dev machine with weights downloaded):
+
+    # 1. Export weights into ~/.vireo/models via the dev export script or
+    #    the Pipeline page's Download button.
+    # 2. Drop a reference mammal portrait into tests/fixtures/e2e_mammal.jpg
+    #    — a frame where the eye is clearly in the upper-center of the
+    #    bounding box.
+    # 3. Set the hand-labeled ground truth eye coord in EXPECTED_EYE below.
+    # 4. Run:
+    #       pytest tests/e2e/test_eye_keypoints.py -v
+
+The fixture image + expected coordinate are environment-specific; committing
+them here would make the test either brittle (different library) or heavy
+(binary in git). Keep the fixture local.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "vireo"))
+
+# Hand-labeled ground truth — overwrite with your fixture's actual eye coord.
+# A ±5-px radius matches the plan's Milestone 11.5 acceptance bar.
+EXPECTED_EYE = {"x": 1200, "y": 850}
+EXPECTED_RADIUS_PX = 5
+
+_FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "fixtures", "e2e_mammal.jpg"
+)
+
+
+def _weights_present(model_name):
+    from keypoints import MODELS_DIR
+    return (
+        os.path.isfile(os.path.join(MODELS_DIR, model_name, "model.onnx"))
+        and os.path.isfile(os.path.join(MODELS_DIR, model_name, "config.json"))
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    not os.path.isfile(_FIXTURE_PATH),
+    reason=(
+        "Fixture tests/fixtures/e2e_mammal.jpg not present — see module "
+        "docstring for setup."
+    ),
+)
+
+
+def test_stage_finds_eye_on_reference_mammal(tmp_path):
+    """Full pipeline stage on a real mammal frame locates the eye.
+
+    Uses SuperAnimal-Quadruped if present, else RTMPose-animal, else skips.
+    Asserts the stored (eye_x, eye_y) lands within EXPECTED_RADIUS_PX of the
+    hand-labeled ground truth.
+    """
+    if _weights_present("superanimal-quadruped"):
+        expected_class = "Mammalia"
+    elif _weights_present("rtmpose-animal"):
+        # RTMPose-animal is classified as 'Mammalia' for routing purposes
+        # even though its training set is broader — the eye-focus stage
+        # doesn't know which backbone is behind the model name.
+        expected_class = "Mammalia"
+    else:
+        pytest.skip("No keypoint weights on disk; export + place under ~/.vireo/models")
+
+    from db import Database
+    from PIL import Image
+    from pipeline import detect_eye_keypoints_stage
+
+    db = Database(str(tmp_path / "e2e.db"))
+    ws_id = db._active_workspace_id
+    folder_dir = tmp_path / "photos"
+    folder_dir.mkdir()
+    img = Image.open(_FIXTURE_PATH).convert("RGB")
+    img.save(folder_dir / "mammal.jpg")
+    fid = db.add_folder(str(folder_dir), name="photos")
+    db.add_workspace_folder(ws_id, fid)
+    pid = db.add_photo(
+        fid, "mammal.jpg", ".jpg", os.path.getsize(_FIXTURE_PATH), 1.0,
+        timestamp="2026-04-16T10:00:00",
+        width=img.width, height=img.height,
+    )
+
+    # Full-frame mask stand-in — makes the mask gate trivially pass on a
+    # fixture without a SAM2 run. The stage's gate-4 check just needs the
+    # eye to fall inside this mask.
+    import numpy as np
+    mask = np.ones((img.height, img.width), dtype=np.uint8) * 255
+    mask_path = tmp_path / "mask.png"
+    Image.fromarray(mask, mode="L").save(mask_path)
+    db.update_photo_pipeline_features(pid, mask_path=str(mask_path))
+
+    # Bbox covers the subject area of the fixture — loose enough to include
+    # the eye. If your fixture's subject is in a different region, tune this.
+    det_ids = db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.8, "h": 0.8}, "confidence": 0.95}],
+        detector_model="MegaDetector",
+    )
+    db.add_prediction(
+        det_ids[0],
+        species="Vulpes vulpes",
+        confidence=0.92,
+        model="bioclip-2.5",
+        category="match",
+        taxonomy={
+            "kingdom": "Animalia", "phylum": "Chordata",
+            "class": expected_class, "order": "Carnivora",
+            "family": "Canidae", "genus": "Vulpes",
+            "scientific_name": "Vulpes vulpes",
+        },
+    )
+
+    detect_eye_keypoints_stage(db, config={"eye_detect_enabled": True})
+
+    row = db.conn.execute(
+        "SELECT eye_x, eye_y, eye_conf, eye_tenengrad FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert row[0] is not None, (
+        "eye_x not populated — stage rejected at a gate. Inspect "
+        "logs or widen bbox/lower conf gates if the model truly found no eye."
+    )
+
+    dx = row[0] - EXPECTED_EYE["x"]
+    dy = row[1] - EXPECTED_EYE["y"]
+    assert (dx * dx + dy * dy) <= (EXPECTED_RADIUS_PX * EXPECTED_RADIUS_PX), (
+        f"Detected eye ({row[0]:.1f}, {row[1]:.1f}) is outside ±{EXPECTED_RADIUS_PX}px "
+        f"of expected ({EXPECTED_EYE['x']}, {EXPECTED_EYE['y']})."
+    )
+    assert row[3] > 0.0  # eye_tenengrad should be positive on a real photo

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2184,6 +2184,60 @@ def create_app(db_path, thumb_cache_dir=None):
             "dinov2_known": dinov2_variant in DINOV2_VARIANTS,
         })
 
+    # --- Eye-focus keypoint model download (opt-in) ---
+    _ALLOWED_KEYPOINT_MODELS = (
+        "superanimal-quadruped",
+        "superanimal-bird",
+        "rtmpose-animal",
+    )
+
+    @app.route("/api/models/keypoints/status")
+    def api_keypoints_status():
+        """Return download state for each eye-focus keypoint model."""
+        import keypoints as kp
+
+        return jsonify({
+            name.replace("-", "_"): kp.weights_status(name)
+            for name in _ALLOWED_KEYPOINT_MODELS
+        })
+
+    @app.route(
+        "/api/models/keypoints/<model_name>/download",
+        methods=["POST"],
+    )
+    def api_keypoints_download(model_name):
+        """Trigger a background download of the named keypoint model.
+
+        Rejects unknown model names so a bad argument can't be coerced into
+        an arbitrary HuggingFace fetch. Returns immediately; the client
+        polls /api/models/keypoints/status to observe progress.
+        """
+        import threading
+
+        import keypoints as kp
+
+        if model_name not in _ALLOWED_KEYPOINT_MODELS:
+            return json_error(f"unknown keypoint model {model_name!r}", 400)
+
+        current = kp.weights_status(model_name)
+        if current in ("ready", "downloading"):
+            return jsonify({"status": current})
+
+        def _download():
+            kp._download_state[model_name] = "downloading"
+            try:
+                kp.ensure_keypoint_weights(model_name)
+                kp._download_state[model_name] = "idle"
+            except Exception as exc:
+                log.warning(
+                    "Keypoint weights download failed for %s: %s",
+                    model_name, exc,
+                )
+                kp._download_state[model_name] = "failed"
+
+        threading.Thread(target=_download, daemon=True).start()
+        return jsonify({"status": "downloading"})
+
     @app.route("/api/system/install-exiftool", methods=["POST"])
     def api_install_exiftool():
         """Install exiftool via Homebrew."""

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -59,6 +59,12 @@ DEFAULTS = {
         "reject_focus": 0.35,
         "reject_clip_high": 0.30,
         "reject_composite": 0.40,
+        # Eye-focus detection
+        "eye_detect_enabled": True,
+        "eye_classifier_conf_gate": 0.50,
+        "eye_detection_conf_gate": 0.50,
+        "eye_window_k": 0.08,
+        "reject_eye_focus": 0.35,
         "burst_time_gap": 3.0,
         "burst_phash_threshold": 12,
         "burst_embedding_threshold": 0.80,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2689,10 +2689,15 @@ class Database:
           * has not already been processed — eye_tenengrad IS NULL keeps
             the stage idempotent across reruns
 
-        Returns one row per photo, using the highest-confidence prediction
-        on the highest-confidence real detection. Each row is a dict with
-        the fields the eye stage needs to run without further DB calls:
-        id, folder_id, filename, width, height, mask_path,
+        Returns one row per photo. The row chosen is the highest-confidence
+        prediction on the highest-confidence real detection **among
+        predictions that carry routable taxonomy info** (taxonomy_class or
+        scientific_name set); predictions missing both fields are only
+        chosen when nothing else is available. This prevents a top-ranked
+        but taxonomy-less prediction from masking a lower-ranked prediction
+        that ``_resolve_keypoint_model`` could actually route. Each row is
+        a dict with the fields the eye stage needs to run without further
+        DB calls: id, folder_id, filename, width, height, mask_path,
         box_x/y/w/h (normalized 0-1), species_conf, taxonomy_class,
         scientific_name, species.
         """
@@ -2717,6 +2722,11 @@ class Database:
                WHERE p.mask_path IS NOT NULL
                  AND p.eye_tenengrad IS NULL
                ORDER BY p.id,
+                        CASE
+                            WHEN pr.taxonomy_class IS NOT NULL
+                              OR pr.scientific_name IS NOT NULL THEN 0
+                            ELSE 1
+                        END,
                         d.detector_confidence DESC,
                         pr.confidence DESC""",
             (ws_id, ws_id),

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2674,6 +2674,75 @@ class Database:
             })
         return result
 
+    def list_photos_for_eye_keypoint_stage(self):
+        """Return photos eligible for the eye-focus keypoint stage.
+
+        Eligibility:
+          * photo is in the active workspace (via workspace_folders)
+          * mask_path is set (SAM2 produced a subject mask)
+          * has at least one non-synthetic detection (excludes full-image
+            rows that exist only to anchor predictions)
+          * has at least one prediction on that detection
+          * has not already been processed — eye_tenengrad IS NULL keeps
+            the stage idempotent across reruns
+
+        Returns one row per photo, using the highest-confidence prediction
+        on the highest-confidence real detection. Each row is a dict with
+        the fields the eye stage needs to run without further DB calls:
+        id, folder_id, filename, width, height, mask_path,
+        box_x/y/w/h (normalized 0-1), species_conf, taxonomy_class,
+        scientific_name, species.
+        """
+        ws_id = self._ws_id()
+        rows = self.conn.execute(
+            """SELECT p.id, p.folder_id, p.filename, p.width, p.height,
+                      p.mask_path,
+                      d.box_x, d.box_y, d.box_w, d.box_h,
+                      d.detector_confidence,
+                      pr.confidence AS species_conf,
+                      pr.taxonomy_class,
+                      pr.scientific_name,
+                      pr.species
+               FROM photos p
+               JOIN workspace_folders wf
+                 ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+               JOIN detections d
+                 ON d.photo_id = p.id
+                AND d.workspace_id = ?
+                AND d.detector_model != 'full-image'
+               JOIN predictions pr ON pr.detection_id = d.id
+               WHERE p.mask_path IS NOT NULL
+                 AND p.eye_tenengrad IS NULL
+               ORDER BY p.id,
+                        d.detector_confidence DESC,
+                        pr.confidence DESC""",
+            (ws_id, ws_id),
+        ).fetchall()
+
+        seen = set()
+        result = []
+        for r in rows:
+            if r["id"] in seen:
+                continue
+            seen.add(r["id"])
+            result.append({
+                "id": r["id"],
+                "folder_id": r["folder_id"],
+                "filename": r["filename"],
+                "width": r["width"],
+                "height": r["height"],
+                "mask_path": r["mask_path"],
+                "box_x": r["box_x"],
+                "box_y": r["box_y"],
+                "box_w": r["box_w"],
+                "box_h": r["box_h"],
+                "species_conf": r["species_conf"],
+                "taxonomy_class": r["taxonomy_class"],
+                "scientific_name": r["scientific_name"],
+                "species": r["species"],
+            })
+        return result
+
     def update_photo_embeddings(
         self, photo_id, dino_subject_embedding=None, dino_global_embedding=None,
         variant=None,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2677,7 +2677,7 @@ class Database:
             })
         return result
 
-    def list_photos_for_eye_keypoint_stage(self):
+    def list_photos_for_eye_keypoint_stage(self, photo_ids=None):
         """Return photos eligible for the eye-focus keypoint stage.
 
         Eligibility:
@@ -2688,6 +2688,9 @@ class Database:
           * has at least one prediction on that detection
           * has not already been processed — eye_tenengrad IS NULL keeps
             the stage idempotent across reruns
+          * (optional) photo.id is in ``photo_ids`` when provided — lets the
+            caller scope the stage to a collection so a pipeline run doesn't
+            touch unrelated photos elsewhere in the workspace
 
         Returns one row per photo. The row chosen is the highest-confidence
         prediction on the highest-confidence real detection **among
@@ -2702,8 +2705,18 @@ class Database:
         scientific_name, species.
         """
         ws_id = self._ws_id()
+        if photo_ids is not None:
+            photo_ids = list(photo_ids)
+            if not photo_ids:
+                return []
+            placeholders = ",".join("?" for _ in photo_ids)
+            extra_where = f" AND p.id IN ({placeholders})"
+            params = (ws_id, ws_id, *photo_ids)
+        else:
+            extra_where = ""
+            params = (ws_id, ws_id)
         rows = self.conn.execute(
-            """SELECT p.id, p.folder_id, p.filename, p.width, p.height,
+            f"""SELECT p.id, p.folder_id, p.filename, p.width, p.height,
                       p.mask_path,
                       d.box_x, d.box_y, d.box_w, d.box_h,
                       d.detector_confidence,
@@ -2720,7 +2733,7 @@ class Database:
                 AND d.detector_model != 'full-image'
                JOIN predictions pr ON pr.detection_id = d.id
                WHERE p.mask_path IS NOT NULL
-                 AND p.eye_tenengrad IS NULL
+                 AND p.eye_tenengrad IS NULL{extra_where}
                ORDER BY p.id,
                         CASE
                             WHEN pr.taxonomy_class IS NOT NULL
@@ -2729,7 +2742,7 @@ class Database:
                         END,
                         d.detector_confidence DESC,
                         pr.confidence DESC""",
-            (ws_id, ws_id),
+            params,
         ).fetchall()
 
         seen = set()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2577,6 +2577,10 @@ class Database:
         subject_y_median=_UNSET,
         phash_crop=_UNSET,
         noise_estimate=_UNSET,
+        eye_x=_UNSET,
+        eye_y=_UNSET,
+        eye_conf=_UNSET,
+        eye_tenengrad=_UNSET,
     ):
         """Update pipeline feature columns for a photo.
 
@@ -2593,6 +2597,10 @@ class Database:
             "subject_y_median": subject_y_median,
             "phash_crop": phash_crop,
             "noise_estimate": noise_estimate,
+            "eye_x": eye_x,
+            "eye_y": eye_y,
+            "eye_conf": eye_conf,
+            "eye_tenengrad": eye_tenengrad,
         }
         # Filter to only provided values
         updates = {k: v for k, v in cols.items() if v is not _UNSET}

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -394,6 +394,15 @@ class Database:
         except Exception:
             self.conn.execute("ALTER TABLE photos ADD COLUMN working_copy_path TEXT")
 
+        # Eye-focus detection columns (keypoint + windowed tenengrad)
+        try:
+            self.conn.execute("SELECT eye_x FROM photos LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute("ALTER TABLE photos ADD COLUMN eye_x REAL")
+            self.conn.execute("ALTER TABLE photos ADD COLUMN eye_y REAL")
+            self.conn.execute("ALTER TABLE photos ADD COLUMN eye_conf REAL")
+            self.conn.execute("ALTER TABLE photos ADD COLUMN eye_tenengrad REAL")
+
         # Edit history tables migration
         try:
             self.conn.execute("SELECT id FROM edit_history LIMIT 0")

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1606,8 +1606,11 @@ class Database:
                     subject_sharpness, subject_size, quality_score,
                     latitude, longitude, companion_path, working_copy_path"""
 
-    # Columns for single-photo detail queries (includes exif_data JSON)
-    PHOTO_DETAIL_COLS = PHOTO_COLS + ", exif_data"
+    # Columns for single-photo detail queries (includes exif_data JSON +
+    # eye-focus fields consumed by the review lightbox's crosshair overlay)
+    PHOTO_DETAIL_COLS = (
+        PHOTO_COLS + ", exif_data, eye_x, eye_y, eye_conf, eye_tenengrad"
+    )
 
     def get_photo(self, photo_id, verify_workspace=False):
         """Return a single photo by id, including full metadata.

--- a/vireo/keypoints.py
+++ b/vireo/keypoints.py
@@ -12,6 +12,7 @@ Models:
 All models load from ~/.vireo/models/<name>/model.onnx with a sibling
 config.json describing input size, normalization, and keypoint names.
 """
+import json
 import logging
 import os
 import threading
@@ -138,3 +139,131 @@ def decode_simcc(simcc_x, simcc_y, input_size, simcc_split_ratio=2.0):
     x = idx_x / simcc_split_ratio
     y = idx_y / simcc_split_ratio
     return np.stack([x, y, conf], axis=1).astype(np.float32)
+
+
+def decode_heatmaps(heatmaps, input_size):
+    """Decode (1, K, H', W') heatmaps to (K, 3) keypoints in input-image pixels.
+
+    Simple argmax + rescale. SuperAnimal heatmap-head models use this path;
+    RTMPose goes through decode_simcc instead. Subpixel refinement (quadratic
+    fit around argmax) is deferred until real-image tests show the need.
+    """
+    hm = heatmaps[0]  # (K, H', W')
+    K, H, W = hm.shape
+    flat = hm.reshape(K, -1)
+    idx = np.argmax(flat, axis=1)
+    ys = (idx // W).astype(np.float32)
+    xs = (idx % W).astype(np.float32)
+    conf = flat[np.arange(K), idx]
+    xs *= input_size / W
+    ys *= input_size / H
+    return np.stack([xs, ys, conf], axis=1).astype(np.float32)
+
+
+def _load_config(model_name):
+    """Read config.json sibling to model.onnx."""
+    config_path = os.path.join(_model_dir(model_name), "config.json")
+    with open(config_path) as f:
+        return json.load(f)
+
+
+def _load_session(model_name):
+    """Get the cached onnxruntime session for ``model_name``.
+
+    Loads on first use; subsequent calls return the same session. Raises
+    FileNotFoundError if weights are absent — callers should have invoked
+    ensure_keypoint_weights() first.
+    """
+    if model_name in _sessions:
+        return _sessions[model_name]
+    lock = _locks.setdefault(model_name, threading.Lock())
+    with lock:
+        if model_name in _sessions:
+            return _sessions[model_name]
+        import onnxruntime as ort
+
+        onnx_path = os.path.join(_model_dir(model_name), "model.onnx")
+        if not os.path.isfile(onnx_path):
+            raise FileNotFoundError(
+                f"Keypoint model {model_name!r} not found at {onnx_path}. "
+                "Call ensure_keypoint_weights() first."
+            )
+        _sessions[model_name] = ort.InferenceSession(
+            onnx_path, providers=["CPUExecutionProvider"]
+        )
+    return _sessions[model_name]
+
+
+def detect_keypoints(image, bbox, model_name):
+    """Run a keypoint model on the bbox crop; return per-keypoint (x, y, conf).
+
+    Applies aspect-ratio-preserving resize + top-left pad to the model's
+    input size, normalizes per the model config, and maps the detected
+    input-space keypoints back into the original image's pixel space.
+
+    Args:
+        image: PIL.Image (original-resolution RGB).
+        bbox: (x0, y0, x1, y1) in image-pixel space (MegaDetector output).
+        model_name: one of 'rtmpose-animal', 'superanimal-quadruped',
+            'superanimal-bird'.
+
+    Returns:
+        list of dicts ``{"name": str, "x": float, "y": float, "conf": float}``,
+        one entry per keypoint the model produces. Coordinates are in the
+        original image's pixel space.
+    """
+    from PIL import Image
+
+    cfg = _load_config(model_name)
+    input_h = cfg["input_size"][2]
+    input_w = cfg["input_size"][3]
+    mean = np.array(cfg["mean"], dtype=np.float32).reshape(3, 1, 1)
+    std = np.array(cfg["std"], dtype=np.float32).reshape(3, 1, 1)
+    keypoint_names = cfg["keypoints"]
+
+    x0, y0, x1, y1 = bbox
+    crop = image.crop((x0, y0, x1, y1))
+    crop_w, crop_h = crop.size
+    scale = min(input_w / crop_w, input_h / crop_h)
+    new_w = max(1, int(round(crop_w * scale)))
+    new_h = max(1, int(round(crop_h * scale)))
+    resized = crop.resize((new_w, new_h), Image.BILINEAR)
+
+    # Top-left aligned pad. Using a constant pad offset (0, 0) keeps the
+    # inverse transform trivial: input-space coords map directly through
+    # `scale` back to crop-space.
+    padded = Image.new("RGB", (input_w, input_h), color=(0, 0, 0))
+    padded.paste(resized, (0, 0))
+
+    arr = np.array(padded, dtype=np.float32).transpose(2, 0, 1)  # CHW
+    arr = (arr - mean) / std
+    arr = arr[np.newaxis, :, :, :]
+
+    session = _load_session(model_name)
+    outputs = session.run(None, {"pixel_values": arr})
+
+    output_type = cfg.get("output_type", "heatmap")
+    if output_type == "simcc":
+        simcc_x, simcc_y = outputs
+        kps_input_space = decode_simcc(
+            simcc_x,
+            simcc_y,
+            input_size=input_w,
+            simcc_split_ratio=cfg.get("simcc_split_ratio", 2.0),
+        )
+    else:
+        kps_input_space = decode_heatmaps(outputs[0], input_size=input_w)
+
+    result = []
+    for i, name in enumerate(keypoint_names):
+        x_in, y_in, conf = kps_input_space[i]
+        # Inverse-map: input-space → crop-space → image-space.
+        x_img = float(x_in / scale) + x0
+        y_img = float(y_in / scale) + y0
+        result.append({
+            "name": name,
+            "x": float(x_img),
+            "y": float(y_img),
+            "conf": float(conf),
+        })
+    return result

--- a/vireo/keypoints.py
+++ b/vireo/keypoints.py
@@ -1,0 +1,55 @@
+"""Animal keypoint detection via ONNX Runtime.
+
+Top-down keypoint models take a cropped image (MegaDetector bbox) and return
+per-keypoint (x, y, conf) in image-pixel coordinates. Used to localize the
+animal's eye for eye-focus scoring.
+
+Models:
+    rtmpose-animal        — RTMPose-s on AP-10K, integration spike.
+    superanimal-quadruped — DLC 3.x, production mammals.
+    superanimal-bird      — DLC 3.x, production birds.
+
+All models load from ~/.vireo/models/<name>/model.onnx with a sibling
+config.json describing input size, normalization, and keypoint names.
+"""
+import logging
+import os
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+MODELS_DIR = os.path.expanduser("~/.vireo/models")
+
+_sessions = {}
+_locks = {}
+_download_locks = {}
+
+
+def decode_simcc(simcc_x, simcc_y, input_size, simcc_split_ratio=2.0):
+    """Decode RTMPose simcc-format outputs to (K, 3) keypoints.
+
+    RTMPose emits two 1-D classification maps per keypoint (x and y axes);
+    each axis is argmaxed independently and the per-keypoint confidence is
+    the minimum of the two peak activations.
+
+    Args:
+        simcc_x: ndarray of shape (1, K, size_x).
+        simcc_y: ndarray of shape (1, K, size_y).
+        input_size: input image side length in pixels (e.g., 256).
+        simcc_split_ratio: simcc coordinate scale factor (default 2.0).
+
+    Returns:
+        ndarray of shape (K, 3) with columns (x, y, conf) in input-image
+        pixel space.
+    """
+    sx = simcc_x[0]  # (K, size_x)
+    sy = simcc_y[0]  # (K, size_y)
+    idx_x = np.argmax(sx, axis=1)
+    idx_y = np.argmax(sy, axis=1)
+    conf_x = sx[np.arange(sx.shape[0]), idx_x]
+    conf_y = sy[np.arange(sy.shape[0]), idx_y]
+    conf = np.minimum(conf_x, conf_y)
+    x = idx_x / simcc_split_ratio
+    y = idx_y / simcc_split_ratio
+    return np.stack([x, y, conf], axis=1).astype(np.float32)

--- a/vireo/keypoints.py
+++ b/vireo/keypoints.py
@@ -14,6 +14,7 @@ config.json describing input size, normalization, and keypoint names.
 """
 import logging
 import os
+import threading
 
 import numpy as np
 
@@ -24,6 +25,90 @@ MODELS_DIR = os.path.expanduser("~/.vireo/models")
 _sessions = {}
 _locks = {}
 _download_locks = {}
+
+
+def _model_dir(model_name):
+    return os.path.join(MODELS_DIR, model_name)
+
+
+def ensure_keypoint_weights(model_name, progress_callback=None):
+    """Ensure ONNX weights for ``model_name`` are present on disk.
+
+    Returns the path to ``model.onnx`` if both that file and ``config.json``
+    already exist under ``MODELS_DIR/<model_name>/``. Otherwise downloads
+    both from the ``jss367/vireo-onnx-models`` HuggingFace repo.
+
+    Args:
+        model_name: one of 'rtmpose-animal', 'superanimal-quadruped',
+            'superanimal-bird'.
+        progress_callback: optional callable(phase: str, current: int, total: int)
+            invoked before download and after completion.
+
+    Raises:
+        RuntimeError: if the download fails; callers should abort or surface
+            the error to the user rather than silently running without weights.
+    """
+    target = _model_dir(model_name)
+    onnx_path = os.path.join(target, "model.onnx")
+    config_path = os.path.join(target, "config.json")
+
+    if os.path.isfile(onnx_path) and os.path.isfile(config_path):
+        return onnx_path
+
+    # Serialize concurrent first-run downloads per-model so two parallel jobs
+    # don't both fetch the same weights. Locks are created lazily; the outer
+    # setdefault is itself thread-safe for the dict insert.
+    lock = _download_locks.setdefault(model_name, threading.Lock())
+    with lock:
+        if os.path.isfile(onnx_path) and os.path.isfile(config_path):
+            return onnx_path
+
+        os.makedirs(target, exist_ok=True)
+        if progress_callback:
+            progress_callback(
+                f"Downloading {model_name} (first run only)...", 0, 1
+            )
+        log.info("%s weights missing — downloading from Hugging Face", model_name)
+
+        try:
+            import shutil
+
+            import huggingface_hub
+            from models import ONNX_REPO
+
+            for filename, final_path in (
+                ("model.onnx", onnx_path),
+                ("config.json", config_path),
+            ):
+                cached = huggingface_hub.hf_hub_download(
+                    repo_id=ONNX_REPO,
+                    filename=filename,
+                    subfolder=model_name,
+                )
+                # hf_hub_download returns its cache path; copy into the
+                # model dir so the inference code can find it consistently.
+                tmp = final_path + ".download"
+                shutil.copy2(cached, tmp)
+                os.replace(tmp, final_path)
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to download {model_name} weights: {e}. "
+                "Check your network connection and retry, or download manually "
+                "from the pipeline models page."
+            ) from e
+
+        if not (os.path.isfile(onnx_path) and os.path.isfile(config_path)):
+            raise RuntimeError(
+                f"{model_name} download completed but files are missing "
+                f"under {target}."
+            )
+
+        size_mb = round(os.path.getsize(onnx_path) / 1024 / 1024, 1)
+        log.info("%s weights downloaded (%s MB)", model_name, size_mb)
+        if progress_callback:
+            progress_callback(f"{model_name} ready ({size_mb} MB)", 1, 1)
+
+    return onnx_path
 
 
 def decode_simcc(simcc_x, simcc_y, input_size, simcc_split_ratio=2.0):

--- a/vireo/keypoints.py
+++ b/vireo/keypoints.py
@@ -27,9 +27,37 @@ _sessions = {}
 _locks = {}
 _download_locks = {}
 
+# Per-model download state for the pipeline page card. Values:
+#   "idle"         — never requested, or previous download was acknowledged.
+#   "downloading"  — a background thread is actively fetching.
+#   "failed"       — most recent attempt raised; weights not on disk.
+_download_state = {}
+
 
 def _model_dir(model_name):
     return os.path.join(MODELS_DIR, model_name)
+
+
+def weights_status(model_name):
+    """Return the current download/readiness state for ``model_name``.
+
+    Priority order:
+        1. Files on disk → "ready"
+        2. Background thread in flight → "downloading"
+        3. Previous failure without files on disk → "failed"
+        4. Otherwise → "missing"
+    """
+    target = _model_dir(model_name)
+    onnx_path = os.path.join(target, "model.onnx")
+    config_path = os.path.join(target, "config.json")
+    if os.path.isfile(onnx_path) and os.path.isfile(config_path):
+        return "ready"
+    state = _download_state.get(model_name, "idle")
+    if state == "downloading":
+        return "downloading"
+    if state == "failed":
+        return "failed"
+    return "missing"
 
 
 def ensure_keypoint_weights(model_name, progress_callback=None):

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -754,7 +754,10 @@ def _process_photo_for_eye(db, row, folders, *, C, T, k_window):
     )
 
 
-def detect_eye_keypoints_stage(db, config, progress_callback=None, collection_id=None):
+def detect_eye_keypoints_stage(
+    db, config, progress_callback=None,
+    collection_id=None, exclude_photo_ids=None,
+):
     """Pipeline stage: detect eye keypoints and persist raw tenengrad.
 
     For each eligible photo (see Database.list_photos_for_eye_keypoint_stage),
@@ -774,6 +777,11 @@ def detect_eye_keypoints_stage(db, config, progress_callback=None, collection_id
             provided, only photos in that collection are considered — matches
             the scoping that extract/regroup stages already apply so a run
             started for one collection doesn't mutate eye fields elsewhere.
+        exclude_photo_ids: optional iterable of photo IDs to exclude. Mirrors
+            the preview-deselection filter that extract/regroup honor, so
+            photos the user unchecked don't get eye_* values locked in (the
+            stage is idempotent via eye_tenengrad IS NULL, so leaking writes
+            here would survive future reruns).
     """
     skip_reason = eye_keypoint_stage_preflight(config)
     if skip_reason is not None:
@@ -784,12 +792,20 @@ def detect_eye_keypoints_stage(db, config, progress_callback=None, collection_id
     T = config.get("eye_detection_conf_gate", 0.5)
     k_window = config.get("eye_window_k", 0.08)
 
+    exclude_set = set(exclude_photo_ids) if exclude_photo_ids else None
+
     photo_ids = None
     if collection_id is not None:
         photo_ids = _resolve_collection_photo_ids(db, collection_id)
         if not photo_ids:
             return
+    if exclude_set and photo_ids is not None:
+        photo_ids = {pid for pid in photo_ids if pid not in exclude_set}
+        if not photo_ids:
+            return
     photos = db.list_photos_for_eye_keypoint_stage(photo_ids=photo_ids)
+    if exclude_set and photo_ids is None:
+        photos = [p for p in photos if p["id"] not in exclude_set]
     if not photos:
         return
     folders = {f["id"]: f["path"] for f in db.get_folder_tree()}

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -30,7 +30,8 @@ _PIPELINE_PHOTO_COLS = """
     p.dino_subject_embedding, p.dino_global_embedding,
     p.dino_embedding_variant,
     p.focal_length, p.burst_id, p.noise_estimate,
-    p.flag, p.rating
+    p.flag, p.rating,
+    p.eye_x, p.eye_y, p.eye_conf, p.eye_tenengrad
 """
 
 
@@ -242,6 +243,10 @@ def load_photo_features(db, collection_id=None, config=None):
             "noise_estimate": row["noise_estimate"],
             "flag": row["flag"],
             "rating": row["rating"],
+            "eye_x": row["eye_x"],
+            "eye_y": row["eye_y"],
+            "eye_conf": row["eye_conf"],
+            "eye_tenengrad": row["eye_tenengrad"],
         })
 
     log.info("Loaded %d photos with pipeline features", len(photos))

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -738,7 +738,7 @@ def _process_photo_for_eye(db, row, folders, *, C, T, k_window):
     )
 
 
-def detect_eye_keypoints_stage(db, config, progress_callback=None):
+def detect_eye_keypoints_stage(db, config, progress_callback=None, collection_id=None):
     """Pipeline stage: detect eye keypoints and persist raw tenengrad.
 
     For each eligible photo (see Database.list_photos_for_eye_keypoint_stage),
@@ -754,6 +754,10 @@ def detect_eye_keypoints_stage(db, config, progress_callback=None):
             - eye_detection_conf_gate (float, default 0.5)
             - eye_window_k (float, default 0.08)
         progress_callback: optional callable(phase, current, total).
+        collection_id: optional collection ID to scope processing to. When
+            provided, only photos in that collection are considered — matches
+            the scoping that extract/regroup stages already apply so a run
+            started for one collection doesn't mutate eye fields elsewhere.
     """
     if not config.get("eye_detect_enabled", True):
         log.info("Eye-focus detection disabled by config; skipping stage")
@@ -763,7 +767,12 @@ def detect_eye_keypoints_stage(db, config, progress_callback=None):
     T = config.get("eye_detection_conf_gate", 0.5)
     k_window = config.get("eye_window_k", 0.08)
 
-    photos = db.list_photos_for_eye_keypoint_stage()
+    photo_ids = None
+    if collection_id is not None:
+        photo_ids = _resolve_collection_photo_ids(db, collection_id)
+        if not photo_ids:
+            return
+    photos = db.list_photos_for_eye_keypoint_stage(photo_ids=photo_ids)
     if not photos:
         return
     folders = {f["id"]: f["path"] for f in db.get_folder_tree()}

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -580,3 +580,202 @@ def save_results_raw(results, cache_dir, workspace_id):
     with open(path, "w") as f:
         json.dump(results, f)
     return path
+
+
+# ---------------------------------------------------------------------------
+# Eye-focus keypoint detection stage
+# ---------------------------------------------------------------------------
+#
+# Runs between masking and scoring. For each photo with a subject mask and
+# an in-scope (Aves or Mammalia) species classification, route to the
+# appropriate ONNX keypoint model, run top-down keypoint detection, apply a
+# three-gate trust policy, and persist raw (eye_x, eye_y, eye_conf,
+# eye_tenengrad). Scoring picks these up downstream; the normalized
+# eye_focus_score is computed ephemerally at scoring time.
+#
+# Gates:
+#   1. Classifier confidence >= C AND species in {Aves, Mammalia}.
+#   2. ONNX weights for the routed model present on disk (no auto-download
+#      from the stage — weights are user-opt-in via the pipeline page).
+#   3. Eye keypoint confidence >= T.
+#   4. Eye keypoint falls inside the subject mask.
+
+
+_EYE_KEYPOINT_MODEL_FOR_CLASS = {
+    "Aves": "superanimal-bird",
+    "Mammalia": "superanimal-quadruped",
+}
+
+
+def _resolve_keypoint_model(db, photo_row):
+    """Route a photo to a keypoint model name, or None if out of scope.
+
+    Primary path: use ``taxonomy_class`` stored on the prediction — set by
+    classifiers that resolve full iNat lineage. Fallback: look up the
+    scientific name in the local taxa table and walk the parent chain with
+    classify_to_keypoint_group.
+    """
+    tax_class = photo_row.get("taxonomy_class")
+    if tax_class in _EYE_KEYPOINT_MODEL_FOR_CLASS:
+        return _EYE_KEYPOINT_MODEL_FOR_CLASS[tax_class]
+    # Fallback: species name -> taxa.inat_id -> classify_to_keypoint_group.
+    name = photo_row.get("scientific_name") or photo_row.get("species")
+    if not name:
+        return None
+    from taxonomy import classify_to_keypoint_group
+    row = db.conn.execute(
+        "SELECT inat_id FROM taxa WHERE name = ? LIMIT 1", (name,)
+    ).fetchone()
+    if row is None:
+        return None
+    group = classify_to_keypoint_group(db, row[0] if not hasattr(row, "keys") else row["inat_id"])
+    return _EYE_KEYPOINT_MODEL_FOR_CLASS.get(group)
+
+
+def _load_mask_array(mask_path):
+    """Load a saved SAM2 mask PNG as a boolean (H, W) array."""
+    from PIL import Image
+    mask_img = Image.open(mask_path).convert("L")
+    return np.array(mask_img) > 127
+
+
+def _process_photo_for_eye(db, row, folders, *, C, T, k_window):
+    """Run the four-gate policy on a single photo row.
+
+    Persists (eye_x, eye_y, eye_conf, eye_tenengrad) when every gate passes,
+    otherwise returns without writing. Called per-photo from the stage loop;
+    exceptions bubble up so the stage can log and continue.
+    """
+    import os
+
+    import keypoints as kp
+    from PIL import Image
+    from quality import compute_eye_tenengrad
+
+    # Gate 1: classifier confidence + species in scope.
+    if (row.get("species_conf") or 0.0) < C:
+        return
+    model_name = _resolve_keypoint_model(db, row)
+    if model_name is None:
+        return
+
+    # Gate 2: weights present on disk. Stage does NOT auto-download — the
+    # user opts in via the pipeline models card. If a partial download left
+    # model.onnx but no config.json (or vice versa), skip defensively.
+    onnx_path = os.path.join(kp.MODELS_DIR, model_name, "model.onnx")
+    config_path = os.path.join(kp.MODELS_DIR, model_name, "config.json")
+    if not (os.path.isfile(onnx_path) and os.path.isfile(config_path)):
+        return
+
+    folder_path = folders.get(row["folder_id"], "")
+    image_path = os.path.join(folder_path, row["filename"])
+    if not os.path.isfile(image_path):
+        return
+    image = Image.open(image_path).convert("RGB")
+
+    # Normalized 0-1 box → pixel bbox in image coords.
+    iw, ih = image.size
+    bbox = (
+        int(round(row["box_x"] * iw)),
+        int(round(row["box_y"] * ih)),
+        int(round((row["box_x"] + row["box_w"]) * iw)),
+        int(round((row["box_y"] + row["box_h"]) * ih)),
+    )
+    if bbox[2] <= bbox[0] or bbox[3] <= bbox[1]:
+        return
+
+    kps = kp.detect_keypoints(image, bbox, model_name)
+
+    # Resize mask to image dims if needed (masks are typically saved at
+    # proxy resolution and must be compared to full-image keypoint coords).
+    mask = _load_mask_array(row["mask_path"])
+    if mask.shape != (ih, iw):
+        from PIL import Image as _PIL
+        mask_img = _PIL.fromarray(mask.astype(np.uint8) * 255).resize(
+            (iw, ih), _PIL.NEAREST
+        )
+        mask = np.array(mask_img) > 127
+
+    # Gate 3 + 4: eye keypoint conf >= T AND inside the subject mask.
+    eye_candidates = []
+    for k_point in kps:
+        if k_point["name"] not in ("left_eye", "right_eye"):
+            continue
+        if k_point["conf"] < T:
+            continue
+        mx, my = int(k_point["x"]), int(k_point["y"])
+        if not (0 <= mx < mask.shape[1] and 0 <= my < mask.shape[0]):
+            continue
+        if not mask[my, mx]:
+            continue
+        eye_candidates.append(k_point)
+
+    if not eye_candidates:
+        return
+
+    # Pick the eye with the highest windowed tenengrad — "best" eye wins.
+    best = None
+    best_score = -1.0
+    for eye in eye_candidates:
+        score = compute_eye_tenengrad(
+            image, (eye["x"], eye["y"]), bbox, k=k_window
+        )
+        if score > best_score:
+            best_score = score
+            best = eye
+
+    db.update_photo_pipeline_features(
+        row["id"],
+        eye_x=best["x"],
+        eye_y=best["y"],
+        eye_conf=best["conf"],
+        eye_tenengrad=best_score,
+    )
+
+
+def detect_eye_keypoints_stage(db, config, progress_callback=None):
+    """Pipeline stage: detect eye keypoints and persist raw tenengrad.
+
+    For each eligible photo (see Database.list_photos_for_eye_keypoint_stage),
+    run the routed keypoint model, apply the four-gate trust policy, and
+    persist (eye_x, eye_y, eye_conf, eye_tenengrad) for gated-through photos.
+    Per-photo exceptions are logged and do not abort the stage.
+
+    Args:
+        db: Database with an active workspace.
+        config: dict of tunables. Reads:
+            - eye_detect_enabled (bool, default True)
+            - eye_classifier_conf_gate (float, default 0.5)
+            - eye_detection_conf_gate (float, default 0.5)
+            - eye_window_k (float, default 0.08)
+        progress_callback: optional callable(phase, current, total).
+    """
+    if not config.get("eye_detect_enabled", True):
+        log.info("Eye-focus detection disabled by config; skipping stage")
+        return
+
+    C = config.get("eye_classifier_conf_gate", 0.5)
+    T = config.get("eye_detection_conf_gate", 0.5)
+    k_window = config.get("eye_window_k", 0.08)
+
+    photos = db.list_photos_for_eye_keypoint_stage()
+    if not photos:
+        return
+    folders = {f["id"]: f["path"] for f in db.get_folder_tree()}
+    total = len(photos)
+
+    for i, row in enumerate(photos):
+        if progress_callback:
+            progress_callback("Eye keypoints", i, total)
+        try:
+            _process_photo_for_eye(
+                db, row, folders, C=C, T=T, k_window=k_window,
+            )
+        except Exception:
+            log.warning(
+                "Eye keypoint detection failed for photo %s", row["id"],
+                exc_info=True,
+            )
+
+    if progress_callback:
+        progress_callback("Eye keypoints", total, total)

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -753,10 +753,17 @@ def _process_photo_for_eye(db, row, folders, *, C, T, k_window):
             best_score = score
             best = eye
 
+    # Persist eye coords normalized to 0-1 against the loaded (oriented)
+    # image dims. Two reasons: (a) EXIF-rotated JPEGs would otherwise
+    # need the oriented dims stored separately for the lightbox to map
+    # pixel coords back to a percentage — photos.width/height come from
+    # the un-oriented sensor tag so the math goes wrong on orientation
+    # 6/8; (b) this matches the detection-box storage convention
+    # (box_x/box_y are also normalized 0-1).
     db.update_photo_pipeline_features(
         row["id"],
-        eye_x=best["x"],
-        eye_y=best["y"],
+        eye_x=best["x"] / float(iw),
+        eye_y=best["y"] / float(ih),
         eye_conf=best["conf"],
         eye_tenengrad=best_score,
     )

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -612,6 +612,22 @@ _EYE_KEYPOINT_MODEL_FOR_CLASS = {
 }
 
 
+def eye_keypoint_stage_preflight(config):
+    """Return a short skip reason if the eye-keypoint stage cannot do work.
+
+    Returns None when the stage should run. Shared between
+    detect_eye_keypoints_stage and the pipeline job so the job can avoid the
+    O(N) eligibility join when the stage is going to short-circuit anyway.
+    """
+    if not config.get("eye_detect_enabled", True):
+        return "Disabled in config"
+    import keypoints as kp
+    routable = set(_EYE_KEYPOINT_MODEL_FOR_CLASS.values())
+    if not any(kp.weights_status(name) == "ready" for name in routable):
+        return "No keypoint models installed"
+    return None
+
+
 def _resolve_keypoint_model(db, photo_row):
     """Route a photo to a keypoint model name, or None if out of scope.
 
@@ -759,25 +775,9 @@ def detect_eye_keypoints_stage(db, config, progress_callback=None, collection_id
             the scoping that extract/regroup stages already apply so a run
             started for one collection doesn't mutate eye fields elsewhere.
     """
-    if not config.get("eye_detect_enabled", True):
-        log.info("Eye-focus detection disabled by config; skipping stage")
-        return
-
-    # Stage-level preflight: if no routable keypoint model has weights on
-    # disk, the per-photo loop would be a pure no-op (Gate 2 in
-    # _process_photo_for_eye rejects every row). Short-circuit here so
-    # large collections don't pay an O(N) DB/mask/SSE cost for a stage
-    # that's entirely gated off by the default "not downloaded" state.
-    import keypoints as kp
-    routable_models = set(_EYE_KEYPOINT_MODEL_FOR_CLASS.values())
-    if not any(
-        kp.weights_status(name) == "ready" for name in routable_models
-    ):
-        log.info(
-            "Eye-keypoint stage skipped: no routable keypoint model weights "
-            "installed (%s)",
-            ", ".join(sorted(routable_models)),
-        )
+    skip_reason = eye_keypoint_stage_preflight(config)
+    if skip_reason is not None:
+        log.info("Eye-keypoint stage skipped: %s", skip_reason)
         return
 
     C = config.get("eye_classifier_conf_gate", 0.5)

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -670,7 +670,7 @@ def _process_photo_for_eye(db, row, folders, *, C, T, k_window):
     import os
 
     import keypoints as kp
-    from PIL import Image
+    from image_loader import load_image
     from quality import compute_eye_tenengrad
 
     # Gate 1: classifier confidence + species in scope.
@@ -692,7 +692,15 @@ def _process_photo_for_eye(db, row, folders, *, C, T, k_window):
     image_path = os.path.join(folder_path, row["filename"])
     if not os.path.isfile(image_path):
         return
-    image = Image.open(image_path).convert("RGB")
+    # Use image_loader (same path as detector/masking/sharpness) so RAW
+    # inputs decode and EXIF-rotated JPEGs are transposed to match the
+    # frame bbox and mask were authored in. max_size=1024 matches the
+    # sharpness stage so tenengrad operators are applied at the same
+    # pixel scale across the cohort.
+    image = load_image(image_path, max_size=1024)
+    if image is None:
+        return
+    image = image.convert("RGB")
 
     # Normalized 0-1 box → pixel bbox in image coords.
     iw, ih = image.size

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -763,6 +763,23 @@ def detect_eye_keypoints_stage(db, config, progress_callback=None, collection_id
         log.info("Eye-focus detection disabled by config; skipping stage")
         return
 
+    # Stage-level preflight: if no routable keypoint model has weights on
+    # disk, the per-photo loop would be a pure no-op (Gate 2 in
+    # _process_photo_for_eye rejects every row). Short-circuit here so
+    # large collections don't pay an O(N) DB/mask/SSE cost for a stage
+    # that's entirely gated off by the default "not downloaded" state.
+    import keypoints as kp
+    routable_models = set(_EYE_KEYPOINT_MODEL_FOR_CLASS.values())
+    if not any(
+        kp.weights_status(name) == "ready" for name in routable_models
+    ):
+        log.info(
+            "Eye-keypoint stage skipped: no routable keypoint model weights "
+            "installed (%s)",
+            ", ".join(sorted(routable_models)),
+        )
+        return
+
     C = config.get("eye_classifier_conf_gate", 0.5)
     T = config.get("eye_detection_conf_gate", 0.5)
     k_window = config.get("eye_window_k", 0.08)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -90,7 +90,7 @@ def _update_stages(runner, job_id, stages):
 
 def _current_phase(stages):
     """Determine the primary phase label from stage statuses."""
-    for name in ["regroup", "extract_masks", "classify", "detect",
+    for name in ["regroup", "eye_keypoints", "extract_masks", "classify", "detect",
                  "model_loader", "previews", "thumbnails", "scan", "ingest"]:
         info = stages.get(name, {})
         if info.get("status") == "running":
@@ -139,6 +139,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         "detect": {"status": "pending", "count": 0, "label": "Detecting subjects"},
         "classify": {"status": "pending", "count": 0, "label": "Classifying species"},
         "extract_masks": {"status": "pending", "count": 0, "label": "Extracting features"},
+        "eye_keypoints": {"status": "pending", "count": 0, "label": "Detecting eye keypoints"},
         "regroup": {"status": "pending", "label": "Grouping encounters"},
     }
 
@@ -233,6 +234,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             })
     if not params.skip_extract_masks:
         step_defs.append({"id": "extract_masks", "label": "Extract features"})
+        step_defs.append({"id": "eye_keypoints", "label": "Detect eye keypoints"})
     if not params.skip_regroup:
         step_defs.append({"id": "regroup", "label": "Group encounters"})
     runner.set_steps(job["id"], step_defs)
@@ -1874,6 +1876,81 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
         _update_stages(runner, job["id"], stages)
 
+    def eye_keypoints_stage():
+        """Run per-photo eye keypoint detection between mask extraction and scoring.
+
+        No-op when the stage is disabled by config, when no SuperAnimal
+        weights are on disk (users opt-in via the pipeline models card),
+        or when no eligible photos remain. Per-photo failures are logged
+        and do not abort the stage.
+        """
+        if params.skip_extract_masks or abort.is_set() or not collection_id:
+            stages["eye_keypoints"]["status"] = "skipped"
+            runner.update_step(
+                job["id"], "eye_keypoints", status="completed", summary="Skipped",
+            )
+            return
+
+        stages["eye_keypoints"]["status"] = "running"
+        runner.update_step(job["id"], "eye_keypoints", status="running")
+        _update_stages(runner, job["id"], stages)
+
+        try:
+            import config as cfg
+            from pipeline import detect_eye_keypoints_stage
+
+            thread_db = Database(db_path)
+            thread_db.set_active_workspace(workspace_id)
+            effective_cfg = thread_db.get_effective_config(cfg.load())
+            pipeline_cfg = effective_cfg.get("pipeline", {})
+
+            total = len(thread_db.list_photos_for_eye_keypoint_stage())
+            start_time = time.time()
+            processed = {"count": 0}
+
+            def _progress(phase, current, total_steps):
+                processed["count"] = current
+                stages["eye_keypoints"]["count"] = current
+                runner.update_step(
+                    job["id"], "eye_keypoints",
+                    progress={"current": current, "total": total_steps},
+                )
+                runner.push_event(job["id"], "progress", {
+                    "phase": phase,
+                    "stage_id": "eye_keypoints",
+                    "current": current,
+                    "total": total_steps,
+                    "rate": round(
+                        current / max(time.time() - start_time, 0.01) * 60, 1
+                    ),
+                    "stages": {k: dict(v) for k, v in stages.items()},
+                })
+
+            detect_eye_keypoints_stage(
+                thread_db, config=pipeline_cfg, progress_callback=_progress,
+            )
+
+            stages["eye_keypoints"]["status"] = "completed"
+            summary = (
+                f"{processed['count']} of {total} photos processed"
+                if total else "No eligible photos"
+            )
+            runner.update_step(
+                job["id"], "eye_keypoints", status="completed", summary=summary,
+            )
+            result["stages"]["eye_keypoints"] = {
+                "processed": processed["count"], "total": total,
+            }
+        except Exception as e:
+            errors.append(f"[eye_keypoints] Fatal: {e}")
+            log.exception("Pipeline eye-keypoints stage failed")
+            stages["eye_keypoints"]["status"] = "failed"
+            runner.update_step(
+                job["id"], "eye_keypoints", status="failed", error=str(e),
+            )
+
+        _update_stages(runner, job["id"], stages)
+
     def regroup_stage():
         """Run pipeline grouping + scoring + triage from cached features."""
         if params.skip_regroup or abort.is_set() or not collection_id:
@@ -1967,7 +2044,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
     if not abort.is_set():
         extract_masks_stage()
 
-    # Phase 4: regroup (needs extract-masks output)
+    # Phase 3.5: eye keypoints (needs masks + classifier output). No-op when
+    # SuperAnimal weights are absent — users opt in on the pipeline models
+    # card. Per-photo failures log and continue rather than abort the stage.
+    if not abort.is_set():
+        eye_keypoints_stage()
+
+    # Phase 4: regroup (needs extract-masks + eye-keypoints output)
     if not abort.is_set():
         regroup_stage()
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1897,14 +1897,23 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
         try:
             import config as cfg
-            from pipeline import detect_eye_keypoints_stage
+            from pipeline import (
+                _resolve_collection_photo_ids,
+                detect_eye_keypoints_stage,
+            )
 
             thread_db = Database(db_path)
             thread_db.set_active_workspace(workspace_id)
             effective_cfg = thread_db.get_effective_config(cfg.load())
             pipeline_cfg = effective_cfg.get("pipeline", {})
 
-            total = len(thread_db.list_photos_for_eye_keypoint_stage())
+            collection_photo_ids = (
+                _resolve_collection_photo_ids(thread_db, collection_id)
+                if collection_id is not None else None
+            )
+            total = len(thread_db.list_photos_for_eye_keypoint_stage(
+                photo_ids=collection_photo_ids,
+            ))
             start_time = time.time()
             processed = {"count": 0}
 
@@ -1928,6 +1937,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
             detect_eye_keypoints_stage(
                 thread_db, config=pipeline_cfg, progress_callback=_progress,
+                collection_id=collection_id,
             )
 
             stages["eye_keypoints"]["status"] = "completed"

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1900,12 +1900,29 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             from pipeline import (
                 _resolve_collection_photo_ids,
                 detect_eye_keypoints_stage,
+                eye_keypoint_stage_preflight,
             )
 
             thread_db = Database(db_path)
             thread_db.set_active_workspace(workspace_id)
             effective_cfg = thread_db.get_effective_config(cfg.load())
             pipeline_cfg = effective_cfg.get("pipeline", {})
+
+            # Mirror the stage-level preflight so a no-op run doesn't pay the
+            # O(N) eligibility join cost or report a misleading
+            # "0 of N processed" summary on large libraries.
+            skip_reason = eye_keypoint_stage_preflight(pipeline_cfg)
+            if skip_reason is not None:
+                stages["eye_keypoints"]["status"] = "skipped"
+                runner.update_step(
+                    job["id"], "eye_keypoints",
+                    status="completed", summary=f"Skipped — {skip_reason}",
+                )
+                result["stages"]["eye_keypoints"] = {
+                    "processed": 0, "total": 0, "skipped": skip_reason,
+                }
+                _update_stages(runner, job["id"], stages)
+                return
 
             collection_photo_ids = (
                 _resolve_collection_photo_ids(thread_db, collection_id)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1928,6 +1928,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 _resolve_collection_photo_ids(thread_db, collection_id)
                 if collection_id is not None else None
             )
+            # Honor preview-deselection so the eye stage matches the set of
+            # photos extract/regroup will act on. Without this the stage
+            # mutates eye_* for unchecked photos and those values are locked
+            # in by the eye_tenengrad IS NULL idempotency guard on reruns.
+            if params.exclude_photo_ids and collection_photo_ids is not None:
+                collection_photo_ids = {
+                    pid for pid in collection_photo_ids
+                    if pid not in params.exclude_photo_ids
+                }
             total = len(thread_db.list_photos_for_eye_keypoint_stage(
                 photo_ids=collection_photo_ids,
             ))
@@ -1955,6 +1964,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             detect_eye_keypoints_stage(
                 thread_db, config=pipeline_cfg, progress_callback=_progress,
                 collection_id=collection_id,
+                exclude_photo_ids=params.exclude_photo_ids,
             )
 
             stages["eye_keypoints"]["status"] = "completed"

--- a/vireo/quality.py
+++ b/vireo/quality.py
@@ -289,6 +289,43 @@ def compute_noise_estimate(image, mask):
     return round(float(np.var(ring_values)), 2)
 
 
+def compute_eye_tenengrad(image, eye_xy, bbox, k=0.08):
+    """Multi-scale Tenengrad in a small window around an eye keypoint.
+
+    Window side length = ``k * min(bbox_w, bbox_h)``, minimum 8 px, clamped
+    to the image bounds. Reuses _multiscale_tenengrad so the raw scale of
+    this value is directly comparable to subject_tenengrad (same operator,
+    different region).
+
+    Args:
+        image: PIL.Image (original resolution).
+        eye_xy: (x, y) eye keypoint in image-pixel space.
+        bbox: (x0, y0, x1, y1) MegaDetector bbox, image-pixel space. Only
+            used to choose the window size proportional to the subject —
+            not for clamping the window (image bounds handle that).
+        k: window side as fraction of min(bbox_w, bbox_h). Default 0.08.
+
+    Returns:
+        float — raw multi-scale Tenengrad in the window, 0.0 if the window
+        is empty after clamping to image bounds.
+    """
+    x, y = eye_xy
+    x0, y0, x1, y1 = bbox
+    side = max(8, int(round(k * min(x1 - x0, y1 - y0))))
+    half = side // 2
+    img_w, img_h = image.size
+    wx0 = max(0, int(x - half))
+    wy0 = max(0, int(y - half))
+    wx1 = min(img_w, int(x + half))
+    wy1 = min(img_h, int(y + half))
+    if wx1 <= wx0 or wy1 <= wy0:
+        return 0.0
+    window = image.crop((wx0, wy0, wx1, wy1))
+    gray = _to_grayscale_array(window)
+    mask = np.ones_like(gray, dtype=bool)
+    return round(_multiscale_tenengrad(gray, mask), 2)
+
+
 def compute_all_quality_features(image, mask):
     """Compute all quality features for a photo in one call.
 

--- a/vireo/scoring.py
+++ b/vireo/scoring.py
@@ -28,6 +28,10 @@ DEFAULTS = {
     "reject_focus": 0.35,
     "reject_clip_high": 0.30,  # subject highlight clipping fraction
     "reject_composite": 0.40,
+    # Eye-focus reject: fires when an eye is confidently localized but its
+    # windowed sharpness ranks poorly. Catches "sharp body, soft eye" frames
+    # that would otherwise pass subject-level focus checks.
+    "reject_eye_focus": 0.35,
 }
 
 EPS = 1e-8
@@ -330,13 +334,31 @@ def score_encounter(encounter, config=None):
     enc_bg_tenegrads = [p.get("bg_tenengrad", 0) or 0 for p in photos]
     enc_bg_seps = [p.get("bg_separation", 0) or 0 for p in photos]
     enc_noise = [p.get("noise_estimate") for p in photos]
+    # Eye cohort: photos with a populated eye_tenengrad form their own
+    # ranking group so body-based photos don't skew the eye percentile
+    # (Option A from the design doc). A body-only photo compares against
+    # its peers' subject_tenengrad; an eye photo compares against its
+    # peers' eye_tenengrad.
+    enc_eye_tenegrads = [
+        p["eye_tenengrad"] for p in photos
+        if p.get("eye_tenengrad") is not None
+    ]
 
     for photo in photos:
-        f = subject_focus_score(
-            photo.get("subject_tenengrad"),
-            photo.get("bg_tenengrad"),
-            enc_tenegrads,
-        )
+        eye_t = photo.get("eye_tenengrad")
+        if eye_t is not None and enc_eye_tenegrads:
+            # Eye-based focus: pure percentile rank within the eye cohort.
+            # The subject-vs-bg ratio term from subject_focus_score does not
+            # translate to a small eye window, so the normalization is just
+            # the peer comparison — sharper eye relative to peers = higher.
+            f = _percentile_rank(eye_t, enc_eye_tenegrads)
+            photo["eye_focus_score"] = round(f, 4)
+        else:
+            f = subject_focus_score(
+                photo.get("subject_tenengrad"),
+                photo.get("bg_tenengrad"),
+                enc_tenegrads,
+            )
         e = exposure_score(
             photo.get("subject_clip_high"),
             photo.get("subject_clip_low"),
@@ -376,6 +398,19 @@ def score_encounter(encounter, config=None):
         reasons = hard_reject_reasons(photo, q, config=cfg)
         if f < cfg.get("reject_focus", 0.35) and photo.get("mask_path"):
             reasons.append(f"out_of_focus (F={f:.3f} < {cfg['reject_focus']})")
+
+        # Eye-soft reject: catches "sharp body, soft eye" frames. Only fires
+        # when we have a confidently-localized eye — a null eye_tenengrad
+        # means the pipeline stage's gates didn't all pass, and we fall back
+        # to out_of_focus on subject_tenengrad (already handled above).
+        if (
+            photo.get("eye_tenengrad") is not None
+            and f < cfg.get("reject_eye_focus", 0.35)
+            and photo.get("mask_path")
+        ):
+            reasons.append(
+                f"eye_soft (E={f:.3f} < {cfg['reject_eye_focus']})"
+            )
 
         photo["reject_reasons"] = reasons
         photo["label"] = "REJECT" if reasons else None

--- a/vireo/scoring.py
+++ b/vireo/scoring.py
@@ -338,14 +338,17 @@ def score_encounter(encounter, config=None):
     # ranking group so body-based photos don't skew the eye percentile
     # (Option A from the design doc). A body-only photo compares against
     # its peers' subject_tenengrad; an eye photo compares against its
-    # peers' eye_tenengrad.
+    # peers' eye_tenengrad. Skipped entirely when eye detection is
+    # disabled so stale eye_tenengrad values from prior runs don't
+    # influence scoring after the user turns the feature off.
+    eye_enabled = cfg.get("eye_detect_enabled", True)
     enc_eye_tenegrads = [
         p["eye_tenengrad"] for p in photos
         if p.get("eye_tenengrad") is not None
-    ]
+    ] if eye_enabled else []
 
     for photo in photos:
-        eye_t = photo.get("eye_tenengrad")
+        eye_t = photo.get("eye_tenengrad") if eye_enabled else None
         if eye_t is not None and enc_eye_tenegrads:
             # Eye-based focus: pure percentile rank within the eye cohort.
             # The subject-vs-bg ratio term from subject_focus_score does not
@@ -403,8 +406,12 @@ def score_encounter(encounter, config=None):
         # when we have a confidently-localized eye — a null eye_tenengrad
         # means the pipeline stage's gates didn't all pass, and we fall back
         # to out_of_focus on subject_tenengrad (already handled above).
+        # Also skipped when eye detection is disabled so stale eye_tenengrad
+        # values from prior runs can't reject photos after the user toggles
+        # the feature off.
         if (
-            photo.get("eye_tenengrad") is not None
+            eye_enabled
+            and photo.get("eye_tenengrad") is not None
             and f < cfg.get("reject_eye_focus", 0.35)
             and photo.get("mask_path")
         ):

--- a/vireo/scoring.py
+++ b/vireo/scoring.py
@@ -347,6 +347,24 @@ def score_encounter(encounter, config=None):
         if p.get("eye_tenengrad") is not None
     ] if eye_enabled else []
 
+    # Body cohort: photos that will fall back to subject_tenengrad scoring.
+    # In mixed encounters (some photos have eye signal, some don't), body-only
+    # photos must rank against body-only peers, otherwise eye-capable frames
+    # dilute the percentile and change out_of_focus decisions for photos that
+    # never saw the eye stage. Falls back to the full cohort when there are no
+    # body-only photos (every photo has an eye signal) so we never pass an
+    # empty comparison list into subject_focus_score.
+    if eye_enabled and enc_eye_tenegrads:
+        enc_body_tenegrads = [
+            p.get("subject_tenengrad", 0) or 0
+            for p in photos
+            if p.get("eye_tenengrad") is None
+        ]
+        if not enc_body_tenegrads:
+            enc_body_tenegrads = enc_tenegrads
+    else:
+        enc_body_tenegrads = enc_tenegrads
+
     for photo in photos:
         eye_t = photo.get("eye_tenengrad") if eye_enabled else None
         if eye_t is not None and enc_eye_tenegrads:
@@ -360,7 +378,7 @@ def score_encounter(encounter, config=None):
             f = subject_focus_score(
                 photo.get("subject_tenengrad"),
                 photo.get("bg_tenengrad"),
-                enc_tenegrads,
+                enc_body_tenegrads,
             )
         e = exposure_score(
             photo.get("subject_clip_high"),

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -817,6 +817,45 @@ def download_taxonomy(output_path, progress_callback=None):
             os.remove(zip_path)
 
 
+def classify_to_keypoint_group(db, inat_id):
+    """Walk a taxon's lineage; return 'Aves' or 'Mammalia' if in ancestry, else None.
+
+    Used to route keypoint-model selection for eye-focus detection. Returns
+    None for fish, reptiles, insects, invertebrates, or any taxon absent
+    from the local taxa table.
+
+    Note: ``taxa.parent_id`` references ``taxa.id`` (local PK), not
+    ``taxa.inat_id``. The walk chains local IDs after the initial inat_id
+    lookup.
+    """
+    if inat_id is None:
+        return None
+    row = db.conn.execute(
+        "SELECT id, name, rank, parent_id FROM taxa WHERE inat_id=?",
+        (inat_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    seen = set()
+    while row is not None:
+        local_id = row["id"] if hasattr(row, "keys") else row[0]
+        name = row["name"] if hasattr(row, "keys") else row[1]
+        rank = row["rank"] if hasattr(row, "keys") else row[2]
+        parent_id = row["parent_id"] if hasattr(row, "keys") else row[3]
+        if local_id in seen:
+            return None
+        seen.add(local_id)
+        if rank == "class" and name in ("Aves", "Mammalia"):
+            return name
+        if parent_id is None:
+            return None
+        row = db.conn.execute(
+            "SELECT id, name, rank, parent_id FROM taxa WHERE id=?",
+            (parent_id,),
+        ).fetchone()
+    return None
+
+
 def main():
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     parser = argparse.ArgumentParser(

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1813,9 +1813,11 @@ function _lbGetSpeciesColor(species) {
 
 function _lbRenderEyeCrosshair(photo) {
   // Draws a crosshair at the detected eye keypoint on the current lightbox
-  // photo. eye_x / eye_y are stored in original-image pixel space; the
-  // overlay is absolute-positioned inside .lightbox-transform which sits
-  // at the image's natural size, so percentage-of-image is the right unit.
+  // photo. eye_x / eye_y are stored normalized 0-1 against the oriented
+  // (EXIF-transposed) image, same as detection boxes, so we can map
+  // directly to percentage without touching photo.width/photo.height
+  // (which come from the un-oriented sensor tag and would swap axes on
+  // orientation 6/8 rotations).
   var container = document.getElementById('lightboxEye');
   if (!container) return;
   container.innerHTML = '';
@@ -1823,13 +1825,8 @@ function _lbRenderEyeCrosshair(photo) {
     container.style.display = 'none';
     return;
   }
-  if (!photo.width || !photo.height) {
-    // Without dimensions we cannot map pixel coords to percentages.
-    container.style.display = 'none';
-    return;
-  }
-  var xPct = (photo.eye_x / photo.width) * 100;
-  var yPct = (photo.eye_y / photo.height) * 100;
+  var xPct = photo.eye_x * 100;
+  var yPct = photo.eye_y * 100;
   var marker = document.createElement('div');
   marker.className = 'lb-eye-crosshair';
   marker.style.left = xPct.toFixed(3) + '%';

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -482,6 +482,51 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   pointer-events: none;
   box-sizing: border-box;
 }
+/* Crosshair over the detected eye keypoint. Scales with the image via
+   position:% — parent .lightbox-transform absorbs the zoom transform. */
+.lb-eye-crosshair {
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  margin-left: -11px;
+  margin-top: -11px;
+  pointer-events: none;
+  z-index: 2;
+}
+.lb-eye-crosshair::before,
+.lb-eye-crosshair::after {
+  content: "";
+  position: absolute;
+  background: #ffd166;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.45);
+}
+.lb-eye-crosshair::before {
+  left: 50%;
+  top: 0;
+  width: 2px;
+  height: 100%;
+  margin-left: -1px;
+}
+.lb-eye-crosshair::after {
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  margin-top: -1px;
+}
+.lb-eye-crosshair > span {
+  position: absolute;
+  left: 14px;
+  top: -2px;
+  font-size: 10px;
+  font-weight: 600;
+  color: #0A1F2E;
+  background: #ffd166;
+  border-radius: 3px;
+  padding: 1px 5px;
+  white-space: nowrap;
+  line-height: 1.3;
+}
 .lb-detection-label {
   position: absolute;
   top: -1px;
@@ -1670,6 +1715,7 @@ async function createWorkspace() {
     <div class="lightbox-transform" id="lightboxTransform">
       <img id="lightboxImg" src="" alt="">
       <div id="lightboxDetections" style="position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;"></div>
+      <div id="lightboxEye" style="position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;display:none;"></div>
     </div>
   </div>
   <div class="lightbox-filename" id="lightboxFilename"></div>
@@ -1765,6 +1811,38 @@ function _lbGetSpeciesColor(species) {
   return _lbSpeciesColors[species];
 }
 
+function _lbRenderEyeCrosshair(photo) {
+  // Draws a crosshair at the detected eye keypoint on the current lightbox
+  // photo. eye_x / eye_y are stored in original-image pixel space; the
+  // overlay is absolute-positioned inside .lightbox-transform which sits
+  // at the image's natural size, so percentage-of-image is the right unit.
+  var container = document.getElementById('lightboxEye');
+  if (!container) return;
+  container.innerHTML = '';
+  if (!photo || photo.eye_x == null || photo.eye_y == null) {
+    container.style.display = 'none';
+    return;
+  }
+  if (!photo.width || !photo.height) {
+    // Without dimensions we cannot map pixel coords to percentages.
+    container.style.display = 'none';
+    return;
+  }
+  var xPct = (photo.eye_x / photo.width) * 100;
+  var yPct = (photo.eye_y / photo.height) * 100;
+  var marker = document.createElement('div');
+  marker.className = 'lb-eye-crosshair';
+  marker.style.left = xPct.toFixed(3) + '%';
+  marker.style.top = yPct.toFixed(3) + '%';
+  if (photo.eye_conf != null) {
+    var label = document.createElement('span');
+    label.textContent = 'eye ' + Math.round(photo.eye_conf * 100) + '%';
+    marker.appendChild(label);
+  }
+  container.appendChild(marker);
+  container.style.display = 'block';
+}
+
 function _lbLoadDetections(photoId) {
   var container = document.getElementById('lightboxDetections');
   if (!container) return;
@@ -1810,6 +1888,9 @@ function openLightbox(photoId, filename, photoList) {
   // Clear previous detection overlays
   var detContainer = document.getElementById('lightboxDetections');
   if (detContainer) detContainer.innerHTML = '';
+  // Clear previous eye crosshair; re-rendered when /api/photos/<id> resolves.
+  var eyeContainer = document.getElementById('lightboxEye');
+  if (eyeContainer) { eyeContainer.innerHTML = ''; eyeContainer.style.display = 'none'; }
 
   // Reset continuous zoom state for new photo
   _lbZoom = 1.0;
@@ -1833,6 +1914,7 @@ function openLightbox(photoId, filename, photoList) {
       _lbPhotoW = data.width || null;
       _lbPhotoH = data.height || null;
       _lbRecomputeNativeZoom();
+      _lbRenderEyeCrosshair(data);
     })
     .catch(function() {});
 

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2241,9 +2241,16 @@ function _onPipelineComplete(result) {
     var ekpProcessed = ekp.processed || 0;
     var ekpTxt = document.getElementById('txtEyeKeypoints');
     if (ekpTxt) {
-      ekpTxt.textContent = ekpTotal
-        ? (ekpProcessed + ' of ' + ekpTotal + ' processed')
-        : 'No eligible photos';
+      // When the backend preflight skips the stage (disabled config or no
+      // keypoint weights installed), surface the explicit reason so users
+      // know it's a setup issue rather than an empty eligibility set.
+      if (ekp.skipped) {
+        ekpTxt.textContent = 'Skipped \u2014 ' + ekp.skipped;
+      } else {
+        ekpTxt.textContent = ekpTotal
+          ? (ekpProcessed + ' of ' + ekpTotal + ' processed')
+          : 'No eligible photos';
+      }
     }
     var statusEkp = document.getElementById('statusEyeKeypoints');
     var fillEkp = document.getElementById('fillEyeKeypoints');
@@ -2796,7 +2803,15 @@ async function refreshKeypointsStatus() {
       _kpPollTimer = null;
     }
   } catch (e) {
-    // Leave prior UI state if a one-off fetch fails; polling will retry.
+    // Initial page-load call has no timer yet, so render the fallback
+    // 'missing' state (which shows a Download button) and schedule a
+    // retry. Otherwise users see a blank row after a transient API error
+    // until they reload the page. startKeypointsPolling is idempotent,
+    // and a subsequent successful fetch with no in-flight downloads will
+    // clear the timer via the path above.
+    _renderKeypointRow('superanimal-quadruped', 'missing');
+    _renderKeypointRow('superanimal-bird', 'missing');
+    startKeypointsPolling();
   }
 }
 

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -839,8 +839,8 @@ body { padding-bottom: 36px; }
   </div>
 
   <!-- Card 7: Eye Keypoints (optional, off by default until weights downloaded) -->
-  <div class="stage-card" id="card-eye-keypoints" data-testid="stage-card">
-    <div class="stage-header" onclick="toggleCard('eye-keypoints')">
+  <div class="stage-card" id="card-eyekeypoints" data-testid="stage-card">
+    <div class="stage-header" onclick="toggleCard('eyekeypoints')">
       <span class="stage-num" id="numEyeKeypoints">7</span>
       <span class="stage-name">Eye Keypoints (optional)</span>
       <span class="stage-summary" id="summaryEyeKeypoints">
@@ -2054,6 +2054,7 @@ var _stageToCard = {
   model_loader: 'Classify',
   classify: 'Classify',
   extract_masks: 'Extract',
+  eye_keypoints: 'EyeKeypoints',
   regroup: 'Group',
 };
 
@@ -2070,6 +2071,7 @@ var _stageToProgress = {
   detect: 'Classify',
   classify: 'Classify',
   extract_masks: 'Extract',
+  eye_keypoints: 'EyeKeypoints',
   regroup: 'Group',
 };
 

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -838,10 +838,48 @@ body { padding-bottom: 36px; }
     </div>
   </div>
 
-  <!-- Card 7: Group & Score -->
+  <!-- Card 7: Eye Keypoints (optional, off by default until weights downloaded) -->
+  <div class="stage-card" id="card-eye-keypoints" data-testid="stage-card">
+    <div class="stage-header" onclick="toggleCard('eye-keypoints')">
+      <span class="stage-num" id="numEyeKeypoints">7</span>
+      <span class="stage-name">Eye Keypoints (optional)</span>
+      <span class="stage-summary" id="summaryEyeKeypoints">
+        <span id="txtEyeKeypoints"></span>
+      </span>
+      <span class="stage-chevron">&#9656;</span>
+    </div>
+    <div class="stage-body">
+      <p style="font-size:13px;color:var(--text-secondary);margin-bottom:12px;">
+        Per-photo eye localization via SuperAnimal keypoint models. When weights
+        are present, the pipeline refines the focus score using the windowed
+        sharpness around the eye instead of the whole subject. Fish, reptiles,
+        and invertebrates are skipped automatically.
+      </p>
+      <div id="eyeKeypointsReadinessPanel" style="font-size:13px;line-height:1.8;">
+        <div data-keypoint-row="superanimal-quadruped">
+          <span class="kp-state-icon"></span>
+          <span>SuperAnimal-Quadruped</span>
+          <span class="kp-state-text" style="color:var(--text-secondary);margin-left:6px;"></span>
+          <button type="button" class="btn btn-small kp-download-btn"
+                  onclick="downloadKeypointModel('superanimal-quadruped')"
+                  style="margin-left:10px;display:none;">Download</button>
+        </div>
+        <div data-keypoint-row="superanimal-bird">
+          <span class="kp-state-icon"></span>
+          <span>SuperAnimal-Bird</span>
+          <span class="kp-state-text" style="color:var(--text-secondary);margin-left:6px;"></span>
+          <button type="button" class="btn btn-small kp-download-btn"
+                  onclick="downloadKeypointModel('superanimal-bird')"
+                  style="margin-left:10px;display:none;">Download</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Card 8: Group & Score -->
   <div class="stage-card" id="card-group" data-testid="stage-card">
     <div class="stage-header" onclick="toggleCard('group')">
-      <span class="stage-num" id="numGroup">7</span>
+      <span class="stage-num" id="numGroup">8</span>
       <input type="checkbox" class="stage-enable" id="enableGroup" checked
              onchange="onStageToggle('group')" onclick="event.stopPropagation()">
       <span class="stage-name">Group &amp; Score</span>
@@ -959,6 +997,7 @@ function initPipelinePage() {
       updateCardStates();
       if (typeof updateReadiness === 'function') updateReadiness();
       if (typeof updateExtractReadiness === 'function') updateExtractReadiness();
+      if (typeof refreshKeypointsStatus === 'function') refreshKeypointsStatus();
 
       // Populate recent destinations
       var recents = data.recent_destinations || [];
@@ -2658,6 +2697,103 @@ function renderModelReadiness(label, info, known) {
   frag.appendChild(document.createTextNode(
     ' \u2014 will download' + size + ' on first run'));
   return frag;
+}
+
+// -- Card 7: Eye Keypoints (optional) --
+// Status polling is driven by openKeypointsCardPolling / closeKeypointsCardPolling
+// to avoid a permanent background timer that wastes cycles when the card is
+// not expanded.
+
+var _kpPollTimer = null;
+
+function _renderKeypointRow(modelName, state) {
+  // Per-model row in the Eye Keypoints card. state: 'ready' | 'missing' |
+  // 'downloading' | 'failed'.
+  var row = document.querySelector('[data-keypoint-row="' + modelName + '"]');
+  if (!row) return;
+  var iconEl = row.querySelector('.kp-state-icon');
+  var textEl = row.querySelector('.kp-state-text');
+  var btnEl  = row.querySelector('.kp-download-btn');
+
+  if (state === 'ready') {
+    iconEl.textContent = '\u2713';
+    iconEl.style.color = 'var(--accent,#24E5CA)';
+    textEl.textContent = 'Ready';
+    btnEl.style.display = 'none';
+  } else if (state === 'downloading') {
+    iconEl.textContent = '\u25EF';
+    iconEl.style.color = 'var(--warning,#f0c040)';
+    textEl.textContent = 'Downloading...';
+    btnEl.style.display = 'none';
+  } else if (state === 'failed') {
+    iconEl.textContent = '\u2717';
+    iconEl.style.color = 'var(--danger,#e74c3c)';
+    textEl.textContent = 'Download failed \u2014 retry?';
+    btnEl.textContent = 'Retry';
+    btnEl.style.display = '';
+  } else {
+    iconEl.textContent = '\u25CB';
+    iconEl.style.color = 'var(--text-faint,#5A8890)';
+    textEl.textContent = 'Not downloaded';
+    btnEl.textContent = 'Download';
+    btnEl.style.display = '';
+  }
+}
+
+async function refreshKeypointsStatus() {
+  try {
+    var s = await safeFetch(
+      '/api/models/keypoints/status', {}, { toast: false }
+    );
+    _renderKeypointRow(
+      'superanimal-quadruped', s.superanimal_quadruped || 'missing'
+    );
+    _renderKeypointRow(
+      'superanimal-bird', s.superanimal_bird || 'missing'
+    );
+    // If either model is still downloading, keep polling. Otherwise stop —
+    // user will re-trigger via a button click that restarts polling.
+    var inflight = (
+      s.superanimal_quadruped === 'downloading' ||
+      s.superanimal_bird === 'downloading'
+    );
+    if (!inflight && _kpPollTimer) {
+      clearInterval(_kpPollTimer);
+      _kpPollTimer = null;
+    }
+  } catch (e) {
+    // Leave prior UI state if a one-off fetch fails; polling will retry.
+  }
+}
+
+function startKeypointsPolling() {
+  if (_kpPollTimer) return;
+  _kpPollTimer = setInterval(refreshKeypointsStatus, 2000);
+}
+
+async function downloadKeypointModel(modelName) {
+  // Disable the button immediately to prevent double-clicks; refreshKeypointsStatus
+  // will re-render with the real server state on the next poll tick.
+  var row = document.querySelector('[data-keypoint-row="' + modelName + '"]');
+  if (row) {
+    var btn = row.querySelector('.kp-download-btn');
+    if (btn) btn.disabled = true;
+  }
+  try {
+    await safeFetch(
+      '/api/models/keypoints/' + encodeURIComponent(modelName) + '/download',
+      { method: 'POST' },
+      { toast: false }
+    );
+    // Optimistic render: show 'downloading' before the first poll confirms.
+    _renderKeypointRow(modelName, 'downloading');
+    startKeypointsPolling();
+  } catch (e) {
+    if (row) {
+      var btn2 = row.querySelector('.kp-download-btn');
+      if (btn2) btn2.disabled = false;
+    }
+  }
 }
 
 async function runExtractStep(collectionId) {

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -873,6 +873,11 @@ body { padding-bottom: 36px; }
                   style="margin-left:10px;display:none;">Download</button>
         </div>
       </div>
+      <span class="status-msg" id="statusEyeKeypoints"></span>
+      <div class="progress-wrap" id="progressEyeKeypoints" style="display:none;">
+        <div class="progress-bar-track"><div class="progress-bar-fill" id="fillEyeKeypoints"></div></div>
+        <div class="progress-text" id="textEyeKeypoints"></div>
+      </div>
     </div>
   </div>
 
@@ -2226,6 +2231,24 @@ function _onPipelineComplete(result) {
     var fillExt = document.getElementById('fillExtract');
     if (fillExt) fillExt.style.width = '100%';
     if (statusExt) { statusExt.textContent = 'Done!'; statusExt.className = 'status-msg ok'; }
+  }
+
+  // Eye Keypoints card
+  if (stageResults.eye_keypoints) {
+    document.getElementById('numEyeKeypoints').className = 'stage-num complete';
+    var ekp = stageResults.eye_keypoints;
+    var ekpTotal = ekp.total || 0;
+    var ekpProcessed = ekp.processed || 0;
+    var ekpTxt = document.getElementById('txtEyeKeypoints');
+    if (ekpTxt) {
+      ekpTxt.textContent = ekpTotal
+        ? (ekpProcessed + ' of ' + ekpTotal + ' processed')
+        : 'No eligible photos';
+    }
+    var statusEkp = document.getElementById('statusEyeKeypoints');
+    var fillEkp = document.getElementById('fillEyeKeypoints');
+    if (fillEkp) fillEkp.style.width = '100%';
+    if (statusEkp) { statusEkp.textContent = 'Done!'; statusEkp.className = 'status-msg ok'; }
   }
 
   // Show errors if any

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2755,13 +2755,18 @@ async function refreshKeypointsStatus() {
     _renderKeypointRow(
       'superanimal-bird', s.superanimal_bird || 'missing'
     );
-    // If either model is still downloading, keep polling. Otherwise stop —
-    // user will re-trigger via a button click that restarts polling.
+    // If either model is still downloading, ensure polling is running.
+    // Covers the page-reload-mid-download case where init calls
+    // refreshKeypointsStatus once and finds an in-flight download but no
+    // local timer. Otherwise stop polling — user will re-trigger via a
+    // button click that restarts it.
     var inflight = (
       s.superanimal_quadruped === 'downloading' ||
       s.superanimal_bird === 'downloading'
     );
-    if (!inflight && _kpPollTimer) {
+    if (inflight) {
+      startKeypointsPolling();
+    } else if (_kpPollTimer) {
       clearInterval(_kpPollTimer);
       _kpPollTimer = null;
     }

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2708,12 +2708,15 @@ var _kpPollTimer = null;
 
 function _renderKeypointRow(modelName, state) {
   // Per-model row in the Eye Keypoints card. state: 'ready' | 'missing' |
-  // 'downloading' | 'failed'.
+  // 'downloading' | 'failed'. Reset disabled=false up front so a stale
+  // disable from the initial click never survives a transition to a state
+  // that re-shows the button (e.g. 'failed' → Retry).
   var row = document.querySelector('[data-keypoint-row="' + modelName + '"]');
   if (!row) return;
   var iconEl = row.querySelector('.kp-state-icon');
   var textEl = row.querySelector('.kp-state-text');
   var btnEl  = row.querySelector('.kp-download-btn');
+  btnEl.disabled = false;
 
   if (state === 'ready') {
     iconEl.textContent = '\u2713';
@@ -2731,14 +2734,12 @@ function _renderKeypointRow(modelName, state) {
     iconEl.style.color = 'var(--danger,#e74c3c)';
     textEl.textContent = 'Download failed \u2014 retry?';
     btnEl.textContent = 'Retry';
-    btnEl.disabled = false;
     btnEl.style.display = '';
   } else {
     iconEl.textContent = '\u25CB';
     iconEl.style.color = 'var(--text-faint,#5A8890)';
     textEl.textContent = 'Not downloaded';
     btnEl.textContent = 'Download';
-    btnEl.disabled = false;
     btnEl.style.display = '';
   }
 }

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2724,18 +2724,21 @@ function _renderKeypointRow(modelName, state) {
     iconEl.textContent = '\u25EF';
     iconEl.style.color = 'var(--warning,#f0c040)';
     textEl.textContent = 'Downloading...';
+    btnEl.disabled = true;
     btnEl.style.display = 'none';
   } else if (state === 'failed') {
     iconEl.textContent = '\u2717';
     iconEl.style.color = 'var(--danger,#e74c3c)';
     textEl.textContent = 'Download failed \u2014 retry?';
     btnEl.textContent = 'Retry';
+    btnEl.disabled = false;
     btnEl.style.display = '';
   } else {
     iconEl.textContent = '\u25CB';
     iconEl.style.color = 'var(--text-faint,#5A8890)';
     textEl.textContent = 'Not downloaded';
     btnEl.textContent = 'Download';
+    btnEl.disabled = false;
     btnEl.style.display = '';
   }
 }

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -478,6 +478,66 @@
         </div>
       </div>
 
+      <div style="font-size:13px;font-weight:600;color:var(--text-secondary);margin:16px 0 8px 0;border-bottom:1px solid var(--border-primary);padding-bottom:6px;">Eye-Focus Detection</div>
+      <div class="setting-row">
+        <div class="setting-label">
+          Enable eye-focus detection
+          <small>Runs the SuperAnimal keypoint stage to localize the animal's eye and use a windowed sharpness around it for the focus score. Weights are opt-in on the Pipeline page.</small>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;">
+          <input type="checkbox" id="cfgEyeDetectEnabled" checked
+                 onchange="saveConfig()" style="accent-color:var(--accent);">
+        </div>
+      </div>
+      <div class="setting-row">
+        <div class="setting-label">
+          Classifier confidence gate
+          <small>Skip photos whose species classifier confidence is below this — the keypoint model has nothing reliable to route on.</small>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;">
+          <input type="range" id="cfgEyeClassifierConfGate" min="0" max="100" value="50"
+                 style="width:120px;accent-color:var(--accent);"
+                 oninput="document.getElementById('cfgEyeClassifierConfGateVal').textContent = this.value + '%'; saveConfig()">
+          <span style="font-size:13px;color:var(--text-primary);min-width:36px;" id="cfgEyeClassifierConfGateVal">50%</span>
+        </div>
+      </div>
+      <div class="setting-row">
+        <div class="setting-label">
+          Eye keypoint confidence gate
+          <small>Minimum confidence required on the eye keypoint output before the stage trusts it. Back-of-head frames usually fall here.</small>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;">
+          <input type="range" id="cfgEyeDetectionConfGate" min="0" max="100" value="50"
+                 style="width:120px;accent-color:var(--accent);"
+                 oninput="document.getElementById('cfgEyeDetectionConfGateVal').textContent = this.value + '%'; saveConfig()">
+          <span style="font-size:13px;color:var(--text-primary);min-width:36px;" id="cfgEyeDetectionConfGateVal">50%</span>
+        </div>
+      </div>
+      <div class="setting-row">
+        <div class="setting-label">
+          Eye window size
+          <small>Fraction of the subject bbox used as the windowed Tenengrad region. 8% is tuned for portrait crops; raise for small birds, lower for tight head shots.</small>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;">
+          <input type="range" id="cfgEyeWindowK" min="2" max="25" value="8"
+                 style="width:120px;accent-color:var(--accent);"
+                 oninput="document.getElementById('cfgEyeWindowKVal').textContent = (this.value / 100).toFixed(2); saveConfig()">
+          <span style="font-size:13px;color:var(--text-primary);min-width:36px;" id="cfgEyeWindowKVal">0.08</span>
+        </div>
+      </div>
+      <div class="setting-row">
+        <div class="setting-label">
+          Eye-soft reject threshold
+          <small>Photos where the eye is confidently localized but ranks below this percentile within the encounter are rejected as 'sharp body, soft eye'.</small>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;">
+          <input type="range" id="cfgRejectEyeFocus" min="0" max="100" value="35"
+                 style="width:120px;accent-color:var(--accent);"
+                 oninput="document.getElementById('cfgRejectEyeFocusVal').textContent = this.value + '%'; saveConfig()">
+          <span style="font-size:13px;color:var(--text-primary);min-width:36px;" id="cfgRejectEyeFocusVal">35%</span>
+        </div>
+      </div>
+
       <div style="font-size:13px;font-weight:600;color:var(--text-secondary);margin:16px 0 8px 0;border-bottom:1px solid var(--border-primary);padding-bottom:6px;">Burst Detection</div>
       <div class="setting-row">
         <div class="setting-label">Time gap</div>
@@ -1029,6 +1089,22 @@ async function loadConfig() {
     var rco = Math.round((p.reject_composite != null ? p.reject_composite : 0.40) * 100);
     document.getElementById('cfgRejectComposite').value = rco;
     document.getElementById('cfgRejectCompositeVal').textContent = rco + '%';
+
+    // Eye-focus detection tunables
+    document.getElementById('cfgEyeDetectEnabled').checked =
+      p.eye_detect_enabled !== false;  // default true
+    var ecg = Math.round((p.eye_classifier_conf_gate != null ? p.eye_classifier_conf_gate : 0.50) * 100);
+    document.getElementById('cfgEyeClassifierConfGate').value = ecg;
+    document.getElementById('cfgEyeClassifierConfGateVal').textContent = ecg + '%';
+    var edg = Math.round((p.eye_detection_conf_gate != null ? p.eye_detection_conf_gate : 0.50) * 100);
+    document.getElementById('cfgEyeDetectionConfGate').value = edg;
+    document.getElementById('cfgEyeDetectionConfGateVal').textContent = edg + '%';
+    var ewk = Math.round((p.eye_window_k != null ? p.eye_window_k : 0.08) * 100);
+    document.getElementById('cfgEyeWindowK').value = ewk;
+    document.getElementById('cfgEyeWindowKVal').textContent = (ewk / 100).toFixed(2);
+    var rejectEye = Math.round((p.reject_eye_focus != null ? p.reject_eye_focus : 0.35) * 100);
+    document.getElementById('cfgRejectEyeFocus').value = rejectEye;
+    document.getElementById('cfgRejectEyeFocusVal').textContent = rejectEye + '%';
     var btg = p.burst_time_gap != null ? p.burst_time_gap : 3;
     document.getElementById('cfgBurstTimeGap').value = btg;
     document.getElementById('cfgBurstTimeGapVal').textContent = btg + 's';
@@ -1151,6 +1227,11 @@ function saveConfig() {
             reject_focus: parseInt(document.getElementById('cfgRejectFocus').value, 10) / 100,
             reject_clip_high: parseInt(document.getElementById('cfgRejectClip').value, 10) / 100,
             reject_composite: parseInt(document.getElementById('cfgRejectComposite').value, 10) / 100,
+            eye_detect_enabled: document.getElementById('cfgEyeDetectEnabled').checked,
+            eye_classifier_conf_gate: parseInt(document.getElementById('cfgEyeClassifierConfGate').value, 10) / 100,
+            eye_detection_conf_gate: parseInt(document.getElementById('cfgEyeDetectionConfGate').value, 10) / 100,
+            eye_window_k: parseInt(document.getElementById('cfgEyeWindowK').value, 10) / 100,
+            reject_eye_focus: parseInt(document.getElementById('cfgRejectEyeFocus').value, 10) / 100,
             burst_time_gap: parseInt(document.getElementById('cfgBurstTimeGap').value, 10) || 3,
             burst_phash_threshold: parseInt(document.getElementById('cfgBurstPhash').value, 10) || 12,
             burst_embedding_threshold: parseInt(document.getElementById('cfgBurstEmb').value, 10) / 100,
@@ -1181,6 +1262,8 @@ function resetPipelineDefaults() {
     cfgWArea: [10, '%'], cfgWNoise: [10, '%'],
     cfgRejectCrop: [60, '%'], cfgRejectFocus: [35, '%'], cfgRejectClip: [30, '%'],
     cfgRejectComposite: [40, '%'],
+    cfgEyeClassifierConfGate: [50, '%'], cfgEyeDetectionConfGate: [50, '%'],
+    cfgRejectEyeFocus: [35, '%'],
     cfgBurstTimeGap: [3, 's'], cfgBurstPhash: [12, ''], cfgBurstEmb: [80, '%'],
     cfgBurstLambda: [85, '%'], cfgEncLambda: [70, '%'],
     cfgHardCutScore: [42, '%'], cfgSoftCutScore: [52, '%'], cfgMergeScore: [62, '%'],
@@ -1191,6 +1274,12 @@ function resetPipelineDefaults() {
     var span = document.getElementById(id + 'Val');
     if (span) span.textContent = val + suffix;
   }
+  // cfgEyeWindowK shows its display value as a ratio, not a percent — reset
+  // separately so the visible label stays consistent with how loadConfig
+  // renders it.
+  document.getElementById('cfgEyeWindowK').value = 8;
+  document.getElementById('cfgEyeWindowKVal').textContent = '0.08';
+  document.getElementById('cfgEyeDetectEnabled').checked = true;
   document.getElementById('cfgBurstMaxKeep').value = 3;
   document.getElementById('cfgEncMaxKeep').value = 5;
   document.getElementById('cfgWTime').value = 35;

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -154,3 +154,102 @@ def test_deep_merge_preserves_pipeline(tmp_path):
     assert loaded["pipeline"]["burst_time_gap"] == 3.0
     # Top-level defaults preserved
     assert loaded["photos_per_page"] == 50
+
+
+def test_eye_focus_defaults_exist():
+    """Config DEFAULTS includes eye-focus detection tunables."""
+    from config import DEFAULTS
+
+    p = DEFAULTS["pipeline"]
+    assert p["eye_detect_enabled"] is True
+    assert p["eye_classifier_conf_gate"] == 0.50
+    assert p["eye_detection_conf_gate"] == 0.50
+    assert p["eye_window_k"] == 0.08
+    assert p["reject_eye_focus"] == 0.35
+
+
+def test_eye_focus_config_round_trips_through_settings_api(tmp_path, monkeypatch):
+    """Posting eye-focus settings via /api/config persists and reloads.
+
+    Verifies the full wiring from settings.html → /api/config → config.json →
+    cfg.load() → get_effective_config → score_encounter sees the new keys.
+    """
+    import json as _json
+
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    from app import create_app
+    db_path = str(tmp_path / "vireo.db")
+    thumb_dir = tmp_path / "thumbs"
+    thumb_dir.mkdir()
+    app = create_app(db_path, str(thumb_dir))
+    client = app.test_client()
+
+    # Post a pipeline block that sets a non-default reject_eye_focus.
+    r = client.post(
+        "/api/config",
+        data=_json.dumps({
+            "pipeline": {
+                "eye_detect_enabled": False,
+                "eye_classifier_conf_gate": 0.72,
+                "eye_detection_conf_gate": 0.61,
+                "eye_window_k": 0.12,
+                "reject_eye_focus": 0.55,
+            },
+        }),
+        headers={"Content-Type": "application/json"},
+    )
+    assert r.status_code == 200
+
+    loaded = cfg.load()
+    p = loaded["pipeline"]
+    assert p["eye_detect_enabled"] is False
+    assert p["eye_classifier_conf_gate"] == 0.72
+    assert p["eye_detection_conf_gate"] == 0.61
+    assert p["eye_window_k"] == 0.12
+    assert p["reject_eye_focus"] == 0.55
+
+
+def test_reject_eye_focus_flows_from_config_to_scoring(tmp_path, monkeypatch):
+    """A reject_eye_focus value from effective config reaches score_encounter.
+
+    End-to-end: config.json → cfg.load() → db.get_effective_config() → dict
+    passed as score_encounter(config=...). Sets the threshold high enough
+    that a sharp eye still gets rejected, proving the value took effect.
+    """
+    import json as _json
+
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    with open(cfg.CONFIG_PATH, "w") as f:
+        _json.dump({"pipeline": {"reject_eye_focus": 0.99}}, f)
+
+    from db import Database
+    from scoring import score_encounter
+
+    db = Database(str(tmp_path / "vireo.db"))
+    effective = db.get_effective_config(cfg.load())
+    pipeline_cfg = effective.get("pipeline", {})
+
+    photo = {
+        "subject_tenengrad": 50000,
+        "eye_tenengrad": 50000,  # "sharp" eye — yet rule still fires at 0.99
+        "bg_tenengrad": 50,
+        "subject_clip_high": 0.0,
+        "subject_clip_low": 0.0,
+        "subject_y_median": 115,
+        "crop_complete": 0.95,
+        "bg_separation": 10.0,
+        "subject_size": 0.15,
+        "mask_path": "/masks/1.png",
+    }
+    enc = {"photos": [photo]}
+    score_encounter(enc, config=pipeline_cfg)
+
+    assert any(
+        "eye_soft" in r for r in photo.get("reject_reasons", [])
+    ), (
+        "reject_eye_focus from config.json was not applied by score_encounter; "
+        f"reasons={photo.get('reject_reasons')}"
+    )

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1859,6 +1859,46 @@ def test_list_photos_for_eye_keypoint_stage_keeps_confidence_order_when_routable
     assert rows[0]["scientific_name"] == "Turdus migratorius"
 
 
+def test_list_photos_for_eye_keypoint_stage_scopes_to_photo_ids(tmp_path):
+    """When ``photo_ids`` is provided, only those photos are returned even
+    if other eligible photos exist in the workspace. Empty iterables return
+    no rows without hitting the DB.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db._active_workspace_id
+    fid = db.add_folder(str(tmp_path), name="photos")
+    db.add_workspace_folder(ws_id, fid)
+
+    pid_a = db.add_photo(
+        fid, "a.jpg", ".jpg", 1000, 1.0, width=800, height=600,
+    )
+    pid_b = db.add_photo(
+        fid, "b.jpg", ".jpg", 1000, 2.0, width=800, height=600,
+    )
+    for pid in (pid_a, pid_b):
+        db.update_photo_pipeline_features(pid, mask_path=str(tmp_path / "mask.png"))
+        det_ids = db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.8, "h": 0.8}, "confidence": 0.9}],
+            detector_model="MegaDetector",
+        )
+        db.add_prediction(
+            det_ids[0], species="Vulpes vulpes", confidence=0.9,
+            model="bioclip-2.5", category="match",
+            taxonomy={"class": "Mammalia", "scientific_name": "Vulpes vulpes"},
+        )
+
+    # No filter: both photos.
+    assert {r["id"] for r in db.list_photos_for_eye_keypoint_stage()} == {pid_a, pid_b}
+    # Scoped to one photo.
+    rows = db.list_photos_for_eye_keypoint_stage(photo_ids=[pid_a])
+    assert [r["id"] for r in rows] == [pid_a]
+    # Empty iterable short-circuits to [].
+    assert db.list_photos_for_eye_keypoint_stage(photo_ids=set()) == []
+
+
 def test_add_keyword_auto_detects_taxonomy(tmp_path):
     """add_keyword auto-detects taxonomy type when name matches a taxon."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1753,6 +1753,112 @@ def test_update_photo_eye_fields_accept_null(tmp_path):
     assert (row[0], row[1], row[2], row[3]) == (None, None, None, None)
 
 
+def test_list_photos_for_eye_keypoint_stage_prefers_routable_prediction(tmp_path):
+    """When the top-confidence prediction lacks taxonomy_class and
+    scientific_name, a lower-confidence prediction with routable taxonomy
+    info must be chosen instead — otherwise ``_resolve_keypoint_model``
+    gets a non-routable row and the stage skips the photo.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db._active_workspace_id
+    fid = db.add_folder(str(tmp_path), name="photos")
+    db.add_workspace_folder(ws_id, fid)
+
+    pid = db.add_photo(
+        fid,
+        "mammal.jpg",
+        ".jpg",
+        1000,
+        1.0,
+        width=800,
+        height=600,
+    )
+    db.update_photo_pipeline_features(pid, mask_path=str(tmp_path / "mask.png"))
+
+    det_ids = db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.8, "h": 0.8}, "confidence": 0.95}],
+        detector_model="MegaDetector",
+    )
+    # Top-confidence prediction has species but no taxonomy_class/scientific_name.
+    db.add_prediction(
+        det_ids[0],
+        species="Unknown top",
+        confidence=0.99,
+        model="bioclip-2.5",
+        category="match",
+    )
+    # Lower-confidence prediction carries full taxonomy.
+    db.add_prediction(
+        det_ids[0],
+        species="Vulpes vulpes",
+        confidence=0.55,
+        model="bioclip-2.5",
+        category="match",
+        taxonomy={
+            "class": "Mammalia",
+            "scientific_name": "Vulpes vulpes",
+        },
+    )
+
+    rows = db.list_photos_for_eye_keypoint_stage()
+    assert len(rows) == 1
+    assert rows[0]["taxonomy_class"] == "Mammalia"
+    assert rows[0]["scientific_name"] == "Vulpes vulpes"
+
+
+def test_list_photos_for_eye_keypoint_stage_keeps_confidence_order_when_routable(tmp_path):
+    """When multiple predictions carry routable taxonomy info, the
+    highest-confidence one wins — the routability preference must not
+    override confidence among routable rows.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db._active_workspace_id
+    fid = db.add_folder(str(tmp_path), name="photos")
+    db.add_workspace_folder(ws_id, fid)
+
+    pid = db.add_photo(
+        fid,
+        "bird.jpg",
+        ".jpg",
+        1000,
+        1.0,
+        width=800,
+        height=600,
+    )
+    db.update_photo_pipeline_features(pid, mask_path=str(tmp_path / "mask.png"))
+
+    det_ids = db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.8, "h": 0.8}, "confidence": 0.95}],
+        detector_model="MegaDetector",
+    )
+    db.add_prediction(
+        det_ids[0],
+        species="Turdus migratorius",
+        confidence=0.92,
+        model="bioclip-2.5",
+        category="match",
+        taxonomy={"class": "Aves", "scientific_name": "Turdus migratorius"},
+    )
+    db.add_prediction(
+        det_ids[0],
+        species="Corvus corax",
+        confidence=0.55,
+        model="bioclip-2.5",
+        category="match",
+        taxonomy={"class": "Aves", "scientific_name": "Corvus corax"},
+    )
+
+    rows = db.list_photos_for_eye_keypoint_stage()
+    assert len(rows) == 1
+    assert rows[0]["scientific_name"] == "Turdus migratorius"
+
+
 def test_add_keyword_auto_detects_taxonomy(tmp_path):
     """add_keyword auto-detects taxonomy type when name matches a taxon."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1686,6 +1686,18 @@ def test_photos_has_file_hash_and_companion_path(tmp_path):
     assert "companion_path" in col_names
 
 
+def test_photos_has_eye_focus_columns(tmp_path):
+    """Photos table has eye_x, eye_y, eye_conf, eye_tenengrad columns."""
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    cols = {row[1] for row in db.conn.execute("PRAGMA table_info(photos)")}
+    assert "eye_x" in cols
+    assert "eye_y" in cols
+    assert "eye_conf" in cols
+    assert "eye_tenengrad" in cols
+
+
 def test_add_keyword_auto_detects_taxonomy(tmp_path):
     """add_keyword auto-detects taxonomy type when name matches a taxon."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1698,6 +1698,61 @@ def test_photos_has_eye_focus_columns(tmp_path):
     assert "eye_tenengrad" in cols
 
 
+def test_update_photo_eye_fields_roundtrip(tmp_path):
+    """update_photo_pipeline_features persists eye_* fields."""
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos", name="photos")
+    pid = db.add_photo(
+        folder_id=fid,
+        filename="eye.jpg",
+        extension=".jpg",
+        file_size=1000,
+        file_mtime=1.0,
+    )
+    db.update_photo_pipeline_features(
+        pid,
+        eye_x=123.4,
+        eye_y=56.7,
+        eye_conf=0.82,
+        eye_tenengrad=18450.2,
+    )
+    row = db.conn.execute(
+        "SELECT eye_x, eye_y, eye_conf, eye_tenengrad FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert (row[0], row[1], row[2], row[3]) == (123.4, 56.7, 0.82, 18450.2)
+
+
+def test_update_photo_eye_fields_accept_null(tmp_path):
+    """update_photo_pipeline_features accepts explicit None for eye_* fields."""
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos", name="photos")
+    pid = db.add_photo(
+        folder_id=fid,
+        filename="eye.jpg",
+        extension=".jpg",
+        file_size=1000,
+        file_mtime=1.0,
+    )
+    # First set some values
+    db.update_photo_pipeline_features(
+        pid, eye_x=1.0, eye_y=2.0, eye_conf=0.5, eye_tenengrad=9.0
+    )
+    # Then clear them
+    db.update_photo_pipeline_features(
+        pid, eye_x=None, eye_y=None, eye_conf=None, eye_tenengrad=None
+    )
+    row = db.conn.execute(
+        "SELECT eye_x, eye_y, eye_conf, eye_tenengrad FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert (row[0], row[1], row[2], row[3]) == (None, None, None, None)
+
+
 def test_add_keyword_auto_detects_taxonomy(tmp_path):
     """add_keyword auto-detects taxonomy type when name matches a taxon."""
     from db import Database

--- a/vireo/tests/test_keypoints.py
+++ b/vireo/tests/test_keypoints.py
@@ -1,0 +1,30 @@
+# vireo/tests/test_keypoints.py
+"""Tests for animal keypoint detection (eye-focus pipeline).
+
+Keypoint-model inference is mocked at the onnxruntime.InferenceSession level
+so these tests run without real model weights.
+"""
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_decode_simcc_picks_argmax():
+    """decode_simcc returns (K, 3) with x, y in input pixels and min(conf_x, conf_y)."""
+    from keypoints import decode_simcc
+
+    K = 17
+    simcc_x = np.zeros((1, K, 512), dtype=np.float32)
+    simcc_y = np.zeros((1, K, 512), dtype=np.float32)
+    # Eye 0 at (100, 50) in a 256x256 input image (simcc split ratio = 2.0).
+    simcc_x[0, 0, 200] = 1.0  # x = 200 / 2.0 = 100 px
+    simcc_y[0, 0, 100] = 1.0  # y = 100 / 2.0 = 50 px
+
+    kps = decode_simcc(simcc_x, simcc_y, input_size=256, simcc_split_ratio=2.0)
+
+    assert kps.shape == (K, 3)
+    np.testing.assert_allclose(kps[0, :2], [100.0, 50.0], atol=0.5)
+    assert kps[0, 2] == 1.0  # min(max(simcc_x), max(simcc_y))

--- a/vireo/tests/test_keypoints.py
+++ b/vireo/tests/test_keypoints.py
@@ -28,3 +28,64 @@ def test_decode_simcc_picks_argmax():
     assert kps.shape == (K, 3)
     np.testing.assert_allclose(kps[0, :2], [100.0, 50.0], atol=0.5)
     assert kps[0, 2] == 1.0  # min(max(simcc_x), max(simcc_y))
+
+
+def test_ensure_keypoint_weights_short_circuits_if_present(tmp_path, monkeypatch):
+    """When both model.onnx and config.json exist, no download is triggered."""
+    import keypoints as kp
+
+    monkeypatch.setattr(kp, "MODELS_DIR", str(tmp_path))
+    model_dir = tmp_path / "rtmpose-animal"
+    model_dir.mkdir()
+    (model_dir / "model.onnx").write_bytes(b"fake-onnx")
+    (model_dir / "config.json").write_text("{}")
+
+    # If the helper attempted a network download, hf_hub_download is what it
+    # would reach for. Asserting no call here proves short-circuit behavior.
+    called = {"count": 0}
+
+    def _fail_hub(*args, **kwargs):
+        called["count"] += 1
+        raise AssertionError("Should not download when weights are present")
+
+    monkeypatch.setattr(
+        "huggingface_hub.hf_hub_download", _fail_hub, raising=False
+    )
+
+    path = kp.ensure_keypoint_weights("rtmpose-animal")
+    assert path == str(model_dir / "model.onnx")
+    assert called["count"] == 0
+
+
+def test_ensure_keypoint_weights_missing_files_triggers_download(tmp_path, monkeypatch):
+    """When weights are absent, helper calls hf_hub_download for each required file."""
+    import keypoints as kp
+
+    monkeypatch.setattr(kp, "MODELS_DIR", str(tmp_path))
+
+    downloaded = []
+
+    def _fake_hub_download(repo_id, filename, subfolder, **kwargs):
+        downloaded.append((repo_id, subfolder, filename))
+        # Return a path inside tmp_path acting as HF's cache location.
+        cache = tmp_path / "_hfcache" / subfolder
+        cache.mkdir(parents=True, exist_ok=True)
+        dest = cache / filename
+        dest.write_bytes(b"fake" if filename == "model.onnx" else b"{}")
+        return str(dest)
+
+    import huggingface_hub
+
+    monkeypatch.setattr(
+        huggingface_hub, "hf_hub_download", _fake_hub_download
+    )
+
+    onnx_path = kp.ensure_keypoint_weights("rtmpose-animal")
+
+    assert onnx_path == str(tmp_path / "rtmpose-animal" / "model.onnx")
+    # Both model.onnx and config.json must be fetched.
+    names = {name for _, _, name in downloaded}
+    assert names == {"model.onnx", "config.json"}
+    # Both files land at the expected on-disk location.
+    assert (tmp_path / "rtmpose-animal" / "model.onnx").is_file()
+    assert (tmp_path / "rtmpose-animal" / "config.json").is_file()

--- a/vireo/tests/test_keypoints.py
+++ b/vireo/tests/test_keypoints.py
@@ -4,10 +4,13 @@
 Keypoint-model inference is mocked at the onnxruntime.InferenceSession level
 so these tests run without real model weights.
 """
+import json
 import os
 import sys
+from unittest.mock import MagicMock
 
 import numpy as np
+from PIL import Image
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -89,3 +92,92 @@ def test_ensure_keypoint_weights_missing_files_triggers_download(tmp_path, monke
     # Both files land at the expected on-disk location.
     assert (tmp_path / "rtmpose-animal" / "model.onnx").is_file()
     assert (tmp_path / "rtmpose-animal" / "config.json").is_file()
+
+
+def _write_rtmpose_config(model_dir):
+    (model_dir / "config.json").write_text(json.dumps({
+        "input_size": [1, 3, 256, 256],
+        "mean": [123.675, 116.28, 103.53],
+        "std": [58.395, 57.12, 57.375],
+        "keypoints": [
+            "left_eye", "right_eye", "nose", "neck", "root_of_tail",
+            "left_shoulder", "left_elbow", "left_front_paw",
+            "right_shoulder", "right_elbow", "right_front_paw",
+            "left_hip", "left_knee", "left_back_paw",
+            "right_hip", "right_knee", "right_back_paw",
+        ],
+        "output_type": "simcc",
+        "simcc_split_ratio": 2.0,
+    }))
+
+
+def test_detect_keypoints_returns_named_keypoints_in_image_space(tmp_path, monkeypatch):
+    """Eye coord lands correctly after crop + resize + pad + reverse transform."""
+    import keypoints as kp
+
+    monkeypatch.setattr(kp, "MODELS_DIR", str(tmp_path))
+    model_dir = tmp_path / "rtmpose-animal"
+    model_dir.mkdir()
+    (model_dir / "model.onnx").write_bytes(b"fake")
+    _write_rtmpose_config(model_dir)
+
+    # Image is 512x512. Bbox covers the whole image, so scale is 256/512=0.5,
+    # input crop is the whole image. Simcc peak at index 256 along each axis
+    # => (256/2, 256/2) = (128, 128) in the 256x256 input. Inverse: divide by
+    # scale (0.5) => (256, 256) in image space.
+    K = 17
+    simcc_x = np.zeros((1, K, 512), dtype=np.float32)
+    simcc_y = np.zeros((1, K, 512), dtype=np.float32)
+    simcc_x[0, 0, 256] = 0.9  # left_eye x
+    simcc_y[0, 0, 256] = 0.9  # left_eye y
+
+    mock_sess = MagicMock()
+    mock_sess.run.return_value = [simcc_x, simcc_y]
+    monkeypatch.setattr(kp, "_load_session", lambda name: mock_sess)
+
+    img = Image.new("RGB", (512, 512), color=(128, 128, 128))
+    bbox = (0, 0, 512, 512)
+
+    result = kp.detect_keypoints(img, bbox, "rtmpose-animal")
+
+    # Returns one dict per keypoint in the model's order.
+    assert len(result) == K
+    names = [k["name"] for k in result]
+    assert "left_eye" in names
+    left = [k for k in result if k["name"] == "left_eye"][0]
+    assert abs(left["x"] - 256) < 5
+    assert abs(left["y"] - 256) < 5
+    assert left["conf"] > 0.85
+
+
+def test_detect_keypoints_maps_bbox_offset_into_image_space(tmp_path, monkeypatch):
+    """When the bbox is offset within the image, result coords include the offset."""
+    import keypoints as kp
+
+    monkeypatch.setattr(kp, "MODELS_DIR", str(tmp_path))
+    model_dir = tmp_path / "rtmpose-animal"
+    model_dir.mkdir()
+    (model_dir / "model.onnx").write_bytes(b"fake")
+    _write_rtmpose_config(model_dir)
+
+    # 600x400 image, bbox (100, 50, 356, 306) — a 256x256 square offset by
+    # (100, 50). Scale = 256 / 256 = 1.0. Simcc peak at index 100 => input
+    # coord (50, 50). Inverse: + bbox origin => image coord (150, 100).
+    K = 17
+    simcc_x = np.zeros((1, K, 512), dtype=np.float32)
+    simcc_y = np.zeros((1, K, 512), dtype=np.float32)
+    simcc_x[0, 0, 100] = 0.75
+    simcc_y[0, 0, 100] = 0.75
+
+    mock_sess = MagicMock()
+    mock_sess.run.return_value = [simcc_x, simcc_y]
+    monkeypatch.setattr(kp, "_load_session", lambda name: mock_sess)
+
+    img = Image.new("RGB", (600, 400), color=(200, 200, 200))
+    bbox = (100, 50, 356, 306)
+
+    result = kp.detect_keypoints(img, bbox, "rtmpose-animal")
+    left = [k for k in result if k["name"] == "left_eye"][0]
+
+    assert abs(left["x"] - 150) < 2
+    assert abs(left["y"] - 100) < 2

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -650,3 +650,229 @@ def test_eye_keypoint_stage_respects_eye_detect_enabled_flag(tmp_path, monkeypat
         (pid,),
     ).fetchone()
     assert (row[0], row[1], row[2], row[3]) == (None, None, None, None)
+
+
+# --- Four-gate matrix tests for detect_eye_keypoints_stage ---
+
+
+def _make_fake_weights(models_dir, model_name):
+    """Create model.onnx + config.json under MODELS_DIR/<name>/.
+
+    Contents are placeholders; _load_session is monkeypatched elsewhere
+    so the files only exist to pass the gate-2 presence check.
+    """
+    target = os.path.join(models_dir, model_name)
+    os.makedirs(target, exist_ok=True)
+    with open(os.path.join(target, "model.onnx"), "wb") as f:
+        f.write(b"fake")
+    with open(os.path.join(target, "config.json"), "w") as f:
+        f.write("{}")
+
+
+def _setup_eligible_mammal_with_files(tmp_path, *, classifier_conf=0.92,
+                                       taxonomy_class="Mammalia",
+                                       img_size=(800, 600)):
+    """Extended fixture: writes a real image and mask PNG to disk.
+
+    Fake SuperAnimal-Quadruped weights are placed under a tmp MODELS_DIR
+    so gate 2 passes. Caller monkeypatches kp.MODELS_DIR to that location
+    and kp.detect_keypoints to control the eye the stage will evaluate.
+    """
+    from db import Database
+    from PIL import Image
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db._active_workspace_id
+    fid = db.add_folder(str(tmp_path), name="photos")
+    db.add_workspace_folder(ws_id, fid)
+
+    img_w, img_h = img_size
+    img = Image.new("RGB", (img_w, img_h), color=(128, 128, 128))
+    # High-contrast edge block so compute_eye_tenengrad returns >0 when it
+    # runs on a window inside the block.
+    arr = np.array(img)
+    arr[200:400, 200:400] = np.tile([0, 255] * 100, (200, 1)).astype(np.uint8)[:, :, None]
+    Image.fromarray(arr).save(tmp_path / "mammal.jpg")
+
+    # Mask PNG — white where the subject is (center region), black elsewhere.
+    mask = np.zeros((img_h, img_w), dtype=np.uint8)
+    mask[100:500, 100:700] = 255
+    Image.fromarray(mask).save(tmp_path / "mask.png")
+
+    pid = db.add_photo(
+        fid, "mammal.jpg", ".jpg", 1000, 1.0,
+        timestamp="2026-04-16T10:00:00",
+        width=img_w, height=img_h,
+    )
+    db.update_photo_pipeline_features(pid, mask_path=str(tmp_path / "mask.png"))
+
+    det_ids = db.save_detections(
+        pid,
+        [{"box": {"x": 0.125, "y": 0.167, "w": 0.75, "h": 0.667},
+          "confidence": 0.95}],
+        detector_model="MegaDetector",
+    )
+    db.add_prediction(
+        det_ids[0],
+        species="Vulpes vulpes",
+        confidence=classifier_conf,
+        model="bioclip-2.5",
+        category="match",
+        taxonomy={
+            "kingdom": "Animalia", "phylum": "Chordata",
+            "class": taxonomy_class, "order": "Carnivora",
+            "family": "Canidae", "genus": "Vulpes",
+            "scientific_name": "Vulpes vulpes",
+        },
+    )
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    _make_fake_weights(str(models_dir), "superanimal-quadruped")
+    _make_fake_weights(str(models_dir), "superanimal-bird")
+
+    return db, pid, str(models_dir)
+
+
+def _read_eye_fields(db, pid):
+    row = db.conn.execute(
+        "SELECT eye_x, eye_y, eye_conf, eye_tenengrad FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    return (row[0], row[1], row[2], row[3])
+
+
+def test_eye_stage_gate1_low_classifier_conf_no_write(tmp_path, monkeypatch):
+    """Gate 1: classifier conf below threshold → no keypoint model is even loaded."""
+    import keypoints as kp
+    from pipeline import detect_eye_keypoints_stage
+
+    db, pid, models_dir = _setup_eligible_mammal_with_files(
+        tmp_path, classifier_conf=0.3,
+    )
+    monkeypatch.setattr(kp, "MODELS_DIR", models_dir)
+
+    # If the stage reaches keypoint detection, the test setup is broken.
+    def _boom(*a, **kw):
+        raise AssertionError("detect_keypoints should not run when gate 1 fails")
+
+    monkeypatch.setattr(kp, "detect_keypoints", _boom)
+
+    detect_eye_keypoints_stage(
+        db, config={"eye_detect_enabled": True, "eye_classifier_conf_gate": 0.5},
+    )
+    assert _read_eye_fields(db, pid) == (None, None, None, None)
+
+
+def test_eye_stage_gate1_out_of_scope_species_no_write(tmp_path, monkeypatch):
+    """Gate 1: species class not in {Aves, Mammalia} → no write."""
+    import keypoints as kp
+    from pipeline import detect_eye_keypoints_stage
+
+    db, pid, models_dir = _setup_eligible_mammal_with_files(
+        tmp_path, taxonomy_class="Actinopterygii",  # ray-finned fish
+    )
+    monkeypatch.setattr(kp, "MODELS_DIR", models_dir)
+
+    def _boom(*a, **kw):
+        raise AssertionError("detect_keypoints should not run for fish")
+
+    monkeypatch.setattr(kp, "detect_keypoints", _boom)
+
+    detect_eye_keypoints_stage(db, config={"eye_detect_enabled": True})
+    assert _read_eye_fields(db, pid) == (None, None, None, None)
+
+
+def test_eye_stage_gate3_low_eye_conf_no_write(tmp_path, monkeypatch):
+    """Gate 3: both eye keypoints below eye_detection_conf_gate → no write."""
+    import keypoints as kp
+    from pipeline import detect_eye_keypoints_stage
+
+    db, pid, models_dir = _setup_eligible_mammal_with_files(tmp_path)
+    monkeypatch.setattr(kp, "MODELS_DIR", models_dir)
+
+    low = [
+        {"name": "left_eye", "x": 300.0, "y": 300.0, "conf": 0.2},
+        {"name": "right_eye", "x": 350.0, "y": 300.0, "conf": 0.15},
+        {"name": "nose", "x": 325.0, "y": 350.0, "conf": 0.9},
+    ]
+    monkeypatch.setattr(kp, "detect_keypoints", lambda *a, **kw: low)
+
+    detect_eye_keypoints_stage(
+        db, config={"eye_detect_enabled": True, "eye_detection_conf_gate": 0.5},
+    )
+    assert _read_eye_fields(db, pid) == (None, None, None, None)
+
+
+def test_eye_stage_gate4_eye_outside_mask_no_write(tmp_path, monkeypatch):
+    """Gate 4: eye keypoint falls outside the subject mask → no write."""
+    import keypoints as kp
+    from pipeline import detect_eye_keypoints_stage
+
+    db, pid, models_dir = _setup_eligible_mammal_with_files(tmp_path)
+    monkeypatch.setattr(kp, "MODELS_DIR", models_dir)
+
+    # Mask covers [100:500, 100:700]; (50, 50) is well outside it.
+    outside = [
+        {"name": "left_eye", "x": 50.0, "y": 50.0, "conf": 0.9},
+        {"name": "right_eye", "x": 60.0, "y": 50.0, "conf": 0.9},
+    ]
+    monkeypatch.setattr(kp, "detect_keypoints", lambda *a, **kw: outside)
+
+    detect_eye_keypoints_stage(db, config={"eye_detect_enabled": True})
+    assert _read_eye_fields(db, pid) == (None, None, None, None)
+
+
+def test_eye_stage_all_gates_pass_writes_eye_fields(tmp_path, monkeypatch):
+    """All four gates pass → eye_x, eye_y, eye_conf, eye_tenengrad populated."""
+    import keypoints as kp
+    from pipeline import detect_eye_keypoints_stage
+
+    db, pid, models_dir = _setup_eligible_mammal_with_files(tmp_path)
+    monkeypatch.setattr(kp, "MODELS_DIR", models_dir)
+
+    # Eye at (300, 300) is inside mask [100:500, 100:700] and inside the
+    # high-contrast block [200:400, 200:400] so tenengrad > 0.
+    good = [
+        {"name": "left_eye", "x": 300.0, "y": 300.0, "conf": 0.88},
+        {"name": "right_eye", "x": 350.0, "y": 300.0, "conf": 0.85},
+        {"name": "nose", "x": 325.0, "y": 350.0, "conf": 0.9},
+    ]
+    monkeypatch.setattr(kp, "detect_keypoints", lambda *a, **kw: good)
+
+    detect_eye_keypoints_stage(db, config={"eye_detect_enabled": True})
+
+    eye_x, eye_y, eye_conf, eye_teng = _read_eye_fields(db, pid)
+    assert eye_x is not None
+    assert eye_y is not None
+    assert eye_conf is not None and eye_conf >= 0.5
+    assert eye_teng is not None and eye_teng > 0.0
+
+
+def test_eye_stage_picks_eye_with_higher_tenengrad(tmp_path, monkeypatch):
+    """Two valid eyes → pick the one with the higher windowed tenengrad.
+
+    The high-contrast block covers [200:400, 200:400]. A window around
+    (300, 300) lands fully inside it; a window around (600, 300) lands on
+    flat gray. The stage must persist the (300, 300) eye.
+    """
+    import keypoints as kp
+    from pipeline import detect_eye_keypoints_stage
+
+    db, pid, models_dir = _setup_eligible_mammal_with_files(tmp_path)
+    monkeypatch.setattr(kp, "MODELS_DIR", models_dir)
+
+    two_eyes = [
+        {"name": "left_eye", "x": 300.0, "y": 300.0, "conf": 0.80},  # sharp region
+        {"name": "right_eye", "x": 600.0, "y": 300.0, "conf": 0.90}, # flat region (but higher conf)
+    ]
+    monkeypatch.setattr(kp, "detect_keypoints", lambda *a, **kw: two_eyes)
+
+    detect_eye_keypoints_stage(db, config={"eye_detect_enabled": True})
+
+    eye_x, eye_y, eye_conf, eye_teng = _read_eye_fields(db, pid)
+    # Winner is chosen by tenengrad, not conf, so the sharp-region eye wins.
+    assert abs(eye_x - 300.0) < 1.0
+    assert abs(eye_y - 300.0) < 1.0
+    assert eye_conf == 0.80
+    assert eye_teng > 0.0

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -605,6 +605,39 @@ def _setup_eligible_mammal_photo(tmp_path, taxonomy_class="Mammalia"):
     return db, pid
 
 
+def test_eye_keypoint_stage_preflight_disabled(tmp_path, monkeypatch):
+    """Preflight returns a skip reason when eye detection is disabled."""
+    from pipeline import eye_keypoint_stage_preflight
+
+    assert eye_keypoint_stage_preflight({"eye_detect_enabled": False}) \
+        == "Disabled in config"
+
+
+def test_eye_keypoint_stage_preflight_no_weights(tmp_path, monkeypatch):
+    """Preflight returns a skip reason when no routable weights are installed."""
+    import keypoints as kp
+    from pipeline import eye_keypoint_stage_preflight
+
+    empty_models_dir = tmp_path / "empty"
+    empty_models_dir.mkdir()
+    monkeypatch.setattr(kp, "MODELS_DIR", str(empty_models_dir))
+
+    assert eye_keypoint_stage_preflight({}) == "No keypoint models installed"
+
+
+def test_eye_keypoint_stage_preflight_ready(tmp_path, monkeypatch):
+    """Preflight returns None when at least one routable model is ready."""
+    import keypoints as kp
+    from pipeline import eye_keypoint_stage_preflight
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    _make_fake_weights(str(models_dir), "superanimal-quadruped")
+    monkeypatch.setattr(kp, "MODELS_DIR", str(models_dir))
+
+    assert eye_keypoint_stage_preflight({}) is None
+
+
 def test_eye_keypoint_stage_skips_when_weights_absent(tmp_path, monkeypatch):
     """No routable keypoint weights installed → stage-level preflight
     short-circuits before enumerating photos. Confirms that

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -1015,6 +1015,41 @@ def test_eye_stage_all_gates_pass_writes_eye_fields(tmp_path, monkeypatch):
     assert eye_teng is not None and eye_teng > 0.0
 
 
+def test_eye_stage_uses_image_loader_and_tolerates_none(tmp_path, monkeypatch):
+    """Stage calls image_loader.load_image (which handles RAW + EXIF
+    orientation) rather than plain PIL.Image.open. If the loader returns
+    None (unsupported format, decode failure), the stage skips the photo
+    without raising.
+    """
+    import image_loader
+    import keypoints as kp
+    from pipeline import detect_eye_keypoints_stage
+
+    db, pid, models_dir = _setup_eligible_mammal_with_files(tmp_path)
+    monkeypatch.setattr(kp, "MODELS_DIR", models_dir)
+
+    calls = {"n": 0}
+
+    def _fake_loader(path, max_size=1024):
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr("pipeline.load_image", _fake_loader, raising=False)
+    # Also patch in the module where pipeline imports it, in case the
+    # function binds at call time via `from image_loader import load_image`.
+    monkeypatch.setattr(image_loader, "load_image", _fake_loader)
+
+    def _boom(*a, **kw):
+        raise AssertionError("detect_keypoints should not run when image load fails")
+
+    monkeypatch.setattr(kp, "detect_keypoints", _boom)
+
+    detect_eye_keypoints_stage(db, config={"eye_detect_enabled": True})
+
+    assert calls["n"] >= 1
+    assert _read_eye_fields(db, pid) == (None, None, None, None)
+
+
 def test_eye_stage_picks_eye_with_higher_tenengrad(tmp_path, monkeypatch):
     """Two valid eyes → pick the one with the higher windowed tenengrad.
 

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -1072,8 +1072,9 @@ def test_eye_stage_picks_eye_with_higher_tenengrad(tmp_path, monkeypatch):
     detect_eye_keypoints_stage(db, config={"eye_detect_enabled": True})
 
     eye_x, eye_y, eye_conf, eye_teng = _read_eye_fields(db, pid)
-    # Winner is chosen by tenengrad, not conf, so the sharp-region eye wins.
-    assert abs(eye_x - 300.0) < 1.0
-    assert abs(eye_y - 300.0) < 1.0
+    # Winner is chosen by tenengrad, not conf, so the sharp-region eye
+    # wins. Coords are normalized 0-1 against the 800x600 fixture image.
+    assert abs(eye_x - 300.0 / 800.0) < 1.0 / 800.0
+    assert abs(eye_y - 300.0 / 600.0) < 1.0 / 600.0
     assert eye_conf == 0.80
     assert eye_teng > 0.0

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -606,7 +606,11 @@ def _setup_eligible_mammal_photo(tmp_path, taxonomy_class="Mammalia"):
 
 
 def test_eye_keypoint_stage_skips_when_weights_absent(tmp_path, monkeypatch):
-    """Gate 2: no weights on disk → stage processes the photo as a no-op."""
+    """No routable keypoint weights installed → stage-level preflight
+    short-circuits before enumerating photos. Confirms that
+    list_photos_for_eye_keypoint_stage is never called (no O(N) DB pass)
+    and that no eye fields get written.
+    """
     import keypoints as kp
     from pipeline import detect_eye_keypoints_stage
 
@@ -616,8 +620,18 @@ def test_eye_keypoint_stage_skips_when_weights_absent(tmp_path, monkeypatch):
 
     db, pid = _setup_eligible_mammal_photo(tmp_path)
 
+    called = {"listed": False}
+    orig = db.list_photos_for_eye_keypoint_stage
+
+    def _spy(*args, **kwargs):
+        called["listed"] = True
+        return orig(*args, **kwargs)
+
+    monkeypatch.setattr(db, "list_photos_for_eye_keypoint_stage", _spy)
+
     detect_eye_keypoints_stage(db, config={"eye_detect_enabled": True})
 
+    assert called["listed"] is False
     row = db.conn.execute(
         "SELECT eye_x, eye_y, eye_conf, eye_tenengrad FROM photos WHERE id=?",
         (pid,),
@@ -658,7 +672,16 @@ def test_eye_keypoint_stage_scopes_to_collection(tmp_path, monkeypatch):
     targeted at one collection must not touch eye fields on unrelated
     photos elsewhere in the workspace.
     """
+    import keypoints as kp
     from pipeline import detect_eye_keypoints_stage
+
+    # Install fake routable weights so the stage-level preflight doesn't
+    # short-circuit before the scoping check.
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    _make_fake_weights(str(models_dir), "superanimal-quadruped")
+    _make_fake_weights(str(models_dir), "superanimal-bird")
+    monkeypatch.setattr(kp, "MODELS_DIR", str(models_dir))
 
     db, pid = _setup_eligible_mammal_photo(tmp_path)
 

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -636,9 +636,9 @@ def test_eye_keypoint_stage_respects_eye_detect_enabled_flag(tmp_path, monkeypat
     called = {"listed": False}
     orig = db.list_photos_for_eye_keypoint_stage
 
-    def _spy():
+    def _spy(*args, **kwargs):
         called["listed"] = True
-        return orig()
+        return orig(*args, **kwargs)
 
     monkeypatch.setattr(db, "list_photos_for_eye_keypoint_stage", _spy)
 
@@ -650,6 +650,58 @@ def test_eye_keypoint_stage_respects_eye_detect_enabled_flag(tmp_path, monkeypat
         (pid,),
     ).fetchone()
     assert (row[0], row[1], row[2], row[3]) == (None, None, None, None)
+
+
+def test_eye_keypoint_stage_scopes_to_collection(tmp_path, monkeypatch):
+    """When ``collection_id`` is provided, only photos in that collection
+    are passed to ``list_photos_for_eye_keypoint_stage``. A pipeline run
+    targeted at one collection must not touch eye fields on unrelated
+    photos elsewhere in the workspace.
+    """
+    from pipeline import detect_eye_keypoints_stage
+
+    db, pid = _setup_eligible_mammal_photo(tmp_path)
+
+    # Add a second eligible photo not in the collection.
+    fid = db.add_folder(str(tmp_path / "other"), name="other")
+    db.add_workspace_folder(db._active_workspace_id, fid)
+    other_pid = db.add_photo(
+        fid, "mammal2.jpg", ".jpg", 1000, 2.0,
+        timestamp="2026-04-16T11:00:00", width=800, height=600,
+    )
+    db.update_photo_pipeline_features(other_pid, mask_path=str(tmp_path / "mask.png"))
+    det_ids = db.save_detections(
+        other_pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.8, "h": 0.8}, "confidence": 0.9}],
+        detector_model="MegaDetector",
+    )
+    db.add_prediction(
+        det_ids[0], species="Vulpes vulpes", confidence=0.9,
+        model="bioclip-2.5", category="match",
+        taxonomy={"class": "Mammalia", "scientific_name": "Vulpes vulpes"},
+    )
+
+    cid = db.add_collection(
+        "fox set",
+        json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    captured = {}
+    orig = db.list_photos_for_eye_keypoint_stage
+
+    def _spy(photo_ids=None):
+        captured["photo_ids"] = (
+            set(photo_ids) if photo_ids is not None else None
+        )
+        return orig(photo_ids=photo_ids)
+
+    monkeypatch.setattr(db, "list_photos_for_eye_keypoint_stage", _spy)
+
+    detect_eye_keypoints_stage(
+        db, config={"eye_detect_enabled": True}, collection_id=cid,
+    )
+
+    assert captured["photo_ids"] == {pid}
 
 
 # --- Four-gate matrix tests for detect_eye_keypoints_stage ---

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -550,3 +550,103 @@ def test_load_photo_features_no_variant_configured_keeps_embeddings(tmp_path):
     photos = load_photo_features(db)  # no config
     assert len(photos) == 1
     assert photos[0]["dino_subject_embedding"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Eye-focus detection stage
+# ---------------------------------------------------------------------------
+
+def _setup_eligible_mammal_photo(tmp_path, taxonomy_class="Mammalia"):
+    """Create one photo that passes gate 1 + has a mask + has a detection.
+
+    Returns (db, photo_id). Caller controls whether weights exist (gate 2)
+    via monkeypatching keypoints.MODELS_DIR.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db._active_workspace_id  # auto-created Default workspace
+    fid = db.add_folder(str(tmp_path), name="photos")
+    db.add_workspace_folder(ws_id, fid)
+
+    pid = db.add_photo(
+        fid,
+        "mammal.jpg",
+        ".jpg",
+        1000,
+        1.0,
+        timestamp="2026-04-16T10:00:00",
+        width=800,
+        height=600,
+    )
+    db.update_photo_pipeline_features(pid, mask_path=str(tmp_path / "mask.png"))
+
+    det_ids = db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.8, "h": 0.8}, "confidence": 0.95}],
+        detector_model="MegaDetector",
+    )
+    db.add_prediction(
+        det_ids[0],
+        species="Vulpes vulpes",
+        confidence=0.92,
+        model="bioclip-2.5",
+        category="match",
+        taxonomy={
+            "kingdom": "Animalia",
+            "phylum": "Chordata",
+            "class": taxonomy_class,
+            "order": "Carnivora",
+            "family": "Canidae",
+            "genus": "Vulpes",
+            "scientific_name": "Vulpes vulpes",
+        },
+    )
+    return db, pid
+
+
+def test_eye_keypoint_stage_skips_when_weights_absent(tmp_path, monkeypatch):
+    """Gate 2: no weights on disk → stage processes the photo as a no-op."""
+    import keypoints as kp
+    from pipeline import detect_eye_keypoints_stage
+
+    empty_models_dir = tmp_path / "empty_models"
+    empty_models_dir.mkdir()
+    monkeypatch.setattr(kp, "MODELS_DIR", str(empty_models_dir))
+
+    db, pid = _setup_eligible_mammal_photo(tmp_path)
+
+    detect_eye_keypoints_stage(db, config={"eye_detect_enabled": True})
+
+    row = db.conn.execute(
+        "SELECT eye_x, eye_y, eye_conf, eye_tenengrad FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert (row[0], row[1], row[2], row[3]) == (None, None, None, None)
+
+
+def test_eye_keypoint_stage_respects_eye_detect_enabled_flag(tmp_path, monkeypatch):
+    """When config disables eye detection, the stage does not enumerate photos."""
+    from pipeline import detect_eye_keypoints_stage
+
+    db, pid = _setup_eligible_mammal_photo(tmp_path)
+
+    # Any call through to list_photos_for_eye_keypoint_stage would be a bug —
+    # the disabled flag must short-circuit before the DB helper.
+    called = {"listed": False}
+    orig = db.list_photos_for_eye_keypoint_stage
+
+    def _spy():
+        called["listed"] = True
+        return orig()
+
+    monkeypatch.setattr(db, "list_photos_for_eye_keypoint_stage", _spy)
+
+    detect_eye_keypoints_stage(db, config={"eye_detect_enabled": False})
+
+    assert called["listed"] is False
+    row = db.conn.execute(
+        "SELECT eye_x, eye_y, eye_conf, eye_tenengrad FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert (row[0], row[1], row[2], row[3]) == (None, None, None, None)

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -760,6 +760,64 @@ def test_eye_keypoint_stage_scopes_to_collection(tmp_path, monkeypatch):
     assert captured["photo_ids"] == {pid}
 
 
+def test_eye_keypoint_stage_honors_exclude_photo_ids(tmp_path, monkeypatch):
+    """When ``exclude_photo_ids`` is provided, excluded photos are filtered
+    out before the eligibility query so the stage doesn't mutate eye_*
+    fields for photos the user deselected in preview.
+    """
+    import keypoints as kp
+    from pipeline import detect_eye_keypoints_stage
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    _make_fake_weights(str(models_dir), "superanimal-quadruped")
+    _make_fake_weights(str(models_dir), "superanimal-bird")
+    monkeypatch.setattr(kp, "MODELS_DIR", str(models_dir))
+
+    db, pid = _setup_eligible_mammal_photo(tmp_path)
+
+    fid = db.add_folder(str(tmp_path / "other"), name="other")
+    db.add_workspace_folder(db._active_workspace_id, fid)
+    other_pid = db.add_photo(
+        fid, "mammal2.jpg", ".jpg", 1000, 2.0,
+        timestamp="2026-04-16T11:00:00", width=800, height=600,
+    )
+    db.update_photo_pipeline_features(other_pid, mask_path=str(tmp_path / "mask.png"))
+    det_ids = db.save_detections(
+        other_pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.8, "h": 0.8}, "confidence": 0.9}],
+        detector_model="MegaDetector",
+    )
+    db.add_prediction(
+        det_ids[0], species="Vulpes vulpes", confidence=0.9,
+        model="bioclip-2.5", category="match",
+        taxonomy={"class": "Mammalia", "scientific_name": "Vulpes vulpes"},
+    )
+
+    cid = db.add_collection(
+        "both",
+        json.dumps([{"field": "photo_ids", "value": [pid, other_pid]}]),
+    )
+
+    captured = {}
+    orig = db.list_photos_for_eye_keypoint_stage
+
+    def _spy(photo_ids=None):
+        captured["photo_ids"] = (
+            set(photo_ids) if photo_ids is not None else None
+        )
+        return orig(photo_ids=photo_ids)
+
+    monkeypatch.setattr(db, "list_photos_for_eye_keypoint_stage", _spy)
+
+    detect_eye_keypoints_stage(
+        db, config={"eye_detect_enabled": True}, collection_id=cid,
+        exclude_photo_ids={other_pid},
+    )
+
+    assert captured["photo_ids"] == {pid}
+
+
 # --- Four-gate matrix tests for detect_eye_keypoints_stage ---
 
 

--- a/vireo/tests/test_quality.py
+++ b/vireo/tests/test_quality.py
@@ -361,3 +361,58 @@ def test_compute_all_features_compatible_with_db(tmp_path):
     assert row["subject_tenengrad"] == features["subject_tenengrad"]
     assert row["bg_tenengrad"] == features["bg_tenengrad"]
     assert row["phash_crop"] == features["phash_crop"]
+
+
+# -- Eye-focus windowed tenengrad --
+
+
+def test_compute_eye_tenengrad_uses_window_around_eye():
+    """Sharp edge pattern inside the window produces a non-trivial signal."""
+    from quality import compute_eye_tenengrad
+
+    arr = np.full((400, 400), 128, dtype=np.uint8)
+    # High-contrast vertical stripe pattern centered on (200, 200).
+    arr[180:220, 180:220] = np.tile([0, 255] * 20, (40, 1)).astype(np.uint8)
+    img = Image.fromarray(arr, mode="L").convert("RGB")
+
+    bbox = (100, 100, 300, 300)  # 200x200 bbox
+    eye_xy = (200.0, 200.0)
+    result = compute_eye_tenengrad(img, eye_xy, bbox, k=0.08)
+
+    # Window side = 0.08 * 200 = 16 px (clamped to min 8). Fully inside the
+    # stripe pattern → tenengrad should be well above zero on a gray image.
+    assert result > 1000
+
+
+def test_compute_eye_tenengrad_clamps_to_image_bounds():
+    """Eye near image edge: window clips, no crash, returns finite float."""
+    from quality import compute_eye_tenengrad
+
+    img = Image.new("RGB", (100, 100), color=(128, 128, 128))
+    bbox = (0, 0, 100, 100)
+    result = compute_eye_tenengrad(img, (2.0, 2.0), bbox, k=0.1)
+
+    # Uniform gray → zero gradient → 0.0 after multiscale Tenengrad.
+    assert result == 0.0
+
+
+def test_compute_eye_tenengrad_minimum_window_size_is_8():
+    """Tiny bbox still produces a reasonable 8-pixel window rather than a
+    degenerate 0/1-px one that would break the Sobel filter."""
+    from quality import compute_eye_tenengrad
+
+    img = Image.new("RGB", (100, 100), color=(128, 128, 128))
+    # bbox of side 10 * k=0.08 = 0.8 px → clamp to 8 px
+    bbox = (40, 40, 50, 50)
+    result = compute_eye_tenengrad(img, (45.0, 45.0), bbox, k=0.08)
+    assert result == 0.0  # uniform gray, but no crash
+
+
+def test_compute_eye_tenengrad_empty_window_returns_zero():
+    """Eye entirely outside the image bounds → empty window → 0.0."""
+    from quality import compute_eye_tenengrad
+
+    img = Image.new("RGB", (100, 100), color=(128, 128, 128))
+    bbox = (0, 0, 100, 100)
+    result = compute_eye_tenengrad(img, (-50.0, -50.0), bbox, k=0.1)
+    assert result == 0.0

--- a/vireo/tests/test_scoring.py
+++ b/vireo/tests/test_scoring.py
@@ -351,6 +351,46 @@ def test_focus_score_mixed_eye_and_body_ranks_within_their_group():
     assert d["focus_score"] > c["focus_score"]
 
 
+def test_body_only_focus_not_diluted_by_eye_capable_peers():
+    """Body-only photos must rank against body-only peers, not against a cohort
+    polluted by eye-capable frames whose body_tenengrad happens to be low
+    (because they won the eye lottery on a small sharp eye, not a sharp body).
+
+    Without the split cohort fix, a body-only photo's focus_score would depend
+    on unrelated eye-capable subjects' body_tenengrad values.
+    """
+    from scoring import score_encounter
+
+    # Mixed encounter: two eye-capable peers with very low body_tenengrad
+    # (they're eye-ranked, so body sharpness is irrelevant), plus two
+    # body-only photos.
+    eye_a = _make_base_photo(subject_tenengrad=50, eye_tenengrad=1000)
+    eye_b = _make_base_photo(subject_tenengrad=50, eye_tenengrad=10000)
+    body_lo = _make_base_photo(subject_tenengrad=5000, eye_tenengrad=None)
+    body_hi = _make_base_photo(subject_tenengrad=20000, eye_tenengrad=None)
+    mixed_enc = {"photos": [eye_a, eye_b, body_lo, body_hi]}
+    score_encounter(mixed_enc)
+    mixed_body_lo = body_lo["focus_score"]
+    mixed_body_hi = body_hi["focus_score"]
+
+    # Reference: the same two body-only photos alone. Their percentile ranks
+    # should match the mixed case because the split cohort excludes the
+    # eye-capable peers.
+    ref_lo = _make_base_photo(subject_tenengrad=5000, eye_tenengrad=None)
+    ref_hi = _make_base_photo(subject_tenengrad=20000, eye_tenengrad=None)
+    ref_enc = {"photos": [ref_lo, ref_hi]}
+    score_encounter(ref_enc)
+
+    assert mixed_body_lo == ref_lo["focus_score"], (
+        f"body-only low scorer should not be diluted by eye peers: "
+        f"mixed={mixed_body_lo} ref={ref_lo['focus_score']}"
+    )
+    assert mixed_body_hi == ref_hi["focus_score"], (
+        f"body-only high scorer should not be diluted by eye peers: "
+        f"mixed={mixed_body_hi} ref={ref_hi['focus_score']}"
+    )
+
+
 def test_reject_eye_soft_fires_when_eye_present_and_below_threshold():
     """reject_eye_soft rule: eye is the weak link even if body is sharp."""
     from scoring import score_encounter

--- a/vireo/tests/test_scoring.py
+++ b/vireo/tests/test_scoring.py
@@ -271,3 +271,111 @@ def test_score_encounter_labels_rejects():
     assert enc["photos"][0]["label"] is None  # not rejected
     assert enc["photos"][0]["quality_composite"] > 0
     assert enc["photos"][1]["label"] == "REJECT"
+
+
+# ---------------------------------------------------------------------------
+# Eye-focus composite replacement (Milestone 7)
+# ---------------------------------------------------------------------------
+
+def _make_base_photo(**overrides):
+    """Minimal photo dict with fields score_encounter needs."""
+    photo = {
+        "subject_tenengrad": 500,
+        "bg_tenengrad": 50,
+        "subject_clip_high": 0.0,
+        "subject_clip_low": 0.0,
+        "subject_y_median": 115,
+        "crop_complete": 0.95,
+        "bg_separation": 10.0,
+        "subject_size": 0.15,
+        "mask_path": "/masks/1.png",
+    }
+    photo.update(overrides)
+    return photo
+
+
+def test_focus_score_uses_eye_tenengrad_when_populated():
+    """When photos carry eye_tenengrad, focus_score must rank on eye sharpness, not body.
+
+    Two photos with opposite body/eye sharpness patterns:
+      A: sharp body (50000), soft eye (5000)
+      B: soft body (5000), sharp eye (50000)
+    Body-based ranking would score A higher; eye-based ranking scores B higher.
+    """
+    from scoring import score_encounter
+
+    a = _make_base_photo(subject_tenengrad=50000, eye_tenengrad=5000)
+    b = _make_base_photo(subject_tenengrad=5000, eye_tenengrad=50000)
+    enc = {"photos": [a, b]}
+
+    score_encounter(enc)
+
+    assert b["focus_score"] > a["focus_score"], (
+        f"eye-based ranking should put sharp-eye photo ahead; "
+        f"got A={a['focus_score']} vs B={b['focus_score']}"
+    )
+
+
+def test_focus_score_falls_back_to_subject_tenengrad_when_eye_null():
+    """Photos without an eye signal keep the pre-feature body-ranking behavior."""
+    from scoring import score_encounter
+
+    a = _make_base_photo(subject_tenengrad=50000, eye_tenengrad=None)
+    b = _make_base_photo(subject_tenengrad=5000, eye_tenengrad=None)
+    enc = {"photos": [a, b]}
+
+    score_encounter(enc)
+
+    assert a["focus_score"] > b["focus_score"], (
+        "without eye_tenengrad, score_encounter must rank on subject_tenengrad"
+    )
+
+
+def test_focus_score_mixed_eye_and_body_ranks_within_their_group():
+    """Mixed encounter: eye-having photos rank against each other; body-only photos
+    rank against each other. No cross-contamination that would make the
+    percentiles unfair."""
+    from scoring import score_encounter
+
+    # Two eye-having photos (eye sharpness: b > a).
+    a = _make_base_photo(subject_tenengrad=100, eye_tenengrad=1000)
+    b = _make_base_photo(subject_tenengrad=100, eye_tenengrad=10000)
+    # Two body-only photos (body sharpness: d > c).
+    c = _make_base_photo(subject_tenengrad=1000, eye_tenengrad=None)
+    d = _make_base_photo(subject_tenengrad=10000, eye_tenengrad=None)
+    enc = {"photos": [a, b, c, d]}
+
+    score_encounter(enc)
+
+    assert b["focus_score"] > a["focus_score"]
+    assert d["focus_score"] > c["focus_score"]
+
+
+def test_reject_eye_soft_fires_when_eye_present_and_below_threshold():
+    """reject_eye_soft rule: eye is the weak link even if body is sharp."""
+    from scoring import score_encounter
+
+    soft_eye = _make_base_photo(
+        subject_tenengrad=50000, eye_tenengrad=1000,
+    )
+    sharp_eye = _make_base_photo(
+        subject_tenengrad=50000, eye_tenengrad=50000,
+    )
+    enc = {"photos": [soft_eye, sharp_eye]}
+
+    score_encounter(enc, config={"reject_eye_focus": 0.35})
+
+    assert any("eye_soft" in r for r in soft_eye.get("reject_reasons", []))
+    assert not any("eye_soft" in r for r in sharp_eye.get("reject_reasons", []))
+
+
+def test_reject_eye_soft_does_not_fire_when_eye_null():
+    """Photos without an eye signal must not trigger eye_soft — even if body is soft."""
+    from scoring import score_encounter
+
+    photo = _make_base_photo(subject_tenengrad=1000, eye_tenengrad=None)
+    enc = {"photos": [photo]}
+
+    score_encounter(enc, config={"reject_eye_focus": 0.35})
+
+    assert not any("eye_soft" in r for r in photo.get("reject_reasons", []))

--- a/vireo/tests/test_scoring.py
+++ b/vireo/tests/test_scoring.py
@@ -379,3 +379,44 @@ def test_reject_eye_soft_does_not_fire_when_eye_null():
     score_encounter(enc, config={"reject_eye_focus": 0.35})
 
     assert not any("eye_soft" in r for r in photo.get("reject_reasons", []))
+
+
+def test_eye_detect_disabled_falls_back_to_body_focus():
+    """When eye_detect_enabled=False, eye_tenengrad values stored from a prior
+    run must not change scoring — focus ranks on subject_tenengrad as if the
+    eye columns were absent.
+    """
+    from scoring import score_encounter
+
+    # Same pattern as test_focus_score_uses_eye_tenengrad_when_populated but
+    # with the toggle off: the body-ranking result should win.
+    a = _make_base_photo(subject_tenengrad=50000, eye_tenengrad=5000)
+    b = _make_base_photo(subject_tenengrad=5000, eye_tenengrad=50000)
+    enc = {"photos": [a, b]}
+
+    score_encounter(enc, config={"eye_detect_enabled": False})
+
+    assert a["focus_score"] > b["focus_score"]
+    assert "eye_focus_score" not in a
+    assert "eye_focus_score" not in b
+
+
+def test_eye_detect_disabled_suppresses_eye_soft_reject():
+    """Toggling eye detection off must also stop eye_soft from firing on
+    photos that already have eye_tenengrad from prior runs.
+    """
+    from scoring import score_encounter
+
+    soft_eye = _make_base_photo(
+        subject_tenengrad=50000, eye_tenengrad=1000,
+    )
+    enc = {"photos": [soft_eye]}
+
+    score_encounter(
+        enc,
+        config={"eye_detect_enabled": False, "reject_eye_focus": 0.35},
+    )
+
+    assert not any(
+        "eye_soft" in r for r in soft_eye.get("reject_reasons", [])
+    )

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -770,3 +770,85 @@ def test_download_with_resume_no_range_stalls_correctly(tmp_path):
             )
     finally:
         server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# classify_to_keypoint_group — taxonomy routing for eye-focus detection
+# ---------------------------------------------------------------------------
+#
+# The taxa table stores parent_id as a local PK reference (parent_id -> taxa.id),
+# not iNat-id. These fixtures set id explicitly so parent_id resolution is
+# unambiguous.
+
+def test_classify_to_keypoint_group_bird(tmp_path):
+    from taxonomy import classify_to_keypoint_group
+
+    db = Database(str(tmp_path / "x.db"))
+    db.conn.execute(
+        "INSERT INTO taxa (id, inat_id, name, rank, kingdom) "
+        "VALUES (3, 3, 'Aves', 'class', 'Animalia')"
+    )
+    db.conn.execute(
+        "INSERT INTO taxa (id, inat_id, name, rank, kingdom, parent_id) "
+        "VALUES (7019, 7019, 'Passeriformes', 'order', 'Animalia', 3)"
+    )
+    db.conn.execute(
+        "INSERT INTO taxa (id, inat_id, name, rank, kingdom, parent_id) "
+        "VALUES (12345, 12345, 'Cardinalis cardinalis', 'species', 'Animalia', 7019)"
+    )
+    db.conn.commit()
+    assert classify_to_keypoint_group(db, 12345) == "Aves"
+
+
+def test_classify_to_keypoint_group_mammal(tmp_path):
+    from taxonomy import classify_to_keypoint_group
+
+    db = Database(str(tmp_path / "x.db"))
+    db.conn.execute(
+        "INSERT INTO taxa (id, inat_id, name, rank, kingdom) "
+        "VALUES (40151, 40151, 'Mammalia', 'class', 'Animalia')"
+    )
+    db.conn.execute(
+        "INSERT INTO taxa (id, inat_id, name, rank, kingdom, parent_id) "
+        "VALUES (42158, 42158, 'Carnivora', 'order', 'Animalia', 40151)"
+    )
+    db.conn.execute(
+        "INSERT INTO taxa (id, inat_id, name, rank, kingdom, parent_id) "
+        "VALUES (42048, 42048, 'Vulpes vulpes', 'species', 'Animalia', 42158)"
+    )
+    db.conn.commit()
+    assert classify_to_keypoint_group(db, 42048) == "Mammalia"
+
+
+def test_classify_to_keypoint_group_fish_returns_none(tmp_path):
+    from taxonomy import classify_to_keypoint_group
+
+    db = Database(str(tmp_path / "x.db"))
+    db.conn.execute(
+        "INSERT INTO taxa (id, inat_id, name, rank, kingdom) "
+        "VALUES (47178, 47178, 'Actinopterygii', 'class', 'Animalia')"
+    )
+    db.conn.execute(
+        "INSERT INTO taxa (id, inat_id, name, rank, kingdom, parent_id) "
+        "VALUES (47179, 47179, 'Perciformes', 'order', 'Animalia', 47178)"
+    )
+    db.conn.execute(
+        "INSERT INTO taxa (id, inat_id, name, rank, kingdom, parent_id) "
+        "VALUES (99999, 99999, 'Somefish somefish', 'species', 'Animalia', 47179)"
+    )
+    db.conn.commit()
+    assert classify_to_keypoint_group(db, 99999) is None
+
+
+def test_classify_to_keypoint_group_unknown_returns_none(tmp_path):
+    from taxonomy import classify_to_keypoint_group
+
+    db = Database(str(tmp_path / "x.db"))
+    assert classify_to_keypoint_group(db, 999999) is None
+
+
+def test_classify_to_keypoint_group_none_input(tmp_path):
+    from taxonomy import classify_to_keypoint_group
+
+    db = Database(str(tmp_path / "x.db"))
+    assert classify_to_keypoint_group(db, None) is None


### PR DESCRIPTION
## Summary
- New per-photo eye-focus signal replaces body-level sharpness in the composite when a SuperAnimal keypoint model confidently localizes the eye.
- New `reject_eye_soft` hard-reject rule catches "sharp body, soft eye" frames that previously slipped past the existing `out_of_focus` check.
- Two new ONNX keypoint models (SuperAnimal-Quadruped, SuperAnimal-Bird), opt-in download via the Pipeline page, taxonomy-routed from the top-1 species classification. RTMPose-animal shipped alongside as an integration spike.
- Four new nullable columns on `photos` (`eye_x`, `eye_y`, `eye_conf`, `eye_tenengrad`). Safe migration; no rescoring on upgrade.
- Review lightbox shows an amber crosshair at the eye position on photos that ran the stage.

## Architecture
Pipeline stage `detect_eye_keypoints_stage` sits between masking and scoring. For each eligible photo it:
1. Gates on classifier confidence + species class ∈ {Aves, Mammalia} (via `predictions.taxonomy_class`, with a `classify_to_keypoint_group` fallback).
2. Gates on keypoint-model weights being present (no auto-download).
3. Gates on the eye keypoint's own confidence.
4. Gates on the eye keypoint landing inside the subject mask.

If all gates pass, the windowed multi-scale Tenengrad around the eye is persisted raw. Scoring computes an ephemeral `eye_focus_score` as the percentile rank within the eye cohort (photos that also have an eye signal), replacing the body-level focus term for that photo.

## Design and plan
- `docs/plans/2026-04-16-eye-focus-detection-design.md`
- `docs/plans/2026-04-16-eye-focus-detection-plan.md`

## What's not done yet
- **Real SuperAnimal / RTMPose weights have not been exported or uploaded.** Export code and `[export]` extras are in place; manual steps deferred (see docstrings on `export_superanimal_quadruped` + `export_rtmpose_animal` in `scripts/export_onnx.py`). Until weights land on the HF repo, the Pipeline page's Eye Keypoints card shows "Not downloaded" and the stage runs as a no-op, so the rest of the pipeline is unchanged.
- **UI not driven in a browser by me** — I verified rendered HTML for the lightbox crosshair and the Eye Keypoints card, but visual layout and the zoom/pan crosshair-tracking behavior need a human pass on a real library.

## Test plan
- [x] `python -m pytest vireo/tests/ -q` passes (1347 pass, 2 skipped; 3 pre-existing failures on main unchanged by this branch)
- [x] New tests: `test_keypoints.py` (5), `test_quality.py` (4 eye), `test_taxonomy.py` (5), `test_pipeline.py` (8 eye-stage), `test_scoring.py` (5 eye-focus), `test_config.py` (3 eye flow), `test_db.py` (3 eye)
- [ ] Dev-only: `tests/e2e/test_eye_keypoints.py` after dropping a fixture mammal photo + setting hand-labeled ground truth
- [ ] Manual dogfood on a real library: crosshair appears on mammal portraits
- [ ] Manual dogfood: fish / reptile photos unchanged (fallback path)
- [ ] Manual dogfood: back-of-head shots unchanged (gate 3 catches low eye conf)
- [ ] Manual dogfood: `eye_soft` reject reason appears on sharp-body soft-eye frames
- [ ] Manual dogfood: opt-in download via the Pipeline page fetches weights and transitions the card to "Ready"

🤖 Generated with [Claude Code](https://claude.com/claude-code)