### PR TITLE
Headless API for external callers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,7 @@ ML models are downloaded automatically from HuggingFace on first use.
 ```bash
 python -m pytest tests/ vireo/tests/ -q
 ```
+
+## Scripting & automation
+
+Vireo exposes a small stable HTTP API under `/api/v1` for scripts and agents. A running instance advertises its port and auth token via `~/.vireo/runtime.json`. See [docs/headless-api.md](docs/headless-api.md) for discovery, spawning a headless instance, authentication, and a worked `curl` example.

--- a/docs/headless-api.md
+++ b/docs/headless-api.md
@@ -1,0 +1,105 @@
+# Vireo headless API
+
+Vireo is primarily a desktop app, but its Flask server also exposes a small
+stable HTTP API for scripts and agents. This page documents what callers can
+rely on.
+
+## Discovering a running instance
+
+When the Vireo sidecar starts (either as part of the Tauri GUI or directly
+from the command line), it writes `~/.vireo/runtime.json`:
+
+```json
+{
+  "port": 54321,
+  "pid": 12345,
+  "version": "0.8.28",
+  "db_path": "/Users/you/.vireo/vireo.db",
+  "started_at": "2026-04-22T19:30:00Z",
+  "mode": "gui",
+  "token": "…"
+}
+```
+
+The file is `chmod 600` (user-only read) because the token is sensitive.
+
+**Liveness:** treat `runtime.json` as authoritative only after confirming
+`GET http://127.0.0.1:<port>/api/v1/health` (with the token) returns 200.
+If the file is stale (process died without cleanup), the next sidecar start
+will replace it automatically.
+
+## Spawning a headless instance
+
+If no instance is running, spawn one from the installed `.app`:
+
+```bash
+/Applications/Vireo.app/Contents/Resources/bin/vireo-server \
+  --headless --port 0 --db ~/.vireo/vireo.db
+```
+
+`--port 0` picks a free port. Poll `~/.vireo/runtime.json` until it appears
+(typically <2 s), then read the port and token from it.
+
+**Only one Vireo instance can run at a time.** If the GUI is already open,
+the headless spawn will exit with a non-zero status and print a JSON error
+to stderr:
+
+```json
+{"error":"already_running","port":54321,"pid":12345}
+```
+
+In that case, just connect to the running instance using the port and token
+in `runtime.json` — both modes serve the same API.
+
+## Authentication
+
+Every `/api/v1/*` request must include the token from `runtime.json`:
+
+```
+X-Vireo-Token: <token>
+```
+
+Missing or wrong token → 401.
+
+## Stable endpoints
+
+Endpoints under `/api/v1` are covered by a semver contract: breaking changes
+require bumping the version prefix. Everything else under `/api/*` is
+internal to the GUI and may change at any time.
+
+Current stable set:
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET  | `/api/v1/health` | Liveness probe. |
+| GET  | `/api/v1/version` | `{"version": "x.y.z"}`. |
+| POST | `/api/v1/shutdown` | Gracefully stop the sidecar. |
+| GET  | `/api/v1/photos` | List/search photos in the active workspace. |
+| GET  | `/api/v1/photos/<id>` | One photo's metadata. |
+| GET  | `/api/v1/collections` | Collections in the active workspace. |
+| GET  | `/api/v1/collections/<id>/photos` | Photos in a collection. |
+| GET  | `/api/v1/workspaces` | All workspaces. |
+| POST | `/api/v1/workspaces/<id>/activate` | Switch the active workspace. |
+| GET  | `/api/v1/keywords` | Keyword tree. |
+
+Request/response shapes mirror the internal `/api/*` endpoints — see source
+or open `/api/v1/<path>` with the token in your browser's dev tools for
+concrete examples.
+
+## Worked example
+
+```bash
+# 1. Locate the instance.
+PORT=$(jq -r .port ~/.vireo/runtime.json)
+TOKEN=$(jq -r .token ~/.vireo/runtime.json)
+
+# 2. Probe health.
+curl -sf -H "X-Vireo-Token: $TOKEN" "http://127.0.0.1:$PORT/api/v1/health"
+
+# 3. List photos.
+curl -sf -H "X-Vireo-Token: $TOKEN" "http://127.0.0.1:$PORT/api/v1/photos"
+
+# 4. Shut down (only if you spawned the instance yourself).
+curl -sf -X POST -H "X-Vireo-Token: $TOKEN" \
+     "http://127.0.0.1:$PORT/api/v1/shutdown"
+```

--- a/docs/plans/2026-04-22-headless-api-design.md
+++ b/docs/plans/2026-04-22-headless-api-design.md
@@ -1,0 +1,184 @@
+# Headless API design
+
+## Goal
+
+Make Vireo reliably scriptable by agents (and other external callers) when the
+user only has the packaged `.app` — not the source tree. Today the Flask
+sidecar is already a full HTTP server, but the bound port is known only to
+Tauri, the sidecar binary is buried inside the bundle with no documented
+invocation, and there is no advertised API contract. This design closes those
+gaps with three additions: a runtime-discovery file, a single-instance guard,
+and a small versioned API surface.
+
+Scope is deliberately narrow. The UI stays the primary way humans use Vireo.
+Headless mode is for automation: scripts, CI, and agents like Claude Code
+driving the app on behalf of a user who installed it from a DMG.
+
+## User-facing behavior
+
+Single flow. Claude (or any external caller) follows the same steps whether
+Vireo is already running or not:
+
+1. Read `~/.vireo/runtime.json`.
+2. If it exists and `GET http://127.0.0.1:<port>/api/v1/health` (with the
+   token from the file) returns 200, connect to that instance.
+3. If it is missing or the health probe fails, spawn the bundled sidecar
+   headlessly:
+   ```
+   /Applications/Vireo.app/Contents/Resources/bin/vireo-server \
+     --headless --port 0 --db ~/.vireo/vireo.db
+   ```
+   Poll `runtime.json` until it appears, then connect.
+4. When finished, callers that spawned the process may `POST /api/v1/shutdown`.
+   Callers that attached to a running instance leave it alone.
+
+**Concurrent instances are unsupported.** The sidecar refuses to start if
+another healthy instance is already running. Users with the GUI open cannot
+also run a standalone headless server at the same time — the second attempt
+exits non-zero with a machine-readable error.
+
+## `runtime.json`
+
+Location: `~/.vireo/runtime.json`, next to `vireo.log` and `vireo.db`.
+
+Written by the sidecar itself at the end of startup — after Flask has bound
+the port, before it accepts real traffic. The write is atomic (`write to
+.tmp`, then `os.replace`). File mode is `0600` so only the user can read the
+token.
+
+```json
+{
+  "port": 54321,
+  "pid": 12345,
+  "version": "0.8.28",
+  "db_path": "/Users/julius/.vireo/vireo.db",
+  "started_at": "2026-04-22T19:30:00Z",
+  "mode": "gui",
+  "token": "b7c9e4f1a2d8…"
+}
+```
+
+- `port`, `pid` — discovery and liveness.
+- `version` — lets callers check compatibility if the API ever breaks.
+- `db_path` — surfaces which database the running instance has open.
+- `started_at` — debugging only; not load-bearing.
+- `mode` — `"gui"` (sidecar spawned by Tauri) or `"headless"` (spawned
+  directly). Informational.
+- `token` — 32 random bytes, base64url-encoded. Required on every
+  `/api/v1/*` request via `X-Vireo-Token` header.
+
+Cleanup: `atexit` handler and SIGTERM handler both unlink the file. Stale
+files (process died hard, file left behind) are handled by the single-instance
+guard.
+
+## Single-instance guard
+
+Same code path for both GUI-spawn and headless-spawn, runs at the top of the
+sidecar's `main()`:
+
+1. If `~/.vireo/runtime.json` does not exist, proceed.
+2. If it exists and its JSON is invalid, delete it and proceed.
+3. Otherwise, probe `GET http://127.0.0.1:<port>/api/v1/health` with a
+   500 ms timeout, using the token from the file.
+4. If the probe returns 200, the existing instance is alive. Print
+   `{"error":"already_running","port":N,"pid":M}` to stderr and
+   `sys.exit(1)`.
+5. If the probe fails (connection refused, timeout, non-200), the file is
+   stale. Delete it and proceed.
+
+The health probe is authoritative. A PID check is not needed: a port that
+answers Vireo's health endpoint is Vireo.
+
+## API contract
+
+Two tiers, both served from the same Flask app.
+
+**`/api/v1/*` — stable, versioned headless API.** Breaking changes only with
+a version bump. Initial endpoint set:
+
+- `GET /api/v1/health`
+- `GET /api/v1/version`
+- `POST /api/v1/shutdown`
+- `GET /api/v1/photos` (list/search)
+- `GET /api/v1/photos/<id>`
+- `GET /api/v1/collections`
+- `GET /api/v1/collections/<id>/photos`
+- `GET /api/v1/workspaces`
+- `POST /api/v1/workspaces/<id>/activate`
+- `GET /api/v1/keywords`
+
+**`/api/*` — internal, may change without notice.** Everything the Tauri UI
+uses: jobs, SSE log stream, pending changes, thumbnails, preview cache, etc.
+Not advertised for external use. The Tauri sidecar code keeps calling these
+as it does today — no migration needed.
+
+Rather than duplicate handler bodies, `/api/v1/*` routes are thin wrappers
+(or Flask `add_url_rule` aliases) over the existing implementation for the
+endpoints in the stable set. The existing `/api/health` continues to work for
+Tauri's current wait-for-health check; the Tauri sidecar code can migrate to
+`/api/v1/health` later.
+
+## Auth
+
+Every `/api/v1/*` request must include `X-Vireo-Token: <token>` matching the
+value in `runtime.json`. Missing or wrong token returns 401. Loopback-only
+binding plus the token meaningfully reduces the risk of a hostile local
+process (or a DNS-rebinding browser tab) poking the API.
+
+The token is generated fresh on each sidecar start; there is no persistent
+credential file. Callers are expected to read `runtime.json` at the start of
+every session.
+
+## Testing
+
+Unit tests (`vireo/tests/test_runtime_discovery.py`):
+
+- `write_runtime_json` is atomic (temp + rename), `chmod 600`, includes all
+  required fields.
+- Guard: healthy peer → exits with `already_running` and correct JSON on
+  stderr.
+- Guard: stale file (port refuses connection) → deletes file, proceeds.
+- Guard: file with invalid JSON → deletes file, proceeds.
+- Token middleware: missing header → 401, wrong token → 401, correct
+  token → passes.
+
+Integration tests (`tests/test_headless_mode.py`, runs the sidecar binary or
+dev entrypoint):
+
+- Spawn sidecar with `--headless --port 0`, poll `runtime.json` until it
+  appears, verify `GET /api/v1/health` returns 200 with the token.
+- Spawn a second sidecar while the first is running → exits non-zero, stderr
+  contains `already_running`, first instance still healthy.
+- Kill first sidecar hard (SIGKILL). Spawn a new one → detects stale file,
+  starts clean.
+- Graceful shutdown via `POST /api/v1/shutdown` removes `runtime.json`.
+
+Out of scope for CI: testing against the packaged `.app`. That stays a manual
+smoke test after each release.
+
+## Implementation order
+
+1. `vireo/runtime.py`: write/read/delete `runtime.json`, single-instance
+   guard function. Pure unit tests first.
+2. Wire guard + writer into sidecar startup in `vireo/app.py`. Keep the
+   existing `/api/health` endpoint so the Tauri sidecar code keeps working.
+3. Add an explicit `--headless` flag to `vireo/app.py` (currently implicit
+   via `--no-browser`; making it explicit gives future knobs somewhere to
+   hang).
+4. Token generation + `X-Vireo-Token` middleware.
+5. `/api/v1/*` routes for the stable set above.
+6. Integration tests.
+7. `docs/headless-api.md` — user-facing guide. Covers: where `runtime.json`
+   lives, schema, how to spawn the sidecar from the bundle, endpoint list,
+   token usage, worked example with `curl`. Linked from top-level README.
+8. Manual smoke test against a packaged build before merging.
+
+## Non-goals
+
+- Installing a `vireo` CLI launcher at `/usr/local/bin`. Users invoke the
+  in-bundle binary directly. Reconsidered later if real demand appears.
+- Supporting two Vireo instances simultaneously. The single-instance guard
+  makes this an explicit error; the database and filesystem caches are not
+  designed for concurrent writers.
+- Freezing every `/api/*` endpoint. Only `/api/v1/*` is stable.
+- Remote access. Vireo binds to `127.0.0.1` only.

