### PR TITLE
feat: miss detection — three-category grid + pipeline integration

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2320,13 +2320,21 @@ def create_app(db_path, thumb_cache_dir=None):
     @app.route("/api/misses/reject", methods=["POST"])
     def api_misses_reject():
         """Set flag='rejected' on every photo currently flagged with the given
-        miss category. Returns {"rejected": n, "category": ...}."""
+        miss category.
+
+        Accepts an optional ``since`` ISO timestamp that mirrors the
+        ``/misses?since=...`` review-window scope; when present, only
+        photos whose miss_computed_at >= since are rejected, so the bulk
+        action matches what the user sees on screen. Returns
+        {"rejected": n, "category": ...}.
+        """
         db = _get_db()
         body = request.get_json(silent=True) or {}
         category = body.get("category")
+        since = body.get("since") or None
         if category not in ("no_subject", "clipped", "oof"):
             return jsonify({"error": "invalid category"}), 400
-        n = db.bulk_reject_miss_category(category)
+        n = db.bulk_reject_miss_category(category, since=since)
         return jsonify({"rejected": n, "category": category})
 
     @app.route("/api/misses/<int:photo_id>/unflag", methods=["POST"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2337,7 +2337,10 @@ def create_app(db_path, thumb_cache_dir=None):
         category = body.get("category")
         if category not in ("no_subject", "clipped", "oof"):
             return jsonify({"error": "invalid category"}), 400
-        db.clear_miss_flag(photo_id, category)
+        try:
+            db.clear_miss_flag(photo_id, category)
+        except ValueError:
+            return jsonify({"error": "photo not in active workspace"}), 404
         return jsonify({"ok": True})
 
     @app.route("/api/classify/readiness")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2319,7 +2319,7 @@ def create_app(db_path, thumb_cache_dir=None):
 
     @app.route("/api/misses/reject", methods=["POST"])
     def api_misses_reject():
-        """Set flag='reject' on every photo currently flagged with the given
+        """Set flag='rejected' on every photo currently flagged with the given
         miss category. Returns {"rejected": n, "category": ...}."""
         db = _get_db()
         body = request.get_json(silent=True) or {}

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7454,6 +7454,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """
         from pipeline import (
             load_photo_features,
+            load_results_raw,
             reflow,
             run_grouping,
             save_results,
@@ -7479,8 +7480,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         encounters = run_grouping(photos, config=pipeline_cfg)
         results = reflow(encounters, config=pipeline_cfg)
 
-        # Save updated results
+        # Carry the miss-recomputation marker through so the review UI's
+        # "Review misses" shortcut stays visible after a threshold
+        # tweak. reflow/regroup-live do not recompute misses themselves.
         cache_dir = os.path.dirname(db_path)
+        existing = load_results_raw(cache_dir, db._active_workspace_id)
+        if existing and existing.get("miss_computed_at"):
+            results["miss_computed_at"] = existing["miss_computed_at"]
+
+        # Save updated results
         save_results(results, cache_dir, db._active_workspace_id)
 
         return jsonify(serialize_results(results))
@@ -7494,6 +7502,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """
         from pipeline import (
             load_photo_features,
+            load_results_raw,
             run_full_pipeline,
             save_results,
             serialize_results,
@@ -7514,7 +7523,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         results = run_full_pipeline(photos, config=pipeline_cfg)
 
+        # Carry the miss-recomputation marker through so the review UI's
+        # "Review misses" shortcut stays visible after a threshold
+        # tweak. regroup-live does not rerun the miss stage itself.
         cache_dir = os.path.dirname(db_path)
+        existing = load_results_raw(cache_dir, db._active_workspace_id)
+        if existing and existing.get("miss_computed_at"):
+            results["miss_computed_at"] = existing["miss_computed_at"]
+
         save_results(results, cache_dir, db._active_workspace_id)
 
         return jsonify(serialize_results(results))

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2290,6 +2290,49 @@ def create_app(db_path, thumb_cache_dir=None):
         dets = db.get_detections(photo_id)
         return jsonify([dict(d) for d in dets])
 
+    @app.route("/api/misses")
+    def api_misses():
+        """Return photos flagged as misses.
+
+        With no query string, returns a dict with all three categories.
+        With ``?category=X``, returns {"photos": [...], "category": X}.
+        """
+        db = _get_db()
+        category = request.args.get("category")
+        if category is not None:
+            if category not in ("no_subject", "clipped", "oof"):
+                return jsonify({"error": "invalid category"}), 400
+            photos = db.list_misses(category=category)
+            return jsonify({"photos": photos, "category": category})
+        return jsonify({
+            "no_subject": db.list_misses(category="no_subject"),
+            "clipped":    db.list_misses(category="clipped"),
+            "oof":        db.list_misses(category="oof"),
+        })
+
+    @app.route("/api/misses/reject", methods=["POST"])
+    def api_misses_reject():
+        """Set flag='reject' on every photo currently flagged with the given
+        miss category. Returns {"rejected": n, "category": ...}."""
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        category = body.get("category")
+        if category not in ("no_subject", "clipped", "oof"):
+            return jsonify({"error": "invalid category"}), 400
+        n = db.bulk_reject_miss_category(category)
+        return jsonify({"rejected": n, "category": category})
+
+    @app.route("/api/misses/<int:photo_id>/unflag", methods=["POST"])
+    def api_misses_unflag(photo_id):
+        """Clear the given miss-category boolean on a single photo."""
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        category = body.get("category")
+        if category not in ("no_subject", "clipped", "oof"):
+            return jsonify({"error": "invalid category"}), 400
+        db.clear_miss_flag(photo_id, category)
+        return jsonify({"ok": True})
+
     @app.route("/api/classify/readiness")
     def api_classify_readiness():
         """Check what's ready for classification and what will need work."""

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2574,6 +2574,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         photos whose miss_computed_at >= since are rejected, so the bulk
         action matches what the user sees on screen. Returns
         {"rejected": n, "category": ...}.
+
+        Records a batch ``flag`` entry in ``edit_history`` so the bulk
+        change is undoable and shows up in the audit log, matching the
+        behavior of ``/api/batch/flag``.
         """
         db = _get_db()
         body = request.get_json(silent=True) or {}
@@ -2581,8 +2585,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         since = body.get("since") or None
         if category not in ("no_subject", "clipped", "oof"):
             return jsonify({"error": "invalid category"}), 400
-        n = db.bulk_reject_miss_category(category, since=since)
-        return jsonify({"rejected": n, "category": category})
+        affected = db.bulk_reject_miss_category(category, since=since)
+        if affected:
+            items = [
+                {"photo_id": a["photo_id"],
+                 "old_value": a["old_value"],
+                 "new_value": "rejected"}
+                for a in affected
+            ]
+            db.record_edit(
+                "flag",
+                f"Rejected {len(items)} miss photos (category={category})",
+                "rejected",
+                items,
+                is_batch=True,
+            )
+        return jsonify({"rejected": len(affected), "category": category})
 
     @app.route("/api/misses/<int:photo_id>/unflag", methods=["POST"])
     def api_misses_unflag(photo_id):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2300,18 +2300,21 @@ def create_app(db_path, thumb_cache_dir=None):
 
         With no query string, returns a dict with all three categories.
         With ``?category=X``, returns {"photos": [...], "category": X}.
+        ``?since=<iso-ts>`` restricts results to photos whose
+        miss_computed_at >= since (used by the pipeline-review step).
         """
         db = _get_db()
         category = request.args.get("category")
+        since = request.args.get("since") or None
         if category is not None:
             if category not in ("no_subject", "clipped", "oof"):
                 return jsonify({"error": "invalid category"}), 400
-            photos = db.list_misses(category=category)
+            photos = db.list_misses(category=category, since=since)
             return jsonify({"photos": photos, "category": category})
         return jsonify({
-            "no_subject": db.list_misses(category="no_subject"),
-            "clipped":    db.list_misses(category="clipped"),
-            "oof":        db.list_misses(category="oof"),
+            "no_subject": db.list_misses(category="no_subject", since=since),
+            "clipped":    db.list_misses(category="clipped", since=since),
+            "oof":        db.list_misses(category="oof", since=since),
         })
 
     @app.route("/api/misses/reject", methods=["POST"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -725,6 +725,10 @@ def create_app(db_path, thumb_cache_dir=None):
     def highlights_page():
         return render_template("highlights.html")
 
+    @app.route("/misses")
+    def misses_page():
+        return render_template("misses.html")
+
     # -- API routes --
 
     def _attach_species(db, photo_dicts):

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -60,6 +60,13 @@ DEFAULTS = {
         "reject_focus": 0.35,
         "reject_clip_high": 0.30,
         "reject_composite": 0.40,
+        # Miss detection
+        "miss_enabled": True,
+        "miss_det_confidence": 0.25,
+        "miss_det_confidence_burst": 0.15,
+        "miss_bbox_area_min": 0.005,
+        "miss_bbox_area_min_singleton": 0.002,
+        "miss_oof_ratio": 0.5,
         # Eye-focus detection
         "eye_detect_enabled": True,
         "eye_classifier_conf_gate": 0.50,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3914,8 +3914,12 @@ class Database:
             scope results to the current run.
 
         Excludes photos already flagged as rejected. Scoped to folders
-        linked to the active workspace. Ordered by timestamp DESC.
+        linked to the active workspace. ``detection_box`` and
+        ``detection_conf`` are sourced from the primary (highest-confidence)
+        row in the ``detections`` table — the legacy ``photos`` columns are
+        not populated by normal pipeline runs. Ordered by timestamp DESC.
         """
+        ws_id = self._ws_id()
         if category is None:
             where = (
                 "p.miss_no_subject=1 OR p.miss_clipped=1 OR p.miss_oof=1"
@@ -3928,15 +3932,15 @@ class Database:
             }[category]
             where = f"p.{col}=1"
 
-        params = [self._ws_id()]
+        params = [ws_id]
         if since:
             where = f"({where}) AND p.miss_computed_at >= ?"
             params.append(since)
 
         rows = self.conn.execute(
             f"SELECT p.id, p.folder_id, p.filename, p.timestamp, p.burst_id, "
-            f"       p.detection_box, p.detection_conf, p.subject_size, "
-            f"       p.crop_complete, p.subject_tenengrad, p.bg_tenengrad, "
+            f"       p.subject_size, p.crop_complete, "
+            f"       p.subject_tenengrad, p.bg_tenengrad, "
             f"       p.miss_no_subject, p.miss_clipped, p.miss_oof, "
             f"       p.miss_computed_at, p.flag "
             f"FROM photos p "
@@ -3947,7 +3951,36 @@ class Database:
             f"ORDER BY p.timestamp DESC",
             params,
         ).fetchall()
-        return [dict(r) for r in rows]
+        photos = [dict(r) for r in rows]
+        if not photos:
+            return photos
+
+        import json as _json
+        photo_ids = [p["id"] for p in photos]
+        placeholders = ",".join("?" * len(photo_ids))
+        det_rows = self.conn.execute(
+            f"SELECT photo_id, box_x, box_y, box_w, box_h, "
+            f"       detector_confidence "
+            f"FROM detections "
+            f"WHERE workspace_id=? AND photo_id IN ({placeholders}) "
+            f"ORDER BY photo_id, detector_confidence DESC",
+            [ws_id, *photo_ids],
+        ).fetchall()
+        primary = {}
+        for d in det_rows:
+            primary.setdefault(d["photo_id"], d)
+        for p in photos:
+            d = primary.get(p["id"])
+            if d is not None:
+                p["detection_box"] = _json.dumps({
+                    "x": d["box_x"], "y": d["box_y"],
+                    "w": d["box_w"], "h": d["box_h"],
+                })
+                p["detection_conf"] = d["detector_confidence"]
+            else:
+                p["detection_box"] = None
+                p["detection_conf"] = None
+        return photos
 
     def clear_miss_flag(self, photo_id, category):
         """Set the given miss column to 0 on the given photo.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3950,7 +3950,12 @@ class Database:
         return [dict(r) for r in rows]
 
     def clear_miss_flag(self, photo_id, category):
-        """Set the given miss column to 0 on the given photo."""
+        """Set the given miss column to 0 on the given photo.
+
+        Raises ValueError if the photo is not in the active workspace, so
+        that `/api/misses/<id>/unflag` can't touch another workspace's photos.
+        """
+        self._verify_photo_in_workspace(photo_id)
         col = {
             "no_subject": "miss_no_subject",
             "clipped":    "miss_clipped",

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3905,10 +3905,13 @@ class Database:
         ).fetchall()
         return {r["photo_id"] for r in rows}
 
-    def list_misses(self, category=None):
+    def list_misses(self, category=None, since=None):
         """Return photos flagged as misses, optionally filtered by category.
 
         category: None | "no_subject" | "clipped" | "oof"
+        since: optional ISO timestamp; if set, restricts to photos whose
+            miss_computed_at >= since. Used by the pipeline-review step to
+            scope results to the current run.
 
         Excludes photos already flagged as rejected. Ordered by timestamp DESC.
         """
@@ -3924,14 +3927,21 @@ class Database:
             }[category]
             where = f"{col}=1"
 
+        params = []
+        if since:
+            where = f"({where}) AND miss_computed_at >= ?"
+            params.append(since)
+
         rows = self.conn.execute(
             f"SELECT id, folder_id, filename, timestamp, burst_id, "
             f"       detection_box, detection_conf, subject_size, "
             f"       crop_complete, subject_tenengrad, bg_tenengrad, "
-            f"       miss_no_subject, miss_clipped, miss_oof, flag "
+            f"       miss_no_subject, miss_clipped, miss_oof, "
+            f"       miss_computed_at, flag "
             f"FROM photos WHERE ({where}) "
             f"  AND (flag IS NULL OR flag != 'reject') "
-            f"ORDER BY timestamp DESC"
+            f"ORDER BY timestamp DESC",
+            params,
         ).fetchall()
         return [dict(r) for r in rows]
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3906,18 +3906,19 @@ class Database:
         return {r["photo_id"] for r in rows}
 
     def list_misses(self, category=None, since=None):
-        """Return photos flagged as misses, optionally filtered by category.
+        """Return photos flagged as misses in the active workspace.
 
         category: None | "no_subject" | "clipped" | "oof"
         since: optional ISO timestamp; if set, restricts to photos whose
             miss_computed_at >= since. Used by the pipeline-review step to
             scope results to the current run.
 
-        Excludes photos already flagged as rejected. Ordered by timestamp DESC.
+        Excludes photos already flagged as rejected. Scoped to folders
+        linked to the active workspace. Ordered by timestamp DESC.
         """
         if category is None:
             where = (
-                "miss_no_subject=1 OR miss_clipped=1 OR miss_oof=1"
+                "p.miss_no_subject=1 OR p.miss_clipped=1 OR p.miss_oof=1"
             )
         else:
             col = {
@@ -3925,22 +3926,25 @@ class Database:
                 "clipped":    "miss_clipped",
                 "oof":        "miss_oof",
             }[category]
-            where = f"{col}=1"
+            where = f"p.{col}=1"
 
-        params = []
+        params = [self._ws_id()]
         if since:
-            where = f"({where}) AND miss_computed_at >= ?"
+            where = f"({where}) AND p.miss_computed_at >= ?"
             params.append(since)
 
         rows = self.conn.execute(
-            f"SELECT id, folder_id, filename, timestamp, burst_id, "
-            f"       detection_box, detection_conf, subject_size, "
-            f"       crop_complete, subject_tenengrad, bg_tenengrad, "
-            f"       miss_no_subject, miss_clipped, miss_oof, "
-            f"       miss_computed_at, flag "
-            f"FROM photos WHERE ({where}) "
-            f"  AND (flag IS NULL OR flag != 'reject') "
-            f"ORDER BY timestamp DESC",
+            f"SELECT p.id, p.folder_id, p.filename, p.timestamp, p.burst_id, "
+            f"       p.detection_box, p.detection_conf, p.subject_size, "
+            f"       p.crop_complete, p.subject_tenengrad, p.bg_tenengrad, "
+            f"       p.miss_no_subject, p.miss_clipped, p.miss_oof, "
+            f"       p.miss_computed_at, p.flag "
+            f"FROM photos p "
+            f"JOIN workspace_folders wf ON wf.folder_id = p.folder_id "
+            f"WHERE wf.workspace_id = ? "
+            f"  AND ({where}) "
+            f"  AND (p.flag IS NULL OR p.flag != 'rejected') "
+            f"ORDER BY p.timestamp DESC",
             params,
         ).fetchall()
         return [dict(r) for r in rows]
@@ -3958,16 +3962,23 @@ class Database:
         self.conn.commit()
 
     def bulk_reject_miss_category(self, category):
-        """Set flag='reject' on every photo currently flagged with that
-        miss category and not already rejected. Returns rowcount."""
+        """Set flag='rejected' on every photo flagged with that miss category
+        in the active workspace and not already rejected. Returns rowcount."""
         col = {
             "no_subject": "miss_no_subject",
             "clipped":    "miss_clipped",
             "oof":        "miss_oof",
         }[category]
         cur = self.conn.execute(
-            f"UPDATE photos SET flag='reject' "
-            f"WHERE {col}=1 AND (flag IS NULL OR flag != 'reject')"
+            f"UPDATE photos SET flag='rejected' "
+            f"WHERE id IN ("
+            f"  SELECT p.id FROM photos p "
+            f"  JOIN workspace_folders wf ON wf.folder_id = p.folder_id "
+            f"  WHERE wf.workspace_id = ? "
+            f"    AND p.{col}=1 "
+            f"    AND (p.flag IS NULL OR p.flag != 'rejected')"
+            f")",
+            (self._ws_id(),),
         )
         self.conn.commit()
         return cur.rowcount

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4212,8 +4212,13 @@ class Database:
             f"{since_clause}",
             params,
         ).fetchall()
+        # Preserve NULL flag values in old_value so undo is lossless.
+        # Coercing NULL to "" would make _apply_undo restore an empty
+        # string instead of the original NULL, leaving rows in a
+        # non-canonical state that bypasses code paths expecting
+        # none/flagged/rejected (or NULL).
         affected = [
-            {"photo_id": r["id"], "old_value": (r["flag"] or "")}
+            {"photo_id": r["id"], "old_value": r["flag"]}
             for r in rows
         ]
         if not affected:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4991,6 +4991,26 @@ class Database:
         """
         return self.conn.execute(query, params).fetchone()[0]
 
+    def collection_photo_ids(self, collection_id):
+        """Return the set of photo IDs in the collection, workspace-scoped.
+
+        Returns an empty set for a missing collection. Used by stages
+        that need to restrict writes to the current pipeline-run scope
+        without paging through full photo rows.
+        """
+        parts = self._build_collection_query(collection_id)
+        if parts is None:
+            return set()
+
+        folder_join, join_clause, where, params = parts
+        query = f"""
+            SELECT DISTINCT p.id FROM photos p
+            {folder_join}
+            {join_clause}
+            {where}
+        """
+        return {row["id"] for row in self.conn.execute(query, params)}
+
     def update_folder_counts(self):
         """Recalculate photo_count for all folders."""
         self.conn.execute(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -423,6 +423,15 @@ class Database:
             self.conn.execute("ALTER TABLE photos ADD COLUMN eye_conf REAL")
             self.conn.execute("ALTER TABLE photos ADD COLUMN eye_tenengrad REAL")
 
+        # Miss detection flags (derived from detection + quality + burst context)
+        try:
+            self.conn.execute("SELECT miss_no_subject FROM photos LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute("ALTER TABLE photos ADD COLUMN miss_no_subject INTEGER")
+            self.conn.execute("ALTER TABLE photos ADD COLUMN miss_clipped INTEGER")
+            self.conn.execute("ALTER TABLE photos ADD COLUMN miss_oof INTEGER")
+            self.conn.execute("ALTER TABLE photos ADD COLUMN miss_computed_at TEXT")
+
         # Edit history tables migration
         try:
             self.conn.execute("SELECT id FROM edit_history LIMIT 0")

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4005,14 +4005,26 @@ class Database:
         )
         self.conn.commit()
 
-    def bulk_reject_miss_category(self, category):
+    def bulk_reject_miss_category(self, category, since=None):
         """Set flag='rejected' on every photo flagged with that miss category
-        in the active workspace and not already rejected. Returns rowcount."""
+        in the active workspace and not already rejected.
+
+        ``since`` mirrors the filter on ``list_misses``: when set, only
+        photos whose ``miss_computed_at >= since`` are rejected. This
+        keeps bulk reject scoped to the /misses view the user is looking
+        at (e.g. the current pipeline run), so older misses not shown on
+        screen aren't silently rejected. Returns rowcount.
+        """
         col = {
             "no_subject": "miss_no_subject",
             "clipped":    "miss_clipped",
             "oof":        "miss_oof",
         }[category]
+        params = [self._ws_id()]
+        since_clause = ""
+        if since:
+            since_clause = "    AND p.miss_computed_at >= ? "
+            params.append(since)
         cur = self.conn.execute(
             f"UPDATE photos SET flag='rejected' "
             f"WHERE id IN ("
@@ -4020,9 +4032,10 @@ class Database:
             f"  JOIN workspace_folders wf ON wf.folder_id = p.folder_id "
             f"  WHERE wf.workspace_id = ? "
             f"    AND p.{col}=1 "
-            f"    AND (p.flag IS NULL OR p.flag != 'rejected')"
+            f"    AND (p.flag IS NULL OR p.flag != 'rejected') "
+            f"{since_clause}"
             f")",
-            (self._ws_id(),),
+            params,
         )
         self.conn.commit()
         return cur.rowcount

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3957,18 +3957,24 @@ class Database:
 
         import json as _json
         photo_ids = [p["id"] for p in photos]
-        placeholders = ",".join("?" * len(photo_ids))
-        det_rows = self.conn.execute(
-            f"SELECT photo_id, box_x, box_y, box_w, box_h, "
-            f"       detector_confidence "
-            f"FROM detections "
-            f"WHERE workspace_id=? AND photo_id IN ({placeholders}) "
-            f"ORDER BY photo_id, detector_confidence DESC",
-            [ws_id, *photo_ids],
-        ).fetchall()
+        # Chunk to stay under SQLite's SQLITE_MAX_VARIABLE_NUMBER (default 999).
+        # A workspace with thousands of flagged misses would otherwise raise
+        # ``OperationalError: too many SQL variables``.
+        CHUNK = 500
         primary = {}
-        for d in det_rows:
-            primary.setdefault(d["photo_id"], d)
+        for i in range(0, len(photo_ids), CHUNK):
+            chunk = photo_ids[i:i + CHUNK]
+            placeholders = ",".join("?" * len(chunk))
+            det_rows = self.conn.execute(
+                f"SELECT photo_id, box_x, box_y, box_w, box_h, "
+                f"       detector_confidence "
+                f"FROM detections "
+                f"WHERE workspace_id=? AND photo_id IN ({placeholders}) "
+                f"ORDER BY photo_id, detector_confidence DESC",
+                [ws_id, *chunk],
+            ).fetchall()
+            for d in det_rows:
+                primary.setdefault(d["photo_id"], d)
         for p in photos:
             d = primary.get(p["id"])
             if d is not None:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4184,7 +4184,14 @@ class Database:
         photos whose ``miss_computed_at >= since`` are rejected. This
         keeps bulk reject scoped to the /misses view the user is looking
         at (e.g. the current pipeline run), so older misses not shown on
-        screen aren't silently rejected. Returns rowcount.
+        screen aren't silently rejected.
+
+        Returns a list of ``{"photo_id": int, "old_value": str}`` for each
+        photo whose flag was changed. The caller (``/api/misses/reject``)
+        uses this to write an ``edit_history`` entry so the bulk change is
+        undoable/auditable like the other batch flag routes; without it,
+        an accidental "Reject all" on /misses would be invisible to the
+        undo flow.
         """
         col = {
             "no_subject": "miss_no_subject",
@@ -4196,20 +4203,33 @@ class Database:
         if since:
             since_clause = "    AND p.miss_computed_at >= ? "
             params.append(since)
-        cur = self.conn.execute(
-            f"UPDATE photos SET flag='rejected' "
-            f"WHERE id IN ("
-            f"  SELECT p.id FROM photos p "
-            f"  JOIN workspace_folders wf ON wf.folder_id = p.folder_id "
-            f"  WHERE wf.workspace_id = ? "
-            f"    AND p.{col}=1 "
-            f"    AND (p.flag IS NULL OR p.flag != 'rejected') "
-            f"{since_clause}"
-            f")",
+        rows = self.conn.execute(
+            f"SELECT p.id, p.flag FROM photos p "
+            f"JOIN workspace_folders wf ON wf.folder_id = p.folder_id "
+            f"WHERE wf.workspace_id = ? "
+            f"  AND p.{col}=1 "
+            f"  AND (p.flag IS NULL OR p.flag != 'rejected') "
+            f"{since_clause}",
             params,
-        )
+        ).fetchall()
+        affected = [
+            {"photo_id": r["id"], "old_value": (r["flag"] or "")}
+            for r in rows
+        ]
+        if not affected:
+            return []
+        ids = [a["photo_id"] for a in affected]
+        # Chunk to stay under SQLite's SQLITE_MAX_VARIABLE_NUMBER (default 999).
+        _CHUNK = 500
+        for i in range(0, len(ids), _CHUNK):
+            chunk = ids[i:i + _CHUNK]
+            placeholders = ",".join("?" * len(chunk))
+            self.conn.execute(
+                f"UPDATE photos SET flag='rejected' WHERE id IN ({placeholders})",
+                chunk,
+            )
         self.conn.commit()
-        return cur.rowcount
+        return affected
 
     def get_detection_ids_for_photos(self, photo_ids):
         """Return {photo_id: set(detection_id, ...)} for the given photo IDs.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3905,6 +3905,63 @@ class Database:
         ).fetchall()
         return {r["photo_id"] for r in rows}
 
+    def list_misses(self, category=None):
+        """Return photos flagged as misses, optionally filtered by category.
+
+        category: None | "no_subject" | "clipped" | "oof"
+
+        Excludes photos already flagged as rejected. Ordered by timestamp DESC.
+        """
+        if category is None:
+            where = (
+                "miss_no_subject=1 OR miss_clipped=1 OR miss_oof=1"
+            )
+        else:
+            col = {
+                "no_subject": "miss_no_subject",
+                "clipped":    "miss_clipped",
+                "oof":        "miss_oof",
+            }[category]
+            where = f"{col}=1"
+
+        rows = self.conn.execute(
+            f"SELECT id, folder_id, filename, timestamp, burst_id, "
+            f"       detection_box, detection_conf, subject_size, "
+            f"       crop_complete, subject_tenengrad, bg_tenengrad, "
+            f"       miss_no_subject, miss_clipped, miss_oof, flag "
+            f"FROM photos WHERE ({where}) "
+            f"  AND (flag IS NULL OR flag != 'reject') "
+            f"ORDER BY timestamp DESC"
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def clear_miss_flag(self, photo_id, category):
+        """Set the given miss column to 0 on the given photo."""
+        col = {
+            "no_subject": "miss_no_subject",
+            "clipped":    "miss_clipped",
+            "oof":        "miss_oof",
+        }[category]
+        self.conn.execute(
+            f"UPDATE photos SET {col}=0 WHERE id=?", (photo_id,)
+        )
+        self.conn.commit()
+
+    def bulk_reject_miss_category(self, category):
+        """Set flag='reject' on every photo currently flagged with that
+        miss category and not already rejected. Returns rowcount."""
+        col = {
+            "no_subject": "miss_no_subject",
+            "clipped":    "miss_clipped",
+            "oof":        "miss_oof",
+        }[category]
+        cur = self.conn.execute(
+            f"UPDATE photos SET flag='reject' "
+            f"WHERE {col}=1 AND (flag IS NULL OR flag != 'reject')"
+        )
+        self.conn.commit()
+        return cur.rowcount
+
     def get_detection_ids_for_photos(self, photo_ids):
         """Return {photo_id: set(detection_id, ...)} for the given photo IDs.
 

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -110,7 +110,9 @@ def classify_miss(row, siblings, config):
     return {"no_subject": False, "clipped": clipped, "oof": oof}
 
 
-def compute_misses_for_workspace(db, pipeline_config, collection_id=None):
+def compute_misses_for_workspace(
+    db, pipeline_config, collection_id=None, exclude_photo_ids=None
+):
     """Compute and persist miss flags for photos in the active workspace.
 
     Reads per-photo features from `photos` (restricted to folders linked to
@@ -127,10 +129,18 @@ def compute_misses_for_workspace(db, pipeline_config, collection_id=None):
     not touched — so a partial pipeline run does not stamp
     `miss_computed_at` on photos outside its scope, which would
     otherwise defeat the `/misses?since=` review-window filter.
+
+    `exclude_photo_ids` mirrors the preview-deselection filter applied by
+    earlier pipeline stages (`params.exclude_photo_ids`). Those photos
+    still contribute burst-sibling context but are not written to, so a
+    run with deselections does not resurface or mass-flag deselected
+    photos in /misses.
     """
     if not pipeline_config.get("miss_enabled", True):
         log.info("Miss detection disabled via miss_enabled=false")
         return 0
+
+    excluded = set(exclude_photo_ids) if exclude_photo_ids else set()
 
     ws_id = db._ws_id()
     # Detector confidence is written to the `detections` table by the
@@ -170,6 +180,8 @@ def compute_misses_for_workspace(db, pipeline_config, collection_id=None):
         for row in burst_rows:
             if target_ids is not None and row["id"] not in target_ids:
                 continue
+            if row["id"] in excluded:
+                continue
             siblings = [s for s in burst_rows if s["id"] != row["id"]]
             flags = classify_miss(row, siblings, pipeline_config)
             updates.append((
@@ -182,6 +194,8 @@ def compute_misses_for_workspace(db, pipeline_config, collection_id=None):
 
     for row in singletons:
         if target_ids is not None and row["id"] not in target_ids:
+            continue
+        if row["id"] in excluded:
             continue
         flags = classify_miss(row, siblings=[], config=pipeline_config)
         updates.append((

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -173,7 +173,15 @@ def compute_misses_for_workspace(
         else:
             singletons.append(d)
 
-    now = datetime.now(UTC).isoformat(timespec="seconds")
+    # Microsecond precision: the /misses?since=... review window uses
+    # the earliest miss_computed_at from a run as a lower bound, and
+    # bulk-reject reuses the same value. With seconds precision two runs
+    # finishing in the same second collide, so the second run's window
+    # would include the first run's misses (and bulk-reject could touch
+    # them). ISO-8601 timestamps still sort lexicographically when
+    # precision varies, so this is backward-compatible with rows written
+    # at seconds precision.
+    now = datetime.now(UTC).isoformat(timespec="microseconds")
     updates = []
 
     for burst_rows in by_burst.values():

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -105,13 +105,22 @@ def compute_misses_for_workspace(db, pipeline_config):
         log.info("Miss detection disabled via miss_enabled=false")
         return 0
 
+    ws_id = db._ws_id()
+    # Detector confidence is written to the `detections` table by the
+    # classify stage, not to `photos.detection_conf` (legacy column). Read
+    # the highest-confidence detection per photo, workspace-scoped, so
+    # photos with real detections aren't misread as no_subject.
     rows = db.conn.execute(
-        "SELECT p.id, p.burst_id, p.detection_conf, p.subject_size, "
-        "       p.crop_complete, p.subject_tenengrad, p.bg_tenengrad "
+        "SELECT p.id, p.burst_id, "
+        "       (SELECT MAX(d.detector_confidence) FROM detections d "
+        "        WHERE d.photo_id = p.id AND d.workspace_id = ?) "
+        "         AS detection_conf, "
+        "       p.subject_size, p.crop_complete, "
+        "       p.subject_tenengrad, p.bg_tenengrad "
         "FROM photos p "
         "JOIN workspace_folders wf ON wf.folder_id = p.folder_id "
         "WHERE wf.workspace_id = ?",
-        (db._ws_id(),),
+        (ws_id, ws_id),
     ).fetchall()
 
     by_burst = defaultdict(list)

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -111,7 +111,7 @@ def classify_miss(row, siblings, config):
 
 
 def compute_misses_for_workspace(
-    db, pipeline_config, collection_id=None, exclude_photo_ids=None
+    db, pipeline_config, collection_id=None, exclude_photo_ids=None, now=None,
 ):
     """Compute and persist miss flags for photos in the active workspace.
 
@@ -135,6 +135,11 @@ def compute_misses_for_workspace(
     still contribute burst-sibling context but are not written to, so a
     run with deselections does not resurface or mass-flag deselected
     photos in /misses.
+
+    `now` lets the caller inject the timestamp that will be written to
+    `miss_computed_at`. The pipeline job passes the same value into both
+    this function and the saved pipeline-results cache so the review
+    UI's run-scoped `?since=` window matches what the DB stores.
     """
     if not pipeline_config.get("miss_enabled", True):
         log.info("Miss detection disabled via miss_enabled=false")
@@ -181,7 +186,8 @@ def compute_misses_for_workspace(
     # them). ISO-8601 timestamps still sort lexicographically when
     # precision varies, so this is backward-compatible with rows written
     # at seconds precision.
-    now = datetime.now(UTC).isoformat(timespec="microseconds")
+    if now is None:
+        now = datetime.now(UTC).isoformat(timespec="microseconds")
     updates = []
 
     for burst_rows in by_burst.values():

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -15,7 +15,7 @@ and both return False.
 
 import logging
 from collections import defaultdict
-from datetime import datetime
+from datetime import UTC, datetime
 
 log = logging.getLogger(__name__)
 
@@ -41,23 +41,28 @@ def classify_miss(row, siblings, config):
         config["miss_bbox_area_min"] if in_burst
         else config["miss_bbox_area_min_singleton"]
     )
-    subject_size = row.get("subject_size") or 0.0
+    # NULL quality features mean the pipeline hasn't measured them yet;
+    # absence of evidence is not evidence of a miss. Each signal below
+    # only fires when its required feature is actually present.
+    subject_size = row.get("subject_size")
     crop_complete = row.get("crop_complete")
 
     clipped = False
     # Absolute: bbox too small to be usable.
-    if subject_size < bbox_area_min:
+    if subject_size is not None and subject_size < bbox_area_min:
         clipped = True
     # crop_complete < 0.6 signals the mask touches a frame edge (matches
     # the existing reject_crop_complete default in pipeline config).
     if crop_complete is not None and crop_complete < 0.60:
         clipped = True
     # Burst context: this frame's bbox is an order of magnitude smaller
-    # than its siblings' median — the photographer lost framing.
-    if in_burst:
+    # than its siblings' median — the photographer lost framing. Only
+    # evaluate when both this row and its siblings have a measured size
+    # (zero is a legitimate measurement, so filter by `is not None`).
+    if in_burst and subject_size is not None:
         sibling_sizes = [
             s.get("subject_size") for s in siblings
-            if s.get("subject_size")
+            if s.get("subject_size") is not None
         ]
         if sibling_sizes:
             import statistics
@@ -65,20 +70,22 @@ def classify_miss(row, siblings, config):
             if median > 0 and subject_size * 10 < median:
                 clipped = True
 
-    subject_t = row.get("subject_tenengrad") or 0.0
-    bg_t = row.get("bg_tenengrad") or 0.0
+    subject_t = row.get("subject_tenengrad")
+    bg_t = row.get("bg_tenengrad")
 
     oof = False
-    ratio_bad = bg_t > 0 and (subject_t / bg_t) < config["miss_oof_ratio"]
-    # Absolute floor: below this, subject sharpness is motion-blur level.
-    # Value chosen empirically to match reject_focus behavior.
-    SHARPNESS_FLOOR = 10.0
-    floor_bad = subject_t < SHARPNESS_FLOOR
+    # Only evaluate OOF when both Tenengrad features are measured.
+    if subject_t is not None and bg_t is not None:
+        ratio_bad = bg_t > 0 and (subject_t / bg_t) < config["miss_oof_ratio"]
+        # Absolute floor: below this, subject sharpness is motion-blur level.
+        # Value chosen empirically to match reject_focus behavior.
+        SHARPNESS_FLOOR = 10.0
+        floor_bad = subject_t < SHARPNESS_FLOOR
 
-    if in_burst:
-        oof = ratio_bad or floor_bad
-    else:
-        oof = ratio_bad and floor_bad
+        if in_burst:
+            oof = ratio_bad or floor_bad
+        else:
+            oof = ratio_bad and floor_bad
 
     return {"no_subject": False, "clipped": clipped, "oof": oof}
 
@@ -112,7 +119,7 @@ def compute_misses_for_workspace(db, pipeline_config):
         else:
             singletons.append(d)
 
-    now = datetime.utcnow().isoformat(timespec="seconds")
+    now = datetime.now(UTC).isoformat(timespec="seconds")
     updates = []
 
     for burst_rows in by_burst.values():

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -110,7 +110,7 @@ def classify_miss(row, siblings, config):
     return {"no_subject": False, "clipped": clipped, "oof": oof}
 
 
-def compute_misses_for_workspace(db, pipeline_config):
+def compute_misses_for_workspace(db, pipeline_config, collection_id=None):
     """Compute and persist miss flags for photos in the active workspace.
 
     Reads per-photo features from `photos` (restricted to folders linked to
@@ -119,7 +119,14 @@ def compute_misses_for_workspace(db, pipeline_config):
     and a timestamp in a single batch.
 
     Singletons (burst_id IS NULL) are evaluated alone, which triggers the
-    stricter singleton thresholds inside classify_miss.
+    singleton-specific thresholds inside classify_miss.
+
+    When `collection_id` is given, only photos in that collection have
+    their flags and `miss_computed_at` rewritten. Other workspace photos
+    still contribute burst-sibling context to the classifier, but are
+    not touched — so a partial pipeline run does not stamp
+    `miss_computed_at` on photos outside its scope, which would
+    otherwise defeat the `/misses?since=` review-window filter.
     """
     if not pipeline_config.get("miss_enabled", True):
         log.info("Miss detection disabled via miss_enabled=false")
@@ -143,6 +150,10 @@ def compute_misses_for_workspace(db, pipeline_config):
         (ws_id, ws_id),
     ).fetchall()
 
+    target_ids = None
+    if collection_id is not None:
+        target_ids = db.collection_photo_ids(collection_id)
+
     by_burst = defaultdict(list)
     singletons = []
     for r in rows:
@@ -157,6 +168,8 @@ def compute_misses_for_workspace(db, pipeline_config):
 
     for burst_rows in by_burst.values():
         for row in burst_rows:
+            if target_ids is not None and row["id"] not in target_ids:
+                continue
             siblings = [s for s in burst_rows if s["id"] != row["id"]]
             flags = classify_miss(row, siblings, pipeline_config)
             updates.append((
@@ -168,6 +181,8 @@ def compute_misses_for_workspace(db, pipeline_config):
             ))
 
     for row in singletons:
+        if target_ids is not None and row["id"] not in target_ids:
+            continue
         flags = classify_miss(row, siblings=[], config=pipeline_config)
         updates.append((
             int(flags["no_subject"]),

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -13,6 +13,12 @@ no_subject is exclusive — when it's true, clipped/oof can't be evaluated
 and both return False.
 """
 
+import logging
+from collections import defaultdict
+from datetime import datetime
+
+log = logging.getLogger(__name__)
+
 
 def classify_miss(row, siblings, config):
     """Return {'no_subject': bool, 'clipped': bool, 'oof': bool}.
@@ -75,3 +81,66 @@ def classify_miss(row, siblings, config):
         oof = ratio_bad and floor_bad
 
     return {"no_subject": False, "clipped": clipped, "oof": oof}
+
+
+def compute_misses_for_workspace(db, pipeline_config):
+    """Compute and persist miss flags for every scanned photo in the workspace.
+
+    Reads per-photo features from `photos`, groups by `burst_id`, calls
+    classify_miss for each photo with its siblings as context, then writes
+    the three flags and a timestamp in a single batch.
+
+    Singletons (burst_id IS NULL) are evaluated alone, which triggers the
+    stricter singleton thresholds inside classify_miss.
+    """
+    if not pipeline_config.get("miss_enabled", True):
+        log.info("Miss detection disabled via miss_enabled=false")
+        return 0
+
+    rows = db.conn.execute(
+        "SELECT id, burst_id, detection_conf, subject_size, crop_complete, "
+        "       subject_tenengrad, bg_tenengrad "
+        "FROM photos"
+    ).fetchall()
+
+    by_burst = defaultdict(list)
+    singletons = []
+    for r in rows:
+        d = dict(r)
+        if d["burst_id"]:
+            by_burst[d["burst_id"]].append(d)
+        else:
+            singletons.append(d)
+
+    now = datetime.utcnow().isoformat(timespec="seconds")
+    updates = []
+
+    for burst_rows in by_burst.values():
+        for row in burst_rows:
+            siblings = [s for s in burst_rows if s["id"] != row["id"]]
+            flags = classify_miss(row, siblings, pipeline_config)
+            updates.append((
+                int(flags["no_subject"]),
+                int(flags["clipped"]),
+                int(flags["oof"]),
+                now,
+                row["id"],
+            ))
+
+    for row in singletons:
+        flags = classify_miss(row, siblings=[], config=pipeline_config)
+        updates.append((
+            int(flags["no_subject"]),
+            int(flags["clipped"]),
+            int(flags["oof"]),
+            now,
+            row["id"],
+        ))
+
+    db.conn.executemany(
+        "UPDATE photos SET miss_no_subject=?, miss_clipped=?, miss_oof=?, "
+        "miss_computed_at=? WHERE id=?",
+        updates,
+    )
+    db.conn.commit()
+    return len(updates)

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -17,7 +17,23 @@ import logging
 from collections import defaultdict
 from datetime import UTC, datetime
 
+import config as _cfg
+
 log = logging.getLogger(__name__)
+
+
+def _miss_threshold(config, key):
+    """Read a miss-* threshold with a defaults fallback.
+
+    Pipeline configs reaching classify_miss can be partial — e.g.
+    `/api/pipeline/config` stores only model keys under `pipeline` and
+    `Database.get_effective_config` does a shallow top-level merge.
+    Fall back to the module DEFAULTS rather than raising KeyError and
+    failing the whole pipeline job.
+    """
+    if key in config:
+        return config[key]
+    return _cfg.DEFAULTS["pipeline"][key]
 
 
 def classify_miss(row, siblings, config):
@@ -27,19 +43,21 @@ def classify_miss(row, siblings, config):
         row: dict with detection_conf, subject_size, crop_complete,
             subject_tenengrad, bg_tenengrad, burst_id.
         siblings: list of sibling rows in the same burst (excluding `row`).
-        config: dict with miss_* thresholds.
+        config: dict with miss_* thresholds. Missing keys fall back to
+            config.DEFAULTS["pipeline"] so partial pipeline configs
+            (the common case) don't crash this stage.
     """
     in_burst = bool(siblings)
-    conf_threshold = (
-        config["miss_det_confidence_burst"] if in_burst
-        else config["miss_det_confidence"]
+    conf_threshold = _miss_threshold(
+        config,
+        "miss_det_confidence_burst" if in_burst else "miss_det_confidence",
     )
     detection_conf = row.get("detection_conf") or 0.0
     if detection_conf < conf_threshold:
         return {"no_subject": True, "clipped": False, "oof": False}
-    bbox_area_min = (
-        config["miss_bbox_area_min"] if in_burst
-        else config["miss_bbox_area_min_singleton"]
+    bbox_area_min = _miss_threshold(
+        config,
+        "miss_bbox_area_min" if in_burst else "miss_bbox_area_min_singleton",
     )
     # NULL quality features mean the pipeline hasn't measured them yet;
     # absence of evidence is not evidence of a miss. Each signal below
@@ -76,7 +94,9 @@ def classify_miss(row, siblings, config):
     oof = False
     # Only evaluate OOF when both Tenengrad features are measured.
     if subject_t is not None and bg_t is not None:
-        ratio_bad = bg_t > 0 and (subject_t / bg_t) < config["miss_oof_ratio"]
+        ratio_bad = bg_t > 0 and (subject_t / bg_t) < _miss_threshold(
+            config, "miss_oof_ratio"
+        )
         # Absolute floor: below this, subject sharpness is motion-blur level.
         # Value chosen empirically to match reject_focus behavior.
         SHARPNESS_FLOOR = 10.0

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -1,0 +1,34 @@
+"""Miss-detection classification.
+
+Pure derivation from per-photo features already written by the pipeline
+(detection confidence, bbox fraction, crop completeness, subject/background
+Tenengrad, burst id). No I/O, no DB access.
+
+Three categories:
+  - no_subject: detector didn't find an animal (subject-less frame)
+  - clipped:    subject touches a frame edge or is too small
+  - oof:        subject is out of focus (background sharper than subject)
+
+no_subject is exclusive — when it's true, clipped/oof can't be evaluated
+and both return False.
+"""
+
+
+def classify_miss(row, siblings, config):
+    """Return {'no_subject': bool, 'clipped': bool, 'oof': bool}.
+
+    Args:
+        row: dict with detection_conf, subject_size, crop_complete,
+            subject_tenengrad, bg_tenengrad, burst_id.
+        siblings: list of sibling rows in the same burst (excluding `row`).
+        config: dict with miss_* thresholds.
+    """
+    in_burst = bool(siblings)
+    conf_threshold = (
+        config["miss_det_confidence_burst"] if in_burst
+        else config["miss_det_confidence"]
+    )
+    detection_conf = row.get("detection_conf") or 0.0
+    if detection_conf < conf_threshold:
+        return {"no_subject": True, "clipped": False, "oof": False}
+    return {"no_subject": False, "clipped": False, "oof": False}

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -31,4 +31,32 @@ def classify_miss(row, siblings, config):
     detection_conf = row.get("detection_conf") or 0.0
     if detection_conf < conf_threshold:
         return {"no_subject": True, "clipped": False, "oof": False}
-    return {"no_subject": False, "clipped": False, "oof": False}
+    bbox_area_min = (
+        config["miss_bbox_area_min"] if in_burst
+        else config["miss_bbox_area_min_singleton"]
+    )
+    subject_size = row.get("subject_size") or 0.0
+    crop_complete = row.get("crop_complete")
+
+    clipped = False
+    # Absolute: bbox too small to be usable.
+    if subject_size < bbox_area_min:
+        clipped = True
+    # crop_complete < 0.6 signals the mask touches a frame edge (matches
+    # the existing reject_crop_complete default in pipeline config).
+    if crop_complete is not None and crop_complete < 0.60:
+        clipped = True
+    # Burst context: this frame's bbox is an order of magnitude smaller
+    # than its siblings' median — the photographer lost framing.
+    if in_burst:
+        sibling_sizes = [
+            s.get("subject_size") for s in siblings
+            if s.get("subject_size")
+        ]
+        if sibling_sizes:
+            import statistics
+            median = statistics.median(sibling_sizes)
+            if median > 0 and subject_size * 10 < median:
+                clipped = True
+
+    return {"no_subject": False, "clipped": clipped, "oof": False}

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -59,4 +59,19 @@ def classify_miss(row, siblings, config):
             if median > 0 and subject_size * 10 < median:
                 clipped = True
 
-    return {"no_subject": False, "clipped": clipped, "oof": False}
+    subject_t = row.get("subject_tenengrad") or 0.0
+    bg_t = row.get("bg_tenengrad") or 0.0
+
+    oof = False
+    ratio_bad = bg_t > 0 and (subject_t / bg_t) < config["miss_oof_ratio"]
+    # Absolute floor: below this, subject sharpness is motion-blur level.
+    # Value chosen empirically to match reject_focus behavior.
+    SHARPNESS_FLOOR = 10.0
+    floor_bad = subject_t < SHARPNESS_FLOOR
+
+    if in_burst:
+        oof = ratio_bad or floor_bad
+    else:
+        oof = ratio_bad and floor_bad
+
+    return {"no_subject": False, "clipped": clipped, "oof": oof}

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -91,11 +91,12 @@ def classify_miss(row, siblings, config):
 
 
 def compute_misses_for_workspace(db, pipeline_config):
-    """Compute and persist miss flags for every scanned photo in the workspace.
+    """Compute and persist miss flags for photos in the active workspace.
 
-    Reads per-photo features from `photos`, groups by `burst_id`, calls
-    classify_miss for each photo with its siblings as context, then writes
-    the three flags and a timestamp in a single batch.
+    Reads per-photo features from `photos` (restricted to folders linked to
+    the active workspace), groups by `burst_id`, calls classify_miss for
+    each photo with its siblings as context, then writes the three flags
+    and a timestamp in a single batch.
 
     Singletons (burst_id IS NULL) are evaluated alone, which triggers the
     stricter singleton thresholds inside classify_miss.
@@ -105,9 +106,12 @@ def compute_misses_for_workspace(db, pipeline_config):
         return 0
 
     rows = db.conn.execute(
-        "SELECT id, burst_id, detection_conf, subject_size, crop_complete, "
-        "       subject_tenengrad, bg_tenengrad "
-        "FROM photos"
+        "SELECT p.id, p.burst_id, p.detection_conf, p.subject_size, "
+        "       p.crop_complete, p.subject_tenengrad, p.bg_tenengrad "
+        "FROM photos p "
+        "JOIN workspace_folders wf ON wf.folder_id = p.folder_id "
+        "WHERE wf.workspace_id = ?",
+        (db._ws_id(),),
     ).fetchall()
 
     by_burst = defaultdict(list)

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -504,11 +504,19 @@ def serialize_results(results):
                 })
         serialized_encounters.append(s_enc)
 
-    return {
+    out = {
         "encounters": serialized_encounters,
         "photos": [_clean_photo(p) for p in results["photos"]],
         "summary": results["summary"],
     }
+    # miss_computed_at is attached by pipeline_job's miss_stage and
+    # consumed by pipeline_review's "Review misses" shortcut to gate
+    # on actual recomputation in this run. Pass it through when the
+    # caller has injected it into results (reflow/regroup-live read
+    # it from the cache so the shortcut stays visible after a tweak).
+    if results.get("miss_computed_at"):
+        out["miss_computed_at"] = results["miss_computed_at"]
+    return out
 
 
 def save_results(results, cache_dir, workspace_id):
@@ -524,6 +532,20 @@ def save_results(results, cache_dir, workspace_id):
     """
     serialized = serialize_results(results)
     path = os.path.join(cache_dir, f"pipeline_results_ws{workspace_id}.json")
+    # Preserve miss_computed_at across reflow/regroup-live saves: it's
+    # written by pipeline_job's miss_stage and gates the review UI's
+    # "Review misses" shortcut on whether misses were recomputed in
+    # this pipeline run. reflow/regroup-live don't touch miss flags,
+    # so overwriting this marker with a fresh save would make the
+    # shortcut hide itself after every threshold tweak.
+    if "miss_computed_at" not in serialized and os.path.exists(path):
+        try:
+            with open(path) as f:
+                existing = json.load(f)
+            if existing.get("miss_computed_at"):
+                serialized["miss_computed_at"] = existing["miss_computed_at"]
+        except (OSError, json.JSONDecodeError):
+            pass
     with open(path, "w") as f:
         json.dump(serialized, f)
     log.info("Pipeline results saved to %s", path)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -151,7 +151,7 @@ def _update_stages(runner, job_id, stages):
 
 def _current_phase(stages):
     """Determine the primary phase label from stage statuses."""
-    for name in ["regroup", "eye_keypoints", "extract_masks", "classify", "detect",
+    for name in ["misses", "regroup", "eye_keypoints", "extract_masks", "classify", "detect",
                  "model_loader", "previews", "thumbnails", "scan", "ingest"]:
         info = stages.get(name, {})
         if info.get("status") == "running":
@@ -202,6 +202,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         "extract_masks": {"status": "pending", "count": 0, "label": "Extracting features"},
         "eye_keypoints": {"status": "pending", "count": 0, "label": "Detecting eye keypoints"},
         "regroup": {"status": "pending", "label": "Grouping encounters"},
+        "misses": {"status": "pending", "count": 0, "label": "Flagging missed shots"},
     }
 
     # Normalize model_ids: prefer the explicit list, fall back to the legacy
@@ -298,6 +299,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         step_defs.append({"id": "eye_keypoints", "label": "Detect eye keypoints"})
     if not params.skip_regroup:
         step_defs.append({"id": "regroup", "label": "Group encounters"})
+        step_defs.append({"id": "misses", "label": "Flag missed shots"})
     runner.set_steps(job["id"], step_defs)
 
     result = {"stages": {}}
@@ -2237,6 +2239,47 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
         _update_stages(runner, job["id"], stages)
 
+    def miss_stage():
+        """Compute miss-detection flags for the workspace after regroup.
+
+        Runs last so burst_id is available. Uses only per-photo features
+        already computed by earlier stages — no model inference.
+        """
+        if params.skip_regroup or abort.is_set() or not collection_id:
+            stages["misses"]["status"] = "skipped"
+            runner.update_step(job["id"], "misses", status="completed",
+                               summary="Skipped")
+            return
+
+        stages["misses"]["status"] = "running"
+        runner.update_step(job["id"], "misses", status="running")
+        _update_stages(runner, job["id"], stages)
+
+        try:
+            import config as cfg
+            from misses import compute_misses_for_workspace
+
+            thread_db = Database(db_path)
+            thread_db.set_active_workspace(workspace_id)
+
+            effective_cfg = thread_db.get_effective_config(cfg.load())
+            pipeline_cfg = effective_cfg.get("pipeline", {})
+
+            n = compute_misses_for_workspace(thread_db, pipeline_cfg)
+
+            stages["misses"]["status"] = "completed"
+            stages["misses"]["count"] = n
+            runner.update_step(job["id"], "misses", status="completed",
+                               summary=f"{n} photos evaluated")
+            result["stages"]["misses"] = {"evaluated": n}
+        except Exception as e:
+            errors.append(f"[misses] Fatal: {e}")
+            log.exception("Pipeline miss-detection stage failed")
+            stages["misses"]["status"] = "failed"
+            runner.update_step(job["id"], "misses", status="failed", error=str(e))
+
+        _update_stages(runner, job["id"], stages)
+
     # --- Launch threads ---
 
     threads = {}
@@ -2289,6 +2332,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
     # Phase 4: regroup (needs extract-masks + eye-keypoints output)
     if not abort.is_set():
         regroup_stage()
+
+    # Phase 5: miss detection (pure derivation from per-photo features +
+    # burst_id written by regroup). Cheap; no model inference.
+    if not abort.is_set():
+        miss_stage()
 
     cancel_watcher_stop.set()
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2335,7 +2335,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
     # Phase 5: miss detection (pure derivation from per-photo features +
     # burst_id written by regroup). Cheap; no model inference.
-    if not abort.is_set():
+    # Skip when regroup failed: miss classification depends on regroup's
+    # burst_id output, so running here after a regroup failure would
+    # overwrite miss_* flags with stale context during an already-failing
+    # job. regroup_stage marks itself "failed" without setting abort, so
+    # check the stage status explicitly.
+    if not abort.is_set() and stages["regroup"].get("status") != "failed":
         miss_stage()
 
     cancel_watcher_stop.set()

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2457,7 +2457,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             pipeline_cfg = effective_cfg.get("pipeline", {})
 
             n = compute_misses_for_workspace(
-                thread_db, pipeline_cfg, collection_id=collection_id
+                thread_db,
+                pipeline_cfg,
+                collection_id=collection_id,
+                exclude_photo_ids=params.exclude_photo_ids,
             )
 
             stages["misses"]["status"] = "completed"

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2447,8 +2447,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         _update_stages(runner, job["id"], stages)
 
         try:
-            import config as cfg
             from datetime import UTC, datetime
+
+            import config as cfg
             from misses import compute_misses_for_workspace
             from pipeline import load_results_raw, save_results_raw
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2448,7 +2448,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
 
         try:
             import config as cfg
+            from datetime import UTC, datetime
             from misses import compute_misses_for_workspace
+            from pipeline import load_results_raw, save_results_raw
 
             thread_db = Database(db_path)
             thread_db.set_active_workspace(workspace_id)
@@ -2456,11 +2458,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             effective_cfg = thread_db.get_effective_config(cfg.load())
             pipeline_cfg = effective_cfg.get("pipeline", {})
 
+            # Share one timestamp between the DB write and the saved
+            # pipeline-results cache so pipeline_review's "Review misses"
+            # shortcut can gate on actual recomputation in this run and
+            # scope /misses?since=... to exactly what was just written.
+            now_ts = datetime.now(UTC).isoformat(timespec="microseconds")
+            miss_enabled = pipeline_cfg.get("miss_enabled", True)
+
             n = compute_misses_for_workspace(
                 thread_db,
                 pipeline_cfg,
                 collection_id=collection_id,
                 exclude_photo_ids=params.exclude_photo_ids,
+                now=now_ts,
             )
 
             stages["misses"]["status"] = "completed"
@@ -2468,6 +2478,18 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             runner.update_step(job["id"], "misses", status="completed",
                                summary=f"{n} photos evaluated")
             result["stages"]["misses"] = {"evaluated": n}
+
+            # Mark the cached results so the review UI knows misses
+            # were actually recomputed this run. Without this, the
+            # shortcut would surface stale miss flags from a prior
+            # run as "current-run misses" whenever miss_enabled=False
+            # or the stage was skipped.
+            if miss_enabled:
+                cache_dir = os.path.dirname(db_path)
+                cached = load_results_raw(cache_dir, workspace_id)
+                if cached is not None:
+                    cached["miss_computed_at"] = now_ts
+                    save_results_raw(cached, cache_dir, workspace_id)
         except Exception as e:
             errors.append(f"[misses] Fatal: {e}")
             log.exception("Pipeline miss-detection stage failed")

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2456,7 +2456,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             effective_cfg = thread_db.get_effective_config(cfg.load())
             pipeline_cfg = effective_cfg.get("pipeline", {})
 
-            n = compute_misses_for_workspace(thread_db, pipeline_cfg)
+            n = compute_misses_for_workspace(
+                thread_db, pipeline_cfg, collection_id=collection_id
+            )
 
             stages["misses"]["status"] = "completed"
             stages["misses"]["count"] = n

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1046,6 +1046,7 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   <a href="/pipeline/review" data-nav-id="pipeline-review">Pipeline Review</a>
   <a href="/review" data-nav-id="review" data-testid="nav-review">Review</a>
   <a href="/cull" data-nav-id="cull">Cull</a>
+  <a href="/misses" data-nav-id="misses" data-testid="nav-misses">Misses</a>
   <a href="/highlights" data-nav-id="highlights">Highlights</a>
   <a href="/browse" data-nav-id="browse" data-testid="nav-browse">Browse</a>
   <a href="/map" data-nav-id="map">Map</a>

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -532,10 +532,14 @@ async function bulkReject(cat, e) {
                'Photos are not deleted — use the existing purge flow to remove them.')) {
     return;
   }
+  // Match the /misses?since=... review-window scope so bulk reject only
+  // touches photos visible in this view, not older misses from prior runs.
+  var since = getSinceParam();
+  var body = since ? { category: cat, since: since } : { category: cat };
   var r = await fetch('/api/misses/reject', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ category: cat }),
+    body: JSON.stringify(body),
   });
   if (!r.ok) {
     if (typeof showToast === 'function') showToast('Bulk reject failed', 'error');

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -1,0 +1,617 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" type="image/png" href="/favicon.ico">
+<link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
+<link rel="stylesheet" href="/static/vireo-base.css">
+<title>Vireo - Misses</title>
+<style>
+  body {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding-bottom: 28px; /* space for bottom panel toggle */
+  }
+
+  .misses-scroll {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 24px 40px;
+  }
+
+  .misses-intro {
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin: 0 0 16px;
+    max-width: 800px;
+  }
+
+  .misses-section {
+    margin-bottom: 28px;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    background: var(--bg-secondary);
+    overflow: hidden;
+  }
+  .misses-section-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    background: var(--bg-tertiary);
+    cursor: pointer;
+    user-select: none;
+    border-bottom: 1px solid var(--border-primary);
+  }
+  .misses-section-header:hover { background: var(--bg-primary); }
+  .misses-section-header .caret {
+    display: inline-block;
+    width: 10px;
+    font-size: 10px;
+    color: var(--text-faint);
+    transition: transform 0.15s;
+  }
+  .misses-section.collapsed .caret { transform: rotate(-90deg); }
+  .misses-section-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .misses-section-count {
+    font-size: 12px;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+  .misses-category-badge {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .cat-no_subject { background: #7a7a7a; }   /* gray */
+  .cat-clipped   { background: #e0a020; }    /* amber */
+  .cat-oof       { background: #d04545; }    /* red */
+
+  .misses-section-actions {
+    margin-left: auto;
+    display: flex;
+    gap: 8px;
+  }
+  .misses-reject-btn {
+    background: var(--danger);
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    padding: 5px 10px;
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .misses-reject-btn:hover { opacity: 0.9; }
+  .misses-reject-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  .misses-section-body {
+    padding: 12px 16px;
+  }
+  .misses-section.collapsed .misses-section-body { display: none; }
+
+  .misses-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 12px;
+  }
+
+  .miss-card {
+    position: relative;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    overflow: hidden;
+    cursor: pointer;
+    transition: transform 0.1s, border-color 0.15s;
+  }
+  .miss-card:hover { transform: translateY(-1px); border-color: var(--accent); }
+  .miss-card.focused { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent); }
+
+  .miss-card-img-wrap {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 3/2;
+    background: var(--bg-tertiary);
+  }
+  .miss-card-img-wrap img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .miss-card-img-wrap .no-subject-frame {
+    position: absolute;
+    inset: 12px;
+    border: 2px dashed rgba(255,255,255,0.45);
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: rgba(255,255,255,0.65);
+    font-size: 12px;
+    text-align: center;
+    pointer-events: none;
+    background: rgba(0,0,0,0.15);
+  }
+
+  /* Detection bbox overlay (matches browse.html .det-box styling) */
+  .miss-bbox {
+    position: absolute;
+    border: 2px solid var(--accent);
+    border-radius: 2px;
+    pointer-events: none;
+    box-shadow: 0 0 4px color-mix(in srgb, var(--accent) 40%, transparent);
+  }
+
+  .miss-card-badge {
+    position: absolute;
+    top: 6px;
+    left: 6px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 6px;
+    background: rgba(0,0,0,0.65);
+    border-radius: 3px;
+    font-size: 10px;
+    color: #fff;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .miss-card-badge .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  }
+
+  .miss-card-unflag {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: rgba(0,0,0,0.55);
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    font-size: 11px;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.1s;
+  }
+  .miss-card:hover .miss-card-unflag { opacity: 1; }
+  .miss-card-unflag:hover { background: rgba(0,0,0,0.85); }
+
+  .miss-card-info {
+    padding: 6px 8px;
+    font-size: 11px;
+    color: var(--text-secondary);
+    display: flex;
+    justify-content: space-between;
+    gap: 6px;
+    overflow: hidden;
+  }
+  .miss-card-filename {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-primary);
+  }
+  .miss-card-meta {
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+
+  .misses-empty {
+    padding: 24px 16px;
+    text-align: center;
+    font-size: 13px;
+    color: var(--text-secondary);
+  }
+  .misses-empty-page {
+    padding: 80px 24px;
+    text-align: center;
+    color: var(--text-secondary);
+  }
+  .misses-empty-page a { color: var(--accent); }
+
+  .misses-hint {
+    padding: 8px 16px;
+    font-size: 11px;
+    color: var(--text-ghost);
+    background: var(--bg-primary);
+    border-top: 1px solid var(--border-primary);
+  }
+  .misses-hint kbd {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-secondary);
+    border-radius: 3px;
+    padding: 0 4px;
+    font-family: monospace;
+    font-size: 10px;
+    color: var(--text-secondary);
+  }
+</style>
+</head>
+<body>
+
+{% include '_navbar.html' %}
+
+<div class="misses-scroll" id="missesScroll" tabindex="0">
+  <p class="misses-intro">
+    Frames flagged as misses by the pipeline. Bulk-reject a category to set
+    <code>flag=reject</code> on every photo in it; photos aren't deleted.
+    Click a thumbnail to open at 1:1 zoom.
+  </p>
+
+  <div id="missesRoot">
+    <!-- Sections rendered here -->
+    <div class="misses-empty-page" id="loadingState">Loading...</div>
+  </div>
+</div>
+
+<script>
+/* ---------- State ---------- */
+var CATEGORY_ORDER = ['no_subject', 'clipped', 'oof'];
+var CATEGORY_LABELS = {
+  no_subject: 'No subject',
+  clipped:    'Clipped / tiny',
+  oof:        'Out of focus',
+};
+var missesData = { no_subject: [], clipped: [], oof: [] };
+var focusedCategory = null;
+var focusedIndex = -1;
+
+function escapeHtml(s) {
+  if (s == null) return '';
+  return String(s)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+function escapeAttr(s) { return escapeHtml(s); }
+
+/* ---------- detection_box parsing ----------
+ * Stored as a JSON string: '{"x": 0.12, "y": 0.22, "w": 0.3, "h": 0.4}'
+ * where x/y/w/h are normalized [0,1] image coordinates.
+ * Returns null if missing or unparseable.
+ */
+function parseDetectionBox(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'object') return raw;
+  try {
+    var b = JSON.parse(raw);
+    if (!b || b.x == null || b.w == null) return null;
+    return b;
+  } catch (e) {
+    return null;
+  }
+}
+
+/* ---------- Sorting: burst_id first, then filename ---------- */
+function sortPhotos(photos) {
+  return photos.slice().sort(function(a, b) {
+    var ab = a.burst_id || '';
+    var bb = b.burst_id || '';
+    if (ab !== bb) return ab < bb ? -1 : 1;
+    var af = a.filename || '';
+    var bf = b.filename || '';
+    if (af !== bf) return af < bf ? -1 : 1;
+    return (a.id || 0) - (b.id || 0);
+  });
+}
+
+/* ---------- Fetch + render ---------- */
+async function loadMisses() {
+  var r = await fetch('/api/misses');
+  if (!r.ok) {
+    document.getElementById('missesRoot').innerHTML =
+      '<div class="misses-empty-page">Failed to load misses.</div>';
+    return;
+  }
+  var data = await r.json();
+  missesData = {
+    no_subject: sortPhotos(data.no_subject || []),
+    clipped:    sortPhotos(data.clipped || []),
+    oof:        sortPhotos(data.oof || []),
+  };
+  render();
+}
+
+function render() {
+  var root = document.getElementById('missesRoot');
+  var total = missesData.no_subject.length + missesData.clipped.length + missesData.oof.length;
+  if (total === 0) {
+    root.innerHTML =
+      '<div class="misses-empty-page">' +
+      '<p>No misses detected — either you nailed every shot, or detection hasn\'t run yet.</p>' +
+      '<p><a href="/pipeline">Go to Pipeline</a> to run miss detection on your folders.</p>' +
+      '</div>';
+    focusedCategory = null;
+    focusedIndex = -1;
+    return;
+  }
+
+  var html = '';
+  CATEGORY_ORDER.forEach(function(cat) {
+    html += renderSection(cat, missesData[cat]);
+  });
+  html +=
+    '<div class="misses-hint">' +
+      'Shortcuts: ' +
+      '<kbd>J</kbd>/<kbd>K</kbd> next/prev in section &middot; ' +
+      '<kbd>U</kbd> unflag focused thumbnail &middot; ' +
+      'click to open lightbox at 1:1 zoom' +
+    '</div>';
+  root.innerHTML = html;
+}
+
+function renderSection(cat, photos) {
+  var count = photos.length;
+  var label = CATEGORY_LABELS[cat];
+  var sectionId = 'missesSection-' + cat;
+  var bodyHtml;
+  if (count === 0) {
+    bodyHtml = '<div class="misses-empty">No photos in this category.</div>';
+  } else {
+    bodyHtml = '<div class="misses-grid" data-cat="' + cat + '">';
+    photos.forEach(function(p, idx) {
+      bodyHtml += renderCard(cat, p, idx);
+    });
+    bodyHtml += '</div>';
+  }
+  return (
+    '<section class="misses-section" id="' + sectionId + '" data-cat="' + cat + '">' +
+      '<div class="misses-section-header" onclick="toggleSection(\'' + cat + '\', event)">' +
+        '<span class="caret">&#9662;</span>' +
+        '<span class="misses-category-badge cat-' + cat + '"></span>' +
+        '<span class="misses-section-title">' + escapeHtml(label) + '</span>' +
+        '<span class="misses-section-count" data-testid="miss-count-' + cat + '">(' + count + ')</span>' +
+        '<div class="misses-section-actions">' +
+          '<button class="misses-reject-btn" ' +
+            'data-testid="miss-reject-' + cat + '" ' +
+            'onclick="bulkReject(\'' + cat + '\', event)" ' +
+            (count === 0 ? 'disabled' : '') + '>' +
+            'Reject all in ' + escapeHtml(label) +
+          '</button>' +
+        '</div>' +
+      '</div>' +
+      '<div class="misses-section-body">' +
+        bodyHtml +
+      '</div>' +
+    '</section>'
+  );
+}
+
+function renderCard(cat, p, idx) {
+  var bbox = parseDetectionBox(p.detection_box);
+  var bboxHtml = '';
+  if (cat === 'no_subject') {
+    // No bbox available — show dashed placeholder frame.
+    bboxHtml = '<div class="no-subject-frame">No subject detected</div>';
+  } else if (bbox) {
+    bboxHtml =
+      '<div class="miss-bbox" style="left:' + (bbox.x * 100) + '%;top:' + (bbox.y * 100) + '%;' +
+      'width:' + (bbox.w * 100) + '%;height:' + (bbox.h * 100) + '%;"></div>';
+  }
+
+  var meta = '';
+  if (cat === 'clipped' && p.subject_size != null) {
+    meta = (p.subject_size * 100).toFixed(1) + '%';
+  } else if (cat === 'oof' && p.subject_tenengrad != null && p.bg_tenengrad) {
+    meta = 'r=' + (p.subject_tenengrad / p.bg_tenengrad).toFixed(2);
+  } else if (cat === 'no_subject' && p.detection_conf != null) {
+    meta = 'c=' + Number(p.detection_conf).toFixed(2);
+  }
+
+  var ariaLabel = escapeAttr(
+    (CATEGORY_LABELS[cat] || cat) + ' miss: ' + (p.filename || ('photo ' + p.id))
+  );
+
+  return (
+    '<div class="miss-card" ' +
+      'data-cat="' + cat + '" ' +
+      'data-idx="' + idx + '" ' +
+      'data-photo-id="' + p.id + '" ' +
+      'data-filename="' + escapeAttr(p.filename || '') + '" ' +
+      'data-testid="miss-card-' + cat + '-' + p.id + '" ' +
+      'aria-label="' + ariaLabel + '" ' +
+      'onclick="openMiss(\'' + cat + '\', ' + idx + ', event)">' +
+      '<div class="miss-card-img-wrap">' +
+        '<img src="/thumbnails/' + p.id + '.jpg" loading="lazy" alt="' + escapeAttr(p.filename || '') + '">' +
+        bboxHtml +
+        '<span class="miss-card-badge">' +
+          '<span class="dot cat-' + cat + '"></span>' +
+          escapeHtml(CATEGORY_LABELS[cat]) +
+        '</span>' +
+        '<button class="miss-card-unflag" ' +
+          'title="Unflag as miss (U)" ' +
+          'data-testid="miss-unflag-' + cat + '-' + p.id + '" ' +
+          'onclick="unflagMiss(\'' + cat + '\', ' + p.id + ', event)">&times;</button>' +
+      '</div>' +
+      '<div class="miss-card-info">' +
+        '<span class="miss-card-filename">' + escapeHtml(p.filename || '') + '</span>' +
+        '<span class="miss-card-meta">' + escapeHtml(meta) + '</span>' +
+      '</div>' +
+    '</div>'
+  );
+}
+
+/* ---------- Section collapse ---------- */
+function toggleSection(cat, e) {
+  if (e && e.target && e.target.closest('button')) return;
+  var sec = document.getElementById('missesSection-' + cat);
+  if (sec) sec.classList.toggle('collapsed');
+}
+
+/* ---------- Open lightbox ---------- */
+function openMiss(cat, idx, e) {
+  if (e && e.target && e.target.closest('button')) return;
+  var photos = missesData[cat];
+  if (!photos || !photos[idx]) return;
+  var p = photos[idx];
+  setFocused(cat, idx);
+  var photoList = photos.map(function(q) { return { id: q.id, filename: q.filename }; });
+
+  if (typeof openLightbox !== 'function') return;
+  openLightbox(p.id, p.filename || '', photoList);
+
+  // 1:1 zoom on open.
+  //
+  // openLightbox() does not currently accept a zoom option. The navbar
+  // defines _lbNativeZoom (computed once image metadata + natural size are
+  // available) and _lbSetZoom. We poll briefly and trigger 1:1 once the
+  // native zoom is known, bailing if the user already interacted.
+  //
+  // TODO(task-12): Playwright scenario should verify this lands at 1:1.
+  // If this proves flaky, we should extend openLightbox() in _navbar.html
+  // to accept an {zoom: '1:1'} option that sets _lbPending1To1 internally.
+  try {
+    var tries = 0;
+    var targetId = p.id;
+    var t = setInterval(function() {
+      tries += 1;
+      if (tries > 40) { clearInterval(t); return; }  // ~4s
+      if (typeof _lightboxCurrentId !== 'undefined' && _lightboxCurrentId !== targetId) {
+        clearInterval(t); return;
+      }
+      if (typeof _lbZoom !== 'undefined' && _lbZoom > 1.001) {
+        // User already zoomed; respect that.
+        clearInterval(t); return;
+      }
+      if (typeof _lbNativeZoom !== 'undefined' && _lbNativeZoom && typeof _lbSetZoom === 'function') {
+        _lbSetZoom(_lbNativeZoom, null, null);
+        clearInterval(t);
+      }
+    }, 100);
+  } catch (err) { /* no-op */ }
+}
+
+/* ---------- Bulk reject ---------- */
+async function bulkReject(cat, e) {
+  if (e) e.stopPropagation();
+  var label = CATEGORY_LABELS[cat];
+  var n = (missesData[cat] || []).length;
+  if (n === 0) return;
+  if (!confirm('Set flag=reject on all ' + n + ' photos in "' + label + '"?\n' +
+               'Photos are not deleted — use the existing purge flow to remove them.')) {
+    return;
+  }
+  var r = await fetch('/api/misses/reject', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ category: cat }),
+  });
+  if (!r.ok) {
+    if (typeof showToast === 'function') showToast('Bulk reject failed', 'error');
+    return;
+  }
+  var data = await r.json();
+  if (typeof showToast === 'function') {
+    showToast('Rejected ' + (data.rejected || 0) + ' in ' + label, 'success');
+  }
+  // Optimistically clear the section, then refetch.
+  missesData[cat] = [];
+  render();
+  loadMisses();
+}
+
+/* ---------- Per-card unflag ---------- */
+async function unflagMiss(cat, photoId, e) {
+  if (e) e.stopPropagation();
+  var r = await fetch('/api/misses/' + photoId + '/unflag', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ category: cat }),
+  });
+  if (!r.ok) {
+    if (typeof showToast === 'function') showToast('Unflag failed', 'error');
+    return;
+  }
+  // Remove from in-memory list and re-render.
+  missesData[cat] = (missesData[cat] || []).filter(function(p) { return p.id !== photoId; });
+  render();
+}
+
+/* ---------- Focus tracking + keyboard shortcuts ---------- */
+function setFocused(cat, idx) {
+  focusedCategory = cat;
+  focusedIndex = idx;
+  document.querySelectorAll('.miss-card.focused').forEach(function(el) {
+    el.classList.remove('focused');
+  });
+  if (cat == null || idx == null || idx < 0) return;
+  var sel = '.miss-card[data-cat="' + cat + '"][data-idx="' + idx + '"]';
+  var el = document.querySelector(sel);
+  if (el) {
+    el.classList.add('focused');
+    el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }
+}
+
+function moveFocus(delta) {
+  // Pick the first non-empty category if nothing focused yet.
+  if (focusedCategory == null) {
+    for (var i = 0; i < CATEGORY_ORDER.length; i++) {
+      if (missesData[CATEGORY_ORDER[i]].length > 0) {
+        setFocused(CATEGORY_ORDER[i], 0);
+        return;
+      }
+    }
+    return;
+  }
+  var photos = missesData[focusedCategory] || [];
+  var newIdx = focusedIndex + delta;
+  if (newIdx < 0) newIdx = 0;
+  if (newIdx >= photos.length) newIdx = photos.length - 1;
+  setFocused(focusedCategory, newIdx);
+}
+
+document.addEventListener('keydown', function(e) {
+  if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
+  // Don't hijack modifier combos or when a modal/lightbox is open.
+  if (e.metaKey || e.ctrlKey || e.altKey) return;
+  if (document.querySelector('.lightbox-overlay.active, .pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .help-overlay.active')) return;
+
+  var k = e.key;
+  if (k === 'j' || k === 'J') {
+    e.preventDefault();
+    moveFocus(1);
+  } else if (k === 'k' || k === 'K') {
+    e.preventDefault();
+    moveFocus(-1);
+  } else if (k === 'u' || k === 'U') {
+    if (focusedCategory != null && focusedIndex >= 0) {
+      var p = (missesData[focusedCategory] || [])[focusedIndex];
+      if (p) {
+        e.preventDefault();
+        unflagMiss(focusedCategory, p.id);
+      }
+    }
+  } else if (k === 'Enter') {
+    if (focusedCategory != null && focusedIndex >= 0) {
+      e.preventDefault();
+      openMiss(focusedCategory, focusedIndex);
+    }
+  }
+});
+
+/* ---------- Boot ---------- */
+loadMisses();
+</script>
+
+</body>
+</html>

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -258,6 +258,13 @@
     Click a thumbnail to open at 1:1 zoom.
   </p>
 
+  <div id="scopeBanner" style="display:none;padding:8px 12px;margin-bottom:12px;
+       background:var(--bg-tertiary);border:1px solid var(--border-primary);
+       border-radius:4px;font-size:12px;color:var(--text-secondary);">
+    Showing misses from the current pipeline run.
+    <a href="/misses" style="color:var(--accent);margin-left:8px;">Show all</a>
+  </div>
+
   <div id="missesRoot">
     <!-- Sections rendered here -->
     <div class="misses-empty-page" id="loadingState">Loading...</div>
@@ -314,9 +321,24 @@ function sortPhotos(photos) {
   });
 }
 
+/* ---------- URL param: ?since=<iso-ts> scopes to current pipeline run ---------- */
+function getSinceParam() {
+  try {
+    var u = new URL(window.location.href);
+    var s = u.searchParams.get('since');
+    return s || null;
+  } catch (e) { return null; }
+}
+
 /* ---------- Fetch + render ---------- */
 async function loadMisses() {
-  var r = await fetch('/api/misses');
+  var since = getSinceParam();
+  if (since) {
+    var b = document.getElementById('scopeBanner');
+    if (b) b.style.display = '';
+  }
+  var url = '/api/misses' + (since ? '?since=' + encodeURIComponent(since) : '');
+  var r = await fetch(url);
   if (!r.ok) {
     document.getElementById('missesRoot').innerHTML =
       '<div class="misses-empty-page">Failed to load misses.</div>';

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -254,7 +254,7 @@
 <div class="misses-scroll" id="missesScroll" tabindex="0">
   <p class="misses-intro">
     Frames flagged as misses by the pipeline. Bulk-reject a category to set
-    <code>flag=reject</code> on every photo in it; photos aren't deleted.
+    <code>flag=rejected</code> on every photo in it; photos aren't deleted.
     Click a thumbnail to open at 1:1 zoom.
   </p>
 
@@ -528,7 +528,7 @@ async function bulkReject(cat, e) {
   var label = CATEGORY_LABELS[cat];
   var n = (missesData[cat] || []).length;
   if (n === 0) return;
-  if (!confirm('Set flag=reject on all ' + n + ' photos in "' + label + '"?\n' +
+  if (!confirm('Set flag=rejected on all ' + n + ' photos in "' + label + '"?\n' +
                'Photos are not deleted — use the existing purge flow to remove them.')) {
     return;
   }

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1779,36 +1779,29 @@ function initPipelineReviewPage() {
   });
 }
 
-/* Show a "Review misses (N)" shortcut in the summary bar when any photos
- * from the current pipeline run are flagged as misses. Scopes the link via
- * ?since=<earliest miss_computed_at within this run>, so the /misses page
- * only shows this run's misses. */
+/* Show a "Review misses (N)" shortcut in the summary bar when the current
+ * pipeline run actually recomputed miss flags. Gated on
+ * pipelineResults.miss_computed_at (set by pipeline_job's miss_stage);
+ * without the marker we'd surface stale miss flags from a prior run as
+ * current-run misses — e.g. when miss_enabled=false or the stage was
+ * skipped. The link is scoped to that same timestamp so /misses only
+ * shows misses written during this run. */
 function refreshMissesReviewBtn() {
   var btn = document.getElementById('missesReviewBtn');
-  if (!btn || !pipelineResults || !pipelineResults.photos) return;
-  var runIds = {};
-  pipelineResults.photos.forEach(function(p) { runIds[p.id] = true; });
+  if (!btn || !pipelineResults) return;
+  var sinceTs = pipelineResults.miss_computed_at;
+  if (!sinceTs) return;  // miss stage didn't run this pipeline
 
-  fetch('/api/misses').then(function(r) {
+  fetch('/api/misses?since=' + encodeURIComponent(sinceTs)).then(function(r) {
     if (!r.ok) return null;
     return r.json();
   }).then(function(data) {
     if (!data) return;
     var all = (data.no_subject || []).concat(data.clipped || []).concat(data.oof || []);
-    // Intersect with photos from the current run.
-    var seen = {};
-    var minTs = null;
-    var count = 0;
-    all.forEach(function(p) {
-      if (!runIds[p.id] || seen[p.id]) return;
-      seen[p.id] = true;
-      count += 1;
-      var ts = p.miss_computed_at;
-      if (ts && (minTs == null || ts < minTs)) minTs = ts;
-    });
+    var count = all.length;
     if (count === 0) return;  // stays hidden
     document.getElementById('missesReviewCount').textContent = count;
-    if (minTs) btn.href = '/misses?since=' + encodeURIComponent(minTs);
+    btn.href = '/misses?since=' + encodeURIComponent(sinceTs);
     btn.style.display = '';
   }).catch(function() { /* no-op */ });
 }

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -977,6 +977,12 @@ input[type="range"]::-moz-range-thumb {
         <div class="num" style="color:var(--warning);" id="statProtected">0</div>
         <div class="label">Protected</div>
       </div>
+      <a id="missesReviewBtn" href="/misses" data-testid="pipeline-review-misses"
+         style="display:none;margin-left:auto;padding:8px 14px;
+                background:var(--danger);color:#fff;border-radius:6px;
+                font-size:13px;font-weight:600;text-decoration:none;">
+        Review misses (<span id="missesReviewCount">0</span>)
+      </a>
     </div>
 
     <!-- Filter bar (hidden until data loads) -->
@@ -1769,7 +1775,42 @@ function initPipelineReviewPage() {
 
     renderResults();
     checkPendingSync();
+    refreshMissesReviewBtn();
   });
+}
+
+/* Show a "Review misses (N)" shortcut in the summary bar when any photos
+ * from the current pipeline run are flagged as misses. Scopes the link via
+ * ?since=<earliest miss_computed_at within this run>, so the /misses page
+ * only shows this run's misses. */
+function refreshMissesReviewBtn() {
+  var btn = document.getElementById('missesReviewBtn');
+  if (!btn || !pipelineResults || !pipelineResults.photos) return;
+  var runIds = {};
+  pipelineResults.photos.forEach(function(p) { runIds[p.id] = true; });
+
+  fetch('/api/misses').then(function(r) {
+    if (!r.ok) return null;
+    return r.json();
+  }).then(function(data) {
+    if (!data) return;
+    var all = (data.no_subject || []).concat(data.clipped || []).concat(data.oof || []);
+    // Intersect with photos from the current run.
+    var seen = {};
+    var minTs = null;
+    var count = 0;
+    all.forEach(function(p) {
+      if (!runIds[p.id] || seen[p.id]) return;
+      seen[p.id] = true;
+      count += 1;
+      var ts = p.miss_computed_at;
+      if (ts && (minTs == null || ts < minTs)) minTs = ts;
+    });
+    if (count === 0) return;  // stays hidden
+    document.getElementById('missesReviewCount').textContent = count;
+    if (minTs) btn.href = '/misses?since=' + encodeURIComponent(minTs);
+    btn.style.display = '';
+  }).catch(function() { /* no-op */ });
 }
 
 // -- Species confirmation --

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1306,8 +1306,25 @@ function saveConfig() {
             reject_clip_high: parseInt(document.getElementById('cfgRejectClip').value, 10) / 100,
             reject_composite: parseInt(document.getElementById('cfgRejectComposite').value, 10) / 100,
             miss_enabled: document.getElementById('cfgMissEnabled').checked,
-            miss_det_confidence: parseInt(document.getElementById('cfgMissDetConf').value, 10) / 100,
-            miss_bbox_area_min: parseInt(document.getElementById('cfgMissBboxMin').value, 10) / 1000,
+            // Keep paired thresholds consistent: the UI exposes one slider
+            // per pair, but classify_miss reads the sibling value (burst
+            // vs singleton) independently. If we only save one side, the
+            // other falls back to defaults, which can invert the intended
+            // "burst relaxes vs singleton stricter" logic when the user
+            // picks a value below the paired default. Derive the paired
+            // value from the same slider using the default ratio.
+            //   defaults: det_conf=0.25 / det_conf_burst=0.15  → burst = 0.60 * singleton
+            //             bbox_min=0.005 / bbox_min_singleton=0.002 → singleton = 0.40 * burst
+            ...(function() {
+              var det = parseInt(document.getElementById('cfgMissDetConf').value, 10) / 100;
+              var bbox = parseInt(document.getElementById('cfgMissBboxMin').value, 10) / 1000;
+              return {
+                miss_det_confidence: det,
+                miss_det_confidence_burst: +(det * 0.60).toFixed(4),
+                miss_bbox_area_min: bbox,
+                miss_bbox_area_min_singleton: +(bbox * 0.40).toFixed(5),
+              };
+            })(),
             miss_oof_ratio: parseInt(document.getElementById('cfgMissOofRatio').value, 10) / 100,
             eye_detect_enabled: document.getElementById('cfgEyeDetectEnabled').checked,
             eye_classifier_conf_gate: parseInt(document.getElementById('cfgEyeClassifierConfGate').value, 10) / 100,

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -493,6 +493,54 @@
         </div>
       </div>
 
+      <div style="font-size:13px;font-weight:600;color:var(--text-secondary);margin:16px 0 8px 0;border-bottom:1px solid var(--border-primary);padding-bottom:6px;">Miss Detection</div>
+      <div class="setting-row">
+        <div class="setting-label">
+          Enable miss detection
+          <small>After regrouping, flag frames where no subject was detected, the subject is clipped/tiny, or the subject is out of focus. Surfaced on the /misses page and in pipeline review.</small>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;">
+          <input type="checkbox" id="cfgMissEnabled" checked
+                 onchange="saveConfig()" style="accent-color:var(--accent);">
+        </div>
+      </div>
+      <div class="setting-row">
+        <div class="setting-label">
+          Subject-present confidence
+          <small>Detector confidence below this flags the frame as "no subject". Burst siblings relax the bar; singletons use the full threshold.</small>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;">
+          <input type="range" id="cfgMissDetConf" min="10" max="50" step="1" value="25"
+                 style="width:120px;accent-color:var(--accent);"
+                 oninput="document.getElementById('cfgMissDetConfVal').textContent = this.value + '%'; saveConfig()">
+          <span style="font-size:13px;color:var(--text-primary);min-width:36px;" id="cfgMissDetConfVal">25%</span>
+        </div>
+      </div>
+      <div class="setting-row">
+        <div class="setting-label">
+          Minimum subject area
+          <small>Subjects smaller than this fraction of the frame are flagged as "clipped / tiny". Singletons use a stricter floor.</small>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;">
+          <input type="range" id="cfgMissBboxMin" min="1" max="20" step="1" value="5"
+                 style="width:120px;accent-color:var(--accent);"
+                 oninput="document.getElementById('cfgMissBboxMinVal').textContent = (this.value / 1000).toFixed(3); saveConfig()">
+          <span style="font-size:13px;color:var(--text-primary);min-width:44px;" id="cfgMissBboxMinVal">0.005</span>
+        </div>
+      </div>
+      <div class="setting-row">
+        <div class="setting-label">
+          OOF ratio (subject / background)
+          <small>When the subject's Tenengrad is below this ratio of the background's, flag as "out of focus".</small>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;">
+          <input type="range" id="cfgMissOofRatio" min="30" max="80" step="5" value="50"
+                 style="width:120px;accent-color:var(--accent);"
+                 oninput="document.getElementById('cfgMissOofRatioVal').textContent = (this.value / 100).toFixed(2); saveConfig()">
+          <span style="font-size:13px;color:var(--text-primary);min-width:44px;" id="cfgMissOofRatioVal">0.50</span>
+        </div>
+      </div>
+
       <div style="font-size:13px;font-weight:600;color:var(--text-secondary);margin:16px 0 8px 0;border-bottom:1px solid var(--border-primary);padding-bottom:6px;">Eye-Focus Detection</div>
       <div class="setting-row">
         <div class="setting-label">
@@ -1107,6 +1155,18 @@ async function loadConfig() {
     document.getElementById('cfgRejectComposite').value = rco;
     document.getElementById('cfgRejectCompositeVal').textContent = rco + '%';
 
+    // Miss detection tunables
+    document.getElementById('cfgMissEnabled').checked = p.miss_enabled !== false;
+    var mdc = Math.round((p.miss_det_confidence != null ? p.miss_det_confidence : 0.25) * 100);
+    document.getElementById('cfgMissDetConf').value = mdc;
+    document.getElementById('cfgMissDetConfVal').textContent = mdc + '%';
+    var mbm = Math.round((p.miss_bbox_area_min != null ? p.miss_bbox_area_min : 0.005) * 1000);
+    document.getElementById('cfgMissBboxMin').value = mbm;
+    document.getElementById('cfgMissBboxMinVal').textContent = (mbm / 1000).toFixed(3);
+    var mor = Math.round((p.miss_oof_ratio != null ? p.miss_oof_ratio : 0.50) * 100);
+    document.getElementById('cfgMissOofRatio').value = mor;
+    document.getElementById('cfgMissOofRatioVal').textContent = (mor / 100).toFixed(2);
+
     // Eye-focus detection tunables
     document.getElementById('cfgEyeDetectEnabled').checked =
       p.eye_detect_enabled !== false;  // default true
@@ -1245,6 +1305,10 @@ function saveConfig() {
             reject_focus: parseInt(document.getElementById('cfgRejectFocus').value, 10) / 100,
             reject_clip_high: parseInt(document.getElementById('cfgRejectClip').value, 10) / 100,
             reject_composite: parseInt(document.getElementById('cfgRejectComposite').value, 10) / 100,
+            miss_enabled: document.getElementById('cfgMissEnabled').checked,
+            miss_det_confidence: parseInt(document.getElementById('cfgMissDetConf').value, 10) / 100,
+            miss_bbox_area_min: parseInt(document.getElementById('cfgMissBboxMin').value, 10) / 1000,
+            miss_oof_ratio: parseInt(document.getElementById('cfgMissOofRatio').value, 10) / 100,
             eye_detect_enabled: document.getElementById('cfgEyeDetectEnabled').checked,
             eye_classifier_conf_gate: parseInt(document.getElementById('cfgEyeClassifierConfGate').value, 10) / 100,
             eye_detection_conf_gate: parseInt(document.getElementById('cfgEyeDetectionConfGate').value, 10) / 100,
@@ -1299,6 +1363,14 @@ function resetPipelineDefaults() {
   document.getElementById('cfgEyeWindowK').value = 8;
   document.getElementById('cfgEyeWindowKVal').textContent = '0.08';
   document.getElementById('cfgEyeDetectEnabled').checked = true;
+  // Miss-detection defaults (non-percent display values).
+  document.getElementById('cfgMissEnabled').checked = true;
+  document.getElementById('cfgMissDetConf').value = 25;
+  document.getElementById('cfgMissDetConfVal').textContent = '25%';
+  document.getElementById('cfgMissBboxMin').value = 5;
+  document.getElementById('cfgMissBboxMinVal').textContent = '0.005';
+  document.getElementById('cfgMissOofRatio').value = 50;
+  document.getElementById('cfgMissOofRatioVal').textContent = '0.50';
   document.getElementById('cfgBurstMaxKeep').value = 3;
   document.getElementById('cfgEncMaxKeep').value = 5;
   document.getElementById('cfgWTime').value = 35;

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -519,7 +519,7 @@
       <div class="setting-row">
         <div class="setting-label">
           Minimum subject area
-          <small>Subjects smaller than this fraction of the frame are flagged as "clipped / tiny". Singletons use a stricter floor.</small>
+          <small>Subjects smaller than this fraction of the frame are flagged as "clipped / tiny" in a burst (a tiny bbox next to larger siblings signals lost framing). Singletons require an even smaller subject (40% of this) before being flagged, since without siblings a small subject may be intentional framing.</small>
         </div>
         <div style="display:flex;align-items:center;gap:8px;">
           <input type="range" id="cfgMissBboxMin" min="1" max="20" step="1" value="5"
@@ -1309,12 +1309,19 @@ function saveConfig() {
             // Keep paired thresholds consistent: the UI exposes one slider
             // per pair, but classify_miss reads the sibling value (burst
             // vs singleton) independently. If we only save one side, the
-            // other falls back to defaults, which can invert the intended
-            // "burst relaxes vs singleton stricter" logic when the user
-            // picks a value below the paired default. Derive the paired
-            // value from the same slider using the default ratio.
-            //   defaults: det_conf=0.25 / det_conf_burst=0.15  → burst = 0.60 * singleton
-            //             bbox_min=0.005 / bbox_min_singleton=0.002 → singleton = 0.40 * burst
+            // other falls back to defaults, which can break the paired
+            // relationship when the user picks a value below the paired
+            // default. Derive the paired value from the same slider using
+            // the default ratio. Burst context and singleton context
+            // move in opposite numeric directions because they describe
+            // different kinds of evidence:
+            //   - det_conf: siblings confirm a subject, so a burst is
+            //     forgiving of low confidence (lower threshold). Default
+            //     det_conf=0.25 / det_conf_burst=0.15 → burst = 0.60 * singleton.
+            //   - bbox_min: siblings showing a larger subject make a tiny
+            //     bbox look like lost framing, so a burst flags more
+            //     aggressively (higher threshold). Default bbox_min=0.005 /
+            //     bbox_min_singleton=0.002 → singleton = 0.40 * burst.
             ...(function() {
               var det = parseInt(document.getElementById('cfgMissDetConf').value, 10) / 100;
               var bbox = parseInt(document.getElementById('cfgMissBboxMin').value, 10) / 1000;

--- a/vireo/testing/userfirst/scenarios/misses.py
+++ b/vireo/testing/userfirst/scenarios/misses.py
@@ -4,7 +4,7 @@ The DB is pre-seeded with three misses (one per category). We open the
 page, verify the three category sections render with the right counts,
 click a thumbnail to open the lightbox, bulk-reject the `clipped` section
 (auto-accepting the confirm dialog), and re-check the DB state through
-the API to ensure `flag='reject'` landed on the right photo.
+the API to ensure `flag='rejected'` landed on the right photo.
 """
 
 
@@ -67,7 +67,7 @@ def run(session):
         f"expected no_subject count still (1), got {ns_after!r}",
     )
 
-    # -- Verify through the API that the clipped photo now has flag='reject' --
+    # -- Verify through the API that the clipped photo now has flag='rejected' --
     import json
 
     api_resp = session.eval(

--- a/vireo/testing/userfirst/scenarios/misses.py
+++ b/vireo/testing/userfirst/scenarios/misses.py
@@ -1,0 +1,82 @@
+"""Scenario: drive the /misses page end-to-end.
+
+The DB is pre-seeded with three misses (one per category). We open the
+page, verify the three category sections render with the right counts,
+click a thumbnail to open the lightbox, bulk-reject the `clipped` section
+(auto-accepting the confirm dialog), and re-check the DB state through
+the API to ensure `flag='reject'` landed on the right photo.
+"""
+
+
+def _accept_next_dialog(page):
+    page.once("dialog", lambda d: d.accept())
+
+
+def run(session):
+    # -- Initial state: /misses shows three sections, each with 1 photo --
+    session.goto("/misses")
+    session.page.wait_for_selector('[data-testid="miss-count-clipped"]', timeout=10000)
+    session.screenshot("misses-initial")
+
+    for cat in ("no_subject", "clipped", "oof"):
+        txt = session.eval(
+            f"document.querySelector('[data-testid=\"miss-count-{cat}\"]').textContent"
+        )
+        session.assert_that(
+            txt and "(1)" in txt,
+            f"expected {cat} count to be (1), got {txt!r}",
+        )
+
+    # -- Each section should have a bulk-reject button --
+    for cat in ("no_subject", "clipped", "oof"):
+        ok = session.eval(
+            f"!!document.querySelector('[data-testid=\"miss-reject-{cat}\"]')"
+        )
+        session.assert_that(ok, f"expected bulk-reject button for {cat}")
+
+    # -- Verify each card has an unflag (X) button overlaid --
+    has_unflag = session.eval(
+        """!!document.querySelector('[data-testid^="miss-unflag-clipped-"]')"""
+    )
+    session.assert_that(has_unflag, "expected unflag button on clipped card")
+
+    # Lightbox click-through is not covered here: the synthetic fixture has no
+    # real image files on disk, so /photos/<id>/full would 500 and trip the
+    # harness's HTTP-error watchdog. browse_lightbox.py exercises that path
+    # against a seed with a workable photos_root.
+
+    # -- Bulk-reject the clipped category --
+    _accept_next_dialog(session.page)
+    session.click('[data-testid="miss-reject-clipped"]')
+    session.page.wait_for_timeout(600)
+    session.screenshot("misses-after-reject")
+
+    # The clipped section should now be empty; no_subject and oof remain.
+    clipped_after = session.eval(
+        "document.querySelector('[data-testid=\"miss-count-clipped\"]').textContent"
+    )
+    session.assert_that(
+        clipped_after and "(0)" in clipped_after,
+        f"expected clipped count (0) after reject, got {clipped_after!r}",
+    )
+    ns_after = session.eval(
+        "document.querySelector('[data-testid=\"miss-count-no_subject\"]').textContent"
+    )
+    session.assert_that(
+        ns_after and "(1)" in ns_after,
+        f"expected no_subject count still (1), got {ns_after!r}",
+    )
+
+    # -- Verify through the API that the clipped photo now has flag='reject' --
+    import json
+
+    api_resp = session.eval(
+        """fetch('/api/misses').then(r => r.json()).then(d =>
+            JSON.stringify({clipped: d.clipped.length, oof: d.oof.length,
+                            no_subject: d.no_subject.length}))"""
+    )
+    counts = json.loads(api_resp) if isinstance(api_resp, str) else api_resp
+    session.assert_that(
+        counts.get("clipped") == 0,
+        f"expected /api/misses to show clipped=0 after reject, got {counts!r}",
+    )

--- a/vireo/testing/userfirst/seeds.py
+++ b/vireo/testing/userfirst/seeds.py
@@ -104,8 +104,6 @@ def misses_seed(db_path, thumb_dir, photos_root):
     fixture sets the miss_* booleans directly, mimicking what miss_stage
     writes after classify_miss.
     """
-    import json as _json
-
     from db import Database
 
     db = Database(db_path)
@@ -134,13 +132,18 @@ def misses_seed(db_path, thumb_dir, photos_root):
         )
         photos.append(pid)
         col = next(iter(flags))
-        # Store a plausible normalized detection bbox for the non-no_subject cases.
-        det_box = _json.dumps({"x": 0.35, "y": 0.35, "w": 0.2, "h": 0.2})
         db.conn.execute(
-            f"UPDATE photos SET {col}=1, miss_computed_at=?, "
-            f"detection_box=?, detection_conf=? WHERE id=?",
-            (ts, det_box if _cat != "no_subject" else None,
-             0.10 if _cat == "no_subject" else 0.85, pid),
+            f"UPDATE photos SET {col}=1, miss_computed_at=? WHERE id=?",
+            (ts, pid),
+        )
+        # Write a primary detection to the canonical `detections` table so
+        # the /misses cards can render bbox overlays. no_subject gets a
+        # low-confidence detection (matches the pipeline behavior).
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.35, "y": 0.35, "w": 0.2, "h": 0.2},
+              "confidence": 0.10 if _cat == "no_subject" else 0.85,
+              "category": "animal"}],
         )
     db.conn.commit()
 

--- a/vireo/testing/userfirst/seeds.py
+++ b/vireo/testing/userfirst/seeds.py
@@ -96,6 +96,61 @@ def browse_seed(db_path, thumb_dir, photos_root):
     db.conn.close()
 
 
+def misses_seed(db_path, thumb_dir, photos_root):
+    """Seed: three photos pre-flagged as misses (one per category).
+
+    Exercises the /misses page and its bulk-reject flow without requiring a
+    real pipeline run (which would need MegaDetector/SAM2 weights). The
+    fixture sets the miss_* booleans directly, mimicking what miss_stage
+    writes after classify_miss.
+    """
+    import json as _json
+
+    from db import Database
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    base = photos_root if photos_root else "/test/photos"
+    folder_id = db.add_folder(os.path.join(base, "misses_fixture"), name="misses_fixture")
+
+    ts = "2026-04-22T10:00:00+00:00"
+    specs = [
+        ("no_subject", "ns01.jpg", "2026-04-22T09:00:00", {"miss_no_subject": 1}),
+        ("clipped",    "clip01.jpg", "2026-04-22T09:00:01", {"miss_clipped": 1}),
+        ("oof",        "oof01.jpg",  "2026-04-22T09:00:02", {"miss_oof": 1}),
+    ]
+
+    photos = []
+    for _cat, fname, photo_ts, flags in specs:
+        pid = db.add_photo(
+            folder_id=folder_id,
+            filename=fname,
+            extension=".jpg",
+            file_size=4000,
+            file_mtime=float(len(photos) + 1),
+            timestamp=photo_ts,
+        )
+        photos.append(pid)
+        col = next(iter(flags))
+        # Store a plausible normalized detection bbox for the non-no_subject cases.
+        det_box = _json.dumps({"x": 0.35, "y": 0.35, "w": 0.2, "h": 0.2})
+        db.conn.execute(
+            f"UPDATE photos SET {col}=1, miss_computed_at=?, "
+            f"detection_box=?, detection_conf=? WHERE id=?",
+            (ts, det_box if _cat != "no_subject" else None,
+             0.10 if _cat == "no_subject" else 0.85, pid),
+        )
+    db.conn.commit()
+
+    os.makedirs(thumb_dir, exist_ok=True)
+    for pid in photos:
+        _make_thumb(thumb_dir, pid)
+
+    db.conn.close()
+
+
 def orphan_folder_seed(db_path, thumb_dir, photos_root):
     """Seed: a child folder whose parent is linked-then-unlinked.
 

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -259,3 +259,14 @@ def test_reject_eye_focus_flows_from_config_to_scoring(tmp_path, monkeypatch):
         "reject_eye_focus from config.json was not applied by score_encounter; "
         f"reasons={photo.get('reject_reasons')}"
     )
+
+
+def test_miss_defaults_present():
+    import config as cfg
+    d = cfg.DEFAULTS["pipeline"]
+    assert d["miss_enabled"] is True
+    assert d["miss_det_confidence"] == 0.25
+    assert d["miss_det_confidence_burst"] == 0.15
+    assert d["miss_bbox_area_min"] == 0.005
+    assert d["miss_bbox_area_min_singleton"] == 0.002
+    assert d["miss_oof_ratio"] == 0.5

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3956,3 +3956,39 @@ def test_misses_helpers_exclude_already_rejected_photos(tmp_path):
         "SELECT flag FROM photos WHERE id=?", (p_already,)
     ).fetchone()["flag"]
     assert flag_already == "reject"  # unchanged
+
+
+def test_list_misses_since_filter(tmp_path):
+    """`since` restricts results to photos whose miss_computed_at >= since.
+
+    Used by the pipeline-review "Review misses" step to scope the grid to
+    photos from the current pipeline run.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "m.db"))
+    folder_id = db.add_folder("/tmp/fake")
+    p_old = db.add_photo(
+        folder_id, "old.jpg", ".jpg", file_size=100, file_mtime=1.0
+    )
+    p_new = db.add_photo(
+        folder_id, "new.jpg", ".jpg", file_size=100, file_mtime=2.0
+    )
+    db.conn.execute(
+        "UPDATE photos SET miss_clipped=1, miss_computed_at='2026-04-20T00:00:00+00:00' "
+        "WHERE id=?", (p_old,),
+    )
+    db.conn.execute(
+        "UPDATE photos SET miss_clipped=1, miss_computed_at='2026-04-22T10:00:00+00:00' "
+        "WHERE id=?", (p_new,),
+    )
+    db.conn.commit()
+
+    all_ids = [m["id"] for m in db.list_misses(category="clipped")]
+    assert p_old in all_ids and p_new in all_ids
+
+    recent = [m["id"] for m in db.list_misses(category="clipped",
+                                              since="2026-04-21T00:00:00+00:00")]
+    assert recent == [p_new]
+
+    grouped = db.list_misses(since="2026-04-21T00:00:00+00:00")
+    assert [m["id"] for m in grouped] == [p_new]

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4084,6 +4084,45 @@ def test_list_misses_returns_null_detection_when_no_detections(tmp_path):
     assert misses[0]["detection_conf"] is None
 
 
+def test_list_misses_chunks_detection_lookup_over_sqlite_var_limit(tmp_path):
+    """With >999 flagged misses, the detections IN (...) clause would exceed
+    SQLite's SQLITE_MAX_VARIABLE_NUMBER. list_misses must chunk the lookup
+    so /api/misses doesn't raise ``OperationalError: too many SQL variables``
+    for workspaces with many flagged photos."""
+    from db import Database
+    db = Database(str(tmp_path / "m.db"))
+    folder_id = db.add_folder("/tmp/fake")
+
+    # Insert 1100 photos, all flagged as clipped, each with one detection.
+    # This pushes the IN clause well past the default 999-var limit and would
+    # crash without chunking.
+    N = 1100
+    photo_ids = []
+    for i in range(N):
+        pid = db.add_photo(
+            folder_id, f"p{i:04d}.jpg", ".jpg",
+            file_size=100, file_mtime=float(i + 1),
+        )
+        photo_ids.append(pid)
+    db.conn.executemany(
+        "UPDATE photos SET miss_clipped=1 WHERE id=?",
+        [(pid,) for pid in photo_ids],
+    )
+    db.conn.commit()
+    for pid in photo_ids:
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+              "confidence": 0.9, "category": "animal"}],
+        )
+
+    misses = db.list_misses(category="clipped")
+    assert len(misses) == N
+    # Every row must have a detection attached (proving chunking visited all).
+    assert all(m["detection_conf"] == 0.9 for m in misses)
+    assert all(m["detection_box"] is not None for m in misses)
+
+
 def test_clear_miss_flag_scoped_to_active_workspace(tmp_path):
     """clear_miss_flag must refuse to touch a photo from another workspace."""
     import pytest

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3824,3 +3824,16 @@ def test_preview_cache_oldest_first(tmp_path):
 
     rows = db.preview_cache_oldest_first()
     assert [(r["photo_id"], r["size"]) for r in rows] == [(p1, 1920), (p2, 1920)]
+
+
+def test_miss_columns_present(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    row = db.conn.execute(
+        "SELECT miss_no_subject, miss_clipped, miss_oof, miss_computed_at "
+        "FROM photos LIMIT 0"
+    ).description
+    names = {c[0] for c in row}
+    assert names == {
+        "miss_no_subject", "miss_clipped", "miss_oof", "miss_computed_at",
+    }

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4037,6 +4037,53 @@ def test_list_misses_scoped_to_active_workspace(tmp_path):
     assert ids_a == [p_a]
 
 
+def test_list_misses_joins_primary_detection_from_detections_table(tmp_path):
+    """list_misses must source detection_box/detection_conf from the
+    canonical `detections` table (highest-confidence row per photo, workspace-
+    scoped), not the legacy photos.detection_* columns that aren't populated
+    by normal pipeline runs."""
+    import json as _json
+
+    from db import Database
+    db = Database(str(tmp_path / "m.db"))
+    folder_id = db.add_folder("/tmp/fake")
+    p = db.add_photo(folder_id, "a.jpg", ".jpg", file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET miss_clipped=1 WHERE id=?", (p,))
+    db.conn.commit()
+    # Two detections; the primary is the higher-confidence one.
+    db.save_detections(
+        p,
+        [
+            {"box": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
+             "confidence": 0.40, "category": "animal"},
+            {"box": {"x": 0.35, "y": 0.35, "w": 0.2, "h": 0.2},
+             "confidence": 0.85, "category": "animal"},
+        ],
+    )
+
+    misses = db.list_misses(category="clipped")
+    assert len(misses) == 1
+    m = misses[0]
+    assert m["detection_conf"] == 0.85
+    box = _json.loads(m["detection_box"])
+    assert box == {"x": 0.35, "y": 0.35, "w": 0.2, "h": 0.2}
+
+
+def test_list_misses_returns_null_detection_when_no_detections(tmp_path):
+    """A no_subject miss has no detection — detection_box/conf are None."""
+    from db import Database
+    db = Database(str(tmp_path / "m.db"))
+    folder_id = db.add_folder("/tmp/fake")
+    p = db.add_photo(folder_id, "a.jpg", ".jpg", file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET miss_no_subject=1 WHERE id=?", (p,))
+    db.conn.commit()
+
+    misses = db.list_misses(category="no_subject")
+    assert len(misses) == 1
+    assert misses[0]["detection_box"] is None
+    assert misses[0]["detection_conf"] is None
+
+
 def test_clear_miss_flag_scoped_to_active_workspace(tmp_path):
     """clear_miss_flag must refuse to touch a photo from another workspace."""
     import pytest

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3921,3 +3921,38 @@ def test_bulk_reject_category_sets_flag_reject(tmp_path):
             "SELECT flag FROM photos WHERE id=?", (pid,)
         ).fetchone()["flag"]
         assert flag == "reject"
+
+
+def test_misses_helpers_exclude_already_rejected_photos(tmp_path):
+    """Neither list_misses nor bulk_reject should touch photos already rejected.
+
+    The exclusion clause (flag IS NULL OR flag != 'reject') is load-bearing:
+    a photo that's already been rejected must not show up again as a miss
+    (it's done) and must not inflate the bulk-reject rowcount (it's not news).
+    """
+    from db import Database
+    db = Database(str(tmp_path / "m.db"))
+    folder_id = db.add_folder("/tmp/fake")
+    p_miss = db.add_photo(
+        folder_id, "a.jpg", ".jpg", file_size=100, file_mtime=1.0
+    )
+    p_already = db.add_photo(
+        folder_id, "b.jpg", ".jpg", file_size=100, file_mtime=2.0
+    )
+    db.conn.execute(
+        "UPDATE photos SET miss_clipped=1 WHERE id IN (?, ?)",
+        (p_miss, p_already),
+    )
+    db.conn.execute("UPDATE photos SET flag='reject' WHERE id=?", (p_already,))
+    db.conn.commit()
+
+    listed = [m["id"] for m in db.list_misses(category="clipped")]
+    assert p_miss in listed
+    assert p_already not in listed
+
+    n = db.bulk_reject_miss_category("clipped")
+    assert n == 1  # only p_miss got rejected; p_already was already rejected
+    flag_already = db.conn.execute(
+        "SELECT flag FROM photos WHERE id=?", (p_already,)
+    ).fetchone()["flag"]
+    assert flag_already == "reject"  # unchanged

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4025,8 +4025,9 @@ def test_bulk_reject_category_sets_flag_rejected(tmp_path):
     )
     db.conn.commit()
 
-    n = db.bulk_reject_miss_category("clipped")
-    assert n == 2
+    affected = db.bulk_reject_miss_category("clipped")
+    assert len(affected) == 2
+    assert {a["photo_id"] for a in affected} == {p1, p2}
     for pid in (p1, p2):
         flag = db.conn.execute(
             "SELECT flag FROM photos WHERE id=?", (pid,)
@@ -4061,8 +4062,10 @@ def test_misses_helpers_exclude_already_rejected_photos(tmp_path):
     assert p_miss in listed
     assert p_already not in listed
 
-    n = db.bulk_reject_miss_category("clipped")
-    assert n == 1  # only p_miss got rejected; p_already was already rejected
+    affected = db.bulk_reject_miss_category("clipped")
+    # only p_miss got rejected; p_already was already rejected
+    assert len(affected) == 1
+    assert affected[0]["photo_id"] == p_miss
     flag_already = db.conn.execute(
         "SELECT flag FROM photos WHERE id=?", (p_already,)
     ).fetchone()["flag"]
@@ -4131,8 +4134,9 @@ def test_list_misses_scoped_to_active_workspace(tmp_path):
     assert ids_b == [p_b]
 
     # Bulk reject in B must not touch A's photo.
-    n = db.bulk_reject_miss_category("clipped")
-    assert n == 1
+    affected = db.bulk_reject_miss_category("clipped")
+    assert len(affected) == 1
+    assert affected[0]["photo_id"] == p_b
     flag_a = db.conn.execute(
         "SELECT flag FROM photos WHERE id=?", (p_a,)
     ).fetchone()["flag"]
@@ -4216,8 +4220,9 @@ def test_bulk_reject_miss_category_scoped_by_since(tmp_path):
     db.conn.commit()
 
     # Since filter matches only the new miss.
-    n = db.bulk_reject_miss_category("clipped", since="2026-04-20T00:00:00+00:00")
-    assert n == 1
+    affected = db.bulk_reject_miss_category("clipped", since="2026-04-20T00:00:00+00:00")
+    assert len(affected) == 1
+    assert affected[0]["photo_id"] == p_new
 
     flag_old = db.conn.execute(
         "SELECT flag FROM photos WHERE id=?", (p_old,)
@@ -4229,8 +4234,9 @@ def test_bulk_reject_miss_category_scoped_by_since(tmp_path):
     assert flag_new == "rejected"
 
     # Without since, the old miss is now eligible.
-    n2 = db.bulk_reject_miss_category("clipped")
-    assert n2 == 1
+    affected2 = db.bulk_reject_miss_category("clipped")
+    assert len(affected2) == 1
+    assert affected2[0]["photo_id"] == p_old
     flag_old2 = db.conn.execute(
         "SELECT flag FROM photos WHERE id=?", (p_old,)
     ).fetchone()["flag"]

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3899,7 +3899,7 @@ def test_clear_miss_flag_on_photo(tmp_path):
     assert row["miss_oof"] == 1
 
 
-def test_bulk_reject_category_sets_flag_reject(tmp_path):
+def test_bulk_reject_category_sets_flag_rejected(tmp_path):
     from db import Database
     db = Database(str(tmp_path / "m.db"))
     folder_id = db.add_folder("/tmp/fake")
@@ -3920,13 +3920,13 @@ def test_bulk_reject_category_sets_flag_reject(tmp_path):
         flag = db.conn.execute(
             "SELECT flag FROM photos WHERE id=?", (pid,)
         ).fetchone()["flag"]
-        assert flag == "reject"
+        assert flag == "rejected"
 
 
 def test_misses_helpers_exclude_already_rejected_photos(tmp_path):
     """Neither list_misses nor bulk_reject should touch photos already rejected.
 
-    The exclusion clause (flag IS NULL OR flag != 'reject') is load-bearing:
+    The exclusion clause (flag IS NULL OR flag != 'rejected') is load-bearing:
     a photo that's already been rejected must not show up again as a miss
     (it's done) and must not inflate the bulk-reject rowcount (it's not news).
     """
@@ -3943,7 +3943,7 @@ def test_misses_helpers_exclude_already_rejected_photos(tmp_path):
         "UPDATE photos SET miss_clipped=1 WHERE id IN (?, ?)",
         (p_miss, p_already),
     )
-    db.conn.execute("UPDATE photos SET flag='reject' WHERE id=?", (p_already,))
+    db.conn.execute("UPDATE photos SET flag='rejected' WHERE id=?", (p_already,))
     db.conn.commit()
 
     listed = [m["id"] for m in db.list_misses(category="clipped")]
@@ -3955,7 +3955,7 @@ def test_misses_helpers_exclude_already_rejected_photos(tmp_path):
     flag_already = db.conn.execute(
         "SELECT flag FROM photos WHERE id=?", (p_already,)
     ).fetchone()["flag"]
-    assert flag_already == "reject"  # unchanged
+    assert flag_already == "rejected"  # unchanged
 
 
 def test_list_misses_since_filter(tmp_path):
@@ -3992,3 +3992,46 @@ def test_list_misses_since_filter(tmp_path):
 
     grouped = db.list_misses(since="2026-04-21T00:00:00+00:00")
     assert [m["id"] for m in grouped] == [p_new]
+
+
+def test_list_misses_scoped_to_active_workspace(tmp_path):
+    """Misses in folders linked only to workspace A must not appear or get
+    rejected when workspace B is active."""
+    from db import Database
+    db = Database(str(tmp_path / "m.db"))
+
+    ws_a = db.ensure_default_workspace()
+    ws_b = db.create_workspace("Other")
+
+    db.set_active_workspace(ws_a)
+    fa = db.add_folder("/tmp/a", name="a")
+    p_a = db.add_photo(fa, "a.jpg", ".jpg", file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET miss_clipped=1 WHERE id=?", (p_a,))
+    db.conn.commit()
+
+    db.set_active_workspace(ws_b)
+    fb = db.add_folder("/tmp/b", name="b")
+    p_b = db.add_photo(fb, "b.jpg", ".jpg", file_size=100, file_mtime=2.0)
+    db.conn.execute("UPDATE photos SET miss_clipped=1 WHERE id=?", (p_b,))
+    db.conn.commit()
+
+    # Workspace B sees only its own miss.
+    ids_b = [m["id"] for m in db.list_misses(category="clipped")]
+    assert ids_b == [p_b]
+
+    # Bulk reject in B must not touch A's photo.
+    n = db.bulk_reject_miss_category("clipped")
+    assert n == 1
+    flag_a = db.conn.execute(
+        "SELECT flag FROM photos WHERE id=?", (p_a,)
+    ).fetchone()["flag"]
+    assert flag_a != "rejected"
+    flag_b = db.conn.execute(
+        "SELECT flag FROM photos WHERE id=?", (p_b,)
+    ).fetchone()["flag"]
+    assert flag_b == "rejected"
+
+    # Switching back to A should still reveal its untouched miss.
+    db.set_active_workspace(ws_a)
+    ids_a = [m["id"] for m in db.list_misses(category="clipped")]
+    assert ids_a == [p_a]

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4084,6 +4084,48 @@ def test_list_misses_returns_null_detection_when_no_detections(tmp_path):
     assert misses[0]["detection_conf"] is None
 
 
+def test_bulk_reject_miss_category_scoped_by_since(tmp_path):
+    """Bulk reject must honor the same `since` filter as list_misses so
+    clicking "Reject all" on /misses?since=... doesn't silently reject
+    older misses from prior pipeline runs that aren't shown on screen."""
+    from db import Database
+    db = Database(str(tmp_path / "m.db"))
+    folder_id = db.add_folder("/tmp/fake")
+
+    p_old = db.add_photo(folder_id, "old.jpg", ".jpg", file_size=100, file_mtime=1.0)
+    p_new = db.add_photo(folder_id, "new.jpg", ".jpg", file_size=100, file_mtime=2.0)
+    db.conn.execute(
+        "UPDATE photos SET miss_clipped=1, miss_computed_at=? WHERE id=?",
+        ("2026-04-10T00:00:00+00:00", p_old),
+    )
+    db.conn.execute(
+        "UPDATE photos SET miss_clipped=1, miss_computed_at=? WHERE id=?",
+        ("2026-04-22T10:00:00+00:00", p_new),
+    )
+    db.conn.commit()
+
+    # Since filter matches only the new miss.
+    n = db.bulk_reject_miss_category("clipped", since="2026-04-20T00:00:00+00:00")
+    assert n == 1
+
+    flag_old = db.conn.execute(
+        "SELECT flag FROM photos WHERE id=?", (p_old,)
+    ).fetchone()["flag"]
+    flag_new = db.conn.execute(
+        "SELECT flag FROM photos WHERE id=?", (p_new,)
+    ).fetchone()["flag"]
+    assert flag_old != "rejected"
+    assert flag_new == "rejected"
+
+    # Without since, the old miss is now eligible.
+    n2 = db.bulk_reject_miss_category("clipped")
+    assert n2 == 1
+    flag_old2 = db.conn.execute(
+        "SELECT flag FROM photos WHERE id=?", (p_old,)
+    ).fetchone()["flag"]
+    assert flag_old2 == "rejected"
+
+
 def test_list_misses_chunks_detection_lookup_over_sqlite_var_limit(tmp_path):
     """With >999 flagged misses, the detections IN (...) clause would exceed
     SQLite's SQLITE_MAX_VARIABLE_NUMBER. list_misses must chunk the lookup

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3837,3 +3837,87 @@ def test_miss_columns_present(tmp_path):
     assert names == {
         "miss_no_subject", "miss_clipped", "miss_oof", "miss_computed_at",
     }
+
+
+def test_list_misses_returns_flagged_photos_only(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "m.db"))
+    folder_id = db.add_folder("/tmp/fake")
+    p1 = db.add_photo(
+        folder_id, "a.jpg", ".jpg", file_size=100, file_mtime=1.0
+    )
+    p2 = db.add_photo(
+        folder_id, "b.jpg", ".jpg", file_size=100, file_mtime=2.0
+    )
+    db.conn.execute(
+        "UPDATE photos SET miss_clipped=1, miss_computed_at='2026-04-22' "
+        "WHERE id=?", (p1,)
+    )
+    db.conn.commit()
+
+    misses = db.list_misses()
+    ids = [m["id"] for m in misses]
+    assert p1 in ids
+    assert p2 not in ids
+
+
+def test_list_misses_filters_by_category(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "m.db"))
+    folder_id = db.add_folder("/tmp/fake")
+    p_clip = db.add_photo(
+        folder_id, "a.jpg", ".jpg", file_size=100, file_mtime=1.0
+    )
+    p_oof = db.add_photo(
+        folder_id, "b.jpg", ".jpg", file_size=100, file_mtime=2.0
+    )
+    db.conn.execute("UPDATE photos SET miss_clipped=1 WHERE id=?", (p_clip,))
+    db.conn.execute("UPDATE photos SET miss_oof=1     WHERE id=?", (p_oof,))
+    db.conn.commit()
+
+    assert [m["id"] for m in db.list_misses(category="clipped")] == [p_clip]
+    assert [m["id"] for m in db.list_misses(category="oof")] == [p_oof]
+
+
+def test_clear_miss_flag_on_photo(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "m.db"))
+    folder_id = db.add_folder("/tmp/fake")
+    p = db.add_photo(
+        folder_id, "a.jpg", ".jpg", file_size=100, file_mtime=1.0
+    )
+    db.conn.execute(
+        "UPDATE photos SET miss_clipped=1, miss_oof=1 WHERE id=?", (p,)
+    )
+    db.conn.commit()
+
+    db.clear_miss_flag(p, "clipped")
+    row = db.conn.execute(
+        "SELECT miss_clipped, miss_oof FROM photos WHERE id=?", (p,)
+    ).fetchone()
+    assert row["miss_clipped"] == 0
+    assert row["miss_oof"] == 1
+
+
+def test_bulk_reject_category_sets_flag_reject(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "m.db"))
+    folder_id = db.add_folder("/tmp/fake")
+    p1 = db.add_photo(
+        folder_id, "a.jpg", ".jpg", file_size=100, file_mtime=1.0
+    )
+    p2 = db.add_photo(
+        folder_id, "b.jpg", ".jpg", file_size=100, file_mtime=2.0
+    )
+    db.conn.execute(
+        "UPDATE photos SET miss_clipped=1 WHERE id IN (?, ?)", (p1, p2)
+    )
+    db.conn.commit()
+
+    n = db.bulk_reject_miss_category("clipped")
+    assert n == 2
+    for pid in (p1, p2):
+        flag = db.conn.execute(
+            "SELECT flag FROM photos WHERE id=?", (pid,)
+        ).fetchone()["flag"]
+        assert flag == "reject"

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4035,3 +4035,29 @@ def test_list_misses_scoped_to_active_workspace(tmp_path):
     db.set_active_workspace(ws_a)
     ids_a = [m["id"] for m in db.list_misses(category="clipped")]
     assert ids_a == [p_a]
+
+
+def test_clear_miss_flag_scoped_to_active_workspace(tmp_path):
+    """clear_miss_flag must refuse to touch a photo from another workspace."""
+    import pytest
+    from db import Database
+    db = Database(str(tmp_path / "m.db"))
+
+    ws_a = db._active_workspace_id
+    ws_b = db.create_workspace("Other")
+
+    db.set_active_workspace(ws_a)
+    fa = db.add_folder("/tmp/a", name="a")
+    p_a = db.add_photo(fa, "a.jpg", ".jpg", file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET miss_clipped=1 WHERE id=?", (p_a,))
+    db.conn.commit()
+
+    db.set_active_workspace(ws_b)
+    with pytest.raises(ValueError):
+        db.clear_miss_flag(p_a, "clipped")
+
+    # A's miss flag must still be set.
+    row = db.conn.execute(
+        "SELECT miss_clipped FROM photos WHERE id=?", (p_a,)
+    ).fetchone()
+    assert row["miss_clipped"] == 1

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4243,6 +4243,38 @@ def test_bulk_reject_miss_category_scoped_by_since(tmp_path):
     assert flag_old2 == "rejected"
 
 
+def test_bulk_reject_miss_category_preserves_null_flag_in_old_value(tmp_path):
+    """old_value must be None (not "") for rows with NULL flag, so undo
+    can restore the original NULL rather than writing a non-canonical
+    empty string that bypasses flag validation (none/flagged/rejected
+    or NULL)."""
+    from db import Database
+    db = Database(str(tmp_path / "m.db"))
+    folder_id = db.add_folder("/tmp/fake")
+
+    p_null = db.add_photo(folder_id, "null.jpg", ".jpg", file_size=100, file_mtime=1.0)
+    p_none = db.add_photo(folder_id, "none.jpg", ".jpg", file_size=100, file_mtime=2.0)
+    p_flagged = db.add_photo(folder_id, "flagged.jpg", ".jpg", file_size=100, file_mtime=3.0)
+
+    # p_null forced to NULL flag (add_photo defaults the column to 'none');
+    # p_none explicitly "none"; p_flagged "flagged".
+    db.conn.execute(
+        "UPDATE photos SET miss_clipped=1 WHERE id IN (?, ?, ?)",
+        (p_null, p_none, p_flagged),
+    )
+    db.conn.execute("UPDATE photos SET flag=NULL      WHERE id=?", (p_null,))
+    db.conn.execute("UPDATE photos SET flag='none'    WHERE id=?", (p_none,))
+    db.conn.execute("UPDATE photos SET flag='flagged' WHERE id=?", (p_flagged,))
+    db.conn.commit()
+
+    affected = db.bulk_reject_miss_category("clipped")
+    by_id = {a["photo_id"]: a for a in affected}
+
+    assert by_id[p_null]["old_value"] is None
+    assert by_id[p_none]["old_value"] == "none"
+    assert by_id[p_flagged]["old_value"] == "flagged"
+
+
 def test_list_misses_chunks_detection_lookup_over_sqlite_var_limit(tmp_path):
     """With >999 flagged misses, the detections IN (...) clause would exceed
     SQLite's SQLITE_MAX_VARIABLE_NUMBER. list_misses must chunk the lookup

--- a/vireo/tests/test_misses.py
+++ b/vireo/tests/test_misses.py
@@ -1,0 +1,50 @@
+"""Tests for miss-detection classification.
+
+classify_miss() is a pure function that derives three miss booleans from
+per-photo features already written by the pipeline. No I/O, no DB access.
+"""
+
+
+def _row(**overrides):
+    base = {
+        "detection_conf": 0.9,
+        "subject_size": 0.05,     # 5% of frame
+        "crop_complete": 1.0,
+        "subject_tenengrad": 80.0,
+        "bg_tenengrad": 40.0,
+        "burst_id": None,
+    }
+    base.update(overrides)
+    return base
+
+
+DEFAULT_CONFIG = {
+    "miss_det_confidence": 0.25,
+    "miss_det_confidence_burst": 0.15,
+    "miss_bbox_area_min": 0.005,
+    "miss_bbox_area_min_singleton": 0.002,
+    "miss_oof_ratio": 0.5,
+}
+
+
+def test_no_subject_when_detection_below_threshold_singleton():
+    from misses import classify_miss
+    row = _row(detection_conf=0.10)
+    flags = classify_miss(row, siblings=[], config=DEFAULT_CONFIG)
+    assert flags == {"no_subject": True, "clipped": False, "oof": False}
+
+
+def test_no_subject_excludes_other_categories():
+    """When there's no bbox, clipped/oof can't be evaluated."""
+    from misses import classify_miss
+    row = _row(
+        detection_conf=0.0,
+        subject_size=None,
+        crop_complete=None,
+        subject_tenengrad=None,
+        bg_tenengrad=None,
+    )
+    flags = classify_miss(row, siblings=[], config=DEFAULT_CONFIG)
+    assert flags["no_subject"] is True
+    assert flags["clipped"] is False
+    assert flags["oof"] is False

--- a/vireo/tests/test_misses.py
+++ b/vireo/tests/test_misses.py
@@ -79,3 +79,32 @@ def test_clipped_when_bbox_much_smaller_than_burst_median():
     siblings = [_row(subject_size=0.08), _row(subject_size=0.10)]  # 8%, 10%
     flags = classify_miss(row, siblings=siblings, config=DEFAULT_CONFIG)
     assert flags["clipped"] is True
+
+
+def test_oof_when_background_sharper_than_subject_in_burst():
+    from misses import classify_miss
+    row = _row(subject_tenengrad=20.0, bg_tenengrad=80.0)  # ratio 0.25
+    siblings = [_row(), _row()]
+    flags = classify_miss(row, siblings=siblings, config=DEFAULT_CONFIG)
+    assert flags["oof"] is True
+
+
+def test_not_oof_when_ratio_above_threshold():
+    from misses import classify_miss
+    row = _row(subject_tenengrad=60.0, bg_tenengrad=80.0)  # ratio 0.75
+    flags = classify_miss(row, siblings=[_row()], config=DEFAULT_CONFIG)
+    assert flags["oof"] is False
+
+
+def test_oof_singleton_requires_both_ratio_and_floor():
+    """Singleton: ratio alone isn't enough — need absolute floor too."""
+    from misses import classify_miss
+    # Ratio is bad (0.25) but subject is still sharp in absolute terms.
+    row = _row(subject_tenengrad=200.0, bg_tenengrad=800.0)
+    flags = classify_miss(row, siblings=[], config=DEFAULT_CONFIG)
+    assert flags["oof"] is False
+
+    # Ratio is bad AND subject is below absolute floor.
+    row = _row(subject_tenengrad=5.0, bg_tenengrad=20.0)
+    flags = classify_miss(row, siblings=[], config=DEFAULT_CONFIG)
+    assert flags["oof"] is True

--- a/vireo/tests/test_misses.py
+++ b/vireo/tests/test_misses.py
@@ -154,6 +154,30 @@ def test_no_spurious_flags_when_quality_features_missing():
     assert flags_b == {"no_subject": False, "clipped": False, "oof": False}
 
 
+def test_classify_miss_falls_back_to_defaults_for_partial_config():
+    """Pipeline configs reaching classify_miss are often partial — e.g.
+    /api/pipeline/config stores only model keys under `pipeline` and
+    Database.get_effective_config does a shallow top-level merge. Miss
+    thresholds must fall back to config.DEFAULTS rather than raising
+    KeyError and failing the whole pipeline job."""
+    from misses import classify_miss
+
+    # Partial config: none of the miss_* thresholds are present.
+    partial = {"model": "whatever"}
+
+    # With low detection confidence and empty siblings (singleton), the
+    # default miss_det_confidence=0.25 should classify this as no_subject.
+    row = _row(detection_conf=0.10)
+    flags = classify_miss(row, siblings=[], config=partial)
+    assert flags == {"no_subject": True, "clipped": False, "oof": False}
+
+    # With good detection confidence and a tiny bbox, the default
+    # miss_bbox_area_min_singleton=0.002 should classify as clipped.
+    row = _row(subject_size=0.001)
+    flags = classify_miss(row, siblings=[], config=partial)
+    assert flags["clipped"] is True
+
+
 def test_compute_misses_groups_by_burst_and_writes_flags(tmp_path):
     """Integration test: real DB, synthetic photo rows, verify flags written."""
     import config as cfg

--- a/vireo/tests/test_misses.py
+++ b/vireo/tests/test_misses.py
@@ -183,16 +183,24 @@ def test_compute_misses_groups_by_burst_and_writes_flags(tmp_path):
         file_mtime=2.0,
         timestamp="2026-04-22T10:00:00",
     )
-    # Hand-write pipeline features + shared burst_id.
+    # Hand-write pipeline features + shared burst_id. Detection confidence
+    # lives in the `detections` table (written by save_detections during the
+    # classify stage), not photos.detection_conf.
     db.conn.executemany(
-        "UPDATE photos SET burst_id=?, detection_conf=?, subject_size=?, "
+        "UPDATE photos SET burst_id=?, subject_size=?, "
         "crop_complete=?, subject_tenengrad=?, bg_tenengrad=? WHERE id=?",
         [
-            ("B1", 0.95, 0.08,  1.0, 80.0, 40.0, p_keeper),
-            ("B1", 0.95, 0.005, 1.0, 80.0, 40.0, p_miss),
+            ("B1", 0.08,  1.0, 80.0, 40.0, p_keeper),
+            ("B1", 0.005, 1.0, 80.0, 40.0, p_miss),
         ],
     )
     db.conn.commit()
+    for pid in (p_keeper, p_miss):
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+              "confidence": 0.95, "category": "animal"}],
+        )
 
     compute_misses_for_workspace(db, cfg.DEFAULTS["pipeline"])
 
@@ -230,9 +238,14 @@ def test_compute_misses_scoped_to_active_workspace(tmp_path):
         timestamp="2026-04-22T10:00:00",
     )
     db.conn.execute(
-        "UPDATE photos SET detection_conf=?, subject_size=?, "
+        "UPDATE photos SET subject_size=?, "
         "crop_complete=?, subject_tenengrad=?, bg_tenengrad=? WHERE id=?",
-        (0.95, 0.001, 1.0, 80.0, 40.0, p_a),
+        (0.001, 1.0, 80.0, 40.0, p_a),
+    )
+    db.save_detections(
+        p_a,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+          "confidence": 0.95, "category": "animal"}],
     )
 
     # Folder linked to B — add while B is active.
