### PR TITLE
fix(classify): self-heal on corrupt ONNX model file

### DIFF
--- a/vireo/classifier.py
+++ b/vireo/classifier.py
@@ -398,16 +398,51 @@ class Classifier:
                     "(first run -- will be cached for next time)...",
                     len(labels),
                 )
-                # Load text encoder session (self-healing on corruption;
-                # reuses the same redownloader resolved for the image
-                # encoder above since both files live in the same model
-                # directory).
+                # Load text encoder session (self-healing on corruption).
+                # A text-side heal invokes download_model which refreshes
+                # the ENTIRE model directory (image_encoder, text_encoder,
+                # config.json, tokenizer). If that happens, the already-
+                # loaded image session is stale — a version bump between
+                # the original install and the heal could leave us with
+                # an old image encoder paired with new text embeddings,
+                # producing silently incompatible features. Wrap the
+                # redownloader in a tracker and rebuild the image side
+                # if we see it fire.
+                text_heal_state = {"triggered": False}
+
+                if redownload is not None:
+                    def _tracked_redownload():
+                        text_heal_state["triggered"] = True
+                        redownload()
+
+                    text_redownload = _tracked_redownload
+                else:
+                    text_redownload = None
+
                 text_session = onnx_runtime.create_session_with_self_heal(
-                    text_encoder_path, redownload=redownload,
+                    text_encoder_path, redownload=text_redownload,
                 )
                 try:
                     text_input_name = text_session.get_inputs()[0].name
                     tokenizer = _load_tokenizer(tokenizer_path)
+
+                    if text_heal_state["triggered"]:
+                        log.info(
+                            "Text-encoder self-heal refreshed model dir; "
+                            "rebuilding image encoder and preprocessing "
+                            "config from the healed snapshot."
+                        )
+                        self._image_session = onnx_runtime.create_session(
+                            image_encoder_path,
+                        )
+                        self._image_input_name = (
+                            self._image_session.get_inputs()[0].name
+                        )
+                        with open(config_path) as f:
+                            preproc = json.load(f)
+                        self._input_size = tuple(preproc["input_size"][-2:])
+                        self._mean = preproc["mean"]
+                        self._std = preproc["std"]
 
                     self._txt_embeddings = _compute_embeddings_with_progress(
                         text_session,

--- a/vireo/classifier.py
+++ b/vireo/classifier.py
@@ -351,9 +351,26 @@ class Classifier:
         import models as _models_mod
 
         redownload = _models_mod.build_self_heal_redownloader(self._model_dir)
+
+        # Track whether image-side self-heal fires. If it does, the
+        # refreshed model dir may have new text_encoder bytes, making
+        # any cached label embeddings (computed against old text
+        # weights) produce silent score drift. We invalidate the
+        # cache before the cache-lookup branch below.
+        image_heal_state = {"triggered": False}
+
+        if redownload is not None:
+            def _image_redownload():
+                image_heal_state["triggered"] = True
+                redownload()
+
+            _image_redownload_cb = _image_redownload
+        else:
+            _image_redownload_cb = None
+
         log.info("Loading BioCLIP image encoder: %s", image_encoder_path)
         self._image_session = onnx_runtime.create_session_with_self_heal(
-            image_encoder_path, redownload=redownload,
+            image_encoder_path, redownload=_image_redownload_cb,
         )
         self._image_input_name = self._image_session.get_inputs()[0].name
 
@@ -385,6 +402,24 @@ class Classifier:
             self._classes = [cls.strip() for cls in labels]
 
             cache_path = _embedding_cache_path(labels, model_str, self._model_dir)
+
+            # If image self-heal refreshed the model dir, the on-disk
+            # text_encoder bytes are different from what any previously-
+            # cached embeddings were computed against. Invalidate the
+            # cache so we re-compute embeddings from the healed weights.
+            if image_heal_state["triggered"] and os.path.exists(cache_path):
+                log.info(
+                    "Image self-heal refreshed model dir; invalidating "
+                    "stale text embedding cache at %s",
+                    cache_path,
+                )
+                try:
+                    os.unlink(cache_path)
+                except OSError:
+                    log.exception(
+                        "Failed to invalidate text embedding cache %s",
+                        cache_path,
+                    )
 
             if os.path.exists(cache_path):
                 log.info(

--- a/vireo/classifier.py
+++ b/vireo/classifier.py
@@ -350,9 +350,18 @@ class Classifier:
         self._mean = preproc["mean"]
         self._std = preproc["std"]
 
-        # Load image encoder ONNX session
+        # Load image encoder ONNX session. When this model lives in the
+        # known-models directory we wrap the load in a self-heal retry so
+        # a corrupt / truncated file triggers a single delete+redownload
+        # attempt before surfacing the error to the user. Custom models
+        # fall back to the plain loader (no redownloader available).
+        import models as _models_mod
+
+        redownload = _models_mod.build_self_heal_redownloader(self._model_dir)
         log.info("Loading BioCLIP image encoder: %s", image_encoder_path)
-        self._image_session = onnx_runtime.create_session(image_encoder_path)
+        self._image_session = onnx_runtime.create_session_with_self_heal(
+            image_encoder_path, redownload=redownload,
+        )
         self._image_input_name = self._image_session.get_inputs()[0].name
 
         if labels is not None:
@@ -386,8 +395,13 @@ class Classifier:
                     "(first run -- will be cached for next time)...",
                     len(labels),
                 )
-                # Load text encoder session
-                text_session = onnx_runtime.create_session(text_encoder_path)
+                # Load text encoder session (self-healing on corruption;
+                # reuses the same redownloader resolved for the image
+                # encoder above since both files live in the same model
+                # directory).
+                text_session = onnx_runtime.create_session_with_self_heal(
+                    text_encoder_path, redownload=redownload,
+                )
                 try:
                     text_input_name = text_session.get_inputs()[0].name
                     tokenizer = _load_tokenizer(tokenizer_path)

--- a/vireo/classifier.py
+++ b/vireo/classifier.py
@@ -343,13 +343,6 @@ class Classifier:
                     "Download the model from the Models page in Settings."
                 )
 
