### PR TITLE
fix(pipeline): weighted overall progress so fast stages don't jump to 100%

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -574,16 +574,29 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
                 from ingest import ingest as do_ingest
 
+                # Same accumulator pattern as scan_acc: do_ingest() is called
+                # once per source folder, with (current, total) local to each
+                # call. Without accumulation, overall progress rewinds at each
+                # source boundary.
+                ingest_acc = {"prior": 0, "last_total": 0}
+
                 def ingest_cb(current, total, filename):
-                    stages["ingest"]["count"] = current
-                    stages["ingest"]["total"] = total
+                    ingest_acc["last_total"] = total
+                    cum_current = ingest_acc["prior"] + current
+                    cum_total = ingest_acc["prior"] + total
+                    stages["ingest"]["count"] = cum_current
+                    stages["ingest"]["total"] = cum_total
                     runner.update_step(job["id"], "ingest",
                                        current_file=filename,
-                                       progress={"current": current, "total": total})
+                                       progress={"current": cum_current, "total": cum_total})
                     runner.push_event(job["id"], "progress", _progress_event(
                         stages, "ingest", "Importing photos",
                         current_file=filename,
                     ))
+
+                def advance_ingest_acc():
+                    ingest_acc["prior"] += ingest_acc["last_total"]
+                    ingest_acc["last_total"] = 0
 
             if params.destination:
                 # Copy mode: ingest all sources first, then scan destination
@@ -598,18 +611,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 total_copied = 0
                 total_skipped = 0
                 for src_folder in sources:
-                    result_info = do_ingest(
-                        source_dir=src_folder,
-                        destination_dir=params.destination,
-                        db=thread_db,
-                        file_types=params.file_types,
-                        folder_template=params.folder_template,
-                        skip_duplicates=params.skip_duplicates,
-                        progress_callback=ingest_cb,
-                        extra_known_hashes=accumulated_hashes,
-                        skip_paths=params.exclude_paths,
-                        recursive=params.recursive,
-                    )
+                    try:
+                        result_info = do_ingest(
+                            source_dir=src_folder,
+                            destination_dir=params.destination,
+                            db=thread_db,
+                            file_types=params.file_types,
+                            folder_template=params.folder_template,
+                            skip_duplicates=params.skip_duplicates,
+                            progress_callback=ingest_cb,
+                            extra_known_hashes=accumulated_hashes,
+                            skip_paths=params.exclude_paths,
+                            recursive=params.recursive,
+                        )
+                    finally:
+                        advance_ingest_acc()
                     all_copied_paths.extend(result_info.get("copied_paths", []))
                     all_duplicate_folders.update(result_info.get("duplicate_folders", []))
                     total_copied += result_info.get("copied", 0)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -427,21 +427,35 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     stages, "scan", message,
                 ))
 
+            # Accumulator so multi-folder scans (repair loop, scan-in-place
+            # with sources=[...]) don't rewind the overall progress at each
+            # folder boundary. scan() reports (current, total) local to the
+            # invocation; we fold those into cumulative counters that the
+            # weighted overall bar reads via stages["scan"].
+            scan_acc = {"prior": 0, "last_total": 0}
+
             def progress_cb(current, total):
-                stages["scan"]["count"] = current
-                stages["scan"]["total"] = total
+                scan_acc["last_total"] = total
+                cum_current = scan_acc["prior"] + current
+                cum_total = scan_acc["prior"] + total
+                stages["scan"]["count"] = cum_current
+                stages["scan"]["total"] = cum_total
                 elapsed = time.time() - job["_start_time"]
-                rate = round(current / max(elapsed, 0.01) * 60, 1)  # files/min
-                remaining = total - current
-                rate_per_sec = current / max(elapsed, 0.01)
-                eta = round(remaining / rate_per_sec) if rate_per_sec > 0 and current >= 10 else None
+                rate = round(cum_current / max(elapsed, 0.01) * 60, 1)  # files/min
+                remaining = cum_total - cum_current
+                rate_per_sec = cum_current / max(elapsed, 0.01)
+                eta = round(remaining / rate_per_sec) if rate_per_sec > 0 and cum_current >= 10 else None
                 runner.update_step(job["id"], "scan",
-                                   progress={"current": current, "total": total})
+                                   progress={"current": cum_current, "total": cum_total})
                 runner.push_event(job["id"], "progress", _progress_event(
                     stages, "scan", "Scanning photos",
                     rate=rate,
                     eta_seconds=eta,
                 ))
+
+            def advance_scan_acc():
+                scan_acc["prior"] += scan_acc["last_total"]
+                scan_acc["last_total"] = 0
 
             # Collection mode: no scan targets, but check whether any
             # photos in the collection have broken metadata (NULL timestamp
@@ -526,6 +540,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                             "Repair scan failed for %s: %s", folder_path, e,
                         )
                         unreachable += 1
+                    finally:
+                        advance_scan_acc()
 
                 summary = f"{total_broken} photos repaired"
                 if unreachable:
@@ -663,16 +679,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 _update_stages(runner, job["id"], stages)
                 for src_folder in sources:
                     scanned_roots.append(src_folder)
