### PR TITLE
fix(scanner): freeze_support + spawn for mp in frozen sidecar

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9023,4 +9023,13 @@ def main():
 
 
 if __name__ == "__main__":
+    # In a PyInstaller bundle, multiprocessing workers re-execute this binary.
+    # Without freeze_support, the child runs main() — argparse rejects the
+    # `--multiprocessing-fork ...` argv (or the `-c` bootstrap), the child
+    # exits, and the parent gets EOFError on the handshake socket. The
+    # PyInstaller runtime hook installs a freeze_support that intercepts
+    # those argv shapes and runs the worker bootstrap instead, but only
+    # when we actually call it.
+    import multiprocessing
+    multiprocessing.freeze_support()
     main()

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -23,10 +23,18 @@ log = logging.getLogger(__name__)
 
 # scan() runs inside JobRunner/pipeline_job background threads, so the
 # default POSIX "fork" start method is unsafe here: forking a
-# multithreaded process can deadlock. Prefer "forkserver" (POSIX, cheap)
-# and fall back to "spawn" (universal).
+# multithreaded process can deadlock. In a PyInstaller bundle, forkserver
+# also fails on macOS — workers fork from a parent that has already
+# loaded PIL/Foundation, and the worker's first Cocoa-touching call
+# crashes the child, surfacing as EOFError on the forkserver handshake
+# in the parent. spawn does fork+exec for each worker, giving a clean
+# process; paired with multiprocessing.freeze_support() in app.py's
+# entry point it works inside the frozen sidecar. Dev runs keep
+# forkserver for its cheap warmup.
 _SCAN_MP_METHOD = (
-    "forkserver"
+    "spawn"
+    if getattr(sys, "frozen", False)
+    else "forkserver"
     if "forkserver" in multiprocessing.get_all_start_methods()
     else "spawn"
 )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -2099,3 +2099,26 @@ def test_rescan_regenerates_working_copy_when_file_content_changes(tmp_path):
         f"Working copy pixel {pixel} does not reflect updated (blue) source; "
         "stale extraction from pre-change content was served."
     )
+
+
+def test_scan_mp_method_is_spawn_when_frozen(monkeypatch):
+    """Frozen (PyInstaller) sidecars must use spawn, not forkserver.
+
+    forkserver in a frozen bundle on macOS forks workers from a parent
+    that has loaded PIL/Foundation; the worker's first Cocoa-touching
+    call crashes the child and the parent sees EOFError on the handshake.
+    spawn does fork+exec for a clean worker process.
+    """
+    import importlib
+
+    import scanner
+
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    reloaded = importlib.reload(scanner)
+    try:
+        assert reloaded._SCAN_MP_METHOD == "spawn"
+    finally:
+        # Restore the unfrozen module-level constant so other tests in
+        # the same process see the dev-mode value.
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        importlib.reload(scanner)


### PR DESCRIPTION
## Summary

Pipeline scans crash inside the v0.8.30 PyInstaller bundle the first time `ProcessPoolExecutor` tries to spawn a worker (≥8 files), with `EOFError` from `multiprocessing.connection.answer_challenge`. Reproduced today at 15:01:35 in `~/.vireo/vireo.log` against the shipped binary.

Two compounding gaps:

1. **`vireo/app.py:9025` never calls `multiprocessing.freeze_support()`.** PyInstaller's runtime hook (`pyi_rth_multiprocessing.py`) installs a `freeze_support` that intercepts the `--multiprocessing-fork ...` (spawn) and `-c "from multiprocessing.forkserver import main"` argv shapes used to relaunch worker processes — but only when user code actually invokes it. Without the call, the relaunched bundle runs `main()` from the top, argparse rejects the bootstrap argv, the child exits, and the parent gets `EOFError` on the handshake.

2. **`scanner._SCAN_MP_METHOD` picks `forkserver` on POSIX.** In a frozen bundle on macOS, forkserver workers fork from a parent that has loaded PIL / Foundation; the worker's first Cocoa-touching call crashes the child, surfacing the same way (EOFError on the forkserver handshake).

## Changes

- `vireo/app.py`: call `multiprocessing.freeze_support()` as the first thing in `if __name__ == "__main__":`.
- `vireo/scanner.py`: prefer `spawn` when `sys.frozen` is truthy; keep `forkserver` for dev where its cheap warmup matters and Foundation isn't loaded.
- `vireo/tests/test_scanner.py`: regression test that asserts `_SCAN_MP_METHOD == "spawn"` when `sys.frozen` is set.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_scanner.py -q` → **703 passed** (17 min)
- [ ] Rebuild the sidecar (`python scripts/build_sidecar.py`), run a scan on ≥8 files in the bundled app, verify no EOFError. (Can't be exercised in CI — needs the frozen binary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)