### PR TITLE
fix(scan): drop stale derived caches on file content change

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3975,7 +3975,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         paths = body.get("paths", [])
         from audit import import_untracked
 
-        import_untracked(db, paths)
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        import_untracked(db, paths, vireo_dir=vireo_dir)
         return jsonify({"ok": True, "imported": len(paths)})
 
     # -- Scan status (kept, non-job) --

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7127,7 +7127,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         active_ws = _get_db()._active_workspace_id
 
         def work(job):
-            return run_pipeline_job(job, runner, db_path, active_ws, params)
+            return run_pipeline_job(
+                job, runner, db_path, active_ws, params,
+                thumb_cache_dir=app.config["THUMB_CACHE_DIR"],
+            )
 
         job_id = runner.start(
             "pipeline", work,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3976,7 +3976,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         from audit import import_untracked
 
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
-        import_untracked(db, paths, vireo_dir=vireo_dir)
+        import_untracked(
+            db, paths,
+            vireo_dir=vireo_dir,
+            thumb_cache_dir=app.config["THUMB_CACHE_DIR"],
+        )
         return jsonify({"ok": True, "imported": len(paths)})
 
     # -- Scan status (kept, non-job) --
@@ -5028,6 +5032,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     extract_full_metadata=pipeline_cfg.get("extract_full_metadata", True),
                     status_callback=status_cb,
                     vireo_dir=vireo_dir,
+                    thumb_cache_dir=app.config["THUMB_CACHE_DIR"],
                 )
             finally:
                 # scanner.scan commits photo rows incrementally, so even a mid-scan
@@ -5785,6 +5790,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     progress_callback=scan_cb,
                     skip_paths=exclude_paths or None,
                     vireo_dir=vireo_dir,
+                    thumb_cache_dir=app.config["THUMB_CACHE_DIR"],
                     restrict_dirs=restrict_dirs,
                 )
             finally:

--- a/vireo/audit.py
+++ b/vireo/audit.py
@@ -185,12 +185,19 @@ def remove_orphans(db, photo_ids):
     log.info("Removed %d orphan entries", len(photo_ids))
 
 
-def import_untracked(db, paths):
+def import_untracked(db, paths, vireo_dir=None):
     """Import untracked files into the database by scanning them.
 
     Args:
         db: Database instance
         paths: list of file paths to import
+        vireo_dir: path to the vireo data directory (parent of
+            ``thumbnails/``, ``working/``, ``previews/``). Required for
+            derived-cache invalidation and working-copy extraction to
+            fire — scanner can't guess it because ``--db`` and
+            ``--thumb-dir`` are independently configurable. When
+            omitted, a rescan that detects a content change will leave
+            stale caches in place.
     """
     from new_images import invalidate_new_images_after_scan
     from scanner import scan
@@ -199,7 +206,7 @@ def import_untracked(db, paths):
     dirs = set(os.path.dirname(p) for p in paths)
     for d in dirs:
         try:
-            scan(d, db, incremental=True)
+            scan(d, db, incremental=True, vireo_dir=vireo_dir)
         finally:
             # scanner.scan commits photo rows incrementally, so even a
             # mid-scan failure can leave DB state that invalidates cached

--- a/vireo/audit.py
+++ b/vireo/audit.py
@@ -185,19 +185,21 @@ def remove_orphans(db, photo_ids):
     log.info("Removed %d orphan entries", len(photo_ids))
 
 
-def import_untracked(db, paths, vireo_dir=None):
+def import_untracked(db, paths, vireo_dir=None, thumb_cache_dir=None):
     """Import untracked files into the database by scanning them.
 
     Args:
         db: Database instance
         paths: list of file paths to import
         vireo_dir: path to the vireo data directory (parent of
-            ``thumbnails/``, ``working/``, ``previews/``). Required for
-            derived-cache invalidation and working-copy extraction to
-            fire — scanner can't guess it because ``--db`` and
-            ``--thumb-dir`` are independently configurable. When
-            omitted, a rescan that detects a content change will leave
-            stale caches in place.
+            ``working/`` and ``previews/``). Required for derived-cache
+            invalidation and working-copy extraction to fire — scanner
+            can't guess it because ``--db`` and ``--thumb-dir`` are
+            independently configurable. When omitted, a rescan that
+            detects a content change will leave stale caches in place.
+        thumb_cache_dir: configured thumbnail cache directory. Forwarded
+            to the scanner so invalidation targets the real cache even
+            when ``--thumb-dir`` points outside ``vireo_dir/thumbnails``.
     """
     from new_images import invalidate_new_images_after_scan
     from scanner import scan
@@ -206,7 +208,9 @@ def import_untracked(db, paths, vireo_dir=None):
     dirs = set(os.path.dirname(p) for p in paths)
     for d in dirs:
         try:
-            scan(d, db, incremental=True, vireo_dir=vireo_dir)
+            scan(d, db, incremental=True,
+                 vireo_dir=vireo_dir,
+                 thumb_cache_dir=thumb_cache_dir)
         finally:
             # scanner.scan commits photo rows incrementally, so even a
             # mid-scan failure can leave DB state that invalidates cached

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -293,6 +293,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
     effective_thumb_cache_dir = thumb_cache_dir or os.path.join(
         os.path.dirname(db_path), "thumbnails",
     )
+    # vireo_dir must match the Flask serve convention — app.py computes
+    # ``vireo_dir = os.path.dirname(THUMB_CACHE_DIR)`` for
+    # previews/working. When the caller provided thumb_cache_dir
+    # explicitly we derive from its parent; otherwise fall back to the
+    # db_dir (same as the historical layout where everything sits
+    # alongside vireo.db).
+    effective_vireo_dir = (
+        os.path.dirname(thumb_cache_dir)
+        if thumb_cache_dir
+        else os.path.dirname(db_path)
+    )
 
     # Snapshot-scoped pipelines: load the snapshot up front so scan targets
     # are derived from the captured file paths (not a folder the user picked
@@ -621,7 +632,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             status_callback=status_cb,
                             restrict_dirs=[folder_path],
                             restrict_files=set(file_paths),
-                            vireo_dir=os.path.dirname(db_path),
+                            vireo_dir=effective_vireo_dir,
                             thumb_cache_dir=effective_thumb_cache_dir,
                         )
                     except (OSError, RuntimeError) as e:
@@ -774,7 +785,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     photo_callback=photo_cb,
                     status_callback=status_cb,
                     restrict_dirs=restrict,
-                    vireo_dir=os.path.dirname(db_path),
+                    vireo_dir=effective_vireo_dir,
                     thumb_cache_dir=effective_thumb_cache_dir,
                 )
             else:
@@ -796,7 +807,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             skip_paths=params.exclude_paths,
                             status_callback=status_cb,
                             recursive=params.recursive,
-                            vireo_dir=os.path.dirname(db_path),
+                            vireo_dir=effective_vireo_dir,
                             thumb_cache_dir=effective_thumb_cache_dir,
                         )
                     finally:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -607,6 +607,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                             status_callback=status_cb,
                             restrict_dirs=[folder_path],
                             restrict_files=set(file_paths),
+                            vireo_dir=os.path.dirname(db_path),
                         )
                     except (OSError, RuntimeError) as e:
                         log.warning(
@@ -758,6 +759,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     photo_callback=photo_cb,
                     status_callback=status_cb,
                     restrict_dirs=restrict,
+                    vireo_dir=os.path.dirname(db_path),
                 )
             else:
                 # Scan-in-place: scan each source folder independently.
@@ -778,6 +780,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                             skip_paths=params.exclude_paths,
                             status_callback=status_cb,
                             recursive=params.recursive,
+                            vireo_dir=os.path.dirname(db_path),
                         )
                     finally:
                         advance_scan_acc()

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -263,7 +263,8 @@ def _collapse_scan_roots(paths):
     return kept
 
 
