### PR TITLE
fix(new-images): drop in-flight handle on invalidation

### DIFF
--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -196,6 +196,16 @@ class NewImagesCache:
                 # fresh recompute via the 30s backoff window in
                 # ``kickoff_compute``.
                 self._errors.pop(key, None)
+                # Drop the in-flight handle so the next ``kickoff_compute``
+                # starts a fresh worker instead of waiting on the obsolete
+                # walk. The stale worker keeps running but its ``set`` call
+                # is dropped by the per-key generation guard, and any error
+                # it raises is dropped by the worker's own gen check. Without
+                # this, a long walk that's mid-flight when a folder/workspace
+                # change fires would force
+                # ``/api/workspaces/active/new-images`` to keep returning
+                # ``pending`` for the full duration of the stale walk.
+                self._inflight.pop(key, None)
                 self._generations[key] = self._generations.get(key, 0) + 1
 
     def get_recent_error(self, db_path, workspace_id):
@@ -275,7 +285,12 @@ class NewImagesCache:
                                              time.monotonic())
             finally:
                 with self._lock:
-                    self._inflight.pop(key, None)
+                    # Identity check: ``invalidate_workspaces`` may have
+                    # cleared our handle and a fresh worker may have
+                    # registered its own event under the same key. Only
+                    # pop our own entry so we don't trample the new worker.
+                    if self._inflight.get(key) is event:
+                        del self._inflight[key]
                 event.set()
 
         threading.Thread(

--- a/vireo/tests/test_new_images_cache.py
+++ b/vireo/tests/test_new_images_cache.py
@@ -205,6 +205,56 @@ def test_invalidate_workspaces_clears_recent_error():
     assert cache.get(DB, 1) == {"new_count": 4}
 
 
+def test_invalidate_workspaces_starts_fresh_compute_after_in_flight_walk():
+    """A long walk that's still running when ``invalidate_workspaces`` fires
+    must not block a fresh recompute. The next ``kickoff_compute`` should
+    start a new worker rather than handing back the in-flight event for the
+    obsolete walk — otherwise ``/api/workspaces/active/new-images`` keeps
+    waiting on stale work for the full duration of the original walk and
+    the UI stays in pending while a folder/workspace change is unreflected.
+    """
+    import threading
+
+    cache = NewImagesCache(ttl_seconds=60)
+
+    release_stale = threading.Event()
+    stale_started = threading.Event()
+    fresh_call_count = {"n": 0}
+
+    def stale_compute():
+        stale_started.set()
+        release_stale.wait(timeout=5)
+        return {"new_count": 999}
+
+    def fresh_compute():
+        fresh_call_count["n"] += 1
+        return {"new_count": 4}
+
+    try:
+        # Kick off a long-running walk and wait until the worker has actually
+        # entered ``stale_compute`` so the in-flight entry exists.
+        cache.kickoff_compute(DB, 1, stale_compute)
+        assert stale_started.wait(timeout=2.0), "stale worker never started"
+
+        # Folder/workspace state changes mid-walk.
+        cache.invalidate_workspaces(DB, [1])
+
+        # The next request must run a fresh compute, not silently wait on
+        # the obsolete in-flight event for the rest of the stale walk.
+        fresh_event = cache.kickoff_compute(DB, 1, fresh_compute)
+        assert fresh_event.wait(timeout=2.0), (
+            "fresh compute after invalidation never finished"
+        )
+        assert fresh_call_count["n"] == 1, (
+            f"expected fresh_compute to run after invalidation; "
+            f"called {fresh_call_count['n']} times"
+        )
+        assert cache.get(DB, 1) == {"new_count": 4}
+    finally:
+        # Let the stale worker finish before the test exits.
+        release_stale.set()
+
+
 def test_invalidate_workspaces_clears_error_only_for_targeted_keys():
     """Invalidation is scoped: a failure on workspace 2 must survive when
     workspace 1's cache is invalidated."""


### PR DESCRIPTION
## Summary

Follow-up to #669 addressing the remaining Codex P2 about in-flight reuse.

`NewImagesCache.kickoff_compute` reused `_inflight[key]` regardless of generation. If `invalidate_workspaces` fired while a walk was in flight (folder/workspace change, completed scan), subsequent requests kept waiting on the obsolete event for the full duration of the stale walk — `/api/workspaces/active/new-images` returned `pending: true` while the cache key had already moved on.

## What changed

- `invalidate_workspaces` now pops `_inflight[key]` so the next `kickoff_compute` starts a fresh worker.
- The stale worker keeps running but is harmless: its `set()` call is dropped by the existing per-key generation guard, and its error write is dropped by the worker's own generation check (added in #669).
- The worker's `_inflight.pop` now does an identity check (`is event`) before deleting, so a stale worker can't trample the new worker's entry under the same key.

## Why this is a small follow-up rather than amending #669

#669 already shipped through the PR-agent's review/autofix cycle and tests are green. This race only costs one polling cycle (~3s) of stale `pending` and the fix is narrow — keeping it isolated makes the diff easy to read and the rebase trivial.

> **Base branch:** `vireo-unresponsive-debug` (will fall back to `main` automatically once #669 merges).

## Test plan

- [x] New regression test `test_invalidate_workspaces_starts_fresh_compute_after_in_flight_walk` in `test_new_images_cache.py` — fails before the fix, passes after.
- [x] All 63 new-images tests pass.
- [x] Full suite from `CLAUDE.md`: **637 passed in 16:58**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)