### PR TITLE
fix(tests): clean up known-flaky and broken tests

### DIFF
--- a/tests/test_headless_integration.py
+++ b/tests/test_headless_integration.py
@@ -37,6 +37,23 @@ def _wait_for_runtime(runtime_path: Path, timeout: float = 20.0) -> dict:
     raise TimeoutError(f"{runtime_path} never appeared")
 
 
+def _wait_for_port(port: int, timeout: float = 20.0) -> None:
+    """Poll until 127.0.0.1:port accepts TCP connections.
+
+    runtime.json is written before Flask binds to the port, so callers
+    that immediately POST after _wait_for_runtime can race the bind and
+    get ECONNREFUSED. This guards against that race.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise TimeoutError(f"127.0.0.1:{port} never accepted connections")
+
+
 def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
@@ -76,6 +93,7 @@ def test_headless_spawn_writes_runtime_and_serves_health(headless_home, tmp_path
     try:
         runtime = headless_home / ".vireo" / "runtime.json"
         data = _wait_for_runtime(runtime)
+        _wait_for_port(port)
         assert data["port"] == port
         assert data["mode"] == "headless"
         assert data["pid"] == proc.pid
@@ -102,6 +120,7 @@ def test_second_spawn_refuses_with_already_running(headless_home, tmp_path):
     try:
         runtime = headless_home / ".vireo" / "runtime.json"
         _wait_for_runtime(runtime)
+        _wait_for_port(first_port)
 
         second_port = _free_port()
         second = _spawn(headless_home, db, second_port)
@@ -181,6 +200,7 @@ def test_shutdown_endpoint_removes_runtime_json(headless_home, tmp_path):
     try:
         runtime = headless_home / ".vireo" / "runtime.json"
         data = _wait_for_runtime(runtime)
+        _wait_for_port(port)
 
         req = urllib.request.Request(
             f"http://127.0.0.1:{port}/api/v1/shutdown",

--- a/vireo/testing/userfirst/scenarios/browse_multiselect.py
+++ b/vireo/testing/userfirst/scenarios/browse_multiselect.py
@@ -27,15 +27,19 @@ def run(session):
     if len(ids) < 3:
         return
 
-    # Normal-click the first card, Ctrl-click the next two. On the first
-    # Ctrl-click the handler folds the focused photo into selectedPhotos, so
+    # Normal-click the first card, Cmd-click the next two. On the first
+    # Cmd-click the handler folds the focused photo into selectedPhotos, so
     # the Set ends up containing all three ids.
+    # Use Meta (Cmd) rather than Control: on macOS Ctrl+click is intercepted
+    # by the OS as a right-click and opens the context menu instead of
+    # dispatching a multi-select click. The JS handler accepts metaKey OR
+    # ctrlKey, so Meta works on all platforms.
     session.page.click(f'.grid-card[data-id="{ids[0]}"]')
     session.page.click(
-        f'.grid-card[data-id="{ids[1]}"]', modifiers=["Control"]
+        f'.grid-card[data-id="{ids[1]}"]', modifiers=["Meta"]
     )
     session.page.click(
-        f'.grid-card[data-id="{ids[2]}"]', modifiers=["Control"]
+        f'.grid-card[data-id="{ids[2]}"]', modifiers=["Meta"]
     )
     session.screenshot("after-multiselect")
 

--- a/vireo/testing/userfirst/seeds.py
+++ b/vireo/testing/userfirst/seeds.py
@@ -23,6 +23,32 @@ def _make_thumb(thumb_dir, photo_id):
         Image.new("RGB", (100, 100), color=(80, 120, 80)).save(path)
 
 
+def _make_source_jpeg(folder_path, filename, photo_id):
+    """Write a small placeholder JPEG at folder_path/filename so that
+    /photos/<id>/full and /photos/<id>/original can serve it instead
+    of returning 500 on cache miss.
+
+    Skips when folder_path is the synthetic /test/photos fallback used
+    in headless CI, where the directory isn't writable.
+    """
+    from PIL import Image
+
+    if not folder_path or folder_path.startswith("/test/"):
+        return
+    if not filename.lower().endswith((".jpg", ".jpeg")):
+        # RAW formats (.nef etc.) — load_image needs a different
+        # decoder, so leave them missing rather than write a fake .nef.
+        return
+    os.makedirs(folder_path, exist_ok=True)
+    path = os.path.join(folder_path, filename)
+    if os.path.exists(path):
+        return
+    # A unique-ish color per photo so the lightbox Next/Prev visibly
+    # advances even though pixels aren't meaningful.
+    color = ((photo_id * 37) % 255, (photo_id * 53) % 255, (photo_id * 89) % 255)
+    Image.new("RGB", (640, 480), color=color).save(path, "JPEG", quality=70)
+
+
 def browse_seed(db_path, thumb_dir, photos_root):
     """Minimal seed: workspace, 3 folders, ~10 photos with keywords and ratings.
 
@@ -43,6 +69,12 @@ def browse_seed(db_path, thumb_dir, photos_root):
     f3 = db.add_folder(
         os.path.join(base, "wildlife", "birds"), name="birds", parent_id=f1
     )
+
+    folder_paths = {
+        f1: os.path.join(base, "wildlife"),
+        f2: os.path.join(base, "landscapes"),
+        f3: os.path.join(base, "wildlife", "birds"),
+    }
 
     photos = []
     specs = [
@@ -69,6 +101,7 @@ def browse_seed(db_path, thumb_dir, photos_root):
             timestamp=ts,
         )
         photos.append(pid)