-def run_pipeline_job(job, runner, db_path, workspace_id, params):
+def run_pipeline_job(job, runner, db_path, workspace_id, params,
+                     thumb_cache_dir=None):
     """Execute streaming pipeline. Called by JobRunner in a background thread.
 
     Args:
@@ -272,6 +273,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
         db_path: path to SQLite database
         workspace_id: active workspace ID
         params: PipelineParams with request parameters
+        thumb_cache_dir: configured thumbnail cache directory. Forwarded
+            to scanner.scan() and used by the thumbnail stage so the
+            pipeline writes and invalidates the real cache even when
+            ``--thumb-dir`` points outside ``dirname(db_path)/thumbnails``.
+            Defaults to that convention for backward compatibility.
 
     Returns:
         dict with stage results, duration, and errors
@@ -279,6 +285,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
     job["_start_time"] = time.time()
     abort = threading.Event()
     errors = job["errors"]  # shared list, append is thread-safe
+
+    # Effective thumbnail cache directory for every internal call below.
+    # Falls back to the historical ``<db_dir>/thumbnails`` convention when
+    # the caller didn't supply an explicit value — matches prior behavior
+    # for the default ~/.vireo layout.
+    effective_thumb_cache_dir = thumb_cache_dir or os.path.join(
+        os.path.dirname(db_path), "thumbnails",
+    )
 
     # Snapshot-scoped pipelines: load the snapshot up front so scan targets
     # are derived from the captured file paths (not a folder the user picked
@@ -608,6 +622,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                             restrict_dirs=[folder_path],
                             restrict_files=set(file_paths),
                             vireo_dir=os.path.dirname(db_path),
+                            thumb_cache_dir=effective_thumb_cache_dir,
                         )
                     except (OSError, RuntimeError) as e:
                         log.warning(
@@ -760,6 +775,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                     status_callback=status_cb,
                     restrict_dirs=restrict,
                     vireo_dir=os.path.dirname(db_path),
+                    thumb_cache_dir=effective_thumb_cache_dir,
                 )
             else:
                 # Scan-in-place: scan each source folder independently.
@@ -781,6 +797,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
                             status_callback=status_cb,
                             recursive=params.recursive,
                             vireo_dir=os.path.dirname(db_path),
+                            thumb_cache_dir=effective_thumb_cache_dir,
                         )
                     finally:
                         advance_scan_acc()
@@ -912,8 +929,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params):
             effective_cfg = thread_db.get_effective_config(cfg.load())
             thumb_size = effective_cfg.get("display", {}).get("thumbnail_size", 300)
 
-            # Resolve thumb cache dir from db_path
-            cache_dir = os.path.join(os.path.dirname(db_path), "thumbnails")
+            # Write thumbnails to the configured cache dir so custom
+            # --thumb-dir layouts receive the files the Flask serve
+            # route (reading from app.config["THUMB_CACHE_DIR"]) will
+            # look for. Falls back to <db_dir>/thumbnails only when the
+            # caller passed no explicit override.
+            cache_dir = effective_thumb_cache_dir
             os.makedirs(cache_dir, exist_ok=True)
 
             generated = 0

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -311,20 +311,45 @@ def _pair_raw_jpeg_companions(db):
     commit_with_retry(db.conn)
 
 
+def _resolve_vireo_dir(db, vireo_dir):
+    """Return an effective vireo_dir, falling back to the DB's parent.
+
+    Callers that forget the explicit ``vireo_dir`` kwarg (audit.py,
+    future entry points) would otherwise silently skip cache
+    invalidation. ``os.path.dirname(db._db_path)`` is the layout every
+    vireo data directory follows — thumbnails/, working/, previews/
+    all live as siblings of the SQLite file.
+
+    Returns an empty string for in-memory or otherwise pathless
+    databases; callers should treat that as "no cache dir, skip".
+    """
+    if vireo_dir:
+        return vireo_dir
+    db_path = getattr(db, "_db_path", None)
+    if not db_path or db_path == ":memory:":
+        return ""
+    return os.path.dirname(db_path)
+
+
 def _invalidate_derived_caches(db, vireo_dir, photo_id):
-    """Delete cached thumbnail / working copy / preview files for a photo.
+    """Delete cached thumbnail / working copy / tracked preview for a photo.
 
     Called when the scanner detects that an existing photo's source content
     has changed (different file_hash). Thumbnails, working copies, and
     preview-pyramid sizes are all derived from the source bytes, so they're
-    stale as soon as the source changes. Clearing them forces the next
-    access to regenerate from current pixels — the self-healing path that
-    prevents thumbnail/full-image mismatches.
+    stale as soon as the source changes.
+
+    Scope is intentionally O(1) per photo — untracked preview files
+    (no preview_cache row) are handled by
+    ``_sweep_untracked_previews_for_photos`` once at the end of
+    ``scan()`` instead, so large rescans don't re-enumerate previews/
+    for every invalidated photo (O(N × M) work).
 
     Also clears ``working_copy_path`` in the database so the scanner's
     working-copy extraction pass at the end of ``scan()`` picks this row
     back up and rebuilds the working copy.
     """
+    vireo_dir = _resolve_vireo_dir(db, vireo_dir)
     if not vireo_dir:
         return
 
@@ -356,9 +381,9 @@ def _invalidate_derived_caches(db, vireo_dir, photo_id):
     rows = db.conn.execute(
         "SELECT size FROM preview_cache WHERE photo_id = ?", (photo_id,)
     ).fetchall()
-    tracked_sizes = {r["size"] for r in rows}
     deleted_sizes = []
-    for size in tracked_sizes:
+    for row in rows:
+        size = row["size"]
         path = os.path.join(preview_dir, f"{photo_id}_{size}.jpg")
         try:
             os.remove(path)
@@ -369,39 +394,70 @@ def _invalidate_derived_caches(db, vireo_dir, photo_id):
         else:
             deleted_sizes.append(size)
 
-    # Also sweep preview files that aren't tracked by preview_cache (older
-    # code paths wrote without inserting a row). These have no matching
-    # row to preserve, so failed unlinks just get logged.
-    if os.path.isdir(preview_dir):
-        prefix = f"{photo_id}_"
-        try:
-            entries = os.listdir(preview_dir)
-        except OSError:
-            entries = []
-        for fname in entries:
-            if not (fname.startswith(prefix) and fname.endswith(".jpg")):
-                continue
-            size_str = fname[len(prefix):-len(".jpg")]
-            try:
-                size = int(size_str)
-            except ValueError:
-                continue
-            if size in tracked_sizes:
-                continue
-            path = os.path.join(preview_dir, fname)
-            try:
-                os.remove(path)
-            except OSError:
-                log.debug(
-                    "Could not delete untracked stale preview %s",
-                    path, exc_info=True,
-                )
-
     if deleted_sizes:
         db.conn.executemany(
             "DELETE FROM preview_cache WHERE photo_id = ? AND size = ?",
             [(photo_id, s) for s in deleted_sizes],
         )
+
+
+def _sweep_untracked_previews_for_photos(db, vireo_dir, photo_ids):
+    """Batched sweep of preview files with no preview_cache row.
+
+    Legacy / orphan preview files (written by older code paths or left
+    over from interrupted inserts) would be lazy-adopted on the next
+    ``/photos/<id>/preview`` request and served as valid cache hits.
+    After a content change that's stale data — the app serves
+    pre-change bytes. We sweep them.
+
+    Runs once per ``scan()`` call, enumerating ``previews/`` at most
+    one time regardless of how many photos were invalidated. Files
+    whose ``(photo_id, size)`` still has a live preview_cache row are
+    preserved (row-driven cleanup in ``_invalidate_derived_caches``
+    keeps rows when unlink fails, and we must not orphan those files
+    here either).
+    """
+    vireo_dir = _resolve_vireo_dir(db, vireo_dir)
+    if not vireo_dir or not photo_ids:
+        return
+    preview_dir = os.path.join(vireo_dir, "previews")
+    if not os.path.isdir(preview_dir):
+        return
+
+    photo_ids_set = {int(p) for p in photo_ids}
+    ids_list = list(photo_ids_set)
+    ph = ",".join("?" * len(ids_list))
+    rows = db.conn.execute(
+        f"SELECT photo_id, size FROM preview_cache WHERE photo_id IN ({ph})",
+        ids_list,
+    ).fetchall()
+    still_tracked = {(r["photo_id"], r["size"]) for r in rows}
+
+    try:
+        entries = os.listdir(preview_dir)
+    except OSError:
+        return
+    for fname in entries:
+        if not fname.endswith(".jpg"):
+            continue
+        stem = fname[: -len(".jpg")]
+        parts = stem.rsplit("_", 1)
+        if len(parts) != 2:
+            continue
+        try:
+            pid = int(parts[0])
+            size = int(parts[1])
+        except ValueError:
+            continue
+        if pid not in photo_ids_set:
+            continue
+        if (pid, size) in still_tracked:
+            continue
+        path = os.path.join(preview_dir, fname)
+        try:
+            os.remove(path)
+        except OSError:
+            log.debug("Could not delete untracked preview %s", path, exc_info=True)
 
 
 def _subtree_like_pattern(path, sep=None):
@@ -656,6 +712,10 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # aborts before the main loop has added any folder, or a successful
     # no-op incremental scan that processes zero files.
     touched_folder_ids = set()
+    # Photo IDs whose derived caches were invalidated this scan. Collected
+    # so the untracked-preview sweep can run once as a batch instead of
+    # per-photo (avoids O(N × M) directory walks on large rescans).
+    invalidated_photo_ids: set[int] = set()
     scoped_paths = {str(root_path)}
     if restrict_dirs is not None:
         scoped_paths.update(str(d) for d in restrict_dirs)
@@ -936,11 +996,14 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             # from the current source. The working-copy extraction pass at
             # the end of scan() picks this row back up because
             # _invalidate_derived_caches also NULLs working_copy_path.
+            # _invalidate_derived_caches self-resolves vireo_dir via the
+            # DB's parent dir, so no explicit guard here — any caller that
+            # forgets the kwarg (audit.import_untracked, etc.) still heals.
             if (prev_file_hash is not None
                     and file_hash is not None
-                    and prev_file_hash != file_hash
-                    and vireo_dir):
+                    and prev_file_hash != file_hash):
                 _invalidate_derived_caches(db, vireo_dir, photo_id)
