### PR TITLE
fix(scan): make scan resilient to DB lock contention

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1194,13 +1194,25 @@ class Database:
     def check_folder_health(self):
         """Check all folders for existence on disk. Update status column.
 
+        ``'partial'`` is preserved while the path still exists on disk — only
+        a successful rescan clears it. Otherwise the 10-minute health loop
+        would auto-promote a partially-scanned folder back to ``'ok'`` and
+        users would lose the visible marker that tells them to rescan. If
+        the disk path is gone we still flip to ``'missing'`` regardless of
+        prior status, since rescanning won't recover data that isn't there.
+
         Returns the number of folders whose status changed.
         """
         rows = self.conn.execute("SELECT id, path, status FROM folders").fetchall()
         changed = 0
         for row in rows:
             exists = os.path.exists(row["path"])
-            new_status = "ok" if exists else "missing"
+            if not exists:
+                new_status = "missing"
+            elif row["status"] == "partial":
+                new_status = "partial"
+            else:
+                new_status = "ok"
             if new_status != row["status"]:
                 self.conn.execute(
                     "UPDATE folders SET status = ? WHERE id = ?",

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1103,12 +1103,17 @@ class Database:
     def get_folder_tree(self):
         """Return folders for the active workspace.
 
+        Includes folders whose status is ``'ok'`` or ``'partial'`` — a
+        partially-scanned folder must stay in the tree so the browse sidebar
+        can render its badge and the user can trigger a rescan. ``'missing'``
+        folders are still excluded (they go through ``get_missing_folders``).
+
         ``parent_id`` is rewritten to the nearest ancestor that is also linked
-        to the active workspace AND has ``status='ok'``. If no such ancestor
-        exists, ``parent_id`` is NULL. This keeps the returned set a
-        well-formed tree: callers that group by ``parent_id`` (notably the
-        browse-page folder sidebar) never leave a linked folder dangling under
-        an ancestor that was filtered out of the result.
+        to the active workspace AND visible here. If no such ancestor exists,
+        ``parent_id`` is NULL. This keeps the returned set a well-formed tree:
+        callers that group by ``parent_id`` (notably the browse-page folder
+        sidebar) never leave a linked folder dangling under an ancestor that
+        was filtered out of the result.
         """
         ws = self._ws_id()
         return self.conn.execute(
@@ -1116,7 +1121,7 @@ class Database:
                visible(id) AS (
                    SELECT f.id FROM folders f
                    JOIN workspace_folders wf ON wf.folder_id = f.id
-                   WHERE wf.workspace_id = ? AND f.status = 'ok'
+                   WHERE wf.workspace_id = ? AND f.status IN ('ok', 'partial')
                ),
                walk(start_id, current_id) AS (
                    SELECT v.id, f.parent_id
@@ -1137,7 +1142,7 @@ class Database:
                )
                SELECT f.id, f.path, f.name,
                       e.parent_id AS parent_id,
-                      f.photo_count
+                      f.photo_count, f.status
                FROM folders f
                JOIN visible v ON v.id = f.id
                JOIN effective e ON e.start_id = f.id

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1544,7 +1544,7 @@ class Database:
         conditions = ["wf.workspace_id = ?"]
         params = [self._ws_id()]
         joins = ["JOIN workspace_folders wf ON wf.folder_id = p.folder_id",
-                 "JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'"]
+                 "JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')"]
 
         if "rating_min" in criteria:
             conditions.append("p.rating >= ?")
@@ -1877,7 +1877,7 @@ class Database:
         return self.conn.execute(
             """SELECT COUNT(*) FROM photos p
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+               JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
                WHERE wf.workspace_id = ?""",
             (self._ws_id(),),
         ).fetchone()[0]
@@ -1887,7 +1887,7 @@ class Database:
         return self.conn.execute(
             """SELECT COUNT(*) FROM folders f
                JOIN workspace_folders wf ON wf.folder_id = f.id
-               WHERE wf.workspace_id = ? AND f.status = 'ok'""",
+               WHERE wf.workspace_id = ? AND f.status IN ('ok', 'partial')""",
             (self._ws_id(),),
         ).fetchone()[0]
 
@@ -1898,7 +1898,7 @@ class Database:
                FROM photo_keywords pk
                JOIN photos p ON p.id = pk.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+               JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
                WHERE wf.workspace_id = ?""",
             (self._ws_id(),),
         ).fetchone()[0]
@@ -1943,8 +1943,8 @@ class Database:
     def get_coverage_stats(self):
         """Return per-stage coverage counts for the active workspace.
 
-        ``total`` is the number of photos in active (status='ok') folders of
-        the workspace. Each other key is the count of those photos for which
+        ``total`` is the number of photos in active (status ``'ok'`` or
+        ``'partial'``) folders of the workspace. Each other key is the count of those photos for which
         the named pipeline stage has produced output. ``detected`` and
         ``classified`` are joined from the detections/predictions tables;
         everything else is a simple NOT NULL check on ``photos``.
@@ -1956,7 +1956,7 @@ class Database:
                 {self._coverage_select_fragment()}
             FROM photos p
             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+            JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
             WHERE wf.workspace_id = ?""",
             (ws,),
         ).fetchone()
@@ -1965,7 +1965,7 @@ class Database:
                FROM detections d
                JOIN photos p ON p.id = d.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+               JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
                WHERE d.workspace_id = ? AND wf.workspace_id = ?""",
             (ws, ws),
         ).fetchone()[0] or 0
@@ -1975,7 +1975,7 @@ class Database:
                JOIN detections d ON d.id = pr.detection_id
                JOIN photos p ON p.id = d.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+               JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
                WHERE d.workspace_id = ? AND wf.workspace_id = ?""",
             (ws, ws),
         ).fetchone()[0] or 0
@@ -1990,7 +1990,7 @@ class Database:
         """Return a list of per-folder coverage counts for the active workspace.
 
         One row per folder that is linked to the workspace and has
-        ``status='ok'``. Each row carries ``folder_id``, ``path``, ``name``,
+        ``status`` of ``'ok'`` or ``'partial'``. Each row carries ``folder_id``, ``path``, ``name``,
         ``total`` (photos in that folder only — descendants are NOT rolled
         in), and the same coverage keys as :meth:`get_coverage_stats`.
         Folders with zero photos are included so the dashboard can still
@@ -2007,7 +2007,7 @@ class Database:
             FROM folders f
             JOIN workspace_folders wf ON wf.folder_id = f.id
             LEFT JOIN photos p ON p.folder_id = f.id
-            WHERE wf.workspace_id = ? AND f.status = 'ok'
+            WHERE wf.workspace_id = ? AND f.status IN ('ok', 'partial')
             GROUP BY f.id
             ORDER BY f.path""",
             (ws,),
@@ -2018,7 +2018,7 @@ class Database:
                FROM detections d
                JOIN photos p ON p.id = d.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+               JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
                WHERE d.workspace_id = ? AND wf.workspace_id = ?
                GROUP BY p.folder_id""",
             (ws, ws),
@@ -2030,7 +2030,7 @@ class Database:
                JOIN detections d ON d.id = pr.detection_id
                JOIN photos p ON p.id = d.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+               JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
                WHERE d.workspace_id = ? AND wf.workspace_id = ?
                GROUP BY p.folder_id""",
             (ws, ws),
@@ -2088,7 +2088,7 @@ class Database:
                JOIN photo_keywords pk ON pk.keyword_id = k.id
                JOIN photos p ON p.id = pk.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+               JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
                WHERE wf.workspace_id = ?
                GROUP BY k.id
                ORDER BY photo_count DESC
@@ -2100,7 +2100,7 @@ class Database:
             """SELECT substr(p.timestamp, 1, 7) as month, COUNT(*) as count
             FROM photos p
             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+            JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
             WHERE p.timestamp IS NOT NULL AND wf.workspace_id = ?
             GROUP BY month
             ORDER BY month""",
@@ -2111,7 +2111,7 @@ class Database:
             """SELECT p.rating, COUNT(*) as count
             FROM photos p
             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+            JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
             WHERE wf.workspace_id = ?
             GROUP BY p.rating
             ORDER BY p.rating""",
@@ -2122,7 +2122,7 @@ class Database:
             """SELECT p.flag, COUNT(*) as count
             FROM photos p
             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+            JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
             WHERE wf.workspace_id = ?
             GROUP BY p.flag""",
             (ws,),
