### PR TITLE
fix(scan): run all roots in a single scan job

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5156,15 +5156,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                summary=thumb_summary(thumb_result))
 
             # Mixed-outcome rollup: any failed root => job is "failed".
-            # JobRunner._run_job reads the raise to flip status; the
-            # error was already appended above so it won't be double-
-            # counted.
+            # JobRunner._run_job dedupes job["errors"] by exact string
+            # match. Raise the first per-root message (already recorded
+            # above) so no extra aggregate entry is appended — that
+            # would inflate error_count in job/history output. The
+            # "N of M roots failed" context is already visible via the
+            # scan step's summary and error_count set above.
             if root_errors:
-                raise RuntimeError(
-                    f"{len(root_errors)} of {len(roots_list)} scan root"
-                    f"{'s' if len(roots_list) != 1 else ''} failed: "
-                    + "; ".join(root_errors)
-                )
+                raise RuntimeError(root_errors[0])
 
             return {"photos_indexed": photo_count, "thumbnails": thumb_result}
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5128,48 +5128,68 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     job["id"], "scan", status="completed",
                     summary=f"{photo_count} photos",
                 )
-            runner.update_step(job["id"], "thumbnails", status="running")
+            # Skip the thumbnail phase when EVERY requested root failed.
+            # generate_all() walks the whole library looking for missing
+            # thumbnails — running it after a total scan failure does a
+            # long, unrelated pass and delays the failure feedback the
+            # user actually needs. When at least one root succeeded we
+            # still run thumbs so those newly-indexed photos get
+            # covered.
+            all_roots_failed = bool(root_errors) and len(root_errors) == len(roots_list)
 
-            # Auto-generate thumbnails for new photos only
-            from thumbnails import generate_all
+            if all_roots_failed:
+                log.info(
+                    "All %d scan root(s) failed; skipping thumbnail phase",
+                    len(roots_list),
+                )
+                runner.update_step(
+                    job["id"], "thumbnails", status="skipped",
+                    summary="skipped (all scan roots failed)",
+                )
+                thumb_result = None
+            else:
+                runner.update_step(job["id"], "thumbnails", status="running")
 
-            log.info("Generating thumbnails...")
-            runner.push_event(
-                job["id"],
-                "progress",
-                {
-                    "current": 0,
-                    "total": 0,
-                    "current_file": "Checking for new thumbnails...",
-                    "rate": 0,
-                    "phase": "Generating thumbnails",
-                },
-            )
+                # Auto-generate thumbnails for new photos only
+                from thumbnails import generate_all
 
-            def thumb_cb(current, total):
-                job["progress"]["current"] = current
-                job["progress"]["total"] = total
+                log.info("Generating thumbnails...")
                 runner.push_event(
                     job["id"],
                     "progress",
                     {
-                        "current": current,
-                        "total": total,
-                        "current_file": "",
-                        "rate": round(
-                            current / max(time.time() - job["_start_time"], 0.01), 1
-                        ),
+                        "current": 0,
+                        "total": 0,
+                        "current_file": "Checking for new thumbnails...",
+                        "rate": 0,
                         "phase": "Generating thumbnails",
                     },
                 )
 
-            thumb_result = generate_all(
-                thread_db, app.config["THUMB_CACHE_DIR"], progress_callback=thumb_cb,
-                vireo_dir=vireo_dir,
-            )
-            from thumbnails import format_summary as thumb_summary
-            runner.update_step(job["id"], "thumbnails", status="completed",
-                               summary=thumb_summary(thumb_result))
+                def thumb_cb(current, total):
+                    job["progress"]["current"] = current
+                    job["progress"]["total"] = total
+                    runner.push_event(
+                        job["id"],
+                        "progress",
+                        {
+                            "current": current,
+                            "total": total,
+                            "current_file": "",
+                            "rate": round(
+                                current / max(time.time() - job["_start_time"], 0.01), 1
+                            ),
+                            "phase": "Generating thumbnails",
+                        },
+                    )
+
+                thumb_result = generate_all(
+                    thread_db, app.config["THUMB_CACHE_DIR"], progress_callback=thumb_cb,
+                    vireo_dir=vireo_dir,
+                )
+                from thumbnails import format_summary as thumb_summary
+                runner.update_step(job["id"], "thumbnails", status="completed",
+                                   summary=thumb_summary(thumb_result))
 
             # Mixed-outcome rollup: any failed root => job is "failed".
             # JobRunner._run_job dedupes job["errors"] by exact string

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5099,13 +5099,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 finally:
                     # scanner.scan commits photo rows incrementally, so
                     # even a mid-scan failure can leave DB state that
-                    # invalidates cached new-image counts.
+                    # invalidates cached new-image counts. A failure
+                    # here must surface: the shared cache has a 5-min
+                    # TTL, so users would see stale "new images" counts
+                    # with no job-level failure signal if we swallowed
+                    # these errors. Keep the try/except so we still
+                    # advance scan_acc and try the remaining roots,
+                    # but record the failure into root_errors so the
+                    # job is flagged failed at the rollup below.
                     try:
                         _invalidate_new_images_after_scan(thread_db, root)
-                    except Exception:
+                    except Exception as cache_exc:
                         log.exception(
                             "Failed to invalidate new-image cache for %s", root,
                         )
