### PR TITLE
feat(export): prefer darktable-developed output over RAW re-decode

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6170,8 +6170,15 @@ def create_app(db_path, thumb_cache_dir=None):
                 folder_path = folders.get(photo["folder_id"], "")
                 input_path = os.path.join(folder_path, photo["filename"])
 
-                # Determine output directory: configured, or "developed" subfolder next to originals
-                out_dir = output_dir if output_dir else os.path.join(folder_path, "developed")
+                # Determine output directory. The per-folder "developed/" default
+                # is naturally disambiguated (one dir per source folder). The
+                # globally configured dir is flat, so nest each photo under its
+                # folder_id to avoid collisions when two source folders contain
+                # files with the same basename (e.g. IMG_0001.CR3 in both).
+                if output_dir:
+                    out_dir = os.path.join(output_dir, str(photo["folder_id"]))
+                else:
+                    out_dir = os.path.join(folder_path, "developed")
                 out_path = output_path_for_photo(photo["filename"], out_dir, output_format)
 
                 result = develop_photo(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5183,6 +5183,10 @@ def create_app(db_path, thumb_cache_dir=None):
         runner = app._job_runner
         active_ws = _get_db()._active_workspace_id
 
+        import config as cfg
+        effective_cfg = _get_db().get_effective_config(cfg.load())
+        developed_dir = effective_cfg.get("darktable_output_dir", "") or ""
+
         def work(job):
             from move import move_folder
 
@@ -5207,6 +5211,7 @@ def create_app(db_path, thumb_cache_dir=None):
                 folder_id=folder_id,
                 destination=destination,
                 progress_cb=progress_cb,
+                developed_dir=developed_dir,
             )
 
         job_id = runner.start(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6147,6 +6147,7 @@ def create_app(db_path, thumb_cache_dir=None):
 
         def work(job):
             from develop import develop_photo, output_path_for_photo
+            from export import developed_folder_key
 
             thread_db = Database(db_path)
             thread_db.set_active_workspace(active_ws)
@@ -6172,11 +6173,13 @@ def create_app(db_path, thumb_cache_dir=None):
 
                 # Determine output directory. The per-folder "developed/" default
                 # is naturally disambiguated (one dir per source folder). The
-                # globally configured dir is flat, so nest each photo under its
-                # folder_id to avoid collisions when two source folders contain
-                # files with the same basename (e.g. IMG_0001.CR3 in both).
+                # globally configured dir is flat, so nest each photo under a
+                # stable key derived from the source folder's path (not its row
+                # id — SQLite reuses those after deletion, which would silently
+                # cross-wire new folders onto stale developed files left on
+                # disk by a previously-deleted folder).
                 if output_dir:
-                    out_dir = os.path.join(output_dir, str(photo["folder_id"]))
+                    out_dir = os.path.join(output_dir, developed_folder_key(folder_path))
                 else:
                     out_dir = os.path.join(folder_path, "developed")
                 out_path = output_path_for_photo(photo["filename"], out_dir, output_format)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5113,6 +5113,9 @@ def create_app(db_path, thumb_cache_dir=None):
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
         effective_cfg = db.get_effective_config(cfg.load())
         wc_max_size = effective_cfg.get("working_copy_max_size", 4096)
+        # Pass the configured darktable output dir so export prefers the
+        # perfected render over a fresh libraw decode of the RAW.
+        developed_dir = effective_cfg.get("darktable_output_dir", "") or ""
 
         def work(job):
             from export import export_photos
@@ -5147,6 +5150,7 @@ def create_app(db_path, thumb_cache_dir=None):
                     "max_size": max_size,
                     "quality": quality,
                     "working_copy_max_size": wc_max_size,
+                    "developed_dir": developed_dir,
                 },
                 progress_cb=progress_cb,
             )

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -869,10 +869,31 @@ def create_app(db_path, thumb_cache_dir=None):
         if not os.path.isdir(new_path):
             return json_error("path does not exist or is not a directory")
 
+        # Capture the old path before the DB rewrite so we can rebase the
+        # corresponding darktable output subdir on disk. Developed outputs
+        # are nested under developed_folder_key(folder_path), so a path
+        # change invalidates the old key and would silently regress export
+        # to RAW until the user re-developed.
+        old_row = db.conn.execute(
+            "SELECT path FROM folders WHERE id = ?", (folder_id,)
+        ).fetchone()
+        old_path = old_row["path"] if old_row else ""
+
         try:
             cascaded = db.relocate_folder(folder_id, new_path)
         except ValueError as e:
             return json_error(str(e), 409)
