### PR TITLE
Schema-driven settings control: search, scopes, backup/restore

### DIFF
--- a/docs/plans/2026-04-25-settings-control-design.md
+++ b/docs/plans/2026-04-25-settings-control-design.md
@@ -1,0 +1,231 @@
+# Settings control — design
+
+Date: 2026-04-25
+Branch: `settings-control`
+
+## Problem
+
+Three pain points the user wants solved (sharing presets is explicitly out of scope):
+
+1. **Backup / portability.** Settings should survive a reinstall and live alongside dotfiles.
+2. **Discoverability / depth.** Many `DEFAULTS` keys (pipeline weights, miss-detection gates, eye-focus tuning, burst tuning) have no UI today. "Full control" currently means hand-editing JSON.
+3. **Visibility.** No way to see what's actually in effect right now (default vs. global vs. workspace) or reset a single knob.
+
+The current `settings.html` is 2482 lines of hand-rolled HTML across 22 sections. Adding a knob means writing more HTML, which is why the long tail is missing.
+
+## Direction
+
+Take VS Code's settings model — schema-driven UI, search-first navigation, per-field provenance + reset, raw-JSON escape hatch — and size it down to one app.
+
+What we steal:
+- Two synced views (pretty UI + raw JSON) on one page.
+- Search-first navigation rather than nested menus.
+- Schema-in-code as the single source of truth for widget rendering and validation.
+- Per-field "default / global / workspace" badge + reset-to-default.
+- "Edit raw JSON" escape hatch, doubling as the export/import surface.
+
+What we skip:
+- A formal JSON Schema spec for editor autocomplete (unnecessary for a single-app config).
+- Settings Sync (dotfiles already cover this).
+- Sanitization / preset sharing (sharing is out of scope).
+
+## Architecture
+
+### Three layers, in order of authority
+
+```
+default (DEFAULTS in code)
+  ↓ overridden by
+global  (~/.vireo/config.json)
+  ↓ overridden by (when applicable)
+workspace (workspaces.config_overrides JSON column)
+```
+
+This is unchanged — `db.get_effective_config()` already merges in this order. We are adding **UI** that makes each layer visible and editable per-key.
+
+### Page layout
+
+Top of `settings.html`:
+
+- Sticky toolbar:
+  - Search box (filters live by key + label + description).
+  - Scope tab strip: `Global · Workspace: <active>`. Switching the tab switches which layer edits write to and which provenance badges are shown.
+  - Action menu: `Export…`, `Import…`, `Open raw JSON`, `Reset all to defaults`.
+
+Body:
+
+- The existing 22 hand-rolled sections, unchanged, in their current order.
+- A new **"All settings"** region rendered from a schema. Grouped by category (Pipeline, Detection, Culling, Display, Working copy, Preview, Ingest, Paths, Integrations). Includes *every* key — including the ones the curated sections also expose, so search always finds it.
+
+Raw-JSON view: separate sub-page or modal. Monospace textarea, validate-on-save, import/export buttons.
+
+## Schema
+
+New module `vireo/config_schema.py` holds metadata in parallel to `DEFAULTS`. Keeping it separate (not extending `DEFAULTS` in place) preserves backward compatibility with every existing `cfg.load().get("…")` call site.
+
+```python
+# vireo/config_schema.py
+SCHEMA = {
+  "classification_threshold": {
+    "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+    "category": "Detection",
+    "scope": "both",
+    "label": "Classification threshold",
+    "desc": "Minimum confidence for a species prediction to be kept.",
+  },
+  "hf_token": {
+    "type": "secret", "category": "Integrations",
+    "scope": "global",
+    "label": "Hugging Face token",
+    "desc": "API token used for model downloads.",
+  },
+  "pipeline.w_focus": {
+    "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+    "category": "Pipeline",
+    "scope": "both",
+    "label": "Focus weight",
+    "desc": "Pipeline scoring weight for focus quality.",
+  },
+  ...
+}
+```
+
+### Field meanings
+
+- `type`: `int | float | bool | string | secret | enum | path | list[string]`. Drives widget choice.
+- `min` / `max` / `step` / `enum`: optional, type-specific.
+- `category`: section header in the schema-rendered region; also the search facet.
+- `scope`: `"global" | "workspace" | "both"`. Controls whether the per-workspace override toggle shows on the row.
+- `label` / `desc`: human strings; `desc` is search-indexed.
+
+### Nested keys
+
+Use dotted paths (`pipeline.w_focus`). Two helpers:
+
+- `get_dotted(d, "pipeline.w_focus") -> 0.45`
+- `set_dotted(d, "pipeline.w_focus", 0.5)` — creates intermediate dicts as needed.
+
+### Drift guard
+
+Unit test asserts `set(SCHEMA.keys()) == set(flatten(DEFAULTS).keys())`. Adding a key to `DEFAULTS` without a schema entry breaks the build — the mechanism that makes "every knob is discoverable" enforced rather than aspirational.
+
+### Validation
+
+One function used by every write path and by import:
+
+```python
+def validate_value(key, raw):
+    spec = SCHEMA[key]
+    coerced = coerce(raw, spec["type"])     # int(...), float(...), bool, ...
+    check_range(coerced, spec)              # min/max/enum
+    return coerced  # raises ValueError with a useful message on failure
+```
+
+## Per-row UX
+
+```
+[Category: Pipeline] ──────────────────────
+  ● Focus weight                    [0.45]   ⟳
+    Pipeline scoring weight for focus quality.
+    [● Per-workspace override]
+
+  ○ Exposure weight                 [0.20]   ⟳
+    Pipeline scoring weight for exposure.
+```
+
+- **Provenance dot** at left:
+  - `○` empty (grey) — current value equals default.
+  - `●` blue — differs from default at the global layer.
+  - `●` purple — differs from global at the workspace layer (only shown on the Workspace scope tab).
+- **Widget**: number input with min/max for floats/ints, toggle for bools, dropdown for enums, text for strings, masked + "Reveal/Copy" for secrets.
+- **`⟳` reset icon** on hover: reverts that one key to its default (or for the workspace tab, deletes the workspace override).
+- **Description** under the row, always visible.
+- **Per-workspace toggle** below the row, only when `scope: "workspace" | "both"` and the scope tab is "Global". Clicking copies the current global value into the workspace override and switches the row to workspace context.
+
+**Search** filters by category, label, key, and `desc`. Empty categories collapse out. Enter on a single match focuses the widget.
+
+**Saving:** debounced auto-save per row (300ms after last keystroke / on blur for inputs, immediate for toggles). Per-row indicator: `Saving… ✓ Saved`. No global Save button — VS Code parity.
+
+**Curated sections at the top** keep their current behavior unchanged. We do not retrofit per-row reset/badge into them — they're hand-built UX and adding that complexity would be inconsistent. Search ignores curated sections; the schema-rendered region below covers their keys, so every key remains findable.
+
+## Backend
+
+New endpoints in `vireo/app.py`:
+
+```
+GET  /api/settings/schema
+     → { "schema": SCHEMA, "categories": [...] }
+
+GET  /api/settings/values
+     → { "default": {...}, "global": {...}, "workspace": {...},
+         "effective": {...} }
+     # All four layers, dotted-flat. UI uses these to render badges.
+
+PATCH /api/settings/global
+     body: { "key": "pipeline.w_focus", "value": 0.5 }
+
+DELETE /api/settings/global/<dotted-key>
+
+PATCH /api/settings/workspace
+     body: { "key": "...", "value": ... }
+     # 400 if scope == "global".
+
+DELETE /api/settings/workspace/<dotted-key>
+
+POST /api/settings/import
+     body: { "json": "<file contents>" }
+     # Validates entire payload against schema.
+     # On success: atomically replaces ~/.vireo/config.json.
+     # Workspace overrides untouched.
+     # Returns 400 with per-key errors on validation failure.
+
+GET /api/settings/export
+     → application/json download of current ~/.vireo/config.json
+```
+
+### Atomicity
+
+`cfg.save()` already writes via tempfile + `os.replace`, so import inherits atomic-replace semantics. Workspace override writes go through `db.set_workspace_config_override(key, value)`.
+
+### Import semantics
+
+Replace global wholesale. Import only touches `~/.vireo/config.json`. Active workspace overrides survive — that's the "restore from backup" mental model: backups capture global state, workspaces are local state.
+
+(Possible future extension: a "Full backup" mode that round-trips workspace overrides too. Out of scope for v1.)
+
+### Scope guards
+
+- `PATCH /api/settings/workspace` rejects keys whose `scope == "global"` (e.g. `hf_token`, `report_url`).
+- `PATCH /api/settings/global` accepts every key.
+
+## File changes
+
+- **New:** `vireo/config_schema.py` — `SCHEMA` dict, `validate_value`, dotted-path helpers.
+- **New:** `vireo/templates/_settings_schema.html` — partial that loops over the schema and renders category sections, included from `settings.html`.
+- **Edit:** `vireo/templates/settings.html` — toolbar (search, scope tabs, action menu) at top; include the new partial below the 22 existing sections; raw-JSON modal.
+- **Edit:** `vireo/app.py` — the seven endpoints above.
+- **Edit:** `vireo/db.py` — add `set_workspace_config_override(key, value)` / `delete_workspace_config_override(key)` if not already present. The merging side already exists in `get_effective_config`.
+
+## Build order
+
+Each step independently shippable:
+
+1. Land `config_schema.py` + drift-guard test. No UI yet. Schema and validators exist; test asserts key parity with `DEFAULTS`.
+2. Land read endpoints (`/schema`, `/values`) and the search-first schema-rendered region in `settings.html`. **Read-only at first** — every key visible with provenance badges, edits still go through curated sections. This alone solves #3 and #4.
+3. Land write endpoints + per-row editing + reset. Auto-save, debounced.
+4. Land per-workspace override toggle and the Workspace scope tab.
+5. Land raw-JSON tab + import/export. This solves #1.
+
+## Testing
+
+- Drift guard: `set(SCHEMA.keys()) == set(flatten(DEFAULTS).keys())`.
+- Validator unit tests: type coercion (`"0.5"` → `0.5`), range rejection, enum rejection, secret/path treated as strings.
+- Endpoint tests in `vireo/tests/test_settings_api.py`: PATCH/DELETE round-trip, scope guard rejects global-only key on `/workspace`, import-replace preserves workspace overrides, import rejects malformed JSON.
+- No browser tests in scope. Manual smoke per CLAUDE.md "user-first testing" before shipping.
+
+## Out of scope (deferred)
+
+- Migrating any of the 22 curated sections into the schema-rendered region.
+- Settings sync / multi-machine sync (dotfiles cover this).
+- Public sharing / preset library (sharing was explicitly excluded).
+- Bundling workspace overrides in export/import (could be added later as a "Full backup" mode).

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3336,6 +3336,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             except schema.ValidationError as e:
                 errors[schema_key] = str(e)
 
+        # Structured non-schema keys still need shape validation, otherwise a
+        # malformed payload like {"keyboard_shortcuts": 5} would write through
+        # to the file and crash downstream UI (shortcuts.html dereferences
+        # `cfg.keyboard_shortcuts.<ctx>.<action>` and assumes a dict tree).
+        if "keyboard_shortcuts" in payload:
+            ks = payload["keyboard_shortcuts"]
+            if not isinstance(ks, dict):
+                errors["keyboard_shortcuts"] = "keyboard_shortcuts must be a JSON object"
+            else:
+                for ctx_name, actions in ks.items():
+                    if not isinstance(actions, dict):
+                        errors[f"keyboard_shortcuts.{ctx_name}"] = (
+                            f"keyboard_shortcuts.{ctx_name} must be a JSON object"
+                        )
+                        continue
+                    for action, key_str in actions.items():
+                        if not isinstance(key_str, str):
+                            errors[f"keyboard_shortcuts.{ctx_name}.{action}"] = (
+                                "must be a string"
+                            )
+
         if errors:
             return jsonify({"error": "validation failed", "errors": errors}), 400
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3337,10 +3337,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 errors[schema_key] = str(e)
 
         # Structured non-schema keys still need shape validation, otherwise a
-        # malformed payload like {"keyboard_shortcuts": 5} would write through
-        # to the file and crash downstream UI (shortcuts.html dereferences
-        # `cfg.keyboard_shortcuts.<ctx>.<action>` and assumes a dict tree).
+        # malformed payload would write through to the file and crash
+        # downstream UI consumers that assume a specific shape.
         if "keyboard_shortcuts" in payload:
+            # shortcuts.html dereferences `cfg.keyboard_shortcuts.<ctx>.<action>`
+            # and assumes a dict tree.
             ks = payload["keyboard_shortcuts"]
             if not isinstance(ks, dict):
                 errors["keyboard_shortcuts"] = "keyboard_shortcuts must be a JSON object"
@@ -3356,6 +3357,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             errors[f"keyboard_shortcuts.{ctx_name}.{action}"] = (
                                 "must be a string"
                             )
+
+        # ingest.recent_destinations is also EXCLUDED from SCHEMA but is a
+        # structured value (list[str]). pipeline.html calls
+        # `recents.forEach(...)` on it, so a non-list value would crash the
+        # pipeline page after a bad import.
+        ingest_section = payload.get("ingest")
+        if isinstance(ingest_section, dict) and "recent_destinations" in ingest_section:
+            recents = ingest_section["recent_destinations"]
+            if not isinstance(recents, list):
+                errors["ingest.recent_destinations"] = (
+                    "ingest.recent_destinations must be a JSON array"
+                )
+            else:
+                for i, item in enumerate(recents):
+                    if not isinstance(item, str):
+                        errors[f"ingest.recent_destinations[{i}]"] = (
+                            "must be a string"
+                        )
+                        break
 
         if errors:
             return jsonify({"error": "validation failed", "errors": errors}), 400

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3265,6 +3265,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         errors = {}
         flat = schema.flatten(payload)
+        parent_prefixes = schema.schema_parent_prefixes()
         for k, v in flat.items():
             if k in schema.SCHEMA:
                 try:
@@ -3272,6 +3273,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     schema.set_dotted(payload, k, coerced)
                 except schema.ValidationError as e:
                     errors[k] = str(e)
+            elif k in parent_prefixes:
+                # ``flatten`` only emits ``k`` as a leaf when payload[k] is not
+                # a dict. Since k is a parent of schema-backed leaves (e.g.
+                # ``pipeline``), the user replaced a required object subtree
+                # with a scalar — reject before it corrupts the on-disk file.
+                errors[k] = f"{k} must be a JSON object"
         if errors:
             return jsonify({"error": "validation failed", "errors": errors}), 400
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3127,6 +3127,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         except (OSError, json.JSONDecodeError):
             return {}
 
+    # Serializes read-modify-write of ~/.vireo/config.json and the active
+    # workspace's config_overrides across the schema-driven settings
+    # endpoints (PATCH/DELETE/import). Without this, with per-field autosave
+    # and `app.run(threaded=True)` two concurrent requests can read the same
+    # snapshot and the later writer drops the earlier change.
+    _settings_write_lock = threading.Lock()
+
     @app.route("/api/settings/global", methods=["PATCH"])
     def api_settings_global_patch():
         """Set a single global config value (validated against SCHEMA)."""
@@ -3142,10 +3149,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         except schema.ValidationError as e:
             return json_error(str(e), status=400)
 
-        raw = _read_raw_config_file()
-        schema.set_dotted(raw, key, value)
-        cfg.save(raw)
-        _settings_post_save_side_effects(cfg.load())
+        with _settings_write_lock:
+            raw = _read_raw_config_file()
+            schema.set_dotted(raw, key, value)
+            cfg.save(raw)
+            _settings_post_save_side_effects(cfg.load())
         return jsonify({"ok": True, "key": key, "value": value})
 
     @app.route("/api/settings/global/<path:key>", methods=["DELETE"])
@@ -3157,22 +3165,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if key not in schema.SCHEMA:
             return json_error(f"unknown setting {key!r}", status=400)
 
-        raw = _read_raw_config_file()
-        schema.delete_dotted(raw, key)
-        cfg.save(raw)
-        _settings_post_save_side_effects(cfg.load())
+        with _settings_write_lock:
+            raw = _read_raw_config_file()
+            schema.delete_dotted(raw, key)
+            cfg.save(raw)
+            _settings_post_save_side_effects(cfg.load())
         return jsonify({"ok": True, "key": key})
 
     def _read_workspace_overrides(db):
-        """Return the active workspace's config_overrides as a dict (or {})."""
+        """Return the active workspace's config_overrides as a dict (or {}).
+
+        Coerces non-dict payloads (possible via legacy workspace
+        create/update APIs) to ``{}`` so dotted-key mutation in the schema
+        write paths can't crash on a malformed override.
+        """
         ws = db.get_workspace(db._active_workspace_id)
         if not ws or not ws["config_overrides"]:
             return {}
         try:
             raw = ws["config_overrides"]
-            return json.loads(raw) if isinstance(raw, str) else raw
+            parsed = json.loads(raw) if isinstance(raw, str) else raw
         except (json.JSONDecodeError, TypeError):
             return {}
+        return parsed if isinstance(parsed, dict) else {}
 
     def _write_workspace_overrides(db, overrides):
         db.update_workspace(
@@ -3200,9 +3215,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(str(e), status=400)
 
         db = _get_db()
-        overrides = _read_workspace_overrides(db)
-        schema.set_dotted(overrides, key, value)
-        _write_workspace_overrides(db, overrides)
+        with _settings_write_lock:
+            overrides = _read_workspace_overrides(db)
+            schema.set_dotted(overrides, key, value)
+            _write_workspace_overrides(db, overrides)
         return jsonify({"ok": True, "key": key, "value": value})
 
     @app.route("/api/settings/workspace/<path:key>", methods=["DELETE"])
@@ -3213,9 +3229,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if key not in schema.SCHEMA:
             return json_error(f"unknown setting {key!r}", status=400)
         db = _get_db()
-        overrides = _read_workspace_overrides(db)
-        schema.delete_dotted(overrides, key)
-        _write_workspace_overrides(db, overrides)
+        with _settings_write_lock:
+            overrides = _read_workspace_overrides(db)
+            schema.delete_dotted(overrides, key)
+            _write_workspace_overrides(db, overrides)
         return jsonify({"ok": True, "key": key})
 
     @app.route("/api/settings/export")
@@ -3282,8 +3299,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if errors:
             return jsonify({"error": "validation failed", "errors": errors}), 400
 
-        cfg.save(payload)
-        _settings_post_save_side_effects(cfg.load())
+        with _settings_write_lock:
+            cfg.save(payload)
+            _settings_post_save_side_effects(cfg.load())
         return jsonify({"ok": True})
 
     @app.route("/api/darktable/status")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3295,36 +3295,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not isinstance(payload, dict):
             return json_error("payload must be a JSON object", status=400)
 
+        # Iterate the schema directly rather than relying on flatten() — empty
+        # objects at schema leaves (e.g. {"classification_threshold": {}}) flatten
+        # to nothing and would otherwise be written as-is, replacing a numeric
+        # leaf with {} on disk and breaking downstream consumers.
+        _MISSING = object()
         errors = {}
-        flat = schema.flatten(payload)
-        parent_prefixes = schema.schema_parent_prefixes()
-        for k, v in flat.items():
-            if k in schema.SCHEMA:
-                try:
-                    coerced = schema.validate_value(k, v)
-                    schema.set_dotted(payload, k, coerced)
-                except schema.ValidationError as e:
-                    errors[k] = str(e)
-            elif k in parent_prefixes:
-                # ``flatten`` only emits ``k`` as a leaf when payload[k] is not
-                # a dict. Since k is a parent of schema-backed leaves (e.g.
-                # ``pipeline``), the user replaced a required object subtree
-                # with a scalar — reject before it corrupts the on-disk file.
-                errors[k] = f"{k} must be a JSON object"
-            else:
-                # ``flat`` only contains leaves, so if ``k`` descends from a
-                # schema entry (e.g. ``classification_threshold.x`` under leaf
-                # ``classification_threshold``), the user supplied an object
-                # where a scalar was expected — flag the schema leaf so the
-                # malformed payload doesn't slip through unvalidated.
-                parts = k.split(".")
-                for i in range(1, len(parts)):
-                    ancestor = ".".join(parts[:i])
-                    if ancestor in schema.SCHEMA:
-                        errors[ancestor] = (
-                            f"{ancestor} must be a JSON scalar, not an object"
-                        )
-                        break
+
+        # 1. Reject scalars where a schema-backed object subtree is expected
+        #    (e.g. {"pipeline": 5}).
+        for prefix in schema.schema_parent_prefixes():
+            val = schema.get_dotted(payload, prefix, default=_MISSING)
+            if val is _MISSING or isinstance(val, dict):
+                continue
+            errors[prefix] = f"{prefix} must be a JSON object"
+
+        # 2. For every schema leaf actually present in the payload, reject any
+        #    object (empty or otherwise) and run the usual value validation.
+        for schema_key in schema.SCHEMA:
+            val = schema.get_dotted(payload, schema_key, default=_MISSING)
+            if val is _MISSING:
+                continue
+            if isinstance(val, dict):
+                errors[schema_key] = f"{schema_key} must be a JSON scalar, not an object"
+                continue
+            try:
+                coerced = schema.validate_value(schema_key, val)
+                schema.set_dotted(payload, schema_key, coerced)
+            except schema.ValidationError as e:
+                errors[schema_key] = str(e)
+
         if errors:
             return jsonify({"error": "validation failed", "errors": errors}), 400
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3088,7 +3088,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     else ws["config_overrides"]
                 )
                 ws_flat = schema.flatten(overrides if isinstance(overrides, dict) else {})
-                workspace_layer = {k: v for k, v in ws_flat.items() if k in schema_keys}
+                # Filter out global-only schema keys: workspace create/update
+                # APIs can persist arbitrary override payloads, so a workspace
+                # may contain entries for keys whose scope is "global".
+                # Runtime paths for those keys read global config only, so
+                # surfacing the workspace value here would mislead the UI
+                # into showing a workspace-effective value that is never
+                # actually applied.
+                workspace_layer = {
+                    k: v for k, v in ws_flat.items()
+                    if k in schema_keys
+                    and schema.SCHEMA[k].get("scope") != "global"
+                }
             except (json.JSONDecodeError, TypeError):
                 workspace_layer = {}
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3163,6 +3163,61 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         _settings_post_save_side_effects(cfg.load())
         return jsonify({"ok": True, "key": key})
 