-                    do_scan(
-                        src_folder, thread_db,
-                        progress_callback=progress_cb,
-                        incremental=True,
-                        extract_full_metadata=pipeline_cfg.get("extract_full_metadata", True),
-                        photo_callback=photo_cb,
-                        skip_paths=params.exclude_paths,
-                        status_callback=status_cb,
-                        recursive=params.recursive,
-                    )
+                    try:
+                        do_scan(
+                            src_folder, thread_db,
+                            progress_callback=progress_cb,
+                            incremental=True,
+                            extract_full_metadata=pipeline_cfg.get("extract_full_metadata", True),
+                            photo_callback=photo_cb,
+                            skip_paths=params.exclude_paths,
+                            status_callback=status_cb,
+                            recursive=params.recursive,
+                        )
+                    finally:
+                        advance_scan_acc()
             stages["scan"]["status"] = "completed"
             runner.update_step(job["id"], "scan", status="completed",
                                summary=f"{stages['scan']['count']} photos")

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -11,6 +11,7 @@ untouched. This is an additive orchestration layer.
 import contextlib
 import json
 import logging
+import math
 import os
 import queue
 import threading
@@ -158,11 +159,17 @@ STAGE_WEIGHTS = {
 
 
 def _stage_fraction(info):
-    """Return a 0..1 completion fraction for one stage entry."""
+    """Return a 0..1 completion fraction for one stage entry.
+
+    'failed' stages still contribute their partial (count/total) progress:
+    heavy stages like classify and extract_masks often process most items
+    before marking themselves failed due to per-item errors, and dropping
+    their weight to 0 would make the overall bar lurch backward when that
+    failure surfaces."""
     status = info.get("status", "pending")
     if status in ("completed", "skipped"):
         return 1.0
-    if status != "running":
+    if status not in ("running", "failed"):
         return 0.0
     total = info.get("total") or 0
     count = info.get("count") or 0
@@ -177,7 +184,12 @@ def _weighted_progress(stages):
     """Overall pipeline progress as (current, total), weighted by stage cost.
 
     Scaled so total == sum(STAGE_WEIGHTS.values()), which keeps the UI's
-    `Math.round(current/total * 100)` rendering whole percent steps."""
+    `Math.round(current/total * 100)` rendering whole percent steps.
+
+    Uses floor rather than round: a done-but-not-quite value like 99.94
+    must not render as 100 because the overall bar reaching total is what
+    the UI treats as 'pipeline complete'. Only a genuinely completed
+    pipeline (all stages completed/skipped) produces done == total."""
     total = sum(STAGE_WEIGHTS.values())
     if total == 0:
         return 0, 0
@@ -185,7 +197,7 @@ def _weighted_progress(stages):
         weight * _stage_fraction(stages.get(name, {}))
         for name, weight in STAGE_WEIGHTS.items()
     )
-    return int(round(done)), total
+    return int(math.floor(done)), total
 
 
 def _progress_event(stages, stage_id, phase, **extra):

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -139,12 +139,80 @@ def _find_broken_metadata_folders(db, photo_ids):
     return [(fp, paths) for fp, paths in by_folder.items()]
 
 
+# Approximate relative runtime cost per stage, used to weight the overall
+# progress bar so a fast stage finishing doesn't push the bar to 100%.
+# Heuristic: classify dominates on big imports; detect and eye_keypoints are
+# also GPU-heavy; ingest / model_loader / regroup are quick.
+STAGE_WEIGHTS = {
+    "ingest": 2,
+    "scan": 8,
+    "thumbnails": 6,
+    "previews": 6,
+    "model_loader": 2,
+    "detect": 15,
+    "classify": 30,
+    "extract_masks": 10,
+    "eye_keypoints": 15,
+    "regroup": 6,
+}
+
+
+def _stage_fraction(info):
+    """Return a 0..1 completion fraction for one stage entry."""
+    status = info.get("status", "pending")
+    if status in ("completed", "skipped"):
+        return 1.0
+    if status != "running":
+        return 0.0
+    total = info.get("total") or 0
+    count = info.get("count") or 0
+    if total <= 0:
+        return 0.0
+    if count >= total:
+        return 1.0
+    return count / total
+
+
+def _weighted_progress(stages):
+    """Overall pipeline progress as (current, total), weighted by stage cost.
+
+    Scaled so total == sum(STAGE_WEIGHTS.values()), which keeps the UI's
+    `Math.round(current/total * 100)` rendering whole percent steps."""
+    total = sum(STAGE_WEIGHTS.values())
+    if total == 0:
+        return 0, 0
+    done = sum(
+        weight * _stage_fraction(stages.get(name, {}))
+        for name, weight in STAGE_WEIGHTS.items()
+    )
+    return int(round(done)), total
+
+
+def _progress_event(stages, stage_id, phase, **extra):
+    """Build a push_event 'progress' payload with weighted overall current/total.
+
+    Call sites pass per-stage context (stage_id, phase, current_file, rate,
+    eta_seconds, step_id). Per-stage counts still live in `stages[...]` and
+    reach the UI via the `stages` snapshot, so step-level bars are unaffected."""
+    current, total = _weighted_progress(stages)
+    data = {
+        "phase": phase,
+        "stage_id": stage_id,
+        "current": current,
+        "total": total,
+        "stages": {k: dict(v) for k, v in stages.items()},
+    }
+    data.update(extra)
+    return data
+
+
 def _update_stages(runner, job_id, stages):
-    """Push a stages progress update."""
+    """Push a stages progress update with weighted overall current/total."""
+    current, total = _weighted_progress(stages)
     runner.push_event(job_id, "progress", {
         "phase": _current_phase(stages),
-        "current": 0,
-        "total": 0,
+        "current": current,
+        "total": total,
         "stages": {k: dict(v) for k, v in stages.items()},
     })
 
@@ -355,17 +423,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
             def status_cb(message):
                 runner.update_step(job["id"], "scan", current_file=message)
-                runner.push_event(job["id"], "progress", {
-                    "phase": message,
-                    "stage_id": "scan",
-                    "current": job["progress"].get("current", 0),
-                    "total": job["progress"].get("total", 0),
-                    "stages": {k: dict(v) for k, v in stages.items()},
-                })
+                runner.push_event(job["id"], "progress", _progress_event(
+                    stages, "scan", message,
+                ))
 
             def progress_cb(current, total):
-                job["progress"]["current"] = current
-                job["progress"]["total"] = total
+                stages["scan"]["count"] = current
+                stages["scan"]["total"] = total
                 elapsed = time.time() - job["_start_time"]
                 rate = round(current / max(elapsed, 0.01) * 60, 1)  # files/min
                 remaining = total - current
@@ -373,15 +437,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 eta = round(remaining / rate_per_sec) if rate_per_sec > 0 and current >= 10 else None
                 runner.update_step(job["id"], "scan",
                                    progress={"current": current, "total": total})
-                runner.push_event(job["id"], "progress", {
-                    "phase": "Scanning photos",
-                    "stage_id": "scan",
-                    "current": current,
-                    "total": total,
-                    "rate": rate,
-                    "eta_seconds": eta,
-                    "stages": {k: dict(v) for k, v in stages.items()},
-                })
+                runner.push_event(job["id"], "progress", _progress_event(
+                    stages, "scan", "Scanning photos",
+                    rate=rate,
+                    eta_seconds=eta,
+                ))
 
             # Collection mode: no scan targets, but check whether any
             # photos in the collection have broken metadata (NULL timestamp
@@ -488,17 +548,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
                 def ingest_cb(current, total, filename):
                     stages["ingest"]["count"] = current
+                    stages["ingest"]["total"] = total
                     runner.update_step(job["id"], "ingest",
                                        current_file=filename,
                                        progress={"current": current, "total": total})
-                    runner.push_event(job["id"], "progress", {
-                        "phase": "Importing photos",
-                        "stage_id": "ingest",
-                        "current": current,
-                        "total": total,
-                        "current_file": filename,
-                        "stages": {k: dict(v) for k, v in stages.items()},
-                    })
+                    runner.push_event(job["id"], "progress", _progress_event(
+                        stages, "ingest", "Importing photos",
+                        current_file=filename,
+                    ))
 
             if params.destination:
                 # Copy mode: ingest all sources first, then scan destination
@@ -738,20 +795,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 # the thumbnail worker catches up with scan before scan's
                 # status flips to "completed".
                 scan_total = stages["scan"].get("count", 0)
+                stages["thumbnails"]["total"] = scan_total
                 runner.update_step(job["id"], "thumbnails",
                                    current_file=os.path.basename(photo_path),
                                    progress={"current": processed, "total": scan_total})
                 elapsed = time.time() - job["_start_time"]
                 rate = round(processed / max(elapsed, 0.01) * 60, 1)
-                runner.push_event(job["id"], "progress", {
-                    "phase": "Generating thumbnails",
-                    "stage_id": "thumbnails",
-                    "current": processed,
-                    "total": scan_total,
-                    "current_file": os.path.basename(photo_path),
-                    "rate": rate,
-                    "stages": {k: dict(v) for k, v in stages.items()},
-                })
+                runner.push_event(job["id"], "progress", _progress_event(
+                    stages, "thumbnails", "Generating thumbnails",
+                    current_file=os.path.basename(photo_path),
+                    rate=rate,
+                ))
 
             # Collection mode: the scanner is skipped so the queue above was
             # empty. Iterate the collection's photos directly — mirrors the
@@ -785,6 +839,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         failed += 1
                         log.debug("Thumbnail failed for photo %s", photo_id)
                     stages["thumbnails"]["count"] = generated + skipped + failed
+                    stages["thumbnails"]["total"] = total
                     processed = generated + skipped + failed
                     runner.update_step(
                         job["id"], "thumbnails",
@@ -793,15 +848,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     )
                     elapsed = time.time() - job["_start_time"]
                     rate = round(processed / max(elapsed, 0.01) * 60, 1)
-                    runner.push_event(job["id"], "progress", {
-                        "phase": "Generating thumbnails",
-                        "stage_id": "thumbnails",
-                        "current": processed,
-                        "total": total,
-                        "current_file": os.path.basename(photo_path),
-                        "rate": rate,
-                        "stages": {k: dict(v) for k, v in stages.items()},
-                    })
+                    runner.push_event(job["id"], "progress", _progress_event(
+                        stages, "thumbnails", "Generating thumbnails",
+                        current_file=os.path.basename(photo_path),
+                        rate=rate,
+                    ))
 
             from thumbnails import format_summary as thumb_summary
             thumb_result = {"generated": generated, "skipped": skipped, "failed": failed}
@@ -907,20 +958,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         failed += 1
 
                 stages["previews"]["count"] = i + 1
+                stages["previews"]["total"] = total
                 runner.update_step(job["id"], "previews",
                                    current_file=photo["filename"],
                                    progress={"current": i + 1, "total": total})
-                runner.push_event(job["id"], "progress", {
-                    "phase": "Generating previews",
-                    "stage_id": "previews",
-                    "current": i + 1,
-                    "total": total,
-                    "current_file": photo["filename"],
-                    "rate": round(
+                runner.push_event(job["id"], "progress", _progress_event(
+                    stages, "previews", "Generating previews",
+                    current_file=photo["filename"],
+                    rate=round(
                         (i + 1) / max(time.time() - job["_start_time"], 0.01) * 60, 1
                     ),
-                    "stages": {k: dict(v) for k, v in stages.items()},
-                })
+                ))
 
             # One eviction pass after the stage so preview_cache_max_mb is
             # enforced even when the pipeline is the only producer (e.g.
@@ -1147,19 +1195,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             if params.download_taxonomy and not os.path.exists(taxonomy_path):
                 try:
                     from taxonomy import download_taxonomy
-                    runner.push_event(job["id"], "progress", {
-                        "phase": "Downloading taxonomy...",
-                        "stage_id": "model_loader",
-                        "current": 0, "total": 0,
-                        "stages": {k: dict(v) for k, v in stages.items()},
-                    })
+                    runner.push_event(job["id"], "progress", _progress_event(
+                        stages, "model_loader", "Downloading taxonomy...",
+                    ))
                     download_taxonomy(taxonomy_path, progress_callback=lambda msg:
-                        runner.push_event(job["id"], "progress", {
-                            "phase": msg,
-                            "stage_id": "model_loader",
-                            "current": 0, "total": 0,
-                            "stages": {k: dict(v) for k, v in stages.items()},
-                        })
+                        runner.push_event(job["id"], "progress", _progress_event(
+                            stages, "model_loader", msg,
+                        ))
                     )
                 except Exception as e:
                     log.warning("Taxonomy download failed, continuing without: %s", e)
@@ -1172,12 +1214,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             # Load the first classifier so classify_stage can start as soon
             # as scan completes; any remaining specs are loaded inside
             # classify_stage so we never hold more than one model in memory.
-            runner.push_event(job["id"], "progress", {
-                "phase": f"Loading {first_name}...",
-                "stage_id": "model_loader",
-                "current": 0, "total": 0,
-                "stages": {k: dict(v) for k, v in stages.items()},
-            })
+            runner.push_event(job["id"], "progress", _progress_event(
+                stages, "model_loader", f"Loading {first_name}...",
+            ))
 
             try:
                 bundle = _load_model_bundle(resolved_specs[0], tax, thread_db)
@@ -1311,12 +1350,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 from detector import ensure_megadetector_weights
 
                 def _dl_progress(phase, current, total_steps):
-                    runner.push_event(job["id"], "progress", {
-                        "phase": phase,
-                        "stage_id": "detect",
-                        "current": current, "total": total_steps,
-                        "stages": {k: dict(v) for k, v in stages.items()},
-                    })
+                    # Weight download is a sub-phase of detect; don't treat
+                    # its bytes as detect's stage-level counter or the bar
+                    # jumps ahead before any photo has been detected.
+                    runner.push_event(job["id"], "progress", _progress_event(
+                        stages, "detect", phase,
+                    ))
 
                 ensure_megadetector_weights(progress_callback=_dl_progress)
 
@@ -1331,18 +1370,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 batch = photos[batch_start:batch_start + _BATCH_SIZE]
                 batch_idx = batch_start + len(batch)
 
-                runner.push_event(job["id"], "progress", {
-                    "phase": "Detecting subjects",
-                    "stage_id": "detect",
-                    "current": batch_idx,
-                    "total": total,
-                    "rate": round(
+                stages["detect"]["count"] = batch_idx
+                stages["detect"]["total"] = total
+                runner.push_event(job["id"], "progress", _progress_event(
+                    stages, "detect", "Detecting subjects",
+                    rate=round(
                         batch_idx / max(time.time() - start_time, 0.01) * 60,
                         1,
                     ),
-                    "stages": {k: dict(v) for k, v in stages.items()},
-                })
-                stages["detect"]["count"] = batch_idx
+                ))
                 runner.update_step(
                     job["id"], "detect",
                     progress={"current": batch_idx, "total": total},
@@ -1520,13 +1556,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     model_type = loaded_models["model_type"]
                     model_name = loaded_models["model_name"]
                 else:
-                    runner.push_event(job["id"], "progress", {
-                        "phase": f"Loading {active_spec['name']}...",
-                        "stage_id": "classify",
-                        "step_id": step_id,
-                        "current": 0, "total": total,
-                        "stages": {k: dict(v) for k, v in stages.items()},
-                    })
+                    stages["classify"]["count"] = spec_idx * total
+                    stages["classify"]["total"] = total * len(resolved_specs_local)
+                    runner.push_event(job["id"], "progress", _progress_event(
+                        stages, "classify", f"Loading {active_spec['name']}...",
+                        step_id=step_id,
+                    ))
                     # Drop the prior model's per-photo payload BEFORE loading
                     # the next bundle so we don't hold old results + new model
                     # weights concurrently. Without this, multi-model runs on
@@ -1589,19 +1624,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                             if len(resolved_specs_local) > 1 else ""
                         )
                     )
-                    runner.push_event(job["id"], "progress", {
-                        "phase": phase_label,
-                        "stage_id": "classify",
-                        "step_id": step_id,
-                        "current": batch_idx,
-                        "total": total,
-                        "rate": round(
+                    # Aggregate classify progress across models: count spans
+                    # [0, total*N] so the overall bar advances smoothly through
+                    # a multi-model run instead of snapping to 100% per model.
+                    stages["classify"]["count"] = spec_idx * total + batch_idx
+                    stages["classify"]["total"] = total * len(resolved_specs_local)
+                    runner.push_event(job["id"], "progress", _progress_event(
+                        stages, "classify", phase_label,
+                        step_id=step_id,
+                        rate=round(
                             batch_idx / max(time.time() - start_time, 0.01) * 60,
                             1,
                         ),
-                        "stages": {k: dict(v) for k, v in stages.items()},
-                    })
-                    stages["classify"]["count"] = batch_idx
+                    ))
                     runner.update_step(
                         job["id"], step_id,
                         progress={"current": batch_idx, "total": total},
@@ -1973,12 +2008,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 from masking import ensure_sam2_weights
 
                 def _dl_progress(phase, current, total_steps):
-                    runner.push_event(job["id"], "progress", {
-                        "phase": phase,
-                        "stage_id": "extract_masks",
-                        "current": current, "total": total_steps,
-                        "stages": {k: dict(v) for k, v in stages.items()},
-                    })
+                    runner.push_event(job["id"], "progress", _progress_event(
+                        stages, "extract_masks", phase,
+                    ))
 
                 ensure_sam2_weights(
                     variant=sam2_variant, progress_callback=_dl_progress,
@@ -2037,17 +2069,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     log.warning("Mask extraction failed for photo %s", photo_id, exc_info=True)
 
                 stages["extract_masks"]["count"] = i + 1
+                stages["extract_masks"]["total"] = total
                 runner.update_step(job["id"], "extract_masks",
                                    progress={"current": i + 1, "total": total},
                                    error_count=em_failed)
-                runner.push_event(job["id"], "progress", {
-                    "phase": "Extracting features (SAM2 + DINOv2)",
-                    "stage_id": "extract_masks",
-                    "current": i + 1,
-                    "total": total,
-                    "rate": round((i + 1) / max(time.time() - start_time, 0.01) * 60, 1),
-                    "stages": {k: dict(v) for k, v in stages.items()},
-                })
+                runner.push_event(job["id"], "progress", _progress_event(
+                    stages, "extract_masks",
+                    "Extracting features (SAM2 + DINOv2)",
+                    rate=round((i + 1) / max(time.time() - start_time, 0.01) * 60, 1),
+                ))
 
             final_status = "failed" if em_failed > 0 else "completed"
             stages["extract_masks"]["status"] = final_status
@@ -2145,20 +2175,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             def _progress(phase, current, total_steps):
                 processed["count"] = current
                 stages["eye_keypoints"]["count"] = current
+                stages["eye_keypoints"]["total"] = total_steps
                 runner.update_step(
                     job["id"], "eye_keypoints",
                     progress={"current": current, "total": total_steps},
                 )
-                runner.push_event(job["id"], "progress", {
-                    "phase": phase,
-                    "stage_id": "eye_keypoints",
-                    "current": current,
-                    "total": total_steps,
-                    "rate": round(
+                runner.push_event(job["id"], "progress", _progress_event(
+                    stages, "eye_keypoints", phase,
+                    rate=round(
                         current / max(time.time() - start_time, 0.01) * 60, 1
                     ),
-                    "stages": {k: dict(v) for k, v in stages.items()},
-                })
+                ))
 
             detect_eye_keypoints_stage(
                 thread_db, config=pipeline_cfg, progress_callback=_progress,

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2126,15 +2126,22 @@ function _updatePipelineStageUI(p) {
   var text = document.getElementById('text' + progressSuffix);
   var status = document.getElementById('status' + progressSuffix);
 
+  // Per-stage progress lives in stages[stage_id]; event top-level
+  // current/total is the WEIGHTED OVERALL progress and must not drive
+  // individual cards (it would make every card read the same %).
+  var si = stages[p.stage_id] || {};
+  var stageCurrent = si.count || 0;
+  var stageTotal = si.total || 0;
+
   var parts = [];
   if (p.phase) parts.push(p.phase);
-  if (p.total > 0 && p.current > 0) {
-    parts.push(p.current.toLocaleString() + ' / ' + p.total.toLocaleString());
+  if (stageTotal > 0 && stageCurrent > 0) {
+    parts.push(stageCurrent.toLocaleString() + ' / ' + stageTotal.toLocaleString());
   }
   if (p.rate) parts.push(Math.round(p.rate) + ' files/min');
   if (p.eta_seconds != null && p.eta_seconds > 0) {
     parts.push('~' + _formatETA(p.eta_seconds) + ' remaining');
-  } else if (p.total > 0 && p.current > 0 && p.current < 10) {
+  } else if (stageTotal > 0 && stageCurrent > 0 && stageCurrent < 10) {
     parts.push('Estimating...');
   }
   if (p.current_file) parts.push(p.current_file);
@@ -2144,9 +2151,9 @@ function _updatePipelineStageUI(p) {
   // "Discovering files..." are visible even before the bar has a total.
   if (status) status.textContent = label;
 
-  if (p.total > 0) {
+  if (stageTotal > 0) {
     if (progressWrap) progressWrap.style.display = '';
-    var pct = Math.round(p.current / p.total * 100);
+    var pct = Math.round(stageCurrent / stageTotal * 100);
     if (fill) fill.style.width = pct + '%';
     if (text) text.textContent = label;
   }

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -4245,6 +4245,24 @@ def test_stage_fraction_clamps_to_one():
     assert _stage_fraction({"status": "running", "count": 105, "total": 100}) == 1.0
 
 
+def test_stage_fraction_failed_counts_partial_work():
+    """Stages like classify can process most items and then mark themselves
+    'failed' due to per-item errors. Their partial completion must still
+    count toward the weighted overall — otherwise the bar drops sharply
+    when a near-done heavy stage fails."""
+    assert _stage_fraction({"status": "failed", "count": 80, "total": 100}) == 0.8
+
+
+def test_stage_fraction_failed_without_progress_is_zero():
+    """A failed stage with no count/total contributes nothing, same as
+    pending/unknown."""
+    assert _stage_fraction({"status": "failed"}) == 0.0
+
+
+def test_stage_fraction_failed_clamps_to_one():
+    assert _stage_fraction({"status": "failed", "count": 105, "total": 100}) == 1.0
+
+
 def test_weighted_progress_all_pending_is_zero():
     current, total = _weighted_progress(_empty_stages())
     assert current == 0
@@ -4288,6 +4306,37 @@ def test_weighted_progress_running_stage_partial():
     expected_done = 39 + 15
     assert current == expected_done
     assert total == sum(STAGE_WEIGHTS.values())
+
+
+def test_weighted_progress_does_not_round_up_to_full():
+    """Overall must not report `current == total` before every stage is
+    actually complete. int(round(done)) would report 100/100 when done is
+    99.5+, falsely showing 100% while a stage is still running."""
+    stages = _empty_stages()
+    for name in STAGE_WEIGHTS:
+        stages[name]["status"] = "completed"
+    # Override the last stage to running at 99/100. Contribution = 5.94
+    # (weight 6 * 0.99); others fully completed = 94. Total done = 99.94.
+    # A naive round(99.94) = 100 would hit total and falsely signal done.
+    stages["regroup"].update(status="running", count=99, total=100)
+    current, total = _weighted_progress(stages)
+    assert current < total, (
+        f"overall hit total ({current}/{total}) before last stage completed"
+    )
+
+
+def test_weighted_progress_does_not_round_up_with_failed_stage():
+    """Same premature-100 guard, but via a failed stage that finished
+    processing most items. If failed now counts partial work, the weighted
+    sum can land at 99.x when only one stage hasn't fully completed."""
+    stages = _empty_stages()
+    for name in STAGE_WEIGHTS:
+        stages[name]["status"] = "completed"
+    stages["regroup"].update(status="failed", count=99, total=100)
+    current, total = _weighted_progress(stages)
+    assert current < total, (
+        f"overall hit total ({current}/{total}) with a non-complete stage"
+    )
 
 
 def test_weighted_progress_monotonic_through_pipeline():

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -8,7 +8,13 @@ import threading
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from pipeline_job import PipelineParams, run_pipeline_job
+from pipeline_job import (
+    STAGE_WEIGHTS,
+    PipelineParams,
+    _stage_fraction,
+    _weighted_progress,
+    run_pipeline_job,
+)
 
 
 def _drop_jpeg(folder_path, filename):
@@ -4114,3 +4120,120 @@ def test_thumbnail_progress_counter_includes_failed(tmp_path, monkeypatch):
         f"stages['thumbnails']['count'] must include failed items (was {thumb_stage_count}). "
         f"Last event stages: {last['stages']}"
     )
