### PR TITLE
Right-click context menus across all surfaces

### DIFF
--- a/docs/plans/2026-04-22-context-menus-design.md
+++ b/docs/plans/2026-04-22-context-menus-design.md
@@ -1,0 +1,172 @@
+# Right-click context menus — design
+
+## Problem
+
+Vireo has zero right-click handlers today. The browser's default context menu appears on every surface — photo grid, lightbox, folder tree, keyword rows, collection items, burst group modal. Photographers arriving from Lightroom, Photo Mechanic, or Finder expect right-click to be a primary interaction for rating, flagging, revealing files, and operating on the current selection. The gap slows one-off actions and hurts discoverability for actions that currently only live in the detail panel or batch bar.
+
+This design adds a cross-surface context-menu system as an **additive** layer. No existing keyboard shortcut or button changes.
+
+## Design decisions
+
+1. **Finder-style selection coupling.** If the right-clicked item is already in the current selection, the menu operates on the whole selection. If it's not in the selection, selection is replaced with just that item before the menu opens.
+2. **All seven surfaces in the first pass.** One shared component, reused everywhere: photo card (browse + review), lightbox, folder tree, keyword row, collection item, burst group modal photo.
+3. **Hybrid menu contents.** Net-new capabilities (Reveal, Copy path, Find Similar, Open in Editor) plus the two highest-frequency existing actions — rating and flagging. Other duplication of detail-panel controls is avoided.
+4. **Cross-platform Reveal.** macOS `open -R`, Linux `xdg-open <parent>`, Windows `explorer /select,<path>`. Failures in remote-server setups are acceptable; Copy Path is the universal fallback.
+5. **Disabled with hint for single-only items.** Reveal, Open in Editor, Find Similar are greyed with a tooltip when >1 photo is selected. Copy Path works with N paths (newline-joined).
+6. **Flat menus with inline chip rows.** Rating, Color, and Flag are single-row chip groups — one pointer-move per action. No submenus except the keyword Change Type menu, which reuses existing floating-dropdown infra.
+
+## Shared component
+
+Lives in `vireo/templates/_navbar.html` alongside the existing `.kw-type-dropdown`. Single API:
+
+```js
+openContextMenu(event, items, { anchor, onDismiss })
+```
+
+- `items`: array of `{ label, icon, onClick, disabled, disabledHint }`, `{ chips: [...] }` for inline rows, or `{ separator: true }`.
+- Menu is appended to `document.body`, `position: absolute`, z-index 1000 (above detail panel and modals).
+- Positioned at `event.clientX/Y`, clamped to viewport edges.
+- Dismissed on outside-click, Escape, scroll, window blur.
+- Arrow-key navigation + Enter to activate.
+
+## Menus by surface
+
+### Photo card — browse grid (`browse.html`)
+
+```
+★ ☆ ☆ ☆ ☆ ☆
+⬤ ⬤ ⬤ ⬤ ⬤
+🏳  ⛔  ◯
+─────────────────
+Find Similar              (disabled if >1)
+Open in Editor            (disabled if >1)
+Reveal in Finder/Folder   (disabled if >1)
+Copy Path
+─────────────────
+Add Keyword…              (opens existing modal)
+Add to Collection…        (opens existing modal)
+─────────────────
+Delete
+```
+
+### Photo card — review grid (`review.html`)
+
+```
+✓ Accept as [species]
+✗ Not [species]
+▾ Accept as…              (opens existing alternatives popup)
+─────────────────
+★ ☆ ☆ ☆ ☆ ☆
+🏳  ⛔  ◯
+─────────────────
+Open in Lightbox
+Find Similar              (disabled if >1)
+Reveal in Finder/Folder   (disabled if >1)
+Copy Path
+```
+
+Multi-select isn't tracked on the review grid today; menu operates on the single clicked card. Finder-style rule drops in automatically if multi-select lands later.
+
+### Lightbox (shared via `_navbar.html`)
+
+```
+★ ☆ ☆ ☆ ☆ ☆
+⬤ ⬤ ⬤ ⬤ ⬤
+🏳  ⛔  ◯
+─────────────────
+Find Similar
+Open in Editor
+Reveal in Finder/Folder
+Copy Path
+─────────────────
+Close Lightbox
+```
+
+`contextmenu` on the `<img>` must `preventDefault()` and skip the existing click-lock handler so zoom-lock doesn't fire alongside the menu.
+
+### Folder tree item (sidebar in `browse.html`)
+
+```
+Filter by this folder
+Expand All Children
+Collapse All Children
+─────────────────
+Reveal in Finder/Folder
+Copy Path
+─────────────────
+Hide from this Workspace      (removes from workspace_folders)
+Rescan this Folder            (queues a scoped scan job)
+```
+
+No "delete folder" — folders are derived from filesystem scans.
+
+### Keyword row (`keywords.html`)
+
+Finder-style selection applies (page already tracks `selectedIds`).
+
+```
+Rename                        (triggers existing inline rename)
+Change Type ▸                 (reuses existing .kw-type-dropdown)
+─────────────────
+Filter Browse by this Keyword
+Show Photos with this Keyword (disabled if >1)
+─────────────────
+Delete
+```
+
+Change Type is the one submenu in the design — existing infra makes it cheaper than flattening.
+
+### Collection item (sidebar in `browse.html`)
+
+```
+Filter by this Collection
+─────────────────
+Rename
+Duplicate
+─────────────────
+Delete Collection
+```
+
+### Burst group modal photo (`review.html`)
+
+```
+⬆  Move to Picks
+⬇  Move to Rejects
+␣  Move to Candidates
+─────────────────
+★ ☆ ☆ ☆ ☆ ☆
+🏳  ⛔  ◯
+─────────────────
+Open in Lightbox
+Reveal in Finder/Folder
+Copy Path
+─────────────────
+Remove from Group
+```
+
+The three move-actions duplicate keybindings but earn their slot because the zone-based modal benefits from explicit right-click-to-move.
+
+## Server endpoints (new)
+
+| Route | Body | Behavior |
+|---|---|---|
+| `POST /api/files/reveal` | `{photo_id}` | Resolves path from DB, shells out per OS (`subprocess.run` with list argv, short timeout, `shell=False`). Returns `{ok: true}` or `{ok: false, reason}`. |
+| `POST /api/folders/rescan` | `{folder_id}` | Queues a `JobRunner` scan job scoped to that folder subtree. |
+| `POST /api/collections/<id>/duplicate` | — | DB-only: copies the collection row and its photo memberships into a new row. |
+
+Copy Path is client-side via `navigator.clipboard.writeText` — no endpoint.
+
+## Testing
+
+- **Pure-JS unit tests** for the Finder-style selection-intersection rule.
+- **pytest** for the three new endpoints:
+  - Reveal: mock `subprocess.run`, parametrize over `darwin`/`linux`/`win32`, assert argv.
+  - Rescan: assert job enqueued with correct folder filter.
+  - Duplicate: assert new collection row + membership rows copied.
+- **Playwright (user-first testing)**: open browse, right-click a photo, click a rating chip, verify rating applied; right-click a folder, Reveal in Finder, verify endpoint called with correct photo.
+
+## Out of scope
+
+- Touch/long-press equivalent — deferred.
+- Configurable menus / per-user reordering — deferred.
+- Context menus for sidebars in pages not listed above (highlights, keywords graph, etc.).