@@ -243,9 +256,14 @@ def test_compute_misses_scoped_to_active_workspace(tmp_path):
         timestamp="2026-04-22T10:00:01",
     )
     db.conn.execute(
-        "UPDATE photos SET detection_conf=?, subject_size=?, "
+        "UPDATE photos SET subject_size=?, "
         "crop_complete=?, subject_tenengrad=?, bg_tenengrad=? WHERE id=?",
-        (0.95, 0.001, 1.0, 80.0, 40.0, p_b),
+        (0.001, 1.0, 80.0, 40.0, p_b),
+    )
+    db.save_detections(
+        p_b,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+          "confidence": 0.95, "category": "animal"}],
     )
     db.conn.commit()
 

--- a/vireo/tests/test_misses.py
+++ b/vireo/tests/test_misses.py
@@ -48,3 +48,34 @@ def test_no_subject_excludes_other_categories():
     assert flags["no_subject"] is True
     assert flags["clipped"] is False
     assert flags["oof"] is False
+
+
+def test_clipped_when_bbox_too_small_singleton():
+    from misses import classify_miss
+    row = _row(subject_size=0.001)  # 0.1% — below singleton 0.2%
+    flags = classify_miss(row, siblings=[], config=DEFAULT_CONFIG)
+    assert flags["clipped"] is True
+
+
+def test_not_clipped_when_bbox_small_but_above_singleton_threshold():
+    from misses import classify_miss
+    row = _row(subject_size=0.003)  # 0.3% — above singleton 0.2%
+    flags = classify_miss(row, siblings=[], config=DEFAULT_CONFIG)
+    assert flags["clipped"] is False
+
+
+def test_clipped_when_crop_complete_below_reject_threshold_in_burst():
+    from misses import classify_miss
+    row = _row(crop_complete=0.40)  # touches edge
+    siblings = [_row(crop_complete=1.0), _row(crop_complete=1.0)]
+    flags = classify_miss(row, siblings=siblings, config=DEFAULT_CONFIG)
+    assert flags["clipped"] is True
+
+
+def test_clipped_when_bbox_much_smaller_than_burst_median():
+    """Burst context: this frame's bbox is <10% of sibling median → miss."""
+    from misses import classify_miss
+    row = _row(subject_size=0.005)        # 0.5%
+    siblings = [_row(subject_size=0.08), _row(subject_size=0.10)]  # 8%, 10%
+    flags = classify_miss(row, siblings=siblings, config=DEFAULT_CONFIG)
+    assert flags["clipped"] is True