+    def _read_workspace_overrides(db):
+        """Return the active workspace's config_overrides as a dict (or {})."""
+        ws = db.get_workspace(db._active_workspace_id)
+        if not ws or not ws["config_overrides"]:
+            return {}
+        try:
+            raw = ws["config_overrides"]
+            return json.loads(raw) if isinstance(raw, str) else raw
+        except (json.JSONDecodeError, TypeError):
+            return {}
+
+    def _write_workspace_overrides(db, overrides):
+        db.update_workspace(
+            db._active_workspace_id,
+            config_overrides=overrides if overrides else None,
+        )
+
+    @app.route("/api/settings/workspace", methods=["PATCH"])
+    def api_settings_workspace_patch():
+        """Set a single per-workspace override (validated against SCHEMA)."""
+        import config_schema as schema
+
+        body = request.get_json(silent=True) or {}
+        key = body.get("key")
+        if not isinstance(key, str) or key not in schema.SCHEMA:
+            return json_error(f"unknown setting {key!r}", status=400)
+        if schema.SCHEMA[key].get("scope") == "global":
+            return json_error(
+                f"{key!r} is global-only and cannot be overridden per workspace",
+                status=400,
+            )
+        try:
+            value = schema.validate_value(key, body.get("value"))
+        except schema.ValidationError as e:
+            return json_error(str(e), status=400)
+
+        db = _get_db()
+        overrides = _read_workspace_overrides(db)
+        schema.set_dotted(overrides, key, value)
+        _write_workspace_overrides(db, overrides)
+        return jsonify({"ok": True, "key": key, "value": value})
+
+    @app.route("/api/settings/workspace/<path:key>", methods=["DELETE"])
+    def api_settings_workspace_delete(key):
+        """Remove a per-workspace override (the key falls back to global/default)."""
+        import config_schema as schema
+
+        if key not in schema.SCHEMA:
+            return json_error(f"unknown setting {key!r}", status=400)
+        db = _get_db()
+        overrides = _read_workspace_overrides(db)
+        schema.delete_dotted(overrides, key)
+        _write_workspace_overrides(db, overrides)
+        return jsonify({"ok": True, "key": key})
+
     @app.route("/api/darktable/status")
     def api_darktable_status():
         import config as cfg

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2230,21 +2230,26 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         body = request.get_json(silent=True) or {}
         # Only allow workspace-overridable keys
         allowed = {"classification_threshold", "grouping_window_seconds", "similarity_threshold", "detector_confidence", "review_min_confidence"}
-        # Merge into existing overrides to preserve non-whitelisted keys
-        ws = db.get_workspace(db._active_workspace_id)
-        existing = {}
-        if ws and ws["config_overrides"]:
-            try:
-                existing = json.loads(ws["config_overrides"]) if isinstance(ws["config_overrides"], str) else ws["config_overrides"]
-            except Exception:
-                pass
-        for k, v in body.items():
-            if k in allowed:
-                if v is None:
-                    existing.pop(k, None)
-                else:
-                    existing[k] = v
-        db.update_workspace(db._active_workspace_id, config_overrides=existing if existing else None)
+        # Share the schema-driven settings write lock so an autosave in the
+        # All-settings region can't race with a curated workspace-form save
+        # and silently drop a recent override.
+        with _settings_write_lock:
+            ws = db.get_workspace(db._active_workspace_id)
+            existing = {}
+            if ws and ws["config_overrides"]:
+                try:
+                    existing = json.loads(ws["config_overrides"]) if isinstance(ws["config_overrides"], str) else ws["config_overrides"]
+                except Exception:
+                    pass
+            if not isinstance(existing, dict):
+                existing = {}
+            for k, v in body.items():
+                if k in allowed:
+                    if v is None:
+                        existing.pop(k, None)
+                    else:
+                        existing[k] = v
+            db.update_workspace(db._active_workspace_id, config_overrides=existing if existing else None)
         return jsonify({"ok": True, "overrides": existing})
 
     @app.route("/api/workspaces/active/nav-order", methods=["PUT"])
@@ -2981,41 +2986,45 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         import config as cfg
 
         body = request.get_json(silent=True) or {}
-        current = cfg.load()
+        # Share the schema-driven settings write lock so an autosave in the
+        # All-settings region can't race with the curated form's full-snapshot
+        # save and silently overwrite a recently-saved schema value.
+        with _settings_write_lock:
+            current = cfg.load()
 
-        # Handle keyboard_shortcuts with validation
-        if "keyboard_shortcuts" in body:
-            shortcuts = body["keyboard_shortcuts"]
-            if isinstance(shortcuts, dict):
-                valid_contexts = cfg.DEFAULTS["keyboard_shortcuts"]
-                validated = {}
-                for ctx_name, actions in shortcuts.items():
-                    if ctx_name in valid_contexts and isinstance(actions, dict):
-                        validated[ctx_name] = {}
-                        for action, key_str in actions.items():
-                            if action in valid_contexts[ctx_name] and isinstance(key_str, str):
-                                validated[ctx_name][action] = key_str.strip().lower()
-                current["keyboard_shortcuts"] = cfg._deep_merge(
-                    cfg.DEFAULTS["keyboard_shortcuts"], validated
-                )
+            # Handle keyboard_shortcuts with validation
+            if "keyboard_shortcuts" in body:
+                shortcuts = body["keyboard_shortcuts"]
+                if isinstance(shortcuts, dict):
+                    valid_contexts = cfg.DEFAULTS["keyboard_shortcuts"]
+                    validated = {}
+                    for ctx_name, actions in shortcuts.items():
+                        if ctx_name in valid_contexts and isinstance(actions, dict):
+                            validated[ctx_name] = {}
+                            for action, key_str in actions.items():
+                                if action in valid_contexts[ctx_name] and isinstance(key_str, str):
+                                    validated[ctx_name][action] = key_str.strip().lower()
+                    current["keyboard_shortcuts"] = cfg._deep_merge(
+                        cfg.DEFAULTS["keyboard_shortcuts"], validated
+                    )
 
-        for key in body:
-            if key == "keyboard_shortcuts":
-                continue
-            if key in cfg.DEFAULTS:
-                current[key] = body[key]
-        # Apply HF token to environment immediately
-        hf_token = current.get("hf_token", "")
-        if hf_token:
-            os.environ["HF_TOKEN"] = hf_token
-        elif "HF_TOKEN" in os.environ:
-            del os.environ["HF_TOKEN"]
-        cfg.save(current)
-        # If the user shrunk the preview cache quota, evict immediately to the
-        # new size rather than waiting for the next cache write. No-op when
-        # already under quota, so always safe to call.
-        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
-        evict_preview_cache_if_over_quota(_get_db(), vireo_dir)
+            for key in body:
+                if key == "keyboard_shortcuts":
+                    continue
+                if key in cfg.DEFAULTS:
+                    current[key] = body[key]
+            # Apply HF token to environment immediately
+            hf_token = current.get("hf_token", "")
+            if hf_token:
+                os.environ["HF_TOKEN"] = hf_token
+            elif "HF_TOKEN" in os.environ:
+                del os.environ["HF_TOKEN"]
+            cfg.save(current)
+            # If the user shrunk the preview cache quota, evict immediately to the
+            # new size rather than waiting for the next cache write. No-op when
+            # already under quota, so always safe to call.
+            vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+            evict_preview_cache_if_over_quota(_get_db(), vireo_dir)
         return jsonify({"ok": True})
 
     @app.route("/api/settings/schema")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3296,6 +3296,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # ``pipeline``), the user replaced a required object subtree
                 # with a scalar — reject before it corrupts the on-disk file.
                 errors[k] = f"{k} must be a JSON object"
+            else:
+                # ``flat`` only contains leaves, so if ``k`` descends from a
+                # schema entry (e.g. ``classification_threshold.x`` under leaf
+                # ``classification_threshold``), the user supplied an object
+                # where a scalar was expected — flag the schema leaf so the
+                # malformed payload doesn't slip through unvalidated.
+                parts = k.split(".")
+                for i in range(1, len(parts)):
+                    ancestor = ".".join(parts[:i])
+                    if ancestor in schema.SCHEMA:
+                        errors[ancestor] = (
+                            f"{ancestor} must be a JSON scalar, not an object"
+                        )
+                        break
         if errors:
             return jsonify({"error": "validation failed", "errors": errors}), 400
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3218,6 +3218,67 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         _write_workspace_overrides(db, overrides)
         return jsonify({"ok": True, "key": key})
 
+    @app.route("/api/settings/export")
+    def api_settings_export():
+        """Download ~/.vireo/config.json as an attachment.
+
+        Returns the raw user-overrides file (or "{}" if absent), pretty-printed.
+        Workspace overrides are not included — they're per-workspace state, not
+        global config.
+        """
+        import datetime as _datetime
+
+        raw = _read_raw_config_file()
+        body = json.dumps(raw, indent=2)
+        today = _datetime.date.today().isoformat()
+        resp = make_response(body)
+        resp.headers["Content-Type"] = "application/json"
+        resp.headers["Content-Disposition"] = (
+            f'attachment; filename="vireo-config-{today}.json"'
+        )
+        return resp
+
+    @app.route("/api/settings/import", methods=["POST"])
+    def api_settings_import():
+        """Replace ~/.vireo/config.json with the supplied JSON payload.
+
+        Validates every schema-known leaf key in the payload before writing;
+        on any validation failure, returns 400 with a per-key error map and
+        leaves the file untouched. Non-schema keys (setup_complete, the
+        keyboard_shortcuts subtree, etc.) pass through unchanged so that
+        backups round-trip cleanly. Workspace overrides are untouched —
+        backups capture global state only.
+        """
+        import config as cfg
+        import config_schema as schema
+
+        body = request.get_json(silent=True) or {}
+        raw_text = body.get("json", "")
+        if not isinstance(raw_text, str):
+            return json_error("body.json must be a string", status=400)
+        try:
+            payload = json.loads(raw_text)
+        except json.JSONDecodeError as e:
+            return json_error(f"invalid JSON: {e}", status=400)
+        if not isinstance(payload, dict):
+            return json_error("payload must be a JSON object", status=400)
+
+        errors = {}
+        flat = schema.flatten(payload)
+        for k, v in flat.items():
+            if k in schema.SCHEMA:
+                try:
+                    coerced = schema.validate_value(k, v)
+                    schema.set_dotted(payload, k, coerced)
+                except schema.ValidationError as e:
+                    errors[k] = str(e)
+        if errors:
+            return jsonify({"error": "validation failed", "errors": errors}), 400
+
+        cfg.save(payload)
+        _settings_post_save_side_effects(cfg.load())
+        return jsonify({"ok": True})
+
     @app.route("/api/darktable/status")
     def api_darktable_status():
         import config as cfg

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3018,6 +3018,83 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         evict_preview_cache_if_over_quota(_get_db(), vireo_dir)
         return jsonify({"ok": True})
 
+    @app.route("/api/settings/schema")
+    def api_settings_schema():
+        """Return the SCHEMA dict and the ordered category list.
+
+        Consumed by the schema-rendered settings UI to generate widgets.
+        """
+        import config_schema as schema
+
+        return jsonify({
+            "schema": schema.SCHEMA,
+            "categories": list(schema.CATEGORIES),
+        })
+
+    @app.route("/api/settings/values")
+    def api_settings_values():
+        """Return values across all four layers (default / global / workspace / effective).
+
+        Each layer is a dotted-flat dict, restricted to keys present in SCHEMA.
+        Keys hand-edited into config.json or stored as workspace metadata
+        (e.g. active_labels) that are not declared in SCHEMA are intentionally
+        omitted from the response so they don't show up as "overridden" in
+        the UI; they are preserved on disk and visible in the raw-JSON tab.
+        """
+        import config as cfg
+        import config_schema as schema
+
+        schema_keys = set(schema.SCHEMA.keys())
+
+        # Default layer: flatten DEFAULTS, restrict to schema keys.
+        default_flat = schema.flatten(cfg.DEFAULTS)
+        default_layer = {k: default_flat[k] for k in schema_keys if k in default_flat}
+
+        # Global layer: read the raw file (not cfg.load(), which deep-merges
+        # with DEFAULTS — we want only what the user explicitly set).
+        global_layer = {}
+        if os.path.exists(cfg.CONFIG_PATH):
+            try:
+                with open(cfg.CONFIG_PATH) as f:
+                    raw = json.load(f)
+                global_flat = schema.flatten(raw if isinstance(raw, dict) else {})
+                global_layer = {k: v for k, v in global_flat.items() if k in schema_keys}
+            except (OSError, json.JSONDecodeError):
+                global_layer = {}
+
+        # Workspace layer: parse config_overrides for the active workspace.
+        workspace_layer = {}
+        db = _get_db()
+        ws = db.get_workspace(db._active_workspace_id)
+        if ws and ws["config_overrides"]:
+            try:
+                overrides = (
+                    json.loads(ws["config_overrides"])
+                    if isinstance(ws["config_overrides"], str)
+                    else ws["config_overrides"]
+                )
+                ws_flat = schema.flatten(overrides if isinstance(overrides, dict) else {})
+                workspace_layer = {k: v for k, v in ws_flat.items() if k in schema_keys}
+            except (json.JSONDecodeError, TypeError):
+                workspace_layer = {}
+
+        # Effective layer: workspace > global > default for every schema key.
+        effective_layer = {}
+        for k in schema_keys:
+            if k in workspace_layer:
+                effective_layer[k] = workspace_layer[k]
+            elif k in global_layer:
+                effective_layer[k] = global_layer[k]
+            elif k in default_layer:
+                effective_layer[k] = default_layer[k]
+
+        return jsonify({
+            "default": default_layer,
+            "global": global_layer,
+            "workspace": workspace_layer,
+            "effective": effective_layer,
+        })
+
     @app.route("/api/darktable/status")
     def api_darktable_status():
         import config as cfg

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2260,15 +2260,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         nav_order = body.get("nav_order")
         if not isinstance(nav_order, list):
             return json_error("nav_order must be a list")
-        ws = db.get_workspace(db._active_workspace_id)
-        existing = {}
-        if ws and ws["config_overrides"]:
-            try:
-                existing = json.loads(ws["config_overrides"]) if isinstance(ws["config_overrides"], str) else ws["config_overrides"]
-            except Exception:
-                pass
-        existing["nav_order"] = nav_order
-        db.update_workspace(db._active_workspace_id, config_overrides=existing)
+        # Share the schema-driven settings write lock so a concurrent schema
+        # autosave can't read this same overrides snapshot and overwrite the
+        # nav-order change with stale data.
+        with _settings_write_lock:
+            ws = db.get_workspace(db._active_workspace_id)
+            existing = {}
+            if ws and ws["config_overrides"]:
+                try:
+                    existing = json.loads(ws["config_overrides"]) if isinstance(ws["config_overrides"], str) else ws["config_overrides"]
+                except Exception:
+                    pass
+            if not isinstance(existing, dict):
+                existing = {}
+            existing["nav_order"] = nav_order
+            db.update_workspace(db._active_workspace_id, config_overrides=existing)
         return jsonify({"ok": True, "nav_order": nav_order})
 
     @app.route("/api/workspaces/active/new-images")
@@ -8527,20 +8533,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not pipeline_updates:
             return json_error("No valid pipeline config keys provided")
 
-        # Load current overrides, merge pipeline updates
-        ws = db.get_workspace(db._active_workspace_id)
-        current_overrides = {}
-        if ws and ws["config_overrides"]:
-            try:
-                current_overrides = json.loads(ws["config_overrides"]) if isinstance(ws["config_overrides"], str) else ws["config_overrides"]
-            except (json.JSONDecodeError, TypeError):
-                pass
+        # Share the schema-driven settings write lock so a concurrent schema
+        # autosave can't read this same overrides snapshot and overwrite the
+        # pipeline change with stale data.
+        with _settings_write_lock:
+            ws = db.get_workspace(db._active_workspace_id)
+            current_overrides = {}
+            if ws and ws["config_overrides"]:
+                try:
+                    current_overrides = json.loads(ws["config_overrides"]) if isinstance(ws["config_overrides"], str) else ws["config_overrides"]
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            if not isinstance(current_overrides, dict):
+                current_overrides = {}
 
-        pipeline_section = current_overrides.get("pipeline", {})
-        pipeline_section.update(pipeline_updates)
-        current_overrides["pipeline"] = pipeline_section
+            pipeline_section = current_overrides.get("pipeline", {})
+            if not isinstance(pipeline_section, dict):
+                pipeline_section = {}
+            pipeline_section.update(pipeline_updates)
+            current_overrides["pipeline"] = pipeline_section
 
-        db.update_workspace(db._active_workspace_id, config_overrides=current_overrides)
+            db.update_workspace(db._active_workspace_id, config_overrides=current_overrides)
 
         return jsonify({"pipeline": pipeline_section, "status": "saved"})
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3051,16 +3051,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         default_layer = {k: default_flat[k] for k in schema_keys if k in default_flat}
 
         # Global layer: read the raw file (not cfg.load(), which deep-merges
-        # with DEFAULTS — we want only what the user explicitly set).
-        global_layer = {}
-        if os.path.exists(cfg.CONFIG_PATH):
-            try:
-                with open(cfg.CONFIG_PATH) as f:
-                    raw = json.load(f)
-                global_flat = schema.flatten(raw if isinstance(raw, dict) else {})
-                global_layer = {k: v for k, v in global_flat.items() if k in schema_keys}
-            except (OSError, json.JSONDecodeError):
-                global_layer = {}
+        # with DEFAULTS — we want only what the user explicitly set). Also
+        # filter out keys whose value equals the default: legacy save paths
+        # write the entire deep-merged config, but a value matching the
+        # default is not really a user override and should not show as one.
+        global_flat = schema.flatten(_read_raw_config_file())
+        global_layer = {
+            k: v for k, v in global_flat.items()
+            if k in schema_keys and default_layer.get(k) != v
+        }
 
         # Workspace layer: parse config_overrides for the active workspace.
         workspace_layer = {}
@@ -3094,6 +3093,75 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "workspace": workspace_layer,
             "effective": effective_layer,
         })
+
+    def _settings_post_save_side_effects(current):
+        """Side effects mirrored from the legacy /api/config POST handler.
+
+        Keeps the new schema-driven write path behaviorally identical to the
+        old curated-form save: HF_TOKEN env var is kept in sync, and the
+        preview cache is evicted if its budget shrunk.
+        """
+        hf_token = current.get("hf_token", "")
+        if hf_token:
+            os.environ["HF_TOKEN"] = hf_token
+        elif "HF_TOKEN" in os.environ:
+            del os.environ["HF_TOKEN"]
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        evict_preview_cache_if_over_quota(_get_db(), vireo_dir)
+
+    def _read_raw_config_file():
+        """Return the parsed contents of ~/.vireo/config.json, or {}.
+
+        Unlike cfg.load(), this does NOT merge DEFAULTS — so it contains
+        only the keys the user has actually set. Used by write paths so the
+        on-disk file stays minimal.
+        """
+        import config as cfg
+
+        if not os.path.exists(cfg.CONFIG_PATH):
+            return {}
+        try:
+            with open(cfg.CONFIG_PATH) as f:
+                raw = json.load(f)
+            return raw if isinstance(raw, dict) else {}
+        except (OSError, json.JSONDecodeError):
+            return {}
+
+    @app.route("/api/settings/global", methods=["PATCH"])
+    def api_settings_global_patch():
+        """Set a single global config value (validated against SCHEMA)."""
+        import config as cfg
+        import config_schema as schema
+
+        body = request.get_json(silent=True) or {}
+        key = body.get("key")
+        if not isinstance(key, str) or key not in schema.SCHEMA:
+            return json_error(f"unknown setting {key!r}", status=400)
+        try:
+            value = schema.validate_value(key, body.get("value"))
+        except schema.ValidationError as e:
+            return json_error(str(e), status=400)
+
+        raw = _read_raw_config_file()
+        schema.set_dotted(raw, key, value)
+        cfg.save(raw)
+        _settings_post_save_side_effects(cfg.load())
+        return jsonify({"ok": True, "key": key, "value": value})
+
+    @app.route("/api/settings/global/<path:key>", methods=["DELETE"])
+    def api_settings_global_delete(key):
+        """Remove a key from the global config file (reverts to default)."""
+        import config as cfg
+        import config_schema as schema
+
+        if key not in schema.SCHEMA:
+            return json_error(f"unknown setting {key!r}", status=400)
+
+        raw = _read_raw_config_file()
+        schema.delete_dotted(raw, key)
+        cfg.save(raw)
+        _settings_post_save_side_effects(cfg.load())
+        return jsonify({"ok": True, "key": key})
 
     @app.route("/api/darktable/status")
     def api_darktable_status():

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -622,8 +622,11 @@ def _coerce(raw, kind):
                 return False
         raise ValidationError(f"cannot coerce {raw!r} to bool")
     if kind == "int":
+        # bool is a subclass of int in Python, so this check must come before
+        # any int(...) call. JSON booleans arriving for a numeric field are a
+        # client-side type error; silently converting True → 1 masks bugs.
         if isinstance(raw, bool):
-            return int(raw)
+            raise ValidationError(f"cannot coerce {raw!r} to int: bool is not a number")
         # JSON numeric values arrive as float when they have a decimal point.
         # Reject non-integral floats so {"key": 1.9} doesn't silently become 1.
         if isinstance(raw, float):
@@ -639,8 +642,10 @@ def _coerce(raw, kind):
         except (TypeError, ValueError) as e:
             raise ValidationError(f"cannot coerce {raw!r} to int: {e}") from e
     if kind == "float":
+        # Same reasoning as int: bool subclasses int and must be rejected
+        # before float(True) silently produces 1.0.
         if isinstance(raw, bool):
