### PR TITLE
perf(rescan): make folder-tree rescan incremental

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3078,7 +3078,7 @@ function rescanFolder(fid) {
   fetch('/api/folders/' + fid + '/rescan', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: '{}',
+    body: JSON.stringify({incremental: true}),
   }).catch(function(err) { console.error('rescanFolder failed', err); });
 }
 


### PR DESCRIPTION
## Summary
- The browse-page **Rescan this Folder** context action posted an empty body to `/api/folders/<id>/rescan`, which the backend interprets as `incremental=False`. That path re-runs ExifTool, perceptual-hash, and SHA-256 on **every** file in the folder, even ones unchanged since the last scan — both phash and SHA-256 read every byte of every image.
- Pass `incremental: true` from the frontend so the scanner skips unchanged files via its existing mtime + self-heal path. This matches how the Pipeline page already invokes scans (`pipeline_job.py:594, 612`) and how the audit drift check works.

### What still gets picked up
Incremental mode's skip check (`scanner.py:568-615`) re-processes files when:
- File mtime changed.
- XMP sidecar mtime changed (keywords re-import).
- New files appear on disk (lookup miss → full process).
- RAW row has suspect <1000px dimensions or NULL exif_data (self-heal).

Only blind spot is content edits that preserve mtime (`touch -r`, `rsync --times` overwrites) — not part of any normal photo workflow.

## Test plan
- [x] `python -m pytest vireo/tests/test_folder_rescan_api.py vireo/tests/test_scanner_callback.py -q` → 11 passed
- [ ] Manual: right-click a folder in the browse tree → "Rescan this Folder" → confirm the scan job completes quickly on a folder with no on-disk changes.
- [ ] Manual: edit a photo's XMP sidecar, trigger rescan, confirm keyword changes land.
- [ ] Manual: drop a new image into a folder, trigger rescan, confirm it appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)