### PR TITLE
fix(logging): only attach file handler when server starts

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -43,6 +43,9 @@ log = logging.getLogger(__name__)
 # fixtures — must NOT touch ~/.vireo/vireo.log, or test tracebacks end up
 # in the user's real log file.
 def _setup_file_logging(log_dir=None):
+    root = logging.getLogger()
+    if any(getattr(h, "_vireo_file_handler", False) for h in root.handlers):
+        return
     if log_dir is None:
         log_dir = os.path.expanduser("~/.vireo")
     os.makedirs(log_dir, exist_ok=True)
@@ -51,13 +54,14 @@ def _setup_file_logging(log_dir=None):
         maxBytes=5 * 1024 * 1024,  # 5 MB
         backupCount=3,
     )
+    handler._vireo_file_handler = True
     handler.setFormatter(
         logging.Formatter(
             "%(asctime)s %(levelname)s %(name)s: %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         )
     )
-    logging.getLogger().addHandler(handler)
+    root.addHandler(handler)
 
 
 # Suppress noisy werkzeug request logs for polling endpoints

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -38,21 +38,26 @@ from preview_cache import evict_if_over_quota as evict_preview_cache_if_over_quo
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
 
-# File logging with rotation — persists across restarts
-_log_dir = os.path.expanduser("~/.vireo")
-os.makedirs(_log_dir, exist_ok=True)
-_file_handler = logging.handlers.RotatingFileHandler(
-    os.path.join(_log_dir, "vireo.log"),
-    maxBytes=5 * 1024 * 1024,  # 5 MB
-    backupCount=3,
-)
-_file_handler.setFormatter(
-    logging.Formatter(
-        "%(asctime)s %(levelname)s %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
+# File logging is attached only when the server actually starts (see
+# main() / _setup_file_logging). Importing this module — e.g. from pytest
+# fixtures — must NOT touch ~/.vireo/vireo.log, or test tracebacks end up
+# in the user's real log file.
+def _setup_file_logging(log_dir=None):
+    if log_dir is None:
+        log_dir = os.path.expanduser("~/.vireo")
+    os.makedirs(log_dir, exist_ok=True)
+    handler = logging.handlers.RotatingFileHandler(
+        os.path.join(log_dir, "vireo.log"),
+        maxBytes=5 * 1024 * 1024,  # 5 MB
+        backupCount=3,
     )
-)
-logging.getLogger().addHandler(_file_handler)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    logging.getLogger().addHandler(handler)
 
 
 # Suppress noisy werkzeug request logs for polling endpoints
@@ -8854,6 +8859,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
 
 def main():
+    _setup_file_logging()
+
     parser = argparse.ArgumentParser(description="Vireo Photo Browser")
     parser.add_argument(
         "--db",

--- a/vireo/tests/test_logging.py
+++ b/vireo/tests/test_logging.py
@@ -1,0 +1,41 @@
+"""Verify that importing the app does not create a log file.
+
+The packaged app attaches a RotatingFileHandler at ~/.vireo/vireo.log.
+Tests must not inherit that handler — otherwise pytest runs in any
+workspace pollute the user's real Vireo log, mixing test tracebacks
+into logs the user is reading to debug their actual app session.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+
+def test_importing_app_does_not_create_log_file(tmp_path):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    env = {**os.environ, "HOME": str(fake_home)}
+    # cwd into the vireo/ package directory so `import app` resolves the
+    # same way conftest.py and the existing test fixtures do.
+    app_pkg_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    code = textwrap.dedent(
+        """
+        from app import create_app  # noqa: F401
+        """
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        check=True,
+        cwd=app_pkg_dir,
+    )
+
+    log_path = fake_home / ".vireo" / "vireo.log"
+    assert not log_path.exists(), (
+        f"Importing app.create_app created {log_path}; the file handler "
+        "should only attach when the server actually starts (main()), not "
+        "at module-import time, so test runs don't pollute the user's log."
+    )

--- a/vireo/tests/test_logging.py
+++ b/vireo/tests/test_logging.py
@@ -6,10 +6,37 @@ workspace pollute the user's real Vireo log, mixing test tracebacks
 into logs the user is reading to debug their actual app session.
 """
 
+import logging
 import os
 import subprocess
 import sys
 import textwrap
+
+
+def test_setup_file_logging_is_idempotent(tmp_path):
+    """Repeated calls must not stack duplicate RotatingFileHandlers.
+
+    main() normally runs once per process, but harness scripts that call
+    main() repeatedly (or anything that re-invokes _setup_file_logging)
+    would otherwise leak handlers and duplicate every log entry.
+    """
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+    from app import _setup_file_logging
+
+    root = logging.getLogger()
+    before = list(root.handlers)
+    try:
+        _setup_file_logging(log_dir=str(tmp_path))
+        _setup_file_logging(log_dir=str(tmp_path))
+        added = [h for h in root.handlers if h not in before]
+        assert len(added) == 1, (
+            f"Expected exactly one new handler after two calls, got {len(added)}"
+        )
+    finally:
+        for h in list(root.handlers):
+            if h not in before:
+                root.removeHandler(h)
+                h.close()
 
 
 def test_importing_app_does_not_create_log_file(tmp_path):


### PR DESCRIPTION
## Summary
- Move the `RotatingFileHandler` setup out of module-level code in `vireo/app.py` into `_setup_file_logging()`, called from `main()`.
- Tests no longer pollute `~/.vireo/vireo.log` when they import `vireo.app` (which they all do via `from app import create_app`).

## Why
Today, importing `vireo.app` attaches the rotating file handler to the root logger and starts writing to `~/.vireo/vireo.log` immediately. Pytest runs in any worktree (e.g. `beijing`, `pangyo`) inherit that handler, so test tracebacks like

```
ERROR jobs: Job pipeline-… failed
RuntimeError: [previews] 3 of 3 previews failed to generate
```

end up interleaved with the real app's logs, making it confusing to debug a running session.

The packaged `Vireo.app` only ever enters via `main()`, so production logging is unchanged. The `userfirst` harness already starts the app in a subprocess with a redirected log, so it's also unaffected.

## Test plan
- [x] New test `vireo/tests/test_logging.py::test_importing_app_does_not_create_log_file` spawns a subprocess with a fake `HOME`, imports `app.create_app`, and asserts `$HOME/.vireo/vireo.log` is not created. Verified RED before the fix, GREEN after.
- [x] Full CLAUDE.md test suite: `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_logging.py -q` → **638 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)