### PR TITLE
fix(develop): mark develop job failed when any photo fails

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6206,12 +6206,20 @@ def create_app(db_path, thumb_cache_dir=None):
                 # so _persist_job (jobs.py ~L197-210) merges them with the
                 # primary error message, then raise so _run_job records
                 # status="failed".
+                #
+                # Re-raise with an existing entry in job["errors"] so
+                # _run_job's dedup guard (err_str not in job["errors"])
+                # skips the append — otherwise a novel exception string
+                # gets tacked on as a synthetic extra error, inflating
+                # error_count by 1. Keep the nicer "N/M failed: <err>"
+                # summary on job["_fatal_error"], which _persist_job
+                # prefers over errors[0] when building the result row.
                 job["result"] = result
-                first_err = job["errors"][0] if job["errors"] else ""
-                msg = f"{errors}/{total} develop operations failed"
-                if first_err:
-                    msg = f"{msg}: {first_err}"
-                raise RuntimeError(msg)
+                first_err = job["errors"][0]
+                job["_fatal_error"] = (
+                    f"{errors}/{total} develop operations failed: {first_err}"
+                )
+                raise RuntimeError(first_err)
             return result
 
         job_id = runner.start(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6199,7 +6199,20 @@ def create_app(db_path, thumb_cache_dir=None):
                     },
                 )
 
