### PR TITLE
feat(new-images): surface background walk as ephemeral job

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2304,12 +2304,65 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         from db import Database
         from new_images import count_new_images_for_workspace
 
-        def compute():
+        def compute(progress_callback=None):
             wdb = Database(db_path)
             wdb.set_active_workspace(ws_id)
-            return count_new_images_for_workspace(wdb, ws_id)
+            return count_new_images_for_workspace(
+                wdb, ws_id, progress_callback=progress_callback,
+            )
 
-        event = cache.kickoff_compute(db_path, ws_id, compute)
+        # Surface the walk as an ephemeral job so the user can see it in the
+        # bottom panel rather than wondering why their workspace is silent.
+        # ``on_spawn`` only fires when this kickoff actually starts a new
+        # worker (cache truly cold) — cache hits and reuse of an in-flight
+        # walk skip job creation, so navbar polls don't clutter the list.
+        ws_row = db.get_workspace(ws_id)
+        ws_name = ws_row["name"] if ws_row else f"workspace #{ws_id}"
+        runner = app._job_runner
+
+        def on_spawn(spawn_event):
+            progress_state = {"checked": 0, "found": 0}
+
+            def job_work_fn(job):
+                # Mirror the cache worker's lifecycle. ``spawn_event`` fires
+                # in the worker's finally clause, so we wake when the walk
+                # ends regardless of success or failure. Final totals come
+                # from progress_state, which the cache worker populated via
+                # progress_callback.
+                spawn_event.wait()
+                return {
+                    "files_checked": progress_state["checked"],
+                    "new_count": progress_state["found"],
+                }
+
+            job_id = runner.start(
+                "new_images_walk",
+                job_work_fn,
+                ephemeral=True,
+                workspace_id=ws_id,
+                config={"workspace_name": ws_name},
+            )
+
+            def progress_callback(files_checked, new_found):
+                progress_state["checked"] = files_checked
+                progress_state["found"] = new_found
+                runner.push_event(
+                    job_id,
+                    "progress",
+                    {
+                        "current": files_checked,
+                        "total": 0,
+                        "phase": (
+                            f"{files_checked:,} checked, {new_found:,} new"
+                        ),
+                        "files_checked": files_checked,
+                        "new_count": new_found,
+                    },
+                )
+
+            return progress_callback
+
+        event = cache.kickoff_compute(db_path, ws_id, compute, on_spawn=on_spawn)
         if event.wait(timeout=0.5):
             cached = cache.get(db_path, ws_id)
             if cached is not None:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2304,12 +2304,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         from db import Database
         from new_images import count_new_images_for_workspace
 
+        # Shared holder for the cache worker's exception (if any), read by
+        # the ephemeral job's work_fn after the cache event fires. Without
+        # this, a walk that raises (e.g. unreadable volume, DB error) would
+        # still mark the job ``completed`` while ``/api/.../new-images``
+        # returns the error from ``get_recent_error`` — contradictory state
+        # in the bottom panel.
+        walk_error = {"exc": None}
+
         def compute(progress_callback=None):
             wdb = Database(db_path)
             wdb.set_active_workspace(ws_id)
-            return count_new_images_for_workspace(
-                wdb, ws_id, progress_callback=progress_callback,
-            )
+            try:
+                return count_new_images_for_workspace(
+                    wdb, ws_id, progress_callback=progress_callback,
+                )
+            except Exception as e:
+                walk_error["exc"] = e
+                raise
 
         # Surface the walk as an ephemeral job so the user can see it in the
         # bottom panel rather than wondering why their workspace is silent.
@@ -2328,8 +2340,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # in the worker's finally clause, so we wake when the walk
                 # ends regardless of success or failure. Final totals come
                 # from progress_state, which the cache worker populated via
-                # progress_callback.
+                # progress_callback. If the walk raised, re-raise the same
+                # exception so JobRunner marks the job ``failed`` with the
+                # original message — keeping the bottom panel and the
+                # ``/api/.../new-images`` payload in agreement.
                 spawn_event.wait()