+
+
+# --- Weighted overall progress ---------------------------------------------
+
+def _empty_stages():
+    return {name: {"status": "pending", "count": 0} for name in STAGE_WEIGHTS}
+
+
+def test_stage_fraction_pending_is_zero():
+    assert _stage_fraction({"status": "pending", "count": 0}) == 0.0
+
+
+def test_stage_fraction_completed_is_one():
+    assert _stage_fraction({"status": "completed", "count": 5, "total": 10}) == 1.0
+
+
+def test_stage_fraction_skipped_is_one():
+    """Skipped stages are "done" for overall-progress purposes — their
+    weight has been paid out, so don't stall the bar at the last skip."""
+    assert _stage_fraction({"status": "skipped"}) == 1.0
+
+
+def test_stage_fraction_running_uses_count_over_total():
+    assert _stage_fraction({"status": "running", "count": 25, "total": 100}) == 0.25
+
+
+def test_stage_fraction_running_without_total_is_zero():
+    """A running stage that hasn't yet reported a total can't compute a
+    fraction; report 0 rather than dividing by zero or claiming completion."""
+    assert _stage_fraction({"status": "running", "count": 5}) == 0.0
+
+
+def test_stage_fraction_clamps_to_one():
+    """Stage counters sometimes overshoot total (last batch rounding)."""
+    assert _stage_fraction({"status": "running", "count": 105, "total": 100}) == 1.0
+
+
+def test_weighted_progress_all_pending_is_zero():
+    current, total = _weighted_progress(_empty_stages())
+    assert current == 0
+    assert total == sum(STAGE_WEIGHTS.values())
+
+
+def test_weighted_progress_all_completed_is_full():
+    stages = {name: {"status": "completed"} for name in STAGE_WEIGHTS}
+    current, total = _weighted_progress(stages)
+    assert current == total
+    assert total == sum(STAGE_WEIGHTS.values())
+
+
+def test_weighted_progress_fast_stage_done_heavy_pending():
+    """After a fast stage finishes and a heavy one hasn't started, the bar
+    should reflect the fast stage's small weight — NOT 100%. This is the
+    bug the helper fixes: previously the last-pushed stage-local current/total
+    dominated the overall bar."""
+    stages = _empty_stages()
+    stages["ingest"]["status"] = "completed"  # weight 2
+    stages["scan"]["status"] = "completed"    # weight 8
+    # classify (weight 30) still pending
+    current, total = _weighted_progress(stages)
+    pct = current / total * 100
+    assert pct < 15, f"Expected <15% with only ingest+scan done, got {pct:.1f}%"
+
+
+def test_weighted_progress_running_stage_partial():
+    stages = _empty_stages()
+    stages["ingest"]["status"] = "completed"
+    stages["scan"]["status"] = "completed"
+    stages["thumbnails"]["status"] = "completed"
+    stages["previews"]["status"] = "completed"
+    stages["model_loader"]["status"] = "completed"
+    stages["detect"]["status"] = "completed"
+    stages["classify"].update(status="running", count=50, total=100)
+    current, total = _weighted_progress(stages)
+    # ingest+scan+thumbs+previews+model_loader+detect = 2+8+6+6+2+15 = 39
+    # classify half-done = 15
+    # total weight sum via STAGE_WEIGHTS
+    expected_done = 39 + 15
+    assert current == expected_done
+    assert total == sum(STAGE_WEIGHTS.values())
+
+
+def test_weighted_progress_monotonic_through_pipeline():
+    """Completing stages in order should produce a monotonically increasing
+    overall percentage — no drops between phases."""
+    stages = _empty_stages()
+    order = ["ingest", "scan", "thumbnails", "previews", "model_loader",
+             "detect", "classify", "extract_masks", "eye_keypoints", "regroup"]
+    last_pct = -1.0
+    for name in order:
+        stages[name]["status"] = "completed"
+        current, total = _weighted_progress(stages)
+        pct = current / total * 100
+        assert pct > last_pct, f"Progress went backwards at {name}: {last_pct} -> {pct}"
+        last_pct = pct
+    assert last_pct == 100.0
+
+
+def test_update_stages_emits_weighted_current_total():
+    """_update_stages must send the weighted overall to push_event instead
+    of hardcoded 0/0. This is what makes the 'Overall %' visible in the UI."""
+    from pipeline_job import _update_stages
+
+    stages = _empty_stages()
+    stages["ingest"]["status"] = "completed"
+    stages["scan"]["status"] = "running"
+    stages["scan"]["count"] = 50
+    stages["scan"]["total"] = 100
+
+    runner = FakeRunner()
+    _update_stages(runner, "job-x", stages)
+    assert runner.events, "no events pushed"
+    _, evt, data = runner.events[-1]
+    assert evt == "progress"
+    assert data["total"] == sum(STAGE_WEIGHTS.values())
+    # ingest (2) + scan half (4) = 6
+    assert data["current"] == 6

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -754,6 +754,94 @@ def test_pipeline_scan_progress_includes_rate_and_eta(tmp_path, monkeypatch):
     assert isinstance(last["eta_seconds"], (int, float))
 
 