+                invalidated_photo_ids.add(photo_id)
                 commit_with_retry(db.conn)
 
             # Import XMP keywords if sidecar exists — must land BEFORE the
@@ -1013,6 +1076,14 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 wc_scope = [str(root_path)]
             _extract_working_copies(
                 db, vireo_dir, progress_callback, status_callback, scope=wc_scope,
+            )
+
+        # Batched untracked-preview sweep. One os.listdir(previews/) for
+        # the whole scan instead of one per invalidated photo — essential
+        # when a rescan touches thousands of content-changed files.
+        if invalidated_photo_ids:
+            _sweep_untracked_previews_for_photos(
+                db, vireo_dir, invalidated_photo_ids,
             )
     except BaseException:
         db.conn.rollback()

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -363,6 +363,13 @@ def _invalidate_derived_caches(db, vireo_dir, photo_id):
                         os.path.join(preview_dir, fname),
                         exc_info=True,
                     )
+    # Drop the LRU accounting rows alongside the files. Leaving them would
+    # inflate preview_cache_total_bytes with bytes for files that no longer
+    # exist, and push quota eviction to target valid previews before the
+    # ghost rows are eventually cleaned up.
+    db.conn.execute(
+        "DELETE FROM preview_cache WHERE photo_id = ?", (photo_id,)
+    )
 
 
 def _subtree_like_pattern(path, sep=None):

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -311,6 +311,60 @@ def _pair_raw_jpeg_companions(db):
     commit_with_retry(db.conn)
 
 
+def _invalidate_derived_caches(db, vireo_dir, photo_id):
+    """Delete cached thumbnail / working copy / preview files for a photo.
+
+    Called when the scanner detects that an existing photo's source content
+    has changed (different file_hash). Thumbnails, working copies, and
+    preview-pyramid sizes are all derived from the source bytes, so they're
+    stale as soon as the source changes. Clearing them forces the next
+    access to regenerate from current pixels — the self-healing path that
+    prevents thumbnail/full-image mismatches.
+
+    Also clears ``working_copy_path`` in the database so the scanner's
+    working-copy extraction pass at the end of ``scan()`` picks this row
+    back up and rebuilds the working copy.
+    """
+    if not vireo_dir:
+        return
+
+    thumb_path = os.path.join(vireo_dir, "thumbnails", f"{photo_id}.jpg")
+    if os.path.exists(thumb_path):
+        try:
+            os.remove(thumb_path)
+        except OSError:
+            log.debug("Could not delete stale thumbnail %s", thumb_path, exc_info=True)
+
+    wc_file = os.path.join(vireo_dir, "working", f"{photo_id}.jpg")
+    if os.path.exists(wc_file):
+        try:
+            os.remove(wc_file)
+        except OSError:
+            log.debug("Could not delete stale working copy %s", wc_file, exc_info=True)
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path = NULL WHERE id = ?",
+        (photo_id,),
+    )
+
+    preview_dir = os.path.join(vireo_dir, "previews")
+    if os.path.isdir(preview_dir):
+        prefix = f"{photo_id}_"
+        try:
+            entries = os.listdir(preview_dir)
+        except OSError:
+            entries = []
+        for fname in entries:
+            if fname.startswith(prefix):
+                try:
+                    os.remove(os.path.join(preview_dir, fname))
+                except OSError:
+                    log.debug(
+                        "Could not delete stale preview %s",
+                        os.path.join(preview_dir, fname),
+                        exc_info=True,
+                    )
+
+
 def _subtree_like_pattern(path, sep=None):
     """Build a SQLite LIKE parameter that matches ``path`` + any descendant.
 
@@ -784,6 +838,15 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 height=height,
             )
 
+            # Capture prior content identity so we can detect file replacement
+            # below. When the bytes on disk change, file_hash will differ from
+            # the stored value and we must drop cached thumbnails / working
+            # copies / previews before they diverge from the new source.
+            prev_row = db.conn.execute(
+                "SELECT file_hash FROM photos WHERE id = ?", (photo_id,)
+            ).fetchone()
+            prev_file_hash = prev_row["file_hash"] if prev_row else None
+
             # Update metadata columns (also fixes existing photos that were
             # inserted before ExifTool metadata was available)
             updates = []
@@ -826,6 +889,19 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     f"UPDATE photos SET {', '.join(updates)} WHERE id=?",
                     update_params,
                 )
+                commit_with_retry(db.conn)
+
+            # Content-change self-heal: if the file's bytes have changed
+            # since the last scan, derived caches are now stale. Drop them
+            # so the next thumbnail / preview / working-copy access rebuilds
+            # from the current source. The working-copy extraction pass at
+            # the end of scan() picks this row back up because
+            # _invalidate_derived_caches also NULLs working_copy_path.
+            if (prev_file_hash is not None
+                    and file_hash is not None
+                    and prev_file_hash != file_hash
+                    and vireo_dir):
+                _invalidate_derived_caches(db, vireo_dir, photo_id)
                 commit_with_retry(db.conn)
 
             # Import XMP keywords if sidecar exists — must land BEFORE the

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -426,12 +426,19 @@ def _sweep_untracked_previews_for_photos(db, vireo_dir, photo_ids):
 
     photo_ids_set = {int(p) for p in photo_ids}
     ids_list = list(photo_ids_set)
-    ph = ",".join("?" * len(ids_list))
-    rows = db.conn.execute(
-        f"SELECT photo_id, size FROM preview_cache WHERE photo_id IN ({ph})",
-        ids_list,
-    ).fetchall()
-    still_tracked = {(r["photo_id"], r["size"]) for r in rows}
+    # Chunk to stay under SQLITE_MAX_VARIABLE_NUMBER (default 999 on
+    # older builds). Without this, a rescan that invalidates thousands
+    # of photos crashes scan post-processing with "too many SQL variables".
+    _CHUNK = 900
+    still_tracked: set[tuple[int, int]] = set()
+    for i in range(0, len(ids_list), _CHUNK):
+        chunk = ids_list[i : i + _CHUNK]
+        ph = ",".join("?" * len(chunk))
+        rows = db.conn.execute(
+            f"SELECT photo_id, size FROM preview_cache WHERE photo_id IN ({ph})",
+            chunk,
+        ).fetchall()
+        still_tracked.update((r["photo_id"], r["size"]) for r in rows)
 
     try:
         entries = os.listdir(preview_dir)

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -930,6 +930,18 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             if longitude is None:
                 longitude = exif_group.get("GPSLongitude")
 
+            # Pre-check: capture prior content identity AND whether the
+            # row existed before add_photo touches it. Brand-new rows
+            # have no derived caches to flush — skipping invalidation
+            # for them avoids O(N) wasted UPDATE + commit round-trips on
+            # large initial scans.
+            existing_row = db.conn.execute(
+                "SELECT file_hash FROM photos WHERE folder_id = ? AND filename = ?",
+                (folder_id, image_path.name),
+            ).fetchone()
+            row_already_existed = existing_row is not None
+            prev_file_hash = existing_row["file_hash"] if existing_row else None
+
             photo_id = db.add_photo(
                 folder_id=folder_id,
                 filename=image_path.name,
@@ -941,15 +953,6 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 width=width,
                 height=height,
             )
-
-            # Capture prior content identity so we can detect file replacement
-            # below. When the bytes on disk change, file_hash will differ from
-            # the stored value and we must drop cached thumbnails / working
-            # copies / previews before they diverge from the new source.
-            prev_row = db.conn.execute(
-                "SELECT file_hash FROM photos WHERE id = ?", (photo_id,)
-            ).fetchone()
-            prev_file_hash = prev_row["file_hash"] if prev_row else None
 
             # Update metadata columns (also fixes existing photos that were
             # inserted before ExifTool metadata was available)
@@ -996,16 +999,18 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 commit_with_retry(db.conn)
 
             # Content-change self-heal: when the computed hash differs
-            # from what's stored, derived caches are stale. Includes the
-            # NULL → concrete transition for legacy rows that predate
-            # hash tracking — we can't prove their caches match current
-            # bytes, so safer to flush and regenerate. For brand-new
-            # photos the invalidation is a cheap no-op (no files yet).
-            # Skips only when the new hash is NULL (computation failed)
-            # — no reliable signal to act on. Requires explicit
-            # vireo_dir; callers must pass it (scan can't guess because
-            # --db and --thumb-dir are independently configurable).
-            if (file_hash is not None
+            # from what was stored before this scan, derived caches are
+            # stale. Includes the NULL → concrete transition for legacy
+            # rows that predate hash tracking — we can't prove their
+            # caches match current bytes, so safer to flush and
+            # regenerate. Gated on ``row_already_existed`` so brand-new
+            # inserts (prev_file_hash is always NULL there) don't
+            # trigger pointless UPDATE + commit round-trips on large
+            # initial scans. Requires explicit vireo_dir; callers must
+            # pass it (scan can't guess because --db and --thumb-dir
+            # are independently configurable).
+            if (row_already_existed
+                    and file_hash is not None
                     and prev_file_hash != file_hash
                     and vireo_dir):
                 _invalidate_derived_caches(

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -311,7 +311,7 @@ def _pair_raw_jpeg_companions(db):
     commit_with_retry(db.conn)
 
 
-def _invalidate_derived_caches(db, vireo_dir, photo_id):
+def _invalidate_derived_caches(db, vireo_dir, photo_id, thumb_cache_dir=None):
     """Delete cached thumbnail / working copy / tracked preview for a photo.
 
     Called when the scanner detects that an existing photo's source content
