### PR TITLE
docs(scanner): explain pending_changes transfer skips dedup

### DIFF
--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -286,7 +286,10 @@ def _pair_raw_jpeg_companions(db):
             (primary["id"], companion["id"]),
         )
 
-        # Transfer pending_changes from companion to primary
+        # Transfer pending_changes from companion to primary. No dedup needed
+        # here (unlike the inat_submissions block below): pending_changes has
+        # no UNIQUE constraint that would crash on collision, and duplicate
+        # rows from a raw+JPEG pairing are harmless and vanishingly unlikely.
         db.conn.execute(
             "UPDATE pending_changes SET photo_id = ? WHERE photo_id = ?",
             (primary["id"], companion["id"]),


### PR DESCRIPTION
Closes #105.

## Summary

In raw+JPEG pairing (`vireo/scanner.py:289`), pending_changes is reassigned from companion to primary with a bare `UPDATE`. The inat_submissions block immediately below explicitly dedupes to avoid a UNIQUE-constraint crash. The asymmetry is intentional but unexplained — pending_changes has no UNIQUE constraint and duplicate rows from a raw+JPEG pairing are harmless and very unlikely. This PR documents that in place so a future reader doesn't bolt on unnecessary dedup or reach for a UNIQUE migration.

## Change

3 lines of comment, no behavior change.

## Test plan

- `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` — 631 passed in 1085s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)