### PR TITLE
feat(storage): per-model photo_embeddings table (Phase 1)

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6798,16 +6798,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # species rows alongside current ones, distorting cluster
         # membership / counts / variant labels and duplicating the same
         # photo embedding.
+        # The embedding used for clustering must come from the same model
+        # that produced the species prediction — otherwise we'd cluster
+        # vectors from different model spaces against each other. The JOIN
+        # against photo_embeddings on (photo_id, model) enforces that and
+        # implicitly drops rows whose model has no cached embedding.
         rows = db.conn.execute(
-            """SELECT d.photo_id, p.embedding, p.filename, p.thumb_path,
+            """SELECT d.photo_id, pe.embedding, p.filename, p.thumb_path,
                       pr.confidence, pr.taxonomy_order, pr.taxonomy_family
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
                JOIN photos p ON p.id = d.photo_id
                JOIN workspace_folders wf
                  ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+               JOIN photo_embeddings pe
+                 ON pe.photo_id = d.photo_id
+                AND pe.model = pr.classifier_model
+                AND pe.variant = ''
                WHERE pr.species = ?
-                 AND p.embedding IS NOT NULL
                  AND d.detector_confidence >= ?
                  AND pr.labels_fingerprint = (
                     SELECT pr2.labels_fingerprint FROM predictions pr2
@@ -8249,7 +8257,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             "reason": "model_no_text_search"})
 
         # Load embeddings for current model
-        emb_pairs = db.get_embeddings_by_model(model_name)
+        emb_pairs = db.get_photos_with_embedding(model_name)
         if not emb_pairs:
             return jsonify({"results": [], "total_matches": 0, "model_used": model_name,
                             "reason": "no_embeddings"})
@@ -8307,22 +8315,33 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         limit = min(max(1, request.args.get("limit", 20, type=int)), 1000)
 
-        # Get the source photo's embedding
-        source = db.conn.execute(
-            "SELECT embedding FROM photos WHERE id = ?", (photo_id,)
-        ).fetchone()
-        if not source or not source["embedding"]:
-            return json_error("No embedding for this photo — run classification first")
+        # Compare against the active classifier's embedding. The per-model
+        # cache means a photo classified under BioCLIP-2 cannot be compared
+        # to one classified under BioCLIP-3 — that mixing is exactly what
+        # Phase 1 of the storage philosophy refactor stops.
+        from models import get_active_model
+        active_model = get_active_model()
+        if not active_model:
+            return json_error("No active classifier configured")
+        model_name = active_model["name"]
+        if active_model.get("model_type", "bioclip") == "timm":
+            return json_error("Active classifier does not produce embeddings")
 
-        source_emb = np.frombuffer(source["embedding"], dtype=np.float32)
+        source_blob = db.get_photo_embedding(photo_id, model_name)
+        if not source_blob:
+            return json_error(
+                f"No {model_name} embedding for this photo — "
+                "run classification first"
+            )
+        source_emb = np.frombuffer(source_blob, dtype=np.float32)
 
-        # Load all embeddings (excluding source photo)
-        rows = db.conn.execute(
-            """SELECT p.id, p.embedding FROM photos p
-            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            WHERE p.embedding IS NOT NULL AND p.id != ? AND wf.workspace_id = ?""",
-            (photo_id, db._active_workspace_id),
-        ).fetchall()
+        # Load all workspace embeddings for the same model, then drop the
+        # source photo before stacking.
+        rows = [
+            (pid, blob)
+            for pid, blob in db.get_photos_with_embedding(model_name)
+            if pid != photo_id
+        ]
 
         if not rows:
             return jsonify({"similar": [], "total_compared": 0})
@@ -8330,9 +8349,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Compute cosine similarities (embeddings are already normalized)
         photo_ids = []
         embeddings = []
-        for row in rows:
-            photo_ids.append(row["id"])
-            embeddings.append(np.frombuffer(row["embedding"], dtype=np.float32))
+        for pid, blob in rows:
+            photo_ids.append(pid)
+            embeddings.append(np.frombuffer(blob, dtype=np.float32))
 
         emb_matrix = np.stack(embeddings)
         similarities = emb_matrix @ source_emb

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6788,21 +6788,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         distance_threshold = request.args.get("threshold", 0.4, type=float)
 
+        # Cluster within a single classifier model. A workspace whose
+        # detections were classified under both BioCLIP-2 and BioCLIP-3
+        # would otherwise emit one prediction row per model, double-count
+        # the photo, and cluster vectors from incompatible model spaces.
+        from models import get_active_model
+        active_model = get_active_model()
+        if not active_model or active_model.get("model_type", "bioclip") == "timm":
+            return jsonify({
+                "species": species_name,
+                "clusters": [],
+                "total_photos": 0,
+            })
+        classifier_model = active_model["name"]
+
         # Find all photos with this species prediction in the active
         # workspace. Predictions are global but membership in the
         # workspace is expressed through workspace_folders.
         #