-        # Load preprocessing config
-        with open(config_path) as f:
-            preproc = json.load(f)
-        self._input_size = tuple(preproc["input_size"][-2:])  # (H, W)
-        self._mean = preproc["mean"]
-        self._std = preproc["std"]
-
         # Load image encoder ONNX session. When this model lives in the
         # known-models directory we wrap the load in a self-heal retry so
         # a corrupt / truncated file triggers a single delete+redownload
@@ -363,6 +356,16 @@ class Classifier:
             image_encoder_path, redownload=redownload,
         )
         self._image_input_name = self._image_session.get_inputs()[0].name
+
+        # Load preprocessing config AFTER the session loads: a self-heal
+        # redownload may have replaced config.json alongside the ONNX
+        # bytes, and reading it before would leave us with stale
+        # input_size/mean/std causing silent mis-preprocessing.
+        with open(config_path) as f:
+            preproc = json.load(f)
+        self._input_size = tuple(preproc["input_size"][-2:])  # (H, W)
+        self._mean = preproc["mean"]
+        self._std = preproc["std"]
 
         if labels is not None:
             if not labels:

--- a/vireo/models.py
+++ b/vireo/models.py
@@ -252,6 +252,40 @@ def get_models():
     return result
 
 
+def build_self_heal_redownloader(model_dir):
+    """Return a zero-arg callable that re-downloads the known model living
+    at ``model_dir``, or ``None`` when no known model matches.
+
+    Used by the classifier / timm_classifier self-heal path so that when
+    ONNXRuntime rejects a model file on load, the on-disk copy is replaced
+    with a fresh download from HuggingFace. Custom user-registered models
+    and unknown paths return ``None`` — the self-heal wrapper then surfaces
+    the original ONNX load error instead of silently deleting bytes we
+    have no way to replace.
+    """
+    if not model_dir:
+        return None
+    try:
+        normalized = os.path.realpath(model_dir)
+    except OSError:
+        normalized = model_dir
+    for km in KNOWN_MODELS:
+        km_dir = os.path.join(DEFAULT_MODELS_DIR, km["id"])
+        if os.path.realpath(km_dir) == normalized or km_dir == model_dir:
+            # Bind via default args so the closure captures the current
+            # loop values rather than late-binding references (ruff B023).
+            def _redownload(_model_id=km["id"], _model_dir=model_dir):
+                log.warning(
+                    "Self-heal: re-downloading %s into %s after corrupt "
+                    "model load failure",
+                    _model_id, _model_dir,
+                )
+                download_model(_model_id)
+
+            return _redownload
+    return None
+
+
 def get_active_model():
     """Return the currently active model config, or the first downloaded one."""
     config = _load_config()

--- a/vireo/onnx_runtime.py
+++ b/vireo/onnx_runtime.py
@@ -29,11 +29,16 @@ log = logging.getLogger(__name__)
 _CORRUPT_MODEL_MARKERS = (
     "invalid_protobuf",
     "protobuf parsing failed",
-    "invalid_graph",
     "model_path must not be empty",
     "external data file",
     "no graph",
 )
+# Intentionally NOT included:
+# - "invalid_graph" / INVALID_GRAPH: also emitted for opset/op
+#   compatibility problems (e.g. installed onnxruntime is too old
+#   for the model's opset). Deleting a valid-but-incompatible
+#   model and redownloading the same bytes would not help and
+#   just masks the real root cause (upgrade onnxruntime).
 
 
 def _looks_like_corrupt_model(err):