--- a/docs/plans/2026-04-22-context-menus-plan.md
+++ b/docs/plans/2026-04-22-context-menus-plan.md
@@ -1,0 +1,1254 @@
+# Right-click context menus — implementation plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add cross-surface right-click context menus to Vireo (photo cards, lightbox, folder tree, keyword row, collection item, burst group modal) without changing any existing keyboard shortcut or button.
+
+**Architecture:** One shared floating-menu component lives in `vireo/templates/_navbar.html` (already included by every page). Each surface attaches its own `contextmenu` handler that calls `openContextMenu(event, items)`. Finder-style selection rule: right-clicking an item outside the current selection replaces selection with that one item before the menu opens. Three new Flask endpoints back the net-new actions (reveal-in-OS-file-manager, folder rescan, collection duplicate). Copy Path is client-side via `navigator.clipboard`.
+
+**Tech Stack:** Flask + Jinja2, vanilla JS in inline `<script>` blocks, Playwright for e2e tests, pytest for server tests.
+
+**Design doc:** `docs/plans/2026-04-22-context-menus-design.md`
+
+**Branch:** `right-click-review` (already in an isolated Conductor worktree — no new worktree needed).
+
+---
+
+## Conventions used throughout this plan
+
+- **Run the full test suite** at the end of each task: `python -m pytest tests/ vireo/tests/ -q`. Individual commands shown per task are the fast-iteration subset.
+- **Commit after each task.** Each task is one logical unit.
+- **All UI work lives in templates** — no new JS/CSS files. Add to the existing inline `<script>` / `<style>` blocks in `_navbar.html` or the per-page template.
+- **Tests.** Server behavior → `vireo/tests/test_*.py` with `app_and_db` fixture. UI behavior → `tests/e2e/test_*.py` with `live_server` + `page` fixtures.
+
+---
+
+## Task 1: Shared context-menu component
+
+**Files:**
+- Modify: `vireo/templates/_navbar.html` (add CSS block near existing `.kw-type-dropdown` patterns, add JS `openContextMenu` at bottom of the shared `<script>`).
+- Test: `tests/e2e/test_context_menu.py` (new file).
+
+**Step 1: Write the failing test**
+
+Create `tests/e2e/test_context_menu.py`:
+
+```python
+from playwright.sync_api import expect
+
+
+def test_open_context_menu_at_cursor(live_server, page):
+    """openContextMenu() places the menu near the event coords and renders items."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    page.evaluate("""
+        openContextMenu({clientX: 200, clientY: 150}, [
+            {label: 'Alpha', onClick: () => window.__ctx_hit = 'alpha'},
+            {separator: true},
+            {label: 'Beta', disabled: true, disabledHint: 'nope'},
+        ]);
+    """)
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="Alpha")).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="Beta")).to_have_class(
+        # contains "disabled" — use a looser check
+        "vireo-ctx-item vireo-ctx-disabled"
+    )
+
+    # Click Alpha; menu closes and handler fires.
+    menu.locator(".vireo-ctx-item", has_text="Alpha").click()
+    expect(menu).to_be_hidden()
+    assert page.evaluate("window.__ctx_hit") == "alpha"
+
+
+def test_context_menu_dismiss_outside_click(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    page.evaluate("""
+        openContextMenu({clientX: 100, clientY: 100},
+            [{label: 'X', onClick: () => {}}]);
+    """)
+    expect(page.locator(".vireo-ctx-menu")).to_be_visible()
+
+    page.mouse.click(500, 500)
+    expect(page.locator(".vireo-ctx-menu")).to_be_hidden()
+
+
+def test_context_menu_escape_closes(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    page.evaluate("""
+        openContextMenu({clientX: 50, clientY: 50},
+            [{label: 'Y', onClick: () => {}}]);
+    """)
+    page.keyboard.press("Escape")
+    expect(page.locator(".vireo-ctx-menu")).to_be_hidden()
+```
+
+**Step 2: Run test to verify it fails**
+
+```
+python -m pytest tests/e2e/test_context_menu.py -v
+```
+Expected: FAIL — `openContextMenu is not defined`.
+
+**Step 3: Implement the shared component**
+
+In `vireo/templates/_navbar.html`, add to the `<style>` block (near existing `.kw-type-dropdown` at keywords.html line ~123, but put it in `_navbar.html` since it's shared):
+
+```css
+.vireo-ctx-menu {
+  position: fixed; z-index: 1000;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-secondary);
+  border-radius: 6px; padding: 4px 0;
+  min-width: 180px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+  font-size: 13px; color: var(--text-primary);
+  user-select: none;
+}
+.vireo-ctx-item {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 12px; cursor: pointer;
+}
+.vireo-ctx-item:hover:not(.vireo-ctx-disabled) {
+  background: var(--bg-tertiary);
+}
+.vireo-ctx-disabled {
+  color: var(--text-tertiary); cursor: default;
+}
+.vireo-ctx-sep {
+  height: 1px; background: var(--border-secondary);
+  margin: 4px 0;
+}
+.vireo-ctx-chips {
+  display: flex; gap: 4px; padding: 6px 12px;
+}
+.vireo-ctx-chip {
+  flex: 0 0 auto; padding: 2px 6px; border-radius: 4px;
+  cursor: pointer; line-height: 1;
+}
+.vireo-ctx-chip:hover { background: var(--bg-tertiary); }
+.vireo-ctx-chip.is-active { background: var(--accent); color: white; }
+```
+
+In `vireo/templates/_navbar.html`, add to the shared `<script>` block:
+
+```javascript
+(function(){
+  let _ctxEl = null;
+  let _ctxDismiss = null;
+
+  window.closeContextMenu = function(){
+    if (_ctxEl) { _ctxEl.remove(); _ctxEl = null; }
+    document.removeEventListener('mousedown', _outside, true);
+    document.removeEventListener('keydown', _keydown, true);
+    window.removeEventListener('blur', closeContextMenu);
+    window.removeEventListener('scroll', closeContextMenu, true);
+    if (_ctxDismiss) { const f = _ctxDismiss; _ctxDismiss = null; f(); }
+  };
+
+  function _outside(e){
+    if (_ctxEl && !_ctxEl.contains(e.target)) closeContextMenu();
+  }
+  function _keydown(e){
+    if (e.key === 'Escape') { e.preventDefault(); closeContextMenu(); }
+  }
+
+  function _renderItem(item){
+    if (item.separator) {
+      const s = document.createElement('div');
+      s.className = 'vireo-ctx-sep';
+      return s;
+    }
+    if (item.chips) {
+      const row = document.createElement('div');
+      row.className = 'vireo-ctx-chips';
+      item.chips.forEach(c => {
+        const b = document.createElement('span');
+        b.className = 'vireo-ctx-chip' + (c.active ? ' is-active' : '');
+        b.textContent = c.label;
+        if (c.title) b.title = c.title;
+        b.addEventListener('click', ev => {
+          ev.stopPropagation();
+          closeContextMenu();
+          try { c.onClick && c.onClick(); } catch(err){ console.error(err); }
+        });
+        row.appendChild(b);
+      });
+      return row;
+    }
+    const d = document.createElement('div');
+    d.className = 'vireo-ctx-item' + (item.disabled ? ' vireo-ctx-disabled' : '');
+    d.textContent = item.label;
+    if (item.disabled && item.disabledHint) d.title = item.disabledHint;
+    if (!item.disabled) {
+      d.addEventListener('click', ev => {
+        ev.stopPropagation();
+        closeContextMenu();
+        try { item.onClick && item.onClick(); } catch(err){ console.error(err); }
+      });
+    }
+    return d;
+  }
+
+  window.openContextMenu = function(event, items, opts){
+    closeContextMenu();
+    const menu = document.createElement('div');
+    menu.className = 'vireo-ctx-menu';
+    items.forEach(it => menu.appendChild(_renderItem(it)));
+    document.body.appendChild(menu);
+    // Clamp to viewport.
+    const vw = window.innerWidth, vh = window.innerHeight;
+    const rect = menu.getBoundingClientRect();
+    let x = event.clientX, y = event.clientY;
+    if (x + rect.width  > vw) x = Math.max(0, vw - rect.width  - 4);
+    if (y + rect.height > vh) y = Math.max(0, vh - rect.height - 4);
+    menu.style.left = x + 'px';
+    menu.style.top  = y + 'px';
+    _ctxEl = menu;
+    _ctxDismiss = (opts && opts.onDismiss) || null;
+    document.addEventListener('mousedown', _outside, true);
+    document.addEventListener('keydown', _keydown, true);
+    window.addEventListener('blur', closeContextMenu);
+    window.addEventListener('scroll', closeContextMenu, true);
+  };
+})();
+```
+
+**Step 4: Run test to verify it passes**
+
+```
+python -m pytest tests/e2e/test_context_menu.py -v
+```
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/templates/_navbar.html tests/e2e/test_context_menu.py
+git commit -m "feat(ui): shared right-click context menu component"
+```
+
+---
+
+## Task 2: Finder-style selection-coupling helper
+
+**Files:**
+- Modify: `vireo/templates/_navbar.html` (add `coerceSelection` helper at the bottom of the shared script).
+- Test: `tests/e2e/test_context_menu.py` (extend).
+
+**Step 1: Write the failing tests**
+
+Append to `tests/e2e/test_context_menu.py`:
+
+```python
+def test_coerce_selection_inside_keeps_set(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    out = page.evaluate("""() => {
+        const sel = new Set([1, 2, 3]);
+        const result = coerceSelectionOnContext(sel, 2);
+        return { size: sel.size, has1: sel.has(1), has2: sel.has(2), has3: sel.has(3), result: Array.from(result) };
+    }""")
+    assert out["size"] == 3
+    assert out["has1"] and out["has2"] and out["has3"]
+    assert sorted(out["result"]) == [1, 2, 3]
+
+
+def test_coerce_selection_outside_replaces(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    out = page.evaluate("""() => {
+        const sel = new Set([1, 2, 3]);
+        const result = coerceSelectionOnContext(sel, 99);
+        return { size: sel.size, has99: sel.has(99), result: Array.from(result) };
+    }""")
+    assert out["size"] == 1
+    assert out["has99"] is True
+    assert out["result"] == [99]
+```
+
+**Step 2: Run test to verify it fails**
+
+```
+python -m pytest tests/e2e/test_context_menu.py::test_coerce_selection_inside_keeps_set tests/e2e/test_context_menu.py::test_coerce_selection_outside_replaces -v
+```
+Expected: FAIL — `coerceSelectionOnContext is not defined`.
+
+**Step 3: Implement**
+
+In the same IIFE in `_navbar.html`, add:
+
+```javascript
+  window.coerceSelectionOnContext = function(selectionSet, clickedId){
+    if (!selectionSet.has(clickedId)) {
+      selectionSet.clear();
+      selectionSet.add(clickedId);
+    }
+    return Array.from(selectionSet);
+  };
+```
+
+**Step 4: Run test to verify it passes**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/templates/_navbar.html tests/e2e/test_context_menu.py
+git commit -m "feat(ui): finder-style selection coercion helper"
+```
+
+---
+
+## Task 3: Server endpoint — reveal in OS file manager
+
+**Files:**
+- Modify: `vireo/app.py` (add `api_files_reveal` route).
+- Test: `vireo/tests/test_reveal_api.py` (new).
+
+**Step 1: Write the failing tests**
+
+```python
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+def test_reveal_macos(app_and_db):
+    app, db = app_and_db
+    pid = db.list_photos()[0]["id"]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "darwin"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0)
+        resp = c.post("/api/files/reveal", json={"photo_id": pid})
+        assert resp.status_code == 200
+        assert resp.get_json()["ok"] is True
+        args = run.call_args[0][0]
+        assert args[0] == "open"
+        assert args[1] == "-R"
+
+
+def test_reveal_linux_opens_parent(app_and_db):
+    app, db = app_and_db
+    pid = db.list_photos()[0]["id"]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "linux"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0)
+        resp = c.post("/api/files/reveal", json={"photo_id": pid})
+        assert resp.status_code == 200
+        args = run.call_args[0][0]
+        assert args[0] == "xdg-open"
+        # argv[1] is the parent dir, not the file itself
+        assert not args[1].endswith(".jpg")
+
+
+def test_reveal_windows_select(app_and_db):
+    app, db = app_and_db
+    pid = db.list_photos()[0]["id"]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "win32"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0)
+        resp = c.post("/api/files/reveal", json={"photo_id": pid})
+        assert resp.status_code == 200
+        args = run.call_args[0][0]
+        assert args[0].lower() == "explorer"
+        assert args[1].startswith("/select,")
+
+
+def test_reveal_unknown_photo_returns_error(app_and_db):
+    app, _ = app_and_db
+    with app.test_client() as c:
+        resp = c.post("/api/files/reveal", json={"photo_id": 999999})
+        assert resp.status_code == 404
+
+
+def test_reveal_shell_failure_reports_reason(app_and_db):
+    app, db = app_and_db
+    pid = db.list_photos()[0]["id"]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "darwin"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.side_effect = FileNotFoundError("no 'open'")
+        resp = c.post("/api/files/reveal", json={"photo_id": pid})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is False
+        assert "reason" in body
+```
+
+**Step 2: Verify it fails**
+
+```
+python -m pytest vireo/tests/test_reveal_api.py -v
+```
+Expected: FAIL — route not registered.
+
+**Step 3: Implement**
+
+In `vireo/app.py`, add a route (near existing file/photo endpoints, e.g. after `api_set_color_label` ~line 1233). Confirm `subprocess` and `sys` are already imported at the top; if not, add them.
+
+```python
+@app.route("/api/files/reveal", methods=["POST"])
+def api_files_reveal():
+    body = request.get_json(silent=True) or {}
+    pid = body.get("photo_id")
+    if pid is None:
+        return json_error("photo_id required")
+    db = _get_db()
+    photo = db.get_photo(int(pid))
+    if not photo:
+        return json_error("photo not found", 404)
+    path = photo.get("path") or db.photo_path(int(pid))
+    if not path:
+        return jsonify({"ok": False, "reason": "no path"})
+    try:
+        if sys.platform == "darwin":
+            subprocess.run(["open", "-R", path], timeout=5, check=False)
+        elif sys.platform.startswith("win"):
+            subprocess.run(["explorer", f"/select,{path}"], timeout=5, check=False)
+        else:
+            import os as _os
+            parent = _os.path.dirname(path) or path
+            subprocess.run(["xdg-open", parent], timeout=5, check=False)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        return jsonify({"ok": False, "reason": str(exc)})
+    return jsonify({"ok": True})
+```
+
+If `db.get_photo` / `db.photo_path` don't exist with these names, read `vireo/db.py` to find the right helper (likely `get_photo_by_id` or similar) and adjust.
+
+**Step 4: Verify passing**
+
+```
+python -m pytest vireo/tests/test_reveal_api.py -v
+```
+Expected: PASS (all 5 tests).
+
+**Step 5: Commit**
+
+```
+git add vireo/app.py vireo/tests/test_reveal_api.py
+git commit -m "feat(api): cross-platform reveal-in-file-manager endpoint"
+```
+
+---
+
+## Task 4: Server endpoint — folder rescan
+
+**Files:**
+- Modify: `vireo/app.py` (add `api_folder_rescan` route, delegate to existing scan job infra with a folder filter).
+- Test: `vireo/tests/test_folder_rescan_api.py` (new).
+
+**Step 1: Write the failing test**
+
+```python
+def test_folder_rescan_queues_job(app_and_db):
+    app, db = app_and_db
+    folder_id = db.list_folders()[0]["id"]
+    with app.test_client() as c:
+        resp = c.post(f"/api/folders/{folder_id}/rescan", json={})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert "job_id" in body
+    # The job runner has one queued job tagged with our folder.
+    runner = app._job_runner
+    jobs = runner.list_jobs()
+    assert any(
+        j.get("type") == "scan" and j.get("folder_id") == folder_id
+        for j in jobs
+    )
+
+
+def test_folder_rescan_unknown_folder(app_and_db):
+    app, _ = app_and_db
+    with app.test_client() as c:
+        resp = c.post("/api/folders/999999/rescan", json={})
+        assert resp.status_code == 404
+```
+
+**Step 2: Verify fails**
+
+```
+python -m pytest vireo/tests/test_folder_rescan_api.py -v
+```
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Read the existing `POST /api/jobs/scan` (around line 4640 of `vireo/app.py`) and extract the work callable. Add:
+
+```python
+@app.route("/api/folders/<int:folder_id>/rescan", methods=["POST"])
+def api_folder_rescan(folder_id):
+    db = _get_db()
+    folder = db.get_folder(folder_id)
+    if not folder:
+        return json_error("folder not found", 404)
+    runner = app._job_runner
+    path = folder["path"]
+
+    def work(job):
+        # Delegate to the same scan path as /api/jobs/scan but scoped to `path`.
+        _run_scan(job, runner, root=path, folder_id=folder_id)
+
+    job = runner.queue(work, label=f"Rescan {folder['name']}",
+                       meta={"type": "scan", "folder_id": folder_id})
+    return jsonify({"job_id": job["id"]})
+```
+
+If `_run_scan` isn't the existing helper name, extract the work body from `api_job_scan` into a shared function `_run_scan(job, runner, root, folder_id=None)` and call it from both places. The meta field (`type`, `folder_id`) is what the test asserts on — if the existing job schema uses different names, adjust both the test and the implementation to match.
+
+**Step 4: Verify passing**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/app.py vireo/tests/test_folder_rescan_api.py
+git commit -m "feat(api): per-folder rescan endpoint"
+```
+
+---
+
+## Task 5: Server endpoint — collection duplicate
+
+**Files:**
+- Modify: `vireo/app.py` (add `api_collection_duplicate` route).
+- Modify: `vireo/db.py` (add `duplicate_collection` method if not present).
+- Test: `vireo/tests/test_collection_duplicate_api.py` (new).
+
+**Step 1: Write the failing tests**
+
+```python
+def test_duplicate_collection_copies_memberships(app_and_db):
+    app, db = app_and_db
+    pids = [p["id"] for p in db.list_photos()][:3]
+    cid = db.create_collection("My Picks")
+    for pid in pids:
+        db.add_photo_to_collection(cid, pid)
+
+    with app.test_client() as c:
+        resp = c.post(f"/api/collections/{cid}/duplicate", json={})
+        assert resp.status_code == 200
+        new_id = resp.get_json()["id"]
+        assert new_id != cid
+
+    cols = {c["id"]: c for c in db.list_collections()}
+    assert new_id in cols
+    assert cols[new_id]["name"].startswith("My Picks")
+    # Membership copied.
+    new_members = db.list_photos_in_collection(new_id)
+    assert sorted(p["id"] for p in new_members) == sorted(pids)
+
+
+def test_duplicate_unknown_collection(app_and_db):
+    app, _ = app_and_db
+    with app.test_client() as c:
+        resp = c.post("/api/collections/999999/duplicate", json={})
+        assert resp.status_code == 404
+```
+
+If helper names like `list_photos_in_collection` or `add_photo_to_collection` differ, read `vireo/db.py` and adjust (common alternatives: `collection_photos`, `add_to_collection`).
+
+**Step 2: Verify fails**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+In `vireo/db.py`, add (inside the workspace-scoped collection section):
+
+```python
+def duplicate_collection(self, collection_id: int) -> int:
+    ws = self._ws_id()
+    row = self.conn.execute(
+        "SELECT name FROM collections WHERE id = ? AND workspace_id = ?",
+        (collection_id, ws),
+    ).fetchone()
+    if not row:
+        raise ValueError("collection not found")
+    new_name = f"{row['name']} (copy)"
+    new_id = self.create_collection(new_name)
+    self.conn.execute(
+        "INSERT INTO collection_photos (collection_id, photo_id) "
+        "SELECT ?, photo_id FROM collection_photos WHERE collection_id = ?",
+        (new_id, collection_id),
+    )
+    self.conn.commit()
+    return new_id
+```
+
+If the membership table is not called `collection_photos`, find the right name with `grep -n collection_ vireo/db.py`.
+
+In `vireo/app.py`:
+
+```python
+@app.route("/api/collections/<int:collection_id>/duplicate", methods=["POST"])
+def api_collection_duplicate(collection_id):
+    db = _get_db()
+    try:
+        new_id = db.duplicate_collection(collection_id)
+    except ValueError:
+        return json_error("collection not found", 404)
+    return jsonify({"id": new_id})
+```
+
+**Step 4: Verify passing**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/app.py vireo/db.py vireo/tests/test_collection_duplicate_api.py
+git commit -m "feat(api): collection duplicate endpoint"
+```
+
+---
+
+## Task 6: Wire photo card (browse grid)
+
+**Files:**
+- Modify: `vireo/templates/browse.html` (attach `contextmenu` handler inside the grid-card event delegation; add `buildPhotoContextMenu(photoIds)` helper).
+- Test: `tests/e2e/test_browse_context_menu.py` (new).
+
+**Step 1: Write the failing test**
+
+```python
+from playwright.sync_api import expect
+
+
+def test_right_click_photo_opens_menu(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    # Rating chips row present.
+    expect(menu.locator(".vireo-ctx-chip")).to_have_count_greater_than(5)
+    # Key actions present.
+    expect(menu.locator(".vireo-ctx-item", has_text="Reveal in")).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="Copy Path")).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="Delete")).to_be_visible()
+
+
+def test_right_click_rating_applies(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click(button="right")
+
+    # Click the "3" chip in the rating row.
+    menu = page.locator(".vireo-ctx-menu")
+    menu.locator(".vireo-ctx-chip", has_text="3").click()
+    expect(menu).to_be_hidden()
+
+    # Rating got applied — the card's detail panel / rating attribute reflects 3.
+    # Wait for a DOM signal. Easiest: poll the card's data attribute or re-fetch.
+    page.wait_for_function(
+        "() => document.querySelector('.grid-card').dataset.rating === '3'"
+    )
+
+
+def test_right_click_outside_selection_replaces_selection(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    cards = page.locator(".grid-card")
+    cards.first.wait_for(state="visible")
+
+    # Select cards 0 and 1.
+    cards.nth(0).click()
+    cards.nth(1).click(modifiers=["Meta"])
+    # Right-click card 2, which is NOT in selection.
+    cards.nth(2).click(button="right")
+
+    expect(page.locator(".vireo-ctx-menu")).to_be_visible()
+    # Selection should now be exactly card 2.
+    size = page.evaluate("selectedPhotos.size")
+    assert size == 1
+```
+
+`to_have_count_greater_than` is pseudo — use `expect(menu.locator('.vireo-ctx-chip').count()).toBeGreaterThan(5)` via `assert menu.locator('.vireo-ctx-chip').count() > 5`.
+
+**Step 2: Verify it fails**
+
+```
+python -m pytest tests/e2e/test_browse_context_menu.py -v
+```
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Read the current grid-card click setup in `browse.html` around line 1924–1940 and the `selectedPhotos` / `selectPhoto` helpers. Add:
+
+```javascript
+function buildPhotoContextMenu(photoIds){
+  const one = photoIds.length === 1;
+  const hint = one ? undefined : 'Select a single photo';
+
+  const rateChip = n => ({
+    label: n === 0 ? '☆' : String(n),
+    title: n === 0 ? 'No rating' : `Rate ${n}`,
+    onClick: () => photoIds.forEach(id => setRatingFor(id, n)),
+  });
+  const colorChip = (c, icon) => ({
+    label: icon,
+    title: c ? `Color ${c}` : 'No color',
+    onClick: () => photoIds.forEach(id => setColorLabelFor(id, c)),
+  });
+  const flagChip = (f, icon, title) => ({
+    label: icon, title,
+    onClick: () => photoIds.forEach(id => setFlagFor(id, f)),
+  });
+
+  return [
+    { chips: [0,1,2,3,4,5].map(rateChip) },
+    { chips: [
+      colorChip(null, '○'), colorChip('red', '●'), colorChip('yellow', '●'),
+      colorChip('green', '●'), colorChip('blue', '●'),
+    ] },
+    { chips: [
+      flagChip('flagged', '🏳', 'Flag'),
+      flagChip('rejected', '⛔', 'Reject'),
+      flagChip('none', '◯', 'Unflag'),
+    ] },
+    { separator: true },
+    { label: 'Find Similar',        disabled: !one, disabledHint: hint,
+      onClick: () => findSimilar(photoIds[0]) },
+    { label: 'Open in Editor',      disabled: !one, disabledHint: hint,
+      onClick: () => openInEditor(photoIds[0]) },
+    { label: 'Reveal in Finder/Folder', disabled: !one, disabledHint: hint,
+      onClick: () => revealPhoto(photoIds[0]) },
+    { label: 'Copy Path',
+      onClick: () => copyPhotoPaths(photoIds) },
+    { separator: true },
+    { label: 'Add Keyword…',        onClick: () => batchAddKeyword() },
+    { label: 'Add to Collection…',  onClick: () => addToCollection() },
+    { separator: true },
+    { label: 'Delete',              onClick: () => batchDelete() },
+  ];
+}
+
+function revealPhoto(photoId){
+  fetch('/api/files/reveal', {
+    method: 'POST', headers: {'Content-Type':'application/json'},
+    body: JSON.stringify({photo_id: photoId}),
+  });
+}
+
+async function copyPhotoPaths(photoIds){
+  const rs = await Promise.all(photoIds.map(id =>
+    fetch(`/api/photos/${id}`).then(r => r.json())));
+  const paths = rs.map(r => r.path).filter(Boolean).join('\n');
+  try { await navigator.clipboard.writeText(paths); } catch(e){ console.error(e); }
+}
+
+document.addEventListener('contextmenu', function(e){
+  const card = e.target.closest('.grid-card');
+  if (!card || !card.dataset.id) return;
+  e.preventDefault();
+  const pid = parseInt(card.dataset.id, 10);
+  const ids = coerceSelectionOnContext(selectedPhotos, pid);
+  // Reflect the coerced selection in the UI.
+  updateSelectionVisual();
+  openContextMenu(e, buildPhotoContextMenu(ids));
+});
+```
+
+If `setRatingFor`, `setColorLabelFor`, `setFlagFor`, `findSimilar`, `openInEditor`, `updateSelectionVisual` don't exist under those names, find the equivalents in `browse.html` (grep for `updateRating`, `applyRating`, `setColorLabel`, `setFlag`, `renderSelection`, `refreshCardSelection`) and use those. Inline a one-photo wrapper as a helper if the existing code only operates on the "current detail-panel photo."
+
+Also: the test `data-rating` assertion requires the card DOM to carry `data-rating`. If it doesn't, change the test to poll the rating star element (`.grid-card-stars .is-filled`) or the server-side value via `fetch /api/photos/<id>`.
+
+**Step 4: Verify passing**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/templates/browse.html tests/e2e/test_browse_context_menu.py
+git commit -m "feat(ui): right-click context menu on browse grid cards"
+```
+
+---
+
+## Task 7: Wire lightbox
+
+**Files:**
+- Modify: `vireo/templates/_navbar.html` (lightbox contextmenu handler; guard against the zoom-lock click handler firing).
+- Test: `tests/e2e/test_lightbox_context_menu.py` (new).
+
+**Step 1: Write the failing test**
+
+```python
+from playwright.sync_api import expect
+
+
+def test_lightbox_right_click_opens_menu(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.locator(".grid-card").first.dblclick()
+    expect(page.locator("#lightboxOverlay")).to_be_visible()
+
+    page.locator("#lightboxImg").click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="Reveal in")).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="Close Lightbox")).to_be_visible()
+
+
+def test_lightbox_right_click_does_not_toggle_zoom_lock(live_server, page):
+    """Right-click must not trip the click-to-lock zoom handler."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.locator(".grid-card").first.dblclick()
+    expect(page.locator("#lightboxOverlay")).to_be_visible()
+    before = page.evaluate("typeof _zoomLocked !== 'undefined' ? !!_zoomLocked : false")
+    page.locator("#lightboxImg").click(button="right")
+    after = page.evaluate("typeof _zoomLocked !== 'undefined' ? !!_zoomLocked : false")
+    assert before == after
+```
+
+**Step 2: Verify fails**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+In `_navbar.html` lightbox script block:
+
+```javascript
+document.getElementById('lightboxImg').addEventListener('contextmenu', function(e){
+  e.preventDefault();
+  e.stopPropagation();
+  const pid = window._currentLightboxPhotoId;
+  if (!pid) return;
+  openContextMenu(e, buildLightboxContextMenu(pid));
+});
+
+function buildLightboxContextMenu(pid){
+  return [
+    { chips: [0,1,2,3,4,5].map(n => ({
+        label: n === 0 ? '☆' : String(n),
+        onClick: () => setRatingFor(pid, n),
+    })) },
+    { chips: [
+      { label: '○', onClick: () => setColorLabelFor(pid, null) },
+      { label: '●', onClick: () => setColorLabelFor(pid, 'red') },
+      { label: '●', onClick: () => setColorLabelFor(pid, 'yellow') },
+      { label: '●', onClick: () => setColorLabelFor(pid, 'green') },
+      { label: '●', onClick: () => setColorLabelFor(pid, 'blue') },
+    ] },
+    { chips: [
+      { label: '🏳', onClick: () => setFlagFor(pid, 'flagged') },
+      { label: '⛔', onClick: () => setFlagFor(pid, 'rejected') },
+      { label: '◯', onClick: () => setFlagFor(pid, 'none') },
+    ] },
+    { separator: true },
+    { label: 'Find Similar',            onClick: () => findSimilar(pid) },
+    { label: 'Open in Editor',          onClick: () => openInEditor(pid) },
+    { label: 'Reveal in Finder/Folder', onClick: () => revealPhoto(pid) },
+    { label: 'Copy Path',               onClick: () => copyPhotoPaths([pid]) },
+    { separator: true },
+    { label: 'Close Lightbox',          onClick: () => closeLightbox() },
+  ];
+}
+```
+
+Also: in the existing click handler on the lightbox that toggles `_zoomLocked`, guard:
+
+```javascript
+// If the most recent contextmenu fired < 100ms ago, ignore this click.
+if (window._ctxMenuJustOpened && Date.now() - window._ctxMenuJustOpened < 120) return;
+```
+
+And set `window._ctxMenuJustOpened = Date.now()` at the top of `openContextMenu`.
+
+Find `_currentLightboxPhotoId` / equivalent: search `browse.html` for the lightbox open path — it usually tracks current photo id in a variable like `_lbPhotoId` or `currentLightboxId`. Use the actual name.
+
+**Step 4: Verify passing**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/templates/_navbar.html tests/e2e/test_lightbox_context_menu.py
+git commit -m "feat(ui): right-click context menu in lightbox"
+```
+
+---
+
+## Task 8: Wire folder tree
+
+**Files:**
+- Modify: `vireo/templates/browse.html` (contextmenu delegation on `.tree-item[data-folder-id]`).
+- Test: `tests/e2e/test_folder_tree_context_menu.py` (new).
+
+**Step 1: Write the failing test**
+
+```python
+from playwright.sync_api import expect
+
+
+def test_folder_tree_right_click_opens_menu(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    item = page.locator(".tree-item[data-folder-id]").first
+    item.wait_for(state="visible")
+    item.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    for label in ["Filter by this folder", "Reveal in", "Copy Path",
+                  "Rescan this Folder", "Hide from this Workspace"]:
+        expect(menu.locator(".vireo-ctx-item", has_text=label)).to_be_visible()
+
+
+def test_folder_rescan_fires_endpoint(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    item = page.locator(".tree-item[data-folder-id]").first
+    item.click(button="right")
+
+    with page.expect_response(lambda r: "/rescan" in r.url and r.status == 200):
+        page.locator(".vireo-ctx-menu .vireo-ctx-item",
+                     has_text="Rescan this Folder").click()
+```
+
+**Step 2: Verify fails**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+In `browse.html`:
+
+```javascript
+document.addEventListener('contextmenu', function(e){
+  const ti = e.target.closest('.tree-item[data-folder-id]');
+  if (!ti) return;
+  e.preventDefault();
+  const fid = parseInt(ti.dataset.folderId, 10);
+  const name = ti.querySelector('span:not(.tree-toggle)')?.textContent || '';
+  openContextMenu(e, [
+    { label: 'Filter by this folder', onClick: () => filterByFolder(fid) },
+    { label: 'Expand All Children',   onClick: () => expandFolderTree(fid) },
+    { label: 'Collapse All Children', onClick: () => collapseFolderTree(fid) },
+    { separator: true },
+    { label: 'Reveal in Finder/Folder',
+      onClick: () => revealFolder(fid) },
+    { label: 'Copy Path',
+      onClick: () => copyFolderPath(fid) },
+    { separator: true },
+    { label: 'Hide from this Workspace',
+      onClick: () => hideFolderFromWorkspace(fid) },
+    { label: 'Rescan this Folder',
+      onClick: () => fetch(`/api/folders/${fid}/rescan`, {method:'POST'}) },
+  ]);
+});
+
+function revealFolder(fid){
+  fetch(`/api/folders/${fid}/reveal`, {method:'POST'});
+}
+async function copyFolderPath(fid){
+  const r = await fetch(`/api/folders/${fid}`); const f = await r.json();
+  if (f.path) await navigator.clipboard.writeText(f.path);
+}
+```
+
+If `expandFolderTree`, `collapseFolderTree`, `hideFolderFromWorkspace` don't exist, either:
+1. Skip them from the menu for this first pass, or
+2. Implement them as thin helpers (e.g. `hideFolderFromWorkspace` = `POST /api/workspaces/current/folders/<id>/hide`).
+
+For `revealFolder`: add a sibling endpoint to `/api/files/reveal` that takes a folder id and reveals its root path directly — OR reuse `/api/files/reveal` by adding support for `folder_id` in that endpoint. Prefer the latter: amend `api_files_reveal` to accept `{folder_id}` as an alternative to `{photo_id}`, resolving the path accordingly, and extend the test file from Task 3 with a folder case.
+
+**Step 4: Verify passing**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/templates/browse.html vireo/app.py vireo/tests/test_reveal_api.py tests/e2e/test_folder_tree_context_menu.py
+git commit -m "feat(ui): right-click context menu on folder tree"
+```
+
+---
+
+## Task 9: Wire collection sidebar item
+
+**Files:**
+- Modify: `vireo/templates/browse.html`.
+- Test: `tests/e2e/test_collection_context_menu.py` (new).
+
+**Step 1: Write the failing test**
+
+```python
+from playwright.sync_api import expect
+
+
+def test_collection_right_click_shows_menu(live_server, page):
+    url = live_server["url"]
+    # Seed a collection via API.
+    page.goto(f"{url}/browse")
+    page.evaluate("""
+        fetch('/api/collections', {
+            method:'POST', headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({name:'Test Pick'})
+        }).then(() => location.reload())
+    """)
+    page.wait_for_load_state("networkidle")
+
+    item = page.locator(".tree-item", has_text="Test Pick").first
+    item.wait_for(state="visible")
+    item.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    for label in ["Filter by this Collection", "Rename", "Duplicate",
+                  "Delete Collection"]:
+        expect(menu.locator(".vireo-ctx-item", has_text=label)).to_be_visible()
+```
+
+**Step 2: Verify fails**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Add a `data-collection-id` attribute to each rendered collection tree-item (in the `renderCollectionList` code), then delegate contextmenu for that attribute. Reuse `filterByCollection`, existing rename/delete helpers if they exist; otherwise add minimal `renameCollection(cid)` and `deleteCollection(cid)` helpers using existing endpoints.
+
+**Step 4: Verify passing**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/templates/browse.html tests/e2e/test_collection_context_menu.py
+git commit -m "feat(ui): right-click context menu on collection sidebar"
+```
+
+---
+
+## Task 10: Wire keyword row
+
+**Files:**
+- Modify: `vireo/templates/keywords.html`.
+- Test: `tests/e2e/test_keyword_context_menu.py` (new).
+
+**Step 1: Write the failing test**
+
+```python
+from playwright.sync_api import expect
+
+
+def test_keyword_right_click_menu(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/keywords")
+    row = page.locator("tr[data-id]").first
+    row.wait_for(state="visible")
+    row.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    for label in ["Rename", "Change Type", "Filter Browse by this Keyword",
+                  "Show Photos with this Keyword", "Delete"]:
+        expect(menu.locator(".vireo-ctx-item", has_text=label)).to_be_visible()
+```
+
+**Step 2: Verify fails**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+In `keywords.html`, delegate `contextmenu` on `tr[data-id]`. Apply Finder-style coercion to `selectedIds`. Call existing `renameKeyword`, the existing type dropdown opener, and bulk delete path. "Filter Browse by this Keyword" → `window.location.href = '/browse?keyword=' + encodeURIComponent(name)`.
+
+**Step 4: Verify passing**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/templates/keywords.html tests/e2e/test_keyword_context_menu.py
+git commit -m "feat(ui): right-click context menu on keyword rows"
+```
+
+---
+
+## Task 11: Wire review photo card
+
+**Files:**
+- Modify: `vireo/templates/review.html`.
+- Test: `tests/e2e/test_review_context_menu.py` (new).
+
+**Step 1: Write the failing test**
+
+```python
+from playwright.sync_api import expect
+
+
+def test_review_card_right_click_menu(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    card = page.locator(".card[data-pred-id]").first
+    card.wait_for(state="visible")
+    card.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    for label in ["Accept as", "Not", "Open in Lightbox",
+                  "Reveal in", "Copy Path"]:
+        expect(menu.locator(".vireo-ctx-item", has_text=label)).to_be_visible()
+```
+
+**Step 2: Verify fails**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Delegate `contextmenu` on `.card[data-pred-id]`. Menu items call the existing `acceptPrediction(predId)` and `rejectPrediction(predId)`, plus rating/flag chips and the reveal/copy/lightbox trio. No `selectedPhotos` coercion — review grid has no multi-select.
+
+**Step 4: Verify passing**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/templates/review.html tests/e2e/test_review_context_menu.py
+git commit -m "feat(ui): right-click context menu on review cards"
+```
+
+---
+
+## Task 12: Wire burst group modal photo
+
+**Files:**
+- Modify: `vireo/templates/review.html` (burst group section).
+- Test: `tests/e2e/test_burst_group_context_menu.py` (new — gated on a seeded burst group, may skip if fixture doesn't supply one).
+
+**Step 1: Write the failing test**
+
+```python
+import pytest
+from playwright.sync_api import expect
+
+
+def test_burst_group_card_right_click_menu(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    # Open burst modal via the test-only button if available.
+    btn = page.locator("[data-open-burst]").first
+    if btn.count() == 0:
+        pytest.skip("no burst group seeded")
+    btn.click()
+
+    expect(page.locator("#grmOverlay")).to_be_visible()
+    card = page.locator(".grm-card[data-photo-id]").first
+    card.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    for label in ["Move to Picks", "Move to Rejects", "Move to Candidates",
+                  "Open in Lightbox", "Reveal in", "Remove from Group"]:
+        expect(menu.locator(".vireo-ctx-item", has_text=label)).to_be_visible()
+```
+
+**Step 2: Verify fails**
+
+Expected: FAIL or SKIPPED (if no burst seed). If skipped, ask the user to seed a burst group in e2e `conftest.py`. Otherwise proceed.
+
+**Step 3: Implement**
+
+In `review.html` burst section: delegate `contextmenu` on `.grm-card[data-photo-id]`. Menu calls `grmMoveUp`, `grmMoveDown`, `grmMoveCandidate`, `grmRemoveFromGroup`, plus the rating/flag chips and reveal/copy/lightbox trio.
+
+**Step 4: Verify passing**
+
+Expected: PASS (or skipped — that's acceptable; the wiring is still verified by manual smoke-test).
+
+**Step 5: Commit**
+
+```
+git add vireo/templates/review.html tests/e2e/test_burst_group_context_menu.py
+git commit -m "feat(ui): right-click context menu in burst group modal"
+```
+
+---
+
+## Task 13: Full suite + manual smoke-test + PR
+
+**Step 1: Run the full test suite**
+
+```
+python -m pytest tests/ vireo/tests/ -q
+```
+Expected: all pass.
+
+**Step 2: Manual smoke-test (per user-first-testing memory)**
+
+Start the dev server, open browse, review, keywords pages in a real browser. For each surface, right-click at least one item and verify:
+- Menu opens at cursor.
+- Outside-click dismisses.
+- Escape dismisses.
+- A rating / flag action actually changes state visible in the detail panel.
+- Reveal in Finder opens Finder on the correct file (macOS).
+- Copy Path paste into terminal yields the right path(s).
+
+**Step 3: Push and open PR**
+
+```
+git push -u origin right-click-review
+gh pr create --title "Right-click context menus across all surfaces" --body "$(cat <<'EOF'
+## Summary
+- Adds a shared floating context-menu component (`openContextMenu`) used across seven surfaces.
+- Finder-style selection coupling: right-clicking an item outside the selection replaces selection with that item.
+- Menus on photo card (browse + review), lightbox, folder tree, keyword row, collection item, burst group modal.
+- New endpoints: `/api/files/reveal`, `/api/folders/<id>/rescan`, `/api/collections/<id>/duplicate`.
+- Client-side Copy Path via `navigator.clipboard`.
+
+Additive only — every existing keyboard shortcut and button is unchanged.
+
+See `docs/plans/2026-04-22-context-menus-design.md` for the design write-up.
+
+## Test plan
+- [x] `python -m pytest tests/ vireo/tests/ -q` passes
+- [x] Manual browser smoke-test on all seven surfaces
+- [x] Reveal in Finder opens the correct file on macOS
+EOF
+)"
+```
+
+---
+
+## Notes for the implementer
+
+- The detailed code in each "Implement" step assumes helper names like `setRatingFor`, `setColorLabelFor`, `setFlagFor`, `findSimilar`, `openInEditor`. Grep `vireo/templates/browse.html` for the actual single-photo helpers these pages already use for the detail panel; if none exist, write two-line wrappers that call the existing fetch endpoints directly.
+- Don't duplicate the detail-panel UI in the menu. Only the rating/color/flag chips + the genuinely new actions.
+- The Finder-style coercion helper (`coerceSelectionOnContext`) must be called *before* the menu opens so the right-click gesture updates the visible selection state first.
+- Favor event delegation on `document` over per-card listeners — the grids re-render frequently.
+- Prefer editing existing files. No new JS/CSS files.

--- a/tests/e2e/test_browse_context_menu.py
+++ b/tests/e2e/test_browse_context_menu.py
@@ -127,6 +127,53 @@ def test_right_click_outside_selection_updates_detail(live_server, page):
     )
 
 
+def test_right_click_updates_shift_range_anchor(live_server, page):
+    """Right-click coercion must sync selectedIndex so Shift-range uses the
+    right-clicked card as the anchor.
+
+    Regression guard: before the fix, right-click set selectedPhotoId but left
+    selectedIndex stale, so a subsequent Shift-click would range-select from
+    the previously-focused card (or fail if selectedIndex was -1).
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    cards = page.locator(".grid-card")
+    cards.first.wait_for(state="visible")
+    assert cards.count() >= 4
+
+    # Left-click card 0 so selectedIndex = 0.
+    cards.nth(0).click()
+    assert page.evaluate("selectedIndex") == 0
+
+    # Right-click card 2 — coercion must update the anchor to index 2.
+    cards.nth(2).click(button="right")
+    expect(page.locator(".vireo-ctx-menu")).to_be_visible()
+    assert page.evaluate("selectedIndex") == 2
+
+    # Dismiss the menu via Escape so the outside-click swallower doesn't
+    # fire — an outside mousedown would eat the subsequent Shift-click.
+    page.keyboard.press("Escape")
+    expect(page.locator(".vireo-ctx-menu")).to_be_hidden()
+
+    # Shift-click card 3 — the shift branch of selectPhoto must see the
+    # anchor at 2, producing the range [2..3]. A stale anchor at 0 would
+    # produce [0..3] and include cards 0 and 1.
+    page.keyboard.down("Shift")
+    cards.nth(3).click()
+    page.keyboard.up("Shift")
+    c0_id = int(cards.nth(0).get_attribute("data-id"))
+    c1_id = int(cards.nth(1).get_attribute("data-id"))
+    c2_id = int(cards.nth(2).get_attribute("data-id"))
+    c3_id = int(cards.nth(3).get_attribute("data-id"))
+    selected_array = page.evaluate("Array.from(selectedPhotos)")
+    assert c2_id in selected_array, f"card 2 (id={c2_id}) missing from selection {selected_array}"
+    assert c3_id in selected_array, f"card 3 (id={c3_id}) missing from selection {selected_array}"
+    # Cards 0 and 1 must NOT be included — the anchor moved with the right-click.
+    assert c0_id not in selected_array, f"stale anchor selected card 0 (id={c0_id}) {selected_array}"
+    assert c1_id not in selected_array, f"stale anchor selected card 1 (id={c1_id}) {selected_array}"
+
+
 def test_copy_path_menu_item_tolerates_missing_paths(live_server, page):
     """Clicking Copy Path must not throw even if the API omits `path`.
 

--- a/tests/e2e/test_browse_context_menu.py
+++ b/tests/e2e/test_browse_context_menu.py
@@ -1,0 +1,95 @@
+from playwright.sync_api import expect
+
+
+def test_right_click_photo_opens_menu(live_server, page):
+    """Right-clicking a grid card opens the context menu with chips + key actions."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    # Rating chips row present. 6 rating chips (0..5) + 5 color chips +
+    # 3 flag chips = 14 chips total; assert the count is clearly > 5 per plan.
+    assert menu.locator(".vireo-ctx-chip").count() > 5
+    # Key actions present.
+    expect(menu.locator(".vireo-ctx-item", has_text="Reveal in")).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="Copy Path")).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="Delete")).to_be_visible()
+
+
+def test_right_click_rating_applies(live_server, page):
+    """Clicking a rating chip applies the rating to the right-clicked photo."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    cards = page.locator(".grid-card")
+    cards.first.wait_for(state="visible")
+    target = cards.nth(1)  # use a photo that starts with no rating
+    pid = int(target.get_attribute("data-id"))
+
+    target.click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    # Click the "3" chip in the rating row.
+    menu.locator(".vireo-ctx-chip", has_text="3").first.click()
+    expect(menu).to_be_hidden()
+
+    # setRating writes to the server and updates the local photos array after
+    # the fetch resolves. Poll the in-memory photo record for the new rating.
+    page.wait_for_function(
+        f"(photos.find(p => p.id === {pid}) || {{}}).rating === 3",
+        timeout=3000,
+    )
+
+
+def test_right_click_outside_selection_replaces_selection(live_server, page):
+    """Right-click on an unselected card replaces selection with that card."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    cards = page.locator(".grid-card")
+    cards.first.wait_for(state="visible")
+    assert cards.count() >= 3
+
+    c2_id = int(cards.nth(2).get_attribute("data-id"))
+
+    # Select cards 0 and 1.
+    cards.nth(0).click()
+    cards.nth(1).click(modifiers=["Meta"])
+    # Right-click card 2, which is NOT in selection.
+    cards.nth(2).click(button="right")
+
+    expect(page.locator(".vireo-ctx-menu")).to_be_visible()
+    # Selection should now be exactly card 2.
+    assert page.evaluate("selectedPhotos.size") == 1
+    assert page.evaluate(f"selectedPhotos.has({c2_id})") is True
+
+
+def test_right_click_inside_selection_preserves_multi(live_server, page):
+    """Right-click on a card already in the selection keeps the full set."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    cards = page.locator(".grid-card")
+    cards.first.wait_for(state="visible")
+    assert cards.count() >= 3
+
+    c0_id = int(cards.nth(0).get_attribute("data-id"))
+    c1_id = int(cards.nth(1).get_attribute("data-id"))
+
+    # Build a 2-item selection via cmd-clicks so selectedPhotos holds both.
+    cards.nth(0).click(modifiers=["Meta"])
+    cards.nth(1).click(modifiers=["Meta"])
+    assert page.evaluate("selectedPhotos.size") == 2
+
+    # Right-click one of the already-selected cards; the set must survive.
+    cards.nth(0).click(button="right")
+
+    expect(page.locator(".vireo-ctx-menu")).to_be_visible()
+    assert page.evaluate("selectedPhotos.size") == 2
+    assert page.evaluate(f"selectedPhotos.has({c0_id})") is True
+    assert page.evaluate(f"selectedPhotos.has({c1_id})") is True

--- a/tests/e2e/test_browse_context_menu.py
+++ b/tests/e2e/test_browse_context_menu.py
@@ -93,3 +93,71 @@ def test_right_click_inside_selection_preserves_multi(live_server, page):
     assert page.evaluate("selectedPhotos.size") == 2
     assert page.evaluate(f"selectedPhotos.has({c0_id})") is True
     assert page.evaluate(f"selectedPhotos.has({c1_id})") is True
+
+
+def test_right_click_outside_selection_updates_detail(live_server, page):
+    """Right-click on an unselected card refreshes the detail side-panel.
+
+    Regression guard: before the fix, coercing selection on right-click would
+    update `selectedPhotoId` but not reload the detail panel, leaving the
+    panel stuck on the previously-focused photo.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    cards = page.locator(".grid-card")
+    cards.first.wait_for(state="visible")
+    assert cards.count() >= 3
+
+    # Left-click card 0 to focus it and load its detail panel.
+    cards.nth(0).click()
+    c0_id = int(cards.nth(0).get_attribute("data-id"))
+    page.wait_for_function(
+        f"window._detailPhotoId === {c0_id}", timeout=3000
+    )
+
+    # Right-click a different card that is NOT in the selection.
+    c2_id = int(cards.nth(2).get_attribute("data-id"))
+    cards.nth(2).click(button="right")
+    expect(page.locator(".vireo-ctx-menu")).to_be_visible()
+
+    # Detail panel must now reflect the right-clicked photo.
+    page.wait_for_function(
+        f"window._detailPhotoId === {c2_id}", timeout=3000
+    )
+
+
+def test_copy_path_menu_item_tolerates_missing_paths(live_server, page):
+    """Clicking Copy Path must not throw even if the API omits `path`.
+
+    Regression guard for the Promise.allSettled refactor: the old
+    Promise.all + .catch would swallow errors silently but a single
+    rejection would drop the whole batch. With allSettled, each response
+    is evaluated independently and the handler never throws.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    # Grant clipboard permissions so a real writeText would not raise.
+    page.context.grant_permissions(["clipboard-read", "clipboard-write"])
+
+    cards = page.locator(".grid-card")
+    cards.first.wait_for(state="visible")
+
+    # Collect JS page errors; clicking Copy Path must not surface any.
+    errors = []
+    page.on("pageerror", lambda exc: errors.append(str(exc)))
+
+    cards.first.click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    copy_item = menu.locator(".vireo-ctx-item", has_text="Copy Path")
+    expect(copy_item).to_be_visible()
+    copy_item.click()
+
+    # Menu closes and no uncaught JS error was raised.
+    expect(menu).to_be_hidden()
+    # Give any async handler time to settle.
+    page.wait_for_timeout(200)
+    assert errors == [], f"copyPhotoPaths raised: {errors}"

--- a/tests/e2e/test_burst_group_context_menu.py
+++ b/tests/e2e/test_burst_group_context_menu.py
@@ -1,0 +1,209 @@
+import pytest
+from playwright.sync_api import expect
+
+
+def _seed_burst_group(db, group_id="grp-test-1", model="test-classifier"):
+    """Promote the fixture's three hawk predictions into a single burst group.
+
+    ``seed_e2e_data`` in conftest.py creates three hawk photos with one
+    prediction each (species=Red-tailed Hawk, model=test-classifier). By
+    setting a shared ``group_id`` on those prediction rows and giving each
+    photo a non-null ``quality_score``, the /review page renders a single
+    group card whose button (``button[data-group-id]``) opens the burst
+    modal via ``openGroupReview``.
+
+    Returns the number of predictions that joined the group (usually 3).
+    """
+    rows = db.conn.execute(
+        """SELECT pr.id, d.photo_id
+             FROM predictions pr
+             JOIN detections d ON d.id = pr.detection_id
+            WHERE pr.species = 'Red-tailed Hawk'
+              AND pr.model = ?
+              AND pr.status != 'alternative'""",
+        (model,),
+    ).fetchall()
+    if not rows:
+        return 0
+    total = len(rows)
+    for i, row in enumerate(rows):
+        db.conn.execute(
+            """UPDATE predictions
+                  SET group_id = ?, vote_count = ?, total_votes = ?
+                WHERE id = ?""",
+            (group_id, total, total, row["id"]),
+        )
+        # Give each photo a different quality score so the modal has a
+        # deterministic AI-best pick.
+        db.conn.execute(
+            "UPDATE photos SET quality_score = ?, subject_sharpness = ? WHERE id = ?",
+            (0.5 + 0.1 * i, 100 + 10 * i, row["photo_id"]),
+        )
+    db.conn.commit()
+    return total
+
+
+def _open_burst_modal(page):
+    """Click the group card button and wait for #grmOverlay to become visible."""
+    trigger = page.locator("button[data-group-id]").first
+    expect(trigger).to_be_visible()
+    trigger.click()
+    # Wait for the modal's open state by polling for a rendered card.
+    page.locator("#grmOverlay .grm-card[data-photo-id]").first.wait_for(
+        state="visible", timeout=2000
+    )
+
+
+def _dispatch_contextmenu(locator):
+    locator.evaluate(
+        "el => el.dispatchEvent(new MouseEvent('contextmenu', "
+        "{clientX: 100, clientY: 100, bubbles: true, cancelable: true}))"
+    )
+
+
+def test_burst_card_right_click_opens_menu(live_server, page):
+    """Right-clicking a burst-modal card opens the context menu."""
+    n = _seed_burst_group(live_server["db"])
+    if n < 1:
+        pytest.skip("could not seed burst group")
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    card = page.locator("#grmOverlay .grm-card[data-photo-id]").first
+    card.wait_for(state="visible")
+    _dispatch_contextmenu(card)
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    for label in (
+        "Move to Picks",
+        "Move to Rejects",
+        "Move to Candidates",
+        "Open in Lightbox",
+        "Reveal in",
+        "Copy Path",
+        "Remove from Group",
+    ):
+        expect(menu.locator(".vireo-ctx-item", has_text=label)).to_be_visible()
+
+
+def test_burst_right_click_force_selects_card(live_server, page):
+    """Right-click must set grmState.selected to the clicked card's photo_id.
+
+    Otherwise the move/remove actions (which operate on grmState.selected)
+    would act on the wrong card when the user right-clicks a non-selected
+    card.
+    """
+    n = _seed_burst_group(live_server["db"])
+    if n < 2:
+        pytest.skip("need at least 2 burst cards for this test")
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    cards = page.locator("#grmOverlay .grm-card[data-photo-id]")
+    assert cards.count() >= 2
+
+    # Click card 0 to seed the selection, then right-click a DIFFERENT card
+    # and confirm grmState.selected flipped to that card's photo_id.
+    first_pid = cards.nth(0).get_attribute("data-photo-id")
+    cards.nth(0).click()
+    # Find a card whose data-photo-id differs from the initial selection.
+    target_card = None
+    target_pid = None
+    for i in range(cards.count()):
+        pid = cards.nth(i).get_attribute("data-photo-id")
+        if pid != first_pid:
+            target_card = cards.nth(i)
+            target_pid = pid
+            break
+    assert target_card is not None
+    _dispatch_contextmenu(target_card)
+
+    selected = page.evaluate("grmState.selected")
+    assert str(selected) == target_pid
+
+
+def test_burst_menu_has_chip_rows(live_server, page):
+    """Burst menu includes rating chips (0-5) and flag chips (3)."""
+    n = _seed_burst_group(live_server["db"])
+    if n < 1:
+        pytest.skip("could not seed burst group")
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    card = page.locator("#grmOverlay .grm-card[data-photo-id]").first
+    _dispatch_contextmenu(card)
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    # 6 rating chips + 3 flag chips = 9.
+    assert menu.locator(".vireo-ctx-chip").count() >= 9
+
+
+def test_burst_move_to_picks_updates_state(live_server, page):
+    """Clicking 'Move to Picks' on a right-clicked card adds it to grmState.picks."""
+    n = _seed_burst_group(live_server["db"])
+    if n < 2:
+        pytest.skip("need at least 2 burst cards")
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    cards = page.locator("#grmOverlay .grm-card[data-photo-id]")
+    # Pick a card that is NOT already the auto-selected AI-best to guarantee
+    # a state change when we click 'Move to Picks'.
+    initially_selected = page.evaluate("grmState.selected")
+    target_card = None
+    target_pid = None
+    for i in range(cards.count()):
+        pid = cards.nth(i).get_attribute("data-photo-id")
+        if str(initially_selected) != pid:
+            target_card = cards.nth(i)
+            target_pid = pid
+            break
+    assert target_card is not None
+
+    _dispatch_contextmenu(target_card)
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    menu.locator(".vireo-ctx-item", has_text="Move to Picks").click()
+
+    in_picks = page.evaluate(
+        f"Array.from(grmState.picks).includes({target_pid})"
+    )
+    assert in_picks is True
+
+
+def test_review_card_menu_has_no_burst_items(live_server, page):
+    """The ordinary review-card menu must not expose burst-only actions.
+
+    Guards against event-listener collision: the burst contextmenu handler
+    keys on ``.grm-card[data-photo-id]`` and must NOT fire for regular
+    ``.card[data-pred-id]`` elements.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+
+    card = page.locator(".card[data-pred-id]").first
+    if card.count() == 0:
+        pytest.skip("no review cards seeded")
+    card.wait_for(state="visible")
+    card.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    # Move to Picks is unique to the burst menu; it must not be here.
+    assert menu.locator(".vireo-ctx-item", has_text="Move to Picks").count() == 0
+    assert menu.locator(".vireo-ctx-item", has_text="Remove from Group").count() == 0

--- a/tests/e2e/test_collection_context_menu.py
+++ b/tests/e2e/test_collection_context_menu.py
@@ -1,0 +1,167 @@
+"""E2E tests for the collection sidebar right-click context menu (Task 9).
+
+Menu items:
+- Filter by this Collection
+- separator
+- Rename
+- Duplicate
+- separator
+- Delete Collection
+"""
+
+from playwright.sync_api import expect
+
+
+def _seed_collection(live_server, name="Test Pick"):
+    """Create a collection via the Flask test client directly (avoids racy
+    page.evaluate(fetch) seeding)."""
+    import json as _json
+    # Use requests-style client through the live_server's db: easiest path is
+    # adding the row directly via the bound db handle, since that matches what
+    # other e2e helpers do.
+    db = live_server["db"]
+    return db.add_collection(name, _json.dumps([]))
+
+
+def test_collection_right_click_shows_menu(live_server, page):
+    """Right-clicking a collection tree-item opens the collection menu."""
+    _seed_collection(live_server, "Test Pick")
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    item = page.locator(
+        ".tree-item[data-collection-id]", has_text="Test Pick"
+    ).first
+    item.wait_for(state="visible")
+    item.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    for label in [
+        "Filter by this Collection",
+        "Rename",
+        "Duplicate",
+        "Delete Collection",
+    ]:
+        expect(
+            menu.locator(".vireo-ctx-item", has_text=label)
+        ).to_be_visible()
+
+
+def test_collection_filter_fires_filter(live_server, page):
+    """Clicking 'Filter by this Collection' sets activeCollectionId."""
+    cid = _seed_collection(live_server, "Picks A")
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    item = page.locator(
+        ".tree-item[data-collection-id]", has_text="Picks A"
+    ).first
+    item.wait_for(state="visible")
+    item.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    menu.locator(
+        ".vireo-ctx-item", has_text="Filter by this Collection"
+    ).click()
+    expect(menu).to_be_hidden()
+
+    page.wait_for_function(
+        f"window.activeCollectionId === {cid}", timeout=3000
+    )
+
+
+def test_collection_duplicate_fires_endpoint_and_rerenders(live_server, page):
+    """Clicking 'Duplicate' POSTs to /duplicate and re-renders the list."""
+    _seed_collection(live_server, "Picks B")
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    item = page.locator(
+        ".tree-item[data-collection-id]", has_text="Picks B"
+    ).first
+    item.wait_for(state="visible")
+    item.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    with page.expect_response(
+        lambda r: "/duplicate" in r.url and r.status == 200
+    ):
+        menu.locator(".vireo-ctx-item", has_text="Duplicate").click()
+
+    # After duplicate, the list re-renders with the copy visible.
+    expect(
+        page.locator(
+            ".tree-item[data-collection-id]", has_text="Picks B (copy)"
+        )
+    ).to_be_visible()
+
+
+def test_collection_rename_fires_put(live_server, page):
+    """Clicking 'Rename' prompts and PUTs the new name."""
+    _seed_collection(live_server, "Picks C")
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    item = page.locator(
+        ".tree-item[data-collection-id]", has_text="Picks C"
+    ).first
+    item.wait_for(state="visible")
+
+    # Accept the rename prompt with a new name. Register BEFORE clicking the
+    # menu item (the dialog may fire synchronously).
+    page.on("dialog", lambda d: d.accept("Picks C Renamed"))
+
+    item.click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    with page.expect_response(
+        lambda r: "/api/collections/" in r.url
+        and r.request.method == "PUT"
+        and r.status == 200
+    ):
+        menu.locator(".vireo-ctx-item", has_text="Rename").click()
+
+    # List re-renders with the new name.
+    expect(
+        page.locator(
+            ".tree-item[data-collection-id]", has_text="Picks C Renamed"
+        )
+    ).to_be_visible()
+
+
+def test_collection_delete_fires_endpoint(live_server, page):
+    """Clicking 'Delete Collection' confirms and DELETEs."""
+    cid = _seed_collection(live_server, "Picks D")
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    item = page.locator(
+        ".tree-item[data-collection-id]", has_text="Picks D"
+    ).first
+    item.wait_for(state="visible")
+
+    # Auto-accept the confirm dialog BEFORE clicking.
+    page.on("dialog", lambda d: d.accept())
+
+    item.click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    with page.expect_response(
+        lambda r: r.url.endswith(f"/api/collections/{cid}")
+        and r.request.method == "DELETE"
+        and r.status == 200
+    ):
+        menu.locator(".vireo-ctx-item", has_text="Delete Collection").click()
+
+    # List re-renders without the deleted collection.
+    expect(
+        page.locator(
+            ".tree-item[data-collection-id]", has_text="Picks D"
+        )
+    ).to_have_count(0)

--- a/tests/e2e/test_context_menu.py
+++ b/tests/e2e/test_context_menu.py
@@ -53,3 +53,25 @@ def test_context_menu_escape_closes(live_server, page):
     """)
     page.keyboard.press("Escape")
     expect(page.locator(".vireo-ctx-menu")).to_be_hidden()