+                        cache_msg = (
+                            f"[{root}] cache invalidation failed "
+                            f"after scan: {cache_exc}"
+                        )
+                        root_errors.append(cache_msg)
+                        if cache_msg not in job["errors"]:
+                            job["errors"].append(cache_msg)
                     advance_scan_acc()
 
             # Use cumulative processed count, not planned total — on a

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5067,7 +5067,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # re-raised so a failure on root A doesn't prevent root B
             # from scanning. Any failure flips the job to "failed" at
             # the end (mixed-outcome rollup).
+            #
+            # Track roots by failure class so the rollup below can
+            # distinguish "this root's scan raised" (no photos indexed
+            # — thumbnails can skip) from "this root's scan succeeded
+            # but cache invalidation raised" (photos DID get indexed —
+            # thumbnails must still run). Using len(root_errors) alone
+            # double-counts roots that hit both failure classes and
+            # misclassifies cache-only failures as scan failures.
             root_errors = []
+            scan_failed_roots = set()
+            cache_failed_roots = set()
             for idx, root in enumerate(roots_list, 1):
                 phase = (
                     f"Scanning root {idx} of {len(roots_list)}: {root}"
@@ -5092,6 +5102,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     )
                 except Exception as exc:
                     log.exception("Scan failed for root %s", root)
+                    scan_failed_roots.add(root)
                     msg = f"[{root}] {exc}"
                     root_errors.append(msg)
                     if msg not in job["errors"]:
@@ -5113,6 +5124,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         log.exception(
                             "Failed to invalidate new-image cache for %s", root,
                         )
+                        cache_failed_roots.add(root)
                         cache_msg = (
                             f"[{root}] cache invalidation failed "
                             f"after scan: {cache_exc}"
@@ -5127,9 +5139,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # reflects the actual photos indexed while "total" includes
             # planned-but-unprocessed files from the failed root(s).
             photo_count = job["progress"].get("current", 0)
+            # Unique roots that hit any failure class. Counting unique
+            # roots (not error entries) avoids inflating the "N of M"
+            # summary when a single root raises in both scan and cache
+            # invalidation.
+            failed_root_count = len(scan_failed_roots | cache_failed_roots)
             if root_errors:
                 scan_summary = (
-                    f"{photo_count} photos ({len(root_errors)} of "
+                    f"{photo_count} photos ({failed_root_count} of "
                     f"{len(roots_list)} root"
                     f"{'s' if len(roots_list) != 1 else ''} failed)"
                 )
@@ -5142,14 +5159,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     job["id"], "scan", status="completed",
                     summary=f"{photo_count} photos",
                 )
