### PR TITLE
fix(export): repair SuperAnimal ONNX export against DLC 3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ export = [
     "timm>=1.0",
     "sam2>=1.0",
     "open_clip_torch>=2.0",
+    "onnx>=1.17",
     "onnxscript>=0.1",
     # RTMPose-animal / SuperAnimal keypoint model export (eye-focus detection).
     # mmpose 1.x depends on mmengine; mmdeploy performs the torch -> ONNX
@@ -40,11 +41,10 @@ export = [
     "mmcv>=2.1",
     "mmpose>=1.3",
     "mmdeploy>=1.3",
-    # SuperAnimal-Quadruped / SuperAnimal-Bird: dlclibrary loads DLC 3.x
-    # PyTorch weights; deeplabcut is pulled for its heatmap decoder utilities
-    # referenced by the export wrapper's validation path.
-    "dlclibrary>=0.0.6",
-    "deeplabcut>=3.0",
+    # SuperAnimal-Quadruped / SuperAnimal-Bird: the export builds a DLC 3.x
+    # PoseModel and loads raw snapshots from DeepLabCut's HuggingFace org.
+    # 3.0 is still pre-release (install with pip --pre).
+    "deeplabcut>=3.0.0rc14",
 ]
 dev = [
     "pytest>=9.0",

--- a/scripts/export_onnx.py
+++ b/scripts/export_onnx.py
@@ -1128,97 +1128,135 @@ def export_rtmpose_animal(output_dir, opset, validate=False):
 # SuperAnimal (DeepLabCut 3.x) — production animal keypoint models
 # ---------------------------------------------------------------------------
 #
-# DLC 3.x publishes SuperAnimal-Quadruped and SuperAnimal-Bird under
-# PyTorch state dicts on HuggingFace. dlclibrary.load_superanimal_model
-# returns a torch.nn.Module whose forward produces per-keypoint heatmaps
-# at 1/4 spatial resolution; the ONNX graph exports the raw forward and
-# decoding happens at inference time via keypoints.decode_heatmaps.
+# DLC 3.x publishes raw .pt snapshots of SuperAnimal-Quadruped and
+# SuperAnimal-Bird on DeepLabCut's HuggingFace org. We:
+#   1. build a DLC 3.x PoseModel with the resnet_50 pose-only architecture,
+#      sized by the official project-config bodypart list,
+#   2. load the snapshot state dict directly (strict=True),
+#   3. export a wrapper that emits just the bodypart heatmap tensor so
+#      Vireo's keypoints.decode_heatmaps sees (1, K, H', W').
+#
+# Keypoint names are read at export time from DLC's packaged project YAML
+# to stay in lockstep with whatever bodypart list the published weights
+# were trained on. Don't hardcode them here — the bird list has 42 entries,
+# the quadruped list has 39, and they've been reordered across DLC releases.
 
-# Keypoint orders below come from the DLC model cards. Left/right eye
-# indices are what the eye-focus pipeline stage actually reads; the rest
-# are included so the config.json documents the full model output and the
-# UI could later label them without re-deriving the order.
-_SUPERANIMAL_QUADRUPED_KEYPOINTS = [
-    "nose", "upper_jaw", "lower_jaw", "mouth_end_right", "mouth_end_left",
-    "right_eye", "right_earbase", "right_earend", "right_antler_base",
-    "right_antler_end",
-    "left_eye", "left_earbase", "left_earend", "left_antler_base",
-    "left_antler_end",
-    "neck_base", "neck_end", "throat_base", "throat_end",
-    "back_base", "back_end", "back_middle", "tail_base", "tail_end",
-    "front_left_thai", "front_left_knee", "front_left_paw",
-    "front_right_thai", "front_right_knee", "front_right_paw",
-    "back_left_paw", "back_left_thai", "back_left_knee",
-    "back_right_thai", "back_right_knee", "back_right_paw",
-    "belly_bottom", "body_middle_right", "body_middle_left",
-]
-_SUPERANIMAL_BIRD_KEYPOINTS = [
-    "beak_tip", "left_eye", "right_eye", "crown", "nape",
-    "left_shoulder", "right_shoulder", "left_wing_tip", "right_wing_tip",
-    "back", "tail_base", "tail_tip",
-    "left_leg", "right_leg",
-    "left_foot", "right_foot",
-]
+# HF repos for each snapshot. Bird lives under DLC's org; quadruped and
+# topview-mouse snapshots live under the maintainer's personal org. The
+# source of truth is dlclibrary.dlcmodelzoo.modelzoo_urls_pytorch.yaml.
+_SUPERANIMAL_HF_REPOS = {
+    "superanimal_bird": (
+        "DeepLabCut/DeepLabCutModelZoo-SuperAnimal-Bird",
+        "superanimal_bird_resnet_50.pt",
+    ),
+    "superanimal_quadruped": (
+        "mwmathis/DeepLabCutModelZoo-SuperAnimal-Quadruped",
+        "superanimal_quadruped_resnet_50.pt",
+    ),
+}
 
 
-class _SuperAnimalWrapper:
-    """Wrap a DLC pose model so ONNX export sees (B,3,H,W) → (B,K,H',W').
+def _superanimal_bodyparts(dlc_name):
+    """Read the official keypoint order from DLC's packaged project YAML."""
+    from pathlib import Path
 
-    DLC's stock forward can return dataclasses / nested dicts depending on
-    the DLC version; torch.onnx.export needs plain tensors. This wrapper
-    exposes only the heatmap tensor, making the export graph clean and the
-    ONNX output shape predictable for keypoints.decode_heatmaps.
+    import deeplabcut
+    import yaml
+
+    p = Path(deeplabcut.__file__).parent / f"modelzoo/project_configs/{dlc_name}.yaml"
+    return yaml.safe_load(p.read_text())["bodyparts"]
+
+
+def _build_superanimal_pose_model(keypoints):
+    """Construct a DLC 3.x PoseModel matching the resnet_50 snapshots on HF."""
+    from pathlib import Path
+
+    import yaml
+    from deeplabcut.pose_estimation_pytorch.config import utils as config_utils
+    from deeplabcut.pose_estimation_pytorch.models import PoseModel
+    from deeplabcut.pose_estimation_pytorch.modelzoo.utils import (
+        get_super_animal_model_config_path,
+    )
+
+    model_cfg_path = get_super_animal_model_config_path("resnet_50")
+    cfg = yaml.safe_load(Path(model_cfg_path).read_text())
+    cfg["metadata"] = {
+        "project_path": "/tmp",
+        "pose_config_path": str(model_cfg_path),
+        "bodyparts": list(keypoints),
+        "unique_bodyparts": [],
+        "individuals": ["animal"],
+        "with_identity": False,
+    }
+    cfg = config_utils.replace_default_values(
+        cfg,
+        num_bodyparts=len(keypoints),
+        num_individuals=1,
+        backbone_output_channels=cfg["model"]["backbone_output_channels"],
+    )
+    return PoseModel.build(cfg["model"], pretrained_backbone=False)
+
+
+def _inline_onnx_external_data(onnx_path):
+    """Consolidate a torch-exported ONNX into a single file.
+
+    torch 2.11's dynamo exporter + onnxscript optimizer emit weights as
+    external ``model.onnx.data`` by default. Vireo's keypoint download
+    path (keypoints.ensure_keypoint_weights) expects a single model.onnx,
+    so we rewrite in-place with all initializers inlined.
+    """
+    import onnx
+
+    model = onnx.load(onnx_path, load_external_data=True)
+    for init in model.graph.initializer:
+        if init.data_location == onnx.TensorProto.EXTERNAL:
+            init.data_location = onnx.TensorProto.DEFAULT
+            del init.external_data[:]
+    onnx.save(model, onnx_path, save_as_external_data=False)
+    sidecar = onnx_path + ".data"
+    if os.path.isfile(sidecar):
+        os.remove(sidecar)
+
+
+class _SuperAnimalWrapper(torch.nn.Module):
+    """Expose the bodypart heatmap so torch.onnx.export sees a single tensor.
+
+    DLC 3.x PoseModel.forward returns ``{head_name: {output_name: tensor}}``;
+    Vireo's keypoints.decode_heatmaps wants just ``(1, K, H', W')``.
     """
 
     def __init__(self, model):
-        import torch.nn as nn
-        if not isinstance(model, nn.Module):
-            raise TypeError(
-                "expected torch.nn.Module from dlclibrary, got "
-                f"{type(model).__name__}"
-            )
+        super().__init__()
         self.model = model.eval()
 
-    def __call__(self, x):
-        out = self.model(x)
-        # DLC's output structure varies by release; we defensively pull the
-        # heatmap tensor wherever it shows up. Raises early if this layout
-        # changes so a silent wrong-tensor export never lands.
-        if hasattr(out, "heatmap"):
-            return out.heatmap
-        if isinstance(out, dict) and "heatmap" in out:
-            return out["heatmap"]
-        if isinstance(out, (list, tuple)):
-            return out[0]
-        import torch
-        if isinstance(out, torch.Tensor):
-            return out
-        raise RuntimeError(
-            f"Unrecognized DLC model output: {type(out).__name__}. "
-            "Update _SuperAnimalWrapper to match the new DLC forward."
-        )
+    def forward(self, x):
+        return self.model(x)["bodypart"]["heatmap"]
 
 
-def _export_superanimal_variant(
-    dlc_name, model_id, keypoint_names, output_dir, opset, validate=False,
-):
-    """Shared export path for SuperAnimal-Quadruped and SuperAnimal-Bird.
-
-    Args:
-        dlc_name: the model name accepted by
-            ``dlclibrary.load_superanimal_model`` (e.g. 'superanimal_quadruped').
-        model_id: the Vireo-side id used for directory naming (e.g.
-            'superanimal-quadruped').
-        keypoint_names: ordered list of keypoint names matching the model's
-            output channels.
-    """
+def _export_superanimal_variant(dlc_name, model_id, output_dir, opset, validate=False):
+    """Shared export path for SuperAnimal-Quadruped and SuperAnimal-Bird."""
+    import huggingface_hub
     import torch
-    from dlclibrary import load_superanimal_model
 
     log.info("Exporting %s...", model_id)
+    keypoints = _superanimal_bodyparts(dlc_name)
+    log.info(
+        "  %d keypoints (left_eye=%d, right_eye=%d)",
+        len(keypoints),
+        keypoints.index("left_eye"),
+        keypoints.index("right_eye"),
+    )
 
-    torch_model = load_superanimal_model(dlc_name)
-    wrapped = _SuperAnimalWrapper(torch_model)
+    model = _build_superanimal_pose_model(keypoints)
+
+    repo_id, filename = _SUPERANIMAL_HF_REPOS[dlc_name]
+    log.info("  downloading %s from %s", filename, repo_id)
+    ckpt_path = huggingface_hub.hf_hub_download(repo_id=repo_id, filename=filename)
+    snapshot = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    model.load_state_dict(snapshot["model"], strict=True)
+    model.eval()
+
+    wrapped = _SuperAnimalWrapper(model).eval()
 
     # 256×256 keeps parity with RTMPose so the pipeline stage's aspect-
     # preserving resize + top-left pad produces the same crop geometry
@@ -1230,7 +1268,7 @@ def _export_superanimal_variant(
     onnx_path = os.path.join(out_dir, "model.onnx")
 
     torch.onnx.export(
-        lambda x: wrapped(x),
+        wrapped,
         dummy,
         onnx_path,
         opset_version=opset,
@@ -1241,6 +1279,7 @@ def _export_superanimal_variant(
         # one crop at a time anyway. If batched export is ever needed,
         # re-add dynamic_axes={"pixel_values": {0: "batch"}} here.
     )
+    _inline_onnx_external_data(onnx_path)
 
     config = {
         "input_size": [1, 3, input_h, input_w],
@@ -1248,23 +1287,23 @@ def _export_superanimal_variant(
         # ImageNet-pretrained backbones and expect the standard normalization.
         "mean": [123.675, 116.28, 103.53],
         "std": [58.395, 57.12, 57.375],
-        "keypoints": keypoint_names,
+        "keypoints": keypoints,
         "output_type": "heatmap",
     }
     _save_json(os.path.join(out_dir, "config.json"), config)
 
     if validate:
-        # Compare decoded keypoints between PyTorch and ONNX Runtime on the
-        # dummy input — ±1-pixel tolerance is the plan's bar. Real-image
-        # validation lives in tests/e2e/.
+        # Compare heatmaps between PyTorch and ONNX Runtime on the dummy
+        # input. Real-image validation lives in tests/e2e/.
+        import numpy as np
         import onnxruntime as ort
+
         sess = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
         with torch.no_grad():
             torch_hm = wrapped(dummy).numpy()
         onnx_hm = sess.run(None, {"pixel_values": dummy.numpy()})[0]
-        import numpy as np
         max_diff = float(np.abs(torch_hm - onnx_hm).max())
-        log.info("  %s ONNX vs PyTorch heatmap max abs diff: %.6f", model_id, max_diff)
+        log.info("  %s ONNX vs PyTorch heatmap max abs diff: %.6e", model_id, max_diff)
         if max_diff > 1e-3:
             raise RuntimeError(
                 f"{model_id} ONNX/PyTorch disagreement too large: {max_diff}"
@@ -1276,18 +1315,14 @@ def _export_superanimal_variant(
 
 def export_superanimal_quadruped(output_dir, opset, validate=False):
     return _export_superanimal_variant(
-        "superanimal_quadruped",
-        "superanimal-quadruped",
-        _SUPERANIMAL_QUADRUPED_KEYPOINTS,
+        "superanimal_quadruped", "superanimal-quadruped",
         output_dir, opset, validate,
     )
 
 
 def export_superanimal_bird(output_dir, opset, validate=False):
     return _export_superanimal_variant(
-        "superanimal_bird",
-        "superanimal-bird",
-        _SUPERANIMAL_BIRD_KEYPOINTS,
+        "superanimal_bird", "superanimal-bird",
         output_dir, opset, validate,
     )
 


### PR DESCRIPTION
## Summary

The SuperAnimal-Bird download in Vireo's UI was failing (\"✗ SuperAnimal-Bird Download failed — retry?\") because the `superanimal-bird/model.onnx` and `superanimal-quadruped/model.onnx` artifacts never made it onto HuggingFace. The export path that was supposed to produce them was broken in several ways; this PR fixes the export and the weights are now published.

## What was broken

- `from dlclibrary import load_superanimal_model` — the function no longer exists in dlclibrary 0.0.11. The export would have ImportError'd at the very first step.
- The hardcoded bird keypoint list in `scripts/export_onnx.py` had 16 entries. The published `superanimal_bird_resnet_50.pt` has 42 output channels, so `load_state_dict` would have errored with a head-size mismatch.
- The quadruped HF repo was pointed at `DeepLabCut/DeepLabCutModelZoo-SuperAnimal-Quadruped` (404). It actually lives under `mwmathis/`.

## Fix

- Build the DLC 3.x `PoseModel` directly via `replace_default_values` + the packaged `resnet_50` pose config, sized to the official bodypart list read from `deeplabcut/modelzoo/project_configs/<name>.yaml` at export time. No more hardcoded keypoint lists — the source of truth is the DLC release itself.
- Load the raw `.pt` snapshot from HuggingFace via `hf_hub_download` and apply `state_dict` with `strict=True`, keyed per-variant in a small `_SUPERANIMAL_HF_REPOS` dict (bird under DLC org, quadruped under `mwmathis`).
- Wrap the DLC forward (which returns `{head: {output: tensor}}`) so `torch.onnx.export` sees a single `(1, K, H', W')` tensor that `keypoints.decode_heatmaps` can consume directly.
- Inline torch 2.11's default external-data sidecar (`model.onnx.data`) back into `model.onnx` so `keypoints.ensure_keypoint_weights`' single-file download path works unchanged.
- `[export]` deps: drop `dlclibrary` (transitive via deeplabcut), pin `deeplabcut>=3.0.0rc14` (3.0 is still pre-release), add `onnx>=1.17`.

## Validation

- Exported bird and quadruped with `torch.onnx.export` opset 18, then compared PyTorch vs onnxruntime CPU heatmaps on the dummy input: max abs diff **2e-5 bird**, **7.5e-5 quadruped** (well under the 1e-3 bar).
- Uploaded to `jss367/vireo-onnx-models/{superanimal-bird,superanimal-quadruped}`.
- `keypoints.ensure_keypoint_weights(\"superanimal-bird\")` now downloads cleanly.
- `keypoints.detect_keypoints` on a random 256×256 returns the expected 42 bird / 39 quadruped points, and `left_eye` / `right_eye` resolve by name (which is what `pipeline.py:731` reads).

## Test plan

- [x] Project-designated test suite passes (555 passed in 18.47s): `tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py`
- [x] `vireo/tests/test_pipeline.py` + `test_keypoints.py` pass (41 passed in 0.62s)
- [x] End-to-end: bird ONNX weights download + keypoint detection work against the published HF artifacts
- [ ] Manual: open UI → trigger a SuperAnimal-Bird classification → confirm no \"Download failed\" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)