+
+
+def test_context_menu_chip_row_renders_and_fires(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.evaluate("""() => {
+        window.__ctx_chip = null;
+        openContextMenu({clientX: 100, clientY: 100}, [
+            { chips: [
+                {label: 'A', onClick: () => window.__ctx_chip = 'a'},
+                {label: 'B', onClick: () => window.__ctx_chip = 'b'},
+            ] },
+        ]);
+    }""")
+    from playwright.sync_api import expect
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    chips = menu.locator(".vireo-ctx-chip")
+    assert chips.count() == 2
+    chips.nth(1).click()
+    expect(menu).to_be_hidden()
+    assert page.evaluate("window.__ctx_chip") == "b"

--- a/tests/e2e/test_context_menu.py
+++ b/tests/e2e/test_context_menu.py
@@ -55,6 +55,34 @@ def test_context_menu_escape_closes(live_server, page):
     expect(page.locator(".vireo-ctx-menu")).to_be_hidden()
 
 
+def test_escape_does_not_propagate_to_page(live_server, page):
+    """Escape dismissing the menu must not reach page-level Escape handlers.
+
+    Regression guard: before the stopPropagation fix, Escape while a menu
+    was open would also fire browse's clearSelection() (resetting
+    selectedPhotos / selectedIndex) and closeDetail(). The Shift-click anchor
+    test relies on the fix and is the primary consumer, but this unit
+    captures the behavior independently so the shared component owns it.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    page.evaluate(
+        """() => {
+            window.__esc_leaked = 0;
+            document.body.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape') window.__esc_leaked++;
+            }, false);
+            openContextMenu({clientX: 40, clientY: 40},
+                [{label: 'Z', onClick: () => {}}]);
+        }"""
+    )
+    expect(page.locator(".vireo-ctx-menu")).to_be_visible()
+    page.keyboard.press("Escape")
+    expect(page.locator(".vireo-ctx-menu")).to_be_hidden()
+    assert page.evaluate("window.__esc_leaked") == 0
+
+
 def test_context_menu_chip_row_renders_and_fires(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/browse")

--- a/tests/e2e/test_context_menu.py
+++ b/tests/e2e/test_context_menu.py
@@ -75,3 +75,29 @@ def test_context_menu_chip_row_renders_and_fires(live_server, page):
     chips.nth(1).click()
     expect(menu).to_be_hidden()
     assert page.evaluate("window.__ctx_chip") == "b"
+
+
+def test_coerce_selection_inside_keeps_set(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    out = page.evaluate("""() => {
+        const sel = new Set([1, 2, 3]);
+        const result = coerceSelectionOnContext(sel, 2);
+        return { size: sel.size, has1: sel.has(1), has2: sel.has(2), has3: sel.has(3), result: Array.from(result) };
+    }""")
+    assert out["size"] == 3
+    assert out["has1"] and out["has2"] and out["has3"]
+    assert sorted(out["result"]) == [1, 2, 3]
+
+
+def test_coerce_selection_outside_replaces(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    out = page.evaluate("""() => {
+        const sel = new Set([1, 2, 3]);
+        const result = coerceSelectionOnContext(sel, 99);
+        return { size: sel.size, has99: sel.has(99), result: Array.from(result) };
+    }""")
+    assert out["size"] == 1
+    assert out["has99"] is True
+    assert out["result"] == [99]

--- a/tests/e2e/test_context_menu.py
+++ b/tests/e2e/test_context_menu.py
@@ -1,0 +1,55 @@
+import re
+
+from playwright.sync_api import expect
+
+
+def test_open_context_menu_at_cursor(live_server, page):
+    """openContextMenu() places the menu near the event coords and renders items."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    page.evaluate("""
+        window.__ctx_hit = null;
+        openContextMenu({clientX: 200, clientY: 150}, [
+            {label: 'Alpha', onClick: () => window.__ctx_hit = 'alpha'},
+            {separator: true},
+            {label: 'Beta', disabled: true, disabledHint: 'nope'},
+        ]);
+    """)
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="Alpha")).to_be_visible()
+    beta = menu.locator(".vireo-ctx-item", has_text="Beta")
+    expect(beta).to_have_class(re.compile(r"vireo-ctx-disabled"))
+
+    # Click Alpha; menu closes and handler fires.
+    menu.locator(".vireo-ctx-item", has_text="Alpha").click()
+    expect(menu).to_be_hidden()
+    assert page.evaluate("window.__ctx_hit") == "alpha"
+
+
+def test_context_menu_dismiss_outside_click(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    page.evaluate("""
+        openContextMenu({clientX: 100, clientY: 100},
+            [{label: 'X', onClick: () => {}}]);
+    """)
+    expect(page.locator(".vireo-ctx-menu")).to_be_visible()
+
+    page.mouse.click(500, 500)
+    expect(page.locator(".vireo-ctx-menu")).to_be_hidden()
+
+
+def test_context_menu_escape_closes(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    page.evaluate("""
+        openContextMenu({clientX: 50, clientY: 50},
+            [{label: 'Y', onClick: () => {}}]);
+    """)
+    page.keyboard.press("Escape")
+    expect(page.locator(".vireo-ctx-menu")).to_be_hidden()

--- a/tests/e2e/test_context_menu.py
+++ b/tests/e2e/test_context_menu.py
@@ -101,3 +101,27 @@ def test_coerce_selection_outside_replaces(live_server, page):
     assert out["size"] == 1
     assert out["has99"] is True
     assert out["result"] == [99]
+
+
+def test_coerce_selection_string_ids(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    out = page.evaluate("""() => {
+        const sel = new Set(["1", "2", "3"]);
+        const result = coerceSelectionOnContext(sel, "2");
+        return { size: sel.size, result: Array.from(result).sort() };
+    }""")
+    assert out["size"] == 3
+    assert out["result"] == ["1", "2", "3"]
+
+
+def test_coerce_selection_null_id_noop(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    out = page.evaluate("""() => {
+        const sel = new Set(["a", "b"]);
+        const result = coerceSelectionOnContext(sel, null);
+        return { size: sel.size, result: Array.from(result).sort() };
+    }""")
+    assert out["size"] == 2
+    assert out["result"] == ["a", "b"]

--- a/tests/e2e/test_folder_tree_context_menu.py
+++ b/tests/e2e/test_folder_tree_context_menu.py
@@ -1,0 +1,145 @@
+"""E2E tests for the folder-tree right-click context menu (Task 8).
+
+Menu items (first pass, per plan's "OPTION: skip for this first pass"):
+- Filter by this folder
+- separator
+- Reveal in Finder/Folder
+- Copy Path
+- separator
+- Rescan this Folder
+
+"Expand All Children", "Collapse All Children", and "Hide from this Workspace"
+are intentionally deferred — no matching helpers exist yet.
+"""
+
+from playwright.sync_api import expect
+
+
+def test_folder_tree_right_click_opens_menu(live_server, page):
+    """Right-clicking a folder tree item shows the folder context menu."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    item = page.locator(".tree-item[data-folder-id]").first
+    item.wait_for(state="visible")
+    item.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    for label in [
+        "Filter by this folder",
+        "Reveal in",
+        "Copy Path",
+        "Rescan this Folder",
+    ]:
+        expect(
+            menu.locator(".vireo-ctx-item", has_text=label)
+        ).to_be_visible()
+
+
+def test_folder_tree_filter_by_folder_fires_filter(live_server, page):
+    """Clicking 'Filter by this folder' sets activeFolderId to that folder."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    item = page.locator(".tree-item[data-folder-id]").first
+    item.wait_for(state="visible")
+    fid = int(item.get_attribute("data-folder-id"))
+
+    item.click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    menu.locator(".vireo-ctx-item", has_text="Filter by this folder").click()
+    expect(menu).to_be_hidden()
+
+    # filterByFolder toggles activeFolderId; the first click should set it.
+    page.wait_for_function(
+        f"window.activeFolderId === {fid}", timeout=3000
+    )
+
+
+def test_folder_tree_rescan_fires_endpoint(live_server, page):
+    """Clicking 'Rescan this Folder' POSTs to /api/folders/<id>/rescan."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    item = page.locator(".tree-item[data-folder-id]").first
+    item.wait_for(state="visible")
+    item.click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    # The seed folder path doesn't exist on disk, so the server may respond
+    # 400 "no longer exists" — that's fine. This test verifies the menu item
+    # fires a POST at the rescan endpoint, not the job queueing itself (which
+    # is covered by vireo/tests/test_folder_rescan_api.py).
+    with page.expect_response(lambda r: "/rescan" in r.url):
+        menu.locator(
+            ".vireo-ctx-item", has_text="Rescan this Folder"
+        ).click()
+
+
+def test_folder_tree_reveal_fires_endpoint(live_server, page):
+    """Clicking 'Reveal in Finder/Folder' POSTs to /api/files/reveal
+    with a folder_id body."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    item = page.locator(".tree-item[data-folder-id]").first
+    item.wait_for(state="visible")
+    item.click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    with page.expect_request(
+        lambda r: r.url.endswith("/api/files/reveal") and r.method == "POST"
+    ) as req_info:
+        menu.locator(
+            ".vireo-ctx-item", has_text="Reveal in"
+        ).click()
+
+    req = req_info.value
+    body = req.post_data_json or {}
+    assert "folder_id" in body, f"reveal request body missing folder_id: {body}"
+
+
+def test_folder_tree_copy_path_fetches_folder(live_server, page):
+    """Clicking 'Copy Path' fetches GET /api/folders/<id> to resolve the path."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    # Grant clipboard perms so the write call doesn't throw.
+    page.context.grant_permissions(["clipboard-read", "clipboard-write"])
+
+    item = page.locator(".tree-item[data-folder-id]").first
+    item.wait_for(state="visible")
+    fid = int(item.get_attribute("data-folder-id"))
+    item.click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    with page.expect_response(
+        lambda r: r.url.endswith(f"/api/folders/{fid}") and r.status == 200
+    ):
+        menu.locator(".vireo-ctx-item", has_text="Copy Path").click()
+
+
+def test_folder_tree_right_click_does_not_trigger_filter(live_server, page):
+    """Right-click must not fire the left-click onclick handler (filterByFolder).
+
+    Regression guard: the folder tree items use inline onclick; a bare
+    right-click must preventDefault and NOT also toggle the filter.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    item = page.locator(".tree-item[data-folder-id]").first
+    item.wait_for(state="visible")
+    assert page.evaluate("window.activeFolderId") in (None, 0)
+
+    item.click(button="right")
+    expect(page.locator(".vireo-ctx-menu")).to_be_visible()
+
+    # activeFolderId should not have been mutated by the right-click itself.
+    assert page.evaluate("window.activeFolderId") in (None, 0)

--- a/tests/e2e/test_keyword_context_menu.py
+++ b/tests/e2e/test_keyword_context_menu.py
@@ -1,0 +1,201 @@
+"""E2E tests for the keyword row right-click context menu (Task 10).
+
+Menu items (simplified per task prompt — the plan listed two redundant
+"Filter Browse" / "Show Photos" items that jump to the same place; keeping
+only "Show Photos with this Keyword"):
+
+- Rename                          (single only)
+- Set Type chip row (6 types)
+- separator
+- Show Photos with this Keyword   (single only)
+- separator
+- Delete
+"""
+
+from playwright.sync_api import expect
+
+
+def test_keyword_right_click_opens_menu(live_server, page):
+    """Right-clicking a keyword row opens the keyword context menu."""
+    url = live_server["url"]
+    page.goto(f"{url}/keywords")
+
+    row = page.locator("tr[data-id]").first
+    row.wait_for(state="visible")
+    row.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    for label in [
+        "Rename",
+        "Show Photos with this Keyword",
+        "Delete",
+    ]:
+        expect(
+            menu.locator(".vireo-ctx-item", has_text=label)
+        ).to_be_visible()
+
+    # Six type chips for the Set Type chip row.
+    chips = menu.locator(".vireo-ctx-chip")
+    assert chips.count() == 6
+
+
+def test_keyword_right_click_set_type_chip_fires_put(live_server, page):
+    """Clicking a type chip PUTs the new type for the right-clicked keyword."""
+    url = live_server["url"]
+    page.goto(f"{url}/keywords")
+
+    row = page.locator("tr[data-id]").first
+    row.wait_for(state="visible")
+    row.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    with page.expect_response(
+        lambda r: "/api/keywords/" in r.url
+        and r.request.method == "PUT"
+        and r.status == 200
+    ):
+        # The 'location' chip: position 3 of the 6-type chip row.
+        menu.locator(".vireo-ctx-chip", has_text="location").click()
+
+
+def test_keyword_right_click_show_photos_navigates(live_server, page):
+    """Clicking 'Show Photos with this Keyword' navigates to /browse?keyword=..."""
+    url = live_server["url"]
+    page.goto(f"{url}/keywords")
+
+    row = page.locator("tr[data-id]").first
+    row.wait_for(state="visible")
+    name = row.locator(".name-text").inner_text()
+    row.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    menu.locator(
+        ".vireo-ctx-item", has_text="Show Photos with this Keyword"
+    ).click()
+
+    # Wait for navigation.
+    page.wait_for_url("**/browse?keyword=**", timeout=3000)
+    assert "keyword=" in page.url
+    # The keyword name appears URL-encoded in the query string.
+    from urllib.parse import quote
+    assert quote(name) in page.url or name in page.url
+
+
+def test_keyword_right_click_rename_fires_put(live_server, page):
+    """Clicking 'Rename' prompts for a new name and PUTs it."""
+    url = live_server["url"]
+    page.goto(f"{url}/keywords")
+
+    row = page.locator("tr[data-id]").first
+    row.wait_for(state="visible")
+
+    # Auto-accept the prompt BEFORE clicking the menu item.
+    page.on("dialog", lambda d: d.accept("Renamed Keyword"))
+
+    row.click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    with page.expect_response(
+        lambda r: "/api/keywords/" in r.url
+        and r.request.method == "PUT"
+        and r.status == 200
+    ):
+        menu.locator(".vireo-ctx-item", has_text="Rename").click()
+
+
+def test_keyword_right_click_delete_fires_delete(live_server, page):
+    """Clicking 'Delete' confirms and DELETEs the keyword."""
+    url = live_server["url"]
+    page.goto(f"{url}/keywords")
+
+    row = page.locator("tr[data-id]").first
+    row.wait_for(state="visible")
+    kw_id = int(row.get_attribute("data-id"))
+
+    # Auto-accept the confirm dialog BEFORE clicking.
+    page.on("dialog", lambda d: d.accept())
+
+    row.click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    with page.expect_response(
+        lambda r: r.url.endswith(f"/api/keywords/{kw_id}")
+        and r.request.method == "DELETE"
+        and r.status == 200
+    ):
+        menu.locator(".vireo-ctx-item", has_text="Delete").click()
+
+    # Row disappears after re-render.
+    expect(
+        page.locator(f'tr[data-id="{kw_id}"]')
+    ).to_have_count(0)
+
+
+def test_keyword_right_click_multi_disables_single_only_items(live_server, page):
+    """When multiple keywords are selected, Rename and Show Photos are disabled."""
+    url = live_server["url"]
+    page.goto(f"{url}/keywords")
+
+    # Select two rows by toggling their checkboxes.
+    rows = page.locator("tr[data-id]")
+    rows.first.wait_for(state="visible")
+    assert rows.count() >= 2
+    rows.nth(0).locator(".kw-cb").check()
+    rows.nth(1).locator(".kw-cb").check()
+
+    # Right-click one of the already-selected rows — selection stays multi.
+    rows.nth(0).click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    rename = menu.locator(".vireo-ctx-item", has_text="Rename")
+    show = menu.locator(
+        ".vireo-ctx-item", has_text="Show Photos with this Keyword"
+    )
+    expect(rename).to_have_class("vireo-ctx-item vireo-ctx-disabled")
+    expect(show).to_have_class("vireo-ctx-item vireo-ctx-disabled")
+
+
+def test_keyword_right_click_outside_selection_coerces(live_server, page):
+    """Right-click outside the current selection replaces it Finder-style."""
+    url = live_server["url"]
+    page.goto(f"{url}/keywords")
+
+    rows = page.locator("tr[data-id]")
+    rows.first.wait_for(state="visible")
+    assert rows.count() >= 2
+
+    # Check rows 0 and 1.
+    rows.nth(0).locator(".kw-cb").check()
+    rows.nth(1).locator(".kw-cb").check()
+
+    # Right-click row 2 which is NOT in the selection.
+    target = rows.nth(2) if rows.count() >= 3 else rows.nth(1)
+    target_id = int(target.get_attribute("data-id"))
+
+    # If we only have 2 rows, fall back to a row outside the first's selection.
+    if rows.count() < 3:
+        # Uncheck row 1 so row 0 is the sole selected; right-click row 1.
+        rows.nth(1).locator(".kw-cb").uncheck()
+        rows.nth(0).locator(".kw-cb").check()
+        target = rows.nth(1)
+        target_id = int(target.get_attribute("data-id"))
+
+    target.click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    # Selection now contains only the right-clicked row.
+    size = page.evaluate("window.__kwSelectedIds && window.__kwSelectedIds.size")
+    assert size == 1
+    has_target = page.evaluate(
+        f"window.__kwSelectedIds && window.__kwSelectedIds.has({target_id})"
+    )
+    assert has_target is True

--- a/tests/e2e/test_lightbox_context_menu.py
+++ b/tests/e2e/test_lightbox_context_menu.py
@@ -1,0 +1,131 @@
+"""E2E tests for the lightbox right-click context menu.
+
+These tests exercise the shared `openContextMenu` handler wired to the
+lightbox `<img id="lightboxImg">`. The E2E seed fixture creates photo rows
+but the underlying files don't exist on disk, so `/photos/<id>/full` returns
+500 and the image element never gets a non-zero size. We dispatch the
+`contextmenu` event directly rather than using Playwright's
+`click(button="right")` which requires visibility/stability.
+"""
+from playwright.sync_api import expect
+
+
+def _open_lightbox(page, url):
+    """Navigate to browse and open the lightbox on the first grid card."""
+    page.goto(f"{url}/browse")
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.dblclick()
+    # Overlay becomes active synchronously once openLightbox() runs.
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+    # Wait until `_lightboxCurrentId` is populated (openLightbox assigns it
+    # synchronously, but the dblclick → handler chain is async from pytest's
+    # point of view).
+    page.wait_for_function(
+        "typeof _lightboxCurrentId !== 'undefined' && _lightboxCurrentId !== null",
+        timeout=3000,
+    )
+
+
+def _fire_contextmenu_on_lightbox(page):
+    """Dispatch a contextmenu event on the lightbox image.
+
+    Using dispatch_event bypasses visibility checks (the underlying image
+    never loads in the test harness because the photo file doesn't exist
+    on disk). The event still reaches the handler, which is what matters.
+    """
+    page.evaluate(
+        """
+        const img = document.getElementById('lightboxImg');
+        const evt = new MouseEvent('contextmenu', {
+            bubbles: true, cancelable: true, clientX: 400, clientY: 300,
+            button: 2,
+        });
+        img.dispatchEvent(evt);
+        """
+    )
+
+
+def test_lightbox_right_click_opens_menu(live_server, page):
+    """Right-clicking the lightbox image opens the shared context menu."""
+    url = live_server["url"]
+    _open_lightbox(page, url)
+
+    _fire_contextmenu_on_lightbox(page)
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    # A handful of the lightbox-specific menu items.
+    expect(
+        menu.locator(".vireo-ctx-item", has_text="Reveal in")
+    ).to_be_visible()
+    expect(
+        menu.locator(".vireo-ctx-item", has_text="Copy Path")
+    ).to_be_visible()
+    expect(
+        menu.locator(".vireo-ctx-item", has_text="Close Lightbox")
+    ).to_be_visible()
+    # Rating / color / flag chip rows are present (14 chips total).
+    assert menu.locator(".vireo-ctx-chip").count() > 5
+
+
+def test_lightbox_right_click_does_not_toggle_zoom(live_server, page):
+    """Right-click must not trip the click-to-zoom / pan handlers.
+
+    The lightbox exposes the current zoom level via `_lbZoom`. A contextmenu
+    event must not change zoom state.
+    """
+    url = live_server["url"]
+    _open_lightbox(page, url)
+
+    before = page.evaluate(
+        "typeof _lbZoom !== 'undefined' ? _lbZoom : null"
+    )
+    _fire_contextmenu_on_lightbox(page)
+    expect(page.locator(".vireo-ctx-menu")).to_be_visible()
+    after = page.evaluate(
+        "typeof _lbZoom !== 'undefined' ? _lbZoom : null"
+    )
+    assert before == after
+
+
+def test_lightbox_close_menu_item_closes_overlay(live_server, page):
+    """The 'Close Lightbox' menu item dismisses the overlay."""
+    url = live_server["url"]
+    _open_lightbox(page, url)
+
+    _fire_contextmenu_on_lightbox(page)
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    menu.locator(".vireo-ctx-item", has_text="Close Lightbox").click()
+    expect(menu).to_be_hidden()
+    page.wait_for_function(
+        "!document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=2000,
+    )
+
+
+def test_lightbox_rating_chip_applies(live_server, page):
+    """Clicking a rating chip in the lightbox menu rates the current photo."""
+    url = live_server["url"]
+    _open_lightbox(page, url)
+
+    pid = page.evaluate("_lightboxCurrentId")
+    assert pid is not None
+
+    _fire_contextmenu_on_lightbox(page)
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    # First chip row is ratings (0..5). Click the "2" chip.
+    menu.locator(".vireo-ctx-chip", has_text="2").first.click()
+    expect(menu).to_be_hidden()
+
+    # setRatingFor is defined on browse.html; it updates the server and the
+    # local photos[] list. Poll for the rating change.
+    page.wait_for_function(
+        f"(photos.find(p => p.id === {pid}) || {{}}).rating === 2",
+        timeout=3000,
+    )

--- a/tests/e2e/test_lightbox_context_menu.py
+++ b/tests/e2e/test_lightbox_context_menu.py
@@ -129,3 +129,32 @@ def test_lightbox_rating_chip_applies(live_server, page):
         f"(photos.find(p => p.id === {pid}) || {{}}).rating === 2",
         timeout=3000,
     )
+
+
+def test_outside_click_dismiss_swallows_next_click(live_server, page):
+    """Outside-click dismissal of the context menu must swallow the click.
+
+    If the click propagates after `_outside` tears the menu down, any
+    underlying handler (e.g. the lightbox overlay's `onclick=closeLightbox`)
+    would fire unexpectedly. We install a body-level click listener,
+    dismiss the menu by clicking outside it, and assert the listener never
+    saw the click.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.evaluate(
+        """() => {
+            window.__outside_click_count = 0;
+            document.body.addEventListener('click', () => {
+                window.__outside_click_count++;
+            }, false);
+            openContextMenu({clientX: 100, clientY: 100},
+                [{label: 'X', onClick: () => {}}]);
+        }"""
+    )
+    expect(page.locator('.vireo-ctx-menu')).to_be_visible()
+    page.mouse.click(500, 500)
+    expect(page.locator('.vireo-ctx-menu')).to_be_hidden()
+    # The outside click should have been swallowed before reaching body.
+    count = page.evaluate("window.__outside_click_count")
+    assert count == 0, f"outside-click-to-dismiss reached body (count={count})"

--- a/tests/e2e/test_review_context_menu.py
+++ b/tests/e2e/test_review_context_menu.py
@@ -118,3 +118,52 @@ def test_review_card_open_lightbox_opens_overlay(live_server, page):
     menu.locator(".vireo-ctx-item", has_text="Open in Lightbox").click()
 
     expect(page.locator("#lightboxOverlay")).to_be_visible()
+
+
+def test_review_lightbox_rating_chip_posts_batch(live_server, page):
+    """Regression guard: rating chips in the lightbox context menu on /review
+    must POST to /api/batch/rating via setReviewRating. Previously the menu
+    called setRatingFor (browse-only) and silently no-oped on /review.
+    The color row is also omitted on /review since there is no
+    setColorLabelFor equivalent.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+
+    card = page.locator(".card[data-pred-id]").first
+    card.wait_for(state="visible")
+    card.click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    menu.locator(".vireo-ctx-item", has_text="Open in Lightbox").click()
+    expect(page.locator("#lightboxOverlay")).to_be_visible()
+
+    # Wait for the lightbox to settle on a photo id.
+    page.wait_for_function(
+        "typeof _lightboxCurrentId !== 'undefined' && _lightboxCurrentId !== null",
+        timeout=3000,
+    )
+
+    # Dispatch contextmenu directly — the in-test image has no real src so
+    # Playwright's visibility check would stall.
+    page.evaluate(
+        """
+        const img = document.getElementById('lightboxImg');
+        const evt = new MouseEvent('contextmenu', {
+            bubbles: true, cancelable: true, clientX: 300, clientY: 300,
+            button: 2,
+        });
+        img.dispatchEvent(evt);
+        """
+    )
+    lb_menu = page.locator(".vireo-ctx-menu")
+    expect(lb_menu).to_be_visible()
+
+    # With no setColorLabelFor on /review, only ratings (6) + flags (3) = 9.
+    assert lb_menu.locator(".vireo-ctx-chip").count() == 9
+
+    with page.expect_response(
+        lambda r: "/api/batch/rating" in r.url and r.status == 200
+    ):
+        lb_menu.locator(".vireo-ctx-chip", has_text="4").first.click()
+    expect(lb_menu).to_be_hidden()

--- a/tests/e2e/test_review_context_menu.py
+++ b/tests/e2e/test_review_context_menu.py
@@ -1,0 +1,120 @@
+from playwright.sync_api import expect
+
+
+def test_review_card_right_click_opens_menu(live_server, page):
+    """Right-clicking a review prediction card opens the context menu."""
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+
+    card = page.locator(".card[data-pred-id]").first
+    card.wait_for(state="visible")
+    card.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    # Core prediction actions name the species.
+    expect(menu.locator(".vireo-ctx-item", has_text="Accept as")).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="Not ")).to_be_visible()
+
+    # Navigation + file-system actions.
+    expect(menu.locator(".vireo-ctx-item", has_text="Open in Lightbox")).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="Reveal in")).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="Copy Path")).to_be_visible()
+
+    # Rating + flag chip rows present (6 rating + 3 flag = 9 chips).
+    assert menu.locator(".vireo-ctx-chip").count() >= 9
+
+
+def test_review_card_accept_fires_endpoint(live_server, page):
+    """Clicking the Accept menu item POSTs to /predictions/<id>/accept."""
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+
+    card = page.locator(".card[data-pred-id]").first
+    card.wait_for(state="visible")
+    pred_id = int(card.get_attribute("data-pred-id"))
+    card.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    with page.expect_response(
+        lambda r: f"/api/predictions/{pred_id}/accept" in r.url and r.status == 200
+    ):
+        menu.locator(".vireo-ctx-item", has_text="Accept as").click()
+    expect(menu).to_be_hidden()
+
+
+def test_review_card_reject_fires_endpoint(live_server, page):
+    """Clicking the reject menu item POSTs to /predictions/<id>/reject."""
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+
+    card = page.locator(".card[data-pred-id]").first
+    card.wait_for(state="visible")
+    pred_id = int(card.get_attribute("data-pred-id"))
+    card.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    with page.expect_response(
+        lambda r: f"/api/predictions/{pred_id}/reject" in r.url and r.status == 200
+    ):
+        menu.locator(".vireo-ctx-item", has_text="Not ").click()
+    expect(menu).to_be_hidden()
+
+
+def test_review_card_rating_chip_fires_batch_endpoint(live_server, page):
+    """Clicking a rating chip applies the rating via /api/batch/rating."""
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+
+    card = page.locator(".card[data-pred-id]").first
+    card.wait_for(state="visible")
+    card.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    with page.expect_response(
+        lambda r: "/api/batch/rating" in r.url and r.status == 200
+    ):
+        menu.locator(".vireo-ctx-chip", has_text="3").first.click()
+    expect(menu).to_be_hidden()
+
+
+def test_review_card_reveal_fires_endpoint(live_server, page):
+    """Reveal in Finder/Folder posts the right photo_id to the reveal API."""
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+
+    card = page.locator(".card[data-pred-id]").first
+    card.wait_for(state="visible")
+    card.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    with page.expect_response(
+        lambda r: "/api/files/reveal" in r.url and r.status == 200
+    ):
+        menu.locator(".vireo-ctx-item", has_text="Reveal in").click()
+    expect(menu).to_be_hidden()
+
+
+def test_review_card_open_lightbox_opens_overlay(live_server, page):
+    """Open in Lightbox opens the shared lightbox overlay."""
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+
+    card = page.locator(".card[data-pred-id]").first
+    card.wait_for(state="visible")
+    card.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    menu.locator(".vireo-ctx-item", has_text="Open in Lightbox").click()
+
+    expect(page.locator("#lightboxOverlay")).to_be_visible()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11,6 +11,7 @@ import logging.handlers
 import os
 import queue
 import subprocess
+import sys
 import time
 import webbrowser
 from datetime import UTC
@@ -1230,6 +1231,44 @@ def create_app(db_path, thumb_cache_dir=None):
             db.remove_color_label(photo_id)
         db.record_edit('color_label', f'Set color to {color or "none"}', new_color,
                        [{'photo_id': photo_id, 'old_value': old_color, 'new_value': new_color}])
+        return jsonify({"ok": True})
+
+    @app.route("/api/files/reveal", methods=["POST"])
+    def api_files_reveal():
+        """Reveal a photo in the OS file manager (Finder / Explorer / xdg-open).
+
+        Body: {"photo_id": <int>}
+        Returns: {"ok": True} on success; {"ok": False, "reason": "..."} if the
+        subprocess failed to launch; 404 if the photo id is unknown; 400 if
+        photo_id is missing from the body.
+        """
+        body = request.get_json(silent=True) or {}
+        pid = body.get("photo_id")
+        if pid is None:
+            return json_error("photo_id required")
+        db = _get_db()
+        photo = db.get_photo(int(pid))
+        if not photo:
+            return json_error("photo not found", 404)
+        folder_row = db.conn.execute(
+            "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+        ).fetchone()
+        folder_path = folder_row["path"] if folder_row else ""
+        if not folder_path or not photo["filename"]:
+            return jsonify({"ok": False, "reason": "no path"})
+        path = os.path.join(folder_path, photo["filename"])
+        try:
+            if sys.platform == "darwin":
+                subprocess.run(["open", "-R", path], timeout=5, check=False)
+            elif sys.platform.startswith("win"):
+                subprocess.run(
+                    ["explorer", f"/select,{path}"], timeout=5, check=False
+                )
+            else:
+                parent = os.path.dirname(path) or path
+                subprocess.run(["xdg-open", parent], timeout=5, check=False)
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            return jsonify({"ok": False, "reason": str(exc)})
         return jsonify({"ok": True})
 
     @app.route("/api/photos/<int:photo_id>/keywords", methods=["POST"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1039,6 +1039,11 @@ def create_app(db_path, thumb_cache_dir=None):
             "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
         ).fetchone()
         if folder:
+            # Full on-disk path: mirrors the folder-join logic in
+            # api_files_reveal. Exposed so the browse-grid "Copy Path"
+            # right-click action can read a real filesystem path from the
+            # detail response.
+            result["path"] = os.path.join(folder["path"], photo["filename"])
             xmp_path = os.path.join(
                 folder["path"],
                 os.path.splitext(photo["filename"])[0] + ".xmp",
@@ -1053,6 +1058,7 @@ def create_app(db_path, thumb_cache_dir=None):
             result["xmp_keywords"] = xmp_keywords
             result["xmp_path"] = xmp_path
         else:
+            result["path"] = ""
             result["xmp_exists"] = False
             result["xmp_keywords"] = []
             result["xmp_path"] = ""

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1786,6 +1786,20 @@ def create_app(db_path, thumb_cache_dir=None):
         db.delete_collection(collection_id)
         return jsonify({"ok": True})
 
+    @app.route("/api/collections/<int:collection_id>", methods=["PUT"])
+    def api_update_collection(collection_id):
+        """Rename a collection. Body: {"name": "..."}."""
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        name = (body.get("name") or "").strip()
+        if not name:
+            return json_error("name required")
+        try:
+            db.rename_collection(collection_id, name)
+        except ValueError:
+            return json_error("collection not found", 404)
+        return jsonify({"ok": True})
+
     @app.route("/api/collections/<int:collection_id>/add-photos", methods=["POST"])
     def api_collection_add_photos(collection_id):
         """Add photos to a static collection by appending to its photo_ids rule."""

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -866,11 +866,18 @@ def create_app(db_path, thumb_cache_dir=None):
 
         Powers the folder-tree context menu's "Copy Path" action. A lean
         response on purpose: callers that want the richer tree data already
-        have /api/folders for that.
+        have /api/folders for that. Scoped to the active workspace so
+        absolute paths from folders hidden in this workspace don't leak.
         """
         db = _get_db()
         folder = db.get_folder(folder_id)
         if not folder:
+            return json_error("folder not found", 404)
+        linked = db.conn.execute(
+            "SELECT 1 FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+            (db._active_workspace_id, folder_id),
+        ).fetchone()
+        if not linked:
             return json_error("folder not found", 404)
         return jsonify({
             "id": folder["id"],
@@ -1290,7 +1297,11 @@ def create_app(db_path, thumb_cache_dir=None):
                 pid_int = int(pid_raw)
             except (TypeError, ValueError):
                 return json_error("photo_id must be an integer")
-            photo = db.get_photo(pid_int)
+            # verify_workspace=True enforces that the photo's folder is
+            # linked to the active workspace — otherwise this endpoint would
+            # expose absolute filesystem paths for photos hidden from the
+            # current workspace.
+            photo = db.get_photo(pid_int, verify_workspace=True)
             if not photo:
                 return json_error("photo not found", 404)
             folder_row = db.conn.execute(
@@ -1307,6 +1318,14 @@ def create_app(db_path, thumb_cache_dir=None):
                 return json_error("folder_id must be an integer")
             folder = db.get_folder(fid_int)
             if not folder:
+                return json_error("folder not found", 404)
+            # Reject reveal for folders not linked to the active workspace,
+            # matching the photo branch's verify_workspace gate.
+            linked = db.conn.execute(
+                "SELECT 1 FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+                (db._active_workspace_id, fid_int),
+            ).fetchone()
+            if not linked:
                 return json_error("folder not found", 404)
             folder_path = folder["path"]
             if not folder_path:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4680,32 +4680,16 @@ def create_app(db_path, thumb_cache_dir=None):
 
     # -- Job API routes --
 
-    @app.route("/api/jobs/scan", methods=["POST"])
-    def api_job_scan():
-        body = request.get_json(silent=True) or {}
-        root = body.get("root", "")
-        incremental = body.get("incremental", False)
-        if not root:
-            return json_error("root path required")
-        if not os.path.isdir(root):
-            return json_error(f"directory not found: {root}")
+    def _build_scan_work(root, incremental, active_ws):
+        """Build the background work function for a scan job.
 
-        # Remember this scan root (skip temp directories from tests)
-        import tempfile
-
+        Shared by ``POST /api/jobs/scan`` and
+        ``POST /api/folders/<id>/rescan`` so per-folder rescans reuse the
+        same scan + thumbnail pipeline as a full scan.
+        """
         import config as cfg
 
-        tmp_prefix = os.path.realpath(tempfile.gettempdir())
-        if not os.path.realpath(root).startswith(tmp_prefix):
-            user_cfg = cfg.load()
-            roots = user_cfg.get("scan_roots", [])
-            if root not in roots:
-                roots.insert(0, root)
-                user_cfg["scan_roots"] = roots
-                cfg.save(user_cfg)
-
         runner = app._job_runner
-        active_ws = _get_db()._active_workspace_id
 
         def work(job):
             from scanner import scan as do_scan
@@ -4813,8 +4797,70 @@ def create_app(db_path, thumb_cache_dir=None):
 
             return {"photos_indexed": photo_count, "thumbnails": thumb_result}
 
+        return work
+
+    @app.route("/api/jobs/scan", methods=["POST"])
+    def api_job_scan():
+        body = request.get_json(silent=True) or {}
+        root = body.get("root", "")
+        incremental = body.get("incremental", False)
+        if not root:
+            return json_error("root path required")
+        if not os.path.isdir(root):
+            return json_error(f"directory not found: {root}")
+
+        # Remember this scan root (skip temp directories from tests)
+        import tempfile
+
+        import config as cfg
+
+        tmp_prefix = os.path.realpath(tempfile.gettempdir())
+        if not os.path.realpath(root).startswith(tmp_prefix):
+            user_cfg = cfg.load()
+            roots = user_cfg.get("scan_roots", [])
+            if root not in roots:
+                roots.insert(0, root)
+                user_cfg["scan_roots"] = roots
+                cfg.save(user_cfg)
+
+        runner = app._job_runner
+        active_ws = _get_db()._active_workspace_id
+
+        work = _build_scan_work(root, incremental, active_ws)
+
         job_id = runner.start(
             "scan", work, config={"root": root, "incremental": incremental},
+            workspace_id=active_ws,
+        )
+        return jsonify({"job_id": job_id})
+
+    @app.route("/api/folders/<int:folder_id>/rescan", methods=["POST"])
+    def api_folder_rescan(folder_id):
+        """Queue a scan job scoped to the given folder's path.
+
+        Body (optional): {"incremental": bool}
+        Returns: {"job_id": "scan-..."} on success; 404 if the folder id
+        is unknown.
+        """
+        body = request.get_json(silent=True) or {}
+        incremental = bool(body.get("incremental", False))
+        db = _get_db()
+        folder = db.get_folder(folder_id)
+        if not folder:
+            return json_error("folder not found", 404)
+        root = folder["path"]
+        active_ws = db._active_workspace_id
+        runner = app._job_runner
+
+        work = _build_scan_work(root, incremental, active_ws)
+
+        job_id = runner.start(
+            "scan", work,
+            config={
+                "root": root,
+                "incremental": incremental,
+                "folder_id": folder_id,
+            },
             workspace_id=active_ws,
         )
         return jsonify({"job_id": job_id})

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4932,7 +4932,7 @@ def create_app(db_path, thumb_cache_dir=None):
 
         Body (optional): {"incremental": bool}
         Returns: {"job_id": "scan-..."} on success; 404 if the folder id
-        is unknown.
+        is unknown or not linked to the active workspace.
         """
         body = request.get_json(silent=True) or {}
         incremental = bool(body.get("incremental", False))
@@ -4940,10 +4940,21 @@ def create_app(db_path, thumb_cache_dir=None):
         folder = db.get_folder(folder_id)
         if not folder:
             return json_error("folder not found", 404)
+        # Folders are global but scans emit workspace-scoped data (predictions,
+        # pending_changes). Reject rescans of folders the active workspace has
+        # no claim on — otherwise a stale UI or crafted request could pollute
+        # this workspace with scan output from an unrelated folder, and
+        # add_folder's auto-link would silently attach it.
+        active_ws = db._active_workspace_id
+        linked = db.conn.execute(
+            "SELECT 1 FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+            (active_ws, folder_id),
+        ).fetchone()
+        if not linked:
+            return json_error("folder not found", 404)
         root = folder["path"]
         if not os.path.isdir(root):
             return json_error(f"folder path no longer exists: {root}")
-        active_ws = db._active_workspace_id
         runner = app._job_runner
 
         work = _build_scan_work(root, incremental, active_ws)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1246,8 +1246,12 @@ def create_app(db_path, thumb_cache_dir=None):
         pid = body.get("photo_id")
         if pid is None:
             return json_error("photo_id required")
+        try:
+            pid_int = int(pid)
+        except (TypeError, ValueError):
+            return json_error("photo_id must be an integer")
         db = _get_db()
-        photo = db.get_photo(int(pid))
+        photo = db.get_photo(pid_int)
         if not photo:
             return json_error("photo not found", 404)
         folder_row = db.conn.execute(
@@ -1259,14 +1263,14 @@ def create_app(db_path, thumb_cache_dir=None):
         path = os.path.join(folder_path, photo["filename"])
         try:
             if sys.platform == "darwin":
-                subprocess.run(["open", "-R", path], timeout=5, check=False)
+                subprocess.run(["open", "-R", "--", path], timeout=5, check=False)
             elif sys.platform.startswith("win"):
                 subprocess.run(
                     ["explorer", f"/select,{path}"], timeout=5, check=False
                 )
             else:
                 parent = os.path.dirname(path) or path
-                subprocess.run(["xdg-open", parent], timeout=5, check=False)
+                subprocess.run(["xdg-open", "--", parent], timeout=5, check=False)
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
             return jsonify({"ok": False, "reason": str(exc)})
         return jsonify({"ok": True})

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -860,6 +860,24 @@ def create_app(db_path, thumb_cache_dir=None):
             "missing": [dict(f) for f in missing],
         })
 
+    @app.route("/api/folders/<int:folder_id>", methods=["GET"])
+    def api_folder_get(folder_id):
+        """Return a single folder's id, name, and path.
+
+        Powers the folder-tree context menu's "Copy Path" action. A lean
+        response on purpose: callers that want the richer tree data already
+        have /api/folders for that.
+        """
+        db = _get_db()
+        folder = db.get_folder(folder_id)
+        if not folder:
+            return json_error("folder not found", 404)
+        return jsonify({
+            "id": folder["id"],
+            "name": folder["name"],
+            "path": folder["path"],
+        })
+
     @app.route("/api/folders/<int:folder_id>/relocate", methods=["POST"])
     def api_folder_relocate(folder_id):
         db = _get_db()
@@ -1241,42 +1259,83 @@ def create_app(db_path, thumb_cache_dir=None):
 
     @app.route("/api/files/reveal", methods=["POST"])
     def api_files_reveal():
-        """Reveal a photo in the OS file manager (Finder / Explorer / xdg-open).
+        """Reveal a photo or folder in the OS file manager.
 
-        Body: {"photo_id": <int>}
-        Returns: {"ok": True} on success; {"ok": False, "reason": "..."} if the
-        subprocess failed to launch; 404 if the photo id is unknown; 400 if
-        photo_id is missing from the body.
+        Body: {"photo_id": <int>} OR {"folder_id": <int>}
+
+        Photo reveals select the file in its parent directory (macOS ``open
+        -R``, Windows ``explorer /select,``, Linux ``xdg-open <parent dir>``).
+        Folder reveals open the folder itself (macOS ``open -R <dir>``,
+        Windows ``explorer <dir>``, Linux ``xdg-open <dir>``) — this differs
+        from the photo case on Windows where we deliberately skip ``/select,``
+        so the user sees the folder's contents rather than its parent.
+
+        Returns: {"ok": True} on success; {"ok": False, "reason": "..."} if
+        the subprocess failed to launch; 404 if the id is unknown; 400 if
+        neither id was provided or either is malformed.
         """
         body = request.get_json(silent=True) or {}
-        pid = body.get("photo_id")
-        if pid is None:
-            return json_error("photo_id required")
-        try:
-            pid_int = int(pid)
-        except (TypeError, ValueError):
-            return json_error("photo_id must be an integer")
+        pid_raw = body.get("photo_id")
+        fid_raw = body.get("folder_id")
+
+        if pid_raw is None and fid_raw is None:
+            return json_error("photo_id or folder_id required")
+
         db = _get_db()
-        photo = db.get_photo(pid_int)
-        if not photo:
-            return json_error("photo not found", 404)
-        folder_row = db.conn.execute(
-            "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
-        ).fetchone()
-        folder_path = folder_row["path"] if folder_row else ""
-        if not folder_path or not photo["filename"]:
-            return jsonify({"ok": False, "reason": "no path"})
-        path = os.path.join(folder_path, photo["filename"])
+        is_folder = False
+        path = ""
+
+        if pid_raw is not None:
+            try:
+                pid_int = int(pid_raw)
+            except (TypeError, ValueError):
+                return json_error("photo_id must be an integer")
+            photo = db.get_photo(pid_int)
+            if not photo:
+                return json_error("photo not found", 404)
+            folder_row = db.conn.execute(
+                "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+            ).fetchone()
+            folder_path = folder_row["path"] if folder_row else ""
+            if not folder_path or not photo["filename"]:
+                return jsonify({"ok": False, "reason": "no path"})
+            path = os.path.join(folder_path, photo["filename"])
+        else:
+            try:
+                fid_int = int(fid_raw)
+            except (TypeError, ValueError):
+                return json_error("folder_id must be an integer")
+            folder = db.get_folder(fid_int)
+            if not folder:
+                return json_error("folder not found", 404)
+            folder_path = folder["path"]
+            if not folder_path:
+                return jsonify({"ok": False, "reason": "no path"})
+            path = folder_path
+            is_folder = True
+
         try:
             if sys.platform == "darwin":
+                # "open -R <dir>" reveals the folder inside its parent; that's
+                # the right behavior for folder reveals too, consistent with
+                # how Finder treats folder-targeted reveal.
                 subprocess.run(["open", "-R", "--", path], timeout=5, check=False)
             elif sys.platform.startswith("win"):
-                subprocess.run(
-                    ["explorer", f"/select,{path}"], timeout=5, check=False
-                )
+                if is_folder:
+                    # Open the folder itself so the user sees its contents.
+                    subprocess.run(["explorer", path], timeout=5, check=False)
+                else:
+                    subprocess.run(
+                        ["explorer", f"/select,{path}"], timeout=5, check=False
+                    )
             else:
-                parent = os.path.dirname(path) or path
-                subprocess.run(["xdg-open", "--", parent], timeout=5, check=False)
+                # xdg-open on a file has inconsistent behavior across desktops
+                # (some open the image viewer, not the file manager), so for
+                # photo reveals we open the parent directory instead. Passing
+                # a directory to xdg-open opens the folder in the file manager,
+                # which is exactly what we want for folder reveals.
+                target = path if is_folder else (os.path.dirname(path) or path)
+                subprocess.run(["xdg-open", "--", target], timeout=5, check=False)
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
             return jsonify({"ok": False, "reason": str(exc)})
         return jsonify({"ok": True})

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4849,6 +4849,8 @@ def create_app(db_path, thumb_cache_dir=None):
         if not folder:
             return json_error("folder not found", 404)
         root = folder["path"]
+        if not os.path.isdir(root):
+            return json_error(f"folder path no longer exists: {root}")
         active_ws = db._active_workspace_id
         runner = app._job_runner
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1335,7 +1335,10 @@ def create_app(db_path, thumb_cache_dir=None):
                 # a directory to xdg-open opens the folder in the file manager,
                 # which is exactly what we want for folder reveals.
                 target = path if is_folder else (os.path.dirname(path) or path)
-                subprocess.run(["xdg-open", "--", target], timeout=5, check=False)
+                # xdg-open doesn't honor `--`; abspath guarantees a leading `/`
+                # so a crafted leading-dash path can't be parsed as a flag.
+                target = os.path.abspath(target)
+                subprocess.run(["xdg-open", target], timeout=5, check=False)
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
             return jsonify({"ok": False, "reason": str(exc)})
         return jsonify({"ok": True})

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1765,6 +1765,16 @@ def create_app(db_path, thumb_cache_dir=None):
         db.conn.commit()
         return jsonify({"ok": True, "total": len(ids_rule["value"])})
 
+    @app.route("/api/collections/<int:collection_id>/duplicate", methods=["POST"])
+    def api_collection_duplicate(collection_id):
+        """Duplicate a collection within the active workspace. Returns {id}."""
+        db = _get_db()
+        try:
+            new_id = db.duplicate_collection(collection_id)
+        except ValueError:
+            return json_error("collection not found", 404)
+        return jsonify({"ok": True, "id": new_id})
+
     @app.route("/api/collections/<int:collection_id>/photos")
     def api_collection_photos(collection_id):
         import config as cfg

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1134,6 +1134,19 @@ class Database:
         ).fetchall()
         return [r["id"] for r in rows]
 
+    def get_folder(self, folder_id):
+        """Return a single folder row by id, or None if not found.
+
+        Not scoped to the active workspace — callers that need workspace
+        scoping should additionally verify membership via
+        ``workspace_folders``.
+        """
+        return self.conn.execute(
+            "SELECT id, path, name, parent_id, status, photo_count "
+            "FROM folders WHERE id = ?",
+            (folder_id,),
+        ).fetchone()
+
     def check_folder_health(self):
         """Check all folders for existence on disk. Update status column.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4346,6 +4346,45 @@ class Database:
         )
         self.conn.commit()
 
+    def duplicate_collection(self, collection_id):
+        """Copy a collection (name + rules) within the active workspace.
+
+        The new collection's name is ``"{original} (copy)"``; if that name is
+        already taken, append an incrementing counter like ``"(copy 2)"``.
+        Rules are copied verbatim, which means static collections (photo_ids
+        rules) keep their memberships.
+
+        Returns the new collection id. Raises ``ValueError`` if the source
+        collection isn't in the active workspace.
+        """
+        ws = self._ws_id()
+        row = self.conn.execute(
+            "SELECT name, rules FROM collections WHERE id = ? AND workspace_id = ?",
+            (collection_id, ws),
+        ).fetchone()
+        if not row:
+            raise ValueError("collection not found")
+
+        existing = {
+            c["name"]
+            for c in self.conn.execute(
+                "SELECT name FROM collections WHERE workspace_id = ?", (ws,)
+            ).fetchall()
+        }
+        base = f"{row['name']} (copy)"
+        new_name = base
+        n = 2
+        while new_name in existing:
+            new_name = f"{row['name']} (copy {n})"
+            n += 1
+
+        cur = self.conn.execute(
+            "INSERT INTO collections (name, rules, workspace_id) VALUES (?, ?, ?)",
+            (new_name, row["rules"], ws),
+        )
+        self.conn.commit()
+        return cur.lastrowid
+
     def _build_collection_query(self, collection_id):
         """Build SQL clauses from collection rules.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4346,6 +4346,20 @@ class Database:
         )
         self.conn.commit()
 
+    def rename_collection(self, collection_id, new_name):
+        """Rename a collection within the active workspace.
+
+        Raises ``ValueError`` if the collection isn't in the active workspace.
+        """
+        ws = self._ws_id()
+        cur = self.conn.execute(
+            "UPDATE collections SET name = ? WHERE id = ? AND workspace_id = ?",
+            (new_name, collection_id, ws),
+        )
+        if cur.rowcount == 0:
+            raise ValueError("collection not found")
+        self.conn.commit()
+
     def duplicate_collection(self, collection_id):
         """Copy a collection (name + rules) within the active workspace.
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1269,6 +1269,14 @@ function sendReport() {
     document.addEventListener('keydown', _keydown, true);
     window.addEventListener('blur', closeContextMenu);
   };
+
+  window.coerceSelectionOnContext = function(selectionSet, clickedId){
+    if (!selectionSet.has(clickedId)) {
+      selectionSet.clear();
+      selectionSet.add(clickedId);
+    }
+    return Array.from(selectionSet);
+  };
 })();
 </script>
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1027,7 +1027,7 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 
 /* Shared right-click context menu */
 .vireo-ctx-menu {
-  position: fixed; z-index: 1000;
+  position: fixed; z-index: 99999;
   background: var(--bg-secondary);
   border: 1px solid var(--border-secondary);
   border-radius: 6px; padding: 4px 0;
@@ -1200,7 +1200,6 @@ function sendReport() {
     document.removeEventListener('mousedown', _outside, true);
     document.removeEventListener('keydown', _keydown, true);
     window.removeEventListener('blur', closeContextMenu);
-    window.removeEventListener('scroll', closeContextMenu, true);
     if (_ctxDismiss) { const f = _ctxDismiss; _ctxDismiss = null; f(); }
   };
 
@@ -1252,6 +1251,7 @@ function sendReport() {
     closeContextMenu();
     const menu = document.createElement('div');
     menu.className = 'vireo-ctx-menu';
+    menu.style.visibility = 'hidden';
     items.forEach(it => menu.appendChild(_renderItem(it)));
     document.body.appendChild(menu);
     // Clamp to viewport.
@@ -1262,12 +1262,12 @@ function sendReport() {
     if (y + rect.height > vh) y = Math.max(0, vh - rect.height - 4);
     menu.style.left = x + 'px';
     menu.style.top  = y + 'px';
+    menu.style.visibility = 'visible';
     _ctxEl = menu;
     _ctxDismiss = (opts && opts.onDismiss) || null;
     document.addEventListener('mousedown', _outside, true);
     document.addEventListener('keydown', _keydown, true);
     window.addEventListener('blur', closeContextMenu);
-    window.addEventListener('scroll', closeContextMenu, true);
   };
 })();
 </script>

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1024,6 +1024,41 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 }
 /* When the missing-folders banner is visible above, new-images stacks
    naturally in document flow — both are non-fixed block-level elements. */
+
+/* Shared right-click context menu */
+.vireo-ctx-menu {
+  position: fixed; z-index: 1000;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-secondary);
+  border-radius: 6px; padding: 4px 0;
+  min-width: 180px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+  font-size: 13px; color: var(--text-primary);
+  user-select: none;
+}
+.vireo-ctx-item {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 12px; cursor: pointer;
+}
+.vireo-ctx-item:hover:not(.vireo-ctx-disabled) {
+  background: var(--bg-tertiary);
+}
+.vireo-ctx-disabled {
+  color: var(--text-tertiary); cursor: default;
+}
+.vireo-ctx-sep {
+  height: 1px; background: var(--border-secondary);
+  margin: 4px 0;
+}
+.vireo-ctx-chips {
+  display: flex; gap: 4px; padding: 6px 12px;
+}
+.vireo-ctx-chip {
+  flex: 0 0 auto; padding: 2px 6px; border-radius: 4px;
+  cursor: pointer; line-height: 1;
+}
+.vireo-ctx-chip:hover { background: var(--bg-tertiary); }
+.vireo-ctx-chip.is-active { background: var(--accent); color: white; }
 </style>
 
 <nav class="navbar">
@@ -1154,6 +1189,87 @@ function sendReport() {
     btn.textContent = 'Send Report';
   });
 }
+
+/* Shared right-click context menu component. */
+(function(){
+  let _ctxEl = null;
+  let _ctxDismiss = null;
+
+  window.closeContextMenu = function(){
+    if (_ctxEl) { _ctxEl.remove(); _ctxEl = null; }
+    document.removeEventListener('mousedown', _outside, true);
+    document.removeEventListener('keydown', _keydown, true);
+    window.removeEventListener('blur', closeContextMenu);
+    window.removeEventListener('scroll', closeContextMenu, true);
+    if (_ctxDismiss) { const f = _ctxDismiss; _ctxDismiss = null; f(); }
+  };
+
+  function _outside(e){
+    if (_ctxEl && !_ctxEl.contains(e.target)) closeContextMenu();
+  }
+  function _keydown(e){
+    if (e.key === 'Escape') { e.preventDefault(); closeContextMenu(); }
+  }
+
+  function _renderItem(item){
+    if (item.separator) {
+      const s = document.createElement('div');
+      s.className = 'vireo-ctx-sep';
+      return s;
+    }
+    if (item.chips) {
+      const row = document.createElement('div');
+      row.className = 'vireo-ctx-chips';
+      item.chips.forEach(c => {
+        const b = document.createElement('span');
+        b.className = 'vireo-ctx-chip' + (c.active ? ' is-active' : '');
+        b.textContent = c.label;
+        if (c.title) b.title = c.title;
+        b.addEventListener('click', ev => {
+          ev.stopPropagation();
+          closeContextMenu();
+          try { c.onClick && c.onClick(); } catch(err){ console.error(err); }
+        });
+        row.appendChild(b);
+      });
+      return row;
+    }
+    const d = document.createElement('div');
+    d.className = 'vireo-ctx-item' + (item.disabled ? ' vireo-ctx-disabled' : '');
+    d.textContent = item.label;
+    if (item.disabled && item.disabledHint) d.title = item.disabledHint;
+    if (!item.disabled) {
+      d.addEventListener('click', ev => {
+        ev.stopPropagation();
+        closeContextMenu();
+        try { item.onClick && item.onClick(); } catch(err){ console.error(err); }
+      });
+    }
+    return d;
+  }
+
+  window.openContextMenu = function(event, items, opts){
+    closeContextMenu();
+    const menu = document.createElement('div');
+    menu.className = 'vireo-ctx-menu';
+    items.forEach(it => menu.appendChild(_renderItem(it)));
+    document.body.appendChild(menu);
+    // Clamp to viewport.
+    const vw = window.innerWidth, vh = window.innerHeight;
+    const rect = menu.getBoundingClientRect();
+    let x = event.clientX, y = event.clientY;
+    if (x + rect.width  > vw) x = Math.max(0, vw - rect.width  - 4);
+    if (y + rect.height > vh) y = Math.max(0, vh - rect.height - 4);
+    menu.style.left = x + 'px';
+    menu.style.top  = y + 'px';
+    _ctxEl = menu;
+    _ctxDismiss = (opts && opts.onDismiss) || null;
+    document.addEventListener('mousedown', _outside, true);
+    document.addEventListener('keydown', _keydown, true);
+    window.addEventListener('blur', closeContextMenu);
+    window.addEventListener('scroll', closeContextMenu, true);
+  };
+})();
 </script>
 
 <!-- Missing Folders Banner -->

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2220,6 +2220,8 @@ function toggleLightboxZoom(e) {
   var DRAG_THRESHOLD = 5;
 
   document.addEventListener('mousedown', function(e) {
+    // Right-click (button 2) opens the context menu — never start a pan.
+    if (e.button !== 0) return;
     var wrap = document.getElementById('lightboxWrap');
     if (!wrap || _lbZoom <= 1.001) return;
     if (e.target.tagName === 'BUTTON' || e.target.closest('button')) return;
@@ -2274,6 +2276,97 @@ function closeLightbox(e) {
   if (detContainer) detContainer.innerHTML = '';
   document.body.style.overflow = '';
 }
+
+/* ---------- Lightbox right-click context menu ----------
+ * The lightbox is shared across pages (browse, review, etc.), so the menu
+ * sits in _navbar.html alongside the overlay. Rating / color / flag / reveal
+ * helpers (`setRatingFor`, `setColorLabelFor`, `setFlagFor`, `findSimilar`,
+ * `openInEditor`, `revealPhoto`, `copyPhotoPaths`) are defined on pages that
+ * carry a photo grid (browse.html). On pages without those helpers, the
+ * corresponding menu items are omitted so clicking them can never throw.
+ */
+function buildLightboxContextMenu(pid) {
+  var has = function(name) { return typeof window[name] === 'function'; };
+
+  var rateChip = function(n) {
+    return {
+      label: n === 0 ? '\u2606' : String(n),
+      title: n === 0 ? 'No rating' : 'Rate ' + n,
+      onClick: function() { if (has('setRatingFor')) window.setRatingFor(pid, n); },
+    };
+  };
+  var colorChip = function(c, icon, title) {
+    return {
+      label: icon, title: title,
+      onClick: function() { if (has('setColorLabelFor')) window.setColorLabelFor(pid, c); },
+    };
+  };
+  var flagChip = function(f, icon, title) {
+    return {
+      label: icon, title: title,
+      onClick: function() { if (has('setFlagFor')) window.setFlagFor(pid, f); },
+    };
+  };
+
+  var items = [
+    { chips: [0, 1, 2, 3, 4, 5].map(rateChip) },
+    { chips: [
+      colorChip(null, '\u25CB', 'No color'),
+      colorChip('red', '\u25CF', 'Red'),
+      colorChip('yellow', '\u25CF', 'Yellow'),
+      colorChip('green', '\u25CF', 'Green'),
+      colorChip('blue', '\u25CF', 'Blue'),
+    ] },
+    { chips: [
+      flagChip('flagged', '\u2691', 'Flag as pick'),
+      flagChip('rejected', '\u2715', 'Reject'),
+      flagChip('none', '\u25CB', 'Unflag'),
+    ] },
+    { separator: true },
+  ];
+
+  if (has('findSimilar')) {
+    items.push({ label: 'Find Similar',
+      onClick: function() { window.findSimilar(pid); } });
+  }
+  if (has('openInEditor')) {
+    items.push({ label: 'Open in Editor',
+      onClick: function() { window.openInEditor([pid]); } });
+  }
+  if (has('revealPhoto')) {
+    items.push({ label: 'Reveal in Finder/Folder',
+      onClick: function() { window.revealPhoto(pid); } });
+  }
+  if (has('copyPhotoPaths')) {
+    items.push({ label: 'Copy Path',
+      onClick: function() { window.copyPhotoPaths([pid]); } });
+  }
+
+  items.push({ separator: true });
+  items.push({ label: 'Close Lightbox',
+    onClick: function() { closeLightbox(); } });
+
+  return items;
+}
+
+(function() {
+  var img = document.getElementById('lightboxImg');
+  if (!img) return;
+  img.addEventListener('contextmenu', function(e) {
+    // Stop the event before the browser's native menu or the wrap's
+    // mousedown pan handler can react. (contextmenu fires after mousedown
+    // in Chromium; stopPropagation + preventDefault together keep our
+    // handler in full control.)
+    e.preventDefault();
+    e.stopPropagation();
+    // Mark so any click-listener that wakes up later can bail.
+    window._ctxMenuJustOpened = Date.now();
+    var pid = _lightboxCurrentId;
+    if (!pid) return;
+    openContextMenu(e, buildLightboxContextMenu(pid));
+  });
+})();
+
 /* ---------- Delete Confirmation ---------- */
 var _deletePhotoIds = [];
 var _deleteCallback = null;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1271,6 +1271,7 @@ function sendReport() {
   };
 
   window.coerceSelectionOnContext = function(selectionSet, clickedId){
+    if (clickedId == null) return Array.from(selectionSet);
     if (!selectionSet.has(clickedId)) {
       selectionSet.clear();
       selectionSet.add(clickedId);

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1204,7 +1204,24 @@ function sendReport() {
   };
 
   function _outside(e){
-    if (_ctxEl && !_ctxEl.contains(e.target)) closeContextMenu();
+    if (_ctxEl && !_ctxEl.contains(e.target)) {
+      // Swallow the click that will follow this mousedown so that outside-
+      // click dismissal does not also trigger underlying handlers (e.g. the
+      // lightbox overlay's onclick=closeLightbox). Only applies when
+      // dismissal was triggered by mousedown — Escape / item selection paths
+      // don't install the swallow because no click follows.
+      const swallow = (ev) => {
+        ev.stopPropagation();
+        ev.preventDefault();
+        window.removeEventListener('click', swallow, true);
+      };
+      window.addEventListener('click', swallow, true);
+      // Safety net: if no click follows (e.g. user released outside the
+      // window), remove the swallow listener after a short delay so we
+      // don't eat an unrelated later click.
+      setTimeout(() => window.removeEventListener('click', swallow, true), 200);
+      closeContextMenu();
+    }
   }
   function _keydown(e){
     if (e.key === 'Escape') { e.preventDefault(); closeContextMenu(); }
@@ -2359,8 +2376,6 @@ function buildLightboxContextMenu(pid) {
     // handler in full control.)
     e.preventDefault();
     e.stopPropagation();
-    // Mark so any click-listener that wakes up later can bail.
-    window._ctxMenuJustOpened = Date.now();
     var pid = _lightboxCurrentId;
     if (!pid) return;
     openContextMenu(e, buildLightboxContextMenu(pid));

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2306,8 +2306,12 @@ function closeLightbox(e) {
  * sits in _navbar.html alongside the overlay. Rating / color / flag / reveal
  * helpers (`setRatingFor`, `setColorLabelFor`, `setFlagFor`, `findSimilar`,
  * `openInEditor`, `revealPhoto`, `copyPhotoPaths`) are defined on pages that
- * carry a photo grid (browse.html). On pages without those helpers, the
- * corresponding menu items are omitted so clicking them can never throw.
+ * carry a photo grid (browse.html). On /review, there is no selection model
+ * but per-photo `setReviewRating` / `setReviewFlag` helpers exist and the
+ * rating/flag chips fall through to them. Color labels are not part of the
+ * review workflow, so the color row is omitted when `setColorLabelFor` is
+ * absent. Any still-missing helper becomes a silent no-op so clicking can
+ * never throw.
  */
 function buildLightboxContextMenu(pid) {
   var has = function(name) { return typeof window[name] === 'function'; };
@@ -2316,7 +2320,10 @@ function buildLightboxContextMenu(pid) {
     return {
       label: n === 0 ? '\u2606' : String(n),
       title: n === 0 ? 'No rating' : 'Rate ' + n,
-      onClick: function() { if (has('setRatingFor')) window.setRatingFor(pid, n); },
+      onClick: function() {
+        if (has('setRatingFor')) window.setRatingFor(pid, n);
+        else if (has('setReviewRating')) window.setReviewRating(pid, n);
+      },
     };
   };
   var colorChip = function(c, icon, title) {
@@ -2328,26 +2335,31 @@ function buildLightboxContextMenu(pid) {
   var flagChip = function(f, icon, title) {
     return {
       label: icon, title: title,
-      onClick: function() { if (has('setFlagFor')) window.setFlagFor(pid, f); },
+      onClick: function() {
+        if (has('setFlagFor')) window.setFlagFor(pid, f);
+        else if (has('setReviewFlag')) window.setReviewFlag(pid, f);
+      },
     };
   };
 
   var items = [
     { chips: [0, 1, 2, 3, 4, 5].map(rateChip) },
-    { chips: [
+  ];
+  if (has('setColorLabelFor')) {
+    items.push({ chips: [
       colorChip(null, '\u25CB', 'No color'),
       colorChip('red', '\u25CF', 'Red'),
       colorChip('yellow', '\u25CF', 'Yellow'),
       colorChip('green', '\u25CF', 'Green'),
       colorChip('blue', '\u25CF', 'Blue'),
-    ] },
-    { chips: [
-      flagChip('flagged', '\u2691', 'Flag as pick'),
-      flagChip('rejected', '\u2715', 'Reject'),
-      flagChip('none', '\u25CB', 'Unflag'),
-    ] },
-    { separator: true },
-  ];
+    ] });
+  }
+  items.push({ chips: [
+    flagChip('flagged', '\u2691', 'Flag as pick'),
+    flagChip('rejected', '\u2715', 'Reject'),
+    flagChip('none', '\u25CB', 'Unflag'),
+  ] });
+  items.push({ separator: true });
 
   if (has('findSimilar')) {
     items.push({ label: 'Find Similar',

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1224,7 +1224,14 @@ function sendReport() {
     }
   }
   function _keydown(e){
-    if (e.key === 'Escape') { e.preventDefault(); closeContextMenu(); }
+    if (e.key === 'Escape') {
+      // Stop propagation in the capture phase so page-level Escape handlers
+      // (e.g. browse.html's clearSelection, lightbox close) don't also fire.
+      // The user dismissed the menu, not the underlying surface.
+      e.preventDefault();
+      e.stopPropagation();
+      closeContextMenu();
+    }
   }
 
   function _renderItem(item){

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2915,16 +2915,31 @@ function revealPhoto(photoId) {
 }
 
 async function copyPhotoPaths(photoIds) {
-  try {
-    var results = await Promise.all(photoIds.map(function(id) {
-      return safeFetch('/api/photos/' + id, {}, { toast: false });
-    }));
-    var paths = results.map(function(r) { return r && r.path; }).filter(Boolean).join('\n');
-    if (paths && navigator.clipboard) {
-      await navigator.clipboard.writeText(paths);
-      showToast(photoIds.length === 1 ? 'Path copied' : 'Paths copied');
+  var settled = await Promise.allSettled(photoIds.map(function(id) {
+    return safeFetch('/api/photos/' + id, {}, { toast: false });
+  }));
+  var paths = settled
+    .filter(function(s) { return s.status === 'fulfilled' && s.value && s.value.path; })
+    .map(function(s) { return s.value.path; });
+  var failed = settled.length - paths.length;
+  if (!paths.length) {
+    if (failed > 0) {
+      console.warn('copyPhotoPaths: ' + failed + ' path(s) failed');
+      showToast(failed === 1 ? '1 path could not be copied' : failed + ' paths could not be copied');
     }
-  } catch(e) { /* clipboard can throw in non-focused contexts */ }
+    return;
+  }
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(paths.join('\n'));
+      showToast(photoIds.length === 1 ? 'Path copied' : 'Paths copied');
+    } catch (e) {
+      console.error(e);
+    }
+  }
+  if (failed > 0) {
+    console.warn('copyPhotoPaths: ' + failed + ' path(s) failed');
+  }
 }
 
 // Re-apply the .selected highlight to match the current state of
@@ -3022,6 +3037,7 @@ document.addEventListener('contextmenu', function(e) {
   // reflects the photo the user right-clicked on.
   if (ids.length === 1 && ids[0] === pid && selectedPhotoId !== pid) {
     selectedPhotoId = pid;
+    loadDetail(pid);
   }
   refreshCardSelectionVisuals();
   updateBatchBar();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3044,6 +3044,56 @@ document.addEventListener('contextmenu', function(e) {
   openContextMenu(e, buildPhotoContextMenu(ids));
 });
 
+/* ---------- Folder tree context menu ---------- */
+function revealFolder(fid) {
+  // Fire-and-forget: user-visible feedback is the OS file manager opening.
+  // Server logs any failure via the reason field on the response body.
+  fetch('/api/files/reveal', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({folder_id: fid}),
+  }).catch(function(err) { console.error('revealFolder failed', err); });
+}
+
+async function copyFolderPath(fid) {
+  try {
+    var resp = await fetch('/api/folders/' + fid);
+    if (!resp.ok) return;
+    var folder = await resp.json();
+    if (folder && folder.path) {
+      await navigator.clipboard.writeText(folder.path);
+    }
+  } catch (err) {
+    console.error('copyFolderPath failed', err);
+  }
+}
+
+function rescanFolder(fid) {
+  fetch('/api/folders/' + fid + '/rescan', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: '{}',
+  }).catch(function(err) { console.error('rescanFolder failed', err); });
+}
+
+document.addEventListener('contextmenu', function(e) {
+  var ti = e.target.closest('.tree-item[data-folder-id]');
+  if (!ti) return;
+  // Don't fire if the right-click landed on another context menu.
+  if (e.target.closest('.vireo-ctx-menu')) return;
+  e.preventDefault();
+  var fid = parseInt(ti.dataset.folderId, 10);
+  if (isNaN(fid)) return;
+  openContextMenu(e, [
+    { label: 'Filter by this folder', onClick: function() { filterByFolder(fid); } },
+    { separator: true },
+    { label: 'Reveal in Finder/Folder', onClick: function() { revealFolder(fid); } },
+    { label: 'Copy Path', onClick: function() { copyFolderPath(fid); } },
+    { separator: true },
+    { label: 'Rescan this Folder', onClick: function() { rescanFolder(fid); } },
+  ]);
+});
+
 /* ---------- Deep-link: scroll to photo_id if present in URL ---------- */
 (async function() {
   var params = new URLSearchParams(window.location.search);

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1172,7 +1172,7 @@ function renderCollectionList(collections) {
   var html = '';
   collections.forEach(function(c) {
     var count = c.photo_count != null ? c.photo_count : '';
-    html += '<div class="tree-item" onclick="filterByCollection(' + c.id + ')">' +
+    html += '<div class="tree-item" data-collection-id="' + c.id + '" onclick="filterByCollection(' + c.id + ')">' +
       '<span>' + escapeHtml(c.name) + '</span>' +
       '<span class="count">' + count + '</span></div>';
   });
@@ -1332,10 +1332,14 @@ async function loadCollectionCounts() {
     var countsById = {};
     data.forEach(function(c) { countsById[c.id] = c.photo_count; });
     items.forEach(function(el) {
-      var onclick = el.getAttribute('onclick') || '';
-      var m = onclick.match(/filterByCollection\((\d+)\)/);
-      if (m) {
-        var id = parseInt(m[1], 10);
+      var id = parseInt(el.dataset.collectionId, 10);
+      if (isNaN(id)) {
+        // Fallback for any stragglers without data-collection-id.
+        var onclick = el.getAttribute('onclick') || '';
+        var m = onclick.match(/filterByCollection\((\d+)\)/);
+        if (m) id = parseInt(m[1], 10);
+      }
+      if (!isNaN(id)) {
         var span = el.querySelector('.count');
         if (span && countsById[id] != null) span.textContent = countsById[id];
       }
@@ -3091,6 +3095,83 @@ document.addEventListener('contextmenu', function(e) {
     { label: 'Copy Path', onClick: function() { copyFolderPath(fid); } },
     { separator: true },
     { label: 'Rescan this Folder', onClick: function() { rescanFolder(fid); } },
+  ]);
+});
+
+/* ---------- Collection sidebar context menu ---------- */
+async function renameCollection(cid, currentName) {
+  var next = window.prompt('Rename collection', currentName || '');
+  if (next === null) return;             // user cancelled
+  next = next.trim();
+  if (!next || next === currentName) return;
+  try {
+    await safeFetch('/api/collections/' + cid, {
+      method: 'PUT',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({name: next}),
+    });
+  } catch (err) {
+    console.error('renameCollection failed', err);
+    return;
+  }
+  await loadCollections();
+  loadCollectionCounts();
+}
+
+async function duplicateCollection(cid) {
+  try {
+    await safeFetch('/api/collections/' + cid + '/duplicate', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: '{}',
+    });
+  } catch (err) {
+    console.error('duplicateCollection failed', err);
+    return;
+  }
+  await loadCollections();
+  loadCollectionCounts();
+}
+
+async function deleteCollectionById(cid, name) {
+  if (!window.confirm('Delete collection "' + (name || '') + '"?')) return;
+  try {
+    await safeFetch('/api/collections/' + cid, { method: 'DELETE' });
+  } catch (err) {
+    console.error('deleteCollectionById failed', err);
+    return;
+  }
+  // If we were filtering by the deleted collection, clear the filter.
+  if (activeCollectionId === cid) {
+    activeCollectionId = null;
+    resetAndLoad();
+  }
+  await loadCollections();
+  loadCollectionCounts();
+}
+
+document.addEventListener('contextmenu', function(e) {
+  var ti = e.target.closest('.tree-item[data-collection-id]');
+  if (!ti) return;
+  // Don't fire inside another menu, and don't collide with folder-tree delegate.
+  if (e.target.closest('.vireo-ctx-menu')) return;
+  if (ti.hasAttribute('data-folder-id')) return;
+  e.preventDefault();
+  var cid = parseInt(ti.dataset.collectionId, 10);
+  if (isNaN(cid)) return;
+  var nameEl = ti.querySelector('span');
+  var name = nameEl ? nameEl.textContent : '';
+  openContextMenu(e, [
+    { label: 'Filter by this Collection',
+      onClick: function() { filterByCollection(cid); } },
+    { separator: true },
+    { label: 'Rename',
+      onClick: function() { renameCollection(cid, name); } },
+    { label: 'Duplicate',
+      onClick: function() { duplicateCollection(cid); } },
+    { separator: true },
+    { label: 'Delete Collection',
+      onClick: function() { deleteCollectionById(cid, name); } },
   ]);
 });
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3037,10 +3037,12 @@ document.addEventListener('contextmenu', function(e) {
     selectedPhotos.add(selectedPhotoId);
   }
   var ids = coerceSelectionOnContext(selectedPhotos, pid);
-  // If coercion replaced the set, align selectedPhotoId so the detail panel
-  // reflects the photo the user right-clicked on.
+  // If coercion replaced the set, align selectedPhotoId (so the detail panel
+  // reflects the right-clicked photo) and selectedIndex (the Shift-range
+  // anchor — a subsequent Shift-click must range-select from this card).
   if (ids.length === 1 && ids[0] === pid && selectedPhotoId !== pid) {
     selectedPhotoId = pid;
+    selectedIndex = photos.findIndex(function(p) { return p.id === pid; });
     loadDetail(pid);
   }
   refreshCardSelectionVisuals();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2862,6 +2862,172 @@ function openInEditorBatch() {
   openInEditor(ids);
 }
 
+/* ---------- Right-click context menu on grid cards ---------- */
+// Single-photo wrappers around the existing batch endpoints. The detail-panel
+// helpers (setFlag, setColorLabel) are coupled to selectedPhotoId; the context
+// menu needs to target an arbitrary id without mutating that focus, so we
+// post directly to the batch endpoints with a 1-photo list.
+async function setRatingFor(photoId, rating) {
+  try {
+    await safeFetch('/api/batch/rating', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: [photoId], rating: rating}),
+    });
+  } catch(e) { return; }
+  var p = photos.find(function(x) { return x.id === photoId; });
+  if (p) p.rating = rating;
+  renderGrid();
+  if (selectedPhotoId === photoId) loadDetail(photoId);
+}
+
+async function setFlagFor(photoId, flag) {
+  try {
+    await safeFetch('/api/batch/flag', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: [photoId], flag: flag}),
+    });
+  } catch(e) { return; }
+  var p = photos.find(function(x) { return x.id === photoId; });
+  if (p) p.flag = flag;
+  renderGrid();
+  if (selectedPhotoId === photoId) loadDetail(photoId);
+}
+
+async function setColorLabelFor(photoId, color) {
+  colorLabelGen++;
+  try {
+    await safeFetch('/api/batch/color_label', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: [photoId], color: color}),
+    });
+  } catch(e) { return; }
+  if (color) colorLabels[photoId] = color;
+  else delete colorLabels[photoId];
+  renderGrid();
+  if (selectedPhotoId === photoId) updateDetailColors();
+}
+
+function revealPhoto(photoId) {
+  safeFetch('/api/files/reveal', {
+    method: 'POST', headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({photo_id: photoId}),
+  }, { toast: false }).catch(function(){});
+}
+
+async function copyPhotoPaths(photoIds) {
+  try {
+    var results = await Promise.all(photoIds.map(function(id) {
+      return safeFetch('/api/photos/' + id, {}, { toast: false });
+    }));
+    var paths = results.map(function(r) { return r && r.path; }).filter(Boolean).join('\n');
+    if (paths && navigator.clipboard) {
+      await navigator.clipboard.writeText(paths);
+      showToast(photoIds.length === 1 ? 'Path copied' : 'Paths copied');
+    }
+  } catch(e) { /* clipboard can throw in non-focused contexts */ }
+}
+
+// Re-apply the .selected highlight to match the current state of
+// selectedPhotos / selectedPhotoId. Mirrors the refresh block at the tail
+// of selectPhoto(); factored out so the context-menu handler can coerce
+// selection without paying the full selectPhoto side-effects.
+function refreshCardSelectionVisuals() {
+  document.querySelectorAll('.grid-card').forEach(function(el) {
+    var cardId = parseInt(el.dataset.id, 10);
+    el.classList.toggle('selected', cardId === selectedPhotoId || selectedPhotos.has(cardId));
+  });
+}
+
+function buildPhotoContextMenu(photoIds) {
+  var one = photoIds.length === 1;
+  var hint = one ? undefined : 'Select a single photo';
+
+  var rateChip = function(n) {
+    return {
+      label: n === 0 ? '\u2606' : String(n),
+      title: n === 0 ? 'No rating' : 'Rate ' + n,
+      onClick: function() {
+        photoIds.forEach(function(id) { setRatingFor(id, n); });
+      },
+    };
+  };
+  var colorChip = function(c, icon, title) {
+    return {
+      label: icon,
+      title: title,
+      onClick: function() {
+        photoIds.forEach(function(id) { setColorLabelFor(id, c); });
+      },
+    };
+  };
+  var flagChip = function(f, icon, title) {
+    return {
+      label: icon, title: title,
+      onClick: function() {
+        photoIds.forEach(function(id) { setFlagFor(id, f); });
+      },
+    };
+  };
+
+  return [
+    { chips: [0, 1, 2, 3, 4, 5].map(rateChip) },
+    { chips: [
+      colorChip(null, '\u25CB', 'No color'),
+      colorChip('red', '\u25CF', 'Red'),
+      colorChip('yellow', '\u25CF', 'Yellow'),
+      colorChip('green', '\u25CF', 'Green'),
+      colorChip('blue', '\u25CF', 'Blue'),
+    ] },
+    { chips: [
+      flagChip('flagged', '\u2691', 'Flag as pick'),
+      flagChip('rejected', '\u2715', 'Reject'),
+      flagChip('none', '\u25CB', 'Unflag'),
+    ] },
+    { separator: true },
+    { label: 'Find Similar', disabled: !one, disabledHint: hint,
+      onClick: function() { if (typeof findSimilar === 'function') findSimilar(photoIds[0]); } },
+    { label: 'Open in Editor',
+      onClick: function() { if (typeof openInEditor === 'function') openInEditor(photoIds); } },
+    { label: 'Reveal in Finder/Folder', disabled: !one, disabledHint: hint,
+      onClick: function() { revealPhoto(photoIds[0]); } },
+    { label: 'Copy Path',
+      onClick: function() { copyPhotoPaths(photoIds); } },
+    { separator: true },
+    { label: 'Add Keyword\u2026', onClick: function() { batchAddKeyword(); } },
+    { label: 'Add to Collection\u2026', onClick: function() { addToCollection(); } },
+    { separator: true },
+    { label: 'Delete', onClick: function() { batchDelete(); } },
+  ];
+}
+
+// Document-level delegation: grids re-render on sort/filter/scroll, so
+// per-card listeners would go stale.
+document.addEventListener('contextmenu', function(e) {
+  var card = e.target.closest('.grid-card');
+  if (!card || !card.dataset.id) return;
+  // Ignore right-clicks that came from inside the lightbox or a modal; this
+  // handler owns only grid-card context menus. Modal right-clicks are either
+  // handled by their own delegation (lightbox) or fall through to the browser.
+  if (e.target.closest('.vireo-ctx-menu')) return;
+  e.preventDefault();
+  var pid = parseInt(card.dataset.id, 10);
+  // Finder-style coercion: right-click on an item outside the selection
+  // replaces the selection with that one item. Fold selectedPhotoId in first
+  // so a single-focus click doesn't get silently dropped.
+  if (selectedPhotos.size === 0 && selectedPhotoId !== null) {
+    selectedPhotos.add(selectedPhotoId);
+  }
+  var ids = coerceSelectionOnContext(selectedPhotos, pid);
+  // If coercion replaced the set, align selectedPhotoId so the detail panel
+  // reflects the photo the user right-clicked on.
+  if (ids.length === 1 && ids[0] === pid && selectedPhotoId !== pid) {
+    selectedPhotoId = pid;
+  }
+  refreshCardSelectionVisuals();
+  updateBatchBar();
+  openContextMenu(e, buildPhotoContextMenu(ids));
+});
+
 /* ---------- Deep-link: scroll to photo_id if present in URL ---------- */
 (async function() {
   var params = new URLSearchParams(window.location.search);

--- a/vireo/templates/keywords.html
+++ b/vireo/templates/keywords.html
@@ -514,7 +514,7 @@
   });
 
   // -- Bulk delete --
-  document.getElementById('kwBulkDelete').addEventListener('click', async function() {
+  async function deleteSelectedKeywords() {
     const ids = Array.from(selectedIds);
     if (!ids.length) return;
     if (!confirm('Delete ' + ids.length + ' keyword(s)? This will also remove them from all photos.')) return;
@@ -528,6 +528,64 @@
     }
     selectedIds.clear();
     render();
+  }
+  document.getElementById('kwBulkDelete').addEventListener('click', deleteSelectedKeywords);
+
+  // -- Right-click context menu on keyword rows --
+  // Expose selectedIds for tests to inspect Finder-style coercion.
+  window.__kwSelectedIds = selectedIds;
+
+  function buildKeywordContextMenu(kwIds) {
+    const one = kwIds.length === 1;
+    const hint = one ? undefined : 'Select a single keyword';
+    const singleKw = one ? allKeywords.find(k => k.id === kwIds[0]) : null;
+
+    const typeChip = function(t) {
+      return {
+        label: t,
+        title: 'Set type to ' + t,
+        onClick: function() {
+          kwIds.forEach(function(id) { updateType(id, t); });
+        },
+      };
+    };
+
+    return [
+      { label: 'Rename', disabled: !one, disabledHint: hint,
+        onClick: function() {
+          if (!singleKw) return;
+          const newName = prompt('Rename keyword:', singleKw.name);
+          if (newName && newName.trim() && newName.trim() !== singleKw.name) {
+            renameKeyword(singleKw.id, newName.trim());
+          }
+        } },
+      { chips: TYPES.map(typeChip) },
+      { separator: true },
+      { label: 'Show Photos with this Keyword',
+        disabled: !one, disabledHint: hint,
+        onClick: function() {
+          if (!singleKw) return;
+          window.location.href = '/browse?keyword=' + encodeURIComponent(singleKw.name);
+        } },
+      { separator: true },
+      { label: 'Delete',
+        onClick: function() { deleteSelectedKeywords(); } },
+    ];
+  }
+
+  document.addEventListener('contextmenu', function(e) {
+    const row = e.target.closest('tr[data-id]');
+    if (!row) return;
+    // Ignore right-clicks that land inside the context menu itself.
+    if (e.target.closest('.vireo-ctx-menu')) return;
+    e.preventDefault();
+    const kwId = parseInt(row.dataset.id, 10);
+    if (!kwId) return;
+    // Finder-style coercion: right-click outside current selection replaces it.
+    const ids = coerceSelectionOnContext(selectedIds, kwId);
+    // Re-render so the checkbox visual state reflects the coerced selection.
+    render();
+    openContextMenu(e, buildKeywordContextMenu(ids));
   });
 
   // -- Init --

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1265,6 +1265,74 @@ document.addEventListener('contextmenu', function(e) {
   openContextMenu(e, buildReviewCardContextMenu(pred));
 });
 
+/* ---------- Burst group modal context menu ----------
+ * The grm-card selector (.grm-card[data-photo-id]) does NOT collide with
+ * the review grid's .card[data-pred-id] handler above — different class
+ * names, different closest() matches.
+ *
+ * Critical: grmMovePick / grmMoveReject / grmMoveCandidate / grmRemoveFromGroup
+ * all operate on grmState.selected. On right-click we MUST force-set
+ * grmState.selected to the clicked card's photo_id before opening the menu.
+ * We assign directly (not via grmSelect, which toggles) so a right-click on
+ * a non-selected card doesn't deselect it.
+ */
+function buildBurstGroupContextMenu(photoId, filename) {
+  var rateChip = function(n) {
+    return {
+      label: n === 0 ? '\u2606' : String(n),
+      title: n === 0 ? 'No rating' : 'Rate ' + n,
+      onClick: function() { setReviewRating(photoId, n); },
+    };
+  };
+  var flagChip = function(f, icon, title) {
+    return {
+      label: icon, title: title,
+      onClick: function() { setReviewFlag(photoId, f); },
+    };
+  };
+  return [
+    { label: '\u2B06  Move to Picks',      onClick: function() { grmMovePick(); } },
+    { label: '\u2B07  Move to Rejects',    onClick: function() { grmMoveReject(); } },
+    { label: '\u2423  Move to Candidates', onClick: function() { grmMoveCandidate(); } },
+    { separator: true },
+    { chips: [0, 1, 2, 3, 4, 5].map(rateChip) },
+    { chips: [
+        flagChip('flagged', '\u2691', 'Flag as pick'),
+        flagChip('rejected', '\u2715', 'Reject'),
+        flagChip('none', '\u25CB', 'Unflag'),
+    ] },
+    { separator: true },
+    { label: 'Open in Lightbox',        onClick: function() { openReviewLightbox(photoId, filename); } },
+    { label: 'Reveal in Finder/Folder', onClick: function() { revealReviewPhoto(photoId); } },
+    { label: 'Copy Path',               onClick: function() { copyReviewPhotoPath(photoId); } },
+    { separator: true },
+    { label: 'Remove from Group',       onClick: function() { grmRemoveFromGroup(); } },
+  ];
+}
+
+document.addEventListener('contextmenu', function(e) {
+  var card = e.target.closest('.grm-card[data-photo-id]');
+  if (!card) return;
+  // Only fire when the burst modal is actually open — the handler is on
+  // document and grm-cards never exist outside #grmOverlay, but belt-and-
+  // suspenders against any future render path that reuses the class.
+  var overlay = document.getElementById('grmOverlay');
+  if (!overlay || !overlay.classList.contains('open')) return;
+  e.preventDefault();
+  var photoId = parseInt(card.dataset.photoId, 10);
+  if (!photoId) return;
+  var item = grmState.items.find(function(it) { return it.photo_id === photoId; });
+  var filename = item ? item.filename : '';
+  // Force-select the right-clicked card so move/remove actions target it.
+  // Assign directly rather than calling grmSelect() — that helper toggles
+  // selection, which would deselect when right-clicking the already-selected
+  // card.
+  grmState.selected = photoId;
+  renderGroupModal();
+  if (typeof openContextMenu !== 'function') return;
+  openContextMenu(e, buildBurstGroupContextMenu(photoId, filename));
+});
+
 /* ---------- Settings ---------- */
 function updateThumbSize(val) {
   thumbSize = parseInt(val, 10);

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1140,6 +1140,131 @@ document.addEventListener('keydown', function(e) {
   else if (matchesShortcut(e, _shortcuts.skip)) { e.preventDefault(); rejectPrediction(pending[0].id); }
 });
 
+/* ---------- Right-click context menu ----------
+ * The review grid has no multi-select — the menu always targets the single
+ * card under the cursor. Rating / flag chips POST directly to the batch
+ * endpoints so they don't depend on helpers that only exist on browse.html.
+ */
+function setReviewRating(photoId, rating) {
+  safeFetch('/api/batch/rating', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ photo_ids: [photoId], rating: rating }),
+  }, { toast: false }).catch(function() {});
+}
+
+function setReviewFlag(photoId, flag) {
+  safeFetch('/api/batch/flag', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ photo_ids: [photoId], flag: flag }),
+  }, { toast: false }).catch(function() {});
+}
+
+function revealReviewPhoto(photoId) {
+  safeFetch('/api/files/reveal', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ photo_id: photoId }),
+  }, { toast: false }).catch(function() {});
+}
+
+async function copyReviewPhotoPath(photoId) {
+  try {
+    var data = await safeFetch('/api/photos/' + photoId, {}, { toast: false });
+    if (data && data.path) {
+      try { await navigator.clipboard.writeText(data.path); } catch(e) {}
+    }
+  } catch(e) {}
+}
+
+function openReviewLightbox(photoId, filename) {
+  // Build the same photoList the grid click handler builds, so arrow-key
+  // navigation inside the lightbox walks the current review grid.
+  var seen = {};
+  var photoList = [];
+  var thumbs = document.getElementById('grid').querySelectorAll('img[data-photo-id]');
+  for (var i = 0; i < thumbs.length; i++) {
+    var pid = parseInt(thumbs[i].dataset.photoId, 10);
+    if (seen[pid]) continue;
+    seen[pid] = true;
+    photoList.push({ id: pid, filename: thumbs[i].dataset.filename || '' });
+  }
+  openLightbox(photoId, filename || '', photoList);
+}
+
+function buildReviewCardContextMenu(pred) {
+  var photoId = pred.photo_id;
+  var predId = pred.id;
+  var species = pred.group_id ? getConsensusSpecies(pred) : pred.species;
+  var speciesLabel = species || 'species';
+  var pending = pred.status === 'pending';
+
+  var rateChip = function(n) {
+    return {
+      label: n === 0 ? '\u2606' : String(n),
+      title: n === 0 ? 'No rating' : 'Rate ' + n,
+      onClick: function() { setReviewRating(photoId, n); },
+    };
+  };
+  var flagChip = function(f, icon, title) {
+    return {
+      label: icon, title: title,
+      onClick: function() { setReviewFlag(photoId, f); },
+    };
+  };
+
+  var items = [];
+  items.push({
+    label: 'Accept as "' + speciesLabel + '"',
+    disabled: !pending,
+    disabledHint: pending ? undefined : 'Already resolved',
+    onClick: function() { acceptPrediction(predId); },
+  });
+  items.push({
+    label: 'Not "' + speciesLabel + '"',
+    disabled: !pending,
+    disabledHint: pending ? undefined : 'Already resolved',
+    onClick: function() { rejectPrediction(predId); },
+  });
+  items.push({ separator: true });
+  items.push({ chips: [0, 1, 2, 3, 4, 5].map(rateChip) });
+  items.push({ chips: [
+    flagChip('flagged', '\u2691', 'Flag as pick'),
+    flagChip('rejected', '\u2715', 'Reject'),
+    flagChip('none', '\u25CB', 'Unflag'),
+  ] });
+  items.push({ separator: true });
+  items.push({
+    label: 'Open in Lightbox',
+    onClick: function() { openReviewLightbox(photoId, pred.filename); },
+  });
+  items.push({
+    label: 'Reveal in Finder/Folder',
+    onClick: function() { revealReviewPhoto(photoId); },
+  });
+  items.push({
+    label: 'Copy Path',
+    onClick: function() { copyReviewPhotoPath(photoId); },
+  });
+  return items;
+}
+
+document.addEventListener('contextmenu', function(e) {
+  var card = e.target.closest('.card[data-pred-id]');
+  if (!card) return;
+  // Only hijack contextmenu for cards that live inside the review grid —
+  // the burst-group modal and other surfaces handle their own menus.
+  var grid = document.getElementById('grid');
+  if (!grid || !grid.contains(card)) return;
+  e.preventDefault();
+  var predId = parseInt(card.dataset.predId, 10);
+  var pred = predictions.find(function(p) { return p.id === predId; });
+  if (!pred) return;
+  if (typeof openContextMenu !== 'function') return;
+  openContextMenu(e, buildReviewCardContextMenu(pred));
+});
+
 /* ---------- Settings ---------- */
 function updateThumbSize(val) {
   thumbSize = parseInt(val, 10);

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -49,6 +49,35 @@ def test_api_folders(app_and_db):
     assert '/photos/2024' in paths
 
 
+def test_api_folder_get_returns_linked_folder(app_and_db):
+    """GET /api/folders/<id> returns id/name/path for a folder in the active ws."""
+    app, db = app_and_db
+    fid = db.get_folder_tree()[0]['id']
+    client = app.test_client()
+    resp = client.get(f'/api/folders/{fid}')
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body['id'] == fid
+    assert body['path'] == '/photos/2024'
+
+
+def test_api_folder_get_rejects_other_workspace(app_and_db):
+    """GET /api/folders/<id> must 404 when folder is not linked to the active
+    workspace — otherwise absolute paths leak across workspace boundaries via
+    the folder-tree Copy Path action.
+    """
+    app, db = app_and_db
+    default_ws = db._active_workspace_id
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+    # Folder added while other_ws is active; only linked to other_ws.
+    other_fid = db.add_folder('/secret/ws', name='secret')
+    db.set_active_workspace(default_ws)
+    client = app.test_client()
+    resp = client.get(f'/api/folders/{other_fid}')
+    assert resp.status_code == 404
+
+
 def test_api_keywords(app_and_db):
     """GET /api/keywords returns keyword tree."""
     app, _ = app_and_db

--- a/vireo/tests/test_collection_duplicate_api.py
+++ b/vireo/tests/test_collection_duplicate_api.py
@@ -1,0 +1,102 @@
+"""Tests for POST /api/collections/<id>/duplicate and db.duplicate_collection."""
+
+import json
+
+
+def _clear_default_collections(db):
+    for c in db.get_collections():
+        db.delete_collection(c["id"])
+
+
+def test_duplicate_collection_copies_name_and_rules(app_and_db):
+    """Duplicating a collection creates a new collection with a '(copy)' name
+    and identical rules."""
+    app, db = app_and_db
+    _clear_default_collections(db)
+
+    rules = [{"field": "rating", "op": ">=", "value": 3}]
+    cid = db.add_collection("My Picks", json.dumps(rules))
+
+    with app.test_client() as c:
+        resp = c.post(f"/api/collections/{cid}/duplicate", json={})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert "id" in body
+        new_id = body["id"]
+        assert new_id != cid
+
+    collections = {c["id"]: c for c in db.get_collections()}
+    assert new_id in collections
+    new = collections[new_id]
+    assert new["name"].startswith("My Picks")
+    assert new["name"] != "My Picks"
+    # Rules copied verbatim
+    assert json.loads(new["rules"]) == rules
+
+
+def test_duplicate_collection_copies_static_photo_memberships(app_and_db):
+    """A static collection (photo_ids rule) duplicates with its membership
+    intact, since rules are copied verbatim."""
+    app, db = app_and_db
+    _clear_default_collections(db)
+
+    photos = db.get_photos()
+    pids = [p["id"] for p in photos][:3]
+
+    cid = db.add_collection("Static", json.dumps([]))
+    # Use the existing add-photos endpoint to seed membership.
+    with app.test_client() as c:
+        resp = c.post(
+            f"/api/collections/{cid}/add-photos",
+            json={"photo_ids": pids},
+        )
+        assert resp.status_code == 200
+
+        resp = c.post(f"/api/collections/{cid}/duplicate", json={})
+        assert resp.status_code == 200
+        new_id = resp.get_json()["id"]
+
+    # New collection returns the same photos as the source.
+    orig_photos = {p["id"] for p in db.get_collection_photos(cid, per_page=100)}
+    new_photos = {p["id"] for p in db.get_collection_photos(new_id, per_page=100)}
+    assert orig_photos == new_photos
+    assert orig_photos == set(pids)
+
+
+def test_duplicate_unknown_collection_returns_404(app_and_db):
+    app, _ = app_and_db
+    with app.test_client() as c:
+        resp = c.post("/api/collections/999999/duplicate", json={})
+        assert resp.status_code == 404
+        body = resp.get_json()
+        assert "error" in body
+
+
+def test_duplicate_collection_is_workspace_scoped(app_and_db):
+    """db.duplicate_collection is scoped to the active workspace: duplicating
+    a collection that belongs to a different workspace raises, and the new
+    collection lands in the active workspace."""
+    app, db = app_and_db
+    _clear_default_collections(db)
+
+    source_ws = db._active_workspace_id
+    cid = db.add_collection("Wsp", json.dumps([{"field": "all"}]))
+
+    # Create a second workspace with no collections, and make it active.
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+
+    # Collection belongs to source_ws — not findable from other_ws.
+    import pytest
+
+    with pytest.raises(ValueError):
+        db.duplicate_collection(cid)
+
+    # Duplicating from the source workspace lands the copy there.
+    db.set_active_workspace(source_ws)
+    new_id = db.duplicate_collection(cid)
+
+    row = db.conn.execute(
+        "SELECT workspace_id FROM collections WHERE id = ?", (new_id,)
+    ).fetchone()
+    assert row["workspace_id"] == source_ws

--- a/vireo/tests/test_folder_rescan_api.py
+++ b/vireo/tests/test_folder_rescan_api.py
@@ -79,6 +79,28 @@ def test_folder_rescan_missing_path_returns_400(app_and_db, tmp_path, monkeypatc
         assert "no longer exists" in resp.get_json().get("error", "")
 
 
+def test_folder_rescan_rejects_folder_outside_active_workspace(app_and_db, tmp_path):
+    """A folder that exists globally but is NOT linked to the active
+    workspace must 404 — otherwise a rescan would pollute the active
+    workspace with scan output (add_folder auto-links any discovered
+    subfolders) from an unrelated folder.
+    """
+    app, db = app_and_db
+    real_dir = tmp_path / "other-ws"
+    real_dir.mkdir()
+    # Create a second workspace, add the folder while it's active, then
+    # switch back so the folder is only linked to the other workspace.
+    default_ws = db._active_workspace_id
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+    folder_id = db.add_folder(str(real_dir), name="other-ws")
+    db.set_active_workspace(default_ws)
+
+    with app.test_client() as c:
+        resp = c.post(f"/api/folders/{folder_id}/rescan", json={})
+        assert resp.status_code == 404
+
+
 def test_folder_rescan_job_config_includes_folder_path(app_and_db, tmp_path):
     """The queued job's config carries the folder path so the work
     function can target the right directory."""

--- a/vireo/tests/test_folder_rescan_api.py
+++ b/vireo/tests/test_folder_rescan_api.py
@@ -28,12 +28,13 @@ def _wait_for_job_listed(runner, job_id, timeout=2.0):
     return runner.list_jobs()
 
 
-def test_folder_rescan_queues_job(app_and_db):
+def test_folder_rescan_queues_job(app_and_db, tmp_path):
     app, db = app_and_db
-    folder_row = db.conn.execute(
-        "SELECT id FROM folders ORDER BY id LIMIT 1"
-    ).fetchone()
-    folder_id = folder_row["id"]
+    # The fixture folders use fabricated paths; create a real on-disk
+    # directory so the on-disk existence check passes.
+    real_dir = tmp_path / "scan-me"
+    real_dir.mkdir()
+    folder_id = db.add_folder(str(real_dir), name="scan-me")
 
     with app.test_client() as c:
         resp = c.post(f"/api/folders/{folder_id}/rescan", json={})
@@ -68,15 +69,25 @@ def test_folder_rescan_invalid_id_returns_404(app_and_db):
         assert resp.status_code == 404
 
 
-def test_folder_rescan_job_config_includes_folder_path(app_and_db):
+def test_folder_rescan_missing_path_returns_400(app_and_db, tmp_path, monkeypatch):
+    app, db = app_and_db
+    # Add a folder row whose on-disk path does not exist.
+    fid = db.add_folder(str(tmp_path / "does-not-exist"), name="ghost")
+    with app.test_client() as c:
+        resp = c.post(f"/api/folders/{fid}/rescan", json={})
+        assert resp.status_code == 400
+        assert "no longer exists" in resp.get_json().get("error", "")
+
+
+def test_folder_rescan_job_config_includes_folder_path(app_and_db, tmp_path):
     """The queued job's config carries the folder path so the work
     function can target the right directory."""
     app, db = app_and_db
-    folder_row = db.conn.execute(
-        "SELECT id, path FROM folders ORDER BY id LIMIT 1"
-    ).fetchone()
-    folder_id = folder_row["id"]
-    folder_path = folder_row["path"]
+    # Use a real on-disk directory so the existence check passes.
+    real_dir = tmp_path / "scan-config"
+    real_dir.mkdir()
+    folder_path = str(real_dir)
+    folder_id = db.add_folder(folder_path, name="scan-config")
 
     with app.test_client() as c:
         resp = c.post(f"/api/folders/{folder_id}/rescan", json={})

--- a/vireo/tests/test_folder_rescan_api.py
+++ b/vireo/tests/test_folder_rescan_api.py
@@ -1,0 +1,91 @@
+"""Tests for POST /api/folders/<id>/rescan — per-folder rescan endpoint.
+
+The rescan endpoint queues a background scan job scoped to a single folder's
+path. It re-uses the same job infrastructure as POST /api/jobs/scan.
+
+Schema note: the job runner's job dict exposes `type` at the top level and
+stores caller-supplied config (including `folder_id`) under `config`. Tests
+read the folder id through `job["config"]["folder_id"]` to match the actual
+schema produced by `JobRunner.start()`.
+"""
+
+import time
+
+
+def _wait_for_job_listed(runner, job_id, timeout=2.0):
+    """Wait until `list_jobs()` reports the given job id.
+
+    The runner registers the job synchronously inside `start()`, so this
+    should return immediately in practice; the poll loop is just a safety
+    net against scheduler jitter on slow CI.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        jobs = runner.list_jobs()
+        if any(j.get("id") == job_id for j in jobs):
+            return jobs
+        time.sleep(0.05)
+    return runner.list_jobs()
+
+
+def test_folder_rescan_queues_job(app_and_db):
+    app, db = app_and_db
+    folder_row = db.conn.execute(
+        "SELECT id FROM folders ORDER BY id LIMIT 1"
+    ).fetchone()
+    folder_id = folder_row["id"]
+
+    with app.test_client() as c:
+        resp = c.post(f"/api/folders/{folder_id}/rescan", json={})
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert "job_id" in body
+        assert body["job_id"].startswith("scan-")
+
+    runner = app._job_runner
+    jobs = _wait_for_job_listed(runner, body["job_id"])
+    # The job is tagged as a scan and carries the folder id in its config.
+    assert any(
+        j.get("type") == "scan"
+        and (j.get("config") or {}).get("folder_id") == folder_id
+        for j in jobs
+    ), jobs
+
+
+def test_folder_rescan_unknown_folder(app_and_db):
+    app, _ = app_and_db
+    with app.test_client() as c:
+        resp = c.post("/api/folders/999999/rescan", json={})
+        assert resp.status_code == 404
+
+
+def test_folder_rescan_invalid_id_returns_404(app_and_db):
+    """Routing restricts the id to <int:...>, so non-int paths should
+    fall through to a 404 from Flask itself."""
+    app, _ = app_and_db
+    with app.test_client() as c:
+        resp = c.post("/api/folders/abc/rescan", json={})
+        assert resp.status_code == 404
+
+
+def test_folder_rescan_job_config_includes_folder_path(app_and_db):
+    """The queued job's config carries the folder path so the work
+    function can target the right directory."""
+    app, db = app_and_db
+    folder_row = db.conn.execute(
+        "SELECT id, path FROM folders ORDER BY id LIMIT 1"
+    ).fetchone()
+    folder_id = folder_row["id"]
+    folder_path = folder_row["path"]
+
+    with app.test_client() as c:
+        resp = c.post(f"/api/folders/{folder_id}/rescan", json={})
+        assert resp.status_code == 200
+        job_id = resp.get_json()["job_id"]
+
+    runner = app._job_runner
+    jobs = _wait_for_job_listed(runner, job_id)
+    job = next(j for j in jobs if j.get("id") == job_id)
+    cfg = job.get("config") or {}
+    assert cfg.get("folder_id") == folder_id
+    assert cfg.get("root") == folder_path

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -117,6 +117,33 @@ def test_api_photo_detail(app_and_db):
     assert 'keywords' in data
 
 
+def test_api_photo_detail_includes_on_disk_path(app_and_db):
+    """GET /api/photos/<id> returns a `path` field equal to folder_path + '/' + filename.
+
+    The browse-grid right-click "Copy Path" action depends on this field being
+    present in the photo detail response. PHOTO_DETAIL_COLS intentionally does
+    not store the full on-disk path in the photos table, so the route handler
+    must compute it by joining the owning folder's path with the photo's
+    filename (same idiom as /api/files/reveal).
+    """
+    import os as _os
+
+    app, db = app_and_db
+    client = app.test_client()
+    photos = db.get_photos()
+    target = [p for p in photos if p['filename'] == 'bird1.jpg'][0]
+    folder_row = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (target['folder_id'],)
+    ).fetchone()
+    expected_path = _os.path.join(folder_row['path'], target['filename'])
+
+    resp = client.get(f"/api/photos/{target['id']}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'path' in data, "photo detail should expose full on-disk path"
+    assert data['path'] == expected_path
+
+
 def test_api_photos_calendar(app_and_db):
     """GET /api/photos/calendar returns daily photo counts for a year."""
     app, _ = app_and_db

--- a/vireo/tests/test_reveal_api.py
+++ b/vireo/tests/test_reveal_api.py
@@ -1,0 +1,68 @@
+"""Tests for POST /api/files/reveal — cross-platform reveal-in-file-manager."""
+
+from unittest.mock import MagicMock, patch
+
+
+def test_reveal_macos(app_and_db):
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "darwin"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0)
+        resp = c.post("/api/files/reveal", json={"photo_id": pid})
+        assert resp.status_code == 200
+        assert resp.get_json()["ok"] is True
+        args = run.call_args[0][0]
+        assert args[0] == "open"
+        assert args[1] == "-R"
+
+
+def test_reveal_linux_opens_parent(app_and_db):
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "linux"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0)
+        resp = c.post("/api/files/reveal", json={"photo_id": pid})
+        assert resp.status_code == 200
+        args = run.call_args[0][0]
+        assert args[0] == "xdg-open"
+        # argv[1] is the parent dir, not the file itself
+        assert not args[1].endswith(".jpg")
+
+
+def test_reveal_windows_select(app_and_db):
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "win32"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0)
+        resp = c.post("/api/files/reveal", json={"photo_id": pid})
+        assert resp.status_code == 200
+        args = run.call_args[0][0]
+        assert args[0].lower() == "explorer"
+        assert args[1].startswith("/select,")
+
+
+def test_reveal_unknown_photo_returns_error(app_and_db):
+    app, _ = app_and_db
+    with app.test_client() as c:
+        resp = c.post("/api/files/reveal", json={"photo_id": 999999})
+        assert resp.status_code == 404
+
+
+def test_reveal_shell_failure_reports_reason(app_and_db):
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "darwin"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.side_effect = FileNotFoundError("no 'open'")
+        resp = c.post("/api/files/reveal", json={"photo_id": pid})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is False
+        assert "reason" in body

--- a/vireo/tests/test_reveal_api.py
+++ b/vireo/tests/test_reveal_api.py
@@ -91,3 +91,82 @@ def test_reveal_invalid_photo_id_returns_400(app_and_db):
         assert resp.status_code == 400
         body = resp.get_json()
         assert "photo_id" in (body.get("error") or "").lower()
+
+
+def test_reveal_folder_macos(app_and_db):
+    """Passing {folder_id} reveals the folder itself on macOS (open -R <dir>)."""
+    app, db = app_and_db
+    folder = db.get_folder_tree()[0]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "darwin"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0)
+        resp = c.post("/api/files/reveal", json={"folder_id": folder["id"]})
+        assert resp.status_code == 200
+        assert resp.get_json()["ok"] is True
+        args = run.call_args[0][0]
+        # argv shape: ["open", "-R", "--", <folder path>]
+        assert args[0] == "open"
+        assert args[1] == "-R"
+        assert args[2] == "--"
+        assert args[3] == folder["path"]
+
+
+def test_reveal_folder_linux_opens_folder(app_and_db):
+    """On Linux, passing {folder_id} opens the folder itself with xdg-open."""
+    app, db = app_and_db
+    folder = db.get_folder_tree()[0]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "linux"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0)
+        resp = c.post("/api/files/reveal", json={"folder_id": folder["id"]})
+        assert resp.status_code == 200
+        args = run.call_args[0][0]
+        # argv shape: ["xdg-open", "--", <folder path>]
+        assert args[0] == "xdg-open"
+        assert args[1] == "--"
+        assert args[2] == folder["path"]
+
+
+def test_reveal_folder_windows_opens_folder(app_and_db):
+    """On Windows, passing {folder_id} opens the folder itself in Explorer
+    (no /select, since we want to show the folder's contents, not its parent).
+    """
+    app, db = app_and_db
+    folder = db.get_folder_tree()[0]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "win32"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0)
+        resp = c.post("/api/files/reveal", json={"folder_id": folder["id"]})
+        assert resp.status_code == 200
+        args = run.call_args[0][0]
+        assert args[0].lower() == "explorer"
+        # No /select, for folder reveals — open the folder itself.
+        assert not args[1].startswith("/select,")
+        assert args[1] == folder["path"]
+
+
+def test_reveal_unknown_folder_returns_404(app_and_db):
+    app, _ = app_and_db
+    with app.test_client() as c:
+        resp = c.post("/api/files/reveal", json={"folder_id": 999999})
+        assert resp.status_code == 404
+
+
+def test_reveal_invalid_folder_id_returns_400(app_and_db):
+    app, _ = app_and_db
+    with app.test_client() as c:
+        resp = c.post("/api/files/reveal", json={"folder_id": "abc"})
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert "folder_id" in (body.get("error") or "").lower()
+
+
+def test_reveal_requires_photo_or_folder_id(app_and_db):
+    """With neither photo_id nor folder_id, return 400."""
+    app, _ = app_and_db
+    with app.test_client() as c:
+        resp = c.post("/api/files/reveal", json={})
+        assert resp.status_code == 400

