### PR TITLE
fix: browse keyboard shortcuts act on full multi-selection

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1958,7 +1958,12 @@ function selectPhoto(e, id, idx) {
       if (photos[i]) selectedPhotos.add(photos[i].id);
     }
   } else if (e.metaKey || e.ctrlKey) {
-    // Cmd/Ctrl-click: toggle in selection
+    // Cmd/Ctrl-click: toggle in selection. Fold the focused photo into the
+    // set so batch operations include it (otherwise the highlighted
+    // selectedPhotoId is silently excluded from keyboard shortcuts).
+    if (selectedPhotos.size === 0 && selectedPhotoId !== null) {
+      selectedPhotos.add(selectedPhotoId);
+    }
     if (selectedPhotos.has(id)) {
       selectedPhotos.delete(id);
     } else {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2024,6 +2024,24 @@ async function batchSetFlag(flag) {
   showUndoToast();
 }
 
+async function batchSetColorLabel(color) {
+  var ids = Array.from(selectedPhotos);
+  if (!ids.length) return;
+  colorLabelGen++;
+  try {
+    await safeFetch('/api/batch/color_label', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: ids, color: color}),
+    });
+  } catch(e) { return; }
+  ids.forEach(function(id) {
+    if (color) colorLabels[id] = color;
+    else delete colorLabels[id];
+  });
+  renderGrid();
+  showUndoToast();
+}
+
 function batchAddKeyword() {
   document.getElementById('batchKeywordTitle').textContent = 'Add keyword to ' + selectedPhotos.size + ' photos';
   document.getElementById('batchKeywordInput').value = '';
@@ -2689,24 +2707,32 @@ document.addEventListener('keydown', function(e) {
     }
   }
 
+  var multi = selectedPhotos.size > 1;
+
   // Ratings: 0-5
-  if (selectedPhotoId) {
+  if (multi || selectedPhotoId) {
     for (var r = 0; r <= 5; r++) {
-      if (matchesShortcut(e, _shortcuts['rate_' + r])) { setRating(selectedPhotoId, r); return; }
+      if (matchesShortcut(e, _shortcuts['rate_' + r])) {
+        if (multi) batchSetRating(r);
+        else setRating(selectedPhotoId, r);
+        return;
+      }
     }
   }
 
   // Flag, reject, unflag
-  if (selectedPhotoId) {
-    if (matchesShortcut(e, _shortcuts.flag)) { e.preventDefault(); setFlag('flagged'); }
-    else if (matchesShortcut(e, _shortcuts.reject)) { e.preventDefault(); setFlag('rejected'); }
-    else if (matchesShortcut(e, _shortcuts.unflag)) { e.preventDefault(); setFlag('none'); }
+  if (multi || selectedPhotoId) {
+    var applyFlag = multi ? batchSetFlag : setFlag;
+    var applyColor = multi ? batchSetColorLabel : setColorLabel;
+    if (matchesShortcut(e, _shortcuts.flag)) { e.preventDefault(); applyFlag('flagged'); }
+    else if (matchesShortcut(e, _shortcuts.reject)) { e.preventDefault(); applyFlag('rejected'); }
+    else if (matchesShortcut(e, _shortcuts.unflag)) { e.preventDefault(); applyFlag('none'); }
 
     // Color labels
-    if (matchesShortcut(e, _shortcuts.color_red)) { e.preventDefault(); setColorLabel('red'); }
-    else if (matchesShortcut(e, _shortcuts.color_yellow)) { e.preventDefault(); setColorLabel('yellow'); }
-    else if (matchesShortcut(e, _shortcuts.color_green)) { e.preventDefault(); setColorLabel('green'); }
-    else if (matchesShortcut(e, _shortcuts.color_blue)) { e.preventDefault(); setColorLabel('blue'); }
+    if (matchesShortcut(e, _shortcuts.color_red)) { e.preventDefault(); applyColor('red'); }
+    else if (matchesShortcut(e, _shortcuts.color_yellow)) { e.preventDefault(); applyColor('yellow'); }
+    else if (matchesShortcut(e, _shortcuts.color_green)) { e.preventDefault(); applyColor('green'); }
+    else if (matchesShortcut(e, _shortcuts.color_blue)) { e.preventDefault(); applyColor('blue'); }
   }
 });
 


### PR DESCRIPTION
## Summary

In browse mode, pressing **X** (reject), **P** (flag), **U** (unflag), a rating digit, or a color-label key after multi-selecting photos only affected `selectedPhotoId` — the single photo loaded into the detail pane — instead of the full selection. Rejecting 3 cmd-/shift-selected photos by hitting X would reject just one (or none, if no normal click had preceded the range select).

This PR routes those shortcuts through the existing batch handlers when `selectedPhotos.size > 1`.

## Changes

- `vireo/templates/browse.html`: added `batchSetColorLabel(color)` wrapping `/api/batch/color_label`, and updated the global keydown handler so flag/rating/color-label shortcuts call `batchSet*` when multi-select is active. Single-select behavior unchanged.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` — 499 passed
- [x] Headless-browser check: click photo A, shift-click photo C → `selectedPhotos = {A, B, C}`, press X → all 3 have `flag == "rejected"` via `/api/photos/<id>`
- [x] Regression: normal-click single photo, press X → only that photo rejected, others untouched