### PR TITLE
fix(import): scan only new folders after copy, not full destination

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5251,6 +5251,13 @@ def create_app(db_path, thumb_cache_dir=None):
             job["_start_time"] = time.time()
 
             scan_target = str(Path(source))  # normalize (strips trailing slash)
+            # restrict_dirs narrows the post-ingest scan to just the subfolders
+            # that received files, instead of walking the full destination
+            # tree. Populated in the copy branch from ingest_result's
+            # copied_paths (parent dirs) and duplicate_folders. Left as None
+            # for copy=false so scan-in-place keeps its original full-tree
+            # behavior.
+            restrict_dirs = None
 
             # Define steps based on whether we're copying
             steps = []
@@ -5290,7 +5297,40 @@ def create_app(db_path, thumb_cache_dir=None):
                     skip_paths=exclude_paths or None,
                 )
                 copied_paths = ingest_result.get("copied_paths", [])
+                duplicate_folders = ingest_result.get("duplicate_folders", [])
                 scan_target = destination
+
+                # Build restrict_dirs from the folders ingest actually touched
+                # so the post-ingest scan doesn't re-walk the entire
+                # destination tree. Without this, importing ~2k RAWs into a
+                # populated library caused scanner.scan to enumerate tens of
+                # thousands of already-indexed files (observed: 59k). Mirrors
+                # the same pattern in pipeline_job.py. Only paths under the
+                # normalized destination are included; ".." tricks cannot
+                # escape. If nothing was copied and no duplicate folders were
+                # reported, restrict_dirs stays an empty list — scanner.scan
+                # then has no directories to enumerate, which matches intent
+                # (there is nothing new to index).
+                dest_normalized = Path(os.path.normpath(destination))
+
+                def _under_destination(path_str):
+                    try:
+                        return Path(os.path.normpath(path_str)).is_relative_to(
+                            dest_normalized
+                        )
+                    except ValueError:
+                        return False
+
+                restrict_set = set()
+                for cp in copied_paths:
+                    parent = str(Path(cp).parent)
+                    if _under_destination(parent):
+                        restrict_set.add(parent)
+                for folder in duplicate_folders:
+                    if _under_destination(folder):
+                        restrict_set.add(folder)
+                restrict_dirs = sorted(restrict_set)
+
                 runner.update_step(job["id"], "ingest", status="completed",
                                    summary=f"{ingest_result.get('copied', 0)} copied")
 
@@ -5308,7 +5348,20 @@ def create_app(db_path, thumb_cache_dir=None):
 
             vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
             try:
-                do_scan(scan_target, thread_db, progress_callback=scan_cb, skip_paths=exclude_paths or None, vireo_dir=vireo_dir)
+                # copy=false: scan_target is the source and restrict_dirs is
+                #   None, so scanner walks the full source tree (unchanged).
+                # copy=true: scan_target is the destination (folder hierarchy
+                #   root, for parent-folder chain creation), but restrict_dirs
+                #   narrows enumeration to only the subfolders ingest wrote
+                #   into. An empty list means "nothing new to scan" — a no-op
+                #   inside scanner.scan.
+                do_scan(
+                    scan_target, thread_db,
+                    progress_callback=scan_cb,
+                    skip_paths=exclude_paths or None,
+                    vireo_dir=vireo_dir,
+                    restrict_dirs=restrict_dirs,
+                )
             finally:
                 # scanner.scan commits photo rows incrementally, so even a mid-scan
                 # failure can leave DB state that invalidates cached new-image counts.

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -2,7 +2,9 @@
 import os
 import shutil
 import tempfile
+import time
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 from app import create_app
@@ -357,3 +359,141 @@ def test_destination_preview_rejects_absolute_template(setup, tmp_path):
             "folder_template": "/tmp/%Y",
         })
         assert resp.status_code == 400
