### PR TITLE
fix(scanner): scope working-copy backfill to scanned folders

### DIFF
--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -259,8 +259,11 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
 
     ``scope`` restricts which folders are considered:
       * ``None`` (default) — library-wide backfill (every missing WC).
-      * list/tuple of folder paths — only photos whose folder equals one of
-        the paths or lives under one of them are eligible.
+      * list/tuple of entries — only folders matching an entry are eligible.
+        Each entry is either:
+          - a path string → matches the folder and every descendant (subtree);
+          - a ``(path, "exact")`` tuple → matches the folder only;
+          - a ``(path, "subtree")`` tuple → explicit form of the string case.
       * empty list/tuple — no-op (used by callers that want an explicit
         "scan matched nothing" signal instead of backfilling everything).
     """
@@ -293,9 +296,22 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
     scope_clause = ""
     if scope is not None:
         scope_terms = []
-        for p in scope:
-            scope_terms.append("(f.path = ? OR f.path LIKE ?)")
-            params.extend([str(p), str(p) + os.sep + "%"])
+        for entry in scope:
+            if isinstance(entry, tuple):
+                path, mode = entry
+            else:
+                path, mode = entry, "subtree"
+            path = str(path)
+            if mode == "exact":
+                scope_terms.append("f.path = ?")
+                params.append(path)
+            else:
+                # Subtree match. Escape `_`, `%`, and the escape char itself
+                # so literal wildcards in folder names don't leak into
+                # unrelated siblings (e.g. `2024_06` matching `2024A06`).
+                esc = path.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                scope_terms.append("(f.path = ? OR f.path LIKE ? ESCAPE '\\')")
+                params.extend([path, esc + os.sep + "%"])
         scope_clause = " AND (" + " OR ".join(scope_terms) + ")"
 
     rows = db.conn.execute(
@@ -682,9 +698,14 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         # Extract working copies for RAW photos (after pairing so companion is known).
         # Scope to the folders the caller just scanned so a fresh import doesn't
         # trigger library-wide backfill for every pre-existing large JPEG.
+        # Match-mode mirrors what scan() actually traversed: restrict_dirs and
+        # non-recursive scans only touch direct children, so the scope uses an
+        # exact-folder match; a recursive walk from `root` matches the subtree.
         if vireo_dir:
             if restrict_dirs is not None:
-                wc_scope = [str(d) for d in restrict_dirs]
+                wc_scope = [(str(d), "exact") for d in restrict_dirs]
+            elif not recursive:
+                wc_scope = [(str(root_path), "exact")]
             else:
                 wc_scope = [str(root_path)]
             _extract_working_copies(

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -256,9 +256,16 @@ def _subtree_like_pattern(path, sep=None):
     names don't leak into sibling matches and — critically on Windows — the
     trailing backslash separator doesn't turn the appended ``%`` into a
     literal character.
+
+    Trailing separators on the input are collapsed to exactly one before the
+    wildcard. Without this, ``"/photos/"`` and the filesystem root ``"/"``
+    produce ``"//%"``, which matches nothing.
     """
     if sep is None:
         sep = os.sep
+
+    while path.endswith(sep):
+        path = path[: -len(sep)]
 
     def _escape(s):
         return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -248,7 +248,7 @@ def _pair_raw_jpeg_companions(db):
     db.conn.commit()
 
 
-def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callback=None):
+def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callback=None, scope=None):
     """Extract working copies for all RAW photos missing one.
 
     For each RAW photo without a working_copy_path, extract a JPEG working
@@ -256,8 +256,18 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
     companion JPEG (RAW+JPEG pair), the companion is used as the extraction
     source because the in-camera JPEG is higher quality than extracting from
     the RAW.
+
+    ``scope`` restricts which folders are considered:
+      * ``None`` (default) — library-wide backfill (every missing WC).
+      * list/tuple of folder paths — only photos whose folder equals one of
+        the paths or lives under one of them are eligible.
+      * empty list/tuple — no-op (used by callers that want an explicit
+        "scan matched nothing" signal instead of backfilling everything).
     """
     import config as cfg