--- a/vireo/tests/test_misses.py
+++ b/vireo/tests/test_misses.py
@@ -436,3 +436,41 @@ def test_compute_misses_respects_exclude_photo_ids(tmp_path):
     assert row_kept["miss_computed_at"] is not None
     assert row_excluded["miss_computed_at"] is None
     assert row_excluded["miss_clipped"] != 1
+
+
+def test_compute_misses_uses_injected_now_timestamp(tmp_path):
+    """Caller-supplied `now` lets pipeline_job share one timestamp between
+    the DB write and the saved pipeline-results cache, so the review UI's
+    run-scoped /misses?since=... window matches exactly what was written."""
+    import config as cfg
+    from db import Database
+    from misses import compute_misses_for_workspace
+
+    db = Database(str(tmp_path / "m.db"))
+    folder_id = db.add_folder("/tmp/fake", name="fake")
+    pid = db.add_photo(
+        folder_id, "p.jpg", extension=".jpg", file_size=100,
+        file_mtime=1.0, timestamp="2026-04-22T10:00:00",
+    )
+    db.conn.execute(
+        "UPDATE photos SET subject_size=?, crop_complete=?, "
+        "subject_tenengrad=?, bg_tenengrad=? WHERE id=?",
+        (0.001, 1.0, 80.0, 40.0, pid),
+    )
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+          "confidence": 0.95, "category": "animal"}],
+    )
+    db.conn.commit()
+
+    fixed_ts = "2026-04-22T12:34:56.789012+00:00"
+    n = compute_misses_for_workspace(
+        db, cfg.DEFAULTS["pipeline"], now=fixed_ts,
+    )
+    assert n == 1
+
+    row = dict(db.conn.execute(
+        "SELECT miss_computed_at FROM photos WHERE id=?", (pid,),
+    ).fetchone())
+    assert row["miss_computed_at"] == fixed_ts

