### PR TITLE
test: user-first regression scenarios for recent UI bugs

### DIFF
--- a/vireo/testing/userfirst/scenarios/browse_folders.py
+++ b/vireo/testing/userfirst/scenarios/browse_folders.py
@@ -1,0 +1,65 @@
+"""Regression scenario for #597: orphan folders stay visible on /browse.
+
+A folder whose ``parent_id`` points at an unlinked (or ``status != 'ok'``)
+parent used to disappear from the browse sidebar tree — the renderer groups
+by ``parent_id`` and only descends from the ``'root'`` bucket, so any folder
+whose parent wasn't in the returned set was stranded. ``get_folder_tree``
+now rewrites ``parent_id`` to the nearest visible ancestor (or NULL).
+
+This scenario uses ``orphan_folder_seed``: one folder (``2024``) is linked to
+the workspace but its DB-level parent (``archive``) is unlinked. The child
+must still appear in the browse sidebar.
+"""
+
+
+def run(session):
+    session.goto("/browse")
+    session.page.wait_for_selector("#folderTree .tree-item", state="visible", timeout=5000)
+    session.screenshot("browse-folder-tree")
+
+    tree = session.eval(
+        """(() => {
+            return Array.from(document.querySelectorAll('#folderTree .tree-item'))
+                .map(el => ({
+                    id: parseInt(el.dataset.folderId, 10),
+                    name: (el.querySelector('span') || {}).textContent || '',
+                }));
+        })()"""
+    )
+
+    names = [t["name"] for t in tree]
+    session.assert_that(
+        "2024" in names,
+        f"expected orphan-parent folder '2024' to appear in sidebar; got {names!r}",
+    )
+    session.assert_that(
+        "inbox" in names,
+        f"expected control folder 'inbox' in sidebar; got {names!r}",
+    )
+    # The unlinked parent must not leak into the sidebar.
+    session.assert_that(
+        "archive" not in names,
+        f"unlinked parent 'archive' should not appear in sidebar; got {names!r}",
+    )
+
+    # Clicking the orphan folder should filter the grid to its one photo.
+    orphan = next((t for t in tree if t["name"] == "2024"), None)
+    if orphan is None:
+        return
+
+    session.page.click(f'#folderTree .tree-item[data-folder-id="{orphan["id"]}"]')
+    session.page.wait_for_function(
+        f'() => document.querySelectorAll(\'.grid-card[data-id]\').length >= 1'
+        f' && document.querySelector(\'#folderTree .tree-item[data-folder-id="{orphan["id"]}"]\').classList.contains(\'active\')',
+        timeout=5000,
+    )
+    session.screenshot("browse-folder-filtered")
+
+    filtered_filenames = session.eval(
+        """(() => Array.from(document.querySelectorAll('.grid-card[data-id]'))
+            .map(c => c.dataset.filename || ''))()"""
+    )
+    session.assert_that(
+        any("archive2024" in f for f in filtered_filenames),
+        f"expected orphan folder's photo to appear when filtered; got {filtered_filenames!r}",
+    )

--- a/vireo/testing/userfirst/scenarios/browse_folders.py
+++ b/vireo/testing/userfirst/scenarios/browse_folders.py
@@ -53,9 +53,17 @@ def run(session):
         return
 
     session.page.click(f'#folderTree .tree-item[data-folder-id="{orphan["id"]}"]')
+    # Wait until the grid has narrowed to exactly the orphan's one photo. The
+    # unfiltered grid contains both archive2024_01.jpg and inbox_01.jpg, so
+    # asserting only that archive2024 is present would pass on a filter no-op.
     session.page.wait_for_function(
-        f'() => document.querySelectorAll(\'.grid-card[data-id]\').length >= 1'
-        f' && document.querySelector(\'#folderTree .tree-item[data-folder-id="{orphan["id"]}"]\').classList.contains(\'active\')',
+        f'() => {{'
+        f'  const cards = Array.from(document.querySelectorAll(\'.grid-card[data-id]\'));'
+        f'  const item = document.querySelector(\'#folderTree .tree-item[data-folder-id="{orphan["id"]}"]\');'
+        f'  return item && item.classList.contains(\'active\')'
+        f'    && cards.length === 1'
+        f'    && (cards[0].dataset.filename || \'\').includes(\'archive2024\');'
+        f'}}',
         timeout=5000,
     )
     session.screenshot("browse-folder-filtered")
