### PR TITLE
feat(review): per-thumbnail pan offsets in burst loupe

### DIFF
--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -401,13 +401,43 @@
     background: var(--bg-tertiary, #14374E);
     border-radius: 6px;
     overflow: hidden;
-    cursor: pointer;
+    cursor: grab;
     border: 2px solid transparent;
     transition: border-color 0.15s;
+    position: relative;
   }
   .grm-card:hover { border-color: var(--text-ghost, #555); }
   .grm-card.selected { border-color: var(--accent, #24E5CA); }
   .grm-card.ai-best { border-color: var(--warning, #f0c040); }
+  .grm-card.dragging { cursor: grabbing; }
+  .grm-card.dragging img { pointer-events: none; }
+  .grm-card.has-offset::after {
+    content: '';
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--accent, #24E5CA);
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.55);
+    pointer-events: none;
+    z-index: 3;
+  }
+  .grm-reset-offsets-btn {
+    display: none;
+    margin: 6px 12px 0;
+    background: var(--bg-tertiary, #14374E);
+    color: var(--text-muted, #888);
+    border: none;
+    border-radius: 4px;
+    padding: 4px 10px;
+    font-size: 11px;
+    cursor: pointer;
+    align-self: center;
+  }
+  .grm-reset-offsets-btn.visible { display: inline-block; }
+  .grm-reset-offsets-btn:hover { color: var(--text-primary, #E0F0F0); }
   .grm-card img {
     width: 100%;
     aspect-ratio: 3/2;
@@ -1153,12 +1183,21 @@ var grmState = { groupId: null, model: null, items: [], picks: new Set(), reject
 function openGroupReview(groupId, model) {
   grmState = { groupId: groupId, model: model, items: [], picks: new Set(), rejects: new Set(), removed: new Set(), selected: null };
   _grmLoupeLocked = false;
+  _grmOffsets = {};
+  _grmDragging = null;
+  _grmSuppressNextClick = false;
+  _grmLoupeLastX = null;
+  _grmLoupeLastY = null;
+  grmRefreshResetAllVisibility();
   document.getElementById('grmOverlay').classList.add('open');
   loadGroupData(groupId);
 }
 
 function closeGroupReview() {
   document.getElementById('grmOverlay').classList.remove('open');
+  _grmOffsets = {};
+  _grmDragging = null;
+  grmRefreshResetAllVisibility();
 }
 
 async function loadGroupData(groupId) {
@@ -1212,8 +1251,11 @@ function renderGroupModal() {
     var sharp = it.subject_sharpness != null ? Math.round(it.subject_sharpness) : (it.sharpness != null ? Math.round(it.sharpness) : '-');
     var confPct = Math.round((it.confidence || 0) * 100);
 
-    return '<div class="' + cls + '" data-photo-id="' + it.photo_id + '" data-pred-id="' + it.id + '" onclick="grmSelect(' + it.photo_id + ')">' +
-      '<img src="/thumbnails/' + it.photo_id + '.jpg" loading="lazy">' +
+    return '<div class="' + cls + '" data-photo-id="' + it.photo_id + '" data-pred-id="' + it.id + '"' +
+      ' onmousedown="grmCardMouseDown(event)"' +
+      ' onclick="grmCardClick(event, ' + it.photo_id + ')"' +
+      ' ondblclick="grmCardDblClick(event)">' +
+      '<img src="/thumbnails/' + it.photo_id + '.jpg" loading="lazy" draggable="false">' +
       '<div class="grm-card-info">' +
         '<div class="grm-card-species">' + escapeHtml(it.species || '') + ' <span style="font-weight:400;color:var(--text-dim,#888);">' + confPct + '%</span></div>' +
         '<div class="grm-card-scores">Q: <span class="score-val">' + qScore + '</span> S: <span class="score-val">' + sharp + '</span></div>' +
@@ -1256,6 +1298,16 @@ function renderGroupModal() {
   }
 
   document.getElementById('grmCount').textContent = pickItems.length + ' picks, ' + rejectItems.length + ' rejects, ' + candidateItems.length + ' unsorted';
+
+  // Re-apply offset indicators and — if the loupe is currently zoomed — the
+  // per-card transforms, since innerHTML wipes them on every re-render.
+  document.querySelectorAll('.grm-card').forEach(function(card) {
+    _grmUpdateIndicator(card);
+  });
+  if (_grmLoupeLocked && _grmLoupeLastX !== null) {
+    _grmApplyAllCardTransforms(_grmLoupeLastX, _grmLoupeLastY);
+  }
+  grmRefreshResetAllVisibility();
 }
 
 function grmSelect(photoId) {
@@ -1305,6 +1357,17 @@ function renderLoupePreds(item) {
 
 var _grmZoomLevel = 4;
 var _grmLoupeLocked = false;
+// Per-photo pan offsets, in pre-scale CSS pixels of the thumbnail img box.
+// Because we apply `scale(z) translate(tx, ty)`, the translate is in the
+// unscaled coordinate space, which is a fixed fraction of the underlying
+// image — so offsets remain correct as zoom level changes.
+var _grmOffsets = {};
+var _grmDragging = null;
+var _grmSuppressNextClick = false;
+// Latest cursor position over the loupe image, used to re-apply transforms
+// during a drag even though the cursor is no longer on the loupe.
+var _grmLoupeLastX = null;
+var _grmLoupeLastY = null;
 
 function grmLoupeToggleLock(e) {
   _grmLoupeLocked = !_grmLoupeLocked;
@@ -1326,17 +1389,34 @@ function grmLoupeMove(e) {
   var rect = e.currentTarget.getBoundingClientRect();
   var x = ((e.clientX - rect.left) / rect.width) * 100;
   var y = ((e.clientY - rect.top) / rect.height) * 100;
+  _grmLoupeLastX = x;
+  _grmLoupeLastY = y;
 
   // Update crosshairs
   document.getElementById('grmCrosshairH').style.top = y + '%';
   document.getElementById('grmCrosshairV').style.left = x + '%';
 
-  // Zoom all strip thumbnails to the same position
-  document.querySelectorAll('.grm-card img').forEach(function(img) {
+  _grmApplyAllCardTransforms(x, y);
+}
+
+function _grmApplyAllCardTransforms(x, y) {
+  document.querySelectorAll('.grm-card').forEach(function(card) {
+    var img = card.querySelector('img');
+    if (!img) return;
+    var off = _grmOffsets[card.dataset.photoId] || { tx: 0, ty: 0 };
     img.style.transformOrigin = x + '% ' + y + '%';
-    img.style.transform = 'scale(' + _grmZoomLevel + ')';
-    img.parentElement.classList.add('zoomed');
+    img.style.transform = 'scale(' + _grmZoomLevel + ') translate(' + off.tx + 'px, ' + off.ty + 'px)';
+    card.classList.add('zoomed');
   });
+}
+
+function _grmApplyCardTransform(card) {
+  var img = card.querySelector('img');
+  if (!img) return;
+  var off = _grmOffsets[card.dataset.photoId] || { tx: 0, ty: 0 };
+  if (card.classList.contains('zoomed')) {
+    img.style.transform = 'scale(' + _grmZoomLevel + ') translate(' + off.tx + 'px, ' + off.ty + 'px)';
+  }
 }
 
 function grmLoupeZoom(e) {
@@ -1355,11 +1435,107 @@ function grmLoupeZoom(e) {
 
 function grmLoupeReset() {
   if (_grmLoupeLocked) return;
+  if (_grmDragging) return;
   document.querySelectorAll('.grm-card img').forEach(function(img) {
     img.style.transform = '';
     img.style.transformOrigin = '';
     img.parentElement.classList.remove('zoomed');
   });
+}
+
+function grmCardMouseDown(e) {
+  if (e.button !== 0) return;
+  var card = e.currentTarget;
+  var photoId = card.dataset.photoId;
+  var cur = _grmOffsets[photoId] || { tx: 0, ty: 0 };
+  _grmDragging = {
+    card: card,
+    photoId: photoId,
+    startX: e.clientX,
+    startY: e.clientY,
+    origTx: cur.tx,
+    origTy: cur.ty,
+    moved: false,
+  };
+  document.addEventListener('mousemove', grmCardMouseMove);
+  document.addEventListener('mouseup', grmCardMouseUp);
+  e.preventDefault();
+}
+
+function grmCardMouseMove(e) {
+  if (!_grmDragging) return;
+  var dx = e.clientX - _grmDragging.startX;
+  var dy = e.clientY - _grmDragging.startY;
+  if (!_grmDragging.moved && (Math.abs(dx) > 3 || Math.abs(dy) > 3)) {
+    _grmDragging.moved = true;
+    _grmDragging.card.classList.add('dragging');
+  }
+  if (!_grmDragging.moved) return;
+  var z = Math.max(1, _grmZoomLevel);
+  var newTx = _grmDragging.origTx + dx / z;
+  var newTy = _grmDragging.origTy + dy / z;
+  _grmOffsets[_grmDragging.photoId] = { tx: newTx, ty: newTy };
+  _grmApplyCardTransform(_grmDragging.card);
+  _grmUpdateIndicator(_grmDragging.card);
+}
+
+function grmCardMouseUp(e) {
+  if (!_grmDragging) return;
+  var moved = _grmDragging.moved;
+  _grmDragging.card.classList.remove('dragging');
+  document.removeEventListener('mousemove', grmCardMouseMove);
+  document.removeEventListener('mouseup', grmCardMouseUp);
+  _grmDragging = null;
+  if (moved) _grmSuppressNextClick = true;
+  grmRefreshResetAllVisibility();
+}
+
+function grmCardClick(e, photoId) {
+  if (_grmSuppressNextClick) {
+    _grmSuppressNextClick = false;
+    return;
+  }
+  grmSelect(photoId);
+}
+
+function grmCardDblClick(e) {
+  var card = e.currentTarget;
+  var photoId = card.dataset.photoId;
+  if (!_grmOffsets[photoId]) return;
+  delete _grmOffsets[photoId];
+  _grmUpdateIndicator(card);
+  _grmApplyCardTransform(card);
+  grmRefreshResetAllVisibility();
+  _grmSuppressNextClick = true;
+  e.stopPropagation();
+}
+
+function grmResetAllOffsets() {
+  _grmOffsets = {};
+  document.querySelectorAll('.grm-card').forEach(function(card) {
+    _grmUpdateIndicator(card);
+    _grmApplyCardTransform(card);
+  });
+  grmRefreshResetAllVisibility();
+}
+
+function _grmUpdateIndicator(card) {
+  var off = _grmOffsets[card.dataset.photoId];
+  if (off && (off.tx !== 0 || off.ty !== 0)) {
+    card.classList.add('has-offset');
+  } else {
+    card.classList.remove('has-offset');
+  }
+}
+
+function grmRefreshResetAllVisibility() {
+  var hasAny = false;
+  for (var k in _grmOffsets) {
+    var o = _grmOffsets[k];
+    if (o && (o.tx !== 0 || o.ty !== 0)) { hasAny = true; break; }
+  }
+  var btn = document.getElementById('grmResetAllOffsets');
+  if (btn) btn.classList.toggle('visible', hasAny);
 }
 
 function _grmGetZone(photoId) {
@@ -1519,6 +1695,7 @@ document.addEventListener('keydown', function(e) {
         <div class="grm-loupe-crosshair-v" id="grmCrosshairV"></div>
       </div>
       <div class="grm-loupe-info" id="grmLoupeInfo">Select a photo to preview. Hover to compare sharpness across all frames.</div>
+      <button type="button" class="grm-reset-offsets-btn" id="grmResetAllOffsets" onclick="grmResetAllOffsets()">Reset pan offsets</button>
       <div class="grm-loupe-preds" id="grmLoupePreds"></div>
     </div>
   </div>
@@ -1526,7 +1703,7 @@ document.addEventListener('keydown', function(e) {
     <label style="font-size:12px;color:var(--text-muted,#888);">Consensus species:</label>
     <input type="text" id="grmSpecies" style="background:var(--bg-input,#14374E);color:var(--text-primary,#E0F0F0);border:1px solid var(--border-secondary,#1A4560);border-radius:4px;padding:6px 10px;font-size:13px;width:200px;">
     <button onclick="grmRemoveFromGroup()" style="background:var(--bg-tertiary,#14374E);color:var(--text-muted,#888);border:none;border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;">Remove from group</button>
-    <span class="grm-hint">↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom</span>
+    <span class="grm-hint">↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
     <button onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;">Apply & Close</button>
   </div>
 </div>

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1464,6 +1464,13 @@ function grmCardMouseDown(e) {
 
 function grmCardMouseMove(e) {
   if (!_grmDragging) return;
+  // If the primary button is no longer held (e.g. mouseup fired outside the
+  // window and was missed), end the drag instead of continuing to mutate
+  // offsets from passive cursor motion.
+  if ((e.buttons & 1) === 0) {
+    grmCardMouseUp(e);
+    return;
+  }
   var dx = e.clientX - _grmDragging.startX;
   var dy = e.clientY - _grmDragging.startY;
   if (!_grmDragging.moved && (Math.abs(dx) > 3 || Math.abs(dy) > 3)) {
@@ -1482,11 +1489,18 @@ function grmCardMouseMove(e) {
 function grmCardMouseUp(e) {
   if (!_grmDragging) return;
   var moved = _grmDragging.moved;
-  _grmDragging.card.classList.remove('dragging');
+  var card = _grmDragging.card;
+  card.classList.remove('dragging');
   document.removeEventListener('mousemove', grmCardMouseMove);
   document.removeEventListener('mouseup', grmCardMouseUp);
   _grmDragging = null;
-  if (moved) _grmSuppressNextClick = true;
+  // Only suppress the trailing click when the release is inside the dragged
+  // card — that's the only case where a `click` will fire on the card and
+  // need to be swallowed. Off-card releases produce no card click, so
+  // setting the flag would eat the user's next real selection.
+  if (moved && e && e.target && card.contains(e.target)) {
+    _grmSuppressNextClick = true;
+  }
   grmRefreshResetAllVisibility();
 }
 

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1506,7 +1506,6 @@ function grmCardDblClick(e) {
   _grmUpdateIndicator(card);
   _grmApplyCardTransform(card);
   grmRefreshResetAllVisibility();
-  _grmSuppressNextClick = true;
   e.stopPropagation();
 }
 


### PR DESCRIPTION
## Summary

In burst-group review, a single bird's-eye position in the main loupe rarely lines up perfectly across every frame — the bird shifts slightly between shots, so the eye drifts out of the zoomed strip thumbnails. This adds a per-thumbnail pan offset so each frame can be nudged independently to keep the eye (or any detail) pinned across all frames.

- **Click-drag** a strip thumbnail to pan its view relative to the main loupe cursor
- **Double-click** a thumbnail to clear its offset
- **Reset pan offsets** button (in the loupe panel) clears all of them at once
- Small accent dot appears on any thumbnail with a non-zero offset

Offsets are stored in pre-scale image coordinates (applied as `scale(z) translate(tx, ty)`), so the eye stays aligned when you change zoom level or move the main cursor. They're per-session — closing the modal clears them.

Because moving the cursor from the loupe to a thumbnail would normally reset the loupe zoom, the intended flow is: hover the main loupe onto the bird's eye → **click to lock** the crosshair → drag thumbnails to align.

## Test plan

- [ ] Open a burst group with several frames; hover main loupe, click to lock crosshair
- [ ] Drag a thumbnail: its view pans under the grab cursor, indicator dot appears
- [ ] Change main crosshair position (unlock, move, re-lock): dragged thumbnail's offset persists relative to the new center
- [ ] Change zoom level: offsets still align (image-pixel space)
- [ ] Double-click a thumbnail: offset clears, dot disappears
- [ ] Click "Reset pan offsets": all offsets clear, button disappears
- [ ] Single-click a thumbnail (no drag): still selects for loupe preview
- [ ] Close and reopen the modal: offsets are gone
- [ ] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` — 555 passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)