### PR TITLE
fix(browse): show batch bar for single-photo selection

### DIFF
--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -83,3 +83,35 @@ def test_clear_button_clears_single_focus(live_server, page):
     expect(bar).to_be_hidden()
     # selectedPhotoId must be cleared too so batch actions no longer target it.
     assert page.evaluate("selectedPhotoId") is None
+
+
+def test_clear_button_closes_detail_panel(live_server, page):
+    """Clear in the batch bar must also hide the detail panel.
+
+    Regression: clearSelection() nulled selectedPhotoId but left the detail
+    panel visible. Detail-panel handlers (setFlag, setColorLabel, addKeyword)
+    early-return on null selectedPhotoId, so buttons silently did nothing
+    while the panel remained on screen.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click()
+
+    # Detail panel gains the "visible" class when a photo is focused.
+    page.wait_for_function(
+        "document.getElementById('detailContent').classList.contains('visible')",
+        timeout=2000,
+    )
+
+    page.locator("#batchBar button", has_text="Clear").click()
+
+    # Detail panel must drop the visible class so the summary comes back.
+    assert not page.evaluate(
+        "document.getElementById('detailContent').classList.contains('visible')"
+    )
+    assert not page.evaluate(
+        "document.getElementById('summaryPanel').classList.contains('hidden')"
+    )

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -59,3 +59,27 @@ def test_cmd_click_single_photo_shows_bar(live_server, page):
     bar = page.locator("#batchBar")
     expect(bar).to_be_visible()
     expect(page.locator("#batchCount")).to_have_text("1 selected")
+
+
+def test_clear_button_clears_single_focus(live_server, page):
+    """Clear in the batch bar must hide the bar after a single-click focus.
+
+    Regression: clearSelection() only emptied selectedPhotos, so the focused
+    selectedPhotoId survived and updateBatchBar() re-showed "1 selected",
+    leaving batch actions silently armed against that photo.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click()
+
+    bar = page.locator("#batchBar")
+    expect(bar).to_be_visible()
+
+    page.locator("#batchBar button", has_text="Clear").click()
+
+    expect(bar).to_be_hidden()
+    # selectedPhotoId must be cleared too so batch actions no longer target it.
+    assert page.evaluate("selectedPhotoId") is None

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -115,3 +115,30 @@ def test_clear_button_closes_detail_panel(live_server, page):
     assert not page.evaluate(
         "document.getElementById('summaryPanel').classList.contains('hidden')"
     )
