### PR TITLE
fix(settings): explicit value="20" on detector_confidence override slider

### DIFF
--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -344,7 +344,7 @@
           Override for "<span class="ws-override-name">…</span>"
         </label>
         <div id="wsOverrideCtrl_detector_confidence" style="display:none;align-items:center;gap:8px;margin-left:24px;margin-top:4px;">
-          <input type="range" id="wsVal_detector_confidence" min="5" max="50" step="1"
+          <input type="range" id="wsVal_detector_confidence" min="5" max="50" step="1" value="20"
                  style="width:120px;accent-color:var(--accent);"
                  oninput="document.getElementById('wsDetectorConfVal').textContent=(this.value/100).toFixed(2); saveWsConfig()">
           <span id="wsDetectorConfVal" style="font-size:12px;color:var(--text-dim);min-width:36px;">-</span>

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1698,6 +1698,29 @@ def test_workspace_config_post_preserves_non_whitelisted_keys(app_and_db):
         assert overrides["active_labels"] == ["/path/to/birds.txt"]
 
 
+def test_ws_detector_confidence_slider_has_explicit_default(app_and_db):
+    """The wsVal_detector_confidence range input must carry value="20".
+
+    HTML5 range inputs with no `value` initialize to (min+max)/2, so a
+    5..50 range silently sits at ~27 on first render. toggleWsOverride
+    only applies its 20 default when `!input.value`, which is never
+    falsy for range elements. Without the explicit attribute, enabling
+    the override would persist ~0.27 instead of 0.20 and unexpectedly
+    hide low-confidence detections.
+    """
+    import re
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get('/settings')
+    assert resp.status_code == 200
+    m = re.search(
+        rb'<input[^>]*\bid="wsVal_detector_confidence"[^>]*\bvalue="20"',
+        resp.data,
+    )
+    assert m, ('wsVal_detector_confidence range needs explicit value="20" '
+               'to avoid HTML5 range midpoint default (would persist ~0.27)')
+
+
 def test_get_all_keywords(app_and_db):
     """GET /api/keywords/all returns only keywords used in the active workspace."""
     app, db = app_and_db


### PR DESCRIPTION
## Summary

Follow-up to #657, which closed #648 but didn't carry over the slider-default fix Codex flagged on this PR.

HTML5 range inputs with no `value` attribute initialize to `(min+max)/2`. The new override slider has `min="5" max="50"`, so on first render `input.value` is ~`27`. `toggleWsOverride`'s default-setter is gated on `!input.value`, which is never falsy for range elements — so enabling the override checkbox without touching the slider would silently persist `0.27` and hide low-confidence detections.

This PR adds `value="20"` to the override slider plus a regression test on the rendered HTML.

## Test plan

- [x] `vireo/tests/test_app.py::test_ws_detector_confidence_slider_has_explicit_default` — fails on main, passes here
- [x] `vireo/tests/test_app.py` — 133 passed