-            return {"developed": developed, "errors": errors, "total": total}
+            result = {"developed": developed, "errors": errors, "total": total}
+            if errors > 0:
+                # Rollup rule: if any per-photo develop failed, the overall
+                # job is failed (not completed). Stash the counts on the job
+                # so _persist_job (jobs.py ~L197-210) merges them with the
+                # primary error message, then raise so _run_job records
+                # status="failed".
+                job["result"] = result
+                first_err = job["errors"][0] if job["errors"] else ""
+                msg = f"{errors}/{total} develop operations failed"
+                if first_err:
+                    msg = f"{msg}: {first_err}"
+                raise RuntimeError(msg)
+            return result
 
         job_id = runner.start(
             "develop",

--- a/vireo/tests/test_darktable_api.py
+++ b/vireo/tests/test_darktable_api.py
@@ -111,6 +111,10 @@ def test_api_job_develop_all_failures_marks_job_failed(app_and_db, tmp_path, mon
     # And the primary per-photo error should be surfaced in job['errors'].
     errs = data.get('errors') or []
     assert any('fake failure' in e for e in errs), f"expected fake failure in errors: {errs}"
+    # Regression: the rollup failure raise must not synthesize a second,
+    # non-matching error string that _run_job then appends on top of the
+    # real per-photo failure (would inflate error_count to 2 for 1 photo).
+    assert len(errs) == 1, f"expected exactly one error entry, got {len(errs)}: {errs}"
 
 
 def test_api_job_develop_mixed_outcomes_marks_job_failed(app_and_db, tmp_path, monkeypatch):
@@ -158,3 +162,8 @@ def test_api_job_develop_mixed_outcomes_marks_job_failed(app_and_db, tmp_path, m
     assert result.get('developed') == 1
     assert result.get('errors') == 1
     assert result.get('total') == 2
+    # Regression: only the actual per-photo failure should appear in the
+    # errors list — no synthetic summary string tacked on by _run_job.
+    errs = data.get('errors') or []
+    assert len(errs) == 1, f"expected exactly one error entry, got {len(errs)}: {errs}"
+    assert any('fake failure on second photo' in e for e in errs), errs

--- a/vireo/tests/test_darktable_api.py
+++ b/vireo/tests/test_darktable_api.py
@@ -1,4 +1,6 @@
 import json
+import os
+import time
 
 
 def test_api_darktable_status(app_and_db):
@@ -43,3 +45,116 @@ def test_api_config_saves_darktable_settings(app_and_db):
     assert cfg["darktable_style"] == "Wildlife"
     assert cfg["darktable_output_format"] == "tiff"
     assert cfg["darktable_output_dir"] == "/output"
+
+
+def _poll_job(client, job_id, timeout_iters=50):
+    """Poll /api/jobs/<id> until it reaches a terminal state or times out."""
+    data = None
+    for _ in range(timeout_iters):
+        resp = client.get(f'/api/jobs/{job_id}')
+        data = resp.get_json()
+        if data['status'] in ('completed', 'failed', 'cancelled'):
+            return data
+        time.sleep(0.05)
+    return data
+
+
+def test_api_job_develop_all_failures_marks_job_failed(app_and_db, tmp_path, monkeypatch):
+    """If every develop_photo call fails, the rollup status must be 'failed',
+    not 'completed' (rollups with any failed item report failure)."""
+    app, db = app_and_db
+    client = app.test_client()
+
+    # develop requires a configured/findable binary or we short-circuit with
+    # a 400 before the job even starts. Monkeypatch find_darktable in the
+    # develop module so the endpoint proceeds into the job.
+    import develop as develop_mod
+    fake_bin = str(tmp_path / "darktable-cli")
+    with open(fake_bin, "w") as f:
+        f.write("")
+    os.chmod(fake_bin, 0o755)
+    monkeypatch.setattr(develop_mod, "find_darktable", lambda _p: fake_bin)
+
+    # Make every develop_photo call fail deterministically.
+    monkeypatch.setattr(
+        develop_mod,
+        "develop_photo",
+        lambda **kwargs: {
+            "success": False,
+            "output_path": kwargs.get("output_path", ""),
+            "error": "fake failure",
+        },
+    )
+
+    # Pick one photo from the fixture.
+    photos = db.get_photos(per_page=1)
+    assert photos, "fixture should provide at least one photo"
+    pid = photos[0]['id']
+
+    resp = client.post(
+        '/api/jobs/develop',
+        data=json.dumps({"photo_ids": [pid]}),
+        content_type='application/json',
+    )
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    job_id = resp.get_json()['job_id']
+
+    data = _poll_job(client, job_id)
+    assert data is not None
+    # Bug being fixed: used to be 'completed' with 0/1 developed.
+    assert data['status'] == 'failed', f"expected failed, got {data['status']}: {data}"
+    # Result counts must still be present so the UI can show them.
+    result = data.get('result') or {}
+    assert result.get('developed') == 0
+    assert result.get('errors') == 1
+    assert result.get('total') == 1
+    # And the primary per-photo error should be surfaced in job['errors'].
+    errs = data.get('errors') or []
+    assert any('fake failure' in e for e in errs), f"expected fake failure in errors: {errs}"
+
+
+def test_api_job_develop_mixed_outcomes_marks_job_failed(app_and_db, tmp_path, monkeypatch):
+    """If some photos succeed and some fail, the rollup status is still
+    'failed' (any failure => failed, per the rollup rule)."""
+    app, db = app_and_db
+    client = app.test_client()
+
+    import develop as develop_mod
+    fake_bin = str(tmp_path / "darktable-cli")
+    with open(fake_bin, "w") as f:
+        f.write("")
+    os.chmod(fake_bin, 0o755)
+    monkeypatch.setattr(develop_mod, "find_darktable", lambda _p: fake_bin)
+
+    # Alternate success/failure based on input filename.
+    def flaky_develop(**kwargs):
+        in_path = kwargs.get("input_path", "")
+        if "bird1" in in_path:
+            return {"success": True, "output_path": kwargs["output_path"], "error": None}
+        return {
+            "success": False,
+            "output_path": kwargs["output_path"],
+            "error": "fake failure on second photo",
+        }
+
+    monkeypatch.setattr(develop_mod, "develop_photo", flaky_develop)
+
+    photos = db.get_photos(per_page=2)
+    assert len(photos) >= 2, "fixture should provide at least two photos"
+    pids = [photos[0]['id'], photos[1]['id']]
+
+    resp = client.post(
+        '/api/jobs/develop',
+        data=json.dumps({"photo_ids": pids}),
+        content_type='application/json',
+    )
+    assert resp.status_code == 200
+    job_id = resp.get_json()['job_id']
+
+    data = _poll_job(client, job_id)
+    assert data is not None
+    assert data['status'] == 'failed', f"expected failed, got {data['status']}: {data}"
+    result = data.get('result') or {}
+    assert result.get('developed') == 1
+    assert result.get('errors') == 1
+    assert result.get('total') == 2


### PR DESCRIPTION
## Summary

- `POST /api/jobs/develop` was marking the rollup `status="completed"` even when every per-photo develop failed, because the work closure always returned normally with `{"developed": 0, "errors": N, "total": N}`. The UI showed a green check for a job where zero photos actually developed.
- Fix: in the develop work closure, when `errors > 0` stash the counts on `job["result"]` and raise `RuntimeError` so `_run_job` records `status="failed"`. `_persist_job` (`vireo/jobs.py:~L197-210`) already merges the primary error into a structured result dict, so the history row still carries `developed`/`errors`/`total` for UI display.
- Chose an in-place fix in the work closure rather than touching `jobs.py`: `_run_job` does not overwrite `job["result"]` on the exception path (only on success, `jobs.py:149`), so pre-setting it before raising is sufficient.
- Scope kept narrow: only the develop job. Classify/export/thumbnails rollups were not audited or modified in this PR.

## Test plan

- [x] New `test_api_job_develop_all_failures_marks_job_failed` (1 photo, develop_photo monkeypatched to always fail): asserts `status="failed"`, result counts `developed=0/errors=1/total=1` preserved, and per-photo error surfaced in `job["errors"]`.
- [x] New `test_api_job_develop_mixed_outcomes_marks_job_failed` (2 photos, one ok one fail): asserts `status="failed"`, counts `developed=1/errors=1/total=2`.
- [x] Verified both tests fail against pre-fix `app.py` (reverting produced `status="completed"` as expected).
- [x] Full smoke set passed (556 passed). One unrelated pre-existing failure in `test_find_darktable_returns_none_for_bad_configured_path` — that test assumes no system-wide `darktable-cli`; it fails on `main` too (darktable is installed at `/usr/local/bin/darktable-cli` on this machine). Not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)