+
+
+def test_resetAndLoad_clears_multiselect_set(live_server, page):
+    """Changing sort/filter/folder must drop a surviving multi-select set.
+
+    Regression: resetAndLoad() cleared selectedPhotoId but left selectedPhotos
+    intact, so a cmd-click selection survived sort/filter/folder changes. The
+    bar would reappear in the new view with stale ids, arming delete/export/
+    develop against photos that might not be present anymore.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click(modifiers=["Meta"])
+
+    bar = page.locator("#batchBar")
+    expect(bar).to_be_visible()
+    assert page.evaluate("selectedPhotos.size") == 1
+
+    # Simulate any dataset-changing action (sort change, filter, folder click).
+    page.evaluate("resetAndLoad()")
+
+    assert page.evaluate("selectedPhotos.size") == 0
+    assert page.evaluate("selectedPhotoId") is None
+    expect(bar).to_be_hidden()

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -1,3 +1,5 @@
+import json
+
 from playwright.sync_api import expect
 
 
@@ -224,6 +226,41 @@ def test_resetAndLoad_clears_multiselect_set(live_server, page):
 
     # Simulate any dataset-changing action (sort change, filter, folder click).
     page.evaluate("resetAndLoad()")
+
+    assert page.evaluate("selectedPhotos.size") == 0
+    assert page.evaluate("selectedPhotoId") is None
+    expect(bar).to_be_hidden()
+
+
+def test_filterByCollection_clears_multiselect_set(live_server, page):
+    """Switching to a collection must drop a surviving multi-select set.
+
+    Regression: filterByCollection() reset `photos = []` and called
+    closeDetail() but never cleared selectedPhotos, so a cmd-click selection
+    from the previous view survived the collection switch. The batch bar
+    would reappear in the new view with stale ids, arming Delete/Export/
+    Develop against photos that weren't visible.
+    """
+    db = live_server["db"]
+    rules = json.dumps([{"field": "extension", "op": "is", "value": ".jpg"}])
+    collection_id = db.add_collection("All JPGs", rules)
+
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click(modifiers=["Meta"])
+
+    bar = page.locator("#batchBar")
+    expect(bar).to_be_visible()
+    assert page.evaluate("selectedPhotos.size") == 1
+
+    # Switch to a collection; stale selection must drop before loadPhotos.
+    page.evaluate(f"filterByCollection({collection_id})")
+    page.wait_for_function(
+        f"activeCollectionId === {collection_id}", timeout=2000
+    )
 
     assert page.evaluate("selectedPhotos.size") == 0
     assert page.evaluate("selectedPhotoId") is None

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -232,6 +232,39 @@ def test_resetAndLoad_clears_multiselect_set(live_server, page):
     expect(bar).to_be_hidden()
 
 
+def test_singleton_set_keyboard_shortcut_applies(live_server, page):
+    """Cmd-click one photo, then press a rating shortcut — the rating must apply.
+
+    Regression: the keydown handler used `selectedPhotos.size > 1` while the
+    batch bar used `>= 1`, so rating/flag/color shortcuts were silent no-ops
+    whenever a one-item set was the only active selection (e.g. a single
+    cmd-click from fresh state, or cmd-click-toggle dropping focus). The bar
+    advertised "1 selected" but digit keys did nothing.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    cards = page.locator(".grid-card")
+    cards.first.wait_for(state="visible")
+
+    a_id = int(cards.nth(0).get_attribute("data-id"))
+    cards.nth(0).click(modifiers=["Meta"])
+
+    # Cmd-click one item from fresh state leaves set={A} with no single-focus.
+    assert page.evaluate("Array.from(selectedPhotos)") == [a_id]
+    assert page.evaluate("selectedPhotoId") is None
+    expect(page.locator("#batchBar")).to_be_visible()
+
+    # "3" maps to _shortcuts.rate_3 by default.
+    page.keyboard.press("3")
+
+    # batchSetRating updates local state after the API call returns.
+    page.wait_for_function(
+        f"(photos.find(function(p){{return p.id==={a_id};}}) || {{}}).rating === 3",
+        timeout=3000,
+    )
+
+
 def test_filterByCollection_clears_multiselect_set(live_server, page):
     """Switching to a collection must drop a surviving multi-select set.
 

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -117,6 +117,51 @@ def test_clear_button_closes_detail_panel(live_server, page):
     )
 
 
+def test_cmd_click_toggles_focus_out_of_set_reconciles(live_server, page):
+    """click A, cmd-click B, cmd-click A: the focus must not linger on A.
+
+    Regression: getActiveSelection() prefers selectedPhotos over
+    selectedPhotoId, so after this sequence the set was {B} while
+    selectedPhotoId was still A. A remained visibly highlighted (and the
+    detail panel still showed A), but batch actions silently targeted B.
+    Fix: after a cmd-click toggle that removes selectedPhotoId from a
+    non-empty set, clear selectedPhotoId and close the stale detail panel.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    cards = page.locator(".grid-card")
+    cards.first.wait_for(state="visible")
+    assert cards.count() >= 2
+
+    a_id = int(cards.nth(0).get_attribute("data-id"))
+    b_id = int(cards.nth(1).get_attribute("data-id"))
+
+    cards.nth(0).click()  # click A: focus A
+    cards.nth(1).click(modifiers=["Meta"])  # cmd-click B: set={A,B}, focus=A
+    cards.nth(0).click(modifiers=["Meta"])  # cmd-click A: set={B}, stale focus
+
+    # Active selection must only contain B, and the focused id must be cleared
+    # so the visible highlight and getActiveSelection() agree.
+    active = page.evaluate("getActiveSelection()")
+    assert active == [b_id], f"expected [{b_id}], got {active}"
+    assert page.evaluate("selectedPhotoId") is None
+
+    # The stale detail panel must be hidden so its (now no-op) handlers
+    # can't be invoked against a null selectedPhotoId.
+    assert not page.evaluate(
+        "document.getElementById('detailContent').classList.contains('visible')"
+    )
+
+    # Card A must no longer carry the "selected" highlight; card B still does.
+    assert not page.evaluate(
+        f"document.querySelector('.grid-card[data-id=\"{a_id}\"]').classList.contains('selected')"
+    )
+    assert page.evaluate(
+        f"document.querySelector('.grid-card[data-id=\"{b_id}\"]').classList.contains('selected')"
+    )
+
+
 def test_resetAndLoad_clears_multiselect_set(live_server, page):
     """Changing sort/filter/folder must drop a surviving multi-select set.
 

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -1,0 +1,61 @@
+from playwright.sync_api import expect
+
+
+def test_single_click_reveals_batch_bar(live_server, page):
+    """Normal-click on one photo reveals the batch bar so Develop/Export/Delete
+    are reachable with a single photo selected.
+
+    Regression: updateBatchBar() previously only showed the bar when
+    selectedPhotos.size > 1, leaving single-click users with no UI path to
+    batch actions against the focused photo.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    bar = page.locator("#batchBar")
+    expect(bar).to_be_hidden()
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click()
+
+    expect(bar).to_be_visible()
+    expect(page.locator("#batchCount")).to_have_text("1 selected")
+    expect(page.locator("#developBtn")).to_be_visible()
+
+
+def test_closing_detail_hides_batch_bar(live_server, page):
+    """Closing the detail panel clears single-focus selection and hides the bar."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click()
+
+    bar = page.locator("#batchBar")
+    expect(bar).to_be_visible()
+
+    # Trigger closeDetail via the summary/close button inside the detail panel.
+    # Falling back to pressing Escape which browse.html wires to the same path.
+    page.evaluate("closeDetail()")
+
+    expect(bar).to_be_hidden()
+
+
+def test_cmd_click_single_photo_shows_bar(live_server, page):
+    """Cmd-clicking one tile (size==1) now reveals the bar too.
+
+    Previously size>1 was required; users had to cmd-click two photos before
+    any batch action became reachable.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click(modifiers=["Meta"])
+
+    bar = page.locator("#batchBar")
+    expect(bar).to_be_visible()
+    expect(page.locator("#batchCount")).to_have_text("1 selected")

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -162,6 +162,47 @@ def test_cmd_click_toggles_focus_out_of_set_reconciles(live_server, page):
     )
 
 