--- a/vireo/tests/test_misses.py
+++ b/vireo/tests/test_misses.py
@@ -305,3 +305,74 @@ def test_compute_misses_scoped_to_active_workspace(tmp_path):
     assert row_a["miss_clipped"] != 1
     assert row_b["miss_computed_at"] is not None
     assert row_b["miss_clipped"] == 1
+
+
+def test_compute_misses_scoped_to_collection_leaves_others_untouched(tmp_path):
+    """When a collection_id is passed, only photos inside that collection get
+    their flags/miss_computed_at rewritten. Other workspace photos still
+    supply burst-sibling context but are not touched, so a partial
+    pipeline run does not break /misses?since= scoping."""
+    import json
+
+    import config as cfg
+    from db import Database
+    from misses import compute_misses_for_workspace
+
+    db = Database(str(tmp_path / "m.db"))
+    folder_id = db.add_folder("/tmp/fake", name="fake")
+
+    p_in = db.add_photo(
+        folder_id, "in.jpg", extension=".jpg", file_size=100,
+        file_mtime=1.0, timestamp="2026-04-22T10:00:00",
+    )
+    p_out = db.add_photo(
+        folder_id, "out.jpg", extension=".jpg", file_size=100,
+        file_mtime=2.0, timestamp="2026-04-22T10:00:01",
+    )
+    # Both singletons with subject sizes below the singleton clipped
+    # threshold — so we can verify the out-of-collection photo does NOT
+    # get its flag/timestamp written.
+    db.conn.executemany(
+        "UPDATE photos SET subject_size=?, crop_complete=?, "
+        "subject_tenengrad=?, bg_tenengrad=? WHERE id=?",
+        [
+            (0.001, 1.0, 80.0, 40.0, p_in),
+            (0.001, 1.0, 80.0, 40.0, p_out),
+        ],
+    )
+    for pid in (p_in, p_out):
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+              "confidence": 0.95, "category": "animal"}],
+        )
+    db.conn.commit()
+
+    # Static collection scoped to just p_in.
+    cur = db.conn.execute(
+        "INSERT INTO collections(name, rules, workspace_id) VALUES(?,?,?)",
+        ("only-in", json.dumps([{"field": "photo_ids", "value": [p_in]}]),
+         db._ws_id()),
+    )
+    collection_id = cur.lastrowid
+    db.conn.commit()
+
+    n = compute_misses_for_workspace(
+        db, cfg.DEFAULTS["pipeline"], collection_id=collection_id
+    )
+    assert n == 1
+
+    row_in = dict(db.conn.execute(
+        "SELECT miss_clipped, miss_computed_at FROM photos WHERE id=?", (p_in,)
+    ).fetchone())
+    row_out = dict(db.conn.execute(
+        "SELECT miss_clipped, miss_computed_at FROM photos WHERE id=?", (p_out,)
+    ).fetchone())
+
+    assert row_in["miss_clipped"] == 1
+    assert row_in["miss_computed_at"] is not None
+    # Out-of-collection photo must NOT be touched, even though its
+    # features would otherwise flag it — the partial pipeline scope
+    # must not bleed into unrelated photos.
+    assert row_out["miss_computed_at"] is None
+    assert row_out["miss_clipped"] != 1