+
+    if scope is not None and len(scope) == 0:
+        return
 
     user_cfg = cfg.load()
     wc_max_size = user_cfg.get("working_copy_max_size", 4096)
@@ -279,6 +289,15 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
             "     AND (p.width > ? OR p.height > ?))"
         )
         params.extend([wc_max_size, wc_max_size])
+
+    scope_clause = ""
+    if scope is not None:
+        scope_terms = []
+        for p in scope:
+            scope_terms.append("(f.path = ? OR f.path LIKE ?)")
+            params.extend([str(p), str(p) + os.sep + "%"])
+        scope_clause = " AND (" + " OR ".join(scope_terms) + ")"
+
     rows = db.conn.execute(
         f"""
         SELECT p.id, p.filename, p.companion_path, p.working_copy_path,
@@ -291,6 +310,7 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
                p.extension IN ({placeholders})
                {jpeg_clause}
            )
+           {scope_clause}
         """,
         params,
     ).fetchall()
@@ -659,9 +679,17 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     try:
         _pair_raw_jpeg_companions(db)
 
-        # Extract working copies for RAW photos (after pairing so companion is known)
+        # Extract working copies for RAW photos (after pairing so companion is known).
+        # Scope to the folders the caller just scanned so a fresh import doesn't
+        # trigger library-wide backfill for every pre-existing large JPEG.
         if vireo_dir:
-            _extract_working_copies(db, vireo_dir, progress_callback, status_callback)
+            if restrict_dirs is not None:
+                wc_scope = [str(d) for d in restrict_dirs]
+            else:
+                wc_scope = [str(root_path)]
+            _extract_working_copies(
+                db, vireo_dir, progress_callback, status_callback, scope=wc_scope,
+            )
     except BaseException:
         db.conn.rollback()
         raise

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -248,6 +248,24 @@ def _pair_raw_jpeg_companions(db):
     db.conn.commit()
 
 