@@ -67,4 +75,14 @@ def run(session):
     session.assert_that(
         any("archive2024" in f for f in filtered_filenames),
         f"expected orphan folder's photo to appear when filtered; got {filtered_filenames!r}",
+    )
+    # The control folder's photo must be filtered out — otherwise the click
+    # was a no-op and the regression guard would miss the failure mode.
+    session.assert_that(
+        not any("inbox_" in f for f in filtered_filenames),
+        f"expected control folder's photo to be excluded when filtering by orphan; got {filtered_filenames!r}",
+    )
+    session.assert_that(
+        len(filtered_filenames) == 1,
+        f"expected exactly one photo after filtering by orphan folder; got {filtered_filenames!r}",
     )

--- a/vireo/testing/userfirst/scenarios/browse_folders.py
+++ b/vireo/testing/userfirst/scenarios/browse_folders.py
@@ -20,10 +20,15 @@ def run(session):
     tree = session.eval(
         """(() => {
             return Array.from(document.querySelectorAll('#folderTree .tree-item'))
-                .map(el => ({
-                    id: parseInt(el.dataset.folderId, 10),
-                    name: (el.querySelector('span') || {}).textContent || '',
-                }));
+                .map(el => {
+                    const nameEl = el.querySelector(
+                        'span:not(.tree-indent):not(.tree-toggle):not(.count)'
+                    );
+                    return {
+                        id: parseInt(el.dataset.folderId, 10),
+                        name: (nameEl ? nameEl.textContent : '').trim(),
+                    };
+                });
         })()"""
     )
 

--- a/vireo/testing/userfirst/scenarios/browse_lightbox.py
+++ b/vireo/testing/userfirst/scenarios/browse_lightbox.py
@@ -1,0 +1,81 @@
+"""Regression scenario for #598: lightbox arrows work when opened from /browse.
+
+Before the fix, ``openLightbox()`` was called without the ``photoList``
+argument from browse.html, so ``_lightboxPhotoList`` stayed empty and the
+on-screen Next/Prev arrows silently no-op'd. Double-clicking a grid card,
+then clicking Next, should advance to a different photo.
+"""
+
+
+def run(session):
+    session.goto("/browse")
+
+    session.page.wait_for_selector(".grid-card[data-id]", state="visible", timeout=5000)
+    session.screenshot("browse-loaded")
+
+    first = session.eval(
+        """(() => {
+            const card = document.querySelector('.grid-card[data-id]');
+            return card ? {id: card.dataset.id, filename: card.dataset.filename || ''} : null;
+        })()"""
+    )
+    session.assert_that(first is not None, "expected at least one grid card")
+    if first is None:
+        return
+
+    session.page.dblclick(f'.grid-card[data-id="{first["id"]}"]')
+    session.page.wait_for_selector("#lightboxOverlay.active", timeout=5000)
+    session.screenshot("lightbox-open")
+
+    shown_before = session.eval(
+        "(document.getElementById('lightboxFilename') || {}).textContent || ''"
+    )
+    session.assert_that(
+        shown_before == first["filename"],
+        f"lightbox should show clicked photo first; expected {first['filename']!r}, got {shown_before!r}",
+    )
+
+    counter_before = session.eval(
+        "(document.getElementById('lightboxCounter') || {}).textContent || ''"
+    )
+    session.assert_that(
+        "1 /" in counter_before,
+        f"counter should start at '1 / N'; got {counter_before!r}",
+    )
+
+    session.page.click("[title='Next (\u2192)']")
+    # Give the filename label a beat to update before reading it.
+    session.page.wait_for_function(
+        f"() => (document.getElementById('lightboxFilename') || {{}}).textContent !== {first['filename']!r}",
+        timeout=3000,
+    )
+    session.screenshot("lightbox-after-next")
+
+    shown_after_next = session.eval(
+        "(document.getElementById('lightboxFilename') || {}).textContent || ''"
+    )
+    session.assert_that(
+        shown_after_next != first["filename"],
+        "Next arrow should advance to a different photo "
+        f"(still showing {shown_after_next!r})",
+    )
+    counter_after_next = session.eval(
+        "(document.getElementById('lightboxCounter') || {}).textContent || ''"
+    )
+    session.assert_that(
+        "2 /" in counter_after_next,
+        f"counter should read '2 / N' after Next; got {counter_after_next!r}",
+    )
+
+    session.page.click("[title='Previous (\u2190)']")
+    session.page.wait_for_function(
+        f"() => (document.getElementById('lightboxFilename') || {{}}).textContent === {first['filename']!r}",
+        timeout=3000,
+    )
+    shown_after_prev = session.eval(
+        "(document.getElementById('lightboxFilename') || {}).textContent || ''"
+    )
+    session.assert_that(
+        shown_after_prev == first["filename"],
+        f"Previous arrow should return to the first photo; got {shown_after_prev!r}",
+    )