-            # Skip the thumbnail phase when EVERY requested root failed.
-            # generate_all() walks the whole library looking for missing
-            # thumbnails — running it after a total scan failure does a
-            # long, unrelated pass and delays the failure feedback the
-            # user actually needs. When at least one root succeeded we
-            # still run thumbs so those newly-indexed photos get
-            # covered.
-            all_roots_failed = bool(root_errors) and len(root_errors) == len(roots_list)
+            # Skip the thumbnail phase when EVERY requested root's scan
+            # raised. generate_all() walks the whole library looking
+            # for missing thumbnails — running it after a total scan
+            # failure does a long, unrelated pass and delays the
+            # failure feedback the user actually needs. When at least
+            # one root's scan succeeded we still run thumbs so those
+            # newly-indexed photos get covered. Cache-invalidation
+            # failures do NOT gate this decision: the scan for that
+            # root did produce indexed photos that need thumbnails.
+            all_roots_failed = (
+                bool(roots_list) and len(scan_failed_roots) == len(roots_list)
+            )
 
             if all_roots_failed:
                 log.info(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4963,16 +4963,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     # -- Job API routes --
 
-    def _build_scan_work(root, incremental, active_ws):
+    def _build_scan_work(roots, incremental, active_ws):
         """Build the background work function for a scan job.
 
         Shared by ``POST /api/jobs/scan`` and
         ``POST /api/folders/<id>/rescan`` so per-folder rescans reuse the
         same scan + thumbnail pipeline as a full scan.
+
+        ``roots`` may be a single path string (back-compat, one root) or a
+        list of paths. When multiple roots are given they are scanned
+        **serially** inside this single job -- that's the whole point of
+        this wrapper: parallel scan jobs used to fight for the SQLite
+        writer lock, so we now process roots one after another. A failure
+        on one root does not abort the others; the error is recorded and
+        the job ends in ``"failed"`` (mixed-outcome rollup convention).
         """
         import config as cfg
 
         runner = app._job_runner
+
+        # Back-compat: accept a bare string in addition to a list.
+        if isinstance(roots, str):
+            roots_list = [roots]
+        else:
+            roots_list = list(roots)
 
         def work(job):
             from scanner import scan as do_scan
@@ -4982,24 +4996,39 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # Check folder health before scanning to prevent duplicate imports
             thread_db.check_folder_health()
 
+            # Accumulator so multi-root progress doesn't rewind at each
+            # root boundary. scanner.scan() reports (current, total) local
+            # to its invocation; we fold those into cumulative counters
+            # that the SSE/status stream reads.
+            scan_acc = {"prior": 0, "last_total": 0}
+
             def progress_cb(current, total):
-                job["progress"]["current"] = current
-                job["progress"]["total"] = total
-                runner.update_step(job["id"], "scan",
-                                   progress={"current": current, "total": total})
+                scan_acc["last_total"] = total
+                cum_current = scan_acc["prior"] + current
+                cum_total = scan_acc["prior"] + total
+                job["progress"]["current"] = cum_current
+                job["progress"]["total"] = cum_total
+                runner.update_step(
+                    job["id"], "scan",
+                    progress={"current": cum_current, "total": cum_total},
+                )
                 runner.push_event(
                     job["id"],
                     "progress",
                     {
-                        "current": current,
-                        "total": total,
+                        "current": cum_current,
+                        "total": cum_total,
                         "current_file": job["progress"].get("current_file", ""),
                         "rate": round(
-                            current / max(time.time() - job["_start_time"], 0.01), 1
+                            cum_current / max(time.time() - job["_start_time"], 0.01), 1
                         ),
                         "phase": "Scanning photos",
                     },
                 )
+
+            def advance_scan_acc():
+                scan_acc["prior"] += scan_acc["last_total"]
+                scan_acc["last_total"] = 0
 
             job["_start_time"] = time.time()
             runner.set_steps(job["id"], [
@@ -5021,20 +5050,68 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 })
 
             vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
-            try:
-                do_scan(
-                    root, thread_db, progress_callback=progress_cb, incremental=incremental,
-                    extract_full_metadata=pipeline_cfg.get("extract_full_metadata", True),
-                    status_callback=status_cb,
-                    vireo_dir=vireo_dir,
+
+            # Per-root failures are caught and recorded rather than
+            # re-raised so a failure on root A doesn't prevent root B
+            # from scanning. Any failure flips the job to "failed" at
+            # the end (mixed-outcome rollup).
+            root_errors = []
+            for idx, root in enumerate(roots_list, 1):
+                phase = (
+                    f"Scanning root {idx} of {len(roots_list)}: {root}"
+                    if len(roots_list) > 1
+                    else "Scanning photos"
                 )
-            finally:
-                # scanner.scan commits photo rows incrementally, so even a mid-scan
-                # failure can leave DB state that invalidates cached new-image counts.
-                _invalidate_new_images_after_scan(thread_db, root)
+                runner.push_event(job["id"], "progress", {
+                    "phase": phase,
+                    "current": job["progress"].get("current", 0),
+                    "total": job["progress"].get("total", 0),
+                    "current_file": phase,
+                    "rate": 0,
+                })
+                try:
+                    do_scan(
+                        root, thread_db,
+                        progress_callback=progress_cb,
+                        incremental=incremental,
+                        extract_full_metadata=pipeline_cfg.get("extract_full_metadata", True),
+                        status_callback=status_cb,
+                        vireo_dir=vireo_dir,
+                    )
+                except Exception as exc:
+                    log.exception("Scan failed for root %s", root)
+                    msg = f"[{root}] {exc}"
+                    root_errors.append(msg)
+                    if msg not in job["errors"]:
+                        job["errors"].append(msg)
+                finally:
+                    # scanner.scan commits photo rows incrementally, so
+                    # even a mid-scan failure can leave DB state that
+                    # invalidates cached new-image counts.
+                    try:
+                        _invalidate_new_images_after_scan(thread_db, root)
+                    except Exception:
+                        log.exception(
+                            "Failed to invalidate new-image cache for %s", root,
+                        )
+                    advance_scan_acc()
+
             photo_count = job["progress"].get("total", 0)
-            runner.update_step(job["id"], "scan", status="completed",
-                               summary=f"{photo_count} photos")
+            if root_errors:
+                scan_summary = (
+                    f"{photo_count} photos ({len(root_errors)} of "
+                    f"{len(roots_list)} root"
+                    f"{'s' if len(roots_list) != 1 else ''} failed)"
+                )
+                runner.update_step(
+                    job["id"], "scan", status="failed", summary=scan_summary,
+                    error=root_errors[0], error_count=len(root_errors),
+                )
+            else:
+                runner.update_step(
+                    job["id"], "scan", status="completed",
+                    summary=f"{photo_count} photos",
+                )
             runner.update_step(job["id"], "thumbnails", status="running")
 
             # Auto-generate thumbnails for new photos only
@@ -5078,42 +5155,87 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             runner.update_step(job["id"], "thumbnails", status="completed",
                                summary=thumb_summary(thumb_result))
 
+            # Mixed-outcome rollup: any failed root => job is "failed".
+            # JobRunner._run_job reads the raise to flip status; the
+            # error was already appended above so it won't be double-
+            # counted.
+            if root_errors:
+                raise RuntimeError(
+                    f"{len(root_errors)} of {len(roots_list)} scan root"
+                    f"{'s' if len(roots_list) != 1 else ''} failed: "
+                    + "; ".join(root_errors)
+                )
+
             return {"photos_indexed": photo_count, "thumbnails": thumb_result}
 
         return work
 
     @app.route("/api/jobs/scan", methods=["POST"])
     def api_job_scan():
-        body = request.get_json(silent=True) or {}
-        root = body.get("root", "")
-        incremental = body.get("incremental", False)
-        if not root:
-            return json_error("root path required")
-        if not os.path.isdir(root):
-            return json_error(f"directory not found: {root}")
+        """Queue a scan job.
 
-        # Remember this scan root (skip temp directories from tests)
+        Body accepts either:
+          * ``{"root": "/path"}`` -- single root (back-compat).
+          * ``{"roots": ["/a", "/b", ...]}`` -- multiple roots, scanned
+            serially inside a single job. Multi-root support avoids the
+            SQLite writer-lock contention that used to happen when the
+            UI enqueued one job per root (PR #634 added retry/backoff
+            as defense-in-depth; this is the root-cause fix).
+        """
+        body = request.get_json(silent=True) or {}
+        incremental = body.get("incremental", False)
+
+        # Normalize inputs. Prefer the explicit plural form when both are
+        # provided; a caller who sends ``roots`` has opted into the new API.
+        if "roots" in body:
+            roots_in = body.get("roots")
+            if not isinstance(roots_in, list) or not roots_in:
+                return json_error("roots must be a non-empty list")
+            roots_list = [str(r) for r in roots_in if r]
+            if not roots_list:
+                return json_error("roots must be a non-empty list")
+        else:
+            root = body.get("root", "")
+            if not root:
+                return json_error("root path required")
+            roots_list = [root]
+
+        for r in roots_list:
+            if not os.path.isdir(r):
+                return json_error(f"directory not found: {r}")
+
+        # Remember scan roots (skip temp directories from tests)
         import tempfile
 
         import config as cfg
 
         tmp_prefix = os.path.realpath(tempfile.gettempdir())
-        if not os.path.realpath(root).startswith(tmp_prefix):
-            user_cfg = cfg.load()
-            roots = user_cfg.get("scan_roots", [])
-            if root not in roots:
-                roots.insert(0, root)
-                user_cfg["scan_roots"] = roots
-                cfg.save(user_cfg)
+        user_cfg = cfg.load()
+        saved_roots = user_cfg.get("scan_roots", [])
+        changed = False
+        for r in roots_list:
+            if os.path.realpath(r).startswith(tmp_prefix):
+                continue
+            if r not in saved_roots:
+                saved_roots.insert(0, r)
+                changed = True
+        if changed:
+            user_cfg["scan_roots"] = saved_roots
+            cfg.save(user_cfg)
 
         runner = app._job_runner
         active_ws = _get_db()._active_workspace_id
 
-        work = _build_scan_work(root, incremental, active_ws)
+        work = _build_scan_work(roots_list, incremental, active_ws)
+
+        job_config = {"roots": roots_list, "incremental": incremental}
+        # Back-compat: keep ``root`` in config when exactly one was given,
+        # so existing consumers (history viewers, etc.) still find it.
+        if len(roots_list) == 1:
+            job_config["root"] = roots_list[0]
 
         job_id = runner.start(
-            "scan", work, config={"root": root, "incremental": incremental},
-            workspace_id=active_ws,
+            "scan", work, config=job_config, workspace_id=active_ws,
         )
         return jsonify({"job_id": job_id})
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5000,9 +5000,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # root boundary. scanner.scan() reports (current, total) local
             # to its invocation; we fold those into cumulative counters
             # that the SSE/status stream reads.
-            scan_acc = {"prior": 0, "last_total": 0}
+            # Track both the last reported *processed* count and the
+            # last reported *total* for the current root. On root
+            # boundary we advance the cumulative baseline by the
+            # processed count (not the planned total) so a root that
+            # fails mid-scan doesn't inflate the baseline with phantom
+            # files the next root would start above.
+            scan_acc = {"prior": 0, "last_current": 0, "last_total": 0}
 
             def progress_cb(current, total):
+                scan_acc["last_current"] = current
                 scan_acc["last_total"] = total
                 cum_current = scan_acc["prior"] + current
                 cum_total = scan_acc["prior"] + total
@@ -5027,7 +5034,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 )
 
             def advance_scan_acc():
-                scan_acc["prior"] += scan_acc["last_total"]
+                # Use processed count, not planned total — a root that
+                # raised mid-scan will have last_current < last_total,
+                # and starting the next root above the actual processed
+                # count would overreport photos indexed.
+                scan_acc["prior"] += scan_acc["last_current"]
+                scan_acc["last_current"] = 0
                 scan_acc["last_total"] = 0
 
             job["_start_time"] = time.time()
@@ -5096,7 +5108,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         )
                     advance_scan_acc()
 
