### PR TITLE
fix(keywords): re-run taxonomy auto-detection on keyword rename

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3470,14 +3470,18 @@ class Database:
         if not updates:
             return
 
-        # Auto-retype on rename: same logic as add_keyword.
+        # Auto-retype on rename: same logic as add_keyword. Only fires
+        # on an actual name change so idempotent PUT-style updates
+        # (client re-sending the existing name) don't unexpectedly
+        # reclassify a 'general' keyword once the taxa table is
+        # populated.
         if 'name' in updates:
             new_name = updates['name']
             current = self.conn.execute(
-                "SELECT type, taxon_id FROM keywords WHERE id = ?",
+                "SELECT name, type, taxon_id FROM keywords WHERE id = ?",
                 (keyword_id,),
             ).fetchone()
-            if current is not None:
+            if current is not None and new_name != current["name"]:
                 cur_type = current["type"]
                 taxon = self.conn.execute(
                     """SELECT t.id FROM taxa t

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3499,18 +3499,22 @@ class Database:
                     # leave type/taxon_id alone.
                     if taxon:
                         updates.setdefault('type', 'taxonomy')
-                        updates.setdefault('taxon_id', taxon["id"])
-                        # Mirror add_keyword's invariant: a taxonomy
-                        # keyword backed by a matched taxon is is_species=1,
-                        # so species-only queries (filtering on
-                        # is_species=1, e.g. get_species_keywords_for_photos)
-                        # include the auto-promoted keyword.
+                        # Gate taxon_id on the EFFECTIVE type so an
+                        # explicit non-taxonomy type kwarg (e.g.
+                        # type='location') doesn't end up with a
+                        # taxonomy link. Mirror add_keyword's invariant
+                        # for the auto-promoted case: type='taxonomy'
+                        # backed by a matched taxon implies is_species=1.
                         if updates.get('type') == 'taxonomy':
+                            updates.setdefault('taxon_id', taxon["id"])
                             updates['is_species'] = 1
-                elif cur_type == 'taxonomy' and taxon:
+                elif (cur_type == 'taxonomy' and taxon
+                      and updates.get('type', 'taxonomy') == 'taxonomy'):
                     # Already taxonomy: refresh taxon_id only if the new
-                    # name matches a (possibly different) taxon. If no
-                    # match, leave the existing link in place.
+                    # name matches a (possibly different) taxon AND the
+                    # effective type stays 'taxonomy' (caller may demote
+                    # to 'location' etc.). If no match, leave the existing
+                    # link in place.
                     updates.setdefault('taxon_id', taxon["id"])
                 # Other manual types ('location', 'people', etc.) are
                 # preserved — user intent wins.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3500,6 +3500,13 @@ class Database:
                     if taxon:
                         updates.setdefault('type', 'taxonomy')
                         updates.setdefault('taxon_id', taxon["id"])
+                        # Mirror add_keyword's invariant: a taxonomy
+                        # keyword backed by a matched taxon is is_species=1,
+                        # so species-only queries (filtering on
+                        # is_species=1, e.g. get_species_keywords_for_photos)
+                        # include the auto-promoted keyword.
+                        if updates.get('type') == 'taxonomy':
+                            updates['is_species'] = 1
                 elif cur_type == 'taxonomy' and taxon:
                     # Already taxonomy: refresh taxon_id only if the new
                     # name matches a (possibly different) taxon. If no

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3452,13 +3452,62 @@ class Database:
     VALID_KEYWORD_TYPES = ('general', 'taxonomy', 'location', 'descriptive', 'people', 'event')
 
     def update_keyword(self, keyword_id, **kwargs):
-        """Update keyword fields. Supports: type, taxon_id, latitude, longitude, name."""
+        """Update keyword fields. Supports: type, taxon_id, latitude, longitude, name.
+
+        On a name change, re-runs the same taxonomy auto-detection that
+        add_keyword does on insert: if the keyword's current type is
+        'general' and the new name matches a taxon, it's promoted to
+        type='taxonomy' with the matching taxon_id. If the current type is
+        already 'taxonomy' and the new name matches a different taxon,
+        taxon_id is updated. Manually-set non-'general' types (e.g.
+        'location', 'people') are preserved. Explicit type/taxon_id
+        kwargs always win over auto-detection.
+        """
         if 'type' in kwargs and kwargs['type'] not in self.VALID_KEYWORD_TYPES:
             raise ValueError(f"Invalid keyword type: {kwargs['type']}")
         allowed = {'type', 'taxon_id', 'latitude', 'longitude', 'name'}
         updates = {k: v for k, v in kwargs.items() if k in allowed}
         if not updates:
             return
+
+        # Auto-retype on rename: same logic as add_keyword.
+        if 'name' in updates:
+            new_name = updates['name']
+            current = self.conn.execute(
+                "SELECT type, taxon_id FROM keywords WHERE id = ?",
+                (keyword_id,),
+            ).fetchone()
+            if current is not None:
+                cur_type = current["type"]
+                taxon = self.conn.execute(
+                    """SELECT t.id FROM taxa t
+                       WHERE t.common_name = ? COLLATE NOCASE
+                          OR t.name = ? COLLATE NOCASE
+                       LIMIT 1""",
+                    (new_name, new_name),
+                ).fetchone()
+                if not taxon:
+                    taxon = self.conn.execute(
+                        """SELECT t.taxon_id AS id FROM taxa_common_names t
+                           WHERE t.name = ? COLLATE NOCASE
+                           LIMIT 1""",
+                        (new_name,),
+                    ).fetchone()
+
+                if cur_type == 'general':
+                    # Only promote to taxonomy if a match exists; otherwise
+                    # leave type/taxon_id alone.
+                    if taxon:
+                        updates.setdefault('type', 'taxonomy')
+                        updates.setdefault('taxon_id', taxon["id"])
+                elif cur_type == 'taxonomy' and taxon:
+                    # Already taxonomy: refresh taxon_id only if the new
+                    # name matches a (possibly different) taxon. If no
+                    # match, leave the existing link in place.
+                    updates.setdefault('taxon_id', taxon["id"])
+                # Other manual types ('location', 'people', etc.) are
+                # preserved — user intent wins.
+
         set_clause = ", ".join(f"{k} = ?" for k in updates)
         values = list(updates.values()) + [keyword_id]
         self.conn.execute(f"UPDATE keywords SET {set_clause} WHERE id = ?", values)

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6250,3 +6250,220 @@ def test_get_folder_tree_includes_partial_folders_with_status(tmp_path):
     assert missing_id not in rows, "missing folder must not appear in tree"
     assert rows[ok_id]["status"] == "ok"
     assert rows[partial_id]["status"] == "partial"
+
+
+# -- update_keyword: rename re-runs taxonomy auto-detection --
+#
+# Regression tests for: when a keyword name is changed (e.g. fixing a typo
+# like "Lesser scaub" -> "Lesser Scaup"), the same auto-detection logic
+# that add_keyword uses on insert must re-fire so the keyword gets
+# re-typed as 'taxonomy' with a linked taxon_id. Manual user overrides
+# (any non-'general' type, or explicit type/taxon_id kwargs) win over
+# auto-detection.
+
+
+def _seed_taxa(db, rows):
+    """Insert minimal taxa rows for keyword auto-detect tests.
+
+    rows: list of (inat_id, scientific_name, common_name) tuples.
+    Returns dict mapping common_name -> taxa.id (local PK).
+    """
+    out = {}
+    for inat_id, sci, common in rows:
+        cur = db.conn.execute(
+            "INSERT INTO taxa (inat_id, name, common_name, rank, kingdom) "
+            "VALUES (?, ?, ?, 'species', 'Animalia')",
+            (inat_id, sci, common),
+        )
+        out[common] = cur.lastrowid
+    db.conn.commit()
+    return out
+
+
+def test_update_keyword_rename_general_to_matching_taxon_auto_retypes(tmp_path):
+    """Renaming a 'general' keyword to a name matching a taxon retypes it
+    as 'taxonomy' and links taxon_id. This is the typo-fix path."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    taxa = _seed_taxa(db, [(7000, "Aythya affinis", "Lesser Scaup")])
+
+    # User adds a typo'd keyword that does NOT match any taxon.
+    kid = db.add_keyword("Lesser scaub")
+    pre = db.conn.execute(
+        "SELECT type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert pre["type"] == "general"
+    assert pre["taxon_id"] is None
+
+    # User fixes the typo via update_keyword.
+    db.update_keyword(kid, name="Lesser Scaup")
+
+    row = db.conn.execute(
+        "SELECT name, type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["name"] == "Lesser Scaup"
+    assert row["type"] == "taxonomy"
+    assert row["taxon_id"] == taxa["Lesser Scaup"]
+
+
+def test_update_keyword_rename_general_no_match_stays_general(tmp_path):
+    """Renaming a 'general' keyword to a name with no taxon match leaves
+    it as 'general' with NULL taxon_id."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    _seed_taxa(db, [(7000, "Aythya affinis", "Lesser Scaup")])
+
+    kid = db.add_keyword("Misc thing")
+    db.update_keyword(kid, name="Still misc")
+
+    row = db.conn.execute(
+        "SELECT name, type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["name"] == "Still misc"
+    assert row["type"] == "general"
+    assert row["taxon_id"] is None
+
+
+def test_update_keyword_rename_taxonomy_to_different_taxon_updates_taxon_id(tmp_path):
+    """Renaming a keyword that's already 'taxonomy' to a name matching a
+    DIFFERENT taxon updates taxon_id and keeps type='taxonomy'."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    taxa = _seed_taxa(db, [
+        (7000, "Aythya affinis", "Lesser Scaup"),
+        (7001, "Aythya marila", "Greater Scaup"),
+    ])
+
+    kid = db.add_keyword("Lesser Scaup")
+    pre = db.conn.execute(
+        "SELECT type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert pre["type"] == "taxonomy"
+    assert pre["taxon_id"] == taxa["Lesser Scaup"]
+
+    db.update_keyword(kid, name="Greater Scaup")
+
+    row = db.conn.execute(
+        "SELECT name, type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["name"] == "Greater Scaup"
+    assert row["type"] == "taxonomy"
+    # Documented behavior: when the new name matches a different taxon,
+    # taxon_id is updated to point at the new match.
+    assert row["taxon_id"] == taxa["Greater Scaup"]
+
+
+def test_update_keyword_rename_taxonomy_to_unknown_name_keeps_taxon_id(tmp_path):
+    """Renaming a 'taxonomy' keyword to a name with no taxon match keeps
+    type='taxonomy' and leaves taxon_id as-is (don't drop the link)."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    taxa = _seed_taxa(db, [(7000, "Aythya affinis", "Lesser Scaup")])
+
+    kid = db.add_keyword("Lesser Scaup")
+    pre_taxon_id = taxa["Lesser Scaup"]
+    assert db.conn.execute(
+        "SELECT taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()["taxon_id"] == pre_taxon_id
+
+    db.update_keyword(kid, name="Some custom name")
+
+    row = db.conn.execute(
+        "SELECT name, type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["name"] == "Some custom name"
+    # type is preserved (not 'general'), taxon_id is preserved.
+    assert row["type"] == "taxonomy"
+    assert row["taxon_id"] == pre_taxon_id
+
+
+def test_update_keyword_rename_location_keyword_preserves_type_and_taxon_id(tmp_path):
+    """User intent wins: a manually-typed 'location' keyword that's
+    renamed to a string matching a taxon must NOT be re-classified as
+    'taxonomy'. type and taxon_id stay intact."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    _seed_taxa(db, [(7000, "Aythya affinis", "Lesser Scaup")])
+
+    # Add a general keyword, then user marks it as 'location'.
+    kid = db.add_keyword("Backyard")
+    db.update_keyword(kid, type="location")
+    pre = db.conn.execute(
+        "SELECT type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert pre["type"] == "location"
+    assert pre["taxon_id"] is None
+
+    # User renames it to a name that happens to match a taxon.
+    db.update_keyword(kid, name="Lesser Scaup")
+
+    row = db.conn.execute(
+        "SELECT name, type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["name"] == "Lesser Scaup"
+    assert row["type"] == "location", "manual 'location' must not be auto-overridden"
+    assert row["taxon_id"] is None
+
+
+def test_update_keyword_no_name_change_does_not_touch_type(tmp_path):
+    """Updates that don't include 'name' don't trigger auto-detect logic
+    and behave like the pre-fix update_keyword."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    _seed_taxa(db, [(7000, "Aythya affinis", "Lesser Scaup")])
+
+    kid = db.add_keyword("Backyard")
+    # Just change type — name stays 'Backyard'.
+    db.update_keyword(kid, type="location")
+    row = db.conn.execute(
+        "SELECT name, type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["name"] == "Backyard"
+    assert row["type"] == "location"
+    assert row["taxon_id"] is None
+
+
+def test_update_keyword_explicit_type_and_taxon_id_kwargs_win(tmp_path):
+    """Caller-supplied type and taxon_id win over auto-detection. Used by
+    the bulk-type-apply UI path."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    taxa = _seed_taxa(db, [
+        (7000, "Aythya affinis", "Lesser Scaup"),
+        (7001, "Aythya marila", "Greater Scaup"),
+    ])
+
+    kid = db.add_keyword("Misc")  # general, no taxon
+    # Caller renames AND explicitly sets type+taxon_id to a different taxon.
+    # Auto-detect would pick "Lesser Scaup" -> taxa["Lesser Scaup"], but
+    # the explicit kwargs must override.
+    db.update_keyword(
+        kid,
+        name="Lesser Scaup",
+        type="taxonomy",
+        taxon_id=taxa["Greater Scaup"],
+    )
+    row = db.conn.execute(
+        "SELECT name, type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["name"] == "Lesser Scaup"
+    assert row["type"] == "taxonomy"
+    assert row["taxon_id"] == taxa["Greater Scaup"]
+
+
+def test_update_keyword_rename_with_empty_taxa_table_no_op(tmp_path):
+    """If the taxa table is empty (user hasn't downloaded taxonomy yet),
+    rename succeeds without error and without auto-reclassification."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    # No _seed_taxa call — taxa table is empty.
+
+    kid = db.add_keyword("Lesser scaub")
+    db.update_keyword(kid, name="Lesser Scaup")
+
+    row = db.conn.execute(
+        "SELECT name, type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["name"] == "Lesser Scaup"
+    assert row["type"] == "general"
+    assert row["taxon_id"] is None

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6299,11 +6299,43 @@ def test_update_keyword_rename_general_to_matching_taxon_auto_retypes(tmp_path):
     db.update_keyword(kid, name="Lesser Scaup")
 
     row = db.conn.execute(
-        "SELECT name, type, taxon_id FROM keywords WHERE id = ?", (kid,)
+        "SELECT name, type, taxon_id, is_species FROM keywords WHERE id = ?",
+        (kid,),
     ).fetchone()
     assert row["name"] == "Lesser Scaup"
     assert row["type"] == "taxonomy"
     assert row["taxon_id"] == taxa["Lesser Scaup"]
+    # Mirror add_keyword's invariant: an auto-promoted taxonomy keyword
+    # backed by a matched taxon must have is_species=1, otherwise
+    # species-only queries (filtering on is_species=1) would silently
+    # exclude it.
+    assert row["is_species"] == 1
+
+
+def test_update_keyword_rename_general_to_matching_taxon_visible_to_species_query(tmp_path):
+    """After auto-promoting a renamed 'general' keyword to 'taxonomy',
+    species-only queries (which filter on is_species=1) must include it.
+    Regression for the case where update_keyword set type/taxon_id but
+    forgot to flip is_species, leaving auto-promoted keywords invisible
+    to get_species_keywords_for_photos."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    _seed_taxa(db, [(7000, "Aythya affinis", "Lesser Scaup")])
+
+    fid = db.add_folder('/photos', name='photos')
+    pid = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    kid = db.add_keyword("Lesser scaub")  # typo, no taxon match
+    db.tag_photo(pid, kid)
+
+    # Before rename: general keyword, species query returns nothing.
+    assert db.get_species_keywords_for_photos([pid]) == {}
+
+    db.update_keyword(kid, name="Lesser Scaup")
+
+    # After rename: auto-promoted to taxonomy + is_species=1, so the
+    # species query now includes it.
+    assert db.get_species_keywords_for_photos([pid]) == {pid: ["Lesser Scaup"]}
 
 
 def test_update_keyword_rename_general_no_match_stays_general(tmp_path):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6563,3 +6563,39 @@ def test_update_keyword_rename_with_empty_taxa_table_no_op(tmp_path):
     assert row["name"] == "Lesser Scaup"
     assert row["type"] == "general"
     assert row["taxon_id"] is None
+
+
+def test_update_keyword_idempotent_name_update_does_not_auto_retype(tmp_path):
+    """Sending the same name (idempotent PUT) must NOT trigger
+    auto-detection. A pre-existing 'general' keyword whose name happens
+    to match a taxon stays 'general' when a client re-sends the full
+    keyword object with no actual rename — auto-detection only fires on
+    a real name change."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+
+    # Add a 'general' keyword BEFORE the taxa table is populated so it
+    # doesn't get auto-typed on insert. This mirrors a realistic
+    # scenario: user added "Lesser Scaup" as a freeform tag before
+    # downloading taxonomy.
+    kid = db.add_keyword("Lesser Scaup")
+    pre = db.conn.execute(
+        "SELECT type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert pre["type"] == "general"
+    assert pre["taxon_id"] is None
+
+    # Now populate taxonomy.
+    _seed_taxa(db, [(7000, "Aythya affinis", "Lesser Scaup")])
+
+    # Idempotent update: same name. Must NOT auto-promote to 'taxonomy'.
+    db.update_keyword(kid, name="Lesser Scaup")
+
+    row = db.conn.execute(
+        "SELECT name, type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["name"] == "Lesser Scaup"
+    assert row["type"] == "general", (
+        "no actual name change — auto-detection must not fire"
+    )
+    assert row["taxon_id"] is None

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6483,6 +6483,70 @@ def test_update_keyword_explicit_type_and_taxon_id_kwargs_win(tmp_path):
     assert row["taxon_id"] == taxa["Greater Scaup"]
 
 
+def test_update_keyword_rename_with_explicit_non_taxonomy_type_skips_taxon_link(tmp_path):
+    """Combined rename + explicit non-taxonomy type must not auto-fill
+    taxon_id. Otherwise the row ends up as type='location' with a
+    taxonomy link, which violates the docstring's precedence ('explicit
+    kwargs win') and creates inconsistent state for callers that send
+    combined name/type updates from the API."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    _seed_taxa(db, [(7000, "Aythya affinis", "Lesser Scaup")])
+
+    kid = db.add_keyword("Lesser scaub")  # general, no taxon match
+    pre = db.conn.execute(
+        "SELECT type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert pre["type"] == "general"
+    assert pre["taxon_id"] is None
+
+    # Caller renames AND explicitly types as 'location'. Even though
+    # "Lesser Scaup" matches a taxon, the effective type is 'location',
+    # so taxon_id MUST NOT be auto-filled.
+    db.update_keyword(kid, name="Lesser Scaup", type="location")
+
+    row = db.conn.execute(
+        "SELECT name, type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["name"] == "Lesser Scaup"
+    assert row["type"] == "location"
+    assert row["taxon_id"] is None, (
+        "explicit non-taxonomy type must suppress taxon_id auto-fill"
+    )
+
+
+def test_update_keyword_rename_taxonomy_to_explicit_non_taxonomy_type_does_not_relink(tmp_path):
+    """When changing a 'taxonomy' keyword's type to something else AND
+    renaming, do not auto-refresh taxon_id to the new name's match.
+    The existing taxon_id is left untouched (no auto-fill, no auto-clear)."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    taxa = _seed_taxa(db, [
+        (7000, "Aythya affinis", "Lesser Scaup"),
+        (7001, "Aythya marila", "Greater Scaup"),
+    ])
+
+    kid = db.add_keyword("Lesser Scaup")
+    pre_taxon_id = taxa["Lesser Scaup"]
+    assert db.conn.execute(
+        "SELECT taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()["taxon_id"] == pre_taxon_id
+
+    # Rename to a name that matches a different taxon, but explicitly
+    # demote type to 'location'. taxon_id should NOT auto-refresh to
+    # taxa["Greater Scaup"] because the effective type isn't 'taxonomy'.
+    db.update_keyword(kid, name="Greater Scaup", type="location")
+
+    row = db.conn.execute(
+        "SELECT name, type, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["name"] == "Greater Scaup"
+    assert row["type"] == "location"
+    assert row["taxon_id"] == pre_taxon_id, (
+        "explicit non-taxonomy type must suppress taxon_id auto-refresh"
+    )
+
+
 def test_update_keyword_rename_with_empty_taxa_table_no_op(tmp_path):
     """If the taxa table is empty (user hasn't downloaded taxonomy yet),
     rename succeeds without error and without auto-reclassification."""


### PR DESCRIPTION
## Bug

\`Database.update_keyword\` writes the new keyword fields but never re-runs
the taxa lookup that \`add_keyword\` performs on insert. So when a user
fixes a typo like \"Lesser scaub\" -> \"Lesser Scaup\" via the rename UI,
the keyword stays \`type='general'\` with \`taxon_id=NULL\` instead of being
auto-promoted to \`type='taxonomy'\` linked to the matching taxon.

## Fix

On a name change, re-run the same taxa lookup as \`add_keyword\`
(\`taxa.common_name\` / \`taxa.name\` / fallback \`taxa_common_names.name\`,
COLLATE NOCASE, LIMIT 1) and apply this precedence:

1. **Caller-explicit \`type\` / \`taxon_id\` kwargs always win.** Implemented
   with \`updates.setdefault(...)\` so an explicit value passed by the
   caller is never overwritten by auto-detection. (This is what the
   bulk-type-apply UI relies on.)
2. **Current type \`'general'\` + name matches a taxon** -> promote to
   \`type='taxonomy'\`, \`taxon_id=<match>\`. No match -> leave alone.
3. **Current type \`'taxonomy'\` + name matches** -> refresh \`taxon_id\`
   (handles renaming Lesser Scaup -> Greater Scaup). No match -> leave
   existing \`taxon_id\` in place; don't drop the link.
4. **Current type in \`{location, people, descriptive, event}\`** ->
   neither \`type\` nor \`taxon_id\` is touched even if the new name happens
   to match a taxon. Manual user intent wins.
5. **Empty \`taxa\` table** (taxonomy not yet downloaded) -> graceful
   no-op: rename succeeds, no auto-reclassification, no errors.

Updates with no \`name\` change skip the lookup entirely (preserving
prior behavior).

## Test coverage

8 new regression tests in \`vireo/tests/test_db.py\`, one per branch:

- \`test_update_keyword_rename_general_to_matching_taxon_auto_retypes\` - the typo-fix path
- \`test_update_keyword_rename_general_no_match_stays_general\`
- \`test_update_keyword_rename_taxonomy_to_different_taxon_updates_taxon_id\`
- \`test_update_keyword_rename_taxonomy_to_unknown_name_keeps_taxon_id\` - don't drop the link
- \`test_update_keyword_rename_location_keyword_preserves_type_and_taxon_id\` - manual type wins
- \`test_update_keyword_no_name_change_does_not_touch_type\`
- \`test_update_keyword_explicit_type_and_taxon_id_kwargs_win\`
- \`test_update_keyword_rename_with_empty_taxa_table_no_op\`

## Test results

Full project test gate (per CLAUDE.md):

\`\`\`
python -m pytest tests/test_workspaces.py vireo/tests/test_db.py \\
  vireo/tests/test_app.py vireo/tests/test_photos_api.py \\
  vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py \\
  vireo/tests/test_darktable_api.py vireo/tests/test_config.py
\`\`\`

**645 passed, 1 warning in 1186.62s** - all green, including the 8 new tests.

## Scope

Only \`vireo/db.py::Database.update_keyword\` and tests are touched. No
refactor of surrounding code, no unrelated lint cleanup.