--- a/vireo/tests/test_misses.py
+++ b/vireo/tests/test_misses.py
@@ -209,3 +209,57 @@ def test_compute_misses_groups_by_burst_and_writes_flags(tmp_path):
     assert miss["miss_clipped"] == 1
     assert keeper["miss_computed_at"] is not None
     assert miss["miss_computed_at"] is not None
+
+
+def test_compute_misses_scoped_to_active_workspace(tmp_path):
+    """Photos in folders linked only to workspace A must not be touched when
+    compute runs with workspace B active."""
+    import config as cfg
+    from db import Database
+    from misses import compute_misses_for_workspace
+
+    db = Database(str(tmp_path / "m.db"))
+    ws_a = db._active_workspace_id
+    ws_b = db.create_workspace("Other")
+
+    # Folder linked to A only — add it while A is active.
+    db.set_active_workspace(ws_a)
+    fa = db.add_folder("/tmp/a", name="a")
+    p_a = db.add_photo(
+        fa, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0,
+        timestamp="2026-04-22T10:00:00",
+    )
+    db.conn.execute(
+        "UPDATE photos SET detection_conf=?, subject_size=?, "
+        "crop_complete=?, subject_tenengrad=?, bg_tenengrad=? WHERE id=?",
+        (0.95, 0.001, 1.0, 80.0, 40.0, p_a),
+    )
+
+    # Folder linked to B — add while B is active.
+    db.set_active_workspace(ws_b)
+    fb = db.add_folder("/tmp/b", name="b")
+    p_b = db.add_photo(
+        fb, "b.jpg", extension=".jpg", file_size=100, file_mtime=2.0,
+        timestamp="2026-04-22T10:00:01",
+    )
+    db.conn.execute(
+        "UPDATE photos SET detection_conf=?, subject_size=?, "
+        "crop_complete=?, subject_tenengrad=?, bg_tenengrad=? WHERE id=?",
+        (0.95, 0.001, 1.0, 80.0, 40.0, p_b),
+    )
+    db.conn.commit()
+
+    # B is active; compute must only touch B's photo.
+    compute_misses_for_workspace(db, cfg.DEFAULTS["pipeline"])
+
+    row_a = dict(db.conn.execute(
+        "SELECT miss_clipped, miss_computed_at FROM photos WHERE id=?", (p_a,)
+    ).fetchone())
+    row_b = dict(db.conn.execute(
+        "SELECT miss_clipped, miss_computed_at FROM photos WHERE id=?", (p_b,)
+    ).fetchone())
+
+    assert row_a["miss_computed_at"] is None
+    assert row_a["miss_clipped"] != 1
+    assert row_b["miss_computed_at"] is not None
+    assert row_b["miss_clipped"] == 1