+def _subtree_like_pattern(path, sep=None):
+    """Build a SQLite LIKE parameter that matches ``path`` + any descendant.
+
+    Intended for use with ``LIKE ? ESCAPE '\\'``. Escapes ``\\``, ``%``, and
+    ``_`` inside the path and the separator, so literal wildcards in folder
+    names don't leak into sibling matches and — critically on Windows — the
+    trailing backslash separator doesn't turn the appended ``%`` into a
+    literal character.
+    """
+    if sep is None:
+        sep = os.sep
+
+    def _escape(s):
+        return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+    return _escape(path) + _escape(sep) + "%"
+
+
 def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callback=None, scope=None):
     """Extract working copies for all RAW photos missing one.
 
@@ -306,12 +324,14 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
                 scope_terms.append("f.path = ?")
                 params.append(path)
             else:
-                # Subtree match. Escape `_`, `%`, and the escape char itself
-                # so literal wildcards in folder names don't leak into
-                # unrelated siblings (e.g. `2024_06` matching `2024A06`).
-                esc = path.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                # Subtree match. The LIKE pattern needs to escape `_`, `%`,
+                # and the escape char itself — both in the path and in the
+                # separator — so (a) literal wildcards in folder names don't
+                # leak into siblings (`2024_06` matching `2024A06`) and
+                # (b) the Windows `\` separator doesn't turn the trailing
+                # `%` into a literal under ESCAPE '\\'.
                 scope_terms.append("(f.path = ? OR f.path LIKE ? ESCAPE '\\')")
-                params.extend([path, esc + os.sep + "%"])
+                params.extend([path, _subtree_like_pattern(path)])
         scope_clause = " AND (" + " OR ".join(scope_terms) + ")"
 
     rows = db.conn.execute(

--- a/vireo/tests/test_scanner_working_copy.py
+++ b/vireo/tests/test_scanner_working_copy.py
@@ -190,6 +190,87 @@ def test_extract_working_copies_empty_scope_is_noop(tmp_path, monkeypatch):
     assert row["working_copy_path"] is None
 
 
+def test_extract_working_copies_scope_escapes_like_wildcards(tmp_path, monkeypatch):
+    """An underscore in a scope path must not match unrelated siblings.
+
+    SQLite LIKE treats `_` and `%` as wildcards. Without escaping, scoping to
+    ``/photos/2024_06`` would also match a sibling like ``/photos/2024A06``.
+    """
+    import config as cfg
+    from db import Database
+    from scanner import _extract_working_copies
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    wanted = tmp_path / "2024_06"
+    wanted.mkdir()
+    # Sibling whose path would match the naive `2024_06/%` pattern because `_`
+    # is a LIKE wildcard. Both folders end in a directory separator boundary
+    # so the tail matches a single arbitrary character.
+    sibling = tmp_path / "2024A06"
+    sibling.mkdir()
+    (sibling / "sub").mkdir()
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+    wanted_id = _seed_large_jpeg(db, wanted, "w.jpg")
+    sibling_sub = sibling / "sub"
+    sibling_id = _seed_large_jpeg(db, sibling_sub, "s.jpg")
+
+    _extract_working_copies(db, str(vireo_dir), scope=[str(wanted)])
+
+    assert (vireo_dir / "working" / f"{wanted_id}.jpg").exists()
+    assert not (vireo_dir / "working" / f"{sibling_id}.jpg").exists(), (
+        "wildcard `_` in wanted path leaked into sibling match"
+    )
+
+
+def test_scan_non_recursive_scopes_working_copies_to_root_only(tmp_path, monkeypatch):
+    """scan(..., recursive=False) must not backfill working copies in subfolders.
+
+    Regression: without honoring `recursive`, the derived scope used a subtree
+    match that touched photos the caller explicitly chose not to walk.
+    """
+    import config as cfg
+    from db import Database
+    from scanner import scan
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+
+    root = tmp_path / "scan"
+    root.mkdir()
+    # A large JPEG sitting at the scan root (on disk + to-be-scanned).
+    _make_jpeg(str(root / "top.jpg"), 2000, 1500)
+
+    # A pre-existing subfolder photo already in the DB that the caller does
+    # NOT want touched because `recursive=False`.
+    sub = root / "sub"
+    sub.mkdir()
+    sub_id = _seed_large_jpeg(db, sub, "in_sub.jpg")
+
+    scan(str(root), db, recursive=False, vireo_dir=str(vireo_dir))
+
+    top_row = db.conn.execute(
+        "SELECT id, working_copy_path FROM photos WHERE filename='top.jpg'"
+    ).fetchone()
+    assert top_row is not None
+    assert top_row["working_copy_path"] == f"working/{top_row['id']}.jpg"
+
+    # Subfolder photo is outside the non-recursive scan; must NOT be touched.
+    assert not (vireo_dir / "working" / f"{sub_id}.jpg").exists()
+    sub_wc = db.conn.execute(
+        "SELECT working_copy_path FROM photos WHERE id=?", (sub_id,)
+    ).fetchone()["working_copy_path"]
+    assert sub_wc is None
+
+
 def test_scan_scopes_working_copies_to_scan_root(tmp_path, monkeypatch):
     """scan() with a root only extracts working copies for photos under that root.
 

--- a/vireo/tests/test_scanner_working_copy.py
+++ b/vireo/tests/test_scanner_working_copy.py
@@ -88,6 +88,153 @@ def test_no_jpeg_working_copy_when_max_size_zero(tmp_path, monkeypatch):
     assert row["working_copy_path"] is None
 
 