-            photo_count = job["progress"].get("total", 0)
+            # Use cumulative processed count, not planned total — on a
+            # clean run they're equal; on mixed-outcome runs "current"
+            # reflects the actual photos indexed while "total" includes
+            # planned-but-unprocessed files from the failed root(s).
+            photo_count = job["progress"].get("current", 0)
             if root_errors:
                 scan_summary = (
                     f"{photo_count} photos ({len(root_errors)} of "

--- a/vireo/tests/test_multi_root_scan.py
+++ b/vireo/tests/test_multi_root_scan.py
@@ -296,3 +296,89 @@ def test_failed_root_does_not_inflate_cumulative_progress(app_and_db, tmp_path, 
         f"photo_count inflated by phantom planned-but-unprocessed files: "
         f"summary={summary!r}"
     )
+
+
+def test_thumbnails_skipped_when_all_roots_fail(app_and_db, tmp_path, monkeypatch):
+    """If every scan root fails, the thumbnail phase must be skipped.
+    generate_all() walks the whole library looking for missing thumbs;
+    running it after a total scan failure does a long unrelated pass
+    that delays failure feedback and does work the user didn't ask for.
+    When at least one root succeeds, thumbs still run normally."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    bad_a = str(tmp_path / "bad_a")
+    bad_b = str(tmp_path / "bad_b")
+    _make_photo(bad_a, "a.jpg")
+    _make_photo(bad_b, "b.jpg")
+
+
+    def always_fails(root, db, *args, **kwargs):
+        raise RuntimeError(f"simulated immediate failure on {root}")
+
+    monkeypatch.setattr("scanner.scan", always_fails)
+
+    # Sentinel to detect if generate_all was called.
+    generate_calls = {"n": 0}
+    import thumbnails as real_thumb
+    real_generate_all = real_thumb.generate_all
+
+    def tracking_generate_all(*args, **kwargs):
+        generate_calls["n"] += 1
+        return real_generate_all(*args, **kwargs)
+
+    monkeypatch.setattr("thumbnails.generate_all", tracking_generate_all)
+
+    resp = client.post("/api/jobs/scan", json={"roots": [bad_a, bad_b]})
+    job_id = resp.get_json()["job_id"]
+    data = _wait_for_terminal(client, job_id)
+
+    assert data["status"] == "failed"
+    assert generate_calls["n"] == 0, (
+        "generate_all must NOT run when every scan root failed "
+        f"(called {generate_calls['n']} times)"
+    )
+    # Thumbnail step should be marked skipped, not running/failed.
+    thumb_step = next(s for s in data["steps"] if s["id"] == "thumbnails")
+    assert thumb_step["status"] == "skipped", thumb_step
+
+
+def test_thumbnails_still_run_when_some_roots_succeed(app_and_db, tmp_path, monkeypatch):
+    """Mixed outcome (some roots fail, some succeed) still runs thumbs
+    so the successfully-indexed photos get covered."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    bad = str(tmp_path / "bad")
+    good = str(tmp_path / "good")
+    _make_photo(bad, "b.jpg")
+    _make_photo(good, "g.jpg")
+
+    import scanner as real_scanner
+    real_scan = real_scanner.scan
+
+    def flaky_scan(root, db, *args, **kwargs):
+        if root == bad:
+            raise RuntimeError("simulated fail on bad root")
+        return real_scan(root, db, *args, **kwargs)
+
+    monkeypatch.setattr("scanner.scan", flaky_scan)
+
+    generate_calls = {"n": 0}
+    import thumbnails as real_thumb
+    real_generate_all = real_thumb.generate_all
+
+    def tracking_generate_all(*args, **kwargs):
+        generate_calls["n"] += 1
+        return real_generate_all(*args, **kwargs)
+
+    monkeypatch.setattr("thumbnails.generate_all", tracking_generate_all)
+
+    resp = client.post("/api/jobs/scan", json={"roots": [bad, good]})
+    job_id = resp.get_json()["job_id"]
+    data = _wait_for_terminal(client, job_id)
+
+    assert data["status"] == "failed"  # mixed-outcome rollup
+    assert generate_calls["n"] == 1, (
+        "generate_all must run when at least one root succeeded"
+    )

--- a/vireo/tests/test_multi_root_scan.py
+++ b/vireo/tests/test_multi_root_scan.py
@@ -384,6 +384,130 @@ def test_thumbnails_still_run_when_some_roots_succeed(app_and_db, tmp_path, monk
     )
 
 
+def test_summary_counts_unique_failed_roots_not_error_entries(
+    app_and_db, tmp_path, monkeypatch
+):
+    """A root that raises in both scan AND cache invalidation counts
+    as ONE failed root in the summary, not two.
+
+    Regression: summary used to derive "N of M failed" from
+    len(root_errors), so a single root hitting both scan failure and
+    cache-invalidation failure would report "2 of 2 failed" even when
+    one of the two roots succeeded.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+
+    bad = str(tmp_path / "bad")
+    good = str(tmp_path / "good")
+    _make_photo(bad, "b.jpg")
+    _make_photo(good, "g.jpg")
+
+    import scanner as real_scanner
+    real_scan = real_scanner.scan
+
+    def flaky_scan(root, db, *args, **kwargs):
+        if root == bad:
+            raise RuntimeError("scan boom")
+        return real_scan(root, db, *args, **kwargs)
+
+    monkeypatch.setattr("scanner.scan", flaky_scan)
+
+    # Also make cache invalidation fail on the SAME bad root so it
+    # contributes two error entries but is still only one failed root.
+    import app as app_module
+    real_invalidate = app_module._invalidate_new_images_after_scan
+
+    def flaky_invalidate(db, root, *args, **kwargs):
+        if root == bad:
+            raise RuntimeError("cache boom")
+        return real_invalidate(db, root, *args, **kwargs)
+
+    monkeypatch.setattr(
+        app_module, "_invalidate_new_images_after_scan", flaky_invalidate,
+    )
+
+    resp = client.post("/api/jobs/scan", json={"roots": [bad, good]})
+    job_id = resp.get_json()["job_id"]
+    data = _wait_for_terminal(client, job_id)
+
+    assert data["status"] == "failed"
+    scan_step = next(s for s in data["steps"] if s["id"] == "scan")
+    summary = scan_step.get("summary", "")
+    # Exactly one root failed, out of two. NOT "2 of 2".
+    assert "1 of 2" in summary, (
+        f"expected '1 of 2 roots failed' in summary, got {summary!r}"
+    )
+
+
+def test_cache_only_failure_still_runs_thumbnails(
+    app_and_db, tmp_path, monkeypatch
+):
+    """A root whose scan succeeds but cache invalidation fails still
+    produced indexed photos, so thumbnails must still run.
+
+    Regression: all_roots_failed used to be len(root_errors) ==
+    len(roots_list). A two-root run where root A's scan raised and
+    root B's cache invalidation raised produced 2 errors across 2
+    roots — incorrectly triggering the thumbnail skip even though
+    root B had indexed photos that needed thumbs.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+
+    bad = str(tmp_path / "bad")
+    good = str(tmp_path / "good")
+    _make_photo(bad, "b.jpg")
+    _make_photo(good, "g.jpg")
+
+    import scanner as real_scanner
+    real_scan = real_scanner.scan
+
+    def flaky_scan(root, db, *args, **kwargs):
+        if root == bad:
+            raise RuntimeError("scan boom")
+        return real_scan(root, db, *args, **kwargs)
+
+    monkeypatch.setattr("scanner.scan", flaky_scan)
+
+    # Cache invalidation fails only on the good root — its scan
+    # succeeded (photos indexed), but its cache invalidation raised.
+    import app as app_module
+    real_invalidate = app_module._invalidate_new_images_after_scan
+
+    def flaky_invalidate(db, root, *args, **kwargs):
+        if root == good:
+            raise RuntimeError("cache boom on good")
+        return real_invalidate(db, root, *args, **kwargs)
+
+    monkeypatch.setattr(
+        app_module, "_invalidate_new_images_after_scan", flaky_invalidate,
+    )
+
+    generate_calls = {"n": 0}
+    import thumbnails as real_thumb
+    real_generate_all = real_thumb.generate_all
+
+    def tracking_generate_all(*args, **kwargs):
+        generate_calls["n"] += 1
+        return real_generate_all(*args, **kwargs)
+
+    monkeypatch.setattr("thumbnails.generate_all", tracking_generate_all)
+
+    resp = client.post("/api/jobs/scan", json={"roots": [bad, good]})
+    job_id = resp.get_json()["job_id"]
+    data = _wait_for_terminal(client, job_id)
+
+    assert data["status"] == "failed"  # mixed outcome
+    assert generate_calls["n"] == 1, (
+        "generate_all must run when any root's scan succeeded, even if "
+        f"that root had a cache-invalidation failure (called "
+        f"{generate_calls['n']} times)"
+    )
+    thumb_step = next(s for s in data["steps"] if s["id"] == "thumbnails")
+    assert thumb_step["status"] != "skipped", thumb_step
+
+
 def test_cache_invalidation_failure_flips_job_to_failed(app_and_db, tmp_path, monkeypatch):
     """If _invalidate_new_images_after_scan raises after a scan, the
     job must NOT report success. Previously the error was logged and

--- a/vireo/tests/test_multi_root_scan.py
+++ b/vireo/tests/test_multi_root_scan.py
@@ -1,0 +1,196 @@
+"""Multi-root scan: one job, multiple roots, scanned serially.
+
+Root cause fix complementary to PR #634 (DB-lock resilience): instead of
+the UI enqueueing one scan job per folder root (which made the jobs race
+for the SQLite writer lock), a single scan job now iterates roots
+serially so there is no contention in the first place.
+"""
+import os
+import time
+
+import pytest
+from PIL import Image
+
+
+def _make_photo(folder, name):
+    os.makedirs(folder, exist_ok=True)
+    Image.new("RGB", (100, 100), color="red").save(os.path.join(folder, name))
+
+
+def _wait_for_terminal(client, job_id, timeout=15.0):
+    """Poll /api/jobs/<id> until status is completed/failed/cancelled."""
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        resp = client.get(f"/api/jobs/{job_id}")
+        data = resp.get_json()
+        last = data
+        if data["status"] in ("completed", "failed", "cancelled"):
+            return data
+        time.sleep(0.1)
+    pytest.fail(f"job {job_id} did not terminate within {timeout}s: last={last}")
+
+
+def test_scan_handles_multiple_roots_serially(app_and_db, tmp_path):
+    """POST /api/jobs/scan with a list of roots scans them all in one job."""
+    app, db = app_and_db
+    client = app.test_client()
+
+    root_a = str(tmp_path / "a")
+    root_b = str(tmp_path / "b")
+    _make_photo(root_a, "a1.jpg")
+    _make_photo(root_a, "a2.jpg")
+    _make_photo(root_b, "b1.jpg")
+
+    resp = client.post("/api/jobs/scan", json={"roots": [root_a, root_b]})
+    assert resp.status_code == 200, resp.get_json()
+    job_id = resp.get_json()["job_id"]
+
+    data = _wait_for_terminal(client, job_id)
+    assert data["status"] == "completed", data
+
+    # Both roots ended up in the DB.
+    filenames = {
+        r["filename"]
+        for r in db.conn.execute("SELECT filename FROM photos").fetchall()
+    }
+    assert {"a1.jpg", "a2.jpg", "b1.jpg"}.issubset(filenames), filenames
+
+    # Only ONE scan job was enqueued — not one-per-root.
+    scan_jobs = [j for j in app._job_runner.list_jobs() if j.get("type") == "scan"]
+    assert len(scan_jobs) == 1, scan_jobs
+
+
+def test_single_scan_job_for_all_roots(app_and_db, tmp_path):
+    """Verify only one JobRunner job is created for a multi-root request."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    roots = []
+    for name in ("r1", "r2", "r3"):
+        root = str(tmp_path / name)
+        _make_photo(root, f"{name}.jpg")
+        roots.append(root)
+
+    baseline = len(app._job_runner.list_jobs())
+    resp = client.post("/api/jobs/scan", json={"roots": roots})
+    assert resp.status_code == 200, resp.get_json()
+    _wait_for_terminal(client, resp.get_json()["job_id"])
+
+    # One new job, not three.
+    after = len(app._job_runner.list_jobs())
+    assert after - baseline == 1, (
+        f"expected exactly 1 new job for 3 roots, got {after - baseline}"
+    )
+
+
+def test_scan_continues_after_one_root_fails(app_and_db, tmp_path, monkeypatch):
+    """If root A raises mid-scan, root B still completes and job is 'failed'.
+
+    Mixed-outcome rollup convention: any failed sub-task makes the
+    aggregate status 'failed', not 'completed'.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    root_bad = str(tmp_path / "bad")
+    root_good = str(tmp_path / "good")
+    _make_photo(root_bad, "x.jpg")
+    _make_photo(root_good, "y.jpg")
+
+    # Patch scanner.scan so the first root raises, second succeeds.
+    import scanner as real_scanner
+    real_scan = real_scanner.scan
+
+    def flaky_scan(root, db, *args, **kwargs):
+        if root == root_bad:
+            raise RuntimeError("simulated failure on bad root")
+        return real_scan(root, db, *args, **kwargs)
+
+    monkeypatch.setattr("scanner.scan", flaky_scan)
+
+    resp = client.post("/api/jobs/scan", json={"roots": [root_bad, root_good]})
+    assert resp.status_code == 200
+    job_id = resp.get_json()["job_id"]
+
+    data = _wait_for_terminal(client, job_id)
+
+    # Mixed outcome -> "failed" per project convention.
+    assert data["status"] == "failed", data
+    # But the good root was still processed.
+    filenames = {
+        r["filename"]
+        for r in db.conn.execute("SELECT filename FROM photos").fetchall()
+    }
+    assert "y.jpg" in filenames, (
+        f"good root should still have been scanned after bad root failed, "
+        f"got {filenames}"
+    )
+    # And errors carry the failure context.
+    assert any("bad" in e or "simulated failure" in e for e in data["errors"]), data
+
+
+def test_single_root_string_still_works(app_and_db, tmp_path):
+    """Back-compat: posting {"root": "..."} (singular) still works."""
+    app, db = app_and_db
+    client = app.test_client()
+
+    root = str(tmp_path / "only")
+    _make_photo(root, "only.jpg")
+
+    resp = client.post("/api/jobs/scan", json={"root": root})
+    assert resp.status_code == 200
+    job_id = resp.get_json()["job_id"]
+
+    data = _wait_for_terminal(client, job_id)
+    assert data["status"] == "completed", data
+
+    filenames = {
+        r["filename"]
+        for r in db.conn.execute("SELECT filename FROM photos").fetchall()
+    }
+    assert "only.jpg" in filenames
+
+
+def test_scan_job_config_preserves_roots_list(app_and_db, tmp_path):
+    """Job config carries the full list of roots so history shows them."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    roots = []
+    for name in ("one", "two"):
+        root = str(tmp_path / name)
+        _make_photo(root, f"{name}.jpg")
+        roots.append(root)
+
+    resp = client.post("/api/jobs/scan", json={"roots": roots})
+    job_id = resp.get_json()["job_id"]
+    _wait_for_terminal(client, job_id)
+
+    job = next(j for j in app._job_runner.list_jobs() if j.get("id") == job_id)
+    cfg = job.get("config") or {}
+    assert cfg.get("roots") == roots, cfg
+
+
+def test_scan_roots_empty_list_returns_error(app_and_db):
+    """POST with an empty roots list is a 400, not a no-op success."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    resp = client.post("/api/jobs/scan", json={"roots": []})
+    assert resp.status_code == 400
+
+
+def test_scan_roots_invalid_path_returns_error(app_and_db, tmp_path):
+    """If any root in the list is bogus, we reject the whole request."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    good = str(tmp_path / "good")
+    _make_photo(good, "g.jpg")
+
+    resp = client.post(
+        "/api/jobs/scan",
+        json={"roots": [good, "/definitely/not/a/real/path"]},
+    )
+    assert resp.status_code == 400

--- a/vireo/tests/test_multi_root_scan.py
+++ b/vireo/tests/test_multi_root_scan.py
@@ -194,3 +194,47 @@ def test_scan_roots_invalid_path_returns_error(app_and_db, tmp_path):
         json={"roots": [good, "/definitely/not/a/real/path"]},
     )
     assert resp.status_code == 400