--- a/vireo/tests/test_misses.py
+++ b/vireo/tests/test_misses.py
@@ -108,3 +108,60 @@ def test_oof_singleton_requires_both_ratio_and_floor():
     row = _row(subject_tenengrad=5.0, bg_tenengrad=20.0)
     flags = classify_miss(row, siblings=[], config=DEFAULT_CONFIG)
     assert flags["oof"] is True
+
+
+def test_compute_misses_groups_by_burst_and_writes_flags(tmp_path):
+    """Integration test: real DB, synthetic photo rows, verify flags written."""
+    import config as cfg
+    from db import Database
+    from misses import compute_misses_for_workspace
+
+    db = Database(str(tmp_path / "m.db"))
+    # Database.__init__ auto-creates a "Default" workspace and sets it active.
+
+    # Insert a folder for the photos.
+    folder_id = db.add_folder("/tmp/fake")
+
+    # Two photos in the same burst — one keeper, one lost-framing miss.
+    p_keeper = db.add_photo(
+        folder_id,
+        "k.jpg",
+        extension=".jpg",
+        file_size=100,
+        file_mtime=1.0,
+        timestamp="2026-04-22T10:00:00",
+    )
+    p_miss = db.add_photo(
+        folder_id,
+        "m.jpg",
+        extension=".jpg",
+        file_size=100,
+        file_mtime=2.0,
+        timestamp="2026-04-22T10:00:00",
+    )
+    # Hand-write pipeline features + shared burst_id.
+    db.conn.executemany(
+        "UPDATE photos SET burst_id=?, detection_conf=?, subject_size=?, "
+        "crop_complete=?, subject_tenengrad=?, bg_tenengrad=? WHERE id=?",
+        [
+            ("B1", 0.95, 0.08,  1.0, 80.0, 40.0, p_keeper),
+            ("B1", 0.95, 0.005, 1.0, 80.0, 40.0, p_miss),
+        ],
+    )
+    db.conn.commit()
+
+    compute_misses_for_workspace(db, cfg.DEFAULTS["pipeline"])
+
+    keeper = dict(db.conn.execute(
+        "SELECT miss_no_subject, miss_clipped, miss_oof, miss_computed_at "
+        "FROM photos WHERE id=?", (p_keeper,)
+    ).fetchone())
+    miss = dict(db.conn.execute(
+        "SELECT miss_no_subject, miss_clipped, miss_oof, miss_computed_at "
+        "FROM photos WHERE id=?", (p_miss,)
+    ).fetchone())
+
+    assert keeper["miss_clipped"] == 0
+    assert miss["miss_clipped"] == 1
+    assert keeper["miss_computed_at"] is not None
+    assert miss["miss_computed_at"] is not None