+
+
+def _wait_for_job(client, job_id, timeout=30.0):
+    """Poll the job-status endpoint until the job completes or fails."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        resp = client.get(f"/api/jobs/{job_id}")
+        data = resp.get_json()
+        if data["status"] in ("completed", "failed"):
+            return data
+        time.sleep(0.05)
+    raise AssertionError(f"job {job_id} did not finish within {timeout}s")
+
+
+def test_import_full_copy_restricts_scan_to_new_subfolders(setup, tmp_path, monkeypatch):
+    """Regression: importing with copy=true into a destination that already
+    contains a large unrelated subtree must NOT walk the whole destination.
+
+    Bug: ``api_job_import_full`` used ``scan_target = destination`` with no
+    restriction, so after copying ~2.2k RAWs into two dated subfolders the
+    scanner walked the full 59k-file destination tree. Fix: pass
+    ``restrict_dirs`` to ``scanner.scan`` derived from
+    ``ingest_result["copied_paths"]`` so only the touched folders are
+    re-enumerated. This test patches scanner.scan to capture the call and
+    asserts the unrelated subtree stays out of ``restrict_dirs``.
+    """
+    app, _ = setup
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # Destination already has an unrelated subtree — this is the "59k files"
+    # case in miniature. It MUST NOT end up in restrict_dirs.
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    unrelated = dest / "2019" / "2019-01-01"
+    unrelated.mkdir(parents=True)
+    for i in range(3):
+        Image.new("RGB", (50, 50), "blue").save(str(unrelated / f"old_{i}.jpg"))
+
+    # Source is a fresh folder of new photos stamped with 2024 mtime so
+    # ingest routes them into new YYYY/YYYY-MM-DD subfolders.
+    src = tmp_path / "source"
+    src.mkdir()
+    for i in range(2):
+        fpath = src / f"new_{i}.jpg"
+        Image.new("RGB", (60, 60), "red").save(str(fpath))
+        mtime = datetime(2024, 6, 15, 12, 0, 0).timestamp()
+        os.utime(str(fpath), (mtime, mtime))
+
+    # Patch scanner.scan where app.py looks it up at runtime. app.py does
+    # ``from scanner import scan as do_scan`` inside the job's work(), so the
+    # target is the ``scanner`` module's attribute.
+    import scanner as scanner_mod
+    calls = []
+    original = scanner_mod.scan
+
+    def tracking_scan(root, *args, **kwargs):
+        calls.append({
+            "root": str(root),
+            "restrict_dirs": kwargs.get("restrict_dirs"),
+        })
+        return original(root, *args, **kwargs)
+
+    with patch.object(scanner_mod, "scan", tracking_scan):
+        with app.test_client() as c:
+            resp = c.post("/api/jobs/import-full", json={
+                "source": str(src),
+                "destination": str(dest),
+                "copy": True,
+            })
+            assert resp.status_code == 200
+            job_id = resp.get_json()["job_id"]
+            status = _wait_for_job(c, job_id)
+            assert status["status"] == "completed", status
+
+    assert calls, "scanner.scan was not invoked"
+    call = calls[-1]
+    assert call["root"] == str(dest), (
+        f"scan root should be destination for folder hierarchy, got {call['root']!r}"
+    )
+    restrict = call["restrict_dirs"]
+    assert restrict is not None, (
+        "restrict_dirs should be populated from copied_paths so the scanner "
+        "doesn't re-walk the entire destination tree after ingest."
+    )
+    restrict_set = {os.path.normpath(d) for d in restrict}
+    assert os.path.normpath(str(unrelated)) not in restrict_set, (
+        f"Unrelated pre-existing folder {unrelated!r} must not be scanned; "
+        f"restrict_dirs={restrict_set!r}"
+    )
+    # The new dated folder (2024/2024-06-15) is what ingest created — it
+    # should be the only thing we re-scan.
+    expected_new = dest / "2024" / "2024-06-15"
+    assert os.path.normpath(str(expected_new)) in restrict_set, (
+        f"Expected new folder {expected_new!r} in restrict_dirs; got {restrict_set!r}"
+    )
+
+
+def test_import_full_copy_false_still_scans_source_root(setup, tmp_path, monkeypatch):
+    """copy=false path must be unchanged: scan the source root with no
+    restrict_dirs so scan-in-place still walks the whole tree."""
+    app, _ = setup
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    src = tmp_path / "source"
+    sub = src / "nested"
+    sub.mkdir(parents=True)
+    Image.new("RGB", (40, 40), "green").save(str(sub / "a.jpg"))
+
+    import scanner as scanner_mod
+    calls = []
+    original = scanner_mod.scan
+
+    def tracking_scan(root, *args, **kwargs):
+        calls.append({
+            "root": str(root),
+            "restrict_dirs": kwargs.get("restrict_dirs"),
+        })
+        return original(root, *args, **kwargs)
+
+    with patch.object(scanner_mod, "scan", tracking_scan):
+        with app.test_client() as c:
+            resp = c.post("/api/jobs/import-full", json={
+                "source": str(src),
+                "copy": False,
+            })
+            assert resp.status_code == 200
+            job_id = resp.get_json()["job_id"]
+            status = _wait_for_job(c, job_id)
+            assert status["status"] == "completed", status
+
+    assert calls, "scanner.scan was not invoked"
+    call = calls[-1]
+    assert call["root"] == str(src), (
+        f"copy=false should scan source, got {call['root']!r}"
+    )
+    assert call["restrict_dirs"] is None, (
+        f"copy=false must leave restrict_dirs unset; got {call['restrict_dirs']!r}"
+    )


### PR DESCRIPTION
## Summary

`POST /api/jobs/import-full` with `copy=true` was scanning the entire destination root after ingest — re-walking tens of thousands of already-indexed files for every import. Observed in practice: importing ~2,200 RAWs into two fresh `YYYY/YYYY-MM-DD/` subfolders caused `scanner.scan` to enumerate **59,192 files**, none of which ingest actually touched.

`api_job_import_full` now derives `restrict_dirs` from `ingest_result["copied_paths"]` (parent dirs) plus `ingest_result["duplicate_folders"]`, and passes that to `scanner.scan`. The scanner already supports `restrict_dirs` (used by `pipeline_job.py`) — no scanner changes were needed, and the public signature is unchanged.

### Key points

- `scan_target` stays set to `destination` so `_ensure_folder` still builds the parent-folder chain correctly.
- Only paths under the normalized destination are added to `restrict_dirs`, so a `..` segment can't defeat the narrowing.
- `copy=false` behavior is preserved: `restrict_dirs=None` means the scanner walks the full source tree as before.
- If nothing was copied and no duplicate folders were reported, `restrict_dirs` is an empty list → `scanner.scan` has no directories to enumerate (matches intent: "nothing new to index"). Documented in a code comment.
- Mirrors the approach already used in `pipeline_job.py`, so the two code paths stay consistent.

## Tests

Added two regression tests in `vireo/tests/test_pipeline_api.py`:

1. `test_import_full_copy_restricts_scan_to_new_subfolders` — seeds the destination with an unrelated pre-existing subtree, drives the real `/api/jobs/import-full` endpoint, patches `scanner.scan` to capture kwargs, and asserts:
   - `root == destination` (folder hierarchy preserved),
   - `restrict_dirs` is populated,
   - the pre-existing unrelated folder is **not** in `restrict_dirs`,
   - the new dated folder that ingest created **is** in `restrict_dirs`.
2. `test_import_full_copy_false_still_scans_source_root` — asserts `copy=false` passes `restrict_dirs=None` and still roots the scan at the source.

Test 1 fails on pre-fix `main` (confirms it exercises the bug), passes after the fix.

## Test results

Required workflow suite — all green:

```
python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py \
    vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py \
    vireo/tests/test_darktable_api.py vireo/tests/test_config.py -v
# 547 passed in 17.35s
```

Adjacent sanity check (pipeline/ingest/scanner/new_images):

```
python -m pytest vireo/tests/test_pipeline_api.py vireo/tests/test_pipeline_job.py \
    vireo/tests/test_ingest.py vireo/tests/test_scanner.py vireo/tests/test_new_images.py -q
# 194 passed in 59.86s
```

## Test plan

- [x] `test_import_full_copy_restricts_scan_to_new_subfolders` passes after fix
- [x] `test_import_full_copy_false_still_scans_source_root` passes
- [x] Required workflow test suite (547 tests) passes
- [x] Pipeline/ingest/scanner/new-images suites (194 tests) pass
- [ ] Manual: import a folder into a destination that already holds an unrelated populated subtree; confirm the scan phase doesn't stat the unrelated files