### PR TITLE
Processing coverage bars on the dashboard

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1742,6 +1742,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         stats["total_photos"] = db.count_photos()
         return jsonify(stats)
 
+    @app.route("/api/coverage")
+    def api_coverage():
+        """Return per-stage processing coverage for the active workspace.
+
+        ``overall`` is the workspace-wide count for each pipeline stage, and
+        ``folders`` is a per-folder breakdown (one row per top-level folder
+        linked to the workspace). Both share the same coverage keys.
+        """
+        db = _get_db()
+        return jsonify({
+            "overall": db.get_coverage_stats(),
+            "folders": db.get_folder_coverage_stats(),
+        })
+
     @app.route("/api/sync/status")
     def api_sync_status():
         db = _get_db()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1854,6 +1854,148 @@ class Database:
             (self._ws_id(),),
         ).fetchone()[0]
 
+    # Coverage signals shown on the dashboard. Each entry is a (key, SQL
+    # predicate) pair; the predicate references the ``photos`` alias ``p`` and
+    # returns 1 when that pipeline stage has run for the row. Detection and
+    # classification are joined in separately since they live in other tables.
+    _COVERAGE_PHOTO_COLUMNS = [
+        ("timestamp", "p.timestamp IS NOT NULL"),
+        ("exif", "p.exif_data IS NOT NULL"),
+        ("gps", "p.latitude IS NOT NULL AND p.longitude IS NOT NULL"),
+        ("file_hash", "p.file_hash IS NOT NULL"),
+        ("phash", "p.phash IS NOT NULL"),
+        ("thumbnail", "p.thumb_path IS NOT NULL"),
+        ("working_copy", "p.working_copy_path IS NOT NULL"),
+        ("mask", "p.mask_path IS NOT NULL"),
+        ("subject_sharpness", "p.subject_tenengrad IS NOT NULL"),
+        ("bg_sharpness", "p.bg_tenengrad IS NOT NULL"),
+        ("eye", "p.eye_x IS NOT NULL"),
+        ("quality", "p.quality_score IS NOT NULL"),
+        ("dino_embedding", "p.dino_subject_embedding IS NOT NULL"),
+        ("label_embedding", "p.embedding IS NOT NULL"),
+        ("burst", "p.burst_id IS NOT NULL"),
+        ("rating", "p.rating IS NOT NULL AND p.rating > 0"),
+    ]
+
+    def _coverage_select_fragment(self):
+        parts = [
+            f"SUM(CASE WHEN {pred} THEN 1 ELSE 0 END) AS {key}"
+            for key, pred in self._COVERAGE_PHOTO_COLUMNS
+        ]
+        return ",\n                ".join(parts)
+
+    def get_coverage_stats(self):
+        """Return per-stage coverage counts for the active workspace.
+
+        ``total`` is the number of photos in active (status='ok') folders of
+        the workspace. Each other key is the count of those photos for which
+        the named pipeline stage has produced output. ``detected`` and
+        ``classified`` are joined from the detections/predictions tables;
+        everything else is a simple NOT NULL check on ``photos``.
+        """
+        ws = self._ws_id()
+        photo_row = self.conn.execute(
+            f"""SELECT
+                COUNT(*) AS total,
+                {self._coverage_select_fragment()}
+            FROM photos p
+            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+            JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+            WHERE wf.workspace_id = ?""",
+            (ws,),
+        ).fetchone()
+        detected = self.conn.execute(
+            """SELECT COUNT(DISTINCT d.photo_id)
+               FROM detections d
+               JOIN photos p ON p.id = d.photo_id
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+               WHERE d.workspace_id = ? AND wf.workspace_id = ?""",
+            (ws, ws),
+        ).fetchone()[0] or 0
+        classified = self.conn.execute(
+            """SELECT COUNT(DISTINCT d.photo_id)
+               FROM predictions pr
+               JOIN detections d ON d.id = pr.detection_id
+               JOIN photos p ON p.id = d.photo_id
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+               WHERE d.workspace_id = ? AND wf.workspace_id = ?""",
+            (ws, ws),
+        ).fetchone()[0] or 0
+        result = {"total": photo_row["total"] or 0}
+        for key, _ in self._COVERAGE_PHOTO_COLUMNS:
+            result[key] = photo_row[key] or 0
+        result["detected"] = detected
+        result["classified"] = classified
+        return result
+
+    def get_folder_coverage_stats(self):
+        """Return a list of per-folder coverage counts for the active workspace.
+
+        One row per folder that is linked to the workspace and has
+        ``status='ok'``. Each row carries ``folder_id``, ``path``, ``name``,
+        ``total`` (photos in that folder only — descendants are NOT rolled
+        in), and the same coverage keys as :meth:`get_coverage_stats`.
+        Folders with zero photos are included so the dashboard can still
+        show them as 0 / 0 if it chooses.
+        """
+        ws = self._ws_id()
+        photo_rows = self.conn.execute(
+            f"""SELECT
+                f.id AS folder_id,
+                f.path AS path,
+                f.name AS name,
+                COUNT(p.id) AS total,
+                {self._coverage_select_fragment()}
+            FROM folders f
+            JOIN workspace_folders wf ON wf.folder_id = f.id
+            LEFT JOIN photos p ON p.folder_id = f.id
+            WHERE wf.workspace_id = ? AND f.status = 'ok'
+            GROUP BY f.id
+            ORDER BY f.path""",
+            (ws,),
+        ).fetchall()
+        det_rows = self.conn.execute(
+            """SELECT p.folder_id AS folder_id,
+                      COUNT(DISTINCT d.photo_id) AS detected
+               FROM detections d
+               JOIN photos p ON p.id = d.photo_id
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+               WHERE d.workspace_id = ? AND wf.workspace_id = ?
+               GROUP BY p.folder_id""",
+            (ws, ws),
+        ).fetchall()
+        cls_rows = self.conn.execute(
+            """SELECT p.folder_id AS folder_id,
+                      COUNT(DISTINCT d.photo_id) AS classified
+               FROM predictions pr
+               JOIN detections d ON d.id = pr.detection_id
+               JOIN photos p ON p.id = d.photo_id
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+               WHERE d.workspace_id = ? AND wf.workspace_id = ?
+               GROUP BY p.folder_id""",
+            (ws, ws),
+        ).fetchall()
+        det_by_folder = {r["folder_id"]: r["detected"] for r in det_rows}
+        cls_by_folder = {r["folder_id"]: r["classified"] for r in cls_rows}
+        out = []
+        for r in photo_rows:
+            entry = {
+                "folder_id": r["folder_id"],
+                "path": r["path"],
+                "name": r["name"],
+                "total": r["total"] or 0,
+            }
+            for key, _ in self._COVERAGE_PHOTO_COLUMNS:
+                entry[key] = r[key] or 0
+            entry["detected"] = det_by_folder.get(r["folder_id"], 0)
+            entry["classified"] = cls_by_folder.get(r["folder_id"], 0)
+            out.append(entry)
+        return out
+
     def get_pipeline_feature_counts(self):
         """Return counts of photos with masks, detections, and sharpness data."""
         ws = self._ws_id()