+def test_pipeline_multi_folder_scan_progress_is_monotonic(tmp_path, monkeypatch):
+    """Scan progress must not move backward at folder boundaries.
+
+    When sources is a list of folders, pipeline_job loops calling scan()
+    once per folder. Each scan() reports progress as local (current, total).
+    The weighted overall bar reads stages["scan"]["count"]/.total, so if
+    those get overwritten rather than accumulated, the UI progress jumps
+    backward when folder N+1 starts.
+    """
+    import time
+
+    import config as cfg
+    from db import Database
+    from jobs import JobRunner
+    from pipeline_job import PipelineParams, run_pipeline_job
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    from PIL import Image
+    folder_a = tmp_path / "folderA"
+    folder_a.mkdir()
+    for i in range(6):
+        Image.new("RGB", (40, 40), "blue").save(str(folder_a / f"a{i:02d}.jpg"))
+    folder_b = tmp_path / "folderB"
+    folder_b.mkdir()
+    for i in range(6):
+        Image.new("RGB", (40, 40), "red").save(str(folder_b / f"b{i:02d}.jpg"))
+
+    runner = JobRunner()
+    scan_counts = []
+    scan_totals = []
+    orig_push = runner.push_event
+
+    def capture_push(job_id, event_type, data):
+        if event_type == "progress":
+            stages = data.get("stages") or {}
+            scan_info = stages.get("scan") or {}
+            if scan_info.get("status") == "running":
+                scan_counts.append(scan_info.get("count") or 0)
+                scan_totals.append(scan_info.get("total") or 0)
+        orig_push(job_id, event_type, data)
+
+    monkeypatch.setattr(runner, "push_event", capture_push)
+
+    params = PipelineParams(
+        sources=[str(folder_a), str(folder_b)],
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    job = {
+        "id": "test-multi-scan-mono",
+        "type": "pipeline",
+        "status": "running",
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "finished_at": None,
+        "progress": {"current": 0, "total": 0, "current_file": ""},
+        "result": None,
+        "errors": [],
+        "config": {},
+        "workspace_id": ws_id,
+        "steps": [],
+    }
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert len(scan_counts) > 0, "Expected at least one running scan progress event"
+    for i in range(1, len(scan_counts)):
+        assert scan_counts[i] >= scan_counts[i - 1], (
+            f"scan count moved backward: {scan_counts[i - 1]} -> "
+            f"{scan_counts[i]} at event {i}; full sequence={scan_counts}"
+        )
+    for i in range(1, len(scan_totals)):
+        assert scan_totals[i] >= scan_totals[i - 1], (
+            f"scan total moved backward: {scan_totals[i - 1]} -> "
+            f"{scan_totals[i]} at event {i}; full sequence={scan_totals}"
+        )
+    assert scan_totals[-1] >= 12, (
+        f"final scan total should cover both folders (>=12), got {scan_totals[-1]}"
+    )
+
+
 def test_pipeline_ingest_updates_step_progress(tmp_path, monkeypatch):
     """Ingest (import) phase should call update_step so the jobs page shows progress."""
     import config as cfg

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -842,6 +842,98 @@ def test_pipeline_multi_folder_scan_progress_is_monotonic(tmp_path, monkeypatch)
     )
 
 