+def test_close_detail_preserves_multiselect_highlight(live_server, page):
+    """click A -> cmd-click B -> cmd-click B -> closeDetail must keep A lit.
+
+    Regression: closeDetail() stripped .selected from every card but left
+    selectedPhotos intact, so the bar kept showing "1 selected" while no
+    card was visibly highlighted. Destructive batch actions (delete/export/
+    develop) would then target a photo the user could no longer identify.
+    Fix: re-apply the .selected class to any card still in selectedPhotos
+    during closeDetail.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    cards = page.locator(".grid-card")
+    cards.first.wait_for(state="visible")
+    assert cards.count() >= 2
+
+    a_id = int(cards.nth(0).get_attribute("data-id"))
+    b_id = int(cards.nth(1).get_attribute("data-id"))
+
+    cards.nth(0).click()  # click A: set={}, focus=A
+    cards.nth(1).click(modifiers=["Meta"])  # cmd-click B: set={A,B}, focus=A
+    cards.nth(1).click(modifiers=["Meta"])  # cmd-click B again: set={A}, focus=A
+
+    page.evaluate("closeDetail()")
+
+    # Bar must still reflect the surviving multi-select entry.
+    expect(page.locator("#batchBar")).to_be_visible()
+    expect(page.locator("#batchCount")).to_have_text("1 selected")
+    assert page.evaluate("Array.from(selectedPhotos)") == [a_id]
+    assert page.evaluate("selectedPhotoId") is None
+
+    # Card A must still paint as selected so the user can see what will be acted on.
+    assert page.evaluate(
+        f"document.querySelector('.grid-card[data-id=\"{a_id}\"]').classList.contains('selected')"
+    )
+    assert not page.evaluate(
+        f"document.querySelector('.grid-card[data-id=\"{b_id}\"]').classList.contains('selected')"
+    )
+
+
 def test_resetAndLoad_clears_multiselect_set(live_server, page):
     """Changing sort/filter/folder must drop a surviving multi-select set.
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2202,6 +2202,16 @@ function clearSelection() {
   document.querySelectorAll('.grid-card').forEach(function(el) {
     el.classList.remove('selected');
   });
+  // If the detail panel is still open after clearing, its actions (setFlag,
+  // setColorLabel, addKeyword, etc.) early-return on the null selectedPhotoId
+  // and silently do nothing. Hide it so there is no ghost UI to interact with.
+  var detail = document.getElementById('detailContent');
+  if (detail && detail.classList.contains('visible')) {
+    detail.classList.remove('visible');
+    var summary = document.getElementById('summaryPanel');
+    if (summary) summary.classList.remove('hidden');
+    loadSummary();
+  }
   updateBatchBar();
 }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2194,7 +2194,11 @@ async function confirmBatchCollection() {
 }
 
 function clearSelection() {
+  // Clear both tracks that feed getActiveSelection(), otherwise the batch bar
+  // reappears immediately with the single-focus photo still armed for actions.
   selectedPhotos.clear();
+  selectedPhotoId = null;
+  selectedIndex = -1;
   document.querySelectorAll('.grid-card').forEach(function(el) {
     el.classList.remove('selected');
   });

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1975,6 +1975,23 @@ function selectPhoto(e, id, idx) {
     } else {
       selectedPhotos.add(id);
     }
+    // If the toggle dropped the focused photo out of a non-empty set, its
+    // highlight/detail focus is now stale: the card still paints "selected"
+    // via the selectedPhotoId branch of the highlight rule, yet
+    // getActiveSelection() returns the set — so destructive actions
+    // (delete/export/develop) would target the set while the user is staring
+    // at a different, visibly-focused card. Reconcile by dropping the focus.
+    if (selectedPhotoId !== null && selectedPhotos.size > 0 && !selectedPhotos.has(selectedPhotoId)) {
+      selectedPhotoId = null;
+      selectedIndex = -1;
+      var detail = document.getElementById('detailContent');
+      if (detail && detail.classList.contains('visible')) {
+        detail.classList.remove('visible');
+        var summary = document.getElementById('summaryPanel');
+        if (summary) summary.classList.remove('hidden');
+        loadSummary();
+      }
+    }
   } else {
     // Normal click: single select
     selectedPhotos.clear();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1462,6 +1462,11 @@ function resetAndLoad() {
   allLoaded = false;
   loadEpoch++;
   loading = false;
+  // Dataset is about to change; any prior selection (multi-select Set or
+  // single-focus id) points at photos that may not exist in the new view.
+  // Leaving them set would let updateBatchBar() keep showing "N selected"
+  // and arm batch actions (delete/export/develop) against stale ids.
+  selectedPhotos.clear();
   selectedPhotoId = null;
   selectedIndex = -1;
   // Leaving collection mode when applying non-collection filters (sort, rating,

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1841,7 +1841,7 @@ async function loadInatStatus(photoIds) {
 }
 
 function batchSubmitInat() {
-  var ids = Array.from(selectedPhotos);
+  var ids = getActiveSelection();
   if (ids.length === 0) return;
   submitToInatBatch(ids);
 }
@@ -1987,19 +1987,30 @@ function selectPhoto(e, id, idx) {
   updateBatchBar();
 }
 
+// The batch bar drives Develop/Export/Delete/etc. "Active selection" is
+// whichever of {selectedPhotos, selectedPhotoId} has entries — the Set for
+// cmd/shift-clicks, the single id for a normal click focus. Single-focused
+// photos count as selected for the purposes of batch actions.
+function getActiveSelection() {
+  if (selectedPhotos.size > 0) return Array.from(selectedPhotos);
+  if (selectedPhotoId != null) return [selectedPhotoId];
+  return [];
+}
+
 function updateBatchBar() {
   var bar = document.getElementById('batchBar');
   if (!bar) return;
-  if (selectedPhotos.size > 1) {
+  var ids = getActiveSelection();
+  if (ids.length >= 1) {
     bar.style.display = 'flex';
-    document.getElementById('batchCount').textContent = selectedPhotos.size + ' selected';
+    document.getElementById('batchCount').textContent = ids.length + ' selected';
   } else {
     bar.style.display = 'none';
   }
 }
 
 async function batchSetRating(rating) {
-  var ids = Array.from(selectedPhotos);
+  var ids = getActiveSelection();
   try {
     await safeFetch('/api/batch/rating', {
       method: 'POST', headers: {'Content-Type': 'application/json'},
@@ -2015,7 +2026,7 @@ async function batchSetRating(rating) {
 }
 
 async function batchSetFlag(flag) {
-  var ids = Array.from(selectedPhotos);
+  var ids = getActiveSelection();
   try {
     await safeFetch('/api/batch/flag', {
       method: 'POST', headers: {'Content-Type': 'application/json'},
@@ -2031,7 +2042,7 @@ async function batchSetFlag(flag) {
 }
 
 async function batchSetColorLabel(color) {
-  var ids = Array.from(selectedPhotos);
+  var ids = getActiveSelection();
   if (!ids.length) return;
   colorLabelGen++;
   try {
@@ -2049,7 +2060,7 @@ async function batchSetColorLabel(color) {
 }
 
 function batchAddKeyword() {
-  document.getElementById('batchKeywordTitle').textContent = 'Add keyword to ' + selectedPhotos.size + ' photos';
+  document.getElementById('batchKeywordTitle').textContent = 'Add keyword to ' + getActiveSelection().length + ' photos';
   document.getElementById('batchKeywordInput').value = '';
   document.getElementById('batchKeywordModal').classList.add('open');
   setTimeout(function() { document.getElementById('batchKeywordInput').focus(); }, 50);
@@ -2063,7 +2074,7 @@ async function confirmBatchKeyword() {
   var name = document.getElementById('batchKeywordInput').value.trim();
   if (!name) return;
   hideBatchKeywordModal();
-  var ids = Array.from(selectedPhotos);
+  var ids = getActiveSelection();
   try {
     await safeFetch('/api/batch/keyword', {
       method: 'POST', headers: {'Content-Type': 'application/json'},
@@ -2074,7 +2085,7 @@ async function confirmBatchKeyword() {
 }
 
 function batchDelete() {
-  var ids = Array.from(selectedPhotos);
+  var ids = getActiveSelection();
   if (ids.length === 0) return;
   var companionCount = 0;
   ids.forEach(function(id) {
@@ -2102,7 +2113,8 @@ var _batchCollections = [];
 var _batchCollectionSelectedId = null;
 
 async function addToCollection() {
-  if (selectedPhotos.size === 0) return;
+  var activeIds = getActiveSelection();
+  if (activeIds.length === 0) return;
 
   var collections;
   try {
@@ -2111,7 +2123,7 @@ async function addToCollection() {
 
   _batchCollections = collections;
   _batchCollectionSelectedId = null;
-  document.getElementById('batchCollectionTitle').textContent = 'Add ' + selectedPhotos.size + ' photo(s) to collection';
+  document.getElementById('batchCollectionTitle').textContent = 'Add ' + activeIds.length + ' photo(s) to collection';
 
   var listHtml = '';
   collections.forEach(function(c) {
@@ -2140,7 +2152,7 @@ function hideBatchCollectionModal() {
 
 async function confirmBatchCollection() {
   var newName = document.getElementById('batchCollectionNewName').value.trim();
-  var ids = Array.from(selectedPhotos);
+  var ids = getActiveSelection();
   var collectionId = _batchCollectionSelectedId;
   var collectionName = '';
 
@@ -2460,6 +2472,7 @@ function closeDetail() {
   document.querySelectorAll('.grid-card').forEach(function(el) {
     el.classList.remove('selected');
   });
+  updateBatchBar();
   loadSummary();
 }
 
@@ -2748,7 +2761,7 @@ function scrollToCard(idx) {
 }
 
 async function developSelected() {
-  var ids = Array.from(selectedPhotos);
+  var ids = getActiveSelection();
   if (!ids.length) return;
 
   // Check darktable availability first
@@ -2788,7 +2801,7 @@ async function developSelected() {
 }
 
 function openInEditorBatch() {
-  var ids = Array.from(selectedPhotos);
+  var ids = getActiveSelection();
   if (!ids.length) return;
   if (ids.length > 20) {
     if (!confirm('Open ' + ids.length + ' photos in editor?')) return;
@@ -2867,8 +2880,9 @@ function openInEditorBatch() {
 
 /* ---------- Export Modal ---------- */
 function openExportModal() {
-  if (selectedPhotos.size === 0) return;
-  document.getElementById('exportSubmitBtn').textContent = 'Export ' + selectedPhotos.size + ' photo' + (selectedPhotos.size === 1 ? '' : 's');
+  var activeIds = getActiveSelection();
+  if (activeIds.length === 0) return;
+  document.getElementById('exportSubmitBtn').textContent = 'Export ' + activeIds.length + ' photo' + (activeIds.length === 1 ? '' : 's');
   document.getElementById('exportSubmitBtn').disabled = false;
   document.getElementById('exportResize').value = '';
   document.getElementById('exportResizeCustom').style.display = 'none';
@@ -2899,7 +2913,7 @@ function updateExportPreview() {
   var template = document.getElementById('exportTemplate').value;
   if (!template) { document.getElementById('exportPreview').textContent = ''; return; }
   // Use first selected photo for preview
-  var firstId = Array.from(selectedPhotos)[0];
+  var firstId = getActiveSelection()[0];
   var photo = photos.find(function(p) { return p.id === firstId; });
   if (!photo) { document.getElementById('exportPreview').textContent = ''; return; }
   var stem = photo.filename.replace(/\.[^.]+$/, '');
@@ -2944,7 +2958,8 @@ async function startExport() {
   var quality = parseInt(document.getElementById('exportQuality').value) || 92;
   var template = document.getElementById('exportTemplate').value || '{original}';
   var btn = document.getElementById('exportSubmitBtn');
-  var count = selectedPhotos.size;
+  var activeIds = getActiveSelection();
+  var count = activeIds.length;
   btn.disabled = true;
 
   try {
@@ -2952,7 +2967,7 @@ async function startExport() {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({
-        photo_ids: Array.from(selectedPhotos),
+        photo_ids: activeIds,
         destination: dest,
         naming_template: template,
         max_size: maxSize,

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2775,13 +2775,17 @@ document.addEventListener('keydown', function(e) {
     }
   }
 
-  var multi = selectedPhotos.size > 1;
+  // Must stay aligned with updateBatchBar(): any non-empty selectedPhotos is
+  // actionable (size >= 1, not > 1), otherwise shortcuts silently no-op while
+  // the bar advertises "1 selected" after cmd-click reduces the set to one.
+  var useBatch = selectedPhotos.size >= 1;
+  var hasActive = useBatch || selectedPhotoId;
 
   // Ratings: 0-5
-  if (multi || selectedPhotoId) {
+  if (hasActive) {
     for (var r = 0; r <= 5; r++) {
       if (matchesShortcut(e, _shortcuts['rate_' + r])) {
-        if (multi) batchSetRating(r);
+        if (useBatch) batchSetRating(r);
         else setRating(selectedPhotoId, r);
         return;
       }
@@ -2789,9 +2793,9 @@ document.addEventListener('keydown', function(e) {
   }
 
   // Flag, reject, unflag
-  if (multi || selectedPhotoId) {
-    var applyFlag = multi ? batchSetFlag : setFlag;
-    var applyColor = multi ? batchSetColorLabel : setColorLabel;
+  if (hasActive) {
+    var applyFlag = useBatch ? batchSetFlag : setFlag;
+    var applyColor = useBatch ? batchSetColorLabel : setColorLabel;
     if (matchesShortcut(e, _shortcuts.flag)) { e.preventDefault(); applyFlag('flagged'); }
     else if (matchesShortcut(e, _shortcuts.reject)) { e.preventDefault(); applyFlag('rejected'); }
     else if (matchesShortcut(e, _shortcuts.unflag)) { e.preventDefault(); applyFlag('none'); }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2505,8 +2505,14 @@ function closeDetail() {
   document.getElementById('summaryPanel').classList.remove('hidden');
   selectedPhotoId = null;
   selectedIndex = -1;
+  // Re-highlight any cmd/shift-click selections that survive detail close.
+  // A blanket .remove('selected') would leave selectedPhotos armed for batch
+  // actions with no visible indicator — e.g. click A -> cmd-click B -> cmd-click
+  // B drops the set to {A}, and closing detail would otherwise show "1 selected"
+  // in the bar against an unhighlighted photo.
   document.querySelectorAll('.grid-card').forEach(function(el) {
-    el.classList.remove('selected');
+    var cardId = parseInt(el.dataset.id);
+    el.classList.toggle('selected', selectedPhotos.has(cardId));
   });
   updateBatchBar();
   loadSummary();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1352,6 +1352,13 @@ async function filterByCollection(id) {
   allLoaded = false;
   loadEpoch++;         // invalidate any in-flight loadPhotos response
   loading = false;     // safe to clear: the stale response will be dropped
+  // Dataset is about to change; a surviving multi-select Set points at
+  // photos from the previous collection. Without this clear, closeDetail()
+  // keeps selectedPhotos intact and updateBatchBar() shows "N selected" with
+  // stale ids, arming Delete/Export/Develop against hidden photos.
+  selectedPhotos.clear();
+  selectedPhotoId = null;
+  selectedIndex = -1;
   document.getElementById('grid').innerHTML = '';
   closeDetail();
   await loadPhotos();
@@ -2873,6 +2880,9 @@ function openInEditorBatch() {
     photos = [];
     currentPage = 1;
     allLoaded = false;
+    // Same hazard as filterByCollection: leaving selectedPhotos populated
+    // across a dataset switch leaves the batch bar armed against stale ids.
+    selectedPhotos.clear();
     selectedPhotoId = null;
     selectedIndex = -1;
     closeDetail();


### PR DESCRIPTION
## Summary

- Normal-click on a `.grid-card` highlighted the tile and opened the detail
  panel but left the batch bar hidden, so **Develop / Export / Delete / rate**
  had no UI path for a single-photo selection. `updateBatchBar()` only showed
  the bar when `selectedPhotos.size > 1`.
- Added `getActiveSelection()` — returns `selectedPhotos` when non-empty,
  otherwise `[selectedPhotoId]` when one is focused — and routed every
  batch-action call site through it.
- `updateBatchBar()` now reveals the bar at active length >= 1;
  `closeDetail()` hides it when focus clears.

Surfaced while driving the app headlessly (bughunt #1 in `.context/bughunt/drive_sharpest.py`):
sorting by sharpness + clicking the top tile gave the user no way to
Develop or Export that single photo.

## Test plan
- [x] `python -m pytest tests/e2e/test_browse_single_select.py -v` — 3 new Playwright regressions (single-click, closeDetail, cmd-click-one)
- [x] `python -m pytest tests/e2e/ -v` — 46 passed, 1 skipped
- [x] CLAUDE.md smoke set — 545 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)