### PR TITLE
fix: update pipeline e2e test to expect 8 stage cards

### DIFF
--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -7,7 +7,7 @@ def test_pipeline_page_loads_with_stages(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/pipeline")
     stages = page.locator("[data-testid='stage-card']")
-    expect(stages).to_have_count(7)
+    expect(stages).to_have_count(8)
 
 
 def test_pipeline_start_button_disabled_without_folders(live_server, page):


### PR DESCRIPTION
## Summary
- Eye-focus detection (#600) added a new `card-eyekeypoints` stage to `vireo/templates/pipeline.html`, bringing the pipeline up to 8 stage cards
- `test_pipeline_page_loads_with_stages` still asserted exactly 7, so the e2e suite was failing on `main`
- Bumps the expected count to 8

## Test plan
- [x] `python -m pytest tests/e2e/test_pipeline.py -v` — all 12 pipeline e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)