### PR TITLE
fix: surface darktable stdout in errors and follow symlinks in binary lookup

### DIFF
--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -7,6 +7,26 @@ import subprocess
 
 log = logging.getLogger(__name__)
 
+_DIAG_MAX_CHARS = 500
+
+
+def _format_subprocess_diag(stdout, stderr):
+    """Combine stdout and stderr into a single short diagnostic string.
+
+    Prefers whichever stream carries output. When both are present, labels
+    them so readers know which channel each line came from. Caps total length
+    at the last _DIAG_MAX_CHARS characters.
+    """
+    out = (stdout or "").strip()
+    err = (stderr or "").strip()
+    if out and err:
+        combined = f"stdout: {out}\nstderr: {err}"
+    else:
+        combined = out or err
+    if len(combined) > _DIAG_MAX_CHARS:
+        combined = "…" + combined[-_DIAG_MAX_CHARS:]
+    return combined
+
 
 def find_darktable(configured_path):
     """Find the darktable-cli binary.
@@ -16,11 +36,23 @@ def find_darktable(configured_path):
 
     Returns:
         absolute path to darktable-cli, or None if not found
+
+    Note:
+        Returned path is resolved via os.path.realpath. On macOS the Homebrew
+        cask installs darktable-cli as a symlink at /usr/local/bin/darktable-cli
+        pointing into /Applications/darktable.app/Contents/MacOS/. Invoking via
+        the symlink dies in dt_init ("can't init develop system") because
+        darktable locates its bundled resources (Resources/share/darktable/,
+        camera profiles, etc.) by walking up from argv[0]; under /usr/local/bin
+        that walk finds nothing. Resolving the symlink first makes every call
+        go through the real bundle path.
     """
     if configured_path and os.path.isfile(configured_path):
-        return configured_path
+        return os.path.realpath(configured_path)
     found = shutil.which("darktable-cli")
-    return found
+    if found:
+        return os.path.realpath(found)
+    return None
 
 
 def build_command(darktable_bin, input_path, output_path, style=None, width=None):
@@ -86,10 +118,12 @@ def develop_photo(darktable_bin, input_path, output_path, style=None, width=None
         log.info("Developing %s -> %s", os.path.basename(input_path), output_path)
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
         if result.returncode != 0:
+            # darktable-cli writes init/IO failures to stdout, not stderr.
+            diag = _format_subprocess_diag(result.stdout, result.stderr)
             return {
                 "success": False,
                 "output_path": output_path,
-                "error": f"darktable-cli exited with code {result.returncode}: {result.stderr.strip()}",
+                "error": f"darktable-cli exited with code {result.returncode}: {diag}",
             }
         if not os.path.isfile(output_path):
             return {"success": False, "output_path": output_path, "error": "Output file was not created"}

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -22,10 +22,11 @@ def test_find_darktable_returns_configured_path(tmp_path):
     assert find_darktable(str(fake_bin)) == str(fake_bin)
 
 
-def test_find_darktable_returns_none_for_bad_configured_path():
-    """find_darktable returns None when configured path doesn't exist."""
+def test_find_darktable_returns_none_for_bad_configured_path(monkeypatch):
+    """find_darktable returns None when configured path doesn't exist and PATH has nothing."""
     from develop import find_darktable
 
+    monkeypatch.setattr("shutil.which", lambda x: None)
     assert find_darktable("/nonexistent/darktable-cli") is None
 
 
@@ -121,3 +122,125 @@ def test_develop_photo_returns_error_when_input_missing():
     )
     assert result["success"] is False
     assert "not found" in result["error"].lower()