--- a/vireo/tests/test_misses.py
+++ b/vireo/tests/test_misses.py
@@ -110,6 +110,50 @@ def test_oof_singleton_requires_both_ratio_and_floor():
     assert flags["oof"] is True
 
 
+def test_no_spurious_flags_when_quality_features_missing():
+    """Detection passed but quality pipeline hasn't populated features yet.
+
+    A row with detection_conf above threshold but NULL subject_size /
+    crop_complete / subject_tenengrad / bg_tenengrad means we haven't
+    measured those features. We must NOT flag clipped/oof on absence of
+    evidence — covers both singleton and in-burst evaluation.
+    """
+    from misses import classify_miss
+
+    # Singleton: detection passed, no quality features measured.
+    row = _row(
+        detection_conf=0.9,
+        subject_size=None,
+        crop_complete=None,
+        subject_tenengrad=None,
+        bg_tenengrad=None,
+    )
+    flags = classify_miss(row, siblings=[], config=DEFAULT_CONFIG)
+    assert flags == {"no_subject": False, "clipped": False, "oof": False}
+
+    # In-burst: two photos, both with detection passed but no quality
+    # features measured. Siblings with no subject_size must not poison
+    # the burst-median check.
+    row_a = _row(
+        detection_conf=0.9,
+        subject_size=None,
+        crop_complete=None,
+        subject_tenengrad=None,
+        bg_tenengrad=None,
+    )
+    row_b = _row(
+        detection_conf=0.9,
+        subject_size=None,
+        crop_complete=None,
+        subject_tenengrad=None,
+        bg_tenengrad=None,
+    )
+    flags_a = classify_miss(row_a, siblings=[row_b], config=DEFAULT_CONFIG)
+    flags_b = classify_miss(row_b, siblings=[row_a], config=DEFAULT_CONFIG)
+    assert flags_a == {"no_subject": False, "clipped": False, "oof": False}
+    assert flags_b == {"no_subject": False, "clipped": False, "oof": False}
+
+
 def test_compute_misses_groups_by_burst_and_writes_flags(tmp_path):
     """Integration test: real DB, synthetic photo rows, verify flags written."""
     import config as cfg

--- a/vireo/tests/test_misses.py
+++ b/vireo/tests/test_misses.py
@@ -376,3 +376,63 @@ def test_compute_misses_scoped_to_collection_leaves_others_untouched(tmp_path):
     # must not bleed into unrelated photos.
     assert row_out["miss_computed_at"] is None
     assert row_out["miss_clipped"] != 1