--- a/vireo/tests/test_reveal_api.py
+++ b/vireo/tests/test_reveal_api.py
@@ -1,11 +1,22 @@
 """Tests for POST /api/files/reveal — cross-platform reveal-in-file-manager."""
 
+import os
 from unittest.mock import MagicMock, patch
+
+
+def _expected_full_path(db, pid):
+    """Resolve the on-disk path the endpoint will build for a given photo id."""
+    photo = db.get_photo(pid)
+    folder_row = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()
+    return os.path.join(folder_row["path"], photo["filename"])
 
 
 def test_reveal_macos(app_and_db):
     app, db = app_and_db
     pid = db.get_photos()[0]["id"]
+    expected_path = _expected_full_path(db, pid)
     with app.test_client() as c, \
          patch("vireo.app.sys.platform", "darwin"), \
          patch("vireo.app.subprocess.run") as run:
@@ -14,13 +25,17 @@ def test_reveal_macos(app_and_db):
         assert resp.status_code == 200
         assert resp.get_json()["ok"] is True
         args = run.call_args[0][0]
+        # argv shape: ["open", "-R", "--", <path>]
         assert args[0] == "open"
         assert args[1] == "-R"
+        assert args[2] == "--"
+        assert args[3] == expected_path
 
 
 def test_reveal_linux_opens_parent(app_and_db):
     app, db = app_and_db
     pid = db.get_photos()[0]["id"]
