### PR TITLE
fix(detect): write detections + detector_runs atomically (#654)

### DIFF
--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -394,13 +394,18 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                 # treats it as "will be retried next pass".
                 continue
 
+            # Persist detection rows and record the detector run atomically —
+            # `write_detection_batch` wraps both writes in one transaction so a
+            # crash between them can't leave a torn state (detections without a
+            # matching detector_runs row, or the reverse for empty scenes).
+            # Failures from `detect_animals` were handled by the ``is None``
+            # early-continue above and must not poison the skip set.
+            det_ids = db.write_detection_batch(
+                photo["id"], "megadetector-v6", detections,
+            )
+
             if detections:
                 detected += 1
-
-                # Store ALL detections in the database
-                det_ids = db.save_detections(
-                    photo["id"], detections, detector_model="megadetector-v6"
-                )
 
                 # Build detection list with database IDs
                 det_list = []
@@ -422,21 +427,6 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                 # pre-run detection rows for this photo rather than leaving them in
                 # place and allowing future non-reclassify runs to reuse them.
                 processed_ids.add(photo["id"])
-            else:
-                # Genuine empty scene (detector ran, produced zero boxes).
-                # Clear any stale rows for this (photo, model) and record
-                # the run below so reruns skip.
-                db.save_detections(
-                    photo["id"], [], detector_model="megadetector-v6"
-                )
-
-            # Record the detector run ONLY for successful outcomes —
-            # boxes-found and real-empty-scene. Failures were handled by
-            # the ``is None`` early-continue above and must not poison
-            # the skip set.
-            db.record_detector_run(
-                photo["id"], "megadetector-v6", box_count=len(detections)
-            )
 
             if detections:
                 # Use highest-confidence detection as primary for quality scoring

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -5143,6 +5143,57 @@ class Database:
         self.conn.commit()
         return ids
 
+    def write_detection_batch(self, photo_id, detector_model, detections):
+        """Atomically replace detections and record the detector_runs row.
+
+        Combines `save_detections` and `record_detector_run` under a single
+        transaction so readers never observe a torn state where one table
+        reflects the new run and the other still reflects the old one.
+        Callers in the detection write path (e.g. `_detect_batch`) should
+        prefer this over invoking the two methods separately.
+
+        Args:
+            photo_id: the photo
+            detector_model: required, e.g. "megadetector-v6"
+            detections: list of dicts {box: {x,y,w,h}, confidence, category}.
+                An empty list records an empty-scene run (box_count=0) and
+                clears any prior detection rows for the same (photo, model).
+        Returns:
+            list of new detection IDs (empty if detections was empty).
+        """
+        if detector_model is None:
+            raise ValueError("detector_model is required")
+        try:
+            self.conn.execute(
+                "DELETE FROM detections WHERE photo_id = ? AND detector_model = ?",
+                (photo_id, detector_model),
+            )
+            ids = []
+            for det in detections:
+                box = det["box"]
+                cur = self.conn.execute(
+                    """INSERT INTO detections
+                         (photo_id, detector_model, box_x, box_y, box_w, box_h,
+                          detector_confidence, category)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (photo_id, detector_model, box["x"], box["y"], box["w"], box["h"],
+                     det["confidence"], det.get("category", "animal")),
+                )
+                ids.append(cur.lastrowid)
+            self.conn.execute(
+                """INSERT INTO detector_runs (photo_id, detector_model, box_count)
+                   VALUES (?, ?, ?)
+                   ON CONFLICT(photo_id, detector_model)
+                   DO UPDATE SET box_count = excluded.box_count,
+                                 run_at = datetime('now')""",
+                (photo_id, detector_model, len(detections)),
+            )
+            self.conn.commit()
+            return ids
+        except Exception:
+            self.conn.rollback()
+            raise
+
     def get_detections(self, photo_id, min_conf=None, detector_model=None):
         """Return all boxes for a photo above `min_conf`, globally.
 

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -191,7 +191,7 @@ def test_detect_subjects_returns_detection_map(tmp_path):
 
     mock_db = MagicMock()
     mock_db.get_existing_detection_photo_ids.return_value = set()
-    mock_db.save_detections.return_value = [101]
+    mock_db.write_detection_batch.return_value = [101]
 
     with patch("classify_job.detect_animals", return_value=[fake_detection]), \
          patch("classify_job.get_primary_detection", return_value=fake_detection), \
@@ -339,7 +339,7 @@ def test_detect_batch_marks_processed_before_quality_scoring(tmp_path):
     """_detect_batch must add photo_id to processed_ids as soon as detection
     rows are committed to the DB, before quality-scoring calls.
 
-    If compute_sharpness or update_photo_quality raises after save_detections,
+    If compute_sharpness or update_photo_quality raises after write_detection_batch,
     the outer except catches the exception and processed_ids.add at the end of
     the per-photo loop body is never reached.  The photo would be missing from
     processed_ids, causing the reclassify purge in pipeline_job to skip
@@ -367,7 +367,7 @@ def test_detect_batch_marks_processed_before_quality_scoring(tmp_path):
     ]
 
     mock_db = MagicMock()
-    mock_db.save_detections.return_value = [42]
+    mock_db.write_detection_batch.return_value = [42]
 
     # quality scoring raises — simulates compute_sharpness or
     # update_photo_quality failing after the detection row is already saved.
@@ -388,11 +388,11 @@ def test_detect_batch_marks_processed_before_quality_scoring(tmp_path):
         )
 
     # The detection was saved to the DB before quality scoring raised.
-    mock_db.save_detections.assert_called_once()
+    mock_db.write_detection_batch.assert_called_once()
     # photo 7 must be in processed_ids even though quality scoring raised, so
     # the reclassify purge correctly removes its stale pre-run detection rows.
     assert 7 in processed_ids, (
-        "photo_id must be in processed_ids after save_detections even when "
+        "photo_id must be in processed_ids after write_detection_batch even when "
         "quality-scoring raises — regression for Codex P2 on #513 line 315"
     )
     # detection_map should still contain the result from this run
@@ -508,7 +508,7 @@ def test_detect_batch_returns_all_detections(tmp_path):
     ]
 
     mock_db = MagicMock()
-    mock_db.save_detections.return_value = [101, 102]
+    mock_db.write_detection_batch.return_value = [101, 102]
 
     with patch("classify_job.detect_animals", return_value=fake_detections), \
          patch("classify_job.get_primary_detection", return_value=fake_detections[0]), \
@@ -531,7 +531,7 @@ def test_detect_batch_returns_all_detections(tmp_path):
     assert detection_map[1][0]["box_x"] == 0.1
     assert detection_map[1][1]["id"] == 102
     assert detection_map[1][1]["box_x"] == 0.5
-    mock_db.save_detections.assert_called_once()
+    mock_db.write_detection_batch.assert_called_once()
 
 
 def test_detect_batch_skips_empty_photo_on_rerun(tmp_path, monkeypatch):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3801,6 +3801,147 @@ def test_get_detector_run_photo_ids_excludes_torn_state(tmp_path):
     assert ok in result, "consistent cached runs must stay cached"
 
 
+def test_write_detection_batch_is_atomic_under_commit_failure(tmp_path):
+    """If commit raises during write_detection_batch, neither detections nor
+    detector_runs may hold partial state. Both inserts must commit together
+    or not at all — the contract that prevents the torn writes described in
+    issue #654 (detections without a matching detector_runs row, or vice
+    versa for empty scenes).
+    """
+    import pytest
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+
+    detections = [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+         "confidence": 0.9, "category": "animal"},
+    ]
+
+    # sqlite3.Connection.commit is read-only at the C level, so we wrap the
+    # connection with a thin proxy whose commit() raises. Everything else
+    # delegates to the real connection so the helper's INSERTs still hit
+    # the underlying DB.
+    real_conn = db.conn
+
+    class FailingCommitConn:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def commit(self):
+            raise RuntimeError("simulated commit failure")
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    db.conn = FailingCommitConn(real_conn)
+    try:
+        with pytest.raises(RuntimeError, match="simulated commit failure"):
+            db.write_detection_batch(
+                photo_id, "megadetector-v6", detections,
+            )
+    finally:
+        db.conn = real_conn
+
+    # If the helper did not roll back, an in-progress transaction is still
+    # holding the half-written state. Attempting a commit here would expose
+    # any leaked rows below.
+    import contextlib
+    with contextlib.suppress(Exception):
+        db.conn.commit()
+
+    det_count = db.conn.execute(
+        "SELECT COUNT(*) AS c FROM detections WHERE photo_id = ?",
+        (photo_id,),
+    ).fetchone()["c"]
+    run_count = db.conn.execute(
+        "SELECT COUNT(*) AS c FROM detector_runs WHERE photo_id = ?",
+        (photo_id,),
+    ).fetchone()["c"]
+
+    assert det_count == 0, (
+        f"detections must roll back when commit fails; got {det_count} rows"
+    )
+    assert run_count == 0, (
+        f"detector_runs must roll back when commit fails; got {run_count} rows"
+    )
+
+
+def test_write_detection_batch_writes_both_tables_atomically(tmp_path):
+    """Successful write_detection_batch persists detection rows + the matching
+    detector_runs row, returns the new detection IDs, and box_count reflects
+    the number of detections written.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+
+    detections = [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+         "confidence": 0.9, "category": "animal"},
+        {"box": {"x": 0.4, "y": 0.4, "w": 0.2, "h": 0.2},
+         "confidence": 0.7, "category": "animal"},
+    ]
+    ids = db.write_detection_batch(photo_id, "megadetector-v6", detections)
+    assert len(ids) == 2
+
+    rows = db.conn.execute(
+        "SELECT id FROM detections WHERE photo_id = ? AND detector_model = ?",
+        (photo_id, "megadetector-v6"),
+    ).fetchall()
+    assert {r["id"] for r in rows} == set(ids)
+
+    run = db.conn.execute(
+        "SELECT box_count FROM detector_runs WHERE photo_id = ? AND detector_model = ?",
+        (photo_id, "megadetector-v6"),
+    ).fetchone()
+    assert run is not None, "detector_runs row must exist after batch write"
+    assert run["box_count"] == 2
+
+
+def test_write_detection_batch_records_empty_scene(tmp_path):
+    """Empty detections must still write a detector_runs row with box_count=0
+    so future passes skip the photo as a known empty scene.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+
+    ids = db.write_detection_batch(photo_id, "megadetector-v6", [])
+    assert ids == []
+    run = db.conn.execute(
+        "SELECT box_count FROM detector_runs WHERE photo_id = ? AND detector_model = ?",
+        (photo_id, "megadetector-v6"),
+    ).fetchone()
+    assert run is not None
+    assert run["box_count"] == 0
+    assert photo_id in db.get_detector_run_photo_ids("megadetector-v6")
+
+
 def test_multiple_predictions_per_detection(tmp_path):
     """Multiple species predictions can be stored for the same detection."""
     from db import Database


### PR DESCRIPTION
## Summary

Closes #654.

The detection write path in \`vireo/classify_job.py:_detect_batch\` called \`db.save_detections()\` and \`db.record_detector_run()\` back-to-back, each ending with its own \`commit()\`. Between the two commits a reader could observe one table's new state without the other's — the contract *"if a detector_runs row exists, the matching detections were written together"* only held probabilistically. The torn-state filter in \`get_detector_run_photo_ids\` papered over the gap, but the underlying invariant was leaky.

This change:
- Adds \`db.write_detection_batch(photo_id, detector_model, detections)\` which does the DELETE+INSERT of \`detections\` and the UPSERT of \`detector_runs\` inside a single transaction, with rollback-on-exception.
- Switches \`_detect_batch\` to call the unified helper for both the boxes-found and real-empty-scene branches (the boxes path's \`save_detections\` + the empty path's \`save_detections([])\` + the shared \`record_detector_run\` all collapse into one call per photo).
- Leaves \`save_detections\` and \`record_detector_run\` as-is for callers that only write one side (full-image synthetic detections in \`_classify_photos\`, scanner seeds, tests that just need a detection row, etc.).

## Tests

Three new tests in \`vireo/tests/test_db.py\`:
- \`test_write_detection_batch_is_atomic_under_commit_failure\` — wraps the connection so \`commit()\` raises; asserts both tables remain empty (rolled back together). I verified this fails when the helper omits the rollback.
- \`test_write_detection_batch_writes_both_tables_atomically\` — happy path: both detection rows and the matching detector_runs row are persisted with the right \`box_count\`.
- \`test_write_detection_batch_records_empty_scene\` — empty detections still record a \`box_count=0\` run that \`get_detector_run_photo_ids\` will surface as cached.

## Test plan
- [x] \`python -m pytest vireo/tests/test_db.py vireo/tests/test_classify_job.py\` — 318 passed.
- [x] Primary suite from CLAUDE.md (\`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py\`) plus \`test_classify_job.py\` and \`test_pipeline_job.py\` — 780 passed, 1 unrelated flaky failure (\`test_pipeline_auto_skips_classify_when_no_model\` — passes when run in isolation; fails only under specific test orderings due to global config state from earlier tests; this code path is untouched by the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)