### PR TITLE
fix: reset species input when opening pipeline review group

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2114,6 +2114,11 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
 
   document.getElementById('grmOverlay').classList.add('open');
 
+  // Reset the species input to this encounter's value so a stale value from a
+  // previously-reviewed group doesn't leak in when the prior modal was closed
+  // via × or Escape (only Apply & Close clears it).
+  document.getElementById('grmSpecies').value = enc.confirmed_species || (enc.species ? enc.species[0] : '') || '';
+
   // Sync slider DOM with persisted resolution choice
   var slider = document.getElementById('grmResSlider');
   if (slider) slider.value = grmResolutionIdx;


### PR DESCRIPTION
## Summary

On the pipeline review page, the group review modal's "Species" input at the bottom leaked the previously-reviewed group's value. E.g. after reviewing a Canada Goose group and opening a Gadwall group, the field still read "Canada Goose" even though the encounter's predictions were gadwall.

## Root cause

- `openGroupReview()` resets `grmState` but never touches the `grmSpecies` DOM input.
- `renderGroupModal()` populates the field only when it is empty (so user edits aren't overwritten on re-render during a session).
- Only the "Apply & Close" path clears the field; closing via × or Escape leaves the old value in the DOM.
- Net effect: opening the next group sees a non-empty field and skips repopulating, showing the stale species.

## Fix

Unconditionally set `grmSpecies` to the opened encounter's `confirmed_species || species[0]` inside `openGroupReview`, mirroring the fresh reset already done for `grmState`. The existing empty-guard in `renderGroupModal` still protects user edits from being clobbered by re-renders.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` — 499 passed
- [x] `python -m pytest tests/e2e/test_pipeline.py` — 12 passed
- [ ] Manual: open a group with species A, close via × or Escape, open a different group with species B — footer now shows B, not A