+def _seed_large_jpeg(db, folder, filename):
+    """Make a large JPEG on disk, register it in `db`, return photo_id."""
+    src = folder / filename
+    _make_jpeg(str(src), 2000, 1500)
+    folder_id = db.add_folder(str(folder))
+    return db.add_photo(
+        folder_id, filename, ".jpg",
+        file_size=os.path.getsize(str(src)),
+        file_mtime=os.path.getmtime(str(src)),
+        width=2000, height=1500,
+    )
+
+
+def test_extract_working_copies_scope_restricts_to_given_folders(tmp_path, monkeypatch):
+    """When `scope` is given, only photos in those folders get working copies."""
+    import config as cfg
+    from db import Database
+    from scanner import _extract_working_copies
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    folder_a = tmp_path / "a"
+    folder_a.mkdir()
+    folder_b = tmp_path / "b"
+    folder_b.mkdir()
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+    a_id = _seed_large_jpeg(db, folder_a, "a.jpg")
+    b_id = _seed_large_jpeg(db, folder_b, "b.jpg")
+
+    _extract_working_copies(db, str(vireo_dir), scope=[str(folder_a)])
+
+    assert (vireo_dir / "working" / f"{a_id}.jpg").exists()
+    assert not (vireo_dir / "working" / f"{b_id}.jpg").exists()
+
+    rows = {
+        r["id"]: r["working_copy_path"]
+        for r in db.conn.execute(
+            "SELECT id, working_copy_path FROM photos WHERE id IN (?, ?)",
+            (a_id, b_id),
+        ).fetchall()
+    }
+    assert rows[a_id] == f"working/{a_id}.jpg"
+    assert rows[b_id] is None
+
+
+def test_extract_working_copies_scope_matches_subtrees(tmp_path, monkeypatch):
+    """Scope entries match their subtree — a photo in a subfolder is included."""
+    import config as cfg
+    from db import Database
+    from scanner import _extract_working_copies
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    child = parent / "2026-04-20"
+    child.mkdir()
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+    child_id = _seed_large_jpeg(db, child, "c.jpg")
+    sibling_id = _seed_large_jpeg(db, sibling, "s.jpg")
+
+    _extract_working_copies(db, str(vireo_dir), scope=[str(parent)])
+
+    assert (vireo_dir / "working" / f"{child_id}.jpg").exists()
+    assert not (vireo_dir / "working" / f"{sibling_id}.jpg").exists()
+
+
+def test_extract_working_copies_empty_scope_is_noop(tmp_path, monkeypatch):
+    """scope=[] → nothing is extracted, even with eligible photos present."""
+    import config as cfg
+    from db import Database
+    from scanner import _extract_working_copies
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+    photo_id = _seed_large_jpeg(db, folder, "big.jpg")
+
+    _extract_working_copies(db, str(vireo_dir), scope=[])
+
+    assert not (vireo_dir / "working" / f"{photo_id}.jpg").exists()
+    row = db.conn.execute(
+        "SELECT working_copy_path FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()
+    assert row["working_copy_path"] is None
+
+
+def test_scan_scopes_working_copies_to_scan_root(tmp_path, monkeypatch):
+    """scan() with a root only extracts working copies for photos under that root.
+
+    Regression: before the fix, scan backfilled working copies library-wide,
+    so a fresh import triggered full-size extraction for every pre-existing
+    large JPEG in the DB — slow and unrelated to what was just scanned.
+    """
+    import config as cfg
+    from db import Database
+    from scanner import scan
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    # Pre-existing large JPEG in the DB, in a folder OUTSIDE the scan root.
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+    outside_id = _seed_large_jpeg(db, outside, "pre.jpg")
+
+    # New folder inside the scan root with its own large JPEG on disk.
+    scan_root = tmp_path / "scan"
+    scan_root.mkdir()
+    new_file = scan_root / "new.jpg"
+    _make_jpeg(str(new_file), 2000, 1500)
+
+    scan(str(scan_root), db, vireo_dir=str(vireo_dir))
+
+    # The photo inside the scan root gets a working copy.
+    inside_row = db.conn.execute(
+        "SELECT id, working_copy_path FROM photos WHERE filename='new.jpg'"
+    ).fetchone()
+    assert inside_row is not None
+    assert inside_row["working_copy_path"] == f"working/{inside_row['id']}.jpg"
+
+    # The pre-existing photo outside the scan root is NOT touched.
+    assert not (vireo_dir / "working" / f"{outside_id}.jpg").exists()
+    outside_wc = db.conn.execute(
+        "SELECT working_copy_path FROM photos WHERE id=?", (outside_id,)
+    ).fetchone()["working_copy_path"]
+    assert outside_wc is None
+
+
 def test_no_working_copy_for_small_jpeg(tmp_path, monkeypatch):
     """A JPEG within the cap does NOT get a working copy."""
     import config as cfg

--- a/vireo/tests/test_scanner_working_copy.py
+++ b/vireo/tests/test_scanner_working_copy.py
@@ -190,6 +190,33 @@ def test_extract_working_copies_empty_scope_is_noop(tmp_path, monkeypatch):
     assert row["working_copy_path"] is None
 
 
+def test_subtree_like_pattern_posix():
+    """Unix separator: LIKE pattern is the path followed by `/%`."""
+    from scanner import _subtree_like_pattern
+    assert _subtree_like_pattern("/photos/2024", sep="/") == "/photos/2024/%"
+
+
+def test_subtree_like_pattern_windows_escapes_separator():
+    r"""On Windows, the trailing `\` must be escape-doubled so `%` remains the
+    wildcard under ``LIKE ? ESCAPE '\'`` — otherwise subtree matching silently
+    matches only the exact folder.
+
+    Input path `C:\a\b` with sep `\`:
+      * every literal `\` in the path is doubled → `C:\\a\\b`
+      * the trailing separator is also doubled → `\\`
+      * the wildcard `%` is appended unescaped.
+    """
+    from scanner import _subtree_like_pattern
+    assert _subtree_like_pattern("C:\\a\\b", sep="\\") == "C:\\\\a\\\\b\\\\%"
+
+
+def test_subtree_like_pattern_escapes_literal_wildcards():
+    """`_` and `%` inside folder names are escaped so they match literally."""
+    from scanner import _subtree_like_pattern
+    assert _subtree_like_pattern("/a/2024_06", sep="/") == "/a/2024\\_06/%"
+    assert _subtree_like_pattern("/a/50%off", sep="/") == "/a/50\\%off/%"
+
+
 def test_extract_working_copies_scope_escapes_like_wildcards(tmp_path, monkeypatch):
     """An underscore in a scope path must not match unrelated siblings.
 

--- a/vireo/tests/test_scanner_working_copy.py
+++ b/vireo/tests/test_scanner_working_copy.py
@@ -217,6 +217,19 @@ def test_subtree_like_pattern_escapes_literal_wildcards():
     assert _subtree_like_pattern("/a/50%off", sep="/") == "/a/50\\%off/%"
 
 
+def test_subtree_like_pattern_normalizes_trailing_separator():
+    """Trailing separator in the scope path must not produce a double separator.
+
+    Before this guard, `/photos/` produced `"//%"` and the root path `"/"`
+    produced `"//%"` — neither matches any real descendant path.
+    """
+    from scanner import _subtree_like_pattern
+    assert _subtree_like_pattern("/photos/", sep="/") == "/photos/%"
+    assert _subtree_like_pattern("/photos///", sep="/") == "/photos/%"
+    assert _subtree_like_pattern("/", sep="/") == "/%"
+    assert _subtree_like_pattern("C:\\a\\", sep="\\") == "C:\\\\a\\\\%"
+
+
 def test_extract_working_copies_scope_escapes_like_wildcards(tmp_path, monkeypatch):
     """An underscore in a scope path must not match unrelated siblings.
 


### PR DESCRIPTION
## Summary

Before this change, `scan()` called `_extract_working_copies` with no filter, so a fresh import triggered a **library-wide** working-copy backfill: every pre-existing large JPEG missing a working copy was re-encoded, even when unrelated to what was just scanned. On libraries with tens of thousands of older JPEGs this turns a one-folder import into hours of unrelated work.

- Add a `scope` kwarg to `_extract_working_copies`. When set, the SQL picks up a `folders.path = ? OR folders.path LIKE "<path><sep>%"` predicate per entry so only photos inside those subtrees are considered.
- Thread scope from `scan()` using `restrict_dirs` when given, else the scan root.
- `scope=None` preserves the existing library-wide behavior (backwards-compatible for direct callers and tests).
- `scope=[]` is an explicit no-op — lets callers say "scan matched nothing, don't backfill" without a special case.

## Test plan

- [x] New unit tests for scope filtering (equal-path, subtree match, empty-list no-op)
- [x] New regression test covering the full `scan()` path: pre-existing outside-root photo is NOT touched, new inside-root photo gets its working copy
- [x] `python -m pytest vireo/tests/test_scanner.py vireo/tests/test_scanner_callback.py vireo/tests/test_scanner_working_copy.py -q` → 53 passed
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` → 555 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)