@@ -332,11 +332,19 @@ def _invalidate_derived_caches(db, vireo_dir, photo_id):
     Requires an explicit ``vireo_dir``: DB path and cache root are
     independently configurable (--db vs --thumb-dir), so we can't guess
     the cache location from the DB. No-op when the caller omits it.
+
+    ``thumb_cache_dir`` overrides the thumbnail location. ``--thumb-dir``
+    may point to any directory name — it is not constrained to
+    ``vireo_dir/thumbnails``. Callers that have the configured value
+    (Flask routes, audit entry points) should pass it here or stale
+    thumbs survive; ``previews/`` and ``working/`` are always siblings
+    of ``vireo_dir`` by convention and need no override.
     """
     if not vireo_dir:
         return
 
-    thumb_path = os.path.join(vireo_dir, "thumbnails", f"{photo_id}.jpg")
+    thumb_dir = thumb_cache_dir or os.path.join(vireo_dir, "thumbnails")
+    thumb_path = os.path.join(thumb_dir, f"{photo_id}.jpg")
     if os.path.exists(thumb_path):
         try:
             os.remove(thumb_path)
@@ -585,7 +593,7 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
     commit_with_retry(db.conn)
 
 
-def scan(root, db, progress_callback=None, incremental=False, extract_full_metadata=True, photo_callback=None, skip_paths=None, status_callback=None, recursive=True, restrict_dirs=None, restrict_files=None, vireo_dir=None):
+def scan(root, db, progress_callback=None, incremental=False, extract_full_metadata=True, photo_callback=None, skip_paths=None, status_callback=None, recursive=True, restrict_dirs=None, restrict_files=None, vireo_dir=None, thumb_cache_dir=None):
     """Walk a folder tree, discover photos, read metadata, populate database.
 
     Args:
@@ -609,7 +617,15 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             touch only photos already in the DB.
         vireo_dir: optional path to the vireo data directory (e.g. ``~/.vireo``).
             When provided, working copies are extracted for RAW photos after
-            companion pairing.
+            companion pairing, and derived-cache invalidation fires on
+            content-changed photos.
+        thumb_cache_dir: optional override for the thumbnail cache
+            directory. ``--thumb-dir`` is independently configurable and
+            can point anywhere — defaulting to ``vireo_dir/thumbnails``
+            silently misses the real cache when those diverge. Callers
+            with the configured value (Flask routes, audit entry points)
+            should pass it. When omitted, falls back to
+            ``vireo_dir/thumbnails``.
     """
     root_path = Path(root)
     if not root_path.is_dir():
@@ -994,7 +1010,9 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     and file_hash is not None
                     and prev_file_hash != file_hash
                     and vireo_dir):
-                _invalidate_derived_caches(db, vireo_dir, photo_id)
+                _invalidate_derived_caches(
+                    db, vireo_dir, photo_id, thumb_cache_dir=thumb_cache_dir,
+                )
                 invalidated_photo_ids.add(photo_id)
                 commit_with_retry(db.conn)
 

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -995,19 +995,17 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 )
                 commit_with_retry(db.conn)
 
-            # Content-change self-heal: if the file's bytes have changed
-            # since the last scan, derived caches are now stale. Drop them
-            # so the next thumbnail / preview / working-copy access rebuilds
-            # from the current source. The working-copy extraction pass at
-            # the end of scan() picks this row back up because
-            # _invalidate_derived_caches also NULLs working_copy_path.
-            # Requires an explicit vireo_dir — we can't guess the cache
-            # root from db_path because --db and --thumb-dir are
-            # independently configurable. Callers that need invalidation
-            # on their entry points (audit, pipeline, Flask job routes)
-            # must pass it.
-            if (prev_file_hash is not None
-                    and file_hash is not None
+            # Content-change self-heal: when the computed hash differs
+            # from what's stored, derived caches are stale. Includes the
+            # NULL → concrete transition for legacy rows that predate
+            # hash tracking — we can't prove their caches match current
+            # bytes, so safer to flush and regenerate. For brand-new
+            # photos the invalidation is a cheap no-op (no files yet).
+            # Skips only when the new hash is NULL (computation failed)
+            # — no reliable signal to act on. Requires explicit
+            # vireo_dir; callers must pass it (scan can't guess because
+            # --db and --thumb-dir are independently configurable).
+            if (file_hash is not None
                     and prev_file_hash != file_hash
                     and vireo_dir):
                 _invalidate_derived_caches(

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -311,26 +311,6 @@ def _pair_raw_jpeg_companions(db):
     commit_with_retry(db.conn)
 
 
-def _resolve_vireo_dir(db, vireo_dir):
-    """Return an effective vireo_dir, falling back to the DB's parent.
-
-    Callers that forget the explicit ``vireo_dir`` kwarg (audit.py,
-    future entry points) would otherwise silently skip cache
-    invalidation. ``os.path.dirname(db._db_path)`` is the layout every
-    vireo data directory follows — thumbnails/, working/, previews/
-    all live as siblings of the SQLite file.
-
-    Returns an empty string for in-memory or otherwise pathless
-    databases; callers should treat that as "no cache dir, skip".
-    """
-    if vireo_dir:
-        return vireo_dir
-    db_path = getattr(db, "_db_path", None)
-    if not db_path or db_path == ":memory:":
-        return ""
-    return os.path.dirname(db_path)
-
-
 def _invalidate_derived_caches(db, vireo_dir, photo_id):
     """Delete cached thumbnail / working copy / tracked preview for a photo.
 
@@ -348,8 +328,11 @@ def _invalidate_derived_caches(db, vireo_dir, photo_id):
     Also clears ``working_copy_path`` in the database so the scanner's
     working-copy extraction pass at the end of ``scan()`` picks this row
     back up and rebuilds the working copy.
+
+    Requires an explicit ``vireo_dir``: DB path and cache root are
+    independently configurable (--db vs --thumb-dir), so we can't guess
+    the cache location from the DB. No-op when the caller omits it.
     """
-    vireo_dir = _resolve_vireo_dir(db, vireo_dir)
     if not vireo_dir:
         return
 
@@ -417,7 +400,6 @@ def _sweep_untracked_previews_for_photos(db, vireo_dir, photo_ids):
     keeps rows when unlink fails, and we must not orphan those files
     here either).
     """
-    vireo_dir = _resolve_vireo_dir(db, vireo_dir)
     if not vireo_dir or not photo_ids:
         return
     preview_dir = os.path.join(vireo_dir, "previews")
@@ -1003,12 +985,15 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             # from the current source. The working-copy extraction pass at
             # the end of scan() picks this row back up because
             # _invalidate_derived_caches also NULLs working_copy_path.
-            # _invalidate_derived_caches self-resolves vireo_dir via the
-            # DB's parent dir, so no explicit guard here — any caller that
-            # forgets the kwarg (audit.import_untracked, etc.) still heals.
+            # Requires an explicit vireo_dir — we can't guess the cache
+            # root from db_path because --db and --thumb-dir are
+            # independently configurable. Callers that need invalidation
+            # on their entry points (audit, pipeline, Flask job routes)
+            # must pass it.
             if (prev_file_hash is not None
                     and file_hash is not None
-                    and prev_file_hash != file_hash):
+                    and prev_file_hash != file_hash
+                    and vireo_dir):
                 _invalidate_derived_caches(db, vireo_dir, photo_id)
                 invalidated_photo_ids.add(photo_id)
                 commit_with_retry(db.conn)

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -346,7 +346,32 @@ def _invalidate_derived_caches(db, vireo_dir, photo_id):
         (photo_id,),
     )
 
+    # Preview pyramid + its LRU accounting. Only drop a preview_cache row
+    # for sizes whose file was successfully removed (or was already
+    # missing): if unlink fails (e.g. Windows file lock) and we drop the
+    # row anyway, the serve path's lazy-adoption shortcut re-adopts the
+    # stranded file and hands out stale pre-change bytes. Mirrors the
+    # self-healing semantics in preview_cache.evict_if_over_quota.
     preview_dir = os.path.join(vireo_dir, "previews")
+    rows = db.conn.execute(
+        "SELECT size FROM preview_cache WHERE photo_id = ?", (photo_id,)
+    ).fetchall()
+    tracked_sizes = {r["size"] for r in rows}
+    deleted_sizes = []
+    for size in tracked_sizes:
+        path = os.path.join(preview_dir, f"{photo_id}_{size}.jpg")
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            deleted_sizes.append(size)
+        except OSError:
+            log.debug("Could not delete stale preview %s", path, exc_info=True)
+        else:
+            deleted_sizes.append(size)
+
+    # Also sweep preview files that aren't tracked by preview_cache (older
+    # code paths wrote without inserting a row). These have no matching
+    # row to preserve, so failed unlinks just get logged.
     if os.path.isdir(preview_dir):
         prefix = f"{photo_id}_"
         try:
@@ -354,22 +379,29 @@ def _invalidate_derived_caches(db, vireo_dir, photo_id):
         except OSError:
             entries = []
         for fname in entries:
-            if fname.startswith(prefix):
-                try:
-                    os.remove(os.path.join(preview_dir, fname))
-                except OSError:
-                    log.debug(
-                        "Could not delete stale preview %s",
-                        os.path.join(preview_dir, fname),
-                        exc_info=True,
-                    )
-    # Drop the LRU accounting rows alongside the files. Leaving them would
-    # inflate preview_cache_total_bytes with bytes for files that no longer
-    # exist, and push quota eviction to target valid previews before the
-    # ghost rows are eventually cleaned up.
-    db.conn.execute(
-        "DELETE FROM preview_cache WHERE photo_id = ?", (photo_id,)
-    )
+            if not (fname.startswith(prefix) and fname.endswith(".jpg")):
+                continue
+            size_str = fname[len(prefix):-len(".jpg")]
+            try:
+                size = int(size_str)
+            except ValueError:
+                continue
+            if size in tracked_sizes:
+                continue
+            path = os.path.join(preview_dir, fname)
+            try:
+                os.remove(path)
+            except OSError:
+                log.debug(
+                    "Could not delete untracked stale preview %s",
+                    path, exc_info=True,
+                )
+
+    if deleted_sizes:
+        db.conn.executemany(
+            "DELETE FROM preview_cache WHERE photo_id = ? AND size = ?",
+            [(photo_id, s) for s in deleted_sizes],
+        )
 
 
 def _subtree_like_pattern(path, sep=None):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -527,7 +527,7 @@ def test_pipeline_accepts_source_snapshot_id(setup, tmp_path):
     called = threading.Event()
     original = pipeline_job.run_pipeline_job
 
-    def spy_run(job, runner, db_path_arg, ws_id, params):
+    def spy_run(job, runner, db_path_arg, ws_id, params, **_kwargs):
         captured["source_snapshot_id"] = params.source_snapshot_id
         called.set()
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -740,6 +740,61 @@ def test_pipeline_passes_vireo_dir_to_scan(tmp_path, monkeypatch):
     )
 
 
