### PR TITLE
perf(scanner): parallelize per-file phash and SHA-256

### DIFF
--- a/vireo/config.py
+++ b/vireo/config.py
@@ -24,6 +24,7 @@ DEFAULTS = {
     "inat_token": "",
     "hf_token": "",
     "scan_roots": [],
+    "scan_workers": 0,
     "setup_complete": False,
     "darktable_bin": "",
     "external_editor": "",

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1,10 +1,12 @@
 """Scan folders, discover photos, read metadata, populate database."""
 
+import contextlib
 import hashlib
 import json
 import logging
 import os
 from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from pathlib import Path
 
@@ -27,6 +29,47 @@ def compute_file_hash(file_path, chunk_size=65536):
                 break
             h.update(chunk)
     return h.hexdigest()
+
+
+def _compute_file_features(path_str):
+    """Compute (phash, file_hash) for one image.
+
+    Module-level so ProcessPoolExecutor can pickle it. Mirrors the
+    best-effort behavior the main scan loop used to have inline: any
+    failure yields None for that field rather than raising.
+    """
+    phash = None
+    with contextlib.suppress(Exception), Image.open(path_str) as img:
+        phash = str(imagehash.phash(img))
+    file_hash = None
+    with contextlib.suppress(Exception):
+        file_hash = compute_file_hash(path_str)
+    return phash, file_hash
+
+
+def _resolve_worker_count(files_to_process):
+    """Decide how many workers to use for feature computation.
+
+    Returns 1 (sequential) when the batch is tiny or config disables
+    parallelism; otherwise honors ``scan_workers`` (0 = auto, cap at
+    cpu_count and batch size).
+    """
+    n = len(files_to_process)
+    if n < 8:
+        return 1
+    try:
+        import config as cfg
+        configured = int(cfg.get("scan_workers") or 0)
+    except Exception:
+        configured = 0
+    if configured == 1:
+        return 1
+    cpu = os.cpu_count() or 1
+    if configured <= 0:
+        workers = cpu
+    else:
+        workers = min(configured, cpu)
+    return max(1, min(workers, n))
 
 
 def _import_keywords_for_photo(db, photo_id, xmp_path_str):
@@ -560,7 +603,22 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         status_callback(f"Extracting metadata ({len(paths_to_extract)} files)...")
     metadata_map = extract_metadata(paths_to_extract) if paths_to_extract else {}
 
-    for image_path in files_to_process:
+    # Compute phash + file_hash in parallel across all files that need
+    # processing. These are the two per-file operations that actually read
+    # every byte of the image; everything else in the loop is cheap DB or
+    # dict work. Order is preserved so results zip 1:1 with files_to_process.
+    workers = _resolve_worker_count(files_to_process)
+    if paths_to_extract and status_callback:
+        status_callback(
+            f"Hashing {len(paths_to_extract)} files ({workers} worker{'s' if workers != 1 else ''})..."
+        )
+    if workers > 1:
+        with ProcessPoolExecutor(max_workers=workers) as pool:
+            features = list(pool.map(_compute_file_features, paths_to_extract))
+    else:
+        features = [_compute_file_features(p) for p in paths_to_extract]
+
+    for image_path, (phash, file_hash) in zip(files_to_process, features, strict=True):
         folder_id = _ensure_folder(image_path.parent)
 
         # File stats
@@ -620,22 +678,6 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         longitude = composite.get("GPSLongitude")
         if longitude is None:
             longitude = exif_group.get("GPSLongitude")
-
-        # Compute perceptual hash (computed, not from EXIF)
-        phash = None
-        try:
-            with Image.open(str(image_path)) as img:
-                phash = str(imagehash.phash(img))
-        except Exception:
-            log.debug("Could not compute pHash for %s", image_path)
-
-        # Compute file hash for duplicate detection
-        file_hash = None
-        try:
-            file_hash = compute_file_hash(str(image_path))
-        except Exception:
-            log.debug("Could not compute file hash for %s", image_path)
-
 
         photo_id = db.add_photo(
             folder_id=folder_id,

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -617,20 +617,28 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # Compute phash + file_hash in parallel across all files that need
     # processing. These are the two per-file operations that actually read
     # every byte of the image; everything else in the loop is cheap DB or
-    # dict work. Order is preserved so results zip 1:1 with files_to_process.
+    # dict work. Results stream in order, so workers keep computing the tail
+    # while the main thread commits the head — no O(n) buffer of features.
     workers = _resolve_worker_count(files_to_process)
     if paths_to_extract and status_callback:
         status_callback(
             f"Hashing {len(paths_to_extract)} files ({workers} worker{'s' if workers != 1 else ''})..."
         )
-    if workers > 1:
-        mp_ctx = multiprocessing.get_context(_SCAN_MP_METHOD)
-        with ProcessPoolExecutor(max_workers=workers, mp_context=mp_ctx) as pool:
-            features = list(pool.map(_compute_file_features, paths_to_extract))
-    else:
-        features = [_compute_file_features(p) for p in paths_to_extract]
 
-    for image_path, (phash, file_hash) in zip(files_to_process, features, strict=True):
+    def _iter_features():
+        if workers > 1:
+            mp_ctx = multiprocessing.get_context(_SCAN_MP_METHOD)
+            with ProcessPoolExecutor(max_workers=workers, mp_context=mp_ctx) as pool:
+                yield from zip(
+                    files_to_process,
+                    pool.map(_compute_file_features, paths_to_extract),
+                    strict=True,
+                )
+        else:
+            for image_path, path_str in zip(files_to_process, paths_to_extract, strict=True):
+                yield image_path, _compute_file_features(path_str)
+
+    for image_path, (phash, file_hash) in _iter_features():
         folder_id = _ensure_folder(image_path.parent)
 
         # File stats

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -6,7 +6,7 @@ import json
 import logging
 import multiprocessing
 import os
-from collections import defaultdict
+from collections import defaultdict, deque
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from pathlib import Path
@@ -629,11 +629,22 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         if workers > 1:
             mp_ctx = multiprocessing.get_context(_SCAN_MP_METHOD)
             with ProcessPoolExecutor(max_workers=workers, mp_context=mp_ctx) as pool:
-                yield from zip(
-                    files_to_process,
-                    pool.map(_compute_file_features, paths_to_extract),
-                    strict=True,
-                )
+                # Bounded in-flight window instead of pool.map(): on Python
+                # 3.11 Executor.map eagerly submits every input, so on a
+                # 200k-file scan we would hold 200k queued futures in RAM.
+                # A few submissions per worker is enough to keep them fed
+                # while the main thread drains results in order.
+                max_in_flight = workers * 4
+                pending = deque()
+                inputs = zip(files_to_process, paths_to_extract, strict=True)
+                for image_path, path_str in inputs:
+                    pending.append((image_path, pool.submit(_compute_file_features, path_str)))
+                    if len(pending) >= max_in_flight:
+                        done_path, done_fut = pending.popleft()
+                        yield done_path, done_fut.result()
+                while pending:
+                    done_path, done_fut = pending.popleft()
+                    yield done_path, done_fut.result()
         else:
             for image_path, path_str in zip(files_to_process, paths_to_extract, strict=True):
                 yield image_path, _compute_file_features(path_str)

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -6,6 +6,7 @@ import json
 import logging
 import multiprocessing
 import os
+import sys
 from collections import defaultdict, deque
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
@@ -28,6 +29,11 @@ _SCAN_MP_METHOD = (
     if "forkserver" in multiprocessing.get_all_start_methods()
     else "spawn"
 )
+
+# Windows' ProcessPoolExecutor raises ValueError when max_workers > 61
+# (the WaitForMultipleObjects handle limit). Clamp on Windows so scans
+# don't fail on high-core-count machines or misconfigured scan_workers.
+_WINDOWS_MAX_WORKERS = 61
 
 
 def compute_file_hash(file_path, chunk_size=65536):
@@ -80,6 +86,8 @@ def _resolve_worker_count(files_to_process):
         workers = cpu
     else:
         workers = min(configured, cpu)
+    if sys.platform == "win32":
+        workers = min(workers, _WINDOWS_MAX_WORKERS)
     return max(1, min(workers, n))
 
 

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -4,6 +4,7 @@ import contextlib
 import hashlib
 import json
 import logging
+import multiprocessing
 import os
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
@@ -17,6 +18,16 @@ from PIL import Image
 from xmp import read_hierarchical_keywords, read_keywords
 
 log = logging.getLogger(__name__)
+
+# scan() runs inside JobRunner/pipeline_job background threads, so the
+# default POSIX "fork" start method is unsafe here: forking a
+# multithreaded process can deadlock. Prefer "forkserver" (POSIX, cheap)
+# and fall back to "spawn" (universal).
+_SCAN_MP_METHOD = (
+    "forkserver"
+    if "forkserver" in multiprocessing.get_all_start_methods()
+    else "spawn"
+)
 
 
 def compute_file_hash(file_path, chunk_size=65536):
@@ -613,7 +624,8 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             f"Hashing {len(paths_to_extract)} files ({workers} worker{'s' if workers != 1 else ''})..."
         )
     if workers > 1:
-        with ProcessPoolExecutor(max_workers=workers) as pool:
+        mp_ctx = multiprocessing.get_context(_SCAN_MP_METHOD)
+        with ProcessPoolExecutor(max_workers=workers, mp_context=mp_ctx) as pool:
             features = list(pool.map(_compute_file_features, paths_to_extract))
     else:
         features = [_compute_file_features(p) for p in paths_to_extract]

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1185,3 +1185,55 @@ def test_incremental_rescan_respects_exif_extracted_guard(tmp_path, monkeypatch)
     assert row["width"] == 160
     assert row["height"] == 120
     assert all(image_path not in batch for batch in called_with)
+
+
+def test_resolve_worker_count_tiny_batch_is_sequential():
+    """Batches below 8 files always use 1 worker."""
+    from scanner import _resolve_worker_count
+    assert _resolve_worker_count(list(range(7))) == 1
+
+
+def test_resolve_worker_count_capped_by_batch_size(monkeypatch):
+    """Worker count never exceeds the batch size."""
+    import config as cfg
+    import scanner
+
+    monkeypatch.setattr(cfg, "get", lambda _k: 0)
+    monkeypatch.setattr(scanner.os, "cpu_count", lambda: 32)
+    # 10 files on a 32-core box should top out at 10 workers.
+    assert scanner._resolve_worker_count(list(range(10))) == 10
+
+
+def test_resolve_worker_count_clamps_to_windows_limit(monkeypatch):
+    """On Windows, ProcessPoolExecutor rejects max_workers > 61, so clamp."""
+    import config as cfg
+    import scanner
+
+    monkeypatch.setattr(cfg, "get", lambda _k: 0)
+    monkeypatch.setattr(scanner.os, "cpu_count", lambda: 128)
+    monkeypatch.setattr(scanner.sys, "platform", "win32")
+    # Batch is large enough that it wouldn't otherwise clamp the count.
+    workers = scanner._resolve_worker_count(list(range(200)))
+    assert workers == scanner._WINDOWS_MAX_WORKERS == 61
+
+
+def test_resolve_worker_count_clamps_configured_value_on_windows(monkeypatch):
+    """Explicit scan_workers above 61 is still clamped on Windows."""
+    import config as cfg
+    import scanner
+
+    monkeypatch.setattr(cfg, "get", lambda _k: 96)
+    monkeypatch.setattr(scanner.os, "cpu_count", lambda: 128)
+    monkeypatch.setattr(scanner.sys, "platform", "win32")
+    assert scanner._resolve_worker_count(list(range(200))) == 61
+
+
+def test_resolve_worker_count_no_windows_cap_on_posix(monkeypatch):
+    """The 61-worker cap must not apply on non-Windows platforms."""
+    import config as cfg
+    import scanner
+
+    monkeypatch.setattr(cfg, "get", lambda _k: 0)
+    monkeypatch.setattr(scanner.os, "cpu_count", lambda: 128)
+    monkeypatch.setattr(scanner.sys, "platform", "linux")
+    assert scanner._resolve_worker_count(list(range(200))) == 128


### PR DESCRIPTION
## Summary

Move the two operations that actually read every byte of each image (perceptual hash + file hash) into a `ProcessPoolExecutor`. DB writes remain on the main thread and order is preserved, so no semantic changes.

New config key `scan_workers`:
- `0` (default) — auto, use `os.cpu_count()`
- `1` — disable parallelism
- `N` — fixed worker count (capped at `cpu_count`)

Falls back to sequential below 8 files so small rescans and the test suite don't pay pool-spawn overhead.

## Benchmark

80 files × ~24MB = 1.86 GB of data, timing just the parallelized portion (phash + SHA-256):

| mode | time | speedup |
|---|---|---|
| sequential | 17.5s | — |
| pool(4) | 5.9s | 2.96× |
| pool(8) | 3.6s | 4.89× |
| pool(16) | 2.8s | 6.37× |

End-to-end scan speedup will be smaller than 6× because ExifTool (already a single batch subprocess) and SQLite writes are still sequential. Those are the next bottlenecks.

## What didn't change

- ExifTool metadata extraction — already batched in one subprocess.
- DB writes — SQLite is single-writer; keeping all writes on the main thread avoids locking.
- Detection/classification — different pipeline; gated on a single GPU/MPS device anyway.

## Test plan

- [x] `python -m pytest vireo/tests/test_scanner.py vireo/tests/test_scanner_callback.py vireo/tests/test_scanner_working_copy.py` — 59 passed
- [x] Full recommended suite from CLAUDE.md — 555 passed
- [ ] Manual scan of a real photo library to confirm wall-clock improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)