### PR TITLE
docs: design for new-images → pipeline source

### DIFF
--- a/docs/plans/2026-04-22-new-images-pipeline-design.md
+++ b/docs/plans/2026-04-22-new-images-pipeline-design.md
@@ -1,0 +1,200 @@
+# New Images → Pipeline Source
+
+## Problem
+
+The "N new images detected in your registered folders" banner (introduced in the 2026-04-15 new-images-banner design) links to `/pipeline`. The pipeline page is a blank wizard: the user lands on it with no indication of which files the banner was talking about, and no way to scope the pipeline to those files specifically. They must manually pick a source folder and trust that the pipeline's incremental scan will pick up the new arrivals.
+
+This is a disconnect: the banner claims specific images are new, but the workflow treats the click as a generic "go build a pipeline" navigation. Users end up running a pipeline against an entire folder when they wanted to process only the one or two files that were just dropped in.
+
+## Goal
+
+Clicking "Create a pipeline" from the new-images banner should land the user on the pipeline wizard with the source already scoped to exactly the images the banner announced.
+
+Also: make "new images" a first-class pipeline source, discoverable from the pipeline page itself — not only from the banner.
+
+## Design Decisions
+
+- **Snapshot at click time.** When the user clicks "Create a pipeline", freeze the current list of new-image file paths into a snapshot. The pipeline processes exactly that set, even if more files arrive between clicking and running. This matches user expectation ("I saw 1 new image, process that one") and avoids the pipeline silently growing.
+- **Snapshot stores file paths, not photo IDs.** New images are files on disk not yet ingested (see `vireo/new_images.py`) — there are no photo records to reference yet. The snapshot captures absolute file paths.
+- **Pipeline still runs the scan stage.** Scanning is how file paths become photo records. Rather than bypass the scanner, we scope the scan to the snapshot's parent folders (incremental, as today) and then filter downstream stages to the snapshot's photo IDs. The snapshot guarantee (only these files propagate) is enforced at the scan-to-classify seam, not by short-circuiting the scan.
+- **"New images" is a first-class Stage 1 source.** Alongside "Import Photos" and "Use Existing Collection", with the card only rendered when `new_count > 0`. No disabled state for caught-up workspaces (YAGNI).
+- **Banner deep-links via snapshot ID in URL.** `POST /api/new-images/snapshot` → receive `snapshot_id` → navigate to `/pipeline?new_images=<snapshot_id>`. Snapshot IDs are short; URLs stay small even for thousands of new files.
+- **No automatic snapshot GC in v1.** Rows are tiny (workspace_id, created_at, paths). Add cleanup later if snapshots accumulate meaningfully.
+
+## Data Model
+
+Two new tables:
+
+```sql
+CREATE TABLE new_image_snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  workspace_id INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL,
+  file_count INTEGER NOT NULL
+);
+
+CREATE TABLE new_image_snapshot_files (
+  snapshot_id INTEGER NOT NULL REFERENCES new_image_snapshots(id) ON DELETE CASCADE,
+  file_path TEXT NOT NULL,
+  PRIMARY KEY (snapshot_id, file_path)
+);
+```
+
+- Workspace-scoped with `ON DELETE CASCADE`, matching the existing pattern for `predictions`, `pending_changes`, `collections`.
+- `file_path` is the absolute filesystem path, matching the identity `new_images.py` and `scanner.py` use.
+- No explicit TTL column — snapshots live until their workspace is deleted.
+
+## API
+
+### `POST /api/new-images/snapshot`
+
+Captures the current output of `count_new_images_for_workspace` (with `sample_limit` raised to unlimited so every new-image path is persisted) into a new snapshot.
+
+Response:
+```json
+{
+  "snapshot_id": 42,
+  "file_count": 3,
+  "folders": ["/Users/me/Photos/2026", "/Users/me/Photos/Archive"]
+}
+```
+
+Called by both the banner and the pipeline page's Stage 1 card.
+
+### `GET /api/new-images/snapshot/<id>`
+
+Returns the snapshot summary for the pipeline page to render:
+```json
+{
+  "file_count": 3,
+  "folder_paths": ["/Users/me/Photos/2026", "/Users/me/Photos/Archive"],
+  "files_sample": ["/Users/me/Photos/2026/IMG_0042.JPG", "..."]
+}
+```
+
+- Full file list is not sent to the client (not needed for UI; pipeline job reads it server-side).
+- Returns 404 if the snapshot ID doesn't exist or belongs to a different workspace (isolation check).
+
+## Pipeline Job Integration
+
+`PipelineJob` gains an optional `source_snapshot_id` parameter.
+
+When set:
+
+1. **Scan stage.** Derive unique parent directories from the snapshot's file paths and run the scanner in its existing incremental mode against those directories only. Do not walk the workspace's full mapped roots — that would be wasteful for a 1-file snapshot. Scanner behavior is otherwise unchanged.
+2. **Resolve snapshot → photo IDs.** Join `new_image_snapshot_files` against `photos` / `folders` on `folder_path + filename`. Any snapshot path that didn't resolve to a photo (file disappeared between snapshot and run, permissions error, etc.) is dropped from the set with a single log line: `"Snapshot <id> had N files, M ingested, K missing on disk"` at INFO.
+3. **Downstream stages.** Classification, extraction, grouping, etc. operate on the resolved photo-ID list only. Any *additional* files the scanner ingested from those folders (arrivals between snapshot and run) are in the DB but do not propagate — the snapshot guarantee holds.
+
+When `source_snapshot_id` is absent, the existing folder-based pipeline behavior is unchanged.
+
+## Frontend
+
+### `vireo/templates/pipeline.html`
+
+Stage 1 gets a third source card:
+
+```
+┌─ New images ──────────────────────┐
+│ 3 new images detected             │
+│ in 2 registered folders           │
+│                                   │
+│ [▸ /Users/me/Photos/2026]         │
+│ [▸ /Users/me/Photos/Archive]      │
+│                                   │
+│ ○ Select this source              │
+└───────────────────────────────────┘
+```
+
+**Render logic:**
+
+- **Deep-link mode (`?new_images=<id>`):** skip the probe; fetch `/api/new-images/snapshot/<id>`, render the card with the snapshot's numbers, pre-select it. If the snapshot is missing or cross-workspace, toast "That snapshot has expired" and fall back to normal mode.
+- **No deep link:** call `/api/new-images` on page load. If `new_count > 0`, render the card (not pre-selected). If `= 0`, don't render it at all.
+
+**Selection behavior:**
+
+- Selecting the card without a pre-loaded snapshot triggers `POST /api/new-images/snapshot` to freeze the current list. Store `snapshot_id` in page state.
+- Pipeline submit POSTs `source_snapshot_id` in lieu of `source_folders` + `file_types`.
+
+Stages 2–4 (Destination, Processing, Advanced) are unchanged.
+
+### `vireo/templates/_navbar.html`
+
+The banner's "Create a pipeline" link becomes a JS-driven button:
+
+1. `POST /api/new-images/snapshot`.
+2. On success → navigate to `/pipeline?new_images=<snapshot_id>`.
+3. On failure → fall back to navigating to `/pipeline` with no param (existing behavior).
+
+## Edge Cases
+
+| Case | Behavior |
+| --- | --- |
+| Snapshot resolves to zero files (all ingested by another flow) | Pipeline short-circuits to completed state; not an error |
+| `?new_images=<bad_id>` or cross-workspace ID | Toast "snapshot expired"; fall back to normal pipeline mode |
+| Files deleted between snapshot and run | Scanner skips missing files (existing behavior); snapshot filter resolves fewer IDs; logged as INFO |
+| Files added to folder between snapshot and run | Scanner ingests them; snapshot filter excludes them from downstream stages |
+| Workspace switch after banner click, before submit | Snapshot is workspace-scoped; `/api/new-images/snapshot/<id>` returns 404; falls back gracefully |
+| Two pipelines running against the same snapshot | Both execute; scan is idempotent, classification upserts — acceptable waste, not locked against in v1 |
+
+## Testing
+
+**Unit (`vireo/tests/test_db.py`):**
+
+- Create a snapshot, read it back, verify `file_count` and file-path list match.
+- Snapshot rows cascade-delete when the workspace is deleted.
+- Reading a snapshot from a different workspace returns nothing (isolation).
+
+**API (`vireo/tests/test_new_images_api.py` — new file):**
+
+- `POST /api/new-images/snapshot` with pending new images → returns `snapshot_id`; DB row exists with expected paths.
+- `POST` with zero new images → returns a snapshot with `file_count: 0` (callers handle empty state; do not 400).
+- `GET /api/new-images/snapshot/<id>` → returns expected summary.
+- `GET` with unknown ID → 404.
+- `GET` with ID from a different workspace → 404 (isolation).
+
+**Pipeline job (extend `vireo/tests/test_pipeline_job.py`):**
+
+- Pipeline with `source_snapshot_id` → scanner walks only the snapshot's parent folders; snapshot's files become photos; downstream stages see only those photo IDs.
+- Files missing on disk at run time → logged, pipeline completes with the partial set.
+- Extra files arriving in the folder between snapshot and run → ingested by the scanner but NOT propagated to classification.
+- Empty snapshot → pipeline short-circuits to completed state with no stage errors.
+
+**E2E (Playwright, per the user-first-testing convention):**
+
+- Drop a file into a registered folder → banner appears.
+- Click "Create a pipeline" → lands on `/pipeline` with "New images" card selected showing "1 new image".
+- Complete the wizard, submit → job runs to completion; the new image appears in the workspace grid.
+- Navigate directly to `/pipeline` with no new images pending → "New images" card is not rendered.
+
+**Explicitly out of scope for v1:**
+
+- Snapshot GC (no GC mechanism exists yet; revisit if rows accumulate).
+- Concurrency tests for two pipelines sharing a snapshot (documented as acceptable waste).
+
+## Open Questions
+
+- **"Extra files between snapshot and run" — warn the user?** Currently silent. If users find it confusing that a file they dropped after clicking the banner got ingested but not classified, we could surface a post-run toast "N additional files were imported but not processed by this pipeline". Low priority; add if reports surface.
+- **Retention cleanup trigger.** Probably a `DELETE FROM new_image_snapshots WHERE workspace_id = ? AND created_at < datetime('now', '-7 days')` on workspace open, if/when rows become meaningful. Deferring.
+
+## Implementation Scope
+
+**Backend (`vireo/db.py`, `vireo/app.py`, `vireo/pipeline_job.py`, `vireo/new_images.py`):**
+
+- Schema migration for the two new tables.
+- `Database.create_new_images_snapshot(paths)` / `get_new_images_snapshot(snapshot_id)` helpers.
+- `count_new_images_for_workspace` gains an "all paths" mode (raise `sample_limit` internally or add a parameter) so snapshots persist the full list.
+- `POST /api/new-images/snapshot` and `GET /api/new-images/snapshot/<id>` routes.
+- `PipelineJob` accepts `source_snapshot_id`; scan stage derives parent dirs from the snapshot; downstream stages filter to resolved photo IDs.
+
+**Frontend (`vireo/templates/pipeline.html`, `vireo/templates/_navbar.html`):**
+
+- New Stage 1 source card with deep-link and empty-state logic.
+- Banner click becomes a `POST` + redirect.
+
+**Tests:** as enumerated above.
+
+**No changes to:**
+
+- The new-images banner's detection logic or caching (`vireo/new_images.py` identity/walk behavior is unchanged).
+- The scanner itself.
+- Classification / extraction internals.

--- a/docs/plans/2026-04-22-new-images-pipeline-plan.md
+++ b/docs/plans/2026-04-22-new-images-pipeline-plan.md
@@ -613,12 +613,17 @@ snapshot_photo_ids: set[int] | None = None
 if snapshot_paths is not None:
     db_resolver = Database(db_path)
     db_resolver.set_active_workspace(workspace_id)