+
+        import config as cfg
+        from export import relocate_developed_dir
+        effective_cfg = db.get_effective_config(cfg.load())
+        developed_dir = effective_cfg.get("darktable_output_dir", "") or ""
+        if developed_dir and old_path:
+            relocate_developed_dir(developed_dir, old_path, new_path)
+            for child in cascaded:
+                relocate_developed_dir(
+                    developed_dir, child["old_path"], child["new_path"]
+                )
         return jsonify({
             "status": "ok",
             "cascaded": cascaded,

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -80,7 +80,10 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
                 default <folder>/developed/<stem>.<ext>) over
                 re-decoding the RAW. The folder_id nesting matches the
                 develop job's write convention and keeps lookups one-to-one
-                even when two source folders share a basename.
+                even when two source folders share a basename. As a legacy
+                fallback, <developed_dir>/<stem>.<ext> is also probed so
+                libraries developed before the folder_id convention was
+                introduced still pick up their developed outputs.
         progress_cb: optional callback(current, total, current_file)
 
     Returns:
@@ -111,6 +114,13 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
     exported = 0
     errors = []
 
+    # Per-export cache of developed-directory scans. Keyed by directory
+    # path; each value is the (stem, ext_lower) → absolute-path map that
+    # _find_developed_output would otherwise rebuild for every photo.
+    # Large exports routinely probe the same directory N times; caching
+    # keeps that cost O(1) per photo after the first hit.
+    developed_index = _DevelopedDirIndex()
+
     for i, pid in enumerate(photo_ids):
         photo = photos_map.get(pid)
         if not photo:
@@ -127,7 +137,11 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
         #   3. original file (default; also used for full-res exports).
         folder_path = folders.get(photo["folder_id"], "")
         source_path = _find_developed_output(
-            photo["filename"], photo["folder_id"], folder_path, developed_dir
+            photo["filename"],
+            photo["folder_id"],
+            folder_path,
+            developed_dir,
+            developed_index,
         )
         if not source_path:
             use_wc = bool(max_size) and max_size <= wc_max
@@ -207,12 +221,50 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
     return {"exported": exported, "errors": errors, "destination": destination}
 
 
-def _find_developed_output(filename, folder_id, folder_path, developed_dir):
+_PREFERRED_DEVELOPED_EXTS = ("jpg", "jpeg", "tiff", "tif")
+
+
+class _DevelopedDirIndex:
+    """Lazy, per-export cache of directory listings for developed lookups.
+
+    Each directory is scanned with os.listdir once and indexed as
+    (exact stem, lowercased ext) → absolute path. Subsequent lookups
+    against the same directory are O(1), which avoids turning the
+    per-photo probe into quadratic work on large exports where many
+    photos share a developed directory.
+    """
+
+    def __init__(self):
+        self._cache = {}
+
+    def lookup(self, base, stem):
+        entries = self._cache.get(base)
+        if entries is None:
+            entries = {}
+            try:
+                names = os.listdir(base)
+            except OSError:
+                names = []
+            # Stem match must be case-sensitive to avoid collisions
+            # between photos whose names differ only by case. Extension
+            # match is case-insensitive so developed files written as
+            # .JPG / .TIFF are still picked up.
+            for name in names:
+                ent_stem, ent_ext = os.path.splitext(name)
+                ext_key = ent_ext[1:].lower() if ent_ext.startswith(".") else ent_ext.lower()
+                entries.setdefault((ent_stem, ext_key), os.path.join(base, name))
+            self._cache[base] = entries
+        for ext in _PREFERRED_DEVELOPED_EXTS:
+            path = entries.get((stem, ext))
+            if path and os.path.isfile(path):
+                return path
+        return None
+
+
+def _find_developed_output(filename, folder_id, folder_path, developed_dir, index=None):
     """Return the path to a darktable-developed output for this photo, or None.
 
-    Both lookup locations are scoped so that two photos with the same basename
-    in different source folders (e.g. IMG_0001.CR3 in folder A and folder B)
-    resolve to distinct developed files:
+    Lookup locations are probed in order:
 
       * <developed_dir>/<folder_id>/<stem>.<ext> — matches how the develop
         job writes when darktable_output_dir is configured (the flat output
@@ -220,6 +272,11 @@ def _find_developed_output(filename, folder_id, folder_path, developed_dir):
       * <folder_path>/developed/<stem>.<ext> — the default develop-job
         location, naturally disambiguated because each source folder has
         its own developed/ subdir.
+      * <developed_dir>/<stem>.<ext> — legacy flat layout used by older
+        versions of the develop job. Probed last so that any new
+        folder-scoped output wins, but kept so libraries developed before
+        the folder_id convention still light up their developed render on
+        export.
 
     Extensions are matched case-insensitively so exports still pick up
     developed files written with uppercase extensions — e.g. IMG_0001.JPG
@@ -231,6 +288,9 @@ def _find_developed_output(filename, folder_id, folder_path, developed_dir):
     developed files.
 
     JPG is preferred over TIFF when both exist.
+
+    Pass `index` (a _DevelopedDirIndex) to amortize directory scans
+    across many photos in the same export.
     """
     stem = os.path.splitext(filename)[0]
     candidates = []
@@ -238,25 +298,14 @@ def _find_developed_output(filename, folder_id, folder_path, developed_dir):
         candidates.append(os.path.join(developed_dir, str(folder_id)))
     if folder_path:
         candidates.append(os.path.join(folder_path, "developed"))
-    preferred_exts = ("jpg", "jpeg", "tiff", "tif")
+    if developed_dir:
+        candidates.append(developed_dir)
+    if index is None:
+        index = _DevelopedDirIndex()
     for base in candidates:
-        try:
-            names = os.listdir(base)
-        except OSError:
-            continue
-        # Map (exact stem, lowercased ext) → actual filename. Stem match
-        # must be case-sensitive to avoid collisions between photos whose
-        # names differ only by case. Extension match is case-insensitive
-        # so developed files written as .JPG / .TIFF are still picked up.
-        entries = {}
-        for name in names:
-            ent_stem, ent_ext = os.path.splitext(name)
-            ext_key = ent_ext[1:].lower() if ent_ext.startswith(".") else ent_ext.lower()
-            entries.setdefault((ent_stem, ext_key), os.path.join(base, name))
-        for ext in preferred_exts:
-            path = entries.get((stem, ext))
-            if path and os.path.isfile(path):
-                return path
+        hit = index.lookup(base, stem)
+        if hit:
+            return hit
     return None
 
 

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import os
 import re
+import shutil
 
 from image_loader import load_image
 
@@ -281,12 +282,32 @@ def relocate_developed_dir(developed_dir, old_folder_path, new_folder_path):
     if not os.path.isdir(old_subdir):
         return False
     if os.path.exists(new_subdir):
-        log.warning(
-            "Cannot relocate developed dir %s -> %s: target already exists; "
-            "leaving source in place",
-            old_subdir, new_subdir,
-        )
-        return False
+        # Target already exists — this is the merge case (e.g.
+        # `/api/folders/<id>/relocate` routing through
+        # `db._merge_into_existing`). Move individual files into the
+        # target so reassigned photos still resolve to their developed
+        # render instead of being stranded under the old key. On
+        # filename collision the target wins, matching the DB merge's
+        # drop-source-on-collision policy.
+        try:
+            for name in os.listdir(old_subdir):
+                src_file = os.path.join(old_subdir, name)
+                dst_file = os.path.join(new_subdir, name)
+                if os.path.exists(dst_file):
+                    if os.path.isdir(src_file) and not os.path.islink(src_file):
+                        shutil.rmtree(src_file)
+                    else:
+                        os.remove(src_file)
+                else:
+                    os.rename(src_file, dst_file)
+            os.rmdir(old_subdir)
+            return True
+        except OSError as exc:
+            log.warning(
+                "Failed to merge developed dir %s into %s: %s",
+                old_subdir, new_subdir, exc,
+            )
+            return False
     try:
         os.rename(old_subdir, new_subdir)
         return True

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -1,5 +1,6 @@
 """Photo export with resize, quality control, and template-based naming."""
 
+import hashlib
 import logging
 import os
 import re
@@ -76,13 +77,16 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
             developed_dir: str -- optional path to darktable-developed
                 outputs (mirrors darktable_output_dir config). Export
                 prefers a developed JPG/TIFF at
-                <developed_dir>/<folder_id>/<stem>.<ext> (or at the
+                <developed_dir>/<path_key>/<stem>.<ext> (or at the
                 default <folder>/developed/<stem>.<ext>) over
-                re-decoding the RAW. The folder_id nesting matches the
-                develop job's write convention and keeps lookups one-to-one
-                even when two source folders share a basename. As a legacy
-                fallback, <developed_dir>/<stem>.<ext> is also probed so
-                libraries developed before the folder_id convention was
+                re-decoding the RAW. `path_key` is a stable hash of the
+                source folder's path (see `developed_folder_key`), so the
+                per-folder nesting matches the develop job's write
+                convention, keeps lookups one-to-one when two source
+                folders share a basename, and survives SQLite row-id
+                reuse after folder deletion. As a legacy fallback,
+                <developed_dir>/<stem>.<ext> is also probed so libraries
+                developed before the per-folder nesting convention was
                 introduced still pick up their developed outputs.
         progress_cb: optional callback(current, total, current_file)
 
@@ -138,7 +142,6 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
         folder_path = folders.get(photo["folder_id"], "")
         source_path = _find_developed_output(
             photo["filename"],
-            photo["folder_id"],
             folder_path,
             developed_dir,
             developed_index,
@@ -224,6 +227,25 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
 _PREFERRED_DEVELOPED_EXTS = ("jpg", "jpeg", "tiff", "tif")
 
 
+def developed_folder_key(folder_path):
+    """Return a stable filesystem-safe key for the given source folder path.
+
+    Derived from the folder's canonical path rather than its SQLite row id
+    so the key survives folder churn. `folders.id` is an INTEGER PRIMARY
+    KEY, which SQLite happily reuses after a row is deleted, and
+    `delete_folder` does not clean the external developed directory. Using
+    the row id as an on-disk key therefore risked a freshly-added folder
+    silently inheriting stale developed files left on disk by a deleted
+    folder whose id it reused. Hashing the path sidesteps that entirely:
+    distinct paths always get distinct keys, and a re-scan of the same
+    path resolves to the same key (so its existing developed outputs are
+    correctly picked up again).
+    """
+    if not folder_path:
+        return ""
+    return hashlib.sha1(folder_path.encode("utf-8")).hexdigest()[:16]
+
+
 class _DevelopedDirIndex:
     """Lazy, per-export cache of directory listings for developed lookups.
 
@@ -261,22 +283,26 @@ class _DevelopedDirIndex:
         return None
 
 
-def _find_developed_output(filename, folder_id, folder_path, developed_dir, index=None):
+def _find_developed_output(filename, folder_path, developed_dir, index=None):
     """Return the path to a darktable-developed output for this photo, or None.
 
     Lookup locations are probed in order:
 
-      * <developed_dir>/<folder_id>/<stem>.<ext> — matches how the develop
-        job writes when darktable_output_dir is configured (the flat output
-        dir is nested per folder_id to avoid collisions).
+      * <developed_dir>/<path_key>/<stem>.<ext> — matches how the develop
+        job writes when darktable_output_dir is configured (the flat
+        output dir is nested per source-folder so basename collisions
+        stay one-to-one). `path_key` is derived from the folder path
+        rather than its SQLite row id, so the on-disk key survives row
+        deletion without risking a reused id silently inheriting stale
+        outputs — see `developed_folder_key`.
       * <folder_path>/developed/<stem>.<ext> — the default develop-job
         location, naturally disambiguated because each source folder has
         its own developed/ subdir.
       * <developed_dir>/<stem>.<ext> — legacy flat layout used by older
         versions of the develop job. Probed last so that any new
         folder-scoped output wins, but kept so libraries developed before
-        the folder_id convention still light up their developed render on
-        export.
+        the per-folder nesting convention still light up their developed
+        render on export.
 
     Extensions are matched case-insensitively so exports still pick up
     developed files written with uppercase extensions — e.g. IMG_0001.JPG
@@ -294,8 +320,8 @@ def _find_developed_output(filename, folder_id, folder_path, developed_dir, inde
     """
     stem = os.path.splitext(filename)[0]
     candidates = []
-    if developed_dir and folder_id is not None:
-        candidates.append(os.path.join(developed_dir, str(folder_id)))
+    if developed_dir and folder_path:
+        candidates.append(os.path.join(developed_dir, developed_folder_key(folder_path)))
     if folder_path:
         candidates.append(os.path.join(folder_path, "developed"))
     if developed_dir:

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -240,10 +240,62 @@ def developed_folder_key(folder_path):
     distinct paths always get distinct keys, and a re-scan of the same
     path resolves to the same key (so its existing developed outputs are
     correctly picked up again).
+
+    Because the key is derived from the *current* path, any operation
+    that rewrites a folder's path (e.g. `/api/jobs/move-folder`) must
+    also rebase the corresponding developed subdirectory on disk — see
+    `relocate_developed_dir` for the rebase helper used by move.
     """
     if not folder_path:
         return ""
     return hashlib.sha1(folder_path.encode("utf-8")).hexdigest()[:16]
+
+
+def relocate_developed_dir(developed_dir, old_folder_path, new_folder_path):
+    """Rebase a folder's developed-output subdir after its path changes.
+
+    The configured `darktable_output_dir` layout is flat, so each source
+    folder is nested under `developed_folder_key(folder_path)`. That key
+    is path-derived for safety against SQLite row-id reuse, but it means
+    a folder move (which rewrites `folders.path`) orphans the old
+    subdirectory. Without this rebase, export would silently fall back
+    to re-decoding the RAW for every previously-developed photo in the
+    moved folder.
+
+    Returns True if a directory was renamed, False otherwise (no
+    developed_dir configured, nothing to move, or the target already
+    exists — in the last case the caller can decide what to do). Never
+    raises; failures are logged and treated as a no-op so a filesystem
+    hiccup here doesn't also fail the folder move.
+    """
+    if not developed_dir or not old_folder_path or not new_folder_path:
+        return False
+    if old_folder_path == new_folder_path:
+        return False
+    old_key = developed_folder_key(old_folder_path)
+    new_key = developed_folder_key(new_folder_path)
+    if not old_key or not new_key or old_key == new_key:
+        return False
+    old_subdir = os.path.join(developed_dir, old_key)
+    new_subdir = os.path.join(developed_dir, new_key)
+    if not os.path.isdir(old_subdir):
+        return False
+    if os.path.exists(new_subdir):
+        log.warning(
+            "Cannot relocate developed dir %s -> %s: target already exists; "
+            "leaving source in place",
+            old_subdir, new_subdir,
+        )
+        return False
+    try:
+        os.rename(old_subdir, new_subdir)
+        return True
+    except OSError as exc:
+        log.warning(
+            "Failed to relocate developed dir %s -> %s: %s",
+            old_subdir, new_subdir, exc,
+        )
+        return False
 
 
 class _DevelopedDirIndex:
@@ -271,10 +323,27 @@ class _DevelopedDirIndex:
             # between photos whose names differ only by case. Extension
             # match is case-insensitive so developed files written as
             # .JPG / .TIFF are still picked up.
-            for name in names:
+            #
+            # When two files in the same directory share a stem and
+            # differ only by extension case (e.g. bird1.jpg vs bird1.JPG
+            # on a case-sensitive filesystem), prefer the file whose
+            # extension is already the canonical lowercase form — that's
+            # what the develop job writes when `darktable_output_format`
+            # is left at its default — and break any remaining ties by
+            # iterating sorted(names) so the winner is stable across
+            # runs rather than depending on os.listdir order.
+            for name in sorted(names):
                 ent_stem, ent_ext = os.path.splitext(name)
-                ext_key = ent_ext[1:].lower() if ent_ext.startswith(".") else ent_ext.lower()
-                entries.setdefault((ent_stem, ext_key), os.path.join(base, name))
+                raw_ext = ent_ext[1:] if ent_ext.startswith(".") else ent_ext
+                ext_key = raw_ext.lower()
+                key = (ent_stem, ext_key)
+                existing = entries.get(key)
+                if existing is None:
+                    entries[key] = os.path.join(base, name)
+                    continue
+                existing_ext = os.path.splitext(existing)[1][1:]
+                if raw_ext == ext_key and existing_ext != ext_key:
+                    entries[key] = os.path.join(base, name)
             self._cache[base] = entries
         for ext in _PREFERRED_DEVELOPED_EXTS:
             path = entries.get((stem, ext))

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -221,6 +221,12 @@ def _find_developed_output(filename, folder_id, folder_path, developed_dir):
         location, naturally disambiguated because each source folder has
         its own developed/ subdir.
 
+    Extensions (and stems) are matched case-insensitively so exports still
+    pick up developed files written with uppercase extensions — e.g.
+    IMG_0001.JPG — which can happen on case-sensitive filesystems when
+    darktable_output_format is configured with uppercase, or for files
+    placed manually.
+
     JPG is preferred over TIFF when both exist.
     """
     stem = os.path.splitext(filename)[0]
@@ -229,10 +235,22 @@ def _find_developed_output(filename, folder_id, folder_path, developed_dir):
         candidates.append(os.path.join(developed_dir, str(folder_id)))
     if folder_path:
         candidates.append(os.path.join(folder_path, "developed"))
+    preferred_exts = ("jpg", "jpeg", "tiff", "tif")
     for base in candidates:
-        for ext in ("jpg", "jpeg", "tiff", "tif"):
-            path = os.path.join(base, f"{stem}.{ext}")
-            if os.path.isfile(path):
+        try:
+            names = os.listdir(base)
+        except OSError:
+            continue
+        # Map lowercased basename → actual path. If two files in the same
+        # dir differ only in case, the first one listed wins (arbitrary but
+        # acceptable — that's a user-engineered collision).
+        entries = {}
+        for name in names:
+            entries.setdefault(name.lower(), os.path.join(base, name))
+        lower_stem = stem.lower()
+        for ext in preferred_exts:
+            path = entries.get(f"{lower_stem}.{ext}")
+            if path and os.path.isfile(path):
                 return path
     return None
 

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -147,6 +147,15 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
             developed_dir,
             developed_index,
         )
+        # Guard against silent downscaling: darktable's develop job can
+        # write the output at --width=N, so a developed file may be
+        # smaller than the original. If it can't satisfy the requested
+        # export size, fall through to the working-copy / original
+        # source.
+        if source_path and not _developed_can_satisfy_size(
+            source_path, photo, max_size
+        ):
+            source_path = None
         if not source_path:
             use_wc = bool(max_size) and max_size <= wc_max
             source_path = _resolve_source(photo, vireo_dir, folders, use_working_copy=use_wc)
@@ -226,6 +235,43 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
 
 
 _PREFERRED_DEVELOPED_EXTS = ("jpg", "jpeg", "tiff", "tif")
+
+
+def _developed_can_satisfy_size(dev_path, photo, max_size):
+    """Return True if the developed file is large enough for this export.
+
+    The develop job may have written a downscaled output (`--width` is
+    honored by darktable-cli), so preferring it unconditionally would
+    silently ship a smaller image than the user asked for. This guard
+    compares the developed file's long edge against:
+
+      * the requested `max_size` when resize is in effect, or
+      * the original photo's stored dimensions when a full-resolution
+        export is requested.
+
+    If we can't determine the required size (no max_size and no stored
+    dimensions on the photo row), fall back to preferring the developed
+    output so the primary "ship the perfected render" feature keeps
+    working for libraries scanned before the dimension columns were
+    populated.
+    """
+    from PIL import Image
+
+    try:
+        with Image.open(dev_path) as img:
+            dev_long = max(img.size)
+    except Exception:
+        return True
+    if max_size is not None:
+        return dev_long >= max_size
+    try:
+        original_w = photo["width"]
+        original_h = photo["height"]
+    except (KeyError, IndexError):
+        return True
+    if original_w and original_h:
+        return dev_long >= max(original_w, original_h)
+    return True
 
 
 def developed_folder_key(folder_path):

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -221,11 +221,14 @@ def _find_developed_output(filename, folder_id, folder_path, developed_dir):
         location, naturally disambiguated because each source folder has
         its own developed/ subdir.
 
-    Extensions (and stems) are matched case-insensitively so exports still
-    pick up developed files written with uppercase extensions — e.g.
-    IMG_0001.JPG — which can happen on case-sensitive filesystems when
+    Extensions are matched case-insensitively so exports still pick up
+    developed files written with uppercase extensions — e.g. IMG_0001.JPG
+    — which can happen on case-sensitive filesystems when
     darktable_output_format is configured with uppercase, or for files
-    placed manually.
+    placed manually. Stems are matched case-sensitively so that two photos
+    whose filenames differ only by case (e.g. Bird1.CR3 and bird1.CR3 in
+    the same folder on a case-sensitive filesystem) resolve to distinct
+    developed files.
 
     JPG is preferred over TIFF when both exist.
     """
@@ -241,15 +244,17 @@ def _find_developed_output(filename, folder_id, folder_path, developed_dir):
             names = os.listdir(base)
         except OSError:
             continue
-        # Map lowercased basename → actual path. If two files in the same
-        # dir differ only in case, the first one listed wins (arbitrary but
-        # acceptable — that's a user-engineered collision).
+        # Map (exact stem, lowercased ext) → actual filename. Stem match
+        # must be case-sensitive to avoid collisions between photos whose
+        # names differ only by case. Extension match is case-insensitive
+        # so developed files written as .JPG / .TIFF are still picked up.
         entries = {}
         for name in names:
-            entries.setdefault(name.lower(), os.path.join(base, name))
-        lower_stem = stem.lower()
+            ent_stem, ent_ext = os.path.splitext(name)
+            ext_key = ent_ext[1:].lower() if ent_ext.startswith(".") else ent_ext.lower()
+            entries.setdefault((ent_stem, ext_key), os.path.join(base, name))
         for ext in preferred_exts:
-            path = entries.get(f"{lower_stem}.{ext}")
+            path = entries.get((stem, ext))
             if path and os.path.isfile(path):
                 return path
     return None

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -75,8 +75,12 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
                 the working copy can satisfy the requested max_size.
             developed_dir: str -- optional path to darktable-developed
                 outputs (mirrors darktable_output_dir config). Export
-                prefers a developed JPG/TIFF at this location (or at
-                <folder>/developed/) over re-decoding the RAW.
+                prefers a developed JPG/TIFF at
+                <developed_dir>/<folder_id>/<stem>.<ext> (or at the
+                default <folder>/developed/<stem>.<ext>) over
+                re-decoding the RAW. The folder_id nesting matches the
+                develop job's write convention and keeps lookups one-to-one
+                even when two source folders share a basename.
         progress_cb: optional callback(current, total, current_file)
 
     Returns:
@@ -122,7 +126,9 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
         #   2. working copy when resizing to a size it can satisfy.
         #   3. original file (default; also used for full-res exports).
         folder_path = folders.get(photo["folder_id"], "")
-        source_path = _find_developed_output(photo["filename"], folder_path, developed_dir)
+        source_path = _find_developed_output(
+            photo["filename"], photo["folder_id"], folder_path, developed_dir
+        )
         if not source_path:
             use_wc = bool(max_size) and max_size <= wc_max
             source_path = _resolve_source(photo, vireo_dir, folders, use_working_copy=use_wc)
@@ -201,17 +207,26 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
     return {"exported": exported, "errors": errors, "destination": destination}
 
 
-def _find_developed_output(filename, folder_path, developed_dir):
+def _find_developed_output(filename, folder_id, folder_path, developed_dir):
     """Return the path to a darktable-developed output for this photo, or None.
 
-    Checks the configured developed_dir first (mirroring darktable_output_dir),
-    then the default "<folder>/developed/" location used by the develop job.
+    Both lookup locations are scoped so that two photos with the same basename
+    in different source folders (e.g. IMG_0001.CR3 in folder A and folder B)
+    resolve to distinct developed files:
+
+      * <developed_dir>/<folder_id>/<stem>.<ext> — matches how the develop
+        job writes when darktable_output_dir is configured (the flat output
+        dir is nested per folder_id to avoid collisions).
+      * <folder_path>/developed/<stem>.<ext> — the default develop-job
+        location, naturally disambiguated because each source folder has
+        its own developed/ subdir.
+
     JPG is preferred over TIFF when both exist.
     """
     stem = os.path.splitext(filename)[0]
     candidates = []
-    if developed_dir:
-        candidates.append(developed_dir)
+    if developed_dir and folder_id is not None:
+        candidates.append(os.path.join(developed_dir, str(folder_id)))
     if folder_path:
         candidates.append(os.path.join(folder_path, "developed"))
     for base in candidates:

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -73,6 +73,10 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
             working_copy_max_size: int -- the cap used when generating
                 working copies (default 4096); used to decide whether
                 the working copy can satisfy the requested max_size.
+            developed_dir: str -- optional path to darktable-developed
+                outputs (mirrors darktable_output_dir config). Export
+                prefers a developed JPG/TIFF at this location (or at
+                <folder>/developed/) over re-decoding the RAW.
         progress_cb: optional callback(current, total, current_file)
 
     Returns:
@@ -88,6 +92,7 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
         wc_max = int(options.get("working_copy_max_size", 4096))
     except (ValueError, TypeError):
         wc_max = 4096
+    developed_dir = options.get("developed_dir") or ""
 
     os.makedirs(destination, exist_ok=True)
 
@@ -110,11 +115,17 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
                 progress_cb(i + 1, len(photo_ids), "")
             continue
 
-        # Resolve source path.  Use the working copy only when resizing to
-        # a size the working copy can satisfy (i.e. max_size <= wc cap).
-        # Otherwise use the original to avoid silent downscaling.
-        use_wc = bool(max_size) and max_size <= wc_max
-        source_path = _resolve_source(photo, vireo_dir, folders, use_working_copy=use_wc)
+        # Resolve source path.  Precedence:
+        #   1. darktable-developed output ("perfected" rendering) — takes
+        #      priority over RAW so Export ships what the user sees after
+        #      Develop, not a fresh libraw decode of the RAW.
+        #   2. working copy when resizing to a size it can satisfy.
+        #   3. original file (default; also used for full-res exports).
+        folder_path = folders.get(photo["folder_id"], "")
+        source_path = _find_developed_output(photo["filename"], folder_path, developed_dir)
+        if not source_path:
+            use_wc = bool(max_size) and max_size <= wc_max
+            source_path = _resolve_source(photo, vireo_dir, folders, use_working_copy=use_wc)
         if not source_path or not os.path.isfile(source_path):
             errors.append(f"{photo['filename']}: source file missing")
             if progress_cb:
@@ -188,6 +199,27 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
             progress_cb(i + 1, len(photo_ids), photo["filename"])
 
     return {"exported": exported, "errors": errors, "destination": destination}
+
+
+def _find_developed_output(filename, folder_path, developed_dir):
+    """Return the path to a darktable-developed output for this photo, or None.
+
+    Checks the configured developed_dir first (mirroring darktable_output_dir),
+    then the default "<folder>/developed/" location used by the develop job.
+    JPG is preferred over TIFF when both exist.
+    """
+    stem = os.path.splitext(filename)[0]
+    candidates = []
+    if developed_dir:
+        candidates.append(developed_dir)
+    if folder_path:
+        candidates.append(os.path.join(folder_path, "developed"))
+    for base in candidates:
+        for ext in ("jpg", "jpeg", "tiff", "tif"):
+            path = os.path.join(base, f"{stem}.{ext}")
+            if os.path.isfile(path):
+                return path
+    return None
 
 
 def _resolve_source(photo, vireo_dir, folders, use_working_copy=False):

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -168,7 +168,7 @@ def move_photos(db, photo_ids, destination, progress_cb=None):
     return {"moved": moved, "errors": errors, "destination_folder_id": dest_folder_id}
 
 
-def move_folder(db, folder_id, destination, progress_cb=None):
+def move_folder(db, folder_id, destination, progress_cb=None, developed_dir=""):
     """Move an entire folder (and subfolders) to a destination.
 
     The folder is placed inside the destination, preserving its name.
@@ -179,6 +179,13 @@ def move_folder(db, folder_id, destination, progress_cb=None):
         folder_id: ID of the source folder
         destination: absolute path to parent destination directory
         progress_cb: optional callback(current, total, filename)
+        developed_dir: optional path to the configured
+            `darktable_output_dir`. When set, the folder's developed
+            subdirectory — nested under a hash of its source path, see
+            `export.developed_folder_key` — is rebased to match the new
+            path after the move. Without this, exports silently fall
+            back to RAW for every previously-developed photo in the
+            moved folder.
 
     Returns dict with keys: moved (int), errors (list of str)
     """
@@ -237,6 +244,23 @@ def move_folder(db, folder_id, destination, progress_cb=None):
     # old folder becomes orphan on disk rather than DB pointing to deleted paths)
     db.move_folder_path(folder_id, dest_path)
     db.update_folder_counts()
+
+    # Rebase any developed-output subdirs nested under the configured
+    # darktable_output_dir. `developed_folder_key` hashes the folder's
+    # path, so the DB update above just invalidated the old subdir's
+    # implicit key — rename it on disk to match the new path, and cascade
+    # to any descendant folders whose paths also shifted.
+    if developed_dir:
+        from export import relocate_developed_dir
+        relocate_developed_dir(developed_dir, src_path, dest_path)
+        descendant_rows = db.conn.execute(
+            "SELECT path FROM folders WHERE path LIKE ?",
+            (dest_path + "/%",),
+        ).fetchall()
+        for row in descendant_rows:
+            new_child = row["path"]
+            old_child = src_path + new_child[len(dest_path):]
+            relocate_developed_dir(developed_dir, old_child, new_child)
 
     # Delete originals
     log.info("Verification passed, deleting originals: %s", src_path)

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -253,12 +253,21 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir=""):
     if developed_dir:
         from export import relocate_developed_dir
         relocate_developed_dir(developed_dir, src_path, dest_path)
+        # SQL LIKE treats `_` and `%` (and the escape char) as wildcards,
+        # all of which are valid POSIX path characters. Without a strict
+        # prefix guard, an unrelated folder like `/dXst/birds/fake` would
+        # match a pattern like `/d_st/birds/%` and feed a bogus computed
+        # old_path into relocate_developed_dir, mis-rebasing the wrong
+        # developed subdir. Filter results by a literal prefix check.
         descendant_rows = db.conn.execute(
             "SELECT path FROM folders WHERE path LIKE ?",
             (dest_path + "/%",),
         ).fetchall()
+        prefix = dest_path + "/"
         for row in descendant_rows:
             new_child = row["path"]
+            if not new_child.startswith(prefix):
+                continue
             old_child = src_path + new_child[len(dest_path):]
             relocate_developed_dir(developed_dir, old_child, new_child)
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2085,6 +2085,83 @@ def test_api_folder_relocate(app_and_db, tmp_path):
     assert row["path"] == new_path
 
 
+def test_api_folder_relocate_rebases_configured_developed_dir(app_and_db, tmp_path):
+    """POST /api/folders/<id>/relocate rebases the darktable output subdir.
+
+    Regression: /api/folders/<id>/relocate only called db.relocate_folder,
+    never invoking relocate_developed_dir. Any previously-developed photo
+    in a relocated folder would silently fall back to RAW on export
+    because the path-derived key changes when the folder's path changes.
+    """
+    import config as cfg
+    from export import developed_folder_key
+
+    app, db = app_and_db
+
+    old_dir = str(tmp_path / "old_birds")
+    new_dir = str(tmp_path / "new_birds")
+    os.makedirs(new_dir)
+
+    fid = db.add_folder(old_dir, name="birds")
+    db.conn.execute("UPDATE folders SET status = 'missing' WHERE id = ?", (fid,))
+    db.conn.commit()
+
+    developed = tmp_path / "darktable_out"
+    developed.mkdir()
+    old_key = developed_folder_key(old_dir)
+    (developed / old_key).mkdir()
+    (developed / old_key / "IMG_0001.jpg").write_bytes(b"developed-bytes")
+
+    cfg.save({"darktable_output_dir": str(developed)})
+
+    client = app.test_client()
+    resp = client.post(f"/api/folders/{fid}/relocate", json={"path": new_dir})
+    assert resp.status_code == 200
+
+    new_key = developed_folder_key(new_dir)
+    assert old_key != new_key
+    assert not (developed / old_key).exists(), "old developed subdir should be gone"
+    assert (developed / new_key / "IMG_0001.jpg").read_bytes() == b"developed-bytes"
+
+
+def test_api_folder_relocate_rebases_cascaded_child_developed_dirs(app_and_db, tmp_path):
+    """Cascaded child folders must also have their developed subdirs rebased."""
+    import config as cfg
+    from export import developed_folder_key
+
+    app, db = app_and_db
+
+    old_parent = str(tmp_path / "old_parent")
+    new_parent = str(tmp_path / "new_parent")
+    old_child = old_parent + "/child"
+    new_child = new_parent + "/child"
+    os.makedirs(new_child)
+
+    pfid = db.add_folder(old_parent, name="parent")
+    cfid = db.add_folder(old_child, name="child", parent_id=pfid)
+    db.conn.execute(
+        "UPDATE folders SET status = 'missing' WHERE id IN (?, ?)", (pfid, cfid)
+    )
+    db.conn.commit()
+
+    developed = tmp_path / "darktable_out"
+    developed.mkdir()
+    old_child_key = developed_folder_key(old_child)
+    (developed / old_child_key).mkdir()
+    (developed / old_child_key / "IMG_0002.jpg").write_bytes(b"child-developed")
+
+    cfg.save({"darktable_output_dir": str(developed)})
+
+    client = app.test_client()
+    resp = client.post(f"/api/folders/{pfid}/relocate", json={"path": new_parent})
+    assert resp.status_code == 200
+
+    new_child_key = developed_folder_key(new_child)
+    assert old_child_key != new_child_key
+    assert not (developed / old_child_key).exists()
+    assert (developed / new_child_key / "IMG_0002.jpg").read_bytes() == b"child-developed"
+
+
 def test_api_folder_relocate_merge(app_and_db, tmp_path):
     """POST /api/folders/<id>/relocate merges into existing folder when paths conflict."""
     app, db = app_and_db

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -339,3 +339,121 @@ def test_export_large_max_size_uses_original(export_env):
     with Image.open(out_path) as img:
         # Should use original (800x600), not working copy (100x75)
         assert img.size == (800, 600)
+
+
+def _avg_rgb(path):
+    """Return the average RGB tuple of an image across a small sample grid."""
+    with Image.open(path) as img:
+        rgb = img.convert("RGB")
+        w, h = rgb.size
+        xs = (w // 10, w // 4, w // 2, 3 * w // 4, 9 * w // 10)
+        ys = (h // 10, h // 4, h // 2, 3 * h // 4, 9 * h // 10)
+        rs, gs, bs, n = 0, 0, 0, 0
+        for x in xs:
+            for y in ys:
+                r, g, b = rgb.getpixel((x, y))
+                rs += r
+                gs += g
+                bs += b
+                n += 1
+        return (rs // n, gs // n, bs // n)
+
+
+def test_export_prefers_developed_jpg_when_present(export_env):
+    """When <folder>/developed/<stem>.jpg exists, export uses it, not the original.
+
+    Motivation: darktable produces the user's intended rendering; export has
+    historically re-decoded the RAW via libraw, discarding that rendering.
+    """
+    env = export_env
+    developed_dir = env["src"] / "developed"
+    developed_dir.mkdir()
+    # Visually distinct from the red original.
+    Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
+        str(developed_dir / "bird1.jpg"), "JPEG", quality=95,
+    )
+
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}"},
+    )
+
+    assert result["exported"] == 1
+    r, g, b = _avg_rgb(os.path.join(env["dest"], "bird1.jpg"))
+    assert g > r and g > b, f"expected green-dominant from developed JPG, got rgb=({r},{g},{b})"
+
+
+def test_export_prefers_developed_tiff_when_jpg_absent(export_env):
+    """Developed output may be .tiff — export prefers it over the RAW."""
+    env = export_env
+    developed_dir = env["src"] / "developed"
+    developed_dir.mkdir()
+    Image.new("RGB", (800, 600), color=(20, 30, 220)).save(
+        str(developed_dir / "bird1.tiff"), "TIFF",
+    )
+
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}"},
+    )
+
+    assert result["exported"] == 1
+    r, g, b = _avg_rgb(os.path.join(env["dest"], "bird1.jpg"))
+    assert b > r and b > g, f"expected blue-dominant from developed TIFF, got rgb=({r},{g},{b})"
+
+
+def test_export_falls_back_to_original_when_no_developed(export_env):
+    """No developed output → export uses the original file (existing behavior)."""
+    env = export_env
+    export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}"},
+    )
+
+    r, g, b = _avg_rgb(os.path.join(env["dest"], "bird1.jpg"))
+    assert r > g and r > b, f"expected red-dominant from original, got rgb=({r},{g},{b})"
+
+
+def test_export_honors_configured_developed_dir(export_env):
+    """When developed_dir option is passed, export looks there, not in <folder>/developed/.
+
+    Mirrors the darktable_output_dir config: users who configure a custom
+    output location expect export to find the developed outputs at that
+    location.
+    """
+    env = export_env
+    # Decoy in the default location — export must NOT pick this.
+    decoy_dir = env["src"] / "developed"
+    decoy_dir.mkdir()
+    Image.new("RGB", (800, 600), color=(200, 200, 0)).save(
+        str(decoy_dir / "bird1.jpg"), "JPEG",
+    )
+    # Real output in the configured dir.
+    configured = env["tmp_path"] / "darktable_out"
+    configured.mkdir()
+    Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
+        str(configured / "bird1.jpg"), "JPEG",
+    )
+
+    export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "developed_dir": str(configured),
+        },
+    )
+
+    r, g, b = _avg_rgb(os.path.join(env["dest"], "bird1.jpg"))
+    assert g > r and g > b, f"expected green-dominant from configured dir, got rgb=({r},{g},{b})"

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import pytest
 from db import Database