-            return float(raw)
+            raise ValidationError(f"cannot coerce {raw!r} to float: bool is not a number")
         try:
             value = float(raw)
         except (TypeError, ValueError) as e:

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -6,6 +6,7 @@ widgets and validate values. Drift between ``DEFAULTS`` and ``SCHEMA`` is
 enforced by ``vireo/tests/test_config_schema.py``.
 """
 
+import math
 
 # Prefixes whose leaf keys are intentionally NOT covered by SCHEMA.
 #   - setup_complete: internal state flag (not a user-facing setting)
@@ -601,6 +602,14 @@ def _coerce(raw, kind):
     if kind == "int":
         if isinstance(raw, bool):
             return int(raw)
+        # JSON numeric values arrive as float when they have a decimal point.
+        # Reject non-integral floats so {"key": 1.9} doesn't silently become 1.
+        if isinstance(raw, float):
+            if not math.isfinite(raw) or not raw.is_integer():
+                raise ValidationError(
+                    f"cannot coerce {raw!r} to int: not an integral value"
+                )
+            return int(raw)
         try:
             if isinstance(raw, str):
                 return int(raw.strip())
@@ -611,9 +620,15 @@ def _coerce(raw, kind):
         if isinstance(raw, bool):
             return float(raw)
         try:
-            return float(raw)
+            value = float(raw)
         except (TypeError, ValueError) as e:
             raise ValidationError(f"cannot coerce {raw!r} to float: {e}") from e
+        # Reject NaN and ±Inf — bound checks (`< min`, `> max`) skip NaN, so
+        # a payload like {"value": "nan"} would otherwise pass validation and
+        # poison downstream comparisons.
+        if not math.isfinite(value):
+            raise ValidationError(f"cannot coerce {raw!r} to float: not a finite number")
+        return value
     if kind in ("string", "secret", "path", "enum"):
         if raw is None:
             return ""

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -510,6 +510,21 @@ def is_excluded(dotted_key):
     return any(dotted_key == p or dotted_key.startswith(p + ".") for p in EXCLUDED)
 
 
+def schema_parent_prefixes():
+    """Return the set of dotted prefixes that are parents of any SCHEMA key.
+
+    For example, with ``pipeline.w_focus`` and ``ingest.folder_template`` in
+    SCHEMA, this returns ``{"pipeline", "ingest"}``. Used to detect malformed
+    imports that replace a schema-backed subtree with a non-object value.
+    """
+    out = set()
+    for k in SCHEMA:
+        parts = k.split(".")
+        for i in range(1, len(parts)):
+            out.add(".".join(parts[:i]))
+    return out
+
+
 def flatten(d, prefix=""):
     """Flatten a nested dict to a single dict keyed by dotted paths."""
     out = {}

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -263,15 +263,22 @@ SCHEMA = {
     },
 
     # --- Ingest -----------------------------------------------------------
+    # NOTE: scope=global for all three. Ingest endpoints currently read
+    # these only from request bodies with hardcoded fallbacks
+    # ("%Y/%Y-%m-%d", "both", True) — neither cfg.load() nor
+    # db.get_effective_config(...) is consulted, so a workspace override
+    # would be silently ignored. The UI exposes them so they round-trip
+    # through Export/Import; promote to "both" only after wiring the ingest
+    # endpoints (and the import page initializer) to the effective config.
     "ingest.folder_template": {
         "type": "string",
-        "category": "Ingest", "scope": "both",
+        "category": "Ingest", "scope": "global",
         "label": "Ingest folder template",
         "desc": "Strftime template for ingest destination subfolders (e.g. %Y/%Y-%m-%d).",
     },
     "ingest.skip_duplicates": {
         "type": "bool",
-        "category": "Ingest", "scope": "both",
+        "category": "Ingest", "scope": "global",
         "label": "Skip duplicates on ingest",
         "desc": "Skip files whose hash already exists in the database.",
     },
@@ -279,7 +286,7 @@ SCHEMA = {
         "type": "enum",
         "enum": ["both", "raw", "jpg"],
         "enum_labels": {"both": "RAW + JPEG", "raw": "RAW only", "jpg": "JPEG only"},
-        "category": "Ingest", "scope": "both",
+        "category": "Ingest", "scope": "global",
         "label": "Ingest file types",
         "desc": "Which file types to import.",
     },

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -1,0 +1,643 @@
+"""Schema metadata for Vireo config keys.
+
+Parallel to ``config.DEFAULTS`` — provides type, category, scope, label, and
+description per leaf key. Used by the schema-rendered settings UI to generate
+widgets and validate values. Drift between ``DEFAULTS`` and ``SCHEMA`` is
+enforced by ``vireo/tests/test_config_schema.py``.
+"""
+
+
+# Prefixes whose leaf keys are intentionally NOT covered by SCHEMA.
+#   - setup_complete: internal state flag (not a user-facing setting)
+#   - ingest.recent_destinations: auto-populated MRU list, not a knob
+#   - keyboard_shortcuts.*: managed by a dedicated curated UI section
+EXCLUDED = ("setup_complete", "ingest.recent_destinations", "keyboard_shortcuts")
+
+
+CATEGORIES = (
+    "Detection",
+    "Pipeline",
+    "Culling",
+    "Display",
+    "Working copy",
+    "Preview",
+    "Ingest",
+    "Paths",
+    "Integrations",
+    "Behavior",
+)
+
+
+# Each entry: type, category, scope, label, desc (required) + optional
+# min/max/step/enum/enum_labels/items_enum.
+SCHEMA = {
+    # --- Detection / classification --------------------------------------
+    "classification_threshold": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Detection", "scope": "both",
+        "label": "Classification threshold",
+        "desc": "Minimum confidence for a species prediction to be kept.",
+    },
+    "detector_confidence": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Detection", "scope": "both",
+        "label": "Detector confidence",
+        "desc": "Minimum confidence for a wildlife detection bounding box.",
+    },
+    "detection_padding": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Detection", "scope": "both",
+        "label": "Detection padding",
+        "desc": "Padding around detected bounding boxes before classification (fraction of bbox size).",
+    },
+    "top_k_predictions": {
+        "type": "int", "min": 1, "max": 50,
+        "category": "Detection", "scope": "both",
+        "label": "Top-K predictions",
+        "desc": "Number of top species predictions to keep per detection.",
+    },
+    "redundancy_threshold": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Detection", "scope": "both",
+        "label": "Redundancy threshold",
+        "desc": "Cosine-similarity threshold for collapsing near-duplicate detections.",
+    },
+
+    # --- Behavior / general ----------------------------------------------
+    "grouping_window_seconds": {
+        "type": "int", "min": 0, "max": 3600,
+        "category": "Behavior", "scope": "both",
+        "label": "Grouping window (seconds)",
+        "desc": "Time gap that separates one shoot/encounter from the next.",
+    },
+    "similarity_threshold": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Behavior", "scope": "both",
+        "label": "Similarity threshold",
+        "desc": "Cosine-similarity threshold above which two photos are visual duplicates.",
+    },
+    "max_edit_history": {
+        "type": "int", "min": 0, "max": 100000,
+        "category": "Behavior", "scope": "both",
+        "label": "Edit history limit",
+        "desc": "Maximum number of undo-able edits kept per workspace.",
+    },
+    "keyword_case": {
+        "type": "enum",
+        "enum": ["auto", "title", "lower"],
+        "enum_labels": {
+            "auto": "Auto-detect",
+            "title": "Title Case (House Finch)",
+            "lower": "Sentence case (House finch)",
+        },
+        "category": "Behavior", "scope": "both",
+        "label": "Keyword case",
+        "desc": "Capitalization convention for species keywords.",
+    },
+    "scan_workers": {
+        "type": "int", "min": 0, "max": 64,
+        "category": "Behavior", "scope": "global",
+        "label": "Scan workers",
+        "desc": "Worker thread count for scans (0 = auto).",
+    },
+
+    # --- Culling ----------------------------------------------------------
+    "cull_time_window": {
+        "type": "int", "min": 0, "max": 3600,
+        "category": "Culling", "scope": "both",
+        "label": "Cull time window (seconds)",
+        "desc": "Burst window for the cull workflow — photos within this gap are eligible for grouping.",
+    },
+    "cull_phash_threshold": {
+        "type": "int", "min": 0, "max": 64,
+        "category": "Culling", "scope": "both",
+        "label": "Cull pHash threshold",
+        "desc": "Maximum perceptual-hash distance for two photos to be considered visually similar.",
+    },
+
+    # --- Display ----------------------------------------------------------
+    "photos_per_page": {
+        "type": "int", "min": 10, "max": 500,
+        "category": "Display", "scope": "global",
+        "label": "Photos per page",
+        "desc": "Page size in browse views.",
+    },
+    "thumbnail_size": {
+        "type": "int", "min": 100, "max": 1024,
+        "category": "Display", "scope": "global",
+        "label": "Thumbnail size (px)",
+        "desc": "Maximum dimension for thumbnails (used in browse grid).",
+    },
+    "thumbnail_quality": {
+        "type": "int", "min": 1, "max": 100,
+        "category": "Display", "scope": "global",
+        "label": "Thumbnail quality",
+        "desc": "JPEG quality for thumbnails (1–100).",
+    },
+    "browse_thumb_default": {
+        "type": "int", "min": 80, "max": 600,
+        "category": "Display", "scope": "global",
+        "label": "Default browse thumbnail size",
+        "desc": "Initial slider position for thumbnail size in the browse view.",
+    },
+    "browse_card_fields": {
+        "type": "list_string",
+        "items_enum": [
+            "filename", "rating", "flag", "sharpness", "species",
+            "dimensions", "file_size", "capture_date", "extension",
+            "quality_score",
+        ],
+        "category": "Display", "scope": "global",
+        "label": "Browse card fields",
+        "desc": "Which metadata badges appear on each photo card in browse.",
+    },
+
+    # --- Working copy -----------------------------------------------------
+    "working_copy_max_size": {
+        "type": "int", "min": 512, "max": 16384,
+        "category": "Working copy", "scope": "global",
+        "label": "Working copy max size (px)",
+        "desc": "Largest dimension of the JPEG working copy extracted from RAW files.",
+    },
+    "working_copy_quality": {
+        "type": "int", "min": 1, "max": 100,
+        "category": "Working copy", "scope": "global",
+        "label": "Working copy quality",
+        "desc": "JPEG quality for the working copy (1–100).",
+    },
+
+    # --- Preview ----------------------------------------------------------
+    "preview_max_size": {
+        "type": "int", "min": 512, "max": 8192,
+        "category": "Preview", "scope": "global",
+        "label": "Preview max size (px)",
+        "desc": "Largest dimension for inline preview images.",
+    },
+    "preview_quality": {
+        "type": "int", "min": 1, "max": 100,
+        "category": "Preview", "scope": "global",
+        "label": "Preview quality",
+        "desc": "JPEG quality for inline previews (1–100).",
+    },
+    "preview_cache_max_mb": {
+        "type": "int", "min": 0, "max": 65536,
+        "category": "Preview", "scope": "global",
+        "label": "Preview cache max (MB)",
+        "desc": "On-disk cache budget for generated previews.",
+    },
+
+    # --- Paths / external tools ------------------------------------------
+    "scan_roots": {
+        "type": "list_string",
+        "category": "Paths", "scope": "global",
+        "label": "Scan roots",
+        "desc": "Top-level folders Vireo scans for photos.",
+    },
+    "darktable_bin": {
+        "type": "path",
+        "category": "Paths", "scope": "global",
+        "label": "darktable-cli path",
+        "desc": "Absolute path to the darktable-cli binary.",
+    },
+    "external_editor": {
+        "type": "path",
+        "category": "Paths", "scope": "global",
+        "label": "External editor",
+        "desc": "Absolute path to an external image editor (used by 'Open in editor').",
+    },
+    "darktable_style": {
+        "type": "string",
+        "category": "Paths", "scope": "global",
+        "label": "Darktable style",
+        "desc": "Darktable style name to apply when developing.",
+    },
+    "darktable_output_format": {
+        "type": "enum",
+        "enum": ["jpg", "tiff"],
+        "enum_labels": {"jpg": "JPEG", "tiff": "TIFF"},
+        "category": "Paths", "scope": "global",
+        "label": "Darktable output format",
+        "desc": "File format for developed photos.",
+    },
+    "darktable_output_dir": {
+        "type": "path",
+        "category": "Paths", "scope": "global",
+        "label": "Darktable output directory",
+        "desc": 'Where developed photos are saved. Empty = create a "developed" subfolder next to originals.',
+    },
+
+    # --- Integrations -----------------------------------------------------
+    "inat_token": {
+        "type": "secret",
+        "category": "Integrations", "scope": "global",
+        "label": "iNaturalist token",
+        "desc": "API token for iNaturalist (used for taxonomy / observations).",
+    },
+    "hf_token": {
+        "type": "secret",
+        "category": "Integrations", "scope": "global",
+        "label": "Hugging Face token",
+        "desc": "API token for Hugging Face (used for model downloads).",
+    },
+    "report_url": {
+        "type": "string",
+        "category": "Integrations", "scope": "global",
+        "label": "Report URL",
+        "desc": "Endpoint for anonymous bug/feedback reports.",
+    },
+
+    # --- Ingest -----------------------------------------------------------
+    "ingest.folder_template": {
+        "type": "string",
+        "category": "Ingest", "scope": "both",
+        "label": "Ingest folder template",
+        "desc": "Strftime template for ingest destination subfolders (e.g. %Y/%Y-%m-%d).",
+    },
+    "ingest.skip_duplicates": {
+        "type": "bool",
+        "category": "Ingest", "scope": "both",
+        "label": "Skip duplicates on ingest",
+        "desc": "Skip files whose hash already exists in the database.",
+    },
+    "ingest.file_types": {
+        "type": "enum",
+        "enum": ["both", "raw", "jpg"],
+        "enum_labels": {"both": "RAW + JPEG", "raw": "RAW only", "jpg": "JPEG only"},
+        "category": "Ingest", "scope": "both",
+        "label": "Ingest file types",
+        "desc": "Which file types to import.",
+    },
+
+    # --- Pipeline (scoring weights & rejection thresholds) ---------------
+    "pipeline.w_focus": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Score weight: focus",
+        "desc": "Weight of focus quality in the photo score.",
+    },
+    "pipeline.w_exposure": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Score weight: exposure",
+        "desc": "Weight of exposure quality in the photo score.",
+    },
+    "pipeline.w_composition": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Score weight: composition",
+        "desc": "Weight of composition quality in the photo score.",
+    },
+    "pipeline.w_area": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Score weight: subject area",
+        "desc": "Weight of subject size in frame.",
+    },
+    "pipeline.w_noise": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Score weight: noise",
+        "desc": "Weight of noise penalty in the photo score.",
+    },
+    "pipeline.reject_crop_complete": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Reject: complete crop",
+        "desc": "Reject threshold for complete-crop detection.",
+    },
+    "pipeline.reject_focus": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Reject: focus",
+        "desc": "Reject threshold for focus failure.",
+    },
+    "pipeline.reject_clip_high": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Reject: highlight clipping",
+        "desc": "Reject threshold for blown highlights.",
+    },
+    "pipeline.reject_composite": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Reject: composite",
+        "desc": "Combined reject threshold.",
+    },
+    "pipeline.miss_enabled": {
+        "type": "bool",
+        "category": "Pipeline", "scope": "both",
+        "label": "Miss-detection enabled",
+        "desc": 'Enable detection of "missed" subject shots.',
+    },
+    "pipeline.miss_det_confidence": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Miss: detection confidence",
+        "desc": "Confidence gate for miss detection.",
+    },
+    "pipeline.miss_det_confidence_burst": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Miss: burst confidence",
+        "desc": "Looser confidence inside a burst.",
+    },
+    "pipeline.miss_bbox_area_min": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.001,
+        "category": "Pipeline", "scope": "both",
+        "label": "Miss: min bbox area",
+        "desc": "Minimum bbox area as fraction of frame.",
+    },
+    "pipeline.miss_bbox_area_min_singleton": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.001,
+        "category": "Pipeline", "scope": "both",
+        "label": "Miss: min bbox area (singleton)",
+        "desc": "Minimum bbox area for non-burst frames.",
+    },
+    "pipeline.miss_oof_ratio": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Miss: out-of-focus ratio",
+        "desc": "Out-of-focus area ratio threshold.",
+    },
+    "pipeline.eye_detect_enabled": {
+        "type": "bool",
+        "category": "Pipeline", "scope": "both",
+        "label": "Eye-focus detection enabled",
+        "desc": "Enable eye-focus detection.",
+    },
+    "pipeline.eye_classifier_conf_gate": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Eye: classifier confidence",
+        "desc": "Classifier confidence gate for eye-focus.",
+    },
+    "pipeline.eye_detection_conf_gate": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Eye: detection confidence",
+        "desc": "Detection confidence gate for eye-focus.",
+    },
+    "pipeline.eye_window_k": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Eye: window k",
+        "desc": "Window size factor for eye-focus measurement.",
+    },
+    "pipeline.reject_eye_focus": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Reject: eye focus",
+        "desc": "Reject threshold for eye out-of-focus.",
+    },
+    "pipeline.burst_time_gap": {
+        "type": "float", "min": 0.0, "max": 600.0, "step": 0.5,
+        "category": "Pipeline", "scope": "both",
+        "label": "Burst: time gap (s)",
+        "desc": "Maximum time gap between frames in a burst.",
+    },
+    "pipeline.burst_phash_threshold": {
+        "type": "int", "min": 0, "max": 64,
+        "category": "Pipeline", "scope": "both",
+        "label": "Burst: pHash threshold",
+        "desc": "pHash distance threshold for burst grouping.",
+    },
+    "pipeline.burst_embedding_threshold": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Burst: embedding threshold",
+        "desc": "Embedding similarity threshold for burst grouping.",
+    },
+    "pipeline.burst_lambda": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Burst: lambda",
+        "desc": "MMR-style diversity weight inside a burst.",
+    },
+    "pipeline.burst_max_keep": {
+        "type": "int", "min": 1, "max": 100,
+        "category": "Pipeline", "scope": "both",
+        "label": "Burst: max keep",
+        "desc": "Maximum frames to keep per burst.",
+    },
+    "pipeline.encounter_lambda": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Encounter: lambda",
+        "desc": "MMR-style diversity weight across an encounter.",
+    },
+    "pipeline.encounter_max_keep": {
+        "type": "int", "min": 1, "max": 100,
+        "category": "Pipeline", "scope": "both",
+        "label": "Encounter: max keep",
+        "desc": "Maximum frames to keep per encounter.",
+    },
+    "pipeline.w_time": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Diversity weight: time",
+        "desc": "Weight of time component in diversity score.",
+    },
+    "pipeline.w_subj": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Diversity weight: subject",
+        "desc": "Weight of subject component in diversity score.",
+    },
+    "pipeline.w_global": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Diversity weight: global",
+        "desc": "Weight of global-embedding component in diversity score.",
+    },
+    "pipeline.w_species": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Diversity weight: species",
+        "desc": "Weight of species component in diversity score.",
+    },
+    "pipeline.w_meta": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Diversity weight: metadata",
+        "desc": "Weight of metadata component in diversity score.",
+    },
+    "pipeline.hard_cut_time": {
+        "type": "float", "min": 0.0, "max": 86400.0, "step": 1.0,
+        "category": "Pipeline", "scope": "both",
+        "label": "Encounter: hard-cut time (s)",
+        "desc": "Time gap that always splits an encounter.",
+    },
+    "pipeline.hard_cut_score": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Encounter: hard-cut score",
+        "desc": "Similarity score that always splits an encounter.",
+    },
+    "pipeline.soft_cut_score": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Encounter: soft-cut score",
+        "desc": "Similarity below which encounters are likely to split.",
+    },
+    "pipeline.merge_score": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Encounter: merge score",
+        "desc": "Similarity above which adjacent encounters merge.",
+    },
+    "pipeline.merge_max_gap": {
+        "type": "float", "min": 0.0, "max": 86400.0, "step": 1.0,
+        "category": "Pipeline", "scope": "both",
+        "label": "Encounter: merge max gap (s)",
+        "desc": "Maximum time gap that still allows a merge.",
+    },
+    "pipeline.extract_full_metadata": {
+        "type": "bool",
+        "category": "Pipeline", "scope": "both",
+        "label": "Extract full metadata",
+        "desc": "Read full EXIF/XMP during pipeline scan (slower but more complete).",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Dotted-path helpers
+# ---------------------------------------------------------------------------
+
+
+def is_excluded(dotted_key):
+    """True if dotted_key is intentionally excluded from SCHEMA coverage."""
+    return any(dotted_key == p or dotted_key.startswith(p + ".") for p in EXCLUDED)
+
+
+def flatten(d, prefix=""):
+    """Flatten a nested dict to a single dict keyed by dotted paths."""
+    out = {}
+    for k, v in d.items():
+        path = f"{prefix}.{k}" if prefix else k
+        if isinstance(v, dict):
+            out.update(flatten(v, path))
+        else:
+            out[path] = v
+    return out
+
+
+def get_dotted(d, key, default=None):
+    """Look up a value at a dotted path. Returns ``default`` if any segment is missing."""
+    cur = d
+    for part in key.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return default
+        cur = cur[part]
+    return cur
+
+
+def set_dotted(d, key, value):
+    """Set a value at a dotted path, creating intermediate dicts as needed.
+
+    Replaces non-dict intermediates (so set_dotted({"a": 1}, "a.b", 2) succeeds).
+    """
+    parts = key.split(".")
+    cur = d
+    for part in parts[:-1]:
+        if part not in cur or not isinstance(cur[part], dict):
+            cur[part] = {}
+        cur = cur[part]
+    cur[parts[-1]] = value
+
+
+def delete_dotted(d, key):
+    """Remove a leaf at a dotted path. Returns True if something was removed."""
+    parts = key.split(".")
+    cur = d
+    for part in parts[:-1]:
+        if part not in cur or not isinstance(cur[part], dict):
+            return False
+        cur = cur[part]
+    return cur.pop(parts[-1], None) is not None
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class ValidationError(ValueError):
+    """Raised by ``validate_value`` on invalid input."""
+
+
+_TRUE_STRINGS = ("true", "1", "yes", "on")
+_FALSE_STRINGS = ("false", "0", "no", "off", "")
+
+
+def _coerce(raw, kind):
+    if kind == "bool":
+        if isinstance(raw, bool):
+            return raw
+        if isinstance(raw, (int, float)):
+            return bool(raw)
+        if isinstance(raw, str):
+            low = raw.strip().lower()
+            if low in _TRUE_STRINGS:
+                return True
+            if low in _FALSE_STRINGS:
+                return False
+        raise ValidationError(f"cannot coerce {raw!r} to bool")
+    if kind == "int":
+        if isinstance(raw, bool):
+            return int(raw)
+        try:
+            if isinstance(raw, str):
+                return int(raw.strip())
+            return int(raw)
+        except (TypeError, ValueError) as e:
+            raise ValidationError(f"cannot coerce {raw!r} to int: {e}") from e
+    if kind == "float":
+        if isinstance(raw, bool):
+            return float(raw)
+        try:
+            return float(raw)
+        except (TypeError, ValueError) as e:
+            raise ValidationError(f"cannot coerce {raw!r} to float: {e}") from e
+    if kind in ("string", "secret", "path", "enum"):
+        if raw is None:
+            return ""
+        return str(raw)
+    if kind == "list_string":
+        if not isinstance(raw, list):
+            raise ValidationError(f"expected list, got {type(raw).__name__}")
+        return [str(x) for x in raw]
+    raise ValidationError(f"unknown type kind {kind!r}")
+
+
+def validate_value(key, raw):
+    """Validate ``raw`` against ``SCHEMA[key]``.
+
+    Returns the coerced value. Raises :class:`ValidationError` on any failure
+    (unknown key, type mismatch, out-of-range, unknown enum value, etc.).
+    """
+    if key not in SCHEMA:
+        raise ValidationError(f"unknown setting {key!r}")
+    spec = SCHEMA[key]
+    kind = spec["type"]
+    value = _coerce(raw, kind)
+
+    if kind in ("int", "float"):
+        if "min" in spec and value < spec["min"]:
+            raise ValidationError(f"{key} must be >= {spec['min']} (got {value})")
+        if "max" in spec and value > spec["max"]:
+            raise ValidationError(f"{key} must be <= {spec['max']} (got {value})")
+
+    if kind == "enum" and value not in spec["enum"]:
+        raise ValidationError(
+            f"{key} must be one of {spec['enum']} (got {value!r})"
+        )
+
+    if kind == "list_string" and "items_enum" in spec:
+        for item in value:
+            if item not in spec["items_enum"]:
+                raise ValidationError(
+                    f"{key}: item {item!r} not in {spec['items_enum']}"
+                )
+
+    return value

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -46,8 +46,11 @@ SCHEMA = {
         "desc": "Minimum confidence for a wildlife detection bounding box.",
     },
     "detection_padding": {
+        # scope=global: only consumers are cfg.load().get(...) in app.py;
+        # promote to "both" only after wiring those reads to
+        # db.get_effective_config(cfg.load()).
         "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
-        "category": "Detection", "scope": "both",
+        "category": "Detection", "scope": "global",
         "label": "Detection padding",
         "desc": "Padding around detected bounding boxes before classification (fraction of bbox size).",
     },
@@ -58,8 +61,11 @@ SCHEMA = {
         "desc": "Number of top species predictions to keep per detection.",
     },
     "redundancy_threshold": {
+        # scope=global: culling.analyze_for_culling reads cfg.load() (not
+        # db.get_effective_config), so a workspace override here would be
+        # silently ignored.
         "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
-        "category": "Detection", "scope": "both",
+        "category": "Detection", "scope": "global",
         "label": "Redundancy threshold",
         "desc": "Cosine-similarity threshold for collapsing near-duplicate detections.",
     },
@@ -78,12 +84,16 @@ SCHEMA = {
         "desc": "Cosine-similarity threshold above which two photos are visual duplicates.",
     },
     "max_edit_history": {
+        # scope=global: Database._prune_edit_history reads cfg.get(...) so a
+        # workspace override would not change actual pruning behavior.
         "type": "int", "min": 0, "max": 100000,
-        "category": "Behavior", "scope": "both",
+        "category": "Behavior", "scope": "global",
         "label": "Edit history limit",
         "desc": "Maximum number of undo-able edits kept per workspace.",
     },
     "keyword_case": {
+        # scope=global: Database.add_keyword reads cfg.get("keyword_case"), so
+        # a workspace override would not change keyword capitalization.
         "type": "enum",
         "enum": ["auto", "title", "lower"],
         "enum_labels": {
@@ -91,7 +101,7 @@ SCHEMA = {
             "title": "Title Case (House Finch)",
             "lower": "Sentence case (House finch)",
         },
-        "category": "Behavior", "scope": "both",
+        "category": "Behavior", "scope": "global",
         "label": "Keyword case",
         "desc": "Capitalization convention for species keywords.",
     },

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -103,15 +103,20 @@ SCHEMA = {
     },
 
     # --- Culling ----------------------------------------------------------
+    # NOTE: scope is "global" — the cull workflow (cull.html init via
+    # /api/config, culling.analyze_for_culling default-fill via cfg.load())
+    # reads only the global config, so a workspace override here would be
+    # silently ignored. Promote to "both" only after wiring those consumers
+    # to db.get_effective_config(cfg.load()).
     "cull_time_window": {
         "type": "int", "min": 0, "max": 3600,
-        "category": "Culling", "scope": "both",
+        "category": "Culling", "scope": "global",
         "label": "Cull time window (seconds)",
         "desc": "Burst window for the cull workflow — photos within this gap are eligible for grouping.",
     },
     "cull_phash_threshold": {
         "type": "int", "min": 0, "max": 64,
-        "category": "Culling", "scope": "both",
+        "category": "Culling", "scope": "global",
         "label": "Cull pHash threshold",
         "desc": "Maximum perceptual-hash distance for two photos to be considered visually similar.",
     },

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -599,16 +599,20 @@ class Database:
         Args:
             global_config: dict from config.load()
         Returns:
-            dict with workspace overrides merged on top of global config
+            dict with workspace overrides deep-merged on top of global config
+            so a nested override (e.g. ``{"pipeline": {"w_focus": 0.5}}``)
+            replaces only the named leaf, not the whole parent dict.
         """