+
+
+def test_mixed_outcome_does_not_inflate_error_count(app_and_db, tmp_path, monkeypatch):
+    """Two failing roots + one good root => error_count is 2, not 3.
+
+    Regression: when the scan loop pre-appends each per-root error to
+    job["errors"] and then raises an aggregated RuntimeError, JobRunner's
+    dedup (exact string match) treats the aggregate as a new distinct
+    entry, inflating error_count by 1 for every mixed-outcome run.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+
+    bad_a = str(tmp_path / "bad_a")
+    bad_b = str(tmp_path / "bad_b")
+    good = str(tmp_path / "good")
+    _make_photo(bad_a, "a.jpg")
+    _make_photo(bad_b, "b.jpg")
+    _make_photo(good, "c.jpg")
+
+    import scanner as real_scanner
+    real_scan = real_scanner.scan
+
+    def flaky_scan(root, db, *args, **kwargs):
+        if root == bad_a:
+            raise RuntimeError("boom A")
+        if root == bad_b:
+            raise RuntimeError("boom B")
+        return real_scan(root, db, *args, **kwargs)
+
+    monkeypatch.setattr("scanner.scan", flaky_scan)
+
+    resp = client.post("/api/jobs/scan", json={"roots": [bad_a, bad_b, good]})
+    job_id = resp.get_json()["job_id"]
+    data = _wait_for_terminal(client, job_id)
+
+    assert data["status"] == "failed"
+    assert len(data["errors"]) == 2, (
+        f"expected exactly 2 error entries (one per failed root), "
+        f"got {len(data['errors'])}: {data['errors']}"
+    )
+    # Both per-root messages preserved.
+    joined = " | ".join(data["errors"])
+    assert "boom A" in joined and "boom B" in joined, data["errors"]

--- a/vireo/tests/test_multi_root_scan.py
+++ b/vireo/tests/test_multi_root_scan.py
@@ -382,3 +382,37 @@ def test_thumbnails_still_run_when_some_roots_succeed(app_and_db, tmp_path, monk
     assert generate_calls["n"] == 1, (
         "generate_all must run when at least one root succeeded"
     )
+
+
+def test_cache_invalidation_failure_flips_job_to_failed(app_and_db, tmp_path, monkeypatch):
+    """If _invalidate_new_images_after_scan raises after a scan, the
+    job must NOT report success. Previously the error was logged and
+    swallowed, so a scan that completed successfully would appear as
+    "completed" even though the shared new-images cache (5-min TTL)
+    was left stale — users would see wrong 'new images' counts with
+    no job-level failure signal.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+
+    root = str(tmp_path / "r")
+    _make_photo(root, "a.jpg")
+
+    import app as app_module
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("cache invalidation exploded")
+
+    monkeypatch.setattr(app_module, "_invalidate_new_images_after_scan", boom)
+
+    resp = client.post("/api/jobs/scan", json={"roots": [root]})
+    job_id = resp.get_json()["job_id"]
+    data = _wait_for_terminal(client, job_id)
+
+    # Scan itself succeeded but cache invalidation failed → job failed.
+    assert data["status"] == "failed", data
+    # The cache failure must be visible in the recorded errors.
+    assert any(
+        "cache invalidation" in e and "exploded" in e
+        for e in data["errors"]
+    ), data["errors"]