--- a/vireo/testing/userfirst/scenarios/browse_multiselect.py
+++ b/vireo/testing/userfirst/scenarios/browse_multiselect.py
@@ -1,0 +1,88 @@
+"""Regression scenario for #601: browse keyboard shortcuts act on the full multi-selection.
+
+Before the fix, the flag (P/X/U), rating (0-5), and color-label (R/Y/G/B)
+shortcuts on /browse only acted on ``selectedPhotoId`` (the single photo
+in the detail pane). Multi-select via Cmd/Ctrl-click was silently ignored.
+
+This scenario normal-clicks one card, Ctrl-clicks two more, presses the
+reject shortcut (``x``), reloads, and verifies all three photos show the
+rejected badge — not just the last-clicked one.
+"""
+
+
+def run(session):
+    session.goto("/browse")
+    session.page.wait_for_selector(".grid-card[data-id]", state="visible", timeout=5000)
+    # Keyboard handler bails out when _shortcuts hasn't been fetched yet.
+    session.page.wait_for_function("() => window._shortcuts !== null", timeout=5000)
+
+    ids = session.eval(
+        """(() => Array.from(document.querySelectorAll('.grid-card[data-id]'))
+            .slice(0, 3).map(c => parseInt(c.dataset.id, 10)))()"""
+    )
+    session.assert_that(
+        len(ids) == 3,
+        f"need at least 3 grid cards for multi-select; got {len(ids)}",
+    )
+    if len(ids) < 3:
+        return
+
+    # Normal-click the first card, Ctrl-click the next two. On the first
+    # Ctrl-click the handler folds the focused photo into selectedPhotos, so
+    # the Set ends up containing all three ids.
+    session.page.click(f'.grid-card[data-id="{ids[0]}"]')
+    session.page.click(
+        f'.grid-card[data-id="{ids[1]}"]', modifiers=["Control"]
+    )
+    session.page.click(
+        f'.grid-card[data-id="{ids[2]}"]', modifiers=["Control"]
+    )
+    session.screenshot("after-multiselect")
+
+    sel_size = session.eval("selectedPhotos.size")
+    session.assert_that(
+        sel_size == 3,
+        f"selectedPhotos should contain all three clicked photos; got size={sel_size}",
+    )
+
+    # Dispatch the reject shortcut as a synthetic keydown on document so it
+    # bypasses whatever element currently holds focus but still trips the
+    # listener (which is bound on document and ignores INPUT/TEXTAREA).
+    with session.page.expect_response(
+        lambda r: "/api/batch/flag" in r.url and r.request.method == "POST",
+        timeout=5000,
+    ) as resp_info:
+        session.page.evaluate(
+            """() => {
+                const evt = new KeyboardEvent('keydown', {
+                    key: 'x', code: 'KeyX', bubbles: true, cancelable: true,
+                });
+                document.dispatchEvent(evt);
+            }"""
+        )
+
+    resp = resp_info.value
+    session.assert_that(
+        resp.status == 200,
+        f"batch flag request should return 200; got {resp.status}",
+    )
+    session.screenshot("after-reject-shortcut")
+
+    session.goto("/browse")
+    session.page.wait_for_selector(".grid-card[data-id]", state="visible", timeout=5000)
+
+    flagged = session.eval(
+        f"""(() => {{
+            const wanted = {ids};
+            return wanted.map(id => {{
+                const card = document.querySelector(`.grid-card[data-id="${{id}}"]`);
+                if (!card) return [id, 'card-missing'];
+                return [id, card.querySelector('.grid-card-flag.flag-rejected') ? 'rejected' : 'not-rejected'];
+            }});
+        }})()"""
+    )
+    for pid, state in flagged:
+        session.assert_that(
+            state == "rejected",
+            f"photo {pid} should show rejected badge after batch shortcut; got {state!r}",
+        )

--- a/vireo/testing/userfirst/seeds.py
+++ b/vireo/testing/userfirst/seeds.py
@@ -94,3 +94,55 @@ def browse_seed(db_path, thumb_dir, photos_root):
         _make_thumb(thumb_dir, pid)
 
     db.conn.close()