-from export import export_photos, resolve_template, sanitize_filename
+from export import developed_folder_key, export_photos, resolve_template, sanitize_filename
 from PIL import Image
 
 
@@ -429,9 +429,10 @@ def test_export_honors_configured_developed_dir(export_env):
 
     Mirrors the darktable_output_dir config: users who configure a custom
     output location expect export to find the developed outputs at that
-    location. Files are looked up under a <folder_id>/ subdir to match the
-    develop job's write convention and keep lookups one-to-one when two
-    source folders share a basename.
+    location. Files are looked up under a per-folder subdir keyed by a
+    hash of the source folder's path (see `developed_folder_key`); that
+    matches the develop job's write convention and keeps lookups
+    one-to-one when two source folders share a basename.
     """
     env = export_env
     # Decoy in the default location — export must NOT pick this.
@@ -440,10 +441,10 @@ def test_export_honors_configured_developed_dir(export_env):
     Image.new("RGB", (800, 600), color=(200, 200, 0)).save(
         str(decoy_dir / "bird1.jpg"), "JPEG",
     )
-    # Real output in the configured dir, under the folder_id subdir.
+    # Real output in the configured dir, under the per-folder subdir.
     configured = env["tmp_path"] / "darktable_out"
     configured.mkdir()
-    folder_subdir = configured / str(env["fid"])
+    folder_subdir = configured / developed_folder_key(str(env["src"]))
     folder_subdir.mkdir()
     Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
         str(folder_subdir / "bird1.jpg"), "JPEG",
@@ -526,7 +527,8 @@ def test_export_configured_developed_dir_disambiguates_same_basename(tmp_path):
     filename stem, so two photos named IMG_0001.CR3 in different source
     folders both resolved to <developed_dir>/IMG_0001.jpg — silently mixing
     developed outputs. Each photo's developed file now lives under a
-    <folder_id>/ subdir, so matches are one-to-one.
+    per-source-folder subdir keyed by a hash of the folder's path
+    (see `developed_folder_key`), so matches are one-to-one.
     """
     db = Database(str(tmp_path / "test.db"))
     ws_id = db.ensure_default_workspace()