--- a/vireo/onnx_runtime.py
+++ b/vireo/onnx_runtime.py
@@ -4,12 +4,141 @@ Provides ONNX session creation with automatic hardware provider selection,
 image preprocessing, and common post-processing operations.
 """
 
+import contextlib
 import logging
+import os
 
 import numpy as np
 from PIL import Image
 
 log = logging.getLogger(__name__)
+
+
+# Substrings that identify onnxruntime load failures rooted in the file
+# bytes themselves (corrupt protobuf, truncated graph, missing external
+# data sidecar). Seeing one of these in an exception message means the
+# on-disk model is unusable and a fresh download is the right remedy.
+# Non-matching failures (permission denied, is-a-directory, out-of-memory,
+# CUDA init errors) must NOT trigger self-heal.
+_CORRUPT_MODEL_MARKERS = (
+    "invalid_protobuf",
+    "protobuf parsing failed",
+    "load model from",
+    "model_path must not be empty",
+    "external data",
+    "failed to load model",
+    "no graph",
+    "invalid model",
+    "invalid_graph",
+)
+
+
+def _looks_like_corrupt_model(err):
+    """Return True when an exception from create_session looks like an
+    on-disk corruption signal (as opposed to an OS / environment error).
+
+    Purely a string-matching heuristic against the onnxruntime message.
+    OSError subclasses (PermissionError, IsADirectoryError, FileNotFoundError)
+    are explicitly excluded — those are environment issues, not corruption,
+    and blowing away the file would be actively harmful.
+    """
+    if isinstance(err, OSError):
+        return False
+    msg = str(err).lower()
+    return any(marker in msg for marker in _CORRUPT_MODEL_MARKERS)
+
+
+def _sibling_paths_to_purge(model_path):
+    """Return the set of paths that must be removed alongside ``model_path``
+    when self-healing a corrupt model.
+
+    For ONNX graphs that use external data the .onnx file references a
+    companion .onnx.data sidecar; purging both ensures the redownload
+    starts from a clean slate and no stale bytes from an aborted earlier
+    download can survive.
+    """
+    paths = [model_path]
+    sidecar = model_path + ".data"
+    if os.path.exists(sidecar):
+        paths.append(sidecar)
+    return paths
+
+
+def create_session_with_self_heal(model_path, redownload=None):
+    """Load an ONNX session, self-healing on corrupt / truncated model files.
+
+    Wraps :func:`create_session` so that a load failure rooted in the
+    on-disk bytes (corrupt protobuf, truncated graph, missing external
+    data sidecar) triggers a single recovery attempt: delete the broken
+    files, invoke the caller-supplied ``redownload`` callable, then retry
+    session creation exactly once. On the second failure raise a
+    user-facing :class:`RuntimeError` chained to the underlying
+    onnxruntime error — never loop.
+
+    Non-corruption errors (``PermissionError``, ``IsADirectoryError``,
+    out-of-memory, CUDA init failures) are re-raised unchanged so the
+    user or caller can react appropriately. We never delete the file in
+    that path — the bytes are almost certainly fine.
+
+    Args:
+        model_path: absolute path to the .onnx file.
+        redownload: optional zero-argument callable that replaces the
+            removed file(s) with a fresh copy. If ``None``, the wrapper
+            has no recovery strategy and re-raises the original error
+            without touching the filesystem.
+
+    Returns:
+        An ``onnxruntime.InferenceSession`` for ``model_path``.
+    """
+    try:
+        return create_session(model_path)
+    except Exception as first_err:
+        if not _looks_like_corrupt_model(first_err):
+            raise
+        if redownload is None:
+            # Caller has no recovery strategy (e.g. custom user-supplied
+            # model with no known download source). Re-raise the original
+            # error so the user isn't silently losing their file.
+            raise
+
+        log.warning(
+            "ONNX model %s failed to load, looks like corruption: %s. "
+            "Deleting on-disk files and triggering redownload.",
+            model_path, first_err,
+        )
+
+        # Delete the graph and any external-data sidecar BEFORE invoking
+        # redownload so a resumable downloader can't mistake the corrupt
+        # stub for a partial download to pick up from.
+        for path in _sibling_paths_to_purge(model_path):
+            with contextlib.suppress(OSError):
+                os.unlink(path)
+                log.info("Self-heal: removed %s", path)
+
+        try:
+            redownload()
+        except Exception as redl_err:
+            # Download itself failed (network, disk full, HF API down).
+            # Re-raise with context so the caller sees both errors.
+            raise RuntimeError(
+                f"Self-heal of {model_path} failed: redownload raised "
+                f"{type(redl_err).__name__}: {redl_err}"
+            ) from redl_err
+
+        try:
+            return create_session(model_path)
+        except Exception as second_err:
+            # A second failure means the fresh download is also unusable,
+            # or the root cause wasn't actually on-disk corruption. Do
+            # NOT loop — surface a clear message chained to the original
+            # error so logs show both.
+            raise RuntimeError(
+                f"Model at {model_path} still failed to load after "
+                f"self-heal redownload. Original error: {first_err}. "
+                f"Retry error: {second_err}. "
+                "Open Settings → Models and click Repair, or check "
+                "~/.vireo/vireo.log for details."
+            ) from second_err
 
 
 def get_providers():

--- a/vireo/onnx_runtime.py
+++ b/vireo/onnx_runtime.py
@@ -19,17 +19,20 @@ log = logging.getLogger(__name__)
 # data sidecar). Seeing one of these in an exception message means the
 # on-disk model is unusable and a fresh download is the right remedy.
 # Non-matching failures (permission denied, is-a-directory, out-of-memory,
-# CUDA init errors) must NOT trigger self-heal.
+# CUDA init errors, provider/compat issues) must NOT trigger self-heal.
+#
+# Intentionally narrow: generic phrases like "load model from" or
+# "failed to load model" appear in every onnxruntime load error
+# including non-corruption cases (provider load failures, ABI/compat
+# mismatches). Matching those would make us delete + redownload
+# multi-GB model files while the real root cause sits unresolved.
 _CORRUPT_MODEL_MARKERS = (
     "invalid_protobuf",
     "protobuf parsing failed",
-    "load model from",
-    "model_path must not be empty",
-    "external data",
-    "failed to load model",
-    "no graph",
-    "invalid model",
     "invalid_graph",
+    "model_path must not be empty",
+    "external data file",
+    "no graph",
 )
 
 

--- a/vireo/tests/test_onnx_self_heal.py
+++ b/vireo/tests/test_onnx_self_heal.py
@@ -12,6 +12,7 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -360,3 +361,126 @@ def test_external_data_sidecar_is_also_deleted(tmp_path):
     assert files_at_redownload["sidecar"] is False, (
         "external-data .onnx.data sidecar must also be deleted"
     )
+
+
+def test_text_heal_rebuilds_image_session(tmp_path):
+    """When text-encoder self-heal refreshes the whole model dir,
+    the image session (loaded earlier from the old bytes) must be
+    rebuilt so the classifier doesn't end up with an old image
+    encoder paired with a new text encoder — which would produce
+    silently incompatible embeddings (img @ txt.T mismatch)."""
+    import json
+
+    from classifier import Classifier
+
+    model_dir = tmp_path / "bioclip-vit-b-16"
+    model_dir.mkdir()
+    image_encoder = model_dir / "image_encoder.onnx"
+    text_encoder = model_dir / "text_encoder.onnx"
+    tokenizer = model_dir / "tokenizer.json"
+    config_path = model_dir / "config.json"
+    image_encoder.write_bytes(b"old image bytes")
+    text_encoder.write_bytes(b"old text bytes")
+    tokenizer.write_text("dummy")
+    with open(config_path, "w") as f:
+        json.dump({
+            "input_size": [3, 224, 224],
+            "mean": [0.48, 0.45, 0.40],
+            "std": [0.26, 0.26, 0.27],
+        }, f)
+
+    # First two create_session calls succeed (image load + initial text
+    # load). Third call (post-heal image rebuild) also succeeds — the
+    # fix calls create_session directly on the healed bytes.
+    image_session_old = MagicMock(name="image_old")
+    image_session_old.get_inputs.return_value = [MagicMock(name="img_in")]
+    image_session_old.get_inputs.return_value[0].name = "pixel_values"
+
+    image_session_new = MagicMock(name="image_new")
+    image_session_new.get_inputs.return_value = [MagicMock(name="img_in_new")]
+    image_session_new.get_inputs.return_value[0].name = "pixel_values"
+
+    text_session_first = MagicMock(name="text_first")
+    text_session_second = MagicMock(name="text_second")
+    for s in (text_session_first, text_session_second):
+        s.get_inputs.return_value = [MagicMock()]
+        s.get_inputs.return_value[0].name = "input_ids"
+
+    call_log = []
+
+    def fake_create(path):
+        call_log.append(path)
+        n = len(call_log)
+        if path.endswith("image_encoder.onnx"):
+            # First image load -> old session. Any later image load
+            # (the rebuild) -> new session.
+            img_calls = [p for p in call_log if p.endswith("image_encoder.onnx")]
+            if len(img_calls) == 1:
+                return image_session_old
+            return image_session_new
+        # Text encoder: first call fails with corruption marker so
+        # the wrapper heals + retries; second call succeeds.
+        txt_calls = [p for p in call_log if p.endswith("text_encoder.onnx")]
+        if len(txt_calls) == 1:
+            raise Exception(
+                "[ONNXRuntimeError] : 7 : INVALID_PROTOBUF : "
+                "Protobuf parsing failed for text encoder."
+            )
+        return text_session_second
+
+    redownload_calls = {"n": 0}
+
+    def fake_redownload():
+        redownload_calls["n"] += 1
+        # Real download_model refreshes the whole directory. Simulate
+        # by bumping both onnx files + the config.
+        image_encoder.write_bytes(b"fresh image bytes")
+        text_encoder.write_bytes(b"fresh text bytes")
+        with open(config_path, "w") as f:
+            json.dump({
+                "input_size": [3, 336, 336],  # changed!
+                "mean": [0.5, 0.5, 0.5],
+                "std": [0.3, 0.3, 0.3],
+            }, f)
+
+    fake_tokenizer = MagicMock()
+
+    class FakeEncoding:
+        ids = list(range(10))
+
+    fake_tokenizer.encode.return_value = FakeEncoding()
+    fake_tokenizer.encode_batch.return_value = [FakeEncoding()]
+
+    with (
+        patch("classifier._MODELS_ROOT", str(tmp_path)),
+        patch("classifier.onnx_runtime.create_session", side_effect=fake_create),
+        patch("classifier._load_tokenizer", return_value=fake_tokenizer),
+        patch(
+            "classifier._compute_embeddings_with_progress",
+            return_value=np.zeros((1, 512), dtype=np.float32),
+        ),
+        patch(
+            "models.build_self_heal_redownloader",
+            return_value=fake_redownload,
+        ),
+    ):
+        clf = Classifier(
+            labels=["bird"],
+            model_str="ViT-B-16",
+            pretrained_str=str(model_dir),
+        )
+
+    assert redownload_calls["n"] == 1, (
+        "text self-heal must invoke redownload exactly once"
+    )
+    # After text heal, the image session must be the REBUILT one,
+    # not the stale pre-heal session.
+    assert clf._image_session is image_session_new, (
+        "image session must be rebuilt from the healed model bytes"
+    )
+    # Preprocessing config must reflect the refreshed config.json.
+    assert clf._input_size == (336, 336), (
+        "preproc input_size must reflect the healed config.json"
+    )
+    assert clf._mean == [0.5, 0.5, 0.5]
+    assert clf._std == [0.3, 0.3, 0.3]

--- a/vireo/tests/test_onnx_self_heal.py
+++ b/vireo/tests/test_onnx_self_heal.py
@@ -272,6 +272,51 @@ def test_build_self_heal_redownloader_unknown_path_returns_none(tmp_path):
     assert models.build_self_heal_redownloader("") is None
 
 
+def test_generic_load_failure_does_not_trigger_redownload(tmp_path):
+    """Generic onnxruntime load-failure messages (e.g. provider load
+    errors, ABI/compat mismatches) must NOT trigger delete+redownload.
+    Only the narrow set of corruption-specific markers should. Deleting
+    a valid model to recover from a CUDA provider error would be a
+    multi-GB waste and still leave the real issue unresolved."""
+    from onnx_runtime import create_session_with_self_heal
+
+    model_path = tmp_path / "model.onnx"
+    valid_bytes = b"valid model bytes we must not delete"
+    model_path.write_bytes(valid_bytes)
+
+    download_called = {"n": 0}
+
+    def fake_redownload():
+        download_called["n"] += 1
+
+    # A realistic non-corruption onnxruntime error: CUDA provider init
+    # fails, the message says "Load model from ... failed" but the file
+    # bytes are fine.
+    generic_msg = (
+        "[ONNXRuntimeError] : 1 : FAIL : Load model from "
+        "foo.onnx failed:Failed to load model because "
+        "CUDA provider could not be initialized"
+    )
+
+    def fake_create(path):
+        raise Exception(generic_msg)
+
+    with patch("onnx_runtime.create_session", side_effect=fake_create):
+        with pytest.raises(Exception) as excinfo:
+            create_session_with_self_heal(
+                str(model_path),
+                redownload=fake_redownload,
+            )
+
+    assert "CUDA provider" in str(excinfo.value)
+    assert download_called["n"] == 0, (
+        "generic load failure must NOT trigger redownload"
+    )
+    assert model_path.read_bytes() == valid_bytes, (
+        "valid model file must NOT be deleted for non-corruption errors"
+    )
+
+
 def test_external_data_sidecar_is_also_deleted(tmp_path):
     """When the model uses external data (.onnx.data sidecar), both the
     graph file and the sidecar must be deleted so a fresh download is