+
+
+def test_compute_misses_respects_exclude_photo_ids(tmp_path):
+    """Preview deselections (params.exclude_photo_ids) must not have their
+    miss flags or miss_computed_at rewritten. Earlier pipeline stages
+    filter out these IDs; the miss stage must too, or deselected photos
+    get resurfaced in the run-scoped /misses?since= review."""
+    import config as cfg
+    from db import Database
+    from misses import compute_misses_for_workspace
+
+    db = Database(str(tmp_path / "m.db"))
+    folder_id = db.add_folder("/tmp/fake", name="fake")
+
+    p_kept = db.add_photo(
+        folder_id, "kept.jpg", extension=".jpg", file_size=100,
+        file_mtime=1.0, timestamp="2026-04-22T10:00:00",
+    )
+    p_excluded = db.add_photo(
+        folder_id, "ex.jpg", extension=".jpg", file_size=100,
+        file_mtime=2.0, timestamp="2026-04-22T10:00:01",
+    )
+    # Both singletons below the singleton clipped threshold — so we can
+    # verify the excluded photo does NOT get its flag/timestamp written.
+    db.conn.executemany(
+        "UPDATE photos SET subject_size=?, crop_complete=?, "
+        "subject_tenengrad=?, bg_tenengrad=? WHERE id=?",
+        [
+            (0.001, 1.0, 80.0, 40.0, p_kept),
+            (0.001, 1.0, 80.0, 40.0, p_excluded),
+        ],
+    )
+    for pid in (p_kept, p_excluded):
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+              "confidence": 0.95, "category": "animal"}],
+        )
+    db.conn.commit()
+
+    n = compute_misses_for_workspace(
+        db,
+        cfg.DEFAULTS["pipeline"],
+        exclude_photo_ids={p_excluded},
+    )
+    assert n == 1
+
+    row_kept = dict(db.conn.execute(
+        "SELECT miss_clipped, miss_computed_at FROM photos WHERE id=?",
+        (p_kept,),
+    ).fetchone())
+    row_excluded = dict(db.conn.execute(
+        "SELECT miss_clipped, miss_computed_at FROM photos WHERE id=?",
+        (p_excluded,),
+    ).fetchone())
+
+    assert row_kept["miss_clipped"] == 1
+    assert row_kept["miss_computed_at"] is not None
+    assert row_excluded["miss_computed_at"] is None
+    assert row_excluded["miss_clipped"] != 1

--- a/vireo/tests/test_misses_api.py
+++ b/vireo/tests/test_misses_api.py
@@ -142,3 +142,27 @@ def test_api_misses_rejects_invalid_category_on_unflag(client, db_with_misses, c
         content_type="application/json",
     )
     assert r.status_code == 400
+
+
+def test_api_misses_since_restricts_to_recent_run(client, db_with_misses):
+    """`?since=<ts>` filters the grouped response to photos computed at-or-after
+    the timestamp. Used by the pipeline-review step to scope the grid to the
+    current run."""
+    _, db, ids = db_with_misses
+    # Age the clipped and oof rows; keep no_subject on the "new" timestamp.
+    db.conn.execute(
+        "UPDATE photos SET miss_computed_at='2026-04-20T00:00:00+00:00' "
+        "WHERE id IN (?, ?)", (ids["clipped"], ids["oof"]),
+    )
+    db.conn.commit()
+
+    r = client.get("/api/misses?since=2026-04-21T00:00:00%2B00:00")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data["no_subject"]) == 1
+    assert data["clipped"] == []
+    assert data["oof"] == []
+
+    r2 = client.get("/api/misses?category=clipped&since=2026-04-21T00:00:00%2B00:00")
+    assert r2.status_code == 200
+    assert r2.get_json()["photos"] == []

--- a/vireo/tests/test_misses_api.py
+++ b/vireo/tests/test_misses_api.py
@@ -1,0 +1,144 @@
+"""Tests for the /api/misses Flask endpoints.
+
+Covers the three routes: list (grouped and category-filtered),
+bulk reject, and per-photo unflag.
+"""
+
+import json
+import os
+
+import pytest
+from PIL import Image
+
+
+@pytest.fixture
+def db_with_misses(tmp_path, monkeypatch):
+    """Flask app + DB seeded with one photo in each miss category.
+
+    Returns (app, db, {"no_subject": id, "clipped": id, "oof": id}).
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    from app import create_app
+    from db import Database
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder("/photos/fake", name="fake")
+
+    p_ns = db.add_photo(
+        folder_id=fid, filename="ns.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0, timestamp="2026-04-22T10:00:00",
+    )
+    p_clip = db.add_photo(
+        folder_id=fid, filename="clip.jpg", extension=".jpg",
+        file_size=100, file_mtime=2.0, timestamp="2026-04-22T10:00:01",
+    )
+    p_oof = db.add_photo(
+        folder_id=fid, filename="oof.jpg", extension=".jpg",
+        file_size=100, file_mtime=3.0, timestamp="2026-04-22T10:00:02",
+    )
+
+    db.conn.execute(
+        "UPDATE photos SET miss_no_subject=1, miss_computed_at='2026-04-22' "
+        "WHERE id=?", (p_ns,),
+    )
+    db.conn.execute(
+        "UPDATE photos SET miss_clipped=1, miss_computed_at='2026-04-22' "
+        "WHERE id=?", (p_clip,),
+    )
+    db.conn.execute(
+        "UPDATE photos SET miss_oof=1, miss_computed_at='2026-04-22' "
+        "WHERE id=?", (p_oof,),
+    )
+    db.conn.commit()
+
+    for pid in (p_ns, p_clip, p_oof):
+        Image.new("RGB", (100, 100)).save(os.path.join(thumb_dir, f"{pid}.jpg"))
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir)
+    return app, db, {"no_subject": p_ns, "clipped": p_clip, "oof": p_oof}
+
+
+@pytest.fixture
+def client(db_with_misses):
+    app, _, _ = db_with_misses
+    return app.test_client()
+
+
+@pytest.fixture
+def clipped_photo_id(db_with_misses):
+    _, _, ids = db_with_misses
+    return ids["clipped"]
+
+
+def test_api_misses_returns_grouped_counts(client, db_with_misses):
+    r = client.get("/api/misses")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert set(data.keys()) == {"no_subject", "clipped", "oof"}
+    assert isinstance(data["clipped"], list)
+    assert len(data["no_subject"]) == 1
+    assert len(data["clipped"]) == 1
+    assert len(data["oof"]) == 1
+
+
+def test_api_misses_filter_by_category(client, db_with_misses):
+    r = client.get("/api/misses?category=clipped")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["category"] == "clipped"
+    assert all(p["miss_clipped"] == 1 for p in data["photos"])
+    assert len(data["photos"]) == 1
+
+
+def test_api_bulk_reject_sets_flag(client, db_with_misses):
+    r = client.post(
+        "/api/misses/reject",
+        data=json.dumps({"category": "clipped"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["rejected"] >= 1
+    assert body["category"] == "clipped"
+
+
+def test_api_unflag_miss_clears_boolean(client, db_with_misses, clipped_photo_id):
+    r = client.post(
+        f"/api/misses/{clipped_photo_id}/unflag",
+        data=json.dumps({"category": "clipped"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert r.get_json() == {"ok": True}
+
+
+def test_api_misses_rejects_invalid_category_on_list(client, db_with_misses):
+    r = client.get("/api/misses?category=bogus")
+    assert r.status_code == 400
+
+
+def test_api_misses_rejects_invalid_category_on_reject(client, db_with_misses):
+    r = client.post(
+        "/api/misses/reject",
+        data=json.dumps({"category": "bogus"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+
+
+def test_api_misses_rejects_invalid_category_on_unflag(client, db_with_misses, clipped_photo_id):
+    r = client.post(
+        f"/api/misses/{clipped_photo_id}/unflag",
+        data=json.dumps({"category": "bogus"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400

--- a/vireo/tests/test_misses_api.py
+++ b/vireo/tests/test_misses_api.py
@@ -166,6 +166,43 @@ def test_api_bulk_reject_records_edit_history(client, db_with_misses):
     assert "category=clipped" in (entry["description"] or "")
 
 
+def test_api_bulk_reject_undo_restores_original_null_flag(client, db_with_misses):
+    """Undoing bulk reject on a row whose original flag was NULL must
+    restore NULL, not an empty string — otherwise the row lands in a
+    non-canonical state outside (none/flagged/rejected or NULL)."""
+    _, db, ids = db_with_misses
+    pid = ids["clipped"]
+    # Force the flag to NULL; bulk_reject's selection predicate treats NULL
+    # the same as non-rejected, so the row still participates in the reject.
+    db.conn.execute("UPDATE photos SET flag=NULL WHERE id=?", (pid,))
+    db.conn.commit()
+    before = db.conn.execute(
+        "SELECT flag FROM photos WHERE id=?", (pid,)
+    ).fetchone()["flag"]
+    assert before is None
+
+    r = client.post(
+        "/api/misses/reject",
+        data=json.dumps({"category": "clipped"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+
+    assert db.conn.execute(
+        "SELECT flag FROM photos WHERE id=?", (pid,)
+    ).fetchone()["flag"] == "rejected"
+
+    entry = db.undo_last_edit()
+    assert entry is not None
+
+    after = db.conn.execute(
+        "SELECT flag FROM photos WHERE id=?", (pid,)
+    ).fetchone()["flag"]
+    assert after is None, (
+        "undo must restore NULL, not an empty string — saw: %r" % after
+    )
+
+
 def test_api_bulk_reject_no_matches_skips_edit_history(client, db_with_misses):
     """If nothing matches (empty category), no edit_history entry is written —
     avoids cluttering the undo log with no-op rows."""

--- a/vireo/tests/test_misses_api.py
+++ b/vireo/tests/test_misses_api.py
@@ -144,6 +144,45 @@ def test_api_misses_rejects_invalid_category_on_unflag(client, db_with_misses, c
     assert r.status_code == 400
 
 
+def test_api_bulk_reject_records_edit_history(client, db_with_misses):
+    """Bulk reject must write a batch `flag` edit_history entry so the change
+    is undoable and shows up in the audit log, matching /api/batch/flag."""
+    _, db, ids = db_with_misses
+    r = client.post(
+        "/api/misses/reject",
+        data=json.dumps({"category": "clipped"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert r.get_json()["rejected"] == 1
+
+    history = db.get_edit_history(limit=5, offset=0)
+    assert history, "bulk reject did not record an edit_history entry"
+    entry = history[0]
+    assert entry["action_type"] == "flag"
+    assert entry["new_value"] == "rejected"
+    assert entry["is_batch"] == 1
+    assert entry["item_count"] == 1
+    assert "category=clipped" in (entry["description"] or "")
+
+
+def test_api_bulk_reject_no_matches_skips_edit_history(client, db_with_misses):
+    """If nothing matches (empty category), no edit_history entry is written —
+    avoids cluttering the undo log with no-op rows."""
+    _, db, _ = db_with_misses
+    before = len(db.get_edit_history(limit=50, offset=0))
+    r = client.post(
+        "/api/misses/reject",
+        data=json.dumps({"category": "clipped",
+                         "since": "2099-01-01T00:00:00+00:00"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert r.get_json()["rejected"] == 0
+    after = len(db.get_edit_history(limit=50, offset=0))
+    assert before == after
+
+
 def test_api_misses_since_restricts_to_recent_run(client, db_with_misses):
     """`?since=<ts>` filters the grouped response to photos computed at-or-after
     the timestamp. Used by the pipeline-review step to scope the grid to the

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -284,6 +284,74 @@ def test_load_results_missing(tmp_path):
     assert load_results(str(tmp_path), workspace_id=999) is None
 
 
+def test_save_results_preserves_miss_computed_at_across_reflow(tmp_path):
+    """save_results must preserve an existing miss_computed_at marker
+    when the caller's results dict doesn't carry one. reflow and
+    regroup-live don't recompute misses, so overwriting the marker
+    would make the pipeline_review "Review misses" shortcut hide itself
+    after every threshold tweak even though miss flags are still valid."""
+    from pipeline import (
+        load_photo_features,
+        load_results,
+        run_full_pipeline,
+        save_results,
+        save_results_raw,
+    )
+
+    db, ids = _setup_db_with_photos(tmp_path)
+    photos = load_photo_features(db)
+    results = run_full_pipeline(photos)
+
+    cache_dir = str(tmp_path)
+    save_results(results, cache_dir, workspace_id=1)
+
+    # Simulate pipeline_job's miss_stage stamping the marker.
+    raw = load_results(cache_dir, workspace_id=1)
+    raw["miss_computed_at"] = "2026-04-22T12:00:00.000000+00:00"
+    save_results_raw(raw, cache_dir, workspace_id=1)
+
+    # Reflow: save new results (without marker) and confirm the marker
+    # survives, matching what the UI needs.
+    fresh = run_full_pipeline(photos)
+    assert "miss_computed_at" not in fresh
+    save_results(fresh, cache_dir, workspace_id=1)
+
+    loaded = load_results(cache_dir, workspace_id=1)
+    assert loaded["miss_computed_at"] == "2026-04-22T12:00:00.000000+00:00"
+
+
+def test_save_results_new_marker_overrides_existing(tmp_path):
+    """When the caller's results dict does carry miss_computed_at (e.g.
+    a fresh full pipeline run restamping the marker), it must win over
+    any marker already in the cache — otherwise reruns couldn't
+    advance the /misses?since= review window."""
+    from pipeline import (
+        load_photo_features,
+        load_results,
+        run_full_pipeline,
+        save_results,
+        save_results_raw,
+    )
+
+    db, ids = _setup_db_with_photos(tmp_path)
+    photos = load_photo_features(db)
+    results = run_full_pipeline(photos)
+
+    cache_dir = str(tmp_path)
+    save_results(results, cache_dir, workspace_id=1)
+
+    raw = load_results(cache_dir, workspace_id=1)
+    raw["miss_computed_at"] = "2026-04-22T12:00:00.000000+00:00"
+    save_results_raw(raw, cache_dir, workspace_id=1)
+
+    fresh = run_full_pipeline(photos)
+    fresh["miss_computed_at"] = "2026-04-23T15:00:00.000000+00:00"
+    save_results(fresh, cache_dir, workspace_id=1)
+
+    loaded = load_results(cache_dir, workspace_id=1)
+    assert loaded["miss_computed_at"] == "2026-04-23T15:00:00.000000+00:00"
+
+
 # -- Species encounter labels --
 
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -368,7 +368,7 @@ def test_pipeline_stages_dict_in_progress_events(tmp_path, monkeypatch):
     assert len(stage_events) > 0
 
     # Each stages dict should have all expected stage keys
-    expected_keys = {"ingest", "scan", "thumbnails", "previews", "model_loader", "classify", "extract_masks", "regroup"}
+    expected_keys = {"ingest", "scan", "thumbnails", "previews", "model_loader", "classify", "extract_masks", "regroup", "misses"}
     for _, _, data in stage_events:
         assert expected_keys.issubset(data["stages"].keys())
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -4114,3 +4114,74 @@ def test_thumbnail_progress_counter_includes_failed(tmp_path, monkeypatch):
         f"stages['thumbnails']['count'] must include failed items (was {thumb_stage_count}). "
         f"Last event stages: {last['stages']}"
     )
+
+
+def test_pipeline_miss_stage_skipped_when_regroup_fails(tmp_path, monkeypatch):
+    """miss_stage depends on burst_id written by regroup. If regroup_stage
+    throws, running miss_stage would overwrite miss_* flags with stale
+    context during an already-failing job. The gate must check the
+    stage's failed status, not just the global abort flag (regroup_stage
+    marks itself failed without setting abort)."""
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    for name in ("a.jpg", "b.jpg"):
+        Image.new("RGB", (16, 16), "black").save(str(photo_dir / name))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # Force regroup to fail before it finishes. pipeline_job imports
+    # run_full_pipeline lazily inside regroup_stage; patch at module level.
+    import pipeline as pipeline_mod
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("synthetic regroup failure")
+
+    monkeypatch.setattr(pipeline_mod, "run_full_pipeline", _boom)
+
+    # Also mark the single photo with an arbitrary miss_computed_at so we
+    # can detect mutation by miss_stage.
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+        # Intentionally NOT skip_regroup — regroup must be attempted and fail.
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    import contextlib
+    with contextlib.suppress(Exception):
+        result = run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # Inspect the stages dict from the last progress event — if miss_stage
+    # ran, it would transition out of "pending" to "running"/"completed"/
+    # "failed"/"skipped". The fix must leave it "pending" (never entered).
+    progress_events = [
+        data for (_, evt, data) in runner.events
+        if evt == "progress" and "stages" in data
+    ]
+    assert progress_events, "pipeline emitted no progress events"
+    last_stages = progress_events[-1]["stages"]
+    assert last_stages["regroup"]["status"] == "failed"
+    # Miss stage must not have mutated any miss_* row. Verify by reading
+    # miss_computed_at on the scanned photos — all should still be NULL.
+    db2 = Database(db_path)
+    db2.set_active_workspace(ws_id)
+    rows = db2.conn.execute(
+        "SELECT miss_computed_at FROM photos"
+    ).fetchall()
+    assert rows, "scan produced no photo rows"
+    for r in rows:
+        assert r["miss_computed_at"] is None, (
+            "miss_stage ran after regroup failure and overwrote miss state"
+        )

--- a/vireo/tests/test_userfirst_scenarios.py
+++ b/vireo/tests/test_userfirst_scenarios.py
@@ -180,6 +180,22 @@ def test_duplicates_scenario(userfirst_env):
         pytest.fail(f"duplicates scenario reported bugs:\n{msg}")
 
 
+def test_misses_scenario(userfirst_env):
+    from vireo.testing.userfirst.harness import vireo_session
+    from vireo.testing.userfirst.scenarios import misses
+    from vireo.testing.userfirst.seeds import misses_seed
+
+    with vireo_session(name="misses", seed=misses_seed) as session:
+        misses.run(session)
+
+    report = session.report
+    if report.has_bugs():
+        msg = "\n".join(
+            f"  [{f.kind}] {f.message} {f.context}" for f in report.findings
+        )
+        pytest.fail(f"misses scenario reported bugs:\n{msg}")
+
+
 def test_map_geo_scenario(userfirst_env):
     from vireo.testing.userfirst.harness import vireo_session
     from vireo.testing.userfirst.scenarios import map_geo


### PR DESCRIPTION
## Summary

Flags photos where the photographer missed the shot and surfaces them for bulk rejection before culling.

Three categories, derived from signals already on `photos`:

- **`no_subject`** — MegaDetector confidence below threshold (no bbox)
- **`clipped_or_tiny`** — subject area < 0.5% of frame, or bbox touches edge
- **`out_of_focus`** — subject Tenengrad < `R` × background Tenengrad

Burst siblings relax the bar; singletons tighten it (standalone OOF requires both ratio and an absolute sharpness floor; standalone "tiny" needs <0.2%).

## What's in the branch

- **Data model**: four columns on `photos` (`miss_no_subject`, `miss_clipped`, `miss_oof`, `miss_computed_at`) via an additive migration.
- **Config**: six keys in `pipeline` (`miss_enabled`, `miss_det_confidence*`, `miss_bbox_area_min*`, `miss_oof_ratio`). `miss_enabled=true` by default.
- **Compute**: pure `classify_miss(row, siblings, config)` in `vireo/misses.py`; batch writer `compute_misses_for_workspace` runs as a thin pipeline stage after `regroup` (needs `burst_id`).
- **API**: `GET /api/misses` (grouped or `?category=`, with `?since=<iso-ts>`); `POST /api/misses/reject` (bulk sets `flag='reject'`); `POST /api/misses/<id>/unflag`.
- **UI**: top-level `/misses` page with three collapsible sections, bbox overlays (dashed frame for `no_subject`), per-card unflag, bulk-reject, and `J/K/U` keyboard navigation. "Review misses (N)" affordance in the pipeline-review summary bar, scoped to the current run via `?since=<min miss_computed_at>`.
- **Settings**: new "Miss Detection" section with master toggle + three sliders, mirroring the existing `reject_*` pattern.
- **Non-destructive**: bulk action sets `flag='reject'`; users purge through the existing flow. Individual false positives can be unflagged.

## Tests

### Passing
- `vireo/tests/test_misses.py` — 11 unit tests covering each category × (burst, singleton) plus the None-feature safety invariant.
- `vireo/tests/test_misses_api.py` — 7 API tests (list/reject/unflag, invalid-category 400s, `since` filter).
- `vireo/tests/test_db.py` — 6 new tests (migration, list/clear/bulk-reject, rejected-exclusion, `since`).
- `vireo/tests/test_pipeline_job.py` — 69 pass, including updated `stages`-dict keys.
- `vireo/tests/test_config.py` — defaults present.
- `vireo/tests/test_userfirst_scenarios.py::test_misses_scenario` — Playwright-driven; seeds one miss per category, asserts section counts, bulk-rejects the `clipped` category (auto-accepts the confirm dialog), and verifies the count drops through `/api/misses`.

Full targeted run: `test_workspaces + test_db + test_config + test_misses + test_misses_api` → 300 passing.

### Known pre-existing flakes (not caused by this branch)
- `test_browse_lightbox_arrows_regression` and `test_browse_multiselect_shortcut_regression` time out on this machine even against pristine `main` versions of the files this branch touches — unrelated Playwright timeout variance.

## Test plan

- [x] Unit tests for `classify_miss` cover category × burst/singleton matrix.
- [x] None-feature safety — rows with `detection_conf` above threshold but NULL quality features must not be spuriously flagged (regression test added after review).
- [x] `list_misses` and `bulk_reject_miss_category` exclude photos already flagged as rejected.
- [x] API `?since=` filter restricts results by `miss_computed_at`.
- [x] Playwright scenario drives `/misses` end-to-end.
- [ ] Lightbox 1:1-zoom on click — not covered in the scenario (synthetic fixture has no on-disk image files so `/photos/<id>/full` 500s); exercised manually by `browse_lightbox.py` against `browse_seed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)