### PR TITLE
ci: open PR instead of pushing website updates direct to main

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -489,7 +489,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WEBSITE_PR_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -525,19 +525,30 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Commit and push
-        id: push-website
+      # Branch protection on `main` requires the `test` check to pass, so we
+      # can't push directly. Open a PR with a PAT (GITHUB_TOKEN-created PRs
+      # don't trigger workflows) and enable auto-merge; deploy-website.yml
+      # fires automatically on the resulting push-to-main.
+      - name: Open website update PR
         run: |
+          VER="${{ steps.version.outputs.ver }}"
+          BRANCH="website/update-download-links-v${VER}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add website/src/pages/download.astro
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "website: update download links for v${{ steps.version.outputs.ver }}"
-          git push
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
-
-      - name: Trigger website deploy
-        if: steps.push-website.outputs.pushed == 'true'
-        run: gh workflow run deploy-website.yml --ref main
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git checkout -b "$BRANCH"
+          git commit -m "website: update download links for v${VER}"
+          git push -u origin "$BRANCH"
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "website: update download links for v${VER}" \
+            --body "Automated update of download links following the v${VER} release. Auto-merges once required checks pass; deploy-website.yml runs on the resulting push to main.")
+          gh pr merge --auto --squash --delete-branch "$PR_URL" \
+            || echo "Auto-merge unavailable — PR left open for manual review: $PR_URL"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WEBSITE_PR_TOKEN }}


### PR DESCRIPTION
## Summary

- Replaces the release workflow's direct push-to-main with a PAT-authenticated PR + squash auto-merge flow.
- Resolves the `GH006: Protected branch update failed — Required status check "test" is expected` error seen on the v0.8.25 release.
- Drops the explicit `gh workflow run deploy-website.yml` step; the post-merge push to `main` touching `website/**` already triggers `deploy-website.yml`.

## Why a PAT

PRs opened using the default `GITHUB_TOKEN` do not trigger other workflows, so `test.yml` would never run on the bot's PR and the `test` required check would stay missing forever. A PAT stored as `WEBSITE_PR_TOKEN` is used for checkout, push, and `gh pr create`/`gh pr merge --auto`.

## Required setup before the next release

Add a repo secret named **`WEBSITE_PR_TOKEN`** — a fine-grained PAT scoped to `jss367/vireo` with:

- Contents: Read and write
- Pull requests: Read and write

(Also requires "Allow auto-merge" enabled in repo settings; if it isn't, the job logs a warning and leaves the PR open for manual merge instead of failing.)

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` — 503 passed
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/build-release.yml'))"` — parses cleanly
- [ ] Next tagged release produces a `website/update-download-links-v<ver>` PR that merges after `test` passes, followed by a `deploy-website` run on `main`