--- a/docs/plans/2026-04-22-headless-api-plan.md
+++ b/docs/plans/2026-04-22-headless-api-plan.md
@@ -1,0 +1,1418 @@
+# Headless API Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make Vireo reliably scriptable by external callers (agents, CI) when only the packaged `.app` is installed, by adding a runtime-discovery file, a single-instance guard, a versioned `/api/v1/*` API, and a local auth token.
+
+**Architecture:** The sidecar writes `~/.vireo/runtime.json` at startup with port, PID, token, and metadata. A single-instance guard at the top of `main()` refuses to start if a healthy peer is running. A new `/api/v1/*` surface aliases a small stable subset of endpoints, gated by an `X-Vireo-Token` header matching the value in `runtime.json`. The existing `/api/*` surface remains unchanged so the Tauri UI keeps working.
+
+**Tech Stack:** Python 3.11+, Flask 3, pytest. Existing dependencies only — no new packages.
+
+**Design reference:** `docs/plans/2026-04-22-headless-api-design.md`.
+
+---
+
+## Preconditions
+
+- Work happens on branch `headless-app-feasibility` in `/Users/julius/conductor/workspaces/vireo/boston`.
+- Before starting: confirm tests pass on the current tree.
+
+Run:
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -v
+```
+Expected: all pass.
+
+---
+
+## Task 1: `runtime.json` atomic writer
+
+**Files:**
+- Create: `vireo/runtime.py`
+- Test: `vireo/tests/test_runtime.py`
+
+**Step 1: Write the failing test**
+
+Create `vireo/tests/test_runtime.py`:
+
+```python
+import json
+import os
+import stat
+
+
+def test_write_runtime_json_atomic_and_locked_down(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    from runtime import write_runtime_json
+
+    write_runtime_json(
+        port=54321,
+        pid=12345,
+        version="0.0.1",
+        db_path="/tmp/x.db",
+        token="tok",
+        mode="headless",
+    )
+
+    path = tmp_path / ".vireo" / "runtime.json"
+    assert path.exists()
+
+    data = json.loads(path.read_text())
+    assert data["port"] == 54321
+    assert data["pid"] == 12345
+    assert data["version"] == "0.0.1"
+    assert data["db_path"] == "/tmp/x.db"
+    assert data["token"] == "tok"
+    assert data["mode"] == "headless"
+    assert "started_at" in data  # ISO8601 timestamp
+
+    # chmod 600 — only the user can read the token
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    assert mode == 0o600
+
+
+def test_write_runtime_json_overwrites_existing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+    (tmp_path / ".vireo" / "runtime.json").write_text('{"stale": true}')
+
+    from runtime import write_runtime_json
+
+    write_runtime_json(port=1, pid=2, version="v", db_path="/x", token="t", mode="gui")
+
+    data = json.loads((tmp_path / ".vireo" / "runtime.json").read_text())
+    assert "stale" not in data
+    assert data["port"] == 1
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest vireo/tests/test_runtime.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'runtime'`.
+
+**Step 3: Write minimal implementation**
+
+Create `vireo/runtime.py`:
+
+```python
+"""Runtime discovery file for the Vireo sidecar.
+
+Writes `~/.vireo/runtime.json` so external callers can discover the running
+instance (port, auth token, PID). Also provides the single-instance guard.
+"""
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def _runtime_path() -> Path:
+    return Path(os.path.expanduser("~/.vireo/runtime.json"))
+
+
+def write_runtime_json(
+    *, port: int, pid: int, version: str, db_path: str, token: str, mode: str
+) -> None:
+    """Atomically write runtime.json with 0600 permissions."""
+    path = _runtime_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "port": port,
+        "pid": pid,
+        "version": version,
+        "db_path": db_path,
+        "started_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "mode": mode,
+        "token": token,
+    }
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    # Write then chmod before replace, so the target is never world-readable.
+    tmp.write_text(json.dumps(payload, indent=2))
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest vireo/tests/test_runtime.py -v`
+Expected: both tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/runtime.py vireo/tests/test_runtime.py
+git commit -m "feat(runtime): atomic runtime.json writer with 0600 perms"
+```
+
+---
+
+## Task 2: `runtime.json` reader + cleanup
+
+**Files:**
+- Modify: `vireo/runtime.py`
+- Modify: `vireo/tests/test_runtime.py`
+
+**Step 1: Write the failing test**
+
+Append to `vireo/tests/test_runtime.py`:
+
+```python
+def test_read_runtime_json_returns_dict(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+    (tmp_path / ".vireo" / "runtime.json").write_text(
+        '{"port": 1234, "token": "abc"}'
+    )
+
+    from runtime import read_runtime_json
+
+    data = read_runtime_json()
+    assert data == {"port": 1234, "token": "abc"}
+
+
+def test_read_runtime_json_missing_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    from runtime import read_runtime_json
+
+    assert read_runtime_json() is None
+
+
+def test_read_runtime_json_malformed_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+    (tmp_path / ".vireo" / "runtime.json").write_text("not json{{{")
+
+    from runtime import read_runtime_json
+
+    assert read_runtime_json() is None
+
+
+def test_delete_runtime_json_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+    (tmp_path / ".vireo" / "runtime.json").write_text("{}")
+
+    from runtime import delete_runtime_json
+
+    delete_runtime_json()
+    assert not (tmp_path / ".vireo" / "runtime.json").exists()
+    delete_runtime_json()  # second call should not raise
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest vireo/tests/test_runtime.py -v`
+Expected: FAIL — `read_runtime_json` / `delete_runtime_json` not found.
+
+**Step 3: Write minimal implementation**
+
+Append to `vireo/runtime.py`:
+
+```python
+def read_runtime_json() -> dict | None:
+    """Return runtime.json contents, or None if missing / malformed."""
+    path = _runtime_path()
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def delete_runtime_json() -> None:
+    """Remove runtime.json if present. Idempotent."""
+    try:
+        _runtime_path().unlink()
+    except FileNotFoundError:
+        pass
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest vireo/tests/test_runtime.py -v`
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/runtime.py vireo/tests/test_runtime.py
+git commit -m "feat(runtime): read and delete helpers for runtime.json"
+```
+
+---
+
+## Task 3: Single-instance guard
+
+**Files:**
+- Modify: `vireo/runtime.py`
+- Modify: `vireo/tests/test_runtime.py`
+
+**Step 1: Write the failing test**
+
+Append to `vireo/tests/test_runtime.py`:
+
+```python
+import http.server
+import json as _json
+import threading
+
+
+class _HealthHandler(http.server.BaseHTTPRequestHandler):
+    expected_token = "goodtoken"
+
+    def do_GET(self):
+        if self.path != "/api/v1/health":
+            self.send_response(404)
+            self.end_headers()
+            return
+        if self.headers.get("X-Vireo-Token") != self.expected_token:
+            self.send_response(401)
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"status":"ok"}')
+
+    def log_message(self, *a, **kw):  # silence
+        pass
+
+
+def _start_fake_server(token):
+    _HealthHandler.expected_token = token
+    server = http.server.HTTPServer(("127.0.0.1", 0), _HealthHandler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return server, port
+
+
+def test_guard_no_file_returns_proceed(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from runtime import check_single_instance
+
+    assert check_single_instance() == ("proceed", None)
+
+
+def test_guard_healthy_peer_returns_conflict(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    server, port = _start_fake_server("goodtoken")
+    try:
+        (tmp_path / ".vireo" / "runtime.json").write_text(_json.dumps({
+            "port": port, "pid": 99999, "token": "goodtoken",
+        }))
+        from runtime import check_single_instance
+        status, info = check_single_instance()
+        assert status == "conflict"
+        assert info["port"] == port
+        assert info["pid"] == 99999
+    finally:
+        server.shutdown()
+
+
+def test_guard_stale_file_is_cleaned_and_proceeds(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    # Port 1 is almost certainly not bound by anything listening.
+    (tmp_path / ".vireo" / "runtime.json").write_text(_json.dumps({
+        "port": 1, "pid": 99999, "token": "x",
+    }))
+
+    from runtime import check_single_instance
+    status, info = check_single_instance()
+    assert status == "proceed"
+    assert not (tmp_path / ".vireo" / "runtime.json").exists()
+
+
+def test_guard_malformed_file_is_cleaned_and_proceeds(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+    (tmp_path / ".vireo" / "runtime.json").write_text("not json")
+
+    from runtime import check_single_instance
+    status, info = check_single_instance()
+    assert status == "proceed"
+    assert not (tmp_path / ".vireo" / "runtime.json").exists()
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest vireo/tests/test_runtime.py -v`
+Expected: FAIL — `check_single_instance` not found.
+
+**Step 3: Write minimal implementation**
+
+Append to `vireo/runtime.py`:
+
+```python
+import urllib.error
+import urllib.request
+
+
+def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | None]:
+    """Check whether another Vireo instance is healthy on the advertised port.
+
+    Returns:
+        ("proceed", None)  — no peer found, or stale file cleaned up.
+        ("conflict", info) — healthy peer. `info` has keys `port`, `pid`.
+    """
+    data = read_runtime_json()
+    if data is None:
+        # Missing or malformed. If malformed, the file still exists on disk;
+        # delete it so the next caller has a clean slate.
+        delete_runtime_json()
+        return ("proceed", None)
+
+    port = data.get("port")
+    token = data.get("token", "")
+    if not isinstance(port, int):
+        delete_runtime_json()
+        return ("proceed", None)
+
+    try:
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/api/v1/health",
+            headers={"X-Vireo-Token": token},
+        )
+        with urllib.request.urlopen(req, timeout=probe_timeout_s) as resp:
+            if resp.status == 200:
+                return ("conflict", {"port": port, "pid": data.get("pid")})
+    except (urllib.error.URLError, TimeoutError, OSError):
+        pass
+
+    # Probe failed — peer is dead. Clean up and proceed.
+    delete_runtime_json()
+    return ("proceed", None)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest vireo/tests/test_runtime.py -v`
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/runtime.py vireo/tests/test_runtime.py
+git commit -m "feat(runtime): single-instance guard via health probe"
+```
+
+---
+
+## Task 4: Token generator
+
+**Files:**
+- Modify: `vireo/runtime.py`
+- Modify: `vireo/tests/test_runtime.py`
+
+**Step 1: Write the failing test**
+
+Append to `vireo/tests/test_runtime.py`:
+
+```python
+def test_generate_token_is_random_and_urlsafe():
+    from runtime import generate_token
+    a = generate_token()
+    b = generate_token()
+    assert a != b
+    assert len(a) >= 32
+    # URL-safe base64: only alphanumerics and -_
+    import re
+    assert re.fullmatch(r"[A-Za-z0-9_-]+", a)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest vireo/tests/test_runtime.py::test_generate_token_is_random_and_urlsafe -v`
+Expected: FAIL — `generate_token` not found.
+
+**Step 3: Write minimal implementation**
+
+Append to `vireo/runtime.py`:
+
+```python
+import secrets
+
+
+def generate_token() -> str:
+    """Return a URL-safe random token suitable for API auth."""
+    return secrets.token_urlsafe(32)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest vireo/tests/test_runtime.py -v`
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/runtime.py vireo/tests/test_runtime.py
+git commit -m "feat(runtime): random token generator"
+```
+
+---
+
+## Task 5: Token-gated middleware for `/api/v1/*`
+
+**Files:**
+- Modify: `vireo/app.py` (add middleware inside `create_app`, immediately before the existing `/api/health` route around line 524)
+- Modify: `vireo/tests/conftest.py` (app fixture must provide a known token)
+- Create: `vireo/tests/test_api_v1_auth.py`
+
+**Step 1: Write the failing test**
+
+Create `vireo/tests/test_api_v1_auth.py`:
+
+```python
+def test_api_v1_requires_token(app_and_db):
+    """GET /api/v1/health without a token → 401."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/v1/health")
+    assert resp.status_code == 401
+
+
+def test_api_v1_wrong_token_rejected(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/v1/health", headers={"X-Vireo-Token": "wrong"})
+    assert resp.status_code == 401
+
+
+def test_api_v1_correct_token_accepted(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    token = app.config["API_TOKEN"]
+    resp = client.get("/api/v1/health", headers={"X-Vireo-Token": token})
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}
+
+
+def test_internal_api_does_not_require_token(app_and_db):
+    """Existing /api/* routes are unaffected by the v1 middleware."""
+    app, _ = app_and_db
+    client = app.test_client()
+    # /api/health is an internal route and must keep working without a token
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+```
+
+Also modify `vireo/tests/conftest.py` — change `create_app` call in `app_and_db` and `client_with_photo` to pass a known token. Replace:
+
+```python
+app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir)
+```
+with:
+```python
+app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="test-token-123")
+```
+
+And in `client_with_photo`:
+```python
+app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir), api_token="test-token-123")
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest vireo/tests/test_api_v1_auth.py -v`
+Expected: FAIL — `/api/v1/health` returns 404 (route doesn't exist yet), and `create_app` rejects the `api_token` kwarg.
+
+**Step 3: Write minimal implementation**
+
+Modify `vireo/app.py`:
+
+1. Change `create_app(db_path, thumb_cache_dir=None)` (line 378) to `create_app(db_path, thumb_cache_dir=None, api_token=None)`.
+
+2. Right after `app.config["THUMB_CACHE_DIR"] = ...` (around line 391), add:
+   ```python
+   app.config["API_TOKEN"] = api_token
+   ```
+
+3. Right after the `_log_requests` after_request handler (before line 524's `@app.route("/api/health")`), add:
+   ```python
+   @app.before_request
+   def _enforce_api_v1_token():
+       if not request.path.startswith("/api/v1/"):
+           return None
+       expected = app.config.get("API_TOKEN")
+       if not expected:
+           # No token configured → deny all v1 traffic.
+           return json_error("API token not configured", 401)
+       if request.headers.get("X-Vireo-Token") != expected:
+           return json_error("Invalid or missing X-Vireo-Token", 401)
+       return None
+   ```
+
+4. Add a `/api/v1/health` route. Place it right after the existing `/api/health` route (around line 527):
+   ```python
+   @app.route("/api/v1/health")
+   def api_v1_health():
+       return jsonify({"status": "ok"})
+   ```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest vireo/tests/test_api_v1_auth.py vireo/tests/test_app.py -v`
+Expected: all PASS. `test_app.py` still passes because the middleware only affects `/api/v1/*`.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_api_v1_auth.py vireo/tests/conftest.py
+git commit -m "feat(api): token-gated /api/v1 surface with /api/v1/health"
+```
+
+---
+
+## Task 6: `/api/v1/version` and `/api/v1/shutdown` aliases
+
+**Files:**
+- Modify: `vireo/app.py`
+- Modify: `vireo/tests/test_api_v1_auth.py`
+
+**Step 1: Write the failing test**
+
+Append to `vireo/tests/test_api_v1_auth.py`:
+
+```python
+def test_api_v1_version(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    token = app.config["API_TOKEN"]
+    resp = client.get("/api/v1/version", headers={"X-Vireo-Token": token})
+    assert resp.status_code == 200
+    assert "version" in resp.get_json()
+
+
+def test_api_v1_shutdown_token_only(app_and_db, monkeypatch):
+    """Unlike /api/shutdown, /api/v1/shutdown uses the token only (no
+    X-Vireo-Shutdown header). The token itself blocks cross-origin attacks
+    because browsers cannot set custom headers without CORS preflight."""
+    app, _ = app_and_db
+    client = app.test_client()
+    token = app.config["API_TOKEN"]
+
+    # Don't actually send SIGTERM during tests — stub os.kill.
+    import os as _os
+    killed = []
+    monkeypatch.setattr(_os, "kill", lambda pid, sig: killed.append((pid, sig)))
+
+    resp = client.post("/api/v1/shutdown", headers={"X-Vireo-Token": token})
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "shutting_down"
+    # The shutdown timer runs in a thread with a 0.5s delay; we don't need to
+    # wait for it here — the response is the contract.
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest vireo/tests/test_api_v1_auth.py -v`
+Expected: FAIL — `/api/v1/version` and `/api/v1/shutdown` return 404.
+
+**Step 3: Write minimal implementation**
+
+In `vireo/app.py`, add right after `/api/v1/health`:
+
+```python
+@app.route("/api/v1/version")
+def api_v1_version():
+    return api_version()  # reuse existing implementation
+
+@app.route("/api/v1/shutdown", methods=["POST"])
+def api_v1_shutdown():
+    import signal
+    import threading
+
+    def _shutdown():
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    threading.Timer(0.5, _shutdown).start()
+    return jsonify({"status": "shutting_down"})
+```
+
+Note: `api_version` is defined later in `create_app` (line 3162). Flask closures resolve at request time, not definition time, so the forward reference is fine — but only if the function is defined in the same scope. Verify by running the test.
+
+If the forward reference is an issue (it shouldn't be, but Flask's debugger can surprise), move the `/api/v1/version` route to live adjacent to `/api/version` at line 3162 instead of clustering all v1 routes together.
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest vireo/tests/test_api_v1_auth.py -v`
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_api_v1_auth.py
+git commit -m "feat(api): /api/v1/version and /api/v1/shutdown"
+```
+
+---
+
+## Task 7: `/api/v1` read aliases for photos, collections, workspaces, keywords
+
+**Files:**
+- Modify: `vireo/app.py`
+- Create: `vireo/tests/test_api_v1_aliases.py`
+
+**Step 1: Write the failing test**
+
+Create `vireo/tests/test_api_v1_aliases.py`:
+
+```python
+def _auth(app):
+    return {"X-Vireo-Token": app.config["API_TOKEN"]}
+
+
+def test_api_v1_photos_returns_list(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/v1/photos", headers=_auth(app))
+    assert resp.status_code == 200
+    assert isinstance(resp.get_json(), (list, dict))
+
+
+def test_api_v1_photo_by_id(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    # pick any existing photo
+    photos = db.list_photos()
+    pid = photos[0]["id"]
+    resp = client.get(f"/api/v1/photos/{pid}", headers=_auth(app))
+    assert resp.status_code == 200
+    assert resp.get_json()["id"] == pid
+
+
+def test_api_v1_collections(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/v1/collections", headers=_auth(app))
+    assert resp.status_code == 200
+
+
+def test_api_v1_workspaces(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/v1/workspaces", headers=_auth(app))
+    assert resp.status_code == 200
+
+
+def test_api_v1_keywords(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/v1/keywords", headers=_auth(app))
+    assert resp.status_code == 200
+    names = {k["name"] for k in resp.get_json()}
+    assert "Cardinal" in names
+
+
+def test_api_v1_workspace_activate(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    ws_id = db.list_workspaces()[0]["id"]
+    resp = client.post(
+        f"/api/v1/workspaces/{ws_id}/activate", headers=_auth(app)
+    )
+    assert resp.status_code == 200
+```
+
+Before running: verify the exact shape of `db.list_photos()` and `db.list_workspaces()` return values by grepping — if the call signatures differ, adjust the test. (e.g. `Database` may use different names like `get_photos`, `get_workspaces`.) Replace the test if necessary to use whatever the `@app.route("/api/photos")` handler already uses for its data source.
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest vireo/tests/test_api_v1_aliases.py -v`
+Expected: FAIL — all `/api/v1/...` endpoints return 404.
+
+**Step 3: Write minimal implementation**
+
+In `vireo/app.py`, register aliases using `add_url_rule` immediately before `return app` (around line 7903). This approach routes both `/api/photos` and `/api/v1/photos` to the same view function, avoiding copy-pasted handlers:
+
+```python
+# --- /api/v1/* aliases over the stable subset of /api/* ---
+# These are the endpoints advertised to external callers in docs/headless-api.md.
+# Keep this list tight — expanding it locks the surface.
+_V1_ALIASES = [
+    # (v1 path, existing endpoint name, methods)
+    ("/api/v1/photos", "api_photos", ["GET"]),
+    ("/api/v1/photos/<int:photo_id>", "api_photo", ["GET"]),
+    ("/api/v1/collections", "api_collections", ["GET"]),
+    ("/api/v1/collections/<int:collection_id>/photos",
+     "api_collection_photos", ["GET"]),
+    ("/api/v1/workspaces", "api_workspaces_list", ["GET"]),
+    ("/api/v1/workspaces/<int:ws_id>/activate",
+     "api_workspace_activate", ["POST"]),
+    ("/api/v1/keywords", "api_keywords", ["GET"]),
+]
+
+for v1_path, endpoint_name, methods in _V1_ALIASES:
+    view = app.view_functions.get(endpoint_name)
+    if view is None:
+        raise RuntimeError(
+            f"Cannot alias {v1_path}: endpoint '{endpoint_name}' not registered"
+        )
+    app.add_url_rule(
+        v1_path,
+        endpoint=f"v1_{endpoint_name}",
+        view_func=view,
+        methods=methods,
+    )
+```
+
+**Note on endpoint names:** Flask's default endpoint name is the function name. The helper name next to each route (e.g. `def api_photos(...)`) is the endpoint name. Before running, `grep -nE "def api_(photos|photo|collections|collection_photos|workspaces_list|workspace_activate|keywords)\b" vireo/app.py` and verify the names match. If any differ (e.g. `api_list_photos` vs `api_photos`), update the `_V1_ALIASES` list.
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest vireo/tests/test_api_v1_aliases.py -v`
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_api_v1_aliases.py
+git commit -m "feat(api): /api/v1 read aliases for photos, collections, workspaces, keywords"
+```
+
+---
+
+## Task 8: `--headless` flag and wire writer + guard into `main()`
+
+**Files:**
+- Modify: `vireo/app.py` (`main()` around lines 7906–7992)
+
+**Step 1: Write the failing test**
+
+We don't need a unit test for CLI plumbing; the integration test in Task 9 covers this end-to-end. But add a small smoke test first.
+
+Create `vireo/tests/test_main_cli.py`:
+
+```python
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_help_includes_headless_flag():
+    repo = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, str(repo / "vireo" / "app.py"), "--help"],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0
+    assert "--headless" in result.stdout
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest vireo/tests/test_main_cli.py -v`
+Expected: FAIL — `--headless` not in help output.
+
+**Step 3: Write minimal implementation**
+
+Modify `main()` in `vireo/app.py`:
+
+1. Add the flag after `parser.add_argument("--no-browser", action="store_true")` (around line 7919):
+   ```python
+   parser.add_argument(
+       "--headless",
+       action="store_true",
+       help="Run without opening a browser; write runtime.json and enable "
+            "the /api/v1 API. Use this when invoking the sidecar directly "
+            "from scripts or agents.",
+   )
+   ```
+
+2. Remove the legacy `--port 0` → `~/.vireo/port` block (lines 7951–7956). The Tauri Rust code does not read this file; `runtime.json` supersedes it.
+
+3. After the port is resolved (after line 7949) and before `create_app(...)` (line 7958), add:
+   ```python
+   from runtime import (
+       check_single_instance,
+       delete_runtime_json,
+       generate_token,
+       write_runtime_json,
+   )
+
+   status, info = check_single_instance()
+   if status == "conflict":
+       import sys as _sys
+       _sys.stderr.write(json.dumps({
+           "error": "already_running",
+           "port": info["port"],
+           "pid": info["pid"],
+       }) + "\n")
+       raise SystemExit(1)
+
+   api_token = generate_token()
+   mode = "headless" if args.headless else "gui"
+   ```
+
+4. Pass the token to `create_app`:
+   ```python
+   app = create_app(
+       db_path=args.db, thumb_cache_dir=args.thumb_dir, api_token=api_token,
+   )
+   ```
+
+5. Immediately before `app.run(...)` (line 7992), write runtime.json and register cleanup:
+   ```python
+   import atexit
+   import signal as _signal
+
+   # Look up the running version from pyproject (same fallback chain as /api/version).
+   try:
+       from importlib.metadata import version as pkg_version
+       ver = pkg_version("vireo")
+   except Exception:
+       ver = "0.0.0"
+
+   write_runtime_json(
+       port=port, pid=os.getpid(), version=ver, db_path=args.db,
+       token=api_token, mode=mode,
+   )
+   atexit.register(delete_runtime_json)
+   _signal.signal(_signal.SIGTERM, lambda *_: (delete_runtime_json(), os._exit(0)))
+   ```
+
+6. Make `--headless` imply `--no-browser`. At the top of `main()` after `args = parser.parse_args()`:
+   ```python
+   if args.headless:
+       args.no_browser = True
+   ```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest vireo/tests/test_main_cli.py vireo/tests/test_app.py vireo/tests/test_api_v1_auth.py vireo/tests/test_api_v1_aliases.py vireo/tests/test_runtime.py -v`
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_main_cli.py
+git commit -m "feat(app): --headless flag; wire runtime.json + single-instance guard"
+```
+
+---
+
+## Task 9: Integration test — spawn headless, discover, hit /api/v1/health
+
+**Files:**
+- Create: `tests/test_headless_integration.py`
+
+**Step 1: Write the failing test**
+
+Create `tests/test_headless_integration.py`:
+
+```python
+"""End-to-end tests for headless sidecar mode.
+
+These spawn the real `python vireo/app.py` subprocess against a temp HOME
+and temp database, then drive it via HTTP exactly as an external caller
+would. They are more expensive than unit tests but the single-instance
+guard, runtime.json writer, and `/api/v1/*` auth are load-bearing enough
+to warrant real-process coverage.
+"""
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+APP = REPO / "vireo" / "app.py"
+
+
+def _wait_for_runtime(runtime_path: Path, timeout: float = 20.0) -> dict:
+    """Poll runtime.json until it exists and is readable."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if runtime_path.exists():
+            try:
+                return json.loads(runtime_path.read_text())
+            except json.JSONDecodeError:
+                pass
+        time.sleep(0.1)
+    raise TimeoutError(f"{runtime_path} never appeared")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _spawn(home: Path, db: Path, port: int):
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PYTHONUNBUFFERED"] = "1"
+    return subprocess.Popen(
+        [sys.executable, str(APP),
+         "--headless", "--port", str(port), "--db", str(db)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _http_get(url: str, token: str, timeout: float = 2.0):
+    req = urllib.request.Request(url, headers={"X-Vireo-Token": token})
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+@pytest.fixture
+def headless_home(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".vireo").mkdir()
+    return home
+
+
+def test_headless_spawn_writes_runtime_and_serves_health(headless_home, tmp_path):
+    db = tmp_path / "vireo.db"
+    port = _free_port()
+    proc = _spawn(headless_home, db, port)
+    try:
+        runtime = headless_home / ".vireo" / "runtime.json"
+        data = _wait_for_runtime(runtime)
+        assert data["port"] == port
+        assert data["mode"] == "headless"
+        assert data["pid"] == proc.pid
+        assert len(data["token"]) >= 32
+
+        resp = _http_get(
+            f"http://127.0.0.1:{port}/api/v1/health", data["token"],
+        )
+        assert resp.status == 200
+        assert json.loads(resp.read())["status"] == "ok"
+    finally:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+```
+
+**Step 2: Run test to verify it passes after Task 8**
+
+Run: `python -m pytest tests/test_headless_integration.py -v`
+Expected: PASS. (If the test is failing, the fault is in Tasks 1–8 — fix the real bug, do not adjust the test.)
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_headless_integration.py
+git commit -m "test: headless sidecar spawn writes runtime.json and serves /api/v1/health"
+```
+
+---
+
+## Task 10: Integration test — second spawn is rejected
+
+**Files:**
+- Modify: `tests/test_headless_integration.py`
+
+**Step 1: Write the failing test**
+
+Append to `tests/test_headless_integration.py`:
+
+```python
+def test_second_spawn_refuses_with_already_running(headless_home, tmp_path):
+    db = tmp_path / "vireo.db"
+    first_port = _free_port()
+    first = _spawn(headless_home, db, first_port)
+    try:
+        runtime = headless_home / ".vireo" / "runtime.json"
+        _wait_for_runtime(runtime)
+
+        second_port = _free_port()
+        second = _spawn(headless_home, db, second_port)
+        out, err = second.communicate(timeout=15)
+
+        assert second.returncode != 0, "second instance should have exited"
+        err_text = err.decode()
+        # The guard writes a machine-readable JSON line to stderr.
+        last_line = [ln for ln in err_text.strip().splitlines() if ln.startswith("{")]
+        assert last_line, f"no JSON error in stderr: {err_text!r}"
+        payload = json.loads(last_line[-1])
+        assert payload["error"] == "already_running"
+        assert payload["port"] == first_port
+
+        # First instance must still be healthy.
+        data = json.loads(runtime.read_text())
+        resp = _http_get(
+            f"http://127.0.0.1:{first_port}/api/v1/health", data["token"],
+        )
+        assert resp.status == 200
+    finally:
+        first.send_signal(signal.SIGTERM)
+        try:
+            first.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            first.kill()
+            first.wait()
+```
+
+**Step 2: Run test**
+
+Run: `python -m pytest tests/test_headless_integration.py -v`
+Expected: both tests PASS.
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_headless_integration.py
+git commit -m "test: second headless spawn exits with already_running"
+```
+
+---
+
+## Task 11: Integration test — stale runtime.json is cleaned up
+
+**Files:**
+- Modify: `tests/test_headless_integration.py`
+
+**Step 1: Write the failing test**
+
+Append to `tests/test_headless_integration.py`:
+
+```python
+def test_stale_runtime_json_is_replaced(headless_home, tmp_path):
+    # Plant a stale runtime.json pointing at an unused port.
+    stale = {
+        "port": 1,  # almost certainly not bound
+        "pid": 999999,
+        "token": "stale",
+        "version": "0.0.0",
+        "db_path": "/nowhere",
+        "mode": "headless",
+        "started_at": "2000-01-01T00:00:00Z",
+    }
+    runtime = headless_home / ".vireo" / "runtime.json"
+    runtime.write_text(json.dumps(stale))
+
+    db = tmp_path / "vireo.db"
+    port = _free_port()
+    proc = _spawn(headless_home, db, port)
+    try:
+        # Poll for the new contents (different port).
+        deadline = time.monotonic() + 20
+        data = None
+        while time.monotonic() < deadline:
+            if runtime.exists():
+                try:
+                    candidate = json.loads(runtime.read_text())
+                    if candidate.get("port") == port:
+                        data = candidate
+                        break
+                except json.JSONDecodeError:
+                    pass
+            time.sleep(0.1)
+        assert data is not None, "runtime.json was not refreshed"
+        assert data["pid"] == proc.pid
+        assert data["token"] != "stale"
+    finally:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+```
+
+**Step 2: Run test**
+
+Run: `python -m pytest tests/test_headless_integration.py -v`
+Expected: all three tests PASS.
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_headless_integration.py
+git commit -m "test: stale runtime.json is replaced on next spawn"
+```
+
+---
+
+## Task 12: Integration test — graceful shutdown removes runtime.json
+
+**Files:**
+- Modify: `tests/test_headless_integration.py`
+
+**Step 1: Write the failing test**
+
+Append to `tests/test_headless_integration.py`:
+
+```python
+def test_shutdown_endpoint_removes_runtime_json(headless_home, tmp_path):
+    db = tmp_path / "vireo.db"
+    port = _free_port()
+    proc = _spawn(headless_home, db, port)
+    try:
+        runtime = headless_home / ".vireo" / "runtime.json"
+        data = _wait_for_runtime(runtime)
+
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/api/v1/shutdown",
+            method="POST",
+            headers={"X-Vireo-Token": data["token"]},
+        )
+        urllib.request.urlopen(req, timeout=3).read()
+
+        # Wait for the process to exit (shutdown timer + signal).
+        proc.wait(timeout=10)
+        assert proc.returncode == 0 or proc.returncode is not None
+
+        # runtime.json should be gone.
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and runtime.exists():
+            time.sleep(0.1)
+        assert not runtime.exists(), "runtime.json still present after shutdown"
+    finally:
+        if proc.poll() is None:
+            proc.send_signal(signal.SIGTERM)
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+```
+
+**Step 2: Run test**
+
+Run: `python -m pytest tests/test_headless_integration.py -v`
+Expected: all four tests PASS.
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_headless_integration.py
+git commit -m "test: /api/v1/shutdown removes runtime.json on exit"
+```
+
+---
+
+## Task 13: User-facing docs
+
+**Files:**
+- Create: `docs/headless-api.md`
+- Modify: `README.md` (add a single-line link under a "Scripting / automation" heading)
+
+**Step 1: Write `docs/headless-api.md`**
+
+Create `docs/headless-api.md`:
+
+````markdown
+# Vireo headless API
+
+Vireo is primarily a desktop app, but its Flask server also exposes a small
+stable HTTP API for scripts and agents. This page documents what callers can
+rely on.
+
+## Discovering a running instance
+
+When the Vireo sidecar starts (either as part of the Tauri GUI or directly
+from the command line), it writes `~/.vireo/runtime.json`:
+
+```json
+{
+  "port": 54321,
+  "pid": 12345,
+  "version": "0.8.28",
+  "db_path": "/Users/you/.vireo/vireo.db",
+  "started_at": "2026-04-22T19:30:00Z",
+  "mode": "gui",
+  "token": "…"
+}
+```
+
+The file is `chmod 600` (user-only read) because the token is sensitive.
+
+**Liveness:** treat `runtime.json` as authoritative only after confirming
+`GET http://127.0.0.1:<port>/api/v1/health` (with the token) returns 200.
+If the file is stale (process died without cleanup), the next sidecar start
+will replace it automatically.
+
+## Spawning a headless instance
+
+If no instance is running, spawn one from the installed `.app`:
+
+```bash
+/Applications/Vireo.app/Contents/Resources/bin/vireo-server \
+  --headless --port 0 --db ~/.vireo/vireo.db
+```
+
+`--port 0` picks a free port. Poll `~/.vireo/runtime.json` until it appears
+(typically <2 s), then read the port and token from it.
+
+**Only one Vireo instance can run at a time.** If the GUI is already open,
+the headless spawn will exit with a non-zero status and print a JSON error
+to stderr:
+
+```json
+{"error":"already_running","port":54321,"pid":12345}
+```
+
+In that case, just connect to the running instance using the port and token
+in `runtime.json` — both modes serve the same API.
+
+## Authentication
+
+Every `/api/v1/*` request must include the token from `runtime.json`:
+
+```
+X-Vireo-Token: <token>
+```
+
+Missing or wrong token → 401.
+
+## Stable endpoints
+
+Endpoints under `/api/v1` are covered by a semver contract: breaking changes
+require bumping the version prefix. Everything else under `/api/*` is
+internal to the GUI and may change at any time.
+
+Current stable set:
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET  | `/api/v1/health` | Liveness probe. |
+| GET  | `/api/v1/version` | `{"version": "x.y.z"}`. |
+| POST | `/api/v1/shutdown` | Gracefully stop the sidecar. |
+| GET  | `/api/v1/photos` | List/search photos in the active workspace. |
+| GET  | `/api/v1/photos/<id>` | One photo's metadata. |
+| GET  | `/api/v1/collections` | Collections in the active workspace. |
+| GET  | `/api/v1/collections/<id>/photos` | Photos in a collection. |
+| GET  | `/api/v1/workspaces` | All workspaces. |
+| POST | `/api/v1/workspaces/<id>/activate` | Switch the active workspace. |
+| GET  | `/api/v1/keywords` | Keyword tree. |
+
+Request/response shapes mirror the internal `/api/*` endpoints — see source
+or open `/api/v1/<path>` with the token in your browser's dev tools for
+concrete examples.
+
+## Worked example
+
+```bash
+# 1. Locate the instance.
+PORT=$(jq -r .port ~/.vireo/runtime.json)
+TOKEN=$(jq -r .token ~/.vireo/runtime.json)
+
+# 2. Probe health.
+curl -sf -H "X-Vireo-Token: $TOKEN" "http://127.0.0.1:$PORT/api/v1/health"
+
+# 3. List photos.
+curl -sf -H "X-Vireo-Token: $TOKEN" "http://127.0.0.1:$PORT/api/v1/photos"
+
+# 4. Shut down (only if you spawned the instance yourself).
+curl -sf -X POST -H "X-Vireo-Token: $TOKEN" \
+     "http://127.0.0.1:$PORT/api/v1/shutdown"
+```
+````
+
+**Step 2: Link from `README.md`**
+
+Add a short section to `README.md` pointing at the new doc. One paragraph, max.
+
+**Step 3: Verify both files render cleanly**
+
+Open them in a Markdown previewer (or just `cat`) and check for broken fences.
+
+**Step 4: Commit**
+
+```bash
+git add docs/headless-api.md README.md
+git commit -m "docs: user-facing guide for the /api/v1 headless surface"
+```
+
+---
+
+## Task 14: Final verification
+
+**Step 1: Run the full project test suite**
+
+Run:
+```bash
+python -m pytest tests/ vireo/tests/ -v
+```
+Expected: all pass, including the new runtime, auth, alias, CLI, and integration tests.
+
+**Step 2: Manual smoke test (optional, recommended before merge)**
+
+In a terminal:
+```bash
+python vireo/app.py --headless --port 0 --db /tmp/vireo-smoke.db
+```
+
+In a second terminal:
+```bash
+cat ~/.vireo/runtime.json
+PORT=$(jq -r .port ~/.vireo/runtime.json)
+TOKEN=$(jq -r .token ~/.vireo/runtime.json)
+curl -sf -H "X-Vireo-Token: $TOKEN" http://127.0.0.1:$PORT/api/v1/health
+curl -sf -X POST -H "X-Vireo-Token: $TOKEN" http://127.0.0.1:$PORT/api/v1/shutdown
+```
+
+Confirm:
+- `runtime.json` appears with the right fields and `chmod 600`.
+- Health probe returns `{"status":"ok"}`.
+- Shutdown endpoint returns, process exits cleanly, `runtime.json` is removed.
+
+**Step 3: Open the PR**
+
+Use the commit log as the PR description skeleton. Link to
+`docs/plans/2026-04-22-headless-api-design.md` for context.
+
+```bash
+gh pr create --title "Headless API for external callers" --body "$(cat <<'EOF'
+## Summary
+- Add `~/.vireo/runtime.json` (port, PID, token, version, mode) so external
+  callers can discover a running Vireo instance.
+- Single-instance guard: sidecar refuses to start if a healthy peer is
+  running; detects and cleans up stale runtime files.
+- New `/api/v1/*` surface with `X-Vireo-Token` auth, covering health,
+  version, shutdown, photos, collections, workspaces, and keywords.
+- `--headless` flag on the sidecar for explicit non-GUI spawns.
+- User-facing docs at `docs/headless-api.md`.
+
+Design: `docs/plans/2026-04-22-headless-api-design.md`.
+
+## Test plan
+- [x] Unit tests: runtime.json writer/reader, single-instance guard, token gen
+- [x] API tests: /api/v1 token auth, /api/v1 alias coverage
+- [x] Integration: spawn → discover → health; second spawn → already_running;
+      stale runtime.json replaced; /api/v1/shutdown removes runtime.json
+- [ ] Manual smoke: `python vireo/app.py --headless --port 0` + curl
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Non-tasks (out of scope)
+
+- Installing a `vireo` CLI launcher at `/usr/local/bin`. Users invoke the
+  in-bundle binary directly.
+- Supporting two Vireo instances simultaneously.
+- Freezing every `/api/*` endpoint; only `/api/v1/*` is stable.
+- Remote / non-loopback access.
+- Migrating the Tauri Rust sidecar code to read `runtime.json`. The Rust
+  code still picks a port itself and passes it via `--port`; the new file
+  is purely additive for external callers.

--- a/tests/test_headless_integration.py
+++ b/tests/test_headless_integration.py
@@ -129,3 +129,46 @@ def test_second_spawn_refuses_with_already_running(headless_home, tmp_path):
         except subprocess.TimeoutExpired:
             first.kill()
             first.wait()
+
+
+def test_stale_runtime_json_is_replaced(headless_home, tmp_path):
+    # Plant a stale runtime.json pointing at an unused port.
+    stale = {
+        "port": 1,  # almost certainly not bound
+        "pid": 999999,
+        "token": "stale",
+        "version": "0.0.0",
+        "db_path": "/nowhere",
+        "mode": "headless",
+        "started_at": "2000-01-01T00:00:00Z",
+    }
+    runtime = headless_home / ".vireo" / "runtime.json"
+    runtime.write_text(json.dumps(stale))
+
+    db = tmp_path / "vireo.db"
+    port = _free_port()
+    proc = _spawn(headless_home, db, port)
+    try:
+        # Poll for the new contents (different port).
+        deadline = time.monotonic() + 20
+        data = None
+        while time.monotonic() < deadline:
+            if runtime.exists():
+                try:
+                    candidate = json.loads(runtime.read_text())
+                    if candidate.get("port") == port:
+                        data = candidate
+                        break
+                except json.JSONDecodeError:
+                    pass
+            time.sleep(0.1)
+        assert data is not None, "runtime.json was not refreshed"
+        assert data["pid"] == proc.pid
+        assert data["token"] != "stale"
+    finally:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()

--- a/tests/test_headless_integration.py
+++ b/tests/test_headless_integration.py
@@ -172,3 +172,37 @@ def test_stale_runtime_json_is_replaced(headless_home, tmp_path):
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait()
+
+
+def test_shutdown_endpoint_removes_runtime_json(headless_home, tmp_path):
+    db = tmp_path / "vireo.db"
+    port = _free_port()
+    proc = _spawn(headless_home, db, port)
+    try:
+        runtime = headless_home / ".vireo" / "runtime.json"
+        data = _wait_for_runtime(runtime)
+
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/api/v1/shutdown",
+            method="POST",
+            headers={"X-Vireo-Token": data["token"]},
+        )
+        urllib.request.urlopen(req, timeout=3).read()
+
+        # Wait for the process to exit (shutdown timer + signal).
+        proc.wait(timeout=10)
+        assert proc.returncode == 0 or proc.returncode is not None
+
+        # runtime.json should be gone.
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and runtime.exists():
+            time.sleep(0.1)
+        assert not runtime.exists(), "runtime.json still present after shutdown"
+    finally:
+        if proc.poll() is None:
+            proc.send_signal(signal.SIGTERM)
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()

--- a/tests/test_headless_integration.py
+++ b/tests/test_headless_integration.py
@@ -93,3 +93,39 @@ def test_headless_spawn_writes_runtime_and_serves_health(headless_home, tmp_path
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait()
+
+
+def test_second_spawn_refuses_with_already_running(headless_home, tmp_path):
+    db = tmp_path / "vireo.db"
+    first_port = _free_port()
+    first = _spawn(headless_home, db, first_port)
+    try:
+        runtime = headless_home / ".vireo" / "runtime.json"
+        _wait_for_runtime(runtime)
+
+        second_port = _free_port()
+        second = _spawn(headless_home, db, second_port)
+        out, err = second.communicate(timeout=15)
+
+        assert second.returncode != 0, "second instance should have exited"
+        err_text = err.decode()
+        # The guard writes a machine-readable JSON line to stderr.
+        last_line = [ln for ln in err_text.strip().splitlines() if ln.startswith("{")]
+        assert last_line, f"no JSON error in stderr: {err_text!r}"
+        payload = json.loads(last_line[-1])
+        assert payload["error"] == "already_running"
+        assert payload["port"] == first_port
+
+        # First instance must still be healthy.
+        data = json.loads(runtime.read_text())
+        resp = _http_get(
+            f"http://127.0.0.1:{first_port}/api/v1/health", data["token"],
+        )
+        assert resp.status == 200
+    finally:
+        first.send_signal(signal.SIGTERM)
+        try:
+            first.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            first.kill()
+            first.wait()

--- a/tests/test_headless_integration.py
+++ b/tests/test_headless_integration.py
@@ -1,0 +1,95 @@
+"""End-to-end tests for headless sidecar mode.
+
+These spawn the real `python vireo/app.py` subprocess against a temp HOME
+and temp database, then drive it via HTTP exactly as an external caller
+would. They are more expensive than unit tests but the single-instance
+guard, runtime.json writer, and `/api/v1/*` auth are load-bearing enough
+to warrant real-process coverage.
+"""
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+APP = REPO / "vireo" / "app.py"
+
+
+def _wait_for_runtime(runtime_path: Path, timeout: float = 20.0) -> dict:
+    """Poll runtime.json until it exists and is readable."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if runtime_path.exists():
+            try:
+                return json.loads(runtime_path.read_text())
+            except json.JSONDecodeError:
+                pass
+        time.sleep(0.1)
+    raise TimeoutError(f"{runtime_path} never appeared")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _spawn(home: Path, db: Path, port: int):
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PYTHONUNBUFFERED"] = "1"
+    return subprocess.Popen(
+        [sys.executable, str(APP),
+         "--headless", "--port", str(port), "--db", str(db)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _http_get(url: str, token: str, timeout: float = 2.0):
+    req = urllib.request.Request(url, headers={"X-Vireo-Token": token})
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+@pytest.fixture
+def headless_home(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".vireo").mkdir()
+    return home
+
+
+def test_headless_spawn_writes_runtime_and_serves_health(headless_home, tmp_path):
+    db = tmp_path / "vireo.db"
+    port = _free_port()
+    proc = _spawn(headless_home, db, port)
+    try:
+        runtime = headless_home / ".vireo" / "runtime.json"
+        data = _wait_for_runtime(runtime)
+        assert data["port"] == port
+        assert data["mode"] == "headless"
+        assert data["pid"] == proc.pid
+        assert len(data["token"]) >= 32
+
+        resp = _http_get(
+            f"http://127.0.0.1:{port}/api/v1/health", data["token"],
+        )
+        assert resp.status == 200
+        assert json.loads(resp.read())["status"] == "ok"
+    finally:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -546,6 +546,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_v1_health():
         return jsonify({"status": "ok"})
 
+    @app.route("/api/v1/version")
+    def api_v1_version():
+        return api_version()  # reuse existing implementation
+
+    @app.route("/api/v1/shutdown", methods=["POST"])
+    def api_v1_shutdown():
+        import signal
+        import threading
+
+        def _shutdown():
+            os.kill(os.getpid(), signal.SIGTERM)
+
+        threading.Timer(0.5, _shutdown).start()
+        return jsonify({"status": "shutting_down"})
+
     @app.route("/api/models/status")
     def api_models_status():
         """Lightweight model readiness check for first-launch detection."""

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -544,7 +544,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/api/v1/health")
     def api_v1_health():
-        return jsonify({"status": "ok"})
+        # The "service" field is a Vireo-specific marker the single-instance
+        # guard's probe checks for. An unrelated local service that happens
+        # to return 200 on /api/v1/health (catch-all) would not carry it,
+        # so Vireo can distinguish a live peer from a port-reusing stranger.
+        from runtime import SERVICE_MARKER
+        return jsonify({"service": SERVICE_MARKER, "status": "ok"})
 
     @app.route("/api/v1/version")
     def api_v1_version():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8040,7 +8040,19 @@ def main():
     # initialization. Reserving up-front (rather than writing runtime.json
     # at the end of startup) closes the race where two near-simultaneous
     # launches both see an empty slot and both start serving.
-    status, info = acquire_single_instance(pid=os.getpid())
+    try:
+        status, info = acquire_single_instance(pid=os.getpid())
+    except OSError as e:
+        # Filesystem fault opening the lock file (unreadable ~/.vireo,
+        # permission denied, etc). Surface the real cause rather than
+        # misreporting as already_running — the two need different
+        # remediation.
+        import sys as _sys
+        _sys.stderr.write(json.dumps({
+            "error": "startup_failed",
+            "reason": str(e),
+        }) + "\n")
+        raise SystemExit(2) from e
     if status == "conflict":
         import sys as _sys
         _sys.stderr.write(json.dumps({
@@ -8102,12 +8114,22 @@ def main():
 
         threading.Thread(target=_open_browser, daemon=True).start()
 
-    # Look up the running version from package metadata (same fallback chain as /api/version).
+    # Look up the running version using the same fallback chain as
+    # /api/version: package metadata, then pyproject.toml, then "0.0.0".
+    # In source/dev runs where importlib.metadata is missing but
+    # pyproject.toml is present, runtime.json must agree with
+    # /api/v1/version — external callers use it to make compatibility
+    # decisions and a bare "0.0.0" would mislead them.
     try:
         from importlib.metadata import version as pkg_version
         ver = pkg_version("vireo")
     except Exception:
-        ver = "0.0.0"
+        import tomllib
+        try:
+            with open(os.path.join(os.path.dirname(__file__), "..", "pyproject.toml"), "rb") as f:
+                ver = tomllib.load(f)["project"]["version"]
+        except Exception:
+            ver = "0.0.0"
 
     # Finalize runtime.json, replacing the reservation marker with the full
     # payload now that the port and token are known. Cleanup handlers were

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7983,11 +7983,21 @@ def main():
     parser.add_argument("--port", type=int, default=8080)
     parser.add_argument("--no-browser", action="store_true")
     parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Run without opening a browser; write runtime.json and enable "
+             "the /api/v1 API. Use this when invoking the sidecar directly "
+             "from scripts or agents.",
+    )
+    parser.add_argument(
         "--load-taxonomy",
         action="store_true",
         help="Download and import the iNaturalist taxonomy, then exit",
     )
     args = parser.parse_args()
+
+    if args.headless:
+        args.no_browser = True
 
     if args.load_taxonomy:
         from db import Database
@@ -8013,14 +8023,29 @@ def main():
             s.bind(("127.0.0.1", 0))
             port = s.getsockname()[1]
 
-    # Write the port file when random port was requested (for Tauri to discover)
-    if args.port == 0:
-        port_file = os.path.join(os.path.expanduser("~/.vireo"), "port")
-        with open(port_file, "w") as f:
-            f.write(str(port))
-        log.info("Random port %d written to %s", port, port_file)
+    from runtime import (
+        check_single_instance,
+        delete_runtime_json,
+        generate_token,
+        write_runtime_json,
+    )
 
-    app = create_app(db_path=args.db, thumb_cache_dir=args.thumb_dir)
+    status, info = check_single_instance()
+    if status == "conflict":
+        import sys as _sys
+        _sys.stderr.write(json.dumps({
+            "error": "already_running",
+            "port": info["port"],
+            "pid": info["pid"],
+        }) + "\n")
+        raise SystemExit(1)
+
+    api_token = generate_token()
+    mode = "headless" if args.headless else "gui"
+
+    app = create_app(
+        db_path=args.db, thumb_cache_dir=args.thumb_dir, api_token=api_token,
+    )
 
     # Startup banner
     import config as cfg
@@ -8053,6 +8078,23 @@ def main():
                     time.sleep(0.1)
 
         threading.Thread(target=_open_browser, daemon=True).start()
+
+    import atexit
+    import signal as _signal
+
+    # Look up the running version from package metadata (same fallback chain as /api/version).
+    try:
+        from importlib.metadata import version as pkg_version
+        ver = pkg_version("vireo")
+    except Exception:
+        ver = "0.0.0"
+
+    write_runtime_json(
+        port=port, pid=os.getpid(), version=ver, db_path=args.db,
+        token=api_token, mode=mode,
+    )
+    atexit.register(delete_runtime_json)
+    _signal.signal(_signal.SIGTERM, lambda *_: (delete_runtime_json(), os._exit(0)))
 
     app.run(host="127.0.0.1", port=port, debug=False, threaded=True)
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8024,21 +8024,39 @@ def main():
             port = s.getsockname()[1]
 
     from runtime import (
-        check_single_instance,
+        acquire_single_instance,
         delete_runtime_json,
         generate_token,
+        release_single_instance,
         write_runtime_json,
     )
 
-    status, info = check_single_instance()
+    # Atomically reserve the single-instance slot BEFORE any heavy
+    # initialization. Reserving up-front (rather than writing runtime.json
+    # at the end of startup) closes the race where two near-simultaneous
+    # launches both see an empty slot and both start serving.
+    status, info = acquire_single_instance(pid=os.getpid())
     if status == "conflict":
         import sys as _sys
         _sys.stderr.write(json.dumps({
             "error": "already_running",
-            "port": info["port"],
-            "pid": info["pid"],
+            "port": info.get("port"),
+            "pid": info.get("pid"),
         }) + "\n")
         raise SystemExit(1)
+
+    # Register cleanup immediately after acquiring the slot so a crash
+    # during initialization still releases the reservation lock and any
+    # runtime.json we may have written.
+    import atexit
+    import signal as _signal
+
+    def _cleanup_runtime_state():
+        delete_runtime_json()
+        release_single_instance()
+
+    atexit.register(_cleanup_runtime_state)
+    _signal.signal(_signal.SIGTERM, lambda *_: (_cleanup_runtime_state(), os._exit(0)))
 
     api_token = generate_token()
     mode = "headless" if args.headless else "gui"
@@ -8079,9 +8097,6 @@ def main():
 
         threading.Thread(target=_open_browser, daemon=True).start()
 
-    import atexit
-    import signal as _signal
-
     # Look up the running version from package metadata (same fallback chain as /api/version).
     try:
         from importlib.metadata import version as pkg_version
@@ -8089,12 +8104,13 @@ def main():
     except Exception:
         ver = "0.0.0"
 
+    # Finalize runtime.json, replacing the reservation marker with the full
+    # payload now that the port and token are known. Cleanup handlers were
+    # registered immediately after `acquire_single_instance` above.
     write_runtime_json(
         port=port, pid=os.getpid(), version=ver, db_path=args.db,
         token=api_token, mode=mode,
     )
-    atexit.register(delete_runtime_json)
-    _signal.signal(_signal.SIGTERM, lambda *_: (delete_runtime_json(), os._exit(0)))
 
     app.run(host="127.0.0.1", port=port, debug=False, threaded=True)
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -375,12 +375,16 @@ def _enforce_preview_cache_quota_at_startup(app):
             pass
 
 
-def create_app(db_path, thumb_cache_dir=None):
+def create_app(db_path, thumb_cache_dir=None, api_token=None):
     """Create the Flask app for the Vireo photo browser.
 
     Args:
         db_path: path to the SQLite database
         thumb_cache_dir: path to thumbnail cache directory
+        api_token: optional token required on /api/v1/* requests via the
+            ``X-Vireo-Token`` header. When ``None`` (default), all /api/v1/*
+            traffic is rejected with 401 — the token is expected to be
+            supplied by ``main()`` after calling ``runtime.generate_token``.
     """
     app = Flask(
         __name__, template_folder=os.path.join(os.path.dirname(__file__), "templates")
@@ -389,6 +393,7 @@ def create_app(db_path, thumb_cache_dir=None):
     app.config["THUMB_CACHE_DIR"] = thumb_cache_dir or os.path.expanduser(
         "~/.vireo/thumbnails"
     )
+    app.config["API_TOKEN"] = api_token
 
     _migrate_legacy_preview_cache(app)
     _enforce_preview_cache_quota_at_startup(app)
@@ -521,8 +526,24 @@ def create_app(db_path, thumb_cache_dir=None):
                         variant, e,
                     )
 
+    @app.before_request
+    def _enforce_api_v1_token():
+        if not request.path.startswith("/api/v1/"):
+            return None
+        expected = app.config.get("API_TOKEN")
+        if not expected:
+            # No token configured → deny all v1 traffic.
+            return json_error("API token not configured", 401)
+        if request.headers.get("X-Vireo-Token") != expected:
+            return json_error("Invalid or missing X-Vireo-Token", 401)
+        return None
+
     @app.route("/api/health")
     def api_health():
+        return jsonify({"status": "ok"})
+
+    @app.route("/api/v1/health")
+    def api_v1_health():
         return jsonify({"status": "ok"})
 
     @app.route("/api/models/status")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7936,6 +7936,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def stats_redirect():
         return redirect("/dashboard")
 
+    # --- /api/v1/* aliases over the stable subset of /api/* ---
+    # These are the endpoints advertised to external callers in docs/headless-api.md.
+    # Keep this list tight — expanding it locks the surface.
+    _V1_ALIASES = [
+        # (v1 path, existing endpoint name, methods)
+        ("/api/v1/photos", "api_photos", ["GET"]),
+        ("/api/v1/photos/<int:photo_id>", "api_photo_detail", ["GET"]),
+        ("/api/v1/collections", "api_collections", ["GET"]),
+        ("/api/v1/collections/<int:collection_id>/photos",
+         "api_collection_photos", ["GET"]),
+        ("/api/v1/workspaces", "api_get_workspaces", ["GET"]),
+        ("/api/v1/workspaces/<int:ws_id>/activate",
+         "api_activate_workspace", ["POST"]),
+        ("/api/v1/keywords", "api_keywords", ["GET"]),
+    ]
+
+    for v1_path, endpoint_name, methods in _V1_ALIASES:
+        view = app.view_functions.get(endpoint_name)
+        if view is None:
+            raise RuntimeError(
+                f"Cannot alias {v1_path}: endpoint '{endpoint_name}' not registered"
+            )
+        app.add_url_rule(
+            v1_path,
+            endpoint=f"v1_{endpoint_name}",
+            view_func=view,
+            methods=methods,
+        )
+
     return app
 
 

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -7,6 +7,7 @@ instance (port, auth token, PID). Also provides the single-instance guard.
 import contextlib
 import json
 import os
+import secrets
 import urllib.error
 import urllib.request
 from datetime import UTC, datetime
@@ -96,3 +97,8 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
     # Probe failed — peer is dead. Clean up and proceed.
     delete_runtime_json()
     return ("proceed", None)
+
+
+def generate_token() -> str:
+    """Return a URL-safe random token suitable for API auth."""
+    return secrets.token_urlsafe(32)

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -75,9 +75,20 @@ def write_runtime_json(
         "token": token,
     }
     tmp = path.with_suffix(path.suffix + ".tmp")
-    # Write then chmod before replace, so the target is never world-readable.
-    tmp.write_text(json.dumps(payload, indent=2))
-    os.chmod(tmp, 0o600)
+    # Create with 0600 from creation. Using write_text() + chmod leaves a
+    # window where the umask-masked default (e.g. 0644) is visible to other
+    # local users — long enough for a co-tenant to read the auth token.
+    # O_EXCL guarantees the `mode` argument is applied (an existing file
+    # from a prior crash would keep its old — possibly permissive — perms),
+    # so we unlink any leftover tmp first.
+    with contextlib.suppress(FileNotFoundError):
+        tmp.unlink()
+    data = json.dumps(payload, indent=2).encode()
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
     os.replace(tmp, path)
 
 

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -1,0 +1,36 @@
+"""Runtime discovery file for the Vireo sidecar.
+
+Writes `~/.vireo/runtime.json` so external callers can discover the running
+instance (port, auth token, PID). Also provides the single-instance guard.
+"""
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def _runtime_path() -> Path:
+    return Path(os.path.expanduser("~/.vireo/runtime.json"))
+
+
+def write_runtime_json(
+    *, port: int, pid: int, version: str, db_path: str, token: str, mode: str
+) -> None:
+    """Atomically write runtime.json with 0600 permissions."""
+    path = _runtime_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "port": port,
+        "pid": pid,
+        "version": version,
+        "db_path": db_path,
+        "started_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "mode": mode,
+        "token": token,
+    }
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    # Write then chmod before replace, so the target is never world-readable.
+    tmp.write_text(json.dumps(payload, indent=2))
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -101,10 +101,14 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
 
     Connection-level failures (refused/timeout) are ambiguous: the peer
     may be dead, or it may be a peer still booting that wrote
-    runtime.json but hasn't started listening yet. We disambiguate via
-    the PID — a live PID means "booting or transient", and we must not
-    delete runtime.json under the running peer, because that would
-    break external discovery even though the peer is still running.
+    runtime.json but hasn't started listening yet. PID liveness alone is
+    not strong enough — after a SIGKILL crash the recorded PID can be
+    recycled by an unrelated process, which would otherwise pin
+    `already_running` forever without cleanup. So we additionally require
+    that `runtime.lock` exists and its holder PID matches runtime.json's
+    PID; only a live Vireo sidecar holds the matching lock. If the lock
+    is missing, holds a different PID, or the PID is dead, runtime.json
+    is treated as stale.
     """
     data = read_runtime_json()
     if data is None:
@@ -135,14 +139,21 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
         # answering our health contract. Treat as stale.
         pass
     except (urllib.error.URLError, TimeoutError, OSError):
-        # Connection refused / timeout. If the advertised PID is still
-        # alive, this is almost certainly a peer that wrote runtime.json
-        # and is still booting (or briefly paused). Preserve runtime.json
-        # so external callers can still discover it once HTTP is up, and
-        # report conflict to the caller.
-        if _pid_alive(pid):
+        # Connection refused / timeout. To distinguish a booting Vireo peer
+        # from a stale advertisement whose PID was recycled by an unrelated
+        # process, require BOTH that the advertised PID is alive AND that
+        # `runtime.lock` is held by the same PID. A live Vireo always holds
+        # the matching lock; an unrelated PID-recycler does not.
+        if (
+            isinstance(pid, int)
+            and _pid_alive(pid)
+            and _read_lock_holder(_lock_path()) == pid
+        ):
+            # Preserve runtime.json so external callers can still discover
+            # the peer once HTTP comes up.
             return ("conflict", {"port": port, "pid": pid})
-        # PID dead — peer is gone, file is stale.
+        # Either PID is dead, lock is missing, or lock holder PID does not
+        # match — runtime.json is stale.
 
     delete_runtime_json()
     return ("proceed", None)

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -1,10 +1,14 @@
 """Runtime discovery file for the Vireo sidecar.
 
 Writes `~/.vireo/runtime.json` so external callers can discover the running
-instance (port, auth token, PID). Also provides the single-instance guard.
+instance (port, auth token, PID). Also provides the single-instance guard,
+including an atomic reservation step (via a separate lock file) so two
+near-simultaneous launches cannot both observe an empty slot and both
+start serving.
 """
 
 import contextlib
+import errno
 import json
 import os
 import secrets
@@ -16,6 +20,10 @@ from pathlib import Path
 
 def _runtime_path() -> Path:
     return Path(os.path.expanduser("~/.vireo/runtime.json"))
+
+
+def _lock_path() -> Path:
+    return Path(os.path.expanduser("~/.vireo/runtime.lock"))
 
 
 def write_runtime_json(
@@ -57,12 +65,39 @@ def delete_runtime_json() -> None:
         _runtime_path().unlink()
 
 
+def _pid_alive(pid) -> bool:
+    """Best-effort liveness check for a PID from another process.
+
+    On Unix, `os.kill(pid, 0)` raises ProcessLookupError when the pid is
+    gone. On Windows, os.kill with signal 0 is not fully portable; fall
+    back to treating unknown errors as "alive" so the guard errs on the
+    side of refusing to start a second instance.
+    """
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but we can't signal it.
+        return True
+    except OSError:
+        return True
+
+
 def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | None]:
     """Check whether another Vireo instance is healthy on the advertised port.
 
     Returns:
         ("proceed", None)  — no peer found, or stale file cleaned up.
-        ("conflict", info) — healthy peer. `info` has keys `port`, `pid`.
+        ("conflict", info) — live peer. `info` has keys `port`, `pid`.
+
+    The probe requires a 200 from `/api/v1/health` (with the token from
+    runtime.json) to classify the peer as alive. Non-200 responses — 401,
+    404, 500, etc. — are treated as stale: the port may have been reused
+    by an unrelated local service, so we clean the file and proceed.
     """
     data = read_runtime_json()
     if data is None:
@@ -73,6 +108,7 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
 
     port = data.get("port")
     token = data.get("token", "")
+    pid = data.get("pid")
     if not isinstance(port, int) or not isinstance(token, str):
         delete_runtime_json()
         return ("proceed", None)
@@ -83,20 +119,106 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
             headers={"X-Vireo-Token": token},
         )
         with urllib.request.urlopen(req, timeout=probe_timeout_s) as resp:
-            # Any HTTP response means something is bound to the port. Treat as
-            # an alive peer regardless of status — a stale token or a transient
-            # 5xx is still "do not start a second instance".
-            _ = resp.status
-            return ("conflict", {"port": port, "pid": data.get("pid")})
+            if resp.status == 200:
+                return ("conflict", {"port": port, "pid": pid})
+            # Any other 2xx is unexpected from our own health endpoint; fall
+            # through to the stale path.
     except urllib.error.HTTPError:
-        # Got a non-2xx status. Peer is alive.
-        return ("conflict", {"port": port, "pid": data.get("pid")})
+        # Non-2xx (401, 404, 500, ...) — either the port was reused by an
+        # unrelated service, or our own peer is answering but the token
+        # doesn't match (shouldn't happen under correct writes). Either way,
+        # treat as stale and clean up so startup can proceed.
+        pass
     except (urllib.error.URLError, TimeoutError, OSError):
+        # Connection refused / timeout — peer is dead.
         pass
 
-    # Probe failed — peer is dead. Clean up and proceed.
     delete_runtime_json()
     return ("proceed", None)
+
+
+def acquire_single_instance(
+    pid: int, probe_timeout_s: float = 0.5, max_retries: int = 5
+) -> tuple[str, dict | None]:
+    """Atomically reserve the single-instance slot via a lock file.
+
+    Creates `~/.vireo/runtime.lock` with `O_CREAT | O_EXCL`, writing the
+    caller's PID. This closes the race where two near-simultaneous
+    launches both call `check_single_instance`, both see no runtime.json,
+    and both start serving before either has written one. Only one
+    process can win the O_EXCL create; the other returns "conflict".
+
+    The lock file is separate from runtime.json to keep runtime.json's
+    external contract clean — it still either does not exist or contains
+    the full payload of a running instance.
+
+    Returns:
+        ("acquired", None) — caller holds the lock. Must call
+            `release_single_instance` on shutdown (e.g. via atexit /
+            SIGTERM handlers).
+        ("conflict", info) — a peer is alive; caller must not start.
+
+    If a stale `runtime.lock` is found (holder PID no longer alive), it
+    is removed and the caller retries. If a live `runtime.json` peer is
+    found, we return conflict regardless of lock state.
+    """
+    lock_path = _lock_path()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    for _attempt in range(max_retries):
+        # First, probe runtime.json for a live peer. A healthy peer always
+        # wins, even if the lock happens to be missing.
+        status, info = check_single_instance(probe_timeout_s=probe_timeout_s)
+        if status == "conflict":
+            return ("conflict", info)
+
+        # No live peer — try to atomically claim the lock.
+        try:
+            fd = os.open(
+                str(lock_path),
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+        except FileExistsError:
+            # Another process holds (or left) the lock. Decide liveness by
+            # the PID written inside.
+            holder_pid = _read_lock_holder(lock_path)
+            if _pid_alive(holder_pid):
+                return ("conflict", {"port": None, "pid": holder_pid})
+            # Stale lock — remove and retry.
+            with contextlib.suppress(FileNotFoundError):
+                lock_path.unlink()
+            continue
+        except OSError as e:
+            if e.errno == errno.EEXIST:
+                continue
+            raise
+
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(str(pid))
+            return ("acquired", None)
+        except Exception:
+            with contextlib.suppress(FileNotFoundError):
+                lock_path.unlink()
+            raise
+
+    # Exhausted retries — some other process keeps winning the race. Treat
+    # as a conflict rather than looping forever.
+    return ("conflict", {"port": None, "pid": None})
+
+
+def release_single_instance() -> None:
+    """Remove the reservation lock file. Idempotent."""
+    with contextlib.suppress(FileNotFoundError):
+        _lock_path().unlink()
+
+
+def _read_lock_holder(lock_path: Path) -> int:
+    try:
+        return int(lock_path.read_text().strip())
+    except (OSError, ValueError):
+        return 0
 
 
 def generate_token() -> str:

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -4,6 +4,7 @@ Writes `~/.vireo/runtime.json` so external callers can discover the running
 instance (port, auth token, PID). Also provides the single-instance guard.
 """
 
+import contextlib
 import json
 import os
 from datetime import UTC, datetime
@@ -34,3 +35,20 @@ def write_runtime_json(
     tmp.write_text(json.dumps(payload, indent=2))
     os.chmod(tmp, 0o600)
     os.replace(tmp, path)
+
+
+def read_runtime_json() -> dict | None:
+    """Return runtime.json contents, or None if missing / malformed."""
+    path = _runtime_path()
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def delete_runtime_json() -> None:
+    """Remove runtime.json if present. Idempotent."""
+    with contextlib.suppress(FileNotFoundError):
+        _runtime_path().unlink()

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -72,7 +72,7 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
 
     port = data.get("port")
     token = data.get("token", "")
-    if not isinstance(port, int):
+    if not isinstance(port, int) or not isinstance(token, str):
         delete_runtime_json()
         return ("proceed", None)
 
@@ -82,8 +82,14 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
             headers={"X-Vireo-Token": token},
         )
         with urllib.request.urlopen(req, timeout=probe_timeout_s) as resp:
-            if resp.status == 200:
-                return ("conflict", {"port": port, "pid": data.get("pid")})
+            # Any HTTP response means something is bound to the port. Treat as
+            # an alive peer regardless of status — a stale token or a transient
+            # 5xx is still "do not start a second instance".
+            _ = resp.status
+            return ("conflict", {"port": port, "pid": data.get("pid")})
+    except urllib.error.HTTPError:
+        # Got a non-2xx status. Peer is alive.
+        return ("conflict", {"port": port, "pid": data.get("pid")})
     except (urllib.error.URLError, TimeoutError, OSError):
         pass
 

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -299,10 +299,12 @@ def acquire_single_instance(
         if status == "conflict":
             return ("conflict", info)
 
-        try:
-            fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
-        except OSError:
-            continue
+        # Open the lock file. If this raises (e.g. unreadable `~/.vireo`,
+        # permission denied, filesystem fault), let the OSError propagate:
+        # misclassifying a startup fault as "already_running" sends the
+        # user to the wrong remediation and can block startup indefinitely
+        # when no peer exists.
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
 
         if not _try_take_lock(fd):
             # Another process holds the lock — a real peer is alive

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -86,7 +86,16 @@ def write_runtime_json(
     data = json.dumps(payload, indent=2).encode()
     fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     try:
-        os.write(fd, data)
+        # os.write is allowed to do partial writes even on regular files
+        # under signal/resource pressure. If we os.replace() a truncated
+        # payload into place, external callers read malformed runtime.json
+        # and discovery fails — loop until the full buffer is flushed.
+        view = memoryview(data)
+        while view:
+            n = os.write(fd, view)
+            if n <= 0:
+                raise OSError("runtime.json.tmp: write returned zero bytes")
+            view = view[n:]
     finally:
         os.close(fd)
     os.replace(tmp, path)
@@ -331,15 +340,22 @@ def acquire_single_instance(
 
 
 def release_single_instance() -> None:
-    """Release the kernel lock, close the FD, and unlink the file. Idempotent."""
+    """Release the kernel lock and close the FD. Idempotent.
+
+    The lock file itself is intentionally left on disk. flock() binds to
+    the inode, not the path — if we unlink after close, a newcomer that
+    already opened the old inode and holds a lock on it keeps that lock,
+    while the next starter creates a fresh inode and also locks it. Two
+    processes end up holding locks on different inodes, defeating the
+    single-instance guarantee. Leaving the file in place forces every
+    process to converge on the same inode.
+    """
     global _lock_fd
     if _lock_fd is not None:
         _release_lock(_lock_fd)
         with contextlib.suppress(OSError):
             os.close(_lock_fd)
         _lock_fd = None
-    with contextlib.suppress(FileNotFoundError):
-        _lock_path().unlink()
 
 
 def _read_lock_holder(lock_path: Path) -> int:

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -102,13 +102,20 @@ def write_runtime_json(
 
 
 def read_runtime_json() -> dict | None:
-    """Return runtime.json contents, or None if missing / malformed."""
+    """Return runtime.json contents, or None if missing / malformed.
+
+    Non-UTF-8 bytes, JSON errors, and I/O errors are all treated as
+    malformed — callers clean up the file as stale rather than aborting
+    startup. `read_bytes()` + explicit `utf-8` decode lets us catch
+    UnicodeDecodeError, which `read_text()` does not surface to the
+    (OSError, JSONDecodeError) handler.
+    """
     path = _runtime_path()
     if not path.exists():
         return None
     try:
-        return json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
+        return json.loads(path.read_bytes().decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return None
 
 
@@ -324,6 +331,12 @@ def acquire_single_instance(
 
         # Lock acquired. Write our PID for diagnostics, then keep the FD
         # open so the lock persists until release / process exit.
+        # A failure here is a real filesystem fault (ENOSPC, EIO, …).
+        # Don't swallow it and retry — retrying won't help, and falling
+        # through to `("conflict", ...)` would let main() misreport the
+        # fault as already_running. Release the lock we just took so
+        # other processes can proceed, then let the OSError bubble up;
+        # main() converts it to `{"error": "startup_failed", ...}`.
         try:
             os.lseek(fd, 0, os.SEEK_SET)
             os.ftruncate(fd, 0)
@@ -331,7 +344,7 @@ def acquire_single_instance(
         except OSError:
             _release_lock(fd)
             os.close(fd)
-            continue
+            raise
 
         _lock_fd = fd
         return ("acquired", None)

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -2,9 +2,11 @@
 
 Writes `~/.vireo/runtime.json` so external callers can discover the running
 instance (port, auth token, PID). Also provides the single-instance guard,
-including an atomic reservation step (via a separate lock file) so two
-near-simultaneous launches cannot both observe an empty slot and both
-start serving.
+anchored to an `fcntl.flock` on `~/.vireo/runtime.lock`. The kernel
+releases the flock when the owning process dies, so the guard is
+self-healing after unclean crashes (SIGKILL, power loss, OOM) — the next
+startup reclaims the slot without manual cleanup, even if the dead PID
+has been recycled by an unrelated process.
 """
 
 import contextlib
@@ -17,6 +19,12 @@ import urllib.request
 from datetime import UTC, datetime
 from pathlib import Path
 
+try:
+    import fcntl  # POSIX only
+    _HAS_FCNTL = True
+except ImportError:
+    _HAS_FCNTL = False
+
 
 def _runtime_path() -> Path:
     return Path(os.path.expanduser("~/.vireo/runtime.json"))
@@ -24,6 +32,13 @@ def _runtime_path() -> Path:
 
 def _lock_path() -> Path:
     return Path(os.path.expanduser("~/.vireo/runtime.lock"))
+
+
+# Module-global FD. When this process owns the single-instance slot, we
+# hold an exclusive fcntl.flock on the lock file via this FD. Keeping
+# the FD open is what keeps the lock held; closing it (or the process
+# dying) releases it.
+_lock_fd: int | None = None
 
 
 def write_runtime_json(
@@ -87,6 +102,40 @@ def _pid_alive(pid) -> bool:
         return True
 
 
+def _is_lock_held_by_peer() -> bool:
+    """Return True if another process currently holds the runtime flock.
+
+    Opens the lock file and attempts a non-blocking exclusive flock. If
+    we can acquire it, nobody else holds it (we release immediately and
+    report no peer). If flock raises BlockingIOError / EAGAIN, another
+    process holds the lock — and since the kernel releases flocks on
+    process exit, that other process is definitely alive, regardless
+    of PID reuse.
+
+    On platforms without fcntl (Windows) we fall back to the PID stored
+    in the lock file as a best-effort signal.
+    """
+    lock_path = _lock_path()
+    if not lock_path.exists():
+        return False
+    if not _HAS_FCNTL:
+        return _pid_alive(_read_lock_holder(lock_path))
+    try:
+        fd = os.open(str(lock_path), os.O_RDONLY)
+    except OSError:
+        return False
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (BlockingIOError, OSError):
+            return True
+        with contextlib.suppress(OSError):
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        return False
+    finally:
+        os.close(fd)
+
+
 def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | None]:
     """Check whether another Vireo instance is healthy on the advertised port.
 
@@ -94,21 +143,16 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
         ("proceed", None)  — no peer found, or stale file cleaned up.
         ("conflict", info) — live peer. `info` has keys `port`, `pid`.
 
-    The probe requires a 200 from `/api/v1/health` (with the token from
-    runtime.json) to classify the peer as alive. Non-200 responses — 401,
+    A 200 from `/api/v1/health` (with the token from runtime.json)
+    definitively classifies the peer as alive. Non-200 responses — 401,
     404, 500, etc. — are treated as stale: the port may have been reused
-    by an unrelated local service, so we clean the file and proceed.
+    by an unrelated local service.
 
     Connection-level failures (refused/timeout) are ambiguous: the peer
-    may be dead, or it may be a peer still booting that wrote
-    runtime.json but hasn't started listening yet. PID liveness alone is
-    not strong enough — after a SIGKILL crash the recorded PID can be
-    recycled by an unrelated process, which would otherwise pin
-    `already_running` forever without cleanup. So we additionally require
-    that `runtime.lock` exists and its holder PID matches runtime.json's
-    PID; only a live Vireo sidecar holds the matching lock. If the lock
-    is missing, holds a different PID, or the PID is dead, runtime.json
-    is treated as stale.
+    may be dead, or it may be a peer still booting that wrote runtime.json
+    before Flask bound. We disambiguate via the flock — a held lock means
+    a live owner (kernel-guaranteed, PID-recycling-proof), an unheld lock
+    means the owner crashed and runtime.json is stale.
     """
     data = read_runtime_json()
     if data is None:
@@ -139,21 +183,13 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
         # answering our health contract. Treat as stale.
         pass
     except (urllib.error.URLError, TimeoutError, OSError):
-        # Connection refused / timeout. To distinguish a booting Vireo peer
-        # from a stale advertisement whose PID was recycled by an unrelated
-        # process, require BOTH that the advertised PID is alive AND that
-        # `runtime.lock` is held by the same PID. A live Vireo always holds
-        # the matching lock; an unrelated PID-recycler does not.
-        if (
-            isinstance(pid, int)
-            and _pid_alive(pid)
-            and _read_lock_holder(_lock_path()) == pid
-        ):
-            # Preserve runtime.json so external callers can still discover
-            # the peer once HTTP comes up.
+        # Connection refused / timeout. Trust the kernel-managed flock,
+        # not the raw PID — a live flock means a live Vireo peer (possibly
+        # still booting), while an unheld flock means the previous owner
+        # is gone and runtime.json is stale, even if the PID happens to
+        # have been recycled by an unrelated process.
+        if _is_lock_held_by_peer():
             return ("conflict", {"port": port, "pid": pid})
-        # Either PID is dead, lock is missing, or lock holder PID does not
-        # match — runtime.json is stale.
 
     delete_runtime_json()
     return ("proceed", None)
@@ -162,44 +198,90 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
 def acquire_single_instance(
     pid: int, probe_timeout_s: float = 0.5, max_retries: int = 5
 ) -> tuple[str, dict | None]:
-    """Atomically reserve the single-instance slot via a lock file.
+    """Atomically reserve the single-instance slot via fcntl.flock.
 
-    Creates `~/.vireo/runtime.lock` with `O_CREAT | O_EXCL`, writing the
-    caller's PID. This closes the race where two near-simultaneous
-    launches both call `check_single_instance`, both see no runtime.json,
-    and both start serving before either has written one. Only one
-    process can win the O_EXCL create; the other returns "conflict".
+    Opens `~/.vireo/runtime.lock` and takes an exclusive, non-blocking
+    fcntl.flock. Only one process can hold the flock at a time, so the
+    guard both (a) closes the boot race where two near-simultaneous
+    launches both see an empty runtime.json and both start serving, and
+    (b) self-heals after unclean crashes — the kernel releases the lock
+    when the owning process dies, so the next startup can reclaim it
+    even if the dead PID has been recycled.
 
-    The lock file is separate from runtime.json to keep runtime.json's
-    external contract clean — it still either does not exist or contains
-    the full payload of a running instance.
+    The PID written inside the lock file is diagnostic only; liveness is
+    determined by the flock, not by reading the file.
 
     Returns:
         ("acquired", None) — caller holds the lock. Must call
             `release_single_instance` on shutdown (e.g. via atexit /
-            SIGTERM handlers).
+            SIGTERM handlers) to release the flock and unlink the file.
         ("conflict", info) — a peer is alive; caller must not start.
 
-    If a stale `runtime.lock` is found (holder PID no longer alive), it
-    is removed and the caller retries. If a live `runtime.json` peer is
-    found, we return conflict regardless of lock state.
+    On platforms without fcntl (Windows), falls back to an
+    `O_CREAT | O_EXCL` + PID-liveness approach, which provides the same
+    boot-race protection but not the crash-self-healing guarantee.
     """
+    global _lock_fd
     lock_path = _lock_path()
     lock_path.parent.mkdir(parents=True, exist_ok=True)
 
+    if not _HAS_FCNTL:
+        return _acquire_without_flock(pid, probe_timeout_s, max_retries)
+
     for _attempt in range(max_retries):
-        # First, probe runtime.json for a live peer. A healthy peer always
-        # wins, even if the lock happens to be missing.
+        # A healthy peer detected via runtime.json always wins, even if
+        # the flock happens to be unheld at this instant.
         status, info = check_single_instance(probe_timeout_s=probe_timeout_s)
         if status == "conflict":
             return ("conflict", info)
 
-        # Publish the lock atomically with its PID payload. We write the PID
-        # to a per-caller temp file first, then use os.link to move it into
-        # place — os.link fails if the destination exists, and the file is
-        # never observable in an empty state. This closes the race where a
-        # concurrent caller sees a freshly-created empty lock file, reads
-        # PID=0, classifies it as stale, and unlinks the winner's lock.
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+        except OSError:
+            continue
+
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (BlockingIOError, OSError):
+            # Another process holds the lock — a real peer is alive
+            # (kernel-guaranteed).
+            holder_pid = _read_lock_holder(lock_path)
+            os.close(fd)
+            return ("conflict", {"port": None, "pid": holder_pid})
+
+        # Lock acquired. Write our PID for diagnostics, then keep the FD
+        # open so the flock persists until release / process exit.
+        try:
+            os.ftruncate(fd, 0)
+            os.write(fd, str(pid).encode())
+        except OSError:
+            with contextlib.suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+            continue
+
+        _lock_fd = fd
+        return ("acquired", None)
+
+    return ("conflict", {"port": None, "pid": None})
+
+
+def _acquire_without_flock(
+    pid: int, probe_timeout_s: float, max_retries: int
+) -> tuple[str, dict | None]:
+    """Non-flock fallback for platforms without fcntl (Windows).
+
+    Uses atomic hardlink publishing (os.link) so the lock file is never
+    observable in an empty state, then classifies staleness by PID
+    liveness. Does not self-heal from crash + PID-recycling (the core
+    weakness Codex P2 flagged); that path needs a kernel-managed lock.
+    """
+    lock_path = _lock_path()
+    for _attempt in range(max_retries):
+        status, info = check_single_instance(probe_timeout_s=probe_timeout_s)
+        if status == "conflict":
+            return ("conflict", info)
+
         tmp = lock_path.parent / f"runtime.lock.tmp.{os.getpid()}.{pid}"
         try:
             tmp.write_text(str(pid))
@@ -207,13 +289,9 @@ def acquire_single_instance(
             try:
                 os.link(str(tmp), str(lock_path))
             except FileExistsError:
-                # Another process holds (or left) the lock.
                 holder_pid = _read_lock_holder(lock_path)
                 if _pid_alive(holder_pid):
                     return ("conflict", {"port": None, "pid": holder_pid})
-                # Stale lock — remove and retry. If someone else won the
-                # unlink/recreate race in the meantime, the next loop
-                # iteration will observe their live lock and conflict.
                 with contextlib.suppress(FileNotFoundError):
                     lock_path.unlink()
                 continue
@@ -227,13 +305,19 @@ def acquire_single_instance(
             with contextlib.suppress(FileNotFoundError):
                 tmp.unlink()
 
-    # Exhausted retries — some other process keeps winning the race. Treat
-    # as a conflict rather than looping forever.
     return ("conflict", {"port": None, "pid": None})
 
 
 def release_single_instance() -> None:
-    """Remove the reservation lock file. Idempotent."""
+    """Release the flock, close the FD, and unlink the lock file. Idempotent."""
+    global _lock_fd
+    if _lock_fd is not None:
+        if _HAS_FCNTL:
+            with contextlib.suppress(OSError):
+                fcntl.flock(_lock_fd, fcntl.LOCK_UN)
+        with contextlib.suppress(OSError):
+            os.close(_lock_fd)
+        _lock_fd = None
     with contextlib.suppress(FileNotFoundError):
         _lock_path().unlink()
 

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -2,15 +2,15 @@
 
 Writes `~/.vireo/runtime.json` so external callers can discover the running
 instance (port, auth token, PID). Also provides the single-instance guard,
-anchored to an `fcntl.flock` on `~/.vireo/runtime.lock`. The kernel
-releases the flock when the owning process dies, so the guard is
+anchored to a kernel-managed file lock on `~/.vireo/runtime.lock`
+(`fcntl.flock` on POSIX, `msvcrt.locking` on Windows). The kernel
+releases the lock when the owning process dies, so the guard is
 self-healing after unclean crashes (SIGKILL, power loss, OOM) — the next
 startup reclaims the slot without manual cleanup, even if the dead PID
 has been recycled by an unrelated process.
 """
 
 import contextlib
-import errno
 import json
 import os
 import secrets
@@ -20,10 +20,28 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 try:
-    import fcntl  # POSIX only
+    import fcntl  # POSIX
     _HAS_FCNTL = True
 except ImportError:
     _HAS_FCNTL = False
+
+try:
+    import msvcrt  # Windows
+    _HAS_MSVCRT = True
+except ImportError:
+    _HAS_MSVCRT = False
+
+
+# A Vireo-specific marker echoed by /api/v1/health. The probe verifies this
+# value so an unrelated local service that happens to return 200 for
+# /api/v1/health cannot be mistaken for a live Vireo peer and cause a
+# false `already_running`.
+SERVICE_MARKER = "vireo"
+
+# One byte is enough to uniquely identify the lock region on Windows;
+# msvcrt.locking takes a length and locks a byte range starting at the
+# current file position.
+_LOCK_BYTES = 1
 
 
 def _runtime_path() -> Path:
@@ -35,7 +53,7 @@ def _lock_path() -> Path:
 
 
 # Module-global FD. When this process owns the single-instance slot, we
-# hold an exclusive fcntl.flock on the lock file via this FD. Keeping
+# hold an exclusive kernel lock on the lock file via this FD. Keeping
 # the FD open is what keeps the lock held; closing it (or the process
 # dying) releases it.
 _lock_fd: int | None = None
@@ -83,10 +101,8 @@ def delete_runtime_json() -> None:
 def _pid_alive(pid) -> bool:
     """Best-effort liveness check for a PID from another process.
 
-    On Unix, `os.kill(pid, 0)` raises ProcessLookupError when the pid is
-    gone. On Windows, os.kill with signal 0 is not fully portable; fall
-    back to treating unknown errors as "alive" so the guard errs on the
-    side of refusing to start a second instance.
+    Used only for diagnostic info (info["pid"] on conflict); the guard
+    itself trusts the kernel-managed file lock, not this check.
     """
     if not isinstance(pid, int) or pid <= 0:
         return False
@@ -96,42 +112,71 @@ def _pid_alive(pid) -> bool:
     except ProcessLookupError:
         return False
     except PermissionError:
-        # Process exists but we can't signal it.
         return True
     except OSError:
         return True
 
 
+def _try_take_lock(fd: int) -> bool:
+    """Take an exclusive, non-blocking, kernel-managed lock on fd.
+
+    Returns True on success (we now own the lock for the lifetime of this
+    FD), False if another process already holds it. The kernel releases
+    the lock automatically when the owning process exits or the FD is
+    closed, which is what makes the guard self-healing after unclean
+    crashes and invulnerable to PID reuse.
+    """
+    if _HAS_FCNTL:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except (BlockingIOError, OSError):
+            return False
+    if _HAS_MSVCRT:
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, _LOCK_BYTES)
+            return True
+        except OSError:
+            return False
+    # No kernel-managed locking available; callers must treat this as
+    # an unsupported platform. We avoid raising here so the module can
+    # still import; release_single_instance handles the no-op case.
+    return False
+
+
+def _release_lock(fd: int) -> None:
+    """Release the kernel lock on fd. Idempotent; swallows errors."""
+    if _HAS_FCNTL:
+        with contextlib.suppress(OSError):
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    elif _HAS_MSVCRT:
+        with contextlib.suppress(OSError):
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, _LOCK_BYTES)
+
+
 def _is_lock_held_by_peer() -> bool:
-    """Return True if another process currently holds the runtime flock.
+    """Return True if another process currently holds the runtime lock.
 
-    Opens the lock file and attempts a non-blocking exclusive flock. If
-    we can acquire it, nobody else holds it (we release immediately and
-    report no peer). If flock raises BlockingIOError / EAGAIN, another
-    process holds the lock — and since the kernel releases flocks on
-    process exit, that other process is definitely alive, regardless
-    of PID reuse.
-
-    On platforms without fcntl (Windows) we fall back to the PID stored
-    in the lock file as a best-effort signal.
+    Opens the lock file and tries to acquire it non-blocking. If we
+    succeed, nobody else holds it (release immediately, report no peer).
+    If the kernel refuses, another process holds it — and since the
+    kernel releases locks on process death, "held" reliably means "live
+    peer", regardless of PID reuse.
     """
     lock_path = _lock_path()
     if not lock_path.exists():
         return False
-    if not _HAS_FCNTL:
-        return _pid_alive(_read_lock_holder(lock_path))
     try:
-        fd = os.open(str(lock_path), os.O_RDONLY)
+        fd = os.open(str(lock_path), os.O_RDWR)
     except OSError:
         return False
     try:
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except (BlockingIOError, OSError):
-            return True
-        with contextlib.suppress(OSError):
-            fcntl.flock(fd, fcntl.LOCK_UN)
-        return False
+        if _try_take_lock(fd):
+            _release_lock(fd)
+            return False
+        return True
     finally:
         os.close(fd)
 
@@ -143,16 +188,16 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
         ("proceed", None)  — no peer found, or stale file cleaned up.
         ("conflict", info) — live peer. `info` has keys `port`, `pid`.
 
-    A 200 from `/api/v1/health` (with the token from runtime.json)
-    definitively classifies the peer as alive. Non-200 responses — 401,
-    404, 500, etc. — are treated as stale: the port may have been reused
-    by an unrelated local service.
+    A 200 from `/api/v1/health` (with the token from runtime.json) is
+    a necessary but not sufficient signal — we also require the response
+    body to carry the Vireo service marker, so an unrelated local
+    service that happens to return 200 on that path cannot be mistaken
+    for a live Vireo peer. Non-200 responses are treated as stale.
 
     Connection-level failures (refused/timeout) are ambiguous: the peer
     may be dead, or it may be a peer still booting that wrote runtime.json
-    before Flask bound. We disambiguate via the flock — a held lock means
-    a live owner (kernel-guaranteed, PID-recycling-proof), an unheld lock
-    means the owner crashed and runtime.json is stale.
+    before Flask bound. We disambiguate via the kernel-managed lock —
+    held = live owner (PID-reuse-proof), unheld = owner crashed, stale.
     """
     data = read_runtime_json()
     if data is None:
@@ -174,18 +219,18 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
             headers={"X-Vireo-Token": token},
         )
         with urllib.request.urlopen(req, timeout=probe_timeout_s) as resp:
-            if resp.status == 200:
+            if resp.status == 200 and _response_is_vireo(resp):
                 return ("conflict", {"port": port, "pid": pid})
-            # Any other 2xx is unexpected from our own health endpoint; fall
-            # through to the stale path.
+            # 200 without the Vireo marker, or any other 2xx, is not
+            # proof of a live Vireo peer — fall through to stale.
     except urllib.error.HTTPError:
         # Non-2xx (401, 404, 500, ...) — port is held by something that isn't
         # answering our health contract. Treat as stale.
         pass
     except (urllib.error.URLError, TimeoutError, OSError):
-        # Connection refused / timeout. Trust the kernel-managed flock,
-        # not the raw PID — a live flock means a live Vireo peer (possibly
-        # still booting), while an unheld flock means the previous owner
+        # Connection refused / timeout. Trust the kernel-managed lock,
+        # not the raw PID — a held lock means a live Vireo peer (possibly
+        # still booting), while an unheld lock means the previous owner
         # is gone and runtime.json is stale, even if the PID happens to
         # have been recycled by an unrelated process.
         if _is_lock_held_by_peer():
@@ -195,42 +240,50 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
     return ("proceed", None)
 
 
+def _response_is_vireo(resp) -> bool:
+    """Return True if the health response carries the Vireo service marker.
+
+    Reading the body is bounded to a few hundred bytes — /api/v1/health
+    is tiny, and we only need to inspect the JSON envelope.
+    """
+    try:
+        body = resp.read(1024)
+        data = json.loads(body.decode("utf-8", errors="replace"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    return isinstance(data, dict) and data.get("service") == SERVICE_MARKER
+
+
 def acquire_single_instance(
     pid: int, probe_timeout_s: float = 0.5, max_retries: int = 5
 ) -> tuple[str, dict | None]:
-    """Atomically reserve the single-instance slot via fcntl.flock.
+    """Atomically reserve the single-instance slot via a kernel file lock.
 
     Opens `~/.vireo/runtime.lock` and takes an exclusive, non-blocking
-    fcntl.flock. Only one process can hold the flock at a time, so the
-    guard both (a) closes the boot race where two near-simultaneous
-    launches both see an empty runtime.json and both start serving, and
-    (b) self-heals after unclean crashes — the kernel releases the lock
-    when the owning process dies, so the next startup can reclaim it
-    even if the dead PID has been recycled.
+    lock (fcntl.flock on POSIX, msvcrt.locking on Windows). Only one
+    process can hold the lock at a time, so the guard both (a) closes
+    the boot race where two near-simultaneous launches both see an
+    empty runtime.json and both start serving, and (b) self-heals after
+    unclean crashes — the kernel releases the lock when the owning
+    process dies, so the next startup can reclaim it even if the dead
+    PID has been recycled by an unrelated process.
 
-    The PID written inside the lock file is diagnostic only; liveness is
-    determined by the flock, not by reading the file.
+    The PID written inside the lock file is diagnostic only; liveness
+    is determined by the kernel lock, not by reading the file.
 
     Returns:
         ("acquired", None) — caller holds the lock. Must call
             `release_single_instance` on shutdown (e.g. via atexit /
-            SIGTERM handlers) to release the flock and unlink the file.
+            SIGTERM handlers) to release the lock and unlink the file.
         ("conflict", info) — a peer is alive; caller must not start.
-
-    On platforms without fcntl (Windows), falls back to an
-    `O_CREAT | O_EXCL` + PID-liveness approach, which provides the same
-    boot-race protection but not the crash-self-healing guarantee.
     """
     global _lock_fd
     lock_path = _lock_path()
     lock_path.parent.mkdir(parents=True, exist_ok=True)
 
-    if not _HAS_FCNTL:
-        return _acquire_without_flock(pid, probe_timeout_s, max_retries)
-
     for _attempt in range(max_retries):
         # A healthy peer detected via runtime.json always wins, even if
-        # the flock happens to be unheld at this instant.
+        # the lock happens to be unheld at this instant.
         status, info = check_single_instance(probe_timeout_s=probe_timeout_s)
         if status == "conflict":
             return ("conflict", info)
@@ -240,9 +293,7 @@ def acquire_single_instance(
         except OSError:
             continue
 
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except (BlockingIOError, OSError):
+        if not _try_take_lock(fd):
             # Another process holds the lock — a real peer is alive
             # (kernel-guaranteed).
             holder_pid = _read_lock_holder(lock_path)
@@ -250,13 +301,13 @@ def acquire_single_instance(
             return ("conflict", {"port": None, "pid": holder_pid})
 
         # Lock acquired. Write our PID for diagnostics, then keep the FD
-        # open so the flock persists until release / process exit.
+        # open so the lock persists until release / process exit.
         try:
+            os.lseek(fd, 0, os.SEEK_SET)
             os.ftruncate(fd, 0)
             os.write(fd, str(pid).encode())
         except OSError:
-            with contextlib.suppress(OSError):
-                fcntl.flock(fd, fcntl.LOCK_UN)
+            _release_lock(fd)
             os.close(fd)
             continue
 
@@ -266,55 +317,11 @@ def acquire_single_instance(
     return ("conflict", {"port": None, "pid": None})
 
 
-def _acquire_without_flock(
-    pid: int, probe_timeout_s: float, max_retries: int
-) -> tuple[str, dict | None]:
-    """Non-flock fallback for platforms without fcntl (Windows).
-
-    Uses atomic hardlink publishing (os.link) so the lock file is never
-    observable in an empty state, then classifies staleness by PID
-    liveness. Does not self-heal from crash + PID-recycling (the core
-    weakness Codex P2 flagged); that path needs a kernel-managed lock.
-    """
-    lock_path = _lock_path()
-    for _attempt in range(max_retries):
-        status, info = check_single_instance(probe_timeout_s=probe_timeout_s)
-        if status == "conflict":
-            return ("conflict", info)
-
-        tmp = lock_path.parent / f"runtime.lock.tmp.{os.getpid()}.{pid}"
-        try:
-            tmp.write_text(str(pid))
-            os.chmod(tmp, 0o600)
-            try:
-                os.link(str(tmp), str(lock_path))
-            except FileExistsError:
-                holder_pid = _read_lock_holder(lock_path)
-                if _pid_alive(holder_pid):
-                    return ("conflict", {"port": None, "pid": holder_pid})
-                with contextlib.suppress(FileNotFoundError):
-                    lock_path.unlink()
-                continue
-            except OSError as e:
-                if e.errno == errno.EEXIST:
-                    continue
-                raise
-            else:
-                return ("acquired", None)
-        finally:
-            with contextlib.suppress(FileNotFoundError):
-                tmp.unlink()
-
-    return ("conflict", {"port": None, "pid": None})
-
-
 def release_single_instance() -> None:
-    """Release the flock, close the FD, and unlink the lock file. Idempotent."""
+    """Release the kernel lock, close the FD, and unlink the file. Idempotent."""
     global _lock_fd
     if _lock_fd is not None:
-        if _HAS_FCNTL:
-            with contextlib.suppress(OSError):
-                fcntl.flock(_lock_fd, fcntl.LOCK_UN)
+        _release_lock(_lock_fd)
         with contextlib.suppress(OSError):
             os.close(_lock_fd)
         _lock_fd = None

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -98,6 +98,13 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
     runtime.json) to classify the peer as alive. Non-200 responses — 401,
     404, 500, etc. — are treated as stale: the port may have been reused
     by an unrelated local service, so we clean the file and proceed.
+
+    Connection-level failures (refused/timeout) are ambiguous: the peer
+    may be dead, or it may be a peer still booting that wrote
+    runtime.json but hasn't started listening yet. We disambiguate via
+    the PID — a live PID means "booting or transient", and we must not
+    delete runtime.json under the running peer, because that would
+    break external discovery even though the peer is still running.
     """
     data = read_runtime_json()
     if data is None:
@@ -130,8 +137,14 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
         # treat as stale and clean up so startup can proceed.
         pass
     except (urllib.error.URLError, TimeoutError, OSError):
-        # Connection refused / timeout — peer is dead.
-        pass
+        # Connection refused / timeout. If the advertised PID is still
+        # alive, this is almost certainly a peer that wrote runtime.json
+        # and is still booting (or briefly paused). Preserve runtime.json
+        # so external callers can still discover it once HTTP is up, and
+        # report conflict to the caller.
+        if _pid_alive(pid):
+            return ("conflict", {"port": port, "pid": pid})
+        # PID dead — peer is gone, file is stale.
 
     delete_runtime_json()
     return ("proceed", None)

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -131,10 +131,8 @@ def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | Non
             # Any other 2xx is unexpected from our own health endpoint; fall
             # through to the stale path.
     except urllib.error.HTTPError:
-        # Non-2xx (401, 404, 500, ...) — either the port was reused by an
-        # unrelated service, or our own peer is answering but the token
-        # doesn't match (shouldn't happen under correct writes). Either way,
-        # treat as stale and clean up so startup can proceed.
+        # Non-2xx (401, 404, 500, ...) — port is held by something that isn't
+        # answering our health contract. Treat as stale.
         pass
     except (urllib.error.URLError, TimeoutError, OSError):
         # Connection refused / timeout. If the advertised PID is still
@@ -185,36 +183,38 @@ def acquire_single_instance(
         if status == "conflict":
             return ("conflict", info)
 
-        # No live peer — try to atomically claim the lock.
+        # Publish the lock atomically with its PID payload. We write the PID
+        # to a per-caller temp file first, then use os.link to move it into
+        # place — os.link fails if the destination exists, and the file is
+        # never observable in an empty state. This closes the race where a
+        # concurrent caller sees a freshly-created empty lock file, reads
+        # PID=0, classifies it as stale, and unlinks the winner's lock.
+        tmp = lock_path.parent / f"runtime.lock.tmp.{os.getpid()}.{pid}"
         try:
-            fd = os.open(
-                str(lock_path),
-                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
-                0o600,
-            )
-        except FileExistsError:
-            # Another process holds (or left) the lock. Decide liveness by
-            # the PID written inside.
-            holder_pid = _read_lock_holder(lock_path)
-            if _pid_alive(holder_pid):
-                return ("conflict", {"port": None, "pid": holder_pid})
-            # Stale lock — remove and retry.
-            with contextlib.suppress(FileNotFoundError):
-                lock_path.unlink()
-            continue
-        except OSError as e:
-            if e.errno == errno.EEXIST:
+            tmp.write_text(str(pid))
+            os.chmod(tmp, 0o600)
+            try:
+                os.link(str(tmp), str(lock_path))
+            except FileExistsError:
+                # Another process holds (or left) the lock.
+                holder_pid = _read_lock_holder(lock_path)
+                if _pid_alive(holder_pid):
+                    return ("conflict", {"port": None, "pid": holder_pid})
+                # Stale lock — remove and retry. If someone else won the
+                # unlink/recreate race in the meantime, the next loop
+                # iteration will observe their live lock and conflict.
+                with contextlib.suppress(FileNotFoundError):
+                    lock_path.unlink()
                 continue
-            raise
-
-        try:
-            with os.fdopen(fd, "w") as f:
-                f.write(str(pid))
-            return ("acquired", None)
-        except Exception:
+            except OSError as e:
+                if e.errno == errno.EEXIST:
+                    continue
+                raise
+            else:
+                return ("acquired", None)
+        finally:
             with contextlib.suppress(FileNotFoundError):
-                lock_path.unlink()
-            raise
+                tmp.unlink()
 
     # Exhausted retries — some other process keeps winning the race. Treat
     # as a conflict rather than looping forever.

--- a/vireo/runtime.py
+++ b/vireo/runtime.py
@@ -7,6 +7,8 @@ instance (port, auth token, PID). Also provides the single-instance guard.
 import contextlib
 import json
 import os
+import urllib.error
+import urllib.request
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -52,3 +54,39 @@ def delete_runtime_json() -> None:
     """Remove runtime.json if present. Idempotent."""
     with contextlib.suppress(FileNotFoundError):
         _runtime_path().unlink()
+
+
+def check_single_instance(probe_timeout_s: float = 0.5) -> tuple[str, dict | None]:
+    """Check whether another Vireo instance is healthy on the advertised port.
+
+    Returns:
+        ("proceed", None)  — no peer found, or stale file cleaned up.
+        ("conflict", info) — healthy peer. `info` has keys `port`, `pid`.
+    """
+    data = read_runtime_json()
+    if data is None:
+        # Missing or malformed. If malformed, the file still exists on disk;
+        # delete it so the next caller has a clean slate.
+        delete_runtime_json()
+        return ("proceed", None)
+
+    port = data.get("port")
+    token = data.get("token", "")
+    if not isinstance(port, int):
+        delete_runtime_json()
+        return ("proceed", None)
+
+    try:
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/api/v1/health",
+            headers={"X-Vireo-Token": token},
+        )
+        with urllib.request.urlopen(req, timeout=probe_timeout_s) as resp:
+            if resp.status == 200:
+                return ("conflict", {"port": port, "pid": data.get("pid")})
+    except (urllib.error.URLError, TimeoutError, OSError):
+        pass
+
+    # Probe failed — peer is dead. Clean up and proceed.
+    delete_runtime_json()
+    return ("proceed", None)

--- a/vireo/tests/conftest.py
+++ b/vireo/tests/conftest.py
@@ -52,7 +52,7 @@ def app_and_db(tmp_path, monkeypatch):
     for pid in [p1, p2, p3]:
         Image.new('RGB', (100, 100)).save(os.path.join(thumb_dir, f"{pid}.jpg"))
 
-    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir)
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="test-token-123")
     return app, db
 
 
@@ -92,5 +92,5 @@ def client_with_photo(tmp_path, monkeypatch):
         width=800, height=600,
     )
 
-    app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir))
+    app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir), api_token="test-token-123")
     return app, db, pid

--- a/vireo/tests/test_api_v1_aliases.py
+++ b/vireo/tests/test_api_v1_aliases.py
@@ -1,0 +1,54 @@
+def _auth(app):
+    return {"X-Vireo-Token": app.config["API_TOKEN"]}
+
+
+def test_api_v1_photos_returns_list(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/v1/photos", headers=_auth(app))
+    assert resp.status_code == 200
+    assert isinstance(resp.get_json(), (list, dict))
+
+
+def test_api_v1_photo_by_id(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    # pick any existing photo
+    photos = db.get_photos()
+    pid = photos[0]["id"]
+    resp = client.get(f"/api/v1/photos/{pid}", headers=_auth(app))
+    assert resp.status_code == 200
+    assert resp.get_json()["id"] == pid
+
+
+def test_api_v1_collections(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/v1/collections", headers=_auth(app))
+    assert resp.status_code == 200
+
+
+def test_api_v1_workspaces(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/v1/workspaces", headers=_auth(app))
+    assert resp.status_code == 200
+
+
+def test_api_v1_keywords(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/v1/keywords", headers=_auth(app))
+    assert resp.status_code == 200
+    names = {k["name"] for k in resp.get_json()}
+    assert "Cardinal" in names
+
+
+def test_api_v1_workspace_activate(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    ws_id = db.get_workspaces()[0]["id"]
+    resp = client.post(
+        f"/api/v1/workspaces/{ws_id}/activate", headers=_auth(app)
+    )
+    assert resp.status_code == 200

--- a/vireo/tests/test_api_v1_auth.py
+++ b/vireo/tests/test_api_v1_auth.py
@@ -19,7 +19,7 @@ def test_api_v1_correct_token_accepted(app_and_db):
     token = app.config["API_TOKEN"]
     resp = client.get("/api/v1/health", headers={"X-Vireo-Token": token})
     assert resp.status_code == 200
-    assert resp.get_json() == {"status": "ok"}
+    assert resp.get_json() == {"service": "vireo", "status": "ok"}
 
 
 def test_internal_api_does_not_require_token(app_and_db):

--- a/vireo/tests/test_api_v1_auth.py
+++ b/vireo/tests/test_api_v1_auth.py
@@ -59,13 +59,20 @@ def test_api_v1_shutdown_token_only(app_and_db, monkeypatch):
     client = app.test_client()
     token = app.config["API_TOKEN"]
 
-    # Don't actually send SIGTERM during tests — stub os.kill.
-    import os as _os
-    killed = []
-    monkeypatch.setattr(_os, "kill", lambda pid, sig: killed.append((pid, sig)))
+    # Replace threading.Timer with a no-op so the scheduled SIGTERM never
+    # fires and kills the pytest process after monkeypatch teardown. The
+    # endpoint's public contract is the HTTP response; we don't need to
+    # verify the actual kill side-effect here.
+    import threading as _threading
+
+    class _NoopTimer:
+        def __init__(self, *_a, **_kw):
+            pass
+        def start(self):
+            pass
+
+    monkeypatch.setattr(_threading, "Timer", _NoopTimer)
 
     resp = client.post("/api/v1/shutdown", headers={"X-Vireo-Token": token})
     assert resp.status_code == 200
     assert resp.get_json()["status"] == "shutting_down"
-    # The shutdown timer runs in a thread with a 0.5s delay; we don't need to
-    # wait for it here — the response is the contract.

--- a/vireo/tests/test_api_v1_auth.py
+++ b/vireo/tests/test_api_v1_auth.py
@@ -1,0 +1,31 @@
+def test_api_v1_requires_token(app_and_db):
+    """GET /api/v1/health without a token → 401."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/v1/health")
+    assert resp.status_code == 401
+
+
+def test_api_v1_wrong_token_rejected(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/v1/health", headers={"X-Vireo-Token": "wrong"})
+    assert resp.status_code == 401
+
+
+def test_api_v1_correct_token_accepted(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    token = app.config["API_TOKEN"]
+    resp = client.get("/api/v1/health", headers={"X-Vireo-Token": token})
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}
+
+
+def test_internal_api_does_not_require_token(app_and_db):
+    """Existing /api/* routes are unaffected by the v1 middleware."""
+    app, _ = app_and_db
+    client = app.test_client()
+    # /api/health is an internal route and must keep working without a token
+    resp = client.get("/api/health")
+    assert resp.status_code == 200

--- a/vireo/tests/test_api_v1_auth.py
+++ b/vireo/tests/test_api_v1_auth.py
@@ -29,3 +29,43 @@ def test_internal_api_does_not_require_token(app_and_db):
     # /api/health is an internal route and must keep working without a token
     resp = client.get("/api/health")
     assert resp.status_code == 200
+
+
+def test_api_v1_rejects_when_no_token_configured(tmp_path, monkeypatch):
+    """Default api_token=None must deny all /api/v1 traffic."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    from app import create_app
+    app = create_app(db_path=str(tmp_path / "x.db"))  # api_token defaults to None
+    resp = app.test_client().get("/api/v1/health", headers={"X-Vireo-Token": ""})
+    assert resp.status_code == 401
+
+
+def test_api_v1_version(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    token = app.config["API_TOKEN"]
+    resp = client.get("/api/v1/version", headers={"X-Vireo-Token": token})
+    assert resp.status_code == 200
+    assert "version" in resp.get_json()
+
+
+def test_api_v1_shutdown_token_only(app_and_db, monkeypatch):
+    """Unlike /api/shutdown, /api/v1/shutdown uses the token only (no
+    X-Vireo-Shutdown header). The token itself blocks cross-origin attacks
+    because browsers cannot set custom headers without CORS preflight."""
+    app, _ = app_and_db
+    client = app.test_client()
+    token = app.config["API_TOKEN"]
+
+    # Don't actually send SIGTERM during tests — stub os.kill.
+    import os as _os
+    killed = []
+    monkeypatch.setattr(_os, "kill", lambda pid, sig: killed.append((pid, sig)))
+
+    resp = client.post("/api/v1/shutdown", headers={"X-Vireo-Token": token})
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "shutting_down"
+    # The shutdown timer runs in a thread with a 0.5s delay; we don't need to
+    # wait for it here — the response is the contract.

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -150,18 +150,18 @@ def test_failed_job_history_preserves_structured_result(tmp_path):
 
     job_id = runner.start('pipeline', failing_pipeline_like)
 
-    for _ in range(50):
-        job = runner.get(job_id)
-        if job['status'] == 'failed':
+    # Poll for the persisted row rather than sleeping a fixed interval —
+    # the worker thread sets status='failed' before the finally block runs
+    # _persist_job, so a fixed sleep races on slow runners.
+    row = None
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        row = db.conn.execute(
+            "SELECT result, error_count FROM job_history WHERE id = ?", (job_id,)
+        ).fetchone()
+        if row is not None:
             break
         time.sleep(0.05)
-
-    # Let the finally block persist
-    time.sleep(0.15)
-
-    row = db.conn.execute(
-        "SELECT result, error_count FROM job_history WHERE id = ?", (job_id,)
-    ).fetchone()
     assert row is not None
 
     stored = _json.loads(row["result"])
@@ -190,17 +190,16 @@ def test_failed_job_history_falls_back_when_no_structured_result(tmp_path):
 
     job_id = runner.start('test', failing_work)
 
-    for _ in range(50):
-        job = runner.get(job_id)
-        if job['status'] == 'failed':
+    row = None
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        row = db.conn.execute(
+            "SELECT result FROM job_history WHERE id = ?", (job_id,)
+        ).fetchone()
+        if row is not None:
             break
         time.sleep(0.05)
-
-    time.sleep(0.15)
-
-    row = db.conn.execute(
-        "SELECT result FROM job_history WHERE id = ?", (job_id,)
-    ).fetchone()
+    assert row is not None
     stored = _json.loads(row["result"])
     assert stored == {"error": "boom"}
 

--- a/vireo/tests/test_main_cli.py
+++ b/vireo/tests/test_main_cli.py
@@ -1,0 +1,13 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_help_includes_headless_flag():
+    repo = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, str(repo / "vireo" / "app.py"), "--help"],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0
+    assert "--headless" in result.stdout

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -703,6 +703,27 @@ def test_acquire_handles_garbage_lock_contents(tmp_path, monkeypatch):
     assert status == "acquired"
 
 
+def test_acquire_surfaces_lock_open_errors_not_conflict(tmp_path, monkeypatch):
+    """If `os.open` on the lock file fails (e.g. filesystem fault, permission
+    denied on ~/.vireo), that must surface as an OSError — NOT be silently
+    converted to a ('conflict', ...) that main() reports as already_running.
+    The two conditions need different remediation."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    import runtime as rt
+
+    def boom(*_a, **_kw):
+        raise PermissionError(13, "simulated permission denied")
+
+    # Swap in a failing os.open only for the lock-file call. Leave
+    # everything else alone so check_single_instance still works.
+    monkeypatch.setattr(rt.os, "open", boom)
+
+    with pytest.raises(PermissionError):
+        rt.acquire_single_instance(pid=os.getpid())
+
+
 def test_release_single_instance_is_idempotent(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     os.makedirs(tmp_path / ".vireo")

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -176,3 +176,67 @@ def test_guard_malformed_file_is_cleaned_and_proceeds(tmp_path, monkeypatch):
     status, info = check_single_instance()
     assert status == "proceed"
     assert not (tmp_path / ".vireo" / "runtime.json").exists()
+
+
+class _Always500Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(500)
+        self.end_headers()
+
+    def log_message(self, *a, **kw):  # silence
+        pass
+
+
+def _start_fake_500_server():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Always500Handler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return server, port
+
+
+def test_guard_bad_token_401_is_conflict_not_proceed(tmp_path, monkeypatch):
+    """A peer that responds 401 (stale token) must be treated as alive.
+
+    Regression: HTTPError subclasses URLError, so a naive except clause
+    swallowed 401/500 responses and misclassified a running peer as dead.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    server, port = _start_fake_server("goodtoken")
+    try:
+        runtime_path = tmp_path / ".vireo" / "runtime.json"
+        runtime_path.write_text(_json.dumps({
+            "port": port, "pid": 77777, "token": "WRONG-TOKEN",
+        }))
+        from runtime import check_single_instance
+        status, info = check_single_instance()
+        assert status == "conflict"
+        assert info["port"] == port
+        assert info["pid"] == 77777
+        # Critically: the runtime.json must NOT be deleted.
+        assert runtime_path.exists()
+    finally:
+        server.shutdown()
+
+
+def test_guard_peer_returning_500_is_conflict(tmp_path, monkeypatch):
+    """A peer responding 500 must be treated as alive — any HTTP response counts."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    server, port = _start_fake_500_server()
+    try:
+        runtime_path = tmp_path / ".vireo" / "runtime.json"
+        runtime_path.write_text(_json.dumps({
+            "port": port, "pid": 88888, "token": "anything",
+        }))
+        from runtime import check_single_instance
+        status, info = check_single_instance()
+        assert status == "conflict"
+        assert info["port"] == port
+        assert info["pid"] == 88888
+        assert runtime_path.exists()
+    finally:
+        server.shutdown()

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -1,0 +1,49 @@
+import json
+import os
+import stat
+
+
+def test_write_runtime_json_atomic_and_locked_down(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    from runtime import write_runtime_json
+
+    write_runtime_json(
+        port=54321,
+        pid=12345,
+        version="0.0.1",
+        db_path="/tmp/x.db",
+        token="tok",
+        mode="headless",
+    )
+
+    path = tmp_path / ".vireo" / "runtime.json"
+    assert path.exists()
+
+    data = json.loads(path.read_text())
+    assert data["port"] == 54321
+    assert data["pid"] == 12345
+    assert data["version"] == "0.0.1"
+    assert data["db_path"] == "/tmp/x.db"
+    assert data["token"] == "tok"
+    assert data["mode"] == "headless"
+    assert "started_at" in data  # ISO8601 timestamp
+
+    # chmod 600 — only the user can read the token
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    assert mode == 0o600
+
+
+def test_write_runtime_json_overwrites_existing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+    (tmp_path / ".vireo" / "runtime.json").write_text('{"stale": true}')
+
+    from runtime import write_runtime_json
+
+    write_runtime_json(port=1, pid=2, version="v", db_path="/x", token="t", mode="gui")
+
+    data = json.loads((tmp_path / ".vireo" / "runtime.json").read_text())
+    assert "stale" not in data
+    assert data["port"] == 1

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -308,6 +308,75 @@ def test_guard_unrelated_404_service_is_stale_and_proceeds(tmp_path, monkeypatch
         server.shutdown()
 
 
+def test_guard_preserves_runtime_json_when_probe_fails_and_holder_alive(
+    tmp_path, monkeypatch
+):
+    """Codex P1 regression: when a 2nd process probes during the 1st
+    instance's startup window (PID written but Flask not listening yet),
+    the probe raises connection-refused. Previously, check_single_instance
+    deleted the live instance's runtime.json, breaking discovery. With
+    the fix, we preserve the file if the holder PID is alive and return
+    conflict.
+    """
+    import socket as _socket
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    # Reserve a port then close it so the probe gets connection-refused.
+    sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    refused_port = sock.getsockname()[1]
+    sock.close()
+
+    runtime_path = tmp_path / ".vireo" / "runtime.json"
+    runtime_path.write_text(_json.dumps({
+        "port": refused_port,
+        "pid": os.getpid(),  # definitely alive
+        "token": "any",
+    }))
+
+    from runtime import check_single_instance
+    status, info = check_single_instance(probe_timeout_s=0.2)
+    assert status == "conflict"
+    assert info["port"] == refused_port
+    assert info["pid"] == os.getpid()
+    # Critically: file is NOT deleted while the holder is alive.
+    assert runtime_path.exists()
+
+
+def test_guard_deletes_runtime_json_when_probe_fails_and_holder_dead(
+    tmp_path, monkeypatch
+):
+    """Counterpart to the above: a dead-holder stale file is still cleaned up."""
+    import socket as _socket
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    refused_port = sock.getsockname()[1]
+    sock.close()
+
+    runtime_path = tmp_path / ".vireo" / "runtime.json"
+    # PID 1 on macOS/Linux is launchd/init — always alive. Use a high,
+    # implausible PID instead; pair with ProcessLookupError via direct mock.
+    # Simplest: patch _pid_alive via monkeypatch.
+    import runtime
+    monkeypatch.setattr(runtime, "_pid_alive", lambda _p: False)
+
+    runtime_path.write_text(_json.dumps({
+        "port": refused_port,
+        "pid": 99999,
+        "token": "any",
+    }))
+
+    status, _info = runtime.check_single_instance(probe_timeout_s=0.2)
+    assert status == "proceed"
+    assert not runtime_path.exists()
+
+
 def test_generate_token_is_random_and_urlsafe():
     from runtime import generate_token
     a = generate_token()

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -84,6 +84,33 @@ def test_write_runtime_json_atomic_and_locked_down(tmp_path, monkeypatch):
     assert mode == 0o600
 
 
+def test_write_runtime_json_tmp_file_is_never_world_readable(tmp_path, monkeypatch):
+    """The temp file holding the token must be 0600 from the moment it
+    exists on disk — not only after a trailing chmod. A later
+    write_text()+chmod sequence leaves a window where a co-tenant on a
+    multi-user host can read the auth token."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    import runtime as rt
+
+    observed = {}
+    real_replace = os.replace
+
+    def spy_replace(src, dst):
+        # Inspect the tmp file's mode right before it is renamed into place.
+        observed["tmp_mode"] = stat.S_IMODE(os.stat(src).st_mode)
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(rt.os, "replace", spy_replace)
+
+    rt.write_runtime_json(
+        port=1, pid=2, version="v", db_path="/x", token="secret", mode="headless"
+    )
+
+    assert observed["tmp_mode"] == 0o600
+
+
 def test_write_runtime_json_overwrites_existing(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     os.makedirs(tmp_path / ".vireo")

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -187,6 +187,17 @@ class _Always500Handler(http.server.BaseHTTPRequestHandler):
         pass
 
 
+class _Always404Handler(http.server.BaseHTTPRequestHandler):
+    """Simulates an unrelated local HTTP service that reused our port."""
+
+    def do_GET(self):
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, *a, **kw):  # silence
+        pass
+
+
 def _start_fake_500_server():
     server = http.server.HTTPServer(("127.0.0.1", 0), _Always500Handler)
     port = server.server_address[1]
@@ -195,11 +206,21 @@ def _start_fake_500_server():
     return server, port
 
 
-def test_guard_bad_token_401_is_conflict_not_proceed(tmp_path, monkeypatch):
-    """A peer that responds 401 (stale token) must be treated as alive.
+def _start_fake_404_server():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Always404Handler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return server, port
 
-    Regression: HTTPError subclasses URLError, so a naive except clause
-    swallowed 401/500 responses and misclassified a running peer as dead.
+
+def test_guard_401_is_stale_and_proceeds(tmp_path, monkeypatch):
+    """A peer that responds 401 must be treated as stale, not a live Vireo.
+
+    The token in runtime.json is always the one our own writer emitted for
+    the running instance, so a 401 implies the port was reused by an
+    unrelated local service (or state drift). Refusing to start on any
+    HTTP response caused a false `already_running` in that case.
     """
     monkeypatch.setenv("HOME", str(tmp_path))
     os.makedirs(tmp_path / ".vireo")
@@ -211,18 +232,15 @@ def test_guard_bad_token_401_is_conflict_not_proceed(tmp_path, monkeypatch):
             "port": port, "pid": 77777, "token": "WRONG-TOKEN",
         }))
         from runtime import check_single_instance
-        status, info = check_single_instance()
-        assert status == "conflict"
-        assert info["port"] == port
-        assert info["pid"] == 77777
-        # Critically: the runtime.json must NOT be deleted.
-        assert runtime_path.exists()
+        status, _info = check_single_instance()
+        assert status == "proceed"
+        assert not runtime_path.exists()
     finally:
         server.shutdown()
 
 
-def test_guard_peer_returning_500_is_conflict(tmp_path, monkeypatch):
-    """A peer responding 500 must be treated as alive — any HTTP response counts."""
+def test_guard_peer_returning_500_is_stale_and_proceeds(tmp_path, monkeypatch):
+    """A 500 response is not proof of a live Vireo peer — treat as stale."""
     monkeypatch.setenv("HOME", str(tmp_path))
     os.makedirs(tmp_path / ".vireo")
 
@@ -233,11 +251,29 @@ def test_guard_peer_returning_500_is_conflict(tmp_path, monkeypatch):
             "port": port, "pid": 88888, "token": "anything",
         }))
         from runtime import check_single_instance
-        status, info = check_single_instance()
-        assert status == "conflict"
-        assert info["port"] == port
-        assert info["pid"] == 88888
-        assert runtime_path.exists()
+        status, _info = check_single_instance()
+        assert status == "proceed"
+        assert not runtime_path.exists()
+    finally:
+        server.shutdown()
+
+
+def test_guard_unrelated_404_service_is_stale_and_proceeds(tmp_path, monkeypatch):
+    """If the advertised port is now answered by an unrelated HTTP service,
+    treat runtime.json as stale so Vireo can start on a fresh port."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    server, port = _start_fake_404_server()
+    try:
+        runtime_path = tmp_path / ".vireo" / "runtime.json"
+        runtime_path.write_text(_json.dumps({
+            "port": port, "pid": 66666, "token": "anything",
+        }))
+        from runtime import check_single_instance
+        status, _info = check_single_instance()
+        assert status == "proceed"
+        assert not runtime_path.exists()
     finally:
         server.shutdown()
 
@@ -251,3 +287,149 @@ def test_generate_token_is_random_and_urlsafe():
     # URL-safe base64: only alphanumerics and -_
     import re
     assert re.fullmatch(r"[A-Za-z0-9_-]+", a)
+
+
+# ---------------------------------------------------------------------------
+# acquire_single_instance — atomic reservation via runtime.lock
+# ---------------------------------------------------------------------------
+
+
+def test_acquire_on_empty_slot_creates_lock(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    from runtime import acquire_single_instance
+    status, info = acquire_single_instance(pid=os.getpid())
+    assert status == "acquired"
+    assert info is None
+
+    lock_path = tmp_path / ".vireo" / "runtime.lock"
+    assert lock_path.exists()
+    assert lock_path.read_text().strip() == str(os.getpid())
+    # External runtime.json must not be created by the reservation step.
+    assert not (tmp_path / ".vireo" / "runtime.json").exists()
+
+
+def test_acquire_conflicts_with_healthy_peer(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    server, port = _start_fake_server("goodtoken")
+    try:
+        runtime_path = tmp_path / ".vireo" / "runtime.json"
+        runtime_path.write_text(_json.dumps({
+            "port": port, "pid": 12345, "token": "goodtoken",
+        }))
+        from runtime import acquire_single_instance
+        status, info = acquire_single_instance(pid=os.getpid())
+        assert status == "conflict"
+        assert info["port"] == port
+        assert info["pid"] == 12345
+        # The live peer's runtime.json must not have been touched.
+        assert runtime_path.exists()
+    finally:
+        server.shutdown()
+
+
+def test_acquire_replaces_stale_runtime_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    runtime_path = tmp_path / ".vireo" / "runtime.json"
+    # Port 1 is not bound by anything listening — probe will fail.
+    runtime_path.write_text(_json.dumps({
+        "port": 1, "pid": 99999, "token": "stale",
+    }))
+
+    from runtime import acquire_single_instance
+    status, _info = acquire_single_instance(pid=os.getpid())
+    assert status == "acquired"
+    # Stale runtime.json was cleaned up by the probe.
+    assert not runtime_path.exists()
+    assert (tmp_path / ".vireo" / "runtime.lock").exists()
+
+
+def test_acquire_conflicts_with_lock_from_live_pid(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    lock_path = tmp_path / ".vireo" / "runtime.lock"
+    lock_path.write_text(str(os.getpid()))  # live PID
+
+    from runtime import acquire_single_instance
+    status, info = acquire_single_instance(pid=os.getpid() + 1)
+    assert status == "conflict"
+    assert info["pid"] == os.getpid()
+    # Lock must still exist — we did not steal it.
+    assert lock_path.exists()
+
+
+def test_acquire_clears_stale_lock(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    lock_path = tmp_path / ".vireo" / "runtime.lock"
+    lock_path.write_text("0")  # PID 0 is never a real process
+
+    from runtime import acquire_single_instance
+    status, _info = acquire_single_instance(pid=os.getpid())
+    assert status == "acquired"
+    # The stale lock was replaced by ours.
+    assert lock_path.read_text().strip() == str(os.getpid())
+
+
+def test_acquire_handles_garbage_lock_contents(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    lock_path = tmp_path / ".vireo" / "runtime.lock"
+    lock_path.write_text("not a pid")
+
+    from runtime import acquire_single_instance
+    status, _info = acquire_single_instance(pid=os.getpid())
+    assert status == "acquired"
+
+
+def test_release_single_instance_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    lock_path = tmp_path / ".vireo" / "runtime.lock"
+    lock_path.write_text(str(os.getpid()))
+
+    from runtime import release_single_instance
+    release_single_instance()
+    assert not lock_path.exists()
+    release_single_instance()  # second call must not raise
+
+
+def test_acquire_is_atomic_across_concurrent_calls(tmp_path, monkeypatch):
+    """Two threads racing to acquire: exactly one wins, the other conflicts."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    from runtime import acquire_single_instance
+
+    results = []
+    errors = []
+    start = threading.Event()
+
+    def worker():
+        start.wait()
+        try:
+            # Both workers pass our own PID so the loser's probe of the
+            # winner's PID classifies the holder as alive.
+            results.append(acquire_single_instance(pid=os.getpid()))
+        except Exception as e:  # pragma: no cover — shouldn't happen
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for t in threads:
+        t.start()
+    start.set()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert not errors
+    statuses = sorted(s for s, _ in results)
+    assert statuses == ["acquired", "conflict"]

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -725,16 +725,88 @@ def test_acquire_surfaces_lock_open_errors_not_conflict(tmp_path, monkeypatch):
 
 
 def test_release_single_instance_is_idempotent(tmp_path, monkeypatch):
+    """release() must be idempotent and leave the lock file on disk.
+
+    We intentionally keep runtime.lock around after release — flock binds
+    to inodes, so unlinking creates a race where a surviving opener on
+    the old inode and a new starter on a fresh inode can both hold locks
+    simultaneously. Leaving the file in place forces convergence on one
+    inode."""
     monkeypatch.setenv("HOME", str(tmp_path))
     os.makedirs(tmp_path / ".vireo")
 
-    lock_path = tmp_path / ".vireo" / "runtime.lock"
-    lock_path.write_text(str(os.getpid()))
+    from runtime import acquire_single_instance, release_single_instance
 
-    from runtime import release_single_instance
+    status, _ = acquire_single_instance(pid=os.getpid())
+    assert status == "acquired"
+
+    lock_path = tmp_path / ".vireo" / "runtime.lock"
+    assert lock_path.exists()
+
     release_single_instance()
-    assert not lock_path.exists()
+    # File is deliberately preserved — see docstring.
+    assert lock_path.exists()
     release_single_instance()  # second call must not raise
+
+
+def test_release_then_reacquire_converges_on_same_inode(tmp_path, monkeypatch):
+    """After release, a subsequent acquire must lock the same inode.
+
+    If release() unlinked the lock file, a newcomer could open a brand-new
+    inode and hold a lock concurrently with a lingering opener on the old
+    inode, defeating the single-instance guarantee. This test verifies
+    the inode number does not change across a release/re-acquire cycle."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+    lock_path = tmp_path / ".vireo" / "runtime.lock"
+
+    from runtime import acquire_single_instance, release_single_instance
+
+    status, _ = acquire_single_instance(pid=os.getpid())
+    assert status == "acquired"
+    inode_before = os.stat(lock_path).st_ino
+
+    release_single_instance()
+
+    status, _ = acquire_single_instance(pid=os.getpid())
+    assert status == "acquired"
+    inode_after = os.stat(lock_path).st_ino
+
+    assert inode_before == inode_after
+
+
+def test_write_runtime_json_survives_partial_os_write(tmp_path, monkeypatch):
+    """os.write is allowed to do partial writes even on regular files under
+    signal/resource pressure. write_runtime_json must loop until the full
+    payload has been flushed; otherwise os.replace atomically promotes a
+    truncated (malformed) JSON file and discovery fails."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    import runtime as rt
+
+    real_write = os.write
+    call_count = {"n": 0}
+
+    def chunked_write(fd, buf):
+        # First call writes 1 byte, subsequent calls flush the rest —
+        # forces the caller's loop to iterate.
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return real_write(fd, bytes(buf[:1]))
+        return real_write(fd, bytes(buf))
+
+    monkeypatch.setattr(rt.os, "write", chunked_write)
+
+    rt.write_runtime_json(
+        port=1, pid=2, version="v", db_path="/x", token="tok", mode="headless"
+    )
+
+    # File must exist and be fully-formed JSON.
+    data = json.loads((tmp_path / ".vireo" / "runtime.json").read_text())
+    assert data["token"] == "tok"
+    assert data["port"] == 1
+    assert call_count["n"] >= 2  # loop actually iterated
 
 
 def test_acquire_is_atomic_across_concurrent_calls(tmp_path, monkeypatch):

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -161,7 +161,8 @@ class _HealthHandler(http.server.BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.end_headers()
-        self.wfile.write(b'{"status":"ok"}')
+        # Carry the Vireo service marker the probe validates.
+        self.wfile.write(b'{"service":"vireo","status":"ok"}')
 
     def log_message(self, *a, **kw):  # silence
         pass
@@ -341,6 +342,52 @@ def test_guard_booting_peer_preserves_runtime_json(tmp_path, monkeypatch):
     finally:
         holder.terminate()
         holder.wait(timeout=5)
+
+
+class _CatchAll200Handler(http.server.BaseHTTPRequestHandler):
+    """Simulates an unrelated local service that returns 200 for everything,
+    including /api/v1/health — but without the Vireo service marker."""
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"status":"ok"}')
+
+    def log_message(self, *a, **kw):  # silence
+        pass
+
+
+def _start_fake_catchall_server():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _CatchAll200Handler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return server, port
+
+
+def test_guard_unrelated_200_without_service_marker_is_stale(tmp_path, monkeypatch):
+    """Codex P2 regression: a 200 alone is not proof of a live Vireo peer —
+    an unrelated local service that happens to bind Vireo's old port and
+    returns 200 for /api/v1/health would falsely cause `already_running`.
+    The probe now also validates a Vireo-specific service marker in the
+    response body.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    server, port = _start_fake_catchall_server()
+    try:
+        runtime_path = tmp_path / ".vireo" / "runtime.json"
+        runtime_path.write_text(_json.dumps({
+            "port": port, "pid": 55555, "token": "anything",
+        }))
+        from runtime import check_single_instance
+        status, _info = check_single_instance()
+        assert status == "proceed"
+        assert not runtime_path.exists()
+    finally:
+        server.shutdown()
 
 
 def test_guard_unrelated_404_service_is_stale_and_proceeds(tmp_path, monkeypatch):

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -267,7 +267,9 @@ def test_guard_booting_peer_preserves_runtime_json(tmp_path, monkeypatch):
 
     Reproduce by pointing runtime.json at a port where nobody is
     listening (probe will fail with connection-refused) while recording
-    a live PID. The guard should report conflict and keep the file.
+    a live PID and a matching `runtime.lock` (the booting peer holds
+    its reservation lock). The guard should report conflict and keep
+    the file.
     """
     monkeypatch.setenv("HOME", str(tmp_path))
     os.makedirs(tmp_path / ".vireo")
@@ -278,6 +280,8 @@ def test_guard_booting_peer_preserves_runtime_json(tmp_path, monkeypatch):
         "pid": os.getpid(),  # live PID → peer is booting, not dead
         "token": "anything",
     }))
+    # A real booting peer has acquired runtime.lock with its PID.
+    (tmp_path / ".vireo" / "runtime.lock").write_text(str(os.getpid()))
 
     from runtime import check_single_instance
     status, info = check_single_instance()
@@ -315,8 +319,8 @@ def test_guard_preserves_runtime_json_when_probe_fails_and_holder_alive(
     instance's startup window (PID written but Flask not listening yet),
     the probe raises connection-refused. Previously, check_single_instance
     deleted the live instance's runtime.json, breaking discovery. With
-    the fix, we preserve the file if the holder PID is alive and return
-    conflict.
+    the fix, we preserve the file when the holder PID is alive *and*
+    `runtime.lock` confirms the same PID.
     """
     import socket as _socket
 
@@ -335,6 +339,8 @@ def test_guard_preserves_runtime_json_when_probe_fails_and_holder_alive(
         "pid": os.getpid(),  # definitely alive
         "token": "any",
     }))
+    # A real booting peer holds the matching reservation lock.
+    (tmp_path / ".vireo" / "runtime.lock").write_text(str(os.getpid()))
 
     from runtime import check_single_instance
     status, info = check_single_instance(probe_timeout_s=0.2)
@@ -343,6 +349,73 @@ def test_guard_preserves_runtime_json_when_probe_fails_and_holder_alive(
     assert info["pid"] == os.getpid()
     # Critically: file is NOT deleted while the holder is alive.
     assert runtime_path.exists()
+
+
+def test_guard_deletes_runtime_json_when_probe_fails_and_lock_missing(
+    tmp_path, monkeypatch
+):
+    """Codex P2 regression: PID liveness alone is not proof of a Vireo
+    peer — after a SIGKILL crash, the recorded PID can be recycled by
+    an unrelated process. If runtime.lock is missing while runtime.json
+    points to a port that refuses connections, we must treat the file
+    as stale (and clean it up) rather than pinning `already_running`
+    indefinitely.
+    """
+    import socket as _socket
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    refused_port = sock.getsockname()[1]
+    sock.close()
+
+    runtime_path = tmp_path / ".vireo" / "runtime.json"
+    runtime_path.write_text(_json.dumps({
+        "port": refused_port,
+        "pid": os.getpid(),  # alive, but not Vireo (no matching lock)
+        "token": "any",
+    }))
+    # Crucially: no runtime.lock — recycled PID, not a real peer.
+    assert not (tmp_path / ".vireo" / "runtime.lock").exists()
+
+    from runtime import check_single_instance
+    status, _info = check_single_instance(probe_timeout_s=0.2)
+    assert status == "proceed"
+    assert not runtime_path.exists()
+
+
+def test_guard_deletes_runtime_json_when_probe_fails_and_lock_pid_mismatches(
+    tmp_path, monkeypatch
+):
+    """Codex P2 regression (variant): runtime.lock exists but holds a
+    different PID than runtime.json — strong evidence runtime.json is
+    stale (e.g., partial cleanup state). Treat as stale.
+    """
+    import socket as _socket
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    refused_port = sock.getsockname()[1]
+    sock.close()
+
+    runtime_path = tmp_path / ".vireo" / "runtime.json"
+    runtime_path.write_text(_json.dumps({
+        "port": refused_port,
+        "pid": os.getpid(),  # alive
+        "token": "any",
+    }))
+    # Lock claims a different (live) PID — could not be the same Vireo.
+    (tmp_path / ".vireo" / "runtime.lock").write_text(str(os.getpid() + 1))
+
+    from runtime import check_single_instance
+    status, _info = check_single_instance(probe_timeout_s=0.2)
+    assert status == "proceed"
+    assert not runtime_path.exists()
 
 
 def test_guard_deletes_runtime_json_when_probe_fails_and_holder_dead(

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -156,6 +156,20 @@ def test_read_runtime_json_malformed_returns_none(tmp_path, monkeypatch):
     assert read_runtime_json() is None
 
 
+def test_read_runtime_json_non_utf8_returns_none(tmp_path, monkeypatch):
+    """A corrupted runtime.json containing non-UTF-8 bytes must be treated
+    as malformed and cleaned up, NOT raise UnicodeDecodeError out of
+    startup and block launching until the user manually deletes it."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+    # 0xff / 0xfe / 0xfd are invalid as a UTF-8 start byte.
+    (tmp_path / ".vireo" / "runtime.json").write_bytes(b"\xff\xfe\xfd")
+
+    from runtime import read_runtime_json
+
+    assert read_runtime_json() is None
+
+
 def test_delete_runtime_json_is_idempotent(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     os.makedirs(tmp_path / ".vireo")
@@ -722,6 +736,30 @@ def test_acquire_surfaces_lock_open_errors_not_conflict(tmp_path, monkeypatch):
 
     with pytest.raises(PermissionError):
         rt.acquire_single_instance(pid=os.getpid())
+
+
+def test_acquire_surfaces_diag_write_failure_not_conflict(tmp_path, monkeypatch):
+    """If writing the diagnostic PID into runtime.lock fails (ENOSPC, EIO),
+    acquire_single_instance must surface the OSError — not swallow it and
+    retry, which would eventually return ('conflict', ...) and cause
+    main() to misreport a filesystem fault as already_running."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    import runtime as rt
+
+    def boom(*_a, **_kw):
+        raise OSError(28, "simulated ENOSPC")
+
+    # Only ftruncate raises — os.open, os.lseek still work, so the lock
+    # is actually acquired before the failing diagnostic write.
+    monkeypatch.setattr(rt.os, "ftruncate", boom)
+
+    with pytest.raises(OSError):
+        rt.acquire_single_instance(pid=os.getpid())
+
+    # Lock must not remain held by this process — a subsequent acquire
+    # (with ftruncate restored by monkeypatch teardown) must succeed.
 
 
 def test_release_single_instance_is_idempotent(tmp_path, monkeypatch):

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -47,3 +47,46 @@ def test_write_runtime_json_overwrites_existing(tmp_path, monkeypatch):
     data = json.loads((tmp_path / ".vireo" / "runtime.json").read_text())
     assert "stale" not in data
     assert data["port"] == 1
+
+
+def test_read_runtime_json_returns_dict(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+    (tmp_path / ".vireo" / "runtime.json").write_text(
+        '{"port": 1234, "token": "abc"}'
+    )
+
+    from runtime import read_runtime_json
+
+    data = read_runtime_json()
+    assert data == {"port": 1234, "token": "abc"}
+
+
+def test_read_runtime_json_missing_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    from runtime import read_runtime_json
+
+    assert read_runtime_json() is None
+
+
+def test_read_runtime_json_malformed_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+    (tmp_path / ".vireo" / "runtime.json").write_text("not json{{{")
+
+    from runtime import read_runtime_json
+
+    assert read_runtime_json() is None
+
+
+def test_delete_runtime_json_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+    (tmp_path / ".vireo" / "runtime.json").write_text("{}")
+
+    from runtime import delete_runtime_json
+
+    delete_runtime_json()
+    assert not (tmp_path / ".vireo" / "runtime.json").exists()
+    delete_runtime_json()  # second call should not raise

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -1,6 +1,55 @@
 import json
 import os
 import stat
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_lock_state():
+    """Ensure each test starts with a clean flock / module-global state.
+
+    The single-instance guard keeps the lock fd on a module global so
+    the kernel-managed flock persists across function calls within a
+    process. In tests, that state leaks between test cases, so we
+    release any held flock before and after each test.
+    """
+    import runtime  # noqa: PLC0415
+    runtime.release_single_instance()
+    yield
+    runtime.release_single_instance()
+
+
+def _spawn_flock_holder(lock_path):
+    """Spawn a subprocess that takes an exclusive fcntl.flock on lock_path
+    and holds it until killed. Returns the Popen handle; caller must
+    terminate it in a finally block.
+
+    Used to simulate a real live-peer flock holder in tests. We cannot
+    simply write to the lock file, because the guard now trusts the
+    kernel-managed flock, not the PID bytes inside the file.
+    """
+    code = (
+        "import fcntl, os, sys, time;"
+        f"fd = os.open({str(lock_path)!r}, os.O_CREAT | os.O_RDWR, 0o600);"
+        "fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB);"
+        "os.ftruncate(fd, 0);"
+        "os.write(fd, str(os.getpid()).encode());"
+        "sys.stdout.write(str(os.getpid()) + '\\n');"
+        "sys.stdout.flush();"
+        "time.sleep(60)"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    # Wait for the holder to signal ready (its PID on stdout).
+    line = proc.stdout.readline().decode().strip()
+    assert line.isdigit(), f"holder did not signal ready: {line!r}"
+    return proc, int(line)
 
 
 def test_write_runtime_json_atomic_and_locked_down(tmp_path, monkeypatch):
@@ -265,31 +314,33 @@ def test_guard_booting_peer_preserves_runtime_json(tmp_path, monkeypatch):
     not have its runtime.json deleted — that would break discovery for
     external callers even though the peer is still running.
 
-    Reproduce by pointing runtime.json at a port where nobody is
-    listening (probe will fail with connection-refused) while recording
-    a live PID and a matching `runtime.lock` (the booting peer holds
-    its reservation lock). The guard should report conflict and keep
-    the file.
+    The guard trusts the kernel-managed flock to decide whether the peer
+    is alive. We simulate the booting peer by spawning a subprocess that
+    actually holds the flock while the HTTP port is unbound.
     """
     monkeypatch.setenv("HOME", str(tmp_path))
     os.makedirs(tmp_path / ".vireo")
 
-    runtime_path = tmp_path / ".vireo" / "runtime.json"
-    runtime_path.write_text(_json.dumps({
-        "port": 1,  # nothing listening → connection refused
-        "pid": os.getpid(),  # live PID → peer is booting, not dead
-        "token": "anything",
-    }))
-    # A real booting peer has acquired runtime.lock with its PID.
-    (tmp_path / ".vireo" / "runtime.lock").write_text(str(os.getpid()))
+    lock_path = tmp_path / ".vireo" / "runtime.lock"
+    holder, holder_pid = _spawn_flock_holder(lock_path)
+    try:
+        runtime_path = tmp_path / ".vireo" / "runtime.json"
+        runtime_path.write_text(_json.dumps({
+            "port": 1,  # nothing listening → connection refused
+            "pid": holder_pid,
+            "token": "anything",
+        }))
 
-    from runtime import check_single_instance
-    status, info = check_single_instance()
-    assert status == "conflict"
-    assert info["port"] == 1
-    assert info["pid"] == os.getpid()
-    # The live peer's runtime.json must remain intact.
-    assert runtime_path.exists()
+        from runtime import check_single_instance
+        status, info = check_single_instance()
+        assert status == "conflict"
+        assert info["port"] == 1
+        assert info["pid"] == holder_pid
+        # The live peer's runtime.json must remain intact.
+        assert runtime_path.exists()
+    finally:
+        holder.terminate()
+        holder.wait(timeout=5)
 
 
 def test_guard_unrelated_404_service_is_stale_and_proceeds(tmp_path, monkeypatch):
@@ -316,11 +367,11 @@ def test_guard_preserves_runtime_json_when_probe_fails_and_holder_alive(
     tmp_path, monkeypatch
 ):
     """Codex P1 regression: when a 2nd process probes during the 1st
-    instance's startup window (PID written but Flask not listening yet),
-    the probe raises connection-refused. Previously, check_single_instance
-    deleted the live instance's runtime.json, breaking discovery. With
-    the fix, we preserve the file when the holder PID is alive *and*
-    `runtime.lock` confirms the same PID.
+    instance's startup window (runtime.json written but Flask not
+    listening yet), the probe raises connection-refused. Previously,
+    check_single_instance deleted the live instance's runtime.json,
+    breaking discovery. With the fix we trust the kernel flock: a held
+    flock means a live Vireo peer, so preserve the file and conflict.
     """
     import socket as _socket
 
@@ -333,33 +384,40 @@ def test_guard_preserves_runtime_json_when_probe_fails_and_holder_alive(
     refused_port = sock.getsockname()[1]
     sock.close()
 
-    runtime_path = tmp_path / ".vireo" / "runtime.json"
-    runtime_path.write_text(_json.dumps({
-        "port": refused_port,
-        "pid": os.getpid(),  # definitely alive
-        "token": "any",
-    }))
-    # A real booting peer holds the matching reservation lock.
-    (tmp_path / ".vireo" / "runtime.lock").write_text(str(os.getpid()))
+    lock_path = tmp_path / ".vireo" / "runtime.lock"
+    holder, holder_pid = _spawn_flock_holder(lock_path)
+    try:
+        runtime_path = tmp_path / ".vireo" / "runtime.json"
+        runtime_path.write_text(_json.dumps({
+            "port": refused_port,
+            "pid": holder_pid,
+            "token": "any",
+        }))
 
-    from runtime import check_single_instance
-    status, info = check_single_instance(probe_timeout_s=0.2)
-    assert status == "conflict"
-    assert info["port"] == refused_port
-    assert info["pid"] == os.getpid()
-    # Critically: file is NOT deleted while the holder is alive.
-    assert runtime_path.exists()
+        from runtime import check_single_instance
+        status, info = check_single_instance(probe_timeout_s=0.2)
+        assert status == "conflict"
+        assert info["port"] == refused_port
+        assert info["pid"] == holder_pid
+        # Critically: file is NOT deleted while the flock is held.
+        assert runtime_path.exists()
+    finally:
+        holder.terminate()
+        holder.wait(timeout=5)
 
 
-def test_guard_deletes_runtime_json_when_probe_fails_and_lock_missing(
+def test_guard_deletes_runtime_json_when_probe_fails_and_lock_unheld(
     tmp_path, monkeypatch
 ):
-    """Codex P2 regression: PID liveness alone is not proof of a Vireo
-    peer — after a SIGKILL crash, the recorded PID can be recycled by
-    an unrelated process. If runtime.lock is missing while runtime.json
-    points to a port that refuses connections, we must treat the file
-    as stale (and clean it up) rather than pinning `already_running`
-    indefinitely.
+    """Self-healing regression (Codex P2): if runtime.json is stale after
+    a hard crash — recorded PID may even have been recycled — but no
+    process holds the flock, the guard must classify the file as stale
+    and clean it up so the next startup can proceed.
+
+    Before the flock-based guard, check_single_instance trusted `pid_alive`
+    alone, and a recycled PID would cause conflict indefinitely. With
+    the flock-based guard, the kernel releases the flock when the crashed
+    process dies, so "unheld flock" reliably means "stale".
     """
     import socket as _socket
 
@@ -371,81 +429,19 @@ def test_guard_deletes_runtime_json_when_probe_fails_and_lock_missing(
     refused_port = sock.getsockname()[1]
     sock.close()
 
+    # Leftover lock file from crashed process — no live flock on it.
+    lock_path = tmp_path / ".vireo" / "runtime.lock"
+    lock_path.write_text(str(os.getpid()))  # PID looks alive, but no flock
+
     runtime_path = tmp_path / ".vireo" / "runtime.json"
     runtime_path.write_text(_json.dumps({
         "port": refused_port,
-        "pid": os.getpid(),  # alive, but not Vireo (no matching lock)
+        "pid": os.getpid(),  # would fool a naive PID check
         "token": "any",
     }))
-    # Crucially: no runtime.lock — recycled PID, not a real peer.
-    assert not (tmp_path / ".vireo" / "runtime.lock").exists()
 
     from runtime import check_single_instance
     status, _info = check_single_instance(probe_timeout_s=0.2)
-    assert status == "proceed"
-    assert not runtime_path.exists()
-
-
-def test_guard_deletes_runtime_json_when_probe_fails_and_lock_pid_mismatches(
-    tmp_path, monkeypatch
-):
-    """Codex P2 regression (variant): runtime.lock exists but holds a
-    different PID than runtime.json — strong evidence runtime.json is
-    stale (e.g., partial cleanup state). Treat as stale.
-    """
-    import socket as _socket
-
-    monkeypatch.setenv("HOME", str(tmp_path))
-    os.makedirs(tmp_path / ".vireo")
-
-    sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    refused_port = sock.getsockname()[1]
-    sock.close()
-
-    runtime_path = tmp_path / ".vireo" / "runtime.json"
-    runtime_path.write_text(_json.dumps({
-        "port": refused_port,
-        "pid": os.getpid(),  # alive
-        "token": "any",
-    }))
-    # Lock claims a different (live) PID — could not be the same Vireo.
-    (tmp_path / ".vireo" / "runtime.lock").write_text(str(os.getpid() + 1))
-
-    from runtime import check_single_instance
-    status, _info = check_single_instance(probe_timeout_s=0.2)
-    assert status == "proceed"
-    assert not runtime_path.exists()
-
-
-def test_guard_deletes_runtime_json_when_probe_fails_and_holder_dead(
-    tmp_path, monkeypatch
-):
-    """Counterpart to the above: a dead-holder stale file is still cleaned up."""
-    import socket as _socket
-
-    monkeypatch.setenv("HOME", str(tmp_path))
-    os.makedirs(tmp_path / ".vireo")
-
-    sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    refused_port = sock.getsockname()[1]
-    sock.close()
-
-    runtime_path = tmp_path / ".vireo" / "runtime.json"
-    # PID 1 on macOS/Linux is launchd/init — always alive. Use a high,
-    # implausible PID instead; pair with ProcessLookupError via direct mock.
-    # Simplest: patch _pid_alive via monkeypatch.
-    import runtime
-    monkeypatch.setattr(runtime, "_pid_alive", lambda _p: False)
-
-    runtime_path.write_text(_json.dumps({
-        "port": refused_port,
-        "pid": 99999,
-        "token": "any",
-    }))
-
-    status, _info = runtime.check_single_instance(probe_timeout_s=0.2)
     assert status == "proceed"
     assert not runtime_path.exists()
 
@@ -525,48 +521,86 @@ def test_acquire_replaces_stale_runtime_json(tmp_path, monkeypatch):
 
 def test_acquire_preserves_runtime_json_when_peer_is_booting(tmp_path, monkeypatch):
     """When `acquire_single_instance` finds a runtime.json whose HTTP
-    probe fails (connection refused) but whose PID is still alive, it
-    must report conflict without wiping the peer's runtime.json.
+    probe fails (connection refused) but another process holds the
+    flock, it must report conflict without wiping the peer's files.
 
     Regression for the race where a second process starts while the
-    first is mid-boot: the first process has written runtime.json and
-    holds runtime.lock but hasn't opened its HTTP port yet.
+    first is mid-boot: the first process has taken the flock and
+    written runtime.json but hasn't opened its HTTP port yet.
     """
     monkeypatch.setenv("HOME", str(tmp_path))
     os.makedirs(tmp_path / ".vireo")
 
-    runtime_path = tmp_path / ".vireo" / "runtime.json"
-    runtime_path.write_text(_json.dumps({
-        "port": 1,  # nothing listening
-        "pid": os.getpid(),  # peer is alive, just not serving yet
-        "token": "anything",
-    }))
     lock_path = tmp_path / ".vireo" / "runtime.lock"
-    lock_path.write_text(str(os.getpid()))
+    holder, holder_pid = _spawn_flock_holder(lock_path)
+    try:
+        runtime_path = tmp_path / ".vireo" / "runtime.json"
+        runtime_path.write_text(_json.dumps({
+            "port": 1,  # nothing listening
+            "pid": holder_pid,
+            "token": "anything",
+        }))
 
-    from runtime import acquire_single_instance
-    status, info = acquire_single_instance(pid=os.getpid() + 1)
-    assert status == "conflict"
-    assert info["pid"] == os.getpid()
-    # External discovery must still work — do not delete the peer's file.
-    assert runtime_path.exists()
-    # Lock must be preserved too.
-    assert lock_path.exists()
+        from runtime import acquire_single_instance
+        status, info = acquire_single_instance(pid=os.getpid())
+        assert status == "conflict"
+        assert info["pid"] == holder_pid
+        # External discovery must still work — do not delete the peer's file.
+        assert runtime_path.exists()
+        # Lock file must be preserved too.
+        assert lock_path.exists()
+    finally:
+        holder.terminate()
+        holder.wait(timeout=5)
 
 
-def test_acquire_conflicts_with_lock_from_live_pid(tmp_path, monkeypatch):
+def test_acquire_conflicts_with_held_flock(tmp_path, monkeypatch):
+    """If another process holds the flock on runtime.lock, acquire must
+    report conflict. We spawn a real flock holder rather than planting
+    a text file, because the guard trusts the kernel-managed lock, not
+    the PID bytes inside the file (which would be vulnerable to PID
+    recycling after an unclean crash)."""
     monkeypatch.setenv("HOME", str(tmp_path))
     os.makedirs(tmp_path / ".vireo")
 
     lock_path = tmp_path / ".vireo" / "runtime.lock"
-    lock_path.write_text(str(os.getpid()))  # live PID
+    holder, holder_pid = _spawn_flock_holder(lock_path)
+    try:
+        from runtime import acquire_single_instance
+        status, info = acquire_single_instance(pid=os.getpid())
+        assert status == "conflict"
+        assert info["pid"] == holder_pid
+        # Lock must still exist — we did not steal it.
+        assert lock_path.exists()
+    finally:
+        holder.terminate()
+        holder.wait(timeout=5)
 
-    from runtime import acquire_single_instance
-    status, info = acquire_single_instance(pid=os.getpid() + 1)
-    assert status == "conflict"
-    assert info["pid"] == os.getpid()
-    # Lock must still exist — we did not steal it.
-    assert lock_path.exists()
+
+def test_acquire_self_heals_after_crash_with_pid_recycling(tmp_path, monkeypatch):
+    """Self-healing regression (Codex P2): after an unclean crash the
+    lock file persists, but the kernel releases the flock. Even if the
+    dead PID has been recycled to an unrelated process, the next startup
+    must reclaim the slot. The file-level liveness check alone would
+    falsely conflict here — only the kernel-managed flock gets this right.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    lock_path = tmp_path / ".vireo" / "runtime.lock"
+    # Simulate a crashed process's leftover lock file. PID bytes look
+    # alive (we use our own PID — the test process), but no flock is
+    # held on the file.
+    lock_path.write_text(str(os.getpid()))
+
+    from runtime import acquire_single_instance, release_single_instance
+    try:
+        status, _info = acquire_single_instance(pid=os.getpid())
+        assert status == "acquired"
+        # Our PID is now recorded in the lock file.
+        assert lock_path.read_text().strip() == str(os.getpid())
+    finally:
+        release_single_instance()
 
 
 def test_acquire_clears_stale_lock(tmp_path, monkeypatch):

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -156,9 +156,11 @@ def test_guard_stale_file_is_cleaned_and_proceeds(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     os.makedirs(tmp_path / ".vireo")
 
-    # Port 1 is almost certainly not bound by anything listening.
+    # Port 1 is almost certainly not bound by anything listening. PID 0 is
+    # treated as unconditionally dead by the liveness check, so the guard
+    # must classify this file as stale.
     (tmp_path / ".vireo" / "runtime.json").write_text(_json.dumps({
-        "port": 1, "pid": 99999, "token": "x",
+        "port": 1, "pid": 0, "token": "x",
     }))
 
     from runtime import check_single_instance
@@ -258,6 +260,34 @@ def test_guard_peer_returning_500_is_stale_and_proceeds(tmp_path, monkeypatch):
         server.shutdown()
 
 
+def test_guard_booting_peer_preserves_runtime_json(tmp_path, monkeypatch):
+    """A peer that wrote runtime.json but isn't listening on HTTP yet must
+    not have its runtime.json deleted — that would break discovery for
+    external callers even though the peer is still running.
+
+    Reproduce by pointing runtime.json at a port where nobody is
+    listening (probe will fail with connection-refused) while recording
+    a live PID. The guard should report conflict and keep the file.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    runtime_path = tmp_path / ".vireo" / "runtime.json"
+    runtime_path.write_text(_json.dumps({
+        "port": 1,  # nothing listening → connection refused
+        "pid": os.getpid(),  # live PID → peer is booting, not dead
+        "token": "anything",
+    }))
+
+    from runtime import check_single_instance
+    status, info = check_single_instance()
+    assert status == "conflict"
+    assert info["port"] == 1
+    assert info["pid"] == os.getpid()
+    # The live peer's runtime.json must remain intact.
+    assert runtime_path.exists()
+
+
 def test_guard_unrelated_404_service_is_stale_and_proceeds(tmp_path, monkeypatch):
     """If the advertised port is now answered by an unrelated HTTP service,
     treat runtime.json as stale so Vireo can start on a fresh port."""
@@ -336,9 +366,11 @@ def test_acquire_replaces_stale_runtime_json(tmp_path, monkeypatch):
     os.makedirs(tmp_path / ".vireo")
 
     runtime_path = tmp_path / ".vireo" / "runtime.json"
-    # Port 1 is not bound by anything listening — probe will fail.
+    # Port 1 is not bound by anything listening — probe will fail. PID 0
+    # is unconditionally dead, so the guard must classify the file as
+    # stale rather than treating it as a booting peer.
     runtime_path.write_text(_json.dumps({
-        "port": 1, "pid": 99999, "token": "stale",
+        "port": 1, "pid": 0, "token": "stale",
     }))
 
     from runtime import acquire_single_instance
@@ -347,6 +379,37 @@ def test_acquire_replaces_stale_runtime_json(tmp_path, monkeypatch):
     # Stale runtime.json was cleaned up by the probe.
     assert not runtime_path.exists()
     assert (tmp_path / ".vireo" / "runtime.lock").exists()
+
+
+def test_acquire_preserves_runtime_json_when_peer_is_booting(tmp_path, monkeypatch):
+    """When `acquire_single_instance` finds a runtime.json whose HTTP
+    probe fails (connection refused) but whose PID is still alive, it
+    must report conflict without wiping the peer's runtime.json.
+
+    Regression for the race where a second process starts while the
+    first is mid-boot: the first process has written runtime.json and
+    holds runtime.lock but hasn't opened its HTTP port yet.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    runtime_path = tmp_path / ".vireo" / "runtime.json"
+    runtime_path.write_text(_json.dumps({
+        "port": 1,  # nothing listening
+        "pid": os.getpid(),  # peer is alive, just not serving yet
+        "token": "anything",
+    }))
+    lock_path = tmp_path / ".vireo" / "runtime.lock"
+    lock_path.write_text(str(os.getpid()))
+
+    from runtime import acquire_single_instance
+    status, info = acquire_single_instance(pid=os.getpid() + 1)
+    assert status == "conflict"
+    assert info["pid"] == os.getpid()
+    # External discovery must still work — do not delete the peer's file.
+    assert runtime_path.exists()
+    # Lock must be preserved too.
+    assert lock_path.exists()
 
 
 def test_acquire_conflicts_with_lock_from_live_pid(tmp_path, monkeypatch):

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -90,3 +90,89 @@ def test_delete_runtime_json_is_idempotent(tmp_path, monkeypatch):
     delete_runtime_json()
     assert not (tmp_path / ".vireo" / "runtime.json").exists()
     delete_runtime_json()  # second call should not raise
+
+
+import http.server
+import json as _json
+import threading
+
+
+class _HealthHandler(http.server.BaseHTTPRequestHandler):
+    expected_token = "goodtoken"
+
+    def do_GET(self):
+        if self.path != "/api/v1/health":
+            self.send_response(404)
+            self.end_headers()
+            return
+        if self.headers.get("X-Vireo-Token") != self.expected_token:
+            self.send_response(401)
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"status":"ok"}')
+
+    def log_message(self, *a, **kw):  # silence
+        pass
+
+
+def _start_fake_server(token):
+    _HealthHandler.expected_token = token
+    server = http.server.HTTPServer(("127.0.0.1", 0), _HealthHandler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return server, port
+
+
+def test_guard_no_file_returns_proceed(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from runtime import check_single_instance
+
+    assert check_single_instance() == ("proceed", None)
+
+
+def test_guard_healthy_peer_returns_conflict(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    server, port = _start_fake_server("goodtoken")
+    try:
+        (tmp_path / ".vireo" / "runtime.json").write_text(_json.dumps({
+            "port": port, "pid": 99999, "token": "goodtoken",
+        }))
+        from runtime import check_single_instance
+        status, info = check_single_instance()
+        assert status == "conflict"
+        assert info["port"] == port
+        assert info["pid"] == 99999
+    finally:
+        server.shutdown()
+
+
+def test_guard_stale_file_is_cleaned_and_proceeds(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+
+    # Port 1 is almost certainly not bound by anything listening.
+    (tmp_path / ".vireo" / "runtime.json").write_text(_json.dumps({
+        "port": 1, "pid": 99999, "token": "x",
+    }))
+
+    from runtime import check_single_instance
+    status, info = check_single_instance()
+    assert status == "proceed"
+    assert not (tmp_path / ".vireo" / "runtime.json").exists()
+
+
+def test_guard_malformed_file_is_cleaned_and_proceeds(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.makedirs(tmp_path / ".vireo")
+    (tmp_path / ".vireo" / "runtime.json").write_text("not json")
+
+    from runtime import check_single_instance
+    status, info = check_single_instance()
+    assert status == "proceed"
+    assert not (tmp_path / ".vireo" / "runtime.json").exists()

--- a/vireo/tests/test_runtime.py
+++ b/vireo/tests/test_runtime.py
@@ -240,3 +240,14 @@ def test_guard_peer_returning_500_is_conflict(tmp_path, monkeypatch):
         assert runtime_path.exists()
     finally:
         server.shutdown()
+
+
+def test_generate_token_is_random_and_urlsafe():
+    from runtime import generate_token
+    a = generate_token()
+    b = generate_token()
+    assert a != b
+    assert len(a) >= 32
+    # URL-safe base64: only alphanumerics and -_
+    import re
+    assert re.fullmatch(r"[A-Za-z0-9_-]+", a)


### PR DESCRIPTION
## Summary
- Add `~/.vireo/runtime.json` (port, PID, token, version, mode) so external
  callers can discover a running Vireo instance.
- Single-instance guard: sidecar refuses to start if a healthy peer is
  running; detects and cleans up stale runtime files.
- New `/api/v1/*` surface with `X-Vireo-Token` auth, covering health,
  version, shutdown, photos, collections, workspaces, and keywords.
- `--headless` flag on the sidecar for explicit non-GUI spawns.
- User-facing docs at `docs/headless-api.md`.

Design: `docs/plans/2026-04-22-headless-api-design.md`.

## Test plan
- [x] Unit tests: runtime.json writer/reader, single-instance guard, token gen
- [x] API tests: /api/v1 token auth, /api/v1 alias coverage
- [x] Integration: spawn → discover → health; second spawn → already_running;
      stale runtime.json replaced; /api/v1/shutdown removes runtime.json
- [ ] Manual smoke: `python vireo/app.py --headless --port 0` + curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)