+    expected_parent = os.path.dirname(_expected_full_path(db, pid))
     with app.test_client() as c, \
          patch("vireo.app.sys.platform", "linux"), \
          patch("vireo.app.subprocess.run") as run:
@@ -28,9 +43,10 @@ def test_reveal_linux_opens_parent(app_and_db):
         resp = c.post("/api/files/reveal", json={"photo_id": pid})
         assert resp.status_code == 200
         args = run.call_args[0][0]
+        # argv shape: ["xdg-open", "--", <parent_dir>]
         assert args[0] == "xdg-open"
-        # argv[1] is the parent dir, not the file itself
-        assert not args[1].endswith(".jpg")
+        assert args[1] == "--"
+        assert args[2] == expected_parent
 
 
 def test_reveal_windows_select(app_and_db):
@@ -66,3 +82,12 @@ def test_reveal_shell_failure_reports_reason(app_and_db):
         body = resp.get_json()
         assert body["ok"] is False
         assert "reason" in body
+
+
+def test_reveal_invalid_photo_id_returns_400(app_and_db):
+    app, _ = app_and_db
+    with app.test_client() as c:
+        resp = c.post("/api/files/reveal", json={"photo_id": "abc"})
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert "photo_id" in (body.get("error") or "").lower()

--- a/vireo/tests/test_reveal_api.py
+++ b/vireo/tests/test_reveal_api.py
@@ -43,10 +43,11 @@ def test_reveal_linux_opens_parent(app_and_db):
         resp = c.post("/api/files/reveal", json={"photo_id": pid})
         assert resp.status_code == 200
         args = run.call_args[0][0]