-        # Fingerprint filter: for each (detection, classifier_model) only
-        # surface rows from the most recent labels_fingerprint. Without
-        # this, a workspace that rotated label sets would cluster stale
-        # species rows alongside current ones, distorting cluster
-        # membership / counts / variant labels and duplicating the same
-        # photo embedding.
-        # The embedding used for clustering must come from the same model
-        # that produced the species prediction — otherwise we'd cluster
-        # vectors from different model spaces against each other. The JOIN
-        # against photo_embeddings on (photo_id, model) enforces that and
-        # implicitly drops rows whose model has no cached embedding.
+        # Fingerprint filter: for the chosen classifier_model surface only
+        # rows from the most recent labels_fingerprint. Without this, a
+        # workspace that rotated label sets would cluster stale species
+        # rows alongside current ones, distorting cluster membership /
+        # counts / variant labels and duplicating the same photo embedding.
         rows = db.conn.execute(
             """SELECT d.photo_id, pe.embedding, p.filename, p.thumb_path,
                       pr.confidence, pr.taxonomy_order, pr.taxonomy_family
@@ -6816,6 +6824,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 AND pe.model = pr.classifier_model
                 AND pe.variant = ''
                WHERE pr.species = ?
+                 AND pr.classifier_model = ?
                  AND d.detector_confidence >= ?
                  AND pr.labels_fingerprint = (
                     SELECT pr2.labels_fingerprint FROM predictions pr2
@@ -6824,7 +6833,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     ORDER BY pr2.created_at DESC, pr2.id DESC
                     LIMIT 1
                  )""",
-            (ws, species_name, min_conf),
+            (ws, species_name, classifier_model, min_conf),
         ).fetchall()
 
         if len(rows) < 2:

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -750,8 +750,8 @@ def _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=1):
             all_preds, embedding = result
 
             if embedding is not None:
-                db.store_photo_embedding(
-                    entry["photo"]["id"], embedding.tobytes(), model=model_name
+                db.upsert_photo_embedding(
+                    entry["photo"]["id"], model_name, embedding.tobytes()
                 )
 
             if not all_preds:
@@ -906,7 +906,9 @@ def _classify_photos(
                             top = cached[0]  # ordered by confidence DESC
                             embedding = None
                             if model_type != "timm":
-                                emb_blob = db.get_photo_embedding(photo["id"])
+                                emb_blob = db.get_photo_embedding(
+                                    photo["id"], model_name,
+                                )
                                 if emb_blob:
                                     import numpy as np
                                     embedding = np.frombuffer(
@@ -1002,7 +1004,9 @@ def _classify_photos(
                                 pass
                         embedding = None
                         if model_type != "timm":
-                            emb_blob = db.get_photo_embedding(photo["id"])
+                            emb_blob = db.get_photo_embedding(
+                                photo["id"], model_name,
+                            )
                             if emb_blob:
                                 import numpy as np
                                 embedding = np.frombuffer(

--- a/vireo/culling.py
+++ b/vireo/culling.py
@@ -78,11 +78,15 @@ def analyze_for_culling(
             "photos_missing_phash": 0,
         }
 
-    # Load predictions (highest confidence per photo via detections)
+    # Load predictions (highest confidence per photo via detections). The
+    # prediction's classifier_model also drives which row in
+    # photo_embeddings we read for that photo — clustering vectors across
+    # model spaces is meaningless, so the photo's embedding must come from
+    # the same model that named its species.
     predictions = {}
     for pid in photo_ids:
         pred = db.conn.execute(
-            """SELECT pr.species, pr.confidence
+            """SELECT pr.species, pr.confidence, pr.classifier_model
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
                WHERE d.photo_id = ?
@@ -93,6 +97,7 @@ def analyze_for_culling(
             predictions[pid] = {
                 "species": pred["species"],
                 "confidence": pred["confidence"],
+                "classifier_model": pred["classifier_model"],
             }
 
     # Load embeddings, quality scores, file extensions, timestamps, phashes, and filenames
@@ -105,11 +110,14 @@ def analyze_for_culling(
     missing_phash = []
     for pid in photo_ids:
         row = db.conn.execute(
-            "SELECT embedding, quality_score, sharpness, subject_sharpness, extension, timestamp, phash, filename FROM photos WHERE id = ?",
+            "SELECT quality_score, sharpness, subject_sharpness, extension, timestamp, phash, filename FROM photos WHERE id = ?",
             (pid,),
         ).fetchone()
-        if row and row["embedding"]:
-            embeddings[pid] = np.frombuffer(row["embedding"], dtype=np.float32)
+        cm = predictions.get(pid, {}).get("classifier_model")
+        if cm:
+            emb_blob = db.get_photo_embedding(pid, cm)
+            if emb_blob:
+                embeddings[pid] = np.frombuffer(emb_blob, dtype=np.float32)
         q = row["quality_score"] or 0 if row else 0
         if q == 0 and row and row["sharpness"]:
             q = row["sharpness"] / 1000.0

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -129,8 +129,6 @@ class Database:
                 subject_sharpness        REAL,
                 subject_size             REAL,
                 quality_score            REAL,
-                embedding                BLOB,
-                embedding_model          TEXT,
                 latitude                 REAL,
                 longitude                REAL,
                 phash                    TEXT,
@@ -271,6 +269,15 @@ class Database:
                 run_at               TEXT DEFAULT (datetime('now')),
                 prediction_count     INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY (detection_id, classifier_model, labels_fingerprint)
+            );
+
+            CREATE TABLE IF NOT EXISTS photo_embeddings (
+                photo_id    INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
+                model       TEXT NOT NULL,
+                variant     TEXT NOT NULL DEFAULT '',
+                embedding   BLOB NOT NULL,
+                created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (photo_id, model, variant)
             );
 
             CREATE TABLE IF NOT EXISTS labels_fingerprints (
@@ -416,6 +423,8 @@ class Database:
                                labels_fingerprint, species);
             CREATE INDEX IF NOT EXISTS idx_classifier_runs_detection
                 ON classifier_runs(detection_id);
+            CREATE INDEX IF NOT EXISTS idx_photo_embeddings_model
+                ON photo_embeddings(model, variant);
             CREATE INDEX IF NOT EXISTS idx_prediction_review_workspace
                 ON prediction_review(workspace_id);
             CREATE INDEX IF NOT EXISTS idx_collections_workspace
@@ -424,6 +433,33 @@ class Database:
                 ON pending_changes(workspace_id);
         """
         )
+        # Phase 1 storage-philosophy migration: classifier embeddings move
+        # from single-slot photos.(embedding, embedding_model) columns into
+        # the per-(photo, model, variant) photo_embeddings table. Rows whose
+        # embedding_model was never recorded have no key in the new schema
+        # and are dropped — they are recomputable from pixels. Truly legacy
+        # databases that pre-date embedding_model fall into the same bucket.
+        try:
+            self.conn.execute("SELECT embedding FROM photos LIMIT 0")
+        except sqlite3.OperationalError:
+            pass
+        else:
+            try:
+                self.conn.execute("SELECT embedding_model FROM photos LIMIT 0")
+                has_embedding_model = True
+            except sqlite3.OperationalError:
+                has_embedding_model = False
+            if has_embedding_model:
+                self.conn.execute(
+                    """INSERT OR IGNORE INTO photo_embeddings
+                           (photo_id, model, variant, embedding)
+                       SELECT id, embedding_model, '', embedding
+                       FROM photos
+                       WHERE embedding IS NOT NULL
+                         AND embedding_model IS NOT NULL"""
+                )
+                self.conn.execute("ALTER TABLE photos DROP COLUMN embedding_model")
+            self.conn.execute("ALTER TABLE photos DROP COLUMN embedding")
         self.conn.commit()
 
     # -- Workspaces --
@@ -1634,7 +1670,7 @@ class Database:
         ("eye", "p.eye_x IS NOT NULL"),
         ("quality", "p.quality_score IS NOT NULL"),
         ("dino_embedding", "p.dino_subject_embedding IS NOT NULL"),
-        ("label_embedding", "p.embedding IS NOT NULL"),
+        ("label_embedding", "EXISTS (SELECT 1 FROM photo_embeddings pe WHERE pe.photo_id = p.id)"),
         ("burst", "p.burst_id IS NOT NULL"),
         ("rating", "p.rating IS NOT NULL AND p.rating > 0"),
     ]
@@ -4003,45 +4039,64 @@ class Database:
             (self._ws_id(), photo_id, model, labels_fingerprint),
         ).fetchone()
 
-    def get_photo_embedding(self, photo_id):
-        """Return the embedding blob for a photo, or None."""
+    def get_photo_embedding(self, photo_id, model, variant=''):
+        """Return the embedding blob for (photo_id, model, variant), or None."""
         row = self.conn.execute(
-            "SELECT embedding FROM photos WHERE id = ?", (photo_id,),
+            "SELECT embedding FROM photo_embeddings "
+            "WHERE photo_id = ? AND model = ? AND variant = ?",
+            (photo_id, model, variant),
         ).fetchone()
         return row["embedding"] if row else None
 
-    def store_photo_embedding(self, photo_id, embedding_bytes, model=None,
-                              verify_workspace=False):
-        """Store an embedding blob for a photo, optionally with model name.
+    def upsert_photo_embedding(self, photo_id, model, embedding_bytes,
+                               variant='', verify_workspace=False):
+        """Store an embedding blob for (photo_id, model, variant).
+
+        Replaces any existing row with the same primary key. ``model`` is
+        required because the storage philosophy keeps a per-model cache; a
+        missing model name has no key in the table.
 
         Args:
             verify_workspace: when True, raises ValueError if the photo is
-                not in the active workspace.  Defaults to False because this
+                not in the active workspace. Defaults to False because this
                 method is typically called from background classify jobs that
                 already iterate only over workspace-scoped photos.
         """
         if verify_workspace:
             self._verify_photo_in_workspace(photo_id)
         self.conn.execute(
-            "UPDATE photos SET embedding = ?, embedding_model = ? WHERE id = ?",
-            (embedding_bytes, model, photo_id),
+            """INSERT INTO photo_embeddings (photo_id, model, variant, embedding)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(photo_id, model, variant)
+               DO UPDATE SET embedding = excluded.embedding,
+                             created_at = datetime('now')""",
+            (photo_id, model, variant, embedding_bytes),
         )
         self.conn.commit()
 
-    def get_embeddings_by_model(self, model_name):
-        """Return (photo_id, embedding_blob) pairs for photos with given model.
+    def get_photos_with_embedding(self, model, variant='', photo_ids=None):
+        """Return (photo_id, embedding_blob) pairs in the active workspace
+        with a stored embedding for ``(model, variant)``.
 
-        Only returns photos in folders visible to the active workspace.
+        Pass ``photo_ids`` to restrict the result to a subset.
         """
-        rows = self.conn.execute(
-            """SELECT p.id, p.embedding FROM photos p
-               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               WHERE p.embedding IS NOT NULL
-                 AND p.embedding_model = ?
-                 AND wf.workspace_id = ?""",
-            (model_name, self._ws_id()),
-        ).fetchall()
-        return [(row["id"], row["embedding"]) for row in rows]
+        ws = self._ws_id()
+        sql = (
+            "SELECT pe.photo_id, pe.embedding FROM photo_embeddings pe "
+            "JOIN photos p ON p.id = pe.photo_id "
+            "JOIN workspace_folders wf "
+            "  ON wf.folder_id = p.folder_id AND wf.workspace_id = ? "
+            "WHERE pe.model = ? AND pe.variant = ?"
+        )
+        params = [ws, model, variant]
+        if photo_ids is not None:
+            if not photo_ids:
+                return []
+            placeholders = ",".join("?" * len(photo_ids))
+            sql += f" AND pe.photo_id IN ({placeholders})"
+            params.extend(photo_ids)
+        rows = self.conn.execute(sql, params).fetchall()
+        return [(row["photo_id"], row["embedding"]) for row in rows]
 
     def update_prediction_group_info(self, detection_id, model, group_id,
                                      vote_count, total_votes, individual,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1942,7 +1942,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     embedding = None
                                     if model_type != "timm":
                                         emb_blob = thread_db.get_photo_embedding(
-                                            photo["id"]
+                                            photo["id"], model_name,
                                         )
                                         if emb_blob:
                                             import numpy as np

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1210,7 +1210,7 @@ def test_classify_photos_new_photo(tmp_path):
     assert raw_results[0]["confidence"] == 0.95
     assert failed == 0
     assert skipped == 0
-    mock_db.store_photo_embedding.assert_called_once()
+    mock_db.upsert_photo_embedding.assert_called_once()
 
 
 def test_classify_photos_skips_existing(tmp_path):

--- a/vireo/tests/test_culling.py
+++ b/vireo/tests/test_culling.py
@@ -505,24 +505,28 @@ def _setup_culling_db(tmp_path, with_embeddings=True):
         db.add_prediction(det_ids[0], "Robin", 0.95, "test-model")
 
     if with_embeddings:
-        # Add similar embeddings for first 3 (they should cluster), different for 4th
+        # Embeddings are keyed on the same classifier_model the predictions
+        # above use, since culling reads photo_embeddings via the top
+        # prediction's classifier_model.
         base_emb = np.random.randn(128).astype(np.float32)
         base_emb /= np.linalg.norm(base_emb)
         for i, pid in enumerate(photo_ids[:3]):
             noise = np.random.randn(128).astype(np.float32) * 0.01
             emb = base_emb + noise
             emb /= np.linalg.norm(emb)
+            db.upsert_photo_embedding(pid, "test-model", emb.tobytes())
             db.conn.execute(
-                "UPDATE photos SET embedding = ?, quality_score = ? WHERE id = ?",
-                (emb.tobytes(), 0.5 + i * 0.1, pid),
+                "UPDATE photos SET quality_score = ? WHERE id = ?",
+                (0.5 + i * 0.1, pid),
             )
         # 4th photo: orthogonal embedding
         diff_emb = np.random.randn(128).astype(np.float32)
         diff_emb -= diff_emb.dot(base_emb) * base_emb  # Gram-Schmidt
         diff_emb /= np.linalg.norm(diff_emb)
+        db.upsert_photo_embedding(photo_ids[3], "test-model", diff_emb.tobytes())
         db.conn.execute(
-            "UPDATE photos SET embedding = ?, quality_score = ? WHERE id = ?",
-            (diff_emb.tobytes(), 0.9, photo_ids[3]),
+            "UPDATE photos SET quality_score = ? WHERE id = ?",
+            (0.9, photo_ids[3]),
         )
 
     db.conn.commit()

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1544,6 +1544,12 @@ def test_species_clusters_endpoint_filters_to_active_fingerprint(tmp_path, monke
     monkeypatch.setenv("HOME", str(tmp_path))
     import config as cfg
     cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    import models
+    monkeypatch.setattr(models, "get_active_model", lambda: {
+        "id": "bioclip-2", "name": "bioclip-2",
+        "model_str": "hf-hub:imageomics/bioclip-2",
+        "model_type": "bioclip", "downloaded": True,
+    })
     from app import create_app
 
     db_path = str(tmp_path / "test.db")
@@ -1589,6 +1595,78 @@ def test_species_clusters_endpoint_filters_to_active_fingerprint(tmp_path, monke
     # not twice (one per fingerprint row).
     assert data["total_photos"] == 1, (
         f"Expected one photo (deduped to current fingerprint), got "
+        f"{data['total_photos']}"
+    )
+
+
+def test_species_clusters_endpoint_filters_to_active_classifier_model(
+    tmp_path, monkeypatch,
+):
+    """/api/species/<name>/clusters must constrain predictions to a single
+    classifier model — otherwise a workspace whose detection has predictions
+    from two models (e.g. BioCLIP-2 and BioCLIP-3) clusters vectors from
+    two different model spaces and shows the same photo twice (one prediction
+    row per model).
+    """
+    import os
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    import models
+    monkeypatch.setattr(models, "get_active_model", lambda: {
+        "id": "bioclip-3", "name": "bioclip-3",
+        "model_str": "hf-hub:imageomics/bioclip-3",
+        "model_type": "bioclip", "downloaded": True,
+    })
+    from app import create_app
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+    from db import Database
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    fid = db.add_folder("/p", name="p")
+    pid = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                       file_size=100, file_mtime=1.0)
+    import numpy as np
+    emb_old = np.zeros(512, dtype=np.float32).tobytes()
+    emb_new = np.ones(512, dtype=np.float32).tobytes()
+    # Same photo has embeddings under both models — exactly the state Phase 1
+    # is meant to support — but /clusters must pick one.
+    db.upsert_photo_embedding(pid, "bioclip-2", emb_old)
+    db.upsert_photo_embedding(pid, "bioclip-3", emb_new)
+    det_id = db.save_detections(pid, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+         "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")[0]
+    # One prediction row per model on the same detection + species.
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-old', 'Robin', 0.95, '2026-01-01')",
+        (det_id,),
+    )
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-3', 'fp-new', 'Robin', 0.80, '2026-04-24')",
+        (det_id,),
+    )
+    db.conn.commit()
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir,
+                     api_token="t")
+    client = app.test_client()
+    resp = client.get("/api/species/Robin/clusters")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # The photo must appear exactly once (filtered to the active classifier
+    # model), not twice (one per classifier model row).
+    assert data["total_photos"] == 1, (
+        f"Expected one photo (filtered to active classifier model), got "
         f"{data['total_photos']}"
     )
 

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1147,13 +1147,15 @@ def test_get_coverage_stats_counts_each_stage(tmp_path):
          'latitude': 10.0, 'longitude': 20.0, 'file_hash': 'h1',
          'working_copy_path': '/wc/1.jpg', 'mask_path': '/m/1.png',
          'subject_tenengrad': 1.5, 'bg_tenengrad': 0.2,
-         'eye_x': 0.5, 'embedding': b'e', 'burst_id': 'b1',
+         'eye_x': 0.5, 'burst_id': 'b1',
          'rating': 4, 'exif_data': '{}',
          'timestamp': '2024-01-01T00:00:00'},
         {'thumb_path': '/t/2.jpg', 'phash': 'def',
          'timestamp': '2024-02-01T00:00:00'},
         {},  # Nothing set
     ])
+    # Classifier embedding lives in photo_embeddings now, not on photos.
+    db.upsert_photo_embedding(pids[0], 'test', b'e')
     # Add a detection + prediction for the first photo only.
     det_ids = db.save_detections(pids[0], [
         {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4},
@@ -1556,10 +1558,9 @@ def test_species_clusters_endpoint_filters_to_active_fingerprint(tmp_path, monke
                        file_size=100, file_mtime=1.0)
     import numpy as np
     emb = np.zeros(512, dtype=np.float32).tobytes()
-    db.conn.execute(
-        "UPDATE photos SET embedding=?, embedding_model='test' WHERE id=?",
-        (emb, pid),
-    )
+    # /clusters joins photo_embeddings on pr.classifier_model, so the cached
+    # embedding must be keyed on the same model the predictions below use.
+    db.upsert_photo_embedding(pid, "bioclip-2", emb)
     det_id = db.save_detections(pid, [
         {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
     ], detector_model="MDV6")[0]
@@ -2089,16 +2090,48 @@ def test_get_prediction_for_photo(tmp_path):
     assert db.get_prediction_for_photo(pids[0], 'other') is None
 
 
-def test_get_and_store_photo_embedding(tmp_path):
-    """Stores and retrieves a photo embedding."""
+def test_get_and_upsert_photo_embedding(tmp_path):
+    """Stores and retrieves a photo embedding keyed on model."""
     db, pids = _make_workspace_with_photos(tmp_path, [{}])
 
-    assert db.get_photo_embedding(pids[0]) is None
+    assert db.get_photo_embedding(pids[0], "BioCLIP") is None
 
-    db.store_photo_embedding(pids[0], b'\x01\x02\x03\x04')
+    db.upsert_photo_embedding(pids[0], "BioCLIP", b'\x01\x02\x03\x04')
 
-    result = db.get_photo_embedding(pids[0])
+    result = db.get_photo_embedding(pids[0], "BioCLIP")
     assert result == b'\x01\x02\x03\x04'
+
+
+def test_upsert_photo_embedding_replaces_same_model(tmp_path):
+    """Upsert with the same (model, variant) overwrites the previous blob."""
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+
+    db.upsert_photo_embedding(pids[0], "BioCLIP", b'\x01\x02')
+    db.upsert_photo_embedding(pids[0], "BioCLIP", b'\x03\x04')
+
+    assert db.get_photo_embedding(pids[0], "BioCLIP") == b'\x03\x04'
+
+
+def test_photo_embeddings_per_model_isolation(tmp_path):
+    """Two models for the same photo coexist; neither overwrites the other."""
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+
+    db.upsert_photo_embedding(pids[0], "BioCLIP", b'\x01')
+    db.upsert_photo_embedding(pids[0], "BioCLIP-2", b'\x02')
+
+    assert db.get_photo_embedding(pids[0], "BioCLIP") == b'\x01'
+    assert db.get_photo_embedding(pids[0], "BioCLIP-2") == b'\x02'
+
+
+def test_photo_embeddings_variant_isolation(tmp_path):
+    """Different variants for the same model coexist."""
+    db, pids = _make_workspace_with_photos(tmp_path, [{}])
+
+    db.upsert_photo_embedding(pids[0], "BioCLIP", b'\xaa', variant='v1')
+    db.upsert_photo_embedding(pids[0], "BioCLIP", b'\xbb', variant='v2')
+
+    assert db.get_photo_embedding(pids[0], "BioCLIP", variant='v1') == b'\xaa'
+    assert db.get_photo_embedding(pids[0], "BioCLIP", variant='v2') == b'\xbb'
 
 
 def test_update_prediction_group_info(tmp_path):
@@ -2605,51 +2638,110 @@ def test_photo_keywords_includes_type(tmp_path):
     assert keywords[0]['type'] == 'general'
 
 
-def test_embedding_model_column_exists(tmp_path):
-    """The photos table has an embedding_model column."""
+def test_photo_embeddings_table_exists(tmp_path):
+    """photo_embeddings table is created on init with the expected columns."""
     from db import Database
     db = Database(str(tmp_path / "test.db"))
-    db.conn.execute("SELECT embedding_model FROM photos LIMIT 0")
+    cols = {row[1] for row in db.conn.execute("PRAGMA table_info(photo_embeddings)")}
+    assert {"photo_id", "model", "variant", "embedding", "created_at"} <= cols
 
 
-def test_store_photo_embedding_with_model(tmp_path):
-    """store_photo_embedding saves model name alongside the embedding."""
+def test_photos_embedding_columns_dropped(tmp_path):
+    """photos.embedding and photos.embedding_model are no longer present."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    cols = {row[1] for row in db.conn.execute("PRAGMA table_info(photos)")}
+    assert "embedding" not in cols
+    assert "embedding_model" not in cols
+
+
+def test_get_photos_with_embedding_filters_by_model(tmp_path):
+    """get_photos_with_embedding returns only workspace photos with matching model."""
     import numpy as np
-    from db import Database
-    db = Database(str(tmp_path / "test.db"))
-    fid = db.conn.execute("INSERT INTO folders (path, name) VALUES ('/tmp', 'tmp')").lastrowid
-    pid = db.conn.execute("INSERT INTO photos (folder_id, filename) VALUES (?, 'a.jpg')", (fid,)).lastrowid
-    db.conn.commit()
-    emb = np.random.randn(512).astype(np.float32)
-    db.store_photo_embedding(pid, emb.tobytes(), model="BioCLIP")
-    row = db.conn.execute("SELECT embedding_model FROM photos WHERE id = ?", (pid,)).fetchone()
-    assert row["embedding_model"] == "BioCLIP"
+    db, pids = _make_workspace_with_photos(tmp_path, [{}, {}, {}])
+    emb1 = np.random.randn(512).astype(np.float32).tobytes()
+    emb2 = np.random.randn(512).astype(np.float32).tobytes()
+    db.upsert_photo_embedding(pids[0], "BioCLIP", emb1)
+    db.upsert_photo_embedding(pids[1], "BioCLIP-2", emb2)
+    # pids[2] has no embedding
 
-
-def test_get_embeddings_by_model(tmp_path):
-    """get_embeddings_by_model returns only photos with matching model."""
-    import numpy as np
-    from db import Database
-    db = Database(str(tmp_path / "test.db"))
-    fid = db.conn.execute("INSERT INTO folders (path, name) VALUES ('/tmp', 'tmp')").lastrowid
-    # Link folder to workspace
-    db.conn.execute(
-        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
-        (db._active_workspace_id, fid),
-    )
-    emb1 = np.random.randn(512).astype(np.float32)
-    emb2 = np.random.randn(512).astype(np.float32)
-    p1 = db.conn.execute("INSERT INTO photos (folder_id, filename) VALUES (?, 'a.jpg')", (fid,)).lastrowid
-    p2 = db.conn.execute("INSERT INTO photos (folder_id, filename) VALUES (?, 'b.jpg')", (fid,)).lastrowid
-    p3 = db.conn.execute("INSERT INTO photos (folder_id, filename) VALUES (?, 'c.jpg')", (fid,)).lastrowid
-    db.store_photo_embedding(p1, emb1.tobytes(), model="BioCLIP")
-    db.store_photo_embedding(p2, emb2.tobytes(), model="BioCLIP-2")
-    # p3 has no embedding
-    db.conn.commit()
-
-    results = db.get_embeddings_by_model("BioCLIP")
+    results = db.get_photos_with_embedding("BioCLIP")
     assert len(results) == 1
-    assert results[0][0] == p1
+    assert results[0][0] == pids[0]
+    assert results[0][1] == emb1
+
+
+def test_get_photos_with_embedding_excludes_other_workspaces(tmp_path):
+    """Only photos in the active workspace are returned."""
+    import numpy as np
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.ensure_default_workspace()
+    ws_b = db.create_workspace("Other")
+    # add_folder auto-links to the active workspace, so switch before each.
+    db.set_active_workspace(ws_a)
+    fid_a = db.add_folder('/a', name='a')
+    db.set_active_workspace(ws_b)
+    fid_b = db.add_folder('/b', name='b')
+    pid_a = db.add_photo(folder_id=fid_a, filename='a.jpg', extension='.jpg',
+                         file_size=1, file_mtime=1.0)
+    pid_b = db.add_photo(folder_id=fid_b, filename='b.jpg', extension='.jpg',
+                         file_size=1, file_mtime=1.0)
+    emb = np.zeros(8, dtype=np.float32).tobytes()
+    db.upsert_photo_embedding(pid_a, "BioCLIP", emb)
+    db.upsert_photo_embedding(pid_b, "BioCLIP", emb)
+
+    db.set_active_workspace(ws_a)
+    results_a = db.get_photos_with_embedding("BioCLIP")
+    assert [r[0] for r in results_a] == [pid_a]
+
+    db.set_active_workspace(ws_b)
+    results_b = db.get_photos_with_embedding("BioCLIP")
+    assert [r[0] for r in results_b] == [pid_b]
+
+
+def test_migration_from_legacy_embedding_columns(tmp_path):
+    """Legacy photos.(embedding, embedding_model) data migrates into photo_embeddings on open."""
+    from db import Database
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    fid = db.add_folder('/photos', name='photos')
+    p_with_model = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                                file_size=1, file_mtime=1.0)
+    p_no_model = db.add_photo(folder_id=fid, filename='b.jpg', extension='.jpg',
+                              file_size=1, file_mtime=1.0)
+
+    # Simulate a pre-Phase-1 database by re-adding the legacy columns and
+    # populating them. Closing+reopening triggers the migration.
+    db.conn.execute("ALTER TABLE photos ADD COLUMN embedding BLOB")
+    db.conn.execute("ALTER TABLE photos ADD COLUMN embedding_model TEXT")
+    db.conn.execute(
+        "UPDATE photos SET embedding=?, embedding_model=? WHERE id=?",
+        (b'\x01\x02\x03', 'BioCLIP', p_with_model),
+    )
+    db.conn.execute(
+        "UPDATE photos SET embedding=?, embedding_model=NULL WHERE id=?",
+        (b'\x04\x05\x06', p_no_model),
+    )
+    # Clear any embeddings already migrated by Database.__init__.
+    db.conn.execute("DELETE FROM photo_embeddings")
+    db.conn.commit()
+    db.conn.close()
+
+    db2 = Database(db_path)
+
+    cols = {row[1] for row in db2.conn.execute("PRAGMA table_info(photos)")}
+    assert "embedding" not in cols
+    assert "embedding_model" not in cols
+
+    rows = db2.conn.execute(
+        "SELECT photo_id, model, embedding FROM photo_embeddings ORDER BY photo_id"
+    ).fetchall()
+    # Only the row with a non-NULL model is migrated; the other is dropped.
+    assert len(rows) == 1
+    assert rows[0]["photo_id"] == p_with_model
+    assert rows[0]["model"] == "BioCLIP"
+    assert rows[0]["embedding"] == b'\x01\x02\x03'
 
 
 # -- Edit history --


### PR DESCRIPTION
## Summary
First phase of the storage-philosophy roadmap from #643. Classifier embeddings move out of the single-slot `photos.(embedding, embedding_model)` columns and into a per-`(photo, model, variant)` `photo_embeddings` table — so running a different model on the same photo no longer overwrites the previous one.

## What changed

**Schema (`vireo/db.py`)**
- New `photo_embeddings(photo_id, model, variant, embedding, created_at)` with PK on the identity tuple and index on `(model, variant)`
- One-shot migration on `Database` open: copies rows with a non-NULL `embedding_model` into the new table, then drops both legacy columns. Rows whose model was never recorded (and truly legacy DBs that predate `embedding_model`) are dropped — embeddings are recomputable from pixels.

**Database helpers**
- New: `upsert_photo_embedding`, `get_photo_embedding(photo_id, model, variant='')`, `get_photos_with_embedding(model, variant='', photo_ids=None)`
- Removed: `store_photo_embedding`, single-arg `get_photo_embedding`, `get_embeddings_by_model`

**API behavior**
- `/api/photos/<id>/similar` now requires the **active classifier's** embedding (was: any embedding). This is the bug the refactor exists to fix — cross-model similarity comparisons were never meaningful.
- `/api/species/<n>/clusters` JOINs `photo_embeddings` on `pe.model = pr.classifier_model` so cluster vectors come from the same model that named the species.
- `/api/photos/search` switched to `get_photos_with_embedding` (workspace-scoped lookup unchanged in semantics).
- Coverage stats predicate switched to `EXISTS` over `photo_embeddings`.

**Out of scope (deferred to later phases per #643's roadmap)**
- DINO features (Phase 2), SAM2 mask (Phase 3), eye points (Phase 4), noise estimate (Phase 5)
- Proxy-column cleanup (Phase 6), `flag` → `photo_review` (Phase 7), XMP writeback (Phase 8), `miss_*` (Phase 9)
- `classifier_runs` skip-set is unchanged

## Test plan
- [x] 783/783 tests pass across the CLAUDE.md test suite (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_classify_job.py vireo/tests/test_pipeline_job.py`)
- [x] New tests cover: table existence, columns dropped, per-model isolation, per-variant isolation, upsert replacement, workspace scoping, migration from rows-with-model, migration from rows-with-NULL-model, migration from truly-legacy DBs without `embedding_model`