+        from config import _deep_merge
+
         ws = self.get_workspace(self._active_workspace_id)
         if not ws or not ws["config_overrides"]:
             return global_config
         try:
             overrides = json.loads(ws["config_overrides"]) if isinstance(ws["config_overrides"], str) else ws["config_overrides"]
-            result = dict(global_config)
-            result.update(overrides)
-            return result
+            if not isinstance(overrides, dict):
+                return global_config
+            return _deep_merge(global_config, overrides)
         except (json.JSONDecodeError, TypeError):
             return global_config
 

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2921,7 +2921,8 @@ async function importSettingsFile(file) {
     alert('Could not read file: ' + (err && err.message || err));
     return;
   }
-  // Cancel any queued debounced autosaves first — a PATCH that fires
+  // Cancel any queued debounced autosaves first — a PATCH or a curated
+  // /api/config / /api/workspaces/active/config snapshot save that fires
   // mid-import would clobber part of the just-restored config.
   Object.keys(ALL_SETTINGS_DEBOUNCE).forEach(function(token) {
     if (ALL_SETTINGS_DEBOUNCE[token]) {
@@ -2929,6 +2930,14 @@ async function importSettingsFile(file) {
       ALL_SETTINGS_DEBOUNCE[token] = null;
     }
   });
+  if (typeof _saveTimer !== 'undefined' && _saveTimer) {
+    clearTimeout(_saveTimer);
+    _saveTimer = null;
+  }
+  if (typeof _wsSaveTimer !== 'undefined' && _wsSaveTimer) {
+    clearTimeout(_wsSaveTimer);
+    _wsSaveTimer = null;
+  }
   try {
     var resp = await fetch('/api/settings/import', {
       method: 'POST',

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2595,7 +2595,7 @@ function renderAllSettings(container) {
   categories.forEach(function(cat) {
     var keys = byCategory[cat];
     if (!keys || !keys.length) return;
-    parts.push('<div class="setting-category" data-category="' + escapeHtml(cat) + '" style="margin-top:14px;">');
+    parts.push('<div class="setting-category" data-category="' + escapeAttr(cat) + '" style="margin-top:14px;">');
     parts.push('<div style="font-size:13px;font-weight:600;color:var(--text-secondary);margin-bottom:6px;border-bottom:1px solid var(--border-primary);padding-bottom:4px;">'
       + escapeHtml(cat) + '</div>');
     keys.forEach(function(key) {
@@ -2673,8 +2673,8 @@ function renderSettingRow(key) {
     var resetTitle = workspaceTab
       ? 'Remove workspace override (inherit global / default)'
       : 'Reset to default: ' + formatSettingValue(defaultVal, spec, true);
-    resetBtn = '<button type="button" onclick="resetSchemaSetting(\'' + escapeHtml(key) + '\')" '
-             +    'title="' + escapeHtml(resetTitle) + '" '
+    resetBtn = '<button type="button" onclick="resetSchemaSetting(\'' + escapeAttr(key) + '\')" '
+             +    'title="' + escapeAttr(resetTitle) + '" '
              +    'style="background:transparent;border:1px solid var(--border-secondary);color:var(--text-dim);border-radius:4px;padding:2px 8px;font-size:11px;cursor:pointer;flex-shrink:0;">'
              +  'Reset</button>';
   }
@@ -2688,9 +2688,9 @@ function renderSettingRow(key) {
     meta += ' · default: ' + escapeHtml(formatSettingValue(defaultVal, spec, true));
   }
   var search = (key + ' ' + spec.label + ' ' + spec.desc + ' ' + spec.category).toLowerCase();
-  return '<div class="setting-row-card" data-search="' + escapeHtml(search) + '" data-key="' + escapeHtml(key) + '" '
+  return '<div class="setting-row-card" data-search="' + escapeAttr(search) + '" data-key="' + escapeAttr(key) + '" '
        +    'style="display:flex;align-items:flex-start;gap:10px;padding:10px 0;border-bottom:1px solid var(--border-primary);">'
-       +   '<span class="provenance-dot ' + dotClass + '" title="' + escapeHtml(dotTitle) + '"></span>'
+       +   '<span class="provenance-dot ' + dotClass + '" title="' + escapeAttr(dotTitle) + '"></span>'
        +   '<div style="flex:1;min-width:0;">'
        +     '<div style="display:flex;justify-content:space-between;gap:12px;align-items:center;flex-wrap:wrap;">'
        +       '<div style="font-size:13px;color:var(--text-primary);font-weight:500;flex:1;min-width:140px;">' + escapeHtml(spec.label) + '</div>'
@@ -2710,7 +2710,7 @@ function renderSettingRow(key) {
 
 function renderSettingWidget(key, spec, effective) {
   var inputStyle = 'background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:3px 8px;font-size:12px;';
-  var keyAttr = 'data-input-key="' + escapeHtml(key) + '"';
+  var keyAttr = 'data-input-key="' + escapeAttr(key) + '"';
   if (spec.type === 'bool') {
     return '<input type="checkbox" ' + keyAttr + ' '
          +     (effective ? 'checked ' : '')
@@ -2721,7 +2721,7 @@ function renderSettingWidget(key, spec, effective) {
     var opts = (spec.enum || []).map(function(opt) {
       var label = (spec.enum_labels && spec.enum_labels[opt]) ? spec.enum_labels[opt] : opt;
       var sel = (opt === effective) ? ' selected' : '';
-      return '<option value="' + escapeHtml(opt) + '"' + sel + '>' + escapeHtml(label) + '</option>';
+      return '<option value="' + escapeAttr(opt) + '"' + sel + '>' + escapeHtml(label) + '</option>';
     }).join('');
     return '<select ' + keyAttr + ' onchange="onSchemaInputChange(this, true)" '
          +    'style="' + inputStyle + 'min-width:120px;">'
@@ -2732,7 +2732,7 @@ function renderSettingWidget(key, spec, effective) {
     var min = spec.min != null ? ' min="' + spec.min + '"' : '';
     var max = spec.max != null ? ' max="' + spec.max + '"' : '';
     var val = (effective != null) ? effective : '';
-    return '<input type="number" ' + keyAttr + ' value="' + escapeHtml(String(val)) + '" '
+    return '<input type="number" ' + keyAttr + ' value="' + escapeAttr(String(val)) + '" '
          +     'step="' + step + '"' + min + max + ' '
          +     'oninput="this.dataset.dirty = \'1\'; onSchemaInputChange(this, false)" '
      +     'onblur="if (this.dataset.dirty) { delete this.dataset.dirty; onSchemaInputChange(this, true); }" '
@@ -2740,7 +2740,7 @@ function renderSettingWidget(key, spec, effective) {
   }
   if (spec.type === 'secret') {
     var sval = (effective != null) ? String(effective) : '';
-    return '<input type="password" ' + keyAttr + ' value="' + escapeHtml(sval) + '" '
+    return '<input type="password" ' + keyAttr + ' value="' + escapeAttr(sval) + '" '
          +     'placeholder="(unset)" autocomplete="off" '
          +     'oninput="this.dataset.dirty = \'1\'; onSchemaInputChange(this, false)" '
      +     'onblur="if (this.dataset.dirty) { delete this.dataset.dirty; onSchemaInputChange(this, true); }" '
@@ -2752,8 +2752,8 @@ function renderSettingWidget(key, spec, effective) {
       var checks = spec.items_enum.map(function(item) {
         var checked = current.indexOf(item) !== -1 ? ' checked' : '';
         return '<label style="display:inline-flex;align-items:center;gap:4px;font-size:11px;color:var(--text-secondary);cursor:pointer;">'
-             +   '<input type="checkbox" data-list-item="' + escapeHtml(item) + '" data-list-key="' + escapeHtml(key) + '"' + checked
-             +     ' onchange="onSchemaListChange(\'' + escapeHtml(key) + '\')" style="accent-color:var(--accent);">'
+             +   '<input type="checkbox" data-list-item="' + escapeAttr(item) + '" data-list-key="' + escapeAttr(key) + '"' + checked
+             +     ' onchange="onSchemaListChange(\'' + escapeAttr(key) + '\')" style="accent-color:var(--accent);">'
              +   escapeHtml(item)
              + '</label>';
       }).join(' ');
@@ -2761,14 +2761,14 @@ function renderSettingWidget(key, spec, effective) {
     }
     // Read-only fallback for list_string without items_enum (e.g. scan_roots).
     var asText = (Array.isArray(effective) && effective.length) ? effective.join(', ') : '(empty)';
-    return '<span style="font-size:12px;color:var(--text-secondary);font-family:monospace;max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:inline-block;" title="' + escapeHtml(asText) + '">'
+    return '<span style="font-size:12px;color:var(--text-secondary);font-family:monospace;max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:inline-block;" title="' + escapeAttr(asText) + '">'
          +   escapeHtml(asText)
          + '</span>'
          + '<span style="font-size:10px;color:var(--text-ghost);margin-left:6px;">(edit above)</span>';
   }
   // string / path / fallback
   var tval = (effective != null) ? String(effective) : '';
-  return '<input type="text" ' + keyAttr + ' value="' + escapeHtml(tval) + '" '
+  return '<input type="text" ' + keyAttr + ' value="' + escapeAttr(tval) + '" '
        +     'placeholder="(empty)" '
        +     'oninput="this.dataset.dirty = \'1\'; onSchemaInputChange(this, false)" '
      +     'onblur="if (this.dataset.dirty) { delete this.dataset.dirty; onSchemaInputChange(this, true); }" '

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1013,7 +1013,7 @@
              style="flex:1;min-width:200px;max-width:280px;background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:4px 10px;font-size:13px;">
     </div>
     <div style="font-size:12px;color:var(--text-dim);margin-bottom:10px;">
-      Every Vireo setting, including ones not surfaced by the curated sections above. Read-only — edit from the curated sections.
+      Every Vireo setting, including ones not surfaced by the curated sections above. Edits save automatically; click Reset to revert to the default.
     </div>
     <div style="font-size:11px;color:var(--text-dim);margin-bottom:14px;display:flex;gap:14px;flex-wrap:wrap;align-items:center;">
       <span style="display:inline-flex;align-items:center;gap:6px;"><span class="provenance-dot dot-default" style="margin-top:0;"></span> default</span>
@@ -2510,7 +2510,10 @@ async function doInstallUpdate() {
   }
 }
 
-// --- All settings (schema-rendered, read-only) -----------------------------
+// --- All settings (schema-rendered, editable) ------------------------------
+
+var ALL_SETTINGS_CACHE = { schema: null, categories: null, values: null };
+var ALL_SETTINGS_DEBOUNCE = {};   // key -> setTimeout id
 
 async function loadAllSettings() {
   var container = document.getElementById('allSettingsCategories');
@@ -2522,14 +2525,29 @@ async function loadAllSettings() {
     if (!schemaRes.ok || !valuesRes.ok) throw new Error('HTTP error');
     var schemaData = await schemaRes.json();
     var values = await valuesRes.json();
-    renderAllSettings(schemaData.schema, schemaData.categories, values, container);
+    ALL_SETTINGS_CACHE.schema = schemaData.schema;
+    ALL_SETTINGS_CACHE.categories = schemaData.categories;
+    ALL_SETTINGS_CACHE.values = values;
+    renderAllSettings(container);
+    filterAllSettings();
   } catch (err) {
     container.innerHTML = '<span style="color:var(--danger);font-size:13px;">Failed to load settings: '
       + escapeHtml(err && err.message || String(err)) + '</span>';
   }
 }
 
-function renderAllSettings(schema, categories, values, container) {
+async function refreshAllSettingsValues() {
+  var r = await fetch('/api/settings/values');
+  if (!r.ok) return;
+  ALL_SETTINGS_CACHE.values = await r.json();
+}
+
+function renderAllSettings(container) {
+  var schema = ALL_SETTINGS_CACHE.schema;
+  var categories = ALL_SETTINGS_CACHE.categories;
+  var values = ALL_SETTINGS_CACHE.values;
+  if (!schema || !categories || !values) return;
+
   var byCategory = {};
   categories.forEach(function(c) { byCategory[c] = []; });
   Object.keys(schema).sort().forEach(function(key) {
@@ -2546,14 +2564,30 @@ function renderAllSettings(schema, categories, values, container) {
     parts.push('<div style="font-size:13px;font-weight:600;color:var(--text-secondary);margin-bottom:6px;border-bottom:1px solid var(--border-primary);padding-bottom:4px;">'
       + escapeHtml(cat) + '</div>');
     keys.forEach(function(key) {
-      parts.push(renderSettingRow(key, schema[key], values));
+      parts.push(renderSettingRow(key));
     });
     parts.push('</div>');
   });
   container.innerHTML = parts.join('');
 }
 
-function renderSettingRow(key, spec, values) {
+function rerenderSettingRow(key) {
+  var row = document.querySelector('#allSettingsCategories .setting-row-card[data-key="' + cssEscape(key) + '"]');
+  if (!row) return;
+  var tmp = document.createElement('div');
+  tmp.innerHTML = renderSettingRow(key);
+  var fresh = tmp.firstElementChild;
+  if (fresh) row.replaceWith(fresh);
+}
+
+function cssEscape(s) {
+  if (window.CSS && window.CSS.escape) return window.CSS.escape(s);
+  return String(s).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+}
+
+function renderSettingRow(key) {
+  var spec = ALL_SETTINGS_CACHE.schema[key];
+  var values = ALL_SETTINGS_CACHE.values;
   var hasWs = Object.prototype.hasOwnProperty.call(values.workspace, key);
   var hasGlobal = Object.prototype.hasOwnProperty.call(values['global'], key);
   var dotClass, dotTitle;
@@ -2569,10 +2603,16 @@ function renderSettingRow(key, spec, values) {
   }
   var effective = values.effective[key];
   var defaultVal = values['default'][key];
-  var displayValue = formatSettingValue(effective, spec, true);
-  var fullValue = formatSettingValue(effective, spec, false);
+  var widget = renderSettingWidget(key, spec, effective);
+  var resetBtn = '';
+  if (hasGlobal) {
+    resetBtn = '<button type="button" onclick="resetSchemaSetting(\'' + escapeHtml(key) + '\')" '
+             +    'title="Reset to default: ' + escapeHtml(formatSettingValue(defaultVal, spec, true)) + '" '
+             +    'style="background:transparent;border:1px solid var(--border-secondary);color:var(--text-dim);border-radius:4px;padding:2px 8px;font-size:11px;cursor:pointer;flex-shrink:0;">'
+             +  'Reset</button>';
+  }
   var meta = escapeHtml(key);
-  if (hasWs || hasGlobal) {
+  if (hasGlobal) {
     meta += ' · default: ' + escapeHtml(formatSettingValue(defaultVal, spec, true));
   }
   var search = (key + ' ' + spec.label + ' ' + spec.desc + ' ' + spec.category).toLowerCase();
@@ -2580,17 +2620,170 @@ function renderSettingRow(key, spec, values) {
        +    'style="display:flex;align-items:flex-start;gap:10px;padding:10px 0;border-bottom:1px solid var(--border-primary);">'
        +   '<span class="provenance-dot ' + dotClass + '" title="' + escapeHtml(dotTitle) + '"></span>'
        +   '<div style="flex:1;min-width:0;">'
-       +     '<div style="display:flex;justify-content:space-between;gap:12px;align-items:center;">'
-       +       '<div style="font-size:13px;color:var(--text-primary);font-weight:500;">' + escapeHtml(spec.label) + '</div>'
-       +       '<div title="' + escapeHtml(fullValue) + '" '
-       +            'style="font-size:12px;color:var(--text-secondary);font-family:monospace;text-align:right;max-width:50%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">'
-       +         escapeHtml(displayValue)
+       +     '<div style="display:flex;justify-content:space-between;gap:12px;align-items:center;flex-wrap:wrap;">'
+       +       '<div style="font-size:13px;color:var(--text-primary);font-weight:500;flex:1;min-width:140px;">' + escapeHtml(spec.label) + '</div>'
+       +       '<div style="display:flex;align-items:center;gap:8px;flex-shrink:0;">'
+       +         widget
+       +         resetBtn
        +       '</div>'
        +     '</div>'
        +     '<div style="font-size:11px;color:var(--text-dim);margin-top:2px;">' + escapeHtml(spec.desc) + '</div>'
-       +     '<div style="font-size:11px;color:var(--text-ghost);margin-top:2px;font-family:monospace;">' + meta + '</div>'
+       +     '<div style="display:flex;justify-content:space-between;gap:8px;margin-top:2px;">'
+       +       '<div style="font-size:11px;color:var(--text-ghost);font-family:monospace;">' + meta + '</div>'
+       +       '<div class="setting-row-status" style="font-size:11px;color:var(--text-dim);min-height:14px;"></div>'
+       +     '</div>'
        +   '</div>'
        + '</div>';
+}
+
+function renderSettingWidget(key, spec, effective) {
+  var inputStyle = 'background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:3px 8px;font-size:12px;';
+  var keyAttr = 'data-input-key="' + escapeHtml(key) + '"';
+  if (spec.type === 'bool') {
+    return '<input type="checkbox" ' + keyAttr + ' '
+         +     (effective ? 'checked ' : '')
+         +     'onchange="onSchemaInputChange(this, true)" '
+         +     'style="accent-color:var(--accent);transform:scale(1.1);">';
+  }
+  if (spec.type === 'enum') {
+    var opts = (spec.enum || []).map(function(opt) {
+      var label = (spec.enum_labels && spec.enum_labels[opt]) ? spec.enum_labels[opt] : opt;
+      var sel = (opt === effective) ? ' selected' : '';
+      return '<option value="' + escapeHtml(opt) + '"' + sel + '>' + escapeHtml(label) + '</option>';
+    }).join('');
+    return '<select ' + keyAttr + ' onchange="onSchemaInputChange(this, true)" '
+         +    'style="' + inputStyle + 'min-width:120px;">'
+         +   opts + '</select>';
+  }
+  if (spec.type === 'int' || spec.type === 'float') {
+    var step = spec.step != null ? spec.step : (spec.type === 'int' ? 1 : 0.01);
+    var min = spec.min != null ? ' min="' + spec.min + '"' : '';
+    var max = spec.max != null ? ' max="' + spec.max + '"' : '';
+    var val = (effective != null) ? effective : '';
+    return '<input type="number" ' + keyAttr + ' value="' + escapeHtml(String(val)) + '" '
+         +     'step="' + step + '"' + min + max + ' '
+         +     'oninput="this.dataset.dirty = \'1\'; onSchemaInputChange(this, false)" '
+     +     'onblur="if (this.dataset.dirty) { delete this.dataset.dirty; onSchemaInputChange(this, true); }" '
+         +     'style="' + inputStyle + 'width:100px;text-align:right;">';
+  }
+  if (spec.type === 'secret') {
+    var sval = (effective != null) ? String(effective) : '';
+    return '<input type="password" ' + keyAttr + ' value="' + escapeHtml(sval) + '" '
+         +     'placeholder="(unset)" autocomplete="off" '
+         +     'oninput="this.dataset.dirty = \'1\'; onSchemaInputChange(this, false)" '
+     +     'onblur="if (this.dataset.dirty) { delete this.dataset.dirty; onSchemaInputChange(this, true); }" '
+         +     'style="' + inputStyle + 'width:200px;font-family:monospace;">';
+  }
+  if (spec.type === 'list_string') {
+    if (Array.isArray(spec.items_enum)) {
+      var current = Array.isArray(effective) ? effective : [];
+      var checks = spec.items_enum.map(function(item) {
+        var checked = current.indexOf(item) !== -1 ? ' checked' : '';
+        return '<label style="display:inline-flex;align-items:center;gap:4px;font-size:11px;color:var(--text-secondary);cursor:pointer;">'
+             +   '<input type="checkbox" data-list-item="' + escapeHtml(item) + '" data-list-key="' + escapeHtml(key) + '"' + checked
+             +     ' onchange="onSchemaListChange(\'' + escapeHtml(key) + '\')" style="accent-color:var(--accent);">'
+             +   escapeHtml(item)
+             + '</label>';
+      }).join(' ');
+      return '<div style="display:flex;flex-wrap:wrap;gap:6px;max-width:380px;justify-content:flex-end;">' + checks + '</div>';
+    }
+    // Read-only fallback for list_string without items_enum (e.g. scan_roots).
+    var asText = (Array.isArray(effective) && effective.length) ? effective.join(', ') : '(empty)';
+    return '<span style="font-size:12px;color:var(--text-secondary);font-family:monospace;max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:inline-block;" title="' + escapeHtml(asText) + '">'
+         +   escapeHtml(asText)
+         + '</span>'
+         + '<span style="font-size:10px;color:var(--text-ghost);margin-left:6px;">(edit above)</span>';
+  }
+  // string / path / fallback
+  var tval = (effective != null) ? String(effective) : '';
+  return '<input type="text" ' + keyAttr + ' value="' + escapeHtml(tval) + '" '
+       +     'placeholder="(empty)" '
+       +     'oninput="this.dataset.dirty = \'1\'; onSchemaInputChange(this, false)" '
+     +     'onblur="if (this.dataset.dirty) { delete this.dataset.dirty; onSchemaInputChange(this, true); }" '
+       +     'style="' + inputStyle + 'width:240px;font-family:monospace;">';
+}
+
+function onSchemaInputChange(el, immediate) {
+  var key = el.getAttribute('data-input-key');
+  if (!key) return;
+  var spec = ALL_SETTINGS_CACHE.schema[key];
+  var raw;
+  if (spec.type === 'bool') {
+    raw = el.checked;
+  } else if (spec.type === 'int' || spec.type === 'float') {
+    raw = el.value;     // server coerces strings to numbers
+  } else {
+    raw = el.value;
+  }
+  scheduleSchemaSave(key, raw, immediate);
+}
+
+function onSchemaListChange(key) {
+  var checked = [];
+  document.querySelectorAll('input[type="checkbox"][data-list-key="' + cssEscape(key) + '"]:checked').forEach(function(cb) {
+    checked.push(cb.getAttribute('data-list-item'));
+  });
+  scheduleSchemaSave(key, checked, true);
+}
+
+function scheduleSchemaSave(key, value, immediate) {
+  if (ALL_SETTINGS_DEBOUNCE[key]) {
+    clearTimeout(ALL_SETTINGS_DEBOUNCE[key]);
+  }
+  var delay = immediate ? 0 : 300;
+  ALL_SETTINGS_DEBOUNCE[key] = setTimeout(function() {
+    ALL_SETTINGS_DEBOUNCE[key] = null;
+    saveSchemaSetting(key, value);
+  }, delay);
+}
+
+async function saveSchemaSetting(key, value) {
+  setRowStatus(key, 'Saving…', false);
+  try {
+    var resp = await fetch('/api/settings/global', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: key, value: value }),
+    });
+    if (!resp.ok) {
+      var err = await resp.json().catch(function() { return { error: resp.statusText }; });
+      setRowStatus(key, err.error || 'Save failed', true);
+      return;
+    }
+    await refreshAllSettingsValues();
+    rerenderSettingRow(key);
+    setRowStatus(key, '✓ Saved', false);
+    setTimeout(function() { setRowStatus(key, '', false); }, 1500);
+  } catch (err) {
+    setRowStatus(key, 'Network error', true);
+  }
+}
+
+async function resetSchemaSetting(key) {
+  setRowStatus(key, 'Resetting…', false);
+  try {
+    var resp = await fetch('/api/settings/global/' + encodeURIComponent(key), {
+      method: 'DELETE',
+    });
+    if (!resp.ok) {
+      var err = await resp.json().catch(function() { return { error: resp.statusText }; });
+      setRowStatus(key, err.error || 'Reset failed', true);
+      return;
+    }
+    await refreshAllSettingsValues();
+    rerenderSettingRow(key);
+  } catch (err) {
+    setRowStatus(key, 'Network error', true);
+  }
+}
+
+function setRowStatus(key, msg, isError) {
+  var row = document.querySelector('#allSettingsCategories .setting-row-card[data-key="' + cssEscape(key) + '"]');
+  if (!row) return;
+  var status = row.querySelector('.setting-row-status');
+  if (!status) return;
+  status.textContent = msg;
+  status.style.color = isError ? 'var(--danger)' : 'var(--text-dim)';
 }
 
 function formatSettingValue(v, spec, mask) {

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2921,6 +2921,14 @@ async function importSettingsFile(file) {
     alert('Could not read file: ' + (err && err.message || err));
     return;
   }
+  // Cancel any queued debounced autosaves first — a PATCH that fires
+  // mid-import would clobber part of the just-restored config.
+  Object.keys(ALL_SETTINGS_DEBOUNCE).forEach(function(token) {
+    if (ALL_SETTINGS_DEBOUNCE[token]) {
+      clearTimeout(ALL_SETTINGS_DEBOUNCE[token]);
+      ALL_SETTINGS_DEBOUNCE[token] = null;
+    }
+  });
   try {
     var resp = await fetch('/api/settings/import', {
       method: 'POST',

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1022,9 +1022,13 @@
     <div style="font-size:12px;color:var(--text-dim);margin-bottom:10px;">
       Every Vireo setting, including ones not surfaced by the curated sections above. Edits save automatically; click Reset to revert.
     </div>
-    <div style="display:flex;border-bottom:1px solid var(--border-primary);margin-bottom:14px;">
+    <div style="display:flex;align-items:center;border-bottom:1px solid var(--border-primary);margin-bottom:14px;">
       <button class="scope-tab active" data-scope="global" onclick="setSettingsScope('global')">Global</button>
       <button class="scope-tab" data-scope="workspace" onclick="setSettingsScope('workspace')">Workspace</button>
+      <span style="flex:1;"></span>
+      <a href="/api/settings/export" class="btn-sm" style="margin-bottom:6px;text-decoration:none;display:inline-block;">Export…</a>
+      <button class="btn-sm" onclick="document.getElementById('settingsImportInput').click()" style="margin-bottom:6px;">Import…</button>
+      <input type="file" id="settingsImportInput" accept=".json,application/json" style="display:none;" onchange="importSettingsFile(this.files[0]); this.value='';">
     </div>
     <div style="font-size:11px;color:var(--text-dim);margin-bottom:14px;display:flex;gap:14px;flex-wrap:wrap;align-items:center;" id="allSettingsLegend">
       <span style="display:inline-flex;align-items:center;gap:6px;"><span class="provenance-dot dot-default" style="margin-top:0;"></span> default</span>
@@ -2870,6 +2874,44 @@ function formatSettingValue(v, spec, mask) {
     return String(v);
   }
   return String(v);
+}
+
+async function importSettingsFile(file) {
+  if (!file) return;
+  if (!confirm('Replace your global Vireo config with "' + file.name + '"?\n\nWorkspace overrides are not affected.')) {
+    return;
+  }
+  var text;
+  try {
+    text = await file.text();
+  } catch (err) {
+    alert('Could not read file: ' + (err && err.message || err));
+    return;
+  }
+  try {
+    var resp = await fetch('/api/settings/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ json: text }),
+    });
+    var data = await resp.json().catch(function() { return {}; });
+    if (!resp.ok) {
+      var msg = data.error || resp.statusText || 'Import failed';
+      if (data.errors) {
+        msg += '\n\nFailed keys:\n' + Object.keys(data.errors).map(function(k) {
+          return '  ' + k + ': ' + data.errors[k];
+        }).join('\n');
+      }
+      alert(msg);
+      return;
+    }
+    await refreshAllSettingsValues();
+    renderAllSettings(document.getElementById('allSettingsCategories'));
+    filterAllSettings();
+    alert('Settings imported. Workspace overrides preserved.');
+  } catch (err) {
+    alert('Network error: ' + (err && err.message || err));
+  }
 }
 
 function filterAllSettings() {

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1085,6 +1085,12 @@ async function loadWsOverrides() {
           input.value = overrides[key];
         }
         updateWsLabel(key);
+      } else {
+        // Sync removal too — when re-called after a schema-row reset, an
+        // override may have been deleted server-side. Leaving the checkbox
+        // checked would cause the next saveWsConfig to re-add it.
+        checkbox.checked = false;
+        ctrl.style.display = 'none';
       }
     });
     _wsOverridesLoaded = true;
@@ -2528,7 +2534,9 @@ async function doInstallUpdate() {
 // --- All settings (schema-rendered, editable) ------------------------------
 
 var ALL_SETTINGS_CACHE = { schema: null, categories: null, values: null };
-var ALL_SETTINGS_DEBOUNCE = {};   // key -> setTimeout id
+// Keyed by `<key>|<scope>` so a quick edit to the same key in a different
+// scope tab can't clear the pending write of the first scope's edit.
+var ALL_SETTINGS_DEBOUNCE = {};
 var ALL_SETTINGS_SCOPE = 'global';  // 'global' | 'workspace'
 
 function setSettingsScope(scope) {
@@ -2791,15 +2799,16 @@ function onSchemaListChange(key) {
 }
 
 function scheduleSchemaSave(key, value, immediate) {
-  if (ALL_SETTINGS_DEBOUNCE[key]) {
-    clearTimeout(ALL_SETTINGS_DEBOUNCE[key]);
-  }
   // Capture the scope at edit time so a tab switch during the debounce window
   // doesn't redirect the pending write to the wrong layer.
   var scope = ALL_SETTINGS_SCOPE;
+  var token = key + '|' + scope;
+  if (ALL_SETTINGS_DEBOUNCE[token]) {
+    clearTimeout(ALL_SETTINGS_DEBOUNCE[token]);
+  }
   var delay = immediate ? 0 : 300;
-  ALL_SETTINGS_DEBOUNCE[key] = setTimeout(function() {
-    ALL_SETTINGS_DEBOUNCE[key] = null;
+  ALL_SETTINGS_DEBOUNCE[token] = setTimeout(function() {
+    ALL_SETTINGS_DEBOUNCE[token] = null;
     saveSchemaSetting(key, value, scope);
   }, delay);
 }
@@ -2824,10 +2833,14 @@ async function saveSchemaSetting(key, value, scope) {
     }
     await refreshAllSettingsValues();
     rerenderSettingRow(key);
-    // The curated form above this panel posts a full snapshot from its own
+    // The curated forms above this panel post full snapshots from their own
     // inputs. Repopulate those inputs from the server so a later curated
-    // edit doesn't overwrite the value we just saved with a stale snapshot.
+    // edit doesn't overwrite the value we just saved with a stale snapshot —
+    // both the global form (`saveConfig`) and the workspace-overrides form
+    // (`saveWsConfig`, which sends `null` for unchecked rows and would clear
+    // a freshly-saved override).
     if (scope === 'global') await loadConfig();
+    else if (scope === 'workspace') await loadWsOverrides();
     setRowStatus(key, '✓ Saved', false);
     setTimeout(function() { setRowStatus(key, '', false); }, 1500);
   } catch (err) {
@@ -2850,6 +2863,7 @@ async function resetSchemaSetting(key) {
     await refreshAllSettingsValues();
     rerenderSettingRow(key);
     if (scope === 'global') await loadConfig();
+    else if (scope === 'workspace') await loadWsOverrides();
   } catch (err) {
     setRowStatus(key, 'Network error', true);
   }

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2794,21 +2794,25 @@ function scheduleSchemaSave(key, value, immediate) {
   if (ALL_SETTINGS_DEBOUNCE[key]) {
     clearTimeout(ALL_SETTINGS_DEBOUNCE[key]);
   }
+  // Capture the scope at edit time so a tab switch during the debounce window
+  // doesn't redirect the pending write to the wrong layer.
+  var scope = ALL_SETTINGS_SCOPE;
   var delay = immediate ? 0 : 300;
   ALL_SETTINGS_DEBOUNCE[key] = setTimeout(function() {
     ALL_SETTINGS_DEBOUNCE[key] = null;
-    saveSchemaSetting(key, value);
+    saveSchemaSetting(key, value, scope);
   }, delay);
 }
 
-function _settingsScopeBase() {
-  return (ALL_SETTINGS_SCOPE === 'workspace') ? '/api/settings/workspace' : '/api/settings/global';
+function _settingsScopeBaseFor(scope) {
+  return (scope === 'workspace') ? '/api/settings/workspace' : '/api/settings/global';
 }
 
-async function saveSchemaSetting(key, value) {
+async function saveSchemaSetting(key, value, scope) {
+  if (!scope) scope = ALL_SETTINGS_SCOPE;
   setRowStatus(key, 'Saving…', false);
   try {
-    var resp = await fetch(_settingsScopeBase(), {
+    var resp = await fetch(_settingsScopeBaseFor(scope), {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ key: key, value: value }),
@@ -2830,7 +2834,7 @@ async function saveSchemaSetting(key, value) {
 async function resetSchemaSetting(key) {
   setRowStatus(key, 'Resetting…', false);
   try {
-    var resp = await fetch(_settingsScopeBase() + '/' + encodeURIComponent(key), {
+    var resp = await fetch(_settingsScopeBaseFor(ALL_SETTINGS_SCOPE) + '/' + encodeURIComponent(key), {
       method: 'DELETE',
     });
     if (!resp.ok) {

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -31,6 +31,16 @@
   .collapsible-header.open .toggle-icon { transform: rotate(90deg); }
   .collapsible-body { display: none; }
   .collapsible-body.open { display: block; }
+
+  /* All-settings (schema-rendered, read-only) */
+  .provenance-dot {
+    display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+    flex-shrink: 0; margin-top: 6px;
+  }
+  .dot-default { background: var(--border-secondary); }
+  .dot-global { background: var(--accent); }
+  .dot-workspace { background: #a855f7; }
+  .setting-row-card:last-child { border-bottom: none !important; }
 </style>
 </head>
 <body>
@@ -994,6 +1004,27 @@
     </div>
   </div>
 
+  <!-- All settings (schema-driven, read-only) -->
+  <div class="section" id="allSettingsSection">
+    <div class="section-title" style="display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;">
+      <span>All settings</span>
+      <input type="search" id="allSettingsSearch" placeholder="Search settings…" autocomplete="off"
+             oninput="filterAllSettings()"
+             style="flex:1;min-width:200px;max-width:280px;background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:4px 10px;font-size:13px;">
+    </div>
+    <div style="font-size:12px;color:var(--text-dim);margin-bottom:10px;">
+      Every Vireo setting, including ones not surfaced by the curated sections above. Read-only — edit from the curated sections.
+    </div>
+    <div style="font-size:11px;color:var(--text-dim);margin-bottom:14px;display:flex;gap:14px;flex-wrap:wrap;align-items:center;">
+      <span style="display:inline-flex;align-items:center;gap:6px;"><span class="provenance-dot dot-default" style="margin-top:0;"></span> default</span>
+      <span style="display:inline-flex;align-items:center;gap:6px;"><span class="provenance-dot dot-global" style="margin-top:0;"></span> set globally</span>
+      <span style="display:inline-flex;align-items:center;gap:6px;"><span class="provenance-dot dot-workspace" style="margin-top:0;"></span> set for this workspace</span>
+    </div>
+    <div id="allSettingsCategories">
+      <span style="color:var(--text-ghost);font-size:13px;">Loading…</span>
+    </div>
+  </div>
+
 </div>
 
 <script>
@@ -1008,6 +1039,7 @@ loadVersion();
 loadThemePicker();
 loadPreviewCacheStatus();
 loadDetectionCacheStats();
+loadAllSettings();
 
 function toggleSection(header) {
   header.classList.toggle('open');
@@ -2476,6 +2508,126 @@ async function doInstallUpdate() {
     btn.disabled = false;
     status.textContent = 'Install failed. Check logs for details.';
   }
+}
+
+// --- All settings (schema-rendered, read-only) -----------------------------
+
+async function loadAllSettings() {
+  var container = document.getElementById('allSettingsCategories');
+  try {
+    var [schemaRes, valuesRes] = await Promise.all([
+      fetch('/api/settings/schema'),
+      fetch('/api/settings/values'),
+    ]);
+    if (!schemaRes.ok || !valuesRes.ok) throw new Error('HTTP error');
+    var schemaData = await schemaRes.json();
+    var values = await valuesRes.json();
+    renderAllSettings(schemaData.schema, schemaData.categories, values, container);
+  } catch (err) {
+    container.innerHTML = '<span style="color:var(--danger);font-size:13px;">Failed to load settings: '
+      + escapeHtml(err && err.message || String(err)) + '</span>';
+  }
+}
+
+function renderAllSettings(schema, categories, values, container) {
+  var byCategory = {};
+  categories.forEach(function(c) { byCategory[c] = []; });
+  Object.keys(schema).sort().forEach(function(key) {
+    var cat = schema[key].category || 'Other';
+    if (!byCategory[cat]) byCategory[cat] = [];
+    byCategory[cat].push(key);
+  });
+
+  var parts = [];
+  categories.forEach(function(cat) {
+    var keys = byCategory[cat];
+    if (!keys || !keys.length) return;
+    parts.push('<div class="setting-category" data-category="' + escapeHtml(cat) + '" style="margin-top:14px;">');
+    parts.push('<div style="font-size:13px;font-weight:600;color:var(--text-secondary);margin-bottom:6px;border-bottom:1px solid var(--border-primary);padding-bottom:4px;">'
+      + escapeHtml(cat) + '</div>');
+    keys.forEach(function(key) {
+      parts.push(renderSettingRow(key, schema[key], values));
+    });
+    parts.push('</div>');
+  });
+  container.innerHTML = parts.join('');
+}
+
+function renderSettingRow(key, spec, values) {
+  var hasWs = Object.prototype.hasOwnProperty.call(values.workspace, key);
+  var hasGlobal = Object.prototype.hasOwnProperty.call(values['global'], key);
+  var dotClass, dotTitle;
+  if (hasWs) {
+    dotClass = 'dot-workspace';
+    dotTitle = 'Set for this workspace';
+  } else if (hasGlobal) {
+    dotClass = 'dot-global';
+    dotTitle = 'Set globally';
+  } else {
+    dotClass = 'dot-default';
+    dotTitle = 'Using default';
+  }
+  var effective = values.effective[key];
+  var defaultVal = values['default'][key];
+  var displayValue = formatSettingValue(effective, spec, true);
+  var fullValue = formatSettingValue(effective, spec, false);
+  var meta = escapeHtml(key);
+  if (hasWs || hasGlobal) {
+    meta += ' · default: ' + escapeHtml(formatSettingValue(defaultVal, spec, true));
+  }
+  var search = (key + ' ' + spec.label + ' ' + spec.desc + ' ' + spec.category).toLowerCase();
+  return '<div class="setting-row-card" data-search="' + escapeHtml(search) + '" data-key="' + escapeHtml(key) + '" '
+       +    'style="display:flex;align-items:flex-start;gap:10px;padding:10px 0;border-bottom:1px solid var(--border-primary);">'
+       +   '<span class="provenance-dot ' + dotClass + '" title="' + escapeHtml(dotTitle) + '"></span>'
+       +   '<div style="flex:1;min-width:0;">'
+       +     '<div style="display:flex;justify-content:space-between;gap:12px;align-items:center;">'
+       +       '<div style="font-size:13px;color:var(--text-primary);font-weight:500;">' + escapeHtml(spec.label) + '</div>'
+       +       '<div title="' + escapeHtml(fullValue) + '" '
+       +            'style="font-size:12px;color:var(--text-secondary);font-family:monospace;text-align:right;max-width:50%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">'
+       +         escapeHtml(displayValue)
+       +       '</div>'
+       +     '</div>'
+       +     '<div style="font-size:11px;color:var(--text-dim);margin-top:2px;">' + escapeHtml(spec.desc) + '</div>'
+       +     '<div style="font-size:11px;color:var(--text-ghost);margin-top:2px;font-family:monospace;">' + meta + '</div>'
+       +   '</div>'
+       + '</div>';
+}
+
+function formatSettingValue(v, spec, mask) {
+  if (v === undefined || v === null) return '';
+  if (spec.type === 'bool') return v ? 'true' : 'false';
+  if (spec.type === 'secret') {
+    if (!v) return '(unset)';
+    return mask ? '••••••••' : String(v);
+  }
+  if (spec.type === 'enum') {
+    if (spec.enum_labels && spec.enum_labels[v]) return spec.enum_labels[v];
+    return String(v);
+  }
+  if (spec.type === 'list_string') {
+    if (!Array.isArray(v) || v.length === 0) return '(empty)';
+    return v.join(', ');
+  }
+  if (spec.type === 'string' || spec.type === 'path') {
+    if (v === '') return '(empty)';
+    return String(v);
+  }
+  return String(v);
+}
+
+function filterAllSettings() {
+  var q = (document.getElementById('allSettingsSearch').value || '').trim().toLowerCase();
+  var rows = document.querySelectorAll('#allSettingsCategories .setting-row-card');
+  rows.forEach(function(row) {
+    row.style.display = (!q || row.getAttribute('data-search').indexOf(q) !== -1) ? '' : 'none';
+  });
+  document.querySelectorAll('#allSettingsCategories .setting-category').forEach(function(cat) {
+    var anyVisible = false;
+    cat.querySelectorAll('.setting-row-card').forEach(function(r) {
+      if (r.style.display !== 'none') anyVisible = true;
+    });
+    cat.style.display = anyVisible ? '' : 'none';
+  });
 }
 </script>
 </body>

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2824,6 +2824,10 @@ async function saveSchemaSetting(key, value, scope) {
     }
     await refreshAllSettingsValues();
     rerenderSettingRow(key);
+    // The curated form above this panel posts a full snapshot from its own
+    // inputs. Repopulate those inputs from the server so a later curated
+    // edit doesn't overwrite the value we just saved with a stale snapshot.
+    if (scope === 'global') await loadConfig();
     setRowStatus(key, '✓ Saved', false);
     setTimeout(function() { setRowStatus(key, '', false); }, 1500);
   } catch (err) {
@@ -2834,7 +2838,8 @@ async function saveSchemaSetting(key, value, scope) {
 async function resetSchemaSetting(key) {
   setRowStatus(key, 'Resetting…', false);
   try {
-    var resp = await fetch(_settingsScopeBaseFor(ALL_SETTINGS_SCOPE) + '/' + encodeURIComponent(key), {
+    var scope = ALL_SETTINGS_SCOPE;
+    var resp = await fetch(_settingsScopeBaseFor(scope) + '/' + encodeURIComponent(key), {
       method: 'DELETE',
     });
     if (!resp.ok) {
@@ -2844,6 +2849,7 @@ async function resetSchemaSetting(key) {
     }
     await refreshAllSettingsValues();
     rerenderSettingRow(key);
+    if (scope === 'global') await loadConfig();
   } catch (err) {
     setRowStatus(key, 'Network error', true);
   }
@@ -2912,6 +2918,9 @@ async function importSettingsFile(file) {
     await refreshAllSettingsValues();
     renderAllSettings(document.getElementById('allSettingsCategories'));
     filterAllSettings();
+    // Curated form posts its own snapshot — repull so a later edit doesn't
+    // overwrite imported global values with stale form state.
+    await loadConfig();
     alert('Settings imported. Workspace overrides preserved.');
   } catch (err) {
     alert('Network error: ' + (err && err.message || err));

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2852,6 +2852,15 @@ async function resetSchemaSetting(key) {
   setRowStatus(key, 'Resetting…', false);
   try {
     var scope = ALL_SETTINGS_SCOPE;
+    // Cancel any pending debounced autosave for this key+scope. Without
+    // this, a still-queued PATCH from a recent edit would fire 300ms after
+    // the DELETE and re-create the override, making Reset appear to "not
+    // stick" depending on click timing.
+    var token = key + '|' + scope;
+    if (ALL_SETTINGS_DEBOUNCE[token]) {
+      clearTimeout(ALL_SETTINGS_DEBOUNCE[token]);
+      ALL_SETTINGS_DEBOUNCE[token] = null;
+    }
     var resp = await fetch(_settingsScopeBaseFor(scope) + '/' + encodeURIComponent(key), {
       method: 'DELETE',
     });

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -32,7 +32,7 @@
   .collapsible-body { display: none; }
   .collapsible-body.open { display: block; }
 
-  /* All-settings (schema-rendered, read-only) */
+  /* All-settings (schema-rendered) */
   .provenance-dot {
     display: inline-block; width: 8px; height: 8px; border-radius: 50%;
     flex-shrink: 0; margin-top: 6px;
@@ -41,6 +41,13 @@
   .dot-global { background: var(--accent); }
   .dot-workspace { background: #a855f7; }
   .setting-row-card:last-child { border-bottom: none !important; }
+  .scope-tab {
+    background: transparent; border: none; color: var(--text-secondary);
+    padding: 6px 14px; font-size: 13px; cursor: pointer;
+    border-bottom: 2px solid transparent; margin-bottom: -1px;
+  }
+  .scope-tab:hover { color: var(--text-primary); }
+  .scope-tab.active { color: var(--text-primary); border-bottom-color: var(--accent); font-weight: 500; }
 </style>
 </head>
 <body>
@@ -1004,7 +1011,7 @@
     </div>
   </div>
 
-  <!-- All settings (schema-driven, read-only) -->
+  <!-- All settings (schema-driven) -->
   <div class="section" id="allSettingsSection">
     <div class="section-title" style="display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;">
       <span>All settings</span>
@@ -1013,9 +1020,13 @@
              style="flex:1;min-width:200px;max-width:280px;background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:4px 10px;font-size:13px;">
     </div>
     <div style="font-size:12px;color:var(--text-dim);margin-bottom:10px;">
-      Every Vireo setting, including ones not surfaced by the curated sections above. Edits save automatically; click Reset to revert to the default.
+      Every Vireo setting, including ones not surfaced by the curated sections above. Edits save automatically; click Reset to revert.
     </div>
-    <div style="font-size:11px;color:var(--text-dim);margin-bottom:14px;display:flex;gap:14px;flex-wrap:wrap;align-items:center;">
+    <div style="display:flex;border-bottom:1px solid var(--border-primary);margin-bottom:14px;">
+      <button class="scope-tab active" data-scope="global" onclick="setSettingsScope('global')">Global</button>
+      <button class="scope-tab" data-scope="workspace" onclick="setSettingsScope('workspace')">Workspace</button>
+    </div>
+    <div style="font-size:11px;color:var(--text-dim);margin-bottom:14px;display:flex;gap:14px;flex-wrap:wrap;align-items:center;" id="allSettingsLegend">
       <span style="display:inline-flex;align-items:center;gap:6px;"><span class="provenance-dot dot-default" style="margin-top:0;"></span> default</span>
       <span style="display:inline-flex;align-items:center;gap:6px;"><span class="provenance-dot dot-global" style="margin-top:0;"></span> set globally</span>
       <span style="display:inline-flex;align-items:center;gap:6px;"><span class="provenance-dot dot-workspace" style="margin-top:0;"></span> set for this workspace</span>
@@ -2514,6 +2525,18 @@ async function doInstallUpdate() {
 
 var ALL_SETTINGS_CACHE = { schema: null, categories: null, values: null };
 var ALL_SETTINGS_DEBOUNCE = {};   // key -> setTimeout id
+var ALL_SETTINGS_SCOPE = 'global';  // 'global' | 'workspace'
+
+function setSettingsScope(scope) {
+  if (scope !== 'global' && scope !== 'workspace') return;
+  if (ALL_SETTINGS_SCOPE === scope) return;
+  ALL_SETTINGS_SCOPE = scope;
+  document.querySelectorAll('.scope-tab').forEach(function(b) {
+    b.classList.toggle('active', b.dataset.scope === scope);
+  });
+  renderAllSettings(document.getElementById('allSettingsCategories'));
+  filterAllSettings();
+}
 
 async function loadAllSettings() {
   var container = document.getElementById('allSettingsCategories');
@@ -2590,10 +2613,21 @@ function renderSettingRow(key) {
   var values = ALL_SETTINGS_CACHE.values;
   var hasWs = Object.prototype.hasOwnProperty.call(values.workspace, key);
   var hasGlobal = Object.prototype.hasOwnProperty.call(values['global'], key);
+  var globalOnly = (spec.scope === 'global');
+  var workspaceTab = (ALL_SETTINGS_SCOPE === 'workspace');
+
   var dotClass, dotTitle;
-  if (hasWs) {
-    dotClass = 'dot-workspace';
-    dotTitle = 'Set for this workspace';
+  if (workspaceTab) {
+    if (hasWs) {
+      dotClass = 'dot-workspace';
+      dotTitle = 'Set for this workspace';
+    } else if (globalOnly) {
+      dotClass = hasGlobal ? 'dot-global' : 'dot-default';
+      dotTitle = hasGlobal ? 'Global setting (not workspace-overridable)' : 'Global default';
+    } else {
+      dotClass = 'dot-default';
+      dotTitle = hasGlobal ? 'Inheriting global value' : 'Using default';
+    }
   } else if (hasGlobal) {
     dotClass = 'dot-global';
     dotTitle = 'Set globally';
@@ -2601,18 +2635,44 @@ function renderSettingRow(key) {
     dotClass = 'dot-default';
     dotTitle = 'Using default';
   }
-  var effective = values.effective[key];
+
+  // Effective value for the widget on this tab.
+  var rowValue;
+  if (workspaceTab) {
+    if (hasWs) rowValue = values.workspace[key];
+    else if (hasGlobal) rowValue = values['global'][key];
+    else rowValue = values['default'][key];
+  } else {
+    rowValue = hasGlobal ? values['global'][key] : values['default'][key];
+  }
+
   var defaultVal = values['default'][key];
-  var widget = renderSettingWidget(key, spec, effective);
+  var widget;
+  if (workspaceTab && globalOnly) {
+    widget = '<span style="font-size:11px;color:var(--text-ghost);font-style:italic;">'
+           + 'Global only — switch to Global tab</span>';
+  } else {
+    widget = renderSettingWidget(key, spec, rowValue);
+  }
+
+  var hasOverride = workspaceTab ? hasWs : hasGlobal;
   var resetBtn = '';
-  if (hasGlobal) {
+  if (hasOverride) {
+    var resetTitle = workspaceTab
+      ? 'Remove workspace override (inherit global / default)'
+      : 'Reset to default: ' + formatSettingValue(defaultVal, spec, true);
     resetBtn = '<button type="button" onclick="resetSchemaSetting(\'' + escapeHtml(key) + '\')" '
-             +    'title="Reset to default: ' + escapeHtml(formatSettingValue(defaultVal, spec, true)) + '" '
+             +    'title="' + escapeHtml(resetTitle) + '" '
              +    'style="background:transparent;border:1px solid var(--border-secondary);color:var(--text-dim);border-radius:4px;padding:2px 8px;font-size:11px;cursor:pointer;flex-shrink:0;">'
              +  'Reset</button>';
   }
+
   var meta = escapeHtml(key);
-  if (hasGlobal) {
+  if (workspaceTab && hasWs) {
+    var inheritedVal = hasGlobal ? values['global'][key] : defaultVal;
+    var inheritLabel = hasGlobal ? 'inherits global' : 'inherits default';
+    meta += ' · ' + inheritLabel + ': ' + escapeHtml(formatSettingValue(inheritedVal, spec, true));
+  } else if (!workspaceTab && hasGlobal) {
     meta += ' · default: ' + escapeHtml(formatSettingValue(defaultVal, spec, true));
   }
   var search = (key + ' ' + spec.label + ' ' + spec.desc + ' ' + spec.category).toLowerCase();
@@ -2737,10 +2797,14 @@ function scheduleSchemaSave(key, value, immediate) {
   }, delay);
 }
 
+function _settingsScopeBase() {
+  return (ALL_SETTINGS_SCOPE === 'workspace') ? '/api/settings/workspace' : '/api/settings/global';
+}
+
 async function saveSchemaSetting(key, value) {
   setRowStatus(key, 'Saving…', false);
   try {
-    var resp = await fetch('/api/settings/global', {
+    var resp = await fetch(_settingsScopeBase(), {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ key: key, value: value }),
@@ -2762,7 +2826,7 @@ async function saveSchemaSetting(key, value) {
 async function resetSchemaSetting(key) {
   setRowStatus(key, 'Resetting…', false);
   try {
-    var resp = await fetch('/api/settings/global/' + encodeURIComponent(key), {
+    var resp = await fetch(_settingsScopeBase() + '/' + encodeURIComponent(key), {
       method: 'DELETE',
     });
     if (!resp.ok) {

--- a/vireo/tests/test_config_schema.py
+++ b/vireo/tests/test_config_schema.py
@@ -180,6 +180,31 @@ def test_validate_int_enforces_range():
         validate_value("photos_per_page", 5000)
 
 
+def test_validate_int_rejects_fractional_float():
+    from config_schema import ValidationError, validate_value
+
+    # JSON numerics with a decimal point arrive as float — reject non-integral
+    # values so {"photos_per_page": 1.9} doesn't silently truncate to 1.
+    with pytest.raises(ValidationError):
+        validate_value("photos_per_page", 99.5)
+
+
+def test_validate_int_accepts_integral_float():
+    from config_schema import validate_value
+
+    # JSON numbers like 100.0 are still legitimate ints.
+    assert validate_value("photos_per_page", 100.0) == 100
+
+
+def test_validate_int_rejects_nan_and_inf():
+    from config_schema import ValidationError, validate_value
+
+    with pytest.raises(ValidationError):
+        validate_value("photos_per_page", float("nan"))
+    with pytest.raises(ValidationError):
+        validate_value("photos_per_page", float("inf"))
+
+
 def test_validate_float_coerces_string():
     from config_schema import validate_value
 
@@ -193,6 +218,30 @@ def test_validate_float_enforces_range():
         validate_value("classification_threshold", -0.1)
     with pytest.raises(ValidationError):
         validate_value("classification_threshold", 1.5)
+
+
+def test_validate_float_rejects_nan():
+    from config_schema import ValidationError, validate_value
+
+    # NaN sneaks past min/max checks (`< min` / `> max` are both False) so
+    # we must explicitly reject non-finite floats.
+    with pytest.raises(ValidationError):
+        validate_value("classification_threshold", float("nan"))
+    with pytest.raises(ValidationError):
+        validate_value("classification_threshold", "nan")
+    with pytest.raises(ValidationError):
+        validate_value("classification_threshold", "NaN")
+
+
+def test_validate_float_rejects_inf():
+    from config_schema import ValidationError, validate_value
+
+    with pytest.raises(ValidationError):
+        validate_value("classification_threshold", float("inf"))
+    with pytest.raises(ValidationError):
+        validate_value("classification_threshold", float("-inf"))
+    with pytest.raises(ValidationError):
+        validate_value("classification_threshold", "Infinity")
 
 
 def test_validate_bool_coerces_strings():

--- a/vireo/tests/test_config_schema.py
+++ b/vireo/tests/test_config_schema.py
@@ -234,6 +234,27 @@ def test_validate_int_rejects_nan_and_inf():
         validate_value("photos_per_page", float("inf"))
 
 
+def test_validate_int_rejects_bool():
+    """Python bool is a subclass of int, but JSON booleans arriving on a
+    numeric field are a client-side type error — accept them silently and
+    you persist 1/0 instead of flagging the bug."""
+    from config_schema import ValidationError, validate_value
+
+    with pytest.raises(ValidationError):
+        validate_value("photos_per_page", True)
+    with pytest.raises(ValidationError):
+        validate_value("photos_per_page", False)
+
+
+def test_validate_float_rejects_bool():
+    from config_schema import ValidationError, validate_value
+
+    with pytest.raises(ValidationError):
+        validate_value("classification_threshold", True)
+    with pytest.raises(ValidationError):
+        validate_value("classification_threshold", False)
+
+
 def test_validate_float_coerces_string():
     from config_schema import validate_value
 

--- a/vireo/tests/test_config_schema.py
+++ b/vireo/tests/test_config_schema.py
@@ -259,3 +259,20 @@ def test_validate_list_string_with_items_enum_accepts_subset():
 
     out = validate_value("browse_card_fields", ["filename", "rating"])
     assert out == ["filename", "rating"]
+
+
+def test_schema_parent_prefixes_covers_dotted_namespaces():
+    from config_schema import SCHEMA, schema_parent_prefixes
+
+    prefixes = schema_parent_prefixes()
+    # Every dotted SCHEMA key contributes its non-leaf prefixes.
+    for k in SCHEMA:
+        parts = k.split(".")
+        for i in range(1, len(parts)):
+            assert ".".join(parts[:i]) in prefixes
+    # Top-level (no-dot) keys do not contribute prefixes.
+    assert "classification_threshold" not in prefixes
+    # Known dotted namespaces in DEFAULTS show up.
+    assert "pipeline" in prefixes
+    assert "ingest" in prefixes
+

--- a/vireo/tests/test_config_schema.py
+++ b/vireo/tests/test_config_schema.py
@@ -149,16 +149,27 @@ def test_is_excluded_matches_prefixes():
 # ---------------------------------------------------------------------------
 
 
-def test_cull_thresholds_remain_global_until_consumers_wired():
-    """The cull workflow (cull.html init, culling.analyze_for_culling) reads
-    only the global cfg.load(), so a workspace override of these keys would
-    be silently ignored. Pin the scope so a future re-promotion to ``both``
-    has to reckon with the consumer side first.
+def test_keys_with_global_only_consumers_remain_global():
+    """These keys' runtime consumers read only the global ``cfg.load()`` /
+    ``cfg.get(...)`` — they don't go through ``db.get_effective_config``.
+    A workspace override would therefore be silently ignored, which is worse
+    than not offering the option at all. Pin the scope so a future
+    re-promotion to ``both`` has to reckon with the consumer side first.
     """
     from config_schema import SCHEMA
 
+    # Cull workflow: cull.html reads /api/config; culling.analyze_for_culling
+    # falls back to cfg.load().
     assert SCHEMA["cull_time_window"]["scope"] == "global"
     assert SCHEMA["cull_phash_threshold"]["scope"] == "global"
+    # culling.analyze_for_culling consumes redundancy_threshold from cfg.load().
+    assert SCHEMA["redundancy_threshold"]["scope"] == "global"
+    # Detection-padding consumers in app.py use cfg.load().get(...) directly.
+    assert SCHEMA["detection_padding"]["scope"] == "global"
+    # Database._prune_edit_history reads cfg.get('max_edit_history').
+    assert SCHEMA["max_edit_history"]["scope"] == "global"
+    # Database.add_keyword reads cfg.get('keyword_case').
+    assert SCHEMA["keyword_case"]["scope"] == "global"
 
 
 def test_validate_unknown_key_raises():

--- a/vireo/tests/test_config_schema.py
+++ b/vireo/tests/test_config_schema.py
@@ -1,0 +1,261 @@
+"""Tests for vireo/config_schema.py — drift guard, validation, dotted-path helpers."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# ---------------------------------------------------------------------------
+# Drift guard: SCHEMA must cover every leaf in DEFAULTS (modulo EXCLUDED).
+# ---------------------------------------------------------------------------
+
+
+def test_schema_covers_all_defaults_leaf_keys():
+    """Every non-excluded leaf in DEFAULTS has a SCHEMA entry."""
+    from config import DEFAULTS
+    from config_schema import SCHEMA, flatten, is_excluded
+
+    flat = flatten(DEFAULTS)
+    expected = {k for k in flat if not is_excluded(k)}
+    missing = expected - set(SCHEMA.keys())
+    extra = set(SCHEMA.keys()) - expected
+    assert not missing, f"SCHEMA is missing leaf keys: {sorted(missing)}"
+    assert not extra, f"SCHEMA has keys absent from DEFAULTS: {sorted(extra)}"
+
+
+def test_schema_excluded_prefixes_are_real():
+    """Each EXCLUDED prefix actually matches something in DEFAULTS (no dead exclusions)."""
+    from config import DEFAULTS
+    from config_schema import EXCLUDED, flatten
+
+    flat_keys = set(flatten(DEFAULTS).keys())
+    for prefix in EXCLUDED:
+        matches = [k for k in flat_keys if k == prefix or k.startswith(prefix + ".")]
+        assert matches, f"EXCLUDED prefix {prefix!r} matches no DEFAULTS key"
+
+
+def test_schema_entries_have_required_fields():
+    """Every SCHEMA entry declares type, category, scope, label, desc."""
+    from config_schema import CATEGORIES, SCHEMA
+
+    valid_types = {"int", "float", "bool", "string", "secret", "path", "enum", "list_string"}
+    valid_scopes = {"global", "workspace", "both"}
+    for key, spec in SCHEMA.items():
+        for required in ("type", "category", "scope", "label", "desc"):
+            assert required in spec, f"{key} missing field {required!r}"
+        assert spec["type"] in valid_types, f"{key} has unknown type {spec['type']!r}"
+        assert spec["scope"] in valid_scopes, f"{key} has unknown scope {spec['scope']!r}"
+        assert spec["category"] in CATEGORIES, f"{key} has uncategorized category {spec['category']!r}"
+        if spec["type"] == "enum":
+            assert "enum" in spec and isinstance(spec["enum"], list) and spec["enum"], \
+                f"{key} is enum but has no enum values"
+
+
+# ---------------------------------------------------------------------------
+# Dotted-path helpers
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_collapses_nested_dicts_to_dotted_paths():
+    from config_schema import flatten
+
+    assert flatten({"a": 1, "b": {"c": 2, "d": {"e": 3}}}) == {"a": 1, "b.c": 2, "b.d.e": 3}
+
+
+def test_flatten_empty_dict():
+    from config_schema import flatten
+
+    assert flatten({}) == {}
+
+
+def test_get_dotted_returns_value_at_path():
+    from config_schema import get_dotted
+
+    d = {"a": {"b": {"c": 5}}}
+    assert get_dotted(d, "a.b.c") == 5
+    assert get_dotted(d, "a.b") == {"c": 5}
+    assert get_dotted(d, "a") == {"b": {"c": 5}}
+
+
+def test_get_dotted_returns_default_for_missing_key():
+    from config_schema import get_dotted
+
+    assert get_dotted({"a": 1}, "b") is None
+    assert get_dotted({"a": 1}, "b", default="x") == "x"
+    assert get_dotted({"a": {"b": 1}}, "a.c") is None
+
+
+def test_set_dotted_creates_intermediate_dicts():
+    from config_schema import set_dotted
+
+    d = {}
+    set_dotted(d, "a.b.c", 7)
+    assert d == {"a": {"b": {"c": 7}}}
+
+
+def test_set_dotted_overwrites_existing_value():
+    from config_schema import set_dotted
+
+    d = {"a": {"b": 1}}
+    set_dotted(d, "a.b", 2)
+    assert d == {"a": {"b": 2}}
+
+
+def test_set_dotted_replaces_non_dict_intermediate():
+    """If an intermediate path is not a dict, set_dotted replaces it."""
+    from config_schema import set_dotted
+
+    d = {"a": 1}
+    set_dotted(d, "a.b", 2)
+    assert d == {"a": {"b": 2}}
+
+
+def test_delete_dotted_removes_leaf():
+    from config_schema import delete_dotted
+
+    d = {"a": {"b": 1, "c": 2}}
+    assert delete_dotted(d, "a.b") is True
+    assert d == {"a": {"c": 2}}
+
+
+def test_delete_dotted_returns_false_for_missing():
+    from config_schema import delete_dotted
+
+    d = {"a": {"b": 1}}
+    assert delete_dotted(d, "a.x") is False
+    assert delete_dotted(d, "x.y.z") is False
+
+
+def test_is_excluded_matches_prefixes():
+    from config_schema import is_excluded
+
+    # Direct match
+    assert is_excluded("setup_complete") is True
+    # Subtree match
+    assert is_excluded("keyboard_shortcuts.navigation.import") is True
+    assert is_excluded("ingest.recent_destinations") is True
+    # Non-match
+    assert is_excluded("ingest.skip_duplicates") is False
+    assert is_excluded("hf_token") is False
+    # Prefix collision: "setup" alone shouldn't match "setup_complete"
+    assert is_excluded("setup") is False
+
+
+# ---------------------------------------------------------------------------
+# validate_value: type coercion, range, enum, list_string
+# ---------------------------------------------------------------------------
+
+
+def test_validate_unknown_key_raises():
+    from config_schema import ValidationError, validate_value
+
+    with pytest.raises(ValidationError):
+        validate_value("bogus_key_no_one_will_ever_add", 1)
+
+
+def test_validate_int_coerces_string():
+    from config_schema import validate_value
+
+    assert validate_value("photos_per_page", "100") == 100
+    assert validate_value("photos_per_page", 50) == 50
+
+
+def test_validate_int_rejects_garbage():
+    from config_schema import ValidationError, validate_value
+
+    with pytest.raises(ValidationError):
+        validate_value("photos_per_page", "not-a-number")
+
+
+def test_validate_int_enforces_range():
+    from config_schema import ValidationError, validate_value
+
+    # photos_per_page is 10..500
+    with pytest.raises(ValidationError):
+        validate_value("photos_per_page", 5)
+    with pytest.raises(ValidationError):
+        validate_value("photos_per_page", 5000)
+
+
+def test_validate_float_coerces_string():
+    from config_schema import validate_value
+
+    assert validate_value("classification_threshold", "0.5") == 0.5
+
+
+def test_validate_float_enforces_range():
+    from config_schema import ValidationError, validate_value
+
+    with pytest.raises(ValidationError):
+        validate_value("classification_threshold", -0.1)
+    with pytest.raises(ValidationError):
+        validate_value("classification_threshold", 1.5)
+
+
+def test_validate_bool_coerces_strings():
+    from config_schema import validate_value
+
+    # ingest.skip_duplicates is bool
+    assert validate_value("ingest.skip_duplicates", "true") is True
+    assert validate_value("ingest.skip_duplicates", "false") is False
+    assert validate_value("ingest.skip_duplicates", True) is True
+    assert validate_value("ingest.skip_duplicates", 0) is False
+
+
+def test_validate_enum_accepts_declared_values():
+    from config_schema import validate_value
+
+    assert validate_value("keyword_case", "auto") == "auto"
+    assert validate_value("keyword_case", "title") == "title"
+
+
+def test_validate_enum_rejects_unknown():
+    from config_schema import ValidationError, validate_value
+
+    with pytest.raises(ValidationError):
+        validate_value("keyword_case", "screaming-snake")
+
+
+def test_validate_string_passthrough():
+    from config_schema import validate_value
+
+    assert validate_value("darktable_style", "Bird preset") == "Bird preset"
+    assert validate_value("darktable_style", "") == ""
+
+
+def test_validate_secret_passthrough():
+    from config_schema import validate_value
+
+    assert validate_value("hf_token", "hf_xxx") == "hf_xxx"
+
+
+def test_validate_list_string_accepts_list():
+    from config_schema import validate_value
+
+    out = validate_value("scan_roots", ["/a", "/b"])
+    assert out == ["/a", "/b"]
+
+
+def test_validate_list_string_rejects_non_list():
+    from config_schema import ValidationError, validate_value
+
+    with pytest.raises(ValidationError):
+        validate_value("scan_roots", "/a")
+
+
+def test_validate_list_string_with_items_enum_rejects_unknown():
+    from config_schema import ValidationError, validate_value
+
+    # browse_card_fields has items_enum
+    with pytest.raises(ValidationError):
+        validate_value("browse_card_fields", ["filename", "bogus_field"])
+
+
+def test_validate_list_string_with_items_enum_accepts_subset():
+    from config_schema import validate_value
+
+    out = validate_value("browse_card_fields", ["filename", "rating"])
+    assert out == ["filename", "rating"]

--- a/vireo/tests/test_config_schema.py
+++ b/vireo/tests/test_config_schema.py
@@ -149,6 +149,18 @@ def test_is_excluded_matches_prefixes():
 # ---------------------------------------------------------------------------
 
 
+def test_cull_thresholds_remain_global_until_consumers_wired():
+    """The cull workflow (cull.html init, culling.analyze_for_culling) reads
+    only the global cfg.load(), so a workspace override of these keys would
+    be silently ignored. Pin the scope so a future re-promotion to ``both``
+    has to reckon with the consumer side first.
+    """
+    from config_schema import SCHEMA
+
+    assert SCHEMA["cull_time_window"]["scope"] == "global"
+    assert SCHEMA["cull_phash_threshold"]["scope"] == "global"
+
+
 def test_validate_unknown_key_raises():
     from config_schema import ValidationError, validate_value
 

--- a/vireo/tests/test_config_schema.py
+++ b/vireo/tests/test_config_schema.py
@@ -170,6 +170,12 @@ def test_keys_with_global_only_consumers_remain_global():
     assert SCHEMA["max_edit_history"]["scope"] == "global"
     # Database.add_keyword reads cfg.get('keyword_case').
     assert SCHEMA["keyword_case"]["scope"] == "global"
+    # Ingest endpoints read these only from request body params with
+    # hardcoded fallbacks; neither cfg.load() nor db.get_effective_config
+    # is consulted, so a workspace override would silently no-op.
+    assert SCHEMA["ingest.folder_template"]["scope"] == "global"
+    assert SCHEMA["ingest.skip_duplicates"]["scope"] == "global"
+    assert SCHEMA["ingest.file_types"]["scope"] == "global"
 
 
 def test_validate_unknown_key_raises():

--- a/vireo/tests/test_settings_api.py
+++ b/vireo/tests/test_settings_api.py
@@ -138,6 +138,20 @@ def test_get_values_effective_falls_through_layers(app_and_db):
     assert values["effective"]["similarity_threshold"] == 0.95
 
 
+def test_get_values_global_excludes_keys_equal_to_default(app_and_db):
+    """Legacy save paths write the entire DEFAULTS dict to disk; a value matching
+    the default must not appear as a "globally set" override."""
+    app, _ = app_and_db
+    import config as cfg
+
+    # cfg.save(cfg.load()) is what the legacy POST /api/config does — it
+    # produces a file containing every default key.
+    cfg.save(cfg.load())
+    client = app.test_client()
+    values = client.get("/api/settings/values").get_json()
+    assert values["global"] == {}
+
+
 def test_get_values_workspace_excludes_non_schema_keys(app_and_db):
     """Internal keys stored in config_overrides (e.g. active_labels) are not exposed."""
     app, db = app_and_db
@@ -158,3 +172,164 @@ def test_get_values_workspace_excludes_non_schema_keys(app_and_db):
 
 def client_get(app, path):
     return app.test_client().get(path).get_json()
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/settings/global
+# ---------------------------------------------------------------------------
+
+
+def test_patch_global_persists_value(app_and_db):
+    app, _ = app_and_db
+    import config as cfg
+
+    client = app.test_client()
+    resp = client.patch(
+        "/api/settings/global",
+        json={"key": "classification_threshold", "value": 0.65},
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["value"] == 0.65
+    # Persisted to disk.
+    assert cfg.load()["classification_threshold"] == 0.65
+
+
+def test_patch_global_coerces_string_to_float(app_and_db):
+    app, _ = app_and_db
+    import config as cfg
+
+    client = app.test_client()
+    resp = client.patch(
+        "/api/settings/global",
+        json={"key": "classification_threshold", "value": "0.42"},
+    )
+    assert resp.status_code == 200
+    assert cfg.load()["classification_threshold"] == 0.42
+
+
+def test_patch_global_writes_nested_key(app_and_db):
+    app, _ = app_and_db
+    import config as cfg
+
+    client = app.test_client()
+    resp = client.patch(
+        "/api/settings/global",
+        json={"key": "pipeline.w_focus", "value": 0.5},
+    )
+    assert resp.status_code == 200
+    assert cfg.load()["pipeline"]["w_focus"] == 0.5
+
+
+def test_patch_global_rejects_unknown_key(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.patch(
+        "/api/settings/global",
+        json={"key": "no_such_key", "value": 1},
+    )
+    assert resp.status_code == 400
+
+
+def test_patch_global_rejects_out_of_range(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.patch(
+        "/api/settings/global",
+        json={"key": "classification_threshold", "value": 5.0},
+    )
+    assert resp.status_code == 400
+
+
+def test_patch_global_rejects_unknown_enum(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.patch(
+        "/api/settings/global",
+        json={"key": "keyword_case", "value": "screaming-snake"},
+    )
+    assert resp.status_code == 400
+
+
+def test_patch_global_rejects_type_mismatch(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.patch(
+        "/api/settings/global",
+        json={"key": "photos_per_page", "value": "not-a-number"},
+    )
+    assert resp.status_code == 400
+
+
+def test_patch_global_updates_hf_token_env(app_and_db, monkeypatch):
+    """Setting hf_token also pushes it into HF_TOKEN env var (legacy POST behavior)."""
+    app, _ = app_and_db
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    client = app.test_client()
+    client.patch(
+        "/api/settings/global",
+        json={"key": "hf_token", "value": "hf_test_xyz"},
+    )
+    assert os.environ.get("HF_TOKEN") == "hf_test_xyz"
+
+
+def test_patch_global_clears_hf_token_env(app_and_db, monkeypatch):
+    app, _ = app_and_db
+    monkeypatch.setenv("HF_TOKEN", "previous")
+    import config as cfg
+
+    cfg.set("hf_token", "previous")
+    client = app.test_client()
+    client.patch(
+        "/api/settings/global",
+        json={"key": "hf_token", "value": ""},
+    )
+    assert "HF_TOKEN" not in os.environ
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/settings/global/<dotted-key>
+# ---------------------------------------------------------------------------
+
+
+def test_delete_global_reverts_to_default(app_and_db):
+    app, _ = app_and_db
+    import config as cfg
+
+    cfg.set("classification_threshold", 0.65)
+    assert cfg.load()["classification_threshold"] == 0.65
+
+    client = app.test_client()
+    resp = client.delete("/api/settings/global/classification_threshold")
+    assert resp.status_code == 200
+    # Reverted to the DEFAULTS value (deep-merge fills it back in).
+    assert cfg.load()["classification_threshold"] == cfg.DEFAULTS["classification_threshold"]
+
+
+def test_delete_global_nested_key(app_and_db):
+    app, _ = app_and_db
+    import config as cfg
+
+    client = app.test_client()
+    client.patch("/api/settings/global", json={"key": "pipeline.w_focus", "value": 0.99})
+    assert cfg.load()["pipeline"]["w_focus"] == 0.99
+
+    resp = client.delete("/api/settings/global/pipeline.w_focus")
+    assert resp.status_code == 200
+    assert cfg.load()["pipeline"]["w_focus"] == cfg.DEFAULTS["pipeline"]["w_focus"]
+
+
+def test_delete_global_idempotent(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    # Delete a key that has no override — should not error.
+    resp = client.delete("/api/settings/global/classification_threshold")
+    assert resp.status_code == 200
+
+
+def test_delete_global_rejects_unknown_key(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.delete("/api/settings/global/no_such_key")
+    assert resp.status_code == 400

--- a/vireo/tests/test_settings_api.py
+++ b/vireo/tests/test_settings_api.py
@@ -761,6 +761,48 @@ def test_import_rejects_empty_object_at_schema_leaf(app_and_db):
     assert cfg.load()["classification_threshold"] == 0.5
 
 
+def test_import_rejects_non_dict_keyboard_shortcuts(app_and_db):
+    """A malformed keyboard_shortcuts value would slip past the schema-only
+    validator (since the key is in EXCLUDED) and crash shortcuts.html, which
+    indexes cfg.keyboard_shortcuts.<ctx>.<action>."""
+    app, _ = app_and_db
+    import config as cfg
+
+    cfg.set("classification_threshold", 0.5)
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"keyboard_shortcuts": 5})},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "keyboard_shortcuts" in body["errors"]
+    # File untouched.
+    assert cfg.load()["classification_threshold"] == 0.5
+
+
+def test_import_rejects_non_dict_keyboard_shortcut_context(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"keyboard_shortcuts": {"navigation": "not-a-dict"}})},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "keyboard_shortcuts.navigation" in body["errors"]
+
+
+def test_import_accepts_well_formed_keyboard_shortcuts(app_and_db):
+    app, _ = app_and_db
+    import config as cfg
+
+    payload = {"keyboard_shortcuts": cfg.DEFAULTS["keyboard_shortcuts"]}
+    client = app.test_client()
+    resp = client.post("/api/settings/import", json={"json": json.dumps(payload)})
+    assert resp.status_code == 200
+
+
 def test_import_rejects_empty_object_at_nested_schema_leaf(app_and_db):
     app, _ = app_and_db
     client = app.test_client()

--- a/vireo/tests/test_settings_api.py
+++ b/vireo/tests/test_settings_api.py
@@ -674,6 +674,47 @@ def test_import_allows_empty_object_for_schema_subtree(app_and_db):
     assert resp.status_code == 200
 
 
+def test_import_rejects_object_at_schema_leaf(app_and_db):
+    """A nested object where a scalar schema leaf is expected must be rejected.
+
+    ``flatten`` only emits leaf paths, so ``{"classification_threshold": {"x": 1}}``
+    becomes ``classification_threshold.x`` which is neither a SCHEMA entry nor a
+    parent-prefix; without an extra check it would slip through and persist a
+    malformed value.
+    """
+    app, _ = app_and_db
+    import config as cfg
+
+    cfg.set("classification_threshold", 0.5)
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"classification_threshold": {"x": 1}})},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "errors" in body
+    assert "classification_threshold" in body["errors"]
+    # File untouched.
+    assert cfg.load()["classification_threshold"] == 0.5
+
+
+def test_import_rejects_object_at_nested_schema_leaf(app_and_db):
+    """Same guard, but for a leaf that lives inside a schema subtree
+    (e.g. ``pipeline.w_focus`` — a numeric leaf under the ``pipeline`` parent).
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"pipeline": {"w_focus": {"x": 1}}})},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "errors" in body
+    assert "pipeline.w_focus" in body["errors"]
+
+
 def test_delete_workspace_preserves_active_labels(app_and_db):
     app, db = app_and_db
     db.update_workspace(

--- a/vireo/tests/test_settings_api.py
+++ b/vireo/tests/test_settings_api.py
@@ -715,6 +715,40 @@ def test_import_rejects_object_at_nested_schema_leaf(app_and_db):
     assert "pipeline.w_focus" in body["errors"]
 
 
+def test_import_rejects_empty_object_at_schema_leaf(app_and_db):
+    """``flatten`` emits nothing for empty dicts, so a leaf set to ``{}`` would
+    bypass the flatten-based loop and replace a numeric value with ``{}`` on
+    disk. The schema-iteration validator must still catch it."""
+    app, _ = app_and_db
+    import config as cfg
+
+    cfg.set("classification_threshold", 0.5)
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"classification_threshold": {}})},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "errors" in body
+    assert "classification_threshold" in body["errors"]
+    # File untouched.
+    assert cfg.load()["classification_threshold"] == 0.5
+
+
+def test_import_rejects_empty_object_at_nested_schema_leaf(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"pipeline": {"w_focus": {}}})},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "errors" in body
+    assert "pipeline.w_focus" in body["errors"]
+
+
 def test_delete_workspace_preserves_active_labels(app_and_db):
     app, db = app_and_db
     db.update_workspace(

--- a/vireo/tests/test_settings_api.py
+++ b/vireo/tests/test_settings_api.py
@@ -153,6 +153,31 @@ def test_get_values_global_excludes_keys_equal_to_default(app_and_db):
     assert values["global"] == {}
 
 
+def test_get_values_workspace_layer_filters_global_only_keys(app_and_db):
+    """Workspace create/update APIs can persist arbitrary override payloads,
+    so a workspace may contain entries for global-only schema keys (e.g.
+    hf_token, max_edit_history). Runtime never reads those from the workspace
+    layer, so the values endpoint must not surface them as workspace-effective
+    or the UI will mislead the user."""
+    app, db = app_and_db
+    db.update_workspace(
+        db._active_workspace_id,
+        config_overrides={
+            "hf_token": "leaked-from-bad-payload",          # scope=global
+            "max_edit_history": 9999,                       # scope=global
+            "classification_threshold": 0.55,               # scope=both — keep
+        },
+    )
+    client = app.test_client()
+    values = client.get("/api/settings/values").get_json()
+    assert "hf_token" not in values["workspace"]
+    assert "max_edit_history" not in values["workspace"]
+    assert values["workspace"].get("classification_threshold") == 0.55
+    # Effective for global-only keys should fall through to global/default,
+    # not the (now filtered-out) workspace value.
+    assert values["effective"].get("hf_token") != "leaked-from-bad-payload"
+
+
 def test_get_values_workspace_excludes_non_schema_keys(app_and_db):
     """Internal keys stored in config_overrides (e.g. active_labels) are not exposed."""
     app, db = app_and_db

--- a/vireo/tests/test_settings_api.py
+++ b/vireo/tests/test_settings_api.py
@@ -617,6 +617,63 @@ def test_import_empty_object_is_ok(app_and_db):
     assert resp.status_code == 200
 
 
+def test_import_rejects_non_object_for_schema_subtree(app_and_db):
+    """A scalar where a schema-backed subtree (e.g. ``pipeline``) is expected
+    must be rejected — otherwise downstream code that assumes ``pipeline`` is a
+    mapping will crash on the next ``.get(...)`` call."""
+    app, _ = app_and_db
+    import config as cfg
+
+    cfg.set("classification_threshold", 0.5)
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"pipeline": 5})},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "errors" in body
+    assert "pipeline" in body["errors"]
+    # File untouched.
+    assert cfg.load()["classification_threshold"] == 0.5
+
+
+def test_import_rejects_list_for_schema_subtree(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"ingest": ["folder_template"]})},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "ingest" in body["errors"]
+
+
+def test_import_rejects_null_for_schema_subtree(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"pipeline": None})},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "pipeline" in body["errors"]
+
+
+def test_import_allows_empty_object_for_schema_subtree(app_and_db):
+    """An empty object for a schema-backed subtree is fine — every leaf falls
+    back to defaults."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"pipeline": {}})},
+    )
+    assert resp.status_code == 200
+
+
 def test_delete_workspace_preserves_active_labels(app_and_db):
     app, db = app_and_db
     db.update_workspace(

--- a/vireo/tests/test_settings_api.py
+++ b/vireo/tests/test_settings_api.py
@@ -793,6 +793,36 @@ def test_import_rejects_non_dict_keyboard_shortcut_context(app_and_db):
     assert "keyboard_shortcuts.navigation" in body["errors"]
 
 
+def test_import_rejects_non_list_recent_destinations(app_and_db):
+    """ingest.recent_destinations is in EXCLUDED but pipeline.html iterates it
+    with .forEach. A non-list value would crash the page after import."""
+    app, _ = app_and_db
+    import config as cfg
+
+    cfg.set("classification_threshold", 0.5)
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"ingest": {"recent_destinations": "/tmp/out"}})},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "ingest.recent_destinations" in body["errors"]
+    assert cfg.load()["classification_threshold"] == 0.5
+
+
+def test_import_rejects_non_string_inside_recent_destinations(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"ingest": {"recent_destinations": ["/a", 5]}})},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert any(k.startswith("ingest.recent_destinations") for k in body["errors"])
+
+
 def test_import_accepts_well_formed_keyboard_shortcuts(app_and_db):
     app, _ = app_and_db
     import config as cfg

--- a/vireo/tests/test_settings_api.py
+++ b/vireo/tests/test_settings_api.py
@@ -1,5 +1,6 @@
 """Tests for /api/settings/* endpoints (schema-driven settings UI)."""
 
+import json
 import os
 import sys
 
@@ -495,6 +496,125 @@ def test_delete_workspace_rejects_unknown_key(app_and_db):
     client = app.test_client()
     resp = client.delete("/api/settings/workspace/no_such_key")
     assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /api/settings/export
+# ---------------------------------------------------------------------------
+
+
+def test_export_returns_attachment_when_file_exists(app_and_db):
+    app, _ = app_and_db
+    import config as cfg
+
+    cfg.set("classification_threshold", 0.7)
+    client = app.test_client()
+    resp = client.get("/api/settings/export")
+    assert resp.status_code == 200
+    assert "attachment" in resp.headers.get("Content-Disposition", "")
+    body = json.loads(resp.get_data())
+    assert body.get("classification_threshold") == 0.7
+
+
+def test_export_returns_empty_object_when_file_missing(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/settings/export")
+    assert resp.status_code == 200
+    body = json.loads(resp.get_data())
+    assert body == {}
+
+
+# ---------------------------------------------------------------------------
+# POST /api/settings/import
+# ---------------------------------------------------------------------------
+
+
+def test_import_replaces_global_file(app_and_db):
+    app, _ = app_and_db
+    import config as cfg
+
+    cfg.set("classification_threshold", 0.5)
+    client = app.test_client()
+    payload = {"classification_threshold": 0.95, "photos_per_page": 100}
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps(payload)},
+    )
+    assert resp.status_code == 200
+    raw = cfg.load()
+    assert raw["classification_threshold"] == 0.95
+    assert raw["photos_per_page"] == 100
+
+
+def test_import_rejects_invalid_json(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": "{ this is not json"},
+    )
+    assert resp.status_code == 400
+
+
+def test_import_rejects_invalid_value_for_known_key(app_and_db):
+    app, _ = app_and_db
+    import config as cfg
+
+    cfg.set("classification_threshold", 0.5)
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"classification_threshold": 99})},
+    )
+    assert resp.status_code == 400
+    # File untouched — atomic replace happens only after full validation.
+    assert cfg.load()["classification_threshold"] == 0.5
+
+
+def test_import_passes_through_non_schema_keys(app_and_db):
+    """Keys not in SCHEMA (e.g. setup_complete, keyboard_shortcuts) survive an import."""
+    app, _ = app_and_db
+    import config as cfg
+
+    payload = {
+        "classification_threshold": 0.6,
+        "setup_complete": True,
+        "keyboard_shortcuts": cfg.DEFAULTS["keyboard_shortcuts"],
+    }
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps(payload)},
+    )
+    assert resp.status_code == 200
+    raw = cfg.load()
+    assert raw["setup_complete"] is True
+    assert raw["classification_threshold"] == 0.6
+
+
+def test_import_preserves_workspace_overrides(app_and_db):
+    """Workspace overrides survive a global-config import."""
+    app, db = app_and_db
+    db.update_workspace(
+        db._active_workspace_id,
+        config_overrides={"classification_threshold": 0.9},
+    )
+    client = app.test_client()
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"classification_threshold": 0.3})},
+    )
+    assert resp.status_code == 200
+    overrides = _ws_overrides(db)
+    assert overrides.get("classification_threshold") == 0.9
+
+
+def test_import_empty_object_is_ok(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/settings/import", json={"json": "{}"})
+    assert resp.status_code == 200
 
 
 def test_delete_workspace_preserves_active_labels(app_and_db):

--- a/vireo/tests/test_settings_api.py
+++ b/vireo/tests/test_settings_api.py
@@ -1,0 +1,160 @@
+"""Tests for /api/settings/* endpoints (schema-driven settings UI)."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# ---------------------------------------------------------------------------
+# GET /api/settings/schema
+# ---------------------------------------------------------------------------
+
+
+def test_get_schema_returns_schema_and_categories(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/settings/schema")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "schema" in data
+    assert "categories" in data
+    assert isinstance(data["schema"], dict)
+    assert isinstance(data["categories"], list)
+    # Sample-check a couple of well-known keys.
+    assert "classification_threshold" in data["schema"]
+    assert "pipeline.w_focus" in data["schema"]
+
+
+def test_get_schema_entries_have_required_fields(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/settings/schema")
+    schema = resp.get_json()["schema"]
+    for key, spec in schema.items():
+        for required in ("type", "category", "scope", "label", "desc"):
+            assert required in spec, f"{key} missing {required!r} in API response"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/settings/values
+# ---------------------------------------------------------------------------
+
+
+def test_get_values_returns_four_layers(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/settings/values")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    for layer in ("default", "global", "workspace", "effective"):
+        assert layer in data, f"missing layer {layer!r}"
+
+
+def test_get_values_default_layer_covers_schema(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    schema = client.get("/api/settings/schema").get_json()["schema"]
+    values = client.get("/api/settings/values").get_json()
+    # Every schema key has a default value.
+    assert set(schema.keys()) <= set(values["default"].keys())
+
+
+def test_get_values_global_layer_empty_when_no_overrides(app_and_db):
+    """With no config.json written, the global layer is empty (only DEFAULTS apply)."""
+    app, _ = app_and_db
+    client = app.test_client()
+    values = client.get("/api/settings/values").get_json()
+    assert values["global"] == {}
+
+
+def test_get_values_global_reflects_written_file(app_and_db, tmp_path):
+    """After writing a value to the config file, it appears in the global layer."""
+    app, _ = app_and_db
+    import config as cfg
+
+    cfg.set("classification_threshold", 0.7)
+    client = app.test_client()
+    values = client.get("/api/settings/values").get_json()
+    assert values["global"].get("classification_threshold") == 0.7
+    # Effective reflects the override too.
+    assert values["effective"].get("classification_threshold") == 0.7
+
+
+def test_get_values_global_only_includes_schema_known_keys(app_and_db):
+    """Hand-edited unknown keys in the file are not surfaced in the global layer."""
+    app, _ = app_and_db
+    import config as cfg
+
+    raw = cfg.load()
+    raw["bogus_legacy_key"] = "should-not-leak-into-global-layer"
+    cfg.save(raw)
+
+    client = app.test_client()
+    values = client.get("/api/settings/values").get_json()
+    assert "bogus_legacy_key" not in values["global"]
+
+
+def test_get_values_workspace_empty_when_no_overrides(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    values = client.get("/api/settings/values").get_json()
+    assert values["workspace"] == {}
+
+
+def test_get_values_workspace_reflects_overrides(app_and_db):
+    app, db = app_and_db
+    db.update_workspace(
+        db._active_workspace_id,
+        config_overrides={"classification_threshold": 0.9},
+    )
+    client = app.test_client()
+    values = client.get("/api/settings/values").get_json()
+    assert values["workspace"].get("classification_threshold") == 0.9
+    assert values["effective"].get("classification_threshold") == 0.9
+
+
+def test_get_values_effective_falls_through_layers(app_and_db):
+    """Effective = workspace > global > default."""
+    app, db = app_and_db
+    import config as cfg
+
+    # default for similarity_threshold is 0.85
+    values = client_get(app, "/api/settings/values")
+    assert values["effective"]["similarity_threshold"] == 0.85
+
+    # Override globally.
+    cfg.set("similarity_threshold", 0.5)
+    values = client_get(app, "/api/settings/values")
+    assert values["effective"]["similarity_threshold"] == 0.5
+    assert values["global"]["similarity_threshold"] == 0.5
+
+    # Override per-workspace — wins over global.
+    db.update_workspace(
+        db._active_workspace_id,
+        config_overrides={"similarity_threshold": 0.95},
+    )
+    values = client_get(app, "/api/settings/values")
+    assert values["effective"]["similarity_threshold"] == 0.95
+
+
+def test_get_values_workspace_excludes_non_schema_keys(app_and_db):
+    """Internal keys stored in config_overrides (e.g. active_labels) are not exposed."""
+    app, db = app_and_db
+    db.update_workspace(
+        db._active_workspace_id,
+        config_overrides={"active_labels": ["birds.txt"], "classification_threshold": 0.6},
+    )
+    client = app.test_client()
+    values = client.get("/api/settings/values").get_json()
+    assert "active_labels" not in values["workspace"]
+    assert values["workspace"].get("classification_threshold") == 0.6
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def client_get(app, path):
+    return app.test_client().get(path).get_json()

--- a/vireo/tests/test_settings_api.py
+++ b/vireo/tests/test_settings_api.py
@@ -333,3 +333,182 @@ def test_delete_global_rejects_unknown_key(app_and_db):
     client = app.test_client()
     resp = client.delete("/api/settings/global/no_such_key")
     assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/settings/workspace
+# ---------------------------------------------------------------------------
+
+
+def _ws_overrides(db):
+    """Return the active workspace's config_overrides as a dict."""
+    import json as _json
+
+    ws = db.get_workspace(db._active_workspace_id)
+    if not ws or not ws["config_overrides"]:
+        return {}
+    raw = ws["config_overrides"]
+    return _json.loads(raw) if isinstance(raw, str) else raw
+
+
+def test_patch_workspace_persists_value(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    resp = client.patch(
+        "/api/settings/workspace",
+        json={"key": "classification_threshold", "value": 0.55},
+    )
+    assert resp.status_code == 200
+    overrides = _ws_overrides(db)
+    assert overrides.get("classification_threshold") == 0.55
+
+
+def test_patch_workspace_writes_nested_key(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    resp = client.patch(
+        "/api/settings/workspace",
+        json={"key": "pipeline.w_focus", "value": 0.7},
+    )
+    assert resp.status_code == 200
+    overrides = _ws_overrides(db)
+    assert overrides.get("pipeline", {}).get("w_focus") == 0.7
+
+
+def test_patch_workspace_rejects_global_scope_key(app_and_db):
+    """hf_token has scope='global' — cannot be overridden per-workspace."""
+    app, db = app_and_db
+    client = app.test_client()
+    resp = client.patch(
+        "/api/settings/workspace",
+        json={"key": "hf_token", "value": "hf_xxx"},
+    )
+    assert resp.status_code == 400
+    assert "hf_token" not in _ws_overrides(db)
+
+
+def test_patch_workspace_rejects_unknown_key(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.patch(
+        "/api/settings/workspace",
+        json={"key": "no_such", "value": 1},
+    )
+    assert resp.status_code == 400
+
+
+def test_patch_workspace_rejects_out_of_range(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.patch(
+        "/api/settings/workspace",
+        json={"key": "classification_threshold", "value": 99},
+    )
+    assert resp.status_code == 400
+
+
+def test_patch_workspace_preserves_active_labels(app_and_db):
+    """Existing non-schema keys (e.g. active_labels) survive a schema-driven write."""
+    app, db = app_and_db
+    db.update_workspace(
+        db._active_workspace_id,
+        config_overrides={"active_labels": ["birds.txt"]},
+    )
+    client = app.test_client()
+    client.patch(
+        "/api/settings/workspace",
+        json={"key": "classification_threshold", "value": 0.55},
+    )
+    overrides = _ws_overrides(db)
+    assert overrides.get("active_labels") == ["birds.txt"]
+    assert overrides.get("classification_threshold") == 0.55
+
+
+def test_patch_workspace_does_not_affect_other_workspaces(app_and_db):
+    app, db = app_and_db
+    other_ws = db.create_workspace("other")
+    client = app.test_client()
+    client.patch(
+        "/api/settings/workspace",
+        json={"key": "classification_threshold", "value": 0.55},
+    )
+    other = db.get_workspace(other_ws)
+    assert not other["config_overrides"]
+
+
+def test_patch_workspace_value_beats_global_in_effective(app_and_db):
+    app, db = app_and_db
+    import config as cfg
+
+    cfg.set("classification_threshold", 0.5)  # global
+    client = app.test_client()
+    client.patch(
+        "/api/settings/workspace",
+        json={"key": "classification_threshold", "value": 0.95},
+    )
+    values = client.get("/api/settings/values").get_json()
+    assert values["effective"]["classification_threshold"] == 0.95
+    assert values["workspace"]["classification_threshold"] == 0.95
+    assert values["global"]["classification_threshold"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/settings/workspace/<dotted-key>
+# ---------------------------------------------------------------------------
+
+
+def test_delete_workspace_removes_override(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    client.patch(
+        "/api/settings/workspace",
+        json={"key": "classification_threshold", "value": 0.55},
+    )
+    assert "classification_threshold" in _ws_overrides(db)
+    resp = client.delete("/api/settings/workspace/classification_threshold")
+    assert resp.status_code == 200
+    assert "classification_threshold" not in _ws_overrides(db)
+
+
+def test_delete_workspace_nested_key(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    client.patch(
+        "/api/settings/workspace",
+        json={"key": "pipeline.w_focus", "value": 0.99},
+    )
+    assert _ws_overrides(db).get("pipeline", {}).get("w_focus") == 0.99
+    resp = client.delete("/api/settings/workspace/pipeline.w_focus")
+    assert resp.status_code == 200
+    assert "w_focus" not in _ws_overrides(db).get("pipeline", {})
+
+
+def test_delete_workspace_idempotent(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.delete("/api/settings/workspace/classification_threshold")
+    assert resp.status_code == 200
+
+
+def test_delete_workspace_rejects_unknown_key(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.delete("/api/settings/workspace/no_such_key")
+    assert resp.status_code == 400
+
+
+def test_delete_workspace_preserves_active_labels(app_and_db):
+    app, db = app_and_db
+    db.update_workspace(
+        db._active_workspace_id,
+        config_overrides={
+            "active_labels": ["birds.txt"],
+            "classification_threshold": 0.55,
+        },
+    )
+    client = app.test_client()
+    resp = client.delete("/api/settings/workspace/classification_threshold")
+    assert resp.status_code == 200
+    overrides = _ws_overrides(db)
+    assert overrides.get("active_labels") == ["birds.txt"]
+    assert "classification_threshold" not in overrides

--- a/vireo/tests/test_settings_api.py
+++ b/vireo/tests/test_settings_api.py
@@ -689,3 +689,84 @@ def test_delete_workspace_preserves_active_labels(app_and_db):
     overrides = _ws_overrides(db)
     assert overrides.get("active_labels") == ["birds.txt"]
     assert "classification_threshold" not in overrides
+
+
+# ---------------------------------------------------------------------------
+# Workspace override payload coercion (defensive: non-dict on disk)
+# ---------------------------------------------------------------------------
+
+
+def test_patch_workspace_recovers_from_non_dict_overrides(app_and_db):
+    """A scalar payload in config_overrides must not crash the schema PATCH."""
+    app, db = app_and_db
+    # Simulate a malformed override row (e.g. from a hand-edited DB or a
+    # legacy code path) by writing a non-object JSON value.
+    db.update_workspace(db._active_workspace_id, config_overrides=5)
+    client = app.test_client()
+    resp = client.patch(
+        "/api/settings/workspace",
+        json={"key": "classification_threshold", "value": 0.55},
+    )
+    assert resp.status_code == 200
+    overrides = _ws_overrides(db)
+    assert overrides == {"classification_threshold": 0.55}
+
+
+def test_delete_workspace_recovers_from_non_dict_overrides(app_and_db):
+    """A list payload in config_overrides must not crash the schema DELETE."""
+    app, db = app_and_db
+    db.update_workspace(db._active_workspace_id, config_overrides=["junk"])
+    client = app.test_client()
+    resp = client.delete("/api/settings/workspace/classification_threshold")
+    assert resp.status_code == 200
+    # No prior key existed; nothing to remove. Override coerces to {} → cleared.
+    assert _ws_overrides(db) == {}
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: per-key autosave race
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_global_patch_does_not_drop_writes(app_and_db):
+    """Two concurrent PATCHes for different keys must both persist.
+
+    Without a write lock, the read-modify-write (`_read_raw_config_file`
+    → `set_dotted` → `cfg.save`) lets a slow writer overwrite a fast
+    writer's change.
+    """
+    import threading as _threading
+    import time as _time
+
+    app, _ = app_and_db
+    client = app.test_client()
+
+    barrier = _threading.Barrier(2)
+    results = {}
+
+    def patch(key, value, slot):
+        barrier.wait()
+        # Stagger reads slightly so without the lock the second writer
+        # would deterministically clobber the first.
+        if slot == "slow":
+            _time.sleep(0.05)
+        results[slot] = client.patch(
+            "/api/settings/global",
+            json={"key": key, "value": value},
+        ).status_code
+
+    t1 = _threading.Thread(
+        target=patch, args=("classification_threshold", 0.31, "fast"),
+    )
+    t2 = _threading.Thread(
+        target=patch, args=("similarity_threshold", 0.77, "slow"),
+    )
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+    assert results == {"fast": 200, "slow": 200}
+
+    values = client.get("/api/settings/values").get_json()
+    assert values["global"]["classification_threshold"] == 0.31
+    assert values["global"]["similarity_threshold"] == 0.77


### PR DESCRIPTION
## Summary

Closes the three pain points around config: **backup/portability**, **discoverability** of long-tail knobs, and **visibility** of where each effective value comes from. Inspired by VS Code's settings model — schema-rendered list, search-first navigation, per-field provenance, raw-JSON escape hatch — sized down to a single app.

The 22 hand-rolled curated sections at the top of \`settings.html\` are unchanged. The new "All settings" region sits below them and exposes every \`DEFAULTS\` key (incl. pipeline weights, miss/eye/burst tuning, encounter cuts) that previously had no UI.

## What changed

- **\`vireo/config_schema.py\`** — 72 schema entries (type + min/max/enum + category + scope + label + desc), \`validate_value\`, dotted-path helpers. A drift-guard test asserts SCHEMA covers every leaf of \`DEFAULTS\` minus an explicit EXCLUDED list (\`setup_complete\`, \`ingest.recent_destinations\`, \`keyboard_shortcuts.*\`) — adding a knob without a schema entry will fail the build.
- **Read endpoints** — \`GET /api/settings/{schema,values}\` returning the schema and the four-layer view (default / global / workspace / effective), all dotted-flat. The global layer filters out keys whose persisted value equals the default, so legacy save paths that wrote the entire DEFAULTS dict don't make every row look "globally set".
- **Write endpoints** — \`PATCH/DELETE /api/settings/{global,workspace}\` with full schema validation. Workspace endpoint refuses keys whose \`scope='global'\` (e.g. \`hf_token\`). Both writers read the raw file (not \`cfg.load()\`) so the on-disk file stays minimal.
- **\`db.get_effective_config\` deep-merges** workspace overrides instead of doing a shallow top-level update — required so \`pipeline.w_focus\` per-workspace doesn't clobber the entire \`pipeline\` dict.
- **\`settings.html\` toolbar** — search box, \`Global · Workspace\` scope tabs, Export…/Import… buttons. Each schema-rendered row has provenance dot (grey/gold/purple), an editable widget per type (number / checkbox / select / password / multi-checkbox / text), debounced auto-save with a per-input dirty flag (so tabbing through fields doesn't fire phantom saves), and a Reset button when overridden.
- **Backup/restore** — \`GET /api/settings/export\` downloads the current global config as a date-stamped attachment; \`POST /api/settings/import\` replaces the global file wholesale after validating every schema-known leaf. Workspace overrides are not touched by import — they're per-workspace state, not global config.

Design doc: \`docs/plans/2026-04-25-settings-control-design.md\` (force-added per the gitignored-but-committed convention).

## Test plan

- [x] \`config_schema\` unit tests: drift guard, type coercion, range/enum/list_string validation, dotted-path helpers (28 tests).
- [x] Settings API endpoint tests: 46 tests covering schema/values reads, PATCH/DELETE on both \`global\` and \`workspace\`, scope guards, HF_TOKEN env-var sync, default-equality filter, import validation + workspace-overrides-preserved + non-schema-pass-through, export attachment headers.
- [x] Browser smoke tests (Playwright): 4 scripts in \`.context/\` cover read-only render + search filter, edit + reset + bool + enum + reject flow, scope tab switching with global-only read-only on Workspace, export → modify → re-import round-trip with bad-import rejection.
- [x] Full CLAUDE.md-recommended suite: \`test_workspaces test_db test_app test_photos_api test_edits_api test_jobs_api test_darktable_api test_config\` — 711 passed.
- [ ] Manual smoke against your real \`~/.vireo/vireo.db\` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)