### PR TITLE
feat: user-first testing — remaining 6 scenarios (PR #3)

### DIFF
--- a/vireo/testing/userfirst/scenarios/duplicates.py
+++ b/vireo/testing/userfirst/scenarios/duplicates.py
@@ -44,22 +44,30 @@ def run(session):
     )
     session.assert_that(empty_visible, "expected empty state visible before scan")
 
-    # The progress box should be hidden
-    progress_hidden = session.eval(
+    # The progress box should exist and be hidden
+    progress_state = session.eval(
         """(() => {
             const el = document.getElementById('progress');
-            return el ? el.style.display === 'none' : true;
+            if (!el) return 'missing';
+            return el.style.display === 'none' ? 'hidden' : 'visible';
         })()"""
     )
-    session.assert_that(progress_hidden, "expected progress box hidden before scan")
+    session.assert_that(
+        progress_state == "hidden",
+        f"expected progress box present and hidden before scan, got {progress_state!r}",
+    )
 
-    # The apply bar should be hidden (no results to apply)
-    apply_hidden = session.eval(
+    # The apply bar should exist and be hidden (no results to apply)
+    apply_state = session.eval(
         """(() => {
             const el = document.getElementById('applyBar');
-            return el ? el.style.display === 'none' : true;
+            if (!el) return 'missing';
+            return el.style.display === 'none' ? 'hidden' : 'visible';
         })()"""
     )
-    session.assert_that(apply_hidden, "expected apply bar hidden before scan")
+    session.assert_that(
+        apply_state == "hidden",
+        f"expected apply bar present and hidden before scan, got {apply_state!r}",
+    )
 
     session.screenshot("duplicates-empty-state")

--- a/vireo/testing/userfirst/scenarios/duplicates.py
+++ b/vireo/testing/userfirst/scenarios/duplicates.py
@@ -1,0 +1,65 @@
+"""Scenario: visit the duplicates detection page.
+
+Verifies that /duplicates renders, the "Scan for duplicate files" button
+is present, and the empty state is shown when no duplicates have been
+scanned.
+"""
+
+
+def run(session):
+    session.goto("/duplicates")
+    session.screenshot("duplicates-initial")
+
+    # The page header should contain "Duplicate Files"
+    header_text = session.eval(
+        """(() => {
+            const h1 = document.querySelector('.page-header h1');
+            return h1 ? h1.textContent.trim() : '';
+        })()"""
+    )
+    session.assert_that(
+        "Duplicate" in header_text,
+        f"expected 'Duplicate' in page header, got {header_text!r}",
+    )
+
+    # The "Scan for duplicate files" button should exist
+    has_scan_btn = session.eval("!!document.getElementById('scanBtn')")
+    session.assert_that(has_scan_btn, "expected scan button on duplicates page")
+
+    # Verify scan button text
+    scan_btn_text = session.eval(
+        "(document.getElementById('scanBtn') || {}).textContent || ''"
+    )
+    session.assert_that(
+        "Scan" in scan_btn_text,
+        f"expected 'Scan' in button text, got {scan_btn_text!r}",
+    )
+
+    # The empty state should be visible (no scan has been performed)
+    empty_visible = session.eval(
+        """(() => {
+            const el = document.getElementById('emptyState');
+            return el ? el.style.display !== 'none' : false;
+        })()"""
+    )
+    session.assert_that(empty_visible, "expected empty state visible before scan")
+
+    # The progress box should be hidden
+    progress_hidden = session.eval(
+        """(() => {
+            const el = document.getElementById('progress');
+            return el ? el.style.display === 'none' : true;
+        })()"""
+    )
+    session.assert_that(progress_hidden, "expected progress box hidden before scan")
+
+    # The apply bar should be hidden (no results to apply)
+    apply_hidden = session.eval(
+        """(() => {
+            const el = document.getElementById('applyBar');
+            return el ? el.style.display === 'none' : true;
+        })()"""
+    )
+    session.assert_that(apply_hidden, "expected apply bar hidden before scan")
+
+    session.screenshot("duplicates-empty-state")

--- a/vireo/testing/userfirst/scenarios/keywords.py
+++ b/vireo/testing/userfirst/scenarios/keywords.py
@@ -1,0 +1,76 @@
+"""Scenario: visit the keywords management page.
+
+Verifies that /keywords renders the keyword table with seeded data,
+filter pills are present and clickable, and the search input exists.
+"""
+
+
+def run(session):
+    session.goto("/keywords")
+
+    # Wait for the keywords to load via /api/keywords/all
+    session.page.wait_for_timeout(1000)
+
+    session.screenshot("keywords-initial")
+
+    # The search input should be present
+    has_search = session.eval("!!document.getElementById('kwSearch')")
+    session.assert_that(has_search, "expected keyword search input")
+
+    # Filter pills should exist: All, General, Taxonomy, Location, Descriptive, People, Event
+    filter_btns = session.eval(
+        "Array.from(document.querySelectorAll('.kw-filter-btn')).map(b => b.dataset.type)"
+    )
+    expected_types = ["all", "general", "taxonomy", "location", "descriptive", "people", "event"]
+    for t in expected_types:
+        session.assert_that(
+            t in filter_btns,
+            f"expected filter button with data-type='{t}', got {filter_btns!r}",
+        )
+
+    # The "All" filter should be active by default
+    active_filter = session.eval(
+        """(() => {
+            const btn = document.querySelector('.kw-filter-btn.active');
+            return btn ? btn.dataset.type : null;
+        })()"""
+    )
+    session.assert_that(active_filter == "all", f"expected 'all' filter active, got {active_filter!r}")
+
+    # The keyword table should have rows (browse_seed has 4 keywords)
+    row_count = session.eval(
+        "document.querySelectorAll('#kwBody tr').length"
+    )
+    session.assert_that(row_count >= 4, f"expected at least 4 keyword rows, got {row_count}")
+
+    # Stats should show keyword count
+    stats_text = session.eval(
+        "document.getElementById('kwStats').textContent"
+    )
+    session.assert_that(
+        "keywords" in stats_text.lower() or "of" in stats_text.lower(),
+        f"expected stats text to contain keyword count info, got {stats_text!r}",
+    )
+
+    # Click the Taxonomy filter and verify it becomes active
+    session.click('.kw-filter-btn[data-type="taxonomy"]')
+    session.page.wait_for_timeout(300)
+
+    active_after = session.eval(
+        """(() => {
+            const btn = document.querySelector('.kw-filter-btn.active');
+            return btn ? btn.dataset.type : null;
+        })()"""
+    )
+    session.assert_that(
+        active_after == "taxonomy",
+        f"expected 'taxonomy' filter active after click, got {active_after!r}",
+    )
+
+    session.screenshot("keywords-taxonomy-filter")
+
+    # Click "All" to restore full view
+    session.click('.kw-filter-btn[data-type="all"]')
+    session.page.wait_for_timeout(300)
+
+    session.screenshot("keywords-all-filter")

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -94,8 +94,19 @@ def run(session):
             )
         elif probe_status in (408, 429) or 500 <= probe_status < 600:
             # Transient CDN condition (timeout, rate limit, server error).
-            # Template is still correct; don't fail on external availability.
-            _suppress_leaflet_findings()
+            # Only tolerate this when the URL points at a known Leaflet
+            # CDN — otherwise the template was edited to point at a
+            # different host that happens to be returning 5xx/429, which
+            # is a real regression we should surface.
+            host = (urlparse(leaflet_src).hostname or "").lower()
+            if host in _KNOWN_LEAFLET_CDN_HOSTS:
+                _suppress_leaflet_findings()
+            else:
+                session.assert_that(
+                    False,
+                    f"Leaflet script URL returned HTTP {probe_status} from "
+                    f"non-CDN host {host!r}: {leaflet_src}",
+                )
         else:
             # 4xx other than 408/429 — the URL in the template is wrong
             # (e.g. 404 from a typo'd path or deleted CDN version).  This

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -9,16 +9,21 @@ is shown when the seed data has no GPS coordinates.
 def run(session):
     session.goto("/map")
 
-    # The map page loads Leaflet from unpkg.com — external CDN requests
-    # may fail in CI or offline environments.  Filter out those failures
-    # so they don't flag as bugs against Vireo itself.
+    # The map page loads Leaflet from unpkg.com.  The harness only records
+    # context.url for same-origin requests, so CDN failures won't appear
+    # there.  The real offline failure mode is a downstream console error
+    # like "ReferenceError: L is not defined" when the Leaflet global is
+    # missing.  Filter both patterns so CDN outages don't flag as Vireo bugs.
     session.page.wait_for_timeout(2000)
     session.report.findings = [
         f
         for f in session.report.findings
         if not (
             f.kind == "BUG"
-            and "unpkg.com" in f.context.get("url", "")
+            and (
+                "L is not defined" in f.message
+                or "leaflet" in f.message.lower()
+            )
         )
     ]
 

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -16,8 +16,11 @@ def run(session):
     # tag for Leaflet is present but L is undefined, the CDN was
     # unavailable — tolerate it.  If the tag is missing entirely,
     # someone broke map.html — that's a real bug we must surface.
+    # Match the core Leaflet script specifically, not any src containing
+    # "leaflet" — map.html also loads leaflet.markercluster.js which would
+    # match the broader selector even if the primary leaflet.js is removed.
     leaflet_script_present = session.eval(
-        "!!document.querySelector('script[src*=\"leaflet\"]')"
+        "!!document.querySelector('script[src*=\"/leaflet.js\"], script[src*=\"/leaflet.min.js\"]')"
     )
     leaflet_loaded = session.eval("typeof L !== 'undefined'")
 

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -1,0 +1,76 @@
+"""Scenario: visit the map/geo view page.
+
+Verifies that /map renders, the Leaflet map container exists, filter
+controls are present, and the appropriate "no geolocated photos" message
+is shown when the seed data has no GPS coordinates.
+"""
+
+
+def run(session):
+    session.goto("/map")
+
+    # The map page loads Leaflet from unpkg.com — external CDN requests
+    # may fail in CI or offline environments.  Filter out those failures
+    # so they don't flag as bugs against Vireo itself.
+    session.page.wait_for_timeout(2000)
+    session.report.findings = [
+        f
+        for f in session.report.findings
+        if not (
+            f.kind == "BUG"
+            and "unpkg.com" in f.context.get("url", "")
+        )
+    ]
+
+    session.screenshot("map-initial")
+
+    # The map container div should exist
+    has_map = session.eval("!!document.getElementById('map')")
+    session.assert_that(has_map, "expected #map container on map page")
+
+    # Filter controls should be present
+    has_folder_filter = session.eval("!!document.getElementById('filterFolder')")
+    session.assert_that(has_folder_filter, "expected folder filter dropdown")
+
+    has_rating_filter = session.eval("!!document.getElementById('filterRating')")
+    session.assert_that(has_rating_filter, "expected rating filter dropdown")
+
+    has_species_filter = session.eval("!!document.getElementById('filterSpecies')")
+    session.assert_that(has_species_filter, "expected species filter dropdown")
+
+    has_keyword_filter = session.eval("!!document.getElementById('filterKeyword')")
+    session.assert_that(has_keyword_filter, "expected keyword filter input")
+
+    has_date_from = session.eval("!!document.getElementById('filterDateFrom')")
+    session.assert_that(has_date_from, "expected date-from filter")
+
+    has_date_to = session.eval("!!document.getElementById('filterDateTo')")
+    session.assert_that(has_date_to, "expected date-to filter")
+
+    # The sidebar should exist with a photo count header
+    has_sidebar_header = session.eval("!!document.getElementById('sidebarHeader')")
+    session.assert_that(has_sidebar_header, "expected sidebar header on map page")
+
+    # The map status bar should exist
+    has_status = session.eval("!!document.getElementById('mapStatus')")
+    session.assert_that(has_status, "expected map status bar")
+
+    # Without GPS data, the status should indicate no geolocated photos
+    status_text = session.eval(
+        "(document.getElementById('mapStatus') || {}).textContent || ''"
+    )
+    session.assert_that(
+        "No geolocated" in status_text or "0%" in status_text or "Showing 0" in status_text,
+        f"expected 'no geolocated' or '0%' in status, got {status_text!r}",
+    )
+
+    # The sidebar should show "0 photos"
+    sidebar_text = session.eval(
+        "(document.getElementById('sidebarHeader') || {}).textContent || ''"
+    )
+    session.assert_that(
+        "0 photo" in sidebar_text,
+        f"expected '0 photos' in sidebar header, got {sidebar_text!r}",
+    )
+
+    session.screenshot("map-no-gps-data")

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -5,6 +5,18 @@ controls are present, and the appropriate "no geolocated photos" message
 is shown when the seed data has no GPS coordinates.
 """
 import contextlib
+import re
+from urllib.parse import urlparse
+
+# Hosts we trust to be Leaflet CDNs.  When the script URL points at one
+# of these and the probe fails (no response / DNS failure), assume a
+# transient outage rather than a template regression.  Anything else is
+# treated as a bad URL in the template.
+_KNOWN_LEAFLET_CDN_HOSTS = frozenset({
+    "unpkg.com",
+    "cdn.jsdelivr.net",
+    "cdnjs.cloudflare.com",
+})
 
 
 def run(session):
@@ -53,7 +65,20 @@ def run(session):
             ]
 
         if probe_status is None:
-            _suppress_leaflet_findings()  # network failure → CDN outage
+            # Network-level failure (DNS, connection refused, timeout
+            # before HTTP).  Only treat this as a CDN outage when the
+            # URL points at a known Leaflet CDN; otherwise the template
+            # was edited to point at an unresolvable host (e.g. typo'd
+            # or removed CDN), which is a real regression.
+            host = (urlparse(leaflet_src).hostname or "").lower()
+            if host in _KNOWN_LEAFLET_CDN_HOSTS:
+                _suppress_leaflet_findings()
+            else:
+                session.assert_that(
+                    False,
+                    "Leaflet script URL unreachable and host is not a known "
+                    f"CDN ({host!r}): {leaflet_src}",
+                )
         elif 200 <= probe_status < 300:
             pass  # reachable but L undefined — leave findings as-is
         elif probe_status in (408, 429) or 500 <= probe_status < 600:
@@ -97,19 +122,34 @@ def run(session):
         status_text = session.eval(
             "(document.getElementById('mapStatus') || {}).textContent || ''"
         )
-        session.assert_that(
+        # The status bar either shows the explicit "No geolocated photos
+        # found" message or "Showing 0 of 0 geolocated photos | 0% GPS
+        # coverage".  Match those exact zero shapes — a substring check
+        # for "0%" would also match "100% GPS coverage", and "Showing 0"
+        # would match "Showing 0 of 100" (visible-after-filtering, not a
+        # zero-GPS state).
+        zero_gps_status = (
             "No geolocated" in status_text
-            or "0%" in status_text
-            or "Showing 0" in status_text,
-            f"expected 'no geolocated' or '0%' in status, got {status_text!r}",
+            or (
+                re.search(r"\bShowing 0 of 0\b", status_text) is not None
+                and re.search(r"(?<!\d)0% GPS coverage\b", status_text) is not None
+            )
+        )
+        session.assert_that(
+            zero_gps_status,
+            "expected zero-GPS status ('No geolocated' message or "
+            f"'Showing 0 of 0' + '0% GPS coverage'), got {status_text!r}",
         )
 
         sidebar_text = session.eval(
             "(document.getElementById('sidebarHeader') || {}).textContent || ''"
         )
+        # Require an exact zero count — "0 photo" as a substring also
+        # matches "10 photos", "20 photos", etc.  Use a leading
+        # non-digit boundary plus the trailing word boundary.
         session.assert_that(
-            "0 photo" in sidebar_text,
-            f"expected '0 photos' in sidebar header, got {sidebar_text!r}",
+            re.search(r"(?<!\d)0 photos?\b", sidebar_text) is not None,
+            f"expected exactly '0 photos' in sidebar header, got {sidebar_text!r}",
         )
 
     session.screenshot("map-no-gps-data")

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -8,38 +8,36 @@ is shown when the seed data has no GPS coordinates.
 
 def run(session):
     session.goto("/map")
-
-    # The map page loads Leaflet from unpkg.com.  The harness only records
-    # context.url for same-origin requests, so CDN failures won't appear
-    # there.  The real offline failure mode is a downstream console error
-    # "ReferenceError: L is not defined" when the Leaflet global is missing.
-    # Only suppress that specific signature — broader patterns like "leaflet"
-    # would hide real map regressions where Vireo feeds bad data to Leaflet.
     session.page.wait_for_timeout(2000)
-    session.report.findings = [
-        f
-        for f in session.report.findings
-        if not (
-            f.kind == "BUG"
-            and "L is not defined" in f.message
-        )
-    ]
 
     session.screenshot("map-initial")
 
-    # Check whether Leaflet actually loaded.  If the CDN was unavailable,
-    # the map JS throws before loadPhotos() runs, so status/sidebar remain
-    # at their initial "Loading..." text.  In that case, only assert on the
-    # static HTML (container, filters) — not on JS-populated content.
+    # Distinguish CDN outage from template regression.  If the <script>
+    # tag for Leaflet is present but L is undefined, the CDN was
+    # unavailable — tolerate it.  If the tag is missing entirely,
+    # someone broke map.html — that's a real bug we must surface.
+    leaflet_script_present = session.eval(
+        "!!document.querySelector('script[src*=\"leaflet\"]')"
+    )
     leaflet_loaded = session.eval("typeof L !== 'undefined'")
+
+    if not leaflet_script_present:
+        # Template regression: Leaflet script tag removed from map.html
+        session.assert_that(False, "Leaflet <script> tag missing from map.html")
+    elif not leaflet_loaded:
+        # CDN outage: script tag exists but L didn't load.  Suppress
+        # the "L is not defined" console errors — they're not our bug.
+        session.report.findings = [
+            f
+            for f in session.report.findings
+            if not (f.kind == "BUG" and "L is not defined" in f.message)
+        ]
 
     # --- Static HTML assertions (always valid) ---
 
-    # The map container div should exist
     has_map = session.eval("!!document.getElementById('map')")
     session.assert_that(has_map, "expected #map container on map page")
 
-    # Filter controls should be present
     for elem_id, label in [
         ("filterFolder", "folder filter dropdown"),
         ("filterRating", "rating filter dropdown"),
@@ -51,17 +49,15 @@ def run(session):
         present = session.eval(f"!!document.getElementById('{elem_id}')")
         session.assert_that(present, f"expected {label}")
 
-    # The sidebar header and status bar elements should exist in the DOM
     has_sidebar_header = session.eval("!!document.getElementById('sidebarHeader')")
     session.assert_that(has_sidebar_header, "expected sidebar header on map page")
 
     has_status = session.eval("!!document.getElementById('mapStatus')")
     session.assert_that(has_status, "expected map status bar")
 
-    # --- JS-populated assertions (only when Leaflet loaded) ---
+    # --- JS-populated assertions (only when Leaflet loaded successfully) ---
 
     if leaflet_loaded:
-        # Without GPS data, the status should indicate no geolocated photos
         status_text = session.eval(
             "(document.getElementById('mapStatus') || {}).textContent || ''"
         )
@@ -72,7 +68,6 @@ def run(session):
             f"expected 'no geolocated' or '0%' in status, got {status_text!r}",
         )
 
-        # The sidebar should show "0 photos"
         sidebar_text = session.eval(
             "(document.getElementById('sidebarHeader') || {}).textContent || ''"
         )

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -27,53 +27,58 @@ def run(session):
 
     session.screenshot("map-initial")
 
+    # Check whether Leaflet actually loaded.  If the CDN was unavailable,
+    # the map JS throws before loadPhotos() runs, so status/sidebar remain
+    # at their initial "Loading..." text.  In that case, only assert on the
+    # static HTML (container, filters) — not on JS-populated content.
+    leaflet_loaded = session.eval("typeof L !== 'undefined'")
+
+    # --- Static HTML assertions (always valid) ---
+
     # The map container div should exist
     has_map = session.eval("!!document.getElementById('map')")
     session.assert_that(has_map, "expected #map container on map page")
 
     # Filter controls should be present
-    has_folder_filter = session.eval("!!document.getElementById('filterFolder')")
-    session.assert_that(has_folder_filter, "expected folder filter dropdown")
+    for elem_id, label in [
+        ("filterFolder", "folder filter dropdown"),
+        ("filterRating", "rating filter dropdown"),
+        ("filterSpecies", "species filter dropdown"),
+        ("filterKeyword", "keyword filter input"),
+        ("filterDateFrom", "date-from filter"),
+        ("filterDateTo", "date-to filter"),
+    ]:
+        present = session.eval(f"!!document.getElementById('{elem_id}')")
+        session.assert_that(present, f"expected {label}")
 
-    has_rating_filter = session.eval("!!document.getElementById('filterRating')")
-    session.assert_that(has_rating_filter, "expected rating filter dropdown")
-
-    has_species_filter = session.eval("!!document.getElementById('filterSpecies')")
-    session.assert_that(has_species_filter, "expected species filter dropdown")
-
-    has_keyword_filter = session.eval("!!document.getElementById('filterKeyword')")
-    session.assert_that(has_keyword_filter, "expected keyword filter input")
-
-    has_date_from = session.eval("!!document.getElementById('filterDateFrom')")
-    session.assert_that(has_date_from, "expected date-from filter")
-
-    has_date_to = session.eval("!!document.getElementById('filterDateTo')")
-    session.assert_that(has_date_to, "expected date-to filter")
-
-    # The sidebar should exist with a photo count header
+    # The sidebar header and status bar elements should exist in the DOM
     has_sidebar_header = session.eval("!!document.getElementById('sidebarHeader')")
     session.assert_that(has_sidebar_header, "expected sidebar header on map page")
 
-    # The map status bar should exist
     has_status = session.eval("!!document.getElementById('mapStatus')")
     session.assert_that(has_status, "expected map status bar")
 
-    # Without GPS data, the status should indicate no geolocated photos
-    status_text = session.eval(
-        "(document.getElementById('mapStatus') || {}).textContent || ''"
-    )
-    session.assert_that(
-        "No geolocated" in status_text or "0%" in status_text or "Showing 0" in status_text,
-        f"expected 'no geolocated' or '0%' in status, got {status_text!r}",
-    )
+    # --- JS-populated assertions (only when Leaflet loaded) ---
 
-    # The sidebar should show "0 photos"
-    sidebar_text = session.eval(
-        "(document.getElementById('sidebarHeader') || {}).textContent || ''"
-    )
-    session.assert_that(
-        "0 photo" in sidebar_text,
-        f"expected '0 photos' in sidebar header, got {sidebar_text!r}",
-    )
+    if leaflet_loaded:
+        # Without GPS data, the status should indicate no geolocated photos
+        status_text = session.eval(
+            "(document.getElementById('mapStatus') || {}).textContent || ''"
+        )
+        session.assert_that(
+            "No geolocated" in status_text
+            or "0%" in status_text
+            or "Showing 0" in status_text,
+            f"expected 'no geolocated' or '0%' in status, got {status_text!r}",
+        )
+
+        # The sidebar should show "0 photos"
+        sidebar_text = session.eval(
+            "(document.getElementById('sidebarHeader') || {}).textContent || ''"
+        )
+        session.assert_that(
+            "0 photo" in sidebar_text,
+            f"expected '0 photos' in sidebar header, got {sidebar_text!r}",
+        )
 
     session.screenshot("map-no-gps-data")

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -33,31 +33,41 @@ def run(session):
     elif not leaflet_loaded:
         # Script tag present but L undefined — could be a CDN outage
         # (tolerate) or a broken URL / wrong version in map.html
-        # (template regression we must surface).  Probe the script URL:
-        # a non-2xx response means the URL is wrong, a network failure
-        # means the CDN is unreachable, and a 2xx with L undefined is
-        # a real bug worth surfacing.
+        # (template regression we must surface).  Probe the script URL
+        # and classify the response:
+        #   - 2xx: reachable but L undefined → real bug, keep findings
+        #   - 4xx (except 408/429): wrong URL in template → fail
+        #   - 408/429/5xx: transient CDN issue → tolerate
+        #   - no response (network error): CDN unreachable → tolerate
         probe_status = None
         with contextlib.suppress(Exception):
             probe_status = session.page.request.fetch(
                 leaflet_src, method="GET", timeout=5000
             ).status
 
-        if probe_status is not None and 200 <= probe_status < 300:
-            pass  # reachable but L undefined — leave findings as-is
-        elif probe_status is not None:
-            session.assert_that(
-                False,
-                f"Leaflet script URL returned HTTP {probe_status}: {leaflet_src}",
-            )
-        else:
-            # CDN unreachable — suppress the "L is not defined" BUG
-            # findings it produced; they're not our regression.
+        def _suppress_leaflet_findings():
             session.report.findings = [
                 f
                 for f in session.report.findings
                 if not (f.kind == "BUG" and "L is not defined" in f.message)
             ]
+
+        if probe_status is None:
+            _suppress_leaflet_findings()  # network failure → CDN outage
+        elif 200 <= probe_status < 300:
+            pass  # reachable but L undefined — leave findings as-is
+        elif probe_status in (408, 429) or 500 <= probe_status < 600:
+            # Transient CDN condition (timeout, rate limit, server error).
+            # Template is still correct; don't fail on external availability.
+            _suppress_leaflet_findings()
+        else:
+            # 4xx other than 408/429 — the URL in the template is wrong
+            # (e.g. 404 from a typo'd path or deleted CDN version).  This
+            # is a genuine template regression worth surfacing.
+            session.assert_that(
+                False,
+                f"Leaflet script URL returned HTTP {probe_status}: {leaflet_src}",
+            )
 
     # --- Static HTML assertions (always valid) ---
 

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -12,18 +12,16 @@ def run(session):
     # The map page loads Leaflet from unpkg.com.  The harness only records
     # context.url for same-origin requests, so CDN failures won't appear
     # there.  The real offline failure mode is a downstream console error
-    # like "ReferenceError: L is not defined" when the Leaflet global is
-    # missing.  Filter both patterns so CDN outages don't flag as Vireo bugs.
+    # "ReferenceError: L is not defined" when the Leaflet global is missing.
+    # Only suppress that specific signature — broader patterns like "leaflet"
+    # would hide real map regressions where Vireo feeds bad data to Leaflet.
     session.page.wait_for_timeout(2000)
     session.report.findings = [
         f
         for f in session.report.findings
         if not (
             f.kind == "BUG"
-            and (
-                "L is not defined" in f.message
-                or "leaflet" in f.message.lower()
-            )
+            and "L is not defined" in f.message
         )
     ]
 

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -47,7 +47,7 @@ def run(session):
         # (tolerate) or a broken URL / wrong version in map.html
         # (template regression we must surface).  Probe the script URL
         # and classify the response:
-        #   - 2xx: reachable but L undefined → real bug, keep findings
+        #   - 2xx: reachable but L undefined → real bug, fail explicitly
         #   - 4xx (except 408/429): wrong URL in template → fail
         #   - 408/429/5xx: transient CDN issue → tolerate
         #   - no response (network error): CDN unreachable → tolerate
@@ -80,7 +80,18 @@ def run(session):
                     f"CDN ({host!r}): {leaflet_src}",
                 )
         elif 200 <= probe_status < 300:
-            pass  # reachable but L undefined — leave findings as-is
+            # Script URL is reachable but L is undefined — this is a real
+            # regression (e.g. map init logic removed, the URL now serves
+            # non-Leaflet content, or the script errors during execution).
+            # Fail explicitly rather than relying on a downstream "L is not
+            # defined" finding, which may be absent if the page defensively
+            # guards against the missing global.
+            session.assert_that(
+                False,
+                f"Leaflet script reachable at {leaflet_src} "
+                f"(HTTP {probe_status}) but window.L is undefined — "
+                "map initialization regression",
+            )
         elif probe_status in (408, 429) or 500 <= probe_status < 600:
             # Transient CDN condition (timeout, rate limit, server error).
             # Template is still correct; don't fail on external availability.

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -4,6 +4,7 @@ Verifies that /map renders, the Leaflet map container exists, filter
 controls are present, and the appropriate "no geolocated photos" message
 is shown when the seed data has no GPS coordinates.
 """
+import contextlib
 
 
 def run(session):
@@ -12,29 +13,51 @@ def run(session):
 
     session.screenshot("map-initial")
 
-    # Distinguish CDN outage from template regression.  If the <script>
-    # tag for Leaflet is present but L is undefined, the CDN was
-    # unavailable — tolerate it.  If the tag is missing entirely,
-    # someone broke map.html — that's a real bug we must surface.
-    # Match the core Leaflet script specifically, not any src containing
-    # "leaflet" — map.html also loads leaflet.markercluster.js which would
-    # match the broader selector even if the primary leaflet.js is removed.
-    leaflet_script_present = session.eval(
-        "!!document.querySelector('script[src*=\"/leaflet.js\"], script[src*=\"/leaflet.min.js\"]')"
+    # Distinguish CDN outage from template regression.  Match the core
+    # Leaflet script specifically, not any src containing "leaflet" —
+    # map.html also loads leaflet.markercluster.js which would match a
+    # broader selector even if the primary leaflet.js is removed.
+    leaflet_src = session.eval(
+        """(() => {
+            const s = document.querySelector(
+                'script[src*="/leaflet.js"], script[src*="/leaflet.min.js"]'
+            );
+            return s ? s.src : null;
+        })()"""
     )
     leaflet_loaded = session.eval("typeof L !== 'undefined'")
 
-    if not leaflet_script_present:
+    if leaflet_src is None:
         # Template regression: Leaflet script tag removed from map.html
         session.assert_that(False, "Leaflet <script> tag missing from map.html")
     elif not leaflet_loaded:
-        # CDN outage: script tag exists but L didn't load.  Suppress
-        # the "L is not defined" console errors — they're not our bug.
-        session.report.findings = [
-            f
-            for f in session.report.findings
-            if not (f.kind == "BUG" and "L is not defined" in f.message)
-        ]
+        # Script tag present but L undefined — could be a CDN outage
+        # (tolerate) or a broken URL / wrong version in map.html
+        # (template regression we must surface).  Probe the script URL:
+        # a non-2xx response means the URL is wrong, a network failure
+        # means the CDN is unreachable, and a 2xx with L undefined is
+        # a real bug worth surfacing.
+        probe_status = None
+        with contextlib.suppress(Exception):
+            probe_status = session.page.request.fetch(
+                leaflet_src, method="GET", timeout=5000
+            ).status
+
+        if probe_status is not None and 200 <= probe_status < 300:
+            pass  # reachable but L undefined — leave findings as-is
+        elif probe_status is not None:
+            session.assert_that(
+                False,
+                f"Leaflet script URL returned HTTP {probe_status}: {leaflet_src}",
+            )
+        else:
+            # CDN unreachable — suppress the "L is not defined" BUG
+            # findings it produced; they're not our regression.
+            session.report.findings = [
+                f
+                for f in session.report.findings
+                if not (f.kind == "BUG" and "L is not defined" in f.message)
+            ]
 
     # --- Static HTML assertions (always valid) ---
 

--- a/vireo/testing/userfirst/scenarios/pipeline_review.py
+++ b/vireo/testing/userfirst/scenarios/pipeline_review.py
@@ -1,0 +1,54 @@
+"""Scenario: visit the pipeline review page.
+
+Verifies that /pipeline/review renders and shows the expected empty state
+when no pipeline results exist. Also checks that the sidebar and filter
+bar chrome are present.
+"""
+
+
+def run(session):
+    session.goto("/pipeline/review")
+
+    # Wait for the page JS to settle — it fetches /api/pipeline/page-init
+    # and renders either results or the empty state.
+    session.page.wait_for_timeout(1000)
+
+    session.screenshot("pipeline-review-initial")
+
+    # The page layout should have the pipeline sidebar
+    has_sidebar = session.eval("!!document.querySelector('.pipeline-sidebar')")
+    session.assert_that(has_sidebar, "expected pipeline sidebar")
+
+    # The pipeline main content area should exist
+    has_main = session.eval("!!document.querySelector('.pipeline-main')")
+    session.assert_that(has_main, "expected pipeline main area")
+
+    # Without pipeline results, the empty state should be visible
+    empty_visible = session.eval(
+        """(() => {
+            const el = document.getElementById('emptyState');
+            return el ? el.style.display !== 'none' : false;
+        })()"""
+    )
+    session.assert_that(empty_visible, "expected empty state visible when no pipeline results")
+
+    # The empty state should contain a link to /pipeline
+    empty_link = session.eval(
+        """(() => {
+            const el = document.getElementById('emptyState');
+            if (!el) return false;
+            const a = el.querySelector('a[href="/pipeline"]');
+            return !!a;
+        })()"""
+    )
+    session.assert_that(empty_link, "expected link to /pipeline in empty state")
+
+    # The filter bar should be present (even if no results)
+    has_filter_bar = session.eval("!!document.querySelector('.filter-bar')")
+    session.assert_that(has_filter_bar, "expected filter bar on pipeline review page")
+
+    # The encounters container should exist (empty)
+    has_container = session.eval("!!document.getElementById('encountersContainer')")
+    session.assert_that(has_container, "expected encounters container")
+
+    session.screenshot("pipeline-review-empty")

--- a/vireo/testing/userfirst/scenarios/scan.py
+++ b/vireo/testing/userfirst/scenarios/scan.py
@@ -29,6 +29,10 @@ def run(session):
         "Destination" in stage_names,
         f"expected 'Destination' in stage names, got {stage_names!r}",
     )
+    session.assert_that(
+        "Scan & Import" in stage_names,
+        f"expected 'Scan & Import' in stage names, got {stage_names!r}",
+    )
 
     # The "Start Pipeline" button should exist
     has_start_btn = session.eval("!!document.getElementById('btnStartPipeline')")

--- a/vireo/testing/userfirst/scenarios/scan.py
+++ b/vireo/testing/userfirst/scenarios/scan.py
@@ -1,0 +1,41 @@
+"""Scenario: visit the pipeline (scan/import) page.
+
+Verifies that /pipeline renders, the stage cards are present (Source,
+Destination, Scan & Import, etc.), and the "Start Pipeline" button exists.
+We do not trigger an actual scan because that requires real photo files and
+ML models.
+"""
+
+
+def run(session):
+    session.goto("/pipeline")
+    session.screenshot("pipeline-initial")
+
+    # Stage cards should be present (at least the first 3: Source, Destination, Scan & Import)
+    stage_count = session.eval(
+        "document.querySelectorAll('.stage-card').length"
+    )
+    session.assert_that(stage_count >= 3, f"expected at least 3 stage cards, got {stage_count}")
+
+    # Stage names should include Source, Destination, Scan & Import
+    stage_names = session.eval(
+        """Array.from(document.querySelectorAll('.stage-name')).map(el => el.textContent.trim())"""
+    )
+    session.assert_that(
+        "Source" in stage_names,
+        f"expected 'Source' in stage names, got {stage_names!r}",
+    )
+    session.assert_that(
+        "Destination" in stage_names,
+        f"expected 'Destination' in stage names, got {stage_names!r}",
+    )
+
+    # The "Start Pipeline" button should exist
+    has_start_btn = session.eval("!!document.getElementById('btnStartPipeline')")
+    session.assert_that(has_start_btn, "expected Start Pipeline button")
+
+    # The Source card should have the Import radio option
+    has_import_radio = session.eval("!!document.getElementById('radioImport')")
+    session.assert_that(has_import_radio, "expected Import radio button in Source card")
+
+    session.screenshot("pipeline-loaded")

--- a/vireo/testing/userfirst/scenarios/workspaces.py
+++ b/vireo/testing/userfirst/scenarios/workspaces.py
@@ -1,0 +1,57 @@
+"""Scenario: visit the workspace management page.
+
+Verifies that /workspace renders, the active workspace name appears,
+folder and workspace sections are present, and the "New Workspace" button
+exists.
+"""
+
+
+def run(session):
+    session.goto("/workspace")
+
+    # Wait for the workspace page JS to load data
+    session.page.wait_for_timeout(1000)
+
+    session.screenshot("workspace-initial")
+
+    # The workspace name heading should exist and show "Default"
+    ws_name = session.eval(
+        "(document.getElementById('wsPageName') || {}).textContent || ''"
+    )
+    session.assert_that(
+        ws_name.strip() == "Default",
+        f"expected workspace name 'Default', got {ws_name!r}",
+    )
+
+    # The Folders section should exist
+    has_folders = session.eval("!!document.getElementById('wsFoldersContent')")
+    session.assert_that(has_folders, "expected folders section on workspace page")
+
+    # The Recent Jobs section should exist
+    has_history = session.eval("!!document.getElementById('historyContent')")
+    session.assert_that(has_history, "expected recent jobs section on workspace page")
+
+    # The All Workspaces section should exist
+    has_workspaces = session.eval("!!document.getElementById('workspacesContent')")
+    session.assert_that(has_workspaces, "expected all workspaces section on workspace page")
+
+    # The "+ New Workspace" button should exist
+    has_new_ws_btn = session.eval(
+        """!!document.querySelector('button[onclick*="showCreateWorkspaceModal"]')"""
+    )
+    session.assert_that(has_new_ws_btn, "expected '+ New Workspace' button")
+
+    # The "+ Add Folder" link should exist and point to /pipeline
+    has_add_folder = session.eval(
+        """!!document.querySelector('a.btn[href="/pipeline"]')"""
+    )
+    session.assert_that(has_add_folder, "expected '+ Add Folder' link to /pipeline")
+
+    # The workspaces section should show at least the Default workspace
+    # (rendered dynamically by loadWorkspaces JS)
+    ws_inputs = session.eval(
+        """document.querySelectorAll('#workspacesContent input[type="text"]').length"""
+    )
+    session.assert_that(ws_inputs >= 1, f"expected at least 1 workspace entry, got {ws_inputs}")
+
+    session.screenshot("workspace-loaded")

--- a/vireo/testing/userfirst/scenarios/workspaces.py
+++ b/vireo/testing/userfirst/scenarios/workspaces.py
@@ -35,11 +35,15 @@ def run(session):
     has_workspaces = session.eval("!!document.getElementById('workspacesContent')")
     session.assert_that(has_workspaces, "expected all workspaces section on workspace page")
 
-    # The "+ New Workspace" button should exist
+    # The "+ New Workspace" button should exist inside the page-local
+    # `.content` wrapper.  The navbar (_navbar.html) also has a button
+    # with the same `onclick`, so scoping to `.content` ensures we fail
+    # if the workspace page's own button is removed even while the
+    # navbar action remains.
     has_new_ws_btn = session.eval(
-        """!!document.querySelector('button[onclick*="showCreateWorkspaceModal"]')"""
+        """!!document.querySelector('.content button[onclick*="showCreateWorkspaceModal"]')"""
     )
-    session.assert_that(has_new_ws_btn, "expected '+ New Workspace' button")
+    session.assert_that(has_new_ws_btn, "expected '+ New Workspace' button on workspace page")
 
     # The "+ Add Folder" link should exist and point to /pipeline
     has_add_folder = session.eval(

--- a/vireo/tests/test_userfirst_scenarios.py
+++ b/vireo/tests/test_userfirst_scenarios.py
@@ -98,3 +98,99 @@ def test_rate_flag_scenario(userfirst_env):
             f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
         )
         pytest.fail(f"rate_flag scenario reported bugs:\n{msg}")
+
+
+def test_scan_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import scan
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="scan", seed=browse_seed) as session:
+        scan.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"scan scenario reported bugs:\n{msg}")
+
+
+def test_pipeline_review_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import pipeline_review
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="pipeline_review", seed=browse_seed) as session:
+        pipeline_review.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"pipeline_review scenario reported bugs:\n{msg}")
+
+
+def test_keywords_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import keywords
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="keywords", seed=browse_seed) as session:
+        keywords.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"keywords scenario reported bugs:\n{msg}")
+
+
+def test_workspaces_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import workspaces
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="workspaces", seed=browse_seed) as session:
+        workspaces.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"workspaces scenario reported bugs:\n{msg}")
+
+
+def test_duplicates_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import duplicates
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="duplicates", seed=browse_seed) as session:
+        duplicates.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"duplicates scenario reported bugs:\n{msg}")
+
+
+def test_map_geo_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import map_geo
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="map_geo", seed=browse_seed) as session:
+        map_geo.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"map_geo scenario reported bugs:\n{msg}")


### PR DESCRIPTION
## Summary

Re-opened against `main` — the original #606 was merged into the already-dead `claude/userfirst-scenarios` branch and the commits never reached main.

Completes the full 9-scenario first cut (Tier 1 + Tier 2) for user-first testing. Builds on #605.

**New scenarios:**

| Scenario | Page | Key assertions |
|----------|------|----------------|
| scan | `/pipeline` | Stage cards, start button, import radio |
| pipeline_review | `/pipeline/review` | Sidebar, empty state link, filter bar |
| keywords | `/keywords` | Search input, 7 filter pills, 4+ keyword rows, Taxonomy filter toggle |
| workspaces | `/workspace` | Default heading, sections, New Workspace button, Add Folder link |
| duplicates | `/duplicates` | Scan button, empty state, progress/apply bar hidden |
| map_geo | `/map` | Leaflet container, 6 filters, CDN-outage vs template-regression detection |

All 6 reuse `browse_seed`. The map_geo scenario distinguishes CDN outages (tolerate) from template regressions (fail) by checking for the core `leaflet.js` script tag specifically.

## Test plan

- [x] 9/9 scenario tests pass after rebase onto main
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)