@@ -2149,7 +2149,7 @@ class Database:
             """SELECT CAST(substr(p.timestamp, 12, 2) AS INTEGER) as hour, COUNT(*) as count
             FROM photos p
             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+            JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
             WHERE p.timestamp IS NOT NULL AND length(p.timestamp) >= 13 AND wf.workspace_id = ?
             GROUP BY hour
             ORDER BY hour""",
@@ -2165,7 +2165,7 @@ class Database:
                 COUNT(*) as count
             FROM photos p
             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+            JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
             WHERE wf.workspace_id = ?
             GROUP BY bucket
             ORDER BY bucket""",
@@ -2177,7 +2177,7 @@ class Database:
                FROM detections d
                JOIN photos p ON p.id = d.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+               JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
                WHERE d.workspace_id = ? AND wf.workspace_id = ?""",
             (ws, ws),
         ).fetchone()[0]
@@ -2203,7 +2203,7 @@ class Database:
         where_params = [ws, str(year)]
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
-                       "\nJOIN folders f ON f.id = p.folder_id AND f.status = 'ok'")
+                       "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
 
         if folder_id is not None:
             subtree = self.get_folder_subtree_ids(folder_id)
@@ -2246,7 +2246,7 @@ class Database:
                       MAX(substr(p.timestamp, 1, 4)) as max_y
             FROM photos p
             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+            JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
             WHERE wf.workspace_id = ? AND p.timestamp IS NOT NULL""",
             (ws,),
         ).fetchone()
@@ -2291,7 +2291,7 @@ class Database:
             where_params.append(_inclusive_date_to(date_to))
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
-                       "\nJOIN folders f ON f.id = p.folder_id AND f.status = 'ok'")
+                       "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
         if keyword is not None:
             join_clause += """
                 LEFT JOIN photo_keywords pk ON pk.photo_id = p.id
@@ -2370,7 +2370,7 @@ class Database:
             where_params.append(_inclusive_date_to(date_to))
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
-                       "\nJOIN folders f ON f.id = p.folder_id AND f.status = 'ok'")
+                       "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
         if keyword is not None:
             join_clause += """
                 LEFT JOIN photo_keywords pk ON pk.photo_id = p.id
@@ -2449,7 +2449,7 @@ class Database:
                 where_params.extend(coll_params)
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
-                       "\nJOIN folders f ON f.id = p.folder_id AND f.status = 'ok'")
+                       "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
         if keyword is not None:
             join_clause += """
                 LEFT JOIN photo_keywords pk ON pk.photo_id = p.id
@@ -2475,7 +2475,7 @@ class Database:
         total = self.conn.execute(
             """SELECT COUNT(*) FROM photos p
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+               JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
                WHERE wf.workspace_id = ?""",
             (ws,),
         ).fetchone()[0]
@@ -2579,7 +2579,7 @@ class Database:
             params.append(_inclusive_date_to(date_to))
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
-                       "\nJOIN folders f ON f.id = p.folder_id AND f.status = 'ok'")
+                       "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
         if keyword is not None:
             join_clause += """
                 LEFT JOIN photo_keywords pk ON pk.photo_id = p.id
@@ -2646,7 +2646,7 @@ class Database:
                 SELECT DISTINCT k.name
                 FROM photos p
                 JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-                JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+                JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
                 JOIN photo_keywords pk ON pk.photo_id = p.id
                 JOIN keywords k ON k.id = pk.keyword_id AND k.is_species = 1
                 WHERE wf.workspace_id = ?
@@ -2664,7 +2664,7 @@ class Database:
             """
             SELECT COUNT(*) FROM photos p
             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+            JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
             WHERE wf.workspace_id = ?
               AND (p.latitude IS NULL OR p.longitude IS NULL)
             """,
@@ -3531,7 +3531,7 @@ class Database:
                       bp.species
                FROM photos p
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
+               JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
                LEFT JOIN (
                    SELECT photo_id, name AS species FROM (
                        SELECT pk.photo_id, k.name,
@@ -3572,7 +3572,7 @@ class Database:
             """WITH RECURSIVE ancestors(photo_id, folder_id, timestamp) AS (
                    SELECT p.id, p.folder_id, p.timestamp
                    FROM photos p
-                   JOIN folders f0 ON f0.id = p.folder_id AND f0.status = 'ok'
+                   JOIN folders f0 ON f0.id = p.folder_id AND f0.status IN ('ok', 'partial')
                    JOIN workspace_folders wf0
                      ON wf0.folder_id = p.folder_id AND wf0.workspace_id = ?
                    WHERE p.quality_score IS NOT NULL
@@ -3591,7 +3591,7 @@ class Database:
                JOIN workspace_folders wf ON wf.folder_id = f.id
                JOIN ancestors a ON a.folder_id = f.id
                WHERE wf.workspace_id = ?
-                 AND f.status = 'ok'
+                 AND f.status IN ('ok', 'partial')
                GROUP BY f.id
                ORDER BY latest_photo DESC""",
             (ws, ws, ws),
@@ -4838,7 +4838,7 @@ class Database:
             params.insert(0, self._ws_id())
 
         # Always join folders for folder-under rules, scoped to workspace
-        folder_join = " JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'"
+        folder_join = " JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')"
         folder_join += " JOIN workspace_folders wf ON wf.folder_id = f.id AND wf.workspace_id = ?"
 
         # folder_join comes before join_clause in the query, so its param goes first

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import sqlite3
+import time
 import uuid
 
 from new_images import get_shared_cache
@@ -11,6 +12,27 @@ from new_images import get_shared_cache
 log = logging.getLogger(__name__)
 
 _UNSET = object()  # sentinel for "not provided" vs explicit None
+
+
+def commit_with_retry(conn, max_retries=5, base_delay=0.1):
+    """Commit ``conn`` with retry on transient "locked"/"busy" errors.
+
+    Parallel scan workers can still race past the 30s ``busy_timeout`` PRAGMA
+    under sustained write pressure. This helper catches the resulting
+    ``sqlite3.OperationalError`` (``"database is locked"``/``"is busy"``) and
+    retries with exponential backoff. Non-transient OperationalErrors (disk
+    I/O, constraint violations) propagate immediately so the caller can mark
+    folders partial and surface the failure.
+    """
+    for attempt in range(max_retries + 1):
+        try:
+            conn.commit()
+            return
+        except sqlite3.OperationalError as e:
+            msg = str(e).lower()
+            if ("locked" not in msg and "busy" not in msg) or attempt == max_retries:
+                raise
+            time.sleep(base_delay * (2 ** attempt))
 
 
 def _inclusive_date_to(date_to):
@@ -64,6 +86,7 @@ class Database:
         self.conn.execute("PRAGMA cache_size=-10000")  # 10 MB
         self.conn.execute("PRAGMA temp_store=MEMORY")
         self.conn.execute("PRAGMA mmap_size=30000000")  # 30 MB
+        self.conn.execute("PRAGMA busy_timeout=30000")  # 30 s — tolerate parallel scan writers
         self._active_workspace_id = None
         self._new_images_cache = get_shared_cache()
         self._create_tables()
@@ -1064,7 +1087,7 @@ class Database:
             "INSERT OR IGNORE INTO folders (path, name, parent_id) VALUES (?, ?, ?)",
             (path, name, parent_id),
         )
-        self.conn.commit()
+        commit_with_retry(self.conn)
         if cur.rowcount > 0:
             folder_id = cur.lastrowid
         else:
@@ -1614,7 +1637,7 @@ class Database:
                 file_hash,
             ),
         )
-        self.conn.commit()
+        commit_with_retry(self.conn)
         if cur.rowcount > 0:
             photo_id = cur.lastrowid
         else:

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -209,8 +209,11 @@ def ingest(
         # the user copied the same photo into multiple date folders), and
         # every matching folder needs to be walked so all of them get
         # linked to the active workspace. Four guards, layered:
-        #   1. SQL ``f.status = 'ok'`` — exclude folders the DB already
-        #      knows are missing (cheap and visible to static analysis).
+        #   1. SQL ``f.status IN ('ok', 'partial')`` — exclude folders the DB
+        #      already knows are missing (cheap and visible to static
+        #      analysis). Partially-scanned folders still contain valid
+        #      indexed hashes, so we must consult them here to avoid
+        #      re-importing bytes we already know about.
         #   2. SQL prefix match on ``f.path`` with an explicit ``ESCAPE``
         #      clause — rough subtree cut so we don't haul the whole
         #      library into memory on large DBs. Escaping is required
@@ -223,9 +226,9 @@ def ingest(
         #      stored folder path can't lexically appear to be under
         #      the destination while actually resolving outside it.
         #   4. Python ``Path.is_dir`` on the raw stored path — catches
-        #      stale ``status='ok'`` rows when the folder was deleted
-        #      since the last scan and the caller didn't refresh folder
-        #      health first.
+        #      stale ``status IN ('ok', 'partial')`` rows when the folder
+        #      was deleted since the last scan and the caller didn't
+        #      refresh folder health first.
         # A folder passes only if all four guards agree.
         #
         # The SQL prefilter compares against ``dest_path_str`` (derived
@@ -255,7 +258,7 @@ def ingest(
                FROM photos p
                JOIN folders f ON p.folder_id = f.id
                WHERE p.file_hash IS NOT NULL
-                 AND f.status = 'ok'
+                 AND f.status IN ('ok', 'partial')
                  AND (f.path = ? OR f.path LIKE ? ESCAPE '\\')""",
             (dest_path_str, dest_like_prefix),
         ).fetchall()

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -22,7 +22,9 @@ def _known_paths_for_workspace(db, workspace_id):
 
 def _mapped_roots(db, workspace_id):
     """Return the workspace's mapped roots — linked folders whose ancestor chain
-    contains no other linked folder. Skips folders marked 'missing'.
+    contains no other linked folder. Skips folders marked 'missing'. Folders
+    flagged ``'partial'`` from an interrupted scan are kept so a rescan can
+    pick up where the previous one stopped.
 
     Checking only the immediate parent would over-include when an intermediate
     folder was unlinked but a deeper descendant is still linked (e.g. /A linked,
@@ -33,7 +35,7 @@ def _mapped_roots(db, workspace_id):
         """SELECT f.id, f.path, f.parent_id
            FROM folders f
            JOIN workspace_folders wf ON wf.folder_id = f.id