+
+
+def test_find_darktable_resolves_symlink(tmp_path):
+    """find_darktable follows symlinks so macOS bundle lookup works.
+
+    darktable-cli invoked via a symlink (e.g. Homebrew's /usr/local/bin
+    symlink into /Applications/darktable.app) dies in dt_init because the
+    bundle-resource walk starts from argv[0]. Vireo must resolve to the real
+    binary path before handing it to subprocess.
+    """
+    import develop
+
+    real = tmp_path / "real_darktable-cli"
+    real.touch()
+    real.chmod(0o755)
+    link = tmp_path / "symlinked_darktable-cli"
+    link.symlink_to(real)
+
+    # Configured path case
+    assert develop.find_darktable(str(link)) == str(real)
+
+    # PATH-auto-detect case: monkeypatch shutil.which to hand back the symlink
+    import unittest.mock
+    with unittest.mock.patch("shutil.which", return_value=str(link)):
+        assert develop.find_darktable("") == str(real)
+
+
+def _fake_completed(returncode, stdout="", stderr=""):
+    import subprocess
+    return subprocess.CompletedProcess(args=[], returncode=returncode,
+                                        stdout=stdout, stderr=stderr)
+
+
+def test_develop_photo_surfaces_stdout_when_stderr_empty(tmp_path, monkeypatch):
+    """darktable writes critical errors to stdout; error message must not be blank."""
+    import subprocess
+
+    import develop
+
+    raw = tmp_path / "bird.NEF"
+    raw.touch()
+    fake_bin = tmp_path / "darktable-cli"
+    fake_bin.touch()
+    fake_bin.chmod(0o755)
+    out = tmp_path / "out" / "bird.jpg"
+
+    stdout_msg = "     0.1899 [dt_init] ERROR: can't init develop system, aborting."
+    monkeypatch.setattr(subprocess, "run",
+                        lambda *a, **kw: _fake_completed(1, stdout=stdout_msg, stderr=""))
+
+    result = develop.develop_photo(str(fake_bin), str(raw), str(out))
+    assert result["success"] is False
+    assert "can't init develop system" in result["error"]
+    assert "exited with code 1" in result["error"]
+
+
+def test_develop_photo_surfaces_stderr_when_stdout_empty(tmp_path, monkeypatch):
+    """Stderr-only failures still surface (back-compat)."""
+    import subprocess
+
+    import develop
+
+    raw = tmp_path / "bird.NEF"
+    raw.touch()
+    fake_bin = tmp_path / "darktable-cli"
+    fake_bin.touch()
+    fake_bin.chmod(0o755)
+    out = tmp_path / "out" / "bird.jpg"
+
+    monkeypatch.setattr(subprocess, "run",
+                        lambda *a, **kw: _fake_completed(1, stdout="", stderr="Segfault in lua"))
+
+    result = develop.develop_photo(str(fake_bin), str(raw), str(out))
+    assert result["success"] is False
+    assert "Segfault in lua" in result["error"]
+
+
+def test_develop_photo_labels_both_streams_when_both_present(tmp_path, monkeypatch):
+    """When darktable writes to both streams, include both with labels."""
+    import subprocess
+
+    import develop
+
+    raw = tmp_path / "bird.NEF"
+    raw.touch()
+    fake_bin = tmp_path / "darktable-cli"
+    fake_bin.touch()
+    fake_bin.chmod(0o755)
+    out = tmp_path / "out" / "bird.jpg"
+
+    monkeypatch.setattr(subprocess, "run",
+                        lambda *a, **kw: _fake_completed(1, stdout="stdout msg", stderr="stderr msg"))
+
+    result = develop.develop_photo(str(fake_bin), str(raw), str(out))
+    assert "stdout msg" in result["error"]
+    assert "stderr msg" in result["error"]
+    assert "stdout:" in result["error"]
+    assert "stderr:" in result["error"]
+
+
+def test_develop_photo_truncates_verbose_failure(tmp_path, monkeypatch):
+    """A pathological multi-KB failure shouldn't explode the job error list."""
+    import subprocess
+
+    import develop
+
+    raw = tmp_path / "bird.NEF"
+    raw.touch()
+    fake_bin = tmp_path / "darktable-cli"
+    fake_bin.touch()
+    fake_bin.chmod(0o755)
+    out = tmp_path / "out" / "bird.jpg"
+
+    huge = "A" * 5000 + "TAIL_MARKER"
+    monkeypatch.setattr(subprocess, "run",
+                        lambda *a, **kw: _fake_completed(1, stdout=huge, stderr=""))
+
+    result = develop.develop_photo(str(fake_bin), str(raw), str(out))
+    # Most of the head should be dropped; the tail (which carries the actual
+    # error message darktable prints near the end) must survive.
+    assert "TAIL_MARKER" in result["error"]
+    assert len(result["error"]) < 800


### PR DESCRIPTION
## Summary

Fixes two adjacent bugs in `vireo/develop.py`:

- **stdout was being dropped in error messages.** darktable-cli writes its init/IO failures (`"can't init develop system"`, `"cannot find the style 'X' to apply"`) to stdout, not stderr. The old code only captured `result.stderr`, so users saw blank error messages and couldn't diagnose anything. Now both streams are combined, the non-empty one is preferred, and output is capped at 500 characters.
- **Symlinked darktable-cli binaries fail to launch on macOS.** On macOS the Homebrew cask installs darktable-cli as a symlink at `/usr/local/bin/darktable-cli` → `/Applications/darktable.app/Contents/MacOS/darktable-cli`. Invoking via the symlink dies in `dt_init` because darktable locates its bundle resources (`Resources/share/darktable/`, camera profiles, etc.) by walking up from argv[0]; under `/usr/local/bin/` that walk finds nothing. Resolving the detected path with `os.path.realpath` before handing it to subprocess fixes every invocation.

Discovered during a user-first testing session driving the Browse → Develop flow against the real app.

## Test plan
- [x] New unit tests cover the stdout-only, stderr-only, both-streams, and truncation cases
- [x] `find_darktable` resolves a tmp symlink to its real target (covers macOS Homebrew case)
- [x] CLAUDE.md smoke set: `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` → 545 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)