+    # Match on (folder_path, filename) tuples — concatenating with a
+    # hardcoded '/' would mismatch Windows paths captured via os.path.join.
+    pairs = [os.path.split(p) for p in snapshot_paths]
+    values = ",".join("(?, ?)" for _ in pairs)
+    flat = tuple(v for pair in pairs for v in pair)
     rows = db_resolver.conn.execute(f"""
         SELECT p.id
         FROM photos p
         JOIN folders f ON f.id = p.folder_id
-        WHERE (f.path || '/' || p.filename) IN ({",".join("?" * len(snapshot_paths))})
-    """, snapshot_paths).fetchall()
+        WHERE (f.path, p.filename) IN (VALUES {values})
+    """, flat).fetchall()
     snapshot_photo_ids = {r["id"] for r in rows}
     db_resolver.close()
     missing = len(snapshot_paths) - len(snapshot_photo_ids)
@@ -691,10 +696,28 @@ Expected: FAIL.
 
 **Step 3: Add `source_snapshot_id` to the handler**
 
-In `vireo/app.py`'s `api_job_pipeline`, where it builds `PipelineParams`:
+In `vireo/app.py`'s `api_job_pipeline`:
+
+1. Read the new field and extend the presence guard so a snapshot-only
+   payload is not rejected by the existing `source / sources / collection_id`
+   check.
+2. Resolve the snapshot synchronously and return 404 for stale IDs — a 200
+   followed by an async job failure gives clients nothing to act on.
+3. Thread the value into `PipelineParams`.
 
 ```python
 source_snapshot_id = body.get("source_snapshot_id")
+if not source and not sources and not collection_id and not source_snapshot_id:
+    return json_error(
+        "source, sources, collection_id, or source_snapshot_id required"
+    )
+
+if source_snapshot_id is not None:
+    if _get_db().get_new_images_snapshot(source_snapshot_id) is None:
+        return json_error(
+            f"source_snapshot_id {source_snapshot_id} not found",
+            status=404,
+        )
 ...
 params = PipelineParams(
     ...

--- a/docs/plans/2026-04-22-new-images-pipeline-plan.md
+++ b/docs/plans/2026-04-22-new-images-pipeline-plan.md
@@ -1,0 +1,948 @@
+# New Images → Pipeline Source Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wire the "N new images detected" banner into the pipeline so that clicking "Create a pipeline" produces a pipeline scoped to exactly the files the banner announced, and make "New images" a first-class Stage 1 pipeline source.
+
+**Architecture:** A new `new_image_snapshots` workspace-scoped table captures the absolute file paths of new images at click time. Two new endpoints hang off `/api/workspaces/active/new-images/…` for creating and reading snapshots. `PipelineParams` gains a `source_snapshot_id` field; `run_pipeline_job()` scopes its scan stage to the snapshot's parent directories and filters downstream stages to the resolved photo IDs at the scan-to-classify seam. Frontend changes to `pipeline.html` (add third source card) and `_navbar.html` (banner becomes POST + redirect).
+
+**Tech Stack:** Python 3, Flask, SQLite (no ORM — raw cursor), Jinja2 templates, vanilla JS, pytest, Playwright for E2E.
+
+**Design doc:** `docs/plans/2026-04-22-new-images-pipeline-design.md`
+
+---
+
+## Task 1: Schema — add snapshot tables
+
+**Files:**
+- Modify: `vireo/db.py` (the `_create_tables()` / `executescript()` block ending around line 298)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write the failing test**
+
+Add to `vireo/tests/test_db.py`:
+
+```python
+def test_new_image_snapshots_tables_exist(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    tables = {
+        r["name"]
+        for r in db.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    assert "new_image_snapshots" in tables
+    assert "new_image_snapshot_files" in tables
+```
+
+**Step 2: Run the test — verify it fails**
+
+Run: `python -m pytest vireo/tests/test_db.py::test_new_image_snapshots_tables_exist -v`
+Expected: FAIL (tables don't exist).
+
+**Step 3: Add tables to the `executescript()` block**
+
+Append to the initial-schema `executescript()` in `_create_tables()` (before the closing `""")` around line 298):
+
+```sql
+CREATE TABLE IF NOT EXISTS new_image_snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  workspace_id INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL,
+  file_count INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS new_image_snapshot_files (
+  snapshot_id INTEGER NOT NULL REFERENCES new_image_snapshots(id) ON DELETE CASCADE,
+  file_path TEXT NOT NULL,
+  PRIMARY KEY (snapshot_id, file_path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_new_image_snapshots_ws
+  ON new_image_snapshots(workspace_id);
+```
+
+**Step 4: Run the test — verify it passes**
+
+Run: `python -m pytest vireo/tests/test_db.py::test_new_image_snapshots_tables_exist -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: add new_image_snapshots tables"
+```
+
+---
+
+## Task 2: `Database.create_new_images_snapshot` + `get_new_images_snapshot`
+
+**Files:**
+- Modify: `vireo/db.py`
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_create_and_get_new_images_snapshot(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db._active_workspace_id
+    paths = ["/tmp/a/IMG_001.JPG", "/tmp/b/IMG_002.JPG"]
+    snap_id = db.create_new_images_snapshot(paths)
+    assert isinstance(snap_id, int)
+
+    snap = db.get_new_images_snapshot(snap_id)
+    assert snap is not None
+    assert snap["file_count"] == 2
+    assert snap["workspace_id"] == ws_id
+    assert sorted(snap["file_paths"]) == sorted(paths)
+
+
+def test_get_snapshot_from_different_workspace_returns_none(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    other_ws = db.create_workspace("Other")
+    paths = ["/tmp/a/IMG_001.JPG"]
+    snap_id = db.create_new_images_snapshot(paths)
+    db.set_active_workspace(other_ws)
+    assert db.get_new_images_snapshot(snap_id) is None
+
+
+def test_snapshot_deleted_with_workspace(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    throwaway_ws = db.create_workspace("Throwaway")
+    db.set_active_workspace(throwaway_ws)
+    snap_id = db.create_new_images_snapshot(["/tmp/a.jpg"])
+    db.delete_workspace(throwaway_ws)
+    row = db.conn.execute(
+        "SELECT id FROM new_image_snapshots WHERE id = ?", (snap_id,)
+    ).fetchone()
+    assert row is None
+
+
+def test_create_snapshot_empty_paths(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    snap_id = db.create_new_images_snapshot([])
+    snap = db.get_new_images_snapshot(snap_id)
+    assert snap["file_count"] == 0
+    assert snap["file_paths"] == []
+```
+
+**Step 2: Verify they fail**
+
+Run: `python -m pytest vireo/tests/test_db.py -k snapshot -v`
+Expected: FAIL (methods don't exist).
+
+**Step 3: Implement in `vireo/db.py`**
+
+Add near the other workspace-scoped helpers (e.g. below `add_collection`):
+
+```python
+def create_new_images_snapshot(self, file_paths):
+    """Persist a snapshot of new-image file paths for the active workspace.
+
+    Returns the new snapshot id. An empty path list is allowed — the caller
+    decides how to handle zero-file snapshots (the pipeline short-circuits).
+    """
+    ws_id = self._ws_id()
+    cur = self.conn.execute(
+        "INSERT INTO new_image_snapshots (workspace_id, created_at, file_count) "
+        "VALUES (?, datetime('now'), ?)",
+        (ws_id, len(file_paths)),
+    )
+    snap_id = cur.lastrowid
+    if file_paths:
+        # De-duplicate in case the caller passed repeats; PK would reject them
+        # but sending a clean set keeps executemany cheap.
+        unique_paths = sorted(set(file_paths))
+        self.conn.executemany(
+            "INSERT INTO new_image_snapshot_files (snapshot_id, file_path) VALUES (?, ?)",
+            [(snap_id, p) for p in unique_paths],
+        )
+    self.conn.commit()
+    return snap_id
+
+
+def get_new_images_snapshot(self, snapshot_id):
+    """Return snapshot metadata + file paths, or None if not found / cross-workspace.
+
+    Isolation: a snapshot created in workspace A is invisible when workspace B
+    is active. Callers treat None as 'expired / gone'.
+    """
+    row = self.conn.execute(
+        "SELECT id, workspace_id, created_at, file_count "
+        "FROM new_image_snapshots WHERE id = ? AND workspace_id = ?",
+        (snapshot_id, self._ws_id()),
+    ).fetchone()
+    if row is None:
+        return None
+    paths = [
+        r["file_path"]
+        for r in self.conn.execute(
+            "SELECT file_path FROM new_image_snapshot_files WHERE snapshot_id = ? "
+            "ORDER BY file_path",
+            (snapshot_id,),
+        ).fetchall()
+    ]
+    return {
+        "id": row["id"],
+        "workspace_id": row["workspace_id"],
+        "created_at": row["created_at"],
+        "file_count": row["file_count"],
+        "file_paths": paths,
+    }
+```
+
+**Step 4: Verify tests pass**
+
+Run: `python -m pytest vireo/tests/test_db.py -k snapshot -v`
+Expected: PASS (4 tests).
+
+**Step 5: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: add create/get new-images snapshot helpers"
+```
+
+---
+
+## Task 3: Extend new-images detection to return full path list
+
+**Files:**
+- Modify: `vireo/new_images.py`
+- Modify: `vireo/db.py` (the `get_new_images_for_workspace` wrapper, if any filtering applies)
+- Test: `vireo/tests/test_new_images.py`
+
+The existing `count_new_images_for_workspace` has a `sample_limit=5` and only returns up to 5 paths. For snapshot creation we need every path, not a sample.
+
+**Step 1: Write the failing test**
+
+Add to `vireo/tests/test_new_images.py`:
+
+```python
+def test_count_new_images_returns_all_paths_when_sample_limit_is_none(tmp_path):
+    # Set up a workspace with 10 new files on disk.
+    db = Database(str(tmp_path / "test.db"))
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    db.add_folder(str(folder))
+    for i in range(10):
+        _touch_image(folder / f"IMG_{i:03d}.JPG")
+    result = count_new_images_for_workspace(
+        db, db._active_workspace_id, sample_limit=None
+    )
+    assert result["new_count"] == 10
+    assert len(result["sample"]) == 10
+```
+
+**Step 2: Verify fail**
+
+Run: `python -m pytest vireo/tests/test_new_images.py::test_count_new_images_returns_all_paths_when_sample_limit_is_none -v`
+Expected: FAIL (`sample` is capped at 5).
+
+**Step 3: Modify `count_new_images_for_workspace`**
+
+In `vireo/new_images.py`, change the `sample_limit` gate so `None` means unlimited:
+
+```python
+def count_new_images_for_workspace(db, workspace_id, sample_limit=5):
+    ...
+    for root in roots:
+        ...
+        for dirpath, _dirnames, filenames in os.walk(root_path):
+            for name in filenames:
+                ...
+                full = os.path.join(dirpath, name)
+                if full in known:
+                    continue
+                root_new += 1
+                if sample_limit is None or len(sample) < sample_limit:
+                    sample.append(full)
+        ...
+```
+
+Only the `if sample_limit is None or len(sample) < sample_limit:` line changes.
+
+**Step 4: Verify test passes, and existing tests still pass**
+
+Run: `python -m pytest vireo/tests/test_new_images.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/new_images.py vireo/tests/test_new_images.py
+git commit -m "new-images: allow sample_limit=None to return all paths"
+```
+
+---
+
+## Task 4: `POST /api/workspaces/active/new-images/snapshot` endpoint
+
+**Files:**
+- Modify: `vireo/app.py` (near the existing `/api/workspaces/active/new-images` route around line 2046)
+- Test: `vireo/tests/test_new_images_api.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_post_snapshot_creates_row_with_current_new_images(app_and_db, tmp_path):
+    app, db = app_and_db
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    db.add_folder(str(folder))
+    _touch_image(folder / "IMG_001.JPG")
+    _touch_image(folder / "IMG_002.JPG")
+    # Bust the in-process new-images cache so the POST sees fresh disk state.
+    get_shared_cache().clear()
+
+    with app.test_client() as client:
+        resp = client.post("/api/workspaces/active/new-images/snapshot")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["file_count"] == 2
+        assert isinstance(data["snapshot_id"], int)
+        assert str(folder) in data["folders"]
+
+    snap = db.get_new_images_snapshot(data["snapshot_id"])
+    assert snap["file_count"] == 2
+
+
+def test_post_snapshot_zero_new_images_returns_200(app_and_db):
+    app, db = app_and_db
+    with app.test_client() as client:
+        resp = client.post("/api/workspaces/active/new-images/snapshot")
+        assert resp.status_code == 200
+        assert resp.get_json()["file_count"] == 0
+```
+
+Import `get_shared_cache` from `new_images` at the top of the test file.
+
+**Step 2: Verify fail**
+
+Run: `python -m pytest vireo/tests/test_new_images_api.py -k snapshot -v`
+Expected: FAIL (route doesn't exist → 404).
+
+**Step 3: Implement in `vireo/app.py`**
+
+Add below the existing `api_workspace_new_images` handler:
+
+```python
+@app.route("/api/workspaces/active/new-images/snapshot", methods=["POST"])
+def api_workspace_new_images_snapshot_create():
+    db = _get_db()
+    ws_id = db._active_workspace_id
+    if ws_id is None:
+        return jsonify({"error": "no active workspace"}), 400
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id, sample_limit=None)
+    file_paths = list(result["sample"])
+    snap_id = db.create_new_images_snapshot(file_paths)
+    folders = sorted({os.path.dirname(p) for p in file_paths})
+    return jsonify({
+        "snapshot_id": snap_id,
+        "file_count": len(file_paths),
+        "folders": folders,
+    })
+```
+
+(Confirm `os` is already imported; `vireo/app.py` imports it near the top.)
+
+**Step 4: Verify tests pass**
+
+Run: `python -m pytest vireo/tests/test_new_images_api.py -k snapshot -v`
+Expected: PASS (2 tests).
+
+**Step 5: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_new_images_api.py
+git commit -m "api: POST /api/workspaces/active/new-images/snapshot"
+```
+
+---
+
+## Task 5: `GET /api/workspaces/active/new-images/snapshot/<id>` endpoint
+
+**Files:**
+- Modify: `vireo/app.py`
+- Test: `vireo/tests/test_new_images_api.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_get_snapshot_returns_summary(app_and_db, tmp_path):
+    app, db = app_and_db
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    db.add_folder(str(folder))
+    _touch_image(folder / "IMG_001.JPG")
+    get_shared_cache().clear()
+
+    with app.test_client() as client:
+        post = client.post("/api/workspaces/active/new-images/snapshot")
+        snap_id = post.get_json()["snapshot_id"]
+
+        resp = client.get(f"/api/workspaces/active/new-images/snapshot/{snap_id}")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["file_count"] == 1
+        assert data["folder_paths"] == [str(folder)]
+        assert data["files_sample"][0].endswith("IMG_001.JPG")
+
+
+def test_get_snapshot_unknown_id_returns_404(app_and_db):
+    app, _ = app_and_db
+    with app.test_client() as client:
+        resp = client.get("/api/workspaces/active/new-images/snapshot/99999")
+        assert resp.status_code == 404
+
+
+def test_get_snapshot_cross_workspace_returns_404(app_and_db):
+    app, db = app_and_db
+    snap_id = db.create_new_images_snapshot(["/tmp/a.jpg"])
+    other = db.create_workspace("Other")
+    db.set_active_workspace(other)
+    with app.test_client() as client:
+        resp = client.get(f"/api/workspaces/active/new-images/snapshot/{snap_id}")
+        assert resp.status_code == 404
+```
+
+**Step 2: Verify fail**
+
+Run: `python -m pytest vireo/tests/test_new_images_api.py -k get_snapshot -v`
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Add in `vireo/app.py` below the POST handler:
+
+```python
+@app.route(
+    "/api/workspaces/active/new-images/snapshot/<int:snapshot_id>",
+    methods=["GET"],
+)
+def api_workspace_new_images_snapshot_get(snapshot_id):
+    db = _get_db()
+    if db._active_workspace_id is None:
+        abort(404)
+    snap = db.get_new_images_snapshot(snapshot_id)
+    if snap is None:
+        abort(404)
+    paths = snap["file_paths"]
+    folder_paths = sorted({os.path.dirname(p) for p in paths})
+    files_sample = paths[:5]
+    return jsonify({
+        "file_count": snap["file_count"],
+        "folder_paths": folder_paths,
+        "files_sample": files_sample,
+    })
+```
+
+**Step 4: Verify tests pass**
+
+Run: `python -m pytest vireo/tests/test_new_images_api.py -k get_snapshot -v`
+Expected: PASS (3 tests).
+
+**Step 5: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_new_images_api.py
+git commit -m "api: GET /api/workspaces/active/new-images/snapshot/<id>"
+```
+
+---
+
+## Task 6: Add `source_snapshot_id` to `PipelineParams` and scope the scan stage
+
+**Files:**
+- Modify: `vireo/pipeline_job.py`
+- Test: `vireo/tests/test_pipeline_job.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_pipeline_with_snapshot_scans_only_snapshot_folders(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "test.db"))
+    a = tmp_path / "folderA"
+    b = tmp_path / "folderB"
+    a.mkdir(); b.mkdir()
+    db.add_folder(str(a))
+    db.add_folder(str(b))
+    (a / "IMG_001.JPG").write_bytes(_tiny_jpeg_bytes())
+    (b / "IMG_002.JPG").write_bytes(_tiny_jpeg_bytes())
+    snap_id = db.create_new_images_snapshot([str(a / "IMG_001.JPG")])
+
+    scanned_dirs = []
+    real_scan = pipeline_job.do_scan
+    def spy_scan(root, *a, **kw):
+        scanned_dirs.append(root)
+        return real_scan(root, *a, **kw)
+    monkeypatch.setattr(pipeline_job, "do_scan", spy_scan)
+
+    # Run pipeline with snapshot source; just the scan stage is enough here.
+    params = PipelineParams(source_snapshot_id=snap_id, skip_classify=True,
+                            skip_extract_masks=True, skip_regroup=True)
+    runner = make_test_runner()  # existing test helper
+    job = runner.create_job("pipeline")
+    run_pipeline_job(job, runner, str(tmp_path / "test.db"),
+                     db._active_workspace_id, params)
+
+    assert str(a) in scanned_dirs
+    assert str(b) not in scanned_dirs
+```
+
+(Use whatever existing `make_test_runner` / job-creation helper the test file already provides — mirror neighboring tests.)
+
+**Step 2: Verify fail**
+
+Run: `python -m pytest vireo/tests/test_pipeline_job.py::test_pipeline_with_snapshot_scans_only_snapshot_folders -v`
+Expected: FAIL (`source_snapshot_id` is not a valid param).
+
+**Step 3: Extend `PipelineParams`**
+
+In `vireo/pipeline_job.py`, the `@dataclass` near line 28:
+
+```python
+@dataclass
+class PipelineParams:
+    collection_id: int | None = None
+    source: str | None = None
+    sources: list | None = None
+    source_snapshot_id: int | None = None  # <-- add
+    destination: str | None = None
+    ...
+```
+
+**Step 4: Implement snapshot-scoped scan**
+
+In `run_pipeline_job`, before the existing scan-stage setup (around the `scanner_stage()` definition), load the snapshot once and derive the list of folders to scan:
+
+```python
+snapshot_paths: list[str] | None = None
+if params.source_snapshot_id is not None:
+    db_ro = Database(db_path)
+    db_ro.set_active_workspace(workspace_id)
+    snap = db_ro.get_new_images_snapshot(params.source_snapshot_id)
+    db_ro.close()
+    if snap is None:
+        raise ValueError(f"snapshot {params.source_snapshot_id} not found")
+    snapshot_paths = snap["file_paths"]
+    scan_roots = sorted({os.path.dirname(p) for p in snapshot_paths}) or []
+    # Override whatever source/sources was passed so the scan walks only these dirs.
+    params.sources = scan_roots
+    params.source = None
+    params.collection_id = None
+```
+
+The existing scan-stage code walks `params.sources` (or `params.source`), so nothing else changes there.
+
+**Step 5: Verify test passes**
+
+Run: `python -m pytest vireo/tests/test_pipeline_job.py::test_pipeline_with_snapshot_scans_only_snapshot_folders -v`
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add vireo/pipeline_job.py vireo/tests/test_pipeline_job.py
+git commit -m "pipeline: scope scan stage to snapshot folders"
+```
+
+---
+
+## Task 7: Filter downstream stages to snapshot photo IDs
+
+**Files:**
+- Modify: `vireo/pipeline_job.py`
+- Test: `vireo/tests/test_pipeline_job.py`
+
+After the scan stage completes, we resolve snapshot file paths to photo IDs and constrain downstream stages to that set. This is the snapshot-guarantee enforcement point.
+
+**Step 1: Write the failing test**
+
+```python
+def test_pipeline_snapshot_excludes_late_arriving_files(tmp_path, monkeypatch):
+    """Files added to the folder after the snapshot get scanned but NOT classified."""
+    db = Database(str(tmp_path / "test.db"))
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    db.add_folder(str(folder))
+    (folder / "IMG_early.JPG").write_bytes(_tiny_jpeg_bytes())
+    snap_id = db.create_new_images_snapshot([str(folder / "IMG_early.JPG")])
+
+    # Simulate a file arriving between snapshot and run:
+    (folder / "IMG_late.JPG").write_bytes(_tiny_jpeg_bytes())
+
+    classified_photo_ids = []
+    def spy_classify(photo_ids, *a, **kw):
+        classified_photo_ids.extend(photo_ids)
+    monkeypatch.setattr(pipeline_job, "_classify_photos", spy_classify)
+
+    params = PipelineParams(source_snapshot_id=snap_id,
+                            skip_extract_masks=True, skip_regroup=True)
+    runner = make_test_runner()
+    job = runner.create_job("pipeline")
+    run_pipeline_job(job, runner, str(tmp_path / "test.db"),
+                     db._active_workspace_id, params)
+
+    classified_names = {
+        db.conn.execute(
+            "SELECT filename FROM photos WHERE id = ?", (pid,)
+        ).fetchone()["filename"]
+        for pid in classified_photo_ids
+    }
+    assert "IMG_early.JPG" in classified_names
+    assert "IMG_late.JPG" not in classified_names
+```
+
+(If the exact classification entry point in `pipeline_job.py` is named differently, adjust the `monkeypatch.setattr` target. Read the file to confirm.)
+
+**Step 2: Verify fail**
+
+Run: `python -m pytest vireo/tests/test_pipeline_job.py::test_pipeline_snapshot_excludes_late_arriving_files -v`
+Expected: FAIL (no filter yet — both files would be classified).
+
+**Step 3: Resolve snapshot paths → photo IDs after scan, apply filter downstream**
+
+After the scanner completes in `run_pipeline_job`, if `snapshot_paths` is set, resolve them:
+
+```python
+snapshot_photo_ids: set[int] | None = None
+if snapshot_paths is not None:
+    db_resolver = Database(db_path)
+    db_resolver.set_active_workspace(workspace_id)
+    rows = db_resolver.conn.execute(f"""
+        SELECT p.id
+        FROM photos p
+        JOIN folders f ON f.id = p.folder_id
+        WHERE (f.path || '/' || p.filename) IN ({",".join("?" * len(snapshot_paths))})
+    """, snapshot_paths).fetchall()
+    snapshot_photo_ids = {r["id"] for r in rows}
+    db_resolver.close()
+    missing = len(snapshot_paths) - len(snapshot_photo_ids)
+    if missing:
+        logging.info(
+            "pipeline: snapshot %s had %d files, %d ingested, %d missing on disk",
+            params.source_snapshot_id, len(snapshot_paths),
+            len(snapshot_photo_ids), missing,
+        )
+```
+
+Then, at each downstream stage's entry point, constrain its photo-id set:
+
+```python
+if snapshot_photo_ids is not None:
+    photo_ids = [pid for pid in photo_ids if pid in snapshot_photo_ids]
+```
+
+(Exact placement depends on how each stage selects its input set in the current `run_pipeline_job`. When in doubt, confirm by reading each stage's photo-selection code and apply the filter uniformly.)
+
+**Step 4: Verify test passes**
+
+Run: `python -m pytest vireo/tests/test_pipeline_job.py::test_pipeline_snapshot_excludes_late_arriving_files -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/pipeline_job.py vireo/tests/test_pipeline_job.py
+git commit -m "pipeline: filter downstream stages to snapshot photo ids"
+```
+
+---
+
+## Task 8: `/api/jobs/pipeline` accepts `source_snapshot_id`
+
+**Files:**
+- Modify: `vireo/app.py` (the `api_job_pipeline` handler around line 6593)
+- Test: `vireo/tests/test_pipeline_api.py` (or wherever `/api/jobs/pipeline` is tested)
+
+**Step 1: Write the failing test**
+
+```python
+def test_post_pipeline_accepts_source_snapshot_id(app_and_db, tmp_path, monkeypatch):
+    app, db = app_and_db
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    db.add_folder(str(folder))
+    _touch_image(folder / "IMG_001.JPG")
+    snap_id = db.create_new_images_snapshot([str(folder / "IMG_001.JPG")])
+
+    captured = {}
+    def spy_run(job, runner, db_path, ws_id, params):
+        captured["snap_id"] = params.source_snapshot_id
+    monkeypatch.setattr("pipeline_job.run_pipeline_job", spy_run)
+
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={"source_snapshot_id": snap_id})
+        assert resp.status_code == 200
+
+    # JobRunner runs in a thread — wait briefly for spy_run to fire.
+    wait_for(lambda: "snap_id" in captured, timeout=2.0)
+    assert captured["snap_id"] == snap_id
+```
+
+**Step 2: Verify fail**
+
+Run: `python -m pytest vireo/tests/test_pipeline_api.py -k snapshot -v`
+Expected: FAIL.
+
+**Step 3: Add `source_snapshot_id` to the handler**
+
+In `vireo/app.py`'s `api_job_pipeline`, where it builds `PipelineParams`:
+
+```python
+source_snapshot_id = body.get("source_snapshot_id")
+...
+params = PipelineParams(
+    ...
+    source_snapshot_id=source_snapshot_id,
+    ...
+)
+```
+
+**Step 4: Verify test passes**
+
+Run: `python -m pytest vireo/tests/test_pipeline_api.py -k snapshot -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_pipeline_api.py
+git commit -m "api: pipeline endpoint accepts source_snapshot_id"
+```
+
+---
+
+## Task 9: Pipeline page — add "New images" Stage 1 source card
+
+**Files:**
+- Modify: `vireo/templates/pipeline.html` (Stage 1 source area around lines 475–557)
+
+This task is UI-only, no backend changes. Because frontend changes aren't cleanly unit-testable from pytest, verify manually + Playwright in Task 11.
+
+**Step 1: Add the third source card**
+
+After the "Use Existing Collection" card (around line 557), add:
+
+```html
+<div class="source-or" id="sourceOrNewImages" style="display:none;">OR</div>
+<div class="source-option" id="sourceOptionNewImages" style="display:none;">
+  <div class="source-option-header" onclick="selectSourceMode('new_images')">
+    <input type="radio" id="radioNewImages" name="sourceMode" value="new_images">
+    <label for="radioNewImages">
+      <strong id="newImagesCardTitle">New images</strong>
+      <span id="newImagesCardSubtitle" class="muted"></span>
+    </label>
+  </div>
+  <div class="source-option-body" id="sourceNewImagesBody" style="display:none;">
+    <ul id="newImagesFolderList" class="folder-list"></ul>
+  </div>
+</div>
+```
+
+**Step 2: Add JS probe + deep-link handling**
+
+Inline JS (mirror the patterns used by the other source options). Near the page-init block:
+
+```javascript
+let newImagesSnapshotId = null;
+
+async function initNewImagesCard() {
+  const params = new URLSearchParams(window.location.search);
+  const deepLinkId = params.get("new_images");
+  if (deepLinkId) {
+    try {
+      const r = await fetch(`/api/workspaces/active/new-images/snapshot/${deepLinkId}`);
+      if (!r.ok) throw new Error("snapshot expired");
+      const snap = await r.json();
+      newImagesSnapshotId = parseInt(deepLinkId, 10);
+      renderNewImagesCard(snap.file_count, snap.folder_paths);
+      selectSourceMode("new_images");
+    } catch (e) {
+      showToast("That snapshot has expired — please try again from the banner.");
+      await probeNewImagesCard();
+    }
+  } else {
+    await probeNewImagesCard();
+  }
+}
+
+async function probeNewImagesCard() {
+  const r = await fetch("/api/workspaces/active/new-images");
+  const data = await r.json();
+  if ((data.new_count || 0) > 0) {
+    const folders = (data.per_root || []).map(pr => pr.path);
+    renderNewImagesCard(data.new_count, folders);
+  }
+}
+
+function renderNewImagesCard(count, folders) {
+  const card = document.getElementById("sourceOptionNewImages");
+  const orSep = document.getElementById("sourceOrNewImages");
+  card.style.display = "";
+  orSep.style.display = "";
+  document.getElementById("newImagesCardSubtitle").textContent =
+    ` — ${count} new image${count === 1 ? "" : "s"} in ${folders.length} folder${folders.length === 1 ? "" : "s"}`;
+  const list = document.getElementById("newImagesFolderList");
+  list.innerHTML = "";
+  for (const f of folders) {
+    const li = document.createElement("li");
+    li.textContent = f;
+    list.appendChild(li);
+  }
+}
+
+document.addEventListener("DOMContentLoaded", initNewImagesCard);
+```
+
+**Step 3: Extend `selectSourceMode` to capture snapshot on select**
+
+In the existing `selectSourceMode(mode)` function, add a branch:
+
+```javascript
+if (mode === "new_images") {
+  document.getElementById("sourceNewImagesBody").style.display = "";
+  if (newImagesSnapshotId === null) {
+    // User is selecting the card directly (no deep-link) — freeze the list now.
+    const r = await fetch("/api/workspaces/active/new-images/snapshot", {method: "POST"});
+    const data = await r.json();
+    newImagesSnapshotId = data.snapshot_id;
+  }
+} else {
+  document.getElementById("sourceNewImagesBody").style.display = "none";
+}
+```
+
+(Make `selectSourceMode` `async` if it isn't already.)
+
+**Step 4: Include `source_snapshot_id` in the pipeline submit payload**
+
+Where the existing submit code builds the JSON body for `POST /api/jobs/pipeline`, add:
+
+```javascript
+if (currentSourceMode === "new_images") {
+  payload.source_snapshot_id = newImagesSnapshotId;
+  delete payload.source;
+  delete payload.sources;
+  delete payload.file_types;
+}
+```
+
+**Step 5: Manual smoke test**
+
+```bash
+python vireo/app.py --db ~/.vireo/vireo.db --port 8080
+```
+
+- Drop a file into a registered folder, reload `/pipeline`. The "New images" card should appear. Click it — confirm subtitle shows correct count and folders render in the body.
+- Navigate to `/pipeline?new_images=<valid_id>` — card should auto-select and show the snapshot's counts.
+- Navigate to `/pipeline?new_images=999999` — toast "snapshot has expired", card falls back to runtime probe.
+
+**Step 6: Commit**
+
+```bash
+git add vireo/templates/pipeline.html
+git commit -m "ui: add 'New images' source card to pipeline Stage 1"
+```
+
+---
+
+## Task 10: Banner — POST snapshot, then redirect
+
+**Files:**
+- Modify: `vireo/templates/_navbar.html` (banner around line 1167–1172)
+
+**Step 1: Convert the anchor to a button + JS**
+
+Replace the existing `<a href="/pipeline">Create a pipeline</a>` with:
+
+```html
+<button type="button" class="banner-cta" onclick="createPipelineFromNewImages()">
+  Create a pipeline
+</button>
+```
+
+**Step 2: Add the handler near the other banner JS**
+
+```javascript
+async function createPipelineFromNewImages() {
+  try {
+    const r = await fetch("/api/workspaces/active/new-images/snapshot", {method: "POST"});
+    if (!r.ok) throw new Error("snapshot failed");
+    const data = await r.json();
+    window.location.href = `/pipeline?new_images=${data.snapshot_id}`;
+  } catch (e) {
+    // Fall back to the existing behavior — blank pipeline wizard.
+    window.location.href = "/pipeline";
+  }
+}
+```
+
+**Step 3: Manual smoke test**
+
+- Drop a file in a registered folder, reload any Vireo page.
+- Banner appears. Click "Create a pipeline".
+- Browser lands on `/pipeline?new_images=<id>` with the new-images card pre-selected.
+
+**Step 4: Commit**
+
+```bash
+git add vireo/templates/_navbar.html
+git commit -m "ui: banner POSTs snapshot before opening pipeline"
+```
+
+---
+
+## Task 11: E2E Playwright test
+
+**Files:**
+- Create or extend: an existing Playwright test under `tests/` (follow the user-first-testing convention — see `docs/plans/2026-04-16-user-first-testing-design.md` if unclear).
+
+**Step 1: Write the test**
+
+End-to-end flow:
+
+1. Start Vireo against a fresh temp DB + temp photo folder.
+2. Register the folder via the UI or API.
+3. Drop a JPEG into the folder.
+4. Reload the page. Assert banner appears with "1 new image".
+5. Click "Create a pipeline".
+6. Assert URL is `/pipeline?new_images=<id>`.
+7. Assert the "New images" source card is selected and shows "1 new image".
+8. Complete the wizard with minimal options, submit.
+9. Wait for job completion. Assert the photo appears in the browse grid.
+
+**Step 2: Run the test**
+
+(Exact command depends on the project's Playwright runner — mirror neighboring E2E tests.)
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_new_images_pipeline_e2e.py
+git commit -m "test: e2e for new-images banner → pipeline flow"
+```
+
+---
+
+## Final verification
+
+**Step 1: Run the full test suite per CLAUDE.md:**
+
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_new_images.py vireo/tests/test_new_images_api.py vireo/tests/test_pipeline_job.py -v
+```
+
+Expected: all pass.
+
+**Step 2: Update PR description**
+
+The PR (#625) was opened for the design doc. Push these commits to the same branch; the PR re-reviews automatically.
+
+**Step 3: Manual end-to-end check**
+
+Drop a file, click the banner's "Create a pipeline", step through the wizard, verify the photo is ingested and classified. This is the user's real-world acceptance test — skipping would mean we shipped without driving it once.

--- a/tests/e2e/test_new_images_pipeline.py
+++ b/tests/e2e/test_new_images_pipeline.py
@@ -1,0 +1,156 @@
+"""E2E test for the new-images banner -> pipeline flow.
+
+Covers Task 11 of docs/plans/2026-04-22-new-images-pipeline-plan.md:
+drop a JPEG into a registered folder, see the banner, click "Create a
+pipeline", end up on /pipeline?new_images=<id> with the "New images" source
+card pre-selected, start the pipeline, and confirm the photo is visible on
+/browse.
+
+Does not reuse the shared `live_server` fixture from conftest.py because that
+one seeds phantom photos under /photos/park and /photos/yard that don't exist
+on disk — which would make "new images" detection unreliable. Instead this
+module spins up its own Flask server backed by an empty workspace and a real
+temp folder.
+"""
+import os
+import sys
+import threading
+import time
+
+import pytest
+from PIL import Image
+from playwright.sync_api import expect
+from werkzeug.serving import make_server
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "vireo"))
+
+
+def _write_jpeg(path, size=(64, 64), color="red"):
+    """Write a valid JPEG to `path`. Real bytes so `Pillow.open()` works."""
+    Image.new("RGB", size, color=color).save(str(path), "JPEG")
+
+
+@pytest.fixture()
+def fresh_server(tmp_path, monkeypatch):
+    """Start a Flask server against an empty workspace + temp photo folder.
+
+    Returns: {"url", "db", "photo_dir"}.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    import config as cfg
+    from app import create_app
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    # Register the folder so it's "known" to the workspace but empty on disk.
+    folder_id = db.add_folder(str(photo_dir), name="photos")
+    db.add_workspace_folder(ws_id, folder_id)
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir)
+
+    server = make_server("127.0.0.1", 0, app)
+    port = server.socket.getsockname()[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    yield {
+        "url": f"http://127.0.0.1:{port}",
+        "db": db,
+        "photo_dir": photo_dir,
+        "app": app,
+    }
+
+    server.shutdown()
+    thread.join(timeout=5)
+
+
+def _clear_new_images_cache():
+    """Bust the in-process new-images cache so fresh disk state is observed.
+
+    The cache sits in the `new_images` module and is shared by both
+    `count_new_images_for_workspace` and the `/api/workspaces/active/new-images`
+    endpoint. Tests that drop files on disk between page loads must clear it
+    or the banner never appears.
+    """
+    from new_images import get_shared_cache
+    get_shared_cache().clear()
+
+
+def test_new_images_banner_drives_pipeline(fresh_server, page):
+    """Full user flow: drop file -> banner -> pipeline -> photo visible."""
+    url = fresh_server["url"]
+    photo_dir = fresh_server["photo_dir"]
+    db = fresh_server["db"]
+
+    # --- Step 1: drop a JPEG into the registered folder. ---
+    jpeg_path = photo_dir / "IMG_0001.JPG"
+    _write_jpeg(jpeg_path)
+    _clear_new_images_cache()
+
+    # --- Step 2: visit any Vireo page; banner should appear. ---
+    page.goto(f"{url}/browse")
+    banner = page.locator("#newImagesBanner")
+    expect(banner).to_be_visible(timeout=5000)
+    msg = page.locator("#newImagesMsg")
+    expect(msg).to_contain_text("1 new image")
+
+    # --- Step 3: click "Create a pipeline" and land on /pipeline?new_images=<id>. ---
+    page.locator("#newImagesBanner .banner-cta").click()
+    page.wait_for_url("**/pipeline?new_images=*", timeout=5000)
+    assert "new_images=" in page.url
+
+    # --- Step 4: the "New images" source card is visible AND selected. ---
+    card = page.locator("#sourceOptionNewImages")
+    expect(card).to_be_visible()
+    radio = page.locator("[data-testid='source-new-images']")
+    expect(radio).to_be_checked()
+
+    # Subtitle shows the snapshot's count. The JS renders " \u2014 1 new image in 1 folder".
+    subtitle = page.locator("#newImagesCardSubtitle")
+    expect(subtitle).to_contain_text("1 new image")
+
+    # --- Step 5: submit the pipeline with classify/extract/group disabled to
+    # keep it fast (no model in this test environment anyway).
+    # Un-check classify/extract/group to skip the heavy stages.
+    for cb_id in ("enableClassify", "enableExtract", "enableGroup"):
+        checkbox = page.locator(f"#{cb_id}")
+        if checkbox.is_checked():
+            checkbox.uncheck()
+
+    start_btn = page.locator("[data-testid='start-pipeline-btn']")
+    expect(start_btn).to_be_enabled(timeout=5000)
+    start_btn.click()
+
+    # --- Step 6: wait for the job to finish. The snapshot pipeline path runs
+    # scan-only when all the optional stages are skipped, which is fast.
+    # Poll the DB directly rather than scraping the UI.
+    deadline = time.time() + 30
+    photo_row = None
+    while time.time() < deadline:
+        photo_row = db.conn.execute(
+            "SELECT id, filename FROM photos WHERE filename = ?",
+            ("IMG_0001.JPG",),
+        ).fetchone()
+        if photo_row is not None:
+            break
+        time.sleep(0.25)
+    assert photo_row is not None, (
+        "Pipeline never ingested IMG_0001.JPG within 30s"
+    )
+
+    # --- Step 7: navigate to /browse and confirm the photo is visible. ---
+    page.goto(f"{url}/browse")
+    card = page.locator(".grid-card[data-filename='IMG_0001.JPG']")
+    expect(card).to_be_visible(timeout=5000)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6646,6 +6646,17 @@ def create_app(db_path, thumb_cache_dir=None):
         if not source and not sources and not collection_id and not source_snapshot_id:
             return json_error("source, sources, collection_id, or source_snapshot_id required")
 
+        # Resolve the snapshot synchronously so clients get 404 at request
+        # time instead of a 200 followed by an asynchronous job failure.
+        if (
+            source_snapshot_id is not None
+            and _get_db().get_new_images_snapshot(source_snapshot_id) is None
+        ):
+            return json_error(
+                f"source_snapshot_id {source_snapshot_id} not found",
+                status=404,
+            )
+
         # Validate all source directories exist
         if sources:
             for s in sources:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2054,6 +2054,23 @@ def create_app(db_path, thumb_cache_dir=None):
         payload["workspace_id"] = ws_id
         return jsonify(payload)
 
+    @app.route("/api/workspaces/active/new-images/snapshot", methods=["POST"])
+    def api_workspace_new_images_snapshot_create():
+        db = _get_db()
+        ws_id = db._active_workspace_id
+        if ws_id is None:
+            return jsonify({"error": "no active workspace"}), 400
+        from new_images import count_new_images_for_workspace
+        result = count_new_images_for_workspace(db, ws_id, sample_limit=None)
+        file_paths = list(result["sample"])
+        snap_id = db.create_new_images_snapshot(file_paths)
+        folders = sorted({os.path.dirname(p) for p in file_paths})
+        return jsonify({
+            "snapshot_id": snap_id,
+            "file_count": len(file_paths),
+            "folders": folders,
+        })
+
     # -- Prediction API routes --
 
     @app.route("/api/predictions")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6641,9 +6641,10 @@ def create_app(db_path, thumb_cache_dir=None):
         source = body.get("source")
         sources = body.get("sources")
         collection_id = body.get("collection_id")
+        source_snapshot_id = body.get("source_snapshot_id")
 
-        if not source and not sources and not collection_id:
-            return json_error("source, sources, or collection_id required")
+        if not source and not sources and not collection_id and not source_snapshot_id:
+            return json_error("source, sources, collection_id, or source_snapshot_id required")
 
         # Validate all source directories exist
         if sources:
@@ -6667,6 +6668,7 @@ def create_app(db_path, thumb_cache_dir=None):
             collection_id=collection_id,
             source=source,
             sources=sources,
+            source_snapshot_id=source_snapshot_id,
             destination=destination,
             file_types=body.get("file_types", "both"),
             folder_template=folder_template,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6900,6 +6900,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not source and not sources and not collection_id and not source_snapshot_id:
             return json_error("source, sources, collection_id, or source_snapshot_id required")
 
+        # Validate type before touching SQLite. Non-integer bodies (objects,
+        # arrays, non-numeric strings, floats, bools) would otherwise reach
+        # sqlite3 parameter binding and raise ProgrammingError, surfacing as
+        # an opaque 500 instead of a clean 4xx.
+        if source_snapshot_id is not None and (
+            isinstance(source_snapshot_id, bool)
+            or not isinstance(source_snapshot_id, int)
+        ):
+            return json_error("source_snapshot_id must be an integer")
+
         # Resolve the snapshot synchronously so clients get 404 at request
         # time instead of a 200 followed by an asynchronous job failure.
         if (

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6657,13 +6657,17 @@ def create_app(db_path, thumb_cache_dir=None):
                 status=404,
             )
 
-        # Validate all source directories exist
-        if sources:
-            for s in sources:
-                if not os.path.isdir(s):
-                    return json_error(f"source directory not found: {s}")
-        elif source and not os.path.isdir(source):
-            return json_error(f"source directory not found: {source}")
+        # Validate source directories — skipped when a snapshot is present,
+        # since run_pipeline_job overrides source/sources with the snapshot's
+        # folders. Rejecting on stale placeholder paths would falsely 400 an
+        # otherwise-valid snapshot-backed run.
+        if source_snapshot_id is None:
+            if sources:
+                for s in sources:
+                    if not os.path.isdir(s):
+                        return json_error(f"source directory not found: {s}")
+            elif source and not os.path.isdir(source):
+                return json_error(f"source directory not found: {source}")
 
         destination = body.get("destination")
         if destination and not os.path.isabs(destination):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -21,6 +21,7 @@ from db import Database
 from flask import (
     Flask,
     Response,
+    abort,
     g,
     jsonify,
     make_response,
@@ -2069,6 +2070,26 @@ def create_app(db_path, thumb_cache_dir=None):
             "snapshot_id": snap_id,
             "file_count": len(file_paths),
             "folders": folders,
+        })
+
+    @app.route(
+        "/api/workspaces/active/new-images/snapshot/<int:snapshot_id>",
+        methods=["GET"],
+    )
+    def api_workspace_new_images_snapshot_get(snapshot_id):
+        db = _get_db()
+        if db._active_workspace_id is None:
+            abort(404)
+        snap = db.get_new_images_snapshot(snapshot_id)
+        if snap is None:
+            abort(404)
+        paths = snap["file_paths"]
+        folder_paths = sorted({os.path.dirname(p) for p in paths})
+        files_sample = paths[:5]
+        return jsonify({
+            "file_count": snap["file_count"],
+            "folder_paths": folder_paths,
+            "files_sample": files_sample,
         })
 
     # -- Prediction API routes --

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6670,6 +6670,14 @@ def create_app(db_path, thumb_cache_dir=None):
                 return json_error(f"source directory not found: {source}")
 
         destination = body.get("destination")
+        # Copy-ingest ("destination") is incompatible with snapshot runs:
+        # ingest would copy entire source folders, then snapshot filtering
+        # would drop the destination-scanned photo ids, producing empty
+        # downstream stages after an expensive copy. Fail fast.
+        if destination and source_snapshot_id is not None:
+            return json_error(
+                "destination is not allowed when source_snapshot_id is set"
+            )
         if destination and not os.path.isabs(destination):
             return json_error("destination must be an absolute path")
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4349,6 +4349,59 @@ class Database:
         )
         self.conn.commit()
 
+    def create_new_images_snapshot(self, file_paths):
+        """Persist a snapshot of new-image file paths for the active workspace.
+
+        Returns the new snapshot id. An empty path list is allowed — the caller
+        decides how to handle zero-file snapshots (the pipeline short-circuits).
+        """
+        ws_id = self._ws_id()
+        cur = self.conn.execute(
+            "INSERT INTO new_image_snapshots (workspace_id, created_at, file_count) "
+            "VALUES (?, datetime('now'), ?)",
+            (ws_id, len(file_paths)),
+        )
+        snap_id = cur.lastrowid
+        if file_paths:
+            # De-duplicate in case the caller passed repeats; PK would reject them
+            # but sending a clean set keeps executemany cheap.
+            unique_paths = sorted(set(file_paths))
+            self.conn.executemany(
+                "INSERT INTO new_image_snapshot_files (snapshot_id, file_path) VALUES (?, ?)",
+                [(snap_id, p) for p in unique_paths],
+            )
+        self.conn.commit()
+        return snap_id
+
+    def get_new_images_snapshot(self, snapshot_id):
+        """Return snapshot metadata + file paths, or None if not found / cross-workspace.
+
+        Isolation: a snapshot created in workspace A is invisible when workspace B
+        is active. Callers treat None as 'expired / gone'.
+        """
+        row = self.conn.execute(
+            "SELECT id, workspace_id, created_at, file_count "
+            "FROM new_image_snapshots WHERE id = ? AND workspace_id = ?",
+            (snapshot_id, self._ws_id()),
+        ).fetchone()
+        if row is None:
+            return None
+        paths = [
+            r["file_path"]
+            for r in self.conn.execute(
+                "SELECT file_path FROM new_image_snapshot_files WHERE snapshot_id = ? "
+                "ORDER BY file_path",
+                (snapshot_id,),
+            ).fetchall()
+        ]
+        return {
+            "id": row["id"],
+            "workspace_id": row["workspace_id"],
+            "created_at": row["created_at"],
+            "file_count": row["file_count"],
+            "file_paths": paths,
+        }
+
     def _build_collection_query(self, collection_id):
         """Build SQL clauses from collection rules.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -296,6 +296,22 @@ class Database:
 
             CREATE INDEX IF NOT EXISTS preview_cache_last_access
             ON preview_cache(last_access_at);
+
+            CREATE TABLE IF NOT EXISTS new_image_snapshots (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              workspace_id INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+              created_at TEXT NOT NULL,
+              file_count INTEGER NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS new_image_snapshot_files (
+              snapshot_id INTEGER NOT NULL REFERENCES new_image_snapshots(id) ON DELETE CASCADE,
+              file_path TEXT NOT NULL,
+              PRIMARY KEY (snapshot_id, file_path)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_new_image_snapshots_ws
+              ON new_image_snapshots(workspace_id);
         """
         )
         # Migrations for existing databases

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4444,7 +4444,13 @@ class Database:
 
         Isolation: a snapshot created in workspace A is invisible when workspace B
         is active. Callers treat None as 'expired / gone'.
+
+        An id outside SQLite's signed 64-bit range can't match any stored row,
+        so we short-circuit to None rather than let parameter binding raise
+        OverflowError (which would surface as a 500 to API callers).
         """
+        if not -(1 << 63) <= snapshot_id <= (1 << 63) - 1:
+            return None
         row = self.conn.execute(
             "SELECT id, workspace_id, created_at, file_count "
             "FROM new_image_snapshots WHERE id = ? AND workspace_id = ?",

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -96,7 +96,7 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5):
                 if full in known:
                     continue
                 root_new += 1
-                if len(sample) < sample_limit:
+                if sample_limit is None or len(sample) < sample_limit:
                     sample.append(full)
 
         total += root_new

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -31,6 +31,7 @@ class PipelineParams:
     collection_id: int | None = None
     source: str | None = None
     sources: list | None = None
+    source_snapshot_id: int | None = None
     destination: str | None = None
     file_types: str = "both"
     folder_template: str = "%Y/%Y-%m-%d"
@@ -175,6 +176,28 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
     job["_start_time"] = time.time()
     abort = threading.Event()
     errors = job["errors"]  # shared list, append is thread-safe
+
+    # Snapshot-scoped pipelines: load the snapshot up front so scan targets
+    # are derived from the captured file paths (not a folder the user picked
+    # later). Raises if the snapshot has been garbage-collected — the API
+    # layer is expected to return 404 before this job ever runs, but we fail
+    # loud here to avoid silently running an unbounded scan.
+    snapshot_paths: list[str] | None = None
+    if params.source_snapshot_id is not None:
+        db_ro = Database(db_path)
+        db_ro.set_active_workspace(workspace_id)
+        snap = db_ro.get_new_images_snapshot(params.source_snapshot_id)
+        if snap is None:
+            raise ValueError(
+                f"snapshot {params.source_snapshot_id} not found"
+            )
+        snapshot_paths = list(snap["file_paths"])
+        scan_roots = sorted({os.path.dirname(p) for p in snapshot_paths})
+        # Override any source/sources/collection_id the caller passed; the
+        # snapshot is the single source of truth for what to scan.
+        params.sources = scan_roots
+        params.source = None
+        params.collection_id = None
 
     # Bridge user-initiated cancellation (runner.cancel_job) to the local
     # abort Event so all stages that already honor `abort` stop promptly.

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -160,6 +160,28 @@ def _current_phase(stages):
     return "Pipeline"
 
 
+def _collapse_scan_roots(paths):
+    """Reduce ``paths`` to the minimal non-overlapping ancestor set.
+
+    Descendants of a kept path are dropped (the scanner walks recursively).
+    The filesystem root needs special handling because ``'/' + os.sep``
+    is ``'//'`` and would not prefix-match a child like ``/sub``.
+    """
+    candidates = sorted(set(paths), key=len)
+    kept: list[str] = []
+    for cand in candidates:
+        is_descendant = False
+        for k in kept:
+            prefix = k if k.endswith(os.sep) else k + os.sep
+            if cand.startswith(prefix):
+                is_descendant = True
+                break
+        if not is_descendant:
+            kept.append(cand)
+    kept.sort()
+    return kept
+
+
 def run_pipeline_job(job, runner, db_path, workspace_id, params):
     """Execute streaming pipeline. Called by JobRunner in a background thread.
 
@@ -196,13 +218,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         # snapshot has files at both /root/a.jpg and /root/sub/b.jpg the
         # naive derived roots (/root, /root/sub) would make the scanner walk
         # /root/sub twice — once on its own, once as a descendant of /root.
-        candidate_roots = sorted({os.path.dirname(p) for p in snapshot_paths}, key=len)
-        scan_roots: list[str] = []
-        for cand in candidate_roots:
-            if any(cand.startswith(kept + os.sep) for kept in scan_roots):
-                continue
-            scan_roots.append(cand)
-        scan_roots.sort()
+        scan_roots = _collapse_scan_roots(
+            [os.path.dirname(p) for p in snapshot_paths]
+        )
         # Override any source/sources/collection_id the caller passed; the
         # snapshot is the single source of truth for what to scan.
         params.sources = scan_roots

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -192,7 +192,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 f"snapshot {params.source_snapshot_id} not found"
             )
         snapshot_paths = list(snap["file_paths"])
-        scan_roots = sorted({os.path.dirname(p) for p in snapshot_paths})
+        # Collapse to the minimal non-overlapping ancestor set: if the
+        # snapshot has files at both /root/a.jpg and /root/sub/b.jpg the
+        # naive derived roots (/root, /root/sub) would make the scanner walk
+        # /root/sub twice — once on its own, once as a descendant of /root.
+        candidate_roots = sorted({os.path.dirname(p) for p in snapshot_paths}, key=len)
+        scan_roots: list[str] = []
+        for cand in candidate_roots:
+            if any(cand.startswith(kept + os.sep) for kept in scan_roots):
+                continue
+            scan_roots.append(cand)
+        scan_roots.sort()
         # Override any source/sources/collection_id the caller passed; the
         # snapshot is the single source of truth for what to scan.
         params.sources = scan_roots

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -699,22 +699,25 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         if snapshot_paths is not None:
             resolver_db = Database(db_path)
             resolver_db.set_active_workspace(workspace_id)
-            # Chunk the IN () query to stay under SQLite's bound-param
-            # limit on very large snapshots. The join uses
-            # (folders.path || '/' || photos.filename) so we match on
-            # the exact absolute path the snapshot captured.
+            # Split each snapshot path into (dirname, basename) and match on
+            # the two columns directly. Concatenating with a hardcoded '/'
+            # would mismatch Windows paths captured via os.path.join, where
+            # both the snapshot and folders.path use backslash separators.
+            pairs = [os.path.split(p) for p in snapshot_paths]
             resolved: set[int] = set()
-            _CHUNK = 900
-            paths_list = list(snapshot_paths)
-            for i in range(0, len(paths_list), _CHUNK):
-                chunk = paths_list[i : i + _CHUNK]
-                placeholders = ",".join("?" * len(chunk))
+            # 2 placeholders per pair; cap below SQLite's default 999-param
+            # limit (pre-3.32) with headroom.
+            _CHUNK = 400
+            for i in range(0, len(pairs), _CHUNK):
+                chunk = pairs[i : i + _CHUNK]
+                values = ",".join("(?, ?)" for _ in chunk)
+                flat_params = tuple(v for pair in chunk for v in pair)
                 rows = resolver_db.conn.execute(
                     f"""SELECT p.id
                           FROM photos p
                           JOIN folders f ON f.id = p.folder_id
-                         WHERE (f.path || '/' || p.filename) IN ({placeholders})""",
-                    tuple(chunk),
+                         WHERE (f.path, p.filename) IN (VALUES {values})""",
+                    flat_params,
                 ).fetchall()
                 resolved.update(r["id"] for r in rows)
             snapshot_photo_ids = resolved

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -330,6 +330,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
     collection_ready = threading.Event()
     models_ready = threading.Event()
     loaded_models = {}  # populated by model_loader thread
+    # Resolved in collection_stage once the scanner has committed photo rows.
+    # When set (i.e. snapshot-scoped runs), the collection is trimmed to this
+    # set so every downstream stage (classify, extract_masks, eye_keypoints,
+    # regroup) operates only on the files captured in the snapshot — files
+    # that landed in the folder after the snapshot are scanned (we walk the
+    # folder) but not further processed.
+    snapshot_photo_ids: set[int] | None = None
 
     skip_scan = collection_id is not None
 
@@ -669,7 +676,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
     def collection_stage():
         """Wait for scan to finish, build collection, signal classifier."""
-        nonlocal collection_id
+        nonlocal collection_id, snapshot_photo_ids
 
         if skip_scan:
             collection_ready.set()
@@ -681,6 +688,52 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             if stages["scan"]["status"] in ("completed", "failed"):
                 break
             time.sleep(0.1)
+
+        # Snapshot-scoped runs: resolve the captured file paths to photo IDs
+        # now that the scanner has committed rows, and trim the collection
+        # to exactly that set. A late-arriving file (landed in the folder
+        # after the snapshot) was still scanned — we walk the whole folder —
+        # but must not be classified or scored. Any snapshot path that never
+        # resolved (file was moved/deleted between snapshot and pipeline
+        # run) is logged so an unexpectedly small collection is auditable.
+        if snapshot_paths is not None:
+            resolver_db = Database(db_path)
+            resolver_db.set_active_workspace(workspace_id)
+            # Chunk the IN () query to stay under SQLite's bound-param
+            # limit on very large snapshots. The join uses
+            # (folders.path || '/' || photos.filename) so we match on
+            # the exact absolute path the snapshot captured.
+            resolved: set[int] = set()
+            _CHUNK = 900
+            paths_list = list(snapshot_paths)
+            for i in range(0, len(paths_list), _CHUNK):
+                chunk = paths_list[i : i + _CHUNK]
+                placeholders = ",".join("?" * len(chunk))
+                rows = resolver_db.conn.execute(
+                    f"""SELECT p.id
+                          FROM photos p
+                          JOIN folders f ON f.id = p.folder_id
+                         WHERE (f.path || '/' || p.filename) IN ({placeholders})""",
+                    tuple(chunk),
+                ).fetchall()
+                resolved.update(r["id"] for r in rows)
+            snapshot_photo_ids = resolved
+
+            missing = len(snapshot_paths) - len(snapshot_photo_ids)
+            log.info(
+                "pipeline: snapshot %s had %d files, %d ingested, %d missing on disk",
+                params.source_snapshot_id,
+                len(snapshot_paths),
+                len(snapshot_photo_ids),
+                missing,
+            )
+
+            # Filter collected_photo_ids to the snapshot set. collected_photo_ids
+            # is only read by this stage (to build the collection); the thumbnail
+            # queue has already drained it independently.
+            collected_photo_ids[:] = [
+                pid for pid in collected_photo_ids if pid in snapshot_photo_ids
+            ]
 
         if not collected_photo_ids:
             collection_ready.set()

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1013,12 +1013,21 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   gap: 10px;
   border-bottom: 1px solid var(--border-primary, #14374E);
 }
-.new-images-banner a {
+.new-images-banner a,
+.new-images-banner .banner-cta {
   color: var(--accent, #24E5CA);
   font-weight: 600;
   text-decoration: underline;
 }
-.new-images-banner a:hover { opacity: 0.85; }
+.new-images-banner .banner-cta {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+}
+.new-images-banner a:hover,
+.new-images-banner .banner-cta:hover { opacity: 0.85; }
 .new-images-banner .banner-dismiss {
   color: var(--text-secondary, #9fb3bd);
 }
@@ -1166,7 +1175,7 @@ function sendReport() {
 <!-- New Images Banner -->
 <div class="new-images-banner" id="newImagesBanner" style="display:none;">
   <span id="newImagesMsg"></span>
-  <a href="/pipeline">Create a pipeline</a>
+  <button type="button" class="banner-cta" onclick="createPipelineFromNewImages()">Create a pipeline</button>
   <button class="banner-dismiss" onclick="dismissNewImagesBanner()">&times;</button>
 </div>
 
@@ -3807,6 +3816,18 @@ function dismissNewImagesBanner() {
     // Store the dismissed count under a key scoped to this workspace id so
     // dismissing in workspace B doesn't overwrite A's entry.
     sessionStorage.setItem(_newImagesDismissKey(wsId), String(count));
+  }
+}
+
+async function createPipelineFromNewImages() {
+  try {
+    const r = await fetch('/api/workspaces/active/new-images/snapshot', {method: 'POST'});
+    if (!r.ok) throw new Error('snapshot failed');
+    const data = await r.json();
+    window.location.href = `/pipeline?new_images=${data.snapshot_id}`;
+  } catch (e) {
+    // Fall back to the existing behavior — blank pipeline wizard.
+    window.location.href = '/pipeline';
   }
 }
 

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -611,6 +611,9 @@ body { padding-bottom: 36px; }
             <div class="dest-error" id="destWsError" style="display:none;color:var(--error,#f66);font-size:12px;margin-top:4px;" data-testid="workspace-name-error"></div>
           </div>
         </div>
+        <div id="destWsNewImagesNote" style="display:none;margin-top:6px;font-size:12px;color:var(--text-dim);" data-testid="workspace-new-images-note">
+          Processing new images uses the current workspace — the snapshot is scoped to it.
+        </div>
       </div>
 
       <!-- Divider -->
@@ -1812,6 +1815,24 @@ async function selectSourceMode(mode) {
   } else {
     copySection.classList.remove('dimmed');
     copyNote.style.display = 'none';
+  }
+
+  // Snapshot IDs are scoped to the workspace they were captured in, so the
+  // "New workspace" destination would produce a 404 at lookup time. Lock the
+  // destination to the current workspace while new-images mode is active.
+  var wsNewRadio = document.getElementById('radioWsNew');
+  var wsCurrentRadio = document.getElementById('radioWsCurrent');
+  var wsNewNote = document.getElementById('destWsNewImagesNote');
+  if (mode === 'new_images') {
+    if (wsNewRadio) wsNewRadio.disabled = true;
+    if (wsCurrentRadio && !wsCurrentRadio.checked) {
+      wsCurrentRadio.checked = true;
+      onDestWorkspaceChange();
+    }
+    if (wsNewNote) wsNewNote.style.display = '';
+  } else {
+    if (wsNewRadio) wsNewRadio.disabled = false;
+    if (wsNewNote) wsNewNote.style.display = 'none';
   }
 
   updateStartButton();

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -554,6 +554,20 @@ body { padding-bottom: 36px; }
             </div>
           </div>
         </div>
+
+        <div class="source-or" id="sourceOrNewImages" style="display:none;">OR</div>
+        <div class="source-option" id="sourceOptionNewImages" style="display:none;">
+          <div class="source-option-header" onclick="selectSourceMode('new_images')">
+            <input type="radio" id="radioNewImages" name="sourceMode" value="new_images" data-testid="source-new-images">
+            <label for="radioNewImages" style="cursor:pointer;font-weight:600;font-size:13px;">
+              <strong id="newImagesCardTitle">New images</strong>
+              <span id="newImagesCardSubtitle" class="muted" style="font-weight:400;color:var(--text-dim);"></span>
+            </label>
+          </div>
+          <div class="source-option-body dimmed" id="sourceNewImagesBody">
+            <ul id="newImagesFolderList" class="folder-list" style="list-style:none;padding:0;margin:0;font-size:12px;color:var(--text-secondary);"></ul>
+          </div>
+        </div>
       </div>
 
       <div class="progress-wrap" id="progressSource" style="display:none;">
@@ -1051,6 +1065,69 @@ function initPipelinePage() {
 }
 
 document.addEventListener('DOMContentLoaded', initPipelinePage);
+
+// -- New images (Stage 1 third option) --
+var newImagesSnapshotId = null;
+
+async function initNewImagesCard() {
+  var params = new URLSearchParams(window.location.search);
+  var deepLinkId = params.get('new_images');
+  if (deepLinkId) {
+    try {
+      var r = await fetch('/api/workspaces/active/new-images/snapshot/' + encodeURIComponent(deepLinkId));
+      if (!r.ok) throw new Error('snapshot expired');
+      var snap = await r.json();
+      newImagesSnapshotId = parseInt(deepLinkId, 10);
+      renderNewImagesCard(snap.file_count, snap.folder_paths || []);
+      selectSourceMode('new_images');
+    } catch (e) {
+      if (typeof showToast === 'function') {
+        showToast('That snapshot has expired — please try again from the banner.');
+      } else {
+        alert('That snapshot has expired — please try again from the banner.');
+      }
+      await probeNewImagesCard();
+    }
+  } else {
+    await probeNewImagesCard();
+  }
+}
+
+async function probeNewImagesCard() {
+  try {
+    var r = await fetch('/api/workspaces/active/new-images');
+    if (!r.ok) return;
+    var data = await r.json();
+    if ((data.new_count || 0) > 0) {
+      var folders = (data.per_root || [])
+        .filter(function(pr) { return (pr.new_count || 0) > 0; })
+        .map(function(pr) { return pr.path; });
+      renderNewImagesCard(data.new_count, folders);
+    }
+  } catch (e) {
+    // Silent fail — card stays hidden.
+  }
+}
+
+function renderNewImagesCard(count, folders) {
+  var card = document.getElementById('sourceOptionNewImages');
+  var orSep = document.getElementById('sourceOrNewImages');
+  if (!card || !orSep) return;
+  card.style.display = '';
+  orSep.style.display = '';
+  document.getElementById('newImagesCardSubtitle').textContent =
+    ' — ' + count + ' new image' + (count === 1 ? '' : 's') +
+    ' in ' + folders.length + ' folder' + (folders.length === 1 ? '' : 's');
+  var list = document.getElementById('newImagesFolderList');
+  list.innerHTML = '';
+  for (var i = 0; i < folders.length; i++) {
+    var li = document.createElement('li');
+    li.textContent = folders[i];
+    list.appendChild(li);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', initNewImagesCard);
 
 // -- Collection picker --
 async function loadCollections() {
@@ -1688,27 +1765,48 @@ function markFolderPreviewStale() {
   btn.disabled = !(hasSources && hasDest);
 }
 
-function selectSourceMode(mode) {
+async function selectSourceMode(mode) {
   // Cancel any in-flight duplicate scan before switching context
   if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
   _sourceMode = mode;
   document.getElementById('radioImport').checked = (mode === 'import');
   document.getElementById('radioCollection').checked = (mode === 'collection');
+  var newImgRadio = document.getElementById('radioNewImages');
+  if (newImgRadio) newImgRadio.checked = (mode === 'new_images');
 
   var importBody = document.getElementById('sourceImportBody');
   var collBody = document.getElementById('sourceCollectionBody');
+  var newImgBody = document.getElementById('sourceNewImagesBody');
 
   if (mode === 'import') {
     importBody.classList.remove('dimmed');
     collBody.classList.add('dimmed');
-  } else {
+    if (newImgBody) newImgBody.classList.add('dimmed');
+  } else if (mode === 'collection') {
     importBody.classList.add('dimmed');
     collBody.classList.remove('dimmed');
+    if (newImgBody) newImgBody.classList.add('dimmed');
+  } else if (mode === 'new_images') {
+    importBody.classList.add('dimmed');
+    collBody.classList.add('dimmed');
+    if (newImgBody) newImgBody.classList.remove('dimmed');
+    if (newImagesSnapshotId === null) {
+      // User is selecting the card directly (no deep-link) — freeze the list now.
+      try {
+        var resp = await fetch('/api/workspaces/active/new-images/snapshot', {method: 'POST'});
+        if (resp.ok) {
+          var data = await resp.json();
+          newImagesSnapshotId = data.snapshot_id;
+        }
+      } catch (e) {
+        // Leave snapshot id null; submit will fail validation via updateStartButton.
+      }
+    }
   }
 
   var copySection = document.getElementById('destCopySection');
   var copyNote = document.getElementById('destCopyDisabledNote');
-  if (mode === 'collection') {
+  if (mode === 'collection' || mode === 'new_images') {
     copySection.classList.add('dimmed');
     copyNote.style.display = '';
   } else {
@@ -1798,6 +1896,8 @@ function updateStartButton() {
     var hasFolders = _sourceFolders.length > 0;
     var anyType = getIngestFileTypes().length > 0;
     btn.disabled = !hasFolders || !anyType;
+  } else if (_sourceMode === 'new_images') {
+    btn.disabled = !newImagesSnapshotId;
   } else {
     var collId = document.getElementById('collectionPicker').value;
     btn.disabled = !collId;
@@ -1941,6 +2041,11 @@ async function startPipeline() {
       body.skip_duplicates = document.getElementById('chkSkipDuplicates').checked;
       body.folder_template = getSelectedFolderTemplate();
     }
+  } else if (_sourceMode === 'new_images') {
+    body.source_snapshot_id = newImagesSnapshotId;
+    delete body.source;
+    delete body.sources;
+    delete body.file_types;
   } else {
     body.collection_id = parseInt(document.getElementById('collectionPicker').value);
     // Add excluded photo IDs from preview selection

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1793,18 +1793,6 @@ async function selectSourceMode(mode) {
     importBody.classList.add('dimmed');
     collBody.classList.add('dimmed');
     if (newImgBody) newImgBody.classList.remove('dimmed');
-    if (newImagesSnapshotId === null) {
-      // User is selecting the card directly (no deep-link) — freeze the list now.
-      try {
-        var resp = await fetch('/api/workspaces/active/new-images/snapshot', {method: 'POST'});
-        if (resp.ok) {
-          var data = await resp.json();
-          newImagesSnapshotId = data.snapshot_id;
-        }
-      } catch (e) {
-        // Leave snapshot id null; submit will fail validation via updateStartButton.
-      }
-    }
   }
 
   var copySection = document.getElementById('destCopySection');
@@ -1820,6 +1808,9 @@ async function selectSourceMode(mode) {
   // Snapshot IDs are scoped to the workspace they were captured in, so the
   // "New workspace" destination would produce a 404 at lookup time. Lock the
   // destination to the current workspace while new-images mode is active.
+  // Apply the destination lock and button state BEFORE any async snapshot
+  // POST — callers don't await this function, so a click on Start during
+  // the POST's network round-trip would otherwise see stale state.
   var wsNewRadio = document.getElementById('radioWsNew');
   var wsCurrentRadio = document.getElementById('radioWsCurrent');
   var wsNewNote = document.getElementById('destWsNewImagesNote');
@@ -1835,7 +1826,26 @@ async function selectSourceMode(mode) {
     if (wsNewNote) wsNewNote.style.display = 'none';
   }
 
+  // With new-images mode selected but no snapshot yet, updateStartButton()
+  // correctly disables Start (gate on `newImagesSnapshotId`). Call it now
+  // so stale state from the previous mode can't slip through during await.
   updateStartButton();
+
+  if (mode === 'new_images' && newImagesSnapshotId === null) {
+    // User is selecting the card directly (no deep-link) — freeze the list now.
+    try {
+      var resp = await fetch('/api/workspaces/active/new-images/snapshot', {method: 'POST'});
+      if (resp.ok) {
+        var data = await resp.json();
+        newImagesSnapshotId = data.snapshot_id;
+      }
+    } catch (e) {
+      // Leave snapshot id null; submit will fail validation via updateStartButton.
+    }
+    // Snapshot resolved (or failed) — refresh start-button state.
+    updateStartButton();
+  }
+
   fetchFolderPreview();
 }
 

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3824,3 +3824,16 @@ def test_preview_cache_oldest_first(tmp_path):
 
     rows = db.preview_cache_oldest_first()
     assert [(r["photo_id"], r["size"]) for r in rows] == [(p1, 1920), (p2, 1920)]
+
+
+def test_new_image_snapshots_tables_exist(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    tables = {
+        r["name"]
+        for r in db.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    assert "new_image_snapshots" in tables
+    assert "new_image_snapshot_files" in tables

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3837,3 +3837,50 @@ def test_new_image_snapshots_tables_exist(tmp_path):
     }
     assert "new_image_snapshots" in tables
     assert "new_image_snapshot_files" in tables
+
+
+def test_create_and_get_new_images_snapshot(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db._active_workspace_id
+    paths = ["/tmp/a/IMG_001.JPG", "/tmp/b/IMG_002.JPG"]
+    snap_id = db.create_new_images_snapshot(paths)
+    assert isinstance(snap_id, int)
+
+    snap = db.get_new_images_snapshot(snap_id)
+    assert snap is not None
+    assert snap["file_count"] == 2
+    assert snap["workspace_id"] == ws_id
+    assert sorted(snap["file_paths"]) == sorted(paths)
+
+
+def test_get_snapshot_from_different_workspace_returns_none(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    other_ws = db.create_workspace("Other")
+    paths = ["/tmp/a/IMG_001.JPG"]
+    snap_id = db.create_new_images_snapshot(paths)
+    db.set_active_workspace(other_ws)
+    assert db.get_new_images_snapshot(snap_id) is None
+
+
+def test_snapshot_deleted_with_workspace(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    throwaway_ws = db.create_workspace("Throwaway")
+    db.set_active_workspace(throwaway_ws)
+    snap_id = db.create_new_images_snapshot(["/tmp/a.jpg"])
+    db.delete_workspace(throwaway_ws)
+    row = db.conn.execute(
+        "SELECT id FROM new_image_snapshots WHERE id = ?", (snap_id,)
+    ).fetchone()
+    assert row is None
+
+
+def test_create_snapshot_empty_paths(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    snap_id = db.create_new_images_snapshot([])
+    snap = db.get_new_images_snapshot(snap_id)
+    assert snap["file_count"] == 0
+    assert snap["file_paths"] == []

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -46,6 +46,23 @@ def test_count_new_images_detects_unscanned_files(db_with_workspace):
     assert len(result["sample"]) == 2
 
 
+def test_count_new_images_returns_all_paths_when_sample_limit_is_none(tmp_path):
+    # Set up a workspace with 10 new files on disk.
+    db = Database(str(tmp_path / "test.db"))
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    db.add_folder(str(folder))
+    for i in range(10):
+        _touch_image(folder / f"IMG_{i:03d}.JPG")
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(
+        db, db._active_workspace_id, sample_limit=None
+    )
+    assert result["new_count"] == 10
+    assert len(result["sample"]) == 10
+
+
 def test_count_new_images_no_double_counting_with_nested_linked_folders(db_with_workspace):
     """Nested subfolders auto-linked to workspace_folders must not cause double-counting."""
     db, ws_id, tmp_path = db_with_workspace

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -143,6 +143,20 @@ def test_get_snapshot_unknown_id_returns_404(app_and_db):
         assert resp.status_code == 404
 
 
+def test_get_snapshot_oversized_id_returns_404_not_500(app_and_db):
+    """Werkzeug's <int:> converter accepts arbitrary digit strings, producing
+    Python ints larger than SQLite's signed 64-bit range. Passing those
+    straight to the DB would raise OverflowError (→ 500). Treat them as
+    "not found" rather than leaking a server error."""
+    app, db, ws_id, tmp_path = app_and_db
+    huge = 10 ** 100
+    with app.test_client() as client:
+        resp = client.get(f"/api/workspaces/active/new-images/snapshot/{huge}")
+        assert resp.status_code == 404, (
+            f"oversized snapshot id must yield 404, got {resp.status_code}"
+        )
+
+
 def test_get_snapshot_cross_workspace_returns_404(app_and_db):
     app, db, ws_id, tmp_path = app_and_db
     snap_id = db.create_new_images_snapshot(["/tmp/a.jpg"])

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -87,3 +87,31 @@ def test_api_new_images_returns_null_workspace_when_none_active(app_and_db, monk
     assert data["workspace_id"] is None
     assert data["new_count"] == 0
     assert data["per_root"] == []
+
+
+def test_post_snapshot_creates_row_with_current_new_images(app_and_db):
+    app, db, ws_id, tmp_path = app_and_db
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    db.add_folder(str(folder))
+    _touch_image(str(folder / "IMG_001.JPG"))
+    _touch_image(str(folder / "IMG_002.JPG"))
+
+    with app.test_client() as client:
+        resp = client.post("/api/workspaces/active/new-images/snapshot")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["file_count"] == 2
+        assert isinstance(data["snapshot_id"], int)
+        assert str(folder) in data["folders"]
+
+    snap = db.get_new_images_snapshot(data["snapshot_id"])
+    assert snap["file_count"] == 2
+
+
+def test_post_snapshot_zero_new_images_returns_200(app_and_db):
+    app, db, ws_id, tmp_path = app_and_db
+    with app.test_client() as client:
+        resp = client.post("/api/workspaces/active/new-images/snapshot")
+        assert resp.status_code == 200
+        assert resp.get_json()["file_count"] == 0

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -115,3 +115,44 @@ def test_post_snapshot_zero_new_images_returns_200(app_and_db):
         resp = client.post("/api/workspaces/active/new-images/snapshot")
         assert resp.status_code == 200
         assert resp.get_json()["file_count"] == 0
+
+
+def test_get_snapshot_returns_summary(app_and_db):
+    app, db, ws_id, tmp_path = app_and_db
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    db.add_folder(str(folder))
+    _touch_image(str(folder / "IMG_001.JPG"))
+
+    with app.test_client() as client:
+        post = client.post("/api/workspaces/active/new-images/snapshot")
+        snap_id = post.get_json()["snapshot_id"]
+
+        resp = client.get(f"/api/workspaces/active/new-images/snapshot/{snap_id}")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["file_count"] == 1
+        assert data["folder_paths"] == [str(folder)]
+        assert data["files_sample"][0].endswith("IMG_001.JPG")
+
+
+def test_get_snapshot_unknown_id_returns_404(app_and_db):
+    app, db, ws_id, tmp_path = app_and_db
+    with app.test_client() as client:
+        resp = client.get("/api/workspaces/active/new-images/snapshot/99999")
+        assert resp.status_code == 404
+
+
+def test_get_snapshot_cross_workspace_returns_404(app_and_db):
+    app, db, ws_id, tmp_path = app_and_db
+    snap_id = db.create_new_images_snapshot(["/tmp/a.jpg"])
+    other = db.create_workspace("Other")
+    # Persist the switch so per-request Database instances restore "Other" as
+    # the active workspace (Database.__init__ picks the workspace with the most
+    # recent last_opened_at).
+    from datetime import datetime
+    db.update_workspace(other, last_opened_at=datetime.now().isoformat())
+    db.set_active_workspace(other)
+    with app.test_client() as client:
+        resp = client.get(f"/api/workspaces/active/new-images/snapshot/{snap_id}")
+        assert resp.status_code == 404

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -547,3 +547,23 @@ def test_pipeline_accepts_source_snapshot_id(setup, tmp_path):
         assert captured["source_snapshot_id"] == snap_id
     finally:
         pipeline_job.run_pipeline_job = original
+
+
+def test_pipeline_rejects_unknown_snapshot_id(setup, tmp_path):
+    """A pipeline request with a non-existent source_snapshot_id must be
+    rejected synchronously with 404 rather than accepted and failing later
+    on the worker thread with a generic job error. This gives the client
+    an actionable response at request time."""
+    app, db_path = setup
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "source_snapshot_id": 99999,
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 404, (
+            f"stale snapshot id must be rejected synchronously, "
+            f"got {resp.status_code}: {resp.get_json()}"
+        )

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -639,3 +639,24 @@ def test_pipeline_rejects_unknown_snapshot_id(setup, tmp_path):
             f"stale snapshot id must be rejected synchronously, "
             f"got {resp.status_code}: {resp.get_json()}"
         )
+
+
+@pytest.mark.parametrize("bad_id", [{}, [], [1, 2], {"id": 3}, "abc", 1.5, True])
+def test_pipeline_rejects_non_integer_snapshot_id(setup, bad_id):
+    """Malformed source_snapshot_id values (objects, arrays, non-numeric
+    strings, floats, booleans) must be rejected with a 4xx before reaching
+    the DB layer. Without validation, SQLite raises InterfaceError and the
+    client sees an opaque 500."""
+    app, _ = setup
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "source_snapshot_id": bad_id,
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert 400 <= resp.status_code < 500, (
+            f"bad snapshot id {bad_id!r} must be rejected with 4xx, "
+            f"got {resp.status_code}: {resp.get_json()}"
+        )

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -497,3 +497,53 @@ def test_import_full_copy_false_still_scans_source_root(setup, tmp_path, monkeyp
     assert call["restrict_dirs"] is None, (
         f"copy=false must leave restrict_dirs unset; got {call['restrict_dirs']!r}"
     )
+
+
+def test_pipeline_accepts_source_snapshot_id(setup, tmp_path):
+    """POST /api/jobs/pipeline should propagate source_snapshot_id from the
+    request body into the PipelineParams passed to run_pipeline_job."""
+    app, db_path = setup
+
+    # Create a snapshot in the active workspace so the request body references
+    # a real id (run_pipeline_job itself is spied — we only assert what gets
+    # passed to it).
+    from db import Database
+    db = Database(db_path)
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    img_path = folder / "IMG_001.JPG"
+    Image.new("RGB", (1, 1), "white").save(str(img_path), "JPEG")
+    db.add_folder(str(folder))
+    snap_id = db.create_new_images_snapshot([str(img_path)])
+    db.conn.close()
+
+    # The handler does ``from pipeline_job import PipelineParams, run_pipeline_job``
+    # inside the request, so patching the attribute on the module swaps what
+    # the handler's local binding will see on next request.
+    import threading
+
+    import pipeline_job
+    captured = {}
+    called = threading.Event()
+    original = pipeline_job.run_pipeline_job
+
+    def spy_run(job, runner, db_path_arg, ws_id, params):
+        captured["source_snapshot_id"] = params.source_snapshot_id
+        called.set()
+
+    pipeline_job.run_pipeline_job = spy_run
+    try:
+        with app.test_client() as c:
+            resp = c.post("/api/jobs/pipeline", json={
+                "source_snapshot_id": snap_id,
+                "skip_classify": True,
+                "skip_extract_masks": True,
+                "skip_regroup": True,
+            })
+            assert resp.status_code == 200, resp.get_json()
+
+        # JobRunner runs work() on a worker thread; wait briefly for spy to fire.
+        assert called.wait(timeout=5.0), "run_pipeline_job spy was not invoked"
+        assert captured["source_snapshot_id"] == snap_id
+    finally:
+        pipeline_job.run_pipeline_job = original

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -549,6 +549,43 @@ def test_pipeline_accepts_source_snapshot_id(setup, tmp_path):
         pipeline_job.run_pipeline_job = original
 
 
+def test_pipeline_snapshot_overrides_stale_source_paths(setup, tmp_path):
+    """When a valid source_snapshot_id is present, the job overrides any
+    source/sources the caller passed. The handler must not preflight-validate
+    those stale paths — rejecting an otherwise-valid snapshot run because
+    the accompanying placeholder folder no longer exists is a false 400."""
+    app, db_path = setup
+
+    from db import Database
+    db = Database(db_path)
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    img_path = folder / "IMG_001.JPG"
+    Image.new("RGB", (1, 1), "white").save(str(img_path), "JPEG")
+    db.add_folder(str(folder))
+    snap_id = db.create_new_images_snapshot([str(img_path)])
+    db.conn.close()
+
+    import pipeline_job
+    original = pipeline_job.run_pipeline_job
+    pipeline_job.run_pipeline_job = lambda *a, **kw: None
+    try:
+        with app.test_client() as c:
+            resp = c.post("/api/jobs/pipeline", json={
+                "source_snapshot_id": snap_id,
+                "sources": ["/does/not/exist/stale"],  # stale placeholder
+                "skip_classify": True,
+                "skip_extract_masks": True,
+                "skip_regroup": True,
+            })
+            assert resp.status_code == 200, (
+                f"snapshot should override stale sources, got "
+                f"{resp.status_code}: {resp.get_json()}"
+            )
+    finally:
+        pipeline_job.run_pipeline_job = original
+
+
 def test_pipeline_rejects_unknown_snapshot_id(setup, tmp_path):
     """A pipeline request with a non-existent source_snapshot_id must be
     rejected synchronously with 404 rather than accepted and failing later

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -641,6 +641,25 @@ def test_pipeline_rejects_unknown_snapshot_id(setup, tmp_path):
         )
 
 
+def test_pipeline_rejects_oversized_snapshot_id(setup):
+    """An integer outside SQLite's signed 64-bit range would raise
+    OverflowError during parameter binding, surfacing as a 500. The endpoint
+    must reject it cleanly before reaching SQLite."""
+    app, _ = setup
+    huge = 10 ** 100
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "source_snapshot_id": huge,
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert 400 <= resp.status_code < 500, (
+            f"oversized snapshot id must be rejected with 4xx, "
+            f"got {resp.status_code}: {resp.get_json()}"
+        )
+
+
 @pytest.mark.parametrize("bad_id", [{}, [], [1, 2], {"id": 3}, "abc", 1.5, True])
 def test_pipeline_rejects_non_integer_snapshot_id(setup, bad_id):
     """Malformed source_snapshot_id values (objects, arrays, non-numeric

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -586,6 +586,41 @@ def test_pipeline_snapshot_overrides_stale_source_paths(setup, tmp_path):
         pipeline_job.run_pipeline_job = original
 
 
+def test_pipeline_rejects_destination_with_snapshot(setup, tmp_path):
+    """A snapshot-backed run walks the folders that already hold the files
+    — there is no valid `destination` combination. If the handler accepted
+    both, the copy stage would ingest entire source folders (not just the
+    snapshot set), snapshot filtering would then drop the destination-scanned
+    photos, and the user would pay for an expensive copy that produces
+    nothing downstream. Reject synchronously."""
+    app, db_path = setup
+
+    from db import Database
+    db = Database(db_path)
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    img_path = folder / "IMG_001.JPG"
+    Image.new("RGB", (1, 1), "white").save(str(img_path), "JPEG")
+    db.add_folder(str(folder))
+    snap_id = db.create_new_images_snapshot([str(img_path)])
+    db.conn.close()
+
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "source_snapshot_id": snap_id,
+            "destination": str(dest),
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 400, (
+            f"destination is incompatible with snapshot runs, got "
+            f"{resp.status_code}: {resp.get_json()}"
+        )
+
+
 def test_pipeline_rejects_unknown_snapshot_id(setup, tmp_path):
     """A pipeline request with a non-existent source_snapshot_id must be
     rejected synchronously with 404 rather than accepted and failing later

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -4309,3 +4309,62 @@ def test_pipeline_snapshot_excludes_late_arriving_files(tmp_path, monkeypatch):
         f"late (post-snapshot) file must NOT be classified, got "
         f"{classified_names}"
     )
+
+
+def test_pipeline_snapshot_collapses_overlapping_scan_roots(tmp_path, monkeypatch):
+    """When the snapshot contains files at both a folder and a nested subfolder
+    (e.g. /root/a.jpg and /root/sub/b.jpg), deriving scan roots naively would
+    produce overlapping paths (/root and /root/sub). The scanner would then
+    walk the subtree twice. params.sources must be collapsed to the minimal
+    non-overlapping ancestor set."""
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    root = tmp_path / "root"
+    sub = root / "sub"
+    sub.mkdir(parents=True)
+    db.add_folder(str(root))
+    db.add_folder(str(sub))
+
+    top_path = root / "a.jpg"
+    sub_path = sub / "b.jpg"
+    _drop_jpeg(str(root), "a.jpg")
+    _drop_jpeg(str(sub), "b.jpg")
+
+    snap_id = db.create_new_images_snapshot([str(top_path), str(sub_path)])
+
+    # Spy on scanner.scan to count how many distinct roots it walks.
+    import scanner as scanner_mod
+    scan_calls = []
+    original_scan = scanner_mod.scan
+
+    def spy_scan(root_path, db_, **kwargs):
+        scan_calls.append(root_path)
+        return original_scan(root_path, db_, **kwargs)
+
+    monkeypatch.setattr(scanner_mod, "scan", spy_scan)
+
+    params = PipelineParams(
+        source_snapshot_id=snap_id,
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # The nested path is a descendant of the top path; the scanner walks root
+    # recursively, so sub must NOT be re-scanned as a separate root.
+    assert str(root) in scan_calls, f"top root must be scanned, got {scan_calls}"
+    assert str(sub) not in scan_calls, (
+        f"sub is a descendant of root and must not be scanned separately, "
+        f"got {scan_calls}"
+    )

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -4168,3 +4168,144 @@ def test_pipeline_with_snapshot_scans_only_snapshot_folders(tmp_path, monkeypatc
     assert list(b_photos) == [], (
         f"folder B must NOT be scanned (not in snapshot), got {list(b_photos)}"
     )
+
+
+def test_pipeline_snapshot_excludes_late_arriving_files(tmp_path, monkeypatch):
+    """Files that land in a registered folder AFTER a snapshot is captured
+    must still be scanned (we walk the folder), but downstream stages
+    (classify, extract_masks, regroup) must be constrained to the snapshot's
+    photo-id set. Verified via DB state: only the early (snapshot) photo
+    should have a predictions row after the pipeline completes.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    db.add_folder(str(folder))
+
+    # "Early" file — exists at snapshot time, goes into the snapshot.
+    # Use distinct pixel content so the scanner's hash-based duplicate
+    # resolver doesn't collapse the two files into one photo row (same
+    # 16x16 black rectangle hashes to the same bytes).
+    Image.new("RGB", (16, 16), (10, 10, 10)).save(
+        str(folder / "IMG_early.JPG")
+    )
+    snap_id = db.create_new_images_snapshot([str(folder / "IMG_early.JPG")])
+
+    # "Late" file — arrives after the snapshot but before the pipeline runs.
+    # The scanner will ingest it (same folder), but downstream stages must
+    # skip it.
+    Image.new("RGB", (16, 16), (200, 50, 50)).save(
+        str(folder / "IMG_late.JPG")
+    )
+
+    # Wire up fake classifier + detect_batch so classify_stage actually runs
+    # and writes a predictions row for whatever photo it sees.
+    model_id = _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    # detect_stage calls ensure_megadetector_weights() whenever any photo
+    # lacks a cached detection — which is every fresh-scan run. Short-circuit
+    # to avoid a real network download in the test.
+    import detector as detector_mod
+    monkeypatch.setattr(
+        detector_mod, "ensure_megadetector_weights",
+        lambda progress_callback=None: "/tmp/fake-md-weights.onnx",
+    )
+
+    # Map filename → synthetic detection_id; we need a real detection row per
+    # photo fed to classify so _flush_batch has a valid FK to bind to.
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        processed = set()
+        for p in batch:
+            det_ids = db_.save_detections(
+                p["id"],
+                [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+                  "confidence": 0.95, "category": "animal"}],
+                detector_model="MegaDetector",
+            )
+            det_map[p["id"]] = [{
+                "id": det_ids[0],
+                "box_x": 0.1, "box_y": 0.1, "box_w": 0.5, "box_h": 0.5,
+                "confidence": 0.95, "category": "animal",
+            }]
+            processed.add(p["id"])
+        return det_map, len(det_map), processed
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    def fake_prepare_image(photo, folders, detection, vireo_dir=None):
+        return (
+            Image.new("RGB", (32, 32), "white"),
+            folders.get(photo["folder_id"], ""),
+            os.path.join(folders.get(photo["folder_id"], ""), photo["filename"]),
+        )
+
+    monkeypatch.setattr(classify_job, "_prepare_image", fake_prepare_image)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            emb = np.zeros(512, dtype=np.float32)
+            return [
+                ([{"species": "Red-tailed Hawk", "score": 0.99}], emb)
+                for _ in images
+            ]
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        source_snapshot_id=snap_id,
+        model_ids=[model_id],
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # Verify via DB: both files were scanned (scan walks the folder), but
+    # only the early one should have a prediction row.
+    verify_db = Database(db_path)
+    verify_db.set_active_workspace(ws_id)
+
+    scanned = {
+        r["filename"] for r in verify_db.conn.execute(
+            "SELECT filename FROM photos"
+        ).fetchall()
+    }
+    assert scanned == {"IMG_early.JPG", "IMG_late.JPG"}, (
+        f"scan should ingest both files in the folder, got {scanned}"
+    )
+
+    classified_names = {
+        r["filename"] for r in verify_db.conn.execute(
+            """SELECT p.filename
+                 FROM predictions pr
+                 JOIN detections d ON d.id = pr.detection_id
+                 JOIN photos p ON p.id = d.photo_id"""
+        ).fetchall()
+    }
+    assert "IMG_early.JPG" in classified_names, (
+        f"early (snapshot) file should be classified, got {classified_names}"
+    )
+    assert "IMG_late.JPG" not in classified_names, (
+        f"late (post-snapshot) file must NOT be classified, got "
+        f"{classified_names}"
+    )

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -4368,3 +4368,33 @@ def test_pipeline_snapshot_collapses_overlapping_scan_roots(tmp_path, monkeypatc
         f"sub is a descendant of root and must not be scanned separately, "
         f"got {scan_calls}"
     )
+
+
+def test_collapse_scan_roots_handles_filesystem_root():
+    """Unit test for the collapse helper's edge case where a kept root IS
+    the filesystem root ('/' on POSIX, 'C:\\' on Windows). The naive
+    `kept + os.sep` prefix becomes '//' for '/' and fails to match child
+    paths like '/sub'. Descendants of the filesystem root must still be
+    collapsed away."""
+    from pipeline_job import _collapse_scan_roots
+
+    collapsed = _collapse_scan_roots([os.sep, os.path.join(os.sep, "sub")])
+    assert collapsed == [os.sep], (
+        f"descendants of filesystem root must collapse, got {collapsed}"
+    )
+
+    # Non-overlapping peers are preserved.
+    a = os.path.join(os.sep, "a")
+    b = os.path.join(os.sep, "b")
+    collapsed = _collapse_scan_roots([a, b])
+    assert collapsed == sorted([a, b]), (
+        f"peers must both be kept, got {collapsed}"
+    )
+
+    # Prefix-but-not-descendant isn't collapsed (/foo vs /foobar).
+    foo = os.path.join(os.sep, "foo")
+    foobar = os.path.join(os.sep, "foobar")
+    collapsed = _collapse_scan_roots([foo, foobar])
+    assert collapsed == sorted([foo, foobar]), (
+        f"/foo and /foobar are peers, got {collapsed}"
+    )

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -4114,3 +4114,57 @@ def test_thumbnail_progress_counter_includes_failed(tmp_path, monkeypatch):
         f"stages['thumbnails']['count'] must include failed items (was {thumb_stage_count}). "
         f"Last event stages: {last['stages']}"
     )
+
+
+def test_pipeline_with_snapshot_scans_only_snapshot_folders(tmp_path, monkeypatch):
+    """When source_snapshot_id is provided, the scan stage must walk only the
+    parent directories of the snapshot's files — sibling folders registered
+    with the workspace but not in the snapshot must NOT be scanned."""
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # Two sibling folders each with one JPEG. Only folder A is in the snapshot.
+    folder_a = tmp_path / "folderA"
+    folder_b = tmp_path / "folderB"
+    folder_a.mkdir()
+    folder_b.mkdir()
+    folder_a_id = db.add_folder(str(folder_a))
+    folder_b_id = db.add_folder(str(folder_b))
+    _drop_jpeg(str(folder_a), "IMG_001.JPG")
+    _drop_jpeg(str(folder_b), "IMG_002.JPG")
+
+    snap_id = db.create_new_images_snapshot([str(folder_a / "IMG_001.JPG")])
+
+    params = PipelineParams(
+        source_snapshot_id=snap_id,
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # Verify via DB state: folder A has its photo ingested, folder B does not.
+    verify_db = Database(db_path)
+    verify_db.set_active_workspace(ws_id)
+    a_photos = verify_db.conn.execute(
+        "SELECT filename FROM photos WHERE folder_id = ?", (folder_a_id,),
+    ).fetchall()
+    b_photos = verify_db.conn.execute(
+        "SELECT filename FROM photos WHERE folder_id = ?", (folder_b_id,),
+    ).fetchall()
+    assert [r["filename"] for r in a_photos] == ["IMG_001.JPG"], (
+        f"folder A should have its snapshot file ingested, got {list(a_photos)}"
+    )
+    assert list(b_photos) == [], (
+        f"folder B must NOT be scanned (not in snapshot), got {list(b_photos)}"
+    )


### PR DESCRIPTION
## Summary

Design doc for wiring the "N new images detected" banner into the pipeline so that clicking "Create a pipeline" produces a pipeline scoped to exactly the files the banner announced — not a blank wizard.

## Key decisions

- **Snapshot at click time** — freeze the new-image file list into a `new_image_snapshots` row; pipeline processes exactly that set.
- **Snapshot stores file paths, not photo IDs** — new images aren't yet in the DB.
- **Scan stage still runs** — scoped to the snapshot's parent dirs; downstream stages filter to the resolved photo IDs at the scan-to-classify seam, so the snapshot guarantee holds even if more files arrive between snapshot and run.
- **"New images" becomes a first-class Stage 1 source** — rendered only when `new_count > 0` (no disabled state).
- **Banner deep-links via `snapshot_id`** in the URL; short, scales to thousands of files.

## Test plan

- [ ] Review the design doc for anything missed (edge cases, scope creep).
- [ ] Open questions documented in the doc — any before implementation?

Once this is accepted, follow-up PR will turn the doc into an implementation plan (`2026-04-22-new-images-pipeline-plan.md`) and then execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)