-           WHERE wf.workspace_id = ? AND f.status = 'ok'""",
+           WHERE wf.workspace_id = ? AND f.status IN ('ok', 'partial')""",
         (workspace_id,),
     ).fetchall()
     linked_ids = {r["id"] for r in rows}

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -844,20 +844,37 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             log.exception("Failed to flag folders partial after scan failure")
         raise
     else:
-        # Per-file loop completed cleanly. Clear any stale 'partial' flag from
-        # a prior failed scan on the same folders so a successful rescan
-        # restores full visibility.
-        if touched_folder_ids:
-            try:
+        # Per-file loop completed cleanly. Clear any stale 'partial' flag
+        # from a prior failed scan on the folders this scan covered, so a
+        # successful rescan restores full visibility. Scope mirrors the
+        # exception path above: the explicit roots (``root`` and any
+        # ``restrict_dirs``) plus every folder the loop actually touched.
+        # Including the roots catches folders that were flagged 'partial'
+        # by a previous failure inside ``_ensure_folder``, before the new
+        # folder_id reached ``touched_folder_ids``.
+        cleared_paths = {str(root_path)}
+        if restrict_dirs is not None:
+            cleared_paths.update(str(d) for d in restrict_dirs)
+        try:
+            if cleared_paths:
+                path_placeholders = ",".join("?" * len(cleared_paths))
+                db.conn.execute(
+                    f"UPDATE folders SET status = 'ok' "
+                    f"WHERE status = 'partial' "
+                    f"AND path IN ({path_placeholders})",
+                    tuple(cleared_paths),
+                )
+            if touched_folder_ids:
                 id_placeholders = ",".join("?" * len(touched_folder_ids))
                 db.conn.execute(
                     f"UPDATE folders SET status = 'ok' "
-                    f"WHERE id IN ({id_placeholders}) AND status = 'partial'",
+                    f"WHERE status = 'partial' "
+                    f"AND id IN ({id_placeholders})",
                     tuple(touched_folder_ids),
                 )
-                commit_with_retry(db.conn)
-            except Exception:
-                log.exception("Failed to clear partial flag after scan success")
+            commit_with_retry(db.conn)
+        except Exception:
+            log.exception("Failed to clear partial flag after scan success")
 
     # Pair raw+JPEG companions: raw is primary, JPEG becomes companion_path.
     # Wrap post-processing so folder counts are always updated, even on failure.

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from pathlib import Path
 
 import imagehash
+from db import commit_with_retry
 from image_loader import RAW_EXTENSIONS, SUPPORTED_EXTENSIONS, extract_working_copy
 from metadata import extract_metadata
 from PIL import Image
@@ -307,7 +308,7 @@ def _pair_raw_jpeg_companions(db):
         db.conn.execute("DELETE FROM photo_keywords WHERE photo_id = ?", (companion["id"],))
         db.conn.execute("DELETE FROM photos WHERE id = ?", (companion["id"],))
 
-    db.conn.commit()
+    commit_with_retry(db.conn)
 
 
 def _subtree_like_pattern(path, sep=None):
@@ -443,7 +444,7 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
                 (wc_rel, row["id"]),
             )
 
-    db.conn.commit()
+    commit_with_retry(db.conn)
 
 
 def scan(root, db, progress_callback=None, incremental=False, extract_full_metadata=True, photo_callback=None, skip_paths=None, status_callback=None, recursive=True, restrict_dirs=None, restrict_files=None, vireo_dir=None):
@@ -604,7 +605,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                         "UPDATE photos SET xmp_mtime = ? WHERE id = ?",
                         (xmp_mtime, existing["id"]),
                     )
-                    db.conn.commit()
+                    commit_with_retry(db.conn)
 
                 if file_unchanged and not metadata_missing:
                     processed_count += 1
@@ -657,143 +658,191 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             for image_path, path_str in zip(files_to_process, paths_to_extract, strict=True):
                 yield image_path, _compute_file_features(path_str)
 
-    for image_path, (phash, file_hash) in _iter_features():
-        folder_id = _ensure_folder(image_path.parent)
+    # Track folders whose scan touched them, so we can flag them 'partial'
+    # if the per-file loop dies midway (unrecoverable DB error, etc).
+    touched_folder_ids = set()
+    try:
+        for image_path, (phash, file_hash) in _iter_features():
+            folder_id = _ensure_folder(image_path.parent)
+            touched_folder_ids.add(folder_id)
 
-        # File stats
-        stat = image_path.stat()
-        file_size = stat.st_size
-        file_mtime = stat.st_mtime
+            # File stats
+            stat = image_path.stat()
+            file_size = stat.st_size
+            file_mtime = stat.st_mtime
 
-        # XMP sidecar
-        xmp_path = image_path.with_suffix(".xmp")
-        xmp_mtime = xmp_path.stat().st_mtime if xmp_path.exists() else None
+            # XMP sidecar
+            xmp_path = image_path.with_suffix(".xmp")
+            xmp_mtime = xmp_path.stat().st_mtime if xmp_path.exists() else None
 
-        # Get pre-extracted metadata for this file
-        file_meta = metadata_map.get(str(image_path), {})
-        file_group = file_meta.get("File", {})
-        exif_group = file_meta.get("EXIF", {})
-        composite = file_meta.get("Composite", {})
+            # Get pre-extracted metadata for this file
+            file_meta = metadata_map.get(str(image_path), {})
+            file_group = file_meta.get("File", {})
+            exif_group = file_meta.get("EXIF", {})
+            composite = file_meta.get("Composite", {})
 
-        # Dimensions from ExifTool (works for all file types including RAW)
-        width, height = _extract_dimensions(exif_group, file_group, extension=image_path.suffix.lower())
+            # Dimensions from ExifTool (works for all file types including RAW)
+            width, height = _extract_dimensions(exif_group, file_group, extension=image_path.suffix.lower())
 
-        # Fallback if ExifTool didn't provide dimensions
-        if width is None or height is None:
-            ext = image_path.suffix.lower()
-            if ext in RAW_EXTENSIONS:
-                try:
-                    import rawpy
+            # Fallback if ExifTool didn't provide dimensions
+            if width is None or height is None:
+                ext = image_path.suffix.lower()
+                if ext in RAW_EXTENSIONS:
+                    try:
+                        import rawpy
 
-                    with rawpy.imread(str(image_path)) as raw:
-                        width = raw.sizes.width
-                        height = raw.sizes.height
-                except Exception:
-                    log.debug("Could not read RAW dimensions from %s", image_path)
-            else:
-                try:
-                    with Image.open(str(image_path)) as img:
-                        width, height = img.size
-                except Exception:
-                    log.debug("Could not read dimensions from %s", image_path)
+                        with rawpy.imread(str(image_path)) as raw:
+                            width = raw.sizes.width
+                            height = raw.sizes.height
+                    except Exception:
+                        log.debug("Could not read RAW dimensions from %s", image_path)
+                else:
+                    try:
+                        with Image.open(str(image_path)) as img:
+                            width, height = img.size
+                    except Exception:
+                        log.debug("Could not read dimensions from %s", image_path)
 