@@ -556,17 +558,21 @@ def test_export_configured_developed_dir_disambiguates_same_basename(tmp_path):
     pid_b = db.add_photo(folder_id=fid_b, filename="IMG_0001.jpg", extension=".jpg",
                          file_size=1, file_mtime=1.0)
 
-    # Developed outputs under <developed_dir>/<folder_id>/<stem>.jpg — two
-    # distinct files, each a different solid color.
+    # Developed outputs under <developed_dir>/<path_key>/<stem>.jpg — two
+    # distinct files, each a different solid color. Keys derive from each
+    # folder's path, so the two folders get distinct subdirs.
     developed = tmp_path / "darktable_out"
     developed.mkdir()
-    (developed / str(fid_a)).mkdir()
-    (developed / str(fid_b)).mkdir()
+    key_a = developed_folder_key(str(src_a))
+    key_b = developed_folder_key(str(src_b))
+    assert key_a != key_b
+    (developed / key_a).mkdir()
+    (developed / key_b).mkdir()
     Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
-        str(developed / str(fid_a) / "IMG_0001.jpg"), "JPEG", quality=95,
+        str(developed / key_a / "IMG_0001.jpg"), "JPEG", quality=95,
     )
     Image.new("RGB", (800, 600), color=(200, 200, 10)).save(
-        str(developed / str(fid_b) / "IMG_0001.jpg"), "JPEG", quality=95,
+        str(developed / key_b / "IMG_0001.jpg"), "JPEG", quality=95,
     )
 
     export_photos(
@@ -682,7 +688,7 @@ def test_export_developed_stem_match_is_case_sensitive(tmp_path):
 def test_export_legacy_flat_developed_dir_fallback(export_env):
     """Developed outputs written flat to <developed_dir>/<stem>.<ext> still light up.
 
-    Before the folder_id nesting convention existed, the develop job wrote
+    Before the per-folder nesting convention existed, the develop job wrote
     directly into `darktable_output_dir` with no per-folder subdir. Users
     who upgraded would otherwise silently regress to RAW export; the flat
     path is still probed as a last-resort fallback.
@@ -716,8 +722,8 @@ def test_export_folder_scoped_developed_wins_over_legacy_flat(export_env):
     """When both folder-scoped and legacy flat outputs exist, folder-scoped wins.
 
     The legacy flat fallback exists only to avoid regressing libraries that
-    predate the folder_id nesting. Any newly-developed file (written under
-    <folder_id>/) must still take precedence so same-basename collisions
+    predate the per-folder nesting. Any newly-developed file (written under
+    <path_key>/) must still take precedence so same-basename collisions
     across folders stay resolved one-to-one.
     """
     env = export_env
@@ -728,7 +734,7 @@ def test_export_folder_scoped_developed_wins_over_legacy_flat(export_env):
         str(configured / "bird1.jpg"), "JPEG", quality=95,
     )
     # Folder-scoped (green) — wins.
-    folder_subdir = configured / str(env["fid"])
+    folder_subdir = configured / developed_folder_key(str(env["src"]))
     folder_subdir.mkdir()
     Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
         str(folder_subdir / "bird1.jpg"), "JPEG", quality=95,
@@ -797,3 +803,85 @@ def test_export_caches_developed_dir_scans(export_env, monkeypatch):
     # Sanity: any directory we scanned, we scanned at most once.
     for path, n in counts.items():
         assert n <= 1, f"{path} was scanned {n} times; expected ≤1 after caching"
+
+
+def test_export_reused_folder_id_does_not_inherit_stale_developed(tmp_path):
+    """A freshly-added folder that happens to reuse a deleted folder's row id
+    must not inherit the deleted folder's developed files.
+
+    Regression: when the configured developed_dir was nested by folder_id,
+    a SQLite row-id reuse (folders.id is INTEGER PRIMARY KEY, not
+    AUTOINCREMENT) silently cross-wired the new folder's export onto
+    stale pixels left on disk by the deleted folder. Nesting by a hash
+    of the folder path instead makes distinct paths always resolve to
+    distinct on-disk keys, so the stale files never match.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    dest = tmp_path / "export_out"
+    developed = tmp_path / "darktable_out"
+    developed.mkdir()
+
+    # Step 1: add a folder, add a photo, lay down a developed file for it,
+    # then delete the folder. The external developed file is intentionally
+    # left on disk (delete_folder does not reach into darktable_output_dir),
+    # mirroring the real-world scenario.
+    src_old = tmp_path / "old_folder"
+    src_old.mkdir()
+    Image.new("RGB", (800, 600), color=(200, 0, 0)).save(
+        str(src_old / "IMG_0001.jpg"), "JPEG", quality=95,
+    )
+    fid_old = db.add_folder(str(src_old), name="Old")
+    pid_old = db.add_photo(folder_id=fid_old, filename="IMG_0001.jpg", extension=".jpg",
+                           file_size=1, file_mtime=1.0)
+    # Yellow stale file under the OLD folder's path key — must not bleed
+    # into the new folder's export.
+    stale_key = developed_folder_key(str(src_old))
+    (developed / stale_key).mkdir()
+    Image.new("RGB", (800, 600), color=(200, 200, 10)).save(
+        str(developed / stale_key / "IMG_0001.jpg"), "JPEG", quality=95,
+    )
+    db.delete_folder(fid_old)
+    _ = pid_old  # photo row is cascaded away with its folder
+
+    # Step 2: add a NEW folder at a different path, with a photo that has
+    # the same basename as the deleted one. The new folder should receive
+    # a distinct on-disk key and never see the stale yellow file.
+    src_new = tmp_path / "new_folder"
+    src_new.mkdir()
+    # Blue original so we can tell in the output whether we got the stale
+    # yellow developed file (regression) or fell back to the fresh blue
+    # original (correct behavior when no developed file exists yet).
+    Image.new("RGB", (800, 600), color=(0, 0, 200)).save(
+        str(src_new / "IMG_0001.jpg"), "JPEG", quality=95,
+    )
+    fid_new = db.add_folder(str(src_new), name="New")
+    pid_new = db.add_photo(folder_id=fid_new, filename="IMG_0001.jpg", extension=".jpg",
+                           file_size=1, file_mtime=2.0)
+
+    # The path-based key for the new folder must differ from the stale key.
+    new_key = developed_folder_key(str(src_new))
+    assert new_key != stale_key
+
+    export_photos(
+        db=db,
+        vireo_dir=str(vireo_dir),
+        photo_ids=[pid_new],
+        destination=str(dest),
+        options={
+            "naming_template": "{original}",
+            "developed_dir": str(developed),
+        },
+    )
+
+    r, g, b = _avg_rgb(os.path.join(str(dest), "IMG_0001.jpg"))
+    # Blue-dominant = fell back to the fresh original, not the stale
+    # yellow file left behind by the deleted folder.
+    assert b > r and b > g, (
+        f"expected blue-dominant from fresh original (not stale yellow "
+        f"developed file), got rgb=({r},{g},{b})"
+    )

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -1051,3 +1051,71 @@ def test_move_folder_rebases_configured_developed_dir(tmp_path):
     # Old key subdir gone; new key subdir carries the developed file.
     assert not (developed / old_key).exists()
     assert (developed / new_key / "IMG_0001.jpg").read_bytes() == b"developed-bytes"
+
+
+def test_move_folder_descendant_query_ignores_like_wildcard_matches(tmp_path, monkeypatch):
+    """LIKE wildcards in dest_path must not drag unrelated folders into the rebase.
+
+    Regression: `move_folder`'s descendant query used `WHERE path LIKE ?`
+    with `dest_path + "/%"`. SQL LIKE treats `_` and `%` inside `dest_path`
+    as wildcards (valid characters on POSIX paths), so unrelated folders
+    whose paths happen to match the wildcard pattern were returned and
+    fed into `relocate_developed_dir` with a bogus computed old_path.
+    """
+    import export
+    from db import Database
+    from move import move_folder
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    src_parent = tmp_path / "src"
+    src_parent.mkdir()
+    src = src_parent / "birds"
+    src.mkdir()
+    (src / "IMG_0001.jpg").write_bytes(b"raw")
+    fid = db.add_folder(str(src), name="birds")
+
+    # Destination dir whose name contains `_`: SQL LIKE treats `_` as any
+    # single char. Final moved path becomes `<tmp>/d_st/birds`.
+    dest_parent = tmp_path / "d_st"
+    dest_parent.mkdir()
+
+    # Unrelated folder whose path matches the buggy LIKE pattern
+    # `<tmp>/d_st/birds/%` because `_` matches the literal `X`. The folder
+    # is NOT a descendant of the moved folder and must be left alone.
+    unrelated_parent = tmp_path / "dXst" / "birds"
+    unrelated_parent.mkdir(parents=True)
+    unrelated = unrelated_parent / "fake"
+    unrelated.mkdir()
+    db.add_folder(str(unrelated), name="fake")
+
+    developed = tmp_path / "darktable_out"
+    developed.mkdir()
+
+    calls = []
+    real_fn = export.relocate_developed_dir
+
+    def spy(devdir, old, new):
+        calls.append((old, new))
+        return real_fn(devdir, old, new)
+
+    monkeypatch.setattr(export, "relocate_developed_dir", spy)
+
+    result = move_folder(
+        db=db,
+        folder_id=fid,
+        destination=str(dest_parent),
+        developed_dir=str(developed),
+    )
+    assert not result["errors"], result["errors"]
+
+    # Only the parent rebase should have fired; no call should reference
+    # the unrelated path on either side.
+    unrelated_str = str(unrelated)
+    touched = {old for old, _ in calls} | {new for _, new in calls}
+    assert unrelated_str not in touched, (
+        f"relocate_developed_dir was called against the unrelated folder; "
+        f"calls={calls}"
+    )

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -677,3 +677,123 @@ def test_export_developed_stem_match_is_case_sensitive(tmp_path):
     assert r_l > b_l and g_l > b_l, (
         f"bird1: expected yellow-dominant developed, got rgb=({r_l},{g_l},{b_l})"
     )
+
+
+def test_export_legacy_flat_developed_dir_fallback(export_env):
+    """Developed outputs written flat to <developed_dir>/<stem>.<ext> still light up.
+
+    Before the folder_id nesting convention existed, the develop job wrote
+    directly into `darktable_output_dir` with no per-folder subdir. Users
+    who upgraded would otherwise silently regress to RAW export; the flat
+    path is still probed as a last-resort fallback.
+    """
+    env = export_env
+    configured = env["tmp_path"] / "darktable_out"
+    configured.mkdir()
+    # Legacy flat layout — no <folder_id>/ subdir.
+    Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
+        str(configured / "bird1.jpg"), "JPEG", quality=95,
+    )
+
+    export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "developed_dir": str(configured),
+        },
+    )
+
+    r, g, b = _avg_rgb(os.path.join(env["dest"], "bird1.jpg"))
+    assert g > r and g > b, (
+        f"expected green-dominant from legacy flat developed dir, got rgb=({r},{g},{b})"
+    )
+
+
+def test_export_folder_scoped_developed_wins_over_legacy_flat(export_env):
+    """When both folder-scoped and legacy flat outputs exist, folder-scoped wins.
+
+    The legacy flat fallback exists only to avoid regressing libraries that
+    predate the folder_id nesting. Any newly-developed file (written under
+    <folder_id>/) must still take precedence so same-basename collisions
+    across folders stay resolved one-to-one.
+    """
+    env = export_env
+    configured = env["tmp_path"] / "darktable_out"
+    configured.mkdir()
+    # Legacy flat (yellow) — should NOT be picked when a folder-scoped file exists.
+    Image.new("RGB", (800, 600), color=(200, 200, 10)).save(
+        str(configured / "bird1.jpg"), "JPEG", quality=95,
+    )
+    # Folder-scoped (green) — wins.
+    folder_subdir = configured / str(env["fid"])
+    folder_subdir.mkdir()
+    Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
+        str(folder_subdir / "bird1.jpg"), "JPEG", quality=95,
+    )
+
+    export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "developed_dir": str(configured),
+        },
+    )
+
+    r, g, b = _avg_rgb(os.path.join(env["dest"], "bird1.jpg"))
+    assert g > r and g > b, (
+        f"expected green-dominant folder-scoped output to win, got rgb=({r},{g},{b})"
+    )
+
+
+def test_export_caches_developed_dir_scans(export_env, monkeypatch):
+    """os.listdir is called at most once per developed directory across the export.
+
+    Regression guard: without caching, `_find_developed_output` rescans the
+    same folder for every photo, turning a single-directory export of N
+    photos into N×cost(listdir). The per-export index collapses that back
+    to one listdir per distinct base directory.
+    """
+    env = export_env
+    # Develop both photos into a shared directory so every photo probes
+    # the same developed folder(s).
+    developed_dir = env["src"] / "developed"
+    developed_dir.mkdir()
+    Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
+        str(developed_dir / "bird1.jpg"), "JPEG", quality=95,
+    )
+    Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
+        str(developed_dir / "bird2.jpg"), "JPEG", quality=95,
+    )
+
+    import export as export_module
+
+    counts = {}
+    real_listdir = os.listdir
+
+    def counting_listdir(path):
+        counts[path] = counts.get(path, 0) + 1
+        return real_listdir(path)
+
+    monkeypatch.setattr(export_module.os, "listdir", counting_listdir)
+
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"], env["p2"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}"},
+    )
+
+    assert result["exported"] == 2
+    assert counts.get(str(developed_dir), 0) == 1, (
+        f"expected 1 listdir of {developed_dir}, got {counts.get(str(developed_dir), 0)}"
+    )
+    # Sanity: any directory we scanned, we scanned at most once.
+    for path, n in counts.items():
+        assert n <= 1, f"{path} was scanned {n} times; expected ≤1 after caching"

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -1,5 +1,6 @@
 """Tests for photo export operations."""
 
