### PR TITLE
Confirm before unlinking folder from workspace

### DIFF
--- a/vireo/templates/workspace.html
+++ b/vireo/templates/workspace.html
@@ -90,15 +90,19 @@ safeFetch('/api/workspaces/active', {}, { toast: false }).then(function(ws) {
 }).catch(function() {});
 
 /* ---------- Folders ---------- */
+var _wsFoldersById = {};
+
 async function loadWsFolders() {
   try {
     var ws = await safeFetch('/api/workspaces/active', {}, { toast: false });
     var container = document.getElementById('wsFoldersContent');
+    _wsFoldersById = {};
     if (!ws.folders || ws.folders.length === 0) {
       container.innerHTML = '<span style="color:var(--text-ghost);font-size:13px;">No folders in this workspace.</span>';
     } else {
       var html = '';
       ws.folders.forEach(function(f) {
+        _wsFoldersById[f.id] = f;
         html += '<div class="setting-row">';
         html += '<label style="display:flex;align-items:center;gap:8px;flex:1;min-width:0;">';
         html += '<input type="checkbox" class="folder-move-cb" value="' + f.id + '" onchange="updateMoveBtn()" style="accent-color:var(--accent);">';
@@ -116,6 +120,14 @@ async function loadWsFolders() {
 }
 
 async function removeFolderFromWs(wsId, folderId) {
+  var f = _wsFoldersById[folderId];
+  var path = f ? f.path : '';
+  var n = f ? (f.photo_count || 0) : 0;
+  var msg = 'Remove "' + path + '" from this workspace?\n\n' +
+            n + ' photo' + (n === 1 ? '' : 's') + ' in this folder will no longer appear in this workspace, ' +
+            'and predictions, collections, and pending changes referencing them will be hidden here too.\n\n' +
+            'Photos and the folder are not deleted. You can re-add the folder later to restore visibility.';
+  if (!confirm(msg)) return;
   try { await safeFetch('/api/workspaces/' + wsId + '/folders/' + folderId, { method: 'DELETE' }); } catch(e) {}
   loadWsFolders();
 }


### PR DESCRIPTION
## Summary

The `×` button next to a folder in the workspace settings page used to silently fire `DELETE /api/workspaces/<id>/folders/<id>` on a single click — no confirmation, no indication of impact. Since photo visibility in a workspace is gated by `workspace_folders` joins (`get_photos`, `count_photos`, `get_predictions`, `_build_collection_query`), unlinking a folder makes every photo in it disappear from the workspace's gallery, predictions, collections, and counts. Easy to misclick, easy to be alarmed.

This PR adds a `confirm()` dialog matching the pattern already used by `deleteWorkspaceConfirm` elsewhere in the same file. The dialog shows the folder path and the photo count (already available on `f.photo_count` from `/api/workspaces/active`), and explains that photos/files aren't deleted and the folder can be re-added.

## Changes

- `vireo/templates/workspace.html`: stash folders by id during render so `removeFolderFromWs` can look up path + photo_count, then `confirm()` before the DELETE.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py -q` → 326 passed
- [ ] Manual: navigate to workspace settings, click `×` on a folder → dialog appears with path and photo count; cancel leaves folder intact; OK unlinks as before