### PR TITLE
feat: global detection/classifier cache with read-time threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to Vireo are documented in this file.
+
+## Unreleased
+
+### Changed
+- **Global detection/classifier cache.** MegaDetector and classifier results
+  are now cached per-photo instead of per-workspace. Switching to a new
+  workspace or changing your detector confidence threshold no longer
+  triggers a full reprocess.
+- **Threshold is now a read-time filter.** Lowering `detector_confidence` in
+  workspace config takes effect immediately; you no longer need to rerun
+  detection to see previously-subthreshold boxes.
+- Legacy detections from prior versions are preserved but pre-filtered. Run
+  "Reclassify" once per folder to regenerate them with the new raw storage
+  if you want to take full advantage of low-threshold browsing.

--- a/docs/plans/2026-04-23-detection-storage-redesign-design.md
+++ b/docs/plans/2026-04-23-detection-storage-redesign-design.md
@@ -1,0 +1,333 @@
+# Detection storage redesign
+
+## Goal
+
+Cache raw detector and classifier output globally — keyed by the deterministic
+inputs of each model — so that running the pipeline in a new workspace over
+photos that were already processed in another workspace does zero redundant ML
+work, and so that changing a confidence threshold becomes an instant read-time
+filter instead of a full reprocessing job.
+
+Current state: `detections` rows are workspace-scoped and written post-threshold
+(`vireo/db.py:163`, `vireo/classify_job.py:251-259`, `vireo/detector.py:243`).
+Each workspace re-runs MegaDetector on the same photos even though the model
+output is a pure function of `(photo, detector_model)`. The same problem
+applies downstream: `predictions` inherit workspace scope via
+`detection_id` → `detections.workspace_id`, so a BioClip classification that
+would be identical in any workspace is recomputed per workspace.
+
+This design splits deterministic model output from workspace-scoped human
+judgment. The model output becomes a global cache keyed by its inputs; review
+state (approved / rejected / individual / group) moves to a workspace-scoped
+side table. Thresholds become read-time filters.
+
+## Scope
+
+In scope:
+
+- `detections` table goes global, keyed by `(photo_id, detector_model)`.
+- `predictions` table goes global, keyed by `(detection_id, classifier_model,
+  labels_fingerprint, species)`.
+- New `prediction_review` table holds per-workspace review state.
+- New `detector_runs` / `classifier_runs` tables track "has the model been run
+  on this input", independent of whether any rows were produced.
+- New `labels_fingerprints` sidecar maps content hash → display metadata.
+- Read-time threshold filtering throughout the app.
+- One forward migration with dedupe across pre-existing workspace-scoped rows.
+
+Out of scope:
+
+- Moving global per-photo quality scoring (`photos.subject_sharpness`,
+  `photos.subject_size`, `photos.quality_score`) into workspace-aware storage.
+  These remain on the global `photos` row and are computed against the primary
+  detection as selected by the active workspace's threshold at write time.
+  Accepted inconsistency — revisit if it becomes a real problem.
+- Detector weights versioning. Today `detector_model` is a semantic string
+  (e.g. `"megadetector-v6"`); if weights ever change under a fixed name we can
+  append a revision SHA later.
+
+## Schema
+
+```sql
+-- GLOBAL: deterministic model output, no workspace scoping
+CREATE TABLE detections (
+  id                   INTEGER PRIMARY KEY,
+  photo_id             INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
+  detector_model       TEXT NOT NULL,        -- e.g. "megadetector-v6"
+  box_x                REAL,
+  box_y                REAL,
+  box_w                REAL,
+  box_h                REAL,
+  detector_confidence  REAL,                 -- raw, unfiltered
+  category             TEXT,                 -- animal / person / vehicle
+  created_at           TEXT DEFAULT (datetime('now'))
+);
+-- Many boxes per (photo_id, detector_model). Set-level uniqueness is enforced
+-- by the write path: re-detecting clears all rows for the pair and reinserts.
+CREATE INDEX idx_detections_photo_model
+  ON detections(photo_id, detector_model);
+CREATE INDEX idx_detections_conf
+  ON detections(photo_id, detector_confidence);
+
+CREATE TABLE predictions (
+  id                   INTEGER PRIMARY KEY,
+  detection_id         INTEGER NOT NULL REFERENCES detections(id) ON DELETE CASCADE,
+  classifier_model     TEXT NOT NULL,
+  labels_fingerprint   TEXT NOT NULL,        -- sha256 hex prefix, or "tol", or "legacy"
+  species              TEXT,
+  confidence           REAL,                 -- raw, unfiltered
+  category             TEXT,
+  scientific_name      TEXT,
+  taxonomy_kingdom     TEXT,
+  taxonomy_phylum      TEXT,
+  taxonomy_class       TEXT,
+  taxonomy_order       TEXT,
+  taxonomy_family      TEXT,
+  taxonomy_genus       TEXT,
+  created_at           TEXT DEFAULT (datetime('now')),
+  UNIQUE(detection_id, classifier_model, labels_fingerprint, species)
+);
+
+-- "Has the model been run on this input?" — independent of row count.
+-- Prevents re-running MegaDetector on photos that genuinely have no animals.
+CREATE TABLE detector_runs (
+  photo_id        INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
+  detector_model  TEXT NOT NULL,
+  run_at          TEXT DEFAULT (datetime('now')),
+  box_count       INTEGER NOT NULL,          -- 0 means "ran, found nothing"
+  PRIMARY KEY (photo_id, detector_model)
+);
+
+CREATE TABLE classifier_runs (
+  detection_id         INTEGER NOT NULL REFERENCES detections(id) ON DELETE CASCADE,
+  classifier_model     TEXT NOT NULL,
+  labels_fingerprint   TEXT NOT NULL,
+  run_at               TEXT DEFAULT (datetime('now')),
+  prediction_count     INTEGER NOT NULL,
+  PRIMARY KEY (detection_id, classifier_model, labels_fingerprint)
+);
+
+-- WORKSPACE-SCOPED: human judgment only
+CREATE TABLE prediction_review (
+  prediction_id  INTEGER NOT NULL REFERENCES predictions(id) ON DELETE CASCADE,
+  workspace_id   INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  status         TEXT NOT NULL DEFAULT 'pending',   -- pending / approved / rejected
+  reviewed_at    TEXT,
+  individual     TEXT,
+  group_id       TEXT,
+  vote_count     INTEGER,
+  total_votes    INTEGER,
+  PRIMARY KEY (prediction_id, workspace_id)
+);
+-- Absence of a row == pending. Rows are written lazily when a user acts.
+
+-- Optional sidecar for debugging / UX: which labels set is this hash?
+CREATE TABLE labels_fingerprints (
+  fingerprint    TEXT PRIMARY KEY,
+  display_name   TEXT,                       -- e.g. "California birds (merged)"
+  sources_json   TEXT,                       -- JSON array of source file paths
+  label_count    INTEGER,
+  created_at     TEXT DEFAULT (datetime('now'))
+);
+```
+
+### Fingerprinting the labels set
+
+`labels_fingerprint` is `sha256(sorted(deduped(label_strings)))` truncated to 12
+hex chars. Sentinel values:
+
+- `"tol"` — BioClip Tree of Life mode (no labels file; uses built-in taxonomy).
+- `"legacy"` — pre-migration rows. Will not match any new fingerprint; those
+  detections will be re-classified on demand.
+
+When a classifier run begins, the fingerprint is computed and upserted into
+`labels_fingerprints` (with the source file paths as `sources_json`) before any
+prediction rows are written. This keeps the fingerprint → human-name mapping
+available for debugging without coupling it to the predictions hot path.
+
+## Write path
+
+```
+detect_animals(image_path, detector_model)
+  -> MegaDetector ONNX, NMS still applied, hard floor 0.01 in postprocess
+  -> returns ALL boxes >= 0.01 with no workspace-aware filtering
+
+classify_job._detect_batch
+  -> if (photo_id, detector_model) in detector_runs: skip (empty or not)
+  -> else:
+       detections_for_pair = detect_animals(...)
+       DELETE FROM detections WHERE photo_id=? AND detector_model=?
+       INSERT rows for every box returned (may be zero)
+       UPSERT INTO detector_runs (photo_id, detector_model, box_count)
+
+classifier run (bioclip / speciesnet / ...)
+  -> fingerprint = sha256_prefix(sorted(deduped(labels))) or "tol"
+  -> UPSERT INTO labels_fingerprints (cosmetic)
+  -> if (detection_id, classifier_model, fingerprint) in classifier_runs: skip
+  -> else:
+       predictions_for_triple = classify(...)
+       INSERT top-N predictions, no confidence filter
+       UPSERT INTO classifier_runs (..., prediction_count)
+
+prediction_review
+  -> only written when a user acts (approve / reject / set individual / group)
+  -> absence of a row is treated as status='pending' in reads
+```
+
+Key decisions:
+
+- **0.01 floor on the detector.** Running MegaDetector with no floor emits tens
+  of thousands of noise boxes per image. A low floor keeps storage sane while
+  being effectively "raw" — no realistic workspace threshold goes below this.
+- **No per-workspace gate anywhere on the write path.** Detection and
+  classification only care about their own deterministic inputs. Whether the
+  active workspace would have filtered these results at its threshold is
+  irrelevant at write time.
+- **Lazy `prediction_review`.** Materializing a "pending" row per (prediction,
+  workspace) pair scales as O(N_workspaces × N_predictions) and carries no
+  information. Absence is the pending state.
+- **`detector_runs` / `classifier_runs` tables are the single source of truth
+  for "was this model run on this input?"** The existing skip pattern of
+  "does `detections` have at least one row?" is wrong — a photo with no
+  animals produces zero rows and would be re-run forever.
+
+## Read path
+
+All detection and prediction reads apply threshold as a SQL `WHERE` clause,
+resolved from workspace-effective config by default:
+
+```python
+db.get_detections(photo_id, min_conf=None)
+    # min_conf=None => pulls detector_confidence from workspace-effective config
+    # min_conf=0    => raw (debugging / "show all boxes" endpoints)
+
+db.get_detections_for_photos(photo_ids, min_conf=None)
+
+db.get_predictions_for_detection(
+    detection_id,
+    min_classifier_conf=None,
+    classifier_model=None,          # filter to a specific model
+    labels_fingerprint=None,        # filter to a specific list
+)
+
+db.get_review_status(prediction_id, workspace_id)
+    # returns 'pending' if no prediction_review row exists
+```
+
+Sites that need updating (from a repo-wide grep):
+
+- `classify_job._detect_batch` / `_detect_subjects` — bind cached detections
+  with threshold applied; use `detector_runs` for the skip check.
+- `pipeline_job._detect_batch` — same.
+- `pipeline.py` subject-crop extraction queries.
+- `app.py` browse-grid `/detections` endpoint, map view queries, highlights.
+- `db.get_photos_with_detections_but_no_masks` and siblings.
+- `db.get_prediction_stats`, `get_photos_by_prediction`, `get_species_counts`.
+
+`get_primary_detection` (used for global quality scoring) runs over the
+threshold-filtered set of the *writing* workspace. Accepted as an inconsistency
+for this pass — see scope notes above.
+
+**Behavioral consequence**: changing `detector_confidence` in workspace config
+becomes instant. Next page load filters differently. Lowering it below an
+earlier effective threshold works, because raw rows are already stored.
+
+## Migration
+
+One irreversible forward migration, gated on the schema version bump.
+
+1. **Create new tables**: `detector_runs`, `classifier_runs`,
+   `labels_fingerprints`, `prediction_review`.
+
+2. **Backfill `detector_runs`**: one row per distinct `(photo_id,
+   detector_model)` seen in existing `detections`. `box_count` = row count;
+   `run_at` = earliest `created_at` in the group.
+
+3. **Dedupe `detections` across workspaces**:
+   - Group by `(photo_id, detector_model, box_x, box_y, box_w, box_h)` — the
+     model is deterministic so cross-workspace duplicates have identical
+     coords.
+   - Pick lowest `id` in each group as canonical.
+   - `UPDATE predictions SET detection_id = canonical_id` for all dupes.
+   - `DELETE` non-canonical rows.
+   - Drop `workspace_id` column.
+
+4. **Backfill `prediction_review`**: one row per `(prediction_id,
+   workspace_id)`, with `workspace_id` derived from the pre-migration
+   `detections.workspace_id` of each prediction's owner. Copy `status`,
+   `reviewed_at`, `individual`, `group_id`, `vote_count`, `total_votes` into
+   the new table.
+
+5. **Add `labels_fingerprint`** to `predictions` with sentinel `"legacy"` on
+   all existing rows. Existing predictions will not match any new fingerprint
+   going forward — accepted; reclassify refreshes.
+
+6. **Dedupe `predictions`** by the new uniqueness key; re-point
+   `prediction_review` to canonical `prediction_id`; delete duplicates.
+
+7. **Drop workspace/review columns from `predictions`**: `status`,
+   `reviewed_at`, `individual`, `group_id`, `vote_count`, `total_votes`,
+   `workspace_id` (if present). Apply the new `UNIQUE` constraint.
+
+Because pre-migration detections were already threshold-filtered, the migrated
+rows are *not* truly raw. A user who later lowers their threshold below
+whatever the historical filtering level was will not magically recover
+subthreshold boxes — they need to run reclassify. Document this in the
+changelog.
+
+## Testing
+
+**Unit tests**
+
+- `vireo/tests/test_db.py`
+  - `get_detections(photo_id, min_conf=...)` respects threshold.
+  - Cross-workspace reads return identical rows.
+  - `prediction_review` upsert / absence-means-pending semantics.
+- `vireo/tests/test_classify_job.py`
+  - Detect-skip uses `detector_runs`, not row count.
+  - Photos with `box_count=0` are cached and not re-run.
+- `vireo/tests/test_detector.py`
+  - 0.01 floor applied; `detect_animals` no longer takes a workspace threshold.
+- `vireo/tests/test_migration_detection_storage.py` (new)
+  - Captured legacy SQLite fixture covering multi-workspace, overlapping
+    detections, orphaned predictions, mixed review states.
+  - Run migration, assert new schema + row counts + re-pointed references.
+
+**Integration / user-first**
+
+- Scan + classify in workspace A, switch to workspace B over the same folder —
+  no MegaDetector or classifier work fires; detections visible; review state
+  independent.
+- Lower `detector_confidence` in active workspace — browse grid immediately
+  shows more boxes, no job fires, no progress SSE events.
+- Reclassify in workspace B after legacy migration — `labels_fingerprint` gets
+  a real hash, previously-subthreshold boxes become queryable.
+
+## Rollout
+
+- Irreversible forward migration, gated on schema version bump. Document
+  clearly that `~/.vireo/vireo.db` is modified in place and a backup is
+  recommended.
+- Changelog entry:
+  > Detector and classifier results are now cached per-photo rather than
+  > per-workspace. Existing detections keep working; for best results, run
+  > "Reclassify" once to regenerate with raw storage.
+- Headless API (b2ccd9f) audit: endpoints that returned `predictions.status`,
+  `individual`, `group_id` now join to `prediction_review`. Walk the routes
+  touching `predictions` and update shapes / read paths as needed.
+- Settings page stats: add "Detections: N photos × M models cached" so users
+  can see the new global cache's scale.
+
+## Open questions / future work
+
+- **Detector weights versioning**: if MegaDetector V6 weights are ever
+  re-released at the same HF path, same-name rows will be stale. Consider
+  appending a revision SHA to `detector_model` in a later pass.
+- **Quality scoring consistency**: `photos.subject_sharpness` /
+  `subject_size` / `quality_score` are computed against the primary detection
+  as seen by the writing workspace's threshold. Two workspaces with different
+  thresholds could disagree about which box is primary. Not addressed in this
+  refactor. Revisit if it causes user-visible bugs.
+- **Labels fingerprint display**: the sidecar `labels_fingerprints` table is
+  defined but UI integration (showing friendly names in settings / reports)
+  is deferred.

--- a/docs/plans/2026-04-23-detection-storage-redesign-plan.md
+++ b/docs/plans/2026-04-23-detection-storage-redesign-plan.md
@@ -1,0 +1,2218 @@
+# Detection Storage Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move MegaDetector and classifier output from per-workspace to global caches keyed by deterministic inputs, and move confidence thresholds from write-time gates to read-time filters.
+
+**Architecture:** Split "what the model produced" (global `detections` / `predictions`) from "what the user decided" (workspace-scoped `prediction_review`). Track model runs explicitly in `detector_runs` / `classifier_runs` so empty-scene photos don't get re-detected. Classifier identity becomes `(classifier_model, labels_fingerprint)` so two workspaces running BioClip with different lists stay distinct. Threshold becomes a SQL `WHERE` clause resolved from workspace-effective config on every read.
+
+**Tech Stack:** Flask, SQLite, Python, pytest. No frontend framework.
+
+**Design doc:** `docs/plans/2026-04-23-detection-storage-redesign-design.md`
+
+---
+
+## Overview of phases
+
+| Phase | Focus | Tasks |
+|-------|-------|-------|
+| 0 | New schema + helpers (additive, no behavior change) | 1–7 |
+| 1 | One-shot migration of legacy data | 8–13 |
+| 2 | Rewire detector write path | 14–17 |
+| 3 | Rewire classifier write path | 18–19 |
+| 4 | Read-time threshold filters | 20–25 |
+| 5 | UX polish + changelog | 26–27 |
+
+Run `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -v` after each phase to make sure nothing else broke.
+
+---
+
+## Phase 0 — New schema and helpers
+
+These tasks add tables and helpers alongside the existing ones. No existing behavior changes yet.
+
+### Task 1: Add new tables to CREATE script
+
+**Files:**
+- Modify: `vireo/db.py` (the `executescript` block starting around line 80 — same block that creates `folders`, `photos`, `detections`, etc.)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing test**
+
+Add to `vireo/tests/test_db.py`:
+
+```python
+def test_new_cache_tables_exist(tmp_path):
+    """detector_runs, classifier_runs, labels_fingerprints, prediction_review are created."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    tables = {r['name'] for r in db.conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()}
+    assert 'detector_runs' in tables
+    assert 'classifier_runs' in tables
+    assert 'labels_fingerprints' in tables
+    assert 'prediction_review' in tables
+```
+
+**Step 2: Run test to verify it fails**
+
+```
+python -m pytest vireo/tests/test_db.py::test_new_cache_tables_exist -v
+```
+
+Expected: FAIL — tables don't exist.
+
+**Step 3: Add the CREATE TABLE statements**
+
+Inside the `self.conn.executescript("""...""")` block in `vireo/db.py` (the one containing the existing `CREATE TABLE IF NOT EXISTS detections` around line 163), append:
+
+```sql
+CREATE TABLE IF NOT EXISTS detector_runs (
+    photo_id        INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
+    detector_model  TEXT NOT NULL,
+    run_at          TEXT DEFAULT (datetime('now')),
+    box_count       INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (photo_id, detector_model)
+);
+
+CREATE TABLE IF NOT EXISTS classifier_runs (
+    detection_id         INTEGER NOT NULL REFERENCES detections(id) ON DELETE CASCADE,
+    classifier_model     TEXT NOT NULL,
+    labels_fingerprint   TEXT NOT NULL,
+    run_at               TEXT DEFAULT (datetime('now')),
+    prediction_count     INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (detection_id, classifier_model, labels_fingerprint)
+);
+
+CREATE TABLE IF NOT EXISTS labels_fingerprints (
+    fingerprint    TEXT PRIMARY KEY,
+    display_name   TEXT,
+    sources_json   TEXT,
+    label_count    INTEGER,
+    created_at     TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS prediction_review (
+    prediction_id  INTEGER NOT NULL REFERENCES predictions(id) ON DELETE CASCADE,
+    workspace_id   INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    status         TEXT NOT NULL DEFAULT 'pending',
+    reviewed_at    TEXT,
+    individual     TEXT,
+    group_id       TEXT,
+    vote_count     INTEGER,
+    total_votes    INTEGER,
+    PRIMARY KEY (prediction_id, workspace_id)
+);
+```
+
+Also add indexes next to the existing `idx_detections_*` block further down in the method:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_prediction_review_workspace
+  ON prediction_review(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_classifier_runs_detection
+  ON classifier_runs(detection_id);
+```
+
+**Step 4: Run test to verify it passes**
+
+```
+python -m pytest vireo/tests/test_db.py::test_new_cache_tables_exist -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: add detector_runs, classifier_runs, labels_fingerprints, prediction_review tables"
+```
+
+---
+
+### Task 2: Labels fingerprint module
+
+**Files:**
+- Create: `vireo/labels_fingerprint.py`
+- Test: `vireo/tests/test_labels_fingerprint.py` (new)
+
+**Step 1: Write failing test**
+
+```python
+# vireo/tests/test_labels_fingerprint.py
+import os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from labels_fingerprint import compute_fingerprint, TOL_SENTINEL, LEGACY_SENTINEL
+
+
+def test_fingerprint_is_stable_under_ordering_and_duplicates():
+    a = compute_fingerprint(["Bald Eagle", "American Robin", "Bald Eagle"])
+    b = compute_fingerprint(["American Robin", "Bald Eagle"])
+    assert a == b
+    assert len(a) == 12  # sha256 hex prefix
+
+
+def test_fingerprint_differs_on_different_sets():
+    a = compute_fingerprint(["Bald Eagle", "American Robin"])
+    b = compute_fingerprint(["Bald Eagle", "Steller's Jay"])
+    assert a != b
+
+
+def test_tol_sentinel_when_no_labels():
+    assert compute_fingerprint(None) == TOL_SENTINEL
+    assert compute_fingerprint([]) == TOL_SENTINEL
+
+
+def test_sentinels_are_fixed_strings():
+    assert TOL_SENTINEL == "tol"
+    assert LEGACY_SENTINEL == "legacy"
+```
+
+**Step 2: Run test to verify it fails**
+
+```
+python -m pytest vireo/tests/test_labels_fingerprint.py -v
+```
+
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```python
+# vireo/labels_fingerprint.py
+"""Content-addressable fingerprint for a classifier's label set.
+
+The classifier's output is a pure function of (model, labels, input). We key
+cached predictions by (classifier_model, labels_fingerprint) so two workspaces
+running the same model with different regional lists stay disjoint rather than
+conflicting or silently clobbering each other.
+"""
+
+import hashlib
+
+TOL_SENTINEL = "tol"
+LEGACY_SENTINEL = "legacy"
+
+
+def compute_fingerprint(labels):
+    """sha256 hex prefix of sorted, deduped labels. TOL_SENTINEL when empty."""
+    if not labels:
+        return TOL_SENTINEL
+    canonical = "\n".join(sorted(set(labels))).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()[:12]
+```
+
+**Step 4: Run test to verify it passes**
+
+```
+python -m pytest vireo/tests/test_labels_fingerprint.py -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/labels_fingerprint.py vireo/tests/test_labels_fingerprint.py
+git commit -m "labels: add content-addressable fingerprint for label sets"
+```
+
+---
+
+### Task 3: `db.record_detector_run` / `db.get_detector_run_photo_ids`
+
+**Files:**
+- Modify: `vireo/db.py` (add methods near `save_detections` around line 3815)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing tests**
+
+Add to `vireo/tests/test_db.py`:
+
+```python
+def test_record_detector_run_and_lookup(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    db._active_workspace_id = db.create_workspace("WS")
+    db.add_workspace_folder(db._active_workspace_id, folder_id)
+    photo_id = db.add_photo(folder_id, "a.jpg")
+
+    # Initially: no runs recorded
+    assert db.get_detector_run_photo_ids("megadetector-v6") == set()
+
+    db.record_detector_run(photo_id, "megadetector-v6", box_count=0)
+    assert db.get_detector_run_photo_ids("megadetector-v6") == {photo_id}
+
+    # Re-recording is idempotent / updates box_count
+    db.record_detector_run(photo_id, "megadetector-v6", box_count=3)
+    row = db.conn.execute(
+        "SELECT box_count FROM detector_runs WHERE photo_id=? AND detector_model=?",
+        (photo_id, "megadetector-v6"),
+    ).fetchone()
+    assert row["box_count"] == 3
+
+
+def test_detector_run_is_not_workspace_scoped(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws_a = db.create_workspace("A")
+    ws_b = db.create_workspace("B")
+    db.add_workspace_folder(ws_a, folder_id)
+    db.add_workspace_folder(ws_b, folder_id)
+    photo_id = db.add_photo(folder_id, "a.jpg")
+
+    db._active_workspace_id = ws_a
+    db.record_detector_run(photo_id, "megadetector-v6", box_count=2)
+
+    db._active_workspace_id = ws_b
+    assert photo_id in db.get_detector_run_photo_ids("megadetector-v6")
+```
+
+**Step 2: Run tests to verify they fail**
+
+```
+python -m pytest vireo/tests/test_db.py::test_record_detector_run_and_lookup vireo/tests/test_db.py::test_detector_run_is_not_workspace_scoped -v
+```
+
+Expected: FAIL — methods don't exist.
+
+**Step 3: Implement**
+
+Add methods near the existing `save_detections` / `get_detections` in `vireo/db.py`:
+
+```python
+def record_detector_run(self, photo_id, detector_model, box_count):
+    """Record that `detector_model` was run on `photo_id`.
+
+    Global across workspaces — the output is a pure function of (photo, model).
+    """
+    self.conn.execute(
+        """INSERT INTO detector_runs (photo_id, detector_model, box_count)
+           VALUES (?, ?, ?)
+           ON CONFLICT(photo_id, detector_model)
+           DO UPDATE SET box_count = excluded.box_count,
+                         run_at = datetime('now')""",
+        (photo_id, detector_model, box_count),
+    )
+    self.conn.commit()
+
+def get_detector_run_photo_ids(self, detector_model):
+    """Return the set of photo_ids where `detector_model` has run.
+
+    Includes empty-scene photos (box_count=0) — which is the whole point:
+    without this, we'd re-run the model forever on photos with no animals.
+    """
+    rows = self.conn.execute(
+        "SELECT photo_id FROM detector_runs WHERE detector_model = ?",
+        (detector_model,),
+    ).fetchall()
+    return {r["photo_id"] for r in rows}
+```
+
+**Step 4: Run tests to verify they pass**
+
+```
+python -m pytest vireo/tests/test_db.py::test_record_detector_run_and_lookup vireo/tests/test_db.py::test_detector_run_is_not_workspace_scoped -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: add detector_runs helpers (record + lookup)"
+```
+
+---
+
+### Task 4: `db.record_classifier_run` / `db.get_classifier_run_keys`
+
+**Files:**
+- Modify: `vireo/db.py`
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing tests**
+
+```python
+def test_record_classifier_run_and_lookup(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    db._active_workspace_id = db.create_workspace("WS")
+    db.add_workspace_folder(db._active_workspace_id, folder_id)
+    photo_id = db.add_photo(folder_id, "a.jpg")
+    # Need a detection row to reference:
+    det_ids = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    det_id = det_ids[0]
+
+    assert db.get_classifier_run_keys(det_id) == set()
+
+    db.record_classifier_run(det_id, "bioclip-2", "abc123", prediction_count=5)
+    assert db.get_classifier_run_keys(det_id) == {("bioclip-2", "abc123")}
+```
+
+**Step 2: Run tests to verify they fail**
+
+```
+python -m pytest vireo/tests/test_db.py::test_record_classifier_run_and_lookup -v
+```
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Add near the detector-runs helpers in `vireo/db.py`:
+
+```python
+def record_classifier_run(self, detection_id, classifier_model,
+                           labels_fingerprint, prediction_count):
+    self.conn.execute(
+        """INSERT INTO classifier_runs
+             (detection_id, classifier_model, labels_fingerprint, prediction_count)
+           VALUES (?, ?, ?, ?)
+           ON CONFLICT(detection_id, classifier_model, labels_fingerprint)
+           DO UPDATE SET prediction_count = excluded.prediction_count,
+                         run_at = datetime('now')""",
+        (detection_id, classifier_model, labels_fingerprint, prediction_count),
+    )
+    self.conn.commit()
+
+def get_classifier_run_keys(self, detection_id):
+    rows = self.conn.execute(
+        """SELECT classifier_model, labels_fingerprint
+           FROM classifier_runs
+           WHERE detection_id = ?""",
+        (detection_id,),
+    ).fetchall()
+    return {(r["classifier_model"], r["labels_fingerprint"]) for r in rows}
+```
+
+**Step 4: Run test to verify it passes**
+
+```
+python -m pytest vireo/tests/test_db.py::test_record_classifier_run_and_lookup -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: add classifier_runs helpers"
+```
+
+---
+
+### Task 5: `db.upsert_labels_fingerprint` sidecar
+
+**Files:**
+- Modify: `vireo/db.py`
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing test**
+
+```python
+def test_upsert_labels_fingerprint(tmp_path):
+    from db import Database
+    import json
+    db = Database(str(tmp_path / "test.db"))
+    db.upsert_labels_fingerprint(
+        fingerprint="abc123",
+        display_name="California birds",
+        sources=["/labels/ca-birds.txt"],
+        label_count=423,
+    )
+    row = db.conn.execute(
+        "SELECT * FROM labels_fingerprints WHERE fingerprint=?", ("abc123",)
+    ).fetchone()
+    assert row["display_name"] == "California birds"
+    assert json.loads(row["sources_json"]) == ["/labels/ca-birds.txt"]
+    assert row["label_count"] == 423
+
+    # Upsert is idempotent
+    db.upsert_labels_fingerprint("abc123", "California birds (v2)",
+                                  ["/labels/ca-birds-v2.txt"], 500)
+    row = db.conn.execute(
+        "SELECT display_name, label_count FROM labels_fingerprints WHERE fingerprint=?",
+        ("abc123",),
+    ).fetchone()
+    assert row["display_name"] == "California birds (v2)"
+    assert row["label_count"] == 500
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+```python
+def upsert_labels_fingerprint(self, fingerprint, display_name, sources, label_count):
+    import json
+    self.conn.execute(
+        """INSERT INTO labels_fingerprints
+             (fingerprint, display_name, sources_json, label_count)
+           VALUES (?, ?, ?, ?)
+           ON CONFLICT(fingerprint)
+           DO UPDATE SET display_name = excluded.display_name,
+                         sources_json = excluded.sources_json,
+                         label_count  = excluded.label_count""",
+        (fingerprint, display_name, json.dumps(sources or []), label_count),
+    )
+    self.conn.commit()
+```
+
+**Step 4: Run test to verify it passes**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: add labels_fingerprints upsert helper"
+```
+
+---
+
+### Task 6: `db.get_review_status` / `db.set_review_status`
+
+Absence of a row means `'pending'` — implement that in the reader.
+
+**Files:**
+- Modify: `vireo/db.py`
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing tests**
+
+```python
+def test_review_status_absence_is_pending(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("WS")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(folder_id, "a.jpg")
+    det_ids = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    pred_id = db.conn.execute(
+        """INSERT INTO predictions (detection_id, classifier_model, labels_fingerprint,
+                                    species, confidence)
+           VALUES (?, 'bioclip-2', 'abc', 'Robin', 0.8)""",
+        (det_ids[0],),
+    ).lastrowid
+    db.conn.commit()
+
+    # No row in prediction_review yet → pending
+    assert db.get_review_status(pred_id, ws) == "pending"
+
+    db.set_review_status(pred_id, ws, status="approved")
+    assert db.get_review_status(pred_id, ws) == "approved"
+
+    db.set_review_status(pred_id, ws, status="rejected")
+    assert db.get_review_status(pred_id, ws) == "rejected"
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+```python
+def get_review_status(self, prediction_id, workspace_id):
+    row = self.conn.execute(
+        """SELECT status FROM prediction_review
+           WHERE prediction_id = ? AND workspace_id = ?""",
+        (prediction_id, workspace_id),
+    ).fetchone()
+    return row["status"] if row else "pending"
+
+def set_review_status(self, prediction_id, workspace_id, status,
+                       individual=None, group_id=None):
+    self.conn.execute(
+        """INSERT INTO prediction_review
+             (prediction_id, workspace_id, status, reviewed_at, individual, group_id)
+           VALUES (?, ?, ?, datetime('now'), ?, ?)
+           ON CONFLICT(prediction_id, workspace_id)
+           DO UPDATE SET status      = excluded.status,
+                         reviewed_at = excluded.reviewed_at,
+                         individual  = COALESCE(excluded.individual, individual),
+                         group_id    = COALESCE(excluded.group_id,   group_id)""",
+        (prediction_id, workspace_id, status, individual, group_id),
+    )
+    self.conn.commit()
+```
+
+**Step 4: Run test to verify it passes**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: add prediction_review get/set with absence-means-pending semantics"
+```
+
+---
+
+### Task 7: Phase 0 regression run
+
+**Step 1:** Run the full suite — nothing should be broken since everything is additive.
+
+```
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_config.py -v
+```
+
+Expected: all pre-existing tests still pass.
+
+**Step 2: No commit needed.** If regressions appear, investigate before moving to Phase 1.
+
+---
+
+## Phase 1 — Migration of legacy data
+
+These tasks convert existing workspace-scoped `detections` and `predictions` tables into the new global shape. Structured so each task is individually committable and the DB is usable at every step in between.
+
+### Task 8: Migration — backfill `detector_runs`
+
+**Files:**
+- Modify: `vireo/db.py` — the migration block that runs during `__init__` (after the new CREATE TABLE statements run, so `detector_runs` exists).
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing test**
+
+```python
+def test_migration_backfills_detector_runs(tmp_path):
+    """Legacy detections become detector_runs rows on upgrade."""
+    import sqlite3
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER,
+                             filename TEXT, UNIQUE(folder_id, filename));
+        CREATE TABLE workspaces (id INTEGER PRIMARY KEY, name TEXT UNIQUE);
+        CREATE TABLE detections (
+            id INTEGER PRIMARY KEY,
+            photo_id INTEGER,
+            workspace_id INTEGER,
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence REAL,
+            category TEXT,
+            detector_model TEXT,
+            created_at TEXT
+        );
+        INSERT INTO folders (id, path) VALUES (1, '/p');
+        INSERT INTO photos (id, folder_id, filename) VALUES (10, 1, 'a.jpg');
+        INSERT INTO workspaces (id, name) VALUES (1, 'Default');
+        INSERT INTO detections (photo_id, workspace_id, box_x, box_y, box_w, box_h,
+                                detector_confidence, category, detector_model, created_at)
+            VALUES (10, 1, 0, 0, 1, 1, 0.5, 'animal', 'megadetector-v6', '2026-01-01T00:00:00');
+    """)
+    conn.commit()
+    conn.close()
+
+    # Open through Database → migrations run
+    from db import Database
+    db = Database(db_path)
+    run = db.conn.execute(
+        "SELECT box_count FROM detector_runs WHERE photo_id=10 AND detector_model='megadetector-v6'"
+    ).fetchone()
+    assert run is not None
+    assert run["box_count"] == 1
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: FAIL — migration doesn't exist yet.
+
+**Step 3: Implement**
+
+In `vireo/db.py`, find the section where existing schema migrations run (after `executescript`, same place the multi-animal migration lives around line 575). Add:
+
+```python
+# detector_runs backfill (detection-storage redesign): derive one row per
+# distinct (photo_id, detector_model) from existing detections so downstream
+# skip checks don't re-run MegaDetector over photos it has already seen.
+# Idempotent — only inserts rows whose (photo_id, detector_model) isn't
+# already present.
+existing_runs = self.conn.execute(
+    "SELECT COUNT(*) AS n FROM detector_runs"
+).fetchone()["n"]
+legacy_detection_count = self.conn.execute(
+    "SELECT COUNT(*) AS n FROM detections"
+).fetchone()["n"]
+if existing_runs == 0 and legacy_detection_count > 0:
+    self.conn.execute(
+        """INSERT OR IGNORE INTO detector_runs
+             (photo_id, detector_model, box_count, run_at)
+           SELECT photo_id, COALESCE(detector_model, 'megadetector-v6'),
+                  COUNT(*), MIN(created_at)
+           FROM detections
+           GROUP BY photo_id, COALESCE(detector_model, 'megadetector-v6')"""
+    )
+    self.conn.commit()
+```
+
+**Step 4: Run test to verify it passes**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: migrate existing detections into detector_runs on upgrade"
+```
+
+---
+
+### Task 9: Migration — dedupe detections & drop `workspace_id`
+
+This is the highest-risk task. Follow the existing pattern used by the multi-animal migration (`CREATE detections_new`, `INSERT SELECT DISTINCT`, repoint predictions, `DROP`, `RENAME`).
+
+**Files:**
+- Modify: `vireo/db.py`
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing test**
+
+```python
+def test_migration_dedupes_detections_and_repoints_predictions(tmp_path):
+    """Two workspaces with identical detection rows collapse to one; predictions follow."""
+    import sqlite3
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER,
+                             filename TEXT, UNIQUE(folder_id, filename));
+        CREATE TABLE workspaces (id INTEGER PRIMARY KEY, name TEXT UNIQUE);
+        CREATE TABLE detections (
+            id INTEGER PRIMARY KEY, photo_id INTEGER, workspace_id INTEGER,
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence REAL, category TEXT, detector_model TEXT,
+            created_at TEXT
+        );
+        CREATE TABLE predictions (
+            id INTEGER PRIMARY KEY, detection_id INTEGER, species TEXT,
+            confidence REAL, model TEXT, status TEXT DEFAULT 'pending',
+            individual TEXT, group_id TEXT, created_at TEXT
+        );
+        INSERT INTO folders VALUES (1, '/p');
+        INSERT INTO photos  VALUES (10, 1, 'a.jpg');
+        INSERT INTO workspaces VALUES (1, 'A'), (2, 'B');
+        -- Same box, same photo, two workspaces:
+        INSERT INTO detections (id, photo_id, workspace_id, box_x, box_y, box_w, box_h,
+                                detector_confidence, category, detector_model, created_at)
+          VALUES (100, 10, 1, 0.1, 0.1, 0.5, 0.5, 0.9, 'animal', 'megadetector-v6', 't1'),
+                 (200, 10, 2, 0.1, 0.1, 0.5, 0.5, 0.9, 'animal', 'megadetector-v6', 't2');
+        INSERT INTO predictions (id, detection_id, species, model, status) VALUES
+            (1000, 100, 'Robin', 'bioclip-2', 'approved'),
+            (2000, 200, 'Robin', 'bioclip-2', 'pending');
+    """)
+    conn.commit()
+    conn.close()
+
+    from db import Database
+    db = Database(db_path)
+    # Exactly one detection row for (photo=10, model=megadetector-v6)
+    rows = db.conn.execute(
+        "SELECT id FROM detections WHERE photo_id=10 AND detector_model='megadetector-v6'"
+    ).fetchall()
+    assert len(rows) == 1
+    canonical_id = rows[0]["id"]
+    # Both predictions now point at the canonical detection id
+    pred_rows = db.conn.execute(
+        "SELECT id, detection_id FROM predictions ORDER BY id"
+    ).fetchall()
+    assert {r["detection_id"] for r in pred_rows} == {canonical_id}
+    # detections table no longer has workspace_id column
+    cols = {r[1] for r in db.conn.execute("PRAGMA table_info(detections)").fetchall()}
+    assert "workspace_id" not in cols
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Add after the Task 8 backfill in `vireo/db.py`:
+
+```python
+# Global-detections migration: drop workspace_id from detections and dedupe
+# identical boxes that were duplicated across workspaces. Re-point predictions
+# at the canonical detection id.
+#
+# Follows the existing "create new, copy, drop old, rename" pattern used by
+# the multi-animal migration above. Gated on the `detections` table still
+# having a workspace_id column.
+det_cols = {r[1] for r in self.conn.execute(
+    "PRAGMA table_info(detections)"
+).fetchall()}
+if "workspace_id" in det_cols:
+    # Pick the lowest id per group as canonical.
+    self.conn.execute("""
+        CREATE TEMP TABLE detection_canonical AS
+        SELECT MIN(id) AS canonical_id, photo_id,
+               COALESCE(detector_model, 'megadetector-v6') AS detector_model,
+               box_x, box_y, box_w, box_h
+        FROM detections
+        GROUP BY photo_id, COALESCE(detector_model, 'megadetector-v6'),
+                 box_x, box_y, box_w, box_h
+    """)
+    # Re-point predictions that reference a non-canonical duplicate.
+    self.conn.execute("""
+        UPDATE predictions
+        SET detection_id = (
+            SELECT dc.canonical_id
+            FROM detections d
+            JOIN detection_canonical dc
+              ON dc.photo_id       = d.photo_id
+             AND dc.detector_model = COALESCE(d.detector_model, 'megadetector-v6')
+             AND dc.box_x = d.box_x AND dc.box_y = d.box_y
+             AND dc.box_w = d.box_w AND dc.box_h = d.box_h
+            WHERE d.id = predictions.detection_id
+        )
+        WHERE detection_id IN (
+            SELECT d.id
+            FROM detections d
+            JOIN detection_canonical dc
+              ON dc.photo_id       = d.photo_id
+             AND dc.detector_model = COALESCE(d.detector_model, 'megadetector-v6')
+             AND dc.box_x = d.box_x AND dc.box_y = d.box_y
+             AND dc.box_w = d.box_w AND dc.box_h = d.box_h
+            WHERE d.id <> dc.canonical_id
+        )
+    """)
+    # Create new table without workspace_id
+    self.conn.execute("""
+        CREATE TABLE detections_new (
+            id                   INTEGER PRIMARY KEY,
+            photo_id             INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
+            detector_model       TEXT NOT NULL DEFAULT 'megadetector-v6',
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence  REAL,
+            category             TEXT,
+            created_at           TEXT DEFAULT (datetime('now'))
+        )
+    """)
+    self.conn.execute("""
+        INSERT INTO detections_new (id, photo_id, detector_model,
+                                    box_x, box_y, box_w, box_h,
+                                    detector_confidence, category, created_at)
+        SELECT d.id, d.photo_id,
+               COALESCE(d.detector_model, 'megadetector-v6'),
+               d.box_x, d.box_y, d.box_w, d.box_h,
+               d.detector_confidence, d.category, d.created_at
+        FROM detections d
+        JOIN detection_canonical dc ON dc.canonical_id = d.id
+    """)
+    self.conn.execute("DROP TABLE detections")
+    self.conn.execute("ALTER TABLE detections_new RENAME TO detections")
+    self.conn.execute("DROP TABLE detection_canonical")
+    # Recreate the indexes (the CREATE INDEX IF NOT EXISTS at the bottom of
+    # __init__ will no-op if they already exist, but indexes tied to the
+    # dropped table are gone).
+    self.conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_detections_photo ON detections(photo_id)"
+    )
+    self.conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_detections_photo_model "
+        "ON detections(photo_id, detector_model)"
+    )
+    self.conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_detections_conf "
+        "ON detections(photo_id, detector_confidence)"
+    )
+    self.conn.commit()
+```
+
+**Step 4: Run test to verify it passes**
+
+```
+python -m pytest vireo/tests/test_db.py::test_migration_dedupes_detections_and_repoints_predictions -v
+```
+
+Expected: PASS. Also run the previous migration test (Task 8) to make sure it still passes — it should, since dedupe is a no-op when everything is unique.
+
+**Step 5: Commit**
+
+```
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: drop detections.workspace_id, dedupe across workspaces, repoint predictions"
+```
+
+---
+
+### Task 10: Migration — add `labels_fingerprint` column to predictions
+
+Tiny additive migration.
+
+**Files:**
+- Modify: `vireo/db.py` (migration block; also the CREATE script so fresh DBs get it too)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing test**
+
+```python
+def test_predictions_has_labels_fingerprint(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    cols = {r[1] for r in db.conn.execute(
+        "PRAGMA table_info(predictions)"
+    ).fetchall()}
+    assert "labels_fingerprint" in cols
+
+
+def test_migration_sets_labels_fingerprint_legacy(tmp_path):
+    import sqlite3
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER,
+                             filename TEXT, UNIQUE(folder_id, filename));
+        CREATE TABLE workspaces (id INTEGER PRIMARY KEY, name TEXT UNIQUE);
+        CREATE TABLE detections (
+            id INTEGER PRIMARY KEY, photo_id INTEGER, workspace_id INTEGER,
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence REAL, category TEXT, detector_model TEXT,
+            created_at TEXT
+        );
+        CREATE TABLE predictions (
+            id INTEGER PRIMARY KEY, detection_id INTEGER, species TEXT,
+            confidence REAL, model TEXT, status TEXT DEFAULT 'pending',
+            individual TEXT, group_id TEXT, created_at TEXT
+        );
+        INSERT INTO folders VALUES (1, '/p');
+        INSERT INTO photos VALUES (10, 1, 'a.jpg');
+        INSERT INTO workspaces VALUES (1, 'A');
+        INSERT INTO detections (id, photo_id, workspace_id, box_x, box_y, box_w, box_h,
+                                detector_confidence, category, detector_model, created_at)
+            VALUES (100, 10, 1, 0, 0, 1, 1, 0.9, 'animal', 'megadetector-v6', 't1');
+        INSERT INTO predictions (id, detection_id, species, model) VALUES
+            (1, 100, 'Robin', 'bioclip-2');
+    """)
+    conn.commit()
+    conn.close()
+
+    from db import Database
+    db = Database(db_path)
+    row = db.conn.execute(
+        "SELECT labels_fingerprint FROM predictions WHERE id=1"
+    ).fetchone()
+    assert row["labels_fingerprint"] == "legacy"
+```
+
+**Step 2: Run tests to verify they fail**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Two changes to `vireo/db.py`:
+
+1. In the main `CREATE TABLE predictions` block near line 177, add `labels_fingerprint TEXT NOT NULL DEFAULT 'legacy'` as a column. (Don't add the new UNIQUE constraint yet — Task 12 handles that.)
+
+2. In the migration block (after Task 9's migration), add:
+
+```python
+# Add labels_fingerprint column if missing. Existing rows get 'legacy'.
+pred_cols = {r[1] for r in self.conn.execute(
+    "PRAGMA table_info(predictions)"
+).fetchall()}
+if "labels_fingerprint" not in pred_cols:
+    self.conn.execute(
+        "ALTER TABLE predictions ADD COLUMN labels_fingerprint TEXT "
+        "NOT NULL DEFAULT 'legacy'"
+    )
+    self.conn.commit()
+```
+
+**Step 4: Run tests to verify they pass**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: add labels_fingerprint to predictions, default 'legacy' for migrated rows"
+```
+
+---
+
+### Task 11: Migration — backfill `prediction_review` from legacy columns
+
+**Files:**
+- Modify: `vireo/db.py`
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing test**
+
+```python
+def test_migration_backfills_prediction_review(tmp_path):
+    """Approved/rejected predictions get prediction_review rows in the right workspace."""
+    import sqlite3
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER,
+                             filename TEXT, UNIQUE(folder_id, filename));
+        CREATE TABLE workspaces (id INTEGER PRIMARY KEY, name TEXT UNIQUE);
+        CREATE TABLE detections (
+            id INTEGER PRIMARY KEY, photo_id INTEGER, workspace_id INTEGER,
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence REAL, category TEXT, detector_model TEXT,
+            created_at TEXT
+        );
+        CREATE TABLE predictions (
+            id INTEGER PRIMARY KEY, detection_id INTEGER, species TEXT,
+            confidence REAL, model TEXT,
+            status TEXT DEFAULT 'pending', reviewed_at TEXT,
+            individual TEXT, group_id TEXT,
+            vote_count INTEGER, total_votes INTEGER,
+            created_at TEXT
+        );
+        INSERT INTO folders VALUES (1, '/p');
+        INSERT INTO photos VALUES (10, 1, 'a.jpg');
+        INSERT INTO workspaces VALUES (1, 'A'), (2, 'B');
+        INSERT INTO detections (id, photo_id, workspace_id, box_x, box_y, box_w, box_h,
+                                detector_confidence, category, detector_model, created_at)
+            VALUES (100, 10, 1, 0, 0, 1, 1, 0.9, 'animal', 'megadetector-v6', 't1'),
+                   (200, 10, 2, 0, 0, 1, 1, 0.9, 'animal', 'megadetector-v6', 't2');
+        INSERT INTO predictions (id, detection_id, species, model, status, individual)
+            VALUES (1, 100, 'Robin', 'bioclip-2', 'approved', 'Ruby'),
+                   (2, 200, 'Robin', 'bioclip-2', 'rejected', NULL);
+    """)
+    conn.commit()
+    conn.close()
+
+    from db import Database
+    db = Database(db_path)
+    rows = db.conn.execute(
+        "SELECT prediction_id, workspace_id, status, individual "
+        "FROM prediction_review ORDER BY workspace_id"
+    ).fetchall()
+    # After Task 9 dedupes detections, both predictions point to the canonical
+    # detection, so we should have two review rows — one per workspace.
+    assert len(rows) == 2
+    ws_statuses = {r["workspace_id"]: (r["status"], r["individual"]) for r in rows}
+    assert ws_statuses[1] == ("approved", "Ruby")
+    assert ws_statuses[2] == ("rejected", None)
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Add after the Task 10 migration in `vireo/db.py`:
+
+```python
+# Backfill prediction_review from legacy per-prediction review columns.
+# Only runs once (when predictions still has a `status` column).
+pred_cols = {r[1] for r in self.conn.execute(
+    "PRAGMA table_info(predictions)"
+).fetchall()}
+if "status" in pred_cols:
+    # Derive workspace_id from the owning detection's pre-migration
+    # workspace_id... which we've already dropped. Use the post-dedupe
+    # predictions table plus the detection_canonical temp — except we've
+    # dropped that too. Cleanest path: rebuild a (prediction_id -> workspace_id)
+    # map by joining through the ORIGINAL detection IDs captured *before*
+    # we dropped workspace_id.
+    #
+    # Because Tasks 8–10 already ran above, we can no longer recover the
+    # workspace_id from detections. Instead: do this backfill BEFORE Task 9's
+    # drop. Move the snippet earlier. See Note below.
+    pass
+```
+
+Because the prediction_review backfill needs `detections.workspace_id`, the ordering inside the single migration function must be:
+
+1. Task 8 backfill — detector_runs (still has workspace_id).
+2. **Task 11 backfill** — prediction_review (still has workspace_id).
+3. Task 9 — dedupe + drop workspace_id.
+4. Task 10 — labels_fingerprint column.
+5. Task 12 — drop review columns from predictions.
+
+Refactor the migration code in `vireo/db.py` to execute in that order. The Task 11 body becomes:
+
+```python
+# Backfill prediction_review from legacy per-prediction review columns.
+# Must run before the detections.workspace_id drop so we can route each
+# prediction to the correct workspace.
+pred_cols = {r[1] for r in self.conn.execute(
+    "PRAGMA table_info(predictions)"
+).fetchall()}
+review_exists = self.conn.execute(
+    "SELECT COUNT(*) AS n FROM prediction_review"
+).fetchone()["n"]
+if "status" in pred_cols and review_exists == 0:
+    self.conn.execute("""
+        INSERT OR IGNORE INTO prediction_review
+            (prediction_id, workspace_id, status, reviewed_at,
+             individual, group_id, vote_count, total_votes)
+        SELECT p.id, d.workspace_id,
+               COALESCE(p.status, 'pending'),
+               p.reviewed_at, p.individual, p.group_id,
+               p.vote_count, p.total_votes
+        FROM predictions p
+        JOIN detections d ON d.id = p.detection_id
+        WHERE d.workspace_id IS NOT NULL
+          AND COALESCE(p.status, 'pending') <> 'pending'
+    """)
+    self.conn.commit()
+```
+
+Restrict the backfill to non-pending rows — `'pending'` is the default and is implied by row absence, so we don't need those rows.
+
+**Step 4: Run test to verify it passes**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: backfill prediction_review from legacy predictions columns"
+```
+
+---
+
+### Task 12: Migration — drop legacy columns from `predictions`, add new UNIQUE
+
+**Files:**
+- Modify: `vireo/db.py` (both the CREATE script and the migration block)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing test**
+
+```python
+def test_predictions_has_new_unique_and_no_legacy_columns(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    cols = {r[1] for r in db.conn.execute(
+        "PRAGMA table_info(predictions)"
+    ).fetchall()}
+    # Legacy review/workspace columns are gone
+    for legacy in ("status", "reviewed_at", "individual", "group_id",
+                   "vote_count", "total_votes", "workspace_id"):
+        assert legacy not in cols, f"legacy column {legacy} still present"
+    # New unique constraint on (detection_id, classifier_model, labels_fingerprint, species)
+    indexes = db.conn.execute(
+        "SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name='predictions'"
+    ).fetchall()
+    assert any(
+        "labels_fingerprint" in (idx["sql"] or "") and "species" in (idx["sql"] or "")
+        for idx in indexes
+    )
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Update the main `CREATE TABLE predictions` to:
+
+```sql
+CREATE TABLE IF NOT EXISTS predictions (
+    id                   INTEGER PRIMARY KEY,
+    detection_id         INTEGER NOT NULL REFERENCES detections(id) ON DELETE CASCADE,
+    classifier_model     TEXT NOT NULL,
+    labels_fingerprint   TEXT NOT NULL DEFAULT 'legacy',
+    species              TEXT,
+    confidence           REAL,
+    category             TEXT,
+    scientific_name      TEXT,
+    taxonomy_kingdom     TEXT,
+    taxonomy_phylum      TEXT,
+    taxonomy_class       TEXT,
+    taxonomy_order       TEXT,
+    taxonomy_family      TEXT,
+    taxonomy_genus       TEXT,
+    created_at           TEXT DEFAULT (datetime('now')),
+    UNIQUE(detection_id, classifier_model, labels_fingerprint, species)
+);
+```
+
+(Rename `model` → `classifier_model`; drop review columns; add `labels_fingerprint` with default; add new UNIQUE.)
+
+Migration block (after Task 11 backfill):
+
+```python
+# Drop review + legacy model columns, rename `model` -> `classifier_model`,
+# apply new UNIQUE key. Uses create-copy-drop-rename because SQLite
+# can't drop columns + add constraints atomically.
+pred_cols = {r[1] for r in self.conn.execute(
+    "PRAGMA table_info(predictions)"
+).fetchall()}
+needs_pred_rewrite = "status" in pred_cols or "model" in pred_cols
+if needs_pred_rewrite:
+    self.conn.execute("""
+        CREATE TABLE predictions_new (
+            id                   INTEGER PRIMARY KEY,
+            detection_id         INTEGER NOT NULL REFERENCES detections(id) ON DELETE CASCADE,
+            classifier_model     TEXT NOT NULL,
+            labels_fingerprint   TEXT NOT NULL DEFAULT 'legacy',
+            species              TEXT,
+            confidence           REAL,
+            category             TEXT,
+            scientific_name      TEXT,
+            taxonomy_kingdom     TEXT,
+            taxonomy_phylum      TEXT,
+            taxonomy_class       TEXT,
+            taxonomy_order       TEXT,
+            taxonomy_family      TEXT,
+            taxonomy_genus       TEXT,
+            created_at           TEXT DEFAULT (datetime('now')),
+            UNIQUE(detection_id, classifier_model, labels_fingerprint, species)
+        )
+    """)
+    self.conn.execute("""
+        INSERT OR IGNORE INTO predictions_new
+            (id, detection_id, classifier_model, labels_fingerprint,
+             species, confidence, category, scientific_name,
+             taxonomy_kingdom, taxonomy_phylum, taxonomy_class,
+             taxonomy_order, taxonomy_family, taxonomy_genus, created_at)
+        SELECT id, detection_id,
+               COALESCE(model, 'unknown'),
+               COALESCE(labels_fingerprint, 'legacy'),
+               species, confidence, category, scientific_name,
+               taxonomy_kingdom, taxonomy_phylum, taxonomy_class,
+               taxonomy_order, taxonomy_family, taxonomy_genus, created_at
+        FROM predictions
+    """)
+    self.conn.execute("DROP TABLE predictions")
+    self.conn.execute("ALTER TABLE predictions_new RENAME TO predictions")
+    self.conn.commit()
+```
+
+**Step 4: Run test to verify it passes**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: drop predictions.status/individual/group_id/model in favor of classifier_model + prediction_review"
+```
+
+---
+
+### Task 13: End-to-end migration regression test
+
+**Files:**
+- Create: `vireo/tests/test_migration_detection_storage.py`
+
+**Step 1: Write the test**
+
+A single fixture that captures a realistic pre-migration DB (multi-workspace, overlapping detections, mixed review statuses) and asserts the post-migration shape is coherent.
+
+```python
+# vireo/tests/test_migration_detection_storage.py
+import os, sys, sqlite3
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+
+def _build_legacy_db(path):
+    conn = sqlite3.connect(path)
+    conn.executescript("""
+        CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER,
+                             filename TEXT, UNIQUE(folder_id, filename));
+        CREATE TABLE workspaces (id INTEGER PRIMARY KEY, name TEXT UNIQUE);
+        CREATE TABLE workspace_folders (
+            workspace_id INTEGER, folder_id INTEGER,
+            PRIMARY KEY (workspace_id, folder_id)
+        );
+        CREATE TABLE detections (
+            id INTEGER PRIMARY KEY, photo_id INTEGER, workspace_id INTEGER,
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence REAL, category TEXT, detector_model TEXT,
+            created_at TEXT
+        );
+        CREATE TABLE predictions (
+            id INTEGER PRIMARY KEY, detection_id INTEGER, species TEXT,
+            confidence REAL, model TEXT,
+            status TEXT DEFAULT 'pending', reviewed_at TEXT,
+            individual TEXT, group_id TEXT,
+            vote_count INTEGER, total_votes INTEGER,
+            created_at TEXT
+        );
+        INSERT INTO folders VALUES (1, '/p');
+        INSERT INTO photos VALUES (10, 1, 'a.jpg'), (11, 1, 'b.jpg');
+        INSERT INTO workspaces VALUES (1, 'A'), (2, 'B');
+        INSERT INTO workspace_folders VALUES (1, 1), (2, 1);
+        -- photo 10 detected in both workspaces (same box -> dedupes)
+        INSERT INTO detections (id, photo_id, workspace_id, box_x, box_y, box_w, box_h,
+                                detector_confidence, category, detector_model, created_at)
+          VALUES (100, 10, 1, 0.1, 0.1, 0.4, 0.4, 0.92, 'animal', 'megadetector-v6', 't1'),
+                 (200, 10, 2, 0.1, 0.1, 0.4, 0.4, 0.92, 'animal', 'megadetector-v6', 't1'),
+                 -- photo 11 only in workspace A, different box
+                 (300, 11, 1, 0.2, 0.2, 0.5, 0.5, 0.71, 'animal', 'megadetector-v6', 't1');
+        INSERT INTO predictions (id, detection_id, species, model,
+                                 status, individual, group_id)
+          VALUES (1, 100, 'Robin',  'bioclip-2', 'approved', 'Ruby', 'pair-01'),
+                 (2, 200, 'Robin',  'bioclip-2', 'pending',  NULL,   NULL),
+                 (3, 300, 'Sparrow','bioclip-2', 'rejected', NULL,   NULL);
+    """)
+    conn.commit()
+    conn.close()
+
+
+def test_full_migration(tmp_path):
+    db_path = str(tmp_path / "legacy.db")
+    _build_legacy_db(db_path)
+
+    from db import Database
+    db = Database(db_path)
+
+    # detections: one row per unique box; workspace_id column gone
+    det_cols = {r[1] for r in db.conn.execute("PRAGMA table_info(detections)").fetchall()}
+    assert "workspace_id" not in det_cols
+    photo10_rows = db.conn.execute(
+        "SELECT id FROM detections WHERE photo_id=10"
+    ).fetchall()
+    assert len(photo10_rows) == 1
+    canonical_10 = photo10_rows[0]["id"]
+
+    # predictions re-pointed to canonical detection; legacy columns gone
+    pred_cols = {r[1] for r in db.conn.execute("PRAGMA table_info(predictions)").fetchall()}
+    for legacy in ("status", "individual", "group_id", "reviewed_at",
+                   "vote_count", "total_votes", "model"):
+        assert legacy not in pred_cols, f"legacy column {legacy} still present"
+    photo10_preds = db.conn.execute(
+        "SELECT id, detection_id FROM predictions "
+        "WHERE detection_id = ? ORDER BY id",
+        (canonical_10,),
+    ).fetchall()
+    # Two predictions (1, 2) both re-point to canonical_10
+    assert {p["id"] for p in photo10_preds} == {1, 2}
+
+    # review state landed in prediction_review
+    reviews = db.conn.execute(
+        "SELECT prediction_id, workspace_id, status, individual "
+        "FROM prediction_review ORDER BY prediction_id, workspace_id"
+    ).fetchall()
+    review_map = {(r["prediction_id"], r["workspace_id"]):
+                  (r["status"], r["individual"]) for r in reviews}
+    # pred 1 was approved in ws 1, with individual "Ruby"
+    assert review_map[(1, 1)] == ("approved", "Ruby")
+    # pred 2 was pending in ws 2 → absence (not in review_map)
+    assert (2, 2) not in review_map
+    # pred 3 rejected in ws 1
+    assert review_map[(3, 1)] == ("rejected", None)
+
+    # detector_runs backfilled for every (photo, model)
+    run_keys = {(r["photo_id"], r["detector_model"]) for r in db.conn.execute(
+        "SELECT photo_id, detector_model FROM detector_runs"
+    ).fetchall()}
+    assert (10, "megadetector-v6") in run_keys
+    assert (11, "megadetector-v6") in run_keys
+```
+
+**Step 2: Run test — it should already pass** after Tasks 8–12.
+
+```
+python -m pytest vireo/tests/test_migration_detection_storage.py -v
+```
+
+Expected: PASS. If it fails, debug before moving on.
+
+**Step 3: Commit**
+
+```
+git add vireo/tests/test_migration_detection_storage.py
+git commit -m "test: end-to-end migration regression for detection storage redesign"
+```
+
+---
+
+## Phase 2 — Detector write path
+
+### Task 14: Detector hard floor + simplified signature
+
+**Files:**
+- Modify: `vireo/detector.py`
+- Test: `vireo/tests/test_detector.py`
+
+**Step 1: Write failing test**
+
+Add to `vireo/tests/test_detector.py`:
+
+```python
+def test_detect_animals_uses_hard_floor(monkeypatch):
+    """detect_animals no longer takes a confidence_threshold param; it uses 0.01 floor."""
+    from detector import RAW_CONF_FLOOR
+    assert RAW_CONF_FLOOR == 0.01
+
+    # Signature regression: should not accept confidence_threshold kwarg
+    import inspect
+    from detector import detect_animals
+    sig = inspect.signature(detect_animals)
+    assert "confidence_threshold" not in sig.parameters
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: FAIL — `RAW_CONF_FLOOR` doesn't exist; signature still has `confidence_threshold`.
+
+**Step 3: Implement**
+
+In `vireo/detector.py`:
+
+```python
+RAW_CONF_FLOOR = 0.01  # store everything above this; threshold is a read-time filter
+
+def detect_animals(image_path):
+    """Run MegaDetector and return every box above RAW_CONF_FLOOR.
+
+    Threshold is applied at read time from workspace-effective config — don't
+    filter at write time or we can't globally cache the result.
+    """
+    session = _get_session()
+    if session is None:
+        return []
+    ...
+    return _postprocess(outputs, preprocess_info, RAW_CONF_FLOOR)
+```
+
+(Delete the `confidence_threshold` param everywhere in `detector.py`. `_postprocess` keeps its param for internal use; callers just always pass `RAW_CONF_FLOOR`.)
+
+**Step 4: Run test to verify it passes**
+
+```
+python -m pytest vireo/tests/test_detector.py -v
+```
+
+Expected: PASS. Several existing tests may break — fix them to drop the `confidence_threshold` kwarg.
+
+**Step 5: Commit**
+
+```
+git add vireo/detector.py vireo/tests/test_detector.py
+git commit -m "detector: hard-floor at 0.01, remove per-call confidence_threshold"
+```
+
+---
+
+### Task 15: `db.save_detections` clear-and-reinsert semantics
+
+**Files:**
+- Modify: `vireo/db.py` (`save_detections` around line 3815)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing test**
+
+```python
+def test_save_detections_replaces_existing(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(folder_id, "a.jpg")
+
+    det_a = {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    det_b = {"box": {"x": 0.2, "y": 0.2, "w": 0.5, "h": 0.5}, "confidence": 0.7, "category": "animal"}
+
+    # First run: two boxes
+    ids_v1 = db.save_detections(photo_id, [det_a, det_b], detector_model="megadetector-v6")
+    assert len(ids_v1) == 2
+
+    # Second run on same (photo, model): one box — the old rows should be gone
+    ids_v2 = db.save_detections(photo_id, [det_a], detector_model="megadetector-v6")
+    rows = db.conn.execute(
+        "SELECT id FROM detections WHERE photo_id = ? AND detector_model = ?",
+        (photo_id, "megadetector-v6"),
+    ).fetchall()
+    assert {r["id"] for r in rows} == set(ids_v2)
+
+
+def test_save_detections_is_global(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws_a = db.create_workspace("A")
+    ws_b = db.create_workspace("B")
+    db.add_workspace_folder(ws_a, folder_id)
+    db.add_workspace_folder(ws_b, folder_id)
+    photo_id = db.add_photo(folder_id, "a.jpg")
+
+    db._active_workspace_id = ws_a
+    db.save_detections(photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="megadetector-v6")
+
+    db._active_workspace_id = ws_b
+    rows = db.conn.execute(
+        "SELECT id FROM detections WHERE photo_id = ?", (photo_id,),
+    ).fetchall()
+    # Global cache: workspace B sees the row written from A
+    assert len(rows) == 1
+```
+
+**Step 2: Run tests to verify they fail**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Replace `save_detections` and related helpers:
+
+```python
+def save_detections(self, photo_id, detections, detector_model):
+    """Replace all detections for (photo_id, detector_model) with the given list.
+
+    Global: no workspace scoping. The model's output is a pure function of
+    (photo, model); any workspace re-running the same (photo, model) is a
+    bug — callers should short-circuit via `get_detector_run_photo_ids`.
+
+    Args:
+        photo_id: the photo
+        detections: list of dicts {box: {x,y,w,h}, confidence, category}
+        detector_model: required, e.g. "megadetector-v6"
+    Returns:
+        list of new detection IDs (empty if detections was empty).
+    """
+    if detector_model is None:
+        raise ValueError("detector_model is required")
+    self.conn.execute(
+        "DELETE FROM detections WHERE photo_id = ? AND detector_model = ?",
+        (photo_id, detector_model),
+    )
+    ids = []
+    for det in detections:
+        box = det["box"]
+        cur = self.conn.execute(
+            """INSERT INTO detections
+                 (photo_id, detector_model, box_x, box_y, box_w, box_h,
+                  detector_confidence, category)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (photo_id, detector_model, box["x"], box["y"], box["w"], box["h"],
+             det["confidence"], det.get("category", "animal")),
+        )
+        ids.append(cur.lastrowid)
+    self.conn.commit()
+    return ids
+```
+
+Also rewrite `get_existing_detection_photo_ids` to delegate:
+
+```python
+def get_existing_detection_photo_ids(self, detector_model="megadetector-v6"):
+    """Back-compat shim — prefer get_detector_run_photo_ids."""
+    return self.get_detector_run_photo_ids(detector_model)
+```
+
+Delete `clear_detections` workspace-scoped WHERE clause and replace with:
+
+```python
+def clear_detections(self, photo_id, detector_model=None):
+    if detector_model is None:
+        self.conn.execute("DELETE FROM detections WHERE photo_id = ?", (photo_id,))
+    else:
+        self.conn.execute(
+            "DELETE FROM detections WHERE photo_id = ? AND detector_model = ?",
+            (photo_id, detector_model),
+        )
+    self.conn.commit()
+```
+
+**Step 4: Run tests to verify they pass**
+
+```
+python -m pytest vireo/tests/test_db.py -k "save_detections or clear_detections or detection_photo_ids" -v
+```
+
+Expected: PASS. Fix any other `test_db.py` / `test_photos_api.py` failures caused by the signature change.
+
+**Step 5: Commit**
+
+```
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: save_detections is global + clear-and-reinsert per (photo, model)"
+```
+
+---
+
+### Task 16: `classify_job._detect_batch` uses `detector_runs`
+
+**Files:**
+- Modify: `vireo/classify_job.py` (around lines 163–338)
+- Test: `vireo/tests/test_classify_job.py`
+
+**Step 1: Write failing test**
+
+```python
+def test_detect_batch_skips_empty_photo_on_rerun(tmp_path, monkeypatch):
+    """A photo with no animals is recorded in detector_runs; rerun skips detection."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(folder_id, "empty.jpg")
+
+    call_count = {"n": 0}
+    def fake_detect(image_path):
+        call_count["n"] += 1
+        return []  # no animals
+
+    monkeypatch.setattr("classify_job.detect_animals", fake_detect)
+    monkeypatch.setattr("classify_job.get_primary_detection", lambda dets: None)
+
+    import classify_job
+    photos = [{"id": photo_id, "folder_id": folder_id, "filename": "empty.jpg"}]
+    folders = {folder_id: "/tmp/p"}
+
+    # First call: runs detection
+    classify_job._detect_batch(
+        photos, folders, runner=None, job={"id": 0}, reclassify=False, db=db,
+        det_conf_threshold=0.2,
+        already_detected_ids=db.get_detector_run_photo_ids("megadetector-v6"),
+    )
+    assert call_count["n"] == 1
+
+    # Second call: should skip because detector_runs has the row
+    classify_job._detect_batch(
+        photos, folders, runner=None, job={"id": 0}, reclassify=False, db=db,
+        det_conf_threshold=0.2,
+        already_detected_ids=db.get_detector_run_photo_ids("megadetector-v6"),
+    )
+    assert call_count["n"] == 1, "detect_animals should not be re-called for empty photos"
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: FAIL — no detector_runs row is written when the detection list is empty, so the skip check misses.
+
+**Step 3: Implement**
+
+In `vireo/classify_job.py::_detect_batch`, after the `detect_animals(image_path, ...)` call and the branching on empty vs non-empty result, always record the run and always save (even empty):
+
+```python
+detections = detect_animals(image_path)  # signature now has no threshold
+
+# Save detections + record the run. Both cases — boxes-found and
+# empty-scene — need the detector_runs row so reruns skip.
+if detections:
+    detected += 1
+    db.save_detections(photo["id"], detections, detector_model="megadetector-v6")
+    det_list = ...  # existing build
+    detection_map[photo["id"]] = det_list
+else:
+    # Intentionally clear any stale rows for this (photo, model) and
+    # record the run with box_count=0.
+    db.save_detections(photo["id"], [], detector_model="megadetector-v6")
+
+db.record_detector_run(
+    photo["id"], "megadetector-v6", box_count=len(detections)
+)
+
+processed_ids.add(photo["id"])
+```
+
+Also update the top-level skip check:
+
+```python
+if not reclassify and photo["id"] in already_detected_ids:
+    # Either an earlier run produced rows, or it ran and found nothing —
+    # either way, don't invoke the model again. Pull cached rows if the
+    # caller wants them.
+    existing = db.get_detections(photo["id"], min_conf=0)  # raw, no filter
+    if existing:
+        det_list = [...build...]
+        detection_map[photo["id"]] = det_list
+        detected += 1
+    processed_ids.add(photo["id"])
+    continue
+```
+
+(`db.get_detections` with `min_conf=0` — Task 20 adds the param; for now, keep the existing signature and add the threshold later.)
+
+**Step 4: Run test to verify it passes**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/classify_job.py vireo/tests/test_classify_job.py
+git commit -m "classify: use detector_runs to skip re-detecting empty-scene photos"
+```
+
+---
+
+### Task 17: `pipeline_job._detect_batch` mirrors Task 16
+
+**Files:**
+- Modify: `vireo/pipeline_job.py` (around lines 1283–1358)
+- Test: `vireo/tests/test_pipeline_job.py`
+
+**Step 1: Write failing test**
+
+Same shape as Task 16, but driving `pipeline_job._detect_batch`. Copy/adapt.
+
+**Step 2–4:** Apply the same pattern: `detect_animals(image_path)` → always call `db.save_detections` + `db.record_detector_run`. Update the `already_detected` seeding at the top of the function to use `db.get_detector_run_photo_ids`.
+
+**Step 5: Commit**
+
+```
+git add vireo/pipeline_job.py vireo/tests/test_pipeline_job.py
+git commit -m "pipeline: use detector_runs to skip re-detecting empty-scene photos"
+```
+
+---
+
+## Phase 3 — Classifier write path
+
+### Task 18: Compute `labels_fingerprint` at classifier invocation
+
+**Files:**
+- Modify: `vireo/classify_job.py` (wherever a classifier is invoked — `_classify_detections` and similar). Also `vireo/pipeline_job.py` for the pipeline version.
+- Test: `vireo/tests/test_classify_job.py`
+
+**Step 1: Write failing test**
+
+```python
+def test_classifier_fingerprint_upserted(tmp_path, monkeypatch):
+    """When a classifier runs, the labels fingerprint is upserted."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(folder_id, "a.jpg")
+    det_ids = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+
+    from labels_fingerprint import compute_fingerprint
+    labels = ["Robin", "Sparrow"]
+    expected_fp = compute_fingerprint(labels)
+
+    import classify_job
+    classify_job._record_labels_fingerprint(
+        db, fingerprint=expected_fp, labels=labels,
+        sources=["/tmp/active.txt"],
+    )
+    row = db.conn.execute(
+        "SELECT display_name, label_count FROM labels_fingerprints WHERE fingerprint=?",
+        (expected_fp,),
+    ).fetchone()
+    assert row["label_count"] == 2
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Add to `vireo/classify_job.py`:
+
+```python
+def _record_labels_fingerprint(db, fingerprint, labels, sources):
+    """Populate the labels_fingerprints sidecar. Cosmetic — powers UX lookups."""
+    display = ", ".join(os.path.basename(s) for s in (sources or [])) or None
+    db.upsert_labels_fingerprint(
+        fingerprint=fingerprint,
+        display_name=display,
+        sources=sources,
+        label_count=len(labels or []),
+    )
+```
+
+Wire it into the classifier flow: immediately after `_load_labels` returns, compute `compute_fingerprint(labels)` and call `_record_labels_fingerprint(db, fp, labels, sources=...)`. Keep `fp` in scope for Task 19.
+
+**Step 4: Run test to verify it passes**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/classify_job.py vireo/tests/test_classify_job.py
+git commit -m "classify: compute+record labels fingerprint on classifier run"
+```
+
+---
+
+### Task 19: Gate classifier work on `classifier_runs`
+
+**Files:**
+- Modify: `vireo/classify_job.py` and `vireo/pipeline_job.py`
+- Test: `vireo/tests/test_classify_job.py`
+
+**Step 1: Write failing test**
+
+```python
+def test_classifier_skipped_when_run_already_recorded(tmp_path, monkeypatch):
+    """If (detection, classifier_model, fingerprint) already ran, don't invoke again."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(folder_id, "a.jpg")
+    det_ids = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    det_id = det_ids[0]
+
+    # Pre-seed a classifier run — any subsequent invocation should bail
+    db.record_classifier_run(det_id, "bioclip-2", "abc123", prediction_count=0)
+
+    calls = {"n": 0}
+    def fake_classify(*a, **kw):
+        calls["n"] += 1
+        return []
+    monkeypatch.setattr("classify_job._run_classifier_on_detection", fake_classify)
+
+    import classify_job
+    classify_job._classify_detection_gated(
+        db=db, detection_id=det_id,
+        classifier_model="bioclip-2",
+        labels_fingerprint="abc123",
+        labels=["Robin"], reclassify=False,
+    )
+    assert calls["n"] == 0, "classifier should be skipped when run key exists"
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: FAIL — `_classify_detection_gated` doesn't exist.
+
+**Step 3: Implement**
+
+Add to `vireo/classify_job.py`:
+
+```python
+def _classify_detection_gated(db, detection_id, classifier_model,
+                                labels_fingerprint, labels, reclassify):
+    """Run the classifier only if we haven't already for this triple."""
+    if not reclassify:
+        existing = db.get_classifier_run_keys(detection_id)
+        if (classifier_model, labels_fingerprint) in existing:
+            return []
+    predictions = _run_classifier_on_detection(
+        db, detection_id, classifier_model, labels,
+        labels_fingerprint=labels_fingerprint,
+    )
+    db.record_classifier_run(
+        detection_id, classifier_model, labels_fingerprint,
+        prediction_count=len(predictions),
+    )
+    return predictions
+```
+
+Route all existing classifier invocation sites through this helper. `_run_classifier_on_detection` replaces the ad-hoc body that currently builds `predictions` rows and calls `db.conn.execute("INSERT INTO predictions ...")`. That insert must now include `classifier_model` and `labels_fingerprint`.
+
+**Step 4: Run test to verify it passes**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/classify_job.py vireo/tests/test_classify_job.py
+git commit -m "classify: gate classifier work on classifier_runs (det, model, fingerprint)"
+```
+
+Also apply the same shape to `vireo/pipeline_job.py` in the same commit or as a follow-up commit `pipeline: gate classifier work on classifier_runs`.
+
+---
+
+## Phase 4 — Read-time threshold filters
+
+### Task 20: `db.get_detections(min_conf)` resolves from workspace
+
+**Files:**
+- Modify: `vireo/db.py`
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing test**
+
+```python
+def test_get_detections_threshold_filter(tmp_path):
+    from db import Database
+    import config as cfg
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(folder_id, "a.jpg")
+    db.save_detections(photo_id, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.05, "category": "animal"},
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}, "confidence": 0.4, "category": "animal"},
+    ], detector_model="megadetector-v6")
+
+    # min_conf=0: returns everything
+    rows = db.get_detections(photo_id, min_conf=0)
+    assert len(rows) == 2
+
+    # min_conf=0.2: only the 0.4 row
+    rows = db.get_detections(photo_id, min_conf=0.2)
+    assert len(rows) == 1
+
+    # min_conf=None pulls from workspace-effective config (default 0.2)
+    rows = db.get_detections(photo_id)  # min_conf defaults resolved from config
+    assert len(rows) == 1
+
+
+def test_get_detections_cross_workspace_read(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws_a = db.create_workspace("A")
+    ws_b = db.create_workspace("B")
+    db.add_workspace_folder(ws_a, folder_id)
+    db.add_workspace_folder(ws_b, folder_id)
+    photo_id = db.add_photo(folder_id, "a.jpg")
+
+    db._active_workspace_id = ws_a
+    db.save_detections(photo_id, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"},
+    ], detector_model="megadetector-v6")
+
+    db._active_workspace_id = ws_b
+    rows = db.get_detections(photo_id, min_conf=0)
+    assert len(rows) == 1
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Replace existing `get_detections`:
+
+```python
+def get_detections(self, photo_id, min_conf=None, detector_model=None):
+    """Return all boxes for a photo above `min_conf`, globally.
+
+    `min_conf=None` pulls `detector_confidence` from workspace-effective config.
+    `min_conf=0` returns raw. `detector_model=None` returns all models.
+    """
+    if min_conf is None:
+        import config as cfg
+        effective = self.get_effective_config(cfg.load())
+        min_conf = effective.get("detector_confidence", 0.2)
+    q = ("SELECT * FROM detections WHERE photo_id = ? "
+         "AND detector_confidence >= ?")
+    params = [photo_id, min_conf]
+    if detector_model is not None:
+        q += " AND detector_model = ?"
+        params.append(detector_model)
+    q += " ORDER BY detector_confidence DESC"
+    return self.conn.execute(q, params).fetchall()
+```
+
+**Step 4: Run tests to verify they pass**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: get_detections applies threshold at read time, globally"
+```
+
+---
+
+### Task 21: `db.get_detections_for_photos(min_conf)`
+
+Same pattern as Task 20, batch form. Update `vireo/db.py::get_detections_for_photos` to drop `workspace_id` from its WHERE clause and accept `min_conf=None`. Test: cross-workspace read + threshold filter over a batch.
+
+**Commit:** `db: get_detections_for_photos applies threshold at read time, globally`
+
+---
+
+### Task 22: `db.get_predictions_for_detection(classifier filters)`
+
+**Files:**
+- Modify: `vireo/db.py`
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing test**
+
+```python
+def test_get_predictions_for_detection_filters(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(folder_id, "a.jpg")
+    det_id = db.save_detections(photo_id, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+
+    for sp, conf, fp in [("Robin", 0.8, "abc"), ("Sparrow", 0.3, "abc"),
+                          ("Robin", 0.9, "xyz")]:
+        db.conn.execute(
+            """INSERT INTO predictions (detection_id, classifier_model,
+                                         labels_fingerprint, species, confidence)
+               VALUES (?, 'bioclip-2', ?, ?, ?)""",
+            (det_id, fp, sp, conf),
+        )
+    db.conn.commit()
+
+    # All three rows when unfiltered
+    assert len(db.get_predictions_for_detection(det_id, min_classifier_conf=0)) == 3
+    # Only ≥ 0.5
+    assert len(db.get_predictions_for_detection(det_id, min_classifier_conf=0.5)) == 2
+    # Filter by fingerprint
+    by_abc = db.get_predictions_for_detection(det_id, labels_fingerprint="abc", min_classifier_conf=0)
+    assert {r["species"] for r in by_abc} == {"Robin", "Sparrow"}
+```
+
+**Step 2–4:** Implement:
+
+```python
+def get_predictions_for_detection(self, detection_id,
+                                    min_classifier_conf=None,
+                                    classifier_model=None,
+                                    labels_fingerprint=None):
+    if min_classifier_conf is None:
+        import config as cfg
+        effective = self.get_effective_config(cfg.load())
+        min_classifier_conf = effective.get("classifier_confidence", 0.0)
+    q = ("SELECT * FROM predictions WHERE detection_id = ? "
+         "AND confidence >= ?")
+    params = [detection_id, min_classifier_conf]
+    if classifier_model is not None:
+        q += " AND classifier_model = ?"
+        params.append(classifier_model)
+    if labels_fingerprint is not None:
+        q += " AND labels_fingerprint = ?"
+        params.append(labels_fingerprint)
+    q += " ORDER BY confidence DESC"
+    return self.conn.execute(q, params).fetchall()
+```
+
+**Step 5: Commit**
+
+```
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: get_predictions_for_detection with model + fingerprint filters"
+```
+
+---
+
+### Task 23: Update `app.py` detection endpoints to use new filters
+
+**Files:**
+- Modify: `vireo/app.py` — search for `detections` queries (roughly lines 6433, 7042 per earlier grep).
+- Test: `vireo/tests/test_photos_api.py`
+
+**Step 1: Identify all call sites**
+
+Run:
+
+```
+grep -nE "FROM detections|db\.get_detections|get_detections_for_photos" vireo/app.py
+```
+
+Update every `WHERE workspace_id = ?` to drop the clause; if the query needs a threshold filter, use the new helpers instead of inline SQL.
+
+**Step 2: Adjust tests + API to assert read-time filtering works**
+
+Pick one representative test in `vireo/tests/test_photos_api.py` that exercises `/api/photos/<id>/detections` or similar, and assert that lowering `detector_confidence` in workspace config changes the returned count without rewriting any rows.
+
+**Step 3: Run the full test suite**
+
+```
+python -m pytest vireo/tests/ tests/ -v
+```
+
+**Step 4: Commit**
+
+```
+git add vireo/app.py vireo/tests/test_photos_api.py
+git commit -m "api: route detection/prediction reads through global threshold helpers"
+```
+
+---
+
+### Task 24: Update `pipeline.py` subject-crop queries
+
+**Files:**
+- Modify: `vireo/pipeline.py` (subject-crop extraction + detection-driven queries)
+- Test: `vireo/tests/test_pipeline.py`
+
+Walk every `SELECT ... FROM detections` / `JOIN detections`, drop `workspace_id` predicates, and add `detector_confidence >= ?` resolved from the workspace-effective config. Commit:
+
+```
+git add vireo/pipeline.py vireo/tests/test_pipeline.py
+git commit -m "pipeline: filter detections at read time; drop workspace scoping"
+```
+
+---
+
+### Task 25: Update stats / aggregation queries
+
+**Files:**
+- Modify: `vireo/db.py` (all `*stats*`, `get_photos_with_detections_but_no_masks`, `get_photos_by_prediction`, `get_species_counts`, etc.)
+- Test: `vireo/tests/test_db.py`
+
+For each query, the pattern is the same:
+
+- Drop `detections.workspace_id = ?` (it no longer exists).
+- Keep `workspace_folders.workspace_id = ?` to scope *photos* to the active workspace.
+- Add `detections.detector_confidence >= ?` (or predictions equivalent) with threshold resolved from workspace config.
+- For prediction review joins, `LEFT JOIN prediction_review pr ON pr.prediction_id = p.id AND pr.workspace_id = ?` and treat `pr.status IS NULL` as `'pending'`.
+
+Landmarks to convert (from the earlier grep):
+- `get_prediction_stats` (line ~2282)
+- `get_photos_by_prediction` (line ~2300)
+- `get_species_counts` (line ~2441)
+- `get_folders_with_quality_data` (line ~2871)
+- `get_detection_stats` helpers
+
+Commit:
+
+```
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: workspace-scope queries through workspace_folders only; read-time threshold"
+```
+
+---
+
+## Phase 5 — Polish
+
+### Task 26: Settings stats: "Detections: N photos × M models cached"
+
+**Files:**
+- Modify: `vireo/app.py` (stats/settings endpoint)
+- Modify: `vireo/templates/settings.html`
+- Test: `vireo/tests/test_app.py`
+
+Add `db.get_global_detection_stats()`:
+
+```python
+def get_global_detection_stats(self):
+    r = self.conn.execute(
+        """SELECT COUNT(DISTINCT photo_id) AS photo_count,
+                  COUNT(DISTINCT detector_model) AS model_count
+           FROM detector_runs"""
+    ).fetchone()
+    return {"photo_count": r["photo_count"] or 0,
+            "model_count": r["model_count"] or 0}
+```
+
+Render as "N photos × M models cached" on the settings page. Test asserts the number changes after a scan.
+
+Commit:
+
+```
+git add vireo/db.py vireo/app.py vireo/templates/settings.html vireo/tests/test_app.py
+git commit -m "settings: show global detection cache stats"
+```
+
+---
+
+### Task 27: Changelog + headless API audit
+
+**Files:**
+- Modify: `CHANGELOG.md` or equivalent release notes file
+- Modify: Any headless API handlers that expose `predictions.status` / `individual` / `group_id` — those now read from `prediction_review`.
+
+**Step 1:** Grep:
+
+```
+grep -nE "status.*prediction|prediction.*status|\.individual|\.group_id" vireo/app.py
+```
+
+**Step 2:** For each hit, route through `db.get_review_status` / `db.set_review_status`.
+
+**Step 3:** Add changelog entry:
+
+```markdown
+### Changed
+- **Global detection/classifier cache.** MegaDetector and classifier results
+  are now cached per-photo instead of per-workspace. Switching to a new
+  workspace or changing your detector confidence threshold no longer
+  triggers a full reprocess.
+- **Threshold is now a read-time filter.** Lowering `detector_confidence` in
+  workspace config takes effect immediately; you no longer need to rerun
+  detection to see previously-subthreshold boxes.
+- Legacy detections from prior versions are preserved but pre-filtered. Run
+  "Reclassify" once per folder to regenerate them with the new raw storage
+  if you want to take full advantage of low-threshold browsing.
+```
+
+**Step 4:** Full test suite:
+
+```
+python -m pytest tests/ vireo/tests/ -v
+```
+
+Expected: all green.
+
+**Step 5: Commit**
+
+```
+git add CHANGELOG.md vireo/app.py
+git commit -m "docs: changelog for global detection cache; migrate headless API reads to prediction_review"
+```
+
+---
+
+## Final verification
+
+Before opening a PR:
+
+1. Full pytest: `python -m pytest tests/ vireo/tests/ -v`. Expected: all pass.
+2. Hand-check: scan a folder in workspace A, create workspace B, point at the same folder, open pipeline. Expected: detection + classify phases skip everything, complete near-instantly.
+3. In workspace B, lower `detector_confidence` to 0.05 and reload the browse grid. Expected: more boxes visible immediately, no background job fires.
+4. `gh pr create` against `main`, include the design doc path in the PR description.
+
+## References
+
+- Design: `docs/plans/2026-04-23-detection-storage-redesign-design.md`
+- Key files by phase:
+  - Phase 0/1: `vireo/db.py`, `vireo/tests/test_db.py`
+  - Phase 2: `vireo/detector.py`, `vireo/classify_job.py`, `vireo/pipeline_job.py`
+  - Phase 3: `vireo/classify_job.py`, `vireo/pipeline_job.py`, `vireo/labels_fingerprint.py`
+  - Phase 4: `vireo/db.py`, `vireo/app.py`, `vireo/pipeline.py`
+  - Phase 5: `vireo/app.py`, `vireo/templates/settings.html`, `CHANGELOG.md`

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -20,11 +20,6 @@ def test_workspace_tables_exist(db):
     assert "workspace_folders" in tables
 
 
-def test_detections_has_workspace_id(db):
-    cols = [r[1] for r in db.conn.execute("PRAGMA table_info(detections)").fetchall()]
-    assert "workspace_id" in cols
-
-
 def test_collections_has_workspace_id(db):
     cols = [r[1] for r in db.conn.execute("PRAGMA table_info(collections)").fetchall()]
     assert "workspace_id" in cols
@@ -118,33 +113,28 @@ def db_with_workspace(db):
     return db, ws_id, folder_id, photo_id
 
 
-def test_add_prediction_uses_workspace(db_with_workspace):
-    db, ws_id, _, photo_id = db_with_workspace
-    det_ids = db.save_detections(photo_id, [
-        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
-    ], detector_model="MDV6")
-    db.add_prediction(det_ids[0], "Robin", 0.95, "bioclip")
-    row = db.conn.execute(
-        "SELECT workspace_id FROM detections WHERE id = ?", (det_ids[0],)
-    ).fetchone()
-    assert row["workspace_id"] == ws_id
-
-
 def test_get_predictions_scoped_to_workspace(db_with_workspace):
+    """Predictions are global, but get_predictions() scopes visibility through
+    workspace_folders. A prediction on a photo whose folder is linked only to
+    ws1 is invisible to ws2."""
     db, ws_id, folder_id, photo_id = db_with_workspace
     det_ids1 = db.save_detections(photo_id, [
         {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
     ], detector_model="MDV6")
     db.add_prediction(det_ids1[0], "Robin", 0.95, "bioclip")
-    # Create second workspace with same photo, different prediction
+
+    # Second workspace with a different folder + photo.
     ws2 = db.create_workspace("Other")
-    db.add_workspace_folder(ws2, folder_id)
     db.set_active_workspace(ws2)
-    det_ids2 = db.save_detections(photo_id, [
+    folder2 = db.add_folder("/photos2", name="photos2")
+    db.add_workspace_folder(ws2, folder2)
+    photo2 = db.add_photo(folder2, "bird2.jpg", ".jpg", 1000, 1.0)
+    det_ids2 = db.save_detections(photo2, [
         {"box": {"x": 0.2, "y": 0.2, "w": 0.3, "h": 0.4}, "confidence": 0.8, "category": "animal"}
     ], detector_model="MDV6")
     db.add_prediction(det_ids2[0], "Sparrow", 0.8, "bioclip")
-    # Each workspace sees only its own predictions
+
+    # Each workspace sees only predictions on its own folders' photos.
     preds_ws2 = db.get_predictions()
     assert len(preds_ws2) == 1
     assert preds_ws2[0]["species"] == "Sparrow"
@@ -152,51 +142,6 @@ def test_get_predictions_scoped_to_workspace(db_with_workspace):
     preds_ws1 = db.get_predictions()
     assert len(preds_ws1) == 1
     assert preds_ws1[0]["species"] == "Robin"
-
-
-def test_clear_predictions_scoped_to_workspace(db_with_workspace):
-    db, ws_id, folder_id, photo_id = db_with_workspace
-    det_ids1 = db.save_detections(photo_id, [
-        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
-    ], detector_model="MDV6")
-    db.add_prediction(det_ids1[0], "Robin", 0.95, "bioclip")
-    ws2 = db.create_workspace("Other")
-    db.add_workspace_folder(ws2, folder_id)
-    db.set_active_workspace(ws2)
-    det_ids2 = db.save_detections(photo_id, [
-        {"box": {"x": 0.2, "y": 0.2, "w": 0.3, "h": 0.4}, "confidence": 0.8, "category": "animal"}
-    ], detector_model="MDV6")
-    db.add_prediction(det_ids2[0], "Sparrow", 0.8, "bioclip")
-    # Clear ws2 predictions only
-    db.clear_predictions()
-    assert len(db.get_predictions()) == 0
-    # ws1 predictions untouched
-    db.set_active_workspace(ws_id)
-    assert len(db.get_predictions()) == 1
-
-
-def test_cascade_delete_removes_predictions(db_with_workspace):
-    db, ws_id, _, photo_id = db_with_workspace
-    det_ids = db.save_detections(photo_id, [
-        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
-    ], detector_model="MDV6")
-    db.add_prediction(det_ids[0], "Robin", 0.95, "bioclip")
-    db.delete_workspace(ws_id)
-    # Cascade: workspace -> detections -> predictions
-    count = db.conn.execute("SELECT COUNT(*) FROM predictions").fetchone()[0]
-    assert count == 0
-    det_count = db.conn.execute("SELECT COUNT(*) FROM detections").fetchone()[0]
-    assert det_count == 0
-
-
-def test_save_detections_without_active_workspace_raises(db):
-    folder_id = db.add_folder("/photos", name="photos")
-    photo_id = db.add_photo(folder_id, "bird.jpg", ".jpg", 1000, 1.0)
-    db._active_workspace_id = None  # Clear auto-set workspace
-    with pytest.raises(RuntimeError):
-        db.save_detections(photo_id, [
-            {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
-        ], detector_model="MDV6")
 
 
 # -- Task 5: Workspace-scoped collections --
@@ -472,10 +417,10 @@ def test_migration_from_legacy_db(tmp_path):
     pred_count = db.conn.execute("SELECT COUNT(*) FROM predictions").fetchone()[0]
     assert pred_count == 0
 
-    # Detections table exists with workspace_id
+    # Detections table is global now: has photo_id, no workspace_id
     det_cols = [r[1] for r in db.conn.execute("PRAGMA table_info(detections)").fetchall()]
-    assert "workspace_id" in det_cols
     assert "photo_id" in det_cols
+    assert "workspace_id" not in det_cols
 
     # predictions table now uses detection_id
     pred_cols = [r[1] for r in db.conn.execute("PRAGMA table_info(predictions)").fetchall()]
@@ -861,8 +806,12 @@ def test_keyword_tree_includes_ancestors(db):
 # -- Move folders between workspaces --
 
 
-def test_move_folders_moves_detections_and_pending_changes(db_with_workspace):
-    """move_folders_to_workspace moves folders, detections, and pending_changes."""
+def test_move_folders_moves_pending_changes(db_with_workspace):
+    """move_folders_to_workspace moves folders and pending_changes.
+
+    Detections are now global (no workspace_id), so predictions follow the
+    folder via workspace_folders membership rather than being reassigned.
+    """
     db, ws1, folder_id, photo_id = db_with_workspace
     det_ids = db.save_detections(photo_id, [
         {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
@@ -874,14 +823,13 @@ def test_move_folders_moves_detections_and_pending_changes(db_with_workspace):
 
     result = db.move_folders_to_workspace(ws1, ws2, [folder_id])
     assert result["folders_moved"] == 1
-    assert result["detections_moved"] == 1
     assert result["pending_changes_moved"] == 1
 
     # Folder moved: ws2 has it, ws1 does not
     assert len(db.get_workspace_folders(ws2)) == 1
     assert len(db.get_workspace_folders(ws1)) == 0
 
-    # Detections/predictions moved to ws2
+    # Predictions follow the folder's workspace membership (detections are global).
     db.set_active_workspace(ws2)
     preds = db.get_predictions()
     assert len(preds) == 1

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4091,9 +4091,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             """SELECT pr.species, pr.scientific_name, pr.confidence
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
-               WHERE d.photo_id = ? AND d.workspace_id = ?
+               WHERE d.photo_id = ?
                ORDER BY pr.confidence DESC LIMIT 1""",
-            (photo_id, db._active_workspace_id),
+            (photo_id,),
         ).fetchone()
 
         species = pred["species"] if pred else ""
@@ -4184,9 +4184,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             """SELECT pr.species, pr.scientific_name
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
-               WHERE d.photo_id = ? AND d.workspace_id = ?
+               WHERE d.photo_id = ?
                ORDER BY pr.confidence DESC LIMIT 1""",
-            (photo_id, db._active_workspace_id),
+            (photo_id,),
         ).fetchone()
 
         taxon = data.get("taxon_name") or (pred["scientific_name"] if pred else None) or (pred["species"] if pred else None)
@@ -4252,9 +4252,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 """SELECT pr.species, pr.scientific_name
                    FROM predictions pr
                    JOIN detections d ON d.id = pr.detection_id
-                   WHERE d.photo_id = ? AND d.workspace_id = ?
+                   WHERE d.photo_id = ?
                    ORDER BY pr.confidence DESC LIMIT 1""",
-                (photo_id, db._active_workspace_id),
+                (photo_id,),
             ).fetchone()
 
             taxon = sub.get("taxon_name") or (pred["scientific_name"] if pred else None) or (pred["species"] if pred else None)
@@ -6058,8 +6058,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
                JOIN photos p ON p.id = d.photo_id
-               WHERE pr.species = ? AND d.workspace_id = ? AND p.embedding IS NOT NULL""",
-            (species_name, db._active_workspace_id),
+               WHERE pr.species = ? AND p.embedding IS NOT NULL""",
+            (species_name,),
         ).fetchall()
 
         if len(rows) < 2:
@@ -6168,16 +6168,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_species_list():
         """List all species with prediction counts, for the variant explorer."""
         db = _get_db()
+        # NOTE: `pr.status` is deferred to Task 25 (prediction_review refactor).
+        # For now we only drop the dropped-column `d.workspace_id` predicate so
+        # this endpoint stops throwing "no such column"; the status filter will
+        # be re-wired through prediction_review in Task 25.
         rows = db.conn.execute(
             """SELECT pr.species, COUNT(DISTINCT d.photo_id) as photo_count,
                       pr.taxonomy_order, pr.taxonomy_family, pr.taxonomy_genus,
                       pr.scientific_name
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
-               WHERE pr.status != 'rejected' AND d.workspace_id = ?
                GROUP BY pr.species
-               ORDER BY photo_count DESC""",
-            (db._active_workspace_id,),
+               ORDER BY photo_count DESC"""
         ).fetchall()
         return jsonify([dict(r) for r in rows])
 
@@ -6423,20 +6425,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 coll_photos = thread_db.get_collection_photos(
                     collection_id, per_page=999999
                 )
-                # Filter to photos with detections but no masks
-                ws_id = thread_db._active_workspace_id
+                # Filter to photos with detections but no masks. Detection
+                # threshold is resolved at read time from the workspace's
+                # effective config (detections table is global now).
                 photos = []
                 for p in coll_photos:
                     if p["mask_path"]:
                         continue
-                    det = thread_db.conn.execute(
-                        """SELECT box_x, box_y, box_w, box_h, detector_confidence
-                           FROM detections
-                           WHERE photo_id = ? AND workspace_id = ?
-                           ORDER BY detector_confidence DESC LIMIT 1""",
-                        (p["id"], ws_id),
-                    ).fetchone()
-                    if det:
+                    dets = thread_db.get_detections(p["id"])
+                    if dets:
+                        det = dets[0]
                         photos.append({
                             "id": p["id"],
                             "folder_id": p["folder_id"],
@@ -7037,15 +7035,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not row:
             return json_error("Photo not found", 404)
         result = dict(row)
-        # Get primary detection from detections table
-        det = db.conn.execute(
-            """SELECT box_x, box_y, box_w, box_h, detector_confidence
-               FROM detections
-               WHERE photo_id = ? AND workspace_id = ?
-               ORDER BY detector_confidence DESC LIMIT 1""",
-            (photo_id, db._active_workspace_id),
-        ).fetchone()
-        if det:
+        # Get primary detection from global detections table (threshold
+        # resolved from workspace-effective config inside get_detections).
+        dets = db.get_detections(photo_id)
+        if dets:
+            det = dets[0]
             result["detection_box"] = {
                 "x": det["box_x"], "y": det["box_y"],
                 "w": det["box_w"], "h": det["box_h"],
@@ -7547,35 +7541,34 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         result.pop("detection_box", None)
         result.pop("detection_conf", None)
 
-        # Get primary detection from detections table
-        det = db.conn.execute(
-            """SELECT box_x, box_y, box_w, box_h, detector_confidence
-               FROM detections
-               WHERE photo_id = ? AND workspace_id = ?
-               ORDER BY detector_confidence DESC LIMIT 1""",
-            (photo_id, db._active_workspace_id),
-        ).fetchone()
-        if det:
-            result["detection_box"] = {
-                "x": det["box_x"], "y": det["box_y"],
-                "w": det["box_w"], "h": det["box_h"],
-            }
-            result["detection_conf"] = det["detector_confidence"]
-
-        # Get detections for this photo (from detections table)
+        # Get detections for this photo — threshold resolved at read time
+        # from the workspace-effective config.
         dets = db.get_detections(photo_id)
         result["detections"] = [dict(d) for d in dets]
 
-        # Get predictions for this photo (through detections JOIN)
+        # Primary detection = highest-confidence above threshold.
+        if dets:
+            primary = dets[0]
+            result["detection_box"] = {
+                "x": primary["box_x"], "y": primary["box_y"],
+                "w": primary["box_w"], "h": primary["box_h"],
+            }
+            result["detection_conf"] = primary["detector_confidence"]
+
+        # Get predictions for this photo (through detections JOIN).
+        # NOTE: pr.model / pr.status / pr.group_id / pr.vote_count /
+        # pr.total_votes / pr.individual are deferred to Task 25 (they now
+        # live in prediction_review). For this task we only drop the gone
+        # `d.workspace_id` predicate so the query's join shape is valid.
         preds = db.conn.execute(
-            """SELECT pr.species, pr.confidence, pr.model, pr.category, pr.status,
-                      pr.group_id, pr.vote_count, pr.total_votes, pr.individual,
+            """SELECT pr.species, pr.confidence, pr.classifier_model AS model,
+                      pr.category,
                       d.box_x, d.box_y, d.box_w, d.box_h, d.detector_confidence
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
-               WHERE d.photo_id = ? AND d.workspace_id = ?
+               WHERE d.photo_id = ?
                ORDER BY pr.confidence DESC""",
-            (photo_id, db._active_workspace_id),
+            (photo_id,),
         ).fetchall()
         result["predictions"] = [dict(p) for p in preds]
 
@@ -7630,16 +7623,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if img is None:
             return "Could not load image", 500
 
-        # Get primary detection box from detections table
-        det_row = db.conn.execute(
-            """SELECT box_x, box_y, box_w, box_h
-               FROM detections
-               WHERE photo_id = ? AND workspace_id = ?
-               ORDER BY detector_confidence DESC LIMIT 1""",
-            (photo_id, db._active_workspace_id),
-        ).fetchone()
+        # Get primary detection box — global detections table, threshold
+        # resolved from workspace-effective config in get_detections.
+        dets = db.get_detections(photo_id)
         det_box = None
-        if det_row:
+        if dets:
+            det_row = dets[0]
             det_box = {
                 "x": det_row["box_x"], "y": det_row["box_y"],
                 "w": det_row["box_w"], "h": det_row["box_h"],

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4410,8 +4410,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Use the current-fingerprint helper so a photo with cached
         # predictions from multiple label sets doesn't prefill iNat with
-        # a species from a stale label set.
-        pred = db.get_top_prediction_for_photo(photo_id)
+        # a species from a stale label set. Apply the workspace-effective
+        # detector_confidence floor so we never prefill a taxon from a
+        # detection the UI threshold hides.
+        min_conf = db.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
+        pred = db.get_top_prediction_for_photo(
+            photo_id, min_detector_confidence=min_conf,
+        )
 
         species = pred["species"] if pred else ""
         scientific = pred["scientific_name"] if pred else ""
@@ -4498,9 +4505,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Use overrides from request, or fall back to DB data. The helper
         # picks the highest-confidence prediction from the CURRENT
-        # fingerprint, scoped to the active workspace — submitting a stale
-        # taxon to iNaturalist is permanent and not easily reversible.
-        pred = db.get_top_prediction_for_photo(photo_id)
+        # fingerprint, scoped to the active workspace, and respecting the
+        # workspace-effective detector_confidence floor — submitting a
+        # stale or below-threshold taxon to iNaturalist is permanent and
+        # not easily reversible.
+        min_conf = db.get_effective_config(user_cfg).get(
+            "detector_confidence", 0.2
+        )
+        pred = db.get_top_prediction_for_photo(
+            photo_id, min_detector_confidence=min_conf,
+        )
 
         taxon = data.get("taxon_name") or (pred["scientific_name"] if pred else None) or (pred["species"] if pred else None)
         observed_on = data.get("observed_on") or (photo["timestamp"][:10] if photo["timestamp"] else None)
@@ -4544,6 +4558,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("submissions array is required")
 
         db = _get_db()
+        # Resolve the workspace-effective detector_confidence floor once for
+        # the whole batch — read-time thresholding means below-threshold
+        # detections should never seed an iNat submission.
+        min_conf = db.get_effective_config(user_cfg).get(
+            "detector_confidence", 0.2
+        )
         results = []
         for sub in submissions:
             photo_id = sub.get("photo_id")
@@ -4561,9 +4581,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 results.append({"photo_id": photo_id, "error": "Photo file not found on disk"})
                 continue
 
-            # Current-fingerprint + workspace-scoped top prediction —
-            # avoids submitting a stale-label-set taxon to iNaturalist.
-            pred = db.get_top_prediction_for_photo(photo_id)
+            # Current-fingerprint + workspace-scoped top prediction,
+            # respecting the active detector_confidence floor — avoids
+            # submitting a stale-label-set or now-hidden taxon to iNaturalist.
+            pred = db.get_top_prediction_for_photo(
+                photo_id, min_detector_confidence=min_conf,
+            )
 
             taxon = sub.get("taxon_name") or (pred["scientific_name"] if pred else None) or (pred["species"] if pred else None)
             observed_on = sub.get("observed_on") or (photo["timestamp"][:10] if photo["timestamp"] else None)
@@ -6556,7 +6579,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         filtered at read time by the workspace-effective
         ``detector_confidence`` threshold. Review status is sourced from the
         workspace-scoped ``prediction_review`` table; rejected predictions
-        are excluded.
+        are excluded. Predictions are filtered to the most recent
+        ``labels_fingerprint`` per ``(detection, classifier_model)`` so that
+        stale species from old label sets do not contaminate counts after
+        re-classification.
         """
         db = _get_db()
         import config as cfg
@@ -6577,6 +6603,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                  ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
                WHERE d.detector_confidence >= ?
                  AND COALESCE(pr_rev.status, 'pending') != 'rejected'
+                 AND pr.labels_fingerprint = (
+                    SELECT pr2.labels_fingerprint FROM predictions pr2
+                    WHERE pr2.detection_id = pr.detection_id
+                      AND pr2.classifier_model = pr.classifier_model
+                    ORDER BY pr2.created_at DESC, pr2.id DESC
+                    LIMIT 1
+                 )
                GROUP BY pr.species
                ORDER BY photo_count DESC""",
             (ws, ws, min_conf),

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2220,26 +2220,43 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/predictions/<int:pred_id>/reject", methods=["POST"])
     def api_reject_prediction(pred_id):
         db = _get_db()
+        # Review state lives in prediction_review now; predictions.model is
+        # renamed to classifier_model.  Sibling-alternative rejection goes
+        # through the workspace-scoped review table.
+        ws = db._ws_id()
         pred = db.conn.execute(
-            """SELECT pr.id, pr.species, pr.detection_id, pr.model, d.photo_id
+            """SELECT pr.id, pr.species, pr.detection_id,
+                      pr.classifier_model AS model, d.photo_id
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
                WHERE pr.id = ?""",
             (pred_id,),
         ).fetchone()
-        db.update_prediction_status(pred_id, "rejected")
+        db.update_prediction_status(pred_id, "rejected", _commit=False)
         if pred:
-            # Also reject sibling alternative predictions
-            db.conn.execute(
-                """UPDATE predictions SET status = 'rejected'
-                   WHERE detection_id = ? AND model = ? AND id != ? AND status = 'alternative'""",
-                (pred["detection_id"], pred["model"], pred_id),
-            )
+            # Also reject sibling alternative predictions (same detection +
+            # classifier model, currently 'alternative' in this workspace).
+            sibling_ids = [row["id"] for row in db.conn.execute(
+                """SELECT pr.id
+                   FROM predictions pr
+                   JOIN prediction_review pr_rev
+                     ON pr_rev.prediction_id = pr.id
+                    AND pr_rev.workspace_id = ?
+                   WHERE pr.detection_id = ?
+                     AND pr.classifier_model = ?
+                     AND pr.id != ?
+                     AND pr_rev.status = 'alternative'""",
+                (ws, pred["detection_id"], pred["model"], pred_id),
+            ).fetchall()]
+            for sid in sibling_ids:
+                db.update_prediction_status(sid, "rejected", _commit=False)
             db.conn.commit()
             db.record_edit('prediction_reject',
                            f'Rejected prediction "{pred["species"]}"',
                            'rejected',
                            [{'photo_id': pred['photo_id'], 'old_value': 'pending', 'new_value': 'rejected'}])
+        else:
+            db.conn.commit()
         return jsonify({"ok": True})
 
     @app.route("/api/predictions/group/<group_id>")
@@ -5922,8 +5939,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ws_name = ws["name"] if ws else "unknown"
             folder_count = db.conn.execute("SELECT COUNT(*) FROM folders").fetchone()[0]
             photo_count = db.conn.execute("SELECT COUNT(*) FROM photos").fetchone()[0]
+            # Predictions are global now; workspace scoping happens through
+            # the detection -> photo -> workspace_folders join.
             pred_count = db.conn.execute(
-                "SELECT COUNT(*) FROM predictions WHERE workspace_id = ?",
+                """SELECT COUNT(*) FROM predictions pr
+                   JOIN detections d ON d.id = pr.detection_id
+                   JOIN photos p ON p.id = d.photo_id
+                   JOIN workspace_folders wf
+                     ON wf.folder_id = p.folder_id AND wf.workspace_id = ?""",
                 (db._ws_id(),)
             ).fetchone()[0]
         except Exception:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2436,7 +2436,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ws = db._ws_id()
         pred = db.conn.execute(
             """SELECT pr.id, pr.species, pr.detection_id,
-                      pr.classifier_model AS model, d.photo_id
+                      pr.classifier_model AS model,
+                      pr.labels_fingerprint, d.photo_id
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
                WHERE pr.id = ?""",
@@ -2449,8 +2450,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if pred is None:
             return json_error("prediction not found", 404)
         db.update_prediction_status(pred_id, "rejected", _commit=False)
-        # Also reject sibling alternative predictions (same detection +
-        # classifier model, currently 'alternative' in this workspace).
+        # Also reject sibling alternative predictions for the same
+        # (detection, classifier_model, labels_fingerprint) in this
+        # workspace. Fingerprint scoping matters: without it, rejecting a
+        # prediction from a new label set would rewrite review state for
+        # prior fingerprints' alternatives on the same detection.
         sibling_ids = [row["id"] for row in db.conn.execute(
             """SELECT pr.id
                FROM predictions pr
@@ -2459,9 +2463,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 AND pr_rev.workspace_id = ?
                WHERE pr.detection_id = ?
                  AND pr.classifier_model = ?
+                 AND pr.labels_fingerprint = ?
                  AND pr.id != ?
                  AND pr_rev.status = 'alternative'""",
-            (ws, pred["detection_id"], pred["model"], pred_id),
+            (ws, pred["detection_id"], pred["model"],
+             pred["labels_fingerprint"], pred_id),
         ).fetchall()]
         for sid in sibling_ids:
             db.update_prediction_status(sid, "rejected", _commit=False)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4408,14 +4408,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not photo:
             return json_error("Photo not found", 404)
 
-        pred = db.conn.execute(
-            """SELECT pr.species, pr.scientific_name, pr.confidence
-               FROM predictions pr
-               JOIN detections d ON d.id = pr.detection_id
-               WHERE d.photo_id = ?
-               ORDER BY pr.confidence DESC LIMIT 1""",
-            (photo_id,),
-        ).fetchone()
+        # Use the current-fingerprint helper so a photo with cached
+        # predictions from multiple label sets doesn't prefill iNat with
+        # a species from a stale label set.
+        pred = db.get_top_prediction_for_photo(photo_id)
 
         species = pred["species"] if pred else ""
         scientific = pred["scientific_name"] if pred else ""
@@ -4500,15 +4496,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not os.path.isfile(photo_path):
             return json_error("Photo file not found on disk", 404)
 
-        # Use overrides from request, or fall back to DB data
-        pred = db.conn.execute(
-            """SELECT pr.species, pr.scientific_name
-               FROM predictions pr
-               JOIN detections d ON d.id = pr.detection_id
-               WHERE d.photo_id = ?
-               ORDER BY pr.confidence DESC LIMIT 1""",
-            (photo_id,),
-        ).fetchone()
+        # Use overrides from request, or fall back to DB data. The helper
+        # picks the highest-confidence prediction from the CURRENT
+        # fingerprint, scoped to the active workspace — submitting a stale
+        # taxon to iNaturalist is permanent and not easily reversible.
+        pred = db.get_top_prediction_for_photo(photo_id)
 
         taxon = data.get("taxon_name") or (pred["scientific_name"] if pred else None) or (pred["species"] if pred else None)
         observed_on = data.get("observed_on") or (photo["timestamp"][:10] if photo["timestamp"] else None)
@@ -4569,14 +4561,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 results.append({"photo_id": photo_id, "error": "Photo file not found on disk"})
                 continue
 
-            pred = db.conn.execute(
-                """SELECT pr.species, pr.scientific_name
-                   FROM predictions pr
-                   JOIN detections d ON d.id = pr.detection_id
-                   WHERE d.photo_id = ?
-                   ORDER BY pr.confidence DESC LIMIT 1""",
-                (photo_id,),
-            ).fetchone()
+            # Current-fingerprint + workspace-scoped top prediction —
+            # avoids submitting a stale-label-set taxon to iNaturalist.
+            pred = db.get_top_prediction_for_photo(photo_id)
 
             taxon = sub.get("taxon_name") or (pred["scientific_name"] if pred else None) or (pred["species"] if pred else None)
             observed_on = sub.get("observed_on") or (photo["timestamp"][:10] if photo["timestamp"] else None)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6426,17 +6426,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         import numpy as np
 
         db = _get_db()
+        import config as cfg
+        ws = db._active_workspace_id
+        min_conf = db.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
         distance_threshold = request.args.get("threshold", 0.4, type=float)
 
-        # Find all photos with this species prediction
+        # Find all photos with this species prediction in the active
+        # workspace. Predictions are global but membership in the
+        # workspace is expressed through workspace_folders.
         rows = db.conn.execute(
             """SELECT d.photo_id, p.embedding, p.filename, p.thumb_path,
                       pr.confidence, pr.taxonomy_order, pr.taxonomy_family
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
                JOIN photos p ON p.id = d.photo_id
-               WHERE pr.species = ? AND p.embedding IS NOT NULL""",
-            (species_name,),
+               JOIN workspace_folders wf
+                 ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+               WHERE pr.species = ?
+                 AND p.embedding IS NOT NULL
+                 AND d.detector_confidence >= ?""",
+            (ws, species_name, min_conf),
         ).fetchall()
 
         if len(rows) < 2:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8056,7 +8056,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Get predictions for this photo (through detections JOIN).  Per-
         # workspace review state (status, group_id, individual, vote counts)
         # is left-joined from prediction_review; absent rows are 'pending'.
+        #
+        # Apply the same workspace-effective detector_confidence floor used
+        # by `db.get_detections` above so result["predictions"] stays in
+        # sync with result["detections"]. Otherwise raising the threshold
+        # leaves stale species rows for detections the UI is meant to hide.
+        # Also pin to the most recent labels_fingerprint per
+        # (detection, classifier_model) so a workspace that rotated label
+        # sets doesn't see a debug payload mixing stale and current labels.
+        import config as cfg
         ws = db._active_workspace_id
+        min_conf = db.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
         preds = db.conn.execute(
             """SELECT pr.species, pr.confidence, pr.classifier_model AS model,
                       pr.category,
@@ -8071,8 +8083,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                LEFT JOIN prediction_review pr_rev
                  ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
                WHERE d.photo_id = ?
+                 AND d.detector_confidence >= ?
+                 AND pr.labels_fingerprint = (
+                    SELECT pr2.labels_fingerprint FROM predictions pr2
+                    WHERE pr2.detection_id = pr.detection_id
+                      AND pr2.classifier_model = pr.classifier_model
+                    ORDER BY pr2.created_at DESC, pr2.id DESC
+                    LIMIT 1
+                 )
                ORDER BY pr.confidence DESC""",
-            (ws, photo_id),
+            (ws, photo_id, min_conf),
         ).fetchall()
         result["predictions"] = [dict(p) for p in preds]
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6166,20 +6166,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/api/species/summary")
     def api_species_list():
-        """List all species with prediction counts, for the variant explorer."""
+        """List all species with prediction counts, for the variant explorer.
+
+        Scoped to photos in the active workspace via ``workspace_folders`` and
+        filtered at read time by the workspace-effective
+        ``detector_confidence`` threshold. Review status is sourced from the
+        workspace-scoped ``prediction_review`` table; rejected predictions
+        are excluded.
+        """
         db = _get_db()
-        # NOTE: `pr.status` is deferred to Task 25 (prediction_review refactor).
-        # For now we only drop the dropped-column `d.workspace_id` predicate so
-        # this endpoint stops throwing "no such column"; the status filter will
-        # be re-wired through prediction_review in Task 25.
+        import config as cfg
+        ws = db._active_workspace_id
+        min_conf = db.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
         rows = db.conn.execute(
             """SELECT pr.species, COUNT(DISTINCT d.photo_id) as photo_count,
                       pr.taxonomy_order, pr.taxonomy_family, pr.taxonomy_genus,
                       pr.scientific_name
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
+               JOIN photos p ON p.id = d.photo_id
+               JOIN workspace_folders wf
+                 ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+               LEFT JOIN prediction_review pr_rev
+                 ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
+               WHERE d.detector_confidence >= ?
+                 AND COALESCE(pr_rev.status, 'pending') != 'rejected'
                GROUP BY pr.species
-               ORDER BY photo_count DESC"""
+               ORDER BY photo_count DESC""",
+            (ws, ws, min_conf),
         ).fetchall()
         return jsonify([dict(r) for r in rows])
 
@@ -7555,20 +7571,26 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             }
             result["detection_conf"] = primary["detector_confidence"]
 
-        # Get predictions for this photo (through detections JOIN).
-        # NOTE: pr.model / pr.status / pr.group_id / pr.vote_count /
-        # pr.total_votes / pr.individual are deferred to Task 25 (they now
-        # live in prediction_review). For this task we only drop the gone
-        # `d.workspace_id` predicate so the query's join shape is valid.
+        # Get predictions for this photo (through detections JOIN).  Per-
+        # workspace review state (status, group_id, individual, vote counts)
+        # is left-joined from prediction_review; absent rows are 'pending'.
+        ws = db._active_workspace_id
         preds = db.conn.execute(
             """SELECT pr.species, pr.confidence, pr.classifier_model AS model,
                       pr.category,
+                      COALESCE(pr_rev.status, 'pending') AS status,
+                      pr_rev.individual AS individual,
+                      pr_rev.group_id AS group_id,
+                      pr_rev.vote_count AS vote_count,
+                      pr_rev.total_votes AS total_votes,
                       d.box_x, d.box_y, d.box_w, d.box_h, d.detector_confidence
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
+               LEFT JOIN prediction_review pr_rev
+                 ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
                WHERE d.photo_id = ?
                ORDER BY pr.confidence DESC""",
-            (photo_id,),
+            (ws, photo_id),
         ).fetchall()
         result["predictions"] = [dict(p) for p in preds]
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3042,6 +3042,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "failed": len(failed_tracked),
         })
 
+    @app.route("/api/detection-cache/stats")
+    def api_detection_cache_stats():
+        """Return global detector-cache stats for the settings page.
+
+        `detector_runs` is shared across workspaces, so the numbers do
+        not depend on the active workspace.
+        """
+        db = _get_db()
+        return jsonify(db.get_global_detection_stats())
+
     @app.route("/api/embedding-cache")
     def api_embedding_cache():
         """Return info about cached label embeddings."""

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2442,31 +2442,34 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                WHERE pr.id = ?""",
             (pred_id,),
         ).fetchone()
+        # prediction_review has an FK on prediction_id; writing review state
+        # for a missing pred would raise an IntegrityError and return 500
+        # where the legacy endpoint returned a harmless no-op. Gate the
+        # write on existence so stale IDs stay a clean 404.
+        if pred is None:
+            return json_error("prediction not found", 404)
         db.update_prediction_status(pred_id, "rejected", _commit=False)
-        if pred:
-            # Also reject sibling alternative predictions (same detection +
-            # classifier model, currently 'alternative' in this workspace).
-            sibling_ids = [row["id"] for row in db.conn.execute(
-                """SELECT pr.id
-                   FROM predictions pr
-                   JOIN prediction_review pr_rev
-                     ON pr_rev.prediction_id = pr.id
-                    AND pr_rev.workspace_id = ?
-                   WHERE pr.detection_id = ?
-                     AND pr.classifier_model = ?
-                     AND pr.id != ?
-                     AND pr_rev.status = 'alternative'""",
-                (ws, pred["detection_id"], pred["model"], pred_id),
-            ).fetchall()]
-            for sid in sibling_ids:
-                db.update_prediction_status(sid, "rejected", _commit=False)
-            db.conn.commit()
-            db.record_edit('prediction_reject',
-                           f'Rejected prediction "{pred["species"]}"',
-                           'rejected',
-                           [{'photo_id': pred['photo_id'], 'old_value': 'pending', 'new_value': 'rejected'}])
-        else:
-            db.conn.commit()
+        # Also reject sibling alternative predictions (same detection +
+        # classifier model, currently 'alternative' in this workspace).
+        sibling_ids = [row["id"] for row in db.conn.execute(
+            """SELECT pr.id
+               FROM predictions pr
+               JOIN prediction_review pr_rev
+                 ON pr_rev.prediction_id = pr.id
+                AND pr_rev.workspace_id = ?
+               WHERE pr.detection_id = ?
+                 AND pr.classifier_model = ?
+                 AND pr.id != ?
+                 AND pr_rev.status = 'alternative'""",
+            (ws, pred["detection_id"], pred["model"], pred_id),
+        ).fetchall()]
+        for sid in sibling_ids:
+            db.update_prediction_status(sid, "rejected", _commit=False)
+        db.conn.commit()
+        db.record_edit('prediction_reject',
+                       f'Rejected prediction "{pred["species"]}"',
+                       'rejected',
+                       [{'photo_id': pred['photo_id'], 'old_value': 'pending', 'new_value': 'rejected'}])
         return jsonify({"ok": True})
 
     @app.route("/api/predictions/group/<group_id>")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6455,6 +6455,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Find all photos with this species prediction in the active
         # workspace. Predictions are global but membership in the
         # workspace is expressed through workspace_folders.
+        #
+        # Fingerprint filter: for each (detection, classifier_model) only
+        # surface rows from the most recent labels_fingerprint. Without
+        # this, a workspace that rotated label sets would cluster stale
+        # species rows alongside current ones, distorting cluster
+        # membership / counts / variant labels and duplicating the same
+        # photo embedding.
         rows = db.conn.execute(
             """SELECT d.photo_id, p.embedding, p.filename, p.thumb_path,
                       pr.confidence, pr.taxonomy_order, pr.taxonomy_family
@@ -6465,7 +6472,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                  ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
                WHERE pr.species = ?
                  AND p.embedding IS NOT NULL
-                 AND d.detector_confidence >= ?""",
+                 AND d.detector_confidence >= ?
+                 AND pr.labels_fingerprint = (
+                    SELECT pr2.labels_fingerprint FROM predictions pr2
+                    WHERE pr2.detection_id = pr.detection_id
+                      AND pr2.classifier_model = pr.classifier_model
+                    ORDER BY pr2.created_at DESC, pr2.id DESC
+                    LIMIT 1
+                 )""",
             (ws, species_name, min_conf),
         ).fetchall()
 

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1368,19 +1368,15 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             "Classifying %d photos with '%s' (%s)", total, effective_name, model_str
         )
 
-        if params.reclassify:
-            photo_ids = [p["id"] for p in photos]
-            thread_db.clear_predictions(model=effective_name, collection_photo_ids=photo_ids)
-            # Also clear existing detections so they get re-detected
-            for pid in photo_ids:
-                thread_db.clear_detections(pid)
-            log.info(
-                "Cleared existing predictions and detections for %d photos, model=%s (re-classify)",
-                len(photo_ids),
-                effective_name,
-            )
-
         # Phase 4: Initialize classifier
+        # The reclassify purge (destructive clears of detections + predictions +
+        # cascaded review state) is deferred until AFTER the classifier
+        # initializes. Running it before model load means any weight-load
+        # failure leaves affected photos with no predictions AND no
+        # detections AND no replacement results — shared-folder workspaces
+        # lose their cached state too. Deferring preserves the cache on
+        # setup failure; users see a clean error and their workspace is
+        # unchanged.
         runner.update_step(job["id"], "load_model", status="running")
         if model_type == "timm":
             phase_msg = f"Loading {effective_name} timm model..."
@@ -1431,6 +1427,23 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             job["id"], "load_model", status="completed",
             summary=effective_name,
         )
+
+        # Classifier init succeeded — now it's safe to purge existing
+        # cache for reclassify. Any failure before this point leaves the
+        # cache intact (see comment at the top of this function).
+        if params.reclassify:
+            photo_ids = [p["id"] for p in photos]
+            thread_db.clear_predictions(
+                model=effective_name, collection_photo_ids=photo_ids,
+            )
+            # Also clear existing detections so they get re-detected.
+            for pid in photo_ids:
+                thread_db.clear_detections(pid)
+            log.info(
+                "Cleared existing predictions and detections for %d photos, "
+                "model=%s (re-classify, post-model-load)",
+                len(photo_ids), effective_name,
+            )
 
         # Phase 5: Detect subjects
         runner.update_step(job["id"], "detect", status="running")

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -988,9 +988,16 @@ def _record_batch_classifier_runs(db, batch, model_name, labels_fingerprint, raw
         if did is None or did in seen:
             continue
         seen.add(did)
+        # Only record the run for detections that actually produced a
+        # prediction. A count of 0 means the classifier failed (transient
+        # load error, decode error, etc.) — caching it as "done" would
+        # permanently strand the detection on the next non-reclassify run.
+        n = counts.get(did, 0)
+        if n <= 0:
+            continue
         db.record_classifier_run(
             did, model_name, labels_fingerprint,
-            prediction_count=counts.get(did, 0),
+            prediction_count=n,
         )
 
 

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1155,6 +1155,7 @@ def _store_grouped_predictions(
                         vote_count=cons["vote_count"],
                         total_votes=cons["total_votes"],
                         individual=individual_json,
+                        labels_fingerprint=labels_fingerprint,
                     )
                 else:
                     db.add_prediction(

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1357,12 +1357,17 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         # Phase 6: Classify each photo
         existing_preds = set()
         if not params.reclassify:
-            existing_preds = thread_db.get_existing_prediction_photo_ids(model_name)
+            # Key the photo-level short-circuit on BOTH model and fingerprint.
+            # Keying on model alone would cause workspace label changes to
+            # leave stale predictions until the user forces reclassify.
+            existing_preds = thread_db.get_existing_prediction_photo_ids(
+                model_name, labels_fingerprint=fp,
+            )
             if existing_preds:
                 log.info(
-                    "Skipping %d photos with existing predictions (model=%s)",
-                    len(existing_preds),
-                    model_name,
+                    "Skipping %d photos with existing predictions "
+                    "(model=%s, fingerprint=%s)",
+                    len(existing_preds), model_name, fp,
                 )
 
         job["_start_time"] = time.time()  # reset rate timer for classification phase

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -184,9 +184,11 @@ def _run_classifier_on_detection(db, detection_id, classifier_model, labels,
     Returns the list of prediction dicts that were stored (may be empty).
     """
     if classify_fn is None:
-        # No classifier plugged in — record a zero-result run so the gate's
-        # next call notices a prior attempt.  Used in tests that just exercise
-        # the gating logic without actually running a model.
+        # No classifier plugged in — return [] without side effects. The
+        # gate wrapper treats a zero-prediction return as a failed attempt
+        # and does NOT record a classifier_run row, so the next call will
+        # retry. Used in tests that just exercise the gating logic without
+        # actually running a model.
         return []
 
     predictions = classify_fn() or []
@@ -234,8 +236,14 @@ def _classify_detection_gated(db, detection_id, classifier_model,
 
     The gate is keyed on (detection_id, classifier_model, labels_fingerprint):
     if a row exists in classifier_runs and reclassify is False, the classifier
-    is not invoked. After a successful invocation the classifier_runs row is
-    written (or refreshed) so subsequent passes skip.
+    is not invoked. After a successful invocation that produced at least one
+    prediction, the classifier_runs row is written (or refreshed) so
+    subsequent passes skip.
+
+    Mirrors ``_record_batch_classifier_runs`` and the inline pipeline_job
+    guard: a zero-count run is treated as a failed attempt, not a completed
+    one. Recording it would permanently strand the detection on the next
+    non-reclassify pass — the cache would claim "done" with no rows to show.
     """
     if not reclassify:
         existing = db.get_classifier_run_keys(detection_id)
@@ -246,10 +254,11 @@ def _classify_detection_gated(db, detection_id, classifier_model,
         labels_fingerprint=labels_fingerprint,
         classify_fn=classify_fn,
     )
-    db.record_classifier_run(
-        detection_id, classifier_model, labels_fingerprint,
-        prediction_count=len(predictions),
-    )
+    if predictions:
+        db.record_classifier_run(
+            detection_id, classifier_model, labels_fingerprint,
+            prediction_count=len(predictions),
+        )
     return predictions
 
 

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -972,9 +972,51 @@ def _classify_photos(
                 )
                 full_det_id = full_det_ids[0]
             # Gate check for the synthetic full-image detection too.
+            # Mirror the regular detection branch: when gated, surface the
+            # cached top-1 prediction into raw_results so downstream
+            # grouping/storage still sees it. Without this, non-reclassify
+            # reruns silently drop cached full-image photos even though
+            # those photos were intentionally kept in the cache.
             if not reclassify:
                 run_keys = db.get_classifier_run_keys(full_det_id)
                 if (model_name, fp) in run_keys:
+                    cached = db.get_predictions_for_detection(
+                        full_det_id,
+                        classifier_model=model_name,
+                        labels_fingerprint=fp,
+                        min_classifier_conf=0,
+                    )
+                    if cached:
+                        skipped_existing += 1
+                        top = cached[0]
+                        timestamp = None
+                        if photo["timestamp"]:
+                            try:
+                                timestamp = dt.fromisoformat(photo["timestamp"])
+                            except Exception:
+                                pass
+                        embedding = None
+                        if model_type != "timm":
+                            emb_blob = db.get_photo_embedding(photo["id"])
+                            if emb_blob:
+                                import numpy as np
+                                embedding = np.frombuffer(
+                                    emb_blob, dtype=np.float32,
+                                )
+                        raw_results.append({
+                            "photo": photo,
+                            "detection_id": full_det_id,
+                            "folder_path": folder_path,
+                            "image_path": image_path,
+                            "prediction": top["species"],
+                            "confidence": top["confidence"],
+                            "timestamp": timestamp,
+                            "filename": photo["filename"],
+                            "embedding": embedding,
+                            "taxonomy": None,
+                            "alternatives": [],
+                            "_existing": True,
+                        })
                     continue
             img, folder_path, image_path = _prepare_image(photo, folders, None, vireo_dir=vireo_dir)
             if img is None:

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -859,7 +859,9 @@ def _classify_photos(
                 failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=top_k)
                 batch = []
             skipped_existing += 1
-            pred_row = db.get_prediction_for_photo(photo["id"], model_name)
+            pred_row = db.get_prediction_for_photo(
+                photo["id"], model_name, labels_fingerprint=fp,
+            )
             if pred_row:
                 timestamp = None
                 if photo["timestamp"]:
@@ -926,13 +928,33 @@ def _classify_photos(
                     _record_batch_classifier_runs(db, batch, model_name, fp, raw_results)
                     batch = []
         else:
-            # No detections — create a full-image detection and classify it
-            full_image_det = [{"box": {"x": 0, "y": 0, "w": 1, "h": 1},
-                               "confidence": 0, "category": "animal"}]
-            full_det_ids = db.save_detections(photo["id"], full_image_det,
-                                              detector_model="full-image")
+            # No detections — use (or create) a full-image synthetic detection
+            # to carry the classifier output.
+            #
+            # save_detections() does clear-and-reinsert per
+            # (photo_id, detector_model), so calling it on every pass would
+            # generate a new id each time and cascade-delete prior predictions
+            # and classifier_runs tied to the old id. Reuse the existing
+            # full-image detection when one is already cached, and only
+            # create a fresh one if none exists (or if the caller asked for
+            # a reclassify).
+            # min_conf=0 because the synthetic full-image detection is
+            # written with confidence=0 — the default threshold filter would
+            # hide it.
+            existing_full = db.get_detections(
+                photo["id"], detector_model="full-image", min_conf=0,
+            )
+            if existing_full and not reclassify:
+                full_det_id = existing_full[0]["id"]
+            else:
+                full_image_det = [{"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+                                   "confidence": 0, "category": "animal"}]
+                full_det_ids = db.save_detections(
+                    photo["id"], full_image_det,
+                    detector_model="full-image",
+                )
+                full_det_id = full_det_ids[0]
             # Gate check for the synthetic full-image detection too.
-            full_det_id = full_det_ids[0]
             if not reclassify:
                 run_keys = db.get_classifier_run_keys(full_det_id)
                 if (model_name, fp) in run_keys:

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -171,6 +171,88 @@ def _record_labels_fingerprint(db, fingerprint, labels, sources):
     )
 
 
+def _run_classifier_on_detection(db, detection_id, classifier_model, labels,
+                                  labels_fingerprint, classify_fn=None):
+    """Run the classifier for a single detection and persist results.
+
+    This is a thin adapter that the gate wrapper calls. ``classify_fn`` is an
+    injection seam for the higher-level classify/pipeline code that already
+    has a loaded model bundle and prepared image — it should return a list of
+    prediction dicts that get stored in the ``predictions`` table for this
+    (detection, classifier_model, labels_fingerprint) triple.
+
+    Returns the list of prediction dicts that were stored (may be empty).
+    """
+    if classify_fn is None:
+        # No classifier plugged in — record a zero-result run so the gate's
+        # next call notices a prior attempt.  Used in tests that just exercise
+        # the gating logic without actually running a model.
+        return []
+
+    predictions = classify_fn() or []
+    # Persist predictions with the new (classifier_model, labels_fingerprint)
+    # identity. INSERT OR REPLACE on the UNIQUE
+    # (detection_id, classifier_model, labels_fingerprint, species) so a
+    # re-classify with reclassify=True refreshes the row in place.
+    for pred in predictions:
+        species = pred.get("species")
+        if not species:
+            continue
+        confidence = pred.get("confidence") or pred.get("score")
+        tax = pred.get("taxonomy") or {}
+        db.conn.execute(
+            """INSERT OR REPLACE INTO predictions
+                (detection_id, classifier_model, labels_fingerprint, species,
+                 confidence, category, scientific_name,
+                 taxonomy_kingdom, taxonomy_phylum, taxonomy_class,
+                 taxonomy_order, taxonomy_family, taxonomy_genus)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                detection_id,
+                classifier_model,
+                labels_fingerprint,
+                species,
+                confidence,
+                pred.get("category", "new"),
+                tax.get("scientific_name"),
+                tax.get("kingdom"),
+                tax.get("phylum"),
+                tax.get("class"),
+                tax.get("order"),
+                tax.get("family"),
+                tax.get("genus"),
+            ),
+        )
+    db.conn.commit()
+    return predictions
+
+
+def _classify_detection_gated(db, detection_id, classifier_model,
+                               labels_fingerprint, labels, reclassify,
+                               classify_fn=None):
+    """Run the classifier only if we haven't already for this triple.
+
+    The gate is keyed on (detection_id, classifier_model, labels_fingerprint):
+    if a row exists in classifier_runs and reclassify is False, the classifier
+    is not invoked. After a successful invocation the classifier_runs row is
+    written (or refreshed) so subsequent passes skip.
+    """
+    if not reclassify:
+        existing = db.get_classifier_run_keys(detection_id)
+        if (classifier_model, labels_fingerprint) in existing:
+            return []
+    predictions = _run_classifier_on_detection(
+        db, detection_id, classifier_model, labels,
+        labels_fingerprint=labels_fingerprint,
+        classify_fn=classify_fn,
+    )
+    db.record_classifier_run(
+        detection_id, classifier_model, labels_fingerprint,
+        prediction_count=len(predictions),
+    )
+    return predictions
+
+
 def _resolve_label_sources(params, db):
     """Return list of source file paths used to build the active label set.
 
@@ -715,6 +797,7 @@ def _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=1):
 def _classify_photos(
     photos, folders, detection_map, existing_preds, clf, model_type,
     model_name, runner, job, db, top_k=1, vireo_dir=None,
+    labels_fingerprint=None, reclassify=False,
 ):
     """Classify detections in batches, cropping to each detection's bounding box.
 
@@ -725,9 +808,16 @@ def _classify_photos(
     Images are passed directly to classifiers as PIL objects (no temp file I/O).
     Multiple images are batched into a single forward pass for throughput.
 
+    A per-detection classifier_runs gate keyed on (detection_id, model_name,
+    labels_fingerprint) short-circuits re-work when the same triple already
+    ran. reclassify=True bypasses the gate.
+
     Returns:
         (raw_results, failed_count, skipped_existing_count)
     """
+    # Fall back to the legacy sentinel when the caller didn't compute a
+    # fingerprint — matches the default used by classifier_runs.
+    fp = labels_fingerprint or "legacy"
     from datetime import datetime as dt
 
     if load_image is None:
@@ -808,6 +898,14 @@ def _classify_photos(
         if photo_detections:
             # Classify each detection independently
             for detection in photo_detections:
+                # Classifier-run gate: skip (detection, model, fingerprint)
+                # triples that have already produced results, unless the
+                # caller asked for a reclassify pass.
+                if not reclassify:
+                    run_keys = db.get_classifier_run_keys(detection["id"])
+                    if (model_name, fp) in run_keys:
+                        continue
+
                 img, det_folder_path, det_image_path = _prepare_image(
                     photo, folders, detection, vireo_dir=vireo_dir
                 )
@@ -825,6 +923,7 @@ def _classify_photos(
 
                 if len(batch) >= _BATCH_SIZE:
                     failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=top_k)
+                    _record_batch_classifier_runs(db, batch, model_name, fp, raw_results)
                     batch = []
         else:
             # No detections — create a full-image detection and classify it
@@ -832,6 +931,12 @@ def _classify_photos(
                                "confidence": 0, "category": "animal"}]
             full_det_ids = db.save_detections(photo["id"], full_image_det,
                                               detector_model="full-image")
+            # Gate check for the synthetic full-image detection too.
+            full_det_id = full_det_ids[0]
+            if not reclassify:
+                run_keys = db.get_classifier_run_keys(full_det_id)
+                if (model_name, fp) in run_keys:
+                    continue
             img, folder_path, image_path = _prepare_image(photo, folders, None, vireo_dir=vireo_dir)
             if img is None:
                 failed += 1
@@ -839,7 +944,7 @@ def _classify_photos(
 
             batch.append({
                 "photo": photo,
-                "detection_id": full_det_ids[0],
+                "detection_id": full_det_id,
                 "folder_path": folder_path,
                 "image_path": image_path,
                 "img": img,
@@ -847,13 +952,46 @@ def _classify_photos(
 
             if len(batch) >= _BATCH_SIZE:
                 failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=top_k)
+                _record_batch_classifier_runs(db, batch, model_name, fp, raw_results)
                 batch = []
 
     # Flush remaining images
     if batch:
         failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=top_k)
+        _record_batch_classifier_runs(db, batch, model_name, fp, raw_results)
 
     return raw_results, failed, skipped_existing
+
+
+def _record_batch_classifier_runs(db, batch, model_name, labels_fingerprint, raw_results):
+    """Record classifier_runs rows for every detection in ``batch``.
+
+    ``batch`` is the list of entries that were just passed to _flush_batch;
+    ``raw_results`` may already contain entries from prior batches, so we scope
+    the prediction_count lookup to entries that reference this batch's
+    detection_ids.  Called after _flush_batch has committed predictions so the
+    run row is only written for detections that actually produced output.
+    """
+    if not batch:
+        return
+    # Tally how many raw_results entries reference each detection_id. Entries
+    # without a detection_id (unusual, but possible on synthesized rows) are
+    # ignored. For a per-detection batch this is typically 0 or 1.
+    counts: dict = {}
+    for r in raw_results:
+        did = r.get("detection_id")
+        if did is not None:
+            counts[did] = counts.get(did, 0) + 1
+    seen: set = set()
+    for entry in batch:
+        did = entry.get("detection_id")
+        if did is None or did in seen:
+            continue
+        seen.add(did)
+        db.record_classifier_run(
+            did, model_name, labels_fingerprint,
+            prediction_count=counts.get(did, 0),
+        )
 
 
 def _store_grouped_predictions(
@@ -1240,6 +1378,8 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             db=thread_db,
             top_k=top_k,
             vireo_dir=vireo_dir,
+            labels_fingerprint=fp,
+            reclassify=params.reclassify,
         )
         classified_count = len(raw_results) - skipped_existing
         parts = [f"{classified_count} classified"]

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -864,59 +864,65 @@ def _classify_photos(
         folder_path = folders.get(photo["folder_id"], "")
         image_path = os.path.join(folder_path, photo["filename"])
 
-        if photo["id"] in existing_preds:
-            # Flush pending batch to preserve photo ordering in raw_results
-            if batch:
-                failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=top_k)
-                batch = []
-            skipped_existing += 1
-            pred_row = db.get_prediction_for_photo(
-                photo["id"], model_name, labels_fingerprint=fp,
-            )
-            if pred_row:
-                timestamp = None
-                if photo["timestamp"]:
-                    try:
-                        timestamp = dt.fromisoformat(photo["timestamp"])
-                    except Exception:
-                        pass
-                embedding = None
-                if model_type != "timm":
-                    emb_blob = db.get_photo_embedding(photo["id"])
-                    if emb_blob:
-                        import numpy as np
-
-                        embedding = np.frombuffer(emb_blob, dtype=np.float32)
-                raw_results.append(
-                    {
-                        "photo": photo,
-                        "detection_id": pred_row["detection_id"],
-                        "folder_path": folder_path,
-                        "image_path": image_path,
-                        "prediction": pred_row["species"],
-                        "confidence": pred_row["confidence"],
-                        "timestamp": timestamp,
-                        "filename": photo["filename"],
-                        "embedding": embedding,
-                        "taxonomy": None,
-                        "alternatives": [],
-                        "_existing": True,
-                    }
-                )
-            continue
-
         # Get detections for this photo (list of detection dicts with IDs)
         photo_detections = detection_map.get(photo["id"], [])
 
         if photo_detections:
-            # Classify each detection independently
+            # Classify each detection independently.
+            #
+            # No photo-level short-circuit here: a prior short-circuit that
+            # skipped photos with any cached prediction under (model, fp)
+            # silently dropped newly-surfaced detections after the user
+            # lowered `detector_confidence`, leaving them unclassified
+            # until --reclassify. The per-detection classifier_runs gate
+            # below handles incremental work correctly.
+            timestamp = None
+            if photo["timestamp"]:
+                try:
+                    timestamp = dt.fromisoformat(photo["timestamp"])
+                except Exception:
+                    pass
+
             for detection in photo_detections:
                 # Classifier-run gate: skip (detection, model, fingerprint)
                 # triples that have already produced results, unless the
-                # caller asked for a reclassify pass.
+                # caller asked for a reclassify pass. For gated detections
+                # we still surface the cached top-1 prediction into
+                # raw_results so downstream grouping sees it.
                 if not reclassify:
                     run_keys = db.get_classifier_run_keys(detection["id"])
                     if (model_name, fp) in run_keys:
+                        cached = db.get_predictions_for_detection(
+                            detection["id"],
+                            classifier_model=model_name,
+                            labels_fingerprint=fp,
+                            min_classifier_conf=0,
+                        )
+                        if cached:
+                            skipped_existing += 1
+                            top = cached[0]  # ordered by confidence DESC
+                            embedding = None
+                            if model_type != "timm":
+                                emb_blob = db.get_photo_embedding(photo["id"])
+                                if emb_blob:
+                                    import numpy as np
+                                    embedding = np.frombuffer(
+                                        emb_blob, dtype=np.float32,
+                                    )
+                            raw_results.append({
+                                "photo": photo,
+                                "detection_id": detection["id"],
+                                "folder_path": folder_path,
+                                "image_path": image_path,
+                                "prediction": top["species"],
+                                "confidence": top["confidence"],
+                                "timestamp": timestamp,
+                                "filename": photo["filename"],
+                                "embedding": embedding,
+                                "taxonomy": None,
+                                "alternatives": [],
+                                "_existing": True,
+                            })
                         continue
 
                 img, det_folder_path, det_image_path = _prepare_image(
@@ -1399,21 +1405,13 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             summary=f"{detected} animals detected in {total} photos",
         )
 
-        # Phase 6: Classify each photo
+        # Phase 6: Classify each photo. The per-detection classifier_runs
+        # gate inside _classify_photos skips already-done detections and
+        # still surfaces their cached predictions into raw_results, so a
+        # photo-level short-circuit is both unnecessary and actively
+        # harmful (it hides newly-surfaced detections after the user
+        # lowers detector_confidence).
         existing_preds = set()
-        if not params.reclassify:
-            # Key the photo-level short-circuit on BOTH model and fingerprint.
-            # Keying on model alone would cause workspace label changes to
-            # leave stale predictions until the user forces reclassify.
-            existing_preds = thread_db.get_existing_prediction_photo_ids(
-                model_name, labels_fingerprint=fp,
-            )
-            if existing_preds:
-                log.info(
-                    "Skipping %d photos with existing predictions "
-                    "(model=%s, fingerprint=%s)",
-                    len(existing_preds), model_name, fp,
-                )
 
         job["_start_time"] = time.time()  # reset rate timer for classification phase
 

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -238,19 +238,22 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                     processed_ids.add(photo["id"])
                     continue
 
-            # Resolve threshold lazily on first actual detection call so a
-            # batch where every photo hits the cached/already-detected
-            # short-circuit doesn't need a working config/db at all (the
-            # cached-detections short-circuit test relies on this).
+            # Resolve workspace-effective threshold lazily on first actual
+            # detection call so a batch where every photo hits the
+            # cached/already-detected short-circuit doesn't need a working
+            # config/db at all (the cached-detections short-circuit test
+            # relies on this).
+            #
+            # The threshold is NOT passed to detect_animals — detector writes
+            # everything above RAW_CONF_FLOOR so results can be globally
+            # cached. The effective threshold is applied as a read-time
+            # filter by get_detections / stats queries (Tasks 20-22).
             if det_conf_threshold is None:
                 import config as cfg
-                # Use workspace-effective config so per-workspace overrides
-                # (e.g. bird-photography workspaces lowering the threshold)
-                # are honored, not just the bare global default.
                 effective_cfg = db.get_effective_config(cfg.load())
                 det_conf_threshold = effective_cfg.get("detector_confidence", 0.2)
 
-            detections = detect_animals(image_path, confidence_threshold=det_conf_threshold)
+            detections = detect_animals(image_path)
 
             if detections:
                 detected += 1

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -375,6 +375,16 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
 
             detections = detect_animals(image_path)
 
+            if detections is None:
+                # Detector run itself failed (image decode error, ONNX
+                # error, etc.). Do NOT clear prior detections and do NOT
+                # record a run — otherwise future non-reclassify passes
+                # would skip the photo permanently, leaving it without
+                # detections unless the user forces --reclassify.
+                # The photo stays out of processed_ids so the caller
+                # treats it as "will be retried next pass".
+                continue
+
             if detections:
                 detected += 1
 
@@ -404,16 +414,17 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                 # place and allowing future non-reclassify runs to reuse them.
                 processed_ids.add(photo["id"])
             else:
-                # Intentionally clear any stale rows for this (photo, model) and
-                # record the run with box_count=0 below so reruns skip.
+                # Genuine empty scene (detector ran, produced zero boxes).
+                # Clear any stale rows for this (photo, model) and record
+                # the run below so reruns skip.
                 db.save_detections(
                     photo["id"], [], detector_model="megadetector-v6"
                 )
 
-            # Record the detector run for BOTH cases — boxes-found and
-            # empty-scene. Without this, empty-scene photos would have no
-            # detections row AND no detector_runs row, so the skip check on
-            # the next pass would miss and MegaDetector would re-run forever.
+            # Record the detector run ONLY for successful outcomes —
+            # boxes-found and real-empty-scene. Failures were handled by
+            # the ``is None`` early-continue above and must not poison
+            # the skip set.
             db.record_detector_run(
                 photo["id"], "megadetector-v6", box_count=len(detections)
             )
@@ -1025,8 +1036,15 @@ def _record_batch_classifier_runs(db, batch, model_name, labels_fingerprint, raw
 
 def _store_grouped_predictions(
     raw_results, job_id, model_name, grouping_window, similarity_threshold, tax, db,
+    labels_fingerprint="legacy",
 ):
     """Group results by timestamp/similarity, compute consensus, store to DB.
+
+    ``labels_fingerprint`` is written verbatim onto each prediction row so
+    the fingerprint-aware skip gate (``get_existing_prediction_photo_ids``)
+    actually finds them. Defaulting to ``'legacy'`` would make cache
+    lookups miss and force reclassification on every pass — callers must
+    pass the active fingerprint.
 
     Returns:
         dict with predictions_stored, burst_groups, already_labeled counts.
@@ -1076,6 +1094,7 @@ def _store_grouped_predictions(
                 model=model_name,
                 category=category,
                 taxonomy=tax_hierarchy,
+                labels_fingerprint=labels_fingerprint,
             )
             # Store alternative predictions
             for alt in item.get("alternatives", []):
@@ -1090,6 +1109,7 @@ def _store_grouped_predictions(
                     category=category,
                     status="alternative",
                     taxonomy=alt_tax,
+                    labels_fingerprint=labels_fingerprint,
                 )
             predictions_stored += 1
         else:
@@ -1148,6 +1168,7 @@ def _store_grouped_predictions(
                         total_votes=cons["total_votes"],
                         individual=individual_json,
                         taxonomy=item.get("taxonomy") or cons_hierarchy,
+                        labels_fingerprint=labels_fingerprint,
                     )
                     # Store alternative predictions for this group member
                     for alt in item.get("alternatives", []):
@@ -1162,6 +1183,7 @@ def _store_grouped_predictions(
                             category=category,
                             status="alternative",
                             taxonomy=alt_tax,
+                            labels_fingerprint=labels_fingerprint,
                         )
             predictions_stored += len(group)
 
@@ -1448,6 +1470,7 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             similarity_threshold=params.similarity_threshold,
             tax=tax,
             db=thread_db,
+            labels_fingerprint=fp,
         )
         finalize_parts = [f"{group_result['predictions_stored']} predictions"]
         if group_result["burst_groups"]:

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -160,6 +160,34 @@ def _load_labels(model_type, model_str, labels_file, labels_files, db=None):
     return labels, use_tol
 
 
+def _record_labels_fingerprint(db, fingerprint, labels, sources):
+    """Populate the labels_fingerprints sidecar. Cosmetic — powers UX lookups."""
+    display = ", ".join(os.path.basename(s) for s in (sources or [])) or None
+    db.upsert_labels_fingerprint(
+        fingerprint=fingerprint,
+        display_name=display,
+        sources=sources,
+        label_count=len(labels or []),
+    )
+
+
+def _resolve_label_sources(params, db):
+    """Return list of source file paths used to build the active label set.
+
+    Mirrors the lookup order in _load_labels — but only produces the source
+    paths so the caller can stash them on the labels_fingerprints row.
+    """
+    if params.labels_files and isinstance(params.labels_files, list):
+        return list(params.labels_files)
+    if params.labels_file:
+        return [params.labels_file]
+    ws_labels = db.get_workspace_active_labels() if db else None
+    if ws_labels is not None:
+        return list(ws_labels)
+    active_sets = get_active_labels()
+    return [s.get("labels_file") for s in (active_sets or []) if s.get("labels_file")]
+
+
 def _detect_batch(photos, folders, runner, job, reclassify, db,
                    det_conf_threshold=None, already_detected_ids=None,
                    cached_detections=None):
@@ -1061,6 +1089,14 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             labels_files=params.labels_files,
             db=thread_db,
         )
+        # Compute a content-addressable fingerprint for the active label set.
+        # Kept in scope so downstream classifier_runs writes can record the
+        # exact (classifier_model, labels_fingerprint) that produced a result.
+        from labels_fingerprint import compute_fingerprint
+        fp = compute_fingerprint(labels)
+        label_sources = _resolve_label_sources(params, thread_db)
+        _record_labels_fingerprint(thread_db, fp, labels, sources=label_sources)
+
         tax_summary = "Taxonomy loaded" if tax else "No taxonomy"
         labels_summary = f"{len(labels)} labels" if labels else ("Tree of Life" if use_tol else "no labels")
         runner.update_step(

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -884,11 +884,15 @@ def _classify_photos(
                     pass
 
             for detection in photo_detections:
-                # Classifier-run gate: skip (detection, model, fingerprint)
-                # triples that have already produced results, unless the
-                # caller asked for a reclassify pass. For gated detections
-                # we still surface the cached top-1 prediction into
-                # raw_results so downstream grouping sees it.
+                # Classifier-run gate: if (detection, model, fingerprint)
+                # has a run key AND has cached prediction rows, surface the
+                # cached top-1 and skip inference. If the run key exists
+                # but no cached rows do (e.g. the prior pass stored
+                # `category == 'match'` which is intentionally not written,
+                # or transient ordering between record_classifier_run and
+                # _store_grouped_predictions), DON'T short-circuit —
+                # otherwise the photo is stranded until the user forces
+                # --reclassify. Fall through to re-classify instead.
                 if not reclassify:
                     run_keys = db.get_classifier_run_keys(detection["id"])
                     if (model_name, fp) in run_keys:
@@ -923,7 +927,9 @@ def _classify_photos(
                                 "alternatives": [],
                                 "_existing": True,
                             })
-                        continue
+                            continue
+                        # Run key without cached rows → fall through to
+                        # classify this detection.
 
                 img, det_folder_path, det_image_path = _prepare_image(
                     photo, folders, detection, vireo_dir=vireo_dir
@@ -1017,7 +1023,9 @@ def _classify_photos(
                             "alternatives": [],
                             "_existing": True,
                         })
-                    continue
+                        continue
+                    # Run key without cached rows → fall through to
+                    # re-classify this full-image detection.
             img, folder_path, image_path = _prepare_image(photo, folders, None, vireo_dir=vireo_dir)
             if img is None:
                 failed += 1

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -206,7 +206,11 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
             folder_path = folders.get(photo["folder_id"], "")
             image_path = os.path.join(folder_path, photo["filename"])
 
-            # Skip if already detected (unless reclassifying)
+            # Skip if already detected (unless reclassifying). After the
+            # detector_runs migration, `already_detected_ids` includes
+            # empty-scene photos (box_count=0) — we must not re-invoke
+            # MegaDetector for them either. Either the detector produced
+            # rows (reuse them) or it ran and found nothing (skip entirely).
             if not reclassify and photo["id"] in already_detected_ids:
                 # Prefer cached detections from an earlier model in this
                 # same pipeline run so that model 2+ is bound to the
@@ -220,7 +224,13 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                         detected += 1
                     processed_ids.add(photo["id"])
                     continue
-                existing_dets = db.get_detections(photo["id"])
+                # Pull cached rows if any; an empty result means this photo
+                # was scanned and had no animals, which is still a skip.
+                # (Task 20 will add a min_conf filter to get_detections.)
+                try:
+                    existing_dets = db.get_detections(photo["id"])
+                except Exception:
+                    existing_dets = []
                 if existing_dets:
                     det_list = []
                     for d in existing_dets:
@@ -235,8 +245,8 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                         })
                     detection_map[photo["id"]] = det_list
                     detected += 1
-                    processed_ids.add(photo["id"])
-                    continue
+                processed_ids.add(photo["id"])
+                continue
 
             # Resolve workspace-effective threshold lazily on first actual
             # detection call so a batch where every photo hits the
@@ -260,7 +270,7 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
 
                 # Store ALL detections in the database
                 det_ids = db.save_detections(
-                    photo["id"], detections, detector_model="MegaDetector"
+                    photo["id"], detections, detector_model="megadetector-v6"
                 )
 
                 # Build detection list with database IDs
@@ -283,7 +293,22 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                 # pre-run detection rows for this photo rather than leaving them in
                 # place and allowing future non-reclassify runs to reuse them.
                 processed_ids.add(photo["id"])
+            else:
+                # Intentionally clear any stale rows for this (photo, model) and
+                # record the run with box_count=0 below so reruns skip.
+                db.save_detections(
+                    photo["id"], [], detector_model="megadetector-v6"
+                )
 
+            # Record the detector run for BOTH cases — boxes-found and
+            # empty-scene. Without this, empty-scene photos would have no
+            # detections row AND no detector_runs row, so the skip check on
+            # the next pass would miss and MegaDetector would re-run forever.
+            db.record_detector_run(
+                photo["id"], "megadetector-v6", box_count=len(detections)
+            )
+
+            if detections:
                 # Use highest-confidence detection as primary for quality scoring
                 primary = get_primary_detection(detections)
                 if primary:
@@ -353,9 +378,10 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
     total = len(photos)
 
     # Resolve cached-detection state before running MegaDetector so we can skip
-    # the weight download entirely when every photo already has a detection row.
+    # the weight download entirely when every photo already has a detector_runs
+    # row (including empty-scene rows with box_count=0).
     already_detected_ids = (
-        db.get_existing_detection_photo_ids() if not reclassify else set()
+        db.get_detector_run_photo_ids("megadetector-v6") if not reclassify else set()
     )
 
     if detect_animals is not None and get_primary_detection is not None:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4198,14 +4198,31 @@ class Database:
         self.conn.commit()
         return ids
 
-    def get_detections(self, photo_id):
-        """Get all detections for a photo in the active workspace."""
-        return self.conn.execute(
-            """SELECT * FROM detections
-               WHERE photo_id = ? AND workspace_id = ?
-               ORDER BY detector_confidence DESC""",
-            (photo_id, self._ws_id()),
-        ).fetchall()
+    def get_detections(self, photo_id, min_conf=None, detector_model=None):
+        """Return all boxes for a photo above `min_conf`, globally.
+
+        The detections table is global (no workspace_id). Threshold filtering
+        happens at read time so raw boxes stay cached across workspaces.
+
+        Args:
+            photo_id: the photo
+            min_conf: confidence floor. ``None`` pulls ``detector_confidence``
+                from the active workspace's effective config (default 0.2).
+                ``0`` returns raw rows with no filtering.
+            detector_model: optional — filter to a single detector model.
+        """
+        if min_conf is None:
+            import config as cfg
+            effective = self.get_effective_config(cfg.load())
+            min_conf = effective.get("detector_confidence", 0.2)
+        q = ("SELECT * FROM detections WHERE photo_id = ? "
+             "AND detector_confidence >= ?")
+        params = [photo_id, min_conf]
+        if detector_model is not None:
+            q += " AND detector_model = ?"
+            params.append(detector_model)
+        q += " ORDER BY detector_confidence DESC"
+        return self.conn.execute(q, params).fetchall()
 
     def get_detections_for_photos(self, photo_ids):
         """Return {photo_id: [det_dict, ...]} for a batch of photos.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4551,7 +4551,7 @@ class Database:
             ).fetchall()
         return {r["photo_id"] for r in rows}
 
-    def get_top_prediction_for_photo(self, photo_id):
+    def get_top_prediction_for_photo(self, photo_id, min_detector_confidence=None):
         """Return the highest-confidence *current* prediction for a photo.
 
         "Current" means: workspace-scoped via workspace_folders, and for
@@ -4560,9 +4560,36 @@ class Database:
         prior label sets on the same detection are skipped so callers
         like /api/inat/prepare don't prefill a taxon from an old label set.
 
+        ``min_detector_confidence``: optional read-time threshold applied to
+        the joined detection. With read-time thresholding, predictions tied
+        to detections below the active threshold are visually hidden in the
+        UI; callers like the iNat endpoints should pass the workspace-
+        effective threshold so they don't surface a species from a now-
+        hidden detection.
+
         Returns a dict with ``species``, ``scientific_name``, ``confidence``,
         ``detection_id`` or None if no eligible prediction exists.
         """
+        if min_detector_confidence is None:
+            return self.conn.execute(
+                """SELECT pr.species, pr.scientific_name, pr.confidence,
+                          pr.detection_id
+                   FROM predictions pr
+                   JOIN detections d ON d.id = pr.detection_id
+                   JOIN photos p ON p.id = d.photo_id
+                   JOIN workspace_folders wf
+                     ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                   WHERE d.photo_id = ?
+                     AND pr.labels_fingerprint = (
+                        SELECT pr2.labels_fingerprint FROM predictions pr2
+                        WHERE pr2.detection_id = pr.detection_id
+                          AND pr2.classifier_model = pr.classifier_model
+                        ORDER BY pr2.created_at DESC, pr2.id DESC
+                        LIMIT 1
+                     )
+                   ORDER BY pr.confidence DESC LIMIT 1""",
+                (self._ws_id(), photo_id),
+            ).fetchone()
         return self.conn.execute(
             """SELECT pr.species, pr.scientific_name, pr.confidence,
                       pr.detection_id
@@ -4572,6 +4599,7 @@ class Database:
                JOIN workspace_folders wf
                  ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
                WHERE d.photo_id = ?
+                 AND d.detector_confidence >= ?
                  AND pr.labels_fingerprint = (
                     SELECT pr2.labels_fingerprint FROM predictions pr2
                     WHERE pr2.detection_id = pr.detection_id
@@ -4580,7 +4608,7 @@ class Database:
                     LIMIT 1
                  )
                ORDER BY pr.confidence DESC LIMIT 1""",
-            (self._ws_id(), photo_id),
+            (self._ws_id(), photo_id, min_detector_confidence),
         ).fetchone()
 
     def get_prediction_for_photo(self, photo_id, model, labels_fingerprint=None):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3054,6 +3054,10 @@ class Database:
         # Top species (within filter).  Review status is workspace-scoped via
         # prediction_review; absent rows are treated as 'pending' (which is
         # included — we only want to exclude 'rejected' reviews).
+        # Pin to the most recent labels_fingerprint per
+        # (detection, classifier_model) so a workspace that rotated label
+        # sets doesn't have stale higher-confidence rows from an old
+        # fingerprint dominating the top-species ranking.
         top_species = self.conn.execute(
             f"""WITH best_pred AS (
                     SELECT det.photo_id, pred.species,
@@ -3068,6 +3072,13 @@ class Database:
                      AND pr_rev.workspace_id = ?
                     WHERE det.detector_confidence >= ?
                       AND COALESCE(pr_rev.status, 'pending') != 'rejected'
+                      AND pred.labels_fingerprint = (
+                          SELECT pr2.labels_fingerprint FROM predictions pr2
+                          WHERE pr2.detection_id = pred.detection_id
+                            AND pr2.classifier_model = pred.classifier_model
+                          ORDER BY pr2.created_at DESC, pr2.id DESC
+                          LIMIT 1
+                      )
                 )
                 SELECT bp.species, COUNT(DISTINCT p.id) as count
                 FROM photos p
@@ -3750,6 +3761,13 @@ class Database:
                JOIN predictions pr ON pr.detection_id = d.id
                WHERE p.mask_path IS NOT NULL
                  AND p.eye_tenengrad IS NULL{extra_where}
+                 AND pr.labels_fingerprint = (
+                    SELECT pr2.labels_fingerprint FROM predictions pr2
+                    WHERE pr2.detection_id = pr.detection_id
+                      AND pr2.classifier_model = pr.classifier_model
+                    ORDER BY pr2.created_at DESC, pr2.id DESC
+                    LIMIT 1
+                 )
                ORDER BY p.id,
                         CASE
                             WHEN pr.taxonomy_class IS NOT NULL

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -198,6 +198,43 @@ class Database:
                 UNIQUE(detection_id, model, species)
             );
 
+            CREATE TABLE IF NOT EXISTS detector_runs (
+                photo_id        INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
+                detector_model  TEXT NOT NULL,
+                run_at          TEXT DEFAULT (datetime('now')),
+                box_count       INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (photo_id, detector_model)
+            );
+
+            CREATE TABLE IF NOT EXISTS classifier_runs (
+                detection_id         INTEGER NOT NULL REFERENCES detections(id) ON DELETE CASCADE,
+                classifier_model     TEXT NOT NULL,
+                labels_fingerprint   TEXT NOT NULL,
+                run_at               TEXT DEFAULT (datetime('now')),
+                prediction_count     INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (detection_id, classifier_model, labels_fingerprint)
+            );
+
+            CREATE TABLE IF NOT EXISTS labels_fingerprints (
+                fingerprint    TEXT PRIMARY KEY,
+                display_name   TEXT,
+                sources_json   TEXT,
+                label_count    INTEGER,
+                created_at     TEXT DEFAULT (datetime('now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS prediction_review (
+                prediction_id  INTEGER NOT NULL REFERENCES predictions(id) ON DELETE CASCADE,
+                workspace_id   INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+                status         TEXT NOT NULL DEFAULT 'pending',
+                reviewed_at    TEXT,
+                individual     TEXT,
+                group_id       TEXT,
+                vote_count     INTEGER,
+                total_votes    INTEGER,
+                PRIMARY KEY (prediction_id, workspace_id)
+            );
+
             CREATE TABLE IF NOT EXISTS inat_submissions (
                 id              INTEGER PRIMARY KEY,
                 photo_id        INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
@@ -716,6 +753,14 @@ class Database:
         self.conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_detections_workspace "
             "ON detections(workspace_id)"
+        )
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_classifier_runs_detection "
+            "ON classifier_runs(detection_id)"
+        )
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_prediction_review_workspace "
+            "ON prediction_review(workspace_id)"
         )
         self.conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_predictions_detection "

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -5091,6 +5091,13 @@ class Database:
     def clear_detections(self, photo_id, detector_model=None):
         """Remove detections (and cascaded predictions) for a photo.
 
+        Also clears the matching ``detector_runs`` rows so a subsequent
+        non-reclassify pass actually re-runs MegaDetector. Without this,
+        a reclassify that clears detections but leaves the run key behind
+        (e.g. because model init then failed) would cause future runs to
+        skip detection forever — the gate in ``_detect_subjects`` treats
+        any ``detector_runs`` entry as authoritative.
+
         Global: no workspace scoping. If `detector_model` is None, all
         detector models for this photo are cleared; otherwise only the
         rows for that model.
@@ -5099,9 +5106,16 @@ class Database:
             self.conn.execute(
                 "DELETE FROM detections WHERE photo_id = ?", (photo_id,)
             )
+            self.conn.execute(
+                "DELETE FROM detector_runs WHERE photo_id = ?", (photo_id,)
+            )
         else:
             self.conn.execute(
                 "DELETE FROM detections WHERE photo_id = ? AND detector_model = ?",
+                (photo_id, detector_model),
+            )
+            self.conn.execute(
+                "DELETE FROM detector_runs WHERE photo_id = ? AND detector_model = ?",
                 (photo_id, detector_model),
             )
         self.conn.commit()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1896,16 +1896,22 @@ class Database:
             conditions.append(f"p.folder_id IN ({fph})")
             params.extend(criteria["folder_ids"])
         if "has_predictions" in criteria:
+            # Predictions no longer carry photo_id/workspace_id — they reference
+            # a global detection, which references the photo. Workspace scoping
+            # is already enforced by the outer workspace_folders JOIN, so the
+            # EXISTS only needs to link prediction → detection → this photo.
             if criteria["has_predictions"]:
                 conditions.append(
-                    "EXISTS (SELECT 1 FROM predictions pr WHERE pr.photo_id = p.id AND pr.workspace_id = ?)"
+                    "EXISTS (SELECT 1 FROM predictions pr "
+                    "JOIN detections d ON d.id = pr.detection_id "
+                    "WHERE d.photo_id = p.id)"
                 )
-                params.append(self._ws_id())
             else:
                 conditions.append(
-                    "NOT EXISTS (SELECT 1 FROM predictions pr WHERE pr.photo_id = p.id AND pr.workspace_id = ?)"
+                    "NOT EXISTS (SELECT 1 FROM predictions pr "
+                    "JOIN detections d ON d.id = pr.detection_id "
+                    "WHERE d.photo_id = p.id)"
                 )
-                params.append(self._ws_id())
         if "imported_before" in criteria:
             conditions.append("p.timestamp < ?")
             params.append(criteria["imported_before"])

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -175,28 +175,22 @@ class Database:
             );
 
             CREATE TABLE IF NOT EXISTS predictions (
-                id              INTEGER PRIMARY KEY,
-                detection_id    INTEGER REFERENCES detections(id) ON DELETE CASCADE,
-                species         TEXT,
-                confidence      REAL,
-                model           TEXT,
-                labels_fingerprint TEXT NOT NULL DEFAULT 'legacy',
-                category        TEXT,
-                status          TEXT DEFAULT 'pending',
-                group_id        TEXT,
-                vote_count      INTEGER,
-                total_votes     INTEGER,
-                individual      TEXT,
-                taxonomy_kingdom TEXT,
-                taxonomy_phylum TEXT,
-                taxonomy_class  TEXT,
-                taxonomy_order  TEXT,
-                taxonomy_family TEXT,
-                taxonomy_genus  TEXT,
-                scientific_name TEXT,
-                created_at      TEXT DEFAULT (datetime('now')),
-                reviewed_at     TEXT,
-                UNIQUE(detection_id, model, species)
+                id                   INTEGER PRIMARY KEY,
+                detection_id         INTEGER NOT NULL REFERENCES detections(id) ON DELETE CASCADE,
+                classifier_model     TEXT NOT NULL,
+                labels_fingerprint   TEXT NOT NULL DEFAULT 'legacy',
+                species              TEXT,
+                confidence           REAL,
+                category             TEXT,
+                scientific_name      TEXT,
+                taxonomy_kingdom     TEXT,
+                taxonomy_phylum     TEXT,
+                taxonomy_class       TEXT,
+                taxonomy_order       TEXT,
+                taxonomy_family      TEXT,
+                taxonomy_genus       TEXT,
+                created_at           TEXT DEFAULT (datetime('now')),
+                UNIQUE(detection_id, classifier_model, labels_fingerprint, species)
             );
 
             CREATE TABLE IF NOT EXISTS detector_runs (
@@ -343,13 +337,9 @@ class Database:
             self.conn.execute(
                 "ALTER TABLE keywords ADD COLUMN is_species INTEGER DEFAULT 0"
             )
-        try:
-            self.conn.execute("SELECT group_id FROM predictions LIMIT 0")
-        except sqlite3.OperationalError:
-            self.conn.execute("ALTER TABLE predictions ADD COLUMN group_id TEXT")
-            self.conn.execute("ALTER TABLE predictions ADD COLUMN vote_count INTEGER")
-            self.conn.execute("ALTER TABLE predictions ADD COLUMN total_votes INTEGER")
-            self.conn.execute("ALTER TABLE predictions ADD COLUMN individual TEXT")
+        # group_id/vote_count/total_votes/individual were predictions columns
+        # for group-voting review. Task 12 drops them — review state now lives
+        # in prediction_review. No legacy ALTER re-adds here.
         try:
             self.conn.execute("SELECT sharpness FROM photos LIMIT 0")
         except sqlite3.OperationalError:
@@ -865,6 +855,75 @@ class Database:
             )
             self.conn.commit()
 
+        # Drop review + legacy model columns, rename `model` -> `classifier_model`,
+        # apply new UNIQUE key. Uses create-copy-drop-rename because SQLite
+        # can't drop columns + add constraints atomically.
+        #
+        # Legacy schemas vary: some are missing the taxonomy_* / scientific_name /
+        # category columns (they were added by an ALTER-based migration only).
+        # Substitute NULL for any column that isn't present so the SELECT that
+        # feeds predictions_new doesn't fail with "no such column".
+        #
+        # Foreign keys are turned off for the duration of the rewrite: the
+        # DROP TABLE predictions would otherwise cascade-delete every row in
+        # prediction_review (which Task 11 just backfilled). After the rename,
+        # prediction_review.prediction_id continues to point at the same
+        # integer ids (PRIMARY KEYs are copied verbatim into predictions_new),
+        # so the FK is consistent again.
+        pred_cols = {r[1] for r in self.conn.execute(
+            "PRAGMA table_info(predictions)"
+        ).fetchall()}
+        needs_pred_rewrite = "status" in pred_cols or "model" in pred_cols
+        if needs_pred_rewrite:
+            self.conn.execute("PRAGMA foreign_keys=OFF")
+            def _col_or_null(name: str) -> str:
+                return name if name in pred_cols else "NULL"
+            self.conn.execute("""
+                CREATE TABLE predictions_new (
+                    id                   INTEGER PRIMARY KEY,
+                    detection_id         INTEGER NOT NULL REFERENCES detections(id) ON DELETE CASCADE,
+                    classifier_model     TEXT NOT NULL,
+                    labels_fingerprint   TEXT NOT NULL DEFAULT 'legacy',
+                    species              TEXT,
+                    confidence           REAL,
+                    category             TEXT,
+                    scientific_name      TEXT,
+                    taxonomy_kingdom     TEXT,
+                    taxonomy_phylum      TEXT,
+                    taxonomy_class       TEXT,
+                    taxonomy_order       TEXT,
+                    taxonomy_family      TEXT,
+                    taxonomy_genus       TEXT,
+                    created_at           TEXT DEFAULT (datetime('now')),
+                    UNIQUE(detection_id, classifier_model, labels_fingerprint, species)
+                )
+            """)
+            self.conn.execute(f"""
+                INSERT OR IGNORE INTO predictions_new
+                    (id, detection_id, classifier_model, labels_fingerprint,
+                     species, confidence, category, scientific_name,
+                     taxonomy_kingdom, taxonomy_phylum, taxonomy_class,
+                     taxonomy_order, taxonomy_family, taxonomy_genus, created_at)
+                SELECT id, detection_id,
+                       COALESCE(model, 'unknown'),
+                       COALESCE(labels_fingerprint, 'legacy'),
+                       species, confidence,
+                       {_col_or_null('category')},
+                       {_col_or_null('scientific_name')},
+                       {_col_or_null('taxonomy_kingdom')},
+                       {_col_or_null('taxonomy_phylum')},
+                       {_col_or_null('taxonomy_class')},
+                       {_col_or_null('taxonomy_order')},
+                       {_col_or_null('taxonomy_family')},
+                       {_col_or_null('taxonomy_genus')},
+                       created_at
+                FROM predictions
+            """)
+            self.conn.execute("DROP TABLE predictions")
+            self.conn.execute("ALTER TABLE predictions_new RENAME TO predictions")
+            self.conn.commit()
+            self.conn.execute("PRAGMA foreign_keys=ON")
+
         # Folder health status
         try:
             self.conn.execute("SELECT status FROM folders LIMIT 0")
@@ -917,10 +976,20 @@ class Database:
             "CREATE INDEX IF NOT EXISTS idx_predictions_detection "
             "ON predictions(detection_id)"
         )
+        # Explicit unique index on the predictions identity tuple. The
+        # CREATE TABLE above declares the same UNIQUE, but SQLite's auto-
+        # generated unique index (sqlite_autoindex_*) has NULL `sql` in
+        # sqlite_master, which makes it impossible to assert against in tests
+        # that inspect index SQL. This explicit index gives us a stable name
+        # and a visible CREATE statement.
         self.conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_predictions_status "
-            "ON predictions(status)"
+            "CREATE UNIQUE INDEX IF NOT EXISTS "
+            "idx_predictions_identity "
+            "ON predictions(detection_id, classifier_model, "
+            "labels_fingerprint, species)"
         )
+        # predictions.status was dropped in the legacy-column migration above;
+        # review state lives in prediction_review now, so no status index here.
         self.conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_collections_workspace "
             "ON collections(workspace_id)"

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -736,7 +736,9 @@ class Database:
 
         # Backfill prediction_review from legacy per-prediction review columns.
         # Must run before the detections.workspace_id drop (Task 9) so we can route
-        # each prediction to the correct workspace.
+        # each prediction to the correct workspace. Legacy schemas may be missing
+        # some optional columns (reviewed_at/individual/group_id/vote_count/
+        # total_votes); substitute NULL in that case rather than erroring.
         pred_cols = {r[1] for r in self.conn.execute(
             "PRAGMA table_info(predictions)"
         ).fetchall()}
@@ -744,19 +746,111 @@ class Database:
             "SELECT COUNT(*) AS n FROM prediction_review"
         ).fetchone()["n"]
         if "status" in pred_cols and review_exists == 0:
-            self.conn.execute("""
+            def _col_or_null(name: str) -> str:
+                return f"p.{name}" if name in pred_cols else "NULL"
+            self.conn.execute(f"""
                 INSERT OR IGNORE INTO prediction_review
                     (prediction_id, workspace_id, status, reviewed_at,
                      individual, group_id, vote_count, total_votes)
                 SELECT p.id, d.workspace_id,
                        COALESCE(p.status, 'pending'),
-                       p.reviewed_at, p.individual, p.group_id,
-                       p.vote_count, p.total_votes
+                       {_col_or_null('reviewed_at')},
+                       {_col_or_null('individual')},
+                       {_col_or_null('group_id')},
+                       {_col_or_null('vote_count')},
+                       {_col_or_null('total_votes')}
                 FROM predictions p
                 JOIN detections d ON d.id = p.detection_id
                 WHERE d.workspace_id IS NOT NULL
                   AND COALESCE(p.status, 'pending') <> 'pending'
             """)
+            self.conn.commit()
+
+        # Global-detections migration: drop workspace_id from detections and dedupe
+        # identical boxes that were duplicated across workspaces. Re-point predictions
+        # at the canonical detection id.
+        #
+        # Follows the existing "create new, copy, drop old, rename" pattern used by
+        # the multi-animal migration above. Gated on the `detections` table still
+        # having a workspace_id column.
+        det_cols = {r[1] for r in self.conn.execute(
+            "PRAGMA table_info(detections)"
+        ).fetchall()}
+        if "workspace_id" in det_cols:
+            # Pick the lowest id per group as canonical.
+            self.conn.execute("""
+                CREATE TEMP TABLE detection_canonical AS
+                SELECT MIN(id) AS canonical_id, photo_id,
+                       COALESCE(detector_model, 'megadetector-v6') AS detector_model,
+                       box_x, box_y, box_w, box_h
+                FROM detections
+                GROUP BY photo_id, COALESCE(detector_model, 'megadetector-v6'),
+                         box_x, box_y, box_w, box_h
+            """)
+            # Re-point predictions that reference a non-canonical duplicate.
+            self.conn.execute("""
+                UPDATE predictions
+                SET detection_id = (
+                    SELECT dc.canonical_id
+                    FROM detections d
+                    JOIN detection_canonical dc
+                      ON dc.photo_id       = d.photo_id
+                     AND dc.detector_model = COALESCE(d.detector_model, 'megadetector-v6')
+                     AND dc.box_x = d.box_x AND dc.box_y = d.box_y
+                     AND dc.box_w = d.box_w AND dc.box_h = d.box_h
+                    WHERE d.id = predictions.detection_id
+                )
+                WHERE detection_id IN (
+                    SELECT d.id
+                    FROM detections d
+                    JOIN detection_canonical dc
+                      ON dc.photo_id       = d.photo_id
+                     AND dc.detector_model = COALESCE(d.detector_model, 'megadetector-v6')
+                     AND dc.box_x = d.box_x AND dc.box_y = d.box_y
+                     AND dc.box_w = d.box_w AND dc.box_h = d.box_h
+                    WHERE d.id <> dc.canonical_id
+                )
+            """)
+            # Create new table without workspace_id
+            self.conn.execute("""
+                CREATE TABLE detections_new (
+                    id                   INTEGER PRIMARY KEY,
+                    photo_id             INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
+                    detector_model       TEXT NOT NULL DEFAULT 'megadetector-v6',
+                    box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+                    detector_confidence  REAL,
+                    category             TEXT,
+                    created_at           TEXT DEFAULT (datetime('now'))
+                )
+            """)
+            self.conn.execute("""
+                INSERT INTO detections_new (id, photo_id, detector_model,
+                                            box_x, box_y, box_w, box_h,
+                                            detector_confidence, category, created_at)
+                SELECT d.id, d.photo_id,
+                       COALESCE(d.detector_model, 'megadetector-v6'),
+                       d.box_x, d.box_y, d.box_w, d.box_h,
+                       d.detector_confidence, d.category, d.created_at
+                FROM detections d
+                JOIN detection_canonical dc ON dc.canonical_id = d.id
+            """)
+            self.conn.execute("DROP TABLE detections")
+            self.conn.execute("ALTER TABLE detections_new RENAME TO detections")
+            self.conn.execute("DROP TABLE detection_canonical")
+            # Recreate the indexes (the CREATE INDEX IF NOT EXISTS at the bottom of
+            # __init__ will no-op if they already exist, but indexes tied to the
+            # dropped table are gone).
+            self.conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_detections_photo ON detections(photo_id)"
+            )
+            self.conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_detections_photo_model "
+                "ON detections(photo_id, detector_model)"
+            )
+            self.conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_detections_conf "
+                "ON detections(photo_id, detector_confidence)"
+            )
             self.conn.commit()
 
         # Folder health status
@@ -797,10 +891,8 @@ class Database:
             "CREATE INDEX IF NOT EXISTS idx_detections_photo "
             "ON detections(photo_id)"
         )
-        self.conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_detections_workspace "
-            "ON detections(workspace_id)"
-        )
+        # detections.workspace_id is dropped by the global-detections migration
+        # above, so we no longer create idx_detections_workspace here.
         self.conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_classifier_runs_detection "
             "ON classifier_runs(detection_id)"

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3906,6 +3906,20 @@ class Database:
         ).fetchall()
         return {(r["classifier_model"], r["labels_fingerprint"]) for r in rows}
 
+    def upsert_labels_fingerprint(self, fingerprint, display_name, sources, label_count):
+        import json
+        self.conn.execute(
+            """INSERT INTO labels_fingerprints
+                 (fingerprint, display_name, sources_json, label_count)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(fingerprint)
+               DO UPDATE SET display_name = excluded.display_name,
+                             sources_json = excluded.sources_json,
+                             label_count  = excluded.label_count""",
+            (fingerprint, display_name, json.dumps(sources or []), label_count),
+        )
+        self.conn.commit()
+
     def save_detections(self, photo_id, detections, detector_model=None):
         """Store detection bounding boxes for a photo.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -734,6 +734,31 @@ class Database:
             )
             self.conn.commit()
 
+        # Backfill prediction_review from legacy per-prediction review columns.
+        # Must run before the detections.workspace_id drop (Task 9) so we can route
+        # each prediction to the correct workspace.
+        pred_cols = {r[1] for r in self.conn.execute(
+            "PRAGMA table_info(predictions)"
+        ).fetchall()}
+        review_exists = self.conn.execute(
+            "SELECT COUNT(*) AS n FROM prediction_review"
+        ).fetchone()["n"]
+        if "status" in pred_cols and review_exists == 0:
+            self.conn.execute("""
+                INSERT OR IGNORE INTO prediction_review
+                    (prediction_id, workspace_id, status, reviewed_at,
+                     individual, group_id, vote_count, total_votes)
+                SELECT p.id, d.workspace_id,
+                       COALESCE(p.status, 'pending'),
+                       p.reviewed_at, p.individual, p.group_id,
+                       p.vote_count, p.total_votes
+                FROM predictions p
+                JOIN detections d ON d.id = p.detection_id
+                WHERE d.workspace_id IS NOT NULL
+                  AND COALESCE(p.status, 'pending') <> 'pending'
+            """)
+            self.conn.commit()
+
         # Folder health status
         try:
             self.conn.execute("SELECT status FROM folders LIMIT 0")

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4398,27 +4398,27 @@ class Database:
             run_conds.append(f"d.photo_id IN ({placeholders})")
             run_params.extend(collection_photo_ids)
         run_where = (" WHERE " + " AND ".join(run_conds)) if run_conds else ""
-        # Match by (detection_id, classifier_model, labels_fingerprint)
-        # — delete composite key tuples via rowid equivalents.
-        rows = self.conn.execute(
-            f"""SELECT cr.detection_id, cr.classifier_model,
-                       cr.labels_fingerprint
-                FROM classifier_runs cr
-                JOIN detections d ON d.id = cr.detection_id
-                JOIN photos ph ON ph.id = d.photo_id
-                JOIN workspace_folders wf
-                  ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?{run_where}""",
+        # Single set-based DELETE via a rowid subquery — the previous
+        # SELECT + per-row DELETE loop issued one statement per matching
+        # run, which on a reclassify of a multi-thousand-detection
+        # workspace dominates wall time on the startup-blocking thread.
+        # Match semantics are identical: the subquery shape is the same
+        # (JOIN through detections/photos/workspace_folders, same
+        # optional filters), and rowid uniquely identifies each
+        # classifier_runs row under the implicit-rowid default.
+        self.conn.execute(
+            f"""DELETE FROM classifier_runs
+                WHERE rowid IN (
+                    SELECT cr.rowid
+                    FROM classifier_runs cr
+                    JOIN detections d ON d.id = cr.detection_id
+                    JOIN photos ph ON ph.id = d.photo_id
+                    JOIN workspace_folders wf
+                      ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
+                    {run_where}
+                )""",
             [ws, *run_params],
-        ).fetchall()
-        for r in rows:
-            self.conn.execute(
-                """DELETE FROM classifier_runs
-                   WHERE detection_id = ?
-                     AND classifier_model = ?
-                     AND labels_fingerprint = ?""",
-                (r["detection_id"], r["classifier_model"],
-                 r["labels_fingerprint"]),
-            )
+        )
         self.conn.commit()
 
     def get_predictions(self, photo_ids=None, model=None, status=None):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -843,6 +843,62 @@ class Database:
                 GROUP BY photo_id, COALESCE(detector_model, 'megadetector-v6'),
                          box_x, box_y, box_w, box_h
             """)
+            # Legacy predictions carries UNIQUE(detection_id, model, species).
+            # When the same box was classified in multiple workspaces, each
+            # workspace has its own prediction row. Repointing both to the
+            # canonical detection_id would create a duplicate tuple and trip
+            # the UNIQUE. Preserve per-workspace review state on the survivor
+            # before deleting the loser.
+            #
+            # Only runs on truly legacy schemas (predictions still has the
+            # ``model`` column). Fresh installs go through CREATE with the
+            # new UNIQUE that already includes labels_fingerprint, so there
+            # are no collisions to pre-resolve.
+            legacy_pred_cols = {r[1] for r in self.conn.execute(
+                "PRAGMA table_info(predictions)"
+            ).fetchall()}
+            if "model" in legacy_pred_cols:
+                self.conn.execute("""
+                    CREATE TEMP TABLE predictions_to_dedup AS
+                    SELECT p.id AS loser_id,
+                           (SELECT p2.id FROM predictions p2
+                            WHERE p2.detection_id = dc.canonical_id
+                              AND COALESCE(p2.model, '') = COALESCE(p.model, '')
+                              AND COALESCE(p2.species, '') = COALESCE(p.species, '')
+                            LIMIT 1) AS canonical_pred_id
+                    FROM predictions p
+                    JOIN detections d ON d.id = p.detection_id
+                    JOIN detection_canonical dc
+                      ON dc.photo_id       = d.photo_id
+                     AND dc.detector_model = COALESCE(d.detector_model, 'megadetector-v6')
+                     AND dc.box_x = d.box_x AND dc.box_y = d.box_y
+                     AND dc.box_w = d.box_w AND dc.box_h = d.box_h
+                    WHERE d.id <> dc.canonical_id
+                """)
+                # Move review rows from losers to canonicals so workspace-scoped
+                # status/individual/group_id survive the delete. INSERT OR IGNORE
+                # handles the case where a review row already exists on the
+                # canonical for the same workspace.
+                self.conn.execute("""
+                    INSERT OR IGNORE INTO prediction_review
+                        (prediction_id, workspace_id, status, reviewed_at,
+                         individual, group_id, vote_count, total_votes)
+                    SELECT ptd.canonical_pred_id, pr.workspace_id, pr.status,
+                           pr.reviewed_at, pr.individual, pr.group_id,
+                           pr.vote_count, pr.total_votes
+                    FROM prediction_review pr
+                    JOIN predictions_to_dedup ptd ON ptd.loser_id = pr.prediction_id
+                    WHERE ptd.canonical_pred_id IS NOT NULL
+                """)
+                # Delete the loser predictions whose canonical already covers
+                # (det, model, species) — their prediction_review rows cascade
+                # away, but the matching canonical rows were just created above.
+                self.conn.execute("""
+                    DELETE FROM predictions
+                    WHERE id IN (SELECT loser_id FROM predictions_to_dedup
+                                 WHERE canonical_pred_id IS NOT NULL)
+                """)
+                self.conn.execute("DROP TABLE predictions_to_dedup")
             # Re-point predictions that reference a non-canonical duplicate.
             self.conn.execute("""
                 UPDATE predictions

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3884,6 +3884,28 @@ class Database:
         ).fetchall()
         return {r["photo_id"] for r in rows}
 
+    def record_classifier_run(self, detection_id, classifier_model,
+                               labels_fingerprint, prediction_count):
+        self.conn.execute(
+            """INSERT INTO classifier_runs
+                 (detection_id, classifier_model, labels_fingerprint, prediction_count)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(detection_id, classifier_model, labels_fingerprint)
+               DO UPDATE SET prediction_count = excluded.prediction_count,
+                             run_at = datetime('now')""",
+            (detection_id, classifier_model, labels_fingerprint, prediction_count),
+        )
+        self.conn.commit()
+
+    def get_classifier_run_keys(self, detection_id):
+        rows = self.conn.execute(
+            """SELECT classifier_model, labels_fingerprint
+               FROM classifier_runs
+               WHERE detection_id = ?""",
+            (detection_id,),
+        ).fetchall()
+        return {(r["classifier_model"], r["labels_fingerprint"]) for r in rows}
+
     def save_detections(self, photo_id, detections, detector_model=None):
         """Store detection bounding boxes for a photo.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4332,21 +4332,26 @@ class Database:
         rows = [dict(r) for r in primaries]
         if not rows:
             return rows
-        # Alternatives are correlated by (detection_id, classifier_model):
-        # a detection may have been classified by multiple models (and those
-        # may even share a group), so we must not merge alternatives across
-        # models.  Alternatives are scoped per-workspace through
+        # Alternatives are correlated by
+        # (detection_id, classifier_model, labels_fingerprint): a detection
+        # may have been classified by multiple models or multiple label
+        # sets (and those may share a group), so we must not merge
+        # alternatives across any of those dimensions — otherwise stale
+        # label-set rows would bleed into the group UI's alternatives
+        # column. Alternatives are scoped per-workspace through
         # prediction_review.
-        det_model_pairs = {
-            (r['detection_id'], r.get('model'))
+        det_keys = {
+            (r['detection_id'], r.get('model'), r.get('labels_fingerprint'))
             for r in rows if r.get('detection_id') is not None
         }
-        alts_by_key = {pair: [] for pair in det_model_pairs}
-        det_ids = list({did for did, _ in det_model_pairs})
+        alts_by_key = {k: [] for k in det_keys}
+        det_ids = list({did for did, _, _ in det_keys})
         if det_ids:
             placeholders = ','.join('?' * len(det_ids))
             alt_rows = self.conn.execute(
-                f"""SELECT pr.detection_id, pr.classifier_model AS model,
+                f"""SELECT pr.detection_id,
+                           pr.classifier_model AS model,
+                           pr.labels_fingerprint,
                            pr.species, pr.confidence
                     FROM predictions pr
                     JOIN prediction_review pr_rev
@@ -4357,13 +4362,17 @@ class Database:
                 [ws, *det_ids],
             ).fetchall()
             for a in alt_rows:
-                key = (a['detection_id'], a['model'])
+                key = (a['detection_id'], a['model'], a['labels_fingerprint'])
                 if key in alts_by_key:
                     alts_by_key[key].append(
                         {'species': a['species'], 'confidence': a['confidence']}
                     )
         for r in rows:
-            r['alternatives'] = alts_by_key.get((r.get('detection_id'), r.get('model')), [])
+            r['alternatives'] = alts_by_key.get(
+                (r.get('detection_id'), r.get('model'),
+                 r.get('labels_fingerprint')),
+                [],
+            )
         return rows
 
     def update_predictions_status_by_photo(self, photo_id, status):
@@ -4585,18 +4594,26 @@ class Database:
             return None
 
         try:
-            # Reject sibling predictions for same detection+classifier_model
-            # in this workspace (covers both accepting an alternative and
-            # accepting the top-1).  Review state is workspace-scoped, so we
-            # upsert each row rather than UPDATE the base predictions table.
+            # Reject sibling predictions for the same
+            # (detection, classifier_model, labels_fingerprint) in this
+            # workspace (covers both accepting an alternative and accepting
+            # the top-1). Scoping by fingerprint is critical — without it,
+            # accepting a prediction from a new label set would mark old
+            # label-set rows as rejected, silently rewriting review state
+            # for unrelated fingerprints. Review state is workspace-scoped,
+            # so we upsert each row rather than UPDATE the base predictions
+            # table.
             sibs = self.conn.execute(
                 """SELECT pr.id FROM predictions pr
                    LEFT JOIN prediction_review pr_rev
                      ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
-                   WHERE pr.detection_id = ? AND pr.classifier_model = ?
+                   WHERE pr.detection_id = ?
+                     AND pr.classifier_model = ?
+                     AND pr.labels_fingerprint = ?
                      AND pr.id != ?
                      AND COALESCE(pr_rev.status, 'pending') IN ('pending', 'alternative')""",
-                (ws, pred["detection_id"], pred["model"], prediction_id),
+                (ws, pred["detection_id"], pred["model"],
+                 pred["labels_fingerprint"], prediction_id),
             ).fetchall()
             for s in sibs:
                 self.conn.execute(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2516,6 +2516,13 @@ class Database:
     def get_dashboard_stats(self):
         """Return aggregate statistics for the dashboard."""
         ws = self._ws_id()
+        # Hoisted: multiple queries below need the workspace-effective
+        # detector_confidence to keep classified_count / prediction_status /
+        # detected_count in sync as the threshold moves.
+        import config as cfg
+        min_conf = self.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
 
         top_keywords = self.conn.execute(
             """SELECT k.name, k.is_species, COUNT(pk.photo_id) as photo_count
@@ -2566,6 +2573,12 @@ class Database:
         # Review status lives in prediction_review (workspace-scoped).
         # Left-joining lets us count pending rows (those without a review row)
         # and bucket them into the pending column via COALESCE.
+        #
+        # Filter by detector_confidence so dashboard status counts stay in
+        # sync with what the UI threshold actually shows, and scope to the
+        # most recent labels_fingerprint per (detection, classifier_model)
+        # so stale-label predictions from a prior label set don't drift the
+        # totals away from the active labeling context.
         prediction_status = self.conn.execute(
             """SELECT COALESCE(pr_rev.status, 'pending') AS status,
                       COUNT(*) AS count
@@ -2576,18 +2589,37 @@ class Database:
                  ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
                LEFT JOIN prediction_review pr_rev
                  ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
+               WHERE d.detector_confidence >= ?
+                 AND pr.labels_fingerprint = (
+                    SELECT pr2.labels_fingerprint FROM predictions pr2
+                    WHERE pr2.detection_id = pr.detection_id
+                      AND pr2.classifier_model = pr.classifier_model
+                    ORDER BY pr2.created_at DESC, pr2.id DESC
+                    LIMIT 1
+                 )
                GROUP BY COALESCE(pr_rev.status, 'pending')""",
-            (ws, ws),
+            (ws, ws, min_conf),
         ).fetchall()
 
+        # Same threshold + fingerprint rules as prediction_status above, so
+        # classified_count can't drift above detected_count as the threshold
+        # moves.
         classified_count = self.conn.execute(
             """SELECT COUNT(DISTINCT d.photo_id)
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
                JOIN photos ph ON ph.id = d.photo_id
                JOIN workspace_folders wf
-                 ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?""",
-            (ws,),
+                 ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
+               WHERE d.detector_confidence >= ?
+                 AND pr.labels_fingerprint = (
+                    SELECT pr2.labels_fingerprint FROM predictions pr2
+                    WHERE pr2.detection_id = pr.detection_id
+                      AND pr2.classifier_model = pr.classifier_model
+                    ORDER BY pr2.created_at DESC, pr2.id DESC
+                    LIMIT 1
+                 )""",
+            (ws, min_conf),
         ).fetchone()[0]
 
         photos_by_hour = self.conn.execute(
@@ -2617,10 +2649,7 @@ class Database:
             (ws,),
         ).fetchall()
 
-        import config as cfg
-        min_conf = self.get_effective_config(cfg.load()).get(
-            "detector_confidence", 0.2
-        )
+        # min_conf already hoisted at top of get_dashboard_stats.
         detected_count = self.conn.execute(
             """SELECT COUNT(DISTINCT d.photo_id)
                FROM detections d

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3469,18 +3469,24 @@ class Database:
             "detector_confidence", 0.2
         )
         if folder_ids:
+            # Detections are global post-refactor, so folder filtering alone
+            # leaks photos from folders that belong to other workspaces if
+            # the caller happens to pass foreign folder ids. Explicitly
+            # JOIN workspace_folders to keep this helper workspace-scoped.
             placeholders = ",".join("?" * len(folder_ids))
             rows = self.conn.execute(
                 f"""SELECT p.id, p.folder_id, p.filename,
                            d.box_x, d.box_y, d.box_w, d.box_h,
                            d.detector_confidence
                     FROM photos p
+                    JOIN workspace_folders wf
+                      ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
                     JOIN detections d ON d.photo_id = p.id
                     WHERE p.folder_id IN ({placeholders})
                       AND p.mask_path IS NULL
                       AND d.detector_confidence >= ?
                     ORDER BY p.id, d.detector_confidence DESC""",
-                [*folder_ids, min_conf],
+                [ws_id, *folder_ids, min_conf],
             ).fetchall()
         else:
             rows = self.conn.execute(
@@ -4119,9 +4125,14 @@ class Database:
                 tax.get("scientific_name"),
             ),
         )
-        pred_id = cur.lastrowid
-        if not pred_id:
-            # INSERT IGNORE collided with the UNIQUE key; look up the existing row.
+        # SQLite's ``cur.lastrowid`` stays at the previous successful insert
+        # even when this INSERT OR IGNORE was skipped by the UNIQUE
+        # collision — relying on it silently upserted prediction_review for
+        # the wrong prediction_id. Use rowcount (0 on IGNORE, 1 on insert)
+        # to decide, then always re-query by the unique key.
+        if cur.rowcount == 1:
+            pred_id = cur.lastrowid
+        else:
             row = self.conn.execute(
                 """SELECT id FROM predictions
                    WHERE detection_id = ? AND classifier_model = ?

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1220,11 +1220,13 @@ class Database:
     def move_folders_to_workspace(self, source_ws_id, target_ws_id, folder_ids):
         """Move folders and their workspace-scoped data to another workspace.
 
-        Moves: workspace_folders rows, detections (with child predictions),
-        and pending_changes. Collections and edit_history stay behind.
+        Moves: workspace_folders rows and pending_changes. Detections and
+        predictions are global (no workspace_id), so they follow the folder
+        via workspace_folders membership rather than being reassigned.
+        Collections and edit_history stay behind.
 
         Returns:
-            dict with keys: folders_moved, detections_moved, pending_changes_moved
+            dict with keys: folders_moved, pending_changes_moved
         """
         if not self.get_workspace(source_ws_id):
             raise ValueError(f"Source workspace {source_ws_id} not found")
@@ -1242,20 +1244,11 @@ class Database:
                 )
 
         if not folder_ids:
-            return {"folders_moved": 0, "detections_moved": 0, "pending_changes_moved": 0}
+            return {"folders_moved": 0, "pending_changes_moved": 0}
 
         placeholders = ",".join("?" for _ in folder_ids)
 
         try:
-            # Move detections (predictions follow via detection_id FK)
-            cur = self.conn.execute(
-                f"""UPDATE detections SET workspace_id = ?
-                    WHERE workspace_id = ?
-                    AND photo_id IN (SELECT id FROM photos WHERE folder_id IN ({placeholders}))""",
-                [target_ws_id, source_ws_id] + list(folder_ids),
-            )
-            detections_moved = cur.rowcount
-
             # Move pending_changes
             cur = self.conn.execute(
                 f"""UPDATE pending_changes SET workspace_id = ?
@@ -1289,7 +1282,6 @@ class Database:
 
         return {
             "folders_moved": len(folder_ids),
-            "detections_moved": detections_moved,
             "pending_changes_moved": pending_changes_moved,
         }
 
@@ -5214,13 +5206,12 @@ class Database:
             join_clause += " JOIN photo_keywords pk ON pk.photo_id = p.id"
             join_clause += " JOIN keywords k ON k.id = pk.keyword_id"
         if need_prediction_join:
+            # Detections are global (no workspace_id); workspace scoping is
+            # enforced by the folder_join on workspace_folders below.
             join_clause += (
                 " JOIN detections det ON det.photo_id = p.id"
-                " AND det.workspace_id = ?"
                 " JOIN predictions pred ON pred.detection_id = det.id"
             )
-            # Insert workspace param before the existing condition params
-            params.insert(0, self._ws_id())
 
         # Always join folders for folder-under rules, scoped to workspace
         folder_join = " JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'"

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -868,9 +868,15 @@ class Database:
                 "PRAGMA table_info(predictions)"
             ).fetchall()}
             if "model" in legacy_pred_cols:
+                # Carry canonical_det_id alongside loser/canonical_pred_id
+                # so the loser-vs-loser dedup below can group by the
+                # eventual remap target without re-joining detections.
                 self.conn.execute("""
                     CREATE TEMP TABLE predictions_to_dedup AS
                     SELECT p.id AS loser_id,
+                           p.model AS loser_model,
+                           p.species AS loser_species,
+                           dc.canonical_id AS canonical_det_id,
                            (SELECT p2.id FROM predictions p2
                             WHERE p2.detection_id = dc.canonical_id
                               AND COALESCE(p2.model, '') = COALESCE(p.model, '')
@@ -908,6 +914,56 @@ class Database:
                     WHERE id IN (SELECT loser_id FROM predictions_to_dedup
                                  WHERE canonical_pred_id IS NOT NULL)
                 """)
+                # Loser-vs-loser dedup: when the canonical detection has NO
+                # prediction yet (canonical_pred_id IS NULL) but multiple
+                # loser detections share the same (canonical_det_id, model,
+                # species), the upcoming remap would land all of them on
+                # the same (detection_id, model, species) tuple and trip
+                # legacy UNIQUE. Keep the lowest-id loser per group;
+                # delete the rest. Move their review rows to the survivor
+                # first so per-workspace review state is preserved.
+                self.conn.execute("""
+                    CREATE TEMP TABLE loser_survivors AS
+                    SELECT MIN(loser_id) AS survivor_id,
+                           canonical_det_id,
+                           COALESCE(loser_model, '') AS m_key,
+                           COALESCE(loser_species, '') AS s_key
+                    FROM predictions_to_dedup
+                    WHERE canonical_pred_id IS NULL
+                    GROUP BY canonical_det_id,
+                             COALESCE(loser_model, ''),
+                             COALESCE(loser_species, '')
+                """)
+                self.conn.execute("""
+                    INSERT OR IGNORE INTO prediction_review
+                        (prediction_id, workspace_id, status, reviewed_at,
+                         individual, group_id, vote_count, total_votes)
+                    SELECT ls.survivor_id, pr.workspace_id, pr.status,
+                           pr.reviewed_at, pr.individual, pr.group_id,
+                           pr.vote_count, pr.total_votes
+                    FROM prediction_review pr
+                    JOIN predictions_to_dedup ptd ON ptd.loser_id = pr.prediction_id
+                    JOIN loser_survivors ls
+                      ON ls.canonical_det_id = ptd.canonical_det_id
+                     AND ls.m_key = COALESCE(ptd.loser_model, '')
+                     AND ls.s_key = COALESCE(ptd.loser_species, '')
+                    WHERE ptd.canonical_pred_id IS NULL
+                      AND ptd.loser_id <> ls.survivor_id
+                """)
+                self.conn.execute("""
+                    DELETE FROM predictions
+                    WHERE id IN (
+                        SELECT ptd.loser_id
+                        FROM predictions_to_dedup ptd
+                        JOIN loser_survivors ls
+                          ON ls.canonical_det_id = ptd.canonical_det_id
+                         AND ls.m_key = COALESCE(ptd.loser_model, '')
+                         AND ls.s_key = COALESCE(ptd.loser_species, '')
+                        WHERE ptd.canonical_pred_id IS NULL
+                          AND ptd.loser_id <> ls.survivor_id
+                    )
+                """)
+                self.conn.execute("DROP TABLE loser_survivors")
                 self.conn.execute("DROP TABLE predictions_to_dedup")
             # Re-point predictions that reference a non-canonical duplicate.
             self.conn.execute("""

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4295,39 +4295,45 @@ class Database:
         # labels_fingerprint), so delete by the full composite key, not by
         # detection_id alone — otherwise another fingerprint's run key on
         # the same detection would be wiped too.
+        #
+        # Run for every clear_predictions() call: when model is None we just
+        # built a workspace-wide DELETE on predictions, so leaving the run
+        # keys behind would strand those detections (the (detection, model,
+        # fingerprint) gate would treat them as already classified).
+        run_conds = []
+        run_params = []
         if model is not None:
-            run_conds = ["cr.classifier_model = ?"]
-            run_params = [model]
-            if labels_fingerprint is not None:
-                run_conds.append("cr.labels_fingerprint = ?")
-                run_params.append(labels_fingerprint)
-            if collection_photo_ids is not None:
-                placeholders = ",".join("?" for _ in collection_photo_ids)
-                run_conds.append(f"d.photo_id IN ({placeholders})")
-                run_params.extend(collection_photo_ids)
-            where = " AND ".join(run_conds)
-            # Match by (detection_id, classifier_model, labels_fingerprint)
-            # — delete composite key tuples via rowid equivalents.
-            rows = self.conn.execute(
-                f"""SELECT cr.detection_id, cr.classifier_model,
-                           cr.labels_fingerprint
-                    FROM classifier_runs cr
-                    JOIN detections d ON d.id = cr.detection_id
-                    JOIN photos ph ON ph.id = d.photo_id
-                    JOIN workspace_folders wf
-                      ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
-                    WHERE {where}""",
-                [ws, *run_params],
-            ).fetchall()
-            for r in rows:
-                self.conn.execute(
-                    """DELETE FROM classifier_runs
-                       WHERE detection_id = ?
-                         AND classifier_model = ?
-                         AND labels_fingerprint = ?""",
-                    (r["detection_id"], r["classifier_model"],
-                     r["labels_fingerprint"]),
-                )
+            run_conds.append("cr.classifier_model = ?")
+            run_params.append(model)
+        if labels_fingerprint is not None:
+            run_conds.append("cr.labels_fingerprint = ?")
+            run_params.append(labels_fingerprint)
+        if collection_photo_ids is not None:
+            placeholders = ",".join("?" for _ in collection_photo_ids)
+            run_conds.append(f"d.photo_id IN ({placeholders})")
+            run_params.extend(collection_photo_ids)
+        run_where = (" WHERE " + " AND ".join(run_conds)) if run_conds else ""
+        # Match by (detection_id, classifier_model, labels_fingerprint)
+        # — delete composite key tuples via rowid equivalents.
+        rows = self.conn.execute(
+            f"""SELECT cr.detection_id, cr.classifier_model,
+                       cr.labels_fingerprint
+                FROM classifier_runs cr
+                JOIN detections d ON d.id = cr.detection_id
+                JOIN photos ph ON ph.id = d.photo_id
+                JOIN workspace_folders wf
+                  ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?{run_where}""",
+            [ws, *run_params],
+        ).fetchall()
+        for r in rows:
+            self.conn.execute(
+                """DELETE FROM classifier_runs
+                   WHERE detection_id = ?
+                     AND classifier_model = ?
+                     AND labels_fingerprint = ?""",
+                (r["detection_id"], r["classifier_model"],
+                 r["labels_fingerprint"]),
+            )
         self.conn.commit()
 
     def get_predictions(self, photo_ids=None, model=None, status=None):
@@ -4337,6 +4343,11 @@ class Database:
         per-workspace review state (status, group_id, individual, vote_count)
         is left-joined from ``prediction_review`` so absent rows naturally
         surface as ``status = 'pending'``.
+
+        Predictions are filtered to the most recent ``labels_fingerprint``
+        per ``(detection_id, classifier_model)`` so stale rows from prior
+        label sets don't contaminate ``/api/predictions`` or
+        ``/api/predictions/compare`` after re-classification.
         """
         ws = self._ws_id()
         conditions = ["wf.workspace_id = ?"]
@@ -4351,6 +4362,15 @@ class Database:
         if status:
             conditions.append("COALESCE(pr_rev.status, 'pending') = ?")
             params.append(status)
+        # Latest-fingerprint-per-(detection, classifier_model) filter — same
+        # pattern used by /api/species/summary and get_top_prediction_for_photo.
+        conditions.append(
+            "pr.labels_fingerprint = ("
+            "SELECT pr2.labels_fingerprint FROM predictions pr2 "
+            "WHERE pr2.detection_id = pr.detection_id "
+            "AND pr2.classifier_model = pr.classifier_model "
+            "ORDER BY pr2.created_at DESC, pr2.id DESC LIMIT 1)"
+        )
         where = "WHERE " + " AND ".join(conditions)
         return self.conn.execute(
             f"""SELECT pr.*,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -946,9 +946,24 @@ class Database:
                 FROM detections d
                 JOIN detection_canonical dc ON dc.canonical_id = d.id
             """)
+            # Turn OFF foreign keys before dropping the old detections table.
+            # predictions.detection_id has ON DELETE CASCADE against detections,
+            # so DROP TABLE detections with FKs enabled cascade-deletes every
+            # prediction row (and then prediction_review via its own cascade),
+            # which is irreversible data loss during startup migration. After
+            # RENAME, the predictions.detection_id FK consistently points at
+            # the new table (ids are preserved), so re-enabling FKs is safe.
+            #
+            # PRAGMA foreign_keys is a no-op inside an open transaction, so
+            # commit the pending writes (INSERTs into detections_new, etc.)
+            # first and commit again before re-enabling.
+            self.conn.commit()
+            self.conn.execute("PRAGMA foreign_keys=OFF")
             self.conn.execute("DROP TABLE detections")
             self.conn.execute("ALTER TABLE detections_new RENAME TO detections")
             self.conn.execute("DROP TABLE detection_canonical")
+            self.conn.commit()
+            self.conn.execute("PRAGMA foreign_keys=ON")
             # Recreate the indexes (the CREATE INDEX IF NOT EXISTS at the bottom of
             # __init__ will no-op if they already exist, but indexes tied to the
             # dropped table are gone).
@@ -4449,6 +4464,38 @@ class Database:
                 (self._ws_id(), model, labels_fingerprint),
             ).fetchall()
         return {r["photo_id"] for r in rows}
+
+    def get_top_prediction_for_photo(self, photo_id):
+        """Return the highest-confidence *current* prediction for a photo.
+
+        "Current" means: workspace-scoped via workspace_folders, and for
+        each (detection, classifier_model) only the most recent
+        labels_fingerprint's rows are considered — stale predictions from
+        prior label sets on the same detection are skipped so callers
+        like /api/inat/prepare don't prefill a taxon from an old label set.
+
+        Returns a dict with ``species``, ``scientific_name``, ``confidence``,
+        ``detection_id`` or None if no eligible prediction exists.
+        """
+        return self.conn.execute(
+            """SELECT pr.species, pr.scientific_name, pr.confidence,
+                      pr.detection_id
+               FROM predictions pr
+               JOIN detections d ON d.id = pr.detection_id
+               JOIN photos p ON p.id = d.photo_id
+               JOIN workspace_folders wf
+                 ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+               WHERE d.photo_id = ?
+                 AND pr.labels_fingerprint = (
+                    SELECT pr2.labels_fingerprint FROM predictions pr2
+                    WHERE pr2.detection_id = pr.detection_id
+                      AND pr2.classifier_model = pr.classifier_model
+                    ORDER BY pr2.created_at DESC, pr2.id DESC
+                    LIMIT 1
+                 )
+               ORDER BY pr.confidence DESC LIMIT 1""",
+            (self._ws_id(), photo_id),
+        ).fetchone()
 
     def get_prediction_for_photo(self, photo_id, model, labels_fingerprint=None):
         """Return species, confidence, and detection_id for a photo's prediction.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4272,6 +4272,41 @@ class Database:
             })
         return result
 
+    def get_predictions_for_detection(self, detection_id,
+                                        min_classifier_conf=None,
+                                        classifier_model=None,
+                                        labels_fingerprint=None):
+        """Return cached classifier predictions for a single detection.
+
+        Reads the global ``predictions`` table. Review status (accepted /
+        rejected / pending) lives in ``prediction_review`` and is joined in
+        by callers that need workspace-scoped review state.
+
+        Args:
+            detection_id: the detection whose predictions to fetch.
+            min_classifier_conf: confidence floor. ``None`` resolves to the
+                active workspace's effective ``classifier_confidence`` (0.0
+                if unset). ``0`` returns all rows.
+            classifier_model: optional — filter to a single classifier model.
+            labels_fingerprint: optional — filter to predictions produced
+                against a specific label set.
+        """
+        if min_classifier_conf is None:
+            import config as cfg
+            effective = self.get_effective_config(cfg.load())
+            min_classifier_conf = effective.get("classifier_confidence", 0.0)
+        q = ("SELECT * FROM predictions WHERE detection_id = ? "
+             "AND confidence >= ?")
+        params = [detection_id, min_classifier_conf]
+        if classifier_model is not None:
+            q += " AND classifier_model = ?"
+            params.append(classifier_model)
+        if labels_fingerprint is not None:
+            q += " AND labels_fingerprint = ?"
+            params.append(labels_fingerprint)
+        q += " ORDER BY confidence DESC"
+        return self.conn.execute(q, params).fetchall()
+
     def clear_detections(self, photo_id, detector_model=None):
         """Remove detections (and cascaded predictions) for a photo.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4189,12 +4189,16 @@ class Database:
                     [ws, *collection_photo_ids],
                 )
         else:
-            conditions = ["wf.workspace_id = ?"]
+            # Workspace scoping is already enforced by the JOIN ON clause
+            # (one ? bound to ws below). Keep the WHERE filter list only for
+            # the optional model predicate so the placeholder count matches
+            # the params list.
             params = [ws]
+            where_parts = []
             if model:
-                conditions.append("pr.classifier_model = ?")
+                where_parts.append("pr.classifier_model = ?")
                 params.append(model)
-            where = " AND ".join(conditions)
+            where_clause = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
             self.conn.execute(
                 f"""DELETE FROM predictions WHERE id IN (
                     SELECT pr.id FROM predictions pr
@@ -4202,7 +4206,7 @@ class Database:
                     JOIN photos ph ON ph.id = d.photo_id
                     JOIN workspace_folders wf
                       ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
-                    WHERE {where}
+                    {where_clause}
                 )""",
                 params,
             )
@@ -4384,17 +4388,40 @@ class Database:
         )
         self.conn.commit()
 
-    def get_existing_prediction_photo_ids(self, model):
-        """Return photo_ids with predictions for a model, scoped to the active workspace."""
-        rows = self.conn.execute(
-            """SELECT DISTINCT d.photo_id FROM predictions pr
-               JOIN detections d ON d.id = pr.detection_id
-               JOIN photos p ON p.id = d.photo_id
-               JOIN workspace_folders wf
-                 ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
-               WHERE pr.classifier_model = ?""",
-            (self._ws_id(), model),
-        ).fetchall()
+    def get_existing_prediction_photo_ids(self, model, labels_fingerprint=None):
+        """Return photo_ids with predictions for a (model, fingerprint), scoped to active workspace.
+
+        The cache identity of a prediction is
+        ``(detection_id, classifier_model, labels_fingerprint, species)``, so
+        the photo-level short-circuit in classify_job / pipeline_job must key
+        on both model AND fingerprint. Keying only on model means changing
+        the workspace's label set leaves stale predictions and the classifier
+        is never re-run until the user forces ``reclassify``.
+
+        ``labels_fingerprint=None`` preserves the pre-fingerprint behavior
+        for callers that haven't plumbed the fingerprint through yet.
+        """
+        if labels_fingerprint is None:
+            rows = self.conn.execute(
+                """SELECT DISTINCT d.photo_id FROM predictions pr
+                   JOIN detections d ON d.id = pr.detection_id
+                   JOIN photos p ON p.id = d.photo_id
+                   JOIN workspace_folders wf
+                     ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                   WHERE pr.classifier_model = ?""",
+                (self._ws_id(), model),
+            ).fetchall()
+        else:
+            rows = self.conn.execute(
+                """SELECT DISTINCT d.photo_id FROM predictions pr
+                   JOIN detections d ON d.id = pr.detection_id
+                   JOIN photos p ON p.id = d.photo_id
+                   JOIN workspace_folders wf
+                     ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                   WHERE pr.classifier_model = ?
+                     AND pr.labels_fingerprint = ?""",
+                (self._ws_id(), model, labels_fingerprint),
+            ).fetchall()
         return {r["photo_id"] for r in rows}
 
     def get_prediction_for_photo(self, photo_id, model):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -180,6 +180,7 @@ class Database:
                 species         TEXT,
                 confidence      REAL,
                 model           TEXT,
+                labels_fingerprint TEXT NOT NULL DEFAULT 'legacy',
                 category        TEXT,
                 status          TEXT DEFAULT 'pending',
                 group_id        TEXT,
@@ -850,6 +851,17 @@ class Database:
             self.conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_detections_conf "
                 "ON detections(photo_id, detector_confidence)"
+            )
+            self.conn.commit()
+
+        # Add labels_fingerprint column if missing. Existing rows get 'legacy'.
+        pred_cols = {r[1] for r in self.conn.execute(
+            "PRAGMA table_info(predictions)"
+        ).fetchall()}
+        if "labels_fingerprint" not in pred_cols:
+            self.conn.execute(
+                "ALTER TABLE predictions ADD COLUMN labels_fingerprint TEXT "
+                "NOT NULL DEFAULT 'legacy'"
             )
             self.conn.commit()
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4424,20 +4424,36 @@ class Database:
             ).fetchall()
         return {r["photo_id"] for r in rows}
 
-    def get_prediction_for_photo(self, photo_id, model):
-        """Return species, confidence, and detection_id for a photo's prediction by model, or None.
+    def get_prediction_for_photo(self, photo_id, model, labels_fingerprint=None):
+        """Return species, confidence, and detection_id for a photo's prediction.
 
         Detections and predictions are global; the active workspace is
-        enforced through ``workspace_folders``.
+        enforced through ``workspace_folders``. Since prediction cache
+        identity is (detection, model, fingerprint, species), callers
+        should pass ``labels_fingerprint`` to avoid returning a row
+        written under a different label set. ``labels_fingerprint=None``
+        preserves the pre-refactor behavior (any row for the model).
         """
+        if labels_fingerprint is None:
+            return self.conn.execute(
+                """SELECT pr.species, pr.confidence, pr.detection_id FROM predictions pr
+                   JOIN detections d ON d.id = pr.detection_id
+                   JOIN photos p ON p.id = d.photo_id
+                   JOIN workspace_folders wf
+                     ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                   WHERE d.photo_id = ? AND pr.classifier_model = ?""",
+                (self._ws_id(), photo_id, model),
+            ).fetchone()
         return self.conn.execute(
             """SELECT pr.species, pr.confidence, pr.detection_id FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
                JOIN photos p ON p.id = d.photo_id
                JOIN workspace_folders wf
                  ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
-               WHERE d.photo_id = ? AND pr.classifier_model = ?""",
-            (self._ws_id(), photo_id, model),
+               WHERE d.photo_id = ?
+                 AND pr.classifier_model = ?
+                 AND pr.labels_fingerprint = ?""",
+            (self._ws_id(), photo_id, model, labels_fingerprint),
         ).fetchone()
 
     def get_photo_embedding(self, photo_id):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3920,6 +3920,29 @@ class Database:
         )
         self.conn.commit()
 
+    def get_review_status(self, prediction_id, workspace_id):
+        row = self.conn.execute(
+            """SELECT status FROM prediction_review
+               WHERE prediction_id = ? AND workspace_id = ?""",
+            (prediction_id, workspace_id),
+        ).fetchone()
+        return row["status"] if row else "pending"
+
+    def set_review_status(self, prediction_id, workspace_id, status,
+                           individual=None, group_id=None):
+        self.conn.execute(
+            """INSERT INTO prediction_review
+                 (prediction_id, workspace_id, status, reviewed_at, individual, group_id)
+               VALUES (?, ?, ?, datetime('now'), ?, ?)
+               ON CONFLICT(prediction_id, workspace_id)
+               DO UPDATE SET status      = excluded.status,
+                             reviewed_at = excluded.reviewed_at,
+                             individual  = COALESCE(excluded.individual, individual),
+                             group_id    = COALESCE(excluded.group_id,   group_id)""",
+            (prediction_id, workspace_id, status, individual, group_id),
+        )
+        self.conn.commit()
+
     def save_detections(self, photo_id, detections, detector_model=None):
         """Store detection bounding boxes for a photo.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4522,26 +4522,48 @@ class Database:
         ).fetchall()
         return [(row["id"], row["embedding"]) for row in rows]
 
-    def update_prediction_group_info(self, detection_id, model, group_id, vote_count, total_votes, individual):
-        """Upsert group info for the primary prediction of (detection, classifier_model)
-        in the active workspace's ``prediction_review``.
+    def update_prediction_group_info(self, detection_id, model, group_id,
+                                     vote_count, total_votes, individual,
+                                     labels_fingerprint=None):
+        """Upsert group info for the primary prediction of
+        (detection, classifier_model, labels_fingerprint) in the active
+        workspace's ``prediction_review``.
 
         Alternative rows (review status ``'alternative'``) are intentionally
         skipped so they do not inherit grouping metadata that belongs to the
         primary pick.
+
+        ``labels_fingerprint`` scopes the "primary" pick to one label set;
+        omitting it picks the highest-confidence row across all fingerprints
+        for back-compat with legacy callers, but current callers should
+        always pass the active fingerprint so group metadata doesn't land
+        on a row produced under a stale label set.
         """
         ws = self._ws_id()
-        # Identify the primary prediction row: one per (detection_id, classifier_model),
-        # excluding any prediction already marked 'alternative' in this workspace.
-        row = self.conn.execute(
-            """SELECT pr.id FROM predictions pr
-               LEFT JOIN prediction_review pr_rev
-                 ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
-               WHERE pr.detection_id = ? AND pr.classifier_model = ?
-                 AND COALESCE(pr_rev.status, 'pending') != 'alternative'
-               ORDER BY pr.confidence DESC LIMIT 1""",
-            (ws, detection_id, model),
-        ).fetchone()
+        # Identify the primary prediction row for this (detection, model,
+        # [fingerprint]), excluding any prediction already marked
+        # 'alternative' in this workspace.
+        if labels_fingerprint is not None:
+            row = self.conn.execute(
+                """SELECT pr.id FROM predictions pr
+                   LEFT JOIN prediction_review pr_rev
+                     ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
+                   WHERE pr.detection_id = ? AND pr.classifier_model = ?
+                     AND pr.labels_fingerprint = ?
+                     AND COALESCE(pr_rev.status, 'pending') != 'alternative'
+                   ORDER BY pr.confidence DESC LIMIT 1""",
+                (ws, detection_id, model, labels_fingerprint),
+            ).fetchone()
+        else:
+            row = self.conn.execute(
+                """SELECT pr.id FROM predictions pr
+                   LEFT JOIN prediction_review pr_rev
+                     ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
+                   WHERE pr.detection_id = ? AND pr.classifier_model = ?
+                     AND COALESCE(pr_rev.status, 'pending') != 'alternative'
+                   ORDER BY pr.confidence DESC LIMIT 1""",
+                (ws, detection_id, model),
+            ).fetchone()
         if not row:
             return
         pred_id = row["id"]
@@ -5373,22 +5395,34 @@ class Database:
                 if entry['action_type'] == 'prediction_accept' and old_val:
                     pred_id = int(old_val)
                     ws = self._ws_id()
-                    # Restore all predictions for this detection to pre-accept state
+                    # Restore predictions to pre-accept state. Scope by
+                    # labels_fingerprint too — without it, undoing an accept
+                    # in one label set would flip statuses of predictions
+                    # produced under a different fingerprint and could
+                    # promote the wrong fingerprint's top-confidence row
+                    # back to 'pending'.
                     pred_row = self.conn.execute(
-                        """SELECT detection_id, classifier_model AS model
+                        """SELECT detection_id, classifier_model AS model,
+                                  labels_fingerprint
                            FROM predictions WHERE id = ?""",
                         (pred_id,),
                     ).fetchone()
                     if pred_row:
-                        # Identify every sibling prediction for (detection, classifier_model).
+                        # Identify every sibling prediction for
+                        # (detection, classifier_model, labels_fingerprint).
                         siblings = self.conn.execute(
                             """SELECT id, confidence FROM predictions
-                               WHERE detection_id = ? AND classifier_model = ?
+                               WHERE detection_id = ?
+                                 AND classifier_model = ?
+                                 AND labels_fingerprint = ?
                                ORDER BY confidence DESC""",
-                            (pred_row["detection_id"], pred_row["model"]),
+                            (pred_row["detection_id"], pred_row["model"],
+                             pred_row["labels_fingerprint"]),
                         ).fetchall()
                         # Flip any accepted/rejected review rows in this
-                        # workspace back to 'alternative'.
+                        # workspace back to 'alternative' — scoped to the
+                        # same fingerprint so other label sets' statuses
+                        # are preserved.
                         self.conn.execute(
                             """UPDATE prediction_review SET status = 'alternative',
                                                           reviewed_at = datetime('now')
@@ -5396,9 +5430,12 @@ class Database:
                                  AND status IN ('accepted', 'rejected')
                                  AND prediction_id IN (
                                     SELECT id FROM predictions
-                                    WHERE detection_id = ? AND classifier_model = ?
+                                    WHERE detection_id = ?
+                                      AND classifier_model = ?
+                                      AND labels_fingerprint = ?
                                  )""",
-                            (ws, pred_row["detection_id"], pred_row["model"]),
+                            (ws, pred_row["detection_id"], pred_row["model"],
+                             pred_row["labels_fingerprint"]),
                         )
                         # Promote highest-confidence sibling back to 'pending'
                         # in this workspace.
@@ -5478,9 +5515,12 @@ class Database:
                     pred_id = int(item['old_value'])
                     ws = self._ws_id()
                     self.update_prediction_status(pred_id, 'accepted')
-                    # Re-reject siblings (mirrors accept_prediction behavior).
+                    # Re-reject siblings, scoped to the same labels_fingerprint
+                    # so the redo matches the original accept's scope and
+                    # doesn't touch predictions from other label sets.
                     pred_row = self.conn.execute(
-                        """SELECT detection_id, classifier_model AS model
+                        """SELECT detection_id, classifier_model AS model,
+                                  labels_fingerprint
                            FROM predictions WHERE id = ?""",
                         (pred_id,),
                     ).fetchone()
@@ -5492,10 +5532,12 @@ class Database:
                                 AND pr_rev.workspace_id = ?
                                WHERE pr.detection_id = ?
                                  AND pr.classifier_model = ?
+                                 AND pr.labels_fingerprint = ?
                                  AND pr.id != ?
                                  AND COALESCE(pr_rev.status, 'pending')
                                      IN ('pending', 'alternative')""",
-                            (ws, pred_row["detection_id"], pred_row["model"], pred_id),
+                            (ws, pred_row["detection_id"], pred_row["model"],
+                             pred_row["labels_fingerprint"], pred_id),
                         ).fetchall()
                         for s in sibs:
                             self.conn.execute(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2024,18 +2024,31 @@ class Database:
             # a global detection, which references the photo. Workspace scoping
             # is already enforced by the outer workspace_folders JOIN, so the
             # EXISTS only needs to link prediction → detection → this photo.
+            #
+            # Apply the workspace-effective detector_confidence floor so the
+            # rule matches what the UI actually shows: a photo whose only
+            # predictions sit on below-threshold detections must NOT count
+            # as "has predictions".
+            import config as cfg
+            move_min_conf = self.get_effective_config(cfg.load()).get(
+                "detector_confidence", 0.2
+            )
             if criteria["has_predictions"]:
                 conditions.append(
                     "EXISTS (SELECT 1 FROM predictions pr "
                     "JOIN detections d ON d.id = pr.detection_id "
-                    "WHERE d.photo_id = p.id)"
+                    "WHERE d.photo_id = p.id "
+                    "  AND d.detector_confidence >= ?)"
                 )
+                params.append(move_min_conf)
             else:
                 conditions.append(
                     "NOT EXISTS (SELECT 1 FROM predictions pr "
                     "JOIN detections d ON d.id = pr.detection_id "
-                    "WHERE d.photo_id = p.id)"
+                    "WHERE d.photo_id = p.id "
+                    "  AND d.detector_confidence >= ?)"
                 )
+                params.append(move_min_conf)
         if "imported_before" in criteria:
             conditions.append("p.timestamp < ?")
             params.append(criteria["imported_before"])

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4224,25 +4224,42 @@ class Database:
         q += " ORDER BY detector_confidence DESC"
         return self.conn.execute(q, params).fetchall()
 
-    def get_detections_for_photos(self, photo_ids):
+    def get_detections_for_photos(self, photo_ids, min_conf=None,
+                                  detector_model=None):
         """Return {photo_id: [det_dict, ...]} for a batch of photos.
 
-        Each det_dict has keys: x, y, w, h, confidence, category.
-        Lists are ordered by confidence DESC. Scoped to the active workspace.
-        Photos with no detections are omitted from the result.
+        Each det_dict has keys: x, y, w, h, confidence, category. Lists are
+        ordered by confidence DESC. The detections table is global — threshold
+        filtering happens at read time. Photos with no detections above
+        ``min_conf`` are omitted from the result.
+
+        Args:
+            photo_ids: iterable of photo ids
+            min_conf: confidence floor. ``None`` resolves to the active
+                workspace's effective ``detector_confidence`` (default 0.2).
+                ``0`` returns raw rows.
+            detector_model: optional — filter to a single detector model.
         """
         if not photo_ids:
             return {}
+        if min_conf is None:
+            import config as cfg
+            effective = self.get_effective_config(cfg.load())
+            min_conf = effective.get("detector_confidence", 0.2)
         placeholders = ",".join("?" for _ in photo_ids)
-        rows = self.conn.execute(
-            f"""SELECT photo_id, box_x, box_y, box_w, box_h,
-                       detector_confidence, category
-                FROM detections
-                WHERE workspace_id = ?
-                  AND photo_id IN ({placeholders})
-                ORDER BY photo_id, detector_confidence DESC""",
-            [self._ws_id(), *photo_ids],
-        ).fetchall()
+        q = (
+            f"SELECT photo_id, box_x, box_y, box_w, box_h, "
+            f"       detector_confidence, category "
+            f"FROM detections "
+            f"WHERE photo_id IN ({placeholders}) "
+            f"  AND detector_confidence >= ?"
+        )
+        params = [*photo_ids, min_conf]
+        if detector_model is not None:
+            q += " AND detector_model = ?"
+            params.append(detector_model)
+        q += " ORDER BY photo_id, detector_confidence DESC"
+        rows = self.conn.execute(q, params).fetchall()
         result = {}
         for r in rows:
             result.setdefault(r["photo_id"], []).append({
@@ -4280,10 +4297,13 @@ class Database:
     def get_detection_ids_for_photos(self, photo_ids):
         """Return {photo_id: set(detection_id, ...)} for the given photo IDs.
 
-        Only returns rows from the active workspace.  Used to snapshot
-        pre-run detection IDs so that a reclassify pass can delete only
-        the *stale* rows after fresh ones have been inserted, avoiding the
+        The detections table is global (no workspace_id). Used to snapshot
+        pre-run detection IDs so that a reclassify pass can delete only the
+        *stale* rows after fresh ones have been inserted, avoiding the
         cascade-delete that would destroy other-model predictions.
+
+        No threshold filter: the caller needs to see every existing row,
+        including low-confidence ones, so they can all be cleaned up.
 
         IDs are queried in chunks of at most 900 to stay safely under
         SQLite's default bound-parameter limit (SQLITE_LIMIT_VARIABLE_NUMBER,
@@ -4291,7 +4311,6 @@ class Database:
         """
         if not photo_ids:
             return {}
-        ws_id = self._ws_id()
         result: dict = {}
         ids = list(photo_ids)
         _CHUNK = 900
@@ -4300,8 +4319,8 @@ class Database:
             placeholders = ",".join("?" * len(chunk))
             rows = self.conn.execute(
                 f"SELECT id, photo_id FROM detections "
-                f"WHERE photo_id IN ({placeholders}) AND workspace_id = ?",
-                (*chunk, ws_id),
+                f"WHERE photo_id IN ({placeholders})",
+                tuple(chunk),
             ).fetchall()
             for row in rows:
                 result.setdefault(row["photo_id"], set()).add(row["id"])

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -712,6 +712,28 @@ class Database:
             self.conn.execute("DELETE FROM predictions WHERE detection_id IS NULL")
             self.conn.commit()
 
+        # detector_runs backfill (detection-storage redesign): derive one row per
+        # distinct (photo_id, detector_model) from existing detections so downstream
+        # skip checks don't re-run MegaDetector over photos it has already seen.
+        # Idempotent — only inserts rows whose (photo_id, detector_model) isn't
+        # already present.
+        existing_runs = self.conn.execute(
+            "SELECT COUNT(*) AS n FROM detector_runs"
+        ).fetchone()["n"]
+        legacy_detection_count = self.conn.execute(
+            "SELECT COUNT(*) AS n FROM detections"
+        ).fetchone()["n"]
+        if existing_runs == 0 and legacy_detection_count > 0:
+            self.conn.execute(
+                """INSERT OR IGNORE INTO detector_runs
+                     (photo_id, detector_model, box_count, run_at)
+                   SELECT photo_id, COALESCE(detector_model, 'megadetector-v6'),
+                          COUNT(*), MIN(created_at)
+                   FROM detections
+                   GROUP BY photo_id, COALESCE(detector_model, 'megadetector-v6')"""
+            )
+            self.conn.commit()
+
         # Folder health status
         try:
             self.conn.execute("SELECT status FROM folders LIMIT 0")

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -751,6 +751,23 @@ class Database:
             self.conn.execute("DELETE FROM predictions WHERE detection_id IS NULL")
             self.conn.commit()
 
+        # Legacy detector-key normalization: pre-redesign code wrote
+        # ``detector_model='MegaDetector'``; the new code standardizes on
+        # ``'megadetector-v6'``. Without this rewrite the very first run
+        # after upgrade would insert a parallel set of detections instead of
+        # replacing the legacy rows (save_detections keys off detector_model
+        # for clear-and-reinsert), duplicating downstream predictions/stats.
+        # Idempotent: only affects rows still keyed on the legacy string.
+        self.conn.execute(
+            "UPDATE detections SET detector_model='megadetector-v6' "
+            "WHERE detector_model='MegaDetector'"
+        )
+        self.conn.execute(
+            "UPDATE detector_runs SET detector_model='megadetector-v6' "
+            "WHERE detector_model='MegaDetector'"
+        )
+        self.conn.commit()
+
         # detector_runs backfill (detection-storage redesign): derive one row per
         # distinct (photo_id, detector_model) from existing detections so downstream
         # skip checks don't re-run MegaDetector over photos it has already seen.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3857,6 +3857,33 @@ class Database:
 
     # -- Detections --
 
+    def record_detector_run(self, photo_id, detector_model, box_count):
+        """Record that `detector_model` was run on `photo_id`.
+
+        Global across workspaces — the output is a pure function of (photo, model).
+        """
+        self.conn.execute(
+            """INSERT INTO detector_runs (photo_id, detector_model, box_count)
+               VALUES (?, ?, ?)
+               ON CONFLICT(photo_id, detector_model)
+               DO UPDATE SET box_count = excluded.box_count,
+                             run_at = datetime('now')""",
+            (photo_id, detector_model, box_count),
+        )
+        self.conn.commit()
+
+    def get_detector_run_photo_ids(self, detector_model):
+        """Return the set of photo_ids where `detector_model` has run.
+
+        Includes empty-scene photos (box_count=0) — which is the whole point:
+        without this, we'd re-run the model forever on photos with no animals.
+        """
+        rows = self.conn.execute(
+            "SELECT photo_id FROM detector_runs WHERE detector_model = ?",
+            (detector_model,),
+        ).fetchall()
+        return {r["photo_id"] for r in rows}
+
     def save_detections(self, photo_id, detections, detector_model=None):
         """Store detection bounding boxes for a photo.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4163,29 +4163,36 @@ class Database:
         )
         self.conn.commit()
 
-    def save_detections(self, photo_id, detections, detector_model=None):
-        """Store detection bounding boxes for a photo.
+    def save_detections(self, photo_id, detections, detector_model):
+        """Replace all detections for (photo_id, detector_model) with the given list.
+
+        Global: no workspace scoping. The model's output is a pure function of
+        (photo, model); any workspace re-running the same (photo, model) is a
+        bug — callers should short-circuit via `get_detector_run_photo_ids`.
 
         Args:
-            photo_id: the photo ID
-            detections: list of dicts with keys: box (dict with x,y,w,h),
-                        confidence (float), category (str)
-            detector_model: name of the detector model
-
+            photo_id: the photo
+            detections: list of dicts {box: {x,y,w,h}, confidence, category}
+            detector_model: required, e.g. "megadetector-v6"
         Returns:
-            list of detection IDs
+            list of new detection IDs (empty if detections was empty).
         """
-        ws_id = self._ws_id()
+        if detector_model is None:
+            raise ValueError("detector_model is required")
+        self.conn.execute(
+            "DELETE FROM detections WHERE photo_id = ? AND detector_model = ?",
+            (photo_id, detector_model),
+        )
         ids = []
         for det in detections:
             box = det["box"]
             cur = self.conn.execute(
                 """INSERT INTO detections
-                   (photo_id, workspace_id, box_x, box_y, box_w, box_h,
-                    detector_confidence, category, detector_model)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (photo_id, ws_id, box["x"], box["y"], box["w"], box["h"],
-                 det["confidence"], det.get("category", "animal"), detector_model),
+                     (photo_id, detector_model, box_x, box_y, box_w, box_h,
+                      detector_confidence, category)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (photo_id, detector_model, box["x"], box["y"], box["w"], box["h"],
+                 det["confidence"], det.get("category", "animal")),
             )
             ids.append(cur.lastrowid)
         self.conn.commit()
@@ -4231,21 +4238,27 @@ class Database:
             })
         return result
 
-    def clear_detections(self, photo_id):
-        """Remove all detections (and cascaded predictions) for a photo."""
-        self.conn.execute(
-            "DELETE FROM detections WHERE photo_id = ? AND workspace_id = ?",
-            (photo_id, self._ws_id()),
-        )
+    def clear_detections(self, photo_id, detector_model=None):
+        """Remove detections (and cascaded predictions) for a photo.
+
+        Global: no workspace scoping. If `detector_model` is None, all
+        detector models for this photo are cleared; otherwise only the
+        rows for that model.
+        """
+        if detector_model is None:
+            self.conn.execute(
+                "DELETE FROM detections WHERE photo_id = ?", (photo_id,)
+            )
+        else:
+            self.conn.execute(
+                "DELETE FROM detections WHERE photo_id = ? AND detector_model = ?",
+                (photo_id, detector_model),
+            )
         self.conn.commit()
 
-    def get_existing_detection_photo_ids(self):
-        """Return set of photo_ids that already have detections in this workspace."""
-        rows = self.conn.execute(
-            "SELECT DISTINCT photo_id FROM detections WHERE workspace_id = ?",
-            (self._ws_id(),),
-        ).fetchall()
-        return {r["photo_id"] for r in rows}
+    def get_existing_detection_photo_ids(self, detector_model="megadetector-v6"):
+        """Back-compat shim — prefer get_detector_run_photo_ids."""
+        return self.get_detector_run_photo_ids(detector_model)
 
     def get_detection_ids_for_photos(self, photo_ids):
         """Return {photo_id: set(detection_id, ...)} for the given photo IDs.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4315,6 +4315,22 @@ class Database:
         )
         self.conn.commit()
 
+    def get_global_detection_stats(self):
+        """Return global (workspace-agnostic) detector-cache counts.
+
+        `detector_runs` is shared across workspaces by design — switching
+        workspaces or bumping a threshold never invalidates these rows —
+        so the settings page surfaces this as a single "N photos x M
+        models cached" figure.
+        """
+        r = self.conn.execute(
+            """SELECT COUNT(DISTINCT photo_id) AS photo_count,
+                      COUNT(DISTINCT detector_model) AS model_count
+               FROM detector_runs"""
+        ).fetchone()
+        return {"photo_count": r["photo_count"] or 0,
+                "model_count": r["model_count"] or 0}
+
     def get_detector_run_photo_ids(self, detector_model):
         """Return the set of photo_ids where `detector_model` has run.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -804,6 +804,16 @@ class Database:
         if "status" in pred_cols and review_exists == 0:
             def _col_or_null(name: str) -> str:
                 return f"p.{name}" if name in pred_cols else "NULL"
+            # Backfill any row that carries non-default review state OR any
+            # grouping metadata. Legacy grouped predictions commonly stored
+            # group_id/vote_count/individual on `pending` rows — the prior
+            # filter `status <> 'pending'` dropped all of that, so upgraded
+            # DBs silently lost their burst-group membership.
+            group_filter_parts = ["COALESCE(p.status, 'pending') <> 'pending'"]
+            for col in ("group_id", "individual", "vote_count", "total_votes"):
+                if col in pred_cols:
+                    group_filter_parts.append(f"p.{col} IS NOT NULL")
+            group_filter = " OR ".join(group_filter_parts)
             self.conn.execute(f"""
                 INSERT OR IGNORE INTO prediction_review
                     (prediction_id, workspace_id, status, reviewed_at,
@@ -818,7 +828,7 @@ class Database:
                 FROM predictions p
                 JOIN detections d ON d.id = p.detection_id
                 WHERE d.workspace_id IS NOT NULL
-                  AND COALESCE(p.status, 'pending') <> 'pending'
+                  AND ({group_filter})
             """)
             self.conn.commit()
 
@@ -1393,6 +1403,49 @@ class Database:
                 [target_ws_id, source_ws_id] + list(folder_ids),
             )
             pending_changes_moved = cur.rowcount
+
+            # Move prediction_review rows for predictions whose photo is in
+            # the moved folders. Without this the accepted/rejected/group
+            # metadata stays attached to the source workspace_id and the
+            # target reads all predictions as 'pending' — silently dropping
+            # the user's review decisions during a folder move.
+            #
+            # INSERT OR IGNORE into the target first, then DELETE from the
+            # source. That way if the target already has a review row for
+            # the same (prediction_id), we keep the target's value rather
+            # than overwriting it.
+            self.conn.execute(
+                f"""INSERT OR IGNORE INTO prediction_review
+                      (prediction_id, workspace_id, status, reviewed_at,
+                       individual, group_id, vote_count, total_votes)
+                    SELECT pr_rev.prediction_id, ?, pr_rev.status,
+                           pr_rev.reviewed_at, pr_rev.individual,
+                           pr_rev.group_id, pr_rev.vote_count,
+                           pr_rev.total_votes
+                    FROM prediction_review pr_rev
+                    JOIN predictions p ON p.id = pr_rev.prediction_id
+                    JOIN detections d ON d.id = p.detection_id
+                    WHERE pr_rev.workspace_id = ?
+                      AND d.photo_id IN (
+                          SELECT id FROM photos WHERE folder_id IN ({placeholders})
+                      )""",
+                [target_ws_id, source_ws_id] + list(folder_ids),
+            )
+            self.conn.execute(
+                f"""DELETE FROM prediction_review
+                    WHERE workspace_id = ?
+                      AND prediction_id IN (
+                          SELECT pr_rev.prediction_id
+                          FROM prediction_review pr_rev
+                          JOIN predictions p ON p.id = pr_rev.prediction_id
+                          JOIN detections d ON d.id = p.detection_id
+                          WHERE pr_rev.workspace_id = ?
+                            AND d.photo_id IN (
+                                SELECT id FROM photos WHERE folder_id IN ({placeholders})
+                            )
+                      )""",
+                [source_ws_id, source_ws_id] + list(folder_ids),
+            )
 
             # Move workspace_folders: remove from source, add to target
             self.conn.execute(
@@ -4184,64 +4237,97 @@ class Database:
             )
         self.conn.commit()
 
-    def clear_predictions(self, model=None, collection_photo_ids=None):
-        """Clear predictions, optionally filtered by model and/or photo set.
+    def clear_predictions(self, model=None, collection_photo_ids=None,
+                          labels_fingerprint=None):
+        """Clear predictions, optionally filtered by model, photo set, and fingerprint.
 
         The ``predictions`` table is now global (no workspace_id).  This
         still restricts the delete to photos visible in the active workspace
         via ``workspace_folders`` so that calling "clear" in one workspace
         does not nuke another workspace's cached classifier output.
+
+        ``labels_fingerprint`` is strongly recommended for reclassify flows:
+        in shared-folder setups where workspace A and workspace B classify
+        the same photos with different label sets, a reclassify in A keyed
+        only by ``model`` would wipe B's cached predictions under its own
+        fingerprint. And because ``classifier_runs`` keys include
+        fingerprint, B's later non-reclassify runs would skip inference and
+        leave those detections unclassified until forced. With
+        ``labels_fingerprint`` passed, we delete only A's rows AND the
+        matching ``classifier_runs`` rows so A's next pass actually re-runs.
         """
         ws = self._ws_id()
+        # Build a reusable (cond, params) pair for the predictions subquery.
+        extra_conds = []
+        extra_params = []
+        if model:
+            extra_conds.append("pr.classifier_model = ?")
+            extra_params.append(model)
+        if labels_fingerprint is not None:
+            extra_conds.append("pr.labels_fingerprint = ?")
+            extra_params.append(labels_fingerprint)
+
         if collection_photo_ids is not None:
             placeholders = ",".join("?" for _ in collection_photo_ids)
-            if model:
-                self.conn.execute(
-                    f"""DELETE FROM predictions WHERE id IN (
-                        SELECT pr.id FROM predictions pr
-                        JOIN detections d ON d.id = pr.detection_id
-                        JOIN photos ph ON ph.id = d.photo_id
-                        JOIN workspace_folders wf
-                          ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
-                        WHERE pr.classifier_model = ?
-                          AND d.photo_id IN ({placeholders})
-                    )""",
-                    [ws, model, *collection_photo_ids],
-                )
-            else:
-                self.conn.execute(
-                    f"""DELETE FROM predictions WHERE id IN (
-                        SELECT pr.id FROM predictions pr
-                        JOIN detections d ON d.id = pr.detection_id
-                        JOIN photos ph ON ph.id = d.photo_id
-                        JOIN workspace_folders wf
-                          ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
-                        WHERE d.photo_id IN ({placeholders})
-                    )""",
-                    [ws, *collection_photo_ids],
-                )
-        else:
-            # Workspace scoping is already enforced by the JOIN ON clause
-            # (one ? bound to ws below). Keep the WHERE filter list only for
-            # the optional model predicate so the placeholder count matches
-            # the params list.
-            params = [ws]
-            where_parts = []
-            if model:
-                where_parts.append("pr.classifier_model = ?")
-                params.append(model)
-            where_clause = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
-            self.conn.execute(
-                f"""DELETE FROM predictions WHERE id IN (
-                    SELECT pr.id FROM predictions pr
-                    JOIN detections d ON d.id = pr.detection_id
+            extra_conds.append(f"d.photo_id IN ({placeholders})")
+            extra_params.extend(collection_photo_ids)
+
+        where_clause = (" WHERE " + " AND ".join(extra_conds)) if extra_conds else ""
+        self.conn.execute(
+            f"""DELETE FROM predictions WHERE id IN (
+                SELECT pr.id FROM predictions pr
+                JOIN detections d ON d.id = pr.detection_id
+                JOIN photos ph ON ph.id = d.photo_id
+                JOIN workspace_folders wf
+                  ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
+                {where_clause}
+            )""",
+            [ws, *extra_params],
+        )
+
+        # Also clear matching classifier_runs rows so the next pass actually
+        # re-runs the classifier. Without this, the skip gate at
+        # classifier_runs would still report "done" even though the cached
+        # predictions are gone, leaving detections permanently unclassified
+        # unless the user forces a reclassify.
+        #
+        # classifier_runs has PK (detection_id, classifier_model,
+        # labels_fingerprint), so delete by the full composite key, not by
+        # detection_id alone — otherwise another fingerprint's run key on
+        # the same detection would be wiped too.
+        if model is not None:
+            run_conds = ["cr.classifier_model = ?"]
+            run_params = [model]
+            if labels_fingerprint is not None:
+                run_conds.append("cr.labels_fingerprint = ?")
+                run_params.append(labels_fingerprint)
+            if collection_photo_ids is not None:
+                placeholders = ",".join("?" for _ in collection_photo_ids)
+                run_conds.append(f"d.photo_id IN ({placeholders})")
+                run_params.extend(collection_photo_ids)
+            where = " AND ".join(run_conds)
+            # Match by (detection_id, classifier_model, labels_fingerprint)
+            # — delete composite key tuples via rowid equivalents.
+            rows = self.conn.execute(
+                f"""SELECT cr.detection_id, cr.classifier_model,
+                           cr.labels_fingerprint
+                    FROM classifier_runs cr
+                    JOIN detections d ON d.id = cr.detection_id
                     JOIN photos ph ON ph.id = d.photo_id
                     JOIN workspace_folders wf
                       ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
-                    {where_clause}
-                )""",
-                params,
-            )
+                    WHERE {where}""",
+                [ws, *run_params],
+            ).fetchall()
+            for r in rows:
+                self.conn.execute(
+                    """DELETE FROM classifier_runs
+                       WHERE detection_id = ?
+                         AND classifier_model = ?
+                         AND labels_fingerprint = ?""",
+                    (r["detection_id"], r["classifier_model"],
+                     r["labels_fingerprint"]),
+                )
         self.conn.commit()
 
     def get_predictions(self, photo_ids=None, model=None, status=None):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2107,8 +2107,17 @@ class Database:
         ).fetchone()[0]
 
     def get_pipeline_feature_counts(self):
-        """Return counts of photos with masks, detections, and sharpness data."""
+        """Return counts of photos with masks, detections, and sharpness data.
+
+        Detections are global: the per-workspace scope comes from
+        ``workspace_folders``, and low-confidence rows are filtered out at
+        read time using the workspace-effective ``detector_confidence``.
+        """
+        import config as cfg
         ws = self._ws_id()
+        min_conf = self.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
         row = self.conn.execute(
             """SELECT
                 SUM(CASE WHEN p.mask_path IS NOT NULL THEN 1 ELSE 0 END) as masks,
@@ -2123,8 +2132,9 @@ class Database:
                FROM detections d
                JOIN photos p ON p.id = d.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               WHERE d.workspace_id = ? AND wf.workspace_id = ?""",
-            (ws, ws),
+               WHERE wf.workspace_id = ?
+                 AND d.detector_confidence >= ?""",
+            (ws, min_conf),
         ).fetchone()[0]
         return {
             "masks": row["masks"] or 0,
@@ -2182,20 +2192,30 @@ class Database:
             (ws,),
         ).fetchall()
 
+        # Review status lives in prediction_review (workspace-scoped).
+        # Left-joining lets us count pending rows (those without a review row)
+        # and bucket them into the pending column via COALESCE.
         prediction_status = self.conn.execute(
-            """SELECT pr.status, COUNT(*) as count
-            FROM predictions pr
-            JOIN detections d ON d.id = pr.detection_id
-            WHERE d.workspace_id = ?
-            GROUP BY pr.status""",
-            (ws,),
+            """SELECT COALESCE(pr_rev.status, 'pending') AS status,
+                      COUNT(*) AS count
+               FROM predictions pr
+               JOIN detections d ON d.id = pr.detection_id
+               JOIN photos ph ON ph.id = d.photo_id
+               JOIN workspace_folders wf
+                 ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
+               LEFT JOIN prediction_review pr_rev
+                 ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
+               GROUP BY COALESCE(pr_rev.status, 'pending')""",
+            (ws, ws),
         ).fetchall()
 
         classified_count = self.conn.execute(
             """SELECT COUNT(DISTINCT d.photo_id)
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
-               WHERE d.workspace_id = ?""",
+               JOIN photos ph ON ph.id = d.photo_id
+               JOIN workspace_folders wf
+                 ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?""",
             (ws,),
         ).fetchone()[0]
 
@@ -2226,14 +2246,19 @@ class Database:
             (ws,),
         ).fetchall()
 
+        import config as cfg
+        min_conf = self.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
         detected_count = self.conn.execute(
             """SELECT COUNT(DISTINCT d.photo_id)
                FROM detections d
                JOIN photos p ON p.id = d.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                JOIN folders f ON f.id = p.folder_id AND f.status = 'ok'
-               WHERE d.workspace_id = ? AND wf.workspace_id = ?""",
-            (ws, ws),
+               WHERE wf.workspace_id = ?
+                 AND d.detector_confidence >= ?""",
+            (ws, min_conf),
         ).fetchone()[0]
 
         return {
@@ -2540,20 +2565,26 @@ class Database:
             params,
         ).fetchone()[0]
 
-        # Classified vs unclassified (within filter)
+        # Classified vs unclassified (within filter).  Detections and
+        # predictions are global; workspace scoping comes from the outer
+        # join_clause and the detector_confidence read-time threshold.
+        import config as cfg
+        min_conf = self.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
         classified = self.conn.execute(
             f"""SELECT COUNT(DISTINCT p.id) FROM photos p
                 {join_clause}
-                JOIN detections det ON det.photo_id = p.id AND det.workspace_id = ?
+                JOIN detections det ON det.photo_id = p.id
                 JOIN predictions pred ON pred.detection_id = det.id
-                {where}""",
-            [ws] + params,
+                {where}
+                  AND det.detector_confidence >= ?""",
+            params + [min_conf],
         ).fetchone()[0]
 
-        # Top species (within filter)
-        # Use a CTE to select the single best prediction per photo (highest confidence,
-        # non-rejected) to avoid inflating species counts when multiple models have
-        # predicted different species for the same photo.
+        # Top species (within filter).  Review status is workspace-scoped via
+        # prediction_review; absent rows are treated as 'pending' (which is
+        # included — we only want to exclude 'rejected' reviews).
         top_species = self.conn.execute(
             f"""WITH best_pred AS (
                     SELECT det.photo_id, pred.species,
@@ -2563,7 +2594,11 @@ class Database:
                            ) AS rn
                     FROM predictions pred
                     JOIN detections det ON det.id = pred.detection_id
-                    WHERE det.workspace_id = ? AND pred.status != 'rejected'
+                    LEFT JOIN prediction_review pr_rev
+                      ON pr_rev.prediction_id = pred.id
+                     AND pr_rev.workspace_id = ?
+                    WHERE det.detector_confidence >= ?
+                      AND COALESCE(pr_rev.status, 'pending') != 'rejected'
                 )
                 SELECT bp.species, COUNT(DISTINCT p.id) as count
                 FROM photos p
@@ -2573,7 +2608,7 @@ class Database:
                 GROUP BY bp.species
                 ORDER BY count DESC
                 LIMIT 5""",
-            [ws] + params,
+            [ws, min_conf] + params,
         ).fetchall()
 
         # Folder breakdown (within filter)
@@ -3125,7 +3160,11 @@ class Database:
         Returns:
             list of dicts with id, folder_id, filename, detection_box (JSON string), detection_conf
         """
+        import config as cfg
         ws_id = self._ws_id()
+        min_conf = self.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
         if folder_ids:
             placeholders = ",".join("?" * len(folder_ids))
             rows = self.conn.execute(
@@ -3133,11 +3172,12 @@ class Database:
                            d.box_x, d.box_y, d.box_w, d.box_h,
                            d.detector_confidence
                     FROM photos p
-                    JOIN detections d ON d.photo_id = p.id AND d.workspace_id = ?
+                    JOIN detections d ON d.photo_id = p.id
                     WHERE p.folder_id IN ({placeholders})
                       AND p.mask_path IS NULL
+                      AND d.detector_confidence >= ?
                     ORDER BY p.id, d.detector_confidence DESC""",
-                [ws_id, *folder_ids],
+                [*folder_ids, min_conf],
             ).fetchall()
         else:
             rows = self.conn.execute(
@@ -3146,11 +3186,12 @@ class Database:
                           d.detector_confidence
                    FROM photos p
                    JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-                   JOIN detections d ON d.photo_id = p.id AND d.workspace_id = ?
+                   JOIN detections d ON d.photo_id = p.id
                    WHERE wf.workspace_id = ?
                      AND p.mask_path IS NULL
+                     AND d.detector_confidence >= ?
                    ORDER BY p.id, d.detector_confidence DESC""",
-                (ws_id, ws_id),
+                (ws_id, min_conf),
             ).fetchall()
 
         # Deduplicate to one row per photo (primary detection = highest confidence)
@@ -3200,17 +3241,21 @@ class Database:
         box_x/y/w/h (normalized 0-1), species_conf, taxonomy_class,
         scientific_name, species.
         """
+        import config as cfg
         ws_id = self._ws_id()
+        min_conf = self.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
         if photo_ids is not None:
             photo_ids = list(photo_ids)
             if not photo_ids:
                 return []
             placeholders = ",".join("?" for _ in photo_ids)
             extra_where = f" AND p.id IN ({placeholders})"
-            params = (ws_id, ws_id, *photo_ids)
+            params = (ws_id, min_conf, *photo_ids)
         else:
             extra_where = ""
-            params = (ws_id, ws_id)
+            params = (ws_id, min_conf)
         rows = self.conn.execute(
             f"""SELECT p.id, p.folder_id, p.filename, p.width, p.height,
                       p.mask_path,
@@ -3225,8 +3270,8 @@ class Database:
                  ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
                JOIN detections d
                  ON d.photo_id = p.id
-                AND d.workspace_id = ?
                 AND d.detector_model != 'full-image'
+                AND d.detector_confidence >= ?
                JOIN predictions pr ON pr.detection_id = d.id
                WHERE p.mask_path IS NOT NULL
                  AND p.eye_tenengrad IS NULL{extra_where}
@@ -3720,6 +3765,7 @@ class Database:
         total_votes=None,
         individual=None,
         taxonomy=None,
+        labels_fingerprint="legacy",
     ):
         """Store a classification prediction for a detection.
 
@@ -3727,10 +3773,18 @@ class Database:
         existing predictions that the user may have already reviewed.
         Use clear_predictions() first if you want a fresh start.
 
+        The `predictions` table stores only the raw, workspace-independent
+        classifier output (species, confidence, classifier_model, taxonomy).
+        Per-workspace review state (status, group_id, vote_count, individual)
+        is written to ``prediction_review`` for the active workspace when the
+        caller passes a non-default value.
+
         Args:
             detection_id: the detection ID (from detections table)
             taxonomy: optional dict with keys kingdom, phylum, class, order,
                       family, genus, scientific_name from taxonomy lookup
+            labels_fingerprint: fingerprint of the label set used to classify
+                (defaults to 'legacy' for backwards-compatible inserts).
         """
         if detection_id is None:
             raise ValueError(
@@ -3739,24 +3793,20 @@ class Database:
                 "invisible to workspace-scoped queries"
             )
         tax = taxonomy or {}
-        self.conn.execute(
+        cur = self.conn.execute(
             """INSERT OR IGNORE INTO predictions
-               (detection_id, species, confidence, model, category, status,
-                group_id, vote_count, total_votes, individual,
+               (detection_id, classifier_model, labels_fingerprint,
+                species, confidence, category,
                 taxonomy_kingdom, taxonomy_phylum, taxonomy_class,
                 taxonomy_order, taxonomy_family, taxonomy_genus, scientific_name)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 detection_id,
+                model,
+                labels_fingerprint,
                 species,
                 confidence,
-                model,
                 category,
-                status,
-                group_id,
-                vote_count,
-                total_votes,
-                individual,
                 tax.get("kingdom"),
                 tax.get("phylum"),
                 tax.get("class"),
@@ -3766,10 +3816,54 @@ class Database:
                 tax.get("scientific_name"),
             ),
         )
+        pred_id = cur.lastrowid
+        if not pred_id:
+            # INSERT IGNORE collided with the UNIQUE key; look up the existing row.
+            row = self.conn.execute(
+                """SELECT id FROM predictions
+                   WHERE detection_id = ? AND classifier_model = ?
+                     AND labels_fingerprint = ? AND species IS ?""",
+                (detection_id, model, labels_fingerprint, species),
+            ).fetchone()
+            pred_id = row["id"] if row else None
+        # Write workspace-scoped review state only when the caller actually
+        # supplied something beyond the defaults. Keeping pending rows out of
+        # prediction_review is intentional: absence == pending.
+        has_review_state = (
+            status != "pending"
+            or group_id is not None
+            or vote_count is not None
+            or total_votes is not None
+            or individual is not None
+        )
+        if pred_id is not None and has_review_state:
+            ws_id = self._ws_id()
+            self.conn.execute(
+                """INSERT INTO prediction_review
+                     (prediction_id, workspace_id, status, reviewed_at,
+                      individual, group_id, vote_count, total_votes)
+                   VALUES (?, ?, ?, datetime('now'), ?, ?, ?, ?)
+                   ON CONFLICT(prediction_id, workspace_id)
+                   DO UPDATE SET status      = excluded.status,
+                                 reviewed_at = excluded.reviewed_at,
+                                 individual  = COALESCE(excluded.individual, individual),
+                                 group_id    = COALESCE(excluded.group_id,   group_id),
+                                 vote_count  = COALESCE(excluded.vote_count, vote_count),
+                                 total_votes = COALESCE(excluded.total_votes,total_votes)""",
+                (pred_id, ws_id, status, individual, group_id,
+                 vote_count, total_votes),
+            )
         self.conn.commit()
 
     def clear_predictions(self, model=None, collection_photo_ids=None):
-        """Clear predictions, optionally filtered by model and/or photo set."""
+        """Clear predictions, optionally filtered by model and/or photo set.
+
+        The ``predictions`` table is now global (no workspace_id).  This
+        still restricts the delete to photos visible in the active workspace
+        via ``workspace_folders`` so that calling "clear" in one workspace
+        does not nuke another workspace's cached classifier output.
+        """
+        ws = self._ws_id()
         if collection_photo_ids is not None:
             placeholders = ",".join("?" for _ in collection_photo_ids)
             if model:
@@ -3777,31 +3871,40 @@ class Database:
                     f"""DELETE FROM predictions WHERE id IN (
                         SELECT pr.id FROM predictions pr
                         JOIN detections d ON d.id = pr.detection_id
-                        WHERE d.workspace_id = ? AND pr.model = ?
-                        AND d.photo_id IN ({placeholders})
+                        JOIN photos ph ON ph.id = d.photo_id
+                        JOIN workspace_folders wf
+                          ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
+                        WHERE pr.classifier_model = ?
+                          AND d.photo_id IN ({placeholders})
                     )""",
-                    [self._ws_id(), model, *collection_photo_ids],
+                    [ws, model, *collection_photo_ids],
                 )
             else:
                 self.conn.execute(
                     f"""DELETE FROM predictions WHERE id IN (
                         SELECT pr.id FROM predictions pr
                         JOIN detections d ON d.id = pr.detection_id
-                        WHERE d.workspace_id = ? AND d.photo_id IN ({placeholders})
+                        JOIN photos ph ON ph.id = d.photo_id
+                        JOIN workspace_folders wf
+                          ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
+                        WHERE d.photo_id IN ({placeholders})
                     )""",
-                    [self._ws_id(), *collection_photo_ids],
+                    [ws, *collection_photo_ids],
                 )
         else:
-            conditions = ["d.workspace_id = ?"]
-            params = [self._ws_id()]
+            conditions = ["wf.workspace_id = ?"]
+            params = [ws]
             if model:
-                conditions.append("pr.model = ?")
+                conditions.append("pr.classifier_model = ?")
                 params.append(model)
             where = " AND ".join(conditions)
             self.conn.execute(
                 f"""DELETE FROM predictions WHERE id IN (
                     SELECT pr.id FROM predictions pr
                     JOIN detections d ON d.id = pr.detection_id
+                    JOIN photos ph ON ph.id = d.photo_id
+                    JOIN workspace_folders wf
+                      ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
                     WHERE {where}
                 )""",
                 params,
@@ -3809,40 +3912,68 @@ class Database:
         self.conn.commit()
 
     def get_predictions(self, photo_ids=None, model=None, status=None):
-        """Get predictions with photo and detection info, optionally filtered."""
-        conditions = ["d.workspace_id = ?"]
-        params = [self._ws_id()]
+        """Get predictions with photo, detection and review info.
+
+        Workspace scoping is enforced by joining ``workspace_folders``; the
+        per-workspace review state (status, group_id, individual, vote_count)
+        is left-joined from ``prediction_review`` so absent rows naturally
+        surface as ``status = 'pending'``.
+        """
+        ws = self._ws_id()
+        conditions = ["wf.workspace_id = ?"]
+        params = [ws, ws]  # first ? = pr_rev.workspace_id, second = wf.workspace_id
         if photo_ids is not None:
             placeholders = ",".join("?" for _ in photo_ids)
             conditions.append(f"d.photo_id IN ({placeholders})")
             params.extend(photo_ids)
         if model:
-            conditions.append("pr.model = ?")
+            conditions.append("pr.classifier_model = ?")
             params.append(model)
         if status:
-            conditions.append("pr.status = ?")
+            conditions.append("COALESCE(pr_rev.status, 'pending') = ?")
             params.append(status)
         where = "WHERE " + " AND ".join(conditions)
         return self.conn.execute(
-            f"""SELECT pr.*, d.photo_id, d.box_x, d.box_y, d.box_w, d.box_h,
+            f"""SELECT pr.*,
+                       pr.classifier_model AS model,
+                       COALESCE(pr_rev.status, 'pending') AS status,
+                       pr_rev.individual AS individual,
+                       pr_rev.group_id AS group_id,
+                       pr_rev.vote_count AS vote_count,
+                       pr_rev.total_votes AS total_votes,
+                       d.photo_id, d.box_x, d.box_y, d.box_w, d.box_h,
                        d.detector_confidence, d.detector_model,
                        p.filename, p.timestamp
                 FROM predictions pr
                 JOIN detections d ON d.id = pr.detection_id
                 JOIN photos p ON p.id = d.photo_id
+                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                LEFT JOIN prediction_review pr_rev
+                  ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
                 {where} ORDER BY pr.confidence DESC""",
             params,
         ).fetchall()
 
     def update_prediction_status(self, prediction_id, status, _commit=True):
-        """Update prediction status ('pending', 'accepted', 'rejected').
+        """Update per-workspace review status for a prediction.
+
+        Review state lives in ``prediction_review`` keyed by
+        (prediction_id, workspace_id); we upsert here rather than UPDATE
+        so the "first review in a fresh workspace" path still writes a row.
 
         Args:
             _commit: If False, skip the internal commit (caller is responsible
                      for committing the transaction).
         """
+        ws = self._ws_id()
         self.conn.execute(
-            "UPDATE predictions SET status = ? WHERE id = ?", (status, prediction_id)
+            """INSERT INTO prediction_review
+                 (prediction_id, workspace_id, status, reviewed_at)
+               VALUES (?, ?, ?, datetime('now'))
+               ON CONFLICT(prediction_id, workspace_id)
+               DO UPDATE SET status = excluded.status,
+                             reviewed_at = excluded.reviewed_at""",
+            (prediction_id, ws, status),
         )
         if _commit:
             self.conn.commit()
@@ -3850,33 +3981,44 @@ class Database:
     def get_group_predictions(self, group_id):
         """Get all predictions and photo data for a burst group.
 
-        Each returned row is a dict with an ``alternatives`` list containing
-        the per-detection alternative species predictions (status='alternative'),
-        sorted by confidence descending.
+        ``group_id`` lives in the workspace-scoped ``prediction_review``
+        table now, so we join there to find the member predictions.  Each
+        returned row is a dict with an ``alternatives`` list containing the
+        per-detection alternative species predictions (review status
+        ``'alternative'``), sorted by confidence descending.
         """
+        ws = self._ws_id()
         primaries = self.conn.execute(
-            """SELECT pr.*, d.photo_id, d.box_x, d.box_y, d.box_w, d.box_h,
+            """SELECT pr.*,
+                      pr.classifier_model AS model,
+                      COALESCE(pr_rev.status, 'pending') AS status,
+                      pr_rev.individual AS individual,
+                      pr_rev.group_id AS group_id,
+                      pr_rev.vote_count AS vote_count,
+                      pr_rev.total_votes AS total_votes,
+                      d.photo_id, d.box_x, d.box_y, d.box_w, d.box_h,
                       d.detector_confidence, p.filename, p.timestamp, p.sharpness,
                       p.quality_score, p.subject_sharpness, p.subject_size,
                       p.rating, p.flag, p.width, p.height
                FROM predictions pr
+               JOIN prediction_review pr_rev
+                 ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
                JOIN detections d ON d.id = pr.detection_id
                JOIN photos p ON p.id = d.photo_id
-               WHERE pr.group_id = ? AND d.workspace_id = ?
+               JOIN workspace_folders wf
+                 ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+               WHERE pr_rev.group_id = ?
                ORDER BY p.quality_score DESC""",
-            (group_id, self._ws_id()),
+            (ws, ws, group_id),
         ).fetchall()
         rows = [dict(r) for r in primaries]
         if not rows:
             return rows
-        # Alternatives are correlated by (detection_id, model): a detection may
-        # have been classified by multiple models (and those may even share a
-        # group), so we must not merge alternatives across models.
-        #
-        # Fetch all alternatives for the distinct detection_ids in one IN(...)
-        # query, then filter by model in Python. This keeps the SQL expression
-        # depth bounded even for very large burst groups (SQLite's default
-        # expression-depth limit breaks with one OR branch per row).
+        # Alternatives are correlated by (detection_id, classifier_model):
+        # a detection may have been classified by multiple models (and those
+        # may even share a group), so we must not merge alternatives across
+        # models.  Alternatives are scoped per-workspace through
+        # prediction_review.
         det_model_pairs = {
             (r['detection_id'], r.get('model'))
             for r in rows if r.get('detection_id') is not None
@@ -3886,11 +4028,15 @@ class Database:
         if det_ids:
             placeholders = ','.join('?' * len(det_ids))
             alt_rows = self.conn.execute(
-                f"""SELECT detection_id, model, species, confidence
-                    FROM predictions
-                    WHERE status = 'alternative' AND detection_id IN ({placeholders})
-                    ORDER BY confidence DESC""",
-                det_ids,
+                f"""SELECT pr.detection_id, pr.classifier_model AS model,
+                           pr.species, pr.confidence
+                    FROM predictions pr
+                    JOIN prediction_review pr_rev
+                      ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
+                    WHERE pr_rev.status = 'alternative'
+                      AND pr.detection_id IN ({placeholders})
+                    ORDER BY pr.confidence DESC""",
+                [ws, *det_ids],
             ).fetchall()
             for a in alt_rows:
                 key = (a['detection_id'], a['model'])
@@ -3903,45 +4049,71 @@ class Database:
         return rows
 
     def update_predictions_status_by_photo(self, photo_id, status):
-        """Update status for all predictions of a photo in the active workspace."""
-        self.conn.execute(
-            """UPDATE predictions SET status = ?
-               WHERE detection_id IN (
-                   SELECT id FROM detections
-                   WHERE photo_id = ? AND workspace_id = ?
-               )""",
-            (status, photo_id, self._ws_id()),
-        )
+        """Upsert review status for every prediction of a photo in the active workspace.
+
+        Review state is workspace-scoped (``prediction_review``); detections
+        and predictions are global.  We enumerate the prediction ids via the
+        detections join and upsert each review row.
+        """
+        ws = self._ws_id()
+        rows = self.conn.execute(
+            """SELECT pr.id FROM predictions pr
+               JOIN detections d ON d.id = pr.detection_id
+               WHERE d.photo_id = ?""",
+            (photo_id,),
+        ).fetchall()
+        for r in rows:
+            self.conn.execute(
+                """INSERT INTO prediction_review
+                     (prediction_id, workspace_id, status, reviewed_at)
+                   VALUES (?, ?, ?, datetime('now'))
+                   ON CONFLICT(prediction_id, workspace_id)
+                   DO UPDATE SET status = excluded.status,
+                                 reviewed_at = excluded.reviewed_at""",
+                (r["id"], ws, status),
+            )
         self.conn.commit()
 
     def ungroup_prediction(self, prediction_id):
-        """Remove a prediction from its group."""
+        """Remove a prediction from its group in the active workspace.
+
+        ``group_id`` lives in ``prediction_review``; this only clears the
+        review row for the current workspace.
+        """
         self.conn.execute(
-            """UPDATE predictions SET group_id = NULL
-               WHERE id = ? AND detection_id IN (
-                   SELECT id FROM detections WHERE workspace_id = ?
-               )""",
+            """UPDATE prediction_review SET group_id = NULL
+               WHERE prediction_id = ? AND workspace_id = ?""",
             (prediction_id, self._ws_id()),
         )
         self.conn.commit()
 
     def get_existing_prediction_photo_ids(self, model):
-        """Return set of photo_ids that have predictions for a model."""
+        """Return photo_ids with predictions for a model, scoped to the active workspace."""
         rows = self.conn.execute(
             """SELECT DISTINCT d.photo_id FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
-               WHERE pr.model = ? AND d.workspace_id = ?""",
-            (model, self._ws_id()),
+               JOIN photos p ON p.id = d.photo_id
+               JOIN workspace_folders wf
+                 ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+               WHERE pr.classifier_model = ?""",
+            (self._ws_id(), model),
         ).fetchall()
         return {r["photo_id"] for r in rows}
 
     def get_prediction_for_photo(self, photo_id, model):
-        """Return species, confidence, and detection_id for a photo's prediction by model, or None."""
+        """Return species, confidence, and detection_id for a photo's prediction by model, or None.
+
+        Detections and predictions are global; the active workspace is
+        enforced through ``workspace_folders``.
+        """
         return self.conn.execute(
             """SELECT pr.species, pr.confidence, pr.detection_id FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
-               WHERE d.photo_id = ? AND pr.model = ? AND d.workspace_id = ?""",
-            (photo_id, model, self._ws_id()),
+               JOIN photos p ON p.id = d.photo_id
+               JOIN workspace_folders wf
+                 ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+               WHERE d.photo_id = ? AND pr.classifier_model = ?""",
+            (self._ws_id(), photo_id, model),
         ).fetchone()
 
     def get_photo_embedding(self, photo_id):
@@ -3985,17 +4157,40 @@ class Database:
         return [(row["id"], row["embedding"]) for row in rows]
 
     def update_prediction_group_info(self, detection_id, model, group_id, vote_count, total_votes, individual):
-        """Update group info on an existing prediction.
+        """Upsert group info for the primary prediction of (detection, classifier_model)
+        in the active workspace's ``prediction_review``.
 
-        Only updates the primary (non-alternative) prediction row so that
-        alternative rows for the same detection+model are not assigned group
-        metadata they do not belong to.
+        Alternative rows (review status ``'alternative'``) are intentionally
+        skipped so they do not inherit grouping metadata that belongs to the
+        primary pick.
         """
+        ws = self._ws_id()
+        # Identify the primary prediction row: one per (detection_id, classifier_model),
+        # excluding any prediction already marked 'alternative' in this workspace.
+        row = self.conn.execute(
+            """SELECT pr.id FROM predictions pr
+               LEFT JOIN prediction_review pr_rev
+                 ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
+               WHERE pr.detection_id = ? AND pr.classifier_model = ?
+                 AND COALESCE(pr_rev.status, 'pending') != 'alternative'
+               ORDER BY pr.confidence DESC LIMIT 1""",
+            (ws, detection_id, model),
+        ).fetchone()
+        if not row:
+            return
+        pred_id = row["id"]
         self.conn.execute(
-            """UPDATE predictions
-               SET group_id=?, vote_count=?, total_votes=?, individual=?
-               WHERE detection_id=? AND model=? AND status != 'alternative'""",
-            (group_id, vote_count, total_votes, individual, detection_id, model),
+            """INSERT INTO prediction_review
+                 (prediction_id, workspace_id, status, reviewed_at,
+                  individual, group_id, vote_count, total_votes)
+               VALUES (?, ?, 'pending', datetime('now'), ?, ?, ?, ?)
+               ON CONFLICT(prediction_id, workspace_id)
+               DO UPDATE SET individual  = excluded.individual,
+                             group_id    = excluded.group_id,
+                             vote_count  = excluded.vote_count,
+                             total_votes = excluded.total_votes,
+                             reviewed_at = excluded.reviewed_at""",
+            (pred_id, ws, individual, group_id, vote_count, total_votes),
         )
         self.conn.commit()
 
@@ -4015,24 +4210,47 @@ class Database:
         All database changes are performed atomically in a single transaction.
         On failure, all changes are rolled back.
         """
+        ws = self._ws_id()
         pred = self.conn.execute(
-            """SELECT pr.*, d.photo_id
+            """SELECT pr.*,
+                      pr.classifier_model AS model,
+                      pr_rev.group_id AS group_id,
+                      pr_rev.individual AS individual,
+                      d.photo_id
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
+               LEFT JOIN prediction_review pr_rev
+                 ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
                WHERE pr.id = ?""",
-            (prediction_id,),
+            (ws, prediction_id),
         ).fetchone()
         if not pred:
             return None
 
         try:
-            # Reject sibling predictions for same detection+model
-            # (covers both accepting an alternative and accepting the top-1)
-            self.conn.execute(
-                """UPDATE predictions SET status = 'rejected'
-                   WHERE detection_id = ? AND model = ? AND id != ? AND status IN ('pending', 'alternative')""",
-                (pred["detection_id"], pred["model"], prediction_id),
-            )
+            # Reject sibling predictions for same detection+classifier_model
+            # in this workspace (covers both accepting an alternative and
+            # accepting the top-1).  Review state is workspace-scoped, so we
+            # upsert each row rather than UPDATE the base predictions table.
+            sibs = self.conn.execute(
+                """SELECT pr.id FROM predictions pr
+                   LEFT JOIN prediction_review pr_rev
+                     ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
+                   WHERE pr.detection_id = ? AND pr.classifier_model = ?
+                     AND pr.id != ?
+                     AND COALESCE(pr_rev.status, 'pending') IN ('pending', 'alternative')""",
+                (ws, pred["detection_id"], pred["model"], prediction_id),
+            ).fetchall()
+            for s in sibs:
+                self.conn.execute(
+                    """INSERT INTO prediction_review
+                         (prediction_id, workspace_id, status, reviewed_at)
+                       VALUES (?, ?, 'rejected', datetime('now'))
+                       ON CONFLICT(prediction_id, workspace_id)
+                       DO UPDATE SET status = 'rejected',
+                                     reviewed_at = datetime('now')""",
+                    (s["id"], ws),
+                )
 
             # For grouped predictions, derive consensus from individual votes
             species = pred["species"]
@@ -4049,14 +4267,19 @@ class Database:
             kid = self.add_keyword(species, is_species=True, _commit=False)
             affected = []  # list of {"photo_id": int, "prediction_id": int}
 
-            # If grouped, accept all predictions in the group
+            # If grouped, accept all predictions in the group (in this workspace).
             if pred["group_id"]:
                 group_preds = self.conn.execute(
-                    """SELECT pr.*, d.photo_id
+                    """SELECT pr.id, d.photo_id
                        FROM predictions pr
+                       JOIN prediction_review pr_rev
+                         ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
                        JOIN detections d ON d.id = pr.detection_id
-                       WHERE pr.group_id = ? AND pr.model = ? AND d.workspace_id = ?""",
-                    (pred["group_id"], pred["model"], self._ws_id()),
+                       JOIN photos ph ON ph.id = d.photo_id
+                       JOIN workspace_folders wf
+                         ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
+                       WHERE pr_rev.group_id = ? AND pr.classifier_model = ?""",
+                    (ws, ws, pred["group_id"], pred["model"]),
                 ).fetchall()
                 for gp in group_preds:
                     self.update_prediction_status(gp["id"], "accepted", _commit=False)
@@ -4594,30 +4817,46 @@ class Database:
                     self.remove_pending_changes(pid, 'keyword_add', kw['name'])
                 if entry['action_type'] == 'prediction_accept' and old_val:
                     pred_id = int(old_val)
+                    ws = self._ws_id()
                     # Restore all predictions for this detection to pre-accept state
                     pred_row = self.conn.execute(
-                        "SELECT detection_id, model FROM predictions WHERE id = ?",
+                        """SELECT detection_id, classifier_model AS model
+                           FROM predictions WHERE id = ?""",
                         (pred_id,),
                     ).fetchone()
                     if pred_row:
-                        # Set all to 'alternative' first
+                        # Identify every sibling prediction for (detection, classifier_model).
+                        siblings = self.conn.execute(
+                            """SELECT id, confidence FROM predictions
+                               WHERE detection_id = ? AND classifier_model = ?
+                               ORDER BY confidence DESC""",
+                            (pred_row["detection_id"], pred_row["model"]),
+                        ).fetchall()
+                        # Flip any accepted/rejected review rows in this
+                        # workspace back to 'alternative'.
                         self.conn.execute(
-                            """UPDATE predictions SET status = 'alternative'
-                               WHERE detection_id = ? AND model = ?
-                               AND status IN ('accepted', 'rejected')""",
-                            (pred_row["detection_id"], pred_row["model"]),
+                            """UPDATE prediction_review SET status = 'alternative',
+                                                          reviewed_at = datetime('now')
+                               WHERE workspace_id = ?
+                                 AND status IN ('accepted', 'rejected')
+                                 AND prediction_id IN (
+                                    SELECT id FROM predictions
+                                    WHERE detection_id = ? AND classifier_model = ?
+                                 )""",
+                            (ws, pred_row["detection_id"], pred_row["model"]),
                         )
-                        # Promote highest-confidence to 'pending'
-                        top = self.conn.execute(
-                            """SELECT id FROM predictions
-                               WHERE detection_id = ? AND model = ?
-                               ORDER BY confidence DESC LIMIT 1""",
-                            (pred_row["detection_id"], pred_row["model"]),
-                        ).fetchone()
-                        if top:
+                        # Promote highest-confidence sibling back to 'pending'
+                        # in this workspace.
+                        if siblings:
+                            top_id = siblings[0]["id"]
                             self.conn.execute(
-                                "UPDATE predictions SET status = 'pending' WHERE id = ?",
-                                (top["id"],),
+                                """INSERT INTO prediction_review
+                                     (prediction_id, workspace_id, status, reviewed_at)
+                                   VALUES (?, ?, 'pending', datetime('now'))
+                                   ON CONFLICT(prediction_id, workspace_id)
+                                   DO UPDATE SET status = 'pending',
+                                                 reviewed_at = datetime('now')""",
+                                (top_id, ws),
                             )
                         self.conn.commit()
             elif entry['action_type'] == 'keyword_remove':
@@ -4682,19 +4921,37 @@ class Database:
                     self.queue_change(pid, 'keyword_add', kw['name'])
                 if entry['action_type'] == 'prediction_accept' and item['old_value']:
                     pred_id = int(item['old_value'])
+                    ws = self._ws_id()
                     self.update_prediction_status(pred_id, 'accepted')
-                    # Re-reject siblings (mirrors accept_prediction behavior)
+                    # Re-reject siblings (mirrors accept_prediction behavior).
                     pred_row = self.conn.execute(
-                        "SELECT detection_id, model FROM predictions WHERE id = ?",
+                        """SELECT detection_id, classifier_model AS model
+                           FROM predictions WHERE id = ?""",
                         (pred_id,),
                     ).fetchone()
                     if pred_row:
-                        self.conn.execute(
-                            """UPDATE predictions SET status = 'rejected'
-                               WHERE detection_id = ? AND model = ? AND id != ?
-                               AND status IN ('pending', 'alternative')""",
-                            (pred_row["detection_id"], pred_row["model"], pred_id),
-                        )
+                        sibs = self.conn.execute(
+                            """SELECT pr.id FROM predictions pr
+                               LEFT JOIN prediction_review pr_rev
+                                 ON pr_rev.prediction_id = pr.id
+                                AND pr_rev.workspace_id = ?
+                               WHERE pr.detection_id = ?
+                                 AND pr.classifier_model = ?
+                                 AND pr.id != ?
+                                 AND COALESCE(pr_rev.status, 'pending')
+                                     IN ('pending', 'alternative')""",
+                            (ws, pred_row["detection_id"], pred_row["model"], pred_id),
+                        ).fetchall()
+                        for s in sibs:
+                            self.conn.execute(
+                                """INSERT INTO prediction_review
+                                     (prediction_id, workspace_id, status, reviewed_at)
+                                   VALUES (?, ?, 'rejected', datetime('now'))
+                                   ON CONFLICT(prediction_id, workspace_id)
+                                   DO UPDATE SET status = 'rejected',
+                                                 reviewed_at = datetime('now')""",
+                                (s["id"], ws),
+                            )
                         self.conn.commit()
             elif entry['action_type'] == 'keyword_remove':
                 self.untag_photo(pid, int(entry['new_value']))

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4861,13 +4861,26 @@ class Database:
                 "model_count": r["model_count"] or 0}
 
     def get_detector_run_photo_ids(self, detector_model):
-        """Return the set of photo_ids where `detector_model` has run.
+        """Return the set of photo_ids with a consistent cached detector run.
 
         Includes empty-scene photos (box_count=0) — which is the whole point:
         without this, we'd re-run the model forever on photos with no animals.
+
+        Excludes torn states where `detector_runs.box_count > 0` but no matching
+        row exists in `detections`. That shape happens when a reclassify pass
+        clears detections (via `clear_detections`) and then the job fails
+        before writing fresh rows (model init error, etc.). Leaving such
+        photos in the skip set would strand them on full-image fallback
+        until the user manually forces another reclassify.
         """
         rows = self.conn.execute(
-            "SELECT photo_id FROM detector_runs WHERE detector_model = ?",
+            """SELECT dr.photo_id
+               FROM detector_runs dr
+               WHERE dr.detector_model = ?
+                 AND (dr.box_count = 0
+                      OR EXISTS (SELECT 1 FROM detections d
+                                 WHERE d.photo_id = dr.photo_id
+                                   AND d.detector_model = dr.detector_model))""",
             (detector_model,),
         ).fetchall()
         return {r["photo_id"] for r in rows}

--- a/vireo/detector.py
+++ b/vireo/detector.py
@@ -25,6 +25,13 @@ INPUT_SIZE = 640
 # MegaDetector class mapping (index -> label)
 CLASS_NAMES = {0: "animal", 1: "person", 2: "vehicle"}
 
+# Raw-confidence hard floor. Every detection at or above this value is stored;
+# the user-visible threshold is applied as a read-time filter from the
+# workspace-effective config. Filtering at write time would defeat the global
+# detection cache — two workspaces with different thresholds over the same
+# photo would otherwise need separate detector runs.
+RAW_CONF_FLOOR = 0.01
+
 
 def ensure_megadetector_weights(progress_callback=None):
     """Ensure MegaDetector V6 ONNX weights are present on disk.
@@ -290,12 +297,17 @@ def _postprocess(outputs, preprocess_info, confidence_threshold):
     return detections
 
 
-def detect_animals(image_path, confidence_threshold=0.2):
+def detect_animals(image_path):
     """Detect animals in an image using MegaDetector.
+
+    Returns every detection above ``RAW_CONF_FLOOR``. The user-visible
+    confidence threshold is applied as a read-time filter from the
+    workspace-effective config — don't filter at write time or we can't
+    globally cache detector output across workspaces with different
+    thresholds.
 
     Args:
         image_path: path to the image file
-        confidence_threshold: minimum detection confidence (0-1)
 
     Returns:
         list of detections, each with:
@@ -322,7 +334,7 @@ def detect_animals(image_path, confidence_threshold=0.2):
         input_name = session.get_inputs()[0].name
         outputs = session.run(None, {input_name: input_tensor})
 
-        return _postprocess(outputs, preprocess_info, confidence_threshold)
+        return _postprocess(outputs, preprocess_info, RAW_CONF_FLOOR)
     except Exception:
         log.warning("Detection failed for %s", image_path, exc_info=True)
         return []

--- a/vireo/detector.py
+++ b/vireo/detector.py
@@ -314,7 +314,11 @@ def detect_animals(image_path):
             box: {x, y, w, h} normalized 0-1
             confidence: float 0-1
             category: str ('animal', 'person', 'vehicle')
-        Returns empty list on failure.
+
+        ``[]`` means "ran successfully, no boxes above the raw floor"
+        (a real empty scene). ``None`` means "the run itself failed"
+        (image decode error, ONNX error, etc.) — callers should NOT
+        cache a zero-box result for this case.
     """
     session = _get_session()
 
@@ -326,7 +330,7 @@ def detect_animals(image_path):
         img = load_image(str(image_path), max_size=1280)
         if img is None:
             log.warning("Could not load image for detection: %s", image_path)
-            return []
+            return None
         img_array = np.array(img.convert("RGB"))
 
         input_tensor, preprocess_info = _preprocess(img_array)
@@ -337,7 +341,7 @@ def detect_animals(image_path):
         return _postprocess(outputs, preprocess_info, RAW_CONF_FLOOR)
     except Exception:
         log.warning("Detection failed for %s", image_path, exc_info=True)
-        return []
+        return None
 
 
 def get_primary_detection(detections):

--- a/vireo/labels_fingerprint.py
+++ b/vireo/labels_fingerprint.py
@@ -1,0 +1,20 @@
+"""Content-addressable fingerprint for a classifier's label set.
+
+The classifier's output is a pure function of (model, labels, input). We key
+cached predictions by (classifier_model, labels_fingerprint) so two workspaces
+running the same model with different regional lists stay disjoint rather than
+conflicting or silently clobbering each other.
+"""
+
+import hashlib
+
+TOL_SENTINEL = "tol"
+LEGACY_SENTINEL = "legacy"
+
+
+def compute_fingerprint(labels):
+    """sha256 hex prefix of sorted, deduped labels. TOL_SENTINEL when empty."""
+    if not labels:
+        return TOL_SENTINEL
+    canonical = "\n".join(sorted(set(labels))).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()[:12]

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -148,21 +148,27 @@ def compute_misses_for_workspace(
     excluded = set(exclude_photo_ids) if exclude_photo_ids else set()
 
     ws_id = db._ws_id()
-    # Detector confidence is written to the `detections` table by the
-    # classify stage, not to `photos.detection_conf` (legacy column). Read
-    # the highest-confidence detection per photo, workspace-scoped, so
-    # photos with real detections aren't misread as no_subject.
+    # Detections are global now; scope *photos* to the workspace via
+    # workspace_folders and filter detections at read time by the
+    # workspace-effective detector_confidence threshold. Photos whose
+    # highest-confidence box is below threshold are legitimate no_subject
+    # candidates.
+    import config as cfg
+    min_conf = db.get_effective_config(cfg.load()).get(
+        "detector_confidence", 0.2
+    )
     rows = db.conn.execute(
         "SELECT p.id, p.burst_id, "
         "       (SELECT MAX(d.detector_confidence) FROM detections d "
-        "        WHERE d.photo_id = p.id AND d.workspace_id = ?) "
+        "        WHERE d.photo_id = p.id "
+        "          AND d.detector_confidence >= ?) "
         "         AS detection_conf, "
         "       p.subject_size, p.crop_complete, "
         "       p.subject_tenengrad, p.bg_tenengrad "
         "FROM photos p "
         "JOIN workspace_folders wf ON wf.folder_id = p.folder_id "
         "WHERE wf.workspace_id = ?",
-        (ws_id, ws_id),
+        (min_conf, ws_id),
     ).fetchall()
 
     target_ids = None

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -76,7 +76,8 @@ def _resolve_collection_photo_ids(db, collection_id):
     return {r["id"] for r in rows} if rows else set()
 
 
-def load_photo_features(db, collection_id=None, config=None):
+def load_photo_features(db, collection_id=None, config=None,
+                        labels_fingerprint=None):
     """Load all pipeline-relevant features for workspace photos from the database.
 
     Returns a list of photo dicts ready for the pipeline stages, with:
@@ -88,6 +89,12 @@ def load_photo_features(db, collection_id=None, config=None):
         db: Database instance with active workspace
         collection_id: optional collection ID to scope results
         config: optional dict with settings (e.g. top_k_predictions)
+        labels_fingerprint: optional — when set, only predictions produced
+            under this label set are considered. When ``None`` (default),
+            each (detection, classifier_model) surfaces rows from its most
+            recent fingerprint only — otherwise a photo with cached
+            predictions from multiple label sets would leak stale species
+            into the top-k.
 
     Returns:
         list of photo dicts
@@ -137,18 +144,46 @@ def load_photo_features(db, collection_id=None, config=None):
     # NOTE: pr.classifier_model aliased to "model" for back-compat with
     # species_top5 tuple shape consumed downstream. Prediction review
     # fields (status/group_id/individual) are Task 25 scope.
-    pred_rows = db.conn.execute(
-        """SELECT d.photo_id, pr.species, pr.confidence,
-                  pr.classifier_model AS model
-           FROM predictions pr
-           JOIN detections d ON d.id = pr.detection_id
-           JOIN photos p ON p.id = d.photo_id
-           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-           WHERE wf.workspace_id = ?
-             AND d.detector_confidence >= ?
-           ORDER BY d.photo_id, pr.confidence DESC""",
-        (ws_id, min_conf),
-    ).fetchall()
+    #
+    # Fingerprint filter: a detection + classifier_model can have predictions
+    # from multiple label sets (fingerprints) when the user rotates labels.
+    # If the caller pinned a specific fingerprint, use it; otherwise pick
+    # the most recent one per (detection, model) so stale species from an
+    # old label set don't leak into the top-k.
+    if labels_fingerprint is not None:
+        pred_rows = db.conn.execute(
+            """SELECT d.photo_id, pr.species, pr.confidence,
+                      pr.classifier_model AS model
+               FROM predictions pr
+               JOIN detections d ON d.id = pr.detection_id
+               JOIN photos p ON p.id = d.photo_id
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               WHERE wf.workspace_id = ?
+                 AND d.detector_confidence >= ?
+                 AND pr.labels_fingerprint = ?
+               ORDER BY d.photo_id, pr.confidence DESC""",
+            (ws_id, min_conf, labels_fingerprint),
+        ).fetchall()
+    else:
+        pred_rows = db.conn.execute(
+            """SELECT d.photo_id, pr.species, pr.confidence,
+                      pr.classifier_model AS model
+               FROM predictions pr
+               JOIN detections d ON d.id = pr.detection_id
+               JOIN photos p ON p.id = d.photo_id
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               WHERE wf.workspace_id = ?
+                 AND d.detector_confidence >= ?
+                 AND pr.labels_fingerprint = (
+                     SELECT pr2.labels_fingerprint FROM predictions pr2
+                     WHERE pr2.detection_id = pr.detection_id
+                       AND pr2.classifier_model = pr.classifier_model
+                     ORDER BY pr2.created_at DESC, pr2.id DESC
+                     LIMIT 1
+                 )
+               ORDER BY d.photo_id, pr.confidence DESC""",
+            (ws_id, min_conf),
+        ).fetchall()
 
     # Group predictions by photo_id, keep top K
     top_k = (config or {}).get("top_k_predictions", 5)

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -121,18 +121,33 @@ def load_photo_features(db, collection_id=None, config=None):
             (ws_id,),
         ).fetchall()
 
+    # Resolve the workspace-effective detector_confidence threshold once.
+    # The detections table is global (no workspace_id); threshold filtering
+    # happens at read time against the active workspace's effective config.
+    import config as cfg
+    effective_cfg = db.get_effective_config(cfg.load())
+    min_conf = effective_cfg.get("detector_confidence", 0.2)
+
     # Load species predictions (top-5 per photo, ordered by confidence).
     # Predictions reference detections (not photos directly), so JOIN through
-    # the detections table to get photo_id.
+    # the detections table to get photo_id. Only surface predictions whose
+    # backing detection passes the workspace threshold — lowering the
+    # threshold in workspace config should surface more predictions without
+    # rewriting any rows.
+    # NOTE: pr.classifier_model aliased to "model" for back-compat with
+    # species_top5 tuple shape consumed downstream. Prediction review
+    # fields (status/group_id/individual) are Task 25 scope.
     pred_rows = db.conn.execute(
-        """SELECT d.photo_id, pr.species, pr.confidence, pr.model
+        """SELECT d.photo_id, pr.species, pr.confidence,
+                  pr.classifier_model AS model
            FROM predictions pr
            JOIN detections d ON d.id = pr.detection_id
            JOIN photos p ON p.id = d.photo_id
            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-           WHERE d.workspace_id = ? AND wf.workspace_id = ?
+           WHERE wf.workspace_id = ?
+             AND d.detector_confidence >= ?
            ORDER BY d.photo_id, pr.confidence DESC""",
-        (ws_id, ws_id),
+        (ws_id, min_conf),
     ).fetchall()
 
     # Group predictions by photo_id, keep top K
@@ -143,29 +158,26 @@ def load_photo_features(db, collection_id=None, config=None):
         if len(species_by_photo[pid]) < top_k:
             species_by_photo[pid].append((pr["species"], pr["confidence"], pr["model"]))
 
-    # Load primary detection per photo (highest confidence) from detections table.
-    # This replaces the old photos.detection_box / photos.detection_conf columns.
-    det_rows = db.conn.execute(
-        """SELECT d.photo_id, d.box_x, d.box_y, d.box_w, d.box_h,
-                  d.detector_confidence
-           FROM detections d
-           JOIN photos p ON p.id = d.photo_id
-           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-           WHERE d.workspace_id = ? AND wf.workspace_id = ?
-           ORDER BY d.photo_id, d.detector_confidence DESC""",
-        (ws_id, ws_id),
-    ).fetchall()
+    # Load primary detection per photo (highest confidence) via the global
+    # read-time helper. This replaces the old photos.detection_box /
+    # photos.detection_conf columns; the helper applies the same threshold
+    # resolved above.
+    photo_ids_for_dets = [row["id"] for row in rows]
+    dets_by_photo = db.get_detections_for_photos(
+        photo_ids_for_dets, min_conf=min_conf,
+    )
     primary_det_by_photo = {}
-    for dr in det_rows:
-        pid = dr["photo_id"]
-        if pid not in primary_det_by_photo:
-            primary_det_by_photo[pid] = {
-                "x": dr["box_x"],
-                "y": dr["box_y"],
-                "w": dr["box_w"],
-                "h": dr["box_h"],
-                "detection_conf": dr["detector_confidence"],
-            }
+    for pid, dets in dets_by_photo.items():
+        if not dets:
+            continue
+        top = dets[0]  # helper returns each list ordered by confidence DESC
+        primary_det_by_photo[pid] = {
+            "x": top["x"],
+            "y": top["y"],
+            "w": top["w"],
+            "h": top["h"],
+            "detection_conf": top["confidence"],
+        }
 
     # Load user-confirmed species keywords (alphabetically first wins
     # for photos with multiple species tags — rare but deterministic)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1773,18 +1773,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         model=model_name, collection_photo_ids=photo_ids
                     )
 
-                existing_preds = set()
-                if not params.reclassify:
-                    existing_preds = thread_db.get_existing_prediction_photo_ids(
-                        model_name
-                    )
-
                 # The fingerprint for THIS model's label set — pinned by
                 # model_loader_stage for the first model and by _load_model_bundle
                 # for subsequent ones. Used to key the classifier_runs gate so
                 # a repeat pass over the same (detection, model, fingerprint)
                 # skips work instead of re-running inference.
                 spec_fp = loaded_models.get("labels_fingerprint", "legacy")
+
+                existing_preds = set()
+                if not params.reclassify:
+                    # Key the photo-level short-circuit on BOTH model and
+                    # fingerprint so changing the workspace's label set
+                    # doesn't leave stale predictions unprocessed.
+                    existing_preds = thread_db.get_existing_prediction_photo_ids(
+                        model_name, labels_fingerprint=spec_fp,
+                    )
 
                 raw_results: list = []
                 failed = 0

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1957,6 +1957,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 group_result = _store_grouped_predictions(
                     raw_results, job["id"], model_name,
                     grouping_window, similarity_threshold, tax, thread_db,
+                    labels_fingerprint=spec_fp,
                 )
                 preds = group_result["predictions_stored"]
                 total_predictions_stored += preds

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1937,11 +1937,18 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         # the same (detection, model, fingerprint) short-
                         # circuits. prediction_count reflects how many rows
                         # _flush_batch added to raw_results for this detection.
+                        #
+                        # Only persist when the batch produced at least one
+                        # prediction. A count of 0 means the classifier
+                        # failed (transient load error, decode error, etc.);
+                        # caching that would strand the detection without
+                        # predictions until the user forces --reclassify.
                         new_count = len(raw_results) - pre_len
-                        thread_db.record_classifier_run(
-                            primary_det["id"], model_name, spec_fp,
-                            prediction_count=new_count,
-                        )
+                        if new_count > 0:
+                            thread_db.record_classifier_run(
+                                primary_det["id"], model_name, spec_fp,
+                                prediction_count=new_count,
+                            )
 
                 group_result = _store_grouped_predictions(
                     raw_results, job["id"], model_name,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -966,7 +966,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         the first model) and the classify stage (for each subsequent model in
         a multi-model run).
         """
-        from classify_job import _load_labels
+        from classify_job import (
+            _load_labels,
+            _record_labels_fingerprint,
+            _resolve_label_sources,
+        )
+        from labels_fingerprint import compute_fingerprint
         from models import _classify_model_state
 
         model_str = active_model["model_str"]
@@ -982,6 +987,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             labels_files=params.labels_files,
             db=thread_db,
         )
+        # Compute a content-addressable fingerprint for the active label set
+        # and record it in the labels_fingerprints sidecar. Kept on the bundle
+        # so classify_stage can pass it to record_classifier_run for each
+        # (detection, model, fingerprint) triple.
+        fp = compute_fingerprint(labels)
+        label_sources = _resolve_label_sources(params, thread_db)
+        _record_labels_fingerprint(thread_db, fp, labels, sources=label_sources)
 
         # Preflight: validate the on-disk model before handing it to
         # ONNXRuntime. A stale _check_onnx_downloaded result (e.g. after
@@ -1110,6 +1122,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             "model_name": model_name,
             "model_str": model_str,
             "labels": labels,
+            "labels_fingerprint": fp,
             "use_tol": use_tol,
             "active_model": active_model,
         }

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1780,15 +1780,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 # skips work instead of re-running inference.
                 spec_fp = loaded_models.get("labels_fingerprint", "legacy")
 
-                existing_preds = set()
-                if not params.reclassify:
-                    # Key the photo-level short-circuit on BOTH model and
-                    # fingerprint so changing the workspace's label set
-                    # doesn't leave stale predictions unprocessed.
-                    existing_preds = thread_db.get_existing_prediction_photo_ids(
-                        model_name, labels_fingerprint=spec_fp,
-                    )
-
+                # No photo-level short-circuit: it would hide detections
+                # that newly cross the workspace's detector_confidence
+                # threshold on photos that already had a cached prediction
+                # for some other detection. The per-detection
+                # classifier_runs gate below handles skipping correctly
+                # and still surfaces cached results into raw_results so
+                # grouping sees them.
                 raw_results: list = []
                 failed = 0
                 skipped_existing = 0
@@ -1832,47 +1830,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         # restrict deletions to photos actually reclassified.
                         if models_succeeded == 0:
                             first_model_photo_ids.add(photo["id"])
-                        if photo["id"] in existing_preds:
-                            skipped_existing += 1
-                            pred_row = thread_db.get_prediction_for_photo(
-                                photo["id"], model_name,
-                                labels_fingerprint=spec_fp,
-                            )
-                            if pred_row:
-                                folder_path = folders.get(photo["folder_id"], "")
-                                image_path = os.path.join(
-                                    folder_path, photo["filename"],
-                                )
-                                timestamp = None
-                                if photo["timestamp"]:
-                                    with contextlib.suppress(ValueError, TypeError):
-                                        timestamp = dt.fromisoformat(
-                                            photo["timestamp"]
-                                        )
-                                embedding = None
-                                if model_type != "timm":
-                                    emb_blob = thread_db.get_photo_embedding(
-                                        photo["id"]
-                                    )
-                                    if emb_blob:
-                                        import numpy as np
-                                        embedding = np.frombuffer(
-                                            emb_blob, dtype=np.float32,
-                                        )
-                                raw_results.append({
-                                    "photo": photo,
-                                    "detection_id": pred_row["detection_id"],
-                                    "folder_path": folder_path,
-                                    "image_path": image_path,
-                                    "prediction": pred_row["species"],
-                                    "confidence": pred_row["confidence"],
-                                    "timestamp": timestamp,
-                                    "filename": photo["filename"],
-                                    "embedding": embedding,
-                                    "taxonomy": None,
-                                    "_existing": True,
-                                })
-                            continue
 
                         # Pull the primary detection for this photo from the
                         # detect-stage cache. Fall back to db.get_detections()
@@ -1906,12 +1863,58 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         # Classifier-run gate: skip work when this exact
                         # (detection, classifier_model, labels_fingerprint)
                         # triple was already classified. Reclassify bypasses
-                        # the gate so users can force a fresh pass.
+                        # the gate so users can force a fresh pass. When
+                        # gated, surface the cached top-1 prediction into
+                        # raw_results so downstream grouping/storage sees
+                        # it — otherwise the cached detection would silently
+                        # drop out of the grouping pipeline.
                         if not params.reclassify:
                             run_keys = thread_db.get_classifier_run_keys(
                                 primary_det["id"]
                             )
                             if (model_name, spec_fp) in run_keys:
+                                cached = thread_db.get_predictions_for_detection(
+                                    primary_det["id"],
+                                    classifier_model=model_name,
+                                    labels_fingerprint=spec_fp,
+                                    min_classifier_conf=0,
+                                )
+                                if cached:
+                                    skipped_existing += 1
+                                    top = cached[0]
+                                    folder_path = folders.get(photo["folder_id"], "")
+                                    image_path = os.path.join(
+                                        folder_path, photo["filename"],
+                                    )
+                                    timestamp = None
+                                    if photo["timestamp"]:
+                                        with contextlib.suppress(ValueError, TypeError):
+                                            timestamp = dt.fromisoformat(
+                                                photo["timestamp"]
+                                            )
+                                    embedding = None
+                                    if model_type != "timm":
+                                        emb_blob = thread_db.get_photo_embedding(
+                                            photo["id"]
+                                        )
+                                        if emb_blob:
+                                            import numpy as np
+                                            embedding = np.frombuffer(
+                                                emb_blob, dtype=np.float32,
+                                            )
+                                    raw_results.append({
+                                        "photo": photo,
+                                        "detection_id": primary_det["id"],
+                                        "folder_path": folder_path,
+                                        "image_path": image_path,
+                                        "prediction": top["species"],
+                                        "confidence": top["confidence"],
+                                        "timestamp": timestamp,
+                                        "filename": photo["filename"],
+                                        "embedding": embedding,
+                                        "taxonomy": None,
+                                        "_existing": True,
+                                    })
                                 continue
 
                         img, folder_path, image_path = _prepare_image(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1836,6 +1836,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                             skipped_existing += 1
                             pred_row = thread_db.get_prediction_for_photo(
                                 photo["id"], model_name,
+                                labels_fingerprint=spec_fp,
                             )
                             if pred_row:
                                 folder_path = folders.get(photo["folder_id"], "")

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1915,7 +1915,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                                         "taxonomy": None,
                                         "_existing": True,
                                     })
-                                continue
+                                    continue
+                                # Run key with no cached rows (e.g.
+                                # prior pass stored `category == 'match'`
+                                # so the prediction was intentionally not
+                                # written). Fall through to re-classify
+                                # instead of stranding the detection.
 
                         img, folder_path, image_path = _prepare_image(
                             photo, folders, primary_det,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1283,8 +1283,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             # history): start with an empty already_detected so EVERY photo
             # is re-detected; snapshot pre-run detection IDs so we can purge
             # them after this detect pass completes. On a non-reclassify run,
-            # pre-seed already_detected from the DB so _detect_batch reuses
-            # rows instead of re-invoking MegaDetector.
+            # pre-seed already_detected from detector_runs so _detect_batch
+            # reuses rows instead of re-invoking MegaDetector — including
+            # empty-scene photos (box_count=0) which would otherwise be
+            # re-detected forever by a legacy detections-only seed.
             if params.reclassify:
                 already_detected: set = set()
                 photo_ids_list = [p["id"] for p in photos]
@@ -1293,9 +1295,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                 )(photo_ids_list)
             else:
                 already_detected = set(
-                    getattr(
-                        thread_db, "get_existing_detection_photo_ids", lambda: set()
-                    )()
+                    thread_db.get_detector_run_photo_ids("megadetector-v6")
                 )
                 pre_run_det_ids = {}
             detect_state["pre_run_det_ids"] = pre_run_det_ids

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1767,18 +1767,25 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     model_type = bundle["model_type"]
                     model_name = bundle["model_name"]
 
-                if params.reclassify:
-                    photo_ids = [p["id"] for p in photos]
-                    thread_db.clear_predictions(
-                        model=model_name, collection_photo_ids=photo_ids
-                    )
-
                 # The fingerprint for THIS model's label set — pinned by
                 # model_loader_stage for the first model and by _load_model_bundle
                 # for subsequent ones. Used to key the classifier_runs gate so
                 # a repeat pass over the same (detection, model, fingerprint)
-                # skips work instead of re-running inference.
+                # skips work instead of re-running inference. Hoisted above
+                # the reclassify clear so the clear can scope by fingerprint.
                 spec_fp = loaded_models.get("labels_fingerprint", "legacy")
+
+                if params.reclassify:
+                    photo_ids = [p["id"] for p in photos]
+                    # Scope by labels_fingerprint so reclassifying one
+                    # workspace's label set doesn't wipe another
+                    # workspace's cached predictions on the same photos
+                    # under its own fingerprint (shared-folder setups).
+                    thread_db.clear_predictions(
+                        model=model_name,
+                        collection_photo_ids=photo_ids,
+                        labels_fingerprint=spec_fp,
+                    )
 
                 # No photo-level short-circuit: it would hide detections
                 # that newly cross the workspace's detector_confidence

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1487,6 +1487,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             similarity_threshold = user_cfg.get("similarity_threshold", 0.85)
 
             tax = loaded_models["tax"]
+            # Fingerprint for the FIRST model is preloaded by model_loader_stage.
+            # Each subsequent iteration reloads its own bundle (with its own fp)
+            # inside the loop, so we read loaded_models["labels_fingerprint"]
+            # per-spec below rather than capturing a single value here.
             resolved_specs_local = loaded_models.get("resolved_specs") or [
                 loaded_models["active_model"]
             ]
@@ -1582,6 +1586,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     existing_preds = thread_db.get_existing_prediction_photo_ids(
                         model_name
                     )
+
+                # The fingerprint for THIS model's label set — pinned by
+                # model_loader_stage for the first model and by _load_model_bundle
+                # for subsequent ones. Used to key the classifier_runs gate so
+                # a repeat pass over the same (detection, model, fingerprint)
+                # skips work instead of re-running inference.
+                spec_fp = loaded_models.get("labels_fingerprint", "legacy")
 
                 raw_results: list = []
                 failed = 0
@@ -1696,6 +1707,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         if primary_det is None:
                             continue
 
+                        # Classifier-run gate: skip work when this exact
+                        # (detection, classifier_model, labels_fingerprint)
+                        # triple was already classified. Reclassify bypasses
+                        # the gate so users can force a fresh pass.
+                        if not params.reclassify:
+                            run_keys = thread_db.get_classifier_run_keys(
+                                primary_det["id"]
+                            )
+                            if (model_name, spec_fp) in run_keys:
+                                continue
+
                         img, folder_path, image_path = _prepare_image(
                             photo, folders, primary_det,
                         )
@@ -1710,6 +1732,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                             "image_path": image_path,
                             "img": img,
                         }]
+                        pre_len = len(raw_results)
                         n_batch_failed = _flush_batch(
                             img_batch, clf, model_type, model_name,
                             thread_db, raw_results,
@@ -1717,6 +1740,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                         if n_batch_failed:
                             failed_photo_ids.add(photo["id"])
                         failed += n_batch_failed
+
+                        # Record the classifier_runs row so the next pass over
+                        # the same (detection, model, fingerprint) short-
+                        # circuits. prediction_count reflects how many rows
+                        # _flush_batch added to raw_results for this detection.
+                        new_count = len(raw_results) - pre_len
+                        thread_db.record_classifier_run(
+                            primary_det["id"], model_name, spec_fp,
+                            prediction_count=new_count,
+                        )
 
                 group_result = _store_grouped_predictions(
                     raw_results, job["id"], model_name,

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -854,6 +854,16 @@
   </div>
 
 
+  <!-- Detection Cache -->
+  <div class="section">
+    <div class="section-title">Detection Cache</div>
+    <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+      MegaDetector results are cached globally per photo &amp; model. Switching workspaces or changing
+      the detector confidence threshold never re-runs detection on a photo that has already been scanned.
+    </p>
+    <div id="detectionCacheStats" style="font-size:13px;color:var(--text-secondary);">Loading&hellip;</div>
+  </div>
+
   <!-- Embedding Matrix -->
   <div class="section">
     <div class="section-title">Embedding Cache</div>
@@ -937,6 +947,7 @@ loadScanRoots();
 loadVersion();
 loadThemePicker();
 loadPreviewCacheStatus();
+loadDetectionCacheStats();
 
 function toggleSection(header) {
   header.classList.toggle('open');
@@ -2129,6 +2140,22 @@ async function clearPreviewCache() {
   } catch(e) {}
   if (btn) btn.disabled = false;
   loadPreviewCacheStatus();
+}
+
+/* ---------- Detection Cache ---------- */
+async function loadDetectionCacheStats() {
+  var el = document.getElementById('detectionCacheStats');
+  if (!el) return;
+  try {
+    var d = await safeFetch('/api/detection-cache/stats', {}, { toast: false });
+    var pc = d.photo_count || 0;
+    var mc = d.model_count || 0;
+    var photoWord = pc === 1 ? 'photo' : 'photos';
+    var modelWord = mc === 1 ? 'model' : 'models';
+    el.textContent = pc + ' ' + photoWord + ' \u00D7 ' + mc + ' ' + modelWord + ' cached';
+  } catch(e) {
+    el.textContent = 'Failed to load';
+  }
 }
 
 /* ---------- Embedding Cache ---------- */

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -92,6 +92,41 @@ def test_settings_page_has_preview_cache_field(app_and_db):
     assert b'clearPreviewCache' in resp.data
 
 
+def test_detection_cache_stats_endpoint(app_and_db):
+    """GET /api/detection-cache/stats reports global photo/model counts.
+
+    The cache is shared across workspaces, so the stat must reflect
+    every detector_runs row regardless of the active workspace.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    # Zero state: no detector runs recorded yet.
+    resp = client.get('/api/detection-cache/stats')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {"photo_count": 0, "model_count": 0}
+
+    # Settings page advertises the stat with the right DOM hooks.
+    page = client.get('/settings')
+    assert page.status_code == 200
+    assert b'detectionCacheStats' in page.data
+    assert b'photos' in page.data
+
+    # Record runs for two photos across two models and re-check.
+    photos = db.conn.execute("SELECT id FROM photos ORDER BY id").fetchall()
+    p1, p2 = photos[0]["id"], photos[1]["id"]
+    db.record_detector_run(p1, "megadetector-v6", box_count=2)
+    db.record_detector_run(p2, "megadetector-v6", box_count=0)
+    db.record_detector_run(p1, "megadetector-v5", box_count=1)
+
+    resp = client.get('/api/detection-cache/stats')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["photo_count"] == 2
+    assert data["model_count"] == 2
+
+
 def test_encounter_species_confirm(app_and_db):
     """POST /api/encounters/species tags photos with species keyword."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -893,6 +893,63 @@ def test_api_photo_pipeline_detections(app_and_db):
     assert "crop_box" in data
 
 
+def test_api_photo_pipeline_predictions_honor_threshold_and_fingerprint(app_and_db):
+    """The pipeline-debug endpoint's `predictions` list must apply the same
+    detector_confidence floor and fingerprint scoping as `detections`,
+    so the two lists never disagree.
+    """
+    app, db = app_and_db
+    pid = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    # Two detections on the same photo:
+    #   high-conf (0.9) — in active threshold → must surface predictions
+    #   low-conf  (0.05) — below default 0.2 → must be hidden
+    det_high, det_low = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+         "confidence": 0.9, "category": "animal"},
+        {"box": {"x": 0.6, "y": 0.6, "w": 0.3, "h": 0.3},
+         "confidence": 0.05, "category": "animal"},
+    ], detector_model="MDV6")
+    # Stale and current fingerprints on the high-conf detection.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-old', 'Finch', 0.95, '2026-01-01')",
+        (det_high,),
+    )
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-new', 'Robin', 0.85, '2026-04-24')",
+        (det_high,),
+    )
+    # Prediction on the below-threshold detection — must NOT surface.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-new', 'Sparrow', 0.9, '2026-04-24')",
+        (det_low,),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.get(f"/api/photos/{pid}/pipeline")
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    # Only the high-conf detection passes the threshold.
+    assert len(data["detections"]) == 1, (
+        f"detections list must apply detector_confidence floor; got "
+        f"{len(data['detections'])}"
+    )
+    # Predictions must match: no stale-fingerprint species, no
+    # below-threshold species.
+    species = [p["species"] for p in data["predictions"]]
+    assert species == ["Robin"], (
+        f"predictions must match detections (one current-fingerprint "
+        f"row, no stale, no below-threshold); got {species}"
+    )
+
+
 def test_compare_predictions_api_requires_collection(app_and_db):
     """GET /api/predictions/compare without collection_id returns 400."""
     app, _ = app_and_db

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -575,6 +575,43 @@ def test_detect_batch_skips_empty_photo_on_rerun(tmp_path, monkeypatch):
     assert call_count["n"] == 1, "detect_animals should not be re-called for empty photos"
 
 
+def test_classifier_skipped_when_run_already_recorded(tmp_path, monkeypatch):
+    """If (detection, classifier_model, fingerprint) already ran, don't invoke again."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_ids = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    det_id = det_ids[0]
+
+    # Pre-seed a classifier run — any subsequent invocation should bail
+    db.record_classifier_run(det_id, "bioclip-2", "abc123", prediction_count=0)
+
+    calls = {"n": 0}
+    def fake_classify(*a, **kw):
+        calls["n"] += 1
+        return []
+    monkeypatch.setattr("classify_job._run_classifier_on_detection", fake_classify)
+
+    import classify_job
+    classify_job._classify_detection_gated(
+        db=db, detection_id=det_id,
+        classifier_model="bioclip-2",
+        labels_fingerprint="abc123",
+        labels=["Robin"], reclassify=False,
+    )
+    assert calls["n"] == 0, "classifier should be skipped when run key exists"
+
+
 def test_classifier_fingerprint_upserted(tmp_path, monkeypatch):
     """When a classifier runs, the labels fingerprint is upserted."""
     from db import Database

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -970,6 +970,46 @@ def test_classifier_skipped_when_run_already_recorded(tmp_path, monkeypatch):
     assert calls["n"] == 0, "classifier should be skipped when run key exists"
 
 
+def test_classify_detection_gated_does_not_cache_zero_count(tmp_path, monkeypatch):
+    """A classify_fn returning [] (transient failure or no-op test stub) must
+    NOT be recorded as a completed classifier_run — otherwise the next
+    non-reclassify pass short-circuits on the gate and the detection is
+    permanently stranded without predictions.
+
+    Mirrors the guard already in _record_batch_classifier_runs and the
+    inline pipeline_job branch.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_ids = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9,
+          "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    det_id = det_ids[0]
+
+    import classify_job
+    # classify_fn=None returns [] with no side effects (see
+    # _run_classifier_on_detection). The gate must NOT write a run row.
+    classify_job._classify_detection_gated(
+        db=db, detection_id=det_id,
+        classifier_model="bioclip-2",
+        labels_fingerprint="abc123",
+        labels=["Robin"], reclassify=False,
+    )
+    assert db.get_classifier_run_keys(det_id) == set(), (
+        "zero-prediction classify_fn must not record a run key"
+    )
+
+
 def test_record_batch_classifier_runs_skips_zero_count(tmp_path):
     """A failed classifier batch (no prediction for a detection) must not be
     cached as a completed run — otherwise the detection is permanently

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -623,6 +623,79 @@ def test_detect_batch_does_not_cache_failed_detector_runs(tmp_path, monkeypatch)
     assert call_count["n"] == 2, "failed photos must be retried on next pass"
 
 
+def test_reclassify_preserves_cache_on_model_load_failure(tmp_path, monkeypatch):
+    """If the classifier fails to load, a reclassify must NOT have already
+    purged cached predictions/detections — otherwise weight-corruption
+    wipes shared-folder workspaces and there is no replacement.
+    """
+    from classify_job import ClassifyParams, run_classify_job
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder("/tmp/p", name="p")
+    pid = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    det_id = db.save_detections(pid, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="megadetector-v6")[0]
+    db.add_prediction(det_id, species="Robin", confidence=0.9,
+                      model="BioCLIP", labels_fingerprint="legacy")
+
+    # Seed a collection the classify path can consume.
+    coll_id = db.add_collection("c", '[{"field":"photo_ids","value":[' + str(pid) + ']}]')
+
+    # Force the classifier constructor to raise — simulates
+    # weight-corruption or missing-weights at load time.
+    import classifier as classifier_mod
+    class BoomClassifier:
+        def __init__(self, *a, **kw):
+            raise RuntimeError("simulated weights corruption")
+    monkeypatch.setattr(classifier_mod, "Classifier", BoomClassifier)
+
+    runner = FakeRunner()
+    job = _make_job()
+    params = ClassifyParams(
+        collection_id=coll_id,
+        labels_files=None,
+        labels_file=None,
+        model_id="BioCLIP",
+        model_name="BioCLIP",
+        grouping_window=0,
+        similarity_threshold=0.99,
+        reclassify=True,
+    )
+
+    # Run should fail (classifier init crashes) but MUST NOT destroy the
+    # cached prediction or detection.
+    import contextlib
+    with contextlib.suppress(Exception):
+        run_classify_job(job, runner, db_path, ws, params)
+
+    # Re-open the DB to read post-job state
+    db2 = Database(db_path)
+    db2.set_active_workspace(ws)
+    preds_after = db2.conn.execute(
+        "SELECT COUNT(*) AS n FROM predictions WHERE detection_id=?",
+        (det_id,),
+    ).fetchone()["n"]
+    dets_after = db2.conn.execute(
+        "SELECT COUNT(*) AS n FROM detections WHERE id=?",
+        (det_id,),
+    ).fetchone()["n"]
+    assert preds_after == 1, (
+        "Reclassify purge happened before model load failed — cached "
+        "predictions were destroyed without replacement."
+    )
+    assert dets_after == 1, (
+        "Detections purged before model load failure — cache lost."
+    )
+
+
 def test_classify_photos_surfaces_cached_full_image_predictions(tmp_path):
     """When a photo has no real detections and the full-image synthetic
     detection is gated by classifier_runs, the cached top prediction

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -399,15 +399,14 @@ def test_detect_batch_marks_processed_before_quality_scoring(tmp_path):
     assert 7 in detection_map
 
 
-def test_detect_batch_uses_workspace_effective_threshold(tmp_path, monkeypatch):
-    """When det_conf_threshold is unset, _detect_batch must read the
-    workspace-effective config (so per-workspace overrides apply), not
-    the bare global config.
+def test_detect_batch_does_not_pass_threshold_to_detector(tmp_path, monkeypatch):
+    """detect_animals is called with just the image path — the workspace
+    threshold is NOT applied at write time.
 
-    Regression: the old code called cfg.load() directly, which dropped
-    workspace overrides on the floor. A bird-photography workspace
-    setting detector_confidence=0.05 was silently ignored — every call
-    used the 0.2 global default.
+    Regression for the detection-storage redesign: the detector writes
+    everything above RAW_CONF_FLOOR so results can be globally cached
+    across workspaces. Any per-workspace threshold is applied as a
+    read-time filter (get_detections / stats queries), not here.
     """
     from unittest.mock import patch
 
@@ -434,8 +433,9 @@ def test_detect_batch_uses_workspace_effective_threshold(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_detect(image_path, confidence_threshold):
-        captured["threshold"] = confidence_threshold
+    def fake_detect(image_path, *args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
         return []
 
     runner = FakeRunner()
@@ -454,9 +454,13 @@ def test_detect_batch_uses_workspace_effective_threshold(tmp_path, monkeypatch):
             already_detected_ids=set(),
         )
 
-    assert captured["threshold"] == 0.05, (
-        "workspace override detector_confidence=0.05 was dropped; "
-        f"detect_animals was called with {captured.get('threshold')!r}"
+    assert "confidence_threshold" not in captured["kwargs"], (
+        "detect_animals must not receive confidence_threshold; "
+        f"got kwargs={captured['kwargs']!r}"
+    )
+    assert captured["args"] == (), (
+        "detect_animals must only be called with the image path; "
+        f"got extra positional args={captured['args']!r}"
     )
 
 

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -612,6 +612,47 @@ def test_classifier_skipped_when_run_already_recorded(tmp_path, monkeypatch):
     assert calls["n"] == 0, "classifier should be skipped when run key exists"
 
 
+def test_record_batch_classifier_runs_skips_zero_count(tmp_path):
+    """A failed classifier batch (no prediction for a detection) must not be
+    cached as a completed run — otherwise the detection is permanently
+    stranded on the next non-reclassify pass.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_ok, det_failed = db.save_detections(
+        photo_id,
+        [
+            {"box": {"x": 0, "y": 0, "w": 0.5, "h": 0.5}, "confidence": 0.9},
+            {"box": {"x": 0.5, "y": 0.5, "w": 0.5, "h": 0.5}, "confidence": 0.8},
+        ],
+        detector_model="megadetector-v6",
+    )
+
+    batch = [
+        {"detection_id": det_ok, "img": object()},
+        {"detection_id": det_failed, "img": object()},
+    ]
+    # Only the first detection made it into raw_results (second one failed)
+    raw_results = [{"detection_id": det_ok, "species": "Robin", "confidence": 0.9}]
+
+    import classify_job
+    classify_job._record_batch_classifier_runs(
+        db, batch, "bioclip-2", "abc123", raw_results
+    )
+
+    keys_ok = db.get_classifier_run_keys(det_ok)
+    keys_failed = db.get_classifier_run_keys(det_failed)
+    assert keys_ok == {("bioclip-2", "abc123")}, "successful detection should be cached"
+    assert keys_failed == set(), "failed detection must NOT be cached"
+
+
 def test_classifier_fingerprint_upserted(tmp_path, monkeypatch):
     """When a classifier runs, the labels fingerprint is upserted."""
     from db import Database

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -623,6 +623,72 @@ def test_detect_batch_does_not_cache_failed_detector_runs(tmp_path, monkeypatch)
     assert call_count["n"] == 2, "failed photos must be retried on next pass"
 
 
+def test_classify_photos_reclassifies_when_gate_has_no_cached_rows(tmp_path):
+    """If classifier_runs has a (model, fp) key but get_predictions_for_detection
+    returns nothing (e.g. a prior pass stored `category == 'match'` which
+    is intentionally not written, or transient ordering between the run
+    record and _store_grouped_predictions), the detection must fall
+    through to classification — not short-circuit forever.
+    """
+    from unittest.mock import MagicMock
+
+    from classify_job import _classify_photos
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    photos = [
+        {"id": 1, "filename": "bird.jpg", "folder_id": 10,
+         "timestamp": "2024-01-15T10:00:00"},
+    ]
+    folders = {10: str(tmp_path)}
+
+    mock_clf = MagicMock()
+    mock_clf.classify_batch_with_embedding.return_value = [
+        ([{"species": "Robin", "score": 0.9}], None),
+    ]
+    mock_db = MagicMock()
+    # Gate fires (run key present) but no cached prediction rows.
+    mock_db.get_classifier_run_keys.return_value = {("BioCLIP", "fp-x")}
+    mock_db.get_predictions_for_detection.return_value = []
+    mock_db.get_photo_embedding.return_value = None
+
+    # Need a real image on disk so _prepare_image succeeds.
+    import os
+    img_path = os.path.join(str(tmp_path), "bird.jpg")
+    Image.new("RGB", (400, 400), color="green").save(img_path)
+
+    detection_map = {
+        1: [{"id": 101, "box_x": 0.1, "box_y": 0.1,
+             "box_w": 0.5, "box_h": 0.5, "confidence": 0.9,
+             "category": "animal"}],
+    }
+
+    _classify_photos(
+        photos=photos,
+        folders=folders,
+        detection_map=detection_map,
+        existing_preds=set(),
+        clf=mock_clf,
+        model_type="bioclip",
+        model_name="BioCLIP",
+        runner=runner,
+        job=job,
+        db=mock_db,
+        labels_fingerprint="fp-x",
+    )
+
+    # The classifier must have actually been invoked — if the gate
+    # short-circuited on the empty cached result, this assertion fails.
+    assert (
+        mock_clf.classify_batch_with_embedding.called
+        or mock_clf.classify_with_embedding.called
+    ), (
+        "Gate fired with no cached rows and short-circuited classification; "
+        "the detection is stranded until --reclassify."
+    )
+
+
 def test_reclassify_preserves_cache_on_model_load_failure(tmp_path, monkeypatch):
     """If the classifier fails to load, a reclassify must NOT have already
     purged cached predictions/detections — otherwise weight-corruption

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -575,6 +575,54 @@ def test_detect_batch_skips_empty_photo_on_rerun(tmp_path, monkeypatch):
     assert call_count["n"] == 1, "detect_animals should not be re-called for empty photos"
 
 
+def test_detect_batch_does_not_cache_failed_detector_runs(tmp_path, monkeypatch):
+    """When detect_animals returns None (image decode error, ONNX crash,
+    etc.), _detect_batch must NOT write a detector_runs row — otherwise
+    future non-reclassify passes would skip the photo permanently,
+    leaving it without detections unless the user forces --reclassify.
+    A legitimate empty scene still gets cached (separate test).
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "broken.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+
+    call_count = {"n": 0}
+    def failing_detect(image_path):
+        call_count["n"] += 1
+        return None  # simulate detector failure
+
+    monkeypatch.setattr("classify_job.detect_animals", failing_detect)
+    monkeypatch.setattr("classify_job.get_primary_detection", lambda dets: None)
+
+    import classify_job
+    photos = [{"id": photo_id, "folder_id": folder_id, "filename": "broken.jpg"}]
+    folders = {folder_id: "/tmp/p"}
+
+    classify_job._detect_batch(
+        photos, folders, runner=None, job={"id": 0}, reclassify=False, db=db,
+        det_conf_threshold=0.2,
+        already_detected_ids=db.get_detector_run_photo_ids("megadetector-v6"),
+    )
+    assert call_count["n"] == 1, "detector was called"
+    # No detector_run row should have been written for the failed run
+    assert db.get_detector_run_photo_ids("megadetector-v6") == set()
+
+    # A second pass must call the detector again (no cached "already done")
+    classify_job._detect_batch(
+        photos, folders, runner=None, job={"id": 0}, reclassify=False, db=db,
+        det_conf_threshold=0.2,
+        already_detected_ids=db.get_detector_run_photo_ids("megadetector-v6"),
+    )
+    assert call_count["n"] == 2, "failed photos must be retried on next pass"
+
+
 def test_classify_photos_reuses_full_image_detection_on_rerun(tmp_path, monkeypatch):
     """When a photo has no real detections, classify_photos falls back to a
     synthetic ('full-image') detection. Because save_detections is
@@ -631,6 +679,65 @@ def test_classify_photos_reuses_full_image_detection_on_rerun(tmp_path, monkeypa
         (original_det_id,),
     ).fetchone()["n"]
     assert n == 1
+
+
+def test_store_grouped_predictions_writes_active_fingerprint(tmp_path):
+    """Predictions produced under a given label set must be written with
+    that set's fingerprint, not the default 'legacy'. Otherwise the
+    fingerprint-aware skip gate (get_existing_prediction_photo_ids with
+    labels_fingerprint=...) would miss them and force reclassification
+    on every pass.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_ids = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="MDV6",
+    )
+
+    import classify_job
+    raw_results = [{
+        "photo": {
+            "id": photo_id, "filename": "a.jpg",
+            "folder_id": folder_id, "timestamp": None, "burst_id": None,
+        },
+        "folder_path": "/tmp/p",
+        "detection_id": det_ids[0],
+        "prediction": "Robin",
+        "confidence": 0.88,
+        "alternatives": [],
+        "taxonomy": {},
+        "timestamp": None,
+    }]
+    classify_job._store_grouped_predictions(
+        raw_results, job_id="job-abc",
+        model_name="bioclip-2",
+        grouping_window=0,
+        similarity_threshold=0.99,
+        tax=None,
+        db=db,
+        labels_fingerprint="fp-active",
+    )
+
+    row = db.conn.execute(
+        "SELECT labels_fingerprint FROM predictions WHERE species=?", ("Robin",)
+    ).fetchone()
+    assert row is not None, "prediction was not stored"
+    assert row["labels_fingerprint"] == "fp-active"
+
+    # And the fingerprint-aware cache lookup must now find it.
+    hits = db.get_existing_prediction_photo_ids(
+        "bioclip-2", labels_fingerprint="fp-active",
+    )
+    assert hits == {photo_id}
 
 
 def test_classifier_skipped_when_run_already_recorded(tmp_path, monkeypatch):

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -575,6 +575,39 @@ def test_detect_batch_skips_empty_photo_on_rerun(tmp_path, monkeypatch):
     assert call_count["n"] == 1, "detect_animals should not be re-called for empty photos"
 
 
+def test_classifier_fingerprint_upserted(tmp_path, monkeypatch):
+    """When a classifier runs, the labels fingerprint is upserted."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_ids = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+
+    from labels_fingerprint import compute_fingerprint
+    labels = ["Robin", "Sparrow"]
+    expected_fp = compute_fingerprint(labels)
+
+    import classify_job
+    classify_job._record_labels_fingerprint(
+        db, fingerprint=expected_fp, labels=labels,
+        sources=["/tmp/active.txt"],
+    )
+    row = db.conn.execute(
+        "SELECT display_name, label_count FROM labels_fingerprints WHERE fingerprint=?",
+        (expected_fp,),
+    ).fetchone()
+    assert row["label_count"] == 2
+
+
 def test_classify_photos_iterates_over_detections(tmp_path):
     """_classify_photos should classify each detection independently."""
     from unittest.mock import MagicMock, patch

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -831,7 +831,7 @@ def test_store_grouped_predictions_saves_alternatives(tmp_path):
                        file_size=1000, file_mtime=1.0, timestamp="2024-01-15T10:00:00")
     det_ids = db.save_detections(pid, [
         {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}, "confidence": 0.9}
-    ])
+    ], detector_model="megadetector-v6")
 
     raw_results = [{
         "photo": {"id": pid, "filename": "bird.jpg", "timestamp": "2024-01-15T10:00:00"},

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -230,7 +230,7 @@ def test_detect_subjects_skips_existing_detections(tmp_path):
 
     mock_db = MagicMock()
     # Photo 1 already has detections in the database
-    mock_db.get_existing_detection_photo_ids.return_value = {1}
+    mock_db.get_detector_run_photo_ids.return_value = {1}
     mock_db.get_detections.return_value = [
         {"id": 101, "box_x": 0.1, "box_y": 0.1, "box_w": 0.5, "box_h": 0.5,
          "detector_confidence": 0.9, "category": "animal"},
@@ -269,7 +269,7 @@ def test_detect_subjects_skips_weight_download_when_all_cached(tmp_path):
     folders = {10: str(tmp_path)}
 
     mock_db = MagicMock()
-    mock_db.get_existing_detection_photo_ids.return_value = {1}
+    mock_db.get_detector_run_photo_ids.return_value = {1}
     mock_db.get_detections.return_value = [
         {"id": 101, "box_x": 0.1, "box_y": 0.1, "box_w": 0.5, "box_h": 0.5,
          "detector_confidence": 0.9, "category": "animal"},
@@ -299,7 +299,7 @@ def test_detect_subjects_skips_weight_download_for_empty_reclassify(tmp_path):
     job = _make_job()
 
     mock_db = MagicMock()
-    mock_db.get_existing_detection_photo_ids.return_value = set()
+    mock_db.get_detector_run_photo_ids.return_value = set()
 
     with patch("detector.ensure_megadetector_weights") as mock_ensure:
         _detect_subjects(
@@ -532,6 +532,47 @@ def test_detect_batch_returns_all_detections(tmp_path):
     assert detection_map[1][1]["id"] == 102
     assert detection_map[1][1]["box_x"] == 0.5
     mock_db.save_detections.assert_called_once()
+
+
+def test_detect_batch_skips_empty_photo_on_rerun(tmp_path, monkeypatch):
+    """A photo with no animals is recorded in detector_runs; rerun skips detection."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "empty.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+
+    call_count = {"n": 0}
+    def fake_detect(image_path):
+        call_count["n"] += 1
+        return []  # no animals
+
+    monkeypatch.setattr("classify_job.detect_animals", fake_detect)
+    monkeypatch.setattr("classify_job.get_primary_detection", lambda dets: None)
+
+    import classify_job
+    photos = [{"id": photo_id, "folder_id": folder_id, "filename": "empty.jpg"}]
+    folders = {folder_id: "/tmp/p"}
+
+    # First call: runs detection
+    classify_job._detect_batch(
+        photos, folders, runner=None, job={"id": 0}, reclassify=False, db=db,
+        det_conf_threshold=0.2,
+        already_detected_ids=db.get_detector_run_photo_ids("megadetector-v6"),
+    )
+    assert call_count["n"] == 1
+
+    # Second call: should skip because detector_runs has the row
+    classify_job._detect_batch(
+        photos, folders, runner=None, job={"id": 0}, reclassify=False, db=db,
+        det_conf_threshold=0.2,
+        already_detected_ids=db.get_detector_run_photo_ids("megadetector-v6"),
+    )
+    assert call_count["n"] == 1, "detect_animals should not be re-called for empty photos"
 
 
 def test_classify_photos_iterates_over_detections(tmp_path):

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -575,6 +575,64 @@ def test_detect_batch_skips_empty_photo_on_rerun(tmp_path, monkeypatch):
     assert call_count["n"] == 1, "detect_animals should not be re-called for empty photos"
 
 
+def test_classify_photos_reuses_full_image_detection_on_rerun(tmp_path, monkeypatch):
+    """When a photo has no real detections, classify_photos falls back to a
+    synthetic ('full-image') detection. Because save_detections is
+    clear-and-reinsert per (photo, detector_model), calling it on every
+    pass would generate a new id each time and cascade-delete prior
+    predictions/classifier_runs tied to the old id. The non-reclassify
+    path must reuse the existing full-image detection instead.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    # Pre-seed a full-image detection that a prior classify pass would have
+    # left behind.
+    det_ids = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0, "category": "animal"}],
+        detector_model="full-image",
+    )
+    original_det_id = det_ids[0]
+
+    # Sanity check the helper used by the reuse path — must use min_conf=0
+    # because the synthetic full-image detection has confidence=0.
+    existing = db.get_detections(
+        photo_id, detector_model="full-image", min_conf=0,
+    )
+    assert len(existing) == 1
+    assert existing[0]["id"] == original_det_id
+
+    # Simulate what classify_photos does on a subsequent pass: the reuse
+    # branch must NOT call save_detections again, or it would cascade-delete
+    # any cached predictions attached to the original detection.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence) "
+        "VALUES (?, 'bioclip', 'fp1', 'Robin', 0.8)",
+        (original_det_id,),
+    )
+    db.conn.commit()
+
+    # Reuse path via the helper
+    reused = db.get_detections(
+        photo_id, detector_model="full-image", min_conf=0,
+    )
+    assert reused[0]["id"] == original_det_id
+    # Prediction still there
+    n = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM predictions WHERE detection_id = ?",
+        (original_det_id,),
+    ).fetchone()["n"]
+    assert n == 1
+
+
 def test_classifier_skipped_when_run_already_recorded(tmp_path, monkeypatch):
     """If (detection, classifier_model, fingerprint) already ran, don't invoke again."""
     from db import Database

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -981,7 +981,12 @@ def test_classify_photos_new_photo(tmp_path):
 
 
 def test_classify_photos_skips_existing(tmp_path):
-    """Phase 6: skips photos with existing predictions."""
+    """Skipping is now per-detection via classifier_runs, not per-photo.
+
+    When a detection's (model, fingerprint) has a cached classifier run,
+    the classifier is not re-invoked, but the cached top-1 prediction is
+    surfaced into raw_results so downstream grouping still sees it.
+    """
     from unittest.mock import MagicMock
 
     from classify_job import _classify_photos
@@ -994,22 +999,28 @@ def test_classify_photos_skips_existing(tmp_path):
          "timestamp": "2024-01-15T10:00:00"},
     ]
     folders = {10: str(tmp_path)}
-    existing_preds = {1}  # photo 1 already classified
 
     mock_clf = MagicMock()
     mock_db = MagicMock()
-    mock_db.get_prediction_for_photo.return_value = {
-        "species": "Northern Cardinal",
-        "confidence": 0.95,
-        "detection_id": 101,
-    }
+    # Detection 101 has a cached classifier_run for (BioCLIP, legacy).
+    mock_db.get_classifier_run_keys.return_value = {("BioCLIP", "legacy")}
+    mock_db.get_predictions_for_detection.return_value = [
+        {"species": "Northern Cardinal", "confidence": 0.95,
+         "detection_id": 101},
+    ]
     mock_db.get_photo_embedding.return_value = None
+
+    detection_map = {
+        1: [{"id": 101, "box_x": 0.1, "box_y": 0.1,
+             "box_w": 0.5, "box_h": 0.5, "confidence": 0.9,
+             "category": "animal"}],
+    }
 
     raw_results, failed, skipped = _classify_photos(
         photos=photos,
         folders=folders,
-        detection_map={},
-        existing_preds=existing_preds,
+        detection_map=detection_map,
+        existing_preds=set(),  # dead parameter post-refactor
         clf=mock_clf,
         model_type="bioclip",
         model_name="BioCLIP",
@@ -1018,9 +1029,10 @@ def test_classify_photos_skips_existing(tmp_path):
         db=mock_db,
     )
 
-    assert skipped == 1
-    assert len(raw_results) == 1
+    assert skipped == 1, "cached detection should count as skipped"
+    assert len(raw_results) == 1, "cached prediction must be surfaced"
     assert raw_results[0]["_existing"] is True
+    assert raw_results[0]["prediction"] == "Northern Cardinal"
     mock_clf.classify_with_embedding.assert_not_called()
 
 

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -623,6 +623,60 @@ def test_detect_batch_does_not_cache_failed_detector_runs(tmp_path, monkeypatch)
     assert call_count["n"] == 2, "failed photos must be retried on next pass"
 
 
+def test_classify_photos_surfaces_cached_full_image_predictions(tmp_path):
+    """When a photo has no real detections and the full-image synthetic
+    detection is gated by classifier_runs, the cached top prediction
+    must still be surfaced into raw_results as `_existing: True` —
+    otherwise non-reclassify reruns silently drop those photos from
+    downstream grouping.
+    """
+    from unittest.mock import MagicMock
+
+    from classify_job import _classify_photos
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    photos = [
+        {"id": 1, "filename": "bird.jpg", "folder_id": 10,
+         "timestamp": "2024-01-15T10:00:00"},
+    ]
+    folders = {10: str(tmp_path)}
+
+    mock_clf = MagicMock()
+    mock_db = MagicMock()
+    # No real detections → full-image path. Existing full-image
+    # detection is cached.
+    mock_db.get_detections.return_value = [{"id": 999}]
+    mock_db.get_classifier_run_keys.return_value = {("BioCLIP", "fp-x")}
+    mock_db.get_predictions_for_detection.return_value = [
+        {"species": "Robin", "confidence": 0.9, "detection_id": 999},
+    ]
+    mock_db.get_photo_embedding.return_value = None
+
+    raw_results, failed, skipped = _classify_photos(
+        photos=photos,
+        folders=folders,
+        detection_map={},  # no real detections → full-image branch
+        existing_preds=set(),
+        clf=mock_clf,
+        model_type="bioclip",
+        model_name="BioCLIP",
+        runner=runner,
+        job=job,
+        db=mock_db,
+        labels_fingerprint="fp-x",
+    )
+
+    assert skipped == 1, "cached full-image detection should count as skipped"
+    assert len(raw_results) == 1, "cached full-image prediction must surface"
+    assert raw_results[0]["_existing"] is True
+    assert raw_results[0]["prediction"] == "Robin"
+    assert raw_results[0]["detection_id"] == 999
+    mock_clf.classify_with_embedding.assert_not_called()
+    mock_clf.classify_batch_with_embedding.assert_not_called()
+
+
 def test_classify_photos_reuses_full_image_detection_on_rerun(tmp_path, monkeypatch):
     """When a photo has no real detections, classify_photos falls back to a
     synthetic ('full-image') detection. Because save_detections is

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4291,6 +4291,52 @@ def test_detector_run_is_not_workspace_scoped(tmp_path):
     assert photo_id in db.get_detector_run_photo_ids("megadetector-v6")
 
 
+def test_init_normalizes_legacy_detector_model_key(tmp_path):
+    """Legacy rows written with detector_model='MegaDetector' must be
+    renamed to 'megadetector-v6' on init. Without this, the next run
+    would insert a parallel set of detections keyed on the new string
+    instead of clearing-and-reinserting the legacy ones.
+    """
+    from db import Database
+
+    db_path = str(tmp_path / "legacy.db")
+    db = Database(db_path)
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    # Manually write a legacy-keyed detection and detector_runs row, as if
+    # the DB had been populated by pre-refactor code.
+    db.conn.execute(
+        "INSERT INTO detections (photo_id, detector_model, "
+        "box_x, box_y, box_w, box_h, detector_confidence) "
+        "VALUES (?, 'MegaDetector', 0.1, 0.1, 0.2, 0.2, 0.9)",
+        (photo_id,),
+    )
+    db.conn.execute(
+        "INSERT OR IGNORE INTO detector_runs "
+        "(photo_id, detector_model, box_count) VALUES (?, 'MegaDetector', 1)",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.conn.close()
+
+    # Re-open: init-time migration should normalize the key.
+    db2 = Database(db_path)
+    det_keys = {r["detector_model"] for r in db2.conn.execute(
+        "SELECT detector_model FROM detections"
+    ).fetchall()}
+    run_keys = {r["detector_model"] for r in db2.conn.execute(
+        "SELECT detector_model FROM detector_runs"
+    ).fetchall()}
+    assert det_keys == {"megadetector-v6"}
+    assert run_keys == {"megadetector-v6"}
+
+
 def test_record_classifier_run_and_lookup(tmp_path):
     from db import Database
     db = Database(str(tmp_path / "test.db"))

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3969,3 +3969,45 @@ def test_review_status_absence_is_pending(tmp_path):
 
     db.set_review_status(pred_id, ws, status="rejected")
     assert db.get_review_status(pred_id, ws) == "rejected"
+
+
+def test_migration_backfills_detector_runs(tmp_path):
+    """Legacy detections become detector_runs rows on upgrade."""
+    import sqlite3
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER,
+                             filename TEXT, timestamp TEXT, rating INTEGER,
+                             UNIQUE(folder_id, filename));
+        CREATE TABLE workspaces (id INTEGER PRIMARY KEY, name TEXT UNIQUE,
+                                 last_opened_at TEXT);
+        CREATE TABLE detections (
+            id INTEGER PRIMARY KEY,
+            photo_id INTEGER,
+            workspace_id INTEGER,
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence REAL,
+            category TEXT,
+            detector_model TEXT,
+            created_at TEXT
+        );
+        INSERT INTO folders (id, path) VALUES (1, '/p');
+        INSERT INTO photos (id, folder_id, filename) VALUES (10, 1, 'a.jpg');
+        INSERT INTO workspaces (id, name) VALUES (1, 'Default');
+        INSERT INTO detections (photo_id, workspace_id, box_x, box_y, box_w, box_h,
+                                detector_confidence, category, detector_model, created_at)
+            VALUES (10, 1, 0, 0, 1, 1, 0.5, 'animal', 'megadetector-v6', '2026-01-01T00:00:00');
+    """)
+    conn.commit()
+    conn.close()
+
+    # Open through Database → migrations run
+    from db import Database
+    db = Database(db_path)
+    run = db.conn.execute(
+        "SELECT box_count FROM detector_runs WHERE photo_id=10 AND detector_model='megadetector-v6'"
+    ).fetchone()
+    assert run is not None
+    assert run["box_count"] == 1

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3213,6 +3213,48 @@ def test_get_existing_detection_photo_ids(tmp_path):
     assert pid2 not in result
 
 
+def test_get_detector_run_photo_ids_excludes_torn_state(tmp_path):
+    """A detector_runs row with box_count>0 but no matching detections is a
+    torn state left behind by a reclassify that cleared detections and then
+    failed before writing new rows. That photo must NOT be treated as cached —
+    otherwise the next non-reclassify run skips detection and the photo is
+    permanently stranded on full-image fallback.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos")
+    torn = db.add_photo(folder_id=fid, filename="torn.jpg", extension=".jpg",
+                        file_size=100, file_mtime=1.0)
+    empty = db.add_photo(folder_id=fid, filename="empty.jpg", extension=".jpg",
+                         file_size=100, file_mtime=1.0)
+    ok = db.add_photo(folder_id=fid, filename="ok.jpg", extension=".jpg",
+                      file_size=100, file_mtime=1.0)
+
+    # Torn: run recorded with boxes, but detections cleared (simulates a
+    # reclassify that wiped rows then crashed before re-detecting).
+    db.save_detections(torn, [
+        {"box": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4}, "confidence": 0.9,
+         "category": "animal"},
+    ], detector_model="megadetector-v6")
+    db.record_detector_run(torn, "megadetector-v6", box_count=1)
+    db.clear_detections(torn)
+
+    # Legit empty scene: run recorded with box_count=0, no detections.
+    db.record_detector_run(empty, "megadetector-v6", box_count=0)
+
+    # Consistent: run recorded and detection rows present.
+    db.save_detections(ok, [
+        {"box": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4}, "confidence": 0.9,
+         "category": "animal"},
+    ], detector_model="megadetector-v6")
+    db.record_detector_run(ok, "megadetector-v6", box_count=1)
+
+    result = db.get_detector_run_photo_ids("megadetector-v6")
+    assert torn not in result, "torn state must be re-detected, not skipped"
+    assert empty in result, "legit empty scenes must stay cached"
+    assert ok in result, "consistent cached runs must stay cached"
+
+
 def test_multiple_predictions_per_detection(tmp_path):
     """Multiple species predictions can be stored for the same detection."""
     from db import Database
@@ -4814,6 +4856,15 @@ def test_detector_run_is_not_workspace_scoped(tmp_path):
     )
 
     db._active_workspace_id = ws_a
+    # Save the matching detection rows alongside the run so the cached-run
+    # state is consistent — get_detector_run_photo_ids excludes torn states
+    # where box_count>0 has no matching detections.
+    db.save_detections(photo_id, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.9,
+         "category": "animal"},
+        {"box": {"x": 0.4, "y": 0.4, "w": 0.2, "h": 0.2}, "confidence": 0.8,
+         "category": "animal"},
+    ], detector_model="megadetector-v6")
     db.record_detector_run(photo_id, "megadetector-v6", box_count=2)
 
     db._active_workspace_id = ws_b

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1224,6 +1224,65 @@ def test_query_move_rule_matches_has_predictions(tmp_path):
     assert misses == [pids[1]]
 
 
+def test_species_clusters_endpoint_filters_to_active_fingerprint(tmp_path, monkeypatch):
+    """/api/species/<name>/clusters must not mix stale and current-label
+    rows when a detection has been classified under multiple fingerprints.
+    """
+    import os
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    from app import create_app
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+    from db import Database
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    fid = db.add_folder("/p", name="p")
+    pid = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                       file_size=100, file_mtime=1.0)
+    import numpy as np
+    emb = np.zeros(512, dtype=np.float32).tobytes()
+    db.conn.execute(
+        "UPDATE photos SET embedding=?, embedding_model='test' WHERE id=?",
+        (emb, pid),
+    )
+    det_id = db.save_detections(pid, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")[0]
+    # Two fingerprints on the same detection with the same species.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-old', 'Robin', 0.95, '2026-01-01')",
+        (det_id,),
+    )
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-new', 'Robin', 0.80, '2026-04-24')",
+        (det_id,),
+    )
+    db.conn.commit()
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir,
+                     api_token="t")
+    client = app.test_client()
+    resp = client.get("/api/species/Robin/clusters")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Photo must appear exactly once (deduped to the current fingerprint),
+    # not twice (one per fingerprint row).
+    assert data["total_photos"] == 1, (
+        f"Expected one photo (deduped to current fingerprint), got "
+        f"{data['total_photos']}"
+    )
+
+
 def test_clear_detections_also_clears_detector_runs(tmp_path):
     """clear_detections must wipe the matching detector_runs entry, or a
     failed reclassify (clear, then model init crash) would leave a stale

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -5408,6 +5408,70 @@ def test_migration_dedupes_detections_and_repoints_predictions(tmp_path):
     assert "workspace_id" not in cols
 
 
+def test_migration_handles_loser_vs_loser_collision(tmp_path):
+    """When the canonical detection has NO prediction yet but two
+    *non-canonical* duplicate detections both have the same
+    (model, species), the upcoming remap would collapse both onto the
+    same (canonical_id, model, species) tuple and trip the legacy
+    UNIQUE. The pre-remap dedup must keep one loser as the survivor.
+    """
+    import sqlite3
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER,
+                             filename TEXT, timestamp TEXT, rating INTEGER,
+                             UNIQUE(folder_id, filename));
+        CREATE TABLE workspaces (id INTEGER PRIMARY KEY, name TEXT UNIQUE,
+                                 config_overrides TEXT, ui_state TEXT,
+                                 last_opened_at TEXT);
+        CREATE TABLE detections (
+            id INTEGER PRIMARY KEY, photo_id INTEGER, workspace_id INTEGER,
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence REAL, category TEXT, detector_model TEXT,
+            created_at TEXT
+        );
+        CREATE TABLE predictions (
+            id INTEGER PRIMARY KEY, detection_id INTEGER, species TEXT,
+            confidence REAL, model TEXT, status TEXT DEFAULT 'pending',
+            individual TEXT, group_id TEXT, created_at TEXT,
+            UNIQUE(detection_id, model, species)
+        );
+        INSERT INTO folders VALUES (1, '/p');
+        INSERT INTO photos (id, folder_id, filename) VALUES (10, 1, 'a.jpg');
+        INSERT INTO workspaces (id, name) VALUES (1, 'A'), (2, 'B'), (3, 'C');
+        -- Three detections on the same box, three workspaces.
+        -- d1 will be the canonical (lowest id). Critically, d1 has NO
+        -- prediction; predictions exist only on d2 and d3.
+        INSERT INTO detections (id, photo_id, workspace_id, box_x, box_y, box_w, box_h,
+                                detector_confidence, category, detector_model, created_at)
+          VALUES (100, 10, 1, 0.1, 0.1, 0.5, 0.5, 0.9, 'animal', 'megadetector-v6', 't1'),
+                 (200, 10, 2, 0.1, 0.1, 0.5, 0.5, 0.9, 'animal', 'megadetector-v6', 't2'),
+                 (300, 10, 3, 0.1, 0.1, 0.5, 0.5, 0.9, 'animal', 'megadetector-v6', 't3');
+        -- Two non-canonical losers, same (model, species), no canonical
+        -- prediction. The naive remap would put both on (100, 'bioclip-2',
+        -- 'Robin') and trip UNIQUE.
+        INSERT INTO predictions (id, detection_id, species, model, status) VALUES
+            (2000, 200, 'Robin', 'bioclip-2', 'approved'),
+            (3000, 300, 'Robin', 'bioclip-2', 'pending');
+    """)
+    conn.commit()
+    conn.close()
+
+    # Init must not raise IntegrityError.
+    from db import Database
+    db = Database(db_path)
+    rows = db.conn.execute(
+        "SELECT id FROM predictions WHERE species='Robin' "
+        "AND classifier_model='bioclip-2'"
+    ).fetchall()
+    assert len(rows) == 1, (
+        f"Expected exactly one Robin prediction after loser-vs-loser "
+        f"dedup; got {len(rows)}"
+    )
+
+
 def test_migration_handles_prediction_collision_on_repoint(tmp_path):
     """When two workspaces had the SAME (detection, model, species) prediction
     on duplicate detection rows (one per workspace), repointing both to the

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1224,6 +1224,48 @@ def test_query_move_rule_matches_has_predictions(tmp_path):
     assert misses == [pids[1]]
 
 
+def test_update_prediction_group_info_scoped_to_fingerprint(tmp_path):
+    """Group metadata must land on the primary row for the ACTIVE label
+    fingerprint, not whichever fingerprint happens to have higher
+    confidence on the same detection.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    det_id = db.save_detections(pids[0], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")[0]
+
+    # Stale fingerprint has HIGHER confidence than current — so the old
+    # (by-confidence-only) SELECT would pick the wrong one.
+    db.add_prediction(det_id, species="Finch", confidence=0.95,
+                      model="bioclip-2", labels_fingerprint="fp-old")
+    pred_old = db.conn.execute(
+        "SELECT id FROM predictions WHERE labels_fingerprint='fp-old'"
+    ).fetchone()["id"]
+    db.add_prediction(det_id, species="Robin", confidence=0.80,
+                      model="bioclip-2", labels_fingerprint="fp-new")
+    pred_new = db.conn.execute(
+        "SELECT id FROM predictions WHERE labels_fingerprint='fp-new'"
+    ).fetchone()["id"]
+
+    db.update_prediction_group_info(
+        detection_id=det_id, model="bioclip-2",
+        group_id="g1", vote_count=2, total_votes=3, individual=None,
+        labels_fingerprint="fp-new",
+    )
+
+    # Only the fp-new row got the group metadata.
+    new_row = db.conn.execute(
+        "SELECT group_id FROM prediction_review WHERE prediction_id=?",
+        (pred_new,),
+    ).fetchone()
+    old_row = db.conn.execute(
+        "SELECT group_id FROM prediction_review WHERE prediction_id=?",
+        (pred_old,),
+    ).fetchone()
+    assert new_row is not None and new_row["group_id"] == "g1"
+    assert old_row is None, "stale-fingerprint row must not receive group metadata"
+
+
 def test_accept_prediction_sibling_rejection_scoped_to_fingerprint(tmp_path):
     """Accepting a prediction under one labels_fingerprint must not mark
     predictions with OTHER fingerprints on the same detection as rejected.

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4066,3 +4066,60 @@ def test_migration_backfills_prediction_review(tmp_path):
     ws_statuses = {r["workspace_id"]: (r["status"], r["individual"]) for r in rows}
     assert ws_statuses[1] == ("approved", "Ruby")
     assert ws_statuses[2] == ("rejected", None)
+
+
+def test_migration_dedupes_detections_and_repoints_predictions(tmp_path):
+    """Two workspaces with identical detection rows collapse to one; predictions follow."""
+    import sqlite3
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER,
+                             filename TEXT, timestamp TEXT, rating INTEGER,
+                             UNIQUE(folder_id, filename));
+        CREATE TABLE workspaces (id INTEGER PRIMARY KEY, name TEXT UNIQUE,
+                                 config_overrides TEXT, ui_state TEXT,
+                                 last_opened_at TEXT);
+        CREATE TABLE detections (
+            id INTEGER PRIMARY KEY, photo_id INTEGER, workspace_id INTEGER,
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence REAL, category TEXT, detector_model TEXT,
+            created_at TEXT
+        );
+        CREATE TABLE predictions (
+            id INTEGER PRIMARY KEY, detection_id INTEGER, species TEXT,
+            confidence REAL, model TEXT, status TEXT DEFAULT 'pending',
+            individual TEXT, group_id TEXT, created_at TEXT
+        );
+        INSERT INTO folders VALUES (1, '/p');
+        INSERT INTO photos (id, folder_id, filename) VALUES (10, 1, 'a.jpg');
+        INSERT INTO workspaces (id, name) VALUES (1, 'A'), (2, 'B');
+        -- Same box, same photo, two workspaces:
+        INSERT INTO detections (id, photo_id, workspace_id, box_x, box_y, box_w, box_h,
+                                detector_confidence, category, detector_model, created_at)
+          VALUES (100, 10, 1, 0.1, 0.1, 0.5, 0.5, 0.9, 'animal', 'megadetector-v6', 't1'),
+                 (200, 10, 2, 0.1, 0.1, 0.5, 0.5, 0.9, 'animal', 'megadetector-v6', 't2');
+        INSERT INTO predictions (id, detection_id, species, model, status) VALUES
+            (1000, 100, 'Robin', 'bioclip-2', 'approved'),
+            (2000, 200, 'Robin', 'bioclip-2', 'pending');
+    """)
+    conn.commit()
+    conn.close()
+
+    from db import Database
+    db = Database(db_path)
+    # Exactly one detection row for (photo=10, model=megadetector-v6)
+    rows = db.conn.execute(
+        "SELECT id FROM detections WHERE photo_id=10 AND detector_model='megadetector-v6'"
+    ).fetchall()
+    assert len(rows) == 1
+    canonical_id = rows[0]["id"]
+    # Both predictions now point at the canonical detection id
+    pred_rows = db.conn.execute(
+        "SELECT id, detection_id FROM predictions ORDER BY id"
+    ).fetchall()
+    assert {r["detection_id"] for r in pred_rows} == {canonical_id}
+    # detections table no longer has workspace_id column
+    cols = {r[1] for r in db.conn.execute("PRAGMA table_info(detections)").fetchall()}
+    assert "workspace_id" not in cols

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4177,3 +4177,23 @@ def test_migration_sets_labels_fingerprint_legacy(tmp_path):
         "SELECT labels_fingerprint FROM predictions WHERE id=1"
     ).fetchone()
     assert row["labels_fingerprint"] == "legacy"
+
+
+def test_predictions_has_new_unique_and_no_legacy_columns(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    cols = {r[1] for r in db.conn.execute(
+        "PRAGMA table_info(predictions)"
+    ).fetchall()}
+    # Legacy review/workspace columns are gone
+    for legacy in ("status", "reviewed_at", "individual", "group_id",
+                   "vote_count", "total_votes", "workspace_id"):
+        assert legacy not in cols, f"legacy column {legacy} still present"
+    # New unique constraint on (detection_id, classifier_model, labels_fingerprint, species)
+    indexes = db.conn.execute(
+        "SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name='predictions'"
+    ).fetchall()
+    assert any(
+        "labels_fingerprint" in (idx["sql"] or "") and "species" in (idx["sql"] or "")
+        for idx in indexes
+    )

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1376,8 +1376,9 @@ def test_get_accepted_species_excludes_non_geolocated(tmp_path):
     ], detector_model="MDV6")
     db.add_prediction(det_ids[0], 'Red-tailed Hawk', 0.95, 'bioclip')
     preds = db.get_predictions(photo_ids=[p1])
-    db.conn.execute("UPDATE predictions SET status='accepted' WHERE id=?", (preds[0]['id'],))
-    db.conn.commit()
+    # Review status now lives in the workspace-scoped prediction_review
+    # table; absent rows are 'pending'.
+    db.set_review_status(preds[0]['id'], db._active_workspace_id, 'accepted')
 
     species = db.get_accepted_species()
     assert species == []
@@ -2104,7 +2105,12 @@ def test_database_supports_in_memory_sqlite():
 
 
 def test_detections_table_exists(tmp_path):
-    """The detections table should exist with expected columns."""
+    """The detections table should exist with expected columns.
+
+    ``workspace_id`` was dropped when detections became global (cached per
+    photo, not per workspace); the per-workspace scoping now happens via
+    ``workspace_folders`` joins at read time.
+    """
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     row = db.conn.execute(
@@ -2113,7 +2119,7 @@ def test_detections_table_exists(tmp_path):
     assert row is not None
     schema = row[0].lower()
     assert "photo_id" in schema
-    assert "workspace_id" in schema
+    assert "workspace_id" not in schema
     assert "box_x" in schema
     assert "box_y" in schema
     assert "box_w" in schema
@@ -2485,10 +2491,25 @@ def test_init_purges_orphan_predictions(tmp_path):
     from db import Database
     db_path = str(tmp_path / "test.db")
     db = Database(db_path)
-    # Bypass the add_prediction guard to simulate a legacy orphan row.
+    # Simulate a legacy orphan row by dropping the NOT NULL constraint on
+    # detection_id — the current CREATE enforces NOT NULL (that guard was
+    # added after the purge was written), but pre-migration installs still
+    # hold orphans we want the purge to sweep.
+    db.conn.execute("DROP TABLE predictions")
     db.conn.execute(
-        "INSERT INTO predictions (detection_id, species, confidence, model, status) "
-        "VALUES (NULL, 'Elk', 0.9, 'bioclip', 'pending')"
+        """CREATE TABLE predictions (
+            id INTEGER PRIMARY KEY,
+            detection_id INTEGER,
+            classifier_model TEXT,
+            labels_fingerprint TEXT DEFAULT 'legacy',
+            species TEXT,
+            confidence REAL,
+            category TEXT
+        )"""
+    )
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, species, confidence, classifier_model) "
+        "VALUES (NULL, 'Elk', 0.9, 'bioclip')"
     )
     db.conn.commit()
     assert db.conn.execute(
@@ -2559,11 +2580,12 @@ def test_multiple_predictions_per_detection(tmp_path):
     ws_id = db.ensure_default_workspace()
     db.set_active_workspace(ws_id)
     fid = db.add_folder("/photos", name="photos")
+    db.add_workspace_folder(ws_id, fid)
     pid = db.add_photo(folder_id=fid, filename="bird.jpg", extension=".jpg",
                        file_size=1000, file_mtime=1.0)
     det_ids = db.save_detections(pid, [
         {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}, "confidence": 0.9}
-    ])
+    ], detector_model="megadetector-v6")
     det_id = det_ids[0]
 
     db.add_prediction(detection_id=det_id, species="Robin", confidence=0.85,
@@ -2586,11 +2608,12 @@ def test_alternative_predictions_filtered_from_pending(tmp_path):
     ws_id = db.ensure_default_workspace()
     db.set_active_workspace(ws_id)
     fid = db.add_folder("/photos", name="photos")
+    db.add_workspace_folder(ws_id, fid)
     pid = db.add_photo(folder_id=fid, filename="bird.jpg", extension=".jpg",
                        file_size=1000, file_mtime=1.0)
     det_ids = db.save_detections(pid, [
         {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}, "confidence": 0.9}
-    ])
+    ], detector_model="megadetector-v6")
     det_id = det_ids[0]
 
     db.add_prediction(detection_id=det_id, species="Robin", confidence=0.85,
@@ -3370,14 +3393,23 @@ def test_get_highlights_candidates(tmp_path):
             "UPDATE photos SET quality_score = ? WHERE id = ?", (qs, pid)
         )
         if qs is not None and qs >= 0.5:
-            # Add a detection + accepted prediction for photos with decent quality
+            # Add a detection + accepted prediction for photos with decent quality.
+            # Detections are global (no workspace_id); the predictions table
+            # dropped ``model``/``status`` — review state lives in
+            # ``prediction_review``.
             did = db.conn.execute(
-                "INSERT INTO detections (photo_id, workspace_id, detector_confidence) VALUES (?, ?, 0.9)",
-                (pid, db._ws_id()),
+                "INSERT INTO detections (photo_id, detector_confidence) VALUES (?, 0.9)",
+                (pid,),
+            ).lastrowid
+            pred_id = db.conn.execute(
+                "INSERT INTO predictions (detection_id, classifier_model, species, confidence) "
+                "VALUES (?, 'test', ?, 0.95)",
+                (did, f"Species{i}"),
             ).lastrowid
             db.conn.execute(
-                "INSERT INTO predictions (detection_id, species, confidence, status) VALUES (?, ?, 0.95, 'accepted')",
-                (did, f"Species{i}"),
+                "INSERT INTO prediction_review (prediction_id, workspace_id, status) "
+                "VALUES (?, ?, 'accepted')",
+                (pred_id, db._ws_id()),
             )
     db.conn.commit()
 
@@ -4163,8 +4195,9 @@ def test_review_status_absence_is_pending(tmp_path):
         [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
         detector_model="megadetector-v6",
     )
+    # Predictions now carry ``classifier_model`` (the old ``model`` was renamed).
     pred_id = db.conn.execute(
-        """INSERT INTO predictions (detection_id, model, species, confidence)
+        """INSERT INTO predictions (detection_id, classifier_model, species, confidence)
            VALUES (?, 'bioclip-2', 'Robin', 0.8)""",
         (det_ids[0],),
     ).lastrowid

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1470,6 +1470,50 @@ def test_get_top_prediction_for_photo_scoped_to_current_fingerprint(tmp_path):
     )
 
 
+def test_get_top_prediction_for_photo_respects_detector_confidence(tmp_path):
+    """get_top_prediction_for_photo must drop predictions whose backing
+    detection is below the supplied detector_confidence floor — otherwise
+    iNat prefill/submit can use species from detections the UI threshold
+    is supposed to hide (e.g. lower threshold to classify, then raise it).
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    # Two detections on the same photo: one above the upcoming threshold
+    # with a LOWER-confidence prediction, one below with a HIGHER-
+    # confidence prediction. Without the floor, the below-threshold
+    # detection's species wins by confidence.
+    det_high_conf, det_low_conf = db.save_detections(pids[0], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"},
+        {"box": {"x": 1, "y": 1, "w": 1, "h": 1}, "confidence": 0.05, "category": "animal"},
+    ], detector_model="MDV6")
+    db.add_prediction(det_high_conf, species="Robin", confidence=0.4,
+                      model="bioclip-2", labels_fingerprint="fp")
+    db.add_prediction(det_low_conf, species="Finch", confidence=0.95,
+                      model="bioclip-2", labels_fingerprint="fp")
+
+    # Without a floor: confidence-only ranking returns the (now-hidden)
+    # below-threshold detection's species.
+    pred_unfiltered = db.get_top_prediction_for_photo(pids[0])
+    assert pred_unfiltered is not None
+    assert pred_unfiltered["species"] == "Finch"
+
+    # With the floor matching a typical UI threshold, only the above-
+    # threshold detection is eligible, so we get the visible species.
+    pred = db.get_top_prediction_for_photo(
+        pids[0], min_detector_confidence=0.2,
+    )
+    assert pred is not None
+    assert pred["species"] == "Robin", (
+        "Helper returned a species from a below-threshold detection — "
+        "iNat would submit a taxon from a detection the UI hides."
+    )
+
+    # If the floor excludes every detection, the helper returns None
+    # rather than falling back to a hidden detection.
+    assert db.get_top_prediction_for_photo(
+        pids[0], min_detector_confidence=0.99,
+    ) is None
+
+
 def test_update_prediction_group_info_scoped_to_fingerprint(tmp_path):
     """Group metadata must land on the primary row for the ACTIVE label
     fingerprint, not whichever fingerprint happens to have higher

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1224,6 +1224,101 @@ def test_query_move_rule_matches_has_predictions(tmp_path):
     assert misses == [pids[1]]
 
 
+def test_migration_preserves_predictions_when_dropping_detections(tmp_path):
+    """Legacy DB with FK ON DELETE CASCADE from predictions→detections:
+    the global-detections rewrite must NOT cascade-delete predictions
+    when it drops the old detections table. Data loss regression.
+    """
+    import sqlite3
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER,
+                             filename TEXT, timestamp TEXT, rating INTEGER,
+                             UNIQUE(folder_id, filename));
+        CREATE TABLE workspaces (id INTEGER PRIMARY KEY, name TEXT UNIQUE,
+                                 config_overrides TEXT, ui_state TEXT,
+                                 last_opened_at TEXT);
+        CREATE TABLE detections (
+            id INTEGER PRIMARY KEY, photo_id INTEGER, workspace_id INTEGER,
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence REAL, category TEXT, detector_model TEXT,
+            created_at TEXT
+        );
+        -- The REAL legacy schema: FK with ON DELETE CASCADE. Dropping the
+        -- old detections table with FKs enabled would nuke everything here.
+        CREATE TABLE predictions (
+            id INTEGER PRIMARY KEY,
+            detection_id INTEGER REFERENCES detections(id) ON DELETE CASCADE,
+            species TEXT, confidence REAL, model TEXT,
+            status TEXT DEFAULT 'pending',
+            individual TEXT, group_id TEXT, created_at TEXT
+        );
+        INSERT INTO folders VALUES (1, '/p');
+        INSERT INTO photos (id, folder_id, filename) VALUES (10, 1, 'a.jpg');
+        INSERT INTO workspaces (id, name) VALUES (1, 'Default');
+        INSERT INTO detections (id, photo_id, workspace_id, box_x, box_y, box_w, box_h,
+                                detector_confidence, category, detector_model, created_at)
+            VALUES (100, 10, 1, 0, 0, 1, 1, 0.9, 'animal', 'megadetector-v6', 't1');
+        INSERT INTO predictions (id, detection_id, species, model, status) VALUES
+            (1000, 100, 'Robin', 'bioclip-2', 'accepted');
+    """)
+    conn.commit()
+    conn.close()
+
+    from db import Database
+    db = Database(db_path)
+    # Prediction row must still be there after migration.
+    pred_count = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM predictions"
+    ).fetchone()["n"]
+    assert pred_count == 1, (
+        "Migration cascade-deleted predictions when it dropped the old "
+        "detections table — data loss regression."
+    )
+    # And it must still be reachable via the new detection row.
+    row = db.conn.execute(
+        "SELECT p.species FROM predictions p "
+        "JOIN detections d ON d.id = p.detection_id WHERE p.id = 1000"
+    ).fetchone()
+    assert row is not None
+    assert row["species"] == "Robin"
+
+
+def test_get_top_prediction_for_photo_scoped_to_current_fingerprint(tmp_path):
+    """get_top_prediction_for_photo must return the highest-confidence row
+    from the *current* fingerprint only — a stale fingerprint with higher
+    confidence must NOT win. Used by iNat prefill/submit to avoid sending
+    a taxon from an old label set.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    det_id = db.save_detections(pids[0], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")[0]
+    # Stale fingerprint wins by confidence but is from an old label set.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-old', 'Finch', 0.95, '2026-01-01')",
+        (det_id,),
+    )
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-new', 'Robin', 0.80, '2026-04-24')",
+        (det_id,),
+    )
+    db.conn.commit()
+
+    pred = db.get_top_prediction_for_photo(pids[0])
+    assert pred is not None
+    assert pred["species"] == "Robin", (
+        "Helper returned stale-fingerprint species despite higher "
+        "confidence — would prefill iNat with the wrong taxon."
+    )
+
+
 def test_update_prediction_group_info_scoped_to_fingerprint(tmp_path):
     """Group metadata must land on the primary row for the ACTIVE label
     fingerprint, not whichever fingerprint happens to have higher

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1224,6 +1224,86 @@ def test_query_move_rule_matches_has_predictions(tmp_path):
     assert misses == [pids[1]]
 
 
+def test_add_prediction_duplicate_does_not_corrupt_review(tmp_path):
+    """When add_prediction is called twice with the same unique key and the
+    second call carries review metadata, the upsert into prediction_review
+    must target the EXISTING prediction_id — not whatever cur.lastrowid
+    happens to hold after the INSERT OR IGNORE is skipped.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}, {}])
+    # Two distinct detections so we have two prediction ids to confuse.
+    det1 = db.save_detections(pids[0], [
+        {"box": {"x": 0, "y": 0, "w": 0.5, "h": 0.5}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")[0]
+    det2 = db.save_detections(pids[1], [
+        {"box": {"x": 0.5, "y": 0.5, "w": 0.5, "h": 0.5}, "confidence": 0.85, "category": "animal"}
+    ], detector_model="MDV6")[0]
+
+    # First prediction on det1 — no review state, fingerprint="x".
+    db.add_prediction(det1, species="Robin", confidence=0.9,
+                      model="bioclip-2", labels_fingerprint="x")
+    pred1_id = db.conn.execute(
+        "SELECT id FROM predictions WHERE detection_id=?", (det1,)
+    ).fetchone()["id"]
+
+    # Unrelated prediction on det2 to move cur.lastrowid forward.
+    db.add_prediction(det2, species="Sparrow", confidence=0.8,
+                      model="bioclip-2", labels_fingerprint="x")
+
+    # Re-add the SAME (det1, model, fp, species) with review metadata.
+    # INSERT OR IGNORE should skip; the upsert must target pred1_id, not
+    # the most-recent-insert id (which would be det2's prediction).
+    db.add_prediction(
+        det1, species="Robin", confidence=0.9,
+        model="bioclip-2", labels_fingerprint="x",
+        status="accepted", individual="Ruby",
+    )
+    rev_rows = db.conn.execute(
+        "SELECT prediction_id, status, individual FROM prediction_review "
+        "WHERE status = 'accepted'"
+    ).fetchall()
+    assert len(rev_rows) == 1
+    assert rev_rows[0]["prediction_id"] == pred1_id
+    assert rev_rows[0]["individual"] == "Ruby"
+
+
+def test_get_photos_missing_masks_folder_ids_scoped_to_workspace(tmp_path):
+    """The folder_ids branch must enforce workspace scoping so stray folder
+    ids from another workspace don't leak photos into the result.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.create_workspace("A")
+    ws_b = db.create_workspace("B")
+    fa = db.add_folder("/a", name="a")
+    fb = db.add_folder("/b", name="b")
+    db.add_workspace_folder(ws_a, fa)
+    db.add_workspace_folder(ws_b, fb)
+
+    db._active_workspace_id = ws_a
+    pa = db.add_photo(fa, "x.jpg", extension=".jpg",
+                      file_size=100, file_mtime=1.0)
+    db._active_workspace_id = ws_b
+    pb = db.add_photo(fb, "y.jpg", extension=".jpg",
+                      file_size=100, file_mtime=2.0)
+
+    # Both photos have detections.
+    db.save_detections(pa, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")
+    db.save_detections(pb, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")
+
+    # Active ws = A. Even if caller passes B's folder id by mistake,
+    # results must not include B's photo.
+    db._active_workspace_id = ws_a
+    hits = db.get_photos_missing_masks(folder_ids=[fa, fb])
+    hit_ids = {h["id"] for h in hits}
+    assert pa in hit_ids
+    assert pb not in hit_ids, "workspace B photo must not leak into workspace A"
+
+
 def test_clear_predictions_without_collection_photo_ids(tmp_path):
     """The no-collection branch must bind every workspace_id placeholder it
     uses. A bug where the list of bound params had fewer entries than the

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1166,6 +1166,61 @@ def test_get_existing_prediction_photo_ids(tmp_path):
     assert result == set()
 
 
+def test_clear_predictions_without_collection_photo_ids(tmp_path):
+    """The no-collection branch must bind every workspace_id placeholder it
+    uses. A bug where the list of bound params had fewer entries than the
+    ?-count in the SQL would raise sqlite3.ProgrammingError.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}, {}])
+    det_ids = db.save_detections(
+        pids[0],
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="MDV6",
+    )
+    db.add_prediction(det_ids[0], species='Robin', confidence=0.9, model='bioclip')
+
+    # Must not raise. Both with and without the model filter.
+    db.clear_predictions()
+    assert db.get_existing_prediction_photo_ids('bioclip') == set()
+
+    # Restore and try the model branch.
+    db.add_prediction(det_ids[0], species='Robin', confidence=0.9, model='bioclip')
+    db.clear_predictions(model='bioclip')
+    assert db.get_existing_prediction_photo_ids('bioclip') == set()
+
+
+def test_get_existing_prediction_photo_ids_keyed_by_fingerprint(tmp_path):
+    """When a labels_fingerprint is given, the lookup scopes to that fingerprint.
+
+    The cache identity of a prediction is (detection, model, fingerprint,
+    species), so the photo-level short-circuit in classify_job must key on
+    fingerprint too — otherwise changing the workspace's label set would
+    leave stale predictions unprocessed.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    det_ids = db.save_detections(pids[0], [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")
+    # Prediction was produced with label set fp="aaa"
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, labels_fingerprint, "
+        "species, confidence) VALUES (?, 'bioclip', 'aaa', 'Robin', 0.9)",
+        (det_ids[0],),
+    )
+    db.conn.commit()
+
+    # Same fingerprint → photo is skipped
+    assert db.get_existing_prediction_photo_ids(
+        'bioclip', labels_fingerprint='aaa',
+    ) == {pids[0]}
+    # Different fingerprint (label set changed) → photo is NOT skipped
+    assert db.get_existing_prediction_photo_ids(
+        'bioclip', labels_fingerprint='bbb',
+    ) == set()
+    # No fingerprint passed → pre-refactor behavior (skip any model match)
+    assert db.get_existing_prediction_photo_ids('bioclip') == {pids[0]}
+
+
 def test_get_prediction_for_photo(tmp_path):
     """Returns species and confidence for a photo's prediction by model."""
     db, pids = _make_workspace_with_photos(tmp_path, [{}])

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2275,6 +2275,55 @@ def test_get_detections_cross_workspace_read(tmp_path):
     assert rows[0]["detector_confidence"] == 0.9
 
 
+def test_get_detections_for_photos_threshold_filter(tmp_path, monkeypatch):
+    """Batch get_detections_for_photos filters by min_conf across photos and reads cross-workspace."""
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/tmp/p")
+    ws_a = db.create_workspace("A")
+    ws_b = db.create_workspace("B")
+    db.add_workspace_folder(ws_a, fid)
+    db.add_workspace_folder(ws_b, fid)
+    p1 = db.add_photo(fid, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(fid, "b.jpg", extension=".jpg", file_size=100, file_mtime=2.0)
+
+    db._active_workspace_id = ws_a
+    db.save_detections(p1, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.05, "category": "animal"},
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}, "confidence": 0.6, "category": "animal"},
+    ], detector_model="megadetector-v6")
+    db.save_detections(p2, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.1, "category": "animal"},
+    ], detector_model="megadetector-v6")
+
+    # min_conf=0: both photos, all three rows
+    result = db.get_detections_for_photos([p1, p2], min_conf=0)
+    assert len(result[p1]) == 2
+    assert len(result[p2]) == 1
+
+    # min_conf=0.5: only p1's 0.6 row; p2 has nothing above threshold → omitted
+    result = db.get_detections_for_photos([p1, p2], min_conf=0.5)
+    assert set(result.keys()) == {p1}
+    assert len(result[p1]) == 1
+    assert result[p1][0]["confidence"] == 0.6
+
+    # min_conf=None resolves from workspace-effective config (default 0.2):
+    # p1 keeps the 0.6, p2's 0.1 is filtered out.
+    result = db.get_detections_for_photos([p1, p2])
+    assert set(result.keys()) == {p1}
+    assert len(result[p1]) == 1
+
+    # Cross-workspace: read from B, see A's writes.
+    db._active_workspace_id = ws_b
+    result = db.get_detections_for_photos([p1, p2], min_conf=0)
+    assert len(result[p1]) == 2
+    assert len(result[p2]) == 1
+
+
 def test_get_detections_for_photo(tmp_path):
     """get_detections should return all detections for a photo in current workspace."""
     from db import Database
@@ -2326,8 +2375,8 @@ def test_get_detections_for_photos_empty(tmp_path):
     assert db.get_detections_for_photos([]) == {}
 
 
-def test_get_detections_for_photos_scoped_to_workspace(tmp_path):
-    """get_detections_for_photos must not leak detections from other workspaces."""
+def test_get_detections_for_photos_is_global(tmp_path):
+    """get_detections_for_photos reads detections globally — table is no longer workspace-scoped."""
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     fid = db.add_folder("/photos")
@@ -2340,8 +2389,10 @@ def test_get_detections_for_photos_scoped_to_workspace(tmp_path):
     other_ws = db.create_workspace("Other")
     db.set_active_workspace(other_ws)
 
-    result = db.get_detections_for_photos([pid])
-    assert result == {}
+    # Global cache: workspace "Other" sees detections written under the default workspace.
+    result = db.get_detections_for_photos([pid], min_conf=0)
+    assert len(result[pid]) == 1
+    assert result[pid][0]["confidence"] == 0.9
 
 
 def test_clear_detections(tmp_path):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1224,6 +1224,27 @@ def test_query_move_rule_matches_has_predictions(tmp_path):
     assert misses == [pids[1]]
 
 
+def test_clear_detections_also_clears_detector_runs(tmp_path):
+    """clear_detections must wipe the matching detector_runs entry, or a
+    failed reclassify (clear, then model init crash) would leave a stale
+    "done" run key behind and the next non-reclassify pass would skip
+    detection forever, leaving the photo without boxes.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    db.save_detections(pids[0], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="megadetector-v6")
+    db.record_detector_run(pids[0], "megadetector-v6", box_count=1)
+    assert pids[0] in db.get_detector_run_photo_ids("megadetector-v6")
+
+    db.clear_detections(pids[0])
+
+    assert pids[0] not in db.get_detector_run_photo_ids("megadetector-v6"), (
+        "clear_detections left a stale run key — _detect_subjects would "
+        "skip this photo on the next non-reclassify pass."
+    )
+
+
 def test_migration_backfills_group_metadata_on_pending_rows(tmp_path):
     """Legacy burst-grouped predictions stored group_id/vote_count on
     pending rows. The migration must backfill prediction_review for those

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1224,6 +1224,66 @@ def test_query_move_rule_matches_has_predictions(tmp_path):
     assert misses == [pids[1]]
 
 
+def test_dashboard_stats_classified_count_honors_threshold_and_fingerprint(tmp_path):
+    """get_dashboard_stats' classified_count and prediction_status must
+    apply the same detector_confidence floor as detected_count (otherwise
+    the dashboard shows "3 detected, 7 classified" after raising the
+    threshold), and must scope to the most recent labels_fingerprint per
+    (detection, classifier_model) so stale-label predictions don't drift
+    the dashboard away from the active labeling context.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}, {}])
+    # Photo A: high-confidence detection + current-fingerprint prediction.
+    det_a = db.save_detections(pids[0], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")[0]
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-new', 'Robin', 0.9, '2026-04-24')",
+        (det_a,),
+    )
+    # Stale-fingerprint prediction on the SAME detection — must not
+    # inflate classified_count or prediction_status beyond the one photo.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-old', 'Finch', 0.95, '2026-01-01')",
+        (det_a,),
+    )
+
+    # Photo B: LOW-confidence detection (below default 0.2 threshold) with
+    # its own current-fingerprint prediction — must be excluded by the
+    # threshold filter.
+    det_b = db.save_detections(pids[1], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.05, "category": "animal"}
+    ], detector_model="MDV6")[0]
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-new', 'Sparrow', 0.9, '2026-04-24')",
+        (det_b,),
+    )
+    db.conn.commit()
+
+    stats = db.get_dashboard_stats()
+    # detected_count applies threshold → only photo A qualifies.
+    assert stats["detected_count"] == 1
+    # classified_count must match — NOT 2 (ignored threshold) and NOT 3
+    # (also mixed fingerprints on photo A).
+    assert stats["classified_count"] == 1, (
+        f"classified_count ({stats['classified_count']}) must honor "
+        f"detector_confidence + fingerprint; expected 1 like detected_count"
+    )
+    # prediction_status: one pending row for photo A's current-fingerprint
+    # prediction. Stale-fingerprint row and below-threshold row excluded.
+    status_counts = {r["status"]: r["count"] for r in stats["prediction_status"]}
+    assert status_counts.get("pending", 0) == 1, (
+        f"prediction_status must exclude stale fingerprint and below-threshold "
+        f"rows; got {status_counts}"
+    )
+
+
 def test_species_clusters_endpoint_filters_to_active_fingerprint(tmp_path, monkeypatch):
     """/api/species/<name>/clusters must not mix stale and current-label
     rows when a detection has been classified under multiple fingerprints.

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3907,3 +3907,32 @@ def test_record_classifier_run_and_lookup(tmp_path):
 
     db.record_classifier_run(det_id, "bioclip-2", "abc123", prediction_count=5)
     assert db.get_classifier_run_keys(det_id) == {("bioclip-2", "abc123")}
+
+
+def test_upsert_labels_fingerprint(tmp_path):
+    import json
+
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.upsert_labels_fingerprint(
+        fingerprint="abc123",
+        display_name="California birds",
+        sources=["/labels/ca-birds.txt"],
+        label_count=423,
+    )
+    row = db.conn.execute(
+        "SELECT * FROM labels_fingerprints WHERE fingerprint=?", ("abc123",)
+    ).fetchone()
+    assert row["display_name"] == "California birds"
+    assert json.loads(row["sources_json"]) == ["/labels/ca-birds.txt"]
+    assert row["label_count"] == 423
+
+    # Upsert is idempotent
+    db.upsert_labels_fingerprint("abc123", "California birds (v2)",
+                                  ["/labels/ca-birds-v2.txt"], 500)
+    row = db.conn.execute(
+        "SELECT display_name, label_count FROM labels_fingerprints WHERE fingerprint=?",
+        ("abc123",),
+    ).fetchone()
+    assert row["display_name"] == "California birds (v2)"
+    assert row["label_count"] == 500

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2395,6 +2395,42 @@ def test_get_detections_for_photos_is_global(tmp_path):
     assert result[pid][0]["confidence"] == 0.9
 
 
+def test_get_predictions_for_detection_filters(tmp_path):
+    """get_predictions_for_detection filters by min_classifier_conf and labels_fingerprint."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_id = db.save_detections(photo_id, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+
+    for sp, conf, fp in [("Robin", 0.8, "abc"), ("Sparrow", 0.3, "abc"),
+                          ("Robin", 0.9, "xyz")]:
+        db.conn.execute(
+            """INSERT INTO predictions (detection_id, classifier_model,
+                                         labels_fingerprint, species, confidence)
+               VALUES (?, 'bioclip-2', ?, ?, ?)""",
+            (det_id, fp, sp, conf),
+        )
+    db.conn.commit()
+
+    # All three rows when unfiltered
+    assert len(db.get_predictions_for_detection(det_id, min_classifier_conf=0)) == 3
+    # Only >= 0.5
+    assert len(db.get_predictions_for_detection(det_id, min_classifier_conf=0.5)) == 2
+    # Filter by fingerprint
+    by_abc = db.get_predictions_for_detection(
+        det_id, labels_fingerprint="abc", min_classifier_conf=0
+    )
+    assert {r["species"] for r in by_abc} == {"Robin", "Sparrow"}
+
+
 def test_clear_detections(tmp_path):
     """clear_detections should remove detections and cascade to predictions."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1166,6 +1166,43 @@ def test_get_existing_prediction_photo_ids(tmp_path):
     assert result == set()
 
 
+def test_get_prediction_for_photo_keyed_by_fingerprint(tmp_path):
+    """When labels_fingerprint is given, it must scope the lookup.
+
+    Cache identity is (detection, model, fingerprint, species), so the
+    single-photo fetch used by the classify-skip path must honor it;
+    otherwise it would return a row from a different label set and
+    propagate incorrect species metadata into downstream grouping.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    det_ids = db.save_detections(pids[0], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")
+    # Two predictions on the same detection, same model, different fingerprints.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, labels_fingerprint, "
+        "species, confidence) VALUES (?, 'bioclip', 'aaa', 'Robin', 0.9)",
+        (det_ids[0],),
+    )
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, labels_fingerprint, "
+        "species, confidence) VALUES (?, 'bioclip', 'bbb', 'Sparrow', 0.85)",
+        (det_ids[0],),
+    )
+    db.conn.commit()
+
+    assert db.get_prediction_for_photo(
+        pids[0], 'bioclip', labels_fingerprint='aaa',
+    )['species'] == 'Robin'
+    assert db.get_prediction_for_photo(
+        pids[0], 'bioclip', labels_fingerprint='bbb',
+    )['species'] == 'Sparrow'
+    # Absent fingerprint → no row
+    assert db.get_prediction_for_photo(
+        pids[0], 'bioclip', labels_fingerprint='ccc',
+    ) is None
+
+
 def test_clear_predictions_without_collection_photo_ids(tmp_path):
     """The no-collection branch must bind every workspace_id placeholder it
     uses. A bug where the list of bound params had fewer entries than the

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1224,6 +1224,136 @@ def test_query_move_rule_matches_has_predictions(tmp_path):
     assert misses == [pids[1]]
 
 
+def test_migration_backfills_group_metadata_on_pending_rows(tmp_path):
+    """Legacy burst-grouped predictions stored group_id/vote_count on
+    pending rows. The migration must backfill prediction_review for those
+    too — not just non-pending rows — or the group membership is lost
+    and get_group_predictions can't recover the burst.
+    """
+    import sqlite3
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER,
+                             filename TEXT, timestamp TEXT, rating INTEGER,
+                             UNIQUE(folder_id, filename));
+        CREATE TABLE workspaces (id INTEGER PRIMARY KEY, name TEXT UNIQUE,
+                                 config_overrides TEXT, ui_state TEXT,
+                                 last_opened_at TEXT);
+        CREATE TABLE detections (
+            id INTEGER PRIMARY KEY, photo_id INTEGER, workspace_id INTEGER,
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence REAL, category TEXT, detector_model TEXT,
+            created_at TEXT
+        );
+        CREATE TABLE predictions (
+            id INTEGER PRIMARY KEY, detection_id INTEGER, species TEXT,
+            confidence REAL, model TEXT, status TEXT DEFAULT 'pending',
+            group_id TEXT, individual TEXT, vote_count INTEGER,
+            total_votes INTEGER, created_at TEXT
+        );
+        INSERT INTO folders VALUES (1, '/p');
+        INSERT INTO photos (id, folder_id, filename) VALUES (10, 1, 'a.jpg');
+        INSERT INTO workspaces (id, name) VALUES (1, 'Default');
+        INSERT INTO detections (id, photo_id, workspace_id, box_x, box_y, box_w, box_h,
+                                detector_confidence, category, detector_model, created_at)
+            VALUES (100, 10, 1, 0, 0, 1, 1, 0.9, 'animal', 'megadetector-v6', 't1');
+        -- Pending row carrying group metadata from a prior burst pass.
+        INSERT INTO predictions (id, detection_id, species, model, status,
+                                 group_id, vote_count, total_votes)
+            VALUES (1000, 100, 'Robin', 'bioclip-2', 'pending',
+                    'g-2026', 3, 5);
+    """)
+    conn.commit()
+    conn.close()
+
+    from db import Database
+    db = Database(db_path)
+    rev = db.conn.execute(
+        "SELECT group_id, vote_count, total_votes FROM prediction_review "
+        "WHERE prediction_id = 1000 AND workspace_id = 1"
+    ).fetchone()
+    assert rev is not None, (
+        "Pending prediction with group metadata should have been backfilled "
+        "into prediction_review; migration silently dropped the group."
+    )
+    assert rev["group_id"] == "g-2026"
+    assert rev["vote_count"] == 3
+
+
+def test_clear_predictions_scopes_by_fingerprint(tmp_path):
+    """When a fingerprint is supplied, clear_predictions must delete only
+    that label set's rows and leave predictions under other fingerprints
+    untouched. Also wipes the matching classifier_runs so next pass
+    re-runs inference.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    det_id = db.save_detections(pids[0], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")[0]
+    db.add_prediction(det_id, species="Robin", confidence=0.9,
+                      model="bioclip-2", labels_fingerprint="fp-a")
+    db.add_prediction(det_id, species="Sparrow", confidence=0.85,
+                      model="bioclip-2", labels_fingerprint="fp-b")
+    db.record_classifier_run(det_id, "bioclip-2", "fp-a", prediction_count=1)
+    db.record_classifier_run(det_id, "bioclip-2", "fp-b", prediction_count=1)
+
+    db.clear_predictions(model="bioclip-2", labels_fingerprint="fp-a")
+
+    remaining = {r["species"] for r in db.conn.execute(
+        "SELECT species FROM predictions WHERE detection_id=?", (det_id,)
+    ).fetchall()}
+    assert remaining == {"Sparrow"}, "fp-b row must be untouched"
+
+    run_keys = db.get_classifier_run_keys(det_id)
+    assert ("bioclip-2", "fp-a") not in run_keys, \
+        "fp-a classifier_runs key must be cleared or next pass will skip"
+    assert ("bioclip-2", "fp-b") in run_keys, "fp-b run key must be preserved"
+
+
+def test_move_folders_moves_prediction_review(tmp_path):
+    """Moving folders between workspaces must carry prediction_review rows
+    with them — otherwise accepted/rejected/group metadata is silently
+    dropped and the target workspace reads everything as 'pending'.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_src = db.create_workspace("src")
+    ws_tgt = db.create_workspace("tgt")
+    fid = db.add_folder("/p", name="p")
+    db.add_workspace_folder(ws_src, fid)
+
+    db._active_workspace_id = ws_src
+    pid = db.add_photo(fid, "a.jpg", extension=".jpg",
+                       file_size=100, file_mtime=1.0)
+    det_id = db.save_detections(pid, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")[0]
+    db.add_prediction(det_id, species="Robin", confidence=0.9,
+                      model="bioclip-2", labels_fingerprint="fp-x",
+                      status="accepted", individual="Ruby")
+    pred_id = db.conn.execute(
+        "SELECT id FROM predictions WHERE species='Robin'"
+    ).fetchone()["id"]
+    # Sanity: review row exists in source ws.
+    assert db.get_review_status(pred_id, ws_src) == "accepted"
+
+    db.move_folders_to_workspace(ws_src, ws_tgt, [fid])
+
+    # Review row must have followed the folder.
+    assert db.get_review_status(pred_id, ws_tgt) == "accepted"
+    assert db.get_review_status(pred_id, ws_src) == "pending", \
+        "source ws should no longer claim this review row"
+    # Individual carried over.
+    row = db.conn.execute(
+        "SELECT individual FROM prediction_review "
+        "WHERE prediction_id=? AND workspace_id=?",
+        (pred_id, ws_tgt),
+    ).fetchone()
+    assert row["individual"] == "Ruby"
+
+
 def test_migration_preserves_predictions_when_dropping_detections(tmp_path):
     """Legacy DB with FK ON DELETE CASCADE from predictions→detections:
     the global-detections rewrite must NOT cascade-delete predictions

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4578,6 +4578,65 @@ def test_migration_dedupes_detections_and_repoints_predictions(tmp_path):
     assert "workspace_id" not in cols
 
 
+def test_migration_handles_prediction_collision_on_repoint(tmp_path):
+    """When two workspaces had the SAME (detection, model, species) prediction
+    on duplicate detection rows (one per workspace), repointing both to the
+    canonical detection_id would otherwise trip the legacy
+    UNIQUE(detection_id, model, species) index. The migration must delete
+    the non-canonical dup first.
+    """
+    import sqlite3
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER,
+                             filename TEXT, timestamp TEXT, rating INTEGER,
+                             UNIQUE(folder_id, filename));
+        CREATE TABLE workspaces (id INTEGER PRIMARY KEY, name TEXT UNIQUE,
+                                 config_overrides TEXT, ui_state TEXT,
+                                 last_opened_at TEXT);
+        CREATE TABLE detections (
+            id INTEGER PRIMARY KEY, photo_id INTEGER, workspace_id INTEGER,
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence REAL, category TEXT, detector_model TEXT,
+            created_at TEXT
+        );
+        -- Critical: legacy predictions carries the real UNIQUE constraint.
+        CREATE TABLE predictions (
+            id INTEGER PRIMARY KEY, detection_id INTEGER, species TEXT,
+            confidence REAL, model TEXT, status TEXT DEFAULT 'pending',
+            individual TEXT, group_id TEXT, created_at TEXT,
+            UNIQUE(detection_id, model, species)
+        );
+        INSERT INTO folders VALUES (1, '/p');
+        INSERT INTO photos (id, folder_id, filename) VALUES (10, 1, 'a.jpg');
+        INSERT INTO workspaces (id, name) VALUES (1, 'A'), (2, 'B');
+        -- Same box, two workspaces, same prediction in both:
+        INSERT INTO detections (id, photo_id, workspace_id, box_x, box_y, box_w, box_h,
+                                detector_confidence, category, detector_model, created_at)
+          VALUES (100, 10, 1, 0.1, 0.1, 0.5, 0.5, 0.9, 'animal', 'megadetector-v6', 't1'),
+                 (200, 10, 2, 0.1, 0.1, 0.5, 0.5, 0.9, 'animal', 'megadetector-v6', 't2');
+        -- Same (model, species) prediction in both workspaces — would collide on
+        -- repoint to the canonical detection row without pre-deletion.
+        INSERT INTO predictions (id, detection_id, species, model, status) VALUES
+            (1000, 100, 'Robin', 'bioclip-2', 'approved'),
+            (2000, 200, 'Robin', 'bioclip-2', 'pending');
+    """)
+    conn.commit()
+    conn.close()
+
+    # Init must not raise an IntegrityError.
+    from db import Database
+    db = Database(db_path)
+    # Exactly one surviving prediction for this (detection, model, species).
+    rows = db.conn.execute(
+        "SELECT id FROM predictions WHERE species='Robin' "
+        "AND classifier_model='bioclip-2'"
+    ).fetchall()
+    assert len(rows) == 1, "non-canonical duplicate must have been deleted"
+
+
 def test_predictions_has_labels_fingerprint(tmp_path):
     """Fresh DB's predictions table includes the labels_fingerprint column."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3824,3 +3824,16 @@ def test_preview_cache_oldest_first(tmp_path):
 
     rows = db.preview_cache_oldest_first()
     assert [(r["photo_id"], r["size"]) for r in rows] == [(p1, 1920), (p2, 1920)]
+
+
+def test_new_cache_tables_exist(tmp_path):
+    """detector_runs, classifier_runs, labels_fingerprints, prediction_review are created."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    tables = {r['name'] for r in db.conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()}
+    assert 'detector_runs' in tables
+    assert 'classifier_runs' in tables
+    assert 'labels_fingerprints' in tables
+    assert 'prediction_review' in tables

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3883,3 +3883,27 @@ def test_detector_run_is_not_workspace_scoped(tmp_path):
 
     db._active_workspace_id = ws_b
     assert photo_id in db.get_detector_run_photo_ids("megadetector-v6")
+
+
+def test_record_classifier_run_and_lookup(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    db._active_workspace_id = db.create_workspace("WS")
+    db.add_workspace_folder(db._active_workspace_id, folder_id)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    # Need a detection row to reference:
+    det_ids = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    det_id = det_ids[0]
+
+    assert db.get_classifier_run_keys(det_id) == set()
+
+    db.record_classifier_run(det_id, "bioclip-2", "abc123", prediction_count=5)
+    assert db.get_classifier_run_keys(det_id) == {("bioclip-2", "abc123")}

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1392,6 +1392,72 @@ def test_clear_predictions_scopes_by_fingerprint(tmp_path):
     assert ("bioclip-2", "fp-b") in run_keys, "fp-b run key must be preserved"
 
 
+def test_clear_predictions_no_model_clears_classifier_runs(tmp_path):
+    """clear_predictions() with no model must also wipe classifier_runs for
+    affected detections. Otherwise the (detection, model, fingerprint) skip
+    gate treats them as already classified and the next non-reclassify pass
+    leaves those photos permanently without predictions.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    det_id = db.save_detections(pids[0], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")[0]
+    db.add_prediction(det_id, species="Robin", confidence=0.9,
+                      model="bioclip-2", labels_fingerprint="fp-a")
+    db.add_prediction(det_id, species="Sparrow", confidence=0.85,
+                      model="other-model", labels_fingerprint="fp-b")
+    db.record_classifier_run(det_id, "bioclip-2", "fp-a", prediction_count=1)
+    db.record_classifier_run(det_id, "other-model", "fp-b", prediction_count=1)
+
+    db.clear_predictions()
+
+    remaining = db.conn.execute(
+        "SELECT COUNT(*) FROM predictions WHERE detection_id=?",
+        (det_id,),
+    ).fetchone()[0]
+    assert remaining == 0, "All predictions for the detection must be deleted"
+
+    run_keys = db.get_classifier_run_keys(det_id)
+    assert run_keys == set(), (
+        "All classifier_runs entries for the detection must be cleared so "
+        "the next non-reclassify pass actually re-runs inference"
+    )
+
+
+def test_get_predictions_filters_to_latest_fingerprint(tmp_path):
+    """get_predictions() must return only the most recent fingerprint per
+    (detection, classifier_model). Mixing stale and current fingerprints
+    contaminates /api/predictions and /api/predictions/compare with
+    duplicate/conflicting species after a label-set change.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    det_id = db.save_detections(pids[0], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")[0]
+    # Stale fingerprint with HIGHER confidence than current — confidence-only
+    # ranking would surface it; the latest-fingerprint filter must exclude it.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-old', 'Finch', 0.95, '2026-01-01')",
+        (det_id,),
+    )
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-new', 'Robin', 0.80, '2026-04-24')",
+        (det_id,),
+    )
+    db.conn.commit()
+
+    rows = db.get_predictions(photo_ids=[pids[0]])
+    species_seen = {r["species"] for r in rows}
+    assert species_seen == {"Robin"}, (
+        "get_predictions returned stale-fingerprint species — would mix "
+        "old and current label sets in /api/predictions."
+    )
+
+
 def test_move_folders_moves_prediction_review(tmp_path):
     """Moving folders between workspaces must carry prediction_review rows
     with them — otherwise accepted/rejected/group metadata is silently

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3837,3 +3837,49 @@ def test_new_cache_tables_exist(tmp_path):
     assert 'classifier_runs' in tables
     assert 'labels_fingerprints' in tables
     assert 'prediction_review' in tables
+
+
+def test_record_detector_run_and_lookup(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    db._active_workspace_id = db.create_workspace("WS")
+    db.add_workspace_folder(db._active_workspace_id, folder_id)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+
+    # Initially: no runs recorded
+    assert db.get_detector_run_photo_ids("megadetector-v6") == set()
+
+    db.record_detector_run(photo_id, "megadetector-v6", box_count=0)
+    assert db.get_detector_run_photo_ids("megadetector-v6") == {photo_id}
+
+    # Re-recording is idempotent / updates box_count
+    db.record_detector_run(photo_id, "megadetector-v6", box_count=3)
+    row = db.conn.execute(
+        "SELECT box_count FROM detector_runs WHERE photo_id=? AND detector_model=?",
+        (photo_id, "megadetector-v6"),
+    ).fetchone()
+    assert row["box_count"] == 3
+
+
+def test_detector_run_is_not_workspace_scoped(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws_a = db.create_workspace("A")
+    ws_b = db.create_workspace("B")
+    db.add_workspace_folder(ws_a, folder_id)
+    db.add_workspace_folder(ws_b, folder_id)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+
+    db._active_workspace_id = ws_a
+    db.record_detector_run(photo_id, "megadetector-v6", box_count=2)
+
+    db._active_workspace_id = ws_b
+    assert photo_id in db.get_detector_run_photo_ids("megadetector-v6")

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2208,6 +2208,73 @@ def test_save_detections_is_global(tmp_path):
     assert len(rows) == 1
 
 
+def test_get_detections_threshold_filter(tmp_path, monkeypatch):
+    """get_detections filters by min_conf, resolving from workspace-effective config when None."""
+    import config as cfg
+    from db import Database
+
+    # Isolate config from the user's ~/.vireo/config.json so the default
+    # detector_confidence (0.2) is what the test actually resolves.
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    db.save_detections(
+        photo_id,
+        [
+            {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.05, "category": "animal"},
+            {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}, "confidence": 0.4, "category": "animal"},
+        ],
+        detector_model="megadetector-v6",
+    )
+
+    # min_conf=0: returns everything
+    rows = db.get_detections(photo_id, min_conf=0)
+    assert len(rows) == 2
+
+    # min_conf=0.2: only the 0.4 row
+    rows = db.get_detections(photo_id, min_conf=0.2)
+    assert len(rows) == 1
+    assert rows[0]["detector_confidence"] == 0.4
+
+    # min_conf=None pulls from workspace-effective config (default 0.2 → 1 row)
+    rows = db.get_detections(photo_id)
+    assert len(rows) == 1
+    assert rows[0]["detector_confidence"] == 0.4
+
+
+def test_get_detections_cross_workspace_read(tmp_path):
+    """Detections written in workspace A are readable from workspace B — table is global."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws_a = db.create_workspace("A")
+    ws_b = db.create_workspace("B")
+    db.add_workspace_folder(ws_a, folder_id)
+    db.add_workspace_folder(ws_b, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+
+    db._active_workspace_id = ws_a
+    db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+
+    db._active_workspace_id = ws_b
+    rows = db.get_detections(photo_id, min_conf=0)
+    assert len(rows) == 1
+    assert rows[0]["detector_confidence"] == 0.9
+
+
 def test_get_detections_for_photo(tmp_path):
     """get_detections should return all detections for a photo in current workspace."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3936,3 +3936,36 @@ def test_upsert_labels_fingerprint(tmp_path):
     ).fetchone()
     assert row["display_name"] == "California birds (v2)"
     assert row["label_count"] == 500
+
+
+def test_review_status_absence_is_pending(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("WS")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    det_ids = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    pred_id = db.conn.execute(
+        """INSERT INTO predictions (detection_id, model, species, confidence)
+           VALUES (?, 'bioclip-2', 'Robin', 0.8)""",
+        (det_ids[0],),
+    ).lastrowid
+    db.conn.commit()
+
+    # No row in prediction_review yet → pending
+    assert db.get_review_status(pred_id, ws) == "pending"
+
+    db.set_review_status(pred_id, ws, status="approved")
+    assert db.get_review_status(pred_id, ws) == "approved"
+
+    db.set_review_status(pred_id, ws, status="rejected")
+    assert db.get_review_status(pred_id, ws) == "rejected"

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1203,6 +1203,27 @@ def test_get_prediction_for_photo_keyed_by_fingerprint(tmp_path):
     ) is None
 
 
+def test_query_move_rule_matches_has_predictions(tmp_path):
+    """The has_predictions move-rule criterion must work post-refactor.
+
+    Predictions no longer carry photo_id/workspace_id; the EXISTS subquery
+    now routes through detections.photo_id instead. Previously this raised
+    `no such column: pr.photo_id` on any preview/apply of a rule using the
+    "Has predictions" criterion.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}, {}])
+    # Photo 0 has a prediction; photo 1 does not.
+    det_ids = db.save_detections(pids[0], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")
+    db.add_prediction(det_ids[0], species='Robin', confidence=0.9, model='bioclip')
+
+    hits = db.query_move_rule_matches({"has_predictions": True})
+    assert hits == [pids[0]]
+    misses = db.query_move_rule_matches({"has_predictions": False})
+    assert misses == [pids[1]]
+
+
 def test_clear_predictions_without_collection_photo_ids(tmp_path):
     """The no-collection branch must bind every workspace_id placeholder it
     uses. A bug where the list of bound params had fewer entries than the

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -234,6 +234,45 @@ def test_browse_summary_folder_includes_descendants(tmp_path):
     assert summary['filtered_total'] == 2
 
 
+def test_browse_summary_top_species_filters_to_latest_fingerprint(tmp_path):
+    """get_browse_summary's top-species ranking must pin to the most
+    recent labels_fingerprint per (detection, classifier_model).
+    Otherwise a stale higher-confidence row from an old label set wins
+    ROW_NUMBER() and `/api/browse/summary` reports the wrong species.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/p', name='p')
+    pid = db.add_photo(folder_id=fid, filename='a.jpg',
+                       extension='.jpg', file_size=100, file_mtime=1.0)
+    det_id = db.save_detections(pid, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")[0]
+    # Stale fingerprint — HIGHER confidence + 'Finch'.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-old', 'Finch', 0.99, '2026-01-01')",
+        (det_id,),
+    )
+    # Current fingerprint — lower confidence + 'Robin'.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-new', 'Robin', 0.7, '2026-04-25')",
+        (det_id,),
+    )
+    db.conn.commit()
+
+    summary = db.get_browse_summary()
+    species_list = [(s["species"], s["count"]) for s in summary["top_species"]]
+    assert species_list == [("Robin", 1)], (
+        f"top_species must be the active-fingerprint Robin (lower "
+        f"confidence) — not stale-fingerprint Finch (higher); "
+        f"got {species_list}"
+    )
+
+
 def test_calendar_data_folder_includes_descendants(tmp_path):
     """get_calendar_data(folder_id=parent) counts descendants."""
     from db import Database
@@ -2913,6 +2952,53 @@ def test_list_photos_for_eye_keypoint_stage_keeps_confidence_order_when_routable
     rows = db.list_photos_for_eye_keypoint_stage()
     assert len(rows) == 1
     assert rows[0]["scientific_name"] == "Turdus migratorius"
+
+
+def test_list_photos_for_eye_keypoint_stage_filters_to_active_fingerprint(tmp_path):
+    """When a detection has cached predictions from multiple label-set
+    fingerprints, the eye-keypoint candidate query must pick from the
+    most recent one — otherwise a stale high-confidence row can drive
+    `_resolve_keypoint_model` with outdated taxonomy and route the
+    stage to the wrong model.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db._active_workspace_id
+    fid = db.add_folder(str(tmp_path), name="photos")
+    db.add_workspace_folder(ws_id, fid)
+    pid = db.add_photo(fid, "a.jpg", ".jpg", 1000, 1.0, width=800, height=600)
+    db.update_photo_pipeline_features(pid, mask_path=str(tmp_path / "mask.png"))
+    det_id = db.save_detections(pid, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.95}
+    ], detector_model="MegaDetector")[0]
+    # Stale fingerprint — high confidence + bird taxonomy.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, taxonomy_class, "
+        "scientific_name, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-old', 'Robin', 0.99, 'Aves', "
+        "'Turdus migratorius', '2026-01-01')",
+        (det_id,),
+    )
+    # Current fingerprint — lower confidence + mammal taxonomy.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, taxonomy_class, "
+        "scientific_name, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-new', 'Vulpes vulpes', 0.6, 'Mammalia', "
+        "'Vulpes vulpes', '2026-04-25')",
+        (det_id,),
+    )
+    db.conn.commit()
+
+    rows = db.list_photos_for_eye_keypoint_stage()
+    assert len(rows) == 1
+    # Must pick the current-fingerprint row, not the stale higher-confidence one.
+    assert rows[0]["taxonomy_class"] == "Mammalia", (
+        f"Stale-fingerprint Robin row drove the eye-keypoint stage; "
+        f"expected current-fingerprint Vulpes; got {rows[0]['taxonomy_class']}"
+    )
 
 
 def test_list_photos_for_eye_keypoint_stage_scopes_to_photo_ids(tmp_path):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1224,6 +1224,75 @@ def test_query_move_rule_matches_has_predictions(tmp_path):
     assert misses == [pids[1]]
 
 
+def test_accept_prediction_sibling_rejection_scoped_to_fingerprint(tmp_path):
+    """Accepting a prediction under one labels_fingerprint must not mark
+    predictions with OTHER fingerprints on the same detection as rejected.
+    Each label set should have independent review state.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    ws = db._active_workspace_id
+    det_id = db.save_detections(pids[0], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")[0]
+
+    # Two predictions on the same detection, different fingerprints.
+    db.add_prediction(det_id, species="Robin", confidence=0.9,
+                      model="bioclip-2", labels_fingerprint="fp-old")
+    pred_old = db.conn.execute(
+        "SELECT id FROM predictions WHERE labels_fingerprint='fp-old'"
+    ).fetchone()["id"]
+
+    db.add_prediction(det_id, species="Blue Jay", confidence=0.85,
+                      model="bioclip-2", labels_fingerprint="fp-new")
+    pred_new = db.conn.execute(
+        "SELECT id FROM predictions WHERE labels_fingerprint='fp-new'"
+    ).fetchone()["id"]
+
+    # Accept the fp-new prediction. The fp-old one must remain pending.
+    db.accept_prediction(pred_new)
+
+    assert db.get_review_status(pred_new, ws) == "accepted"
+    assert db.get_review_status(pred_old, ws) == "pending", \
+        "sibling rejection must not cross fingerprints"
+
+
+def test_get_group_predictions_alternatives_scoped_to_fingerprint(tmp_path):
+    """Group alternatives must not mix across fingerprints — a detection
+    classified under two label sets should only show the current set's
+    alternatives in the group-review UI.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+    ws = db._active_workspace_id
+    det_id = db.save_detections(pids[0], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")[0]
+
+    # Current fingerprint: primary + alternative.
+    db.add_prediction(det_id, species="Robin", confidence=0.9,
+                      model="bioclip-2", labels_fingerprint="fp-new",
+                      group_id="g1")
+    pred_primary = db.conn.execute(
+        "SELECT id FROM predictions WHERE species='Robin'"
+    ).fetchone()["id"]
+    db.add_prediction(det_id, species="Sparrow", confidence=0.3,
+                      model="bioclip-2", labels_fingerprint="fp-new",
+                      status="alternative")
+
+    # Stale fingerprint: primary + alternative on the SAME detection.
+    db.add_prediction(det_id, species="Finch", confidence=0.8,
+                      model="bioclip-2", labels_fingerprint="fp-old")
+    db.add_prediction(det_id, species="Warbler", confidence=0.2,
+                      model="bioclip-2", labels_fingerprint="fp-old",
+                      status="alternative")
+
+    group = db.get_group_predictions("g1")
+    assert len(group) == 1
+    assert group[0]["species"] == "Robin"
+    alt_species = {a["species"] for a in group[0]["alternatives"]}
+    assert alt_species == {"Sparrow"}, \
+        f"expected only current-fingerprint alternative, got {alt_species}"
+
+
 def test_add_prediction_duplicate_does_not_corrupt_review(tmp_path):
     """When add_prediction is called twice with the same unique key and the
     second call carries review metadata, the upsert into prediction_review

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4123,3 +4123,57 @@ def test_migration_dedupes_detections_and_repoints_predictions(tmp_path):
     # detections table no longer has workspace_id column
     cols = {r[1] for r in db.conn.execute("PRAGMA table_info(detections)").fetchall()}
     assert "workspace_id" not in cols
+
+
+def test_predictions_has_labels_fingerprint(tmp_path):
+    """Fresh DB's predictions table includes the labels_fingerprint column."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    cols = {r[1] for r in db.conn.execute(
+        "PRAGMA table_info(predictions)"
+    ).fetchall()}
+    assert "labels_fingerprint" in cols
+
+
+def test_migration_sets_labels_fingerprint_legacy(tmp_path):
+    """Legacy predictions rows without labels_fingerprint get 'legacy' on migration."""
+    import sqlite3
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER,
+                             filename TEXT, timestamp TEXT, rating INTEGER,
+                             UNIQUE(folder_id, filename));
+        CREATE TABLE workspaces (id INTEGER PRIMARY KEY, name TEXT UNIQUE,
+                                 config_overrides TEXT, ui_state TEXT,
+                                 last_opened_at TEXT);
+        CREATE TABLE detections (
+            id INTEGER PRIMARY KEY, photo_id INTEGER, workspace_id INTEGER,
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence REAL, category TEXT, detector_model TEXT,
+            created_at TEXT
+        );
+        CREATE TABLE predictions (
+            id INTEGER PRIMARY KEY, detection_id INTEGER, species TEXT,
+            confidence REAL, model TEXT, status TEXT DEFAULT 'pending',
+            individual TEXT, group_id TEXT, created_at TEXT
+        );
+        INSERT INTO folders VALUES (1, '/p');
+        INSERT INTO photos (id, folder_id, filename) VALUES (10, 1, 'a.jpg');
+        INSERT INTO workspaces (id, name) VALUES (1, 'A');
+        INSERT INTO detections (id, photo_id, workspace_id, box_x, box_y, box_w, box_h,
+                                detector_confidence, category, detector_model, created_at)
+            VALUES (100, 10, 1, 0, 0, 1, 1, 0.9, 'animal', 'megadetector-v6', 't1');
+        INSERT INTO predictions (id, detection_id, species, model) VALUES
+            (1, 100, 'Robin', 'bioclip-2');
+    """)
+    conn.commit()
+    conn.close()
+
+    from db import Database
+    db = Database(db_path)
+    row = db.conn.execute(
+        "SELECT labels_fingerprint FROM predictions WHERE id=1"
+    ).fetchone()
+    assert row["labels_fingerprint"] == "legacy"

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2149,10 +2149,63 @@ def test_save_detections(tmp_path):
     ]
     ids = db.save_detections(pid, detections, detector_model="MDV6-yolov9-c")
     assert len(ids) == 2
-    rows = db.conn.execute("SELECT * FROM detections WHERE photo_id = ?", (pid,)).fetchall()
+    rows = db.conn.execute(
+        "SELECT * FROM detections WHERE photo_id = ? ORDER BY id",
+        (pid,),
+    ).fetchall()
     assert len(rows) == 2
     assert rows[0]["box_x"] == 0.1
     assert rows[1]["box_x"] == 0.5
+
+
+def test_save_detections_replaces_existing(tmp_path):
+    """Second save for the same (photo, model) wipes prior rows — idempotent."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0)
+
+    det_a = {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    det_b = {"box": {"x": 0.2, "y": 0.2, "w": 0.5, "h": 0.5}, "confidence": 0.7, "category": "animal"}
+
+    # First run: two boxes
+    ids_v1 = db.save_detections(photo_id, [det_a, det_b], detector_model="megadetector-v6")
+    assert len(ids_v1) == 2
+
+    # Second run on same (photo, model): one box — the old rows should be gone
+    ids_v2 = db.save_detections(photo_id, [det_a], detector_model="megadetector-v6")
+    rows = db.conn.execute(
+        "SELECT id FROM detections WHERE photo_id = ? AND detector_model = ?",
+        (photo_id, "megadetector-v6"),
+    ).fetchall()
+    assert {r["id"] for r in rows} == set(ids_v2)
+
+
+def test_save_detections_is_global(tmp_path):
+    """Detections written in workspace A are visible when B is active — the table is global."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws_a = db.create_workspace("A")
+    ws_b = db.create_workspace("B")
+    db.add_workspace_folder(ws_a, folder_id)
+    db.add_workspace_folder(ws_b, folder_id)
+    photo_id = db.add_photo(folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0)
+
+    db._active_workspace_id = ws_a
+    db.save_detections(photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="megadetector-v6")
+
+    db._active_workspace_id = ws_b
+    rows = db.conn.execute(
+        "SELECT id FROM detections WHERE photo_id = ?", (photo_id,),
+    ).fetchall()
+    # Global cache: workspace B sees the row written from A
+    assert len(rows) == 1
 
 
 def test_get_detections_for_photo(tmp_path):
@@ -2233,11 +2286,11 @@ def test_clear_detections(tmp_path):
     det_ids = db.save_detections(pid, [
         {"box": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"},
     ], detector_model="MDV6")
-    # Insert prediction via raw SQL since add_prediction is not yet refactored
-    # for the detection-based schema (Task 3)
     db.conn.execute(
-        "INSERT INTO predictions (detection_id, species, confidence, model, status) VALUES (?, ?, ?, ?, ?)",
-        (det_ids[0], "Elk", 0.9, "bioclip", "pending"),
+        """INSERT INTO predictions
+             (detection_id, classifier_model, labels_fingerprint, species, confidence)
+           VALUES (?, ?, ?, ?, ?)""",
+        (det_ids[0], "bioclip", "legacy", "Elk", 0.9),
     )
     db.conn.commit()
     db.clear_detections(pid)
@@ -2329,7 +2382,8 @@ def test_accept_prediction_tags_photo(tmp_path):
 
 
 def test_get_existing_detection_photo_ids(tmp_path):
-    """get_existing_detection_photo_ids returns photo IDs that have detections."""
+    """get_existing_detection_photo_ids shim returns photo IDs where the default
+    detector model has run (delegates to get_detector_run_photo_ids)."""
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     fid = db.add_folder("/photos")
@@ -2337,7 +2391,8 @@ def test_get_existing_detection_photo_ids(tmp_path):
     pid2 = db.add_photo(folder_id=fid, filename="bird.jpg", extension=".jpg", file_size=100, file_mtime=1.0)
     db.save_detections(pid1, [
         {"box": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"},
-    ], detector_model="MDV6")
+    ], detector_model="megadetector-v6")
+    db.record_detector_run(pid1, "megadetector-v6", box_count=1)
     result = db.get_existing_detection_photo_ids()
     assert pid1 in result
     assert pid2 not in result

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1203,6 +1203,37 @@ def test_get_prediction_for_photo_keyed_by_fingerprint(tmp_path):
     ) is None
 
 
+def test_query_move_rule_matches_has_predictions_honors_threshold(tmp_path):
+    """has_predictions must match the UI's read-time threshold view: a
+    photo whose only prediction sits on a below-threshold detection
+    should NOT count as having predictions.
+    """
+    db, pids = _make_workspace_with_photos(tmp_path, [{}, {}])
+    # Photo 0: above-threshold detection + prediction → "has predictions" = True
+    det_a = db.save_detections(pids[0], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")[0]
+    db.add_prediction(det_a, species='Robin', confidence=0.9, model='bioclip')
+
+    # Photo 1: ONLY a below-threshold detection (default 0.2) with a
+    # prediction. Must NOT count as "has predictions".
+    det_b = db.save_detections(pids[1], [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.05, "category": "animal"}
+    ], detector_model="MDV6")[0]
+    db.add_prediction(det_b, species='Sparrow', confidence=0.9, model='bioclip')
+
+    has = db.query_move_rule_matches({"has_predictions": True})
+    assert has == [pids[0]], (
+        f"has_predictions=True must apply detector_confidence floor; "
+        f"expected only photo 0, got {has}"
+    )
+    none = db.query_move_rule_matches({"has_predictions": False})
+    assert pids[1] in none, (
+        f"Photo with only below-threshold predictions must match "
+        f"has_predictions=False; got {none}"
+    )
+
+
 def test_query_move_rule_matches_has_predictions(tmp_path):
     """The has_predictions move-rule criterion must work post-refactor.
 

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4011,3 +4011,58 @@ def test_migration_backfills_detector_runs(tmp_path):
     ).fetchone()
     assert run is not None
     assert run["box_count"] == 1
+
+
+def test_migration_backfills_prediction_review(tmp_path):
+    """Approved/rejected predictions get prediction_review rows in the right workspace."""
+    import sqlite3
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER,
+                             filename TEXT, timestamp TEXT, rating INTEGER,
+                             UNIQUE(folder_id, filename));
+        CREATE TABLE workspaces (id INTEGER PRIMARY KEY, name TEXT UNIQUE,
+                                 config_overrides TEXT, ui_state TEXT,
+                                 last_opened_at TEXT);
+        CREATE TABLE detections (
+            id INTEGER PRIMARY KEY, photo_id INTEGER, workspace_id INTEGER,
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence REAL, category TEXT, detector_model TEXT,
+            created_at TEXT
+        );
+        CREATE TABLE predictions (
+            id INTEGER PRIMARY KEY, detection_id INTEGER, species TEXT,
+            confidence REAL, model TEXT,
+            status TEXT DEFAULT 'pending', reviewed_at TEXT,
+            individual TEXT, group_id TEXT,
+            vote_count INTEGER, total_votes INTEGER,
+            created_at TEXT
+        );
+        INSERT INTO folders VALUES (1, '/p');
+        INSERT INTO photos (id, folder_id, filename) VALUES (10, 1, 'a.jpg');
+        INSERT INTO workspaces (id, name) VALUES (1, 'A'), (2, 'B');
+        INSERT INTO detections (id, photo_id, workspace_id, box_x, box_y, box_w, box_h,
+                                detector_confidence, category, detector_model, created_at)
+            VALUES (100, 10, 1, 0, 0, 1, 1, 0.9, 'animal', 'megadetector-v6', 't1'),
+                   (200, 10, 2, 0, 0, 1, 1, 0.9, 'animal', 'megadetector-v6', 't2');
+        INSERT INTO predictions (id, detection_id, species, model, status, individual)
+            VALUES (1, 100, 'Robin', 'bioclip-2', 'approved', 'Ruby'),
+                   (2, 200, 'Robin', 'bioclip-2', 'rejected', NULL);
+    """)
+    conn.commit()
+    conn.close()
+
+    from db import Database
+    db = Database(db_path)
+    rows = db.conn.execute(
+        "SELECT prediction_id, workspace_id, status, individual "
+        "FROM prediction_review ORDER BY workspace_id"
+    ).fetchall()
+    # After Task 9 dedupes detections, both predictions point to the canonical
+    # detection, so we should have two review rows — one per workspace.
+    assert len(rows) == 2
+    ws_statuses = {r["workspace_id"]: (r["status"], r["individual"]) for r in rows}
+    assert ws_statuses[1] == ("approved", "Ruby")
+    assert ws_statuses[2] == ("rejected", None)

--- a/vireo/tests/test_detector.py
+++ b/vireo/tests/test_detector.py
@@ -13,6 +13,19 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
+def test_detect_animals_uses_hard_floor(monkeypatch):
+    """detect_animals no longer takes a confidence_threshold param; it uses 0.01 floor."""
+    from detector import RAW_CONF_FLOOR
+    assert RAW_CONF_FLOOR == 0.01
+
+    # Signature regression: should not accept confidence_threshold kwarg
+    import inspect
+
+    from detector import detect_animals
+    sig = inspect.signature(detect_animals)
+    assert "confidence_threshold" not in sig.parameters
+
+
 def test_megadetector_onnx_session_loads():
     """MegaDetector ONNX session must load when model file exists."""
     try:

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -417,9 +417,9 @@ def test_accept_prediction_undo_restores_status(app_and_db):
     resp = client.post(f'/api/predictions/{pred_id}/accept')
     assert resp.status_code == 200
 
-    # Verify accepted state
-    pred_row = db.conn.execute("SELECT status FROM predictions WHERE id = ?", (pred_id,)).fetchone()
-    assert pred_row['status'] == 'accepted'
+    # Verify accepted state (review status lives in prediction_review per workspace)
+    ws_id = db._active_workspace_id
+    assert db.get_review_status(pred_id, ws_id) == 'accepted'
     kws = {k['name'] for k in db.get_photo_keywords(pid)}
     assert 'Blue Jay' in kws
 
@@ -428,8 +428,7 @@ def test_accept_prediction_undo_restores_status(app_and_db):
     assert resp.status_code == 200
 
     # Prediction status restored to pending
-    pred_row = db.conn.execute("SELECT status FROM predictions WHERE id = ?", (pred_id,)).fetchone()
-    assert pred_row['status'] == 'pending'
+    assert db.get_review_status(pred_id, ws_id) == 'pending'
 
     # Keyword removed
     kws = {k['name'] for k in db.get_photo_keywords(pid)}

--- a/vireo/tests/test_labels_fingerprint.py
+++ b/vireo/tests/test_labels_fingerprint.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from labels_fingerprint import LEGACY_SENTINEL, TOL_SENTINEL, compute_fingerprint
+
+
+def test_fingerprint_is_stable_under_ordering_and_duplicates():
+    a = compute_fingerprint(["Bald Eagle", "American Robin", "Bald Eagle"])
+    b = compute_fingerprint(["American Robin", "Bald Eagle"])
+    assert a == b
+    assert len(a) == 12  # sha256 hex prefix
+
+
+def test_fingerprint_differs_on_different_sets():
+    a = compute_fingerprint(["Bald Eagle", "American Robin"])
+    b = compute_fingerprint(["Bald Eagle", "Steller's Jay"])
+    assert a != b
+
+
+def test_tol_sentinel_when_no_labels():
+    assert compute_fingerprint(None) == TOL_SENTINEL
+    assert compute_fingerprint([]) == TOL_SENTINEL
+
+
+def test_sentinels_are_fixed_strings():
+    assert TOL_SENTINEL == "tol"
+    assert LEGACY_SENTINEL == "legacy"

--- a/vireo/tests/test_migration_detection_storage.py
+++ b/vireo/tests/test_migration_detection_storage.py
@@ -1,0 +1,118 @@
+import os
+import sqlite3
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+
+def _build_legacy_db(path):
+    conn = sqlite3.connect(path)
+    conn.executescript("""
+        CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT);
+        CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER,
+                             filename TEXT, timestamp TEXT, rating INTEGER,
+                             UNIQUE(folder_id, filename));
+        CREATE TABLE workspaces (id INTEGER PRIMARY KEY, name TEXT UNIQUE,
+                                 config_overrides TEXT, ui_state TEXT,
+                                 last_opened_at TEXT);
+        CREATE TABLE workspace_folders (
+            workspace_id INTEGER, folder_id INTEGER,
+            PRIMARY KEY (workspace_id, folder_id)
+        );
+        CREATE TABLE detections (
+            id INTEGER PRIMARY KEY, photo_id INTEGER, workspace_id INTEGER,
+            box_x REAL, box_y REAL, box_w REAL, box_h REAL,
+            detector_confidence REAL, category TEXT, detector_model TEXT,
+            created_at TEXT
+        );
+        CREATE TABLE predictions (
+            id INTEGER PRIMARY KEY, detection_id INTEGER, species TEXT,
+            confidence REAL, model TEXT,
+            status TEXT DEFAULT 'pending', reviewed_at TEXT,
+            individual TEXT, group_id TEXT,
+            vote_count INTEGER, total_votes INTEGER,
+            created_at TEXT
+        );
+        INSERT INTO folders VALUES (1, '/p');
+        INSERT INTO photos (id, folder_id, filename) VALUES
+            (10, 1, 'a.jpg'), (11, 1, 'b.jpg');
+        INSERT INTO workspaces (id, name) VALUES (1, 'A'), (2, 'B');
+        INSERT INTO workspace_folders VALUES (1, 1), (2, 1);
+        -- photo 10 detected in both workspaces (same box -> dedupes)
+        INSERT INTO detections (id, photo_id, workspace_id, box_x, box_y, box_w, box_h,
+                                detector_confidence, category, detector_model, created_at)
+          VALUES (100, 10, 1, 0.1, 0.1, 0.4, 0.4, 0.92, 'animal', 'megadetector-v6', 't1'),
+                 (200, 10, 2, 0.1, 0.1, 0.4, 0.4, 0.92, 'animal', 'megadetector-v6', 't1'),
+                 -- photo 11 only in workspace A, different box
+                 (300, 11, 1, 0.2, 0.2, 0.5, 0.5, 0.71, 'animal', 'megadetector-v6', 't1');
+        INSERT INTO predictions (id, detection_id, species, model,
+                                 status, individual, group_id)
+          VALUES (1, 100, 'Robin',  'bioclip-2', 'approved', 'Ruby', 'pair-01'),
+                 (2, 200, 'Robin',  'bioclip-2', 'pending',  NULL,   NULL),
+                 (3, 300, 'Sparrow','bioclip-2', 'rejected', NULL,   NULL);
+    """)
+    conn.commit()
+    conn.close()
+
+
+def test_full_migration(tmp_path):
+    db_path = str(tmp_path / "legacy.db")
+    _build_legacy_db(db_path)
+
+    from db import Database
+    db = Database(db_path)
+
+    # detections: one row per unique box; workspace_id column gone
+    det_cols = {r[1] for r in db.conn.execute(
+        "PRAGMA table_info(detections)"
+    ).fetchall()}
+    assert "workspace_id" not in det_cols
+    photo10_rows = db.conn.execute(
+        "SELECT id FROM detections WHERE photo_id=10"
+    ).fetchall()
+    assert len(photo10_rows) == 1
+    canonical_10 = photo10_rows[0]["id"]
+
+    # predictions re-pointed to canonical detection; legacy columns gone
+    pred_cols = {r[1] for r in db.conn.execute(
+        "PRAGMA table_info(predictions)"
+    ).fetchall()}
+    for legacy in ("status", "individual", "group_id", "reviewed_at",
+                   "vote_count", "total_votes", "model"):
+        assert legacy not in pred_cols, f"legacy column {legacy} still present"
+    photo10_preds = db.conn.execute(
+        "SELECT id, detection_id FROM predictions "
+        "WHERE detection_id = ? ORDER BY id",
+        (canonical_10,),
+    ).fetchall()
+    # Predictions 1 and 2 both pointed at what is now the canonical detection.
+    # Task 9 re-points pred 2's detection_id from 200 -> canonical_10, then
+    # Task 12's rewrite copies predictions through `INSERT OR IGNORE` keyed on
+    # (detection_id, classifier_model, labels_fingerprint, species). Preds 1
+    # and 2 share that tuple exactly, so the lower-id row (pred 1) wins and
+    # pred 2 is dropped. Workspace 2's "pending" review state for that
+    # prediction is correctly represented by absence from prediction_review.
+    assert {p["id"] for p in photo10_preds} == {1}
+
+    # review state landed in prediction_review
+    reviews = db.conn.execute(
+        "SELECT prediction_id, workspace_id, status, individual "
+        "FROM prediction_review ORDER BY prediction_id, workspace_id"
+    ).fetchall()
+    review_map = {(r["prediction_id"], r["workspace_id"]):
+                  (r["status"], r["individual"]) for r in reviews}
+    # pred 1 was approved in ws 1, with individual "Ruby"
+    assert review_map[(1, 1)] == ("approved", "Ruby")
+    # pred 2 was pending in ws 2 -> absence (not in review_map). Pred 2 itself
+    # is also gone (see dedupe comment above), which is why its workspace-2
+    # pending state stays absent.
+    assert (2, 2) not in review_map
+    # pred 3 rejected in ws 1
+    assert review_map[(3, 1)] == ("rejected", None)
+
+    # detector_runs backfilled for every (photo, model)
+    run_keys = {(r["photo_id"], r["detector_model"]) for r in db.conn.execute(
+        "SELECT photo_id, detector_model FROM detector_runs"
+    ).fetchall()}
+    assert (10, "megadetector-v6") in run_keys
+    assert (11, "megadetector-v6") in run_keys

--- a/vireo/tests/test_misses.py
+++ b/vireo/tests/test_misses.py
@@ -224,6 +224,7 @@ def test_compute_misses_groups_by_burst_and_writes_flags(tmp_path):
             pid,
             [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
               "confidence": 0.95, "category": "animal"}],
+            detector_model="megadetector-v6",
         )
 
     compute_misses_for_workspace(db, cfg.DEFAULTS["pipeline"])
@@ -270,6 +271,7 @@ def test_compute_misses_scoped_to_active_workspace(tmp_path):
         p_a,
         [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
           "confidence": 0.95, "category": "animal"}],
+            detector_model="megadetector-v6",
     )
 
     # Folder linked to B — add while B is active.
@@ -288,6 +290,7 @@ def test_compute_misses_scoped_to_active_workspace(tmp_path):
         p_b,
         [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
           "confidence": 0.95, "category": "animal"}],
+            detector_model="megadetector-v6",
     )
     db.conn.commit()
 
@@ -345,6 +348,7 @@ def test_compute_misses_scoped_to_collection_leaves_others_untouched(tmp_path):
             pid,
             [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
               "confidence": 0.95, "category": "animal"}],
+            detector_model="megadetector-v6",
         )
     db.conn.commit()
 
@@ -413,6 +417,7 @@ def test_compute_misses_respects_exclude_photo_ids(tmp_path):
             pid,
             [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
               "confidence": 0.95, "category": "animal"}],
+            detector_model="megadetector-v6",
         )
     db.conn.commit()
 
@@ -461,6 +466,7 @@ def test_compute_misses_uses_injected_now_timestamp(tmp_path):
         pid,
         [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
           "confidence": 0.95, "category": "animal"}],
+            detector_model="megadetector-v6",
     )
     db.conn.commit()
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -352,6 +352,43 @@ def test_api_species_empty(app_and_db):
     assert data['species'] == []
 
 
+def test_api_species_summary_filters_to_latest_fingerprint(app_and_db):
+    """GET /api/species/summary must surface only the most recent
+    labels_fingerprint per (detection, classifier_model). Stale species
+    cached under an old label set must NOT contribute to counts —
+    otherwise the variant explorer mixes pre- and post-relabel results.
+    """
+    app, db = app_and_db
+    det_ids = db.save_detections(1, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"},
+    ], detector_model="MDV6")
+    # Stale fingerprint: species the user used to track.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-old', 'Finch', 0.9, '2026-01-01')",
+        (det_ids[0],),
+    )
+    # Current fingerprint: species under the active label set.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-new', 'Robin', 0.8, '2026-04-24')",
+        (det_ids[0],),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.get('/api/species/summary')
+    assert resp.status_code == 200
+    species = [r['species'] for r in resp.get_json()]
+    assert 'Robin' in species
+    assert 'Finch' not in species, (
+        "Species summary leaked a stale-fingerprint species into counts "
+        "— variant explorer would mix pre- and post-relabel results."
+    )
+
+
 def test_photo_detail_includes_metadata(app_and_db):
     """GET /api/photos/<id> includes parsed metadata when exif_data is populated."""
     app, db = app_and_db

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -93,6 +93,52 @@ def test_api_photos_includes_all_detections(app_and_db):
     assert bird3['detections'] == []
 
 
+def test_api_photos_detections_honor_workspace_threshold(app_and_db):
+    """Lowering the workspace's `detector_confidence` surfaces more boxes at
+    read time, without rewriting any detection rows.
+
+    Exercises the global-detections design: boxes are cached once, each
+    workspace filters on its own threshold when reading.
+    """
+    app, db = app_and_db
+    photos = db.get_photos()
+    target = [p for p in photos if p['filename'] == 'bird1.jpg'][0]
+
+    # Save two boxes: one above the default 0.2 threshold, one below it.
+    db.save_detections(target['id'], [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.05, "category": "animal"},
+        {"box": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2}, "confidence": 0.95, "category": "animal"},
+    ], detector_model="MDV6")
+
+    client = app.test_client()
+
+    # Default workspace threshold (0.2) hides the low-confidence box.
+    resp = client.get('/api/photos')
+    bird1 = [p for p in resp.get_json()['photos'] if p['filename'] == 'bird1.jpg'][0]
+    assert len(bird1['detections']) == 1
+    assert bird1['detections'][0]['confidence'] == 0.95
+
+    # Lower the workspace threshold via a per-workspace config override —
+    # no detection rows are rewritten, only the read-time filter changes.
+    db.update_workspace(db._active_workspace_id,
+                        config_overrides={"detector_confidence": 0.01})
+
+    resp = client.get('/api/photos')
+    bird1 = [p for p in resp.get_json()['photos'] if p['filename'] == 'bird1.jpg'][0]
+    assert len(bird1['detections']) == 2, (
+        "lowering detector_confidence should surface more cached boxes"
+    )
+    # Still ordered by confidence DESC.
+    assert bird1['detections'][0]['confidence'] == 0.95
+    assert bird1['detections'][1]['confidence'] == 0.05
+
+    # And no new rows were written.
+    raw = db.conn.execute(
+        "SELECT COUNT(*) FROM detections WHERE photo_id = ?", (target['id'],)
+    ).fetchone()[0]
+    assert raw == 2
+
+
 def test_api_photos_filter_keyword(app_and_db):
     """GET /api/photos?keyword= filters by keyword."""
     app, _ = app_and_db

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -1078,3 +1078,88 @@ def test_eye_stage_picks_eye_with_higher_tenengrad(tmp_path, monkeypatch):
     assert abs(eye_y - 300.0 / 600.0) < 1.0 / 600.0
     assert eye_conf == 0.80
     assert eye_teng > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Read-time detection threshold filtering (Task 24)
+# ---------------------------------------------------------------------------
+
+
+def test_load_photo_features_honors_workspace_detector_threshold(tmp_path):
+    """Lowering workspace `detector_confidence` surfaces more cached boxes at
+    read time, without rewriting detection rows.
+
+    Exercises the global-detections design: boxes are stored once globally;
+    each workspace's view of subject crops / primary detections is filtered
+    by its effective `detector_confidence` override at read time.
+    """
+    from db import Database
+    from pipeline import load_photo_features
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db._active_workspace_id
+    fid = db.add_folder(str(tmp_path), name="photos")
+    db.add_workspace_folder(ws_id, fid)
+
+    pid = db.add_photo(
+        fid, "bird.jpg", ".jpg", 1000, 1.0,
+        timestamp="2026-04-23T10:00:00",
+        width=4000, height=3000,
+    )
+
+    # Save two boxes globally: one high-conf (surfaces at default threshold),
+    # one low-conf (only surfaces when the workspace lowers its threshold).
+    db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+         "confidence": 0.05, "category": "animal"},
+        {"box": {"x": 0.5, "y": 0.5, "w": 0.3, "h": 0.3},
+         "confidence": 0.95, "category": "animal"},
+    ], detector_model="MDV6")
+
+    # At the default workspace threshold (0.2), only the high-conf box wins
+    # as primary detection.
+    photos = load_photo_features(db)
+    assert len(photos) == 1
+    primary = photos[0]["detection_box"]
+    assert primary is not None
+    assert primary["x"] == 0.5
+    assert photos[0]["detection_conf"] == 0.95
+
+    # Lower the workspace threshold via per-workspace config override so the
+    # low-conf box becomes visible. Primary is still the high-conf one
+    # (helper sorts by confidence DESC), but if we drop the high-conf box
+    # the low-conf one now surfaces — proving the read-time filter actually
+    # changed behavior without any detection-row writes.
+    db.update_workspace(ws_id,
+                        config_overrides={"detector_confidence": 0.01})
+
+    # Delete just the high-conf detection to confirm the low-conf one now
+    # becomes primary under the lowered threshold.
+    db.conn.execute(
+        "DELETE FROM detections WHERE photo_id = ? AND detector_confidence = ?",
+        (pid, 0.95),
+    )
+    db.conn.commit()
+
+    photos = load_photo_features(db)
+    assert len(photos) == 1
+    primary = photos[0]["detection_box"]
+    assert primary is not None, (
+        "lowering detector_confidence should surface the cached low-conf box"
+    )
+    assert primary["x"] == 0.1
+    assert photos[0]["detection_conf"] == 0.05
+
+    # Raise the threshold back above 0.05 — the low-conf box disappears
+    # again, purely through read-time filtering.
+    db.update_workspace(ws_id,
+                        config_overrides={"detector_confidence": 0.5})
+    photos = load_photo_features(db)
+    assert photos[0]["detection_box"] is None
+    assert photos[0]["detection_conf"] is None
+
+    # And the raw row count never changed (no rewrites).
+    raw = db.conn.execute(
+        "SELECT COUNT(*) FROM detections WHERE photo_id = ?", (pid,),
+    ).fetchone()[0]
+    assert raw == 1

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -466,6 +466,55 @@ def test_load_photo_features_includes_model_in_species(tmp_path):
             assert isinstance(entry[2], str), f"Model should be a string, got {type(entry[2])}"
 
 
+def test_load_photo_features_filters_to_latest_fingerprint(tmp_path):
+    """With multiple fingerprints cached for a (detection, model), only the
+    latest one surfaces — otherwise stale species from an old label set
+    would leak into the pipeline top-k.
+    """
+    from db import Database
+    from pipeline import load_photo_features
+
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder("/tmp/p")
+    db.add_workspace_folder(ws, folder_id)
+    pid = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    det_ids = db.save_detections(
+        pid,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.95, "category": "animal"}],
+        detector_model="MDV6",
+    )
+    # Older fingerprint row (stale label set) — Robin.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, labels_fingerprint, "
+        "species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-old', 'Robin', 0.9, '2026-01-01T00:00:00')",
+        (det_ids[0],),
+    )
+    # Newer fingerprint row (current label set) — Blue Jay.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, labels_fingerprint, "
+        "species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-new', 'Blue Jay', 0.85, '2026-04-24T00:00:00')",
+        (det_ids[0],),
+    )
+    db.conn.commit()
+
+    # Default behavior: most recent fingerprint only.
+    photos = load_photo_features(db)
+    species = [e[0] for e in photos[0]["species_top5"]]
+    assert species == ["Blue Jay"], "should surface only the latest fingerprint's species"
+
+    # Explicit override: pin to the stale fingerprint.
+    photos = load_photo_features(db, labels_fingerprint="fp-old")
+    species = [e[0] for e in photos[0]["species_top5"]]
+    assert species == ["Robin"]
+
+
 def test_load_photo_features_collection_scoped(tmp_path):
     """load_photo_features with collection_id returns only collection photos."""
     from db import Database

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -2048,6 +2048,20 @@ def test_pipeline_reclassify_multimodel_ignores_stale_detection_ids(
             import numpy as np
             return np.zeros(512, dtype=np.float32)
 
+        def classify_with_embedding(self, img, threshold=0):
+            import numpy as np
+            return [{"species": "Robin", "score": 0.9}], np.zeros(
+                512, dtype=np.float32,
+            )
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            zero = np.zeros(512, dtype=np.float32)
+            return [(
+                [{"species": "Robin", "score": 0.9}],
+                zero,
+            ) for _ in images]
+
     monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
 
     params = PipelineParams(
@@ -2207,6 +2221,20 @@ def test_pipeline_classify_passes_primary_detection_to_prepare_image(
             import numpy as np
             return np.zeros(512, dtype=np.float32)
 
+        def classify_with_embedding(self, img, threshold=0):
+            import numpy as np
+            return [{"species": "Robin", "score": 0.9}], np.zeros(
+                512, dtype=np.float32,
+            )
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            zero = np.zeros(512, dtype=np.float32)
+            return [(
+                [{"species": "Robin", "score": 0.9}],
+                zero,
+            ) for _ in images]
+
     monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
 
     params = PipelineParams(
@@ -2314,6 +2342,20 @@ def test_pipeline_reclassify_purges_stale_detection_rows(tmp_path, monkeypatch):
         def encode_image(self, *args, **kwargs):
             import numpy as np
             return np.zeros(512, dtype=np.float32)
+
+        def classify_with_embedding(self, img, threshold=0):
+            import numpy as np
+            return [{"species": "Robin", "score": 0.9}], np.zeros(
+                512, dtype=np.float32,
+            )
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            zero = np.zeros(512, dtype=np.float32)
+            return [(
+                [{"species": "Robin", "score": 0.9}],
+                zero,
+            ) for _ in images]
 
     monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
 
@@ -2429,6 +2471,20 @@ def test_detect_batch_skips_empty_photo_on_rerun(tmp_path, monkeypatch):
         def encode_image(self, *args, **kwargs):
             import numpy as np
             return np.zeros(512, dtype=np.float32)
+
+        def classify_with_embedding(self, img, threshold=0):
+            import numpy as np
+            return [{"species": "Robin", "score": 0.9}], np.zeros(
+                512, dtype=np.float32,
+            )
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            zero = np.zeros(512, dtype=np.float32)
+            return [(
+                [{"species": "Robin", "score": 0.9}],
+                zero,
+            ) for _ in images]
 
     monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
 
@@ -2551,6 +2607,20 @@ def test_pipeline_reclassify_partial_abort_preserves_unprocessed_detections(
         def encode_image(self, *args, **kwargs):
             import numpy as np
             return np.zeros(512, dtype=np.float32)
+
+        def classify_with_embedding(self, img, threshold=0):
+            import numpy as np
+            return [{"species": "Robin", "score": 0.9}], np.zeros(
+                512, dtype=np.float32,
+            )
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            zero = np.zeros(512, dtype=np.float32)
+            return [(
+                [{"species": "Robin", "score": 0.9}],
+                zero,
+            ) for _ in images]
 
     monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
 
@@ -2675,6 +2745,20 @@ def test_pipeline_reclassify_partial_batch_exception_preserves_detections(
         def encode_image(self, *args, **kwargs):
             import numpy as np
             return np.zeros(512, dtype=np.float32)
+
+        def classify_with_embedding(self, img, threshold=0):
+            import numpy as np
+            return [{"species": "Robin", "score": 0.9}], np.zeros(
+                512, dtype=np.float32,
+            )
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            zero = np.zeros(512, dtype=np.float32)
+            return [(
+                [{"species": "Robin", "score": 0.9}],
+                zero,
+            ) for _ in images]
 
     monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
 
@@ -3205,7 +3289,7 @@ def test_pipeline_classify_stores_predictions_with_detection_id(
 
     # At least one prediction should have been stored.
     preds = db.conn.execute(
-        "SELECT id, detection_id, species, model FROM predictions"
+        "SELECT id, detection_id, species, classifier_model AS model FROM predictions"
     ).fetchall()
     assert preds, (
         "Pipeline classify stage produced no predictions — test setup did "
@@ -3220,20 +3304,24 @@ def test_pipeline_classify_stores_predictions_with_detection_id(
         "logic never matches and every pipeline run re-classifies everything."
     )
 
-    # Every prediction's detection_id must resolve to a real detection row in
-    # the active workspace (so the workspace-scoped skip query picks it up).
+    # Every prediction's detection_id must resolve to a real detection row.
+    # Detections are global post-refactor — workspace scoping is through
+    # workspace_folders, so we verify that join resolves instead of reading
+    # the dropped workspace_id column on detections.
     for p in preds:
         det = db.conn.execute(
-            "SELECT photo_id, workspace_id FROM detections WHERE id = ?",
-            (p["detection_id"],),
+            """SELECT d.id, d.photo_id, wf.workspace_id
+               FROM detections d
+               JOIN photos ph ON ph.id = d.photo_id
+               JOIN workspace_folders wf
+                 ON wf.folder_id = ph.folder_id
+               WHERE d.id = ? AND wf.workspace_id = ?""",
+            (p["detection_id"], ws_id),
         ).fetchone()
         assert det is not None, (
             f"Prediction {dict(p)} references detection_id "
-            f"{p['detection_id']} which does not exist in detections table."
-        )
-        assert det["workspace_id"] == ws_id, (
-            f"Prediction bound to detection in workspace {det['workspace_id']}, "
-            f"expected {ws_id}."
+            f"{p['detection_id']} which doesn't resolve to a detection in "
+            f"workspace {ws_id} via workspace_folders."
         )
 
     # photo_with_det must be in the skip set so the second run reuses its
@@ -3542,6 +3630,20 @@ def test_pipeline_step_defs_include_detect_and_per_model_classify(
             import numpy as np
             return np.zeros(512, dtype=np.float32)
 
+        def classify_with_embedding(self, img, threshold=0):
+            import numpy as np
+            return [{"species": "Robin", "score": 0.9}], np.zeros(
+                512, dtype=np.float32,
+            )
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            zero = np.zeros(512, dtype=np.float32)
+            return [(
+                [{"species": "Robin", "score": 0.9}],
+                zero,
+            ) for _ in images]
+
     monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
 
     params = PipelineParams(
@@ -3663,6 +3765,20 @@ def test_pipeline_single_model_gets_per_model_classify_row(tmp_path, monkeypatch
         def encode_image(self, *args, **kwargs):
             import numpy as np
             return np.zeros(512, dtype=np.float32)
+
+        def classify_with_embedding(self, img, threshold=0):
+            import numpy as np
+            return [{"species": "Robin", "score": 0.9}], np.zeros(
+                512, dtype=np.float32,
+            )
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            zero = np.zeros(512, dtype=np.float32)
+            return [(
+                [{"species": "Robin", "score": 0.9}],
+                zero,
+            ) for _ in images]
 
     monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
 
@@ -3830,6 +3946,20 @@ def test_pipeline_one_model_fails_to_load_other_model_still_runs(
             import numpy as np
             return np.zeros(512, dtype=np.float32)
 
+        def classify_with_embedding(self, img, threshold=0):
+            import numpy as np
+            return [{"species": "Robin", "score": 0.9}], np.zeros(
+                512, dtype=np.float32,
+            )
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            zero = np.zeros(512, dtype=np.float32)
+            return [(
+                [{"species": "Robin", "score": 0.9}],
+                zero,
+            ) for _ in images]
+
     monkeypatch.setattr(classifier_mod, "Classifier", SelectiveClassifier)
 
     params = PipelineParams(
@@ -3903,6 +4033,20 @@ def test_pipeline_per_model_step_summary_includes_prediction_count(
         def encode_image(self, *args, **kwargs):
             import numpy as np
             return np.zeros(512, dtype=np.float32)
+
+        def classify_with_embedding(self, img, threshold=0):
+            import numpy as np
+            return [{"species": "Robin", "score": 0.9}], np.zeros(
+                512, dtype=np.float32,
+            )
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            zero = np.zeros(512, dtype=np.float32)
+            return [(
+                [{"species": "Robin", "score": 0.9}],
+                zero,
+            ) for _ in images]
 
     monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
 
@@ -4068,6 +4212,20 @@ def test_pipeline_fatal_error_does_not_overwrite_completed_model_rows(
         def encode_image(self, *args, **kwargs):
             import numpy as np
             return np.zeros(512, dtype=np.float32)
+
+        def classify_with_embedding(self, img, threshold=0):
+            import numpy as np
+            return [{"species": "Robin", "score": 0.9}], np.zeros(
+                512, dtype=np.float32,
+            )
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            zero = np.zeros(512, dtype=np.float32)
+            return [(
+                [{"species": "Robin", "score": 0.9}],
+                zero,
+            ) for _ in images]
 
     monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -2159,6 +2159,120 @@ def test_pipeline_reclassify_purges_stale_detection_rows(tmp_path, monkeypatch):
     )
 
 
+def test_detect_batch_skips_empty_photo_on_rerun(tmp_path, monkeypatch):
+    """A photo with no animals, recorded in detector_runs, must not be
+    re-detected on a subsequent non-reclassify pipeline run.
+
+    Mirrors test_classify_job.test_detect_batch_skips_empty_photo_on_rerun
+    but drives through run_pipeline_job's detect_stage so we exercise the
+    pipeline's own already_detected seeding (which must use
+    get_detector_run_photo_ids, not the legacy get_existing_detection_photo_ids
+    shim that misses empty-scene photos).
+    """
+    import json
+
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_id = db.add_photo(folder_id, "empty.jpg", ".jpg", 12345, 1_000_000.0)
+    _drop_jpeg(folder_path, "empty.jpg")
+
+    # Simulate a prior run where MegaDetector scanned the photo and found
+    # NOTHING — there are no detection rows, but detector_runs records the
+    # scan so the next pipeline pass can skip re-invoking the detector.
+    db.save_detections(photo_id, [], detector_model="megadetector-v6")
+    db.record_detector_run(photo_id, "megadetector-v6", box_count=0)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": [photo_id]}]),
+    )
+
+    model_id = _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    # Remove the legacy shim so the pipeline must call
+    # get_detector_run_photo_ids directly. If pipeline still uses the
+    # legacy name (via getattr) it will fall through to the default
+    # `lambda: set()` and miss our empty-scene photo.
+    monkeypatch.delattr(Database, "get_existing_detection_photo_ids")
+
+    # Capture what already_detected_ids the pipeline passes to _detect_batch.
+    # If the pipeline seeds correctly from get_detector_run_photo_ids, our
+    # empty-scene photo will appear in already_detected_ids — meaning the
+    # real _detect_batch would skip re-invoking MegaDetector for it.
+    detect_calls = []
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        detect_calls.append({
+            "already_detected_ids": frozenset(already_detected_ids or set()),
+            "batch_ids": [p["id"] for p in batch],
+        })
+        # Simulate the real _detect_batch's skip behaviour: if the photo
+        # is already in already_detected_ids, don't re-"detect" it.
+        processed = {p["id"] for p in batch}
+        return {}, 0, processed
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    # Patch classify_stage's prediction-photo lookup so classify_stage
+    # doesn't trip on pre-existing schema issues in other migrations.
+    # (This test focuses narrowly on detect_stage's already_detected seed.)
+    monkeypatch.setattr(
+        Database, "get_existing_prediction_photo_ids",
+        lambda self, model_name: set(),
+    )
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=[model_id],
+        reclassify=False,  # non-reclassify: must honour detector_runs skip
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+    # classify_stage may still fail against pre-migration schema bits that
+    # this task doesn't own. We only need detect_stage to have run.
+    with contextlib.suppress(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert detect_calls, "expected detect_stage to call _detect_batch"
+    first_call = detect_calls[0]
+    assert photo_id in first_call["already_detected_ids"], (
+        f"Empty-scene photo {photo_id} was recorded in detector_runs but "
+        f"pipeline did not seed it into already_detected_ids "
+        f"(got {set(first_call['already_detected_ids'])!r}). "
+        f"detect_stage must seed from get_detector_run_photo_ids "
+        f"('megadetector-v6'), not the legacy "
+        f"get_existing_detection_photo_ids shim which misses empty-scene photos."
+    )
+
+
 def test_pipeline_reclassify_partial_abort_preserves_unprocessed_detections(
     tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_predictions_api.py
+++ b/vireo/tests/test_predictions_api.py
@@ -114,6 +114,23 @@ def test_reject_prediction(app_and_db):
     assert 'Northern Cardinal' not in kw_names
 
 
+def test_reject_prediction_missing_id_returns_404(app_and_db):
+    """Stale prediction IDs should 404, not 500.
+
+    prediction_review has an FK on prediction_id, so blindly writing
+    review state for a non-existent prediction would now raise an
+    IntegrityError. The endpoint must check existence first.
+    """
+    app, db = app_and_db
+    _seed_predictions(db)
+    client = app.test_client()
+
+    resp = client.post('/api/predictions/999999/reject')
+    assert resp.status_code == 404
+    # And nothing got written to prediction_review for the stale id
+    assert db.get_review_status(999999, db._active_workspace_id) == 'pending'
+
+
 def test_get_prediction_group(app_and_db):
     """GET /api/predictions/group/1 returns both group members."""
     app, db = app_and_db

--- a/vireo/tests/test_predictions_api.py
+++ b/vireo/tests/test_predictions_api.py
@@ -83,11 +83,8 @@ def test_accept_prediction(app_and_db):
     assert resp.status_code == 200
     assert resp.get_json()['ok'] is True
 
-    # Prediction status should be accepted
-    row = db.conn.execute(
-        "SELECT status FROM predictions WHERE id = ?", (pred['id'],)
-    ).fetchone()
-    assert row['status'] == 'accepted'
+    # Prediction status should be accepted (workspace-scoped via prediction_review)
+    assert db.get_review_status(pred['id'], db._active_workspace_id) == 'accepted'
 
     # Species keyword should have been added to the photo
     keywords = db.get_photo_keywords(photos[2]['id'])
@@ -109,10 +106,7 @@ def test_reject_prediction(app_and_db):
     assert resp.status_code == 200
     assert resp.get_json()['ok'] is True
 
-    row = db.conn.execute(
-        "SELECT status FROM predictions WHERE id = ?", (pred['id'],)
-    ).fetchone()
-    assert row['status'] == 'rejected'
+    assert db.get_review_status(pred['id'], db._active_workspace_id) == 'rejected'
 
     # Verify no species keyword was added
     keywords = db.get_photo_keywords(photos[0]['id'])
@@ -170,19 +164,26 @@ def test_prediction_group_apply(app_and_db):
     reject_photo = db.get_photo(reject_id)
     assert reject_photo['flag'] == 'rejected'
 
-    # Predictions for the pick should be accepted
+    # Predictions for the pick should be accepted (review state in prediction_review)
+    ws_id = db._active_workspace_id
     pick_preds = db.conn.execute(
-        """SELECT pr.status FROM predictions pr
+        """SELECT COALESCE(pr_rev.status, 'pending') AS status
+           FROM predictions pr
            JOIN detections d ON d.id = pr.detection_id
-           WHERE d.photo_id = ?""", (pick_id,)
+           LEFT JOIN prediction_review pr_rev
+             ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
+           WHERE d.photo_id = ?""", (ws_id, pick_id)
     ).fetchall()
     assert all(p['status'] == 'accepted' for p in pick_preds)
 
     # Predictions for the reject should be rejected
     reject_preds = db.conn.execute(
-        """SELECT pr.status FROM predictions pr
+        """SELECT COALESCE(pr_rev.status, 'pending') AS status
+           FROM predictions pr
            JOIN detections d ON d.id = pr.detection_id
-           WHERE d.photo_id = ?""", (reject_id,)
+           LEFT JOIN prediction_review pr_rev
+             ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
+           WHERE d.photo_id = ?""", (ws_id, reject_id)
     ).fetchall()
     assert all(p['status'] == 'rejected' for p in reject_preds)
 
@@ -213,14 +214,21 @@ def test_predictions_include_alternatives(app_and_db):
     photos = db.get_photos()
     det_ids = db.save_detections(photos[0]['id'], [
         {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}, "confidence": 0.9}
-    ])
+    ], detector_model="MDV6")
     det_id = det_ids[0]
     db.add_prediction(detection_id=det_id, species='Robin', confidence=0.85,
-                      model='test-model', status='pending')
+                      model='test-model')
     db.add_prediction(detection_id=det_id, species='Sparrow', confidence=0.10,
-                      model='test-model', status='alternative')
+                      model='test-model')
     db.add_prediction(detection_id=det_id, species='Finch', confidence=0.05,
-                      model='test-model', status='alternative')
+                      model='test-model')
+    # Mark alternatives in the prediction_review table for this workspace
+    ws_id = db._active_workspace_id
+    for sp in ('Sparrow', 'Finch'):
+        row = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", (sp,)
+        ).fetchone()
+        db.set_review_status(row['id'], ws_id, 'alternative')
 
     client = app.test_client()
     resp = client.get('/api/predictions')
@@ -243,33 +251,32 @@ def test_accept_alternative_prediction(app_and_db):
     photos = db.get_photos()
     det_ids = db.save_detections(photos[0]['id'], [
         {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}, "confidence": 0.9}
-    ])
+    ], detector_model="MDV6")
     det_id = det_ids[0]
     db.add_prediction(detection_id=det_id, species='Robin', confidence=0.85,
-                      model='test-model', status='pending')
+                      model='test-model')
     db.add_prediction(detection_id=det_id, species='Sparrow', confidence=0.10,
-                      model='test-model', status='alternative')
+                      model='test-model')
 
-    # Get the alternative prediction ID
+    ws_id = db._active_workspace_id
+    # Mark Sparrow as an alternative in the workspace's review table.
     alt = db.conn.execute(
         "SELECT id FROM predictions WHERE species = 'Sparrow'"
     ).fetchone()
+    db.set_review_status(alt['id'], ws_id, 'alternative')
 
     client = app.test_client()
     resp = client.post(f'/api/predictions/{alt["id"]}/accept')
     assert resp.status_code == 200
 
     # Alternative should be accepted
-    row = db.conn.execute(
-        "SELECT status FROM predictions WHERE species = 'Sparrow'"
-    ).fetchone()
-    assert row['status'] == 'accepted'
+    assert db.get_review_status(alt['id'], ws_id) == 'accepted'
 
     # Original top-1 should be rejected
-    row = db.conn.execute(
-        "SELECT status FROM predictions WHERE species = 'Robin'"
+    robin = db.conn.execute(
+        "SELECT id FROM predictions WHERE species = 'Robin'"
     ).fetchone()
-    assert row['status'] == 'rejected'
+    assert db.get_review_status(robin['id'], ws_id) == 'rejected'
 
     # Sparrow keyword should be on the photo
     keywords = db.get_photo_keywords(photos[0]['id'])


### PR DESCRIPTION
## Summary

Globalizes MegaDetector and classifier output caches and moves the `detector_confidence` threshold from a write-time gate to a read-time filter. Design and task-by-task plan live under `docs/plans/`.

- **Detections and predictions are cached per photo, not per workspace.** Switching workspaces or changing the confidence threshold no longer triggers a full reprocess.
- **Threshold applied at read time.** Lowering `detector_confidence` (e.g. from 0.2 → 0.05) takes effect immediately — previously sub-threshold boxes become visible on the next reload with no background job.
- **Review state moved** to a workspace-scoped `prediction_review` table (`status`, `individual`, `group_id`, `vote_count`, `total_votes`). Absence of a row = `'pending'`. `predictions.model` renamed to `classifier_model`; new `labels_fingerprint` column (default `'legacy'`).
- **Online migration** (Tasks 8–12): `detector_runs` backfilled, `prediction_review` backfilled, `detections.workspace_id` dropped with FK-safe table rewrite.
- **Settings page** now shows "Detections: N photos × M models cached" so users can see the shared cache.

## Test plan

Focused runs green on this branch (full suite is slow; ran per file):
- [x] `vireo/tests/test_db.py` — 211 passed
- [x] `vireo/tests/test_app.py` — 127 passed
- [x] `vireo/tests/test_photos_api.py` — 60 passed
- [x] `vireo/tests/test_pipeline.py` — 37 passed
- [x] `vireo/tests/test_jobs_api.py` — 50 passed
- [x] `vireo/tests/test_predictions_api.py` — 9 passed
- [x] `vireo/tests/test_migration_detection_storage.py` — passed (end-to-end migration regression)
- [x] `tests/test_workspaces.py` — 56 passed
- [x] `vireo/tests/test_new_images.py` — 26 passed
- [x] Previously-failing tests in `test_edits_api.py` and `test_workspaces_api.py` — passing

Known pre-existing failures (not regressions, documented in memory): 3 `test_pipeline_job.py` tests (`FakeClassifier` missing `classify_batch_with_embedding`/`classify_with_embedding`) and `test_welcome.py::test_welcome_page_renders` (flaky in full-suite order).

Hand-checks to run before merge:
- [ ] Scan folder in workspace A, create workspace B pointing at the same folder, open pipeline → detection + classify stages skip near-instantly.
- [ ] In workspace B, lower `detector_confidence` to 0.05 and reload browse grid → more boxes visible immediately, no background job fires.

## References

- Design: `docs/plans/2026-04-23-detection-storage-redesign-design.md`
- Plan: `docs/plans/2026-04-23-detection-storage-redesign-plan.md`
- Changelog entry added under "Unreleased"