### PR TITLE
Show all MegaDetector boxes in browse grid

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1523,9 +1523,12 @@ def create_app(db_path, thumb_cache_dir=None):
         per_page = max(1, min(request.args.get("per_page", default_per_page, type=int), _MAX_PER_PAGE))
         photos = db.get_collection_photos(collection_id, page=page, per_page=per_page)
         total = db.count_collection_photos(collection_id)
+        photo_dicts = [dict(p) for p in photos]
+        _attach_species(db, photo_dicts)
+        _attach_detections(db, photo_dicts)
         return jsonify(
             {
-                "photos": [dict(p) for p in photos],
+                "photos": photo_dicts,
                 "page": page,
                 "per_page": per_page,
                 "total": total,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -537,6 +537,21 @@ def create_app(db_path, thumb_cache_dir=None):
             p["species"] = species_map.get(p["id"], [])
         return photo_dicts
 
+    def _attach_detections(db, photo_dicts):
+        """Attach detection bounding boxes to a list of photo dicts (in-place).
+
+        Each photo gets a `detections` list of {x, y, w, h, confidence,
+        category} dicts, ordered by confidence DESC. Photos with no
+        detections get an empty list.
+        """
+        if not photo_dicts:
+            return photo_dicts
+        ids = [p["id"] for p in photo_dicts]
+        det_map = db.get_detections_for_photos(ids)
+        for p in photo_dicts:
+            p["detections"] = det_map.get(p["id"], [])
+        return photo_dicts
+
     @app.route("/api/browse/init")
     def api_browse_init():
         """Combined endpoint for browse page initial load — one request instead of five."""
@@ -555,6 +570,7 @@ def create_app(db_path, thumb_cache_dir=None):
 
         photo_dicts = [dict(p) for p in photos]
         _attach_species(db, photo_dicts)
+        _attach_detections(db, photo_dicts)
 
         return jsonify(
             {
@@ -710,6 +726,7 @@ def create_app(db_path, thumb_cache_dir=None):
 
         photo_dicts = [dict(p) for p in photos]
         _attach_species(db, photo_dicts)
+        _attach_detections(db, photo_dicts)
 
         return jsonify(
             {

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3655,6 +3655,37 @@ class Database:
             (photo_id, self._ws_id()),
         ).fetchall()
 
+    def get_detections_for_photos(self, photo_ids):
+        """Return {photo_id: [det_dict, ...]} for a batch of photos.
+
+        Each det_dict has keys: x, y, w, h, confidence, category.
+        Lists are ordered by confidence DESC. Scoped to the active workspace.
+        Photos with no detections are omitted from the result.
+        """
+        if not photo_ids:
+            return {}
+        placeholders = ",".join("?" for _ in photo_ids)
+        rows = self.conn.execute(
+            f"""SELECT photo_id, box_x, box_y, box_w, box_h,
+                       detector_confidence, category
+                FROM detections
+                WHERE workspace_id = ?
+                  AND photo_id IN ({placeholders})
+                ORDER BY photo_id, detector_confidence DESC""",
+            [self._ws_id(), *photo_ids],
+        ).fetchall()
+        result = {}
+        for r in rows:
+            result.setdefault(r["photo_id"], []).append({
+                "x": r["box_x"],
+                "y": r["box_y"],
+                "w": r["box_w"],
+                "h": r["box_h"],
+                "confidence": r["detector_confidence"],
+                "category": r["category"],
+            })
+        return result
+
     def clear_detections(self, photo_id):
         """Remove all detections (and cascaded predictions) for a photo."""
         self.conn.execute(

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1871,16 +1871,17 @@ function renderGrid() {
   photos.forEach(function(p, idx) {
     var selectedClass = (p.id === selectedPhotoId || selectedPhotos.has(p.id)) ? ' selected' : '';
 
-    // Detection box overlay
+    // Detection box overlays — render one per detection in the photo
     var boxHtml = '';
-    if (showDetectionBoxes && p.detection_box) {
-      var db = typeof p.detection_box === 'string' ? JSON.parse(p.detection_box) : p.detection_box;
-      if (db && db.x != null) {
-        var conf = p.detection_conf ? Math.round(p.detection_conf * 100) + '%' : '';
-        boxHtml = '<div class="det-box" style="left:' + (db.x * 100) + '%;top:' + (db.y * 100) + '%;width:' + (db.w * 100) + '%;height:' + (db.h * 100) + '%;">' +
-          (conf ? '<span class="det-box-label">' + conf + '</span>' : '') +
+    if (showDetectionBoxes && Array.isArray(p.detections)) {
+      p.detections.forEach(function(d) {
+        if (d == null || d.x == null) return;
+        var conf = (d.confidence != null) ? Math.round(d.confidence * 100) + '%' : '';
+        var cat = (d.category && d.category !== 'animal') ? escapeHtml(d.category) + ' ' : '';
+        boxHtml += '<div class="det-box" style="left:' + (d.x * 100) + '%;top:' + (d.y * 100) + '%;width:' + (d.w * 100) + '%;height:' + (d.h * 100) + '%;">' +
+          ((cat || conf) ? '<span class="det-box-label">' + cat + conf + '</span>' : '') +
         '</div>';
-      }
+      });
     }
 
     var clipBadge = '';

--- a/vireo/tests/test_collections_api.py
+++ b/vireo/tests/test_collections_api.py
@@ -127,6 +127,37 @@ def test_collection_photos_with_rating_rule(app_and_db):
     assert data["total"] == 2
 
 
+def test_collection_photos_includes_detections_and_species(app_and_db):
+    """GET /api/collections/<id>/photos attaches detections and species so the
+    browse grid's detection-box toggle works in collection view."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    target = [p for p in db.get_photos() if p["filename"] == "bird1.jpg"][0]
+    db.save_detections(target["id"], [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.7, "category": "animal"},
+        {"box": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2}, "confidence": 0.95, "category": "animal"},
+    ], detector_model="MDV6")
+
+    rules = [{"field": "rating", "op": ">=", "value": 3}]
+    resp = client.post("/api/collections", json={"name": "Rated", "rules": rules})
+    cid = resp.get_json()["id"]
+
+    resp = client.get(f"/api/collections/{cid}/photos")
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    bird1 = [p for p in data["photos"] if p["filename"] == "bird1.jpg"][0]
+    assert "detections" in bird1
+    assert len(bird1["detections"]) == 2
+    assert bird1["detections"][0]["confidence"] == 0.95
+    assert "species" in bird1
+
+    bird3 = [p for p in data["photos"] if p["filename"] == "bird3.jpg"][0]
+    assert bird3["detections"] == []
+
+
 def test_collection_photos_pagination(app_and_db):
     """GET collection photos with per_page=1 returns at most 1 photo."""
     app, db = app_and_db

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1958,6 +1958,59 @@ def test_get_detections_for_photo(tmp_path):
     assert result[0]["detector_model"] == "MDV6"
 
 
+def test_get_detections_for_photos_batch(tmp_path):
+    """get_detections_for_photos should return all detections grouped by photo_id."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos")
+    p1 = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg", file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename="b.jpg", extension=".jpg", file_size=100, file_mtime=2.0)
+    p3 = db.add_photo(folder_id=fid, filename="c.jpg", extension=".jpg", file_size=100, file_mtime=3.0)
+    db.save_detections(p1, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.8, "category": "animal"},
+        {"box": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2}, "confidence": 0.95, "category": "animal"},
+    ], detector_model="MDV6")
+    db.save_detections(p2, [
+        {"box": {"x": 0.2, "y": 0.2, "w": 0.1, "h": 0.1}, "confidence": 0.7, "category": "person"},
+    ], detector_model="MDV6")
+
+    result = db.get_detections_for_photos([p1, p2, p3])
+
+    assert set(result.keys()) == {p1, p2}
+    assert len(result[p1]) == 2
+    assert result[p1][0]["confidence"] == 0.95
+    assert result[p1][1]["confidence"] == 0.8
+    assert result[p1][0]["x"] == 0.5
+    assert result[p1][0]["category"] == "animal"
+    assert len(result[p2]) == 1
+    assert result[p2][0]["category"] == "person"
+
+
+def test_get_detections_for_photos_empty(tmp_path):
+    """get_detections_for_photos with empty input returns empty dict."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    assert db.get_detections_for_photos([]) == {}
+
+
+def test_get_detections_for_photos_scoped_to_workspace(tmp_path):
+    """get_detections_for_photos must not leak detections from other workspaces."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos")
+    db.add_workspace_folder(db._ws_id(), fid)
+    pid = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg", file_size=100, file_mtime=1.0)
+    db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.9, "category": "animal"},
+    ], detector_model="MDV6")
+
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+
+    result = db.get_detections_for_photos([pid])
+    assert result == {}
+
+
 def test_clear_detections(tmp_path):
     """clear_detections should remove detections and cascade to predictions."""
     from db import Database

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -66,6 +66,33 @@ def test_api_photos_filter_single_day(app_and_db):
     assert data['photos'][0]['filename'] == 'bird1.jpg'
 
 
+def test_api_photos_includes_all_detections(app_and_db):
+    """GET /api/photos attaches a `detections` list with every box, not just primary."""
+    app, db = app_and_db
+    photos = db.get_photos()
+    target = [p for p in photos if p['filename'] == 'bird1.jpg'][0]
+    db.save_detections(target['id'], [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.7, "category": "animal"},
+        {"box": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2}, "confidence": 0.95, "category": "animal"},
+    ], detector_model="MDV6")
+
+    client = app.test_client()
+    resp = client.get('/api/photos')
+    data = resp.get_json()
+
+    bird1 = [p for p in data['photos'] if p['filename'] == 'bird1.jpg'][0]
+    assert 'detections' in bird1
+    assert len(bird1['detections']) == 2
+    assert bird1['detections'][0]['confidence'] == 0.95
+    assert bird1['detections'][0]['x'] == 0.5
+    assert bird1['detections'][1]['confidence'] == 0.7
+    assert bird1['detections'][0]['category'] == 'animal'
+
+    # Photos without detections get an empty list, not a missing key
+    bird3 = [p for p in data['photos'] if p['filename'] == 'bird3.jpg'][0]
+    assert bird3['detections'] == []
+
+
 def test_api_photos_filter_keyword(app_and_db):
     """GET /api/photos?keyword= filters by keyword."""
     app, _ = app_and_db