+import contextlib
 import os
 import sys
 
@@ -598,10 +599,8 @@ def _fs_is_case_sensitive(path):
         result = not os.path.exists(probe_up)
         return result
     finally:
-        try:
+        with contextlib.suppress(OSError):
             os.remove(probe_lo)
-        except OSError:
-            pass
 
 
 def test_export_developed_stem_match_is_case_sensitive(tmp_path):

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -428,7 +428,9 @@ def test_export_honors_configured_developed_dir(export_env):
 
     Mirrors the darktable_output_dir config: users who configure a custom
     output location expect export to find the developed outputs at that
-    location.
+    location. Files are looked up under a <folder_id>/ subdir to match the
+    develop job's write convention and keep lookups one-to-one when two
+    source folders share a basename.
     """
     env = export_env
     # Decoy in the default location — export must NOT pick this.
@@ -437,11 +439,13 @@ def test_export_honors_configured_developed_dir(export_env):
     Image.new("RGB", (800, 600), color=(200, 200, 0)).save(
         str(decoy_dir / "bird1.jpg"), "JPEG",
     )
-    # Real output in the configured dir.
+    # Real output in the configured dir, under the folder_id subdir.
     configured = env["tmp_path"] / "darktable_out"
     configured.mkdir()
+    folder_subdir = configured / str(env["fid"])
+    folder_subdir.mkdir()
     Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
-        str(configured / "bird1.jpg"), "JPEG",
+        str(folder_subdir / "bird1.jpg"), "JPEG",
     )
 
     export_photos(
@@ -457,3 +461,74 @@ def test_export_honors_configured_developed_dir(export_env):
 
     r, g, b = _avg_rgb(os.path.join(env["dest"], "bird1.jpg"))
     assert g > r and g > b, f"expected green-dominant from configured dir, got rgb=({r},{g},{b})"
+
+
+def test_export_configured_developed_dir_disambiguates_same_basename(tmp_path):
+    """Two folders with the same basename resolve to distinct developed outputs.
+
+    Regression: previously the configured developed_dir lookup used only the
+    filename stem, so two photos named IMG_0001.CR3 in different source
+    folders both resolved to <developed_dir>/IMG_0001.jpg — silently mixing
+    developed outputs. Each photo's developed file now lives under a
+    <folder_id>/ subdir, so matches are one-to-one.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    # Two source folders, each with a photo that shares the same basename.
+    src_a = tmp_path / "folderA"
+    src_a.mkdir()
+    src_b = tmp_path / "folderB"
+    src_b.mkdir()
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    dest = tmp_path / "export_out"
+
+    # Originals are visually distinct so we can tell them apart in the output.
+    Image.new("RGB", (800, 600), color=(200, 0, 0)).save(
+        str(src_a / "IMG_0001.jpg"), "JPEG", quality=95,
+    )
+    Image.new("RGB", (800, 600), color=(0, 0, 200)).save(
+        str(src_b / "IMG_0001.jpg"), "JPEG", quality=95,
+    )
+
+    fid_a = db.add_folder(str(src_a), name="A")
+    fid_b = db.add_folder(str(src_b), name="B")
+    pid_a = db.add_photo(folder_id=fid_a, filename="IMG_0001.jpg", extension=".jpg",
+                         file_size=1, file_mtime=1.0)
+    pid_b = db.add_photo(folder_id=fid_b, filename="IMG_0001.jpg", extension=".jpg",
+                         file_size=1, file_mtime=1.0)
+
+    # Developed outputs under <developed_dir>/<folder_id>/<stem>.jpg — two
+    # distinct files, each a different solid color.
+    developed = tmp_path / "darktable_out"
+    developed.mkdir()
+    (developed / str(fid_a)).mkdir()
+    (developed / str(fid_b)).mkdir()
+    Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
+        str(developed / str(fid_a) / "IMG_0001.jpg"), "JPEG", quality=95,
+    )
+    Image.new("RGB", (800, 600), color=(200, 200, 10)).save(
+        str(developed / str(fid_b) / "IMG_0001.jpg"), "JPEG", quality=95,
+    )
+
+    export_photos(
+        db=db,
+        vireo_dir=str(vireo_dir),
+        photo_ids=[pid_a, pid_b],
+        destination=str(dest),
+        options={
+            "naming_template": "{folder}/{original}",
+            "developed_dir": str(developed),
+        },
+    )
+
+    # {folder} in the naming template resolves to the source folder's
+    # basename (folderA / folderB), so outputs land under those dirs.
+    r_a, g_a, b_a = _avg_rgb(os.path.join(str(dest), "folderA", "IMG_0001.jpg"))
+    r_b, g_b, b_b = _avg_rgb(os.path.join(str(dest), "folderB", "IMG_0001.jpg"))
+    # Folder A got the green-dominant developed output.
+    assert g_a > r_a and g_a > b_a, f"A: expected green-dominant, got rgb=({r_a},{g_a},{b_a})"
+    # Folder B got the yellow-dominant (red+green) developed output.
+    assert r_b > b_b and g_b > b_b, f"B: expected yellow-dominant, got rgb=({r_b},{g_b},{b_b})"

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -1058,6 +1058,108 @@ def test_move_folder_rebases_configured_developed_dir(tmp_path):
     assert (developed / new_key / "IMG_0001.jpg").read_bytes() == b"developed-bytes"
 
 
