### PR TITLE
feat: user-first testing — remaining 6 scenarios (PR #3)

### DIFF
--- a/vireo/testing/userfirst/scenarios/duplicates.py
+++ b/vireo/testing/userfirst/scenarios/duplicates.py
@@ -1,0 +1,65 @@
+"""Scenario: visit the duplicates detection page.
+
+Verifies that /duplicates renders, the "Scan for duplicate files" button
+is present, and the empty state is shown when no duplicates have been
+scanned.
+"""
+
+
+def run(session):
+    session.goto("/duplicates")
+    session.screenshot("duplicates-initial")
+
+    # The page header should contain "Duplicate Files"
+    header_text = session.eval(
+        """(() => {
+            const h1 = document.querySelector('.page-header h1');
+            return h1 ? h1.textContent.trim() : '';
+        })()"""
+    )
+    session.assert_that(
+        "Duplicate" in header_text,
+        f"expected 'Duplicate' in page header, got {header_text!r}",
+    )
+
+    # The "Scan for duplicate files" button should exist
+    has_scan_btn = session.eval("!!document.getElementById('scanBtn')")
+    session.assert_that(has_scan_btn, "expected scan button on duplicates page")
+
+    # Verify scan button text
+    scan_btn_text = session.eval(
+        "(document.getElementById('scanBtn') || {}).textContent || ''"
+    )
+    session.assert_that(
+        "Scan" in scan_btn_text,
+        f"expected 'Scan' in button text, got {scan_btn_text!r}",
+    )
+
+    # The empty state should be visible (no scan has been performed)
+    empty_visible = session.eval(
+        """(() => {
+            const el = document.getElementById('emptyState');
+            return el ? el.style.display !== 'none' : false;
+        })()"""
+    )
+    session.assert_that(empty_visible, "expected empty state visible before scan")
+
+    # The progress box should be hidden
+    progress_hidden = session.eval(
+        """(() => {
+            const el = document.getElementById('progress');
+            return el ? el.style.display === 'none' : true;
+        })()"""
+    )
+    session.assert_that(progress_hidden, "expected progress box hidden before scan")
+
+    # The apply bar should be hidden (no results to apply)
+    apply_hidden = session.eval(
+        """(() => {
+            const el = document.getElementById('applyBar');
+            return el ? el.style.display === 'none' : true;
+        })()"""
+    )
+    session.assert_that(apply_hidden, "expected apply bar hidden before scan")
+
+    session.screenshot("duplicates-empty-state")

--- a/vireo/testing/userfirst/scenarios/keywords.py
+++ b/vireo/testing/userfirst/scenarios/keywords.py
@@ -4,12 +4,26 @@ Verifies that /keywords renders the keyword table with seeded data,
 filter pills are present and clickable, and the search input exists.
 """
 
+import contextlib
+
 
 def run(session):
     session.goto("/keywords")
 
-    # Wait for the keywords to load via /api/keywords/all
-    session.page.wait_for_timeout(1000)
+    # Wait for the /api/keywords/all fetch to resolve and render() to run,
+    # which replaces the initial "Loading..." stats text.  A fixed sleep
+    # races the fetch on a loaded CI runner and causes false BUGs on the
+    # row/stats assertions below; waiting on the condition makes the
+    # scenario deterministic across network-latency variation.  On
+    # timeout we fall through so the assertions below surface the state.
+    with contextlib.suppress(Exception):
+        session.page.wait_for_function(
+            """() => {
+                const s = document.getElementById('kwStats');
+                return s && !s.textContent.includes('Loading');
+            }""",
+            timeout=10000,
+        )
 
     session.screenshot("keywords-initial")
 

--- a/vireo/testing/userfirst/scenarios/keywords.py
+++ b/vireo/testing/userfirst/scenarios/keywords.py
@@ -1,0 +1,76 @@
+"""Scenario: visit the keywords management page.
+
+Verifies that /keywords renders the keyword table with seeded data,
+filter pills are present and clickable, and the search input exists.
+"""
+
+
+def run(session):
+    session.goto("/keywords")
+
+    # Wait for the keywords to load via /api/keywords/all
+    session.page.wait_for_timeout(1000)
+
+    session.screenshot("keywords-initial")
+
+    # The search input should be present
+    has_search = session.eval("!!document.getElementById('kwSearch')")
+    session.assert_that(has_search, "expected keyword search input")
+
+    # Filter pills should exist: All, General, Taxonomy, Location, Descriptive, People, Event
+    filter_btns = session.eval(
+        "Array.from(document.querySelectorAll('.kw-filter-btn')).map(b => b.dataset.type)"
+    )
+    expected_types = ["all", "general", "taxonomy", "location", "descriptive", "people", "event"]
+    for t in expected_types:
+        session.assert_that(
+            t in filter_btns,
+            f"expected filter button with data-type='{t}', got {filter_btns!r}",
+        )
+
+    # The "All" filter should be active by default
+    active_filter = session.eval(
+        """(() => {
+            const btn = document.querySelector('.kw-filter-btn.active');
+            return btn ? btn.dataset.type : null;
+        })()"""
+    )
+    session.assert_that(active_filter == "all", f"expected 'all' filter active, got {active_filter!r}")
+
+    # The keyword table should have rows (browse_seed has 4 keywords)
+    row_count = session.eval(
+        "document.querySelectorAll('#kwBody tr').length"
+    )
+    session.assert_that(row_count >= 4, f"expected at least 4 keyword rows, got {row_count}")
+
+    # Stats should show keyword count
+    stats_text = session.eval(
+        "document.getElementById('kwStats').textContent"
+    )
+    session.assert_that(
+        "keywords" in stats_text.lower() or "of" in stats_text.lower(),
+        f"expected stats text to contain keyword count info, got {stats_text!r}",
+    )
+
+    # Click the Taxonomy filter and verify it becomes active
+    session.click('.kw-filter-btn[data-type="taxonomy"]')
+    session.page.wait_for_timeout(300)
+
+    active_after = session.eval(
+        """(() => {
+            const btn = document.querySelector('.kw-filter-btn.active');
+            return btn ? btn.dataset.type : null;
+        })()"""
+    )
+    session.assert_that(
+        active_after == "taxonomy",
+        f"expected 'taxonomy' filter active after click, got {active_after!r}",
+    )
+
+    session.screenshot("keywords-taxonomy-filter")
+
+    # Click "All" to restore full view
+    session.click('.kw-filter-btn[data-type="all"]')
+    session.page.wait_for_timeout(300)
+
+    session.screenshot("keywords-all-filter")

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -9,16 +9,21 @@ is shown when the seed data has no GPS coordinates.
 def run(session):
     session.goto("/map")
 
-    # The map page loads Leaflet from unpkg.com — external CDN requests
-    # may fail in CI or offline environments.  Filter out those failures
-    # so they don't flag as bugs against Vireo itself.
+    # The map page loads Leaflet from unpkg.com.  The harness only records
+    # context.url for same-origin requests, so CDN failures won't appear
+    # there.  The real offline failure mode is a downstream console error
+    # like "ReferenceError: L is not defined" when the Leaflet global is
+    # missing.  Filter both patterns so CDN outages don't flag as Vireo bugs.
     session.page.wait_for_timeout(2000)
     session.report.findings = [
         f
         for f in session.report.findings
         if not (
             f.kind == "BUG"
-            and "unpkg.com" in f.context.get("url", "")
+            and (
+                "L is not defined" in f.message
+                or "leaflet" in f.message.lower()
+            )
         )
     ]
 

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -16,8 +16,11 @@ def run(session):
     # tag for Leaflet is present but L is undefined, the CDN was
     # unavailable — tolerate it.  If the tag is missing entirely,
     # someone broke map.html — that's a real bug we must surface.
+    # Match the core Leaflet script specifically, not any src containing
+    # "leaflet" — map.html also loads leaflet.markercluster.js which would
+    # match the broader selector even if the primary leaflet.js is removed.
     leaflet_script_present = session.eval(
-        "!!document.querySelector('script[src*=\"leaflet\"]')"
+        "!!document.querySelector('script[src*=\"/leaflet.js\"], script[src*=\"/leaflet.min.js\"]')"
     )
     leaflet_loaded = session.eval("typeof L !== 'undefined'")
 

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -5,10 +5,25 @@ controls are present, and the appropriate "no geolocated photos" message
 is shown when the seed data has no GPS coordinates.
 """
 
+import contextlib
+
 
 def run(session):
     session.goto("/map")
-    session.page.wait_for_timeout(2000)
+
+    # Wait for Leaflet to load as a condition rather than a fixed sleep.
+    # When the CDN is reachable this resolves in a few hundred ms; when it's
+    # blocked (offline CI) the timeout fires and we fall through to the
+    # CDN-outage handling below.  The generous 15s budget avoids flaking on
+    # slow networks where a fixed 2s wait would prematurely take the
+    # outage path and skip JS-populated assertions.
+    try:
+        session.page.wait_for_function(
+            "() => typeof L !== 'undefined'", timeout=15000
+        )
+        leaflet_loaded = True
+    except Exception:
+        leaflet_loaded = False
 
     session.screenshot("map-initial")
 
@@ -22,7 +37,6 @@ def run(session):
     leaflet_script_present = session.eval(
         "!!document.querySelector('script[src*=\"/leaflet.js\"], script[src*=\"/leaflet.min.js\"]')"
     )
-    leaflet_loaded = session.eval("typeof L !== 'undefined'")
 
     if not leaflet_script_present:
         # Template regression: Leaflet script tag removed from map.html
@@ -61,6 +75,22 @@ def run(session):
     # --- JS-populated assertions (only when Leaflet loaded successfully) ---
 
     if leaflet_loaded:
+        # Wait for the map JS to populate the status and sidebar rather than
+        # reading them at a fixed time — both start as "Loading..." until the
+        # /api/photos fetch resolves and the render path runs.  On timeout
+        # we fall through so the assertions below surface the stale state.
+        with contextlib.suppress(Exception):
+            session.page.wait_for_function(
+                """() => {
+                    const s = document.getElementById('mapStatus');
+                    const sh = document.getElementById('sidebarHeader');
+                    return s && sh
+                        && s.textContent.trim() !== 'Loading...'
+                        && sh.textContent.trim() !== '';
+                }""",
+                timeout=10000,
+            )
+
         status_text = session.eval(
             "(document.getElementById('mapStatus') || {}).textContent || ''"
         )

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -1,0 +1,76 @@
+"""Scenario: visit the map/geo view page.
+
+Verifies that /map renders, the Leaflet map container exists, filter
+controls are present, and the appropriate "no geolocated photos" message
+is shown when the seed data has no GPS coordinates.
+"""
+
+
+def run(session):
+    session.goto("/map")
+
+    # The map page loads Leaflet from unpkg.com — external CDN requests
+    # may fail in CI or offline environments.  Filter out those failures
+    # so they don't flag as bugs against Vireo itself.
+    session.page.wait_for_timeout(2000)
+    session.report.findings = [
+        f
+        for f in session.report.findings
+        if not (
+            f.kind == "BUG"
+            and "unpkg.com" in f.context.get("url", "")
+        )
+    ]
+
+    session.screenshot("map-initial")
+
+    # The map container div should exist
+    has_map = session.eval("!!document.getElementById('map')")
+    session.assert_that(has_map, "expected #map container on map page")
+
+    # Filter controls should be present
+    has_folder_filter = session.eval("!!document.getElementById('filterFolder')")
+    session.assert_that(has_folder_filter, "expected folder filter dropdown")
+
+    has_rating_filter = session.eval("!!document.getElementById('filterRating')")
+    session.assert_that(has_rating_filter, "expected rating filter dropdown")
+
+    has_species_filter = session.eval("!!document.getElementById('filterSpecies')")
+    session.assert_that(has_species_filter, "expected species filter dropdown")
+
+    has_keyword_filter = session.eval("!!document.getElementById('filterKeyword')")
+    session.assert_that(has_keyword_filter, "expected keyword filter input")
+
+    has_date_from = session.eval("!!document.getElementById('filterDateFrom')")
+    session.assert_that(has_date_from, "expected date-from filter")
+
+    has_date_to = session.eval("!!document.getElementById('filterDateTo')")
+    session.assert_that(has_date_to, "expected date-to filter")
+
+    # The sidebar should exist with a photo count header
+    has_sidebar_header = session.eval("!!document.getElementById('sidebarHeader')")
+    session.assert_that(has_sidebar_header, "expected sidebar header on map page")
+
+    # The map status bar should exist
+    has_status = session.eval("!!document.getElementById('mapStatus')")
+    session.assert_that(has_status, "expected map status bar")
+
+    # Without GPS data, the status should indicate no geolocated photos
+    status_text = session.eval(
+        "(document.getElementById('mapStatus') || {}).textContent || ''"
+    )
+    session.assert_that(
+        "No geolocated" in status_text or "0%" in status_text or "Showing 0" in status_text,
+        f"expected 'no geolocated' or '0%' in status, got {status_text!r}",
+    )
+
+    # The sidebar should show "0 photos"
+    sidebar_text = session.eval(
+        "(document.getElementById('sidebarHeader') || {}).textContent || ''"
+    )
+    session.assert_that(
+        "0 photo" in sidebar_text,
+        f"expected '0 photos' in sidebar header, got {sidebar_text!r}",
+    )
+
+    session.screenshot("map-no-gps-data")

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -8,38 +8,36 @@ is shown when the seed data has no GPS coordinates.
 
 def run(session):
     session.goto("/map")
-
-    # The map page loads Leaflet from unpkg.com.  The harness only records
-    # context.url for same-origin requests, so CDN failures won't appear
-    # there.  The real offline failure mode is a downstream console error
-    # "ReferenceError: L is not defined" when the Leaflet global is missing.
-    # Only suppress that specific signature — broader patterns like "leaflet"
-    # would hide real map regressions where Vireo feeds bad data to Leaflet.
     session.page.wait_for_timeout(2000)
-    session.report.findings = [
-        f
-        for f in session.report.findings
-        if not (
-            f.kind == "BUG"
-            and "L is not defined" in f.message
-        )
-    ]
 
     session.screenshot("map-initial")
 
-    # Check whether Leaflet actually loaded.  If the CDN was unavailable,
-    # the map JS throws before loadPhotos() runs, so status/sidebar remain
-    # at their initial "Loading..." text.  In that case, only assert on the
-    # static HTML (container, filters) — not on JS-populated content.
+    # Distinguish CDN outage from template regression.  If the <script>
+    # tag for Leaflet is present but L is undefined, the CDN was
+    # unavailable — tolerate it.  If the tag is missing entirely,
+    # someone broke map.html — that's a real bug we must surface.
+    leaflet_script_present = session.eval(
+        "!!document.querySelector('script[src*=\"leaflet\"]')"
+    )
     leaflet_loaded = session.eval("typeof L !== 'undefined'")
+
+    if not leaflet_script_present:
+        # Template regression: Leaflet script tag removed from map.html
+        session.assert_that(False, "Leaflet <script> tag missing from map.html")
+    elif not leaflet_loaded:
+        # CDN outage: script tag exists but L didn't load.  Suppress
+        # the "L is not defined" console errors — they're not our bug.
+        session.report.findings = [
+            f
+            for f in session.report.findings
+            if not (f.kind == "BUG" and "L is not defined" in f.message)
+        ]
 
     # --- Static HTML assertions (always valid) ---
 
-    # The map container div should exist
     has_map = session.eval("!!document.getElementById('map')")
     session.assert_that(has_map, "expected #map container on map page")
 
-    # Filter controls should be present
     for elem_id, label in [
         ("filterFolder", "folder filter dropdown"),
         ("filterRating", "rating filter dropdown"),
@@ -51,17 +49,15 @@ def run(session):
         present = session.eval(f"!!document.getElementById('{elem_id}')")
         session.assert_that(present, f"expected {label}")
 
-    # The sidebar header and status bar elements should exist in the DOM
     has_sidebar_header = session.eval("!!document.getElementById('sidebarHeader')")
     session.assert_that(has_sidebar_header, "expected sidebar header on map page")
 
     has_status = session.eval("!!document.getElementById('mapStatus')")
     session.assert_that(has_status, "expected map status bar")
 
-    # --- JS-populated assertions (only when Leaflet loaded) ---
+    # --- JS-populated assertions (only when Leaflet loaded successfully) ---
 
     if leaflet_loaded:
-        # Without GPS data, the status should indicate no geolocated photos
         status_text = session.eval(
             "(document.getElementById('mapStatus') || {}).textContent || ''"
         )
@@ -72,7 +68,6 @@ def run(session):
             f"expected 'no geolocated' or '0%' in status, got {status_text!r}",
         )
 
-        # The sidebar should show "0 photos"
         sidebar_text = session.eval(
             "(document.getElementById('sidebarHeader') || {}).textContent || ''"
         )

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -27,53 +27,58 @@ def run(session):
 
     session.screenshot("map-initial")
 
+    # Check whether Leaflet actually loaded.  If the CDN was unavailable,
+    # the map JS throws before loadPhotos() runs, so status/sidebar remain
+    # at their initial "Loading..." text.  In that case, only assert on the
+    # static HTML (container, filters) — not on JS-populated content.
+    leaflet_loaded = session.eval("typeof L !== 'undefined'")
+
+    # --- Static HTML assertions (always valid) ---
+
     # The map container div should exist
     has_map = session.eval("!!document.getElementById('map')")
     session.assert_that(has_map, "expected #map container on map page")
 
     # Filter controls should be present
-    has_folder_filter = session.eval("!!document.getElementById('filterFolder')")
-    session.assert_that(has_folder_filter, "expected folder filter dropdown")
+    for elem_id, label in [
+        ("filterFolder", "folder filter dropdown"),
+        ("filterRating", "rating filter dropdown"),
+        ("filterSpecies", "species filter dropdown"),
+        ("filterKeyword", "keyword filter input"),
+        ("filterDateFrom", "date-from filter"),
+        ("filterDateTo", "date-to filter"),
+    ]:
+        present = session.eval(f"!!document.getElementById('{elem_id}')")
+        session.assert_that(present, f"expected {label}")
 
-    has_rating_filter = session.eval("!!document.getElementById('filterRating')")
-    session.assert_that(has_rating_filter, "expected rating filter dropdown")
-
-    has_species_filter = session.eval("!!document.getElementById('filterSpecies')")
-    session.assert_that(has_species_filter, "expected species filter dropdown")
-
-    has_keyword_filter = session.eval("!!document.getElementById('filterKeyword')")
-    session.assert_that(has_keyword_filter, "expected keyword filter input")
-
-    has_date_from = session.eval("!!document.getElementById('filterDateFrom')")
-    session.assert_that(has_date_from, "expected date-from filter")
-
-    has_date_to = session.eval("!!document.getElementById('filterDateTo')")
-    session.assert_that(has_date_to, "expected date-to filter")
-
-    # The sidebar should exist with a photo count header
+    # The sidebar header and status bar elements should exist in the DOM
     has_sidebar_header = session.eval("!!document.getElementById('sidebarHeader')")
     session.assert_that(has_sidebar_header, "expected sidebar header on map page")
 
-    # The map status bar should exist
     has_status = session.eval("!!document.getElementById('mapStatus')")
     session.assert_that(has_status, "expected map status bar")
 
-    # Without GPS data, the status should indicate no geolocated photos
-    status_text = session.eval(
-        "(document.getElementById('mapStatus') || {}).textContent || ''"
-    )
-    session.assert_that(
-        "No geolocated" in status_text or "0%" in status_text or "Showing 0" in status_text,
-        f"expected 'no geolocated' or '0%' in status, got {status_text!r}",
-    )
+    # --- JS-populated assertions (only when Leaflet loaded) ---
 
-    # The sidebar should show "0 photos"
-    sidebar_text = session.eval(
-        "(document.getElementById('sidebarHeader') || {}).textContent || ''"
-    )
-    session.assert_that(
-        "0 photo" in sidebar_text,
-        f"expected '0 photos' in sidebar header, got {sidebar_text!r}",
-    )
+    if leaflet_loaded:
+        # Without GPS data, the status should indicate no geolocated photos
+        status_text = session.eval(
+            "(document.getElementById('mapStatus') || {}).textContent || ''"
+        )
+        session.assert_that(
+            "No geolocated" in status_text
+            or "0%" in status_text
+            or "Showing 0" in status_text,
+            f"expected 'no geolocated' or '0%' in status, got {status_text!r}",
+        )
+
+        # The sidebar should show "0 photos"
+        sidebar_text = session.eval(
+            "(document.getElementById('sidebarHeader') || {}).textContent || ''"
+        )
+        session.assert_that(
+            "0 photo" in sidebar_text,
+            f"expected '0 photos' in sidebar header, got {sidebar_text!r}",
+        )
 
     session.screenshot("map-no-gps-data")

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -12,18 +12,16 @@ def run(session):
     # The map page loads Leaflet from unpkg.com.  The harness only records
     # context.url for same-origin requests, so CDN failures won't appear
     # there.  The real offline failure mode is a downstream console error
-    # like "ReferenceError: L is not defined" when the Leaflet global is
-    # missing.  Filter both patterns so CDN outages don't flag as Vireo bugs.
+    # "ReferenceError: L is not defined" when the Leaflet global is missing.
+    # Only suppress that specific signature — broader patterns like "leaflet"
+    # would hide real map regressions where Vireo feeds bad data to Leaflet.
     session.page.wait_for_timeout(2000)
     session.report.findings = [
         f
         for f in session.report.findings
         if not (
             f.kind == "BUG"
-            and (
-                "L is not defined" in f.message
-                or "leaflet" in f.message.lower()
-            )
+            and "L is not defined" in f.message
         )
     ]
 

--- a/vireo/testing/userfirst/scenarios/pipeline_review.py
+++ b/vireo/testing/userfirst/scenarios/pipeline_review.py
@@ -5,13 +5,29 @@ when no pipeline results exist. Also checks that the sidebar and filter
 bar chrome are present.
 """
 
+import contextlib
+
 
 def run(session):
     session.goto("/pipeline/review")
 
-    # Wait for the page JS to settle — it fetches /api/pipeline/page-init
-    # and renders either results or the empty state.
-    session.page.wait_for_timeout(1000)
+    # Wait for initPipelineReviewPage()'s /api/pipeline/page-init fetch to
+    # resolve rather than using a fixed sleep.  The callback either shows
+    # #emptyState (no results) or populates #encountersContainer (results
+    # present); either transition means init completed.  A fixed 1s wait
+    # races the fetch on slow CI and produces false BUGs on the
+    # empty-state assertion.  Fall through on timeout so the assertions
+    # below surface the stale state rather than hang.
+    with contextlib.suppress(Exception):
+        session.page.wait_for_function(
+            """() => {
+                const empty = document.getElementById('emptyState');
+                const cont = document.getElementById('encountersContainer');
+                if (!empty || !cont) return false;
+                return empty.style.display !== 'none' || cont.children.length > 0;
+            }""",
+            timeout=10000,
+        )
 
     session.screenshot("pipeline-review-initial")
 

--- a/vireo/testing/userfirst/scenarios/pipeline_review.py
+++ b/vireo/testing/userfirst/scenarios/pipeline_review.py
@@ -1,0 +1,54 @@
+"""Scenario: visit the pipeline review page.
+
+Verifies that /pipeline/review renders and shows the expected empty state
+when no pipeline results exist. Also checks that the sidebar and filter
+bar chrome are present.
+"""
+
+
+def run(session):
+    session.goto("/pipeline/review")
+
+    # Wait for the page JS to settle — it fetches /api/pipeline/page-init
+    # and renders either results or the empty state.
+    session.page.wait_for_timeout(1000)
+
+    session.screenshot("pipeline-review-initial")
+
+    # The page layout should have the pipeline sidebar
+    has_sidebar = session.eval("!!document.querySelector('.pipeline-sidebar')")
+    session.assert_that(has_sidebar, "expected pipeline sidebar")
+
+    # The pipeline main content area should exist
+    has_main = session.eval("!!document.querySelector('.pipeline-main')")
+    session.assert_that(has_main, "expected pipeline main area")
+
+    # Without pipeline results, the empty state should be visible
+    empty_visible = session.eval(
+        """(() => {
+            const el = document.getElementById('emptyState');
+            return el ? el.style.display !== 'none' : false;
+        })()"""
+    )
+    session.assert_that(empty_visible, "expected empty state visible when no pipeline results")
+
+    # The empty state should contain a link to /pipeline
+    empty_link = session.eval(
+        """(() => {
+            const el = document.getElementById('emptyState');
+            if (!el) return false;
+            const a = el.querySelector('a[href="/pipeline"]');
+            return !!a;
+        })()"""
+    )
+    session.assert_that(empty_link, "expected link to /pipeline in empty state")
+
+    # The filter bar should be present (even if no results)
+    has_filter_bar = session.eval("!!document.querySelector('.filter-bar')")
+    session.assert_that(has_filter_bar, "expected filter bar on pipeline review page")
+
+    # The encounters container should exist (empty)
+    has_container = session.eval("!!document.getElementById('encountersContainer')")
+    session.assert_that(has_container, "expected encounters container")
+
+    session.screenshot("pipeline-review-empty")

--- a/vireo/testing/userfirst/scenarios/scan.py
+++ b/vireo/testing/userfirst/scenarios/scan.py
@@ -1,0 +1,41 @@
+"""Scenario: visit the pipeline (scan/import) page.
+
+Verifies that /pipeline renders, the stage cards are present (Source,
+Destination, Scan & Import, etc.), and the "Start Pipeline" button exists.
+We do not trigger an actual scan because that requires real photo files and
+ML models.
+"""
+
+
+def run(session):
+    session.goto("/pipeline")
+    session.screenshot("pipeline-initial")
+
+    # Stage cards should be present (at least the first 3: Source, Destination, Scan & Import)
+    stage_count = session.eval(
+        "document.querySelectorAll('.stage-card').length"
+    )
+    session.assert_that(stage_count >= 3, f"expected at least 3 stage cards, got {stage_count}")
+
+    # Stage names should include Source, Destination, Scan & Import
+    stage_names = session.eval(
+        """Array.from(document.querySelectorAll('.stage-name')).map(el => el.textContent.trim())"""
+    )
+    session.assert_that(
+        "Source" in stage_names,
+        f"expected 'Source' in stage names, got {stage_names!r}",
+    )
+    session.assert_that(
+        "Destination" in stage_names,
+        f"expected 'Destination' in stage names, got {stage_names!r}",
+    )
+
+    # The "Start Pipeline" button should exist
+    has_start_btn = session.eval("!!document.getElementById('btnStartPipeline')")
+    session.assert_that(has_start_btn, "expected Start Pipeline button")
+
+    # The Source card should have the Import radio option
+    has_import_radio = session.eval("!!document.getElementById('radioImport')")
+    session.assert_that(has_import_radio, "expected Import radio button in Source card")
+
+    session.screenshot("pipeline-loaded")

--- a/vireo/testing/userfirst/scenarios/workspaces.py
+++ b/vireo/testing/userfirst/scenarios/workspaces.py
@@ -1,0 +1,57 @@
+"""Scenario: visit the workspace management page.
+
+Verifies that /workspace renders, the active workspace name appears,
+folder and workspace sections are present, and the "New Workspace" button
+exists.
+"""
+
+
+def run(session):
+    session.goto("/workspace")
+
+    # Wait for the workspace page JS to load data
+    session.page.wait_for_timeout(1000)
+
+    session.screenshot("workspace-initial")
+
+    # The workspace name heading should exist and show "Default"
+    ws_name = session.eval(
+        "(document.getElementById('wsPageName') || {}).textContent || ''"
+    )
+    session.assert_that(
+        ws_name.strip() == "Default",
+        f"expected workspace name 'Default', got {ws_name!r}",
+    )
+
+    # The Folders section should exist
+    has_folders = session.eval("!!document.getElementById('wsFoldersContent')")
+    session.assert_that(has_folders, "expected folders section on workspace page")
+
+    # The Recent Jobs section should exist
+    has_history = session.eval("!!document.getElementById('historyContent')")
+    session.assert_that(has_history, "expected recent jobs section on workspace page")
+
+    # The All Workspaces section should exist
+    has_workspaces = session.eval("!!document.getElementById('workspacesContent')")
+    session.assert_that(has_workspaces, "expected all workspaces section on workspace page")
+
+    # The "+ New Workspace" button should exist
+    has_new_ws_btn = session.eval(
+        """!!document.querySelector('button[onclick*="showCreateWorkspaceModal"]')"""
+    )
+    session.assert_that(has_new_ws_btn, "expected '+ New Workspace' button")
+
+    # The "+ Add Folder" link should exist and point to /pipeline
+    has_add_folder = session.eval(
+        """!!document.querySelector('a.btn[href="/pipeline"]')"""
+    )
+    session.assert_that(has_add_folder, "expected '+ Add Folder' link to /pipeline")
+
+    # The workspaces section should show at least the Default workspace
+    # (rendered dynamically by loadWorkspaces JS)
+    ws_inputs = session.eval(
+        """document.querySelectorAll('#workspacesContent input[type="text"]').length"""
+    )
+    session.assert_that(ws_inputs >= 1, f"expected at least 1 workspace entry, got {ws_inputs}")
+
+    session.screenshot("workspace-loaded")

--- a/vireo/testing/userfirst/scenarios/workspaces.py
+++ b/vireo/testing/userfirst/scenarios/workspaces.py
@@ -5,12 +5,26 @@ folder and workspace sections are present, and the "New Workspace" button
 exists.
 """
 
+import contextlib
+
 
 def run(session):
     session.goto("/workspace")
 
-    # Wait for the workspace page JS to load data
-    session.page.wait_for_timeout(1000)
+    # Wait for loadWorkspaces()'s /api/workspaces fetch to resolve and
+    # replace the initial "Loading..." placeholder in #workspacesContent
+    # rather than using a fixed sleep.  On loaded CI the async fetch can
+    # exceed a 1s wait, leaving the page in its loading state and
+    # producing false BUGs on the workspace-input assertion below.  Fall
+    # through on timeout so assertions surface the stale state.
+    with contextlib.suppress(Exception):
+        session.page.wait_for_function(
+            """() => {
+                const c = document.getElementById('workspacesContent');
+                return c && !c.textContent.includes('Loading');
+            }""",
+            timeout=10000,
+        )
 
     session.screenshot("workspace-initial")
 

--- a/vireo/tests/test_userfirst_scenarios.py
+++ b/vireo/tests/test_userfirst_scenarios.py
@@ -84,3 +84,99 @@ def test_rate_flag_scenario(userfirst_env):
             f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
         )
         pytest.fail(f"rate_flag scenario reported bugs:\n{msg}")