### PR DESCRIPTION
## Summary

- The browse grid's detection-box toggle was effectively dead: it read `p.detection_box` / `p.detection_conf`, but those fields are no longer attached anywhere in `/api/photos`. (The columns were removed from the `photos` table when detections moved to their own table — see `pipeline.py:146`.)
- Revived the toggle and widened it to render **every** detection per photo instead of the primary (highest-confidence) one, so multi-animal shots now visually show a box per subject.
- Bonus: each label now shows the MegaDetector category ("person", "vehicle") when it's not a plain "animal", so a photo with a person in it is identifiable at a glance without opening it.

## What changed

- `vireo/db.py` — new `get_detections_for_photos(photo_ids)` batch method that returns `{photo_id: [det_dict, ...]}` scoped to the active workspace.
- `vireo/app.py` — new `_attach_detections(db, photo_dicts)` helper, wired into `/api/photos` and `/api/browse/init` alongside `_attach_species`.
- `vireo/templates/browse.html` — replaced singular `p.detection_box` handling with a loop over `p.detections`, producing one `.det-box` per detection.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` — 503 passed
- [x] New unit tests: `test_get_detections_for_photos_batch`, `test_get_detections_for_photos_empty`, `test_get_detections_for_photos_scoped_to_workspace`
- [x] New API test: `test_api_photos_includes_all_detections`
- [ ] Manual: open browse page on a library with known multi-animal shots, toggle detection boxes on, confirm all boxes render

## Not in this PR (follow-ups from the audit)

Gaps #2–#6 from the multi-animal audit remain open: single-photo API still returns only the primary box; masking/quality scoring run only on the primary detection; no "≥ N detections" or "contains species X AND Y" filter; keyword-derived species picks alphabetically first when multiple apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)