+
+
+def orphan_folder_seed(db_path, thumb_dir, photos_root):
+    """Seed: a child folder whose parent is linked-then-unlinked.
+
+    Reproduces the condition that caused #597 — ``folders.parent_id`` points
+    at a folder that is not linked to the active workspace. Before the
+    ``get_folder_tree`` fix, the child was invisible in the browse sidebar
+    (stranded under an unreachable parent bucket). After the fix, the
+    child reparents to root and renders.
+    """
+    from db import Database
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    base = photos_root if photos_root else "/test/photos"
+
+    # Parent is linked during creation (add_folder auto-links), child is added
+    # with parent_id pointing at it, then the parent is unlinked.
+    parent_id = db.add_folder(os.path.join(base, "archive"), name="archive")
+    child_id = db.add_folder(
+        os.path.join(base, "archive", "2024"), name="2024", parent_id=parent_id
+    )
+    # Independent folder that's always a root — control to prove the tree renders.
+    linked_root_id = db.add_folder(os.path.join(base, "inbox"), name="inbox")
+
+    # Unlink the parent so it's a "ghost" parent of the child.
+    db.remove_workspace_folder(ws_id, parent_id)
+
+    # Give the orphan child one photo so the grid isn't empty when filtered.
+    photos = []
+    for folder_id, fname, ts in (
+        (child_id, "archive2024_01.jpg", "2024-01-15T10:00:00"),
+        (linked_root_id, "inbox_01.jpg", "2024-11-01T09:00:00"),
+    ):
+        pid = db.add_photo(
+            folder_id=folder_id,
+            filename=fname,
+            extension=".jpg",
+            file_size=5000,
+            file_mtime=1.0,
+            timestamp=ts,
+        )
+        photos.append(pid)
+
+    os.makedirs(thumb_dir, exist_ok=True)
+    for pid in photos:
+        _make_thumb(thumb_dir, pid)
+
+    db.conn.close()

--- a/vireo/tests/test_userfirst_scenarios.py
+++ b/vireo/tests/test_userfirst_scenarios.py
@@ -194,3 +194,58 @@ def test_map_geo_scenario(userfirst_env):
             f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
         )
         pytest.fail(f"map_geo scenario reported bugs:\n{msg}")
+
+
+# ---------------------------------------------------------------------------
+# Regression scenarios — each one guards against a specific past bug.
+# ---------------------------------------------------------------------------
+
+def test_browse_lightbox_arrows_regression(userfirst_env):
+    """Regression guard for #598: lightbox arrows navigate photos from /browse."""
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import browse_lightbox
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="browse_lightbox", seed=browse_seed) as session:
+        browse_lightbox.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"browse_lightbox scenario reported bugs:\n{msg}")
+
+
+def test_browse_folders_orphan_parent_regression(userfirst_env):
+    """Regression guard for #597: orphan-parent folders stay visible on /browse."""
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import browse_folders
+    from vireo.testing.userfirst.seeds import orphan_folder_seed
+
+    with vireo_session(name="browse_folders", seed=orphan_folder_seed) as session:
+        browse_folders.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"browse_folders scenario reported bugs:\n{msg}")
+
+
+def test_browse_multiselect_shortcut_regression(userfirst_env):
+    """Regression guard for #601: keyboard shortcuts act on full multi-selection."""
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import browse_multiselect
+    from vireo.testing.userfirst.seeds import browse_seed
+
+    with vireo_session(name="browse_multiselect", seed=browse_seed) as session:
+        browse_multiselect.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"browse_multiselect scenario reported bugs:\n{msg}")


### PR DESCRIPTION
Three Playwright-driven scenarios that guard against bugs already fixed on
main — if any of these recurred, the harness would catch them.

- browse_lightbox (#598): double-click a grid card, verify the on-screen
  Next/Prev arrows actually change the displayed photo. Before the fix,
  openLightbox() was called without the photo-list argument, so
  _lightboxPhotoList stayed empty and lightboxNav() silently no-op'd.
- browse_folders (#597): seed a workspace where a linked folder's DB parent
  is itself unlinked, visit /browse, assert the orphan child still appears
  in the sidebar folder tree (and filtering by it shows its photos).
  Before the get_folder_tree CTE rewrite, the child was stranded under an
  unreachable parent bucket.
- browse_multiselect (#601): normal-click one card, Ctrl-click two more,
  dispatch the reject shortcut, reload, assert all three show the
  rejected badge. Before the fix the shortcut only touched
  selectedPhotoId, so two of the three were silently ignored.

New seed: orphan_folder_seed builds the linked-child / unlinked-parent
topology needed for browse_folders. Verified end-to-end at the DB layer
that the seed produces a folder tree where the orphan child reparents to
root and the unlinked parent does not appear.