--- a/vireo/templates/stats.html
+++ b/vireo/templates/stats.html
@@ -31,6 +31,26 @@ body { padding-bottom: 36px; }
 .hour-bar .bar-fill { background: #a78bfa; }
 .quality-bar .bar-fill { background: #f97316; }
 .pred-bar .bar-fill { background: #38bdf8; }
+.cov-bar .bar-fill { background: var(--accent); }
+.cov-bar .bar-label { width: 160px; }
+.cov-pct { width: 44px; color: var(--text-dim); font-variant-numeric: tabular-nums; flex-shrink: 0; text-align: right; }
+.cov-count { width: 110px; color: var(--text-faint); font-variant-numeric: tabular-nums; flex-shrink: 0; font-size: 11px; }
+.folder-row { padding: 8px 0; border-bottom: 1px solid var(--border-primary); font-size: 12px; }
+.folder-row .fpath {
+  color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; flex: 1; margin-right: 12px;
+}
+.folder-row .fcount { color: var(--text-dim); font-variant-numeric: tabular-nums; flex-shrink: 0; }
+.folder-row .fhead { display: flex; align-items: center; margin-bottom: 6px; cursor: pointer; }
+.folder-row .fchevron { color: var(--text-ghost); margin-right: 4px; font-size: 10px; width: 10px; display: inline-block; }
+.folder-cov-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 4px 16px; padding: 4px 0 2px 14px;
+}
+.folder-cov-grid .bar-row { margin-bottom: 2px; font-size: 11px; }
+.folder-cov-grid .bar-label { width: 110px; }
+.folder-cov-grid .bar-track { height: 10px; }
+.folder-cov-grid .cov-pct { width: 38px; font-size: 11px; }
 
 .grid-2col { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
 @media (max-width: 768px) { .grid-2col { grid-template-columns: 1fr; } }
@@ -130,6 +150,15 @@ body { padding-bottom: 36px; }
     <div id="pendingDetail" style="display:none;margin-top:16px;border-top:1px solid var(--border-primary);padding-top:16px;"></div>
   </div>
 
+  <!-- Processing Coverage -->
+  <div class="section">
+    <div class="section-title">Processing Coverage</div>
+    <div style="font-size:11px;color:var(--text-dim);margin-bottom:8px;">
+      How much of this workspace has gone through each pipeline stage.
+    </div>
+    <div id="coverageChart"><span style="color:var(--text-ghost);font-size:13px;">Loading...</span></div>
+  </div>
+
   <!-- Top Species -->
   <div class="section">
     <div class="section-title">Top Species</div>
@@ -219,6 +248,81 @@ body { padding-bottom: 36px; }
 loadStats();
 loadStoragePanel();
 loadDashboard();
+loadCoverage();
+
+// Order matches the pipeline roughly: ingest → metadata → pixel ops → AI → review.
+var COVERAGE_FIELDS = [
+  {key: 'timestamp',         label: 'EXIF timestamp'},
+  {key: 'exif',              label: 'EXIF data'},
+  {key: 'gps',               label: 'GPS coordinates'},
+  {key: 'file_hash',         label: 'File hash (SHA-256)'},
+  {key: 'phash',             label: 'Perceptual hash'},
+  {key: 'thumbnail',         label: 'Thumbnail'},
+  {key: 'working_copy',      label: 'Working copy (JPG)'},
+  {key: 'detected',          label: 'Subject detection'},
+  {key: 'mask',              label: 'Subject mask'},
+  {key: 'subject_sharpness', label: 'Subject sharpness'},
+  {key: 'bg_sharpness',      label: 'Background sharpness'},
+  {key: 'eye',               label: 'Eye detection'},
+  {key: 'quality',           label: 'Quality score'},
+  {key: 'dino_embedding',    label: 'DINO embedding'},
+  {key: 'label_embedding',   label: 'Label embedding'},
+  {key: 'classified',        label: 'Classification'},
+  {key: 'burst',             label: 'Burst grouping'},
+  {key: 'rating',            label: 'Rated (\u2605+)'},
+];
+
+var _coverageFolders = null;
+
+async function loadCoverage() {
+  var container = document.getElementById('coverageChart');
+  try {
+    var data = await safeFetch('/api/coverage', {}, { toast: false });
+    _coverageFolders = data.folders || [];
+    renderCoverage(container, data.overall || {total: 0});
+  } catch(e) {
+    container.innerHTML = '<span style="color:var(--danger);font-size:12px;">Failed to load coverage.</span>';
+  }
+}
+
+function renderCoverage(container, stats) {
+  var total = stats.total || 0;
+  if (total === 0) {
+    container.innerHTML = '<span style="color:var(--text-ghost);font-size:13px;">No photos in this workspace.</span>';
+    return;
+  }
+  var html = '';
+  COVERAGE_FIELDS.forEach(function(f) {
+    var count = stats[f.key] || 0;
+    var pct = Math.round((count / total) * 100);
+    html += '<div class="bar-row cov-bar">' +
+      '<span class="bar-label">' + f.label + '</span>' +
+      '<div class="bar-track"><div class="bar-fill" style="width:' + pct + '%"></div></div>' +
+      '<span class="cov-pct">' + pct + '%</span>' +
+      '<span class="cov-count">' + count.toLocaleString() + ' / ' + total.toLocaleString() + '</span>' +
+    '</div>';
+  });
+  container.innerHTML = html;
+}
+
+function renderFolderCoverage(folder) {
+  var total = folder.total || 0;
+  if (total === 0) {
+    return '<div style="padding:4px 0 6px 14px;font-size:11px;color:var(--text-ghost);">No photos in this folder.</div>';
+  }
+  var html = '<div class="folder-cov-grid">';
+  COVERAGE_FIELDS.forEach(function(f) {
+    var count = folder[f.key] || 0;
+    var pct = Math.round((count / total) * 100);
+    html += '<div class="bar-row cov-bar">' +
+      '<span class="bar-label" title="' + f.label + ' \u2014 ' + count.toLocaleString() + ' / ' + total.toLocaleString() + '">' + f.label + '</span>' +
+      '<div class="bar-track"><div class="bar-fill" style="width:' + pct + '%"></div></div>' +
+      '<span class="cov-pct">' + pct + '%</span>' +
+    '</div>';
+  });
+  html += '</div>';
+  return html;
+}
 
 async function loadStats() {
   try {
@@ -477,27 +581,42 @@ async function toggleFolderDetail() {
   panel.innerHTML = '<span style="color:var(--text-ghost);font-size:13px;">Loading...</span>';
   folderOpen = true;
   try {
-    var folders = await safeFetch('/api/folders', {}, { toast: false });
-    if (folders.length === 0) {
-      panel.innerHTML = '<span style="color:var(--text-ghost);font-size:13px;">No folders scanned yet.</span>';
-      return;
+    // Coverage endpoint already carries per-folder totals + stage counts, so
+    // we don't need a separate /api/folders fetch here.
+    if (_coverageFolders === null) {
+      var data = await safeFetch('/api/coverage', {}, { toast: false });
+      _coverageFolders = data.folders || [];
     }
-    var html = '';
-    folders.forEach(function(f) {
-      if (f.photo_count === 0) return;
-      html += '<div style="display:flex;justify-content:space-between;align-items:center;padding:6px 0;border-bottom:1px solid var(--border-primary);font-size:12px;">' +
-        '<span style="color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;margin-right:12px;" title="' + escapeHtml(f.path) + '">' + escapeHtml(f.path) + '</span>' +
-        '<span style="color:var(--text-dim);font-variant-numeric:tabular-nums;flex-shrink:0;">' + f.photo_count.toLocaleString() + ' photos</span>' +
-      '</div>';
-    });
-    if (!html) {
+    var folders = (_coverageFolders || []).filter(function(f) { return (f.total || 0) > 0; });
+    if (folders.length === 0) {
       panel.innerHTML = '<span style="color:var(--text-ghost);font-size:13px;">No folders with photos.</span>';
       return;
     }
+    var html = '';
+    folders.forEach(function(f, i) {
+      var fid = 'fcov_' + i;
+      html += '<div class="folder-row">' +
+        '<div class="fhead" onclick="toggleFolderCov(\'' + fid + '\', this)">' +
+          '<span class="fchevron">\u25B8</span>' +
+          '<span class="fpath" title="' + escapeHtml(f.path) + '">' + escapeHtml(f.path) + '</span>' +
+          '<span class="fcount">' + (f.total || 0).toLocaleString() + ' photos</span>' +
+        '</div>' +
+        '<div id="' + fid + '" style="display:none;">' + renderFolderCoverage(f) + '</div>' +
+      '</div>';
+    });
     panel.innerHTML = html;
   } catch(e) {
     panel.innerHTML = '<span style="color:var(--danger);font-size:12px;">Failed to load folders.</span>';
   }
+}
+
+function toggleFolderCov(id, head) {
+  var el = document.getElementById(id);
+  if (!el) return;
+  var open = el.style.display !== 'none';
+  el.style.display = open ? 'none' : 'block';
+  var chevron = head.querySelector('.fchevron');
+  if (chevron) chevron.textContent = open ? '\u25B8' : '\u25BE';
 }
 
 var pendingOpen = false;

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -49,6 +49,30 @@ def test_api_folders(app_and_db):
     assert '/photos/2024' in paths
 
 
+def test_api_coverage(app_and_db):
+    """GET /api/coverage returns workspace-level and per-folder coverage."""
+    app, db = app_and_db
+    # Mark one photo as having a thumbnail so at least one stage is non-zero.
+    db.conn.execute(
+        "UPDATE photos SET thumb_path = '/t/x.jpg' WHERE filename = 'bird1.jpg'"
+    )
+    db.conn.commit()
+    client = app.test_client()
+    resp = client.get('/api/coverage')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'overall' in data
+    assert 'folders' in data
+    assert data['overall']['total'] == 3
+    assert data['overall']['thumbnail'] == 1
+    # Per-folder rows carry the same keys
+    paths = {f['path']: f for f in data['folders']}
+    assert '/photos/2024' in paths
+    assert paths['/photos/2024']['total'] == 2
+    assert paths['/photos/2024']['thumbnail'] == 1  # bird1.jpg lives here
+    assert paths['/photos/2024/January']['total'] == 1
+
+
 def test_api_folder_get_returns_linked_folder(app_and_db):
     """GET /api/folders/<id> returns id/name/path for a folder in the active ws."""
     app, db = app_and_db

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -907,6 +907,117 @@ def test_get_dashboard_stats_with_data(tmp_path):
     assert hours[8] == 1
 
 
+# --- Cluster 2b: Coverage Stats ---
+
+def test_get_coverage_stats_empty_workspace(tmp_path):
+    """Totals are zero when the workspace has no photos at all."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    stats = db.get_coverage_stats()
+    assert stats['total'] == 0
+    for key in ('thumbnail', 'phash', 'quality', 'detected', 'classified',
+                'gps', 'file_hash', 'working_copy', 'mask', 'rating'):
+        assert stats[key] == 0, f"{key} should be 0 on empty workspace"
+
+
+def test_get_coverage_stats_counts_each_stage(tmp_path):
+    """Each pipeline stage is counted independently based on its column."""
+    db, pids = _make_workspace_with_photos(tmp_path, [
+        {'thumb_path': '/t/1.jpg', 'phash': 'abc', 'quality_score': 0.9,
+         'latitude': 10.0, 'longitude': 20.0, 'file_hash': 'h1',
+         'working_copy_path': '/wc/1.jpg', 'mask_path': '/m/1.png',
+         'subject_tenengrad': 1.5, 'bg_tenengrad': 0.2,
+         'eye_x': 0.5, 'embedding': b'e', 'burst_id': 'b1',
+         'rating': 4, 'exif_data': '{}',
+         'timestamp': '2024-01-01T00:00:00'},
+        {'thumb_path': '/t/2.jpg', 'phash': 'def',
+         'timestamp': '2024-02-01T00:00:00'},
+        {},  # Nothing set
+    ])
+    # Add a detection + prediction for the first photo only.
+    det_ids = db.save_detections(pids[0], [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4},
+         "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")
+    db.add_prediction(det_ids[0], 'Robin', 0.95, 'test')
+
+    stats = db.get_coverage_stats()
+    assert stats['total'] == 3
+    assert stats['thumbnail'] == 2
+    assert stats['phash'] == 2
+    assert stats['quality'] == 1
+    assert stats['gps'] == 1
+    assert stats['file_hash'] == 1
+    assert stats['working_copy'] == 1
+    assert stats['mask'] == 1
+    assert stats['subject_sharpness'] == 1
+    assert stats['bg_sharpness'] == 1
+    assert stats['eye'] == 1
+    assert stats['label_embedding'] == 1
+    assert stats['burst'] == 1
+    assert stats['rating'] == 1  # rating > 0
+    assert stats['exif'] == 1
+    assert stats['timestamp'] == 2
+    assert stats['detected'] == 1
+    assert stats['classified'] == 1
+
+
+def test_coverage_stats_scoped_to_active_workspace(tmp_path):
+    """Photos and detections in other workspaces must not leak in."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws1 = db.ensure_default_workspace()
+    ws2 = db.create_workspace('Other')
+    db.set_active_workspace(ws1)
+    fid1 = db.add_folder('/ws1', name='ws1')
+    db.add_workspace_folder(ws1, fid1)
+    db.add_photo(folder_id=fid1, filename='a.jpg', extension='.jpg',
+                 file_size=1, file_mtime=1.0)
+    db.set_active_workspace(ws2)
+    fid2 = db.add_folder('/ws2', name='ws2')
+    db.add_workspace_folder(ws2, fid2)
+    db.add_photo(folder_id=fid2, filename='b.jpg', extension='.jpg',
+                 file_size=1, file_mtime=1.0)
+    db.add_photo(folder_id=fid2, filename='c.jpg', extension='.jpg',
+                 file_size=1, file_mtime=1.0)
+    db.set_active_workspace(ws1)
+    assert db.get_coverage_stats()['total'] == 1
+    db.set_active_workspace(ws2)
+    assert db.get_coverage_stats()['total'] == 2
+
+
+def test_get_folder_coverage_stats_per_folder_totals(tmp_path):
+    """Returned rows are one per workspace folder with correct per-folder totals."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid_a = db.add_folder('/A', name='A')
+    fid_b = db.add_folder('/B', name='B')
+    db.add_workspace_folder(ws_id, fid_a)
+    db.add_workspace_folder(ws_id, fid_b)
+    pa = db.add_photo(folder_id=fid_a, filename='1.jpg', extension='.jpg',
+                      file_size=1, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET thumb_path = '/t/1.jpg', "
+                    "phash = 'x' WHERE id = ?", (pa,))
+    db.add_photo(folder_id=fid_b, filename='2.jpg', extension='.jpg',
+                 file_size=1, file_mtime=1.0)
+    db.add_photo(folder_id=fid_b, filename='3.jpg', extension='.jpg',
+                 file_size=1, file_mtime=1.0)
+    db.conn.commit()
+
+    folders = db.get_folder_coverage_stats()
+    by_path = {f['path']: f for f in folders}
+    assert by_path['/A']['total'] == 1
+    assert by_path['/A']['thumbnail'] == 1
+    assert by_path['/A']['phash'] == 1
+    assert by_path['/B']['total'] == 2
+    assert by_path['/B']['thumbnail'] == 0
+    assert by_path['/B']['phash'] == 0
+
+
 # --- Cluster 3: Prediction Management ---
 
 def test_get_group_predictions(tmp_path):


### PR DESCRIPTION
## Summary
- Adds a **Processing Coverage** section to the dashboard showing, for every pipeline stage, how much of the active workspace has been through it: EXIF timestamp, EXIF data, GPS, file hash (SHA-256), perceptual hash, thumbnail, working copy, subject detection, subject mask, subject sharpness, background sharpness, eye detection, quality score, DINO embedding, label embedding, classification, burst grouping, and rated (≥1 star).
- Expanding the **Folders** card on the dashboard now reveals the same set of bars for each folder individually, so you can tell at a glance where the pipeline has and hasn't run per-folder.
- New `GET /api/coverage` endpoint returns `{overall, folders[]}`; both share the same stage keys.
- Implemented as two DB methods on `Database`: `get_coverage_stats()` and `get_folder_coverage_stats()`, each using a single aggregate `SELECT` over `photos` plus two `COUNT(DISTINCT photo_id)` joins for detections and predictions. Existing Classification-status and Detection-Coverage cards stay as-is — they show review-status / model-installed info the new section doesn't duplicate.

## Test plan
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` — **563 passed**
- [x] New unit tests: empty workspace, per-stage counting for a photo with every column set, workspace isolation, per-folder totals
- [x] New API test: `/api/coverage` returns expected `overall.total`, stage counts, and per-folder rows
- [x] Browser smoke test against a copy of the user's real DB: loaded `/stats`, confirmed the Processing Coverage section renders all bars with correct percentages and counts, confirmed the Folders card expansion shows per-folder bars when each row is clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)