+def test_pipeline_multi_source_ingest_progress_is_monotonic(tmp_path, monkeypatch):
+    """Ingest progress must not move backward at source folder boundaries.
+
+    Copy mode with sources=[folderA, folderB] calls do_ingest() once per
+    folder. Each call reports (current, total) local to that folder. The
+    weighted overall bar reads stages["ingest"]["count"]/.total, so if
+    those get overwritten rather than accumulated, overall progress
+    rewinds each time a new source starts — the exact regression the
+    scan accumulator already prevents. Same treatment needed for ingest.
+    """
+    import time
+
+    import config as cfg
+    from db import Database
+    from jobs import JobRunner
+    from pipeline_job import PipelineParams, run_pipeline_job
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    from PIL import Image
+    src_a = tmp_path / "srcA"
+    src_a.mkdir()
+    for i in range(5):
+        Image.new("RGB", (40, 40), "blue").save(str(src_a / f"a{i:02d}.jpg"))
+    src_b = tmp_path / "srcB"
+    src_b.mkdir()
+    for i in range(5):
+        Image.new("RGB", (40, 40), "red").save(str(src_b / f"b{i:02d}.jpg"))
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    runner = JobRunner()
+    ingest_counts = []
+    ingest_totals = []
+    orig_push = runner.push_event
+
+    def capture_push(job_id, event_type, data):
+        if event_type == "progress":
+            stages = data.get("stages") or {}
+            ingest_info = stages.get("ingest") or {}
+            if ingest_info.get("status") == "running":
+                ingest_counts.append(ingest_info.get("count") or 0)
+                ingest_totals.append(ingest_info.get("total") or 0)
+        orig_push(job_id, event_type, data)
+
+    monkeypatch.setattr(runner, "push_event", capture_push)
+
+    params = PipelineParams(
+        sources=[str(src_a), str(src_b)],
+        destination=str(dest),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    job = {
+        "id": "test-multi-ingest-mono",
+        "type": "pipeline",
+        "status": "running",
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "finished_at": None,
+        "progress": {"current": 0, "total": 0, "current_file": ""},
+        "result": None,
+        "errors": [],
+        "config": {},
+        "workspace_id": ws_id,
+        "steps": [],
+    }
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert len(ingest_counts) > 0, "Expected at least one running ingest progress event"
+    for i in range(1, len(ingest_counts)):
+        assert ingest_counts[i] >= ingest_counts[i - 1], (
+            f"ingest count moved backward: {ingest_counts[i - 1]} -> "
+            f"{ingest_counts[i]} at event {i}; full sequence={ingest_counts}"
+        )
+    for i in range(1, len(ingest_totals)):
+        assert ingest_totals[i] >= ingest_totals[i - 1], (
+            f"ingest total moved backward: {ingest_totals[i - 1]} -> "
+            f"{ingest_totals[i]} at event {i}; full sequence={ingest_totals}"
+        )
+    assert ingest_totals[-1] >= 10, (
+        f"final ingest total should cover both sources (>=10), got {ingest_totals[-1]}"
+    )
+
+
 def test_pipeline_ingest_updates_step_progress(tmp_path, monkeypatch):
     """Ingest (import) phase should call update_step so the jobs page shows progress."""
     import config as cfg


### PR DESCRIPTION
## Summary

The overall pipeline progress bar would show ~100% while tons of work remained. Root cause: every stage pushed its own 0→100% ratio into \`job.progress.current/total\`, and between stages \`_update_stages\` pushed \`{0, 0}\` which the UI hides — so the bar stuck at the last stage's 100% until the next stage fired its first event.

## What changed

- Added \`STAGE_WEIGHTS\` reflecting relative runtime cost (classify: 30, detect/eye_keypoints: 15, thumbnails/previews: 6, ingest/model_loader: 2, etc.).
- \`_weighted_progress(stages)\` computes a weighted overall from per-stage fractions (skipped counts as 1.0, running uses count/total, pending 0.0).
- \`_update_stages\` and every \`runner.push_event("progress", …)\` site now emits weighted overall in top-level \`current\`/\`total\` via \`_progress_event(...)\`. Per-stage progress moves into \`stages[stage_id].count/total\`.
- \`templates/pipeline.html\` reads per-card progress from the \`stages\` snapshot (not the event's top-level \`current\`/\`total\` — that's now overall).
- Multi-model classify aggregates across models: count spans \`[0, total * N]\`, so a 3-model run advances smoothly to 100% once, instead of snapping 0→100 three times.

## Test plan

- [x] \`python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_pipeline_job.py\` — 636 passed
- [x] New unit tests cover: \`_stage_fraction\` (pending/running/completed/skipped/clamping), \`_weighted_progress\` (all-pending, all-complete, monotonic through pipeline, fast-stage-done-doesn't-hit-100%, weighted partials), and \`_update_stages\` (emits weighted not 0/0)
- [ ] Manual check: run a real pipeline and watch the Overall % advance smoothly instead of spiking to 100% between stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)