+                if walk_error["exc"] is not None:
+                    raise walk_error["exc"]
                 return {
                     "files_checked": progress_state["checked"],
                     "new_count": progress_state["found"],

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -70,7 +70,8 @@ class JobRunner:
         except Exception:
             db.conn.execute("ALTER TABLE job_history ADD COLUMN summary TEXT DEFAULT ''")
 
-    def start(self, job_type, work_fn, config=None, workspace_id=None):
+    def start(self, job_type, work_fn, config=None, workspace_id=None,
+              ephemeral=False):
         """Start a background job.
 
         Args:
@@ -79,6 +80,12 @@ class JobRunner:
                      job['progress'] and return a result dict.
             config: optional dict of job configuration (persisted to history)
             workspace_id: optional workspace id to associate with this job
+            ephemeral: if True, the job runs and streams events normally but
+                       is never written to ``job_history``. Use for transient
+                       background work surfaced to the user for transparency
+                       (e.g. the new-images filesystem walk) — it is fine to
+                       lose the record on process restart and we don't want
+                       it to clutter the history list.
 
         Returns:
             job_id string
@@ -98,6 +105,7 @@ class JobRunner:
             "config": config or {},
             "workspace_id": workspace_id,
             "steps": [],
+            "ephemeral": ephemeral,
         }
 
         with self._lock:
@@ -183,7 +191,7 @@ class JobRunner:
                     "errors": job["errors"],
                 },
             )
-            if self._db_path:
+            if self._db_path and not job.get("ephemeral"):
                 self._persist_job(job, elapsed)
 
     def _persist_job(self, job, duration):

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -67,11 +67,20 @@ def mapped_roots(db, workspace_id):
     ]
 
 
-def count_new_images_for_workspace(db, workspace_id, sample_limit=5):
+def count_new_images_for_workspace(db, workspace_id, sample_limit=5,
+                                   progress_callback=None,
+                                   progress_every=250):
     """Return {'new_count': int, 'per_root': [...], 'sample': [abs_path, ...]}.
 
     Walks each mapped root recursively, collects image files, and diffs against
     the set of photo paths already ingested into the workspace.
+
+    ``progress_callback``, if given, is invoked as
+    ``progress_callback(files_checked, new_found)`` once every
+    ``progress_every`` files traversed (counting all candidate filenames,
+    including ones we skip), and once at the end with the final totals.
+    Callers use this to surface live progress for transparency without
+    needing to refactor the walk.
     """
     known = _known_paths_for_workspace(db, workspace_id)
     roots = mapped_roots(db, workspace_id)
@@ -79,6 +88,17 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5):
     per_root = []
     sample = []
     total = 0
+    files_checked = 0
+    last_emitted = 0
+
+    def _maybe_emit():
+        nonlocal last_emitted
+        if progress_callback is None:
+            return
+        if files_checked - last_emitted >= progress_every:
+            progress_callback(files_checked, total)
+            last_emitted = files_checked
+
     for root in roots:
         root_path = root["path"]
         if not os.path.isdir(root_path):
@@ -88,24 +108,32 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5):
         root_new = 0
         for dirpath, _dirnames, filenames in os.walk(root_path):
             for name in filenames:
+                files_checked += 1
                 # Mirror ``vireo/scanner.py``: skip dotfiles (e.g. macOS
                 # AppleDouble sidecars ``._IMG_0001.JPG``) so we don't count
                 # files the scanner will never ingest, which would otherwise
                 # produce a stuck "new images" banner.
                 if name.startswith("."):
+                    _maybe_emit()
                     continue
                 ext = Path(name).suffix.lower()
                 if ext not in SUPPORTED_EXTENSIONS:
+                    _maybe_emit()
                     continue
                 full = os.path.join(dirpath, name)
                 if full in known:
+                    _maybe_emit()
                     continue
                 root_new += 1
+                total += 1
                 if sample_limit is None or len(sample) < sample_limit:
                     sample.append(full)
+                _maybe_emit()
 
-        total += root_new
         per_root.append({"folder_id": root["id"], "path": root_path, "new_count": root_new})
+
+    if progress_callback is not None:
+        progress_callback(files_checked, total)
 
     return {"new_count": total, "per_root": per_root, "sample": sample}
 
@@ -222,7 +250,7 @@ class NewImagesCache:
                 return None
             return err_msg
 
-    def kickoff_compute(self, db_path, workspace_id, compute_fn):
+    def kickoff_compute(self, db_path, workspace_id, compute_fn, on_spawn=None):
         """Ensure a background compute is running for ``(db_path, workspace_id)``.
 
         If a recent compute failed (within ``ERROR_BACKOFF_SECONDS``), no new
@@ -241,6 +269,19 @@ class NewImagesCache:
         (e.g. the scan path's per-folder ``invalidate_workspaces``), avoiding
         a fan-out of concurrent ``os.walk`` jobs that would thrash disk/CPU
         on large libraries.
+
+        ``on_spawn`` is an optional callable invoked exactly once if (and
+        only if) this kickoff causes a new background worker to be spawned
+        — not when an in-flight worker is reused or when the error backoff
+        short-circuits the call. It is called after the in-flight slot has
+        been claimed but before the worker thread starts, with the spawned
+        ``threading.Event`` as its only argument so the caller can block on
+        it (e.g. from a separate JobRunner thread that wants to mirror the
+        worker's lifecycle). If ``on_spawn`` returns a callable, that
+        callable is used as a ``progress_callback(files_checked, new_found)``
+        and passed to ``compute_fn`` via keyword. Use this to register a
+        transparency-only job entry that streams progress while the walk
+        runs.
 
         Returns an ``Event`` that fires when the in-flight compute finishes
         so the caller can ``Event.wait(timeout=...)`` to optionally block
@@ -281,9 +322,24 @@ class NewImagesCache:
             event = threading.Event()
             self._inflight[key] = (event, generation)
 
+        # Run on_spawn outside the cache lock so user code (e.g. JobRunner
+        # registration) cannot deadlock the cache on a contended lock.
+        progress_cb = None
+        if on_spawn is not None:
+            try:
+                progress_cb = on_spawn(event)
+            except Exception:
+                log.exception(
+                    "new-images on_spawn callback raised; continuing without it"
+                )
+                progress_cb = None
+
         def worker():
             try:
-                result = compute_fn()
+                if progress_cb is not None:
+                    result = compute_fn(progress_callback=progress_cb)
+                else:
+                    result = compute_fn()
                 self.set(db_path, workspace_id, result, generation=generation)
                 # Successful compute clears any prior failure so a transient
                 # error doesn't keep suppressing retries after recovery.

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -322,6 +322,62 @@ def test_job_history_persistence(tmp_path):
     assert rows[0]['status'] == 'completed'
 
 
+def test_ephemeral_job_skips_history_persistence(tmp_path):
+    """Ephemeral jobs run normally but never write a row to job_history."""
+    from db import Database
+    from jobs import JobRunner
+
+    db = Database(str(tmp_path / "test.db"))
+    runner = JobRunner(db=db)
+
+    def work(job):
+        return {"new_count": 7}
+
+    job_id = runner.start("new_images_walk", work, ephemeral=True)
+
+    for _ in range(50):
+        job = runner.get(job_id)
+        if job and job["status"] == "completed":
+            break
+        time.sleep(0.05)
+    time.sleep(0.1)
+
+    job = runner.get(job_id)
+    assert job["status"] == "completed"
+    assert job["result"] == {"new_count": 7}
+
+    rows = db.conn.execute(
+        "SELECT * FROM job_history WHERE id = ?", (job_id,)
+    ).fetchall()
+    assert rows == [], "ephemeral jobs must not be persisted to job_history"
+
+
+def test_ephemeral_failed_job_skips_history_persistence(tmp_path):
+    """Ephemeral jobs that fail still must not be persisted."""
+    from db import Database
+    from jobs import JobRunner
+
+    db = Database(str(tmp_path / "test.db"))
+    runner = JobRunner(db=db)
+
+    def work(job):
+        raise RuntimeError("boom")
+
+    job_id = runner.start("new_images_walk", work, ephemeral=True)
+
+    for _ in range(50):
+        job = runner.get(job_id)
+        if job and job["status"] == "failed":
+            break
+        time.sleep(0.05)
+    time.sleep(0.1)
+
+    rows = db.conn.execute(
+        "SELECT * FROM job_history WHERE id = ?", (job_id,)
+    ).fetchall()
+    assert rows == []
+
+
 def test_job_history_stores_tree_and_summary(tmp_path):
     """Job history persists tree JSON and summary string."""
     from db import Database

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -130,6 +130,81 @@ def test_mapped_roots_excludes_folder_with_any_linked_ancestor(db_with_workspace
     )
 
 
+def test_progress_callback_fires_during_walk_and_on_completion(db_with_workspace):
+    """count_new_images_for_workspace must invoke an optional progress_callback
+    while walking and once at the end, so the new-images job entry can stream
+    a live ``files checked / new found`` counter.
+
+    We disable throttling (``progress_every=1``) so the test sees a callback per
+    file and can assert monotonic counts; the production caller passes a larger
+    interval to keep event volume bounded.
+    """
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    for i in range(3):
+        _touch_image(str(root / f"IMG_{i:03d}.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    events = []
+
+    def cb(files_checked, new_found):
+        events.append((files_checked, new_found))
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(
+        db, ws_id, progress_callback=cb, progress_every=1,
+    )
+
+    assert result["new_count"] == 3
+    assert events, "progress_callback was never invoked"
+    # Counters must be monotonic non-decreasing.
+    for prev, nxt in zip(events, events[1:], strict=False):
+        assert nxt[0] >= prev[0]
+        assert nxt[1] >= prev[1]
+    # Final event reflects the totals so the UI can show a clean end state.
+    assert events[-1] == (3, 3)
+
+
+def test_progress_callback_throttled_by_progress_every(db_with_workspace):
+    """With progress_every=N, the callback fires every N files plus one final
+    call. Keeps event volume sane on 25k-file libraries.
+    """
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    for i in range(5):
+        _touch_image(str(root / f"IMG_{i:03d}.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    events = []
+    from new_images import count_new_images_for_workspace
+    count_new_images_for_workspace(
+        db, ws_id,
+        progress_callback=lambda c, n: events.append((c, n)),
+        progress_every=2,
+    )
+
+    # 5 files at every-2 throttling => mid-walk events at ~2,4 plus a final
+    # event with totals (5, 5). We don't pin the exact mid-walk count list
+    # because filesystem ordering is platform-dependent; the contract is
+    # "at most one event per progress_every files, plus one final".
+    assert events, "progress_callback was never invoked"
+    assert events[-1] == (5, 5)
+    # No more than ceil(5/2) intermediate + 1 final = 4 total events.
+    assert len(events) <= 4
+
+
+def test_count_new_images_works_without_progress_callback(db_with_workspace):
+    """Backwards-compatible: callers that don't pass progress_callback still work."""
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG_001.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+    assert result["new_count"] == 1
+
+
 def test_count_new_images_basename_collision_across_subdirs(db_with_workspace):
     db, ws_id, tmp_path = db_with_workspace
     root = tmp_path / "shoot"

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -266,6 +266,57 @@ def test_api_new_images_registers_ephemeral_job_on_cache_cold(app_and_db, monkey
     )
 
 
+def test_api_new_images_job_marked_failed_when_walk_raises(app_and_db, monkeypatch):
+    """If the cache worker raises (unreadable volume, DB error, etc.) the
+    ephemeral job must be reported as ``failed`` rather than ``completed``.
+
+    Without this, /api/jobs and /api/workspaces/active/new-images disagree:
+    the endpoint surfaces an error via get_recent_error but the job entry
+    still says it succeeded — misleading the user about what actually
+    happened.
+    """
+    import time
+
+    import new_images as new_images_module
+
+    app, db, ws_id, tmp_path = app_and_db
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("disk unreachable")
+
+    monkeypatch.setattr(
+        new_images_module, "count_new_images_for_workspace", boom,
+    )
+
+    client = app.test_client()
+    client.get("/api/workspaces/active/new-images")
+
+    deadline = time.monotonic() + 2.0
+    walk_job = None
+    while time.monotonic() < deadline:
+        active = client.get("/api/jobs").get_json()["active"]
+        candidates = [j for j in active if j["type"] == "new_images_walk"]
+        if candidates and candidates[0]["status"] in ("failed", "completed"):
+            walk_job = candidates[0]
+            break
+        time.sleep(0.02)
+
+    assert walk_job is not None, "ephemeral new_images_walk job never finished"
+    assert walk_job["status"] == "failed", (
+        f"job should be 'failed' when walk raised, got {walk_job['status']}; "
+        f"errors={walk_job.get('errors')}"
+    )
+    # The walker's exception message is preserved on the job so the user can
+    # see WHY it failed in the bottom panel, not just that something failed.
+    assert any("disk unreachable" in e for e in walk_job["errors"]), (
+        f"job errors should include the walker's failure message; "
+        f"got {walk_job['errors']}"
+    )
+
+
 def test_api_new_images_no_extra_job_on_cache_hit(app_and_db):
     """A second request that hits the cache must NOT spawn another job entry —
     only the cache-cold path surfaces a job, otherwise every navbar poll

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -192,6 +192,129 @@ def test_api_new_images_returns_error_when_compute_fails(app_and_db, monkeypatch
     assert data["workspace_id"] == ws_id
 
 
+def test_api_new_images_registers_ephemeral_job_on_cache_cold(app_and_db, monkeypatch):
+    """When the new-images walk has to actually run (cache cold, no error
+    backoff), an ephemeral ``new_images_walk`` job appears in the active jobs
+    list while it runs, and is *not* persisted to job_history when it
+    finishes. This is the transparency hook: the user can see the walk
+    happening in the bottom panel rather than the silent background thread.
+    """
+    import threading
+    import time
+
+    import new_images as new_images_module
+
+    app, db, ws_id, tmp_path = app_and_db
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    release = threading.Event()
+    started = threading.Event()
+    real_count = new_images_module.count_new_images_for_workspace
+
+    def slow_count(*args, **kwargs):
+        started.set()
+        release.wait(timeout=5)
+        return real_count(*args, **kwargs)
+
+    monkeypatch.setattr(
+        new_images_module, "count_new_images_for_workspace", slow_count,
+    )
+
+    client = app.test_client()
+    try:
+        resp = client.get("/api/workspaces/active/new-images")
+        assert resp.status_code == 200
+        # While the walk is blocked, /api/jobs must show our ephemeral job.
+        deadline = time.monotonic() + 2.0
+        walk_jobs = []
+        while time.monotonic() < deadline:
+            jobs_resp = client.get("/api/jobs")
+            jobs_data = jobs_resp.get_json()
+            walk_jobs = [
+                j for j in jobs_data["active"]
+                if j["type"] == "new_images_walk"
+            ]
+            if walk_jobs:
+                break
+            time.sleep(0.02)
+        assert walk_jobs, (
+            "expected a new_images_walk job in /api/jobs while walk is in flight"
+        )
+        job = walk_jobs[0]
+        assert job["status"] == "running"
+        assert job["workspace_id"] == ws_id
+        # Job is tied to the workspace via config.workspace_name for the UI label.
+        assert "workspace_name" in job["config"]
+    finally:
+        release.set()
+
+    # After the walk finishes, no row was written to job_history — ephemeral.
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        jobs_data = client.get("/api/jobs").get_json()
+        if not any(j["type"] == "new_images_walk" and j["status"] == "running"
+                   for j in jobs_data["active"]):
+            break
+        time.sleep(0.02)
+    history_rows = db.conn.execute(
+        "SELECT id FROM job_history WHERE type = 'new_images_walk'"
+    ).fetchall()
+    assert history_rows == [], (
+        f"new_images_walk must not persist to job_history, got {history_rows}"
+    )
+
+
+def test_api_new_images_no_extra_job_on_cache_hit(app_and_db):
+    """A second request that hits the cache must NOT spawn another job entry —
+    only the cache-cold path surfaces a job, otherwise every navbar poll
+    would clutter the jobs list.
+    """
+    import time
+
+    from new_images import get_shared_cache
+
+    app, db, ws_id, tmp_path = app_and_db
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    client = app.test_client()
+    # Prime the cache.
+    client.get("/api/workspaces/active/new-images")
+    cache = get_shared_cache()
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        if cache.get(db._db_path, ws_id) is not None:
+            break
+        time.sleep(0.01)
+    assert cache.get(db._db_path, ws_id) is not None
+
+    # Wait for any prior job to leave the running state, then count.
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        active = client.get("/api/jobs").get_json()["active"]
+        if not any(j["type"] == "new_images_walk" and j["status"] == "running"
+                   for j in active):
+            break
+        time.sleep(0.02)
+
+    before = sum(
+        1 for j in client.get("/api/jobs").get_json()["active"]
+        if j["type"] == "new_images_walk"
+    )
+    # Cache hit — should not spawn anything new.
+    client.get("/api/workspaces/active/new-images")
+    after = sum(
+        1 for j in client.get("/api/jobs").get_json()["active"]
+        if j["type"] == "new_images_walk"
+    )
+    assert after == before, (
+        f"cache hits must not spawn new jobs (before={before}, after={after})"
+    )
+
+
 def test_api_new_images_does_not_hot_loop_on_persistent_failure(app_and_db, monkeypatch):
     """Repeated requests within the error backoff window must not spawn a
     fresh compute every time — otherwise a broken volume gets hammered by


### PR DESCRIPTION
## Summary

The new-images filesystem walk runs invisibly on every workspace open and on cache invalidation. With 25k+ unscanned files on a USB drive, the user sees no indication that anything is happening — the navbar just shows pending. This PR surfaces the walk as an ephemeral job entry in the bottom panel jobs list, with a live `N checked, M new` progress phase, and removes the entry on completion without writing to `job_history`.

- `JobRunner.start(..., ephemeral=True)` runs the job normally but skips `_persist_job` so navbar polls don't clutter the history list.
- `count_new_images_for_workspace(..., progress_callback, progress_every=250)` emits throttled progress with a guaranteed final-totals call.
- `NewImagesCache.kickoff_compute(..., on_spawn=...)` fires the hook only when a fresh worker is actually launched — cache hits, in-flight reuse, and error-backoff short-circuits never spawn a job, so steady-state polling stays quiet.
- The endpoint `api_workspace_new_images` registers the ephemeral job in `on_spawn` and plumbs progress events to it. The job's work_fn blocks on the cache event so its lifecycle mirrors the actual walk.

## Test plan

- [x] `vireo/tests/test_jobs.py` — ephemeral jobs (success + failure) skip `job_history` persistence
- [x] `vireo/tests/test_new_images.py` — `progress_callback` fires monotonically, respects `progress_every` throttling, emits final totals; existing behavior preserved when no callback is given
- [x] `vireo/tests/test_new_images_api.py` — `/api/jobs` surfaces a `new_images_walk` job during a cold walk; cache hits do not spawn additional jobs; nothing is persisted to `job_history`
- [x] Full project suite per CLAUDE.md: **637 passed in 1102s**

🤖 Generated with [Claude Code](https://claude.com/claude-code)