### PR TITLE
feat: user-first testing scenarios — browse, cull, rate/flag (PR #2)

### DIFF
--- a/vireo/testing/userfirst/harness.py
+++ b/vireo/testing/userfirst/harness.py
@@ -1,5 +1,6 @@
 """User-first testing harness — runs Vireo in a subprocess, drives it via Playwright."""
 import contextlib
+import json
 import os
 import shutil
 import socket
@@ -193,8 +194,17 @@ class VireoSession:
 
 
 @contextmanager
-def vireo_session(name="session", startup_timeout=30.0, keep_runs=20):
+def vireo_session(name="session", startup_timeout=30.0, keep_runs=20, seed=None):
     """Start Vireo against the test profile + launch Playwright; yield a session.
+
+    Args:
+        name: Label for the session (used in reports).
+        startup_timeout: Max seconds to wait for the app health endpoint.
+        keep_runs: Number of past run directories to retain.
+        seed: Optional callable ``(db_path, thumb_dir, photos_root)`` that
+              populates the database and creates thumbnails before the app
+              starts.  When provided, any existing DB at ``db_path`` is
+              deleted first so every session starts from a clean slate.
 
     Requires:
       - VIREO_PROFILE env var set to a safe test directory
@@ -213,6 +223,15 @@ def vireo_session(name="session", startup_timeout=30.0, keep_runs=20):
     paths["thumbnails"].mkdir(parents=True, exist_ok=True)
     paths["runs"].mkdir(parents=True, exist_ok=True)
 
+    # -- Seed: populate DB + thumbnails from scratch if a seed callable is provided --
+    if seed is not None:
+        db_file = paths["db"]
+        # Remove stale DB so the seed always starts fresh
+        for suffix in ("", "-wal", "-shm"):
+            with contextlib.suppress(FileNotFoundError):
+                Path(str(db_file) + suffix).unlink()
+        seed(str(db_file), str(paths["thumbnails"]), str(photos_root) if photos_root else None)
+
     validate_db_folders(paths["db"], photos_root)
 
     run_id = _new_run_id()
@@ -230,6 +249,16 @@ def vireo_session(name="session", startup_timeout=30.0, keep_runs=20):
     # resolve to <profile>/fake_home/.vireo/* — isolated from real data.
     fake_home = profile / "fake_home"
     (fake_home / ".vireo").mkdir(parents=True, exist_ok=True)
+
+    # Ensure the subprocess skips the welcome/setup screen by writing
+    # setup_complete into the config that the subprocess will read.
+    _fake_config = fake_home / ".vireo" / "config.json"
+    _cfg_data = {}
+    if _fake_config.exists():
+        with contextlib.suppress(Exception):
+            _cfg_data = json.loads(_fake_config.read_text())
+    _cfg_data["setup_complete"] = True
+    _fake_config.write_text(json.dumps(_cfg_data, indent=2))
 
     proc, log_fh = _start_app(paths, port, log_file, fake_home)
     print(f"USER-FIRST TEST MODE — profile={profile}, photos={photos_root}, port={port}")

--- a/vireo/testing/userfirst/scenarios/__init__.py
+++ b/vireo/testing/userfirst/scenarios/__init__.py
@@ -1,0 +1,1 @@
+"""Tier-1 user-first test scenarios."""

--- a/vireo/testing/userfirst/scenarios/browse.py
+++ b/vireo/testing/userfirst/scenarios/browse.py
@@ -1,0 +1,32 @@
+"""Scenario: browse the photo grid.
+
+Verifies that /browse renders seeded photos in grid cards, the sidebar is
+present, and the filter bar is visible.
+"""
+
+
+def run(session):
+    session.goto("/browse")
+    session.screenshot("browse-initial")
+
+    # Assert photos appear in the grid
+    photo_count = session.eval(
+        "document.querySelectorAll('.grid-card[data-id]').length"
+    )
+    session.assert_that(photo_count > 0, "expected photos in browse grid")
+
+    # Sidebar should be present with folder tree
+    has_sidebar = session.eval("!!document.querySelector('.sidebar')")
+    session.assert_that(has_sidebar, "expected sidebar on browse page")
+
+    # Filter bar should be visible
+    has_filter_bar = session.eval("!!document.querySelector('.filter-bar')")
+    session.assert_that(has_filter_bar, "expected filter bar on browse page")
+
+    # At least one photo should show a rating (stars)
+    rated_count = session.eval(
+        "document.querySelectorAll('.grid-card-rating').length"
+    )
+    session.assert_that(rated_count > 0, "expected at least one rated photo")
+
+    session.screenshot("browse-populated")

--- a/vireo/testing/userfirst/scenarios/cull.py
+++ b/vireo/testing/userfirst/scenarios/cull.py
@@ -1,0 +1,52 @@
+"""Scenario: visit the culling page.
+
+Verifies that /cull renders, the "Analyze for Culling" button is present,
+and the collection dropdown is populated.  We do not trigger actual analysis
+because that requires ML models.
+"""
+
+
+def run(session):
+    session.goto("/cull")
+
+    # The cull page auto-loads previous results via /api/culling/results.
+    # When no analysis has been run yet this returns a 404, which is
+    # expected behavior — not a bug.  Wait for the page to settle, then
+    # clear any findings that came from that expected 404.
+    session.page.wait_for_timeout(500)
+    session.report.findings = [
+        f
+        for f in session.report.findings
+        if not (
+            f.kind == "BUG"
+            and "/api/culling/results" in f.context.get("url", "")
+            and "404" in f.message
+        )
+    ]
+
+    session.screenshot("cull-initial")
+
+    # The "Analyze for Culling" button should be present
+    has_analyze_btn = session.eval(
+        "!!document.querySelector('button.btn-primary')"
+    )
+    session.assert_that(has_analyze_btn, "expected Analyze for Culling button")
+
+    # Verify the button text matches
+    btn_text = session.eval(
+        "(document.querySelector('button.btn-primary') || {}).textContent || ''"
+    )
+    session.assert_that(
+        "Analyze" in btn_text,
+        f"expected button text to contain 'Analyze', got: {btn_text!r}",
+    )
+
+    # The collection dropdown should exist
+    has_dropdown = session.eval("!!document.getElementById('cullCollection')")
+    session.assert_that(has_dropdown, "expected collection dropdown on cull page")
+
+    # Settings toggle should exist
+    has_settings_btn = session.eval("!!document.getElementById('cullSettingsBtn')")
+    session.assert_that(has_settings_btn, "expected settings toggle button")
+
+    session.screenshot("cull-loaded")

--- a/vireo/testing/userfirst/scenarios/rate_flag.py
+++ b/vireo/testing/userfirst/scenarios/rate_flag.py
@@ -50,14 +50,34 @@ def run(session):
     session.goto("/browse")
     session.screenshot("after-rating-and-flag")
 
-    # Verify the flagged photo shows the flag badge somewhere in the grid
-    flag_badges = session.eval(
-        "document.querySelectorAll('.grid-card-flag.flag-flagged').length"
+    # Verify the *specific* photo we targeted shows the flag badge. A grid-wide
+    # check would pass even if the endpoint failed, because browse_seed already
+    # includes pre-flagged photos.
+    target_flag = session.eval(
+        f"""(() => {{
+            const card = document.querySelector('.grid-card[data-id="{first_id}"]');
+            if (!card) return 'card-missing';
+            return card.querySelector('.grid-card-flag.flag-flagged') ? 'flagged' : 'not-flagged';
+        }})()"""
     )
-    session.assert_that(flag_badges > 0, "expected at least one flagged badge after flagging")
+    session.assert_that(
+        target_flag == "flagged",
+        f"expected photo {first_id} to show flagged badge, got {target_flag!r}",
+    )
 
-    # Verify ratings are displayed (at least one card should have stars)
-    star_spans = session.eval(
-        "document.querySelectorAll('.grid-card-rating').length"
+    # Verify the *specific* photo's rating badge shows 4 stars. Same reasoning
+    # as above: the seed includes pre-rated photos, so a grid-wide check is
+    # insufficient.
+    target_stars = session.eval(
+        f"""(() => {{
+            const card = document.querySelector('.grid-card[data-id="{first_id}"]');
+            if (!card) return null;
+            const el = card.querySelector('.grid-card-rating');
+            return el ? el.textContent : '';
+        }})()"""
     )
-    session.assert_that(star_spans > 0, "expected rating stars after setting rating")
+    star_count = target_stars.count("\u2605") if isinstance(target_stars, str) else -1
+    session.assert_that(
+        star_count == 4,
+        f"expected photo {first_id} to show 4 stars, got {target_stars!r}",
+    )

--- a/vireo/testing/userfirst/scenarios/rate_flag.py
+++ b/vireo/testing/userfirst/scenarios/rate_flag.py
@@ -1,0 +1,63 @@
+"""Scenario: rate and flag photos via the API, verify the browse grid reflects changes.
+
+Uses fetch() calls through page.evaluate to hit the rating and flag API
+endpoints, then reloads the browse page to confirm the UI reflects the
+persisted state.
+"""
+
+
+def run(session):
+    session.goto("/browse")
+    session.screenshot("before-rating")
+
+    # Grab the first photo's data-id from the grid
+    first_id = session.eval(
+        """(() => {
+            const card = document.querySelector('.grid-card[data-id]');
+            return card ? parseInt(card.getAttribute('data-id'), 10) : null;
+        })()"""
+    )
+    session.assert_that(first_id is not None, "expected at least one photo card")
+    if first_id is None:
+        return  # nothing to test
+
+    # Set rating to 4 via API — use XMLHttpRequest synchronously to avoid
+    # race conditions with Playwright's network listeners on navigation.
+    rate_status = session.eval(
+        f"""(() => {{
+            const xhr = new XMLHttpRequest();
+            xhr.open('POST', '/api/photos/{first_id}/rating', false);
+            xhr.setRequestHeader('Content-Type', 'application/json');
+            xhr.send(JSON.stringify({{rating: 4}}));
+            return xhr.status;
+        }})()"""
+    )
+    session.assert_that(rate_status == 200, f"expected rating API 200, got {rate_status}")
+
+    # Flag the photo via API (synchronous XHR)
+    flag_status = session.eval(
+        f"""(() => {{
+            const xhr = new XMLHttpRequest();
+            xhr.open('POST', '/api/photos/{first_id}/flag', false);
+            xhr.setRequestHeader('Content-Type', 'application/json');
+            xhr.send(JSON.stringify({{flag: 'flagged'}}));
+            return xhr.status;
+        }})()"""
+    )
+    session.assert_that(flag_status == 200, f"expected flag API 200, got {flag_status}")
+
+    # Reload browse to see the updated state
+    session.goto("/browse")
+    session.screenshot("after-rating-and-flag")
+
+    # Verify the flagged photo shows the flag badge somewhere in the grid
+    flag_badges = session.eval(
+        "document.querySelectorAll('.grid-card-flag.flag-flagged').length"
+    )
+    session.assert_that(flag_badges > 0, "expected at least one flagged badge after flagging")
+
+    # Verify ratings are displayed (at least one card should have stars)
+    star_spans = session.eval(
+        "document.querySelectorAll('.grid-card-rating').length"
+    )
+    session.assert_that(star_spans > 0, "expected rating stars after setting rating")

--- a/vireo/testing/userfirst/seeds.py
+++ b/vireo/testing/userfirst/seeds.py
@@ -1,0 +1,96 @@
+"""Pre-built seed functions for user-first test scenarios.
+
+Each seed is a callable ``(db_path, thumb_dir, photos_root)`` that populates
+the database and creates placeholder thumbnails so the app starts with
+realistic data visible in the UI.
+"""
+import os
+import sys
+
+# The Database class lives in vireo/ and expects ``from db import Database``.
+# Mirror conftest.py's approach: ensure vireo/ is on sys.path.
+_VIREO_DIR = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+if _VIREO_DIR not in sys.path:
+    sys.path.insert(0, _VIREO_DIR)
+
+
+def _make_thumb(thumb_dir, photo_id):
+    """Create a 100x100 placeholder JPEG thumbnail for *photo_id*."""
+    from PIL import Image
+
+    path = os.path.join(thumb_dir, f"{photo_id}.jpg")
+    if not os.path.exists(path):
+        Image.new("RGB", (100, 100), color=(80, 120, 80)).save(path)
+
+
+def browse_seed(db_path, thumb_dir, photos_root):
+    """Minimal seed: workspace, 3 folders, ~10 photos with keywords and ratings.
+
+    Creates tiny placeholder thumbnails so the browse grid renders cards.
+    """
+    from db import Database
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    # Use photos_root when available so validate_db_folders passes;
+    # fall back to synthetic paths for headless CI.
+    base = photos_root if photos_root else "/test/photos"
+
+    f1 = db.add_folder(os.path.join(base, "wildlife"), name="wildlife")
+    f2 = db.add_folder(os.path.join(base, "landscapes"), name="landscapes")
+    f3 = db.add_folder(
+        os.path.join(base, "wildlife", "birds"), name="birds", parent_id=f1
+    )
+
+    photos = []
+    specs = [
+        # (folder, filename, ext, size, mtime, timestamp, rating, flag)
+        (f1, "eagle01.jpg", ".jpg", 5000, 1.0, "2024-03-10T08:00:00", 5, None),
+        (f1, "eagle02.jpg", ".jpg", 4800, 2.0, "2024-03-10T08:01:00", 4, None),
+        (f3, "robin01.jpg", ".jpg", 3200, 3.0, "2024-04-05T07:30:00", 3, None),
+        (f3, "robin02.nef", ".nef", 25000, 4.0, "2024-04-05T07:31:00", 0, None),
+        (f3, "sparrow01.jpg", ".jpg", 2800, 5.0, "2024-05-12T06:00:00", 0, None),
+        (f2, "sunset01.jpg", ".jpg", 6000, 6.0, "2024-06-20T19:45:00", 2, "flagged"),
+        (f2, "mountain01.jpg", ".jpg", 7000, 7.0, "2024-07-04T10:00:00", 0, None),
+        (f1, "hawk01.jpg", ".jpg", 4500, 8.0, "2024-08-15T11:00:00", 1, None),
+        (f3, "finch01.jpg", ".jpg", 3100, 9.0, "2024-09-01T16:00:00", 0, "rejected"),
+        (f1, "heron01.jpg", ".jpg", 5200, 10.0, "2024-10-22T14:30:00", 0, None),
+    ]
+
+    for folder_id, fname, ext, size, mtime, ts, rating, flag in specs:
+        pid = db.add_photo(
+            folder_id=folder_id,
+            filename=fname,
+            extension=ext,
+            file_size=size,
+            file_mtime=mtime,
+            timestamp=ts,
+        )
+        photos.append(pid)
+        if rating:
+            db.update_photo_rating(pid, rating)
+        if flag:
+            db.update_photo_flag(pid, flag)
+
+    # Add keywords and tag some photos
+    k_eagle = db.add_keyword("Eagle", is_species=True)
+    k_robin = db.add_keyword("Robin", is_species=True)
+    k_sparrow = db.add_keyword("Sparrow", is_species=True)
+    k_wildlife = db.add_keyword("Wildlife")
+
+    db.tag_photo(photos[0], k_eagle)
+    db.tag_photo(photos[1], k_eagle)
+    db.tag_photo(photos[2], k_robin)
+    db.tag_photo(photos[3], k_robin)
+    db.tag_photo(photos[4], k_sparrow)
+    db.tag_photo(photos[0], k_wildlife)
+    db.tag_photo(photos[2], k_wildlife)
+
+    # Create thumbnails
+    os.makedirs(thumb_dir, exist_ok=True)
+    for pid in photos:
+        _make_thumb(thumb_dir, pid)
+
+    db.conn.close()

--- a/vireo/tests/test_userfirst_scenarios.py
+++ b/vireo/tests/test_userfirst_scenarios.py
@@ -1,0 +1,86 @@
+"""Integration tests for Tier-1 user-first scenarios.
+
+Each test starts Vireo in a subprocess with seeded data, runs a scenario
+via Playwright, and asserts the report contains no BUG findings.
+
+Requirements:
+  - ``playwright`` with Chromium installed (``playwright install chromium``)
+  - ``Pillow`` for thumbnail generation
+"""
+import pytest
+
+try:
+    from playwright.sync_api import sync_playwright as _sync_playwright  # noqa: F401
+
+    _HAS_PLAYWRIGHT = True
+except ImportError:
+    _HAS_PLAYWRIGHT = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_PLAYWRIGHT,
+    reason="playwright is not installed or chromium is not available",
+)
+
+
+@pytest.fixture()
+def userfirst_env(tmp_path, monkeypatch):
+    """Set up env vars pointing at a temp profile + fake photos root."""
+    profile_dir = tmp_path / "profile"
+    profile_dir.mkdir()
+    photos_root = tmp_path / "photos"
+    photos_root.mkdir()
+    monkeypatch.setenv("VIREO_PROFILE", str(profile_dir))
+    monkeypatch.setenv("VIREO_TEST_PHOTOS", str(photos_root))
+    return {"profile": profile_dir, "photos_root": photos_root}
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+def test_browse_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import browse
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="browse", seed=browse_seed) as session:
+        browse.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"browse scenario reported bugs:\n{msg}")
+
+
+def test_cull_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import cull
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="cull", seed=browse_seed) as session:
+        cull.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"cull scenario reported bugs:\n{msg}")
+
+
+def test_rate_flag_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import rate_flag
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="rate_flag", seed=browse_seed) as session:
+        rate_flag.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"rate_flag scenario reported bugs:\n{msg}")

--- a/vireo/tests/test_userfirst_scenarios.py
+++ b/vireo/tests/test_userfirst_scenarios.py
@@ -7,6 +7,8 @@ Requirements:
   - ``playwright`` with Chromium installed (``playwright install chromium``)
   - ``Pillow`` for thumbnail generation
 """
+from pathlib import Path
+
 import pytest
 
 try:
@@ -16,8 +18,20 @@ try:
 except ImportError:
     _HAS_PLAYWRIGHT = False
 
+
+def _chromium_installed():
+    if not _HAS_PLAYWRIGHT:
+        return False
+    cache = Path.home() / "Library" / "Caches" / "ms-playwright"
+    if not cache.exists():
+        cache = Path.home() / ".cache" / "ms-playwright"
+    if not cache.exists():
+        return False
+    return any(p.name.startswith("chromium") for p in cache.iterdir())
+
+
 pytestmark = pytest.mark.skipif(
-    not _HAS_PLAYWRIGHT,
+    not _chromium_installed(),
     reason="playwright is not installed or chromium is not available",
 )
 


### PR DESCRIPTION
## Summary

Second PR of the rollout plan from #594. Adds the seed mechanism and three Tier-1 scenarios that actually drive the UI.

**Seed mechanism:** \`vireo_session(seed=browse_seed)\` now accepts a callable that populates the test DB before Flask starts. Includes \`browse_seed()\` which creates a workspace, 3 folders, 10 photos with varied ratings/flags/keywords, and placeholder thumbnails.

**Scenarios:**

- **browse.py** — navigates \`/browse\`, asserts grid cards render with photo IDs, verifies sidebar + filter bar exist, checks rated photos show stars
- **cull.py** — navigates \`/cull\`, asserts "Analyze for Culling" button + settings toggle exist. Filters the expected 404 from \`/api/culling/results\` (no analysis has been run)
- **rate_flag.py** — navigates \`/browse\`, reads first photo ID from the grid, rates it 4 stars and flags it via synchronous XHR, reloads the page, verifies the flag badge and rating stars render in the UI

## Test plan

- [x] 3 new integration tests pass (browse, cull, rate_flag scenarios)
- [x] Mandated suite: 503 passed
- [x] Ruff clean
- [ ] Run scenarios manually against a seeded profile and inspect screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)