### PR TITLE
fix(pipeline): retry on 'database is locked' in per-photo write paths

### DIFF
--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -30,7 +30,7 @@ except ImportError:
     load_image = None
     load_working_image = None
 
-from db import Database
+from db import Database, commit_with_retry
 from models import get_active_model, get_models
 
 try:
@@ -225,7 +225,7 @@ def _run_classifier_on_detection(db, detection_id, classifier_model, labels,
                 tax.get("genus"),
             ),
         )
-    db.conn.commit()
+    commit_with_retry(db.conn)
     return predictions
 
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2870,7 +2870,7 @@ class Database:
         self.conn.execute(
             "UPDATE photos SET sharpness = ? WHERE id = ?", (sharpness, photo_id)
         )
-        self.conn.commit()
+        commit_with_retry(self.conn)
 
     def update_photo_quality(
         self,
@@ -2893,7 +2893,7 @@ class Database:
                 photo_id,
             ),
         )
-        self.conn.commit()
+        commit_with_retry(self.conn)
 
     def update_photo_mask(self, photo_id, mask_path):
         """Store the mask file path for a photo."""
@@ -2901,7 +2901,7 @@ class Database:
             "UPDATE photos SET mask_path=? WHERE id=?",
             (mask_path, photo_id),
         )
-        self.conn.commit()
+        commit_with_retry(self.conn)
 
     def update_photo_pipeline_features(
         self,
@@ -2950,7 +2950,7 @@ class Database:
         self.conn.execute(
             f"UPDATE photos SET {set_clause} WHERE id=?", values
         )
-        self.conn.commit()
+        commit_with_retry(self.conn)
 
     def get_photos_missing_masks(self, folder_ids=None):
         """Get photos that have detections but no masks yet.
@@ -3148,7 +3148,7 @@ class Database:
             "dino_embedding_variant=? WHERE id=?",
             (dino_subject_embedding, dino_global_embedding, variant, photo_id),
         )
-        self.conn.commit()
+        commit_with_retry(self.conn)
 
     # -- Keywords --
 
@@ -4285,7 +4285,7 @@ class Database:
                              reviewed_at = excluded.reviewed_at""",
             (pred_id, ws, individual, group_id, vote_count, total_votes),
         )
-        self.conn.commit()
+        commit_with_retry(self.conn)
 
     def is_keyword_species(self, keyword_id):
         """Return True if the keyword is marked as a species."""
@@ -4468,7 +4468,7 @@ class Database:
                              run_at = datetime('now')""",
             (detection_id, classifier_model, labels_fingerprint, prediction_count),
         )
-        self.conn.commit()
+        commit_with_retry(self.conn)
 
     def get_classifier_run_keys(self, detection_id):
         rows = self.conn.execute(
@@ -4548,7 +4548,7 @@ class Database:
                  det["confidence"], det.get("category", "animal")),
             )
             ids.append(cur.lastrowid)
-        self.conn.commit()
+        commit_with_retry(self.conn)
         return ids
 
     def write_detection_batch(self, photo_id, detector_model, detections):
@@ -4596,7 +4596,7 @@ class Database:
                                  run_at = datetime('now')""",
                 (photo_id, detector_model, len(detections)),
             )
-            self.conn.commit()
+            commit_with_retry(self.conn)
             return ids
         except Exception:
             self.conn.rollback()

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -18,6 +18,7 @@ from collections import defaultdict
 from datetime import UTC, datetime
 
 import config as _cfg
+from db import commit_with_retry
 
 log = logging.getLogger(__name__)
 
@@ -231,5 +232,5 @@ def compute_misses_for_workspace(
         "miss_computed_at=? WHERE id=?",
         updates,
     )
-    db.conn.commit()
+    commit_with_retry(db.conn)
     return len(updates)

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1771,3 +1771,51 @@ def test_prepare_image_no_vireo_dir_uses_original(tmp_path):
     )
 
     assert img is not None
+
+
+def test_run_classifier_retries_on_database_is_locked(tmp_path):
+    """Per-detection prediction commit must retry transient 'database is locked'.
+
+    Concurrent pipelines on the same SQLite file (observed in production: a
+    second pipeline failed at classify after ~5h with 'Fatal: database is
+    locked') exceed the 30s busy_timeout under sustained writer contention.
+    Without retry the whole stage aborts and the run is lost.
+    """
+    import sqlite3
+
+    import classify_job
+    from db import Database
+    from tests.test_scanner import _FlakyConn
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_ids = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9,
+          "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    det_id = det_ids[0]
+
+    locked = sqlite3.OperationalError("database is locked")
+    db.conn = _FlakyConn(db.conn, fail_on_calls={1: locked, 2: locked})
+
+    classify_job._run_classifier_on_detection(
+        db=db, detection_id=det_id,
+        classifier_model="bioclip-2",
+        labels=["Robin"],
+        labels_fingerprint="abc123",
+        classify_fn=lambda: [{"species": "Robin", "confidence": 0.9}],
+    )
+
+    n = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM predictions WHERE detection_id = ?",
+        (det_id,),
+    ).fetchone()["n"]
+    assert n == 1, "prediction must be persisted after transient lock retries"


### PR DESCRIPTION
## Summary

A pipeline run last night failed with `[classify] Fatal: database is locked` after ~5 hours of writing alongside a second concurrent pipeline (logs at `~/.vireo/vireo.log` 2026-04-26 00:05:36). Root cause: classify called bare `db.conn.commit()` with no retry, so when SQLite's 30s `busy_timeout` was exceeded under sustained writer contention the whole stage aborted.

The scanner already uses `commit_with_retry` (5x exponential backoff). This PR extends that wrapper to every per-photo write path exercised by long-running pipeline stages so transient lock contention recovers instead of killing the stage.

**Sites patched:**
- `classify_job.py:_run_classifier_on_detection` — the documented failure point
- `db.py` — `update_photo_sharpness`, `update_photo_quality`, `update_photo_mask`, `update_photo_pipeline_features`, `update_photo_embeddings`, `update_prediction_group_info`, `record_classifier_run`, `save_detections`, `write_detection_batch`
- `misses.py:compute_misses_for_workspace`

**Not addressed:** running two pipelines concurrently against one SQLite file is fragile in general; retries are the floor, not the ceiling. If concurrent-pipeline contention keeps surfacing, a UI-side guard (or a serialization queue) would be the next step.

## Test plan

- [x] New regression test `test_run_classifier_retries_on_database_is_locked` injects two `database is locked` errors into `_run_classifier_on_detection` and verifies the prediction is persisted
- [x] Test fails on `main` (bare commit aborts), passes after the fix
- [x] `python -m pytest vireo/tests/test_classify_job.py vireo/tests/test_db.py vireo/tests/test_misses.py vireo/tests/test_scanner.py vireo/tests/test_pipeline.py vireo/tests/test_pipeline_job.py -q` → 546 passed
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` → 662 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)