-        # argv shape: ["xdg-open", "--", <parent_dir>]
+        # argv shape: ["xdg-open", <parent_dir>]. xdg-open does not accept `--`;
+        # the endpoint relies on os.path.abspath to guarantee a leading slash.
         assert args[0] == "xdg-open"
-        assert args[1] == "--"
-        assert args[2] == expected_parent
+        assert args[1] == os.path.abspath(expected_parent)
+        assert len(args) == 2
 
 
 def test_reveal_windows_select(app_and_db):
@@ -123,10 +124,11 @@ def test_reveal_folder_linux_opens_folder(app_and_db):
         resp = c.post("/api/files/reveal", json={"folder_id": folder["id"]})
         assert resp.status_code == 200
         args = run.call_args[0][0]
-        # argv shape: ["xdg-open", "--", <folder path>]
+        # argv shape: ["xdg-open", <folder path>]. xdg-open does not accept `--`;
+        # the endpoint relies on os.path.abspath to guarantee a leading slash.
         assert args[0] == "xdg-open"
-        assert args[1] == "--"
-        assert args[2] == folder["path"]
+        assert args[1] == os.path.abspath(folder["path"])
+        assert len(args) == 2
 
 
 def test_reveal_folder_windows_opens_folder(app_and_db):

--- a/vireo/tests/test_reveal_api.py
+++ b/vireo/tests/test_reveal_api.py
@@ -172,3 +172,37 @@ def test_reveal_requires_photo_or_folder_id(app_and_db):
     with app.test_client() as c:
         resp = c.post("/api/files/reveal", json={})
         assert resp.status_code == 400