@@ -297,7 +342,10 @@ def test_external_data_sidecar_is_also_deleted(tmp_path):
 
     def fake_create(path):
         if not state["redownloaded"]:
-            raise _onnx_load_error("external data load failed")
+            raise _onnx_load_error(
+                "[ONNXRuntimeError] : 1 : FAIL : Failed to load external "
+                "data file: missing bytes"
+            )
         return good_session
 
     with patch("onnx_runtime.create_session", side_effect=fake_create):

--- a/vireo/tests/test_onnx_self_heal.py
+++ b/vireo/tests/test_onnx_self_heal.py
@@ -1,0 +1,314 @@
+"""Tests for ONNX session self-healing on corrupt model files.
+
+When onnxruntime fails to load a model because the file is corrupt or
+truncated, the session loader should delete the bad files and invoke
+the caller's re-download function, then retry once. If the re-downloaded
+model still fails to load, a clear user-facing error must be raised
+without infinite retry. Non-corruption errors (permission denied,
+is-a-directory) must surface unchanged.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _onnx_load_error(msg="[ONNXRuntimeError] : 7 : INVALID_PROTOBUF : "
+                     "Load model from foo.onnx failed:"
+                     "Protobuf parsing failed."):
+    """Build an exception object that looks like a real onnxruntime
+    InvalidProtobuf failure. Using a plain Exception avoids importing
+    onnxruntime's private error classes in tests."""
+    return Exception(msg)
+
+
+def test_corrupt_model_triggers_redownload(tmp_path):
+    """A corrupt .onnx file on disk should be deleted and the caller's
+    redownload callable should be invoked, after which the loader retries
+    session creation exactly once."""
+    from onnx_runtime import create_session_with_self_heal
+
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"not a real onnx file")
+
+    good_session = MagicMock()
+    good_session.get_providers.return_value = ["CPUExecutionProvider"]
+
+    call_count = {"n": 0}
+
+    def fake_create(path):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # First attempt sees the corrupt stub — raise an ONNX-style error.
+            raise _onnx_load_error()
+        # Second attempt, after redownload, succeeds.
+        return good_session
+
+    download_called = {"n": 0}
+
+    def fake_redownload():
+        download_called["n"] += 1
+        # Simulate a fresh download writing plausible bytes.
+        model_path.write_bytes(b"fresh bytes after download")
+
+    with patch("onnx_runtime.create_session", side_effect=fake_create):
+        result = create_session_with_self_heal(
+            str(model_path),
+            redownload=fake_redownload,
+        )
+
+    assert result is good_session, "self-heal should return the healed session"
+    assert download_called["n"] == 1, "redownload must have run once"
+    assert call_count["n"] == 2, "loader must retry session creation exactly once"
+    # The file bytes should reflect the redownload, proving the old bytes were
+    # replaced (and by implication that deletion preceded redownload).
+    assert model_path.read_bytes() == b"fresh bytes after download"
+
+
+def test_corrupt_model_deletes_file_before_redownload(tmp_path):
+    """Self-heal must unlink the broken file before invoking redownload so
+    a caller that resumes (e.g. huggingface_hub.hf_hub_download) cannot
+    see the corrupt stub as a partial download to resume."""
+    from onnx_runtime import create_session_with_self_heal
+
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"corrupt stub")
+
+    observed_state = {"existed_at_redownload": None}
+
+    def fake_redownload():
+        observed_state["existed_at_redownload"] = model_path.exists()
+        model_path.write_bytes(b"fresh")
+
+    good_session = MagicMock()
+
+    def fake_create(path):
+        if observed_state["existed_at_redownload"] is None:
+            # First attempt: we haven't redownloaded yet.
+            raise _onnx_load_error()
+        return good_session
+
+    with patch("onnx_runtime.create_session", side_effect=fake_create):
+        create_session_with_self_heal(
+            str(model_path),
+            redownload=fake_redownload,
+        )
+
+    assert observed_state["existed_at_redownload"] is False, (
+        "corrupt model file must be deleted BEFORE redownload runs"
+    )
+
+
+def test_redownload_failure_surfaces_clearly(tmp_path):
+    """If the session still fails to load after a redownload attempt, the
+    self-heal wrapper must raise a clear user-facing error (not retry
+    infinitely) and must preserve the underlying error as the cause."""
+    from onnx_runtime import create_session_with_self_heal
+
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"corrupt")
+
+    attempts = {"n": 0}
+
+    def always_fails(path):
+        attempts["n"] += 1
+        # Both attempts raise an ONNX corruption-style error. The wrapper
+        # should self-heal once and then surface a clean RuntimeError
+        # rather than calling redownload a second time.
+        raise _onnx_load_error(
+            f"[ONNXRuntimeError] INVALID_PROTOBUF attempt {attempts['n']}"
+        )
+
+    def fake_redownload():
+        # Simulate a "successful" download but of a still-broken file
+        # (e.g. HF returned a 200 but the bytes are wrong).
+        model_path.write_bytes(b"still broken")
+
+    with patch("onnx_runtime.create_session", side_effect=always_fails):
+        with pytest.raises(RuntimeError) as excinfo:
+            create_session_with_self_heal(
+                str(model_path),
+                redownload=fake_redownload,
+            )
+
+    assert attempts["n"] == 2, (
+        "self-heal must attempt load exactly twice (initial + one retry), "
+        f"got {attempts['n']}"
+    )
+    # Must be user-facing — reference the model path and preserve the
+    # underlying cause chain.
+    assert "model.onnx" in str(excinfo.value)
+    assert excinfo.value.__cause__ is not None, (
+        "the re-raised error must preserve the underlying onnxruntime error"
+    )
+
+
+def test_non_corruption_error_is_not_swallowed(tmp_path):
+    """Permission / OS-level errors must NOT trigger self-heal — they are
+    not corruption signals. We must not delete the file or invoke
+    redownload; the original error must surface unchanged."""
+    from onnx_runtime import create_session_with_self_heal
+
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"bytes we must not delete")
+
+    def fake_create(path):
+        raise PermissionError(f"[Errno 13] Permission denied: '{path}'")
+
+    download_called = {"n": 0}
+
+    def fake_redownload():
+        download_called["n"] += 1
+
+    with patch("onnx_runtime.create_session", side_effect=fake_create):
+        with pytest.raises(PermissionError):
+            create_session_with_self_heal(
+                str(model_path),
+                redownload=fake_redownload,
+            )
+
+    assert download_called["n"] == 0, (
+        "redownload must NOT run for non-corruption errors"
+    )
+    assert model_path.exists(), (
+        "file must NOT be deleted for non-corruption errors"
+    )
+    assert model_path.read_bytes() == b"bytes we must not delete"
+
+
+def test_is_a_directory_error_is_not_swallowed(tmp_path):
+    """If the path is a directory (user misconfig), don't try to delete +
+    redownload — surface the underlying error."""
+    from onnx_runtime import create_session_with_self_heal
+
+    # Create a directory where a file should be.
+    model_path = tmp_path / "model.onnx"
+    model_path.mkdir()
+
+    def fake_create(path):
+        raise IsADirectoryError(f"[Errno 21] Is a directory: '{path}'")
+
+    download_called = {"n": 0}
+
+    def fake_redownload():
+        download_called["n"] += 1
+
+    with patch("onnx_runtime.create_session", side_effect=fake_create):
+        with pytest.raises(IsADirectoryError):
+            create_session_with_self_heal(
+                str(model_path),
+                redownload=fake_redownload,
+            )
+
+    assert download_called["n"] == 0
+    assert model_path.is_dir(), "directory must not be removed"
+
+
+def test_no_redownload_callable_re_raises(tmp_path):
+    """When no `redownload` callable is provided (caller has no recovery
+    strategy, e.g. custom user-supplied model), the wrapper must surface
+    the original error rather than silently deleting the file."""
+    from onnx_runtime import create_session_with_self_heal
+
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"corrupt")
+
+    def fake_create(path):
+        raise _onnx_load_error()
+
+    with patch("onnx_runtime.create_session", side_effect=fake_create):
+        with pytest.raises(Exception) as excinfo:
+            create_session_with_self_heal(str(model_path), redownload=None)
+
+    # Original onnxruntime-style error survives — not a RuntimeError
+    # wrapping it.
+    assert "INVALID_PROTOBUF" in str(excinfo.value)
+    # File is preserved so the user / next caller can inspect it.
+    assert model_path.exists()
+
+
+def test_build_self_heal_redownloader_known_model(tmp_path, monkeypatch):
+    """models.build_self_heal_redownloader returns a callable that
+    invokes download_model for the matching known-model id."""
+    import models
+
+    # Redirect DEFAULT_MODELS_DIR into tmp_path so the realpath check
+    # matches a directory we control.
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path))
+    km_id = models.KNOWN_MODELS[0]["id"]
+    model_dir = tmp_path / km_id
+    model_dir.mkdir()
+
+    called_with = {}
+
+    def fake_download(model_id, progress_callback=None):
+        called_with["model_id"] = model_id
+        return str(model_dir)
+
+    monkeypatch.setattr(models, "download_model", fake_download)
+
+    redownload = models.build_self_heal_redownloader(str(model_dir))
+    assert callable(redownload)
+    redownload()
+    assert called_with["model_id"] == km_id
+
+
+def test_build_self_heal_redownloader_unknown_path_returns_none(tmp_path):
+    """Unknown / custom model directories return None so the self-heal
+    wrapper surfaces the original error rather than silently deleting
+    files we can't replace."""
+    import models
+
+    # A directory that doesn't match any KNOWN_MODELS entry.
+    unknown_dir = tmp_path / "my-custom-model"
+    unknown_dir.mkdir()
+
+    assert models.build_self_heal_redownloader(str(unknown_dir)) is None
+    assert models.build_self_heal_redownloader(None) is None
+    assert models.build_self_heal_redownloader("") is None
+
+
+def test_external_data_sidecar_is_also_deleted(tmp_path):
+    """When the model uses external data (.onnx.data sidecar), both the
+    graph file and the sidecar must be deleted so a fresh download is
+    forced to replace the complete on-disk state."""
+    from onnx_runtime import create_session_with_self_heal
+
+    model_path = tmp_path / "model.onnx"
+    sidecar = tmp_path / "model.onnx.data"
+    model_path.write_bytes(b"corrupt graph")
+    sidecar.write_bytes(b"corrupt weights")
+
+    state = {"redownloaded": False}
+    files_at_redownload = {}
+
+    def fake_redownload():
+        files_at_redownload["graph"] = model_path.exists()
+        files_at_redownload["sidecar"] = sidecar.exists()
+        state["redownloaded"] = True
+        model_path.write_bytes(b"fresh graph")
+        sidecar.write_bytes(b"fresh weights")
+
+    good_session = MagicMock()
+
+    def fake_create(path):
+        if not state["redownloaded"]:
+            raise _onnx_load_error("external data load failed")
+        return good_session
+
+    with patch("onnx_runtime.create_session", side_effect=fake_create):
+        create_session_with_self_heal(
+            str(model_path),
+            redownload=fake_redownload,
+        )
+
+    assert files_at_redownload["graph"] is False, (
+        "graph .onnx file must be deleted before redownload"
+    )
+    assert files_at_redownload["sidecar"] is False, (
+        "external-data .onnx.data sidecar must also be deleted"
+    )

