### PR TITLE
fix(test): update burst-group seed helper to current schema

### DIFF
--- a/tests/e2e/test_burst_group_context_menu.py
+++ b/tests/e2e/test_burst_group_context_menu.py
@@ -6,11 +6,13 @@ def _seed_burst_group(db, group_id="grp-test-1", model="test-classifier"):
     """Promote the fixture's three hawk predictions into a single burst group.
 
     ``seed_e2e_data`` in conftest.py creates three hawk photos with one
-    prediction each (species=Red-tailed Hawk, model=test-classifier). By
-    setting a shared ``group_id`` on those prediction rows and giving each
-    photo a non-null ``quality_score``, the /review page renders a single
-    group card whose button (``button[data-group-id]``) opens the burst
-    modal via ``openGroupReview``.
+    prediction each (species=Red-tailed Hawk, classifier_model=test-classifier).
+    Group state (``group_id``, ``vote_count``, ``total_votes``) lives in the
+    workspace-scoped ``prediction_review`` table, so we upsert one row per
+    prediction in the active workspace. Setting a non-null ``quality_score``
+    on each photo is what makes the /review page render a group card whose
+    button (``button[data-group-id]``) opens the burst modal via
+    ``openGroupReview``.
 
     Returns the number of predictions that joined the group (usually 3).
     """
@@ -19,19 +21,24 @@ def _seed_burst_group(db, group_id="grp-test-1", model="test-classifier"):
              FROM predictions pr
              JOIN detections d ON d.id = pr.detection_id
             WHERE pr.species = 'Red-tailed Hawk'
-              AND pr.model = ?
-              AND pr.status != 'alternative'""",
+              AND pr.classifier_model = ?""",
         (model,),
     ).fetchall()
     if not rows:
         return 0
     total = len(rows)
+    ws_id = db._active_workspace_id
     for i, row in enumerate(rows):
         db.conn.execute(
-            """UPDATE predictions
-                  SET group_id = ?, vote_count = ?, total_votes = ?
-                WHERE id = ?""",
-            (group_id, total, total, row["id"]),
+            """INSERT INTO prediction_review
+                 (prediction_id, workspace_id, status,
+                  group_id, vote_count, total_votes)
+               VALUES (?, ?, 'pending', ?, ?, ?)
+               ON CONFLICT(prediction_id, workspace_id)
+               DO UPDATE SET group_id    = excluded.group_id,
+                             vote_count  = excluded.vote_count,
+                             total_votes = excluded.total_votes""",
+            (row["id"], ws_id, group_id, total, total),
         )
         # Give each photo a different quality score so the modal has a
         # deterministic AI-best pick.


### PR DESCRIPTION
## Summary

The four `test_burst_group_context_menu.py` tests fail at setup with `sqlite3.OperationalError: no such column: pr.model`. The `_seed_burst_group` helper queries `predictions.model` and writes `group_id`/`vote_count`/`total_votes` directly on the predictions table — both pre-date the workspace-scoped review refactor:

- `predictions.model` → `predictions.classifier_model`
- `predictions.{status,group_id,vote_count,total_votes}` → `prediction_review` (keyed on workspace)

Updated the helper to use `classifier_model` and upsert one `prediction_review` row per prediction in the active workspace. Dropped the `pr.status != 'alternative'` filter — the seed has no `prediction_review` rows yet, so the filter was a no-op pre-refactor and removing it preserves intent.

## Test plan

- [x] `pytest tests/e2e/test_burst_group_context_menu.py -v` — 5/5 pass (was 4 failing)
- [x] `pytest tests/e2e/ -q` — 106 passed, 1 pre-existing skip
- [x] Pure test-file change; no production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)