+def test_export_skips_smaller_developed_for_full_res(export_env):
+    """Full-res export must not silently use a down-scaled developed file.
+
+    Regression: export_photos preferred the developed file whenever one
+    existed, but `/api/jobs/develop` lets users pass `--width`, which
+    writes a smaller JPEG/TIFF. A subsequent full-resolution export
+    (max_size unset) would silently ship that smaller file instead of
+    decoding the full-resolution original, dropping resolution without
+    warning.
+    """
+    env = export_env
+    # Record the original's true dimensions so the size-aware guard can
+    # detect that the developed file is smaller than the original. In
+    # production this is populated by the scan job.
+    env["db"].conn.execute(
+        "UPDATE photos SET width = ?, height = ? WHERE id = ?",
+        (800, 600, env["p1"]),
+    )
+    env["db"].conn.commit()
+
+    developed_dir = env["src"] / "developed"
+    developed_dir.mkdir()
+    # Smaller than the 800x600 original the fixture writes to disk.
+    Image.new("RGB", (200, 150), color=(10, 200, 40)).save(
+        str(developed_dir / "bird1.jpg"), "JPEG", quality=95,
+    )
+
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}"},
+    )
+
+    assert result["exported"] == 1
+    with Image.open(os.path.join(env["dest"], "bird1.jpg")) as out:
+        assert out.size == (800, 600), (
+            f"full-res export should ship the 800x600 original, not the "
+            f"200x150 developed file; got {out.size}"
+        )
+
+
+def test_export_skips_developed_when_max_size_exceeds_developed_dims(export_env):
+    """Export with max_size larger than the developed file's long edge skips it.
+
+    If the developed output can't satisfy the requested max_size, using
+    it silently downscales the output below the user's requested cap.
+    """
+    env = export_env
+    developed_dir = env["src"] / "developed"
+    developed_dir.mkdir()
+    # Developed long-edge is 200; user asks for max_size=400.
+    Image.new("RGB", (200, 150), color=(10, 200, 40)).save(
+        str(developed_dir / "bird1.jpg"), "JPEG", quality=95,
+    )
+
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}", "max_size": 400},
+    )
+
+    assert result["exported"] == 1
+    with Image.open(os.path.join(env["dest"], "bird1.jpg")) as out:
+        # Original (800x600) resized to max=400 → 400x300.
+        # Developed would have silently capped at 200x150.
+        assert max(out.size) == 400, (
+            f"expected 400 long edge (from 800x600 original), got {out.size}"
+        )
+
+
+def test_export_uses_developed_when_max_size_fits(export_env):
+    """Resize exports still use developed when it can satisfy max_size.
+
+    Guardrail for the primary feature: resize workflows with max_size
+    <= developed's long edge must ship the perfected rendering.
+    """
+    env = export_env
+    developed_dir = env["src"] / "developed"
+    developed_dir.mkdir()
+    Image.new("RGB", (600, 450), color=(10, 200, 40)).save(
+        str(developed_dir / "bird1.jpg"), "JPEG", quality=95,
+    )
+
+    export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}", "max_size": 300},
+    )
+
+    r, g, b = _avg_rgb(os.path.join(env["dest"], "bird1.jpg"))
+    assert g > r and g > b, (
+        f"expected green-dominant (developed used for fitting resize), "
+        f"got rgb=({r},{g},{b})"
+    )
+
+
 def test_relocate_developed_dir_merges_into_existing_target(tmp_path):
     """When target exists, merge source files in; don't strand them at old key.
 

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -987,8 +987,14 @@ def test_relocate_developed_dir_noop_when_nothing_to_move(tmp_path):
     assert relocate_developed_dir(str(developed), "/same", "/same") is False
 
 
-def test_relocate_developed_dir_skips_when_target_exists(tmp_path):
-    """If the target key already exists, leave the source in place and log."""
+def test_relocate_developed_dir_merges_empty_source_into_existing_target(tmp_path):
+    """Empty source + existing target: merge succeeds, empty source is removed.
+
+    With the merge semantics in place (relocation into an existing target
+    is a merge, not a skip), an empty source directory is a no-op merge:
+    there's nothing to move in, and the empty source is cleaned up so
+    callers don't leak orphaned directories.
+    """
     developed = tmp_path / "darktable_out"
     developed.mkdir()
     old_path = "/srv/photos/a"
@@ -997,9 +1003,8 @@ def test_relocate_developed_dir_skips_when_target_exists(tmp_path):
     (developed / developed_folder_key(old_path)).mkdir()
     (developed / developed_folder_key(new_path)).mkdir()
 
-    assert relocate_developed_dir(str(developed), old_path, new_path) is False
-    # Both still present — nothing was clobbered.
-    assert (developed / developed_folder_key(old_path)).is_dir()
+    assert relocate_developed_dir(str(developed), old_path, new_path) is True
+    assert not (developed / developed_folder_key(old_path)).exists()
     assert (developed / developed_folder_key(new_path)).is_dir()
 
 
@@ -1051,6 +1056,48 @@ def test_move_folder_rebases_configured_developed_dir(tmp_path):
     # Old key subdir gone; new key subdir carries the developed file.
     assert not (developed / old_key).exists()
     assert (developed / new_key / "IMG_0001.jpg").read_bytes() == b"developed-bytes"
+
+
+def test_relocate_developed_dir_merges_into_existing_target(tmp_path):
+    """When target exists, merge source files in; don't strand them at old key.
+
+    Regression: relocate_developed_dir used to bail out when the target
+    subdir existed, but `db._merge_into_existing` (hit by
+    /api/folders/<id>/relocate when the new path is already tracked)
+    reassigns source photos to the target folder — their developed files
+    belong under the target's key after the merge. The previous behaviour
+    left them stranded under the old key, so export silently fell back
+    to RAW for every merged photo.
+    """
+    developed = tmp_path / "darktable_out"
+    developed.mkdir()
+    old_path = "/srv/photos/source"
+    new_path = "/srv/photos/target"
+
+    old_key = developed_folder_key(old_path)
+    new_key = developed_folder_key(new_path)
+
+    old_subdir = developed / old_key
+    new_subdir = developed / new_key
+    old_subdir.mkdir()
+    new_subdir.mkdir()
+
+    # Source-only file (must move into target).
+    (old_subdir / "unique_src.jpg").write_bytes(b"src-only")
+    # Collision: target-side wins (matches merge semantics where target
+    # folder's photos are authoritative on filename collisions).
+    (old_subdir / "collision.jpg").write_bytes(b"src-version")
+    (new_subdir / "collision.jpg").write_bytes(b"target-wins")
+    # Target-only file (must stay untouched).
+    (new_subdir / "unique_tgt.jpg").write_bytes(b"tgt-only")
+
+    assert relocate_developed_dir(str(developed), old_path, new_path) is True
+
+    assert not old_subdir.exists(), "source subdir must be removed after merge"
+    assert (new_subdir / "unique_src.jpg").read_bytes() == b"src-only"
+    assert (new_subdir / "unique_tgt.jpg").read_bytes() == b"tgt-only"
+    # Collision: target's version must survive.
+    assert (new_subdir / "collision.jpg").read_bytes() == b"target-wins"
 
 
 def test_move_folder_descendant_query_ignores_like_wildcard_matches(tmp_path, monkeypatch):

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -463,6 +463,61 @@ def test_export_honors_configured_developed_dir(export_env):
     assert g > r and g > b, f"expected green-dominant from configured dir, got rgb=({r},{g},{b})"
 
 
+def test_export_developed_matches_uppercase_extension(export_env):
+    """Developed files with uppercase extensions are still matched.
+
+    Regression: `_find_developed_output` previously probed only lowercase
+    extensions, so on case-sensitive filesystems a developed file written
+    as IMG_0001.JPG (or .TIFF) silently fell through to the RAW fallback.
+    That can happen when darktable_output_format is configured uppercase
+    or for files placed manually.
+    """
+    env = export_env
+    developed_dir = env["src"] / "developed"
+    developed_dir.mkdir()
+    Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
+        str(developed_dir / "bird1.JPG"), "JPEG", quality=95,
+    )
+
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}"},
+    )
+
+    assert result["exported"] == 1
+    r, g, b = _avg_rgb(os.path.join(env["dest"], "bird1.jpg"))
+    assert g > r and g > b, (
+        f"expected green-dominant from uppercase-ext developed JPG, got rgb=({r},{g},{b})"
+    )
+
+
+def test_export_developed_matches_uppercase_tiff(export_env):
+    """Uppercase TIFF extensions also match when no JPG is present."""
+    env = export_env
+    developed_dir = env["src"] / "developed"
+    developed_dir.mkdir()
+    Image.new("RGB", (800, 600), color=(20, 30, 220)).save(
+        str(developed_dir / "bird1.TIFF"), "TIFF",
+    )
+
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}"},
+    )
+
+    assert result["exported"] == 1
+    r, g, b = _avg_rgb(os.path.join(env["dest"], "bird1.jpg"))
+    assert b > r and b > g, (
+        f"expected blue-dominant from uppercase-ext developed TIFF, got rgb=({r},{g},{b})"
+    )
+
+
 def test_export_configured_developed_dir_disambiguates_same_basename(tmp_path):
     """Two folders with the same basename resolve to distinct developed outputs.
 

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -587,3 +587,94 @@ def test_export_configured_developed_dir_disambiguates_same_basename(tmp_path):
     assert g_a > r_a and g_a > b_a, f"A: expected green-dominant, got rgb=({r_a},{g_a},{b_a})"
     # Folder B got the yellow-dominant (red+green) developed output.
     assert r_b > b_b and g_b > b_b, f"B: expected yellow-dominant, got rgb=({r_b},{g_b},{b_b})"