-        # Timestamp from ExifTool
-        timestamp = _extract_timestamp(exif_group)
+            # Timestamp from ExifTool
+            timestamp = _extract_timestamp(exif_group)
 
-        # Focal length
-        focal_length = exif_group.get("FocalLength")
-        if focal_length is not None:
-            focal_length = float(focal_length)
+            # Focal length
+            focal_length = exif_group.get("FocalLength")
+            if focal_length is not None:
+                focal_length = float(focal_length)
 
-        # Burst ID (ImageUniqueID)
-        burst_id = exif_group.get("ImageUniqueID")
-        if burst_id:
-            burst_id = str(burst_id)
+            # Burst ID (ImageUniqueID)
+            burst_id = exif_group.get("ImageUniqueID")
+            if burst_id:
+                burst_id = str(burst_id)
 
-        # GPS coordinates — ExifTool with -n gives decimal degrees directly
-        latitude = composite.get("GPSLatitude")
-        if latitude is None:
-            latitude = exif_group.get("GPSLatitude")
-        longitude = composite.get("GPSLongitude")
-        if longitude is None:
-            longitude = exif_group.get("GPSLongitude")
+            # GPS coordinates — ExifTool with -n gives decimal degrees directly
+            latitude = composite.get("GPSLatitude")
+            if latitude is None:
+                latitude = exif_group.get("GPSLatitude")
+            longitude = composite.get("GPSLongitude")
+            if longitude is None:
+                longitude = exif_group.get("GPSLongitude")
 