--- a/vireo/tests/test_multi_root_scan.py
+++ b/vireo/tests/test_multi_root_scan.py
@@ -238,3 +238,61 @@ def test_mixed_outcome_does_not_inflate_error_count(app_and_db, tmp_path, monkey
     # Both per-root messages preserved.
     joined = " | ".join(data["errors"])
     assert "boom A" in joined and "boom B" in joined, data["errors"]
+
+
+def test_failed_root_does_not_inflate_cumulative_progress(app_and_db, tmp_path, monkeypatch):
+    """Root A fails after partial progress; root B's cumulative counters
+    must start from root A's processed count, not its planned total.
+
+    Regression: advance_scan_acc() previously added last_total (planned
+    ceiling) to the accumulator. If root A had 10 files planned and
+    failed after processing 3, root B started from a baseline of 10,
+    inflating both cumulative progress and the final "photos indexed"
+    summary with 7 phantom files.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    root_bad = str(tmp_path / "bad")
+    root_good = str(tmp_path / "good")
+    # 10 files in the bad root, one processes then scan raises.
+    for i in range(10):
+        _make_photo(root_bad, f"bad_{i}.jpg")
+    for i in range(2):
+        _make_photo(root_good, f"good_{i}.jpg")
+
+    import scanner as real_scanner
+    real_scan = real_scanner.scan
+
+    def flaky_scan(root, db, *args, progress_callback=None, **kwargs):
+        if root == root_bad:
+            # Report partial progress (3 of 10) then fail, simulating
+            # a mid-scan error after some photos were processed.
+            if progress_callback is not None:
+                progress_callback(3, 10)
+            raise RuntimeError("simulated failure after partial progress")
+        return real_scan(root, db, *args, progress_callback=progress_callback, **kwargs)
+
+    monkeypatch.setattr("scanner.scan", flaky_scan)
+
+    resp = client.post("/api/jobs/scan", json={"roots": [root_bad, root_good]})
+    job_id = resp.get_json()["job_id"]
+    data = _wait_for_terminal(client, job_id)
+
+    assert data["status"] == "failed"
+    # The scan summary should reflect photos ACTUALLY indexed, not the
+    # inflated planned total. Good root contributes 2, bad root
+    # contributes its processed count (3), so the summary should cite
+    # a number consistent with that — and critically, must NOT include
+    # the 7 phantom planned-but-unprocessed files from the bad root.
+    scan_step = next(s for s in data["steps"] if s["id"] == "scan")
+    summary = scan_step.get("summary", "")
+    # Extract the leading "<N> photos" number.
+    leading_n = int(summary.split()[0])
+    # Planned total across both roots was 10 + 2 = 12. With the bug,
+    # photo_count would be 12 (inflated). With the fix it's <= 5 (3
+    # processed from bad + 2 from good).
+    assert leading_n < 12, (
+        f"photo_count inflated by phantom planned-but-unprocessed files: "
+        f"summary={summary!r}"
+    )


### PR DESCRIPTION
## Summary
- `POST /api/jobs/scan` now accepts `{"roots": [...]}` and iterates roots serially inside a single JobRunner job
- Back-compat: `{"root": "/path"}` still works (one-element list)
- Continue-on-error: a failure on root A does not abort root B; the error is recorded and the aggregate status is "failed" per the mixed-outcome rollup convention
- Per-root progress: "Scanning root N of M: /path" transitions with cumulative counters that don't rewind at root boundaries
- `/api/folders/<id>/rescan` unchanged

## Why
The UI used to enqueue one scan job per root. Those threads fought for the SQLite writer lock — the root cause of the contention that #634 papered over with retry/backoff + 'partial' folder marking. This PR fixes the root cause: serial iteration inside one job means no two threads ever hold the writer lock at once. #634's resilience stays as defense-in-depth for contention from other sources (external processes, other background jobs).

## Test plan
- [x] `vireo/tests/test_multi_root_scan.py` — 7/7 pass (serial multi-root success, single-job invariant, continue-after-failure with mixed-outcome rollup, back-compat, config preservation, empty-list + invalid-path rejection)
- [x] Required test bundle — 656/656 passing