+
+
+def _fs_is_case_sensitive(path):
+    """Return True if creating 'x' and 'X' in path yields two distinct files."""
+    probe_lo = os.path.join(str(path), "_case_probe_a")
+    probe_up = os.path.join(str(path), "_CASE_PROBE_A")
+    try:
+        open(probe_lo, "w").close()
+        result = not os.path.exists(probe_up)
+        return result
+    finally:
+        try:
+            os.remove(probe_lo)
+        except OSError:
+            pass
+
+
+def test_export_developed_stem_match_is_case_sensitive(tmp_path):
+    """Two photos whose filenames differ only by case resolve to distinct developed files.
+
+    Regression: `_find_developed_output` used to lowercase the search stem
+    as well as the directory entries, so on case-sensitive filesystems
+    Bird1.CR3 and bird1.CR3 in the same source folder silently collided
+    on the same developed file. Stems must match case-sensitively.
+    """
+    if not _fs_is_case_sensitive(tmp_path):
+        pytest.skip("filesystem is case-insensitive; scenario cannot occur here")
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    src = tmp_path / "src"
+    src.mkdir()
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    dest = tmp_path / "export_out"
+
+    # Two originals in the same folder with stems that differ only by case.
+    Image.new("RGB", (800, 600), color=(200, 0, 0)).save(
+        str(src / "Bird1.jpg"), "JPEG", quality=95,
+    )
+    Image.new("RGB", (800, 600), color=(0, 0, 200)).save(
+        str(src / "bird1.jpg"), "JPEG", quality=95,
+    )
+
+    fid = db.add_folder(str(src), name="Mixed")
+    pid_upper = db.add_photo(folder_id=fid, filename="Bird1.jpg", extension=".jpg",
+                             file_size=1, file_mtime=1.0)
+    pid_lower = db.add_photo(folder_id=fid, filename="bird1.jpg", extension=".jpg",
+                             file_size=1, file_mtime=2.0)
+
+    # Developed outputs with matching cases. If the lookup lowercases the
+    # stem, both photos resolve to whichever entry os.listdir happens to
+    # return first — a silent data-correctness bug.
+    developed = src / "developed"
+    developed.mkdir()
+    Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
+        str(developed / "Bird1.jpg"), "JPEG", quality=95,
+    )
+    Image.new("RGB", (800, 600), color=(200, 200, 10)).save(
+        str(developed / "bird1.jpg"), "JPEG", quality=95,
+    )
+
+    # Export one at a time so the two output filenames don't collide on
+    # a case-insensitive destination view; they land with their own cases.
+    export_photos(
+        db=db,
+        vireo_dir=str(vireo_dir),
+        photo_ids=[pid_upper],
+        destination=str(dest),
+        options={"naming_template": "{original}"},
+    )
+    export_photos(
+        db=db,
+        vireo_dir=str(vireo_dir),
+        photo_ids=[pid_lower],
+        destination=str(dest),
+        options={"naming_template": "{original}"},
+    )
+
+    r_u, g_u, b_u = _avg_rgb(os.path.join(str(dest), "Bird1.jpg"))
+    r_l, g_l, b_l = _avg_rgb(os.path.join(str(dest), "bird1.jpg"))
+    # Bird1.jpg (upper) → green-dominant developed output.
+    assert g_u > r_u and g_u > b_u, (
+        f"Bird1: expected green-dominant developed, got rgb=({r_u},{g_u},{b_u})"
+    )
+    # bird1.jpg (lower) → yellow-dominant developed output.
+    assert r_l > b_l and g_l > b_l, (
+        f"bird1: expected yellow-dominant developed, got rgb=({r_l},{g_l},{b_l})"
+    )

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -8,7 +8,13 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import pytest
 from db import Database