-        photo_id = db.add_photo(
-            folder_id=folder_id,
-            filename=image_path.name,
-            extension=image_path.suffix.lower(),
-            file_size=file_size,
-            file_mtime=file_mtime,
-            xmp_mtime=xmp_mtime,
-            timestamp=timestamp,
-            width=width,
-            height=height,
-        )
-
-        # Update metadata columns (also fixes existing photos that were
-        # inserted before ExifTool metadata was available)
-        updates = []
-        update_params = []
-        if timestamp is not None:
-            updates.append("timestamp=?")
-            update_params.append(timestamp)
-        if width is not None:
-            updates.append("width=?")
-            update_params.append(width)
-        if height is not None:
-            updates.append("height=?")
-            update_params.append(height)
-        if latitude is not None:
-            updates.extend(["latitude=?", "longitude=?"])
-            update_params.extend([latitude, longitude])
-        if phash is not None:
-            updates.append("phash=?")
-            update_params.append(phash)
-        if focal_length is not None:
-            updates.append("focal_length=?")
-            update_params.append(focal_length)
-        if burst_id is not None:
-            updates.append("burst_id=?")
-            update_params.append(burst_id)
-        if file_hash is not None:
-            updates.append("file_hash=?")
-            update_params.append(file_hash)
-        if file_meta and extract_full_metadata:
-            updates.append("exif_data=?")
-            update_params.append(json.dumps(file_meta))
-        elif file_meta:
-            # Store minimal marker so we know ExifTool ran (even when
-            # extract_full_metadata is off) — prevents perpetual retry
-            updates.append("exif_data=COALESCE(exif_data, ?)")
-            update_params.append("{}")
-        if updates:
-            update_params.append(photo_id)
-            db.conn.execute(
-                f"UPDATE photos SET {', '.join(updates)} WHERE id=?",
-                update_params,
+            photo_id = db.add_photo(
+                folder_id=folder_id,
+                filename=image_path.name,
+                extension=image_path.suffix.lower(),
+                file_size=file_size,
+                file_mtime=file_mtime,
+                xmp_mtime=xmp_mtime,
+                timestamp=timestamp,
+                width=width,
+                height=height,
             )
-            db.conn.commit()
 
-        # Import XMP keywords if sidecar exists — must land BEFORE the
-        # duplicate auto-resolve hook below, so if this row turns out to be
-        # the loser its keywords are visible to apply_duplicate_resolution's
-        # metadata query and get merged onto the winner. Otherwise the
-        # keywords would be stranded on the rejected row.
-        if xmp_path.exists():
-            _import_keywords_for_photo(db, photo_id, str(xmp_path))
+            # Update metadata columns (also fixes existing photos that were
+            # inserted before ExifTool metadata was available)
+            updates = []
+            update_params = []
+            if timestamp is not None:
+                updates.append("timestamp=?")
+                update_params.append(timestamp)
+            if width is not None:
+                updates.append("width=?")
+                update_params.append(width)
+            if height is not None:
+                updates.append("height=?")
+                update_params.append(height)
+            if latitude is not None:
+                updates.extend(["latitude=?", "longitude=?"])
+                update_params.extend([latitude, longitude])
+            if phash is not None:
+                updates.append("phash=?")
+                update_params.append(phash)
+            if focal_length is not None:
+                updates.append("focal_length=?")
+                update_params.append(focal_length)
+            if burst_id is not None:
+                updates.append("burst_id=?")
+                update_params.append(burst_id)
+            if file_hash is not None:
+                updates.append("file_hash=?")
+                update_params.append(file_hash)
+            if file_meta and extract_full_metadata:
+                updates.append("exif_data=?")
+                update_params.append(json.dumps(file_meta))
+            elif file_meta:
+                # Store minimal marker so we know ExifTool ran (even when
+                # extract_full_metadata is off) — prevents perpetual retry
+                updates.append("exif_data=COALESCE(exif_data, ?)")
+                update_params.append("{}")
+            if updates:
+                update_params.append(photo_id)
+                db.conn.execute(
+                    f"UPDATE photos SET {', '.join(updates)} WHERE id=?",
+                    update_params,
+                )
+                commit_with_retry(db.conn)
 
-        # Trigger duplicate auto-resolve now that file_hash AND XMP keywords
-        # are committed. add_photo was called without the hash, so the hook
-        # there was a no-op — we own firing it here.
-        if file_hash is not None:
-            db.check_and_resolve_duplicates_for_hash(file_hash)
+            # Import XMP keywords if sidecar exists — must land BEFORE the
+            # duplicate auto-resolve hook below, so if this row turns out to be
+            # the loser its keywords are visible to apply_duplicate_resolution's
+            # metadata query and get merged onto the winner. Otherwise the
+            # keywords would be stranded on the rejected row.
+            if xmp_path.exists():
+                _import_keywords_for_photo(db, photo_id, str(xmp_path))
 
-        if photo_callback:
-            photo_callback(photo_id, str(image_path))
+            # Trigger duplicate auto-resolve now that file_hash AND XMP keywords
+            # are committed. add_photo was called without the hash, so the hook
+            # there was a no-op — we own firing it here.
+            if file_hash is not None:
+                db.check_and_resolve_duplicates_for_hash(file_hash)
 
-        processed_count += 1
-        if progress_callback:
-            progress_callback(processed_count, total)
+            if photo_callback:
+                photo_callback(photo_id, str(image_path))
+
+            processed_count += 1
+            if progress_callback:
+                progress_callback(processed_count, total)
+    except BaseException:
+        # Per-file loop died mid-way (DB error, signal, etc). Roll back any
+        # half-applied write so the partial-status UPDATE below runs on a
+        # clean transaction, then flag every folder in scope as 'partial' so
+        # callers can detect and re-scan.
+        #
+        # We intentionally use the scanned scope (root + restrict_dirs) rather
+        # than ``touched_folder_ids`` alone: a failure inside ``_ensure_folder``
+        # commits the folder row but the exception propagates before the
+        # folder_id reaches the scanner loop, so the set can be empty even
+        # when a folder row exists.
+        try:
+            db.conn.rollback()
+        except Exception:
+            log.exception("Rollback after scan failure also failed")
+        scoped_paths = set()
+        scoped_paths.add(str(root_path))
+        if restrict_dirs is not None:
+            scoped_paths.update(str(d) for d in restrict_dirs)
+        if touched_folder_ids:
+            scoped_paths.add(None)  # sentinel to use id-list below too
+        try:
+            # Match by path for the in-scope roots.
+            if scoped_paths - {None}:
+                path_placeholders = ",".join(
+                    "?" * len(scoped_paths - {None})
+                )
+                db.conn.execute(
+                    f"UPDATE folders SET status = 'partial' "
+                    f"WHERE path IN ({path_placeholders})",
+                    tuple(scoped_paths - {None}),
+                )
+            if touched_folder_ids:
+                id_placeholders = ",".join("?" * len(touched_folder_ids))
+                db.conn.execute(
+                    f"UPDATE folders SET status = 'partial' "
+                    f"WHERE id IN ({id_placeholders})",
+                    tuple(touched_folder_ids),
+                )
+            commit_with_retry(db.conn)
+        except Exception:
+            log.exception("Failed to flag folders partial after scan failure")
+        raise
 
     # Pair raw+JPEG companions: raw is primary, JPEG becomes companion_path.
     # Wrap post-processing so folder counts are always updated, even on failure.

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -556,66 +556,117 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         folder_cache[folder_str] = folder_id
         return folder_id
 
+    # Track folders whose scan touched them (so we can flag them 'partial'
+    # if anything between the pre-pass and scan completion dies midway) and
+    # the outer scan scope as a fallback. The scope matters when
+    # ``touched_folder_ids`` is empty — e.g. a pre-pass XMP commit that
+    # aborts before the main loop has added any folder, or a successful
+    # no-op incremental scan that processes zero files.
+    touched_folder_ids = set()
+    scoped_paths = {str(root_path)}
+    if restrict_dirs is not None:
+        scoped_paths.update(str(d) for d in restrict_dirs)
+
+    def _update_folder_status(new_status, only_from_partial):
+        """Stamp folders in the scan scope with ``new_status``.
+
+        Applies to every folder matched by ``scoped_paths`` (outer roots)
+        OR ``touched_folder_ids`` (folder rows the main loop has reached).
+        When ``only_from_partial`` is True, restricts the UPDATE to rows
+        already in ``'partial'`` — used on the success path so completed
+        scans don't clobber ``'missing'`` or future statuses.
+        """
+        guard = " AND status = 'partial'" if only_from_partial else ""
+        if scoped_paths:
+            path_placeholders = ",".join("?" * len(scoped_paths))
+            db.conn.execute(
+                f"UPDATE folders SET status = ? "
+                f"WHERE path IN ({path_placeholders}){guard}",
+                (new_status, *scoped_paths),
+            )
+        if touched_folder_ids:
+            id_placeholders = ",".join("?" * len(touched_folder_ids))
+            db.conn.execute(
+                f"UPDATE folders SET status = ? "
+                f"WHERE id IN ({id_placeholders}){guard}",
+                (new_status, *touched_folder_ids),
+            )
+        commit_with_retry(db.conn)
+
     # First pass: determine which files need full processing (for incremental mode).
     # Handle XMP-only changes inline; collect files needing metadata extraction.
     files_to_process = []
     processed_count = 0
-    for image_path in image_files:
-        stat = image_path.stat()
-        file_mtime = stat.st_mtime
-        xmp_path = image_path.with_suffix(".xmp")
-        xmp_mtime = xmp_path.stat().st_mtime if xmp_path.exists() else None
+    try:
+        for image_path in image_files:
+            stat = image_path.stat()
+            file_mtime = stat.st_mtime
+            xmp_path = image_path.with_suffix(".xmp")
+            xmp_mtime = xmp_path.stat().st_mtime if xmp_path.exists() else None
 
-        if incremental:
-            full_path_str = str(image_path)
-            existing = existing_by_path.get(full_path_str)
-            if existing:
-                file_unchanged = existing["file_mtime"] == file_mtime
-                xmp_unchanged = existing["xmp_mtime"] == xmp_mtime
-                # Re-process if ExifTool never ran for this photo (both
-                # timestamp and exif_data are NULL). Photos with genuinely
-                # missing timestamps (screenshots, exports) will have
-                # exif_data set after one extraction attempt.
-                # Also flag rows where a RAW file has absurdly small
-                # dimensions (<1000px) — that's the embedded JPEG thumb
-                # leaking through when ExifTool's File group was missing
-                # on the original scan.
-                dims_suspect = (
-                    existing["extension"] in RAW_EXTENSIONS
-                    and existing["width"] is not None
-                    and existing["width"] < 1000
-                )
-                metadata_missing = (
-                    (existing["timestamp"] is None or dims_suspect)
-                    and existing["id"] not in exif_extracted
-                )
-
-                if file_unchanged and xmp_unchanged and not metadata_missing:
-                    processed_count += 1
-                    if photo_callback:
-                        photo_callback(existing["id"], full_path_str)
-                    if progress_callback:
-                        progress_callback(processed_count, total)
-                    continue
-
-                # XMP changed: re-import keywords
-                if not xmp_unchanged and xmp_mtime is not None:
-                    _import_keywords_for_photo(db, existing["id"], str(xmp_path))
-                    db.conn.execute(
-                        "UPDATE photos SET xmp_mtime = ? WHERE id = ?",
-                        (xmp_mtime, existing["id"]),
+            if incremental:
+                full_path_str = str(image_path)
+                existing = existing_by_path.get(full_path_str)
+                if existing:
+                    file_unchanged = existing["file_mtime"] == file_mtime
+                    xmp_unchanged = existing["xmp_mtime"] == xmp_mtime
+                    # Re-process if ExifTool never ran for this photo (both
+                    # timestamp and exif_data are NULL). Photos with genuinely
+                    # missing timestamps (screenshots, exports) will have
+                    # exif_data set after one extraction attempt.
+                    # Also flag rows where a RAW file has absurdly small
+                    # dimensions (<1000px) — that's the embedded JPEG thumb
+                    # leaking through when ExifTool's File group was missing
+                    # on the original scan.
+                    dims_suspect = (
+                        existing["extension"] in RAW_EXTENSIONS
+                        and existing["width"] is not None
+                        and existing["width"] < 1000
                     )
-                    commit_with_retry(db.conn)
+                    metadata_missing = (
+                        (existing["timestamp"] is None or dims_suspect)
+                        and existing["id"] not in exif_extracted
+                    )
 
-                if file_unchanged and not metadata_missing:
-                    processed_count += 1
-                    if photo_callback:
-                        photo_callback(existing["id"], full_path_str)
-                    if progress_callback:
-                        progress_callback(processed_count, total)
-                    continue
+                    if file_unchanged and xmp_unchanged and not metadata_missing:
+                        processed_count += 1
+                        if photo_callback:
+                            photo_callback(existing["id"], full_path_str)
+                        if progress_callback:
+                            progress_callback(processed_count, total)
+                        continue
 
-        files_to_process.append(image_path)
+                    # XMP changed: re-import keywords
+                    if not xmp_unchanged and xmp_mtime is not None:
+                        _import_keywords_for_photo(db, existing["id"], str(xmp_path))
+                        db.conn.execute(
+                            "UPDATE photos SET xmp_mtime = ? WHERE id = ?",
+                            (xmp_mtime, existing["id"]),
+                        )
+                        commit_with_retry(db.conn)
+
+                    if file_unchanged and not metadata_missing:
+                        processed_count += 1
+                        if photo_callback:
+                            photo_callback(existing["id"], full_path_str)
+                        if progress_callback:
+                            progress_callback(processed_count, total)
+                        continue
+
+            files_to_process.append(image_path)
+    except BaseException:
+        # Pre-pass died (e.g. non-retryable DB error on an XMP commit).
+        # Route through the same partial-status path as a main-loop failure
+        # so users see the badge and can rescan.
+        try:
+            db.conn.rollback()
+        except Exception:
+            log.exception("Rollback after pre-pass failure also failed")
+        try:
+            _update_folder_status("partial", only_from_partial=False)
+        except Exception:
+            log.exception("Failed to flag folders partial after pre-pass failure")
+        raise
 
     # Batch extract metadata via ExifTool only for files that need processing
     paths_to_extract = [str(ip) for ip in files_to_process]
@@ -658,9 +709,6 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             for image_path, path_str in zip(files_to_process, paths_to_extract, strict=True):
                 yield image_path, _compute_file_features(path_str)
 
-    # Track folders whose scan touched them, so we can flag them 'partial'
-    # if the per-file loop dies midway (unrecoverable DB error, etc).
-    touched_folder_ids = set()
     try:
         for image_path, (phash, file_hash) in _iter_features():
             folder_id = _ensure_folder(image_path.parent)
@@ -805,74 +853,25 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         # half-applied write so the partial-status UPDATE below runs on a
         # clean transaction, then flag every folder in scope as 'partial' so
         # callers can detect and re-scan.
-        #
-        # We intentionally use the scanned scope (root + restrict_dirs) rather
-        # than ``touched_folder_ids`` alone: a failure inside ``_ensure_folder``
-        # commits the folder row but the exception propagates before the
-        # folder_id reaches the scanner loop, so the set can be empty even
-        # when a folder row exists.
         try:
             db.conn.rollback()
         except Exception:
             log.exception("Rollback after scan failure also failed")
-        scoped_paths = set()
-        scoped_paths.add(str(root_path))
-        if restrict_dirs is not None:
-            scoped_paths.update(str(d) for d in restrict_dirs)
-        if touched_folder_ids:
-            scoped_paths.add(None)  # sentinel to use id-list below too
         try:
-            # Match by path for the in-scope roots.
-            if scoped_paths - {None}:
-                path_placeholders = ",".join(
-                    "?" * len(scoped_paths - {None})
-                )
-                db.conn.execute(
-                    f"UPDATE folders SET status = 'partial' "
-                    f"WHERE path IN ({path_placeholders})",
-                    tuple(scoped_paths - {None}),
-                )
-            if touched_folder_ids:
-                id_placeholders = ",".join("?" * len(touched_folder_ids))
-                db.conn.execute(
-                    f"UPDATE folders SET status = 'partial' "
-                    f"WHERE id IN ({id_placeholders})",
-                    tuple(touched_folder_ids),
-                )
-            commit_with_retry(db.conn)
+            _update_folder_status("partial", only_from_partial=False)
         except Exception:
             log.exception("Failed to flag folders partial after scan failure")
         raise
     else:
-        # Per-file loop completed cleanly. Clear any stale 'partial' flag
-        # from a prior failed scan on the folders this scan covered, so a
-        # successful rescan restores full visibility. Scope mirrors the
-        # exception path above: the explicit roots (``root`` and any
-        # ``restrict_dirs``) plus every folder the loop actually touched.
-        # Including the roots catches folders that were flagged 'partial'
-        # by a previous failure inside ``_ensure_folder``, before the new
-        # folder_id reached ``touched_folder_ids``.
-        cleared_paths = {str(root_path)}
-        if restrict_dirs is not None:
-            cleared_paths.update(str(d) for d in restrict_dirs)
+        # Per-file loop completed cleanly. Clear any stale 'partial' flag on
+        # scanned folders so a successful rescan restores full visibility.
+        # Uses both the scan scope (root + restrict_dirs) AND the touched
+        # folder ids: a successful no-op incremental scan has an empty
+        # ``touched_folder_ids`` set but must still clear the badge for the
+        # roots the user asked us to scan; a recursive scan that failed and
+        # then succeeds needs the touched ids to reach touched subfolders.
         try:
-            if cleared_paths:
-                path_placeholders = ",".join("?" * len(cleared_paths))
-                db.conn.execute(
-                    f"UPDATE folders SET status = 'ok' "
-                    f"WHERE status = 'partial' "
-                    f"AND path IN ({path_placeholders})",
-                    tuple(cleared_paths),
-                )
-            if touched_folder_ids:
-                id_placeholders = ",".join("?" * len(touched_folder_ids))
-                db.conn.execute(
-                    f"UPDATE folders SET status = 'ok' "
-                    f"WHERE status = 'partial' "
-                    f"AND id IN ({id_placeholders})",
-                    tuple(touched_folder_ids),
-                )
-            commit_with_retry(db.conn)
+            _update_folder_status("ok", only_from_partial=True)
         except Exception:
             log.exception("Failed to clear partial flag after scan success")
 

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -843,6 +843,21 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         except Exception:
             log.exception("Failed to flag folders partial after scan failure")
         raise
+    else:
+        # Per-file loop completed cleanly. Clear any stale 'partial' flag from
+        # a prior failed scan on the same folders so a successful rescan
+        # restores full visibility.
+        if touched_folder_ids:
+            try:
+                id_placeholders = ",".join("?" * len(touched_folder_ids))
+                db.conn.execute(
+                    f"UPDATE folders SET status = 'ok' "
+                    f"WHERE id IN ({id_placeholders}) AND status = 'partial'",
+                    tuple(touched_folder_ids),
+                )
+                commit_with_retry(db.conn)
+            except Exception:
+                log.exception("Failed to clear partial flag after scan success")
 
     # Pair raw+JPEG companions: raw is primary, JPEG becomes companion_path.
     # Wrap post-processing so folder counts are always updated, even on failure.

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -62,6 +62,17 @@ body {
   color: var(--text-faint);
   font-variant-numeric: tabular-nums;
 }
+.tree-item .folder-status-partial {
+  margin-left: 6px;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: var(--warning-bg, #fef3c7);
+  color: var(--warning-fg, #92400e);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
 .tree-indent { width: 16px; flex-shrink: 0; }
 .tree-toggle {
   width: 16px;
@@ -1215,9 +1226,13 @@ function renderFolderTree(folders) {
       for (var i = 0; i < depth; i++) indent += '<span class="tree-indent"></span>';
       var toggle = hasChildren ? '<span class="tree-toggle" onclick="toggleTree(event,this)">&#9654;</span>' : '<span class="tree-indent"></span>';
       var activeClass = activeFolderId === f.id ? ' active' : '';
+      var partialBadge = f.status === 'partial'
+        ? '<span class="folder-status-partial" title="Scan did not complete — re-scan to finish">partial</span>'
+        : '';
       html += '<div class="tree-item' + activeClass + '" onclick="filterByFolder(' + f.id + ')" data-folder-id="' + f.id + '">' +
         indent + toggle +
         '<span>' + escapeHtml(f.name) + '</span>' +
+        partialBadge +
         '<span class="count">' + rolledUp[f.id] + '</span>' +
       '</div>';
       if (hasChildren) {

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3995,3 +3995,70 @@ def test_create_snapshot_empty_paths(tmp_path):
     snap = db.get_new_images_snapshot(snap_id)
     assert snap["file_count"] == 0
     assert snap["file_paths"] == []
+
+
+# -- busy_timeout / lock resilience --
+
+
+def test_busy_timeout_pragma_is_set(tmp_path):
+    """Each connection explicitly sets PRAGMA busy_timeout to at least 30s.
+
+    Python's sqlite3 default (5000ms) is too tight under load — heavy
+    pipeline writes can hold the writer lock longer than that. A real-world
+    scan against a busy DB hit 'database is locked' with the implicit default.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    timeout_ms = db.conn.execute("PRAGMA busy_timeout").fetchone()[0]
+    assert timeout_ms >= 30000
+
+
+def test_concurrent_writers_wait_rather_than_fail(tmp_path):
+    """A second writer queues behind the first instead of crashing.
+
+    Repro of the failure mode that killed 3 of 4 parallel scans in prod: the
+    default 5s busy_timeout wasn't enough under load. With a longer timeout
+    explicitly set, the second writer waits and succeeds.
+    """
+    import sqlite3
+    import threading
+    import time
+
+    from db import Database
+
+    db_path = str(tmp_path / "concurrent.db")
+    db = Database(db_path)
+    db.add_folder("/a")
+
+    blocker = sqlite3.connect(db_path, check_same_thread=False)
+    blocker.execute("BEGIN IMMEDIATE")
+    blocker.execute("UPDATE folders SET name = 'held' WHERE path = '/a'")
+
+    def release_after_delay():
+        time.sleep(0.8)
+        blocker.commit()
+        blocker.close()
+
+    threading.Thread(target=release_after_delay, daemon=True).start()
+
+    start = time.time()
+    db.add_folder("/b")
+    elapsed = time.time() - start
+
+    assert elapsed >= 0.5, f"writer did not wait for lock (elapsed={elapsed:.2f}s)"
+    assert elapsed < 5.0, f"writer waited too long (elapsed={elapsed:.2f}s)"
+    paths = {r["path"] for r in db.conn.execute("SELECT path FROM folders").fetchall()}
+    assert {"/a", "/b"}.issubset(paths)
+
+
+def test_folder_status_partial_value_allowed(tmp_path):
+    """folders.status accepts 'partial' as a value — scan abort marker."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/x")
+    db.conn.execute("UPDATE folders SET status = 'partial' WHERE id = ?", (fid,))
+    db.conn.commit()
+    row = db.conn.execute(
+        "SELECT status FROM folders WHERE id = ?", (fid,)
+    ).fetchone()
+    assert row["status"] == "partial"

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4062,3 +4062,37 @@ def test_folder_status_partial_value_allowed(tmp_path):
         "SELECT status FROM folders WHERE id = ?", (fid,)
     ).fetchone()
     assert row["status"] == "partial"
+
+
+def test_get_folder_tree_includes_partial_folders_with_status(tmp_path):
+    """Partial folders must stay in the tree so the browse sidebar can render
+    a badge and the user can rescan. Also, the returned rows must carry
+    ``status`` so the UI can tell ok from partial. Missing folders are still
+    excluded — they have their own ``get_missing_folders`` path.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "tree.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    ok_id = db.add_folder("/ok", name="ok")
+    partial_id = db.add_folder("/partial", name="partial")
+    missing_id = db.add_folder("/missing", name="missing")
+    db.conn.execute(
+        "UPDATE folders SET status = 'partial' WHERE id = ?", (partial_id,)
+    )
+    db.conn.execute(
+        "UPDATE folders SET status = 'missing' WHERE id = ?", (missing_id,)
+    )
+    db.conn.commit()
+
+    rows = {row["id"]: dict(row) for row in db.get_folder_tree()}
+
+    assert ok_id in rows, "ok folder must appear in tree"
+    assert partial_id in rows, (
+        "partial folder must appear in tree so badge renders and rescan works"
+    )
+    assert missing_id not in rows, "missing folder must not appear in tree"
+    assert rows[ok_id]["status"] == "ok"
+    assert rows[partial_id]["status"] == "partial"

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2574,6 +2574,60 @@ def test_check_folder_health_recovers(tmp_path):
     assert db.conn.execute("SELECT status FROM folders WHERE id = ?", (fid,)).fetchone()["status"] == "ok"
 
 
+def test_check_folder_health_preserves_partial_when_path_exists(tmp_path):
+    """check_folder_health must NOT overwrite 'partial' with 'ok'.
+
+    Regression: the app runs this health check in a 10-minute background loop.
+    If it blindly sets every existing folder to 'ok', a folder flagged
+    'partial' by a failed scan gets auto-cleared before the user has a chance
+    to rescan, and the UI badge silently disappears. Only a successful rescan
+    should clear partial.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    folder = str(tmp_path / "partial_folder")
+    os.makedirs(folder)
+    fid = db.add_folder(folder, name="partial_folder")
+    db.conn.execute("UPDATE folders SET status = 'partial' WHERE id = ?", (fid,))
+    db.conn.commit()
+
+    changed = db.check_folder_health()
+    assert changed == 0, "partial folder on disk should not change status"
+    status = db.conn.execute(
+        "SELECT status FROM folders WHERE id = ?", (fid,)
+    ).fetchone()["status"]
+    assert status == "partial"
+
+
+def test_check_folder_health_partial_becomes_missing_when_path_gone(tmp_path):
+    """A 'partial' folder whose path disappears still flips to 'missing'.
+
+    Rescanning a vanished directory can't recover the data, so the usual
+    missing-folder UX (relocate or remove) is more useful than keeping the
+    partial badge.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    fid = db.add_folder("/nope/partial_gone", name="partial_gone")
+    db.conn.execute("UPDATE folders SET status = 'partial' WHERE id = ?", (fid,))
+    db.conn.commit()
+
+    changed = db.check_folder_health()
+    assert changed == 1
+    status = db.conn.execute(
+        "SELECT status FROM folders WHERE id = ?", (fid,)
+    ).fetchone()["status"]
+    assert status == "missing"
+
+
 def test_get_missing_folders(tmp_path):
     """get_missing_folders returns missing folders with photo counts."""
     from db import Database

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1409,3 +1409,76 @@ def test_successful_scan_clears_partial_flag(tmp_path):
     assert row["status"] == "ok", (
         f"successful rescan should flip partial → ok, got {row['status']!r}"
     )
+
+
+def test_successful_scan_clears_partial_on_touched_subfolders(tmp_path):
+    """Recursive scan clears 'partial' on subfolders the scan actually touched.
+
+    The exception path flags every touched subfolder as partial; the success
+    path must reset those same subfolders so a user who rescans after a
+    failure sees a clean tree.
+    """
+    import scanner as scanner_mod
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {
+        '': ['root.jpg'],
+        'sub': ['nested.jpg'],
+    })
+    db = Database(str(tmp_path / "test.db"))
+
+    scanner_mod.scan(root, db)
+    # Mark both folders partial to simulate a prior mid-scan abort.
+    db.conn.execute("UPDATE folders SET status = 'partial'")
+    db.conn.commit()
+
+    scanner_mod.scan(root, db)
+
+    rows = db.conn.execute(
+        "SELECT path, status FROM folders ORDER BY path"
+    ).fetchall()
+    statuses = {r["path"]: r["status"] for r in rows}
+    assert statuses[root] == "ok", (
+        f"root should be cleared back to ok, got {statuses[root]!r}"
+    )
+    sub_path = os.path.join(root, "sub")
+    assert statuses[sub_path] == "ok", (
+        f"touched subfolder should be cleared back to ok, "
+        f"got {statuses[sub_path]!r}"
+    )
+
+
+def test_partial_folder_photos_remain_visible_in_queries(tmp_path):
+    """Photos in 'partial' folders must stay queryable through read paths.
+
+    Before this fix, `f.status = 'ok'` joins across `db.py` excluded photos
+    from partial folders, so an interrupted scan could make already-imported
+    photos disappear from the UI.
+    """
+    import scanner as scanner_mod
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['seen.jpg']})
+    db = Database(str(tmp_path / "test.db"))
+
+    scanner_mod.scan(root, db)
+    db.conn.execute(
+        "UPDATE folders SET status = 'partial' WHERE path = ?", (root,)
+    )
+    db.conn.commit()
+
+    # Photo queries should still return the photo.
+    photos = db.get_photos(per_page=100)
+    filenames = {p["filename"] for p in photos}
+    assert "seen.jpg" in filenames, (
+        f"photo in partial folder should remain visible, got {filenames}"
+    )
+
+    # And coverage stats should still count it.
+    stats = db.get_coverage_stats()
+    assert stats["total"] >= 1, (
+        f"coverage should count photos in partial folders, "
+        f"got total={stats['total']!r}"
+    )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1482,3 +1482,89 @@ def test_partial_folder_photos_remain_visible_in_queries(tmp_path):
         f"coverage should count photos in partial folders, "
         f"got total={stats['total']!r}"
     )
+
+
+def test_successful_noop_incremental_scan_clears_partial(tmp_path):
+    """A no-op incremental rescan must still clear 'partial' on scoped folders.
+
+    If the success-path reset is gated only on the main loop's
+    ``touched_folder_ids`` set, a successful incremental scan that processes
+    zero files (all photos unchanged) leaves ``status='partial'`` stuck and
+    the folder hidden from ``status='ok'`` read paths. The reset must also
+    run for the outer scan scope (root + restrict_dirs).
+    """
+    import scanner as scanner_mod
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['a.jpg', 'b.jpg']})
+    db = Database(str(tmp_path / "test.db"))
+
+    # Initial clean scan so photos are indexed.
+    scanner_mod.scan(root, db)
+
+    # Simulate the after-failure state: folder got flagged 'partial' by a
+    # prior aborted scan even though all photo rows are already present.
+    db.conn.execute(
+        "UPDATE folders SET status = 'partial' WHERE path = ?", (root,)
+    )
+    db.conn.commit()
+
+    # Incremental rescan — no files changed, so the main loop touches zero
+    # folders. The scan scope fallback should still clear 'partial'.
+    scanner_mod.scan(root, db, incremental=True)
+
+    row = db.conn.execute(
+        "SELECT status FROM folders WHERE path = ?", (root,)
+    ).fetchone()
+    assert row["status"] == "ok", (
+        f"no-op incremental scan should flip partial → ok, got {row['status']!r}"
+    )
+
+
+def test_pre_pass_failure_marks_folder_partial(tmp_path):
+    """A non-retryable DB error during the pre-pass XMP commit flags the folder.
+
+    Pre-pass XMP re-imports commit before the main scan loop begins. If that
+    commit raises a non-transient error, the scan aborts with the folder row
+    still ``status='ok'`` unless the pre-pass is wrapped in the same partial-
+    status recovery path as the main loop.
+    """
+    import sqlite3
+
+    import scanner as scanner_mod
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['a.jpg']})
+    db = Database(str(tmp_path / "test.db"))
+
+    # Initial clean scan so the photo row exists for incremental mode.
+    scanner_mod.scan(root, db)
+
+    # Touch the XMP sidecar so the pre-pass re-imports keywords and commits.
+    xmp_path = os.path.join(root, "a.xmp")
+    with open(xmp_path, "w") as f:
+        f.write("<x:xmpmeta xmlns:x='adobe:ns:meta/'></x:xmpmeta>")
+    # Make the existing row's xmp_mtime stale so pre-pass treats it as changed.
+    db.conn.execute("UPDATE photos SET xmp_mtime = 0 WHERE filename = 'a.jpg'")
+    db.conn.commit()
+
+    # First commit after scan starts is the pre-pass XMP UPDATE. Raise a
+    # non-retryable OperationalError there.
+    db.conn = _FlakyConn(
+        db.conn,
+        fail_on_calls={1: sqlite3.OperationalError("disk I/O error")},
+    )
+
+    with pytest.raises(sqlite3.OperationalError):
+        scanner_mod.scan(root, db, incremental=True)
+
+    real_conn = db.conn._real
+    row = real_conn.execute(
+        "SELECT status FROM folders WHERE path = ?", (root,)
+    ).fetchone()
+    assert row is not None
+    assert row["status"] == "partial", (
+        f"expected folder.status='partial' after pre-pass failure, got {row['status']!r}"
+    )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1352,3 +1352,60 @@ def test_scan_marks_folder_partial_on_unrecoverable_failure(tmp_path):
     assert row["status"] == "partial", (
         f"expected folder.status='partial' after mid-scan failure, got {row['status']!r}"
     )
+
+
+def test_partial_folder_is_visible_in_folder_tree(tmp_path):
+    """Folders flagged 'partial' must still render in the browse-page tree.
+
+    get_folder_tree() historically required status='ok'. After marking a
+    folder partial we need it to STILL appear so the user can see the badge
+    and initiate a rescan — otherwise 'partial' silently hides the folder.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/p")
+    db.conn.execute("UPDATE folders SET status = 'partial' WHERE id = ?", (fid,))
+    db.conn.commit()
+
+    tree = db.get_folder_tree()
+    ids = {row["id"] for row in tree}
+    assert fid in ids, "partial folder should still appear in get_folder_tree"
+    # Status should be queryable so the UI can render the badge.
+    partial_row = next(row for row in tree if row["id"] == fid)
+    assert partial_row["status"] == "partial"
+
+
+def test_successful_scan_clears_partial_flag(tmp_path):
+    """A successful rescan of a previously-partial folder restores 'ok'."""
+    import sqlite3
+
+    import scanner as scanner_mod
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['a.jpg', 'b.jpg']})
+    db = Database(str(tmp_path / "test.db"))
+
+    # First scan: fail partway through to leave the folder 'partial'.
+    db.conn = _FlakyConn(
+        db.conn,
+        fail_on_calls={2: sqlite3.OperationalError("disk I/O error")},
+    )
+    with pytest.raises(sqlite3.OperationalError):
+        scanner_mod.scan(root, db)
+    real_conn = db.conn._real
+    row = real_conn.execute(
+        "SELECT status FROM folders WHERE path = ?", (root,)
+    ).fetchone()
+    assert row["status"] == "partial"
+
+    # Second scan: succeed and clear the flag.
+    db.conn = real_conn
+    scanner_mod.scan(root, db)
+    row = db.conn.execute(
+        "SELECT status FROM folders WHERE path = ?", (root,)
+    ).fetchone()
+    assert row["status"] == "ok", (
+        f"successful rescan should flip partial → ok, got {row['status']!r}"
+    )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1237,3 +1237,118 @@ def test_resolve_worker_count_no_windows_cap_on_posix(monkeypatch):
     monkeypatch.setattr(scanner.os, "cpu_count", lambda: 128)
     monkeypatch.setattr(scanner.sys, "platform", "linux")
     assert scanner._resolve_worker_count(list(range(200))) == 128
+
+
+# -- scan resilience: retry on locked DB, mark folder partial on abort --
+
+
+class _FlakyConn:
+    """Connection proxy that injects commit failures for testing.
+
+    sqlite3.Connection.commit is read-only at the instance level, so tests
+    that need to simulate transient commit failures wrap the real connection
+    in this proxy. All other attributes pass through to the real connection
+    so code that calls ``conn.execute(...)`` etc. behaves identically.
+    """
+
+    def __init__(self, real, fail_on_calls):
+        """fail_on_calls: dict {call_number: exception_to_raise}."""
+        self._real = real
+        self._fail_on_calls = dict(fail_on_calls)
+        self._call_count = 0
+
+    def commit(self):
+        self._call_count += 1
+        exc = self._fail_on_calls.get(self._call_count)
+        if exc is not None:
+            raise exc
+        return self._real.commit()
+
+    # sqlite3.Connection is used as a context manager in db.py
+    # (``with self.conn:`` for transactions). Python bypasses ``__getattr__``
+    # for dunder lookups, so we must forward these explicitly. Route commit
+    # through our own method so the fail injection still fires.
+    def __enter__(self):
+        self._real.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            try:
+                self.commit()
+            except BaseException:
+                self._real.rollback()
+                raise
+        else:
+            self._real.rollback()
+        return False
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def test_scan_retries_on_database_is_locked(tmp_path):
+    """If a commit hits 'database is locked', scan retries instead of aborting.
+
+    busy_timeout covers most cases, but a retry wrapper handles the tail where
+    a contended DB exceeds the timeout mid-scan. Without it, a single transient
+    lock aborts the whole scan and leaves the folder partially populated.
+    """
+    import sqlite3
+
+    import scanner as scanner_mod
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['a.jpg', 'b.jpg']})
+    db = Database(str(tmp_path / "test.db"))
+
+    # First two commits raise 'database is locked'; subsequent commits succeed.
+    locked = sqlite3.OperationalError("database is locked")
+    db.conn = _FlakyConn(db.conn, fail_on_calls={1: locked, 2: locked})
+
+    scanner_mod.scan(root, db)
+
+    filenames = {
+        p["filename"]
+        for p in db.conn.execute("SELECT filename FROM photos").fetchall()
+    }
+    assert filenames == {"a.jpg", "b.jpg"}, (
+        f"expected both photos persisted after retries, got {filenames}"
+    )
+
+
+def test_scan_marks_folder_partial_on_unrecoverable_failure(tmp_path):
+    """When scan can't recover, the folder is marked 'partial' before raising.
+
+    Visible state: user sees the folder in its UI with a 'partial' badge and
+    knows to rescan, instead of believing the folder is fully imported.
+    """
+    import sqlite3
+
+    import scanner as scanner_mod
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['a.jpg', 'b.jpg', 'c.jpg']})
+    db = Database(str(tmp_path / "test.db"))
+
+    # Second commit raises a non-lock OperationalError that retry won't
+    # swallow. Scan must mark the folder partial and re-raise.
+    db.conn = _FlakyConn(
+        db.conn,
+        fail_on_calls={2: sqlite3.OperationalError("disk I/O error")},
+    )
+
+    with pytest.raises(sqlite3.OperationalError):
+        scanner_mod.scan(root, db)
+
+    # Unwrap proxy for the final assertion.
+    real_conn = db.conn._real
+    row = real_conn.execute(
+        "SELECT status FROM folders WHERE path = ?", (root,)
+    ).fetchone()
+    assert row is not None, "folder row should exist despite aborted scan"
+    assert row["status"] == "partial", (
+        f"expected folder.status='partial' after mid-scan failure, got {row['status']!r}"
+    )