+
+
+def test_reveal_photo_outside_active_workspace_returns_404(app_and_db):
+    """A photo whose folder is not linked to the active workspace must 404.
+
+    Without this gate, a caller could reveal absolute file paths for photos
+    hidden from the current workspace by guessing photo IDs.
+    """
+    app, db = app_and_db
+    default_ws = db._active_workspace_id
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+    other_fid = db.add_folder('/secret/ws-photos', name='secret')
+    pid = db.add_photo(
+        folder_id=other_fid, filename='hidden.jpg', extension='.jpg',
+        file_size=10, file_mtime=1.0, timestamp='2024-01-01T00:00:00',
+    )
+    db.set_active_workspace(default_ws)
+    with app.test_client() as c:
+        resp = c.post("/api/files/reveal", json={"photo_id": pid})
+        assert resp.status_code == 404
+
+
+def test_reveal_folder_outside_active_workspace_returns_404(app_and_db):
+    """A folder not linked to the active workspace must 404."""
+    app, db = app_and_db
+    default_ws = db._active_workspace_id
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+    other_fid = db.add_folder('/secret/ws-dir', name='secret')
+    db.set_active_workspace(default_ws)
+    with app.test_client() as c:
+        resp = c.post("/api/files/reveal", json={"folder_id": other_fid})
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Adds a shared floating context-menu component (`openContextMenu`) used across seven surfaces in Vireo. Right-clicking anywhere in the app now opens a Vireo-styled menu instead of the browser default — no existing keyboard shortcut or button changes.

