### PR TITLE
fix(map): use photo id for thumbnail URLs

### DIFF
--- a/vireo/templates/map.html
+++ b/vireo/templates/map.html
@@ -458,7 +458,7 @@ function renderSidebar(photos) {
     card.className = 'sidebar-card';
     card.setAttribute('data-id', p.id);
 
-    var thumbSrc = p.thumb_path ? '/thumbnails/' + encodeURIComponent(p.thumb_path) : '';
+    var thumbSrc = p.id != null ? '/thumbnails/' + p.id + '.jpg' : '';
     var color = getSpeciesColor(p.species);
     var speciesHtml = p.species
       ? '<div class="card-species"><span class="species-dot" style="background:' + color + '"></span>'
@@ -499,9 +499,9 @@ function showClusterPreview(e) {
   var gridHtml = '<div class="preview-grid">';
   for (var i = 0; i < previewCount; i++) {
     var p = childMarkers[i]._photoData;
-    if (p && p.thumb_path) {
-      gridHtml += '<img src="/thumbnails/' + encodeURIComponent(p.thumb_path)
-        + '" alt="" onerror="this.style.visibility=\'hidden\'">';
+    if (p && p.id != null) {
+      gridHtml += '<img src="/thumbnails/' + p.id + '.jpg"'
+        + ' alt="" onerror="this.style.visibility=\'hidden\'">';
     } else {
       gridHtml += '<div style="width:56px;height:56px;background:var(--bg-tertiary,#14374E);border-radius:3px"></div>';
     }
@@ -566,7 +566,7 @@ async function loadPhotos() {
     legendControl.update(speciesColorMap);
 
     data.photos.forEach(function(p) {
-      var thumbSrc = p.thumb_path ? '/thumbnails/' + encodeURIComponent(p.thumb_path) : '';
+      var thumbSrc = p.id != null ? '/thumbnails/' + p.id + '.jpg' : '';
       var imgTag = thumbSrc
         ? '<img src="' + escapeAttr(thumbSrc) + '" alt="" onerror="this.style.display=\'none\'">'
         : '';


### PR DESCRIPTION
## Summary
- Map page was constructing `/thumbnails/` URLs from `photos.thumb_path`, but that column is NULL for every photo in the DB — the `p.thumb_path ? ... : ''` ternary always produced an empty string, so `<img>` tags were never emitted and the map showed only the placeholder div. Logs confirmed: no `/thumbnails/` requests fired when loading `/map`.
- Switched the three occurrences in `map.html` (sidebar cards, cluster preview grid, marker popup) to `/thumbnails/<photo_id>.jpg`, matching the convention used in every other template. The existing `serve_thumbnail` route generates missing thumbnails on demand, so no backend change is needed.

## Test plan
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` — 568 passed
- [x] Browser test with Playwright: loaded `/map`, observed 740 `/thumbnails/<id>.jpg` requests all returning 200, sidebar card imgs render (naturalWidth=300)
- [x] Browser test with Playwright: clicked a sidebar card to open marker popup — popup `<img>` loads (naturalWidth=300)

🤖 Generated with [Claude Code](https://claude.com/claude-code)