+        _make_source_jpeg(folder_paths[folder_id], fname, pid)
         if rating:
             db.update_photo_rating(pid, rating)
         if flag:

--- a/vireo/tests/conftest.py
+++ b/vireo/tests/conftest.py
@@ -20,9 +20,20 @@ def app_and_db(tmp_path, monkeypatch):
     from db import Database
     monkeypatch.setenv("HOME", str(tmp_path))
     import config as cfg
+    import models
     from app import create_app
 
-    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    # `models.DEFAULT_MODELS_DIR` and `models.CONFIG_PATH` are resolved
+    # at import time from the real `~`. Redirect them so tests don't see
+    # the developer's locally-downloaded weights and don't write to the
+    # real `~/.vireo/models.json`.
+    monkeypatch.setattr(
+        models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"),
+    )
+    monkeypatch.setattr(
+        models, "CONFIG_PATH", str(tmp_path / "models.json"),
+    )
 
     db_path = str(tmp_path / "test.db")
     thumb_dir = str(tmp_path / "thumbs")
@@ -65,10 +76,17 @@ def client_with_photo(tmp_path, monkeypatch):
     """
     monkeypatch.setenv("HOME", str(tmp_path))
     import config as cfg
+    import models
     from app import create_app
     from db import Database
 
-    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(
+        models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"),
+    )
+    monkeypatch.setattr(
+        models, "CONFIG_PATH", str(tmp_path / "models.json"),
+    )
 
     photos_dir = tmp_path / "photos"
     photos_dir.mkdir()

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -106,13 +106,10 @@ def test_get_models_no_downloads(tmp_path, monkeypatch):
     import models
 
     monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
-    # Stub os.path.exists within models so the legacy /tmp path check
-    # doesn't leak host filesystem state into the test.
-    _real_exists = os.path.exists
-    monkeypatch.setattr(
-        os.path, "exists",
-        lambda p: _real_exists(p) if p.startswith(str(tmp_path)) else False,
-    )
+    # Redirect DEFAULT_MODELS_DIR to an empty tmp dir so a developer's
+    # locally-downloaded weights in ~/.vireo/models don't make this test
+    # report models as already-downloaded.
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
     result = models.get_models()
     assert len(result) >= len(models.KNOWN_MODELS)
     for m in result:
@@ -181,6 +178,7 @@ def test_get_active_model_none(tmp_path, monkeypatch):
     import models
 
     monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
     assert models.get_active_model() is None
 
 


### PR DESCRIPTION
Fixes #647.

## Summary

Six tests called out in #647 were either crashing pytest collection, leaking state into later tests, or racing subprocess startup. Each is fixed at the root cause:

- **`vireo/tests/test_models.py::test_get_models_no_downloads`** — INTERNALERROR on `PosixPath.startswith`. The `os.path.exists` monkeypatch was also wrong: `_classify_model_state` uses `os.path.isdir`/`isfile`, never `exists`. Drop the broken patch and redirect `models.DEFAULT_MODELS_DIR` to `tmp_path` instead. Now passes on any dev machine regardless of which models are downloaded locally.
- **`vireo/tests/test_welcome.py::test_welcome_page_renders`** + **`vireo/tests/test_jobs_api.py::test_pipeline_auto_skips_classify_when_no_model`** — 302 / missing-`model_warning` from a developer's real `~/.vireo/models` leaking into the test app. The `app_and_db` fixture set `HOME=tmp_path` but `models.DEFAULT_MODELS_DIR` and `models.CONFIG_PATH` are resolved at module-import time. Switch the fixture to `monkeypatch.setattr` for those module attrs.
- **`vireo/tests/test_userfirst_scenarios.py::test_browse_multiselect_shortcut_regression`** — on macOS, Playwright's `modifiers=["Control"]` triggers a secondary-click and opens the context menu instead of multi-selecting. The browse handler accepts `metaKey || ctrlKey`, so the scenario now uses `Meta`.
- **`vireo/tests/test_userfirst_scenarios.py::test_browse_lightbox_arrows_regression`** — HTTP 500 on `/photos/N/full` because the seed only wrote DB rows, not on-disk JPEGs. Seed now writes 640×480 placeholder JPEGs at the photo paths.
- **`tests/test_headless_integration.py::test_shutdown_endpoint_removes_runtime_json`** — ECONNREFUSED race: `runtime.json` is written before Flask binds the port. Add `_wait_for_port` that polls TCP connect after `_wait_for_runtime`, applied to all three tests in the file that issue HTTP requests.

## Out of scope

`vireo/tests/test_userfirst_scenarios.py::test_misses_scenario` also fails (on main as well) due to a `Database.save_detections()` signature mismatch — that's a separate seed-vs-API drift, not part of #647.

## Test plan

- [x] `python -m pytest vireo/tests/test_models.py -v` → 49 passed
- [x] `python -m pytest vireo/tests/test_welcome.py vireo/tests/test_jobs_api.py -v` → 67 passed
- [x] `python -m pytest tests/test_headless_integration.py -v` → 4 passed
- [x] `python -m pytest vireo/tests/test_userfirst_scenarios.py::test_browse_multiselect_shortcut_regression vireo/tests/test_userfirst_scenarios.py::test_browse_lightbox_arrows_regression -v` → 2 passed
- [x] Targeted full-suite run of all affected files: 132 passed (excluding the unrelated `test_misses_scenario`)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)