**Surfaces:** photo card (browse grid), photo card (review grid), lightbox, folder tree, keyword row, collection sidebar item, burst group modal thumbnail.

**Behavior:**
- Finder-style selection coupling — right-clicking an item outside the current selection replaces selection with that single item; right-clicking inside preserves the selection.
- Flat menus with inline chip rows for rating / color / flag — one pointer-move per action.
- Actions disabled (with tooltip) when unavailable for multi-select (Reveal, Open in Editor, Find Similar).

**New endpoints:**
- `POST /api/files/reveal` — cross-platform reveal in Finder / Explorer / file manager. Accepts `{photo_id}` or `{folder_id}`. Uses `subprocess.run` with list argv, `--` separator, `shell=False`, short timeout.
- `POST /api/folders/<id>/rescan` — per-folder scoped rescan, queued via existing `JobRunner`.
- `POST /api/collections/<id>/duplicate` — DB-only copy of collection row and its rules.

**Client-side Copy Path** via `navigator.clipboard` (no endpoint).

See `docs/plans/2026-04-22-context-menus-design.md` and `docs/plans/2026-04-22-context-menus-plan.md` for the full design and TDD plan.

## Test plan

- [x] 7 new Playwright e2e test files (~40 tests) covering every surface and interaction
- [x] 3 new pytest files for reveal / folder-rescan / collection-duplicate endpoints
- [x] `python -m pytest tests/ vireo/tests/ -q` — 1692 passed; 4 pre-existing/flaky failures verified independent of this branch (see `vireo/tests/test_models.py` INTERNALERROR, `test_userfirst_scenarios` regressions, and two flaky tests that pass in isolation — all reproduce on `origin/main`)
- [ ] Manual smoke test on macOS — right-click each surface; verify Reveal opens Finder on the correct file; verify Copy Path pastes valid paths; verify keyboard shortcuts are unchanged
- [ ] Manual smoke test on Windows / Linux — verify Reveal shells out correctly (failure modes acceptable in remote-server setups per design doc)