+def test_pipeline_forwards_thumb_cache_dir_to_scan(tmp_path, monkeypatch):
+    """Pipeline must forward the configured thumb_cache_dir to scanner.scan().
+
+    ``--thumb-dir`` can point outside ``vireo_dir/thumbnails`` — scanner's
+    invalidation now accepts a ``thumb_cache_dir`` override for exactly
+    that reason. If pipeline scans drop it, the default fallback
+    (``vireo_dir/thumbnails``) targets the wrong directory on custom
+    layouts and stale thumbnails survive.
+    """
+    import config as cfg
+    from db import Database
+    from pipeline_job import PipelineParams, run_pipeline_job
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "vireo.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    src = tmp_path / "photos"
+    src.mkdir()
+    (src / "img.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+
+    scan_kwargs = {}
+
+    def fake_scan(root, db_arg, **kwargs):
+        scan_kwargs.update(kwargs)
+
+    monkeypatch.setattr("scanner.scan", fake_scan)
+
+    custom_thumb_dir = str(tmp_path / "custom-thumbs")
+
+    params = PipelineParams(
+        source=str(src),
+        recursive=False,
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(
+        job, runner, db_path, ws_id, params,
+        thumb_cache_dir=custom_thumb_dir,
+    )
+
+    assert scan_kwargs.get("thumb_cache_dir") == custom_thumb_dir, (
+        "Pipeline must thread the configured thumb_cache_dir to scan() "
+        "so invalidation targets the real cache on custom --thumb-dir "
+        "layouts."
+    )
+
+
 def test_pipeline_scan_progress_includes_rate_and_eta(tmp_path, monkeypatch):
     """Scan progress events should include rate and eta_seconds fields."""
     import time

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -795,6 +795,66 @@ def test_pipeline_forwards_thumb_cache_dir_to_scan(tmp_path, monkeypatch):
     )
 
 
+def test_pipeline_vireo_dir_aligns_with_thumb_cache_dir_parent(tmp_path, monkeypatch):
+    """On custom --thumb-dir layouts, the Flask serve path computes
+    ``vireo_dir = os.path.dirname(THUMB_CACHE_DIR)`` — that's where it
+    reads previews/ and working/. Pipeline scans must align with that
+    convention, or invalidation runs against one tree while the app
+    serves from another (so stale previews/working_copies survive).
+    """
+    import config as cfg
+    from db import Database
+    from pipeline_job import PipelineParams, run_pipeline_job
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    # DB and thumb cache on *different* roots (simulates
+    # --db ~/.vireo/vireo.db --thumb-dir /data/thumbs).
+    db_dir = tmp_path / "dbstore"
+    db_dir.mkdir()
+    db_path = str(db_dir / "vireo.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    custom_thumb_dir = tmp_path / "cache" / "thumbs"
+    custom_thumb_dir.mkdir(parents=True)
+
+    src = tmp_path / "photos"
+    src.mkdir()
+    (src / "img.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+
+    scan_kwargs = {}
+
+    def fake_scan(root, db_arg, **kwargs):
+        scan_kwargs.update(kwargs)
+
+    monkeypatch.setattr("scanner.scan", fake_scan)
+
+    params = PipelineParams(
+        source=str(src),
+        recursive=False,
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(
+        job, runner, db_path, ws_id, params,
+        thumb_cache_dir=str(custom_thumb_dir),
+    )
+
+    expected_vireo_dir = os.path.dirname(str(custom_thumb_dir))
+    assert scan_kwargs.get("vireo_dir") == expected_vireo_dir, (
+        f"Pipeline should derive vireo_dir from thumb_cache_dir's parent "
+        f"({expected_vireo_dir}); got {scan_kwargs.get('vireo_dir')!r}. "
+        "Otherwise scan's previews/working paths diverge from the "
+        "Flask serve paths."
+    )
+
+
 def test_pipeline_scan_progress_includes_rate_and_eta(tmp_path, monkeypatch):
     """Scan progress events should include rate and eta_seconds fields."""
     import time

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -690,6 +690,56 @@ def test_pipeline_passes_recursive_false_to_scan(tmp_path, monkeypatch):
     assert scan_kwargs.get("recursive") is False
 
 
+def test_pipeline_passes_vireo_dir_to_scan(tmp_path, monkeypatch):
+    """Pipeline must forward vireo_dir to scanner.scan() so the
+    content-change cache invalidation (thumbnail/working-copy/preview)
+    actually fires for pipeline-triggered rescans.
+
+    Without this, _invalidate_derived_caches short-circuits (guard:
+    ``if not vireo_dir: return``) and the bird/squirrel divergence this
+    PR fixes still occurs for anyone using the pipeline to scan.
+    """
+    import config as cfg
+    from db import Database
+    from pipeline_job import PipelineParams, run_pipeline_job
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "vireo.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    src = tmp_path / "photos"
+    src.mkdir()
+    (src / "img.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+
+    scan_kwargs = {}
+
+    def fake_scan(root, db_arg, **kwargs):
+        scan_kwargs.update(kwargs)
+
+    monkeypatch.setattr("scanner.scan", fake_scan)
+
+    params = PipelineParams(
+        source=str(src),
+        recursive=False,
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert scan_kwargs.get("vireo_dir") == os.path.dirname(db_path), (
+        "Pipeline must pass vireo_dir (the DB's parent dir) to scan() so "
+        "derived-cache invalidation is reachable on pipeline rescans."
+    )
+
+
 def test_pipeline_scan_progress_includes_rate_and_eta(tmp_path, monkeypatch):
     """Scan progress events should include rate and eta_seconds fields."""
     import time

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1858,6 +1858,55 @@ def test_audit_import_untracked_invalidates_stale_thumbnail(tmp_path):
     )
 
 
+def test_preview_sweep_chunks_large_photo_id_sets(tmp_path):
+    """_sweep_untracked_previews_for_photos must chunk its IN (...) query.
+
+    Older SQLite builds cap bound parameters at 999
+    (SQLITE_MAX_VARIABLE_NUMBER). A rescan that invalidates thousands
+    of photos would otherwise raise ``too many SQL variables`` during
+    post-processing and fail the whole scan.
+    """
+    import scanner
+    from db import Database
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    (vireo_dir / "previews").mkdir()
+
+    db = Database(str(vireo_dir / "test.db"))
+
+    real_conn = db.conn
+    max_params_seen = 0
+
+    class TrackingConn:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def execute(self, sql, params=()):
+            nonlocal max_params_seen
+            if isinstance(params, (list, tuple)):
+                max_params_seen = max(max_params_seen, len(params))
+            return self._inner.execute(sql, params)
+
+        def executemany(self, sql, seq):
+            return self._inner.executemany(sql, seq)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    db.conn = TrackingConn(real_conn)
+
+    scanner._sweep_untracked_previews_for_photos(
+        db, str(vireo_dir), list(range(1, 2001)),
+    )
+
+    assert max_params_seen <= 999, (
+        f"Preview sweep sent {max_params_seen} bound parameters in one "
+        f"query; would crash on SQLite builds with "
+        f"SQLITE_MAX_VARIABLE_NUMBER=999."
+    )
+
+
 def test_rescan_regenerates_working_copy_when_file_content_changes(tmp_path):
     """When a large JPEG's content changes, re-scan must invalidate the stale
     working copy so the subsequent extraction reflects current pixels."""

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1964,6 +1964,45 @@ def test_invalidation_honors_custom_thumb_cache_dir(tmp_path):
     assert not (vireo_dir / "thumbnails").exists()
 
 
+def test_initial_scan_does_not_invoke_invalidation_for_new_photos(tmp_path, monkeypatch):
+    """Brand-new rows have no derived caches to flush. Firing
+    _invalidate_derived_caches for every new photo turns a 50k-file
+    initial scan into 50k pointless UPDATE/commit round-trips and
+    preview-sweep bookkeeping. Invalidation should only fire for rows
+    that already existed before this scan.
+    """
+    import scanner
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    for i in range(3):
+        Image.new("RGB", (200, 150), color=(i * 80, 0, 0)).save(
+            os.path.join(root, f"photo_{i}.jpg"), "JPEG",
+        )
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+
+    calls = []
+    real_invalidate = scanner._invalidate_derived_caches
+
+    def counting_invalidate(db, vireo_dir_arg, photo_id, thumb_cache_dir=None):
+        calls.append(photo_id)
+        return real_invalidate(db, vireo_dir_arg, photo_id, thumb_cache_dir=thumb_cache_dir)
+
+    monkeypatch.setattr(scanner, "_invalidate_derived_caches", counting_invalidate)
+
+    db = Database(str(vireo_dir / "test.db"))
+    scanner.scan(root, db, vireo_dir=str(vireo_dir))
+
+    assert calls == [], (
+        f"Invalidation fired {len(calls)} times for brand-new rows with "
+        f"no derived caches to flush. On large initial scans that turns "
+        f"into O(N) wasted SQL + commit round-trips."
+    )
+
+
 def test_rescan_invalidates_when_prev_file_hash_was_null(tmp_path):
     """Legacy photo rows predating file_hash tracking (or where prior
     hash computation failed) have file_hash=NULL. When a later rescan

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1633,6 +1633,51 @@ def test_rescan_invalidates_stale_thumbnail_when_file_content_changes(tmp_path):
     )
 
 
+def test_rescan_invalidates_preview_cache_rows_when_file_content_changes(tmp_path):
+    """preview_cache LRU rows must be removed alongside preview files when
+    a photo's content changes, or total_bytes accounting reports ghost
+    bytes for files that no longer exist and quota eviction starts
+    targeting valid previews.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    img_path = os.path.join(root, "photo.jpg")
+    Image.new("RGB", (800, 600), color=(255, 0, 0)).save(img_path, "JPEG")
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    preview_dir = vireo_dir / "previews"
+    preview_dir.mkdir()
+
+    db = Database(str(vireo_dir / "test.db"))
+    scan(root, db, vireo_dir=str(vireo_dir))
+
+    photo_id = db.get_photos(per_page=100)[0]["id"]
+
+    # Seed a preview file + accounting row, as /photos/<id>/preview would.
+    preview_file = preview_dir / f"{photo_id}_1920.jpg"
+    Image.new("RGB", (1920, 1440), color=(255, 0, 0)).save(str(preview_file), "JPEG")
+    file_bytes = preview_file.stat().st_size
+    db.preview_cache_insert(photo_id, 1920, file_bytes)
+    assert db.preview_cache_total_bytes() == file_bytes
+
+    # Replace source pixels → new file_hash → invalidation should fire.
+    time.sleep(0.05)
+    Image.new("RGB", (800, 600), color=(0, 0, 255)).save(img_path, "JPEG")
+    scan(root, db, incremental=True, vireo_dir=str(vireo_dir))
+
+    assert not preview_file.exists(), "preview file should be deleted"
+    assert db.preview_cache_get(photo_id, 1920) is None, (
+        "preview_cache row must be deleted alongside the file; "
+        "leaving it inflates preview_cache_total_bytes and triggers "
+        "unnecessary eviction of valid previews."
+    )
+    assert db.preview_cache_total_bytes() == 0
+
+
 def test_rescan_regenerates_working_copy_when_file_content_changes(tmp_path):
     """When a large JPEG's content changes, re-scan must invalidate the stale
     working copy so the subsequent extraction reflects current pixels."""

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1818,27 +1818,35 @@ def test_rescan_preview_sweep_is_batched_not_per_photo(tmp_path, monkeypatch):
     )
 
 
-def test_audit_import_untracked_invalidates_stale_thumbnail(tmp_path):
-    """audit.import_untracked calls scan() without an explicit vireo_dir.
-    Invalidation must still fire so stale thumbnails don't survive a
-    re-import of a folder that contains content-changed files. Exercises
-    the db._db_path fallback inside _invalidate_derived_caches.
+def test_audit_import_untracked_invalidates_using_caller_vireo_dir(tmp_path):
+    """audit.import_untracked must accept vireo_dir and forward it to
+    scan() so invalidation hits the real cache root.
+
+    The DB and thumb directory are independently configurable (--db vs
+    --thumb-dir). A fallback that derives vireo_dir from ``db._db_path``
+    touches the wrong filesystem when those flags diverge, leaving the
+    actual thumbnails/previews stale. The caller knows the configured
+    cache root; it must pass it.
     """
     from audit import import_untracked
     from db import Database
     from scanner import scan
     from thumbnails import generate_thumbnail
 
+    # DB and thumb cache intentionally on different roots (simulates
+    # --db /fast-ssd/vireo.db --thumb-dir /big-hdd/cache).
+    db_dir = tmp_path / "dbstore"
+    db_dir.mkdir()
+    vireo_dir = tmp_path / "cache"
+    vireo_dir.mkdir()
+    (vireo_dir / "thumbnails").mkdir()
+
     root = tmp_path / "photos"
     root.mkdir()
     img = root / "photo.jpg"
     Image.new("RGB", (800, 600), color=(255, 0, 0)).save(str(img), "JPEG")
 
-    vireo_dir = tmp_path / "vireo"
-    vireo_dir.mkdir()
-    (vireo_dir / "thumbnails").mkdir()
-
-    db = Database(str(vireo_dir / "vireo.db"))
+    db = Database(str(db_dir / "vireo.db"))
     scan(str(root), db, vireo_dir=str(vireo_dir))
 
     photo_id = db.get_photos(per_page=100)[0]["id"]
@@ -1849,12 +1857,12 @@ def test_audit_import_untracked_invalidates_stale_thumbnail(tmp_path):
     time.sleep(0.05)
     Image.new("RGB", (800, 600), color=(0, 0, 255)).save(str(img), "JPEG")
 
-    # audit.import_untracked does scan(d, db, incremental=True) without vireo_dir.
-    import_untracked(db, [str(img)])
+    # Caller supplies the real cache root — no fallback guessing.
+    import_untracked(db, [str(img)], vireo_dir=str(vireo_dir))
 
     assert not thumb_path.exists(), (
-        "Invalidation must fire even when the caller omits vireo_dir; "
-        "otherwise audit-driven rescans bake stale thumbnails into the cache."
+        "audit.import_untracked must invalidate the caller-provided "
+        "cache root, not a path guessed from db._db_path."
     )
 
 

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1568,3 +1568,115 @@ def test_pre_pass_failure_marks_folder_partial(tmp_path):
     assert row["status"] == "partial", (
         f"expected folder.status='partial' after pre-pass failure, got {row['status']!r}"
     )
+
+
+def test_rescan_invalidates_stale_thumbnail_when_file_content_changes(tmp_path):
+    """When a file's content changes on disk, re-scan must invalidate the
+    stale thumbnail so the next serve regenerates from fresh pixels.
+
+    Regression test for the _D851925.NEF bug where a photo's thumbnail showed
+    a bird but the full image (derived from the current file) was a squirrel:
+    the source had been replaced, file_hash was updated on re-scan, but the
+    thumbnail cache was never invalidated.
+    """
+    from db import Database
+    from scanner import scan
+    from thumbnails import generate_thumbnail
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    img_path = os.path.join(root, "photo.jpg")
+    # Original content: solid red
+    Image.new("RGB", (800, 600), color=(255, 0, 0)).save(img_path, "JPEG")
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    cache_dir = vireo_dir / "thumbnails"
+    cache_dir.mkdir()
+
+    db = Database(str(vireo_dir / "test.db"))
+    scan(root, db, vireo_dir=str(vireo_dir))
+
+    photos = db.get_photos(per_page=100)
+    assert len(photos) == 1
+    photo_id = photos[0]["id"]
+    original_hash = db.conn.execute(
+        "SELECT file_hash FROM photos WHERE id = ?", (photo_id,)
+    ).fetchone()[0]
+    assert original_hash is not None
+
+    thumb_path = str(cache_dir / f"{photo_id}.jpg")
+    generate_thumbnail(photo_id, img_path, str(cache_dir))
+    assert os.path.exists(thumb_path)
+
+    # Replace file content (same filename, different pixels → new hash + new mtime)
+    time.sleep(0.05)
+    Image.new("RGB", (800, 600), color=(0, 0, 255)).save(img_path, "JPEG")
+    # Ensure file_mtime differs from the DB value so incremental scan re-processes.
+    new_mtime = os.path.getmtime(img_path)
+    db_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id = ?", (photo_id,)
+    ).fetchone()[0]
+    assert new_mtime != db_mtime
+
+    # Re-scan: scanner must detect the content change and drop the stale thumbnail.
+    scan(root, db, incremental=True, vireo_dir=str(vireo_dir))
+
+    updated_hash = db.conn.execute(
+        "SELECT file_hash FROM photos WHERE id = ?", (photo_id,)
+    ).fetchone()[0]
+    assert updated_hash != original_hash, "sanity: scanner should have updated file_hash"
+
+    assert not os.path.exists(thumb_path), (
+        "Scanner must invalidate the cached thumbnail when file content changes; "
+        "leaving it on disk is how thumbnail/full-image mismatches get baked in."
+    )
+
+
+def test_rescan_regenerates_working_copy_when_file_content_changes(tmp_path):
+    """When a large JPEG's content changes, re-scan must invalidate the stale
+    working copy so the subsequent extraction reflects current pixels."""
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    img_path = os.path.join(root, "big.jpg")
+    # Larger than the default working_copy_max_size (4096) so a working copy is extracted.
+    Image.new("RGB", (5000, 3000), color=(255, 0, 0)).save(img_path, "JPEG")
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+
+    db = Database(str(vireo_dir / "test.db"))
+    scan(root, db, vireo_dir=str(vireo_dir))
+
+    photos = db.get_photos(per_page=100)
+    assert len(photos) == 1
+    photo_id = photos[0]["id"]
+    assert photos[0]["working_copy_path"] is not None
+    wc_path = vireo_dir / photos[0]["working_copy_path"]
+    assert wc_path.exists()
+
+    # Record what the working copy looks like now (top-left pixel = red).
+    with Image.open(wc_path) as img:
+        assert img.convert("RGB").getpixel((0, 0))[0] > 200  # red channel dominant
+
+    # Replace file content with a very different image.
+    time.sleep(0.05)
+    Image.new("RGB", (5000, 3000), color=(0, 0, 255)).save(img_path, "JPEG")
+
+    scan(root, db, incremental=True, vireo_dir=str(vireo_dir))
+
+    # Working copy should point to a regenerated file whose pixels match the new source.
+    photos = db.get_photos(per_page=100)
+    wc_rel = photos[0]["working_copy_path"]
+    assert wc_rel is not None, "Scanner must re-set working_copy_path after invalidation"
+    wc_path = vireo_dir / wc_rel
+    assert wc_path.exists()
+    with Image.open(wc_path) as img:
+        pixel = img.convert("RGB").getpixel((0, 0))
+    assert pixel[2] > 200 and pixel[0] < 100, (
+        f"Working copy pixel {pixel} does not reflect updated (blue) source; "
+        "stale extraction from pre-change content was served."
+    )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1678,6 +1678,59 @@ def test_rescan_invalidates_preview_cache_rows_when_file_content_changes(tmp_pat
     assert db.preview_cache_total_bytes() == 0
 
 
+def test_rescan_keeps_preview_cache_row_when_file_unlink_fails(tmp_path, monkeypatch):
+    """If a preview file can't be deleted (e.g. locked on Windows), the
+    matching preview_cache row must stay. Otherwise the serve path's
+    lazy-adoption shortcut (app.py ~L8131) re-adopts the stale file on
+    the next /photos/<id>/preview and hands out pre-change content, and
+    quota eviction stops accounting for the leaked bytes.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    img_path = os.path.join(root, "photo.jpg")
+    Image.new("RGB", (800, 600), color=(255, 0, 0)).save(img_path, "JPEG")
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    preview_dir = vireo_dir / "previews"
+    preview_dir.mkdir()
+
+    db = Database(str(vireo_dir / "test.db"))
+    scan(root, db, vireo_dir=str(vireo_dir))
+    photo_id = db.get_photos(per_page=100)[0]["id"]
+
+    preview_file = preview_dir / f"{photo_id}_1920.jpg"
+    Image.new("RGB", (1920, 1440), color=(255, 0, 0)).save(str(preview_file), "JPEG")
+    file_bytes = preview_file.stat().st_size
+    db.preview_cache_insert(photo_id, 1920, file_bytes)
+
+    # Simulate the preview file being un-removable (locked, ACL, etc.).
+    real_remove = os.remove
+    stuck = str(preview_file)
+
+    def selective_remove(path):
+        if os.fspath(path) == stuck:
+            raise PermissionError("simulated lock")
+        real_remove(path)
+
+    monkeypatch.setattr(os, "remove", selective_remove)
+
+    # Force a content-change rescan so invalidation fires.
+    time.sleep(0.05)
+    Image.new("RGB", (800, 600), color=(0, 0, 255)).save(img_path, "JPEG")
+    scan(root, db, incremental=True, vireo_dir=str(vireo_dir))
+
+    assert preview_file.exists(), "sanity: stuck preview file should remain"
+    assert db.preview_cache_get(photo_id, 1920) is not None, (
+        "When preview unlink fails, the cache row must stay so quota "
+        "accounting keeps the leaked bytes visible and the serve path "
+        "does not lazy-adopt stale content."
+    )
+
+
 def test_rescan_regenerates_working_copy_when_file_content_changes(tmp_path):
     """When a large JPEG's content changes, re-scan must invalidate the stale
     working copy so the subsequent extraction reflects current pixels."""

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1915,6 +1915,55 @@ def test_preview_sweep_chunks_large_photo_id_sets(tmp_path):
     )
 
 
+def test_invalidation_honors_custom_thumb_cache_dir(tmp_path):
+    """``--thumb-dir`` can point to any directory — not necessarily a
+    ``thumbnails/`` subdirectory of the vireo data dir. Invalidation
+    must target the caller-supplied thumb cache dir directly, not
+    assume a ``vireo_dir/thumbnails/`` layout. Otherwise stale
+    thumbnails survive and an unrelated sibling ``thumbnails/`` can
+    have files removed.
+    """
+    from db import Database
+    from scanner import scan
+    from thumbnails import generate_thumbnail
+
+    # Custom layout: thumb dir has a non-default basename, not adjacent
+    # to a "thumbnails" subdir of vireo_dir.
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    thumb_dir = tmp_path / "custom-thumbs"
+    thumb_dir.mkdir()
+
+    root = tmp_path / "photos"
+    root.mkdir()
+    img = root / "p.jpg"
+    Image.new("RGB", (400, 300), color=(255, 0, 0)).save(str(img), "JPEG")
+
+    db = Database(str(vireo_dir / "test.db"))
+    scan(str(root), db,
+         vireo_dir=str(vireo_dir),
+         thumb_cache_dir=str(thumb_dir))
+    photo_id = db.get_photos(per_page=100)[0]["id"]
+
+    thumb = thumb_dir / f"{photo_id}.jpg"
+    generate_thumbnail(photo_id, str(img), str(thumb_dir))
+    assert thumb.exists()
+
+    time.sleep(0.05)
+    Image.new("RGB", (400, 300), color=(0, 0, 255)).save(str(img), "JPEG")
+
+    scan(str(root), db, incremental=True,
+         vireo_dir=str(vireo_dir),
+         thumb_cache_dir=str(thumb_dir))
+
+    assert not thumb.exists(), (
+        "Invalidation must target the configured thumb_cache_dir, not "
+        "the vireo_dir/thumbnails convention."
+    )
+    # Sanity: no accidental 'thumbnails/' directory got created either.
+    assert not (vireo_dir / "thumbnails").exists()
+
+
 def test_rescan_regenerates_working_copy_when_file_content_changes(tmp_path):
     """When a large JPEG's content changes, re-scan must invalidate the stale
     working copy so the subsequent extraction reflects current pixels."""

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1731,6 +1731,133 @@ def test_rescan_keeps_preview_cache_row_when_file_unlink_fails(tmp_path, monkeyp
     )
 
 
+def test_rescan_sweeps_untracked_preview_files(tmp_path):
+    """Legacy preview files that pre-date preview_cache accounting (no
+    row) must still be cleaned up when a photo's content changes.
+    Otherwise app.py's lazy-adoption path (~L8131) re-adopts them on
+    the next /photos/<id>/preview request and hands out pre-change
+    bytes.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    img_path = os.path.join(root, "photo.jpg")
+    Image.new("RGB", (800, 600), color=(255, 0, 0)).save(img_path, "JPEG")
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    preview_dir = vireo_dir / "previews"
+    preview_dir.mkdir()
+
+    db = Database(str(vireo_dir / "test.db"))
+    scan(root, db, vireo_dir=str(vireo_dir))
+    photo_id = db.get_photos(per_page=100)[0]["id"]
+
+    # Seed an *untracked* preview (file exists, no preview_cache row).
+    untracked = preview_dir / f"{photo_id}_800.jpg"
+    Image.new("RGB", (800, 600), color=(255, 0, 0)).save(str(untracked), "JPEG")
+    assert db.preview_cache_get(photo_id, 800) is None
+
+    time.sleep(0.05)
+    Image.new("RGB", (800, 600), color=(0, 0, 255)).save(img_path, "JPEG")
+    scan(root, db, incremental=True, vireo_dir=str(vireo_dir))
+
+    assert not untracked.exists(), (
+        "Untracked preview files for invalidated photos must be swept "
+        "or serve's lazy-adoption path re-adopts stale pre-change bytes."
+    )
+
+
+def test_rescan_preview_sweep_is_batched_not_per_photo(tmp_path, monkeypatch):
+    """The untracked-preview sweep must run at most once per scan,
+    not once per invalidated photo. Per-photo os.listdir on the
+    preview dir turns large rescans into O(N × M) work.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    paths = []
+    for i in range(3):
+        p = os.path.join(root, f"photo_{i}.jpg")
+        Image.new("RGB", (800, 600), color=(255, i * 40, 0)).save(p, "JPEG")
+        paths.append(p)
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    preview_dir = vireo_dir / "previews"
+    preview_dir.mkdir()
+
+    db = Database(str(vireo_dir / "test.db"))
+    scan(root, db, vireo_dir=str(vireo_dir))
+
+    # Replace all three files' contents so each invalidation fires.
+    time.sleep(0.05)
+    for i, p in enumerate(paths):
+        Image.new("RGB", (800, 600), color=(0, 0, 255 - i * 30)).save(p, "JPEG")
+
+    preview_listings = []
+    real_listdir = os.listdir
+
+    def counting_listdir(path):
+        if str(path).rstrip(os.sep).endswith("previews"):
+            preview_listings.append(str(path))
+        return real_listdir(path)
+
+    monkeypatch.setattr(os, "listdir", counting_listdir)
+
+    scan(root, db, incremental=True, vireo_dir=str(vireo_dir))
+
+    assert len(preview_listings) <= 1, (
+        f"previews/ must be enumerated at most once per scan regardless "
+        f"of how many photos were invalidated; got {len(preview_listings)} "
+        f"listings across 3 invalidations."
+    )
+
+
+def test_audit_import_untracked_invalidates_stale_thumbnail(tmp_path):
+    """audit.import_untracked calls scan() without an explicit vireo_dir.
+    Invalidation must still fire so stale thumbnails don't survive a
+    re-import of a folder that contains content-changed files. Exercises
+    the db._db_path fallback inside _invalidate_derived_caches.
+    """
+    from audit import import_untracked
+    from db import Database
+    from scanner import scan
+    from thumbnails import generate_thumbnail
+
+    root = tmp_path / "photos"
+    root.mkdir()
+    img = root / "photo.jpg"
+    Image.new("RGB", (800, 600), color=(255, 0, 0)).save(str(img), "JPEG")
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    (vireo_dir / "thumbnails").mkdir()
+
+    db = Database(str(vireo_dir / "vireo.db"))
+    scan(str(root), db, vireo_dir=str(vireo_dir))
+
+    photo_id = db.get_photos(per_page=100)[0]["id"]
+    thumb_path = vireo_dir / "thumbnails" / f"{photo_id}.jpg"
+    generate_thumbnail(photo_id, str(img), str(vireo_dir / "thumbnails"))
+    assert thumb_path.exists()
+
+    time.sleep(0.05)
+    Image.new("RGB", (800, 600), color=(0, 0, 255)).save(str(img), "JPEG")
+
+    # audit.import_untracked does scan(d, db, incremental=True) without vireo_dir.
+    import_untracked(db, [str(img)])
+
+    assert not thumb_path.exists(), (
+        "Invalidation must fire even when the caller omits vireo_dir; "
+        "otherwise audit-driven rescans bake stale thumbnails into the cache."
+    )
+
+
 def test_rescan_regenerates_working_copy_when_file_content_changes(tmp_path):
     """When a large JPEG's content changes, re-scan must invalidate the stale
     working copy so the subsequent extraction reflects current pixels."""

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1964,6 +1964,55 @@ def test_invalidation_honors_custom_thumb_cache_dir(tmp_path):
     assert not (vireo_dir / "thumbnails").exists()
 
 
+def test_rescan_invalidates_when_prev_file_hash_was_null(tmp_path):
+    """Legacy photo rows predating file_hash tracking (or where prior
+    hash computation failed) have file_hash=NULL. When a later rescan
+    computes a concrete hash, derived caches written during the NULL
+    era must be invalidated — we can't prove the bytes are unchanged,
+    so safer to flush than leave a stale thumbnail in place.
+    """
+    from db import Database
+    from scanner import scan
+    from thumbnails import generate_thumbnail
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    img_path = os.path.join(root, "legacy.jpg")
+    Image.new("RGB", (800, 600), color=(255, 0, 0)).save(img_path, "JPEG")
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    cache_dir = vireo_dir / "thumbnails"
+    cache_dir.mkdir()
+
+    db = Database(str(vireo_dir / "test.db"))
+    scan(root, db, vireo_dir=str(vireo_dir))
+    photo_id = db.get_photos(per_page=100)[0]["id"]
+
+    thumb_path = str(cache_dir / f"{photo_id}.jpg")
+    generate_thumbnail(photo_id, img_path, str(cache_dir))
+    assert os.path.exists(thumb_path)
+
+    # Simulate a legacy row: wipe the hash as if it was recorded before
+    # file_hash tracking existed.
+    db.conn.execute("UPDATE photos SET file_hash = NULL WHERE id = ?", (photo_id,))
+    # Also bump file_mtime backwards so incremental scan reprocesses the row.
+    db.conn.execute("UPDATE photos SET file_mtime = 0 WHERE id = ?", (photo_id,))
+    db.conn.commit()
+
+    scan(root, db, incremental=True, vireo_dir=str(vireo_dir))
+
+    new_hash = db.conn.execute(
+        "SELECT file_hash FROM photos WHERE id = ?", (photo_id,)
+    ).fetchone()[0]
+    assert new_hash is not None, "sanity: rescan must populate the hash"
+
+    assert not os.path.exists(thumb_path), (
+        "Invalidation must fire on NULL → concrete transitions too; "
+        "otherwise legacy rows keep stale derived caches forever."
+    )
+
+
 def test_rescan_regenerates_working_copy_when_file_content_changes(tmp_path):
     """When a large JPEG's content changes, re-scan must invalidate the stale
     working copy so the subsequent extraction reflects current pixels."""


### PR DESCRIPTION
## Summary

Fixes the thumbnail/full-image mismatch symptom reported for `_D851925.NEF` in the Feb2026 workspace (thumbnail showed a bird, lightbox showed a squirrel).

**Root cause.** When a file's bytes change on disk, the scanner updates `photos.file_hash` but leaves derived caches (thumbnail, working copy, preview pyramid) untouched. `generate_thumbnail` short-circuits when `<photo_id>.jpg` already exists, so the stale pixels stick around forever. Meanwhile `/photos/<id>/original` re-extracts the working copy on demand (1:1 zoom), so the working copy drifts to the new content while the thumbnail stays frozen on the old content — exact symptom the user reported.

**Fix.** Scanner captures the prior `file_hash` before the `UPDATE` and, if the newly computed hash differs, calls `_invalidate_derived_caches(db, vireo_dir, photo_id)`:
- deletes `thumbnails/<id>.jpg`
- deletes `working/<id>.jpg` and NULLs `working_copy_path` (so `_extract_working_copies` at the end of `scan()` rebuilds it this pass)
- deletes `previews/<id>_*.jpg`

Aligns with the "app self-heals broken state — no rm -rf fixes" convention.

## Test plan

- [x] New `test_rescan_invalidates_stale_thumbnail_when_file_content_changes` (reproduces the bird/squirrel divergence; fails without the fix)
- [x] New `test_rescan_regenerates_working_copy_when_file_content_changes` (asserts working-copy pixels reflect the new source)
- [x] `python -m pytest vireo/tests/test_scanner.py vireo/tests/test_thumbnails.py vireo/tests/test_scanner_working_copy.py -q` → 76 passed
- [x] Project default suite (`tests/test_workspaces.py`, `vireo/tests/test_db.py`, `test_app.py`, `test_photos_api.py`, `test_edits_api.py`, `test_jobs_api.py`, `test_darktable_api.py`, `test_config.py`) → 589 passed

## Notes / out of scope

- The fix is going-forward. Photos whose thumbnails drifted *before* this patch landed will only heal if their source file is touched again (scanner needs a file-hash change to fire the invalidation). For the specific `_D851925.NEF` case, a one-time `rm ~/.vireo/thumbnails/24146.jpg` will trigger regeneration from the current NEF on next view.
- Pre-existing: `file_mtime` is never updated on existing photo rows by the main loop. Not in scope here, but it means every incremental re-scan re-hashes the file until mtime matches. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)