### PR TITLE
fix(classifier): self-heal stale BioCLIP text encoder via Repair flow

### DIFF
--- a/vireo/classifier.py
+++ b/vireo/classifier.py
@@ -215,27 +215,48 @@ def _normalize(vec):
     return vec / norm
 
 
+def _looks_like_stale_batched_export(err):
+    """Heuristic: does this exception match the BioCLIP stale-export
+    Reshape failure?
+
+    Old BioCLIP ONNX exports baked batch=1 into a Reshape node named
+    ``gemm_input_reshape``. ONNXRuntime surfaces the failure as
+    ``Reshape node Name:'gemm_input_reshape' ... input_shape_size == size
+    was false`` whenever batch>1. The node name is the discriminator:
+    matching only on "Reshape" would also flag unrelated reshape failures
+    in healthy installs and write a sentinel that locks them out of
+    inference until a forced re-download.
+    """
+    msg = str(err)
+    return "gemm_input_reshape" in msg
+
+
 def _run_text_batched(text_session, text_input_name, tokens, model_dir=None):
     """Run the text encoder on a (N, seq_len) token batch.
 
     Vireo's text encoder ONNX exports are batch-agnostic (see
     ``scripts/export_onnx.py:_TextEncoderWrapper``). If a session rejects a
-    batched input, the model file is from an older export with a hardcoded
-    batch dimension. We write the standard ``.verify_failed`` sentinel into
-    ``model_dir`` so Settings → Models flips the install to "incomplete"
-    and surfaces the existing Repair button — the same self-heal flow used
-    for hash-mismatch corruption — and raise the same incomplete-model
-    error the pipeline uses elsewhere.
+    batched input with the stale-export Reshape signature, write the
+    standard ``.verify_failed`` sentinel into ``model_dir`` so Settings →
+    Models flips the install to "incomplete" and surfaces the existing
+    Repair button — the same self-heal flow used for hash-mismatch
+    corruption.
 
     The pinned-revision verifier can't catch this on its own: the user's
     on-disk bytes legitimately match the upstream commit they were
     downloaded from, so SHA256 verification passes even though the export
     is broken. Detection has to happen at inference, repair has to happen
     through Settings.
+
+    Other inference failures (memory pressure, provider glitches, mmap
+    races) are passed through unchanged so a transient runtime error
+    can't permanently flag a healthy install for Repair.
     """
     try:
         return text_session.run(None, {text_input_name: tokens})[0]
     except Exception as e:
+        if not _looks_like_stale_batched_export(e):
+            raise
         if model_dir:
             import model_verify
             sentinel = os.path.join(

--- a/vireo/classifier.py
+++ b/vireo/classifier.py
@@ -215,28 +215,55 @@ def _normalize(vec):
     return vec / norm
 
 
-def _run_text_batched(text_session, text_input_name, tokens):
+def _run_text_batched(text_session, text_input_name, tokens, model_dir=None):
     """Run the text encoder on a (N, seq_len) token batch.
 
     Vireo's text encoder ONNX exports are batch-agnostic (see
     ``scripts/export_onnx.py:_TextEncoderWrapper``). If a session rejects a
     batched input, the model file is from an older export with a hardcoded
-    batch dimension — fail loudly so the user re-downloads via the Models
-    page rather than silently falling back to a 50× slower per-row path.
+    batch dimension. We write the standard ``.verify_failed`` sentinel into
+    ``model_dir`` so Settings → Models flips the install to "incomplete"
+    and surfaces the existing Repair button — the same self-heal flow used
+    for hash-mismatch corruption — and raise the same incomplete-model
+    error the pipeline uses elsewhere.
+
+    The pinned-revision verifier can't catch this on its own: the user's
+    on-disk bytes legitimately match the upstream commit they were
+    downloaded from, so SHA256 verification passes even though the export
+    is broken. Detection has to happen at inference, repair has to happen
+    through Settings.
     """
     try:
         return text_session.run(None, {text_input_name: tokens})[0]
     except Exception as e:
+        if model_dir:
+            import model_verify
+            sentinel = os.path.join(
+                model_dir, model_verify.VERIFY_FAILED_SENTINEL
+            )
+            try:
+                with open(sentinel, "w") as f:
+                    f.write(
+                        "stale-export: text encoder rejected batched input "
+                        f"(underlying: {type(e).__name__}: {e})\n"
+                    )
+            except OSError:
+                pass
         raise RuntimeError(
-            "Text encoder ONNX rejected batched input — the local model "
-            "file is from a stale export with a hardcoded batch dimension. "
-            "Re-download the model from the Models page in Settings. "
+            "Text encoder is from a stale export with a hardcoded batch "
+            "dimension. Open Settings → Models and click Repair to "
+            "re-download the model. "
             f"Underlying error: {type(e).__name__}: {e}"
         ) from e
 
 
 def _compute_embeddings_with_progress(
-    text_session, text_input_name, tokenizer, labels, progress_callback=None
+    text_session,
+    text_input_name,
+    tokenizer,
+    labels,
+    progress_callback=None,
+    model_dir=None,
 ):
     """Compute text embeddings for labels with progress logging.
 
@@ -263,7 +290,9 @@ def _compute_embeddings_with_progress(
     for i, classname in enumerate(labels):
         txts = [template(classname) for template in OPENAI_IMAGENET_TEMPLATE]
         tokens = _tokenize(tokenizer, txts)
-        txt_features = _run_text_batched(text_session, text_input_name, tokens)
+        txt_features = _run_text_batched(
+            text_session, text_input_name, tokens, model_dir=model_dir
+        )
         txt_features = txt_features.astype(np.float32)
         # Normalize each template's output, then average
         txt_features = _normalize(txt_features)
@@ -485,6 +514,7 @@ class Classifier:
                         tokenizer,
                         self._classes,
                         progress_callback=embedding_progress_callback,
+                        model_dir=self._model_dir,
                     )
                 finally:
                     del text_session

--- a/vireo/tests/test_classifier.py
+++ b/vireo/tests/test_classifier.py
@@ -480,13 +480,23 @@ class TestTextEncoderBatchRejection:
         session.run = fake_run
         return session
 
-    def test_raises_clear_error_when_batch_rejected(self, tmp_path):
-        """A stale text encoder ONNX must surface a re-download instruction
-        rather than silently falling back to slow per-row inference."""
+    def test_batch_rejection_writes_verify_failed_sentinel(self, tmp_path):
+        """A stale text encoder ONNX must self-heal via the existing Repair
+        flow: write `.verify_failed` into the model dir so Settings → Models
+        flips the install to 'incomplete' and surfaces the Repair button.
+
+        Without the sentinel, the install keeps passing pinned-revision
+        verification (because the user's bytes still match the old upstream
+        commit they were downloaded from), so Settings shows the model as
+        healthy while every pipeline run blows up at inference. The sentinel
+        bridges that gap: detection happens at runtime, repair happens via
+        the same Settings flow used for any other corruption case.
+        """
+        import model_verify
         import pytest
         from classifier import Classifier
 
-        _make_model_dir(tmp_path)
+        model_dir = _make_model_dir(tmp_path)
         fake_image_session = _make_fake_image_session()
         fake_text_session = self._make_batch1_only_text_session()
         fake_tokenizer = _make_fake_tokenizer()
@@ -503,9 +513,33 @@ class TestTextEncoderBatchRejection:
                 side_effect=[fake_image_session, fake_text_session],
             ),
             patch("classifier._load_tokenizer", return_value=fake_tokenizer),
-            pytest.raises(RuntimeError, match="Re-download"),
+            pytest.raises(RuntimeError) as excinfo,
         ):
             Classifier(labels=["bird", "cat"], model_str="ViT-B-16")
+
+        # The error message must point users at the existing Repair flow,
+        # not tell them to manually re-download.
+        msg = str(excinfo.value)
+        assert "Settings" in msg and "Models" in msg, (
+            f"error should direct user to Settings → Models, got: {msg!r}"
+        )
+        assert "Repair" in msg, (
+            f"error should mention Repair button, got: {msg!r}"
+        )
+
+        # The sentinel must have been written so models._classify_model_state
+        # flips this install to 'incomplete'.
+        sentinel = model_dir / model_verify.VERIFY_FAILED_SENTINEL
+        assert sentinel.is_file(), (
+            f".verify_failed sentinel must be written to {sentinel}"
+        )
+        # The sentinel reason should identify the specific failure mode so
+        # future debugging from .vireo logs / support output can distinguish
+        # this from hash-mismatch corruption.
+        reason = sentinel.read_text()
+        assert "stale-export" in reason or "batched" in reason.lower(), (
+            f"sentinel reason should identify stale-export, got: {reason!r}"
+        )
 
 
 class TestEmbeddingCache:

--- a/vireo/tests/test_classifier.py
+++ b/vireo/tests/test_classifier.py
@@ -541,6 +541,63 @@ class TestTextEncoderBatchRejection:
             f"sentinel reason should identify stale-export, got: {reason!r}"
         )
 
+    def test_transient_text_session_error_does_not_write_sentinel(
+        self, tmp_path
+    ):
+        """A transient ONNX runtime failure (memory pressure, provider
+        glitch, mmap race) must NOT mark the install as needing Repair.
+
+        Only the specific stale-export signature (the ``gemm_input_reshape``
+        node from old BioCLIP exports) flips the install to incomplete.
+        Other inference errors propagate without mutating model state, so
+        a healthy install isn't permanently flagged for Repair after a
+        one-off runtime hiccup.
+        """
+        import model_verify
+        from classifier import Classifier
+
+        session = MagicMock()
+        mock_input = MagicMock()
+        mock_input.name = "input_ids"
+        session.get_inputs.return_value = [mock_input]
+
+        # A generic ORT runtime error that doesn't match the stale-export
+        # signature — e.g. an out-of-memory failure during inference.
+        def fake_run(output_names, input_dict):
+            raise RuntimeError(
+                "Failed to allocate memory for inference; "
+                "system under memory pressure."
+            )
+
+        session.run = fake_run
+
+        model_dir = _make_model_dir(tmp_path)
+        fake_image_session = _make_fake_image_session()
+        fake_tokenizer = _make_fake_tokenizer()
+
+        with (
+            patch("classifier._MODELS_ROOT", str(tmp_path)),
+            patch("classifier.CACHE_DIR", str(tmp_path / "cache")),
+            patch(
+                "classifier._MANIFEST_PATH",
+                str(tmp_path / "cache" / "manifest.json"),
+            ),
+            patch(
+                "classifier.onnx_runtime.create_session",
+                side_effect=[fake_image_session, session],
+            ),
+            patch("classifier._load_tokenizer", return_value=fake_tokenizer),
+            pytest.raises(RuntimeError, match="memory"),
+        ):
+            Classifier(labels=["bird", "cat"], model_str="ViT-B-16")
+
+        # The sentinel must NOT have been written: no Repair badge for
+        # transient errors.
+        sentinel = model_dir / model_verify.VERIFY_FAILED_SENTINEL
+        assert not sentinel.is_file(), (
+            f"transient error must not write sentinel; found at {sentinel}"
+        )
+
 
 class TestEmbeddingCache:
     """Tests for the embedding cache path utility."""


### PR DESCRIPTION
## Summary

When the text encoder ONNX rejects batched input, classifier startup
hits the runtime error from #546's strict-batched path and tells the
user to manually re-download — leaving the model dir in a "looks
healthy" state that gives the Settings UI no signal to surface a fix.

This routes the failure through the same self-heal path used for
hash-mismatch corruption: write `.verify_failed` into the model dir
on detection, raise the canonical incomplete-model message, and let
Settings → Models surface the existing Repair button.

## Why pinned-revision verification can't catch this on its own

The user's on-disk bytes legitimately match the upstream commit they
were downloaded from (only the export _logic_ changed in #546, not
the model bytes), so SHA256 verification against `.hf_revision`
passes even though the export is broken. Detection has to happen at
inference; repair has to happen through Settings.

## Changes

- `vireo/classifier.py`: thread `model_dir` through
  `_compute_embeddings_with_progress` → `_run_text_batched`. On
  batched-reshape failure, write `.verify_failed` with reason
  `"stale-export: text encoder rejected batched input ..."` and
  raise the standard incomplete-model error ("Open Settings →
  Models and click Repair to re-download the model").
- `vireo/tests/test_classifier.py`: monkeypatches
  `text_session.run` to raise an ORT-style reshape RuntimeException
  and asserts (a) the sentinel exists with a stale-export reason
  and (b) the raised error directs the user to the Repair flow.

## Real-world trigger

Encountered with bioclip-2.5-vith14 on a freshly-rebuilt `~/.vireo/models`
install — see `~/.vireo/vireo.log` traceback:

```
Reshape node Name:'gemm_input_reshape' ...
Input shape:{77,80,1024}, requested shape:{77,1024}
```

Companion artifact uploads to `jss367/vireo-onnx-models` re-export
all three BioCLIP variants with the batch-agnostic `_TextEncoderWrapper`
(commits `0dac2f5`, `fe861f9`, `6b27d8a`), so once installs hit the
sentinel-driven Repair, the fresh download from current HF main
will load and run cleanly.

## Test plan

- [x] `python -m pytest vireo/tests/test_classifier.py -v` — 20 passed
- [x] `python -m pytest vireo/tests/test_classifier.py vireo/tests/test_pipeline_job.py vireo/tests/test_models.py vireo/tests/test_model_verify.py -q` — 196 passed
- [x] CLAUDE.md workflow suite (`tests/test_workspaces.py vireo/tests/{test_db,test_app,test_photos_api,test_edits_api,test_jobs_api,test_darktable_api,test_config}.py`) — 641 passed
- [x] Verified red→green: test fails on main with old "Re-download" wording, passes after fix
- [ ] Manual: trigger on a real install, verify Settings → Models flips to "Incomplete" and Repair completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)