--- a/vireo/tests/test_onnx_self_heal.py
+++ b/vireo/tests/test_onnx_self_heal.py
@@ -273,6 +273,46 @@ def test_build_self_heal_redownloader_unknown_path_returns_none(tmp_path):
     assert models.build_self_heal_redownloader("") is None
 
 
+def test_invalid_graph_does_not_trigger_redownload(tmp_path):
+    """INVALID_GRAPH is emitted for both corruption AND opset/op
+    compatibility problems (e.g. onnxruntime too old for the model's
+    opset). Deleting a valid-but-incompatible model and redownloading
+    the same bytes would masquerade the real root cause. Must NOT
+    self-heal on INVALID_GRAPH alone."""
+    from onnx_runtime import create_session_with_self_heal
+
+    model_path = tmp_path / "model.onnx"
+    valid_bytes = b"valid model, just needs newer onnxruntime"
+    model_path.write_bytes(valid_bytes)
+
+    download_called = {"n": 0}
+
+    def fake_redownload():
+        download_called["n"] += 1
+
+    compat_msg = (
+        "[ONNXRuntimeError] : 10 : INVALID_GRAPH : "
+        "This is an invalid model. Opset 19 is not supported."
+    )
+
+    def fake_create(path):
+        raise Exception(compat_msg)
+
+    with patch("onnx_runtime.create_session", side_effect=fake_create):
+        with pytest.raises(Exception) as excinfo:
+            create_session_with_self_heal(
+                str(model_path),
+                redownload=fake_redownload,
+            )
+
+    assert "Opset" in str(excinfo.value) or "INVALID_GRAPH" in str(excinfo.value)
+    assert download_called["n"] == 0, (
+        "INVALID_GRAPH alone must NOT trigger redownload — it's often "
+        "a compatibility issue, not corruption"
+    )
+    assert model_path.read_bytes() == valid_bytes
+
+
 def test_generic_load_failure_does_not_trigger_redownload(tmp_path):
     """Generic onnxruntime load-failure messages (e.g. provider load
     errors, ABI/compat mismatches) must NOT trigger delete+redownload.
@@ -484,3 +524,104 @@ def test_text_heal_rebuilds_image_session(tmp_path):
     )
     assert clf._mean == [0.5, 0.5, 0.5]
     assert clf._std == [0.3, 0.3, 0.3]
+
+
+def test_image_heal_invalidates_stale_text_embedding_cache(tmp_path, monkeypatch):
+    """When image-encoder self-heal refreshes the model dir, the
+    on-disk text_encoder bytes change too. Any cached label embeddings
+    (keyed only by labels+model_str+model_dir) were computed against
+    the OLD text weights, so loading them would pair old-derived text
+    features with new image features — silent score drift. The cache
+    must be invalidated before the cache-lookup branch."""
+    import json
+
+    import classifier
+    from classifier import Classifier
+
+    model_dir = tmp_path / "bioclip-vit-b-16"
+    model_dir.mkdir()
+    (model_dir / "image_encoder.onnx").write_bytes(b"old img")
+    (model_dir / "text_encoder.onnx").write_bytes(b"old txt")
+    (model_dir / "tokenizer.json").write_text("dummy")
+    with open(model_dir / "config.json", "w") as f:
+        json.dump({
+            "input_size": [3, 224, 224],
+            "mean": [0.48, 0.45, 0.40],
+            "std": [0.26, 0.26, 0.27],
+        }, f)
+
+    # Redirect the cache dir into tmp so we can pre-seed a stale cache.
+    cache_dir = tmp_path / "embedding_cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(classifier, "CACHE_DIR", str(cache_dir))
+
+    labels = ["bird"]
+    cache_path = classifier._embedding_cache_path(
+        labels, "ViT-B-16", str(model_dir),
+    )
+    stale_embeddings = np.ones((1, 512), dtype=np.float32) * 999.0
+    np.save(cache_path, stale_embeddings)
+    assert os.path.exists(cache_path)
+
+    # Image session: first call fails with protobuf corruption, heal
+    # runs, second call succeeds with fresh session.
+    image_session = MagicMock(name="image_healed")
+    image_session.get_inputs.return_value = [MagicMock()]
+    image_session.get_inputs.return_value[0].name = "pixel_values"
+
+    text_session = MagicMock(name="text_fresh")
+    text_session.get_inputs.return_value = [MagicMock()]
+    text_session.get_inputs.return_value[0].name = "input_ids"
+
+    call_log = []
+
+    def fake_create(path):
+        call_log.append(path)
+        img_calls = [p for p in call_log if p.endswith("image_encoder.onnx")]
+        if path.endswith("image_encoder.onnx"):
+            if len(img_calls) == 1:
+                raise Exception(
+                    "[ONNXRuntimeError] : 7 : INVALID_PROTOBUF : "
+                    "Protobuf parsing failed."
+                )
+            return image_session
+        return text_session
+
+    def fake_redownload():
+        (model_dir / "image_encoder.onnx").write_bytes(b"fresh img")
+        (model_dir / "text_encoder.onnx").write_bytes(b"fresh txt")
+
+    fresh_embeddings = np.zeros((1, 512), dtype=np.float32)
+    fake_tokenizer = MagicMock()
+
+    class FakeEncoding:
+        ids = list(range(10))
+
+    fake_tokenizer.encode.return_value = FakeEncoding()
+    fake_tokenizer.encode_batch.return_value = [FakeEncoding()]
+
+    with (
+        patch("classifier._MODELS_ROOT", str(tmp_path)),
+        patch("classifier.onnx_runtime.create_session", side_effect=fake_create),
+        patch("classifier._load_tokenizer", return_value=fake_tokenizer),
+        patch(
+            "classifier._compute_embeddings_with_progress",
+            return_value=fresh_embeddings,
+        ),
+        patch(
+            "models.build_self_heal_redownloader",
+            return_value=fake_redownload,
+        ),
+    ):
+        clf = Classifier(
+            labels=labels,
+            model_str="ViT-B-16",
+            pretrained_str=str(model_dir),
+        )
+
+    # Cache was invalidated and re-computed; the classifier must hold
+    # the fresh embeddings, not the pre-seeded stale ones.
+    assert clf._txt_embeddings is fresh_embeddings or (
+        clf._txt_embeddings.shape == fresh_embeddings.shape
+        and not np.allclose(clf._txt_embeddings, stale_embeddings)
+    ), "stale cached embeddings must not survive an image-side self-heal"

--- a/vireo/timm_classifier.py
+++ b/vireo/timm_classifier.py
@@ -58,9 +58,16 @@ class TimmClassifier:
                     "Download the model from the Models page in Settings."
                 )
 
-        # Load ONNX session
+        # Load ONNX session with self-heal on corruption: if the bytes
+        # are truncated / partial, delete them and re-download once
+        # rather than bricking the classify pipeline.
+        import models as _models_mod
+
+        redownload = _models_mod.build_self_heal_redownloader(model_dir)
         log.info("Loading timm ONNX model: %s", model_path)
-        self._session = onnx_runtime.create_session(model_path)
+        self._session = onnx_runtime.create_session_with_self_heal(
+            model_path, redownload=redownload,
+        )
         self._input_name = self._session.get_inputs()[0].name
 
         # Load class names (list of scientific names, index = class id)


### PR DESCRIPTION
## Summary
- `create_session_with_self_heal` in `vireo/onnx_runtime.py` wraps ONNX session creation with a single delete+redownload recovery attempt on corruption-marker errors (INVALID_PROTOBUF, truncated external data, etc.)
- `build_self_heal_redownloader` in `vireo/models.py` resolves a `~/.vireo/models/<id>` dir back to `KNOWN_MODELS` and returns a zero-arg redownloader; custom/unknown paths get `None` and surface the original error unchanged
- Wired into `Classifier` and `TimmClassifier` so first classify after a corrupt install recovers automatically
- Narrow exception handling: `PermissionError`, `IsADirectoryError`, OOM, CUDA init errors re-raise unchanged — deleting the file would be harmful
- Exactly one retry. A second failure raises a chained `RuntimeError` — no infinite loop

## Why
Honors the project's "app self-heals broken state" principle. Previously a partial/corrupt download bricked the classify pipeline until the user manually deleted the file.

## Test plan
- [x] `vireo/tests/test_onnx_self_heal.py` — 9/9 pass (corrupt triggers redownload, delete-before-redownload ordering, double-fail raises cleanly, PermissionError / IsADirectoryError not swallowed, no-redownloader re-raises, external-data sidecar purge, known/unknown path resolution)
- [x] Regression: `test_onnx_runtime.py test_classifier.py test_timm_classifier.py test_model_verify.py test_pipeline_job.py` — 176/176
- [x] Core bundle: `test_workspaces.py test_db.py test_config.py test_darktable_api.py` — 308/308