### PR TITLE
fix(new-images): non-blocking endpoint with background walk

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2263,10 +2263,44 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ws_id = db._active_workspace_id
         if ws_id is None:
             return jsonify({"workspace_id": None, "new_count": 0, "per_root": [], "sample": []})
-        payload = db.get_new_images_for_workspace(ws_id)
-        payload = dict(payload)
-        payload["workspace_id"] = ws_id
-        return jsonify(payload)
+
+        cache = db._new_images_cache
+        db_path = db._db_path
+        cached = cache.get(db_path, ws_id)
+        if cached is not None:
+            payload = dict(cached)
+            payload["workspace_id"] = ws_id
+            return jsonify(payload)
+
+        # Cache cold: run the filesystem walk in a background thread so the
+        # navbar's poll doesn't tie up a Flask worker for seconds while
+        # os.walk grinds through a large library. Wait briefly so small
+        # libraries (and the test suite's tmp_path filesystems) still
+        # observe a real count synchronously; longer walks return
+        # ``pending: true`` and the front-end re-polls.
+        from db import Database
+        from new_images import count_new_images_for_workspace
+
+        def compute():
+            wdb = Database(db_path)
+            wdb.set_active_workspace(ws_id)
+            return count_new_images_for_workspace(wdb, ws_id)
+
+        event = cache.kickoff_compute(db_path, ws_id, compute)
+        if event.wait(timeout=0.5):
+            cached = cache.get(db_path, ws_id)
+            if cached is not None:
+                payload = dict(cached)
+                payload["workspace_id"] = ws_id
+                return jsonify(payload)
+
+        return jsonify({
+            "workspace_id": ws_id,
+            "new_count": None,
+            "per_root": [],
+            "sample": [],
+            "pending": True,
+        })
 
     @app.route("/api/workspaces/active/new-images/snapshot", methods=["POST"])
     def api_workspace_new_images_snapshot_create():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2272,6 +2272,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             payload["workspace_id"] = ws_id
             return jsonify(payload)
 
+        # If a recent compute failed and we're still inside the backoff
+        # window, surface the error instead of kicking off another walk.
+        # Without this, the navbar's pending re-poll keeps hammering a
+        # broken volume / DB and the UI is stuck "checking" forever.
+        recent_err = cache.get_recent_error(db_path, ws_id)
+        if recent_err is not None:
+            return jsonify({
+                "workspace_id": ws_id,
+                "new_count": None,
+                "per_root": [],
+                "sample": [],
+                "error": recent_err,
+            })
+
         # Cache cold: run the filesystem walk in a background thread so the
         # navbar's poll doesn't tie up a Flask worker for seconds while
         # os.walk grinds through a large library. Wait briefly so small
@@ -2293,6 +2307,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 payload = dict(cached)
                 payload["workspace_id"] = ws_id
                 return jsonify(payload)
