### PR TITLE
fix(settings): expose detector_confidence as a workspace override

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2220,7 +2220,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         body = request.get_json(silent=True) or {}
         # Only allow workspace-overridable keys
-        allowed = {"classification_threshold", "grouping_window_seconds", "similarity_threshold", "review_min_confidence"}
+        allowed = {"classification_threshold", "grouping_window_seconds", "similarity_threshold", "detector_confidence", "review_min_confidence"}
         # Merge into existing overrides to preserve non-whitelisted keys
         ws = db.get_workspace(db._active_workspace_id)
         existing = {}

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1078,12 +1078,17 @@ function saveWsConfig() {
     ['classification_threshold', 'grouping_window_seconds', 'similarity_threshold', 'detector_confidence'].forEach(function(key) {
       var checkbox = document.getElementById('wsOverride_' + key);
       var input = document.getElementById('wsVal_' + key);
-      if (checkbox && checkbox.checked && input) {
+      if (!checkbox || !input) return;
+      if (checkbox.checked) {
         if (key === 'classification_threshold' || key === 'similarity_threshold' || key === 'detector_confidence') {
           overrides[key] = parseInt(input.value) / 100;
         } else {
           overrides[key] = parseInt(input.value);
         }
+      } else {
+        // Explicit null tells the backend to clear this override.
+        // Without this, omitted keys are preserved and unchecking has no effect.
+        overrides[key] = null;
       }
     });
     try {

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -338,6 +338,18 @@
           <span style="font-size:13px;color:var(--text-primary);min-width:36px;" id="cfgDetectorConfVal">0.20</span>
         </div>
       </div>
+      <div class="setting-row" style="padding:0 0 8px 16px;">
+        <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:12px;color:var(--text-dim);">
+          <input type="checkbox" id="wsOverride_detector_confidence" onchange="toggleWsOverride('detector_confidence')" style="accent-color:var(--accent);">
+          Override for "<span class="ws-override-name">…</span>"
+        </label>
+        <div id="wsOverrideCtrl_detector_confidence" style="display:none;align-items:center;gap:8px;margin-left:24px;margin-top:4px;">
+          <input type="range" id="wsVal_detector_confidence" min="5" max="50" step="1"
+                 style="width:120px;accent-color:var(--accent);"
+                 oninput="document.getElementById('wsDetectorConfVal').textContent=(this.value/100).toFixed(2); saveWsConfig()">
+          <span id="wsDetectorConfVal" style="font-size:12px;color:var(--text-dim);min-width:36px;">-</span>
+        </div>
+      </div>
       <div class="setting-row">
         <div class="setting-label">
           Detection box padding
@@ -1011,7 +1023,7 @@ async function loadWsOverrides() {
       document.querySelectorAll('.ws-override-name').forEach(function(el) { el.textContent = ws.name; });
     }
     var overrides = await safeFetch('/api/workspaces/active/config', {}, { toast: false });
-    ['classification_threshold', 'grouping_window_seconds', 'similarity_threshold'].forEach(function(key) {
+    ['classification_threshold', 'grouping_window_seconds', 'similarity_threshold', 'detector_confidence'].forEach(function(key) {
       var checkbox = document.getElementById('wsOverride_' + key);
       var input = document.getElementById('wsVal_' + key);
       var ctrl = document.getElementById('wsOverrideCtrl_' + key);
@@ -1019,7 +1031,7 @@ async function loadWsOverrides() {
       if (overrides[key] !== undefined) {
         checkbox.checked = true;
         ctrl.style.display = 'flex';
-        if (key === 'classification_threshold' || key === 'similarity_threshold') {
+        if (key === 'classification_threshold' || key === 'similarity_threshold' || key === 'detector_confidence') {
           input.value = Math.round(overrides[key] * 100);
         } else {
           input.value = overrides[key];
@@ -1037,6 +1049,8 @@ function updateWsLabel(key) {
     document.getElementById('wsThresholdVal').textContent = input.value + '%';
   } else if (key === 'similarity_threshold') {
     document.getElementById('wsSimilarityVal').textContent = input.value + '%';
+  } else if (key === 'detector_confidence') {
+    document.getElementById('wsDetectorConfVal').textContent = (parseInt(input.value) / 100).toFixed(2);
   }
 }
 
@@ -1050,6 +1064,7 @@ function toggleWsOverride(key) {
     if (key === 'classification_threshold') input.value = 40;
     else if (key === 'grouping_window_seconds') input.value = 10;
     else if (key === 'similarity_threshold') input.value = 85;
+    else if (key === 'detector_confidence') input.value = 20;
     updateWsLabel(key);
   }
   saveWsConfig();
@@ -1060,11 +1075,11 @@ function saveWsConfig() {
   clearTimeout(_wsSaveTimer);
   _wsSaveTimer = setTimeout(async function() {
     var overrides = {};
-    ['classification_threshold', 'grouping_window_seconds', 'similarity_threshold'].forEach(function(key) {
+    ['classification_threshold', 'grouping_window_seconds', 'similarity_threshold', 'detector_confidence'].forEach(function(key) {
       var checkbox = document.getElementById('wsOverride_' + key);
       var input = document.getElementById('wsVal_' + key);
       if (checkbox && checkbox.checked && input) {
-        if (key === 'classification_threshold' || key === 'similarity_threshold') {
+        if (key === 'classification_threshold' || key === 'similarity_threshold' || key === 'detector_confidence') {
           overrides[key] = parseInt(input.value) / 100;
         } else {
           overrides[key] = parseInt(input.value);

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1016,6 +1016,7 @@ function toggleSection(header) {
 }
 
 /* ---------- Workspace Config Overrides ---------- */
+var _wsOverridesLoaded = false;
 async function loadWsOverrides() {
   try {
     var ws = await safeFetch('/api/workspaces/active', {}, { toast: false });
@@ -1039,6 +1040,7 @@ async function loadWsOverrides() {
         updateWsLabel(key);
       }
     });
+    _wsOverridesLoaded = true;
   } catch(e) {}
 }
 
@@ -1072,6 +1074,10 @@ function toggleWsOverride(key) {
 
 var _wsSaveTimer = null;
 function saveWsConfig() {
+  // If the initial load failed, every checkbox shows unchecked even though the
+  // server may have overrides. Saving now would send null for every key and
+  // wipe persisted state we never displayed. Bail out instead.
+  if (!_wsOverridesLoaded) return;
   clearTimeout(_wsSaveTimer);
   _wsSaveTimer = setTimeout(async function() {
     var overrides = {};

--- a/vireo/tests/test_workspaces_api.py
+++ b/vireo/tests/test_workspaces_api.py
@@ -282,6 +282,33 @@ def test_workspace_config_get_and_set(app_and_db):
     assert config["grouping_window_seconds"] == 120
 
 
+def test_workspace_config_detector_confidence_override(app_and_db):
+    """POST detector_confidence override is accepted by the API and reaches get_effective_config.
+
+    Regression for #648: the API whitelist used to silently drop detector_confidence,
+    so the read-time threshold filter promised in the #636 CHANGELOG was unreachable
+    via the public API.
+    """
+    import config as cfg
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    resp = client.post("/api/workspaces/active/config", json={"detector_confidence": 0.05})
+    assert resp.status_code == 200
+    stored = resp.get_json()["overrides"]
+    assert stored["detector_confidence"] == 0.05
+
+    effective = db.get_effective_config(cfg.load())
+    assert effective["detector_confidence"] == 0.05
+
+    # Clearing via null removes the override and reverts to the global default
+    clear_resp = client.post("/api/workspaces/active/config", json={"detector_confidence": None})
+    assert clear_resp.status_code == 200
+    assert "detector_confidence" not in clear_resp.get_json()["overrides"]
+    assert db.get_effective_config(cfg.load())["detector_confidence"] == cfg.DEFAULTS["detector_confidence"]
+
+
 def test_workspace_config_ignores_unknown_keys(app_and_db):
     """Only allowed keys are stored; unknown keys are silently ignored."""
     app, _db = app_and_db


### PR DESCRIPTION
## Summary

Closes #648.

The data layer has supported per-workspace `detector_confidence` since #636 (read-time threshold filter), but the public `POST /api/workspaces/active/config` silently dropped the key and `settings.html` had no override checkbox for it — making the unreleased CHANGELOG promise reachable only via direct DB writes.

- **`vireo/app.py`** — add `detector_confidence` to the allowed-keys whitelist in `api_set_workspace_config`.
- **`vireo/templates/settings.html`** — add the standard "Override for '<workspace>'" checkbox + slider beneath the global Detector confidence slider, mirroring the existing pattern (5-50 → 0.05-0.50). Wire the key through `loadWsOverrides`, `updateWsLabel`, `toggleWsOverride`, and `saveWsConfig`.
- **`vireo/tests/test_workspaces_api.py`** — new end-to-end test that POSTs the override and asserts it surfaces through `db.get_effective_config(cfg.load())`. Existing tests bypassed the API via `create_workspace(config_overrides=...)`, so the whitelist gap was uncovered.

### Note on the issue's bonus cleanup

I did **not** remove `review_min_confidence` from the whitelist. The issue called it a no-op since it's not in `cfg.DEFAULTS`, but it's actually used by the pipeline review confidence slider — `pipeline_review.html` saves it via this API and reads it back from `workspace_overrides` in `/api/pipeline/page-init`. Removing it would break slider persistence.

## Test plan

- [x] `python -m pytest vireo/tests/test_workspaces_api.py -v` — 19 passed including the new `test_workspace_config_detector_confidence_override`
- [x] Full CLAUDE.md suite (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_workspaces_api.py`) — 657 passed, 0 failures after the `review_min_confidence` revert