+
+
+def test_scan_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import scan
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="scan", seed=browse_seed) as session:
+        scan.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"scan scenario reported bugs:\n{msg}")
+
+
+def test_pipeline_review_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import pipeline_review
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="pipeline_review", seed=browse_seed) as session:
+        pipeline_review.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"pipeline_review scenario reported bugs:\n{msg}")
+
+
+def test_keywords_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import keywords
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="keywords", seed=browse_seed) as session:
+        keywords.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"keywords scenario reported bugs:\n{msg}")
+
+
+def test_workspaces_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import workspaces
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="workspaces", seed=browse_seed) as session:
+        workspaces.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"workspaces scenario reported bugs:\n{msg}")
+
+
+def test_duplicates_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import duplicates
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="duplicates", seed=browse_seed) as session:
+        duplicates.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"duplicates scenario reported bugs:\n{msg}")
+
+
+def test_map_geo_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import map_geo
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="map_geo", seed=browse_seed) as session:
+        map_geo.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"map_geo scenario reported bugs:\n{msg}")


### PR DESCRIPTION
## Summary

Completes the full 9-scenario first cut (Tier 1 + Tier 2) for user-first testing. Builds on #605.

**New scenarios:**

| Scenario | Page | Key assertions |
|----------|------|----------------|
| scan | `/pipeline` | Stage cards, start button, import radio |
| pipeline_review | `/pipeline/review` | Sidebar, empty state link, filter bar |
| keywords | `/keywords` | Search input, 7 filter pills, 4+ keyword rows, Taxonomy filter toggle |
| workspaces | `/workspace` | Default heading, sections, New Workspace button, Add Folder link |
| duplicates | `/duplicates` | Scan button, empty state, progress/apply bar hidden |
| map_geo | `/map` | Leaflet container, 6 filters, "No geolocated" status |

All 6 reuse `browse_seed` — no new seeds needed.

## Test plan

- [x] 9/9 scenario tests pass (3 from #605 + 6 new)
- [x] Mandated suite: 503/503 passed
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)