+            # Compute finished but produced no cached entry — it must have
+            # raised. Surface the error captured by the worker.
+            recent_err = cache.get_recent_error(db_path, ws_id)
+            if recent_err is not None:
+                return jsonify({
+                    "workspace_id": ws_id,
+                    "new_count": None,
+                    "per_root": [],
+                    "sample": [],
+                    "error": recent_err,
+                })
 
         return jsonify({
             "workspace_id": ws_id,

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -1,10 +1,13 @@
 """Detect image files present on disk but not yet ingested into a workspace."""
+import logging
 import os
 import threading
 import time
 from pathlib import Path
 
 from image_loader import SUPPORTED_EXTENSIONS
+
+log = logging.getLogger(__name__)
 
 
 def _known_paths_for_workspace(db, workspace_id):
@@ -133,6 +136,9 @@ class NewImagesCache:
         self._entries = {}
         # key=(db_path, workspace_id) -> int
         self._generations = {}
+        # key=(db_path, workspace_id) -> Event signalling the in-flight
+        # background compute has finished (success or failure).
+        self._inflight = {}
         self._lock = threading.Lock()
 
     def get(self, db_path, workspace_id):
@@ -177,10 +183,53 @@ class NewImagesCache:
                 self._entries.pop(key, None)
                 self._generations[key] = self._generations.get(key, 0) + 1
 
+    def kickoff_compute(self, db_path, workspace_id, compute_fn):
+        """Ensure a background compute is running for ``(db_path, workspace_id)``.
+
+        If no compute is in flight, spawn a daemon thread that calls
+        ``compute_fn()`` and stores the result in the cache. If one is already
+        in flight, the existing thread is reused. Either way, returns an
+        ``Event`` that fires when the in-flight compute finishes (success or
+        failure) so the caller can ``Event.wait(timeout=...)`` to optionally
+        block briefly for a fresh result.
+
+        The generation snapshot is taken inside the lock at kickoff time so a
+        concurrent invalidation can still drop the stale write — same race
+        protection as :meth:`get_new_images_for_workspace`.
+        """
+        key = (db_path, workspace_id)
+        with self._lock:
+            existing = self._inflight.get(key)
+            if existing is not None:
+                return existing
+            event = threading.Event()
+            self._inflight[key] = event
+            generation = self._generations.get(key, 0)
+
+        def worker():
+            try:
+                result = compute_fn()
+                self.set(db_path, workspace_id, result, generation=generation)
+            except Exception:
+                log.exception(
+                    "new-images background compute failed for %s ws=%s",
+                    db_path, workspace_id,
+                )
+            finally:
+                with self._lock:
+                    self._inflight.pop(key, None)
+                event.set()
+
+        threading.Thread(
+            target=worker, daemon=True, name="new-images-compute",
+        ).start()
+        return event
+
     def clear(self):
         with self._lock:
             self._entries.clear()
             self._generations.clear()
+            self._inflight.clear()
 
 
 _shared_cache = NewImagesCache()

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -143,11 +143,18 @@ class NewImagesCache:
         # key=(db_path, workspace_id) -> int
         self._generations = {}
         # key=(db_path, workspace_id) -> (Event, generation) for the in-flight
-        # background compute. The generation is captured at kickoff so a
-        # subsequent invalidation makes the in-flight entry detectably stale —
-        # the next kickoff replaces it with a fresh compute instead of waiting
-        # on obsolete work.
+        # background compute. Only one compute per key runs at a time; stale-
+        # generation kickoffs queue a rerun token rather than spawning a
+        # parallel walk (see ``_rerun_pending``).
         self._inflight = {}
+        # key=(db_path, workspace_id) -> compute_fn for a deferred rerun. Set
+        # when a kickoff arrives during an in-flight stale-generation compute:
+        # rather than fan out a second concurrent ``os.walk`` (a real risk on
+        # the scan path where ``invalidate_workspaces`` fires per discovered
+        # folder), we let the current thread finish and have it spawn one
+        # follow-up using the latest compute_fn. Multiple kickoffs collapse to
+        # the same slot — last writer wins, so we never queue a backlog.
+        self._rerun_pending = {}
         # key=(db_path, workspace_id) -> (error_message, set_at_monotonic).
         # Recent failures suppress retries within ``ERROR_BACKOFF_SECONDS``.
         self._errors = {}
@@ -225,12 +232,21 @@ class NewImagesCache:
 
         Otherwise: if no compute is in flight, spawn a daemon thread that
         calls ``compute_fn()`` and stores the result in the cache. If one is
-        already in flight *for the current generation*, the existing thread
-        is reused. If the in-flight thread belongs to an older generation
-        (an ``invalidate_workspaces`` ran mid-walk), a fresh compute is
-        started so callers don't block on obsolete work. Either way, returns
-        an ``Event`` that fires when the compute finishes so the caller can
-        ``Event.wait(timeout=...)`` to optionally block briefly for the result.
+        already in flight — for the current or an older generation — the
+        existing thread is reused; the caller waits on its event. When the
+        in-flight thread is stale (an ``invalidate_workspaces`` ran mid-walk),
+        the latest ``compute_fn`` is stashed as a deferred rerun token and
+        the worker spawns one follow-up after it finishes. This keeps at most
+        one walk per key in flight even when generations advance repeatedly
+        (e.g. the scan path's per-folder ``invalidate_workspaces``), avoiding
+        a fan-out of concurrent ``os.walk`` jobs that would thrash disk/CPU
+        on large libraries.
+
+        Returns an ``Event`` that fires when the in-flight compute finishes
+        so the caller can ``Event.wait(timeout=...)`` to optionally block
+        briefly for the result. After a stale-generation compute finishes,
+        the deferred rerun runs asynchronously — callers re-poll to pick up
+        its result, exactly as they re-poll any ``pending: true`` response.
 
         The generation snapshot is taken inside the lock at kickoff time so a
         concurrent invalidation can still drop the stale write — same race
@@ -253,16 +269,15 @@ class NewImagesCache:
             existing = self._inflight.get(key)
             if existing is not None:
                 existing_event, existing_generation = existing
-                if existing_generation == generation:
-                    return existing_event
-                # The in-flight thread is computing for an older generation
-                # (an ``invalidate_workspaces`` ran mid-walk). Its result
-                # would be dropped by :meth:`set`'s stale-write guard, so
-                # waiting on it would leave callers in ``pending`` for the
-                # full duration of obsolete work. Start a fresh compute and
-                # let the stale thread finish in the background — its
-                # finally block won't pop ``_inflight[key]`` because we're
-                # about to overwrite the entry with the new event.
+                if existing_generation != generation:
+                    # Stale-generation compute is running. Coalesce: stash the
+                    # latest compute_fn so the worker spawns one follow-up
+                    # when it finishes, instead of starting a parallel walk.
+                    # Last writer wins — multiple kickoffs collapse to one
+                    # rerun, so a burst of polls during scan-time invalidation
+                    # storms can't queue a backlog of walks.
+                    self._rerun_pending[key] = compute_fn
+                return existing_event
             event = threading.Event()
             self._inflight[key] = (event, generation)
 
@@ -295,14 +310,24 @@ class NewImagesCache:
             finally:
                 with self._lock:
                     # Only clear the in-flight slot if it still belongs to
-                    # this thread. A fresh kickoff may have superseded us
-                    # after the generation advanced; popping unconditionally
-                    # would drop the live entry and let two threads race to
-                    # repopulate it.
+                    # this thread. Defensive: under the coalescing design
+                    # nothing else writes to this slot while we're alive,
+                    # but the identity check keeps the invariant locally
+                    # checkable rather than relying on global reasoning.
                     current = self._inflight.get(key)
                     if current is not None and current[0] is event:
                         del self._inflight[key]
+                    rerun_fn = self._rerun_pending.pop(key, None)
                 event.set()
+                if rerun_fn is not None:
+                    # A kickoff arrived during this compute while the
+                    # generation was stale. Fire the deferred rerun now that
+                    # the in-flight slot is free; it picks up the current
+                    # generation inside the lock. Recursion depth is bounded:
+                    # each rerun consumes its token and a new one is only
+                    # added by another stale-generation kickoff arriving
+                    # during the next worker.
+                    self.kickoff_compute(db_path, workspace_id, rerun_fn)
 
         threading.Thread(
             target=worker, daemon=True, name="new-images-compute",
@@ -315,6 +340,7 @@ class NewImagesCache:
             self._generations.clear()
             self._inflight.clear()
             self._errors.clear()
+            self._rerun_pending.clear()
 
 
 _shared_cache = NewImagesCache()

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -258,8 +258,15 @@ class NewImagesCache:
                     db_path, workspace_id,
                 )
                 with self._lock:
-                    self._errors[key] = (str(e) or e.__class__.__name__,
-                                         time.monotonic())
+                    # Drop the failure if the generation moved while we were
+                    # running. Mirrors the stale-write guard in :meth:`set`:
+                    # if ``invalidate_workspaces`` ran mid-compute (workspace
+                    # switched, scan completed), this error is for a key that
+                    # has already moved on and must not force the next
+                    # request into the 30s backoff window.
+                    if self._generations.get(key, 0) == generation:
+                        self._errors[key] = (str(e) or e.__class__.__name__,
+                                             time.monotonic())
             finally:
                 with self._lock:
                     self._inflight.pop(key, None)

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -190,6 +190,12 @@ class NewImagesCache:
             for wid in workspace_ids:
                 key = (db_path, wid)
                 self._entries.pop(key, None)
+                # Drop any recorded failure too: the cache key has moved on
+                # (folder/workspace change, completed scan), so the old error
+                # no longer reflects the current state and must not gate a
+                # fresh recompute via the 30s backoff window in
+                # ``kickoff_compute``.
+                self._errors.pop(key, None)
                 self._generations[key] = self._generations.get(key, 0) + 1
 
     def get_recent_error(self, db_path, workspace_id):

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -130,6 +130,12 @@ class NewImagesCache:
     silently dropped instead of repopulating the cache.
     """
 
+    # Persistent compute failures (unreachable volume, DB error) suppress
+    # retries for this long so we don't hammer the failing resource on every
+    # navbar poll. Short enough that natural recovery is observable; long
+    # enough that ten open tabs can't hot-loop the disk.
+    ERROR_BACKOFF_SECONDS = 30
+
     def __init__(self, ttl_seconds=300):
         self._ttl = ttl_seconds
         # key=(db_path, workspace_id) -> (result_dict, set_at_monotonic)
@@ -139,6 +145,9 @@ class NewImagesCache:
         # key=(db_path, workspace_id) -> Event signalling the in-flight
         # background compute has finished (success or failure).
         self._inflight = {}
+        # key=(db_path, workspace_id) -> (error_message, set_at_monotonic).
+        # Recent failures suppress retries within ``ERROR_BACKOFF_SECONDS``.
+        self._errors = {}
         self._lock = threading.Lock()
 
     def get(self, db_path, workspace_id):
@@ -183,15 +192,33 @@ class NewImagesCache:
                 self._entries.pop(key, None)
                 self._generations[key] = self._generations.get(key, 0) + 1
 
+    def get_recent_error(self, db_path, workspace_id):
+        """Return the most recent compute error if it's still inside the
+        backoff window, else None. Stale entries are cleared lazily."""
+        key = (db_path, workspace_id)
+        with self._lock:
+            entry = self._errors.get(key)
+            if entry is None:
+                return None
+            err_msg, set_at = entry
+            if time.monotonic() - set_at > self.ERROR_BACKOFF_SECONDS:
+                del self._errors[key]
+                return None
+            return err_msg
+
     def kickoff_compute(self, db_path, workspace_id, compute_fn):
         """Ensure a background compute is running for ``(db_path, workspace_id)``.
 
-        If no compute is in flight, spawn a daemon thread that calls
-        ``compute_fn()`` and stores the result in the cache. If one is already
-        in flight, the existing thread is reused. Either way, returns an
-        ``Event`` that fires when the in-flight compute finishes (success or
-        failure) so the caller can ``Event.wait(timeout=...)`` to optionally
-        block briefly for a fresh result.
+        If a recent compute failed (within ``ERROR_BACKOFF_SECONDS``), no new
+        compute is started — readers should call :meth:`get_recent_error` and
+        surface the failure instead of looping pending forever. Returns a
+        pre-set Event so callers that ``wait`` don't block.
+
+        Otherwise: if no compute is in flight, spawn a daemon thread that
+        calls ``compute_fn()`` and stores the result in the cache. If one is
+        already in flight, the existing thread is reused. Either way, returns
+        an ``Event`` that fires when the compute finishes so the caller can
+        ``Event.wait(timeout=...)`` to optionally block briefly for the result.
 
         The generation snapshot is taken inside the lock at kickoff time so a
         concurrent invalidation can still drop the stale write — same race
@@ -199,6 +226,17 @@ class NewImagesCache:
         """
         key = (db_path, workspace_id)
         with self._lock:
+            err_entry = self._errors.get(key)
+            if err_entry is not None:
+                _err_msg, set_at = err_entry
+                if time.monotonic() - set_at <= self.ERROR_BACKOFF_SECONDS:
+                    # Suppress retry inside the backoff window.
+                    done = threading.Event()
+                    done.set()
+                    return done
+                # Backoff window elapsed — let a fresh attempt run.
+                del self._errors[key]
+
             existing = self._inflight.get(key)
             if existing is not None:
                 return existing
@@ -210,11 +248,18 @@ class NewImagesCache:
             try:
                 result = compute_fn()
                 self.set(db_path, workspace_id, result, generation=generation)
-            except Exception:
+                # Successful compute clears any prior failure so a transient
+                # error doesn't keep suppressing retries after recovery.
+                with self._lock:
+                    self._errors.pop(key, None)
+            except Exception as e:
                 log.exception(
                     "new-images background compute failed for %s ws=%s",
                     db_path, workspace_id,
                 )
+                with self._lock:
+                    self._errors[key] = (str(e) or e.__class__.__name__,
+                                         time.monotonic())
             finally:
                 with self._lock:
                     self._inflight.pop(key, None)
@@ -230,6 +275,7 @@ class NewImagesCache:
             self._entries.clear()
             self._generations.clear()
             self._inflight.clear()
+            self._errors.clear()
 
 
 _shared_cache = NewImagesCache()

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -142,8 +142,11 @@ class NewImagesCache:
         self._entries = {}
         # key=(db_path, workspace_id) -> int
         self._generations = {}
-        # key=(db_path, workspace_id) -> Event signalling the in-flight
-        # background compute has finished (success or failure).
+        # key=(db_path, workspace_id) -> (Event, generation) for the in-flight
+        # background compute. The generation is captured at kickoff so a
+        # subsequent invalidation makes the in-flight entry detectably stale —
+        # the next kickoff replaces it with a fresh compute instead of waiting
+        # on obsolete work.
         self._inflight = {}
         # key=(db_path, workspace_id) -> (error_message, set_at_monotonic).
         # Recent failures suppress retries within ``ERROR_BACKOFF_SECONDS``.
@@ -222,7 +225,10 @@ class NewImagesCache:
 
         Otherwise: if no compute is in flight, spawn a daemon thread that
         calls ``compute_fn()`` and stores the result in the cache. If one is
-        already in flight, the existing thread is reused. Either way, returns
+        already in flight *for the current generation*, the existing thread
+        is reused. If the in-flight thread belongs to an older generation
+        (an ``invalidate_workspaces`` ran mid-walk), a fresh compute is
+        started so callers don't block on obsolete work. Either way, returns
         an ``Event`` that fires when the compute finishes so the caller can
         ``Event.wait(timeout=...)`` to optionally block briefly for the result.
 
@@ -243,12 +249,22 @@ class NewImagesCache:
                 # Backoff window elapsed — let a fresh attempt run.
                 del self._errors[key]
 
+            generation = self._generations.get(key, 0)
             existing = self._inflight.get(key)
             if existing is not None:
-                return existing
+                existing_event, existing_generation = existing
+                if existing_generation == generation:
+                    return existing_event
+                # The in-flight thread is computing for an older generation
+                # (an ``invalidate_workspaces`` ran mid-walk). Its result
+                # would be dropped by :meth:`set`'s stale-write guard, so
+                # waiting on it would leave callers in ``pending`` for the
+                # full duration of obsolete work. Start a fresh compute and
+                # let the stale thread finish in the background — its
+                # finally block won't pop ``_inflight[key]`` because we're
+                # about to overwrite the entry with the new event.
             event = threading.Event()
-            self._inflight[key] = event
-            generation = self._generations.get(key, 0)
+            self._inflight[key] = (event, generation)
 
         def worker():
             try:
@@ -256,8 +272,11 @@ class NewImagesCache:
                 self.set(db_path, workspace_id, result, generation=generation)
                 # Successful compute clears any prior failure so a transient
                 # error doesn't keep suppressing retries after recovery.
+                # Generation-guarded so a stale thread finishing after a
+                # fresh one started doesn't wipe the fresh thread's error.
                 with self._lock:
-                    self._errors.pop(key, None)
+                    if self._generations.get(key, 0) == generation:
+                        self._errors.pop(key, None)
             except Exception as e:
                 log.exception(
                     "new-images background compute failed for %s ws=%s",
@@ -275,7 +294,14 @@ class NewImagesCache:
                                              time.monotonic())
             finally:
                 with self._lock:
-                    self._inflight.pop(key, None)
+                    # Only clear the in-flight slot if it still belongs to
+                    # this thread. A fresh kickoff may have superseded us
+                    # after the generation advanced; popping unconditionally
+                    # would drop the live entry and let two threads race to
+                    # repopulate it.
+                    current = self._inflight.get(key)
+                    if current is not None and current[0] is event:
+                        del self._inflight[key]
                 event.set()
 
         threading.Thread(

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4027,7 +4027,17 @@ function _isNewImagesDismissed(wsId, newCount) {
   return stored === Number(newCount);
 }
 
+// Single-slot retry timer so a long pending state can't stack independent
+// 3s polling chains on top of each 60s interval tick — without this dedup,
+// every interval that lands during pending forks another retry chain and
+// request volume snowballs over time.
+let _newImagesPendingTimer = null;
+
 async function checkNewImages() {
+  if (_newImagesPendingTimer !== null) {
+    clearTimeout(_newImagesPendingTimer);
+    _newImagesPendingTimer = null;
+  }
   try {
     const resp = await fetch('/api/workspaces/active/new-images');
     if (!resp.ok) return;
@@ -4036,7 +4046,15 @@ async function checkNewImages() {
     // running in the background. The result will land in the cache shortly,
     // so re-poll soon instead of waiting for the next 60s tick.
     if (data && data.pending) {
-      setTimeout(checkNewImages, 3000);
+      _newImagesPendingTimer = setTimeout(checkNewImages, 3000);
+      return;
+    }
+    // Persistent backend failure (unreachable volume, DB error). Don't
+    // re-poll fast — let the 60s interval try again after the backoff
+    // window so we don't hammer a broken resource. Hide the banner.
+    if (data && data.error) {
+      const banner = document.getElementById('newImagesBanner');
+      if (banner) banner.style.display = 'none';
       return;
     }
     const banner = document.getElementById('newImagesBanner');

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4032,6 +4032,13 @@ async function checkNewImages() {
     const resp = await fetch('/api/workspaces/active/new-images');
     if (!resp.ok) return;
     const data = await resp.json();
+    // The backend returns ``pending: true`` when a fresh-cache walk is still
+    // running in the background. The result will land in the cache shortly,
+    // so re-poll soon instead of waiting for the next 60s tick.
+    if (data && data.pending) {
+      setTimeout(checkNewImages, 3000);
+      return;
+    }
     const banner = document.getElementById('newImagesBanner');
     const msg = document.getElementById('newImagesMsg');
     if (!banner || !msg) return;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4027,17 +4027,21 @@ function _isNewImagesDismissed(wsId, newCount) {
   return stored === Number(newCount);
 }
 
-// Single-slot retry timer so a long pending state can't stack independent
-// 3s polling chains on top of each 60s interval tick — without this dedup,
-// every interval that lands during pending forks another retry chain and
-// request volume snowballs over time.
+// Single-slot retry timer + in-flight guard so a long pending state can't
+// stack independent 3s polling chains on top of each 60s interval tick.
+// Without the in-flight guard, two ticks whose fetches are still in flight
+// both schedule timers when their responses land, leaking chains; the
+// start-of-call clearTimeout only catches the most recent handle.
 let _newImagesPendingTimer = null;
+let _newImagesInFlight = false;
 
 async function checkNewImages() {
+  if (_newImagesInFlight) return;
   if (_newImagesPendingTimer !== null) {
     clearTimeout(_newImagesPendingTimer);
     _newImagesPendingTimer = null;
   }
+  _newImagesInFlight = true;
   try {
     const resp = await fetch('/api/workspaces/active/new-images');
     if (!resp.ok) return;
@@ -4082,6 +4086,7 @@ async function checkNewImages() {
       banner.style.display = 'none';
     }
   } catch (e) { /* ignore */ }
+  finally { _newImagesInFlight = false; }
 }
 
 function dismissNewImagesBanner() {

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1097,14 +1097,20 @@ async function initNewImagesCard() {
   }
 }
 
-// Single-slot retry timer so a long pending state can't stack chains.
+// Single-slot retry timer + in-flight guard so a long pending state can't
+// stack chains: two ticks whose fetches overlap would otherwise both
+// schedule timers on response, leaking chains the start-of-call
+// clearTimeout can't catch (it only nulls the most recent handle).
 var _newImagesProbeTimer = null;
+var _newImagesProbeInFlight = false;
 
 async function probeNewImagesCard() {
+  if (_newImagesProbeInFlight) return;
   if (_newImagesProbeTimer !== null) {
     clearTimeout(_newImagesProbeTimer);
     _newImagesProbeTimer = null;
   }
+  _newImagesProbeInFlight = true;
   try {
     var r = await fetch('/api/workspaces/active/new-images');
     if (!r.ok) return;
@@ -1125,6 +1131,8 @@ async function probeNewImagesCard() {
     }
   } catch (e) {
     // Silent fail — card stays hidden.
+  } finally {
+    _newImagesProbeInFlight = false;
   }
 }
 

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1102,6 +1102,12 @@ async function probeNewImagesCard() {
     var r = await fetch('/api/workspaces/active/new-images');
     if (!r.ok) return;
     var data = await r.json();
+    // Cache cold: backend returned pending while a background walk runs.
+    // Re-probe shortly so the card appears once the count is ready.
+    if (data && data.pending) {
+      setTimeout(probeNewImagesCard, 3000);
+      return;
+    }
     if ((data.new_count || 0) > 0) {
       var folders = (data.per_root || [])
         .filter(function(pr) { return (pr.new_count || 0) > 0; })

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1097,7 +1097,14 @@ async function initNewImagesCard() {
   }
 }
 
+// Single-slot retry timer so a long pending state can't stack chains.
+var _newImagesProbeTimer = null;
+
 async function probeNewImagesCard() {
+  if (_newImagesProbeTimer !== null) {
+    clearTimeout(_newImagesProbeTimer);
+    _newImagesProbeTimer = null;
+  }
   try {
     var r = await fetch('/api/workspaces/active/new-images');
     if (!r.ok) return;
@@ -1105,9 +1112,11 @@ async function probeNewImagesCard() {
     // Cache cold: backend returned pending while a background walk runs.
     // Re-probe shortly so the card appears once the count is ready.
     if (data && data.pending) {
-      setTimeout(probeNewImagesCard, 3000);
+      _newImagesProbeTimer = setTimeout(probeNewImagesCard, 3000);
       return;
     }
+    // Persistent backend failure — leave the card hidden, don't re-probe.
+    if (data && data.error) return;
     if ((data.new_count || 0) > 0) {
       var folders = (data.per_root || [])
         .filter(function(pr) { return (pr.new_count || 0) > 0; })

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -70,6 +70,85 @@ def test_api_new_images_zero_when_fully_ingested(app_and_db):
     assert data["workspace_id"] == ws_id
 
 
+def test_api_new_images_returns_pending_when_walk_is_slow(app_and_db, monkeypatch):
+    """Cold-cache calls return pending instead of blocking the request thread
+    on a long os.walk. Without this, the navbar's poll on app start ties up a
+    Flask worker for the entire walk (observed at 12.9s on a real library)."""
+    import threading
+
+    import new_images as new_images_module
+
+    app, db, ws_id, tmp_path = app_and_db
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    release = threading.Event()
+    started = threading.Event()
+    real_count = new_images_module.count_new_images_for_workspace
+
+    def slow_count(*args, **kwargs):
+        started.set()
+        # Block until the test releases us, so the kickoff thread is still
+        # in flight when the request returns.
+        release.wait(timeout=5)
+        return real_count(*args, **kwargs)
+
+    monkeypatch.setattr(new_images_module, "count_new_images_for_workspace", slow_count)
+
+    client = app.test_client()
+    try:
+        resp = client.get("/api/workspaces/active/new-images")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data.get("pending") is True, (
+            f"expected pending=True while walk is in flight, got {data!r}"
+        )
+        assert data["new_count"] is None
+        assert data["workspace_id"] == ws_id
+        # The endpoint must have actually kicked off the background compute.
+        assert started.is_set()
+    finally:
+        # Let the background thread finish before pytest tears down tmp_path,
+        # otherwise it walks a deleted directory tree.
+        release.set()
+
+
+def test_api_new_images_returns_cached_after_background_compute_finishes(app_and_db):
+    """Once the background walk finishes, the cache is populated and the next
+    request returns the real count instantly — no second walk."""
+    import time
+
+    from new_images import get_shared_cache
+
+    app, db, ws_id, tmp_path = app_and_db
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    client = app.test_client()
+    # First request: walk is fast on tmp_path so the 500ms wait will catch it
+    # and we'll see the count synchronously. To exercise the *cache hit after
+    # async compute* path we wait for the cache key to appear, then re-probe.
+    resp1 = client.get("/api/workspaces/active/new-images")
+    assert resp1.status_code == 200
+
+    cache = get_shared_cache()
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        if cache.get(db._db_path, ws_id) is not None:
+            break
+        time.sleep(0.01)
+    assert cache.get(db._db_path, ws_id) is not None, (
+        "background compute never populated the cache"
+    )
+
+    resp2 = client.get("/api/workspaces/active/new-images")
+    data = resp2.get_json()
+    assert data.get("pending") is None or data.get("pending") is False
+    assert data["new_count"] == 1
+
+
 def test_api_new_images_returns_null_workspace_when_none_active(app_and_db, monkeypatch):
     app, db, ws_id, tmp_path = app_and_db
     # Each request creates its own Database via _get_db(), which auto-restores

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -149,6 +149,96 @@ def test_api_new_images_returns_cached_after_background_compute_finishes(app_and
     assert data["new_count"] == 1
 
 
+def test_api_new_images_returns_error_when_compute_fails(app_and_db, monkeypatch):
+    """If the background walk raises (e.g. unavailable volume, DB error), the
+    endpoint must surface an error instead of looping forever on pending.
+
+    Without this, the navbar's 3s pending re-poll keeps firing because the
+    cache stays empty after every failed compute — leaving the UI in a
+    permanent retry state and hammering the failing resource.
+    """
+    import time
+
+    import new_images as new_images_module
+
+    app, db, ws_id, tmp_path = app_and_db
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("disk unreachable")
+
+    monkeypatch.setattr(new_images_module, "count_new_images_for_workspace", boom)
+
+    client = app.test_client()
+    resp = client.get("/api/workspaces/active/new-images")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Wait briefly for the worker thread to finish raising and storing the
+    # error — the 500ms grace inside the endpoint may have already caught it,
+    # but in case it didn't, repoll once.
+    if data.get("pending"):
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            time.sleep(0.05)
+            data = client.get("/api/workspaces/active/new-images").get_json()
+            if not data.get("pending"):
+                break
+    assert data.get("error"), f"expected an error in payload, got {data!r}"
+    assert "disk unreachable" in data["error"]
+    assert data.get("pending") is None or data.get("pending") is False
+    assert data["new_count"] is None or data["new_count"] == 0
+    assert data["workspace_id"] == ws_id
+
+
+def test_api_new_images_does_not_hot_loop_on_persistent_failure(app_and_db, monkeypatch):
+    """Repeated requests within the error backoff window must not spawn a
+    fresh compute every time — otherwise a broken volume gets hammered by
+    every navbar poll across every open page."""
+    import threading
+    import time
+
+    import new_images as new_images_module
+
+    app, db, ws_id, tmp_path = app_and_db
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    call_count = {"n": 0}
+    lock = threading.Lock()
+
+    def boom(*args, **kwargs):
+        with lock:
+            call_count["n"] += 1
+        raise RuntimeError("disk unreachable")
+
+    monkeypatch.setattr(new_images_module, "count_new_images_for_workspace", boom)
+
+    client = app.test_client()
+    # Fire one request; wait for compute to finish and the error to land.
+    client.get("/api/workspaces/active/new-images")
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        if call_count["n"] >= 1:
+            break
+        time.sleep(0.01)
+    initial = call_count["n"]
+    assert initial >= 1, "compute_fn was never called for the first request"
+
+    # Hammer the endpoint several more times immediately. Each call is
+    # within the error backoff window so no new compute should fire.
+    for _ in range(5):
+        client.get("/api/workspaces/active/new-images")
+    # Give any spurious thread a moment to actually hit boom().
+    time.sleep(0.1)
+    assert call_count["n"] == initial, (
+        f"compute_fn called {call_count['n']} times; expected backoff after "
+        f"{initial} call(s)"
+    )
+
+
 def test_api_new_images_returns_null_workspace_when_none_active(app_and_db, monkeypatch):
     app, db, ws_id, tmp_path = app_and_db
     # Each request creates its own Database via _get_db(), which auto-restores

--- a/vireo/tests/test_new_images_cache.py
+++ b/vireo/tests/test_new_images_cache.py
@@ -171,6 +171,59 @@ def test_kickoff_compute_clears_prior_error_on_success():
     assert cache.get_recent_error(DB, 1) is None
 
 
+def test_invalidate_workspaces_clears_recent_error():
+    """A recorded failure must not survive an invalidation: when a scan or
+    workspace/folder change advances the generation, the old error reflects
+    state that no longer applies and would otherwise force the next request
+    into the 30s backoff window even though the key has moved on. The next
+    ``kickoff_compute`` after invalidation should run fresh, not be gated."""
+    cache = NewImagesCache(ttl_seconds=60)
+
+    # Record a failure the normal way (via kickoff) so the backoff entry
+    # exists and ``get_recent_error`` would surface it.
+    def boom():
+        raise RuntimeError("disk unreachable")
+
+    event = cache.kickoff_compute(DB, 1, boom)
+    assert event.wait(timeout=2.0)
+    assert cache.get_recent_error(DB, 1) is not None
+
+    # Invalidation simulates a finished scan or workspace folder change.
+    cache.invalidate_workspaces(DB, [1])
+    assert cache.get_recent_error(DB, 1) is None, (
+        "invalidate_workspaces must drop stale failures so a fresh recompute "
+        "isn't suppressed by the prior error's 30s backoff"
+    )
+
+    # And the next kickoff actually runs (not short-circuited by the error
+    # gate), letting a successful compute repopulate the cache.
+    def ok():
+        return {"new_count": 4}
+
+    event = cache.kickoff_compute(DB, 1, ok)
+    assert event.wait(timeout=2.0)
+    assert cache.get(DB, 1) == {"new_count": 4}
+
+
+def test_invalidate_workspaces_clears_error_only_for_targeted_keys():
+    """Invalidation is scoped: a failure on workspace 2 must survive when
+    workspace 1's cache is invalidated."""
+    cache = NewImagesCache(ttl_seconds=60)
+
+    def boom():
+        raise RuntimeError("disk unreachable")
+
+    cache.kickoff_compute(DB, 1, boom).wait(timeout=2.0)
+    cache.kickoff_compute(DB, 2, boom).wait(timeout=2.0)
+    assert cache.get_recent_error(DB, 1) is not None
+    assert cache.get_recent_error(DB, 2) is not None
+
+    cache.invalidate_workspaces(DB, [1])
+
+    assert cache.get_recent_error(DB, 1) is None
+    assert cache.get_recent_error(DB, 2) is not None
+
+
 def test_cache_generation_is_scoped_by_db_path():
     """A bump to one db's generation must not race-drop a concurrent write for
     a different db with the same workspace_id."""

--- a/vireo/tests/test_new_images_cache.py
+++ b/vireo/tests/test_new_images_cache.py
@@ -248,11 +248,17 @@ def test_kickoff_compute_reuses_in_flight_for_current_generation():
     assert call_count[0] == 1
 
 
-def test_kickoff_compute_restarts_when_generation_advances():
+def test_kickoff_compute_coalesces_stale_generation_into_deferred_rerun():
     """If ``invalidate_workspaces`` runs while a compute is in flight, the next
-    kickoff must start a fresh compute instead of waiting on the obsolete
-    thread. Otherwise pollers stay in ``pending`` for the full duration of an
-    outdated walk after a workspace/folder change."""
+    kickoff must NOT spawn a parallel walk. Generations advance per discovered
+    folder during a scan, and the navbar re-polls pending every 3s; without
+    coalescing, both effects fan out concurrent ``os.walk`` jobs that thrash
+    disk/CPU on large libraries.
+
+    The contract: at most one walk per key in flight; the latest
+    ``compute_fn`` is queued as a deferred rerun and fires once the current
+    walk finishes."""
+    import time as _t
     cache = NewImagesCache(ttl_seconds=60)
     stale_started = threading.Event()
     stale_proceed = threading.Event()
@@ -275,22 +281,102 @@ def test_kickoff_compute_restarts_when_generation_advances():
         return {"new_count": 7}
 
     e2 = cache.kickoff_compute(DB, 1, fresh_compute)
-    assert e1 is not e2, "stale in-flight thread must not be reused after invalidation"
-    assert fresh_called.wait(timeout=2.0), "fresh compute must actually run"
-    assert e2.wait(timeout=2.0)
-    assert cache.get(DB, 1) == {"new_count": 7}
+    # Caller waits on the in-flight (stale) event; no parallel walk spawned.
+    assert e1 is e2, "stale-generation kickoff must reuse in-flight, not fork"
+    assert not fresh_called.is_set(), (
+        "fresh compute must not run in parallel with stale in-flight thread"
+    )
 
-    # Drain the stale thread; its result must not overwrite the fresh one.
+    # A burst of polls during the scan-time invalidation storm must collapse
+    # to a single rerun token, not queue a backlog of walks.
+    e3 = cache.kickoff_compute(DB, 1, fresh_compute)
+    e4 = cache.kickoff_compute(DB, 1, fresh_compute)
+    assert e3 is e1 and e4 is e1
+    assert not fresh_called.is_set()
+
+    # Release the stale thread; the deferred rerun fires asynchronously after
+    # its finally block runs.
     stale_proceed.set()
     assert e1.wait(timeout=2.0)
+    assert fresh_called.wait(timeout=2.0), (
+        "deferred rerun must spawn fresh compute after stale finishes"
+    )
+
+    # Wait for the rerun's result to land in the cache.
+    deadline = _t.monotonic() + 2.0
+    while _t.monotonic() < deadline:
+        if cache.get(DB, 1) == {"new_count": 7}:
+            break
+        _t.sleep(0.01)
     assert cache.get(DB, 1) == {"new_count": 7}, (
-        "stale compute result must be dropped by the generation guard in set()"
+        "stale result must be dropped by set()'s generation guard, and the "
+        "deferred rerun's result must populate the cache"
     )
 
 
-def test_kickoff_compute_stale_thread_does_not_clear_inflight_for_fresh():
-    """When a stale thread finishes after a fresh compute has taken over the
-    in-flight slot, its cleanup must not pop the fresh entry."""
+def test_kickoff_compute_coalesces_repeated_invalidations_into_single_rerun():
+    """Multiple stale-generation kickoffs during a single in-flight walk must
+    all collapse onto one rerun token (last writer wins). Otherwise a long
+    walk plus repeated scan-time invalidations could backlog walks."""
+    cache = NewImagesCache(ttl_seconds=60)
+    stale_started = threading.Event()
+    stale_proceed = threading.Event()
+    stale_calls = [0]
+
+    def stale_compute():
+        stale_calls[0] += 1
+        stale_started.set()
+        stale_proceed.wait(timeout=5.0)
+        return {"new_count": 0}
+
+    cache.kickoff_compute(DB, 1, stale_compute)
+    assert stale_started.wait(timeout=2.0)
+
+    # Several rounds of invalidation + kickoff with different compute_fns;
+    # only the last one's result should ultimately land in the cache.
+    rerun_calls = {"a": 0, "b": 0, "c": 0}
+
+    def make_rerun(tag, value):
+        def fn():
+            rerun_calls[tag] += 1
+            return {"new_count": value, "tag": tag}
+        return fn
+
+    cache.invalidate_workspaces(DB, [1])
+    cache.kickoff_compute(DB, 1, make_rerun("a", 1))
+    cache.invalidate_workspaces(DB, [1])
+    cache.kickoff_compute(DB, 1, make_rerun("b", 2))
+    cache.invalidate_workspaces(DB, [1])
+    cache.kickoff_compute(DB, 1, make_rerun("c", 3))
+
+    stale_proceed.set()
+
+    # Wait for the deferred rerun to finish populating the cache.
+    import time as _t
+    deadline = _t.monotonic() + 2.0
+    while _t.monotonic() < deadline:
+        cached = cache.get(DB, 1)
+        if cached is not None and cached.get("tag") == "c":
+            break
+        _t.sleep(0.01)
+
+    assert cache.get(DB, 1) == {"new_count": 3, "tag": "c"}, (
+        "last queued compute_fn must win — earlier ones are overwritten "
+        "in the rerun slot, not run as parallel walks"
+    )
+    assert stale_calls[0] == 1
+    assert rerun_calls["a"] == 0 and rerun_calls["b"] == 0, (
+        "earlier rerun candidates must not run — they were superseded "
+        f"in the rerun slot before the stale walk finished (got {rerun_calls})"
+    )
+    assert rerun_calls["c"] == 1
+
+
+def test_kickoff_compute_stale_thread_clears_inflight_slot_for_rerun():
+    """The stale worker's finally block must clear ``_inflight[key]`` so the
+    deferred rerun spawned from that finally can take ownership of the slot.
+    Otherwise the rerun's ``kickoff_compute`` would see a stale in-flight
+    entry and queue itself as another rerun, deadlocking progress."""
     cache = NewImagesCache(ttl_seconds=60)
     stale_started = threading.Event()
     stale_proceed = threading.Event()
@@ -304,39 +390,26 @@ def test_kickoff_compute_stale_thread_does_not_clear_inflight_for_fresh():
     assert stale_started.wait(timeout=2.0)
     cache.invalidate_workspaces(DB, [1])
 
-    fresh_started = threading.Event()
-    fresh_proceed = threading.Event()
+    rerun_done = threading.Event()
 
-    def fresh_compute():
-        fresh_started.set()
-        fresh_proceed.wait(timeout=5.0)
+    def rerun_compute():
+        rerun_done.set()
         return {"new_count": 2}
 
-    fresh_event = cache.kickoff_compute(DB, 1, fresh_compute)
-    assert fresh_started.wait(timeout=2.0)
-
-    # Let the stale thread finish first. Its finally block must not clear
-    # ``_inflight[key]`` because that slot now belongs to the fresh thread.
+    cache.kickoff_compute(DB, 1, rerun_compute)
     stale_proceed.set()
 
-    # The fresh thread is still running, so the in-flight slot must remain.
-    # Poll briefly to let the stale thread's finally complete.
-    import time as _t
-    deadline = _t.monotonic() + 1.0
-    while _t.monotonic() < deadline:
-        with cache._lock:
-            entry = cache._inflight.get((DB, 1))
-        if entry is not None and entry[0] is fresh_event:
-            break
-        _t.sleep(0.01)
-    with cache._lock:
-        entry = cache._inflight.get((DB, 1))
-    assert entry is not None and entry[0] is fresh_event, (
-        "stale thread's finally must not pop the fresh thread's in-flight slot"
+    assert rerun_done.wait(timeout=2.0), (
+        "rerun must run after stale thread finishes and frees the in-flight slot"
     )
 
-    fresh_proceed.set()
-    assert fresh_event.wait(timeout=2.0)
+    # Cache eventually reflects the rerun's result.
+    import time as _t
+    deadline = _t.monotonic() + 2.0
+    while _t.monotonic() < deadline:
+        if cache.get(DB, 1) == {"new_count": 2}:
+            break
+        _t.sleep(0.01)
     assert cache.get(DB, 1) == {"new_count": 2}
 
 

--- a/vireo/tests/test_new_images_cache.py
+++ b/vireo/tests/test_new_images_cache.py
@@ -103,6 +103,74 @@ def test_cache_keys_by_db_path_isolates_identical_workspace_ids():
     assert cache.get("/path/b.db", 1) == {"new_count": 99, "tag": "B"}
 
 
+def test_kickoff_compute_drops_stale_error_when_generation_changes():
+    """If ``invalidate_workspaces`` runs while a background compute is in
+    flight, a subsequent failure for that stale generation must not be
+    recorded. Mirrors the stale-write guard in :meth:`set` — without it,
+    the next request goes into the 30s backoff window for a key that has
+    already moved on, suppressing a fresh recompute after workspace/folder
+    changes."""
+    cache = NewImagesCache(ttl_seconds=60)
+
+    # Compute simulates the race: it bumps the generation (as a finishing
+    # scan or workspace switch would) and *then* fails. The error reflects
+    # the old generation and must be dropped.
+    def compute():
+        cache.invalidate_workspaces(DB, [1])
+        raise RuntimeError("disk unreachable")
+
+    event = cache.kickoff_compute(DB, 1, compute)
+    assert event.wait(timeout=2.0), "background compute did not finish"
+
+    assert cache.get_recent_error(DB, 1) is None, (
+        "stale error must be dropped when the generation moved during compute"
+    )
+
+
+def test_kickoff_compute_records_error_when_generation_unchanged():
+    """The generation guard must not regress the normal failure path: if no
+    invalidation happens during compute, the error is recorded so the next
+    request hits the backoff window."""
+    cache = NewImagesCache(ttl_seconds=60)
+
+    def compute():
+        raise RuntimeError("disk unreachable")
+
+    event = cache.kickoff_compute(DB, 1, compute)
+    assert event.wait(timeout=2.0)
+
+    err = cache.get_recent_error(DB, 1)
+    assert err is not None and "disk unreachable" in err
+
+
+def test_kickoff_compute_clears_prior_error_on_success():
+    """A successful compute must clear any prior failure so a transient error
+    doesn't keep suppressing retries after recovery."""
+    cache = NewImagesCache(ttl_seconds=60)
+
+    def boom():
+        raise RuntimeError("transient")
+
+    event = cache.kickoff_compute(DB, 1, boom)
+    assert event.wait(timeout=2.0)
+    assert cache.get_recent_error(DB, 1) is not None
+
+    # The error sits in the backoff window and would normally suppress the
+    # next kickoff. Bypass that by calling set() directly to simulate a
+    # later successful compute (the worker calls set() then clears errors).
+    # Easier: poke the internal state to drop the error and re-run via the
+    # public API.
+    cache._errors.clear()  # simulate window expiry
+
+    def ok():
+        return {"new_count": 3}
+
+    event = cache.kickoff_compute(DB, 1, ok)
+    assert event.wait(timeout=2.0)
+    assert cache.get(DB, 1) == {"new_count": 3}
+    assert cache.get_recent_error(DB, 1) is None
+
+
 def test_cache_generation_is_scoped_by_db_path():
     """A bump to one db's generation must not race-drop a concurrent write for
     a different db with the same workspace_id."""

--- a/vireo/tests/test_new_images_cache.py
+++ b/vireo/tests/test_new_images_cache.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import threading
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -222,6 +223,121 @@ def test_invalidate_workspaces_clears_error_only_for_targeted_keys():
 
     assert cache.get_recent_error(DB, 1) is None
     assert cache.get_recent_error(DB, 2) is not None
+
+
+def test_kickoff_compute_reuses_in_flight_for_current_generation():
+    """A second kickoff that arrives while a compute is in flight for the same
+    generation must reuse the existing thread — not spawn a duplicate walk."""
+    cache = NewImagesCache(ttl_seconds=60)
+    started = threading.Event()
+    proceed = threading.Event()
+    call_count = [0]
+
+    def slow_compute():
+        call_count[0] += 1
+        started.set()
+        proceed.wait(timeout=5.0)
+        return {"new_count": 3}
+
+    e1 = cache.kickoff_compute(DB, 1, slow_compute)
+    assert started.wait(timeout=2.0)
+    e2 = cache.kickoff_compute(DB, 1, slow_compute)
+    assert e1 is e2, "concurrent kickoff for same generation must reuse in-flight"
+    proceed.set()
+    assert e1.wait(timeout=2.0)
+    assert call_count[0] == 1
+
+
+def test_kickoff_compute_restarts_when_generation_advances():
+    """If ``invalidate_workspaces`` runs while a compute is in flight, the next
+    kickoff must start a fresh compute instead of waiting on the obsolete
+    thread. Otherwise pollers stay in ``pending`` for the full duration of an
+    outdated walk after a workspace/folder change."""
+    cache = NewImagesCache(ttl_seconds=60)
+    stale_started = threading.Event()
+    stale_proceed = threading.Event()
+
+    def stale_compute():
+        stale_started.set()
+        stale_proceed.wait(timeout=5.0)
+        return {"new_count": 999}  # stale value — must be dropped
+
+    e1 = cache.kickoff_compute(DB, 1, stale_compute)
+    assert stale_started.wait(timeout=2.0)
+
+    # Invalidation advances the generation while the compute is still running.
+    cache.invalidate_workspaces(DB, [1])
+
+    fresh_called = threading.Event()
+
+    def fresh_compute():
+        fresh_called.set()
+        return {"new_count": 7}
+
+    e2 = cache.kickoff_compute(DB, 1, fresh_compute)
+    assert e1 is not e2, "stale in-flight thread must not be reused after invalidation"
+    assert fresh_called.wait(timeout=2.0), "fresh compute must actually run"
+    assert e2.wait(timeout=2.0)
+    assert cache.get(DB, 1) == {"new_count": 7}
+
+    # Drain the stale thread; its result must not overwrite the fresh one.
+    stale_proceed.set()
+    assert e1.wait(timeout=2.0)
+    assert cache.get(DB, 1) == {"new_count": 7}, (
+        "stale compute result must be dropped by the generation guard in set()"
+    )
+
+
+def test_kickoff_compute_stale_thread_does_not_clear_inflight_for_fresh():
+    """When a stale thread finishes after a fresh compute has taken over the
+    in-flight slot, its cleanup must not pop the fresh entry."""
+    cache = NewImagesCache(ttl_seconds=60)
+    stale_started = threading.Event()
+    stale_proceed = threading.Event()
+
+    def stale_compute():
+        stale_started.set()
+        stale_proceed.wait(timeout=5.0)
+        return {"new_count": 1}
+
+    cache.kickoff_compute(DB, 1, stale_compute)
+    assert stale_started.wait(timeout=2.0)
+    cache.invalidate_workspaces(DB, [1])
+
+    fresh_started = threading.Event()
+    fresh_proceed = threading.Event()
+
+    def fresh_compute():
+        fresh_started.set()
+        fresh_proceed.wait(timeout=5.0)
+        return {"new_count": 2}
+
+    fresh_event = cache.kickoff_compute(DB, 1, fresh_compute)
+    assert fresh_started.wait(timeout=2.0)
+
+    # Let the stale thread finish first. Its finally block must not clear
+    # ``_inflight[key]`` because that slot now belongs to the fresh thread.
+    stale_proceed.set()
+
+    # The fresh thread is still running, so the in-flight slot must remain.
+    # Poll briefly to let the stale thread's finally complete.
+    import time as _t
+    deadline = _t.monotonic() + 1.0
+    while _t.monotonic() < deadline:
+        with cache._lock:
+            entry = cache._inflight.get((DB, 1))
+        if entry is not None and entry[0] is fresh_event:
+            break
+        _t.sleep(0.01)
+    with cache._lock:
+        entry = cache._inflight.get((DB, 1))
+    assert entry is not None and entry[0] is fresh_event, (
+        "stale thread's finally must not pop the fresh thread's in-flight slot"
+    )
+
+    fresh_proceed.set()
+    assert fresh_event.wait(timeout=2.0)
+    assert cache.get(DB, 1) == {"new_count": 2}
 
 
 def test_cache_generation_is_scoped_by_db_path():


### PR DESCRIPTION
## Summary

When you opened Vireo today, the navbar's `checkNewImages()` poll
synchronously walked every mapped root on a cold cache —
`/api/workspaces/active/new-images` took **12.9s** in `~/.vireo/vireo.log`,
which is what made the UI feel like it "didn't respond" on startup.

## What changed

- The endpoint now returns `pending: true` immediately when the cache is
  cold and runs the `os.walk` in a daemon thread that populates the
  shared `NewImagesCache`.
- A small 500ms grace wait keeps existing synchronous behavior for fast
  walks (and for the test suite, whose `tmp_path` filesystems return
  almost instantly).
- The generation snapshot is taken at kickoff time so a concurrent
  invalidation still drops the stale write — the same race protection
  the synchronous path already had.
- Navbar (`_navbar.html`) and pipeline (`pipeline.html`) detect
  `pending` and re-poll in 3s instead of waiting for the next 60s tick,
  so the banner / source card appear shortly after the walk finishes.

## Test plan

- [x] Existing `vireo/tests/test_new_images_api.py` and friends still pass
      (the brief 500ms wait covers the fast tmp_path case).
- [x] New test: cold cache + slow `count_new_images_for_workspace`
      returns `pending: true` and kicks off the background compute.
- [x] New test: after the background compute finishes, the next request
      returns the real count from cache.
- [x] Full suite from `CLAUDE.md`: **637 passed in 17:53**.

## Notes

- The pre-existing `NewImagesCache` cross-instance share (`get_shared_cache()`)
  means the background worker's fresh `Database` writes hit the same
  cache the foreground request reads.
- `POST /api/workspaces/active/new-images/snapshot` is unchanged — it
  still computes synchronously because the user explicitly asked for a
  snapshot at that moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)