-from export import developed_folder_key, export_photos, resolve_template, sanitize_filename
+from export import (
+    developed_folder_key,
+    export_photos,
+    relocate_developed_dir,
+    resolve_template,
+    sanitize_filename,
+)
 from PIL import Image
 
 
@@ -885,3 +891,163 @@ def test_export_reused_folder_id_does_not_inherit_stale_developed(tmp_path):
         f"expected blue-dominant from fresh original (not stale yellow "
         f"developed file), got rgb=({r},{g},{b})"
     )
+
+
+def test_export_case_variant_developed_prefers_lowercase_extension(tmp_path):
+    """When both bird1.jpg and bird1.JPG exist, export picks the lowercase one deterministically.
+
+    Regression: the developed directory index previously used
+    `setdefault` keyed on the lowercased extension, so whichever entry
+    `os.listdir` returned first won. That made the exported pixels
+    nondeterministic across filesystems and between runs. The index now
+    breaks ties in favour of the canonical lowercase extension — which
+    is what `darktable-cli` writes when `darktable_output_format` is
+    left at its default — so the winner is stable.
+    """
+    if not _fs_is_case_sensitive(tmp_path):
+        pytest.skip("filesystem is case-insensitive; scenario cannot occur here")
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    src = tmp_path / "src"
+    src.mkdir()
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    dest = tmp_path / "export_out"
+
+    Image.new("RGB", (800, 600), color=(200, 0, 0)).save(
+        str(src / "bird1.jpg"), "JPEG", quality=95,
+    )
+    fid = db.add_folder(str(src), name="Src")
+    pid = db.add_photo(folder_id=fid, filename="bird1.jpg", extension=".jpg",
+                        file_size=1, file_mtime=1.0)
+
+    developed = src / "developed"
+    developed.mkdir()
+    # Two developed files for the same stem, differing only by extension
+    # case. The lowercase .jpg file encodes green; the uppercase .JPG
+    # file encodes yellow. A deterministic winner is the lowercase one.
+    Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
+        str(developed / "bird1.jpg"), "JPEG", quality=95,
+    )
+    Image.new("RGB", (800, 600), color=(200, 200, 10)).save(
+        str(developed / "bird1.JPG"), "JPEG", quality=95,
+    )
+
+    export_photos(
+        db=db,
+        vireo_dir=str(vireo_dir),
+        photo_ids=[pid],
+        destination=str(dest),
+        options={"naming_template": "{original}"},
+    )
+
+    r, g, b = _avg_rgb(os.path.join(str(dest), "bird1.jpg"))
+    assert g > r and g > b, (
+        f"expected green-dominant (lowercase .jpg) developed output to win "
+        f"the tie over yellow (.JPG), got rgb=({r},{g},{b})"
+    )
+
+
+def test_relocate_developed_dir_renames_subdir_on_path_change(tmp_path):
+    """After a folder move, its developed subdir is rebased to the new path key."""
+    developed = tmp_path / "darktable_out"
+    developed.mkdir()
+    old_path = "/srv/photos/birds"
+    new_path = "/srv/photos/archive/birds"
+
+    old_key = developed_folder_key(old_path)
+    new_key = developed_folder_key(new_path)
+    assert old_key != new_key
+
+    old_subdir = developed / old_key
+    old_subdir.mkdir()
+    (old_subdir / "IMG_0001.jpg").write_bytes(b"developed-bytes")
+
+    assert relocate_developed_dir(str(developed), old_path, new_path) is True
+
+    assert not old_subdir.exists()
+    new_subdir = developed / new_key
+    assert new_subdir.is_dir()
+    assert (new_subdir / "IMG_0001.jpg").read_bytes() == b"developed-bytes"
+
+
+def test_relocate_developed_dir_noop_when_nothing_to_move(tmp_path):
+    """No-ops when developed_dir is unset, old subdir is absent, or paths match."""
+    developed = tmp_path / "darktable_out"
+    developed.mkdir()
+
+    # No developed_dir configured.
+    assert relocate_developed_dir("", "/a", "/b") is False
+    # Old subdir missing.
+    assert relocate_developed_dir(str(developed), "/missing", "/other") is False
+    # Same path on both sides.
+    assert relocate_developed_dir(str(developed), "/same", "/same") is False
+
+
+def test_relocate_developed_dir_skips_when_target_exists(tmp_path):
+    """If the target key already exists, leave the source in place and log."""
+    developed = tmp_path / "darktable_out"
+    developed.mkdir()
+    old_path = "/srv/photos/a"
+    new_path = "/srv/photos/b"
+
+    (developed / developed_folder_key(old_path)).mkdir()
+    (developed / developed_folder_key(new_path)).mkdir()
+
+    assert relocate_developed_dir(str(developed), old_path, new_path) is False
+    # Both still present — nothing was clobbered.
+    assert (developed / developed_folder_key(old_path)).is_dir()
+    assert (developed / developed_folder_key(new_path)).is_dir()
+
+
+def test_move_folder_rebases_configured_developed_dir(tmp_path):
+    """End-to-end: `move_folder` relocates the darktable output subdir to match the new path.
+
+    Before this fix, a folder move updated `folders.path` in the DB
+    without touching the external `darktable_output_dir` layout, so
+    every previously-developed photo in the moved folder would silently
+    fall back to RAW on export until re-developed.
+    """
+    from move import move_folder
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    src_parent = tmp_path / "old_parent"
+    src_parent.mkdir()
+    src = src_parent / "birds"
+    src.mkdir()
+    # One photo in the source folder (contents don't matter for this test).
+    (src / "IMG_0001.jpg").write_bytes(b"raw-bytes")
+
+    developed = tmp_path / "darktable_out"
+    developed.mkdir()
+    old_key = developed_folder_key(str(src))
+    (developed / old_key).mkdir()
+    (developed / old_key / "IMG_0001.jpg").write_bytes(b"developed-bytes")
+
+    fid = db.add_folder(str(src), name="birds")
+
+    dest_parent = tmp_path / "new_parent"
+    dest_parent.mkdir()
+
+    result = move_folder(
+        db=db,
+        folder_id=fid,
+        destination=str(dest_parent),
+        developed_dir=str(developed),
+    )
+
+    assert not result["errors"], result["errors"]
+    new_src = dest_parent / "birds"
+    assert new_src.is_dir()
+
+    new_key = developed_folder_key(str(new_src))
+    assert old_key != new_key
+    # Old key subdir gone; new key subdir carries the developed file.
+    assert not (developed / old_key).exists()
+    assert (developed / new_key / "IMG_0001.jpg").read_bytes() == b"developed-bytes"


### PR DESCRIPTION
## Summary

Closes the last open bughunt finding. When a user runs **Develop**, darktable
writes a tone-mapped JPG that reflects their creative intent. Export was
ignoring it and re-decoding the RAW through libraw (PIL built-in), so the
downloaded file looked nothing like the on-screen perfected render.

Export now checks, in order, before falling back to the RAW:
1. A developed file at the configured `darktable_output_dir` (if set in Settings).
2. A developed file at `<folder>/developed/<stem>.{jpg,tiff}` — the default path the develop job uses when no custom output dir is configured.
3. Working copy (when resizing within its cap) or the original — existing behavior, preserved for photos that were never developed.

## Notes
- The develop job does not record output paths in the DB, so export reconstructs the path convention from config rather than reading a `developed_path` column.
- `/api/jobs/export` threads `darktable_output_dir` through to the exporter as `developed_dir`.
- No schema changes, no new columns.

## Test plan
- [x] `python -m pytest vireo/tests/test_export.py -v` — 23 pass, 4 new (RED→GREEN verified): developed JPG preferred, developed TIFF preferred when no JPG, fallback to original when none, configured dir beats default.
- [x] CLAUDE.md smoke set — 570 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)