### PR DESCRIPTION
## Summary

When four parallel scans race against the same SQLite file, Python's default 5s `busy_timeout` is too short: transient writer-lock contention raises `database is locked` mid-scan and the whole folder is abandoned. I hit this dogfooding a Feb-2026 best-of album — 525/1549 photos imported across four folders, three scans dying silently.

- **`PRAGMA busy_timeout=30000`** on every connection. The stdlib defaults to 5s; 30s is the engine-level wait under contention.
- **`commit_with_retry()` helper** — exponential backoff for transient "locked"/"busy" `OperationalError`. Second line of defense for the tail that still exceeds `busy_timeout`. Non-transient errors (disk I/O, constraints) propagate immediately.
- **Folder `status='partial'` on unrecoverable failure.** The scan loop now flags every folder in scope as partial if it dies mid-way, and the browse-page folder tree renders a badge so the user can see (and re-scan) what didn't finish.

## Test plan

- [x] `test_busy_timeout_pragma_is_set` — every connection has busy_timeout ≥ 30s
- [x] `test_concurrent_writers_wait_rather_than_fail` — concurrent writer waits rather than aborts
- [x] `test_folder_status_partial_value_allowed` — schema accepts 'partial' value
- [x] `test_scan_retries_on_database_is_locked` — scan retries through transient lock errors
- [x] `test_scan_marks_folder_partial_on_unrecoverable_failure` — non-lock OperationalError marks folder partial then re-raises
- [x] Full core suite: 619 tests passing (`test_workspaces`, `test_db`, `test_app`, `test_photos_api`, `test_edits_api`, `test_jobs_api`, `test_darktable_api`, `test_config`, `test_scanner`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)