### PR TITLE
feat: subject keyword types — generalize 'is identified' beyond species

### DIFF
--- a/docs/plans/2026-04-25-subject-keyword-types-design.md
+++ b/docs/plans/2026-04-25-subject-keyword-types-design.md
@@ -1,0 +1,168 @@
+# Subject Keyword Types Design
+
+**Date**: 2026-04-25
+**Status**: Design
+
+## Problem
+
+Vireo's "Needs Classification" smart collection filters for photos with no species keyword (`has_species == 0`). This conflates two distinct cases:
+
+1. Wildlife photos the user hasn't classified yet.
+2. Photos that aren't wildlife at all (landscapes, portraits, places).
+
+There's no way for the user to say "this is a landscape, stop showing it as needing classification, and stop running the classifier on it." The closest existing mechanisms (`flag=rejected`, `prediction_review.status=rejected`, `box_count=0`) are either overloaded with other meanings or don't affect the queue / classifier.
+
+## Solution overview
+
+Generalize the existing `keywords.type` column from a partly-used field (`taxonomy` and `general` in practice) into a fixed five-value enum representing what *kind of thing* a keyword identifies. Define a per-workspace configurable subset of these types as "subject types" — having a keyword of a subject type means the photo is identified.
+
+The "Needs Classification" queue and the classifier both consult this set: an identified photo drops out of the queue and the classifier skips it (with a `reclassify=True` bypass for explicit re-verification).
+
+## 1. Data model
+
+No new tables. No new columns. Reuse the existing `keywords.type` column (`db.py:180`).
+
+**Fixed enum values**:
+
+```python
+KEYWORD_TYPES = {'taxonomy', 'individual', 'place', 'scene', 'general'}
+SUBJECT_TYPES_DEFAULT = {'taxonomy', 'individual', 'scene'}
+```
+
+| Type | Meaning | Examples |
+|------|---------|----------|
+| `taxonomy` | A species (links to `taxa` via `taxon_id`) | Canada Goose, House Sparrow |
+| `individual` | A named person or pet | Charlie, Fido, John |
+| `place` | A named location (uses `latitude`/`longitude`) | Golden Gate Bridge, my backyard |
+| `scene` | A non-wildlife category | Landscape, Sunset, Architecture |
+| `general` | Catch-all untyped tags | needs_review, client_A, portfolio |
+
+**Existing columns repurposed**:
+
+- `keywords.is_species` (`db.py:179`) — kept as a redundant fast-path flag, maintained in sync with `type='taxonomy'` via existing `mark_species_keywords` (`db.py:5652`).
+- `keywords.latitude`, `keywords.longitude` (`db.py:181-182`) — already exist; meaningful when `type='place'`.
+- `keywords.taxon_id` (`db.py:183`) — meaningful only when `type='taxonomy'`.
+- `keywords.parent_id` — taxonomy hierarchy; unused for non-taxonomy types.
+
+**Validation**: application-level (in `add_keyword` and any API endpoint accepting `type`). No DB CHECK constraint — consistent with existing patterns and avoids future migration friction.
+
+**Existing data**: 366 `taxonomy` and 255 `general` rows stay valid as-is. No backfill.
+
+**Explicit non-goals**:
+- No `species_keyword_id` FK on individuals (YAGNI; individuals are people/pets, not named wildlife).
+- No DB CHECK constraint on `type`.
+
+## 2. Workspace config
+
+Per-workspace override stored in the existing `workspaces.config_overrides` JSON column (`db.py:196`). New top-level key:
+
+```json
+{
+  "subject_types": ["taxonomy", "individual", "scene"]
+}
+```
+
+**Default** is set in `vireo/config.py` at the global config level. Workspace overrides only need to write the key when the user actively changes it from the default.
+
+**Read path**: new helper `db.get_subject_types() -> set[str]` derives from `get_effective_config(cfg.load())`. Used by:
+- The `has_subject` collection rule
+- The classifier's skip check
+- Any future "is this photo identified?" predicate
+
+**Validation on write**: incoming list intersected with `KEYWORD_TYPES` — unknown values silently dropped. Empty list allowed (effectively disables the queue's filter) but logs a warning.
+
+**API**: new `PUT /api/workspaces/<id>/subject-types`, body `{"types": [...]}`. Reads via the existing workspace config GET endpoint.
+
+## 3. The `has_subject` collection rule
+
+New rule operator added to the rules engine in `db.py:5414-5557`:
+
+```json
+{"field": "has_subject", "op": "equals", "value": 0}
+```
+
+Generates `NOT EXISTS` (`==0`) or `EXISTS` (`==1`) against `photo_keywords` joined to `keywords` filtered by the workspace's `subject_types`:
+
+```sql
+NOT EXISTS (
+  SELECT 1 FROM photo_keywords pk
+  JOIN keywords k ON k.id = pk.keyword_id
+  WHERE pk.photo_id = p.id AND k.type IN (?, ?, ?)
+)
+```
+
+The `IN` placeholders are bound at query-build time from `db.get_subject_types()`. Empty `subject_types` short-circuits to a no-op (matches all photos for `==0`, no photos for `==1`) — handled in the rule builder.
+
+**`has_species` is kept** as a narrower predicate. Users can still build queues like "photos already tagged Charlie but with no species confirmed."
+
+**Default collection migration**: the auto-created "Needs Classification" collection (`db.py:5710`) is renamed to **"Needs Identification"** and its rule changes from `has_species == 0` to `has_subject == 0`.
+
+## 4. Classifier integration
+
+Two skip layers in `classify_job.py`, both bypassed when `reclassify=True`:
+
+1. **Existing**: skip photos with prior `classifier_runs` rows (`classify_job.py:248-271`).
+2. **New**: skip photos with any keyword whose `type` is in the workspace's `subject_types`.
+
+```python
+if not reclassify:
+    subject_types = thread_db.get_subject_types()
+    if subject_types:
+        photo_ids = thread_db.filter_out_subject_tagged(photo_ids, subject_types)
+```
+
+`filter_out_subject_tagged()` is a new method on `Database`. Implemented as a single `WHERE id NOT IN (SELECT pk.photo_id FROM photo_keywords pk JOIN keywords k ON k.id = pk.keyword_id WHERE k.type IN (?, ?, ?))` query.
+
+Skip happens *before* detection runs — MegaDetector also benefits from the gate.
+
+**Verify mode**: the existing `reclassify=True` flag's semantics extend to bypass *both* the classifier_runs skip *and* the new subject-tag skip. The "Re-classify" toggle in `pipeline.html` keeps its label; tooltip is updated.
+
+**Job logging**: progress events include skip counts (`{skipped_subject: N, skipped_already_classified: M}`) so the bottom panel shows why fewer photos were processed than the input collection size.
+
+## 5. UI changes
+
+**Keyword creation** gets a type picker. New `<select>` defaulting to `general` next to the keyword name input on the keywords page (`keywords.html`) and inline tag inputs in the lightbox. `taxonomy` is disabled in the inline picker (taxonomy keywords are created by the classifier or `mark_species_keywords`, not free text).
+
+**Keywords page filter buttons** (`keywords.html:162-164`) updated from `general | taxonomy | location` to `general | taxonomy | individual | place | scene`. Existing list view shows `type` per keyword (`db.py:3319`); add a dropdown to edit it on existing rows (except `taxonomy`, locked once linked to `taxon_id`).
+
+**Default scene keywords** shipped via `Database.__init__`: `Landscape`, `Sunset`, `Architecture`, `Abstract`. None for `place` or `individual`. Makes the lightbox autocomplete path work for the common "tag a landscape" case.
+
+**Lightbox quick-tag affordance**: a "Not Wildlife" button next to the existing species accept/reject controls. Clicking it tags the photo with `Landscape` (the default `scene` keyword) and advances. One click per photo to clear from the queue.
+
+**Workspace settings panel**: small "What counts as identified?" section with checkboxes for the five types. Defaults to `taxonomy`, `individual`, `scene`. Saves via the new endpoint.
+
+**Collections panel**: "Needs Classification" → "Needs Identification" in the default collection list.
+
+**Pipeline page**: "Re-classify" toggle keeps its label; tooltip updated to mention it bypasses the new subject-tag skip.
+
+## 6. Migration & idempotence
+
+Three idempotent ops in `Database.__init__`:
+
+1. **Rename the default collection.** If a workspace has a "Needs Classification" collection with rule `has_species == 0` and no "Needs Identification" collection, rename and update the rule. Skip if the user customized either field.
+2. **Insert default `scene` keywords** if none exist with `type='scene'`: `Landscape`, `Sunset`, `Architecture`, `Abstract`.
+3. **No backfill** of existing keywords.
+
+UI cleanup: rename `data-type="location"` filter button (`keywords.html:164`) to `data-type="place"`.
+
+## 7. Edge cases & testing
+
+**Edge cases**:
+- Empty `subject_types` set → `has_subject` rule short-circuits; no malformed SQL.
+- Photo with both `taxonomy` and `general` keywords → counted as identified (any matching type wins).
+- Workspace switch mid-classify-job → job uses the workspace it was started under (existing pattern via `thread_db.set_active_workspace`).
+- User edits a keyword's `type` from `taxonomy` → blocked once linked to `taxon_id`.
+- Reclassify-mode on a `scene=Landscape` photo → runs detection + classification, leaves the keyword in place.
+
+**Test coverage**:
+- `test_db.py`: `has_subject` rule SQL generation across configurations; `filter_out_subject_tagged` correctness; default-collection migration idempotence; default scene keyword insertion idempotence.
+- `test_workspaces.py`: `subject_types` config read/write; isolation across workspaces.
+- `test_jobs_api.py`: classify job skips subject-tagged photos by default; `reclassify=True` bypasses; skip counts in progress events.
+- `test_app.py`: `PUT /api/workspaces/<id>/subject-types` validation (unknown types dropped, empty allowed-with-warning).
+
+## Out of scope
+
+- Linking individuals to species (e.g., Charlie → Great Blue Heron). YAGNI — individuals here are people/pets.
+- Auto-detecting scene type from image content (could ship a "scene classifier" later if useful).
+- Per-photo "skip forever" boolean — the keyword tag is the mechanism.
+- Editing collection rules through the UI — done via API or by recreating the default collection.

--- a/docs/plans/2026-04-25-subject-keyword-types-plan.md
+++ b/docs/plans/2026-04-25-subject-keyword-types-plan.md
@@ -1,0 +1,1093 @@
+# Subject Keyword Types Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Generalize Vireo's "is this photo identified" predicate from species-only (`has_species`) to a configurable set of keyword *types* (`taxonomy`, `individual`, `place`, `scene`, `general`), so users can drop landscape/portrait/place photos out of the species-classification queue and skip the AI classifier on them.
+
+**Architecture:** Reuse existing `keywords.type` column. Add a per-workspace config key `subject_types` (default `{taxonomy, individual, scene}`) stored in `workspaces.config_overrides`. Introduce a new `has_subject` collection rule and a classifier skip-gate that both read this set. Migrate the default "Needs Classification" collection to use the new rule. No schema changes.
+
+**Tech Stack:** Python 3, Flask, SQLite, Jinja2, vanilla JS.
+
+**Design doc:** `docs/plans/2026-04-25-subject-keyword-types-design.md`
+
+**Working directory:** `/Users/julius/conductor/workspaces/vireo/missoula` (worktree on branch `unlabeled-query`).
+
+**Testing baseline (run between tasks):**
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -v
+```
+
+**YAGNI deferrals from design** (noted, not blockers):
+- Type-editing dropdown for existing keywords on the keywords page (only filter buttons updated in v1)
+- Type picker in the inline-tag input on the lightbox (defer; the lightbox "Not Wildlife" button + autocomplete on the four shipped scene keywords cover the common case)
+
+---
+
+## Task 1: KEYWORD_TYPES constant + validation in `add_keyword`
+
+**Files:**
+- Modify: `vireo/db.py:3138` (add `kw_type` parameter to `add_keyword`)
+- Modify: top of `vireo/db.py` (add module-level constant)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write the failing test**
+
+Add to `vireo/tests/test_db.py`:
+
+```python
+def test_add_keyword_accepts_valid_types(temp_db):
+    """add_keyword stores the requested type when it's a valid enum value."""
+    db = temp_db
+    db.set_active_workspace(db.create_workspace("ws"))
+    kid = db.add_keyword("Charlie", kw_type="individual")
+    row = db.conn.execute("SELECT type FROM keywords WHERE id = ?", (kid,)).fetchone()
+    assert row["type"] == "individual"
+
+
+def test_add_keyword_rejects_unknown_type(temp_db):
+    """add_keyword raises ValueError for unknown type values."""
+    import pytest
+    db = temp_db
+    db.set_active_workspace(db.create_workspace("ws"))
+    with pytest.raises(ValueError, match="invalid keyword type"):
+        db.add_keyword("BadType", kw_type="alien")
+
+
+def test_keyword_types_constant():
+    """KEYWORD_TYPES contains exactly the five valid enum values."""
+    from vireo.db import KEYWORD_TYPES
+    assert KEYWORD_TYPES == frozenset({"taxonomy", "individual", "place", "scene", "general"})
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest vireo/tests/test_db.py::test_keyword_types_constant -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'KEYWORD_TYPES'` (or similar).
+
+**Step 3: Add the constant**
+
+Near the top of `vireo/db.py` (after imports, before class definitions):
+
+```python
+KEYWORD_TYPES = frozenset({"taxonomy", "individual", "place", "scene", "general"})
+SUBJECT_TYPES_DEFAULT = frozenset({"taxonomy", "individual", "scene"})
+```
+
+**Step 4: Update `add_keyword` signature and validation**
+
+In `vireo/db.py:3138`, change:
+
+```python
+def add_keyword(self, name, parent_id=None, is_species=False, _commit=True):
+```
+
+to:
+
+```python
+def add_keyword(self, name, parent_id=None, is_species=False, kw_type=None, _commit=True):
+    if kw_type is not None and kw_type not in KEYWORD_TYPES:
+        raise ValueError(f"invalid keyword type: {kw_type!r}")
+```
+
+Then update the type-resolution block (`vireo/db.py:3186-3208`) to honor the explicit `kw_type` argument when provided, falling back to the existing auto-detection only when `kw_type is None`. Concretely, replace:
+
+```python
+        # Auto-detect taxonomy type from taxa table
+        kw_type = 'general'
+        taxon_id = None
+        if is_species:
+            kw_type = 'taxonomy'
+        else:
+            ...
+```
+
+with:
+
+```python
+        taxon_id = None
+        if kw_type is None:
+            # Auto-detect taxonomy type from taxa table
+            kw_type = 'general'
+            if is_species:
+                kw_type = 'taxonomy'
+            else:
+                ...  # existing taxa lookup, keep unchanged
+```
+
+(Wrap the existing taxa-lookup block in the new `if kw_type is None:` branch.)
+
+**Step 5: Run all three new tests**
+
+```bash
+python -m pytest vireo/tests/test_db.py::test_keyword_types_constant vireo/tests/test_db.py::test_add_keyword_accepts_valid_types vireo/tests/test_db.py::test_add_keyword_rejects_unknown_type -v
+```
+
+Expected: 3 PASS.
+
+**Step 6: Run full test suite to confirm no regressions**
+
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py -v
+```
+
+Expected: all PASS (modulo the pre-existing failures noted in MEMORY.md).
+
+**Step 7: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "feat(keywords): add KEYWORD_TYPES enum and validation in add_keyword
+
+Introduce KEYWORD_TYPES = {taxonomy, individual, place, scene, general}
+and SUBJECT_TYPES_DEFAULT = {taxonomy, individual, scene}. add_keyword
+now accepts an optional kw_type override and validates it. Existing
+auto-detection (taxonomy lookup via taxa table) only runs when no
+explicit type is passed."
+```
+
+---
+
+## Task 2: Default `subject_types` in global config
+
+**Files:**
+- Modify: `vireo/config.py`
+- Test: `vireo/tests/test_config.py`
+
+**Step 1: Inspect current config defaults**
+
+Read `vireo/config.py` to find the existing `_DEFAULTS` (or equivalent) dict. Add `subject_types` alongside other top-level keys.
+
+**Step 2: Write the failing test**
+
+In `vireo/tests/test_config.py`:
+
+```python
+def test_default_subject_types_includes_taxonomy_individual_scene(tmp_path, monkeypatch):
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    loaded = cfg.load()
+    assert set(loaded.get("subject_types", [])) == {"taxonomy", "individual", "scene"}
+```
+
+**Step 3: Run test to verify it fails**
+
+```bash
+python -m pytest vireo/tests/test_config.py::test_default_subject_types_includes_taxonomy_individual_scene -v
+```
+
+Expected: FAIL (key missing).
+
+**Step 4: Add the default**
+
+In `vireo/config.py`, add to the defaults dict:
+
+```python
+"subject_types": ["taxonomy", "individual", "scene"],
+```
+
+**Step 5: Run test to verify it passes**
+
+```bash
+python -m pytest vireo/tests/test_config.py::test_default_subject_types_includes_taxonomy_individual_scene -v
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add vireo/config.py vireo/tests/test_config.py
+git commit -m "feat(config): add default subject_types config key
+
+Defaults to [taxonomy, individual, scene] — the keyword types that
+count as 'identifying' a photo for queue/classifier purposes."
+```
+
+---
+
+## Task 3: `db.get_subject_types()` helper
+
+**Files:**
+- Modify: `vireo/db.py` (add method on `Database`)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_get_subject_types_returns_default(temp_db):
+    db = temp_db
+    db.set_active_workspace(db.create_workspace("ws"))
+    assert db.get_subject_types() == {"taxonomy", "individual", "scene"}
+
+
+def test_get_subject_types_honors_workspace_override(temp_db):
+    db = temp_db
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    db.update_workspace_config(ws_id, {"subject_types": ["taxonomy"]})
+    assert db.get_subject_types() == {"taxonomy"}
+
+
+def test_get_subject_types_drops_unknown_values(temp_db):
+    db = temp_db
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    db.update_workspace_config(ws_id, {"subject_types": ["taxonomy", "alien"]})
+    assert db.get_subject_types() == {"taxonomy"}
+```
+
+(If `update_workspace_config` doesn't exist as-named, find the equivalent setter via `grep -n "config_overrides" vireo/db.py` and use it.)
+
+**Step 2: Run tests**
+
+```bash
+python -m pytest vireo/tests/test_db.py::test_get_subject_types_returns_default vireo/tests/test_db.py::test_get_subject_types_honors_workspace_override vireo/tests/test_db.py::test_get_subject_types_drops_unknown_values -v
+```
+
+Expected: FAIL (method doesn't exist).
+
+**Step 3: Implement**
+
+Add to `Database` class in `vireo/db.py` (near other config-reading helpers — search for `get_effective_config`):
+
+```python
+def get_subject_types(self) -> set[str]:
+    """Return the keyword types that count as 'identified' for the active workspace."""
+    import config as cfg
+    effective = self.get_effective_config(cfg.load())
+    raw = effective.get("subject_types", list(SUBJECT_TYPES_DEFAULT))
+    if not isinstance(raw, list):
+        return set(SUBJECT_TYPES_DEFAULT)
+    return {t for t in raw if t in KEYWORD_TYPES}
+```
+
+**Step 4: Run tests to verify pass**
+
+```bash
+python -m pytest vireo/tests/test_db.py -k "get_subject_types" -v
+```
+
+Expected: 3 PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "feat(db): add get_subject_types() reading workspace config
+
+Returns the set of keyword types that count as 'identifying' a photo,
+sourced from the workspace's config_overrides with the global default
+as fallback. Unknown type strings are dropped at read time."
+```
+
+---
+
+## Task 4: `db.filter_out_subject_tagged()` helper
+
+**Files:**
+- Modify: `vireo/db.py`
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_filter_out_subject_tagged_excludes_tagged_photos(temp_db):
+    """filter_out_subject_tagged drops photos that have any keyword whose
+    type is in the supplied set."""
+    db = temp_db
+    db.set_active_workspace(db.create_workspace("ws"))
+
+    # Two photos: p1 has a 'scene' keyword, p2 has a 'general' keyword
+    # only. Filtering with {scene} should keep p2 but drop p1.
+    p1 = _make_photo(db, "p1.jpg")  # use existing test helper
+    p2 = _make_photo(db, "p2.jpg")
+    scene_kid = db.add_keyword("Landscape", kw_type="scene")
+    gen_kid = db.add_keyword("note", kw_type="general")
+    db.tag_photo(p1, scene_kid)
+    db.tag_photo(p2, gen_kid)
+
+    kept = db.filter_out_subject_tagged([p1, p2], {"scene"})
+    assert kept == [p2]
+
+
+def test_filter_out_subject_tagged_empty_set_returns_all(temp_db):
+    db = temp_db
+    db.set_active_workspace(db.create_workspace("ws"))
+    p1 = _make_photo(db, "p1.jpg")
+    assert db.filter_out_subject_tagged([p1], set()) == [p1]
+```
+
+(If `_make_photo` doesn't exist, use the pattern from existing `test_db.py` tests for inserting a photo. `grep -n "INSERT INTO photos" vireo/tests/test_db.py` to find one.)
+
+**Step 2: Run tests to verify fail**
+
+```bash
+python -m pytest vireo/tests/test_db.py -k "filter_out_subject_tagged" -v
+```
+
+Expected: FAIL (`AttributeError`).
+
+**Step 3: Implement**
+
+Add to `Database`:
+
+```python
+def filter_out_subject_tagged(self, photo_ids, subject_types):
+    """Return the subset of photo_ids whose photos do NOT have any keyword
+    of a type in subject_types. Empty subject_types returns photo_ids unchanged."""
+    if not subject_types or not photo_ids:
+        return list(photo_ids)
+    types = [t for t in subject_types if t in KEYWORD_TYPES]
+    if not types:
+        return list(photo_ids)
+    pid_placeholders = ",".join("?" * len(photo_ids))
+    type_placeholders = ",".join("?" * len(types))
+    rows = self.conn.execute(
+        f"""SELECT id FROM photos
+            WHERE id IN ({pid_placeholders})
+              AND id NOT IN (
+                SELECT pk.photo_id FROM photo_keywords pk
+                JOIN keywords k ON k.id = pk.keyword_id
+                WHERE k.type IN ({type_placeholders})
+              )""",
+        list(photo_ids) + types,
+    ).fetchall()
+    kept_set = {r["id"] for r in rows}
+    # Preserve original order
+    return [pid for pid in photo_ids if pid in kept_set]
+```
+
+**Step 4: Run tests**
+
+```bash
+python -m pytest vireo/tests/test_db.py -k "filter_out_subject_tagged" -v
+```
+
+Expected: 2 PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "feat(db): add filter_out_subject_tagged batch helper
+
+Drops photos with any keyword of a configured 'subject' type. Used by
+the classifier skip-gate in a follow-up task."
+```
+
+---
+
+## Task 5: `has_subject` collection rule
+
+**Files:**
+- Modify: `vireo/db.py:5414-5557` (rules engine in `_build_collection_query`)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing tests**
+
+```python
+def test_has_subject_rule_matches_photos_without_subject_keywords(temp_db):
+    """A collection with has_subject==0 returns photos that have no
+    keyword of type in the workspace's subject_types set."""
+    db = temp_db
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    folder_id = _make_folder(db)  # helper from existing tests
+    p1 = _make_photo_in_folder(db, "p1.jpg", folder_id)
+    p2 = _make_photo_in_folder(db, "p2.jpg", folder_id)
+    db.add_workspace_folder(ws_id, folder_id)
+
+    scene_kid = db.add_keyword("Landscape", kw_type="scene")
+    db.tag_photo(p1, scene_kid)  # p1 is identified, p2 is not
+
+    cid = db.add_collection(
+        "Needs Subject",
+        json.dumps([{"field": "has_subject", "op": "equals", "value": 0}]),
+    )
+    photos = db.get_collection_photos(cid, per_page=999)
+    pids = {p["id"] for p in photos}
+    assert pids == {p2}
+
+
+def test_has_subject_rule_with_value_one_matches_identified(temp_db):
+    """has_subject==1 returns the inverse — photos WITH a subject keyword."""
+    # Mirror of above; assert pids == {p1}
+    ...
+
+
+def test_has_subject_rule_empty_subject_types_no_match_for_value_one(temp_db):
+    """When subject_types is empty, has_subject==1 should match no photos."""
+    db = temp_db
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    db.update_workspace_config(ws_id, {"subject_types": []})
+    folder_id = _make_folder(db)
+    p1 = _make_photo_in_folder(db, "p1.jpg", folder_id)
+    db.add_workspace_folder(ws_id, folder_id)
+    cid = db.add_collection(
+        "Has Subject",
+        json.dumps([{"field": "has_subject", "op": "equals", "value": 1}]),
+    )
+    photos = db.get_collection_photos(cid, per_page=999)
+    assert photos == []
+```
+
+**Step 2: Run tests to verify fail**
+
+Expected: FAIL (rule field unhandled, returns all photos).
+
+**Step 3: Implement the rule branch**
+
+In `vireo/db.py`, inside `_build_collection_query`, add a branch alongside `has_species` (around line 5510):
+
+```python
+            elif field == "has_subject":
+                subject_types = list(self.get_subject_types())
+                if not subject_types:
+                    # Empty set: no keyword type counts as "identifying"
+                    if op == "equals" and (value is True or value == 1):
+                        conditions.append("0")  # nothing matches
+                    # value==0 is a no-op (every photo is "not identified")
+                    continue
+                type_placeholders = ",".join("?" * len(subject_types))
+                if op == "equals" and (value is False or value == 0):
+                    conditions.append(
+                        f"""NOT EXISTS (
+                        SELECT 1 FROM photo_keywords pk5
+                        JOIN keywords k5 ON k5.id = pk5.keyword_id
+                        WHERE pk5.photo_id = p.id AND k5.type IN ({type_placeholders}))"""
+                    )
+                    params.extend(subject_types)
+                elif op == "equals" and (value is True or value == 1):
+                    conditions.append(
+                        f"""EXISTS (
+                        SELECT 1 FROM photo_keywords pk5
+                        JOIN keywords k5 ON k5.id = pk5.keyword_id
+                        WHERE pk5.photo_id = p.id AND k5.type IN ({type_placeholders}))"""
+                    )
+                    params.extend(subject_types)
+```
+
+**Step 4: Run tests**
+
+Expected: 3 PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "feat(collections): add has_subject rule for the configured type set
+
+Mirrors has_species but reads the workspace's subject_types config so
+users can include scene/individual/place keywords in the 'identified'
+predicate. has_species is preserved for narrower queries."
+```
+
+---
+
+## Task 6: `PUT /api/workspaces/<id>/subject-types` endpoint
+
+**Files:**
+- Modify: `vireo/app.py` (add route)
+- Test: `vireo/tests/test_app.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_put_subject_types_persists_valid_values(client, db):
+    ws_id = db.create_workspace("ws")
+    resp = client.put(
+        f"/api/workspaces/{ws_id}/subject-types",
+        json={"types": ["taxonomy", "scene"]},
+    )
+    assert resp.status_code == 200
+    assert set(db.get_workspace_config_overrides(ws_id).get("subject_types", [])) == {"taxonomy", "scene"}
+
+
+def test_put_subject_types_drops_unknown(client, db):
+    ws_id = db.create_workspace("ws")
+    resp = client.put(
+        f"/api/workspaces/{ws_id}/subject-types",
+        json={"types": ["taxonomy", "bogus"]},
+    )
+    assert resp.status_code == 200
+    assert db.get_workspace_config_overrides(ws_id).get("subject_types") == ["taxonomy"]
+
+
+def test_put_subject_types_empty_list_allowed(client, db):
+    ws_id = db.create_workspace("ws")
+    resp = client.put(
+        f"/api/workspaces/{ws_id}/subject-types",
+        json={"types": []},
+    )
+    assert resp.status_code == 200
+```
+
+(Use the test fixtures already in `vireo/tests/test_app.py`. If `get_workspace_config_overrides` isn't a real method, use whatever existing helper reads `workspaces.config_overrides` — `grep -n "config_overrides" vireo/db.py`.)
+
+**Step 2: Run tests to verify fail (404)**
+
+**Step 3: Add the route**
+
+In `vireo/app.py`, near other workspace routes (search for `@app.route("/api/workspaces`):
+
+```python
+@app.route("/api/workspaces/<int:ws_id>/subject-types", methods=["PUT"])
+def api_set_subject_types(ws_id):
+    body = request.get_json() or {}
+    raw_types = body.get("types", [])
+    if not isinstance(raw_types, list):
+        return jsonify({"error": "types must be a list"}), 400
+    from vireo.db import KEYWORD_TYPES
+    cleaned = [t for t in raw_types if t in KEYWORD_TYPES]
+    dropped = set(raw_types) - set(cleaned)
+    if dropped:
+        log.warning("subject-types: dropped unknown values %s", sorted(dropped))
+    if not cleaned:
+        log.warning("subject-types: empty list set for workspace %d", ws_id)
+    db.update_workspace_config_key(ws_id, "subject_types", cleaned)
+    return jsonify({"types": cleaned})
+```
+
+(Add `update_workspace_config_key(ws_id, key, value)` to `Database` if no equivalent exists — small wrapper around the JSON-merge into `workspaces.config_overrides`. Add a parallel test for that helper.)
+
+**Step 4: Run tests**
+
+Expected: 3 PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/app.py vireo/db.py vireo/tests/test_app.py vireo/tests/test_db.py
+git commit -m "feat(api): PUT /api/workspaces/<id>/subject-types
+
+Lets clients configure which keyword types count as 'identifying' for
+this workspace. Unknown values silently dropped (logged); empty list
+allowed (logged warning)."
+```
+
+---
+
+## Task 7: Migrate the default "Needs Classification" collection
+
+**Files:**
+- Modify: `vireo/db.py:5706` (`create_default_collections`)
+- Modify: `vireo/db.py` (add a one-shot migration in `Database.__init__` or a numbered migration)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write failing tests**
+
+```python
+def test_default_collection_uses_has_subject_for_new_workspaces(temp_db):
+    db = temp_db
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    cols = {c["name"]: json.loads(c["rules"]) for c in db.get_collections()}
+    assert "Needs Identification" in cols
+    assert cols["Needs Identification"] == [{"field": "has_subject", "op": "equals", "value": 0}]
+
+
+def test_existing_needs_classification_collection_renamed_idempotently(temp_db):
+    """A workspace pre-populated with the old default gets renamed; running
+    again is a no-op."""
+    db = temp_db
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    # Force-create the legacy state
+    db.add_collection(
+        "Needs Classification",
+        json.dumps([{"field": "has_species", "op": "equals", "value": 0}]),
+    )
+    db.migrate_default_subject_collection()
+    db.migrate_default_subject_collection()  # idempotent
+    cols = {c["name"]: json.loads(c["rules"]) for c in db.get_collections()}
+    assert "Needs Identification" in cols
+    assert "Needs Classification" not in cols
+    assert cols["Needs Identification"] == [{"field": "has_subject", "op": "equals", "value": 0}]
+
+
+def test_migration_skips_user_customized_collection(temp_db):
+    """If 'Needs Classification' has a non-default rule (user edited it),
+    leave it alone."""
+    db = temp_db
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    custom = [{"field": "rating", "op": ">=", "value": 3}]
+    db.add_collection("Needs Classification", json.dumps(custom))
+    db.migrate_default_subject_collection()
+    cols = {c["name"]: json.loads(c["rules"]) for c in db.get_collections()}
+    assert "Needs Classification" in cols
+    assert cols["Needs Classification"] == custom
+```
+
+**Step 2: Run tests to verify fail**
+
+**Step 3: Update `create_default_collections` and add migration**
+
+In `vireo/db.py:5710-5715`, change the second tuple from:
+
+```python
+("Needs Classification", [{"field": "has_species", "op": "equals", "value": 0}]),
+```
+
+to:
+
+```python
+("Needs Identification", [{"field": "has_subject", "op": "equals", "value": 0}]),
+```
+
+Add a new method:
+
+```python
+def migrate_default_subject_collection(self):
+    """Rename 'Needs Classification' → 'Needs Identification' and switch
+    its rule to has_subject==0, but only if it still matches the prior
+    default rule (so user customizations are preserved). Idempotent."""
+    rows = self.conn.execute(
+        "SELECT id, name, rules FROM collections WHERE workspace_id = ? AND name = ?",
+        (self._ws_id(), "Needs Classification"),
+    ).fetchall()
+    legacy_rule = [{"field": "has_species", "op": "equals", "value": 0}]
+    for row in rows:
+        try:
+            current = json.loads(row["rules"])
+        except (TypeError, ValueError):
+            continue
+        if current != legacy_rule:
+            continue
+        # Don't clobber an existing "Needs Identification"
+        existing = self.conn.execute(
+            "SELECT 1 FROM collections WHERE workspace_id = ? AND name = ?",
+            (self._ws_id(), "Needs Identification"),
+        ).fetchone()
+        if existing:
+            continue
+        self.conn.execute(
+            "UPDATE collections SET name = ?, rules = ? WHERE id = ?",
+            (
+                "Needs Identification",
+                json.dumps([{"field": "has_subject", "op": "equals", "value": 0}]),
+                row["id"],
+            ),
+        )
+    self.conn.commit()
+```
+
+Call `migrate_default_subject_collection()` after `create_default_collections()` in workspace setup (find the existing call site of `create_default_collections` via `grep -n "create_default_collections" vireo/db.py`).
+
+**Step 4: Run tests**
+
+Expected: 3 PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "feat(collections): migrate default to Needs Identification + has_subject
+
+New workspaces get 'Needs Identification' (rule has_subject==0). Existing
+workspaces with the legacy 'Needs Classification' default are renamed
+in place; user-customized collections are left untouched. Idempotent."
+```
+
+---
+
+## Task 8: Default `scene` keywords
+
+**Files:**
+- Modify: `vireo/db.py` (add to `Database.__init__` or workspace-setup path)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_default_scene_keywords_inserted(temp_db):
+    db = temp_db
+    db.set_active_workspace(db.create_workspace("ws"))
+    rows = db.conn.execute(
+        "SELECT name FROM keywords WHERE type = 'scene' ORDER BY name"
+    ).fetchall()
+    assert [r["name"] for r in rows] == ["Abstract", "Architecture", "Landscape", "Sunset"]
+
+
+def test_default_scene_keywords_idempotent(temp_db):
+    db = temp_db
+    db.set_active_workspace(db.create_workspace("ws"))
+    db.ensure_default_scene_keywords()  # idempotent
+    rows = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM keywords WHERE type = 'scene'"
+    ).fetchone()
+    assert rows["n"] == 4
+```
+
+**Step 2: Run tests to verify fail**
+
+**Step 3: Add the method and call site**
+
+```python
+def ensure_default_scene_keywords(self):
+    """Insert the default scene keywords if none exist of type='scene'.
+    Idempotent."""
+    existing = self.conn.execute(
+        "SELECT 1 FROM keywords WHERE type = 'scene' LIMIT 1"
+    ).fetchone()
+    if existing:
+        return
+    for name in ("Landscape", "Sunset", "Architecture", "Abstract"):
+        self.conn.execute(
+            "INSERT OR IGNORE INTO keywords (name, type, is_species) VALUES (?, 'scene', 0)",
+            (name,),
+        )
+    self.conn.commit()
+```
+
+Call from `Database.__init__` (after schema creation, before `create_default_collections`).
+
+**Step 4: Run tests**
+
+Expected: 2 PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "feat(keywords): ship default scene keywords
+
+Landscape, Sunset, Architecture, Abstract — created once on first DB
+init, idempotent thereafter. Enables the lightbox 'Not Wildlife' button
+and inline-tag autocomplete for the common landscape case."
+```
+
+---
+
+## Task 9: Classifier skip-gate
+
+**Files:**
+- Modify: `vireo/classify_job.py:1369` (post-load filtering of photos)
+- Test: `vireo/tests/test_jobs_api.py` or a new dedicated test file
+
+**Step 1: Read the relevant block** at `classify_job.py:1369-1480` to confirm the photo-list flows through `photos = thread_db.get_collection_photos(...)` and then `photo_ids` later. Identify the right insertion point — after the load step, before model load (so we can short-circuit total to zero if everything is filtered).
+
+**Step 2: Write failing test**
+
+```python
+def test_classify_job_skips_photos_with_subject_keywords(monkeypatch, tmp_path, ...):
+    """When a photo has a keyword whose type is in subject_types, the
+    classifier doesn't include it in the run."""
+    # Set up: workspace, two photos in the collection. Tag p1 with a
+    # 'scene' keyword. Run classify_job with a stubbed classifier that
+    # records which photo IDs got passed in. Assert only p2 was processed.
+    ...
+
+
+def test_classify_job_reclassify_true_bypasses_subject_skip(...):
+    """With reclassify=True, even subject-tagged photos are reprocessed."""
+    ...
+```
+
+(Mirror the harness from existing tests in `vireo/tests/test_jobs_api.py`. The test stubs the classifier model so we don't actually load weights.)
+
+**Step 3: Run tests to verify fail**
+
+**Step 4: Implement**
+
+After `photos = thread_db.get_collection_photos(...)` at line 1369, insert:
+
+```python
+        if not params.reclassify:
+            subject_types = thread_db.get_subject_types()
+            if subject_types:
+                pre_count = len(photos)
+                kept_ids = set(thread_db.filter_out_subject_tagged(
+                    [p["id"] for p in photos], subject_types,
+                ))
+                photos = [p for p in photos if p["id"] in kept_ids]
+                skipped_subject = pre_count - len(photos)
+                if skipped_subject:
+                    log.info(
+                        "Skipping %d photo(s) with subject keywords (types=%s)",
+                        skipped_subject, sorted(subject_types),
+                    )
+                    runner.push_event(
+                        job["id"], "progress",
+                        {
+                            "current": 0,
+                            "total": len(photos),
+                            "current_file": (
+                                f"Skipped {skipped_subject} already-identified "
+                                f"photo(s)"
+                            ),
+                            "rate": 0,
+                            "phase": "Step 2/5: Loading photos",
+                            "skipped_subject": skipped_subject,
+                        },
+                    )
+```
+
+**Step 5: Run tests**
+
+Expected: 2 PASS.
+
+**Step 6: Run job-related tests for regressions**
+
+```bash
+python -m pytest vireo/tests/test_jobs_api.py -v
+```
+
+**Step 7: Commit**
+
+```bash
+git add vireo/classify_job.py vireo/tests/test_jobs_api.py
+git commit -m "feat(classify): skip photos already tagged with a subject keyword
+
+Default behavior: classify job filters out photos whose keywords
+include any type in the workspace's subject_types. reclassify=True
+bypasses, allowing explicit re-verification. Skip count is surfaced
+in progress events."
+```
+
+---
+
+## Task 10: Keywords page filter-button rename
+
+**Files:**
+- Modify: `vireo/templates/keywords.html:162-164`
+- Test: `vireo/testing/userfirst/scenarios/keywords.py` (existing scenario uses `data-type="taxonomy"` — should still work; add a new assertion if useful)
+
+**Step 1: Update the markup**
+
+In `keywords.html`, replace:
+
+```html
+<button class="kw-filter-btn" data-type="general">General</button>
+<button class="kw-filter-btn" data-type="taxonomy">Taxonomy</button>
+<button class="kw-filter-btn" data-type="location">Location</button>
+```
+
+with:
+
+```html
+<button class="kw-filter-btn" data-type="general">General</button>
+<button class="kw-filter-btn" data-type="taxonomy">Taxonomy</button>
+<button class="kw-filter-btn" data-type="individual">Individual</button>
+<button class="kw-filter-btn" data-type="place">Place</button>
+<button class="kw-filter-btn" data-type="scene">Scene</button>
+```
+
+(Search the file for any JS handler that switches on the `data-type` value to make sure the new ones flow through correctly. The handler likely just compares to `keywords.type` strings, which is exactly what we need.)
+
+**Step 2: Quick smoke check**
+
+```bash
+python -m pytest vireo/testing/userfirst/scenarios/keywords.py -v
+```
+
+Expected: PASS (existing scenario uses `data-type="taxonomy"` which is unchanged).
+
+**Step 3: Commit**
+
+```bash
+git add vireo/templates/keywords.html
+git commit -m "ui(keywords): expand filter buttons to full type enum
+
+general | taxonomy | individual | place | scene. Replaces the
+previously-stub 'location' button with 'place' to match the canonical
+type name."
+```
+
+---
+
+## Task 11: Lightbox "Not Wildlife" button
+
+**Files:**
+- Modify: `vireo/templates/_navbar.html` or wherever the lightbox markup lives (search via `grep -rn "lightbox" vireo/templates/`)
+- Modify: corresponding JS handler
+- Test: write a Playwright/userfirst scenario or a manual test plan
+
+**Step 1: Locate the lightbox controls**
+
+```bash
+grep -n "accept\|reject\|species" vireo/templates/_navbar.html | head -30
+```
+
+Find the row of controls near the species accept/reject buttons.
+
+**Step 2: Add the button (HTML)**
+
+Adjacent to the species accept/reject controls, add:
+
+```html
+<button id="not-wildlife-btn" class="lightbox-action-btn" title="Mark as not wildlife (Landscape)">
+  Not Wildlife
+</button>
+```
+
+**Step 3: Add the JS handler**
+
+```javascript
+document.getElementById("not-wildlife-btn")?.addEventListener("click", async () => {
+  const photoId = currentLightboxPhotoId;  // use whatever existing variable holds this
+  if (!photoId) return;
+  const resp = await fetch(`/api/photos/${photoId}/keywords`, {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({name: "Landscape"}),
+  });
+  if (resp.ok) {
+    advanceLightbox();  // existing function
+  } else {
+    console.error("Failed to tag as Landscape", await resp.text());
+  }
+});
+```
+
+(The exact name of the keyword-tagging endpoint and the advance function should be confirmed by `grep -n "/api/photos.*keywords" vireo/app.py` and `grep -n "advance" vireo/templates/_navbar.html`.)
+
+**Step 4: Verify the endpoint accepts a name and resolves to the existing scene keyword**
+
+The "Landscape" keyword was inserted in Task 8. The tagging endpoint should look up by name (case-insensitive) and reuse the existing keyword rather than creating a new `general` one. If the endpoint creates a new keyword via `add_keyword`, double-check it doesn't override the existing scene-typed one. (`add_keyword` already returns the existing ID for case-insensitive matches — `db.py:3152-3171` — so reuse is automatic.)
+
+**Step 5: Manual smoke test**
+
+```bash
+python vireo/app.py --db /tmp/vireo-test.db --port 8080
+```
+
+Open http://localhost:8080, tag a photo via the new button, confirm:
+- The Landscape keyword appears on the photo
+- The photo no longer appears in "Needs Identification"
+- The lightbox advances to the next photo
+
+**Step 6: Commit**
+
+```bash
+git add vireo/templates/_navbar.html
+git commit -m "ui(lightbox): add 'Not Wildlife' quick-tag button
+
+Tags the current photo with the default 'Landscape' scene keyword and
+advances. Drops the photo from 'Needs Identification' immediately."
+```
+
+---
+
+## Task 12: Workspace settings panel — subject-types section
+
+**Files:**
+- Modify: workspace-settings template (find via `grep -rn "workspace.*settings\|settings.*workspace" vireo/templates/`)
+- Test: write a scenario or manual test
+
+**Step 1: Locate the settings template** and identify a good place for a new "What counts as identified?" section.
+
+**Step 2: Add the form section**
+
+```html
+<section class="settings-section">
+  <h3>What counts as identified?</h3>
+  <p class="hint">Photos with at least one keyword of these types drop out of "Needs Identification" and are skipped by the classifier.</p>
+  <label><input type="checkbox" name="subject-type" value="taxonomy" checked> Taxonomy (species)</label>
+  <label><input type="checkbox" name="subject-type" value="individual" checked> Individual (people, pets)</label>
+  <label><input type="checkbox" name="subject-type" value="place"> Place</label>
+  <label><input type="checkbox" name="subject-type" value="scene" checked> Scene (landscape, sunset, etc.)</label>
+  <label><input type="checkbox" name="subject-type" value="general"> General</label>
+  <button id="save-subject-types">Save</button>
+</section>
+```
+
+**Step 3: Wire up the JS** to:
+- On page load: GET the current workspace config, set checkbox state from `subject_types`
+- On Save: PUT to `/api/workspaces/<id>/subject-types` with the checked values
+
+**Step 4: Manual smoke test** — change the set, reload page, confirm persistence; flip a workspace to `{taxonomy}` only and confirm a `scene=Landscape` photo reappears in Needs Identification.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/templates/<settings-template>.html
+git commit -m "ui(settings): add subject-types configuration section
+
+Per-workspace checkbox group lets users pick which keyword types count
+as 'identifying' a photo for queue/classifier purposes."
+```
+
+---
+
+## Task 13: Pipeline page tooltip update
+
+**Files:**
+- Modify: `vireo/templates/pipeline.html` (find the Re-classify control via `grep -n -i "reclassify\|re-classify" vireo/templates/pipeline.html`)
+
+**Step 1: Update the tooltip/help text**
+
+Change the existing tooltip from something like "Re-classify already-classified photos" to:
+
+> "Re-classify already-classified photos. Also bypasses the skip for photos already tagged with a subject keyword (e.g. Landscape) — useful for double-checking existing tags."
+
+**Step 2: Commit**
+
+```bash
+git add vireo/templates/pipeline.html
+git commit -m "ui(pipeline): clarify re-classify tooltip mentions subject-tag bypass"
+```
+
+---
+
+## Verification & PR
+
+**Final test run:**
+
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -v
+```
+
+Expected: all PASS (modulo MEMORY-noted pre-existing failures).
+
+**Manual end-to-end scenario:**
+
+1. Start with a fresh DB.
+2. Open browser, confirm "Needs Identification" appears in Collections (not "Needs Classification").
+3. Run a small classify on a folder of mixed photos.
+4. In the lightbox, click "Not Wildlife" on a landscape photo. Confirm it disappears from Needs Identification.
+5. In Workspace Settings, uncheck "Scene" — that landscape photo reappears in Needs Identification.
+6. Re-check "Scene", confirm it disappears again.
+7. Run classify a second time WITHOUT reclassify — the landscape photo is not re-processed (skip count appears in the bottom panel).
+8. Run classify with reclassify=True — the landscape photo IS re-processed.
+
+**Create the PR:**
+
+```bash
+git push -u origin unlabeled-query
+gh pr create --base main --title "feat: subject keyword types — generalize 'is identified' beyond species" --body "$(cat <<'EOF'
+## Summary
+- Add fixed five-value enum for `keywords.type`: `taxonomy`, `individual`, `place`, `scene`, `general`
+- New per-workspace `subject_types` config (default `{taxonomy, individual, scene}`) defines which types count as "identifying" a photo
+- New `has_subject` collection rule; default "Needs Classification" → "Needs Identification" with the new rule
+- Classifier skips photos with any subject-typed keyword (bypassed by `reclassify=True`)
+- Lightbox "Not Wildlife" button → tags with default `Landscape` scene keyword
+- Workspace settings: checkbox UI for the subject-types set
+- Ship four default `scene` keywords: Landscape, Sunset, Architecture, Abstract
+
+Design doc: `docs/plans/2026-04-25-subject-keyword-types-design.md`
+Plan: `docs/plans/2026-04-25-subject-keyword-types-plan.md`
+
+## Test plan
+- [x] Unit tests for KEYWORD_TYPES, get_subject_types, filter_out_subject_tagged, has_subject rule
+- [x] API tests for PUT /subject-types
+- [x] Migration tests (rename idempotent, doesn't clobber customizations)
+- [x] Classify-job skip + bypass tests
+- [x] Manual end-to-end: Not Wildlife button + settings panel toggle
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Out-of-scope follow-ups (post-merge)
+
+- Type-editing dropdown for existing keywords on the keywords page (deferred YAGNI from design)
+- Type picker in inline-tag input on the lightbox (deferred YAGNI)
+- Optional `species_keyword_id` FK on individuals (only if individual-tracking workflows materialize)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,4 +11,6 @@ from db import Database
 @pytest.fixture
 def db(tmp_path):
     """Return a Database backed by a temp file."""
-    return Database(str(tmp_path / "test.db"))
+    d = Database(str(tmp_path / "test.db"))
+    yield d
+    d.close()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -660,10 +660,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     # because the target name already exists, leaving a duplicate.
     init_db.migrate_default_subject_collection()
     init_db.create_default_collections()
-    # One-shot keyword migrations / backfills. Hoisted out of Database.__init__
-    # so they don't re-run on every request (each request gets a fresh
-    # Database instance via _get_db()).
-    init_db.migrate_legacy_keyword_types()
+    # Wildlife backfill: gated by a db_meta marker so it runs at most once
+    # per database. Kept in create_app rather than __init__ because (unlike
+    # migrate_legacy_keyword_types) the warm-path still requires a write to
+    # set the marker on first run, and we don't want that on every _get_db().
+    # migrate_legacy_keyword_types runs in Database.__init__ now (before
+    # ensure_default_genre_keywords) so the seed sees normalized types.
     init_db.backfill_wildlife_genre()
 
     # Mark species keywords from taxonomy in background (avoids slow startup)
@@ -1467,14 +1469,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         name = body.get("name", "").strip()
         if not name:
             return json_error("name required")
-        kid = db.add_keyword(name)
-        # Override type if explicitly provided. Guard against non-string
-        # JSON values (e.g. {"type": []} or {"type": {}}) — `x in frozenset`
-        # raises TypeError on unhashable input, which would 500 the request.
-        kw_type = body.get("type")
-        if isinstance(kw_type, str) and kw_type in KEYWORD_TYPES:
-            db.conn.execute("UPDATE keywords SET type = ? WHERE id = ?", (kw_type, kid))
-            db.conn.commit()
+        # Validate kw_type at the boundary (isinstance guard against
+        # non-hashable JSON; membership against the canonical enum).
+        # Pass it through to add_keyword so its type-reconciliation logic
+        # runs — a post-update SQL `UPDATE keywords SET type = ?` would
+        # silently rewrite an existing user-typed row (e.g. someone's
+        # 'individual' Charlie) and bypass the taxonomy/general upgrade
+        # rules in add_keyword.
+        kw_type_raw = body.get("type")
+        kw_type = (
+            kw_type_raw
+            if isinstance(kw_type_raw, str) and kw_type_raw in KEYWORD_TYPES
+            else None
+        )
+        kid = db.add_keyword(name, kw_type=kw_type)
         db.tag_photo(photo_id, kid)
         _queue_keyword_add(photo_id, name)
         db.record_edit('keyword_add', f'Added keyword "{name}"', str(kid),
@@ -1630,12 +1638,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         name = body.get("name", "").strip()
         if not photo_ids or not name:
             return json_error("photo_ids and name required")
-        kid = db.add_keyword(name)
-        # Guard against non-string JSON values — see api_add_keyword note.
-        kw_type = body.get("type")
-        if isinstance(kw_type, str) and kw_type in KEYWORD_TYPES:
-            db.conn.execute("UPDATE keywords SET type = ? WHERE id = ?", (kw_type, kid))
-            db.conn.commit()
+        # Route kw_type through add_keyword so its type-reconciliation logic
+        # runs (preserves existing user-typed rows; only upgrades 'general').
+        # See api_add_keyword for the rationale.
+        kw_type_raw = body.get("type")
+        kw_type = (
+            kw_type_raw
+            if isinstance(kw_type_raw, str) and kw_type_raw in KEYWORD_TYPES
+            else None
+        )
+        kid = db.add_keyword(name, kw_type=kw_type)
         for pid in photo_ids:
             db.tag_photo(pid, kid)
             _queue_keyword_add(pid, name)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2293,6 +2293,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db.update_workspace(db._active_workspace_id, config_overrides=existing)
         return jsonify({"ok": True, "nav_order": nav_order})
 
+    @app.route("/api/workspaces/active/subject-types", methods=["GET"])
+    def api_get_active_subject_types():
+        """Return the active workspace's effective subject_types — global
+        defaults merged with workspace overrides. The workspace settings UI
+        needs this rather than just the override JSON, so checkboxes render
+        the actual current state when the user has only customized at the
+        global config layer."""
+        db = _get_db()
+        types = sorted(db.get_subject_types())
+        return jsonify({"types": types})
+
     @app.route("/api/workspaces/<int:ws_id>/subject-types", methods=["PUT"])
     def api_set_subject_types(ws_id):
         """Set the subject_types config override for a workspace.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -639,6 +639,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     log.info("Database init took %.2fs (workspace: %s)", time.time() - _t0,
              init_db.get_workspace(init_db._active_workspace_id)["name"])
     init_db.create_default_collections()
+    init_db.migrate_default_subject_collection()
 
     # Mark species keywords from taxonomy in background (avoids slow startup)
     import threading

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2266,6 +2266,41 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db.update_workspace(db._active_workspace_id, config_overrides=existing)
         return jsonify({"ok": True, "nav_order": nav_order})
 
+    @app.route("/api/workspaces/<int:ws_id>/subject-types", methods=["PUT"])
+    def api_set_subject_types(ws_id):
+        """Set the subject_types config override for a workspace.
+
+        Unknown type values are dropped (logged). An empty list is allowed
+        (logged warning) and effectively disables the 'identified' filter.
+        """
+        from db import KEYWORD_TYPES
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        raw_types = body.get("types")
+        if not isinstance(raw_types, list):
+            return json_error("types must be a list")
+        cleaned = [t for t in raw_types if t in KEYWORD_TYPES]
+        dropped = [t for t in raw_types if t not in KEYWORD_TYPES]
+        if dropped:
+            log.warning(
+                "subject-types: dropped unknown values %s for ws=%s",
+                dropped, ws_id,
+            )
+        if not cleaned:
+            log.warning("subject-types: empty list set for workspace %s", ws_id)
+        ws = db.get_workspace(ws_id)
+        if not ws:
+            return json_error("workspace not found", 404)
+        existing = {}
+        if ws["config_overrides"]:
+            try:
+                existing = json.loads(ws["config_overrides"]) if isinstance(ws["config_overrides"], str) else ws["config_overrides"]
+            except Exception:
+                existing = {}
+        existing["subject_types"] = cleaned
+        db.update_workspace(ws_id, config_overrides=existing)
+        return jsonify({"types": cleaned})
+
     @app.route("/api/workspaces/active/new-images")
     def api_workspace_new_images():
         db = _get_db()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2342,6 +2342,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 existing = json.loads(ws["config_overrides"]) if isinstance(ws["config_overrides"], str) else ws["config_overrides"]
             except Exception:
                 existing = {}
+        # `config_overrides` is JSON, so a previous PUT /api/workspaces/<id>
+        # could have stored a list/string/number. Coerce to {} before key
+        # assignment to keep this endpoint from 500-ing on malformed state.
+        if not isinstance(existing, dict):
+            existing = {}
         existing["subject_types"] = cleaned
         db.update_workspace(ws_id, config_overrides=existing)
         return jsonify({"types": cleaned})

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -640,6 +640,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
              init_db.get_workspace(init_db._active_workspace_id)["name"])
     init_db.create_default_collections()
     init_db.migrate_default_subject_collection()
+    # One-shot keyword migrations / backfills. Hoisted out of Database.__init__
+    # so they don't re-run on every request (each request gets a fresh
+    # Database instance via _get_db()).
+    init_db.migrate_legacy_keyword_types()
+    init_db.backfill_wildlife_genre()
 
     # Mark species keywords from taxonomy in background (avoids slow startup)
     import threading

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -680,14 +680,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             log.debug("Could not open background db for species marking", exc_info=True)
             return
         tax = load_local_taxonomy()
-        if tax is not None:
-            try:
-                updated = bg_db.mark_species_keywords(tax)
-                if updated:
-                    log.info("Marked %d keywords as species from taxonomy", updated)
-            except Exception:
-                log.debug("Could not mark species from taxonomy", exc_info=True)
-                return
+        if tax is None:
+            # Skip the backfill too: it's one-shot via wildlife_backfill_done,
+            # so on an upgraded DB without taxonomy yet, running it would
+            # match zero plain-text species rows AND set the marker, leaving
+            # those photos un-Wildlife'd even after taxonomy is later loaded.
+            return
+        try:
+            updated = bg_db.mark_species_keywords(tax)
+            if updated:
+                log.info("Marked %d keywords as species from taxonomy", updated)
+        except Exception:
+            log.debug("Could not mark species from taxonomy", exc_info=True)
+            return
         try:
             bg_db.backfill_wildlife_genre()
         except Exception:
@@ -2380,22 +2385,26 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
         if not cleaned:
             log.warning("subject-types: empty list set for workspace %s", ws_id)
-        ws = db.get_workspace(ws_id)
-        if not ws:
-            return json_error("workspace not found", 404)
-        existing = {}
-        if ws["config_overrides"]:
-            try:
-                existing = json.loads(ws["config_overrides"]) if isinstance(ws["config_overrides"], str) else ws["config_overrides"]
-            except Exception:
-                existing = {}
-        # `config_overrides` is JSON, so a previous PUT /api/workspaces/<id>
-        # could have stored a list/string/number. Coerce to {} before key
-        # assignment to keep this endpoint from 500-ing on malformed state.
-        if not isinstance(existing, dict):
+        # Share the schema-driven settings write lock so a concurrent
+        # autosave on the same workspace can't read this same overrides
+        # snapshot and overwrite our subject_types change with stale data.
+        with _settings_write_lock:
+            ws = db.get_workspace(ws_id)
+            if not ws:
+                return json_error("workspace not found", 404)
             existing = {}
-        existing["subject_types"] = cleaned
-        db.update_workspace(ws_id, config_overrides=existing)
+            if ws["config_overrides"]:
+                try:
+                    existing = json.loads(ws["config_overrides"]) if isinstance(ws["config_overrides"], str) else ws["config_overrides"]
+                except Exception:
+                    existing = {}
+            # `config_overrides` is JSON, so a previous PUT /api/workspaces/<id>
+            # could have stored a list/string/number. Coerce to {} before key
+            # assignment to keep this endpoint from 500-ing on malformed state.
+            if not isinstance(existing, dict):
+                existing = {}
+            existing["subject_types"] = cleaned
+            db.update_workspace(ws_id, config_overrides=existing)
         return jsonify({"types": cleaned})
 
     @app.route("/api/workspace/tabs/open", methods=["POST"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1452,9 +1452,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not name:
             return json_error("name required")
         kid = db.add_keyword(name)
-        # Override type if explicitly provided
+        # Override type if explicitly provided. Guard against non-string
+        # JSON values (e.g. {"type": []} or {"type": {}}) — `x in frozenset`
+        # raises TypeError on unhashable input, which would 500 the request.
         kw_type = body.get("type")
-        if kw_type and kw_type in KEYWORD_TYPES:
+        if isinstance(kw_type, str) and kw_type in KEYWORD_TYPES:
             db.conn.execute("UPDATE keywords SET type = ? WHERE id = ?", (kw_type, kid))
             db.conn.commit()
         db.tag_photo(photo_id, kid)
@@ -1613,8 +1615,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not photo_ids or not name:
             return json_error("photo_ids and name required")
         kid = db.add_keyword(name)
+        # Guard against non-string JSON values — see api_add_keyword note.
         kw_type = body.get("type")
-        if kw_type and kw_type in KEYWORD_TYPES:
+        if isinstance(kw_type, str) and kw_type in KEYWORD_TYPES:
             db.conn.execute("UPDATE keywords SET type = ? WHERE id = ?", (kw_type, kid))
             db.conn.commit()
         for pid in photo_ids:
@@ -2317,8 +2320,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         raw_types = body.get("types")
         if not isinstance(raw_types, list):
             return json_error("types must be a list")
-        cleaned = [t for t in raw_types if t in KEYWORD_TYPES]
-        dropped = [t for t in raw_types if t not in KEYWORD_TYPES]
+        # Guard the membership test against non-string entries (e.g. nested
+        # lists or objects). `x in frozenset` raises TypeError on unhashable
+        # input — that would 500 the request instead of dropping the bad
+        # element per the documented "unknown values are dropped" contract.
+        cleaned = [t for t in raw_types if isinstance(t, str) and t in KEYWORD_TYPES]
+        dropped = [t for t in raw_types if not isinstance(t, str) or t not in KEYWORD_TYPES]
         if dropped:
             log.warning(
                 "subject-types: dropped unknown values %s for ws=%s",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18,7 +18,7 @@ from datetime import UTC
 from pathlib import Path
 from urllib.parse import quote
 
-from db import Database
+from db import KEYWORD_TYPES, Database
 from flask import (
     Flask,
     Response,
@@ -1428,7 +1428,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         kid = db.add_keyword(name)
         # Override type if explicitly provided
         kw_type = body.get("type")
-        if kw_type and kw_type in ('general', 'taxonomy', 'location', 'descriptive', 'people', 'event'):
+        if kw_type and kw_type in KEYWORD_TYPES:
             db.conn.execute("UPDATE keywords SET type = ? WHERE id = ?", (kw_type, kid))
             db.conn.commit()
         db.tag_photo(photo_id, kid)
@@ -1588,7 +1588,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("photo_ids and name required")
         kid = db.add_keyword(name)
         kw_type = body.get("type")
-        if kw_type and kw_type in ('general', 'taxonomy', 'location', 'descriptive', 'people', 'event'):
+        if kw_type and kw_type in KEYWORD_TYPES:
             db.conn.execute("UPDATE keywords SET type = ? WHERE id = ?", (kw_type, kid))
             db.conn.commit()
         for pid in photo_ids:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -661,42 +661,66 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     init_db.migrate_default_subject_collection()
     init_db.create_default_collections()
 
-    # Mark species keywords from taxonomy in background (avoids slow startup),
-    # then run the Wildlife backfill. Order matters: the backfill is one-shot
-    # via a db_meta marker, and it only matches rows where
-    # ``type='taxonomy' OR is_species=1``. Plain-text species tags on upgraded
-    # DBs start as ``is_species=0`` / non-taxonomy and only get retyped by
-    # ``mark_species_keywords``. Running the backfill before that pass would
-    # match zero rows on first boot and set the marker, permanently leaving
-    # those photos un-Wildlife'd.
+    # Wildlife backfill timing:
+    # - Subsequent boots: marker is set, nothing to do, fast.
+    # - First boot after upgrade (marker unset): run species marking +
+    #   backfill SYNCHRONOUSLY before accepting requests. Otherwise a
+    #   user could remove Wildlife from a species-tagged photo during
+    #   the few-second window before the background thread completes,
+    #   and the backfill would silently re-add it (clobbering user
+    #   intent before the marker gets set).
+    # - mark_species runs in the background regardless, to catch new
+    #   species keywords added between boots. The backfill won't re-run
+    #   from the background path (marker check inside backfill).
     import threading
 
-    def _mark_species():
+    from db import Database as _Database  # avoid shadowing in nested fn
+
+    _WILDLIFE_BACKFILL_DONE_KEY = _Database._WILDLIFE_BACKFILL_DONE_KEY
+
+    def _mark_species_and_maybe_backfill(db, log_label):
+        """Load taxonomy, mark species keywords, and run the one-shot
+        Wildlife backfill. Returns silently on any failure so callers
+        can choose between sync (block startup) and async (log only)."""
         from taxonomy import load_local_taxonomy
 
+        tax = load_local_taxonomy()
+        if tax is None:
+            # No taxonomy yet — leave the marker unset so the backfill
+            # retries on a future boot once taxonomy is downloaded.
+            log.debug("[%s] taxonomy not loaded; deferring species marking", log_label)
+            return
+        try:
+            updated = db.mark_species_keywords(tax)
+            if updated:
+                log.info("[%s] Marked %d keywords as species from taxonomy",
+                         log_label, updated)
+        except Exception:
+            log.debug("[%s] mark_species_keywords failed", log_label, exc_info=True)
+            return
+        try:
+            db.backfill_wildlife_genre()
+        except Exception:
+            log.debug("[%s] backfill_wildlife_genre failed", log_label, exc_info=True)
+
+    if init_db.get_meta(_WILDLIFE_BACKFILL_DONE_KEY) != "1":
+        # First boot after upgrade. Block startup until the one-shot
+        # backfill completes so concurrent user edits in that window
+        # can't be overwritten.
+        log.info("Wildlife backfill marker unset; running species marking "
+                 "+ backfill synchronously before serving requests")
+        _t1 = time.time()
+        _mark_species_and_maybe_backfill(init_db, "sync-startup")
+        log.info("Synchronous species marking + backfill took %.2fs",
+                 time.time() - _t1)
+
+    def _mark_species():
         try:
             bg_db = Database(db_path)
         except Exception:
             log.debug("Could not open background db for species marking", exc_info=True)
             return
-        tax = load_local_taxonomy()
-        if tax is None:
-            # Skip the backfill too: it's one-shot via wildlife_backfill_done,
-            # so on an upgraded DB without taxonomy yet, running it would
-            # match zero plain-text species rows AND set the marker, leaving
-            # those photos un-Wildlife'd even after taxonomy is later loaded.
-            return
-        try:
-            updated = bg_db.mark_species_keywords(tax)
-            if updated:
-                log.info("Marked %d keywords as species from taxonomy", updated)
-        except Exception:
-            log.debug("Could not mark species from taxonomy", exc_info=True)
-            return
-        try:
-            bg_db.backfill_wildlife_genre()
-        except Exception:
-            log.debug("Wildlife backfill failed", exc_info=True)
+        _mark_species_and_maybe_backfill(bg_db, "background")
 
     threading.Thread(target=_mark_species, daemon=True).start()
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -638,8 +638,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     init_db = Database(db_path)
     log.info("Database init took %.2fs (workspace: %s)", time.time() - _t0,
              init_db.get_workspace(init_db._active_workspace_id)["name"])
-    init_db.create_default_collections()
+    # Migrate the legacy 'Needs Classification' default collection BEFORE
+    # seeding defaults — otherwise create_default_collections inserts
+    # 'Needs Identification' first, then the migration skips renaming
+    # because the target name already exists, leaving a duplicate.
     init_db.migrate_default_subject_collection()
+    init_db.create_default_collections()
     # One-shot keyword migrations / backfills. Hoisted out of Database.__init__
     # so they don't re-run on every request (each request gets a fresh
     # Database instance via _get_db()).

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -660,30 +660,38 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     # because the target name already exists, leaving a duplicate.
     init_db.migrate_default_subject_collection()
     init_db.create_default_collections()
-    # Wildlife backfill: gated by a db_meta marker so it runs at most once
-    # per database. Kept in create_app rather than __init__ because (unlike
-    # migrate_legacy_keyword_types) the warm-path still requires a write to
-    # set the marker on first run, and we don't want that on every _get_db().
-    # migrate_legacy_keyword_types runs in Database.__init__ now (before
-    # ensure_default_genre_keywords) so the seed sees normalized types.
-    init_db.backfill_wildlife_genre()
 
-    # Mark species keywords from taxonomy in background (avoids slow startup)
+    # Mark species keywords from taxonomy in background (avoids slow startup),
+    # then run the Wildlife backfill. Order matters: the backfill is one-shot
+    # via a db_meta marker, and it only matches rows where
+    # ``type='taxonomy' OR is_species=1``. Plain-text species tags on upgraded
+    # DBs start as ``is_species=0`` / non-taxonomy and only get retyped by
+    # ``mark_species_keywords``. Running the backfill before that pass would
+    # match zero rows on first boot and set the marker, permanently leaving
+    # those photos un-Wildlife'd.
     import threading
 
     def _mark_species():
         from taxonomy import load_local_taxonomy
 
-        tax = load_local_taxonomy()
-        if tax is None:
-            return
         try:
             bg_db = Database(db_path)
-            updated = bg_db.mark_species_keywords(tax)
-            if updated:
-                log.info("Marked %d keywords as species from taxonomy", updated)
         except Exception:
-            log.debug("Could not mark species from taxonomy", exc_info=True)
+            log.debug("Could not open background db for species marking", exc_info=True)
+            return
+        tax = load_local_taxonomy()
+        if tax is not None:
+            try:
+                updated = bg_db.mark_species_keywords(tax)
+                if updated:
+                    log.info("Marked %d keywords as species from taxonomy", updated)
+            except Exception:
+                log.debug("Could not mark species from taxonomy", exc_info=True)
+                return
+        try:
+            bg_db.backfill_wildlife_genre()
+        except Exception:
+            log.debug("Wildlife backfill failed", exc_info=True)
 
     threading.Thread(target=_mark_species, daemon=True).start()
 

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1407,6 +1407,34 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             summary=f"{total} photos",
         )
 
+        # If the subject-skip filter (or an empty source collection) left
+        # nothing to classify, short-circuit before model load. Loading the
+        # model is expensive (and can fail) and there is no work to do.
+        if total == 0:
+            log.info(
+                "Classify job: no photos to process after filtering; "
+                "skipping model load and detection",
+            )
+            runner.push_event(
+                job["id"], "progress",
+                {
+                    "current": 0,
+                    "total": 0,
+                    "current_file": "No photos to classify",
+                    "rate": 0,
+                    "phase": "Step 2/5: Loading photos",
+                },
+            )
+            return {
+                "total": 0,
+                "predictions_stored": 0,
+                "burst_groups": 0,
+                "already_classified": 0,
+                "already_labeled": 0,
+                "detected": 0,
+                "failed": 0,
+            }
+
         log.info(
             "Classifying %d photos with '%s' (%s)", total, effective_name, model_str
         )

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1284,76 +1284,19 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         job["_start_time"] = time.time()
 
         runner.set_steps(job["id"], [
-            {"id": "load_taxonomy", "label": "Load taxonomy"},
             {"id": "load_photos", "label": "Load photos"},
+            {"id": "load_taxonomy", "label": "Load taxonomy"},
             {"id": "load_model", "label": "Load model"},
             {"id": "detect", "label": "Detect subjects"},
             {"id": "classify", "label": "Classify species"},
             {"id": "finalize", "label": "Finalize results"},
         ])
 
-        # Resolve model
-        if params.model_id:
-            all_models = get_models()
-            active_model = next(
-                (m for m in all_models if m["id"] == params.model_id and m["downloaded"]),
-                None,
-            )
-            if not active_model:
-                raise RuntimeError(
-                    f"Model '{params.model_id}' not found or not downloaded."
-                )
-        else:
-            active_model = get_active_model()
-        if not active_model:
-            raise RuntimeError("No model available. Download one in Settings.")
-
-        model_str = active_model["model_str"]
-        weights_path = active_model["weights_path"]
-        effective_name = active_model["name"]
-        model_type = active_model.get("model_type", "bioclip")
-        model_name = params.model_name or effective_name
-
-        # Phase 1: Load taxonomy
-        runner.update_step(job["id"], "load_taxonomy", status="running")
-        runner.push_event(
-            job["id"],
-            "progress",
-            {
-                "current": 0,
-                "total": 0,
-                "current_file": "Loading taxonomy...",
-                "rate": 0,
-                "phase": "Step 1/5: Loading taxonomy",
-            },
-        )
-        from taxonomy import load_local_taxonomy
-        tax = load_local_taxonomy()
-
-        # Phase 2: Load labels
-        labels, use_tol = _load_labels(
-            model_type=model_type,
-            model_str=model_str,
-            labels_file=params.labels_file,
-            labels_files=params.labels_files,
-            db=thread_db,
-        )
-        # Compute a content-addressable fingerprint for the active label set.
-        # Kept in scope so downstream classifier_runs writes can record the
-        # exact (classifier_model, labels_fingerprint) that produced a result.
-        from labels_fingerprint import compute_fingerprint
-        fp = compute_fingerprint(labels)
-        label_sources = _resolve_label_sources(params, thread_db)
-        _record_labels_fingerprint(thread_db, fp, labels, sources=label_sources)
-
-        tax_summary = "Taxonomy loaded" if tax else "No taxonomy"
-        labels_summary = f"{len(labels)} labels" if labels else ("Tree of Life" if use_tol else "no labels")
-        runner.update_step(
-            job["id"], "load_taxonomy", status="completed",
-            summary=f"{tax_summary}, {labels_summary}",
-        )
-
-        # Phase 3: Get photos from collection
+        # Phase 1: Get photos from collection — runs before model resolution
+        # so that a collection fully filtered out by the subject-skip gate
+        # short-circuits without ever attempting to load (or fail to load)
+        # a classifier model. Otherwise users with no model downloaded would
+        # see "No model available" for jobs that have zero work to do.
         runner.update_step(job["id"], "load_photos", status="running")
         runner.push_event(
             job["id"],
@@ -1363,11 +1306,10 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                 "total": 0,
                 "current_file": "Loading collection photos...",
                 "rate": 0,
-                "phase": "Step 2/5: Loading photos",
+                "phase": "Step 1/5: Loading photos",
             },
         )
         photos = thread_db.get_collection_photos(params.collection_id, per_page=999999)
-        folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
 
         # Skip photos already tagged with a 'subject' keyword (per workspace
         # config). reclassify=True bypasses so users can verify existing tags.
@@ -1395,7 +1337,7 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                                 f"photo(s)"
                             ),
                             "rate": 0,
-                            "phase": "Step 2/5: Loading photos",
+                            "phase": "Step 1/5: Loading photos",
                             "skipped_subject": skipped_subject,
                         },
                     )
@@ -1408,12 +1350,13 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         )
 
         # If the subject-skip filter (or an empty source collection) left
-        # nothing to classify, short-circuit before model load. Loading the
-        # model is expensive (and can fail) and there is no work to do.
+        # nothing to classify, short-circuit before model resolution. Model
+        # resolution can fail with RuntimeError when no model is downloaded,
+        # which would surface as a hard error for a job that has no work.
         if total == 0:
             log.info(
                 "Classify job: no photos to process after filtering; "
-                "skipping model load and detection",
+                "skipping model resolution and detection",
             )
             runner.push_event(
                 job["id"], "progress",
@@ -1422,7 +1365,7 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                     "total": 0,
                     "current_file": "No photos to classify",
                     "rate": 0,
-                    "phase": "Step 2/5: Loading photos",
+                    "phase": "Step 1/5: Loading photos",
                 },
             )
             return {
@@ -1434,6 +1377,69 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                 "detected": 0,
                 "failed": 0,
             }
+
+        # Resolve model (deferred until we know there is work to do)
+        if params.model_id:
+            all_models = get_models()
+            active_model = next(
+                (m for m in all_models if m["id"] == params.model_id and m["downloaded"]),
+                None,
+            )
+            if not active_model:
+                raise RuntimeError(
+                    f"Model '{params.model_id}' not found or not downloaded."
+                )
+        else:
+            active_model = get_active_model()
+        if not active_model:
+            raise RuntimeError("No model available. Download one in Settings.")
+
+        model_str = active_model["model_str"]
+        weights_path = active_model["weights_path"]
+        effective_name = active_model["name"]
+        model_type = active_model.get("model_type", "bioclip")
+        model_name = params.model_name or effective_name
+
+        folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
+
+        # Phase 2: Load taxonomy
+        runner.update_step(job["id"], "load_taxonomy", status="running")
+        runner.push_event(
+            job["id"],
+            "progress",
+            {
+                "current": 0,
+                "total": total,
+                "current_file": "Loading taxonomy...",
+                "rate": 0,
+                "phase": "Step 2/5: Loading taxonomy",
+            },
+        )
+        from taxonomy import load_local_taxonomy
+        tax = load_local_taxonomy()
+
+        # Phase 3: Load labels (uses model_type/model_str from above)
+        labels, use_tol = _load_labels(
+            model_type=model_type,
+            model_str=model_str,
+            labels_file=params.labels_file,
+            labels_files=params.labels_files,
+            db=thread_db,
+        )
+        # Compute a content-addressable fingerprint for the active label set.
+        # Kept in scope so downstream classifier_runs writes can record the
+        # exact (classifier_model, labels_fingerprint) that produced a result.
+        from labels_fingerprint import compute_fingerprint
+        fp = compute_fingerprint(labels)
+        label_sources = _resolve_label_sources(params, thread_db)
+        _record_labels_fingerprint(thread_db, fp, labels, sources=label_sources)
+
+        tax_summary = "Taxonomy loaded" if tax else "No taxonomy"
+        labels_summary = f"{len(labels)} labels" if labels else ("Tree of Life" if use_tol else "no labels")
+        runner.update_step(
+            job["id"], "load_taxonomy", status="completed",
+            summary=f"{tax_summary}, {labels_summary}",
+        )
 
         log.info(
             "Classifying %d photos with '%s' (%s)", total, effective_name, model_str

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1368,6 +1368,38 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         )
         photos = thread_db.get_collection_photos(params.collection_id, per_page=999999)
         folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
+
+        # Skip photos already tagged with a 'subject' keyword (per workspace
+        # config). reclassify=True bypasses so users can verify existing tags.
+        if not params.reclassify:
+            subject_types = thread_db.get_subject_types()
+            if subject_types:
+                pre_count = len(photos)
+                kept_ids = set(thread_db.filter_out_subject_tagged(
+                    [p["id"] for p in photos], subject_types,
+                ))
+                photos = [p for p in photos if p["id"] in kept_ids]
+                skipped_subject = pre_count - len(photos)
+                if skipped_subject:
+                    log.info(
+                        "Skipping %d photo(s) with subject keywords (types=%s)",
+                        skipped_subject, sorted(subject_types),
+                    )
+                    runner.push_event(
+                        job["id"], "progress",
+                        {
+                            "current": 0,
+                            "total": len(photos),
+                            "current_file": (
+                                f"Skipped {skipped_subject} already-identified "
+                                f"photo(s)"
+                            ),
+                            "rate": 0,
+                            "phase": "Step 2/5: Loading photos",
+                            "skipped_subject": skipped_subject,
+                        },
+                    )
+
         total = len(photos)
         job["progress"]["total"] = total
         runner.update_step(

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -32,6 +32,11 @@ DEFAULTS = {
     "darktable_style": "",
     "darktable_output_format": "jpg",
     "darktable_output_dir": "",
+    # --- Subject identification ---
+    # Keyword types that count as "identifying" a photo for queue/classifier
+    # purposes. Photos with at least one keyword of one of these types drop
+    # out of "Needs Identification" and are skipped by the classifier.
+    "subject_types": ["taxonomy", "individual", "scene"],
     # --- Display ---
     "browse_card_fields": ["filename", "rating", "flag", "sharpness"],
     "photos_per_page": 50,

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -36,7 +36,7 @@ DEFAULTS = {
     # Keyword types that count as "identifying" a photo for queue/classifier
     # purposes. Photos with at least one keyword of one of these types drop
     # out of "Needs Identification" and are skipped by the classifier.
-    "subject_types": ["taxonomy", "individual", "scene"],
+    "subject_types": ["taxonomy", "individual", "genre"],
     # --- Display ---
     "browse_card_fields": ["filename", "rating", "flag", "sharpness"],
     "photos_per_page": 50,

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -168,6 +168,19 @@ SCHEMA = {
         "desc": "Which metadata badges appear on each photo card in browse.",
     },
 
+    # --- Subject identification -------------------------------------------
+    # Workspace-overridable. Photos with at least one keyword of one of
+    # these types drop out of "Needs Identification" and are skipped by
+    # the classifier. PUT /api/workspaces/<id>/subject-types persists the
+    # override into config_overrides.
+    "subject_types": {
+        "type": "list_string",
+        "items_enum": ["taxonomy", "individual", "location", "genre", "general"],
+        "category": "Behavior", "scope": "both",
+        "label": "What counts as identified",
+        "desc": "Keyword types that mark a photo as 'identified' for queue and classifier purposes.",
+    },
+
     # --- Working copy -----------------------------------------------------
     "working_copy_max_size": {
         "type": "int", "min": 512, "max": 16384,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3729,12 +3729,12 @@ class Database:
         (a user who intentionally removed Wildlife from a species-tagged
         photo would see it re-added on the next app restart).
 
-        Matches keywords by ``type='taxonomy' OR is_species=1`` so the backfill
-        works on upgraded databases whose species rows still carry legacy
-        ``is_species=1`` but have not yet been retyped to ``taxonomy`` by the
-        background ``mark_species_keywords`` pass. Without that, the backfill
-        could write the one-shot marker after matching zero rows and never
-        run again, leaving species photos un-Wildlife'd.
+        Matches keywords by ``type='taxonomy' OR is_species=1``. Plain-text
+        species tags on upgraded DBs start as ``is_species=0`` /
+        non-taxonomy and won't be matched until ``mark_species_keywords``
+        retypes them — so callers must run that pass *before* this backfill
+        on upgraded databases, otherwise the one-shot marker gets set on a
+        zero-row scan and species photos are permanently missed.
 
         Args:
             force: re-run even if the marker is set. Used by tests; not for

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3537,20 +3537,28 @@ class Database:
             self.conn.commit()
 
     def _maybe_apply_auto_wildlife(self, photo_id, just_added_keyword_id):
-        """If just_added_keyword_id is a taxonomy keyword AND it's the only
-        taxonomy keyword on this photo, also add the Wildlife genre."""
+        """If just_added_keyword_id is a species keyword (taxonomy type OR
+        legacy is_species=1) AND it's the only such keyword on this photo,
+        also add the Wildlife genre.
+
+        Treats ``is_species=1`` as a species candidate too: upgraded databases
+        carry legacy species rows whose ``type`` hasn't been retyped to
+        ``taxonomy`` yet by the background ``mark_species_keywords`` pass,
+        and the auto-Wildlife trigger needs to fire for those tags during
+        that window."""
         row = self.conn.execute(
-            "SELECT type FROM keywords WHERE id = ?",
+            "SELECT type, is_species FROM keywords WHERE id = ?",
             (just_added_keyword_id,),
         ).fetchone()
-        if not row or row["type"] != "taxonomy":
+        if not row or (row["type"] != "taxonomy" and not row["is_species"]):
             return
-        # Count taxonomy keywords on this photo. If > 1, this isn't the first
+        # Count species keywords on this photo. If > 1, this isn't the first
         # — skip (sticky removal).
         species_count = self.conn.execute(
             """SELECT COUNT(*) AS n FROM photo_keywords pk
                JOIN keywords k ON k.id = pk.keyword_id
-               WHERE pk.photo_id = ? AND k.type = 'taxonomy'""",
+               WHERE pk.photo_id = ?
+                 AND (k.type = 'taxonomy' OR k.is_species = 1)""",
             (photo_id,),
         ).fetchone()["n"]
         if species_count != 1:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -13,6 +13,18 @@ log = logging.getLogger(__name__)
 
 _UNSET = object()  # sentinel for "not provided" vs explicit None
 
+# Canonical set of keyword type values stored in keywords.type.
+# - taxonomy: a species/genus/etc. (linked to taxa via taxon_id)
+# - individual: a named person, pet, or otherwise tracked individual
+# - place: a named location ("Yosemite", "backyard")
+# - scene: a non-subject visual category ("Landscape", "Sunset")
+# - general: catch-all/free-form tag (the legacy default)
+KEYWORD_TYPES = frozenset({"taxonomy", "individual", "place", "scene", "general"})
+
+# Default set of types that count as "identifying" a photo for queue
+# membership / classifier skip purposes. Workspaces can override.
+SUBJECT_TYPES_DEFAULT = frozenset({"taxonomy", "individual", "scene"})
+
 
 def commit_with_retry(conn, max_retries=5, base_delay=0.1):
     """Commit ``conn`` with retry on transient "locked"/"busy" errors.
@@ -3135,7 +3147,7 @@ class Database:
             return name.title()
         return name
 
-    def add_keyword(self, name, parent_id=None, is_species=False, _commit=True):
+    def add_keyword(self, name, parent_id=None, is_species=False, kw_type=None, _commit=True):
         """Insert a keyword. Returns existing id if duplicate (case-insensitive).
 
         If a keyword with the same name but different casing exists, reuses
@@ -3145,9 +3157,15 @@ class Database:
         from existing keywords and applies it (unless overridden by config).
 
         Args:
+            kw_type: Optional explicit keyword type. Must be one of
+                     ``KEYWORD_TYPES`` if provided. When ``None``, the type is
+                     auto-detected (``taxonomy`` for species or names matching
+                     a known taxon, otherwise ``general``).
             _commit: If False, skip the internal commit (caller is responsible
                      for committing the transaction).
         """
+        if kw_type is not None and kw_type not in KEYWORD_TYPES:
+            raise ValueError(f"invalid keyword type: {kw_type!r}")
         # Case-insensitive lookup
         if parent_id is None:
             existing = self.conn.execute(
@@ -3182,30 +3200,31 @@ class Database:
                 if convention:
                     name = self._apply_case_convention(name, convention)
 
-        # Auto-detect taxonomy type from taxa table
-        kw_type = 'general'
         taxon_id = None
-        if is_species:
-            kw_type = 'taxonomy'
-        else:
-            # Check if name matches a known taxon (common name or scientific name)
-            taxon = self.conn.execute(
-                """SELECT t.id FROM taxa t
-                   WHERE t.common_name = ? COLLATE NOCASE
-                      OR t.name = ? COLLATE NOCASE
-                   LIMIT 1""",
-                (name, name),
-            ).fetchone()
-            if not taxon:
-                taxon = self.conn.execute(
-                    """SELECT t.taxon_id AS id FROM taxa_common_names t
-                       WHERE t.name = ? COLLATE NOCASE
-                       LIMIT 1""",
-                    (name,),
-                ).fetchone()
-            if taxon:
+        if kw_type is None:
+            # Auto-detect taxonomy type from taxa table
+            kw_type = 'general'
+            if is_species:
                 kw_type = 'taxonomy'
-                taxon_id = taxon["id"]
+            else:
+                # Check if name matches a known taxon (common name or scientific name)
+                taxon = self.conn.execute(
+                    """SELECT t.id FROM taxa t
+                       WHERE t.common_name = ? COLLATE NOCASE
+                          OR t.name = ? COLLATE NOCASE
+                       LIMIT 1""",
+                    (name, name),
+                ).fetchone()
+                if not taxon:
+                    taxon = self.conn.execute(
+                        """SELECT t.taxon_id AS id FROM taxa_common_names t
+                           WHERE t.name = ? COLLATE NOCASE
+                           LIMIT 1""",
+                        (name,),
+                    ).fetchone()
+                if taxon:
+                    kw_type = 'taxonomy'
+                    taxon_id = taxon["id"]
 
         cur = self.conn.execute(
             "INSERT INTO keywords (name, parent_id, is_species, type, taxon_id) VALUES (?, ?, ?, ?, ?)",

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -624,6 +624,15 @@ class Database:
         except (json.JSONDecodeError, TypeError):
             return global_config
 
+    def get_subject_types(self) -> set[str]:
+        """Return the keyword types that count as 'identified' for the active workspace."""
+        import config as cfg
+        effective = self.get_effective_config(cfg.load())
+        raw = effective.get("subject_types", list(SUBJECT_TYPES_DEFAULT))
+        if not isinstance(raw, list):
+            return set(SUBJECT_TYPES_DEFAULT)
+        return {t for t in raw if t in KEYWORD_TYPES}
+
     def get_workspace_active_labels(self):
         """Return the active_labels list from workspace config_overrides, or None."""
         ws = self.get_workspace(self._ws_id())

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -103,9 +103,11 @@ class Database:
         self._new_images_cache = get_shared_cache()
         self._create_tables()
         self.ensure_default_workspace()
-        self.migrate_legacy_keyword_types()
+        # Idempotent default-keyword seed. Cheap warm-path (single
+        # SELECT 1 LIMIT 1 short-circuit) — matches ensure_default_workspace
+        # above. One-shot migrations and backfills are hoisted to create_app
+        # so they don't run on every request via _get_db().
         self.ensure_default_genre_keywords()
-        self.backfill_wildlife_genre()
         # Restore last-used workspace, or fall back to Default
         last = self.conn.execute(
             "SELECT id FROM workspaces ORDER BY CASE WHEN last_opened_at IS NULL THEN 0 ELSE 1 END DESC, last_opened_at DESC, id ASC LIMIT 1"

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3585,13 +3585,20 @@ class Database:
     _WILDLIFE_BACKFILL_DONE_KEY = "wildlife_backfill_done"
 
     def backfill_wildlife_genre(self, force=False):
-        """One-shot backfill: every photo that has at least one taxonomy
+        """One-shot backfill: every photo that has at least one species
         keyword AND no Wildlife genre keyword gets Wildlife added.
 
         Gated by a db_meta marker so it runs at most once per database.
         Re-running unconditionally would clobber sticky-removed Wildlife rows
         (a user who intentionally removed Wildlife from a species-tagged
         photo would see it re-added on the next app restart).
+
+        Matches keywords by ``type='taxonomy' OR is_species=1`` so the backfill
+        works on upgraded databases whose species rows still carry legacy
+        ``is_species=1`` but have not yet been retyped to ``taxonomy`` by the
+        background ``mark_species_keywords`` pass. Without that, the backfill
+        could write the one-shot marker after matching zero rows and never
+        run again, leaving species photos un-Wildlife'd.
 
         Args:
             force: re-run even if the marker is set. Used by tests; not for
@@ -3610,7 +3617,7 @@ class Database:
                SELECT DISTINCT pk.photo_id, ?
                FROM photo_keywords pk
                JOIN keywords k ON k.id = pk.keyword_id
-               WHERE k.type = 'taxonomy'""",
+               WHERE k.type = 'taxonomy' OR k.is_species = 1""",
             (wildlife_id,),
         )
         self.set_meta(self._WILDLIFE_BACKFILL_DONE_KEY, "1", _commit=False)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1077,17 +1077,31 @@ class Database:
         # Cold / upgrade path: promote any same-name top-level 'general'
         # rows to 'genre' first, so an upgraded DB with a hand-tagged
         # 'general' Wildlife (or other default name) ends up with a
-        # canonical genre row instead of being blocked by the
-        # UNIQUE(name, parent_id) constraint on the subsequent INSERT.
+        # canonical genre row.
         for name in defaults:
             self.conn.execute(
                 """UPDATE keywords SET type = 'genre'
-                   WHERE name = ? AND parent_id IS NULL AND type = 'general'""",
+                   WHERE name = ? COLLATE NOCASE
+                     AND parent_id IS NULL AND type = 'general'""",
                 (name,),
             )
+        # Insert each default only if no top-level row with that name (any
+        # type, any case) exists. Cannot rely on INSERT OR IGNORE against
+        # UNIQUE(name, parent_id) here — SQLite treats NULL parent_id as
+        # distinct (per SQL standard), so a same-name top-level row would
+        # not actually block the insert and we'd silently produce
+        # duplicates that split add_keyword's case-insensitive lookup.
         for name in defaults:
+            existing_row = self.conn.execute(
+                """SELECT id FROM keywords
+                   WHERE name = ? COLLATE NOCASE AND parent_id IS NULL
+                   LIMIT 1""",
+                (name,),
+            ).fetchone()
+            if existing_row:
+                continue
             self.conn.execute(
-                "INSERT OR IGNORE INTO keywords (name, type, is_species) VALUES (?, 'genre', 0)",
+                "INSERT INTO keywords (name, type, is_species) VALUES (?, 'genre', 0)",
                 (name,),
             )
         self.conn.commit()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3544,12 +3544,17 @@ class Database:
             )
         if kw_type == 'taxonomy':
             is_species = True
-        # Case-insensitive lookup. When kw_type is supplied, prefer a
-        # same-typed match — duplicates by name across different types
-        # are permitted (e.g. a user-tagged 'location' Landscape
-        # coexisting with a default 'genre' Landscape), and callers who
-        # explicitly ask for kw_type='genre' must deterministically get
-        # the genre row.
+        # Case-insensitive lookup with type-aware matching:
+        #
+        # When kw_type is supplied, only same-type or 'general' rows are
+        # candidates. Same-type wins; 'general' is promotable to the
+        # requested type via the UPDATE below. Other deliberate types
+        # (location/individual/etc.) are intentionally NOT candidates —
+        # returning one and finding the upgrade no-op'd would leave the
+        # caller with a mismatched type. Falling through to INSERT
+        # creates a new row of the requested type alongside the
+        # deliberate one (duplicates by name across types are
+        # intentional in this PR).
         #
         # When kw_type is None, prefer the most "structured"
         # interpretation in a fixed priority — taxonomy > genre >
@@ -3577,9 +3582,9 @@ class Database:
             else:
                 existing = self.conn.execute(
                     "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
-                    "AND parent_id IS NULL "
+                    "AND parent_id IS NULL AND type IN (?, 'general') "
                     "ORDER BY (type = ?) DESC, id ASC LIMIT 1",
-                    (name, kw_type),
+                    (name, kw_type, kw_type),
                 ).fetchone()
         else:
             if kw_type is None:
@@ -3592,9 +3597,9 @@ class Database:
             else:
                 existing = self.conn.execute(
                     "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
-                    "AND parent_id = ? "
+                    "AND parent_id = ? AND type IN (?, 'general') "
                     "ORDER BY (type = ?) DESC, id ASC LIMIT 1",
-                    (name, parent_id, kw_type),
+                    (name, parent_id, kw_type, kw_type),
                 ).fetchone()
         if existing:
             # Promote an unset row to taxonomy when this call indicates a

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -665,30 +665,46 @@ class Database:
             return set(SUBJECT_TYPES_DEFAULT)
         return {t for t in raw if t in KEYWORD_TYPES}
 
+    # Conservative chunk size for filter_out_subject_tagged. Most modern
+    # SQLite builds default to SQLITE_MAX_VARIABLE_NUMBER=32766, but older
+    # / Linux-distro builds still ship with the historical 999 cap. 800
+    # leaves comfortable headroom for the type binds (up to 5) plus a
+    # safety margin. Module-level constant so tests can monkeypatch.
+    _FILTER_SUBJECT_CHUNK = 800
+
     def filter_out_subject_tagged(self, photo_ids, subject_types):
         """Return the subset of photo_ids whose photos do NOT have any keyword
         of a type in subject_types. Empty subject_types or empty photo_ids
-        returns photo_ids unchanged (preserving input order)."""
+        returns photo_ids unchanged (preserving input order).
+
+        Photo ids are chunked under SQLite's bind-variable limit so callers
+        can safely pass arbitrarily large lists. The classify job sources
+        photo ids from get_collection_photos(per_page=999999), which can
+        exceed older SQLite builds' 999-variable cap and trip
+        OperationalError: too many SQL variables.
+        """
         if not subject_types or not photo_ids:
             return list(photo_ids)
         types = [t for t in subject_types if t in KEYWORD_TYPES]
         if not types:
             return list(photo_ids)
-        pid_placeholders = ",".join("?" * len(photo_ids))
         type_placeholders = ",".join("?" * len(types))
-        rows = self.conn.execute(
-            f"""SELECT id FROM photos
-                WHERE id IN ({pid_placeholders})
-                  AND id NOT IN (
-                    SELECT pk.photo_id FROM photo_keywords pk
+        photo_ids_list = list(photo_ids)
+        excluded = set()
+        chunk_size = self._FILTER_SUBJECT_CHUNK
+        for i in range(0, len(photo_ids_list), chunk_size):
+            chunk = photo_ids_list[i:i + chunk_size]
+            pid_placeholders = ",".join("?" * len(chunk))
+            rows = self.conn.execute(
+                f"""SELECT DISTINCT pk.photo_id FROM photo_keywords pk
                     JOIN keywords k ON k.id = pk.keyword_id
                     WHERE k.type IN ({type_placeholders})
-                  )""",
-            list(photo_ids) + types,
-        ).fetchall()
-        kept_set = {r["id"] for r in rows}
-        # Preserve original input order for kept rows.
-        return [pid for pid in photo_ids if pid in kept_set]
+                      AND pk.photo_id IN ({pid_placeholders})""",
+                types + chunk,
+            ).fetchall()
+            for r in rows:
+                excluded.add(r["photo_id"])
+        return [pid for pid in photo_ids_list if pid not in excluded]
 
     def get_workspace_active_labels(self):
         """Return the active_labels list from workspace config_overrides, or None."""

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -110,10 +110,18 @@ class Database:
         self._new_images_cache = get_shared_cache()
         self._create_tables()
         self.ensure_default_workspace()
+        # Idempotent legacy-type migration. MUST run before genre seeding
+        # so an upgraded DB with e.g. 'descriptive'/'event'/'people' rows
+        # named 'Wildlife' gets normalized first. Otherwise the seed's
+        # UNIQUE(name, parent_id) INSERT OR IGNORE skips the Wildlife
+        # genre, then the migration converts that legacy row to 'general',
+        # leaving auto-Wildlife and backfill queries unable to find a
+        # canonical 'Wildlife' / type='genre' row. Cheap warm-path (single
+        # SELECT 1 LIMIT 1) once all legacy rows are gone.
+        self.migrate_legacy_keyword_types()
         # Idempotent default-keyword seed. Cheap warm-path (single
         # SELECT 1 LIMIT 1 short-circuit) — matches ensure_default_workspace
-        # above. One-shot migrations and backfills are hoisted to create_app
-        # so they don't run on every request via _get_db().
+        # above.
         self.ensure_default_genre_keywords()
         # Restore last-used workspace, or fall back to Default
         last = self.conn.execute(
@@ -1006,8 +1014,24 @@ class Database:
         self.conn.commit()
 
     def migrate_legacy_keyword_types(self):
-        """One-shot migration of legacy keyword type names to the canonical enum.
-        Idempotent — running again is a no-op once all rows are migrated."""
+        """One-shot migration of legacy keyword type names to the canonical
+        enum. Idempotent — once all rows are migrated, the warm-path
+        short-circuits cheaply (single SELECT 1 LIMIT 1) so this is safe to
+        call from Database.__init__ on every instantiation.
+
+        Order matters: this runs BEFORE ensure_default_genre_keywords in
+        __init__ so a legacy 'descriptive'/'event'/'people'-typed Wildlife
+        gets normalized first. Otherwise the seed's UNIQUE(name, parent_id)
+        INSERT OR IGNORE would silently skip Wildlife, then this migration
+        would convert the legacy row to 'general', leaving the auto-Wildlife
+        and backfill queries (WHERE name='Wildlife' AND type='genre') with
+        no canonical row to find.
+        """
+        legacy = self.conn.execute(
+            "SELECT 1 FROM keywords WHERE type IN ('people', 'descriptive', 'event') LIMIT 1"
+        ).fetchone()
+        if not legacy:
+            return
         self.conn.execute("UPDATE keywords SET type = 'individual' WHERE type = 'people'")
         self.conn.execute("UPDATE keywords SET type = 'general' WHERE type = 'descriptive'")
         self.conn.execute("UPDATE keywords SET type = 'general' WHERE type = 'event'")
@@ -3434,10 +3458,15 @@ class Database:
                 (name, parent_id),
             ).fetchone()
         if existing:
-            # Update is_species and type if it wasn't set before
+            # Promote an unset row to taxonomy when this call indicates a
+            # species. Restrict to 'general' (the legacy default for unknown
+            # rows) so a deliberate user type — 'individual', 'location',
+            # 'genre' — is preserved instead of silently rewritten when a
+            # later caller passes is_species=True or kw_type='taxonomy'.
             if is_species:
                 self.conn.execute(
-                    "UPDATE keywords SET is_species = 1, type = 'taxonomy' WHERE id = ? AND is_species = 0",
+                    "UPDATE keywords SET is_species = 1, type = 'taxonomy' "
+                    "WHERE id = ? AND is_species = 0 AND type IN ('general', 'taxonomy')",
                     (existing["id"],),
                 )
                 if _commit:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -16,14 +16,14 @@ _UNSET = object()  # sentinel for "not provided" vs explicit None
 # Canonical set of keyword type values stored in keywords.type.
 # - taxonomy: a species/genus/etc. (linked to taxa via taxon_id)
 # - individual: a named person, pet, or otherwise tracked individual
-# - place: a named location ("Yosemite", "backyard")
-# - scene: a non-subject visual category ("Landscape", "Sunset")
+# - location: a named location ("Yosemite", "backyard")
+# - genre: a non-subject visual category ("Landscape", "Sunset")
 # - general: catch-all/free-form tag (the legacy default)
-KEYWORD_TYPES = frozenset({"taxonomy", "individual", "place", "scene", "general"})
+KEYWORD_TYPES = frozenset({"taxonomy", "individual", "location", "genre", "general"})
 
 # Default set of types that count as "identifying" a photo for queue
 # membership / classifier skip purposes. Workspaces can override.
-SUBJECT_TYPES_DEFAULT = frozenset({"taxonomy", "individual", "scene"})
+SUBJECT_TYPES_DEFAULT = frozenset({"taxonomy", "individual", "genre"})
 
 
 def commit_with_retry(conn, max_retries=5, base_delay=0.1):
@@ -103,7 +103,8 @@ class Database:
         self._new_images_cache = get_shared_cache()
         self._create_tables()
         self.ensure_default_workspace()
-        self.ensure_default_scene_keywords()
+        self.migrate_legacy_keyword_types()
+        self.ensure_default_genre_keywords()
         # Restore last-used workspace, or fall back to Default
         last = self.conn.execute(
             "SELECT id FROM workspaces ORDER BY CASE WHEN last_opened_at IS NULL THEN 0 ELSE 1 END DESC, last_opened_at DESC, id ASC LIMIT 1"
@@ -846,23 +847,31 @@ class Database:
             return row[0]
         return self.create_workspace("Default")
 
-    def ensure_default_scene_keywords(self):
-        """Insert the default scene keywords if none exist of type='scene'.
+    def ensure_default_genre_keywords(self):
+        """Insert the default genre keywords if none exist of type='genre'.
 
-        Idempotent: a single existing scene keyword (user-created or otherwise)
+        Idempotent: a single existing genre keyword (user-created or otherwise)
         short-circuits the insert. Keywords are global, so this runs once per
         database (not per workspace).
         """
         existing = self.conn.execute(
-            "SELECT 1 FROM keywords WHERE type = 'scene' LIMIT 1"
+            "SELECT 1 FROM keywords WHERE type = 'genre' LIMIT 1"
         ).fetchone()
         if existing:
             return
-        for name in ("Landscape", "Sunset", "Architecture", "Abstract"):
+        for name in ("Landscape", "Sunset", "Architecture", "Abstract", "Wildlife"):
             self.conn.execute(
-                "INSERT OR IGNORE INTO keywords (name, type, is_species) VALUES (?, 'scene', 0)",
+                "INSERT OR IGNORE INTO keywords (name, type, is_species) VALUES (?, 'genre', 0)",
                 (name,),
             )
+        self.conn.commit()
+
+    def migrate_legacy_keyword_types(self):
+        """One-shot migration of legacy keyword type names to the canonical enum.
+        Idempotent — running again is a no-op once all rows are migrated."""
+        self.conn.execute("UPDATE keywords SET type = 'individual' WHERE type = 'people'")
+        self.conn.execute("UPDATE keywords SET type = 'general' WHERE type = 'descriptive'")
+        self.conn.execute("UPDATE keywords SET type = 'general' WHERE type = 'event'")
         self.conn.commit()
 
     # -- Folders --
@@ -3545,11 +3554,9 @@ class Database:
             (ws, ws, ws),
         ).fetchall()
 
-    VALID_KEYWORD_TYPES = ('general', 'taxonomy', 'location', 'descriptive', 'people', 'event')
-
     def update_keyword(self, keyword_id, **kwargs):
         """Update keyword fields. Supports: type, taxon_id, latitude, longitude, name."""
-        if 'type' in kwargs and kwargs['type'] not in self.VALID_KEYWORD_TYPES:
+        if 'type' in kwargs and kwargs['type'] not in KEYWORD_TYPES:
             raise ValueError(f"Invalid keyword type: {kwargs['type']}")
         allowed = {'type', 'taxon_id', 'latitude', 'longitude', 'name'}
         updates = {k: v for k, v in kwargs.items() if k in allowed}

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3545,36 +3545,55 @@ class Database:
         if kw_type == 'taxonomy':
             is_species = True
         # Case-insensitive lookup. When kw_type is supplied, prefer a
-        # same-typed match — duplicates by name across different types are
-        # permitted (e.g. a user-tagged 'location' Landscape coexisting
-        # with a default 'genre' Landscape), and callers who explicitly
-        # ask for kw_type='genre' must deterministically get the genre
-        # row rather than an arbitrary same-name row of another type.
-        type_preference = "ORDER BY (type = ?) DESC, id ASC LIMIT 1"
+        # same-typed match — duplicates by name across different types
+        # are permitted (e.g. a user-tagged 'location' Landscape
+        # coexisting with a default 'genre' Landscape), and callers who
+        # explicitly ask for kw_type='genre' must deterministically get
+        # the genre row.
+        #
+        # When kw_type is None, prefer the most "structured"
+        # interpretation in a fixed priority — taxonomy > genre >
+        # individual > location > general — so a type-agnostic caller
+        # (e.g. typing into a generic keyword input) doesn't silently
+        # bind to a hand-tagged 'general' duplicate when a canonical
+        # typed row exists. Tie-break by id for determinism.
+        # NB: SQL literals here are constants, not parameter bindings.
+        type_priority_case = (
+            "CASE type "
+            "WHEN 'taxonomy' THEN 0 "
+            "WHEN 'genre' THEN 1 "
+            "WHEN 'individual' THEN 2 "
+            "WHEN 'location' THEN 3 "
+            "ELSE 4 END"
+        )
         if parent_id is None:
             if kw_type is None:
                 existing = self.conn.execute(
-                    "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
-                    "AND parent_id IS NULL ORDER BY id ASC LIMIT 1",
+                    f"SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
+                    f"AND parent_id IS NULL "
+                    f"ORDER BY {type_priority_case}, id ASC LIMIT 1",
                     (name,),
                 ).fetchone()
             else:
                 existing = self.conn.execute(
-                    f"SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
-                    f"AND parent_id IS NULL {type_preference}",
+                    "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
+                    "AND parent_id IS NULL "
+                    "ORDER BY (type = ?) DESC, id ASC LIMIT 1",
                     (name, kw_type),
                 ).fetchone()
         else:
             if kw_type is None:
                 existing = self.conn.execute(
-                    "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
-                    "AND parent_id = ? ORDER BY id ASC LIMIT 1",
+                    f"SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
+                    f"AND parent_id = ? "
+                    f"ORDER BY {type_priority_case}, id ASC LIMIT 1",
                     (name, parent_id),
                 ).fetchone()
             else:
                 existing = self.conn.execute(
-                    f"SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
-                    f"AND parent_id = ? {type_preference}",
+                    "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
+                    "AND parent_id = ? "
+                    "ORDER BY (type = ?) DESC, id ASC LIMIT 1",
                     (name, parent_id, kw_type),
                 ).fetchone()
         if existing:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -5584,6 +5584,34 @@ class Database:
                         JOIN keywords k3 ON k3.id = pk3.keyword_id
                         WHERE pk3.photo_id = p.id AND k3.is_species = 1)"""
                     )
+            elif field == "has_subject":
+                # Match the has_species pattern, but resolve "subject" via
+                # the workspace's configured subject_types (a set of keyword
+                # types). Sorted for deterministic SQL parameter order.
+                subject_types = sorted(self.get_subject_types())
+                if not subject_types:
+                    if op == "equals" and (value is True or value == 1):
+                        conditions.append("0")  # nothing matches
+                    # value==0 with empty subject_types is a no-op (every
+                    # photo is "not identified" by the empty set)
+                    continue
+                type_placeholders = ",".join("?" * len(subject_types))
+                if op == "equals" and (value is False or value == 0):
+                    conditions.append(
+                        f"""NOT EXISTS (
+                        SELECT 1 FROM photo_keywords pk5
+                        JOIN keywords k5 ON k5.id = pk5.keyword_id
+                        WHERE pk5.photo_id = p.id AND k5.type IN ({type_placeholders}))"""
+                    )
+                    params.extend(subject_types)
+                elif op == "equals" and (value is True or value == 1):
+                    conditions.append(
+                        f"""EXISTS (
+                        SELECT 1 FROM photo_keywords pk5
+                        JOIN keywords k5 ON k5.id = pk5.keyword_id
+                        WHERE pk5.photo_id = p.id AND k5.type IN ({type_placeholders}))"""
+                    )
+                    params.extend(subject_types)
             elif field == "keyword_count":
                 if op == "equals":
                     conditions.append(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3519,8 +3519,15 @@ class Database:
                     (kw_type, existing["id"]),
                 )
                 if kw_type == 'taxonomy':
+                    # Gate on type='taxonomy' so a preserved deliberate type
+                    # (e.g. 'individual') doesn't get is_species=1 stamped on
+                    # it when the type update above was a no-op. Otherwise
+                    # _maybe_apply_auto_wildlife / backfill_wildlife_genre /
+                    # subject filters with `OR is_species=1` would treat that
+                    # non-taxonomy row as a species.
                     self.conn.execute(
-                        "UPDATE keywords SET is_species = 1 WHERE id = ?",
+                        "UPDATE keywords SET is_species = 1 "
+                        "WHERE id = ? AND type = 'taxonomy'",
                         (existing["id"],),
                     )
                 if _commit:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -5814,8 +5814,8 @@ class Database:
         defaults = [
             ("All Photos", [{"field": "all"}]),
             (
-                "Needs Classification",
-                [{"field": "has_species", "op": "equals", "value": 0}],
+                "Needs Identification",
+                [{"field": "has_subject", "op": "equals", "value": 0}],
             ),
             ("Untagged", [{"field": "keyword_count", "op": "equals", "value": 0}]),
             ("Flagged", [{"field": "flag", "op": "equals", "value": "flagged"}]),
@@ -5827,6 +5827,42 @@ class Database:
         for name, rules in defaults:
             if name not in existing_names:
                 self.add_collection(name, json.dumps(rules))
+
+    def migrate_default_subject_collection(self):
+        """Rename legacy 'Needs Classification' (with rule has_species==0)
+        to 'Needs Identification' (rule has_subject==0). Skips collections
+        the user has customized. Idempotent."""
+        rows = self.conn.execute(
+            "SELECT id, rules FROM collections "
+            "WHERE workspace_id = ? AND name = ?",
+            (self._ws_id(), "Needs Classification"),
+        ).fetchall()
+        legacy_rule = [{"field": "has_species", "op": "equals", "value": 0}]
+        for row in rows:
+            try:
+                current = json.loads(row["rules"])
+            except (TypeError, ValueError):
+                continue
+            if current != legacy_rule:
+                continue
+            # Don't clobber an existing "Needs Identification"
+            existing = self.conn.execute(
+                "SELECT 1 FROM collections WHERE workspace_id = ? AND name = ?",
+                (self._ws_id(), "Needs Identification"),
+            ).fetchone()
+            if existing:
+                continue
+            self.conn.execute(
+                "UPDATE collections SET name = ?, rules = ? WHERE id = ?",
+                (
+                    "Needs Identification",
+                    json.dumps(
+                        [{"field": "has_subject", "op": "equals", "value": 0}]
+                    ),
+                    row["id"],
+                ),
+            )
+        self.conn.commit()
 
     # ------ iNaturalist submissions ------
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -470,6 +470,12 @@ class Database:
             CREATE INDEX IF NOT EXISTS idx_photos_file_hash ON photos(file_hash);
 
             CREATE INDEX IF NOT EXISTS idx_keywords_name ON keywords(name);
+            -- type is low-cardinality (5-value enum) but heavily filtered:
+            -- has_subject rule, filter_out_subject_tagged, backfill_wildlife,
+            -- and the warm-path migration probes all do WHERE type [IN/=] ...
+            -- Without an index those scan the full keywords table on every
+            -- _get_db()-per-request Database instantiation.
+            CREATE INDEX IF NOT EXISTS idx_keywords_type ON keywords(type);
             CREATE INDEX IF NOT EXISTS idx_photo_keywords_photo ON photo_keywords(photo_id);
             CREATE INDEX IF NOT EXISTS idx_photo_keywords_keyword ON photo_keywords(keyword_id);
             CREATE INDEX IF NOT EXISTS idx_photo_color_labels_ws

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -103,6 +103,7 @@ class Database:
         self._new_images_cache = get_shared_cache()
         self._create_tables()
         self.ensure_default_workspace()
+        self.ensure_default_scene_keywords()
         # Restore last-used workspace, or fall back to Default
         last = self.conn.execute(
             "SELECT id FROM workspaces ORDER BY CASE WHEN last_opened_at IS NULL THEN 0 ELSE 1 END DESC, last_opened_at DESC, id ASC LIMIT 1"
@@ -844,6 +845,25 @@ class Database:
         if row:
             return row[0]
         return self.create_workspace("Default")
+
+    def ensure_default_scene_keywords(self):
+        """Insert the default scene keywords if none exist of type='scene'.
+
+        Idempotent: a single existing scene keyword (user-created or otherwise)
+        short-circuits the insert. Keywords are global, so this runs once per
+        database (not per workspace).
+        """
+        existing = self.conn.execute(
+            "SELECT 1 FROM keywords WHERE type = 'scene' LIMIT 1"
+        ).fetchone()
+        if existing:
+            return
+        for name in ("Landscape", "Sunset", "Architecture", "Abstract"):
+            self.conn.execute(
+                "INSERT OR IGNORE INTO keywords (name, type, is_species) VALUES (?, 'scene', 0)",
+                (name,),
+            )
+        self.conn.commit()
 
     # -- Folders --
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -633,6 +633,31 @@ class Database:
             return set(SUBJECT_TYPES_DEFAULT)
         return {t for t in raw if t in KEYWORD_TYPES}
 
+    def filter_out_subject_tagged(self, photo_ids, subject_types):
+        """Return the subset of photo_ids whose photos do NOT have any keyword
+        of a type in subject_types. Empty subject_types or empty photo_ids
+        returns photo_ids unchanged (preserving input order)."""
+        if not subject_types or not photo_ids:
+            return list(photo_ids)
+        types = [t for t in subject_types if t in KEYWORD_TYPES]
+        if not types:
+            return list(photo_ids)
+        pid_placeholders = ",".join("?" * len(photo_ids))
+        type_placeholders = ",".join("?" * len(types))
+        rows = self.conn.execute(
+            f"""SELECT id FROM photos
+                WHERE id IN ({pid_placeholders})
+                  AND id NOT IN (
+                    SELECT pk.photo_id FROM photo_keywords pk
+                    JOIN keywords k ON k.id = pk.keyword_id
+                    WHERE k.type IN ({type_placeholders})
+                  )""",
+            list(photo_ids) + types,
+        ).fetchall()
+        kept_set = {r["id"] for r in rows}
+        # Preserve original input order for kept rows.
+        return [pid for pid in photo_ids if pid in kept_set]
+
     def get_workspace_active_labels(self):
         """Return the active_labels list from workspace config_overrides, or None."""
         ws = self.get_workspace(self._ws_id())

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -690,6 +690,13 @@ class Database:
         photo ids from get_collection_photos(per_page=999999), which can
         exceed older SQLite builds' 999-variable cap and trip
         OperationalError: too many SQL variables.
+
+        When ``'taxonomy'`` is among the requested types, legacy species rows
+        (``is_species=1`` with a non-taxonomy ``type``) also count as
+        subject-tagged. Upgraded databases carry these rows until the
+        background ``mark_species_keywords`` pass retypes them; without this
+        guard, already-identified photos would still be classified and would
+        appear in 'Needs Identification' during that window.
         """
         if not subject_types or not photo_ids:
             return list(photo_ids)
@@ -697,6 +704,9 @@ class Database:
         if not types:
             return list(photo_ids)
         type_placeholders = ",".join("?" * len(types))
+        type_clause = f"k.type IN ({type_placeholders})"
+        if "taxonomy" in types:
+            type_clause = f"({type_clause} OR k.is_species = 1)"
         photo_ids_list = list(photo_ids)
         excluded = set()
         chunk_size = self._FILTER_SUBJECT_CHUNK
@@ -706,7 +716,7 @@ class Database:
             rows = self.conn.execute(
                 f"""SELECT DISTINCT pk.photo_id FROM photo_keywords pk
                     JOIN keywords k ON k.id = pk.keyword_id
-                    WHERE k.type IN ({type_placeholders})
+                    WHERE {type_clause}
                       AND pk.photo_id IN ({pid_placeholders})""",
                 types + chunk,
             ).fetchall()
@@ -5913,6 +5923,13 @@ class Database:
                 # Match the has_species pattern, but resolve "subject" via
                 # the workspace's configured subject_types (a set of keyword
                 # types). Sorted for deterministic SQL parameter order.
+                #
+                # When 'taxonomy' is among the subject types, also count
+                # legacy species rows (is_species=1 with a non-taxonomy
+                # type). Upgraded databases retain those rows until the
+                # background mark_species_keywords pass retypes them; the
+                # type-only predicate would otherwise place already-
+                # identified photos into 'Needs Identification'.
                 subject_types = sorted(self.get_subject_types())
                 if not subject_types:
                     if op == "equals" and (value is True or value == 1):
@@ -5921,12 +5938,15 @@ class Database:
                     # photo is "not identified" by the empty set)
                     continue
                 type_placeholders = ",".join("?" * len(subject_types))
+                type_clause = f"k5.type IN ({type_placeholders})"
+                if "taxonomy" in subject_types:
+                    type_clause = f"({type_clause} OR k5.is_species = 1)"
                 if op == "equals" and (value is False or value == 0):
                     conditions.append(
                         f"""NOT EXISTS (
                         SELECT 1 FROM photo_keywords pk5
                         JOIN keywords k5 ON k5.id = pk5.keyword_id
-                        WHERE pk5.photo_id = p.id AND k5.type IN ({type_placeholders}))"""
+                        WHERE pk5.photo_id = p.id AND {type_clause})"""
                     )
                     params.extend(subject_types)
                 elif op == "equals" and (value is True or value == 1):
@@ -5934,7 +5954,7 @@ class Database:
                         f"""EXISTS (
                         SELECT 1 FROM photo_keywords pk5
                         JOIN keywords k5 ON k5.id = pk5.keyword_id
-                        WHERE pk5.photo_id = p.id AND k5.type IN ({type_placeholders}))"""
+                        WHERE pk5.photo_id = p.id AND {type_clause})"""
                     )
                     params.extend(subject_types)
             elif field == "keyword_count":

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -657,13 +657,21 @@ class Database:
             return global_config
 
     def get_subject_types(self) -> set[str]:
-        """Return the keyword types that count as 'identified' for the active workspace."""
+        """Return the keyword types that count as 'identified' for the active
+        workspace.
+
+        config_overrides is arbitrary JSON (api_update_workspace persists
+        whatever the client sends), so subject_types entries may not be
+        strings — guard the membership test against unhashable values
+        (nested lists/objects) to avoid TypeError downstream in callers
+        like collection filtering and the classify skip-gate.
+        """
         import config as cfg
         effective = self.get_effective_config(cfg.load())
         raw = effective.get("subject_types", list(SUBJECT_TYPES_DEFAULT))
         if not isinstance(raw, list):
             return set(SUBJECT_TYPES_DEFAULT)
-        return {t for t in raw if t in KEYWORD_TYPES}
+        return {t for t in raw if isinstance(t, str) and t in KEYWORD_TYPES}
 
     # Conservative chunk size for filter_out_subject_tagged. Most modern
     # SQLite builds default to SQLITE_MAX_VARIABLE_NUMBER=32766, but older
@@ -3770,8 +3778,15 @@ class Database:
         'location', 'individual') are preserved. Explicit type/taxon_id
         kwargs always win over auto-detection.
         """
-        if 'type' in kwargs and kwargs['type'] not in KEYWORD_TYPES:
-            raise ValueError(f"Invalid keyword type: {kwargs['type']}")
+        if 'type' in kwargs:
+            kt = kwargs['type']
+            # Guard the membership test against non-hashable JSON values —
+            # api_update_keyword passes the request body through, and
+            # `x in frozenset` raises TypeError on unhashable input. Treat
+            # any non-string as invalid (raise ValueError so the route's
+            # existing catch yields the documented 400).
+            if not isinstance(kt, str) or kt not in KEYWORD_TYPES:
+                raise ValueError(f"Invalid keyword type: {kt!r}")
         allowed = {'type', 'taxon_id', 'latitude', 'longitude', 'name'}
         updates = {k: v for k, v in kwargs.items() if k in allowed}
         if not updates:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1,5 +1,6 @@
 """SQLite database for Vireo photo browser metadata cache."""
 
+import contextlib
 import json
 import logging
 import os
@@ -97,6 +98,8 @@ class Database:
         # don't cross-read each other's cached results (workspace_id=1 is
         # reused across every database as the default workspace).
         self._db_path = db_path
+        # Pre-set so __del__ can run safely if sqlite3.connect raises.
+        self.conn = None
         self.conn = sqlite3.connect(db_path, check_same_thread=False)
         self.conn.row_factory = sqlite3.Row
         self.conn.execute("PRAGMA journal_mode=WAL")
@@ -128,6 +131,36 @@ class Database:
             "SELECT id FROM workspaces ORDER BY CASE WHEN last_opened_at IS NULL THEN 0 ELSE 1 END DESC, last_opened_at DESC, id ASC LIMIT 1"
         ).fetchone()
         self.set_active_workspace(last[0])
+
+    def close(self):
+        """Close the underlying sqlite3 connection.
+
+        Safe to call multiple times. Without an explicit close, the
+        connection's file descriptors only release when CPython gc collects
+        the object — under Python 3.14's stricter ResourceWarning handling,
+        accumulating unclosed connections in long-running test suites
+        exhausts the per-process fd limit and breaks coverage's own
+        sqlite database.
+        """
+        conn = getattr(self, "conn", None)
+        if conn is not None:
+            with contextlib.suppress(Exception):
+                conn.close()
+            self.conn = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+        return False
+
+    def __del__(self):
+        # Safety net for callers that don't use the context manager or call
+        # close() explicitly. __del__ may run during interpreter shutdown
+        # when sqlite3 is already torn down — swallow everything.
+        with contextlib.suppress(Exception):
+            self.close()
 
     def _create_tables(self):
         self.conn.executescript(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3166,6 +3166,14 @@ class Database:
         """
         if kw_type is not None and kw_type not in KEYWORD_TYPES:
             raise ValueError(f"invalid keyword type: {kw_type!r}")
+        # Reconcile is_species and kw_type to keep the legacy column coherent
+        # with the type enum.
+        if is_species and kw_type is not None and kw_type != 'taxonomy':
+            raise ValueError(
+                f"is_species=True requires kw_type='taxonomy', got {kw_type!r}"
+            )
+        if kw_type == 'taxonomy':
+            is_species = True
         # Case-insensitive lookup
         if parent_id is None:
             existing = self.conn.execute(
@@ -3184,6 +3192,21 @@ class Database:
                     "UPDATE keywords SET is_species = 1, type = 'taxonomy' WHERE id = ? AND is_species = 0",
                     (existing["id"],),
                 )
+                if _commit:
+                    self.conn.commit()
+            # Upgrade an existing 'general' row to the explicitly requested type.
+            # Without this, callers like the "Not Wildlife" button would hit the
+            # case-insensitive fast path and silently get back a wrong-typed row.
+            if kw_type and kw_type != 'general':
+                self.conn.execute(
+                    "UPDATE keywords SET type = ? WHERE id = ? AND type = 'general'",
+                    (kw_type, existing["id"]),
+                )
+                if kw_type == 'taxonomy':
+                    self.conn.execute(
+                        "UPDATE keywords SET is_species = 1 WHERE id = ?",
+                        (existing["id"],),
+                    )
                 if _commit:
                     self.conn.commit()
             return existing["id"]

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -105,6 +105,7 @@ class Database:
         self.ensure_default_workspace()
         self.migrate_legacy_keyword_types()
         self.ensure_default_genre_keywords()
+        self.backfill_wildlife_genre()
         # Restore last-used workspace, or fall back to Default
         last = self.conn.execute(
             "SELECT id FROM workspaces ORDER BY CASE WHEN last_opened_at IS NULL THEN 0 ELSE 1 END DESC, last_opened_at DESC, id ASC LIMIT 1"
@@ -3401,8 +3402,62 @@ class Database:
             "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
             (photo_id, keyword_id),
         )
+        # If we just attached a taxonomy keyword AND this is the first
+        # taxonomy keyword on the photo, auto-add the Wildlife genre keyword.
+        # The "first species" check makes sticky-removal work: a user-removed
+        # Wildlife isn't re-added on subsequent species tags as long as at
+        # least one species remains.
+        self._maybe_apply_auto_wildlife(photo_id, keyword_id)
         if _commit:
             self.conn.commit()
+
+    def _maybe_apply_auto_wildlife(self, photo_id, just_added_keyword_id):
+        """If just_added_keyword_id is a taxonomy keyword AND it's the only
+        taxonomy keyword on this photo, also add the Wildlife genre."""
+        row = self.conn.execute(
+            "SELECT type FROM keywords WHERE id = ?",
+            (just_added_keyword_id,),
+        ).fetchone()
+        if not row or row["type"] != "taxonomy":
+            return
+        # Count taxonomy keywords on this photo. If > 1, this isn't the first
+        # — skip (sticky removal).
+        species_count = self.conn.execute(
+            """SELECT COUNT(*) AS n FROM photo_keywords pk
+               JOIN keywords k ON k.id = pk.keyword_id
+               WHERE pk.photo_id = ? AND k.type = 'taxonomy'""",
+            (photo_id,),
+        ).fetchone()["n"]
+        if species_count != 1:
+            return
+        wildlife_row = self.conn.execute(
+            "SELECT id FROM keywords WHERE name = 'Wildlife' AND type = 'genre' LIMIT 1"
+        ).fetchone()
+        if not wildlife_row:
+            return
+        self.conn.execute(
+            "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+            (photo_id, wildlife_row["id"]),
+        )
+
+    def backfill_wildlife_genre(self):
+        """One-shot backfill: every photo that has at least one taxonomy
+        keyword AND no Wildlife genre keyword gets Wildlife added. Idempotent."""
+        wildlife_row = self.conn.execute(
+            "SELECT id FROM keywords WHERE name = 'Wildlife' AND type = 'genre' LIMIT 1"
+        ).fetchone()
+        if not wildlife_row:
+            return  # No Wildlife keyword exists yet (very early init); nothing to do.
+        wildlife_id = wildlife_row["id"]
+        self.conn.execute(
+            """INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id)
+               SELECT DISTINCT pk.photo_id, ?
+               FROM photo_keywords pk
+               JOIN keywords k ON k.id = pk.keyword_id
+               WHERE k.type = 'taxonomy'""",
+            (wildlife_id,),
+        )
+        self.conn.commit()
 
     def untag_photo(self, photo_id, keyword_id, _commit=True):
         """Remove a keyword association from a photo.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1085,20 +1085,24 @@ class Database:
                      AND parent_id IS NULL AND type = 'general'""",
                 (name,),
             )
-        # Insert each default only if no top-level row with that name (any
-        # type, any case) exists. Cannot rely on INSERT OR IGNORE against
-        # UNIQUE(name, parent_id) here — SQLite treats NULL parent_id as
-        # distinct (per SQL standard), so a same-name top-level row would
-        # not actually block the insert and we'd silently produce
-        # duplicates that split add_keyword's case-insensitive lookup.
+        # Always guarantee a canonical genre row for each default. Skip
+        # only when a same-name + same-type ('genre') row already exists.
+        # If a user has previously tagged e.g. 'Landscape' as 'location'
+        # (a deliberate non-default type), we still create the genre
+        # 'Landscape' alongside it so the lightbox "Not Wildlife" flow
+        # (which tags with type='genre') has a canonical row to reuse.
+        # This intentionally permits duplicates BY NAME across different
+        # types — disambiguation is handled by add_keyword's lookup,
+        # which prefers same-typed matches when kw_type is supplied.
         for name in defaults:
-            existing_row = self.conn.execute(
+            existing_genre = self.conn.execute(
                 """SELECT id FROM keywords
-                   WHERE name = ? COLLATE NOCASE AND parent_id IS NULL
+                   WHERE name = ? COLLATE NOCASE
+                     AND parent_id IS NULL AND type = 'genre'
                    LIMIT 1""",
                 (name,),
             ).fetchone()
-            if existing_row:
+            if existing_genre:
                 continue
             self.conn.execute(
                 "INSERT INTO keywords (name, type, is_species) VALUES (?, 'genre', 0)",
@@ -3540,17 +3544,39 @@ class Database:
             )
         if kw_type == 'taxonomy':
             is_species = True
-        # Case-insensitive lookup
+        # Case-insensitive lookup. When kw_type is supplied, prefer a
+        # same-typed match — duplicates by name across different types are
+        # permitted (e.g. a user-tagged 'location' Landscape coexisting
+        # with a default 'genre' Landscape), and callers who explicitly
+        # ask for kw_type='genre' must deterministically get the genre
+        # row rather than an arbitrary same-name row of another type.
+        type_preference = "ORDER BY (type = ?) DESC, id ASC LIMIT 1"
         if parent_id is None:
-            existing = self.conn.execute(
-                "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE AND parent_id IS NULL",
-                (name,),
-            ).fetchone()
+            if kw_type is None:
+                existing = self.conn.execute(
+                    "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
+                    "AND parent_id IS NULL ORDER BY id ASC LIMIT 1",
+                    (name,),
+                ).fetchone()
+            else:
+                existing = self.conn.execute(
+                    f"SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
+                    f"AND parent_id IS NULL {type_preference}",
+                    (name, kw_type),
+                ).fetchone()
         else:
-            existing = self.conn.execute(
-                "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE AND parent_id = ?",
-                (name, parent_id),
-            ).fetchone()
+            if kw_type is None:
+                existing = self.conn.execute(
+                    "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
+                    "AND parent_id = ? ORDER BY id ASC LIMIT 1",
+                    (name, parent_id),
+                ).fetchone()
+            else:
+                existing = self.conn.execute(
+                    f"SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
+                    f"AND parent_id = ? {type_preference}",
+                    (name, parent_id, kw_type),
+                ).fetchone()
         if existing:
             # Promote an unset row to taxonomy when this call indicates a
             # species. Restrict to 'general' (the legacy default for unknown

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -214,6 +214,15 @@ class Database:
                 PRIMARY KEY (photo_id, keyword_id)
             );
 
+            -- Singleton key/value table for one-shot migration markers.
+            -- Used to gate non-idempotent backfills (where re-running would
+            -- overwrite user intent — e.g. Wildlife genre backfill that
+            -- would clobber sticky-removed Wildlife rows).
+            CREATE TABLE IF NOT EXISTS db_meta (
+                key   TEXT PRIMARY KEY,
+                value TEXT
+            );
+
             CREATE TABLE IF NOT EXISTS workspaces (
                 id              INTEGER PRIMARY KEY,
                 name            TEXT NOT NULL UNIQUE,
@@ -921,13 +930,37 @@ class Database:
         Idempotent: a single existing genre keyword (user-created or otherwise)
         short-circuits the insert. Keywords are global, so this runs once per
         database (not per workspace).
+
+        Upgrade path: if a same-name top-level keyword exists with type='general'
+        (legacy free-form tag with the same name as a default genre), promote
+        it to type='genre' rather than silently leaving it as 'general'. The
+        UNIQUE(name, parent_id) constraint would block INSERT OR IGNORE in
+        that case, leaving e.g. an existing 'Wildlife' general keyword to
+        defeat _maybe_apply_auto_wildlife and backfill_wildlife_genre. Other
+        explicit user types (individual, location) are preserved — the user
+        meant something specific.
         """
+        defaults = ("Landscape", "Sunset", "Architecture", "Abstract", "Wildlife")
+        # Warm-path short-circuit: if any genre row already exists, the
+        # database has already been seeded — nothing to do. Cheap (single
+        # SELECT 1 LIMIT 1).
         existing = self.conn.execute(
             "SELECT 1 FROM keywords WHERE type = 'genre' LIMIT 1"
         ).fetchone()
         if existing:
             return
-        for name in ("Landscape", "Sunset", "Architecture", "Abstract", "Wildlife"):
+        # Cold / upgrade path: promote any same-name top-level 'general'
+        # rows to 'genre' first, so an upgraded DB with a hand-tagged
+        # 'general' Wildlife (or other default name) ends up with a
+        # canonical genre row instead of being blocked by the
+        # UNIQUE(name, parent_id) constraint on the subsequent INSERT.
+        for name in defaults:
+            self.conn.execute(
+                """UPDATE keywords SET type = 'genre'
+                   WHERE name = ? AND parent_id IS NULL AND type = 'general'""",
+                (name,),
+            )
+        for name in defaults:
             self.conn.execute(
                 "INSERT OR IGNORE INTO keywords (name, type, is_species) VALUES (?, 'genre', 0)",
                 (name,),
@@ -3465,16 +3498,17 @@ class Database:
             _commit: If False, skip the internal commit (caller is responsible
                      for committing the transaction).
         """
-        self.conn.execute(
+        cur = self.conn.execute(
             "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
             (photo_id, keyword_id),
         )
-        # If we just attached a taxonomy keyword AND this is the first
-        # taxonomy keyword on the photo, auto-add the Wildlife genre keyword.
-        # The "first species" check makes sticky-removal work: a user-removed
-        # Wildlife isn't re-added on subsequent species tags as long as at
-        # least one species remains.
-        self._maybe_apply_auto_wildlife(photo_id, keyword_id)
+        # Only fire auto-Wildlife when we actually inserted a new association.
+        # A no-op INSERT OR IGNORE (re-tag of an already-tagged keyword) must
+        # not retrigger the rule — otherwise removing Wildlife and re-tagging
+        # the same species would silently re-add Wildlife and break sticky
+        # removal.
+        if cur.rowcount > 0:
+            self._maybe_apply_auto_wildlife(photo_id, keyword_id)
         if _commit:
             self.conn.commit()
 
@@ -3507,9 +3541,40 @@ class Database:
             (photo_id, wildlife_row["id"]),
         )
 
-    def backfill_wildlife_genre(self):
+    def get_meta(self, key):
+        """Return the db_meta value for `key`, or None if unset."""
+        row = self.conn.execute(
+            "SELECT value FROM db_meta WHERE key = ?", (key,)
+        ).fetchone()
+        return row["value"] if row else None
+
+    def set_meta(self, key, value, _commit=True):
+        """Upsert a db_meta row."""
+        self.conn.execute(
+            "INSERT INTO db_meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (key, str(value)),
+        )
+        if _commit:
+            self.conn.commit()
+
+    _WILDLIFE_BACKFILL_DONE_KEY = "wildlife_backfill_done"
+
+    def backfill_wildlife_genre(self, force=False):
         """One-shot backfill: every photo that has at least one taxonomy
-        keyword AND no Wildlife genre keyword gets Wildlife added. Idempotent."""
+        keyword AND no Wildlife genre keyword gets Wildlife added.
+
+        Gated by a db_meta marker so it runs at most once per database.
+        Re-running unconditionally would clobber sticky-removed Wildlife rows
+        (a user who intentionally removed Wildlife from a species-tagged
+        photo would see it re-added on the next app restart).
+
+        Args:
+            force: re-run even if the marker is set. Used by tests; not for
+                   normal startup.
+        """
+        if not force and self.get_meta(self._WILDLIFE_BACKFILL_DONE_KEY) == "1":
+            return
         wildlife_row = self.conn.execute(
             "SELECT id FROM keywords WHERE name = 'Wildlife' AND type = 'genre' LIMIT 1"
         ).fetchone()
@@ -3524,6 +3589,7 @@ class Database:
                WHERE k.type = 'taxonomy'""",
             (wildlife_id,),
         )
+        self.set_meta(self._WILDLIFE_BACKFILL_DONE_KEY, "1", _commit=False)
         self.conn.commit()
 
     def untag_photo(self, photo_id, keyword_id, _commit=True):
@@ -6043,12 +6109,15 @@ class Database:
 
     def migrate_default_subject_collection(self):
         """Rename legacy 'Needs Classification' (with rule has_species==0)
-        to 'Needs Identification' (rule has_subject==0). Skips collections
-        the user has customized. Idempotent."""
+        to 'Needs Identification' (rule has_subject==0) across ALL workspaces.
+
+        Workspace activation does not re-run startup migrations, so an
+        upgraded multi-workspace database would otherwise leave non-active
+        workspaces stuck on the legacy rule. Skips collections the user has
+        customized. Idempotent."""
         rows = self.conn.execute(
-            "SELECT id, rules FROM collections "
-            "WHERE workspace_id = ? AND name = ?",
-            (self._ws_id(), "Needs Classification"),
+            "SELECT id, workspace_id, rules FROM collections WHERE name = ?",
+            ("Needs Classification",),
         ).fetchall()
         legacy_rule = [{"field": "has_species", "op": "equals", "value": 0}]
         for row in rows:
@@ -6058,10 +6127,11 @@ class Database:
                 continue
             if current != legacy_rule:
                 continue
-            # Don't clobber an existing "Needs Identification"
+            # Don't clobber an existing "Needs Identification" in the SAME
+            # workspace (each workspace has its own default collections).
             existing = self.conn.execute(
                 "SELECT 1 FROM collections WHERE workspace_id = ? AND name = ?",
-                (self._ws_id(), "Needs Identification"),
+                (row["workspace_id"], "Needs Identification"),
             ).fetchone()
             if existing:
                 continue

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1913,6 +1913,9 @@ async function createWorkspace() {
     <button id="lightboxToggleBoxes" onclick="event.stopPropagation(); toggleLightboxBoxes();" style="background:rgba(0,0,0,0.6);color:var(--text-secondary);border:1px solid var(--text-faint);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;" title="Toggle detection boxes (b)">
       Hide Boxes
     </button>
+    <button id="lightboxNotWildlife" onclick="event.stopPropagation(); lightboxNotWildlife();" style="background:rgba(0,0,0,0.6);color:var(--warn);border:1px solid var(--warn);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;" title="Mark as Landscape — drops out of Needs Identification and stops the classifier">
+      Not Wildlife
+    </button>
     <button id="lightboxInat" onclick="" style="background:rgba(0,0,0,0.6);color:#74ac00;border:1px solid #74ac00;border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;">
       iNaturalist
     </button>
@@ -2481,6 +2484,27 @@ async function confirmDelete() {
   showToast(msg, 'success');
 
   if (savedCallback) savedCallback(data);
+}
+
+async function lightboxNotWildlife() {
+  if (!_lightboxCurrentId) return;
+  var currentId = _lightboxCurrentId;
+  try {
+    await safeFetch('/api/photos/' + currentId + '/keywords', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Landscape', type: 'genre' }),
+    }, { toast: false });
+    // Advance to next photo if more remain
+    var idx = _lightboxPhotoList.findIndex(function(x) { return x.id === currentId; });
+    if (idx >= 0 && _lightboxPhotoList.length > 1) {
+      var nextIdx = (idx + 1) % _lightboxPhotoList.length;
+      var next = _lightboxPhotoList[nextIdx];
+      openLightbox(next.id, next.filename, _lightboxPhotoList);
+    }
+  } catch (e) {
+    if (window.toast) window.toast('Tag failed: ' + (e && e.message ? e.message : 'unknown'), 'error');
+  }
 }
 
 function lightboxDelete() {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1286,7 +1286,7 @@ function renderKeywordTree(keywords) {
     byParent[pid].push(k);
   });
 
-  var treeTypeIcons = {general:'',taxonomy:'🌿',location:'📍',descriptive:'◆',people:'👤',event:'📅'};
+  var treeTypeIcons = {general:'',taxonomy:'🌿',individual:'👤',location:'📍',genre:'🎭'};
   function buildTree(parentId, depth) {
     var children = byParent[parentId] || [];
     var html = '';
@@ -2324,8 +2324,8 @@ function renderDetail(photo) {
   updateDetailColors();
 
   // Keywords
-  var kwTypeIcons = {general:'●', taxonomy:'🌿', location:'📍', descriptive:'◆', people:'👤', event:'📅'};
-  var kwTypeLabels = {general:'General', taxonomy:'Taxonomy', location:'Location', descriptive:'Descriptive', people:'People', event:'Event'};
+  var kwTypeIcons = {general:'●', taxonomy:'🌿', individual:'👤', location:'📍', genre:'🎭'};
+  var kwTypeLabels = {general:'General', taxonomy:'Taxonomy', individual:'Individual', location:'Location', genre:'Genre'};
   var kwHtml = '';
   (photo.keywords || []).forEach(function(k) {
     var ktype = k.type || 'general';

--- a/vireo/templates/keywords.html
+++ b/vireo/templates/keywords.html
@@ -114,10 +114,9 @@
 
   .kw-type-badge.type-general { background: rgba(176,204,204,0.1); color: var(--text-secondary); }
   .kw-type-badge.type-taxonomy { background: rgba(36,229,202,0.15); color: var(--accent); }
+  .kw-type-badge.type-individual { background: rgba(241,196,15,0.15); color: #f1c40f; }
   .kw-type-badge.type-location { background: rgba(52,152,219,0.15); color: #3498db; }
-  .kw-type-badge.type-descriptive { background: rgba(155,89,182,0.15); color: #9b59b6; }
-  .kw-type-badge.type-people { background: rgba(241,196,15,0.15); color: #f1c40f; }
-  .kw-type-badge.type-event { background: rgba(230,126,34,0.15); color: #e67e22; }
+  .kw-type-badge.type-genre { background: rgba(155,89,182,0.15); color: #9b59b6; }
 
   /* Type dropdown (floating) */
   .kw-type-dropdown {
@@ -161,10 +160,9 @@
       <button class="kw-filter-btn active" data-type="all">All</button>
       <button class="kw-filter-btn" data-type="general">General</button>
       <button class="kw-filter-btn" data-type="taxonomy">Taxonomy</button>
+      <button class="kw-filter-btn" data-type="individual">Individual</button>
       <button class="kw-filter-btn" data-type="location">Location</button>
-      <button class="kw-filter-btn" data-type="descriptive">Descriptive</button>
-      <button class="kw-filter-btn" data-type="people">People</button>
-      <button class="kw-filter-btn" data-type="event">Event</button>
+      <button class="kw-filter-btn" data-type="genre">Genre</button>
       <span class="kw-stats" id="kwStats">Loading...</span>
     </div>
 
@@ -175,10 +173,9 @@
         <option value="">Set type...</option>
         <option value="general">General</option>
         <option value="taxonomy">Taxonomy</option>
+        <option value="individual">Individual</option>
         <option value="location">Location</option>
-        <option value="descriptive">Descriptive</option>
-        <option value="people">People</option>
-        <option value="event">Event</option>
+        <option value="genre">Genre</option>
       </select>
       <button class="kw-bulk-btn" id="kwBulkApply">Apply</button>
       <span style="flex:1"></span>
@@ -209,8 +206,8 @@
 
 <script>
 (function() {
-  const TYPE_ICONS = {general:'\u25CF', taxonomy:'\uD83C\uDF3F', location:'\uD83D\uDCCD', descriptive:'\u25C6', people:'\uD83D\uDC64', event:'\uD83D\uDCC5'};
-  const TYPES = ['general','taxonomy','location','descriptive','people','event'];
+  const TYPE_ICONS = {general:'\u25CF', taxonomy:'\uD83C\uDF3F', individual:'\uD83D\uDC64', location:'\uD83D\uDCCD', genre:'\uD83C\uDFAD'};
+  const TYPES = ['general','taxonomy','individual','location','genre'];
 
   let allKeywords = [];
   let sortCol = 'name';

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -782,7 +782,7 @@ body { padding-bottom: 36px; }
         </div>
       </div>
       <div class="readiness-panel" id="readinessPanel" style="display:none;"></div>
-      <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;">
+      <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;" title="Re-process photos that were already classified. Also bypasses the skip for photos already tagged with a subject keyword (taxonomy, individual, or genre) — useful for double-checking existing tags.">
         <input type="checkbox" id="chkReclassify" style="accent-color:var(--accent);"> Re-classify
       </label>
       <div style="margin-top:8px;">

--- a/vireo/templates/workspace.html
+++ b/vireo/templates/workspace.html
@@ -35,6 +35,23 @@
     </div>
   </div>
 
+  <!-- Subject Types -->
+  <div class="section">
+    <div class="section-title">What counts as identified?</div>
+    <div style="font-size:12px;color:var(--text-secondary);margin-bottom:10px;">
+      Photos with at least one keyword of these types drop out of "Needs Identification" and are skipped by the classifier.
+    </div>
+    <div id="subjectTypesContent" style="display:flex;flex-wrap:wrap;gap:14px;align-items:center;">
+      <label style="font-size:13px;cursor:pointer;"><input type="checkbox" data-subject-type="taxonomy" style="accent-color:var(--accent);margin-right:4px;">Taxonomy <span style="color:var(--text-dim);font-size:11px;">(species)</span></label>
+      <label style="font-size:13px;cursor:pointer;"><input type="checkbox" data-subject-type="individual" style="accent-color:var(--accent);margin-right:4px;">Individual <span style="color:var(--text-dim);font-size:11px;">(people, pets)</span></label>
+      <label style="font-size:13px;cursor:pointer;"><input type="checkbox" data-subject-type="location" style="accent-color:var(--accent);margin-right:4px;">Location</label>
+      <label style="font-size:13px;cursor:pointer;"><input type="checkbox" data-subject-type="genre" style="accent-color:var(--accent);margin-right:4px;">Genre <span style="color:var(--text-dim);font-size:11px;">(landscape, sunset, …)</span></label>
+      <label style="font-size:13px;cursor:pointer;"><input type="checkbox" data-subject-type="general" style="accent-color:var(--accent);margin-right:4px;">General</label>
+      <button id="saveSubjectTypesBtn" style="background:var(--accent);color:var(--accent-text);border:none;border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;font-weight:500;">Save</button>
+      <span id="subjectTypesStatus" style="font-size:12px;color:var(--text-dim);"></span>
+    </div>
+  </div>
+
   <!-- Recent Jobs -->
   <div class="section">
     <div class="section-title">Recent Jobs</div>
@@ -80,6 +97,44 @@
 loadWsFolders();
 loadHistory();
 loadWorkspaces();
+loadSubjectTypes();
+
+/* ---------- Subject Types ---------- */
+const SUBJECT_TYPES_DEFAULT = ['taxonomy', 'individual', 'genre'];
+
+async function loadSubjectTypes() {
+  try {
+    var overrides = await safeFetch('/api/workspaces/active/config', {}, { toast: false });
+    var current = (overrides && Array.isArray(overrides.subject_types))
+      ? overrides.subject_types
+      : SUBJECT_TYPES_DEFAULT;
+    document.querySelectorAll('input[data-subject-type]').forEach(function(cb) {
+      cb.checked = current.indexOf(cb.dataset.subjectType) !== -1;
+    });
+  } catch (e) {
+    /* leave checkboxes unchecked on error; user can save to set */
+  }
+}
+
+document.getElementById('saveSubjectTypesBtn').addEventListener('click', async function() {
+  var types = Array.from(document.querySelectorAll('input[data-subject-type]'))
+    .filter(function(cb) { return cb.checked; })
+    .map(function(cb) { return cb.dataset.subjectType; });
+  var status = document.getElementById('subjectTypesStatus');
+  status.textContent = 'Saving...';
+  try {
+    var ws = await safeFetch('/api/workspaces/active', {}, { toast: false });
+    await safeFetch('/api/workspaces/' + ws.id + '/subject-types', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ types: types }),
+    });
+    status.textContent = 'Saved.';
+    setTimeout(function() { status.textContent = ''; }, 2000);
+  } catch (e) {
+    status.textContent = 'Save failed: ' + (e && e.message ? e.message : 'unknown');
+  }
+});
 
 /* Set workspace name in page heading */
 safeFetch('/api/workspaces/active', {}, { toast: false }).then(function(ws) {

--- a/vireo/templates/workspace.html
+++ b/vireo/templates/workspace.html
@@ -100,14 +100,14 @@ loadWorkspaces();
 loadSubjectTypes();
 
 /* ---------- Subject Types ---------- */
-const SUBJECT_TYPES_DEFAULT = ['taxonomy', 'individual', 'genre'];
-
 async function loadSubjectTypes() {
+  // Read the effective subject_types (global defaults merged with workspace
+  // overrides) so checkboxes match the actual current behavior. Reading
+  // overrides-only with a hardcoded fallback would lie when the user has
+  // customized only the global config.
   try {
-    var overrides = await safeFetch('/api/workspaces/active/config', {}, { toast: false });
-    var current = (overrides && Array.isArray(overrides.subject_types))
-      ? overrides.subject_types
-      : SUBJECT_TYPES_DEFAULT;
+    var resp = await safeFetch('/api/workspaces/active/subject-types', {}, { toast: false });
+    var current = (resp && Array.isArray(resp.types)) ? resp.types : [];
     document.querySelectorAll('input[data-subject-type]').forEach(function(cb) {
       cb.checked = current.indexOf(cb.dataset.subjectType) !== -1;
     });

--- a/vireo/testing/userfirst/scenarios/keywords.py
+++ b/vireo/testing/userfirst/scenarios/keywords.py
@@ -17,11 +17,11 @@ def run(session):
     has_search = session.eval("!!document.getElementById('kwSearch')")
     session.assert_that(has_search, "expected keyword search input")
 
-    # Filter pills should exist: All, General, Taxonomy, Location, Descriptive, People, Event
+    # Filter pills should exist: All, General, Taxonomy, Individual, Location, Genre
     filter_btns = session.eval(
         "Array.from(document.querySelectorAll('.kw-filter-btn')).map(b => b.dataset.type)"
     )
-    expected_types = ["all", "general", "taxonomy", "location", "descriptive", "people", "event"]
+    expected_types = ["all", "general", "taxonomy", "individual", "location", "genre"]
     for t in expected_types:
         session.assert_that(
             t in filter_btns,

--- a/vireo/tests/conftest.py
+++ b/vireo/tests/conftest.py
@@ -11,7 +11,9 @@ from PIL import Image
 @pytest.fixture
 def db(tmp_path):
     """Return a Database backed by a temp file."""
-    return Database(str(tmp_path / "test.db"))
+    d = Database(str(tmp_path / "test.db"))
+    yield d
+    d.close()
 
 
 @pytest.fixture
@@ -64,7 +66,8 @@ def app_and_db(tmp_path, monkeypatch):
         Image.new('RGB', (100, 100)).save(os.path.join(thumb_dir, f"{pid}.jpg"))
 
     app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="test-token-123")
-    return app, db
+    yield app, db
+    db.close()
 
 
 @pytest.fixture
@@ -111,4 +114,5 @@ def client_with_photo(tmp_path, monkeypatch):
     )
 
     app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir), api_token="test-token-123")
-    return app, db, pid
+    yield app, db, pid
+    db.close()

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2312,6 +2312,32 @@ def test_put_subject_types_drops_non_string_entries(app_and_db):
     assert set(body["types"]) == {"taxonomy", "genre"}
 
 
+def test_put_subject_types_normalizes_non_dict_config_overrides(app_and_db):
+    """Regression: PUT /api/workspaces/<id>/subject-types must not 500 when
+    `config_overrides` was previously persisted as a non-dict JSON value.
+    The column is arbitrary JSON (api_update_workspace stores whatever the
+    client sends), so a list/string/number can sit there from a prior PUT.
+    The endpoint must coerce it back to {} before assigning subject_types."""
+    app, db = app_and_db
+    ws_id = db.create_workspace("ws-subject-non-dict")
+    # Plant a list-shaped config_overrides directly via update_workspace,
+    # which json.dumps()es whatever it receives.
+    db.update_workspace(ws_id, config_overrides=["unexpected", "list"])
+    client = app.test_client()
+    resp = client.put(
+        f"/api/workspaces/{ws_id}/subject-types",
+        json={"types": ["taxonomy"]},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, (
+        f"Non-dict config_overrides must be normalized, not crash: "
+        f"{resp.status_code} {resp.get_data(as_text=True)}"
+    )
+    overrides = _read_workspace_overrides(db, ws_id)
+    assert isinstance(overrides, dict)
+    assert overrides.get("subject_types") == ["taxonomy"]
+
+
 def test_add_keyword_route_handles_non_string_type(app_and_db):
     """Regression: POST /api/photos/<id>/keywords with a non-string `type`
     JSON value must not 500 — the bad value should be ignored and the

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2293,6 +2293,74 @@ def test_get_active_subject_types_returns_effective_config(app_and_db, tmp_path,
     )
 
 
+def test_put_subject_types_drops_non_string_entries(app_and_db):
+    """Regression: non-string JSON entries (e.g. nested lists/objects) must
+    be dropped, not crash with TypeError on `x in frozenset`."""
+    app, db = app_and_db
+    ws_id = db.create_workspace("ws-subject-malformed")
+    client = app.test_client()
+    resp = client.put(
+        f"/api/workspaces/{ws_id}/subject-types",
+        json={"types": ["taxonomy", ["nested"], {"obj": 1}, 42, None, "genre"]},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, (
+        f"Expected non-string entries to be dropped, got {resp.status_code}: "
+        f"{resp.get_data(as_text=True)}"
+    )
+    body = resp.get_json()
+    assert set(body["types"]) == {"taxonomy", "genre"}
+
+
+def test_add_keyword_route_handles_non_string_type(app_and_db):
+    """Regression: POST /api/photos/<id>/keywords with a non-string `type`
+    JSON value must not 500 — the bad value should be ignored and the
+    keyword still created with its default type."""
+    app, db = app_and_db
+    folder_id = db.add_folder("/tmp/p")
+    db.add_workspace_folder(db._active_workspace_id, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "p.jpg", extension=".jpg", file_size=1, file_mtime=1.0,
+    )
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{photo_id}/keywords",
+        json={"name": "MaybeWildlife", "type": []},  # bogus list value
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, (
+        f"Non-string type must not 500 the route: "
+        f"{resp.status_code} {resp.get_data(as_text=True)}"
+    )
+    # The keyword should exist; its type wasn't overridden by the bad value.
+    row = db.conn.execute(
+        "SELECT type FROM keywords WHERE name = 'MaybeWildlife'"
+    ).fetchone()
+    assert row is not None
+    # add_keyword's auto-detect runs in the absence of a valid override.
+    # Anything other than a crash is acceptable here; the point is no 500.
+
+
+def test_batch_keyword_route_handles_non_string_type(app_and_db):
+    """Same regression for the batch endpoint."""
+    app, db = app_and_db
+    folder_id = db.add_folder("/tmp/q")
+    db.add_workspace_folder(db._active_workspace_id, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "q.jpg", extension=".jpg", file_size=1, file_mtime=1.0,
+    )
+    client = app.test_client()
+    resp = client.post(
+        "/api/batch/keyword",
+        json={"photo_ids": [photo_id], "name": "BatchTag", "type": {"x": 1}},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, (
+        f"Non-string type must not 500 the batch route: "
+        f"{resp.status_code} {resp.get_data(as_text=True)}"
+    )
+
+
 def test_get_active_subject_types_workspace_override_wins(app_and_db, tmp_path, monkeypatch):
     """When a workspace override is set, it overrides the global default."""
     import config as cfg

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2387,6 +2387,37 @@ def test_batch_keyword_route_handles_non_string_type(app_and_db):
     )
 
 
+def test_add_keyword_route_does_not_clobber_existing_individual_type(app_and_db):
+    """Regression: POST /api/photos/<id>/keywords with type='taxonomy' for a
+    keyword that already exists as 'individual' must not silently rewrite
+    the existing row's type. add_keyword's reconciliation logic (only
+    upgrades 'general') must run instead of a force-UPDATE."""
+    app, db = app_and_db
+    folder_id = db.add_folder("/tmp/p")
+    db.add_workspace_folder(db._active_workspace_id, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "p.jpg", extension=".jpg", file_size=1, file_mtime=1.0,
+    )
+    # Pre-create an 'individual' keyword named "Charlie" (e.g. user's pet).
+    existing_kid = db.add_keyword("Charlie", kw_type="individual")
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{photo_id}/keywords",
+        json={"name": "Charlie", "type": "taxonomy"},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    # The existing row's type must remain 'individual' (not silently
+    # rewritten to 'taxonomy' by a force-UPDATE).
+    row = db.conn.execute(
+        "SELECT type FROM keywords WHERE id = ?", (existing_kid,),
+    ).fetchone()
+    assert row["type"] == "individual", (
+        f"Force-UPDATE silently rewrote a user-typed keyword. "
+        f"Expected type='individual', got {row['type']!r}"
+    )
+
+
 def test_get_active_subject_types_workspace_override_wins(app_and_db, tmp_path, monkeypatch):
     """When a workspace override is set, it overrides the global default."""
     import config as cfg

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1746,12 +1746,12 @@ def test_update_keyword_type(app_and_db):
     app, db = app_and_db
     client = app.test_client()
     kid = db.add_keyword("Tim")
-    resp = client.put(f"/api/keywords/{kid}", json={"type": "people"})
+    resp = client.put(f"/api/keywords/{kid}", json={"type": "individual"})
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["ok"] is True
     row = db.conn.execute("SELECT type FROM keywords WHERE id = ?", (kid,)).fetchone()
-    assert row["type"] == "people"
+    assert row["type"] == "individual"
 
 
 def test_update_keyword_type_invalid(app_and_db):
@@ -2197,14 +2197,14 @@ def test_put_subject_types_persists_valid_values(app_and_db):
     client = app.test_client()
     resp = client.put(
         f"/api/workspaces/{ws_id}/subject-types",
-        json={"types": ["taxonomy", "scene"]},
+        json={"types": ["taxonomy", "genre"]},
         content_type="application/json",
     )
     assert resp.status_code == 200
     body = resp.get_json()
-    assert set(body["types"]) == {"taxonomy", "scene"}
+    assert set(body["types"]) == {"taxonomy", "genre"}
     overrides = _read_workspace_overrides(db, ws_id)
-    assert set(overrides.get("subject_types", [])) == {"taxonomy", "scene"}
+    assert set(overrides.get("subject_types", [])) == {"taxonomy", "genre"}
 
 
 def test_put_subject_types_drops_unknown_values(app_and_db):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2271,6 +2271,44 @@ def test_put_subject_types_preserves_other_overrides(app_and_db):
     assert overrides.get("classification_threshold") == 0.42
 
 
+def test_get_active_subject_types_returns_effective_config(app_and_db, tmp_path, monkeypatch):
+    """Regression: GET /api/workspaces/active/subject-types returns the
+    EFFECTIVE config (global merged with workspace overrides), not just
+    the override JSON. The settings UI needs this so checkboxes match
+    actual behavior even when only the global config has been customized."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "global-config.json"))
+    # Customize ONLY the global config (no workspace override). The
+    # endpoint must return ["taxonomy"], not the hardcoded default
+    # ["taxonomy", "individual", "genre"].
+    cfg.set("subject_types", ["taxonomy"])
+    app, db = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/workspaces/active/subject-types")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["types"] == ["taxonomy"], (
+        "Endpoint must merge global config — workspace settings UI would "
+        "otherwise render wrong checkbox state when only global is set."
+    )
+
+
+def test_get_active_subject_types_workspace_override_wins(app_and_db, tmp_path, monkeypatch):
+    """When a workspace override is set, it overrides the global default."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "global-config.json"))
+    cfg.set("subject_types", ["taxonomy"])  # global = wildlife only
+    app, db = app_and_db
+    # Override the active workspace to include genre too
+    ws_id = db._active_workspace_id
+    db.update_workspace(ws_id, config_overrides={"subject_types": ["taxonomy", "genre"]})
+    client = app.test_client()
+    resp = client.get("/api/workspaces/active/subject-types")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body["types"]) == {"taxonomy", "genre"}
+
+
 def test_workspace_page_no_scan_button(app_and_db):
     """Workspace page should not have a Scan & Add button — folders are added via Pipeline."""
     app, _ = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2387,6 +2387,64 @@ def test_batch_keyword_route_handles_non_string_type(app_and_db):
     )
 
 
+def test_create_app_runs_wildlife_backfill_synchronously_on_first_boot(tmp_path, monkeypatch):
+    """Regression: on first boot after upgrade (wildlife_backfill_done
+    marker unset), create_app must complete the species-marking +
+    Wildlife-backfill pipeline synchronously before returning, so user
+    edits via the served HTTP API can't race with the one-shot backfill
+    overwriting their Wildlife removals."""
+    from unittest.mock import MagicMock, patch
+
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    import models
+    from app import create_app
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+
+    # Pre-create the DB with the marker UNSET (simulates first boot
+    # post-upgrade).
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    assert db.get_meta(Database._WILDLIFE_BACKFILL_DONE_KEY) != "1", (
+        "Pre-condition: marker should be unset before create_app"
+    )
+    db.close()
+
+    # Stub taxonomy loading to return a non-None object so the sync path
+    # runs mark_species + backfill. mark_species_keywords gets a real DB
+    # call but the stub taxonomy returns None for every lookup, so no
+    # rows are actually changed — we just need it to complete without
+    # raising so the marker gets set.
+    fake_tax = MagicMock()
+    fake_tax.lookup.return_value = None
+
+    with patch("taxonomy.load_local_taxonomy", return_value=fake_tax):
+        app = create_app(
+            db_path=db_path, thumb_cache_dir=thumb_dir, api_token="test",
+        )
+        assert app is not None
+
+    # After create_app returns, the marker MUST be set — the synchronous
+    # path ran. (If it had been async, we'd be racing the background
+    # thread here and the marker might or might not be set yet.)
+    db2 = Database(db_path)
+    assert db2.get_meta(Database._WILDLIFE_BACKFILL_DONE_KEY) == "1", (
+        "Wildlife backfill marker must be set synchronously by create_app "
+        "on first boot — otherwise user edits race the backfill."
+    )
+    db2.close()
+
+
 def test_add_keyword_route_does_not_clobber_existing_individual_type(app_and_db):
     """Regression: POST /api/photos/<id>/keywords with type='taxonomy' for a
     keyword that already exists as 'individual' must not silently rewrite

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2180,6 +2180,97 @@ def test_nav_order_rejects_non_list(app_and_db):
     assert resp.status_code == 400
 
 
+def _read_workspace_overrides(db, ws_id):
+    """Helper: read and JSON-decode the config_overrides column for ws_id."""
+    import json
+    ws = db.get_workspace(ws_id)
+    raw = ws["config_overrides"] if ws else None
+    if not raw:
+        return {}
+    return json.loads(raw) if isinstance(raw, str) else raw
+
+
+def test_put_subject_types_persists_valid_values(app_and_db):
+    """PUT /api/workspaces/<id>/subject-types persists requested types."""
+    app, db = app_and_db
+    ws_id = db.create_workspace("ws-subject-1")
+    client = app.test_client()
+    resp = client.put(
+        f"/api/workspaces/{ws_id}/subject-types",
+        json={"types": ["taxonomy", "scene"]},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body["types"]) == {"taxonomy", "scene"}
+    overrides = _read_workspace_overrides(db, ws_id)
+    assert set(overrides.get("subject_types", [])) == {"taxonomy", "scene"}
+
+
+def test_put_subject_types_drops_unknown_values(app_and_db):
+    """Unknown type values are dropped silently (logged)."""
+    app, db = app_and_db
+    ws_id = db.create_workspace("ws-subject-2")
+    client = app.test_client()
+    resp = client.put(
+        f"/api/workspaces/{ws_id}/subject-types",
+        json={"types": ["taxonomy", "bogus"]},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["types"] == ["taxonomy"]
+    overrides = _read_workspace_overrides(db, ws_id)
+    assert overrides.get("subject_types") == ["taxonomy"]
+
+
+def test_put_subject_types_empty_list_allowed(app_and_db):
+    """Empty list is allowed (effectively disables the queue's filter)."""
+    app, db = app_and_db
+    ws_id = db.create_workspace("ws-subject-3")
+    client = app.test_client()
+    resp = client.put(
+        f"/api/workspaces/{ws_id}/subject-types",
+        json={"types": []},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["types"] == []
+    overrides = _read_workspace_overrides(db, ws_id)
+    assert overrides.get("subject_types") == []
+
+
+def test_put_subject_types_rejects_non_list(app_and_db):
+    """Non-list 'types' value returns 400."""
+    app, db = app_and_db
+    ws_id = db.create_workspace("ws-subject-4")
+    client = app.test_client()
+    resp = client.put(
+        f"/api/workspaces/{ws_id}/subject-types",
+        json={"types": "not-a-list"},
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+def test_put_subject_types_preserves_other_overrides(app_and_db):
+    """Setting subject_types must not clobber other config_overrides keys."""
+    app, db = app_and_db
+    ws_id = db.create_workspace("ws-subject-5")
+    db.update_workspace(ws_id, config_overrides={"classification_threshold": 0.42})
+    client = app.test_client()
+    resp = client.put(
+        f"/api/workspaces/{ws_id}/subject-types",
+        json={"types": ["taxonomy"]},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    overrides = _read_workspace_overrides(db, ws_id)
+    assert overrides.get("subject_types") == ["taxonomy"]
+    assert overrides.get("classification_threshold") == 0.42
+
+
 def test_workspace_page_no_scan_button(app_and_db):
     """Workspace page should not have a Scan & Add button — folders are added via Pipeline."""
     app, _ = app_and_db

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1888,7 +1888,7 @@ def test_classify_job_skips_photos_with_subject_keywords(tmp_path):
     ]
     assert progress_events, "Expected a progress event with skipped_subject"
     assert progress_events[0]["skipped_subject"] == 1
-    assert progress_events[0]["phase"] == "Step 2/5: Loading photos"
+    assert progress_events[0]["phase"] == "Step 1/5: Loading photos"
 
 
 def test_classify_job_reclassify_true_bypasses_subject_skip(tmp_path):
@@ -1985,6 +1985,59 @@ def test_classify_job_short_circuits_when_all_photos_skipped(tmp_path):
         "Classifier was initialized despite zero photos to process. "
         "The early-return short-circuit was not taken."
     )
+    assert result["total"] == 0
+    assert result["predictions_stored"] == 0
+
+
+def test_classify_job_zero_photos_skips_model_resolution(tmp_path):
+    """Regression: when the subject-skip filter empties the photo set, the
+    job must short-circuit BEFORE model resolution. Otherwise a user with no
+    classifier downloaded would get a misleading 'No model available' error
+    for a job that has zero work to do."""
+    from unittest.mock import patch
+
+    from classify_job import ClassifyParams, run_classify_job
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+    db.add_workspace_folder(ws, folder_id)
+    p1 = db.add_photo(
+        folder_id, "p1.jpg", extension=".jpg", file_size=100, file_mtime=1.0,
+    )
+    # Tag with a genre keyword so the subject-skip gate filters it out.
+    scene_kid = db.add_keyword("Landscape", kw_type="genre")
+    db.tag_photo(p1, scene_kid)
+    col_id = db.add_collection(
+        "static-only-tagged",
+        json.dumps([{"field": "photo_ids", "value": [p1]}]),
+    )
+    db.conn.close()
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    params = ClassifyParams(
+        collection_id=col_id,
+        labels_file=None,
+        labels_files=None,
+        model_id=None,
+        model_name="TestModel",
+        grouping_window=10,
+        similarity_threshold=0.85,
+        reclassify=False,
+    )
+
+    # Simulate the "no model downloaded" environment: get_active_model
+    # returns None (which would normally raise RuntimeError downstream).
+    # The short-circuit must execute first and avoid touching the model.
+    with patch("classify_job.get_active_model", return_value=None), \
+         patch("classify_job.get_models", return_value=[]):
+        result = run_classify_job(job, runner, db_path, ws, params)
+
     assert result["total"] == 0
     assert result["predictions_stored"] == 0
 

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1913,6 +1913,82 @@ def test_classify_job_reclassify_true_bypasses_subject_skip(tmp_path):
     )
 
 
+def test_classify_job_short_circuits_when_all_photos_skipped(tmp_path):
+    """Regression: when the subject-skip filter empties the photo set, the
+    job must short-circuit before model load. Loading a model is expensive
+    and can fail; doing it for zero photos undermines the skip behavior."""
+    from unittest.mock import patch
+
+    from classify_job import ClassifyParams, run_classify_job
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+    db.add_workspace_folder(ws, folder_id)
+    p1 = db.add_photo(
+        folder_id, "p1.jpg", extension=".jpg", file_size=100, file_mtime=1.0,
+    )
+    # Tag p1 with a genre keyword so the skip-gate filters it out.
+    scene_kid = db.add_keyword("Landscape", kw_type="genre")
+    db.tag_photo(p1, scene_kid)
+    col_id = db.add_collection(
+        "static-only-tagged",
+        json.dumps([{"field": "photo_ids", "value": [p1]}]),
+    )
+    db.conn.close()
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    fake_model = {
+        "id": "test-model",
+        "name": "TestModel",
+        "model_str": "hf-hub:imageomics/bioclip",
+        "weights_path": "/tmp/weights.bin",
+        "model_type": "bioclip",
+        "downloaded": True,
+    }
+
+    classifier_init_calls = []
+
+    def _record_classifier_init(*args, **kwargs):
+        classifier_init_calls.append((args, kwargs))
+        raise AssertionError(
+            "Classifier should NOT be initialized when no photos remain "
+            "after subject-skip filtering."
+        )
+
+    params = ClassifyParams(
+        collection_id=col_id,
+        labels_file=None,
+        labels_files=None,
+        model_id=None,
+        model_name="TestModel",
+        grouping_window=10,
+        similarity_threshold=0.85,
+        reclassify=False,
+    )
+
+    with patch("classify_job.get_active_model", return_value=fake_model), \
+         patch("classify_job.get_models", return_value=[fake_model]), \
+         patch("classify_job._load_taxonomy", return_value=None), \
+         patch(
+            "classify_job._load_labels", return_value=(["Northern Cardinal"], False),
+         ), \
+         patch("classify_job.Classifier", side_effect=_record_classifier_init):
+        result = run_classify_job(job, runner, db_path, ws, params)
+
+    assert classifier_init_calls == [], (
+        "Classifier was initialized despite zero photos to process. "
+        "The early-return short-circuit was not taken."
+    )
+    assert result["total"] == 0
+    assert result["predictions_stored"] == 0
+
+
 def test_run_classifier_retries_on_database_is_locked(tmp_path):
     """Per-detection prediction commit must retry transient 'database is locked'.
 

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1783,7 +1783,7 @@ def test_prepare_image_no_vireo_dir_uses_original(tmp_path):
 
 def _setup_two_photo_classify_workspace(tmp_path):
     """Create a real DB with two photos in a static collection.
-    p1 is tagged with a 'scene' keyword (Landscape); p2 is untagged.
+    p1 is tagged with a 'genre' keyword (Landscape); p2 is untagged.
     Returns (db_path, ws_id, col_id, p1, p2)."""
     from db import Database
 
@@ -1801,8 +1801,8 @@ def _setup_two_photo_classify_workspace(tmp_path):
         folder_id, "p2.jpg", extension=".jpg", file_size=100, file_mtime=2.0,
     )
 
-    # Tag p1 with a scene keyword so it should be filtered out by the skip-gate.
-    scene_kid = db.add_keyword("Landscape", kw_type="scene")
+    # Tag p1 with a genre keyword so it should be filtered out by the skip-gate.
+    scene_kid = db.add_keyword("Landscape", kw_type="genre")
     db.tag_photo(p1, scene_kid)
 
     col_id = db.add_collection(
@@ -1869,7 +1869,7 @@ def test_classify_job_skips_photos_with_subject_keywords(tmp_path):
 
     Verified by capturing the photo IDs passed into the (stubbed)
     _detect_subjects step. Only p2 (untagged) should reach detection;
-    p1 (tagged 'Landscape', type='scene') is skipped at the load step.
+    p1 (tagged 'Landscape', type='genre') is skipped at the load step.
     """
     db_path, ws, col_id, p1, p2 = _setup_two_photo_classify_workspace(tmp_path)
 

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1560,6 +1560,11 @@ def test_run_classify_job_full_pipeline(tmp_path):
     ]
     mock_db_instance.get_existing_prediction_photo_ids.return_value = set()
     mock_db_instance.get_photo_embedding.return_value = None
+    # Subject-skip gate: with no subject types configured the gate is a no-op.
+    mock_db_instance.get_subject_types.return_value = set()
+    mock_db_instance.filter_out_subject_tagged.side_effect = (
+        lambda pids, _types: list(pids)
+    )
 
     fake_model = {
         "id": "test-model",
@@ -1771,3 +1776,138 @@ def test_prepare_image_no_vireo_dir_uses_original(tmp_path):
     )
 
     assert img is not None
+
+
+# ── Task 9: Subject-tagged skip-gate ──────────────────────────────────────────
+
+
+def _setup_two_photo_classify_workspace(tmp_path):
+    """Create a real DB with two photos in a static collection.
+    p1 is tagged with a 'scene' keyword (Landscape); p2 is untagged.
+    Returns (db_path, ws_id, col_id, p1, p2)."""
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+    db.add_workspace_folder(ws, folder_id)
+    p1 = db.add_photo(
+        folder_id, "p1.jpg", extension=".jpg", file_size=100, file_mtime=1.0,
+    )
+    p2 = db.add_photo(
+        folder_id, "p2.jpg", extension=".jpg", file_size=100, file_mtime=2.0,
+    )
+
+    # Tag p1 with a scene keyword so it should be filtered out by the skip-gate.
+    scene_kid = db.add_keyword("Landscape", kw_type="scene")
+    db.tag_photo(p1, scene_kid)
+
+    col_id = db.add_collection(
+        "static",
+        json.dumps([{"field": "photo_ids", "value": [p1, p2]}]),
+    )
+    db.conn.close()
+    return db_path, ws, col_id, p1, p2
+
+
+def _run_classify_capturing_photos(db_path, ws, col_id, reclassify):
+    """Run run_classify_job with all heavy dependencies stubbed and return
+    the list of photo IDs that flowed into _detect_subjects + the events
+    pushed by the runner."""
+    from unittest.mock import patch
+
+    from classify_job import ClassifyParams, run_classify_job
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    fake_model = {
+        "id": "test-model",
+        "name": "TestModel",
+        "model_str": "hf-hub:imageomics/bioclip",
+        "weights_path": "/tmp/weights.bin",
+        "model_type": "bioclip",
+        "downloaded": True,
+    }
+
+    captured_photos = []
+
+    def _fake_detect_subjects(photos, folders, runner, job, reclassify, db):
+        captured_photos.extend([p["id"] for p in photos])
+        return ({}, 0)
+
+    params = ClassifyParams(
+        collection_id=col_id,
+        labels_file=None,
+        labels_files=None,
+        model_id=None,
+        model_name="TestModel",
+        grouping_window=10,
+        similarity_threshold=0.85,
+        reclassify=reclassify,
+    )
+
+    with patch("classify_job.get_active_model", return_value=fake_model), \
+         patch("classify_job.get_models", return_value=[fake_model]), \
+         patch("classify_job._load_taxonomy", return_value=None), \
+         patch(
+            "classify_job._load_labels", return_value=(["Northern Cardinal"], False),
+         ), \
+         patch("classify_job.Classifier"), \
+         patch("classify_job._detect_subjects", side_effect=_fake_detect_subjects):
+        result = run_classify_job(job, runner, db_path, ws, params)
+
+    return captured_photos, runner.events, result
+
+
+def test_classify_job_skips_photos_with_subject_keywords(tmp_path):
+    """When a photo has a keyword whose type is in the workspace's
+    subject_types, the classifier doesn't include it in the run.
+
+    Verified by capturing the photo IDs passed into the (stubbed)
+    _detect_subjects step. Only p2 (untagged) should reach detection;
+    p1 (tagged 'Landscape', type='scene') is skipped at the load step.
+    """
+    db_path, ws, col_id, p1, p2 = _setup_two_photo_classify_workspace(tmp_path)
+
+    seen, events, _ = _run_classify_capturing_photos(
+        db_path, ws, col_id, reclassify=False,
+    )
+
+    assert seen == [p2], (
+        f"Expected only p2 ({p2}) to reach the detector, got {seen}"
+    )
+
+    # The skip-count should be surfaced in a progress event.
+    progress_events = [
+        d for (_jid, kind, d) in events
+        if kind == "progress" and d.get("skipped_subject")
+    ]
+    assert progress_events, "Expected a progress event with skipped_subject"
+    assert progress_events[0]["skipped_subject"] == 1
+    assert progress_events[0]["phase"] == "Step 2/5: Loading photos"
+
+
+def test_classify_job_reclassify_true_bypasses_subject_skip(tmp_path):
+    """With reclassify=True, even subject-tagged photos are reprocessed,
+    so users can verify or refresh existing tags."""
+    db_path, ws, col_id, p1, p2 = _setup_two_photo_classify_workspace(tmp_path)
+
+    seen, events, _ = _run_classify_capturing_photos(
+        db_path, ws, col_id, reclassify=True,
+    )
+
+    assert sorted(seen) == sorted([p1, p2]), (
+        f"reclassify=True should bypass the skip-gate; got {seen}"
+    )
+    skip_events = [
+        d for (_jid, kind, d) in events
+        if kind == "progress" and d.get("skipped_subject")
+    ]
+    assert not skip_events, (
+        f"reclassify=True should not surface a skipped_subject event, got "
+        f"{skip_events}"
+    )

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -270,3 +270,12 @@ def test_miss_defaults_present():
     assert d["miss_bbox_area_min"] == 0.005
     assert d["miss_bbox_area_min_singleton"] == 0.002
     assert d["miss_oof_ratio"] == 0.5
+
+
+def test_default_subject_types_includes_taxonomy_individual_scene(tmp_path, monkeypatch):
+    """Default subject_types is the set of keyword types that count as
+    'identifying' a photo — taxonomy + individual + scene by default."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    loaded = cfg.load()
+    assert set(loaded.get("subject_types", [])) == {"taxonomy", "individual", "scene"}

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -272,10 +272,10 @@ def test_miss_defaults_present():
     assert d["miss_oof_ratio"] == 0.5
 
 
-def test_default_subject_types_includes_taxonomy_individual_scene(tmp_path, monkeypatch):
+def test_default_subject_types_includes_taxonomy_individual_genre(tmp_path, monkeypatch):
     """Default subject_types is the set of keyword types that count as
-    'identifying' a photo — taxonomy + individual + scene by default."""
+    'identifying' a photo — taxonomy + individual + genre by default."""
     import config as cfg
     monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
     loaded = cfg.load()
-    assert set(loaded.get("subject_types", [])) == {"taxonomy", "individual", "scene"}
+    assert set(loaded.get("subject_types", [])) == {"taxonomy", "individual", "genre"}

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7382,13 +7382,15 @@ def test_ensure_default_genre_keywords_preserves_non_general_user_types(tmp_path
     rows = db.conn.execute(
         "SELECT type FROM keywords WHERE name = 'Wildlife' ORDER BY type"
     ).fetchall()
-    types = [r["type"] for r in rows]
-    # The user's 'individual' row stays. Case-insensitive existence check
-    # in ensure_default_genre_keywords sees it and skips inserting a
-    # duplicate genre row.
-    assert types == ["individual"], (
-        f"Expected only the user's 'individual' Wildlife to remain; "
-        f"got types={types}"
+    types = sorted(r["type"] for r in rows)
+    # The user's 'individual' row is preserved AND a canonical 'genre'
+    # row is created alongside it. Duplicates BY NAME across different
+    # types are intentional — disambiguation in add_keyword's lookup
+    # (ORDER BY (type=?) DESC) ensures kw_type-typed callers get the
+    # right row deterministically.
+    assert types == ["genre", "individual"], (
+        f"Expected both 'genre' (canonical) and 'individual' (user's) "
+        f"Wildlife rows; got types={types}"
     )
     # Other genre defaults still seeded
     n_other = db.conn.execute(
@@ -7399,51 +7401,68 @@ def test_ensure_default_genre_keywords_preserves_non_general_user_types(tmp_path
     assert n_other == 4
 
 
-def test_ensure_default_genre_keywords_does_not_duplicate_existing_top_level(tmp_path):
-    """Regression: SQLite UNIQUE(name, parent_id) treats NULL as distinct
-    per SQL standard, so plain INSERT OR IGNORE against a same-name
-    top-level row does NOT actually prevent duplicates. The seed must
-    explicitly check by case-insensitive name first."""
+def test_ensure_default_genre_keywords_seeds_canonical_row_despite_typed_collision(tmp_path):
+    """Regression: the seed must guarantee a canonical genre row for each
+    default name even when a user has previously tagged a same-name
+    keyword with a different type (e.g. 'Landscape' as 'location').
+
+    Otherwise the lightbox 'Not Wildlife' flow would call add_keyword(
+    name='Landscape', kw_type='genre'), find the existing 'location' row,
+    fail to upgrade it (only 'general' is upgraded), and tag the photo
+    with a non-genre keyword — leaving it stuck in 'Needs Identification'
+    under the default subject types.
+    """
     from db import Database
     db = Database(str(tmp_path / "test.db"))
-    # Wipe the genre defaults and force-create same-name top-level rows
-    # with various existing types — simulates upgraded DBs where users
-    # hand-tagged before the genre feature existed.
+    # Wipe the genre defaults and force-create same-name rows with
+    # different types to simulate an upgraded user library.
     db.conn.execute("DELETE FROM keywords WHERE type = 'genre'")
     db.conn.execute(
         "INSERT INTO keywords (name, type, is_species) VALUES (?, 'general', 0)",
-        ("landscape",),  # lowercase — exercises COLLATE NOCASE path
+        ("landscape",),  # lowercase — exercises COLLATE NOCASE
     )
     db.conn.execute(
         "INSERT INTO keywords (name, type, is_species) VALUES (?, 'location', 0)",
-        ("Sunset",),  # legitimately user-typed as location (a place)
+        ("Sunset",),  # user has a "Sunset" location they care about
     )
     db.conn.commit()
 
     db.ensure_default_genre_keywords()
     db.ensure_default_genre_keywords()  # idempotent re-run
 
-    # 'landscape' (general) should be PROMOTED to 'genre' (case-insensitive
-    # match in the promotion query) — no duplicate inserted.
+    # 'landscape' (general) is PROMOTED to 'genre' via the in-place
+    # UPDATE — no duplicate.
     rows = db.conn.execute(
-        "SELECT id, name, type FROM keywords WHERE name = 'landscape' COLLATE NOCASE"
+        "SELECT type FROM keywords WHERE name = 'landscape' COLLATE NOCASE"
     ).fetchall()
-    assert len(rows) == 1, (
-        f"Expected exactly one 'landscape' row after seed; got {len(rows)}: "
-        f"{[(r['name'], r['type']) for r in rows]}"
+    assert sorted(r["type"] for r in rows) == ["genre"], (
+        f"'general' Landscape should be promoted in place to 'genre'; "
+        f"got types={[r['type'] for r in rows]}"
     )
-    assert rows[0]["type"] == "genre"
 
-    # 'Sunset' (location) should be PRESERVED — no duplicate genre Sunset.
+    # 'Sunset' (location) is PRESERVED, AND a canonical 'genre' Sunset
+    # is created alongside it.
     rows = db.conn.execute(
-        "SELECT id, name, type FROM keywords WHERE name = 'Sunset' COLLATE NOCASE"
+        "SELECT type FROM keywords WHERE name = 'Sunset' COLLATE NOCASE"
     ).fetchall()
-    assert len(rows) == 1, (
-        f"Expected exactly one 'Sunset' row after seed; got {len(rows)}"
+    assert sorted(r["type"] for r in rows) == ["genre", "location"], (
+        f"Expected both 'genre' (canonical) and 'location' (user's) "
+        f"Sunset rows; got types={[r['type'] for r in rows]}"
     )
-    assert rows[0]["type"] == "location"
 
-    # And the OTHER defaults should still be created exactly once.
+    # add_keyword's lookup must deterministically pick the genre row
+    # when kw_type='genre' is supplied (otherwise the route flow gets
+    # the wrong-typed row non-deterministically).
+    sunset_id = db.add_keyword("Sunset", kw_type="genre")
+    sunset_type = db.conn.execute(
+        "SELECT type FROM keywords WHERE id = ?", (sunset_id,)
+    ).fetchone()["type"]
+    assert sunset_type == "genre", (
+        f"add_keyword('Sunset', kw_type='genre') must return the genre "
+        f"row, got type={sunset_type!r}"
+    )
+
+    # Other defaults exist exactly once.
     for name in ("Architecture", "Abstract", "Wildlife"):
         n = db.conn.execute(
             "SELECT COUNT(*) FROM keywords WHERE name = ? COLLATE NOCASE",

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1267,10 +1267,11 @@ def test_get_dashboard_stats_with_data(tmp_path):
 
     stats = db.get_dashboard_stats()
 
-    # top_keywords: Robin with 2 photos
-    assert len(stats['top_keywords']) == 1
-    assert stats['top_keywords'][0]['name'] == 'Robin'
-    assert stats['top_keywords'][0]['photo_count'] == 2
+    # top_keywords: Robin with 2 photos. Wildlife is auto-added by the
+    # first-species rule, so it also appears with 2 photos.
+    by_name = {k['name']: k['photo_count'] for k in stats['top_keywords']}
+    assert by_name.get('Robin') == 2
+    assert by_name.get('Wildlife') == 2
 
     # photos_by_month: 2 in 2024-06, 1 in 2024-07
     months = {r['month']: r['count'] for r in stats['photos_by_month']}
@@ -6643,3 +6644,152 @@ def test_filter_out_subject_tagged_preserves_input_order(tmp_path):
     # Provide ids in non-sorted order to confirm the helper preserves input order.
     ordered = [p_c, p_a, p_b]
     assert db.filter_out_subject_tagged(ordered, {"genre"}) == ordered
+
+
+def test_tag_photo_with_first_taxonomy_keyword_adds_wildlife_genre(tmp_path):
+    """Tagging a photo with its first taxonomy keyword auto-adds the
+    Wildlife genre keyword."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    species_kid = db.add_keyword("Northern cardinal", is_species=True)
+
+    db.tag_photo(p1, species_kid)
+
+    # Photo should now have BOTH the species keyword AND Wildlife genre.
+    rows = db.conn.execute(
+        """SELECT k.name, k.type FROM photo_keywords pk
+           JOIN keywords k ON k.id = pk.keyword_id
+           WHERE pk.photo_id = ?
+           ORDER BY k.name""",
+        (p1,),
+    ).fetchall()
+    by_name = {r["name"]: r["type"] for r in rows}
+    assert by_name == {
+        "Northern cardinal": "taxonomy",
+        "Wildlife": "genre",
+    }
+
+
+def test_tag_photo_second_species_does_not_re_add_wildlife(tmp_path):
+    """If a photo already has at least one taxonomy keyword, tagging a
+    second species does NOT touch the Wildlife genre keyword (so user
+    removal sticks)."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    sp_a = db.add_keyword("Robin", is_species=True)
+    sp_b = db.add_keyword("Sparrow", is_species=True)
+
+    db.tag_photo(p1, sp_a)  # Wildlife auto-added
+    # User manually removes Wildlife
+    wildlife_id = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = 'Wildlife' AND type = 'genre'"
+    ).fetchone()["id"]
+    db.untag_photo(p1, wildlife_id)
+
+    db.tag_photo(p1, sp_b)  # second species — should NOT re-add Wildlife
+
+    has_wildlife = db.conn.execute(
+        """SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?""",
+        (p1, wildlife_id),
+    ).fetchone() is not None
+    assert has_wildlife is False
+
+
+def test_tag_photo_with_non_taxonomy_does_not_add_wildlife(tmp_path):
+    """Tagging with a non-species keyword (location, individual, etc.)
+    does NOT add Wildlife."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    loc_kid = db.add_keyword("Park", kw_type="location")
+
+    db.tag_photo(p1, loc_kid)
+
+    n = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM photo_keywords pk "
+        "JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE pk.photo_id = ? AND k.name = 'Wildlife'",
+        (p1,),
+    ).fetchone()["n"]
+    assert n == 0
+
+
+def test_tag_photo_re_adds_wildlife_after_all_species_removed_and_new_added(tmp_path):
+    """Sticky removal only sticks while at least one taxonomy keyword
+    exists. Removing all species and tagging a new one re-adds Wildlife."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    sp_a = db.add_keyword("Robin", is_species=True)
+    sp_b = db.add_keyword("Sparrow", is_species=True)
+    db.tag_photo(p1, sp_a)  # Wildlife added
+    wildlife_id = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = 'Wildlife' AND type = 'genre'"
+    ).fetchone()["id"]
+    db.untag_photo(p1, wildlife_id)
+    # Remove the only species
+    db.untag_photo(p1, sp_a)
+
+    # Tag a new species — this is the "first species again" case
+    db.tag_photo(p1, sp_b)
+
+    has_wildlife = db.conn.execute(
+        """SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?""",
+        (p1, wildlife_id),
+    ).fetchone() is not None
+    assert has_wildlife is True
+
+
+def test_backfill_auto_wildlife_for_existing_species_tagged_photos(tmp_path):
+    """The one-shot backfill adds Wildlife to every photo with a species
+    keyword that doesn't already have Wildlife. Idempotent."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='p2.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+    p3 = db.add_photo(folder_id=fid, filename='p3.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+    sp_a = db.add_keyword("Robin", is_species=True)
+    # Bypass tag_photo so the auto-Wildlife rule does NOT fire — this
+    # simulates a pre-existing DB.
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p1, sp_a),
+    )
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p2, sp_a),
+    )
+    db.conn.commit()
+
+    db.backfill_wildlife_genre()
+    db.backfill_wildlife_genre()  # idempotent
+
+    wildlife_id = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = 'Wildlife' AND type = 'genre'"
+    ).fetchone()["id"]
+
+    # p1, p2 should have Wildlife. p3 (no species) should not.
+    def has_wildlife(pid):
+        return db.conn.execute(
+            "SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
+            (pid, wildlife_id),
+        ).fetchone() is not None
+    assert has_wildlife(p1) is True
+    assert has_wildlife(p2) is True
+    assert has_wildlife(p3) is False

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6354,3 +6354,37 @@ def test_add_keyword_existing_general_upgrades_to_taxonomy_sets_is_species(tmp_p
     ).fetchone()
     assert row2["type"] == "taxonomy"
     assert row2["is_species"] == 1
+
+
+def test_get_subject_types_returns_default(tmp_path, monkeypatch):
+    """A fresh workspace with no overrides falls back to the global default."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    assert db.get_subject_types() == {"taxonomy", "individual", "scene"}
+
+
+def test_get_subject_types_honors_workspace_override(tmp_path, monkeypatch):
+    """Workspace config_overrides for subject_types take precedence over the default."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    db.update_workspace(ws_id, config_overrides={"subject_types": ["taxonomy"]})
+    assert db.get_subject_types() == {"taxonomy"}
+
+
+def test_get_subject_types_drops_unknown_values(tmp_path, monkeypatch):
+    """Unknown type strings in the workspace override are silently dropped."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    db.update_workspace(ws_id, config_overrides={"subject_types": ["taxonomy", "alien"]})
+    assert db.get_subject_types() == {"taxonomy"}

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6276,3 +6276,81 @@ def test_add_keyword_rejects_unknown_type(tmp_path):
     db.set_active_workspace(db.create_workspace("ws"))
     with pytest.raises(ValueError, match="invalid keyword type"):
         db.add_keyword("BadType", kw_type="alien")
+
+
+def test_add_keyword_explicit_taxonomy_for_unknown_name_skips_taxa_lookup(tmp_path):
+    """Explicit kw_type='taxonomy' bypasses taxa-table lookup; taxon_id stays NULL.
+    is_species is auto-corrected to 1 to match the type."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    kid = db.add_keyword("DefinitelyNotASpecies42", kw_type="taxonomy")
+    row = db.conn.execute(
+        "SELECT type, taxon_id, is_species FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["type"] == "taxonomy"
+    assert row["taxon_id"] is None
+    assert row["is_species"] == 1  # auto-set by the new reconciliation
+
+
+def test_add_keyword_is_species_with_non_taxonomy_type_raises(tmp_path):
+    """is_species=True paired with a non-'taxonomy' kw_type is inconsistent and
+    must raise ValueError rather than silently producing a mismatched row."""
+    import pytest
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    with pytest.raises(ValueError, match="is_species=True requires kw_type='taxonomy'"):
+        db.add_keyword("Mismatch", is_species=True, kw_type="general")
+
+
+def test_add_keyword_explicit_taxonomy_sets_is_species(tmp_path):
+    """Explicit kw_type='taxonomy' (without is_species) auto-sets is_species=1
+    so the legacy column stays in sync with the type."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    kid = db.add_keyword("Some Bird", kw_type="taxonomy")
+    row = db.conn.execute(
+        "SELECT type, is_species FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["type"] == "taxonomy"
+    assert row["is_species"] == 1
+
+
+def test_add_keyword_existing_general_upgrades_to_requested_type(tmp_path):
+    """An existing 'general' keyword should be upgraded to the requested type
+    when add_keyword is called again with an explicit kw_type."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    kid1 = db.add_keyword("Landscape")
+    row1 = db.conn.execute("SELECT type FROM keywords WHERE id = ?", (kid1,)).fetchone()
+    assert row1["type"] == "general"
+
+    kid2 = db.add_keyword("Landscape", kw_type="scene")
+    assert kid2 == kid1
+    row2 = db.conn.execute("SELECT type FROM keywords WHERE id = ?", (kid2,)).fetchone()
+    assert row2["type"] == "scene"
+
+
+def test_add_keyword_existing_general_upgrades_to_taxonomy_sets_is_species(tmp_path):
+    """Upgrading an existing 'general' keyword to 'taxonomy' should also
+    flip is_species to 1 so the legacy column stays consistent."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    kid1 = db.add_keyword("Mystery Bird")
+    row1 = db.conn.execute(
+        "SELECT type, is_species FROM keywords WHERE id = ?", (kid1,)
+    ).fetchone()
+    assert row1["type"] == "general"
+    assert row1["is_species"] == 0
+
+    kid2 = db.add_keyword("Mystery Bird", kw_type="taxonomy")
+    assert kid2 == kid1
+    row2 = db.conn.execute(
+        "SELECT type, is_species FROM keywords WHERE id = ?", (kid2,)
+    ).fetchone()
+    assert row2["type"] == "taxonomy"
+    assert row2["is_species"] == 1

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6903,6 +6903,54 @@ def test_backfill_auto_wildlife_for_existing_species_tagged_photos(tmp_path):
     assert has_wildlife(p3) is False
 
 
+def test_backfill_wildlife_genre_matches_legacy_is_species_rows(tmp_path):
+    """Regression: on upgraded DBs, species rows can carry legacy
+    ``is_species=1`` but a non-taxonomy ``type`` (e.g. NULL, 'general')
+    until the background ``mark_species_keywords`` pass retypes them.
+
+    The backfill runs at startup before that pass, so a query that joined
+    only on ``type='taxonomy'`` matched zero rows yet still wrote the
+    one-shot marker — and never re-ran. The backfill must also match
+    ``is_species=1`` so upgraded photos get Wildlife on first startup,
+    independent of background normalization timing.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+
+    # Force a legacy-shaped species keyword via direct SQL: is_species=1
+    # but type='general' (the shape an upgraded DB has before the
+    # background mark_species_keywords pass converts type to 'taxonomy').
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'general', 1)",
+        ("Robin",),
+    )
+    sp = cur.lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p1, sp),
+    )
+    db.conn.commit()
+
+    db.backfill_wildlife_genre()
+
+    wildlife_id = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = 'Wildlife' AND type = 'genre'"
+    ).fetchone()["id"]
+    has_wildlife = db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
+        (p1, wildlife_id),
+    ).fetchone() is not None
+    assert has_wildlife is True, (
+        "Backfill must match is_species=1 rows so upgraded DBs get Wildlife "
+        "added on first startup, even before mark_species_keywords retypes "
+        "legacy species keywords to type='taxonomy'."
+    )
+
+
 def test_tag_photo_no_op_re_tag_does_not_re_add_removed_wildlife(tmp_path):
     """Regression: re-tagging an already-tagged species (a no-op INSERT OR
     IGNORE) must NOT re-fire the auto-Wildlife rule, so user-removed

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6679,6 +6679,44 @@ def test_filter_out_subject_tagged_preserves_input_order(tmp_path):
     assert db.filter_out_subject_tagged(ordered, {"genre"}) == ordered
 
 
+def test_filter_out_subject_tagged_chunks_large_input(tmp_path, monkeypatch):
+    """Regression: photo_ids larger than the SQLite bind-var limit must be
+    chunked, not passed as a single oversized IN clause. The classify job
+    sources up to ~1M photos via get_collection_photos(per_page=999999),
+    which would trip 'too many SQL variables' on builds with the historical
+    999-var cap.
+
+    Force a tiny chunk size so we exercise the chunking path with a small
+    number of real photos, then assert filtering correctness across the
+    boundary.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+
+    # 25 photos, alternating tagged/untagged so the result spans multiple
+    # chunks under our forced chunk size of 10.
+    monkeypatch.setattr(Database, "_FILTER_SUBJECT_CHUNK", 10)
+    genre_kid = db.add_keyword("Landscape", kw_type="genre")
+    pids = []
+    for i in range(25):
+        p = db.add_photo(
+            folder_id=fid, filename=f"p{i}.jpg", extension=".jpg",
+            file_size=100, file_mtime=float(i),
+        )
+        pids.append(p)
+        # Tag every even-index photo with the genre keyword.
+        if i % 2 == 0:
+            db.tag_photo(p, genre_kid)
+
+    kept = db.filter_out_subject_tagged(pids, {"genre"})
+    expected = [p for i, p in enumerate(pids) if i % 2 == 1]
+    assert kept == expected, (
+        f"Chunking corrupted result. Expected odd-index photos, got {kept}"
+    )
+
+
 def test_tag_photo_with_first_taxonomy_keyword_adds_wildlife_genre(tmp_path):
     """Tagging a photo with its first taxonomy keyword auto-adds the
     Wildlife genre keyword."""

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6250,3 +6250,29 @@ def test_get_folder_tree_includes_partial_folders_with_status(tmp_path):
     assert missing_id not in rows, "missing folder must not appear in tree"
     assert rows[ok_id]["status"] == "ok"
     assert rows[partial_id]["status"] == "partial"
+
+
+def test_keyword_types_constant():
+    """KEYWORD_TYPES contains exactly the five valid enum values."""
+    from db import KEYWORD_TYPES
+    assert frozenset({"taxonomy", "individual", "place", "scene", "general"}) == KEYWORD_TYPES
+
+
+def test_add_keyword_accepts_valid_types(tmp_path):
+    """add_keyword stores the requested type when it's a valid enum value."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    kid = db.add_keyword("Charlie", kw_type="individual")
+    row = db.conn.execute("SELECT type FROM keywords WHERE id = ?", (kid,)).fetchone()
+    assert row["type"] == "individual"
+
+
+def test_add_keyword_rejects_unknown_type(tmp_path):
+    """add_keyword raises ValueError for unknown type values."""
+    import pytest
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    with pytest.raises(ValueError, match="invalid keyword type"):
+        db.add_keyword("BadType", kw_type="alien")

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -712,7 +712,7 @@ def test_has_subject_rule_matches_photos_without_subject_keywords(tmp_path, monk
     p2 = db.add_photo(folder_id=fid, filename='p2.jpg', extension='.jpg',
                       file_size=100, file_mtime=1.0)
 
-    scene_kid = db.add_keyword("Landscape", kw_type="scene")
+    scene_kid = db.add_keyword("Landscape", kw_type="genre")
     db.tag_photo(p1, scene_kid)  # p1 is identified, p2 is not
 
     cid = db.add_collection(
@@ -740,7 +740,7 @@ def test_has_subject_rule_value_one_matches_identified_photos(tmp_path, monkeypa
     p2 = db.add_photo(folder_id=fid, filename='p2.jpg', extension='.jpg',
                       file_size=100, file_mtime=1.0)
 
-    scene_kid = db.add_keyword("Landscape", kw_type="scene")
+    scene_kid = db.add_keyword("Landscape", kw_type="genre")
     db.tag_photo(p1, scene_kid)
 
     cid = db.add_collection(
@@ -768,9 +768,9 @@ def test_has_subject_rule_empty_subject_types_value_one_matches_no_photos(tmp_pa
     fid = db.add_folder('/photos', name='photos')
     p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
                       file_size=100, file_mtime=1.0)
-    # Tag with a scene keyword anyway — but with empty subject_types, no
+    # Tag with a genre keyword anyway — but with empty subject_types, no
     # type counts as identifying, so this photo still does not match.
-    scene_kid = db.add_keyword("Landscape", kw_type="scene")
+    scene_kid = db.add_keyword("Landscape", kw_type="genre")
     db.tag_photo(p1, scene_kid)
 
     cid = db.add_collection(
@@ -1096,26 +1096,26 @@ def test_migration_skips_user_customized_collection(tmp_path):
     assert cols["Needs Classification"] == custom
 
 
-def test_default_scene_keywords_inserted(tmp_path):
-    """Database init populates the four default scene keywords."""
+def test_default_genre_keywords_inserted(tmp_path):
+    """Database init populates the default genre keywords."""
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     rows = db.conn.execute(
-        "SELECT name FROM keywords WHERE type = 'scene' ORDER BY name"
+        "SELECT name FROM keywords WHERE type = 'genre' ORDER BY name"
     ).fetchall()
-    assert [r["name"] for r in rows] == ["Abstract", "Architecture", "Landscape", "Sunset"]
+    assert [r["name"] for r in rows] == ["Abstract", "Architecture", "Landscape", "Sunset", "Wildlife"]
 
 
-def test_default_scene_keywords_idempotent(tmp_path):
-    """Calling ensure_default_scene_keywords multiple times doesn't duplicate."""
+def test_default_genre_keywords_idempotent(tmp_path):
+    """Calling ensure_default_genre_keywords multiple times doesn't duplicate."""
     from db import Database
     db = Database(str(tmp_path / "test.db"))
-    db.ensure_default_scene_keywords()
-    db.ensure_default_scene_keywords()
+    db.ensure_default_genre_keywords()
+    db.ensure_default_genre_keywords()
     n = db.conn.execute(
-        "SELECT COUNT(*) AS n FROM keywords WHERE type = 'scene'"
+        "SELECT COUNT(*) AS n FROM keywords WHERE type = 'genre'"
     ).fetchone()["n"]
-    assert n == 4
+    assert n == 5
 
 
 def test_all_photos_collection_returns_all_photos(tmp_path):
@@ -2839,19 +2839,39 @@ def test_is_species_migrated_to_taxonomy_type(tmp_path):
     assert row["is_species"] == 1
 
 
-def test_add_keyword_people_type(tmp_path):
-    """A keyword can be created with type='people' via direct SQL update."""
+def test_add_keyword_individual_type(tmp_path):
+    """A keyword can be created with type='individual' via direct SQL update."""
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     kid = db.add_keyword("John Doe")
     db.conn.execute(
-        "UPDATE keywords SET type = 'people' WHERE id = ?", (kid,)
+        "UPDATE keywords SET type = 'individual' WHERE id = ?", (kid,)
     )
     db.conn.commit()
     row = db.conn.execute(
         "SELECT type FROM keywords WHERE id = ?", (kid,)
     ).fetchone()
-    assert row["type"] == "people"
+    assert row["type"] == "individual"
+
+
+def test_migrate_legacy_keyword_types_renames_people_descriptive_event(tmp_path):
+    """Pre-existing keywords of types 'people', 'descriptive', 'event' get
+    migrated to 'individual', 'general', 'general' respectively. Idempotent."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    # Force-create legacy rows via direct SQL (bypassing add_keyword's validation).
+    db.conn.execute("INSERT INTO keywords (name, type) VALUES (?, 'people')", ("John",))
+    db.conn.execute("INSERT INTO keywords (name, type) VALUES (?, 'descriptive')", ("blurry",))
+    db.conn.execute("INSERT INTO keywords (name, type) VALUES (?, 'event')", ("wedding",))
+    db.conn.commit()
+    db.migrate_legacy_keyword_types()
+    db.migrate_legacy_keyword_types()  # idempotent
+    rows = db.conn.execute(
+        "SELECT name, type FROM keywords WHERE name IN ('John', 'blurry', 'wedding') ORDER BY name"
+    ).fetchall()
+    types = {r["name"]: r["type"] for r in rows}
+    assert types == {"John": "individual", "blurry": "general", "wedding": "general"}
 
 
 def test_keyword_tree_includes_type(tmp_path):
@@ -2878,7 +2898,7 @@ def test_photo_keywords_includes_type(tmp_path):
     fid = db.add_folder('/photos', name='photos')
     pid = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
                        file_size=100, file_mtime=1.0)
-    # Use a name that isn't pre-seeded as a default scene keyword.
+    # Use a name that isn't pre-seeded as a default genre keyword.
     kid = db.add_keyword('MyTag')
     db.tag_photo(pid, kid)
 
@@ -6426,7 +6446,7 @@ def test_get_folder_tree_includes_partial_folders_with_status(tmp_path):
 def test_keyword_types_constant():
     """KEYWORD_TYPES contains exactly the five valid enum values."""
     from db import KEYWORD_TYPES
-    assert frozenset({"taxonomy", "individual", "place", "scene", "general"}) == KEYWORD_TYPES
+    assert frozenset({"taxonomy", "individual", "location", "genre", "general"}) == KEYWORD_TYPES
 
 
 def test_add_keyword_accepts_valid_types(tmp_path):
@@ -6495,15 +6515,15 @@ def test_add_keyword_existing_general_upgrades_to_requested_type(tmp_path):
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     db.set_active_workspace(db.create_workspace("ws"))
-    # Use a name that isn't pre-seeded as a default scene keyword.
+    # Use a name that isn't pre-seeded as a default genre keyword.
     kid1 = db.add_keyword("Cityscape")
     row1 = db.conn.execute("SELECT type FROM keywords WHERE id = ?", (kid1,)).fetchone()
     assert row1["type"] == "general"
 
-    kid2 = db.add_keyword("Cityscape", kw_type="scene")
+    kid2 = db.add_keyword("Cityscape", kw_type="genre")
     assert kid2 == kid1
     row2 = db.conn.execute("SELECT type FROM keywords WHERE id = ?", (kid2,)).fetchone()
-    assert row2["type"] == "scene"
+    assert row2["type"] == "genre"
 
 
 def test_add_keyword_existing_general_upgrades_to_taxonomy_sets_is_species(tmp_path):
@@ -6535,7 +6555,7 @@ def test_get_subject_types_returns_default(tmp_path, monkeypatch):
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     db.set_active_workspace(db.create_workspace("ws"))
-    assert db.get_subject_types() == {"taxonomy", "individual", "scene"}
+    assert db.get_subject_types() == {"taxonomy", "individual", "genre"}
 
 
 def test_get_subject_types_honors_workspace_override(tmp_path, monkeypatch):
@@ -6574,12 +6594,12 @@ def test_filter_out_subject_tagged_excludes_tagged_photos(tmp_path):
                       file_size=100, file_mtime=1.0)
     p2 = db.add_photo(folder_id=fid, filename='p2.jpg', extension='.jpg',
                       file_size=100, file_mtime=1.0)
-    scene_kid = db.add_keyword("Landscape", kw_type="scene")
+    scene_kid = db.add_keyword("Landscape", kw_type="genre")
     gen_kid = db.add_keyword("note", kw_type="general")
     db.tag_photo(p1, scene_kid)
     db.tag_photo(p2, gen_kid)
 
-    kept = db.filter_out_subject_tagged([p1, p2], {"scene"})
+    kept = db.filter_out_subject_tagged([p1, p2], {"genre"})
     assert kept == [p2]
 
 
@@ -6600,7 +6620,7 @@ def test_filter_out_subject_tagged_empty_photo_ids_returns_empty(tmp_path):
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     db.set_active_workspace(db.create_workspace("ws"))
-    assert db.filter_out_subject_tagged([], {"scene"}) == []
+    assert db.filter_out_subject_tagged([], {"genre"}) == []
 
 
 def test_filter_out_subject_tagged_preserves_input_order(tmp_path):
@@ -6622,4 +6642,4 @@ def test_filter_out_subject_tagged_preserves_input_order(tmp_path):
     # No subject-tagged photos here — all three should be kept.
     # Provide ids in non-sorted order to confirm the helper preserves input order.
     ordered = [p_c, p_a, p_b]
-    assert db.filter_out_subject_tagged(ordered, {"scene"}) == ordered
+    assert db.filter_out_subject_tagged(ordered, {"genre"}) == ordered

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6388,3 +6388,66 @@ def test_get_subject_types_drops_unknown_values(tmp_path, monkeypatch):
     db.set_active_workspace(ws_id)
     db.update_workspace(ws_id, config_overrides={"subject_types": ["taxonomy", "alien"]})
     assert db.get_subject_types() == {"taxonomy"}
+
+
+def test_filter_out_subject_tagged_excludes_tagged_photos(tmp_path):
+    """filter_out_subject_tagged drops photos that have any keyword whose
+    type is in the supplied set."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='p2.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    scene_kid = db.add_keyword("Landscape", kw_type="scene")
+    gen_kid = db.add_keyword("note", kw_type="general")
+    db.tag_photo(p1, scene_kid)
+    db.tag_photo(p2, gen_kid)
+
+    kept = db.filter_out_subject_tagged([p1, p2], {"scene"})
+    assert kept == [p2]
+
+
+def test_filter_out_subject_tagged_empty_set_returns_all(tmp_path):
+    """An empty subject_types set means no type counts as 'identifying',
+    so every input photo is kept."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    assert db.filter_out_subject_tagged([p1], set()) == [p1]
+
+
+def test_filter_out_subject_tagged_empty_photo_ids_returns_empty(tmp_path):
+    """An empty photo_ids list short-circuits to an empty result."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    assert db.filter_out_subject_tagged([], {"scene"}) == []
+
+
+def test_filter_out_subject_tagged_preserves_input_order(tmp_path):
+    """Output preserves the input order of photo_ids for the kept rows."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+
+    fid = db.add_folder('/photos', name='photos')
+    # Insert several photos; we'll then ask filter_out_subject_tagged
+    # to keep them all (no subject tags) but in a specific input order.
+    p_a = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    p_b = db.add_photo(folder_id=fid, filename='b.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    p_c = db.add_photo(folder_id=fid, filename='c.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+
+    # No subject-tagged photos here — all three should be kept.
+    # Provide ids in non-sorted order to confirm the helper preserves input order.
+    ordered = [p_c, p_a, p_b]
+    assert db.filter_out_subject_tagged(ordered, {"scene"}) == ordered

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -695,6 +695,92 @@ def test_collection_has_species_rule(tmp_path):
     assert 'classified.jpg' not in filenames
 
 
+def test_has_subject_rule_matches_photos_without_subject_keywords(tmp_path, monkeypatch):
+    """has_subject==0 returns photos that have no keyword whose type is in
+    the workspace's subject_types set."""
+    import json
+
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='p2.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+
+    scene_kid = db.add_keyword("Landscape", kw_type="scene")
+    db.tag_photo(p1, scene_kid)  # p1 is identified, p2 is not
+
+    cid = db.add_collection(
+        "Needs Subject",
+        json.dumps([{"field": "has_subject", "op": "equals", "value": 0}]),
+    )
+    photos = db.get_collection_photos(cid, per_page=999)
+    pids = {p["id"] for p in photos}
+    assert pids == {p2}
+
+
+def test_has_subject_rule_value_one_matches_identified_photos(tmp_path, monkeypatch):
+    """has_subject==1 is the inverse — only identified photos match."""
+    import json
+
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='p2.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+
+    scene_kid = db.add_keyword("Landscape", kw_type="scene")
+    db.tag_photo(p1, scene_kid)
+
+    cid = db.add_collection(
+        "Has Subject",
+        json.dumps([{"field": "has_subject", "op": "equals", "value": 1}]),
+    )
+    photos = db.get_collection_photos(cid, per_page=999)
+    pids = {p["id"] for p in photos}
+    assert pids == {p1}
+
+
+def test_has_subject_rule_empty_subject_types_value_one_matches_no_photos(tmp_path, monkeypatch):
+    """When subject_types is empty, has_subject==1 should match no photos
+    (no type counts as 'identifying')."""
+    import json
+
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    db.update_workspace(ws_id, config_overrides={"subject_types": []})
+
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    # Tag with a scene keyword anyway — but with empty subject_types, no
+    # type counts as identifying, so this photo still does not match.
+    scene_kid = db.add_keyword("Landscape", kw_type="scene")
+    db.tag_photo(p1, scene_kid)
+
+    cid = db.add_collection(
+        "Has Subject (empty types)",
+        json.dumps([{"field": "has_subject", "op": "equals", "value": 1}]),
+    )
+    photos = db.get_collection_photos(cid, per_page=999)
+    assert photos == []
+
+
 def test_add_keyword_is_species(tmp_path):
     """add_keyword with is_species=True marks the keyword."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7383,11 +7383,13 @@ def test_ensure_default_genre_keywords_preserves_non_general_user_types(tmp_path
         "SELECT type FROM keywords WHERE name = 'Wildlife' ORDER BY type"
     ).fetchall()
     types = [r["type"] for r in rows]
-    # The user's 'individual' row stays. Because the existing Wildlife
-    # row blocks INSERT OR IGNORE on (name='Wildlife', parent_id NULL),
-    # no genre row is created — but no clobber either. The early-return
-    # check sees other genre defaults and skips.
-    assert "individual" in types
+    # The user's 'individual' row stays. Case-insensitive existence check
+    # in ensure_default_genre_keywords sees it and skips inserting a
+    # duplicate genre row.
+    assert types == ["individual"], (
+        f"Expected only the user's 'individual' Wildlife to remain; "
+        f"got types={types}"
+    )
     # Other genre defaults still seeded
     n_other = db.conn.execute(
         """SELECT COUNT(*) FROM keywords
@@ -7395,6 +7397,59 @@ def test_ensure_default_genre_keywords_preserves_non_general_user_types(tmp_path
                 ('Landscape', 'Sunset', 'Architecture', 'Abstract')"""
     ).fetchone()[0]
     assert n_other == 4
+
+
+def test_ensure_default_genre_keywords_does_not_duplicate_existing_top_level(tmp_path):
+    """Regression: SQLite UNIQUE(name, parent_id) treats NULL as distinct
+    per SQL standard, so plain INSERT OR IGNORE against a same-name
+    top-level row does NOT actually prevent duplicates. The seed must
+    explicitly check by case-insensitive name first."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    # Wipe the genre defaults and force-create same-name top-level rows
+    # with various existing types — simulates upgraded DBs where users
+    # hand-tagged before the genre feature existed.
+    db.conn.execute("DELETE FROM keywords WHERE type = 'genre'")
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'general', 0)",
+        ("landscape",),  # lowercase — exercises COLLATE NOCASE path
+    )
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'location', 0)",
+        ("Sunset",),  # legitimately user-typed as location (a place)
+    )
+    db.conn.commit()
+
+    db.ensure_default_genre_keywords()
+    db.ensure_default_genre_keywords()  # idempotent re-run
+
+    # 'landscape' (general) should be PROMOTED to 'genre' (case-insensitive
+    # match in the promotion query) — no duplicate inserted.
+    rows = db.conn.execute(
+        "SELECT id, name, type FROM keywords WHERE name = 'landscape' COLLATE NOCASE"
+    ).fetchall()
+    assert len(rows) == 1, (
+        f"Expected exactly one 'landscape' row after seed; got {len(rows)}: "
+        f"{[(r['name'], r['type']) for r in rows]}"
+    )
+    assert rows[0]["type"] == "genre"
+
+    # 'Sunset' (location) should be PRESERVED — no duplicate genre Sunset.
+    rows = db.conn.execute(
+        "SELECT id, name, type FROM keywords WHERE name = 'Sunset' COLLATE NOCASE"
+    ).fetchall()
+    assert len(rows) == 1, (
+        f"Expected exactly one 'Sunset' row after seed; got {len(rows)}"
+    )
+    assert rows[0]["type"] == "location"
+
+    # And the OTHER defaults should still be created exactly once.
+    for name in ("Architecture", "Abstract", "Wildlife"):
+        n = db.conn.execute(
+            "SELECT COUNT(*) FROM keywords WHERE name = ? COLLATE NOCASE",
+            (name,),
+        ).fetchone()[0]
+        assert n == 1, f"Expected exactly one '{name}' row; got {n}"
 
 
 def test_migrate_default_subject_collection_covers_all_workspaces(tmp_path):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6679,6 +6679,43 @@ def test_filter_out_subject_tagged_preserves_input_order(tmp_path):
     assert db.filter_out_subject_tagged(ordered, {"genre"}) == ordered
 
 
+def test_get_subject_types_drops_non_string_entries(tmp_path, monkeypatch):
+    """Regression: config_overrides may contain malformed JSON entries since
+    api_update_workspace persists arbitrary values. Membership against a
+    frozenset raises TypeError on unhashable input; the helper must filter
+    non-strings before testing membership."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    # Persist deliberately-malformed subject_types via the workspace
+    # config (mirrors what api_update_workspace would let through).
+    db.update_workspace(ws_id, config_overrides={
+        "subject_types": ["taxonomy", ["nested"], {"obj": 1}, 42, None, "genre"],
+    })
+    # Must not raise. Returns the string-and-valid subset.
+    assert db.get_subject_types() == {"taxonomy", "genre"}
+
+
+def test_update_keyword_rejects_non_string_type(tmp_path):
+    """Regression: update_keyword(type=...) must raise ValueError (not
+    TypeError) on non-hashable JSON values, so api_update_keyword's
+    existing ValueError catch still translates to 400 instead of 500."""
+    import pytest
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    kid = db.add_keyword("Tag", kw_type="general")
+    with pytest.raises(ValueError, match="Invalid keyword type"):
+        db.update_keyword(kid, type=[])
+    with pytest.raises(ValueError, match="Invalid keyword type"):
+        db.update_keyword(kid, type={"x": 1})
+    with pytest.raises(ValueError, match="Invalid keyword type"):
+        db.update_keyword(kid, type=42)
+
+
 def test_filter_out_subject_tagged_chunks_large_input(tmp_path, monkeypatch):
     """Regression: photo_ids larger than the SQLite bind-var limit must be
     chunked, not passed as a single oversized IN clause. The classify job

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6828,6 +6828,191 @@ def test_backfill_auto_wildlife_for_existing_species_tagged_photos(tmp_path):
     assert has_wildlife(p3) is False
 
 
+def test_tag_photo_no_op_re_tag_does_not_re_add_removed_wildlife(tmp_path):
+    """Regression: re-tagging an already-tagged species (a no-op INSERT OR
+    IGNORE) must NOT re-fire the auto-Wildlife rule, so user-removed
+    Wildlife stays removed."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    sp = db.add_keyword("Robin", is_species=True)
+
+    db.tag_photo(p1, sp)  # First species tag — Wildlife auto-added.
+    wildlife_id = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = 'Wildlife' AND type = 'genre'"
+    ).fetchone()["id"]
+    db.untag_photo(p1, wildlife_id)  # User removes Wildlife.
+
+    # Re-tag the same species (e.g. user clicks the keyword chip twice).
+    # INSERT OR IGNORE is a no-op; auto-Wildlife must NOT fire.
+    db.tag_photo(p1, sp)
+
+    has_wildlife = db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
+        (p1, wildlife_id),
+    ).fetchone() is not None
+    assert has_wildlife is False, (
+        "Re-tagging an already-attached species must not undo a user's "
+        "Wildlife removal."
+    )
+
+
+def test_ensure_default_genre_keywords_upgrades_existing_general_wildlife(tmp_path):
+    """Regression: an upgraded DB with an existing 'Wildlife' general keyword
+    must have it promoted to type='genre' so auto-tagging finds it."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    # Wipe the genre defaults that __init__ seeded (simulate a DB that
+    # never went through this code path) and force-create a 'general'
+    # Wildlife row, mirroring an upgraded DB where the user hand-tagged.
+    db.conn.execute("DELETE FROM keywords WHERE type = 'genre'")
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'general', 0)",
+        ("Wildlife",),
+    )
+    db.conn.commit()
+
+    db.ensure_default_genre_keywords()
+
+    row = db.conn.execute(
+        "SELECT type FROM keywords WHERE name = 'Wildlife' AND parent_id IS NULL"
+    ).fetchone()
+    assert row["type"] == "genre", (
+        "An existing 'general' Wildlife should be promoted to 'genre' so "
+        "auto-Wildlife and the backfill find a canonical genre row."
+    )
+    # Other defaults should also be present (the seed loop still runs).
+    n = db.conn.execute(
+        "SELECT COUNT(*) FROM keywords WHERE type = 'genre'"
+    ).fetchone()[0]
+    assert n >= 5  # Wildlife + Landscape + Sunset + Architecture + Abstract
+
+
+def test_ensure_default_genre_keywords_preserves_non_general_user_types(tmp_path):
+    """If a user deliberately created e.g. an 'individual' Wildlife (a pet
+    named Wildlife), ensure_default_genre_keywords must NOT clobber that."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.conn.execute("DELETE FROM keywords WHERE type = 'genre'")
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'individual', 0)",
+        ("Wildlife",),
+    )
+    db.conn.commit()
+
+    db.ensure_default_genre_keywords()
+
+    rows = db.conn.execute(
+        "SELECT type FROM keywords WHERE name = 'Wildlife' ORDER BY type"
+    ).fetchall()
+    types = [r["type"] for r in rows]
+    # The user's 'individual' row stays. Because the existing Wildlife
+    # row blocks INSERT OR IGNORE on (name='Wildlife', parent_id NULL),
+    # no genre row is created — but no clobber either. The early-return
+    # check sees other genre defaults and skips.
+    assert "individual" in types
+    # Other genre defaults still seeded
+    n_other = db.conn.execute(
+        """SELECT COUNT(*) FROM keywords
+           WHERE type = 'genre' AND name IN
+                ('Landscape', 'Sunset', 'Architecture', 'Abstract')"""
+    ).fetchone()[0]
+    assert n_other == 4
+
+
+def test_migrate_default_subject_collection_covers_all_workspaces(tmp_path):
+    """Regression: the migration must rename the legacy collection in EVERY
+    workspace, not just the currently-active one. Multi-workspace upgrades
+    otherwise leave non-active workspaces stuck on has_species."""
+    import json
+
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws1 = db.ensure_default_workspace()
+    ws2 = db.create_workspace("ws-b")
+
+    legacy_rule = json.dumps([{"field": "has_species", "op": "equals", "value": 0}])
+    # Force-create the legacy collection in BOTH workspaces by direct SQL,
+    # bypassing the active-workspace gating in add_collection.
+    for ws in (ws1, ws2):
+        db.conn.execute(
+            "INSERT INTO collections (workspace_id, name, rules) VALUES (?, ?, ?)",
+            (ws, "Needs Classification", legacy_rule),
+        )
+    db.conn.commit()
+
+    # Active workspace is ws1; migration should cover ws2 as well.
+    db.set_active_workspace(ws1)
+    db.migrate_default_subject_collection()
+
+    for ws in (ws1, ws2):
+        row = db.conn.execute(
+            "SELECT name, rules FROM collections "
+            "WHERE workspace_id = ? AND name IN ('Needs Classification', 'Needs Identification')",
+            (ws,),
+        ).fetchone()
+        assert row is not None, f"workspace {ws} lost its default collection"
+        assert row["name"] == "Needs Identification", (
+            f"workspace {ws} still has legacy 'Needs Classification' name"
+        )
+        assert json.loads(row["rules"]) == [
+            {"field": "has_subject", "op": "equals", "value": 0}
+        ]
+
+
+def test_backfill_wildlife_genre_runs_only_once(tmp_path):
+    """Regression: backfill must be gated by a db_meta marker so subsequent
+    startups don't re-add user-removed Wildlife."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    sp = db.add_keyword("Robin", is_species=True)
+    # Direct-SQL tag so auto-Wildlife doesn't fire — simulates a
+    # pre-auto-Wildlife DB where this photo had only Robin.
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p1, sp),
+    )
+    db.conn.commit()
+
+    db.backfill_wildlife_genre()  # First run: adds Wildlife to p1.
+    wildlife_id = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = 'Wildlife' AND type = 'genre'"
+    ).fetchone()["id"]
+    # Marker should now be set
+    assert db.get_meta("wildlife_backfill_done") == "1"
+
+    # User removes Wildlife (sticky-removal intent).
+    db.untag_photo(p1, wildlife_id)
+
+    # Subsequent backfill calls (simulating subsequent app starts) must
+    # short-circuit without re-adding Wildlife.
+    db.backfill_wildlife_genre()
+    db.backfill_wildlife_genre()
+    has_wildlife = db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
+        (p1, wildlife_id),
+    ).fetchone() is not None
+    assert has_wildlife is False, (
+        "Backfill must not re-add Wildlife on subsequent startups; the "
+        "user's sticky removal would be silently undone."
+    )
+
+    # Force flag exists for tests.
+    db.backfill_wildlife_genre(force=True)
+    has_wildlife = db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
+        (p1, wildlife_id),
+    ).fetchone() is not None
+    assert has_wildlife is True, "force=True must override the marker gate."
+
+
 # -- update_keyword: rename re-runs taxonomy auto-detection --
 #
 # Regression tests for: when a keyword name is changed (e.g. fixing a typo

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6680,6 +6680,34 @@ def test_add_keyword_existing_general_upgrades_to_taxonomy_sets_is_species(tmp_p
     assert row2["is_species"] == 1
 
 
+def test_add_keyword_taxonomy_preserves_individual_type_and_is_species(tmp_path):
+    """If an existing keyword has a deliberate non-general type (e.g. 'individual'),
+    a later add_keyword(..., kw_type='taxonomy') must NOT silently flip type or
+    stamp is_species=1. Otherwise auto-wildlife / backfill / subject filters
+    that include `OR is_species=1` would treat that individual row as a species.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+
+    kid1 = db.add_keyword("Charlie", kw_type="individual")
+    row1 = db.conn.execute(
+        "SELECT type, is_species FROM keywords WHERE id = ?", (kid1,)
+    ).fetchone()
+    assert row1["type"] == "individual"
+    assert row1["is_species"] == 0
+
+    kid2 = db.add_keyword("Charlie", kw_type="taxonomy")
+    assert kid2 == kid1
+    row2 = db.conn.execute(
+        "SELECT type, is_species FROM keywords WHERE id = ?", (kid2,)
+    ).fetchone()
+    assert row2["type"] == "individual", "deliberate type must be preserved"
+    assert row2["is_species"] == 0, (
+        "is_species must NOT be set on a non-taxonomy preserved row"
+    )
+
+
 def test_get_subject_types_returns_default(tmp_path, monkeypatch):
     """A fresh workspace with no overrides falls back to the global default."""
     import config as cfg

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -781,6 +781,104 @@ def test_has_subject_rule_empty_subject_types_value_one_matches_no_photos(tmp_pa
     assert photos == []
 
 
+def test_has_subject_rule_counts_legacy_is_species_when_taxonomy_in_subject_types(tmp_path, monkeypatch):
+    """Regression: on upgraded DBs, species rows can briefly carry
+    ``is_species=1`` with a non-taxonomy ``type`` (e.g. 'general') until
+    the background ``mark_species_keywords`` pass retypes them. The
+    has_subject rule must treat those legacy rows as identifying when
+    'taxonomy' is in subject_types — otherwise already-identified photos
+    show up in 'Needs Identification' during that window.
+    """
+    import json
+
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    db.update_workspace(ws_id, config_overrides={"subject_types": ["taxonomy"]})
+
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='p2.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+
+    # Plant a legacy-shaped species keyword on p1: is_species=1, type='general'.
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'general', 1)",
+        ("Robin",),
+    )
+    legacy_sp = cur.lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p1, legacy_sp),
+    )
+    db.conn.commit()
+
+    # has_subject==0 must EXCLUDE p1 (it's identified by the legacy species
+    # row) and include only p2.
+    cid_unident = db.add_collection(
+        "Needs Identification",
+        json.dumps([{"field": "has_subject", "op": "equals", "value": 0}]),
+    )
+    pids_unident = {p["id"] for p in db.get_collection_photos(cid_unident, per_page=999)}
+    assert pids_unident == {p2}, (
+        "has_subject==0 with 'taxonomy' in subject_types must exclude photos "
+        "tagged with legacy is_species=1 keywords whose type hasn't been "
+        "retyped to 'taxonomy' yet."
+    )
+
+    # has_subject==1 must INCLUDE p1.
+    cid_ident = db.add_collection(
+        "Identified",
+        json.dumps([{"field": "has_subject", "op": "equals", "value": 1}]),
+    )
+    pids_ident = {p["id"] for p in db.get_collection_photos(cid_ident, per_page=999)}
+    assert pids_ident == {p1}
+
+
+def test_has_subject_rule_ignores_legacy_is_species_when_taxonomy_excluded(tmp_path, monkeypatch):
+    """Counter-test: when 'taxonomy' is NOT in subject_types, the
+    legacy-species fallback must not fire — a photo with only an
+    is_species=1 keyword should still register as not-identified."""
+    import json
+
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    db.update_workspace(ws_id, config_overrides={"subject_types": ["genre"]})
+
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'general', 1)",
+        ("Robin",),
+    )
+    legacy_sp = cur.lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p1, legacy_sp),
+    )
+    db.conn.commit()
+
+    cid = db.add_collection(
+        "Needs Identification",
+        json.dumps([{"field": "has_subject", "op": "equals", "value": 0}]),
+    )
+    pids = {p["id"] for p in db.get_collection_photos(cid, per_page=999)}
+    assert pids == {p1}, (
+        "When 'taxonomy' is excluded from subject_types, an is_species=1 "
+        "keyword must not satisfy has_subject — only the configured types do."
+    )
+
+
 def test_add_keyword_is_species(tmp_path):
     """add_keyword with is_species=True marks the keyword."""
     from db import Database
@@ -6751,6 +6849,72 @@ def test_filter_out_subject_tagged_chunks_large_input(tmp_path, monkeypatch):
     expected = [p for i, p in enumerate(pids) if i % 2 == 1]
     assert kept == expected, (
         f"Chunking corrupted result. Expected odd-index photos, got {kept}"
+    )
+
+
+def test_filter_out_subject_tagged_excludes_legacy_is_species_when_taxonomy_requested(tmp_path):
+    """Regression: ``filter_out_subject_tagged`` must drop photos tagged
+    with a legacy species keyword (``is_species=1`` with non-taxonomy
+    ``type``) when 'taxonomy' is in the requested subject_types. Upgraded
+    DBs carry these rows until the background ``mark_species_keywords``
+    pass retypes them; without this guard, the classify job would
+    re-classify already-identified photos during that window.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='p2.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+
+    # Plant a legacy species keyword on p1 (is_species=1, type='general').
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'general', 1)",
+        ("Robin",),
+    )
+    legacy_sp = cur.lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p1, legacy_sp),
+    )
+    db.conn.commit()
+
+    kept = db.filter_out_subject_tagged([p1, p2], {"taxonomy"})
+    assert kept == [p2], (
+        "Legacy is_species=1 rows must count as taxonomy-tagged so upgraded "
+        "DBs don't re-run classify on already-identified photos."
+    )
+
+
+def test_filter_out_subject_tagged_ignores_legacy_is_species_when_taxonomy_excluded(tmp_path):
+    """Counter-test: when 'taxonomy' is not in the requested subject_types,
+    is_species=1 must NOT exclude photos — only keywords whose type
+    matches the requested set count."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'general', 1)",
+        ("Robin",),
+    )
+    legacy_sp = cur.lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p1, legacy_sp),
+    )
+    db.conn.commit()
+
+    kept = db.filter_out_subject_tagged([p1], {"genre"})
+    assert kept == [p1], (
+        "is_species=1 must only count when 'taxonomy' is one of the "
+        "requested subject_types; otherwise the legacy-species fallback "
+        "would over-filter."
     )
 
 

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7115,6 +7115,54 @@ def test_backfill_wildlife_genre_matches_legacy_is_species_rows(tmp_path):
     )
 
 
+def test_backfill_wildlife_genre_after_mark_picks_up_plaintext_species(tmp_path):
+    """Regression: plain-text species tags on upgraded DBs start as
+    ``is_species=0`` and ``type != 'taxonomy'``; only ``mark_species_keywords``
+    can retype them via taxonomy lookup. The Wildlife backfill is one-shot via
+    ``wildlife_backfill_done`` and only matches ``type='taxonomy' OR is_species=1``,
+    so it MUST run after ``mark_species_keywords`` — otherwise it sets the
+    marker on a zero-row scan and never retries.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+
+    # Plain-text species tag: type='general', is_species=0 — neither flag set.
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'general', 0)",
+        ("Robin",),
+    )
+    sp = cur.lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p1, sp),
+    )
+    db.conn.commit()
+
+    class FakeTaxonomy:
+        def lookup(self, name):
+            return {"taxon_id": 1} if name == "Robin" else None
+
+    # Order matches startup: mark first, then backfill.
+    db.mark_species_keywords(FakeTaxonomy())
+    db.backfill_wildlife_genre()
+
+    wildlife_id = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = 'Wildlife' AND type = 'genre'"
+    ).fetchone()["id"]
+    has_wildlife = db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
+        (p1, wildlife_id),
+    ).fetchone() is not None
+    assert has_wildlife is True, (
+        "Plain-text species tags must be retyped by mark_species_keywords "
+        "before backfill_wildlife_genre runs, so the backfill scan sees them."
+    )
+
+
 def test_tag_photo_legacy_is_species_keyword_adds_wildlife_genre(tmp_path):
     """Regression: auto-Wildlife must fire for legacy species rows whose
     ``type`` hasn't been retyped to ``taxonomy`` yet (is_species=1 with

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6951,6 +6951,83 @@ def test_backfill_wildlife_genre_matches_legacy_is_species_rows(tmp_path):
     )
 
 
+def test_tag_photo_legacy_is_species_keyword_adds_wildlife_genre(tmp_path):
+    """Regression: auto-Wildlife must fire for legacy species rows whose
+    ``type`` hasn't been retyped to ``taxonomy`` yet (is_species=1 with
+    non-taxonomy ``type``). On upgraded databases ``mark_species_keywords``
+    runs in a background thread, so newly-tagged photos can briefly hit
+    keywords that satisfy ``is_species=1`` but not ``type='taxonomy'``."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+
+    # Plant a legacy-shaped species keyword: is_species=1 but type='general'
+    # (the shape an upgraded DB has before mark_species_keywords retypes it).
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'general', 1)",
+        ("Robin",),
+    )
+    sp = cur.lastrowid
+    db.conn.commit()
+
+    db.tag_photo(p1, sp)
+
+    wildlife_id = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = 'Wildlife' AND type = 'genre'"
+    ).fetchone()["id"]
+    has_wildlife = db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
+        (p1, wildlife_id),
+    ).fetchone() is not None
+    assert has_wildlife is True, (
+        "Auto-Wildlife must trigger for legacy is_species=1 rows whose type "
+        "hasn't been normalized yet — otherwise photos tagged during the "
+        "background mark_species_keywords window permanently miss Wildlife."
+    )
+
+
+def test_tag_photo_legacy_species_sticky_removal_holds(tmp_path):
+    """Regression complement: sticky removal must still hold across the
+    mixed (legacy + retyped) species states. After removing Wildlife, a
+    second species tag — even one that uses the legacy is_species=1 shape
+    — must NOT re-add Wildlife as long as another species keyword is
+    already attached."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    sp_a = db.add_keyword("Robin", is_species=True)
+    db.tag_photo(p1, sp_a)  # First species — Wildlife auto-added.
+    wildlife_id = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = 'Wildlife' AND type = 'genre'"
+    ).fetchone()["id"]
+    db.untag_photo(p1, wildlife_id)  # User removes Wildlife.
+
+    # Plant a second species with the legacy shape.
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'general', 1)",
+        ("Sparrow",),
+    )
+    sp_b = cur.lastrowid
+    db.conn.commit()
+    db.tag_photo(p1, sp_b)
+
+    has_wildlife = db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
+        (p1, wildlife_id),
+    ).fetchone() is not None
+    assert has_wildlife is False, (
+        "Adding a second (legacy-shaped) species must respect the user's "
+        "Wildlife removal — the count query must consider both 'taxonomy' "
+        "and is_species=1 rows so existing species are seen."
+    )
+
+
 def test_tag_photo_no_op_re_tag_does_not_re_add_removed_wildlife(tmp_path):
     """Regression: re-tagging an already-tagged species (a no-op INSERT OR
     IGNORE) must NOT re-fire the auto-Wildlife rule, so user-removed

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -994,7 +994,7 @@ def test_default_collections_created(tmp_path):
     colls = db.get_collections()
     names = {c['name'] for c in colls}
     assert 'All Photos' in names
-    assert 'Needs Classification' in names
+    assert 'Needs Identification' in names
     assert 'Untagged' in names
     assert 'Flagged' in names
     assert 'Recent Import' in names
@@ -1028,10 +1028,72 @@ def test_default_collections_adds_missing(tmp_path):
     colls = db.get_collections()
     names = {c['name'] for c in colls}
     assert 'All Photos' in names
-    assert 'Needs Classification' in names
+    assert 'Needs Identification' in names
     assert 'Untagged' in names
     assert 'Recent Import' in names
     assert len(colls) == 5  # no duplicate Flagged
+
+
+def test_default_collection_uses_has_subject_for_new_workspaces(tmp_path):
+    """A newly-created workspace gets 'Needs Identification' (not 'Needs
+    Classification') with the has_subject==0 rule."""
+    import json
+
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    db.create_default_collections()
+
+    cols = {c["name"]: json.loads(c["rules"]) for c in db.get_collections()}
+    assert "Needs Identification" in cols
+    assert "Needs Classification" not in cols
+    assert cols["Needs Identification"] == [
+        {"field": "has_subject", "op": "equals", "value": 0}
+    ]
+
+
+def test_existing_needs_classification_collection_migrated_idempotently(tmp_path):
+    """A workspace pre-populated with the legacy default gets renamed; running
+    the migration again is a no-op."""
+    import json
+
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    # Force-create the legacy state.
+    db.add_collection(
+        "Needs Classification",
+        json.dumps([{"field": "has_species", "op": "equals", "value": 0}]),
+    )
+    db.migrate_default_subject_collection()
+    db.migrate_default_subject_collection()  # idempotent
+
+    cols = {c["name"]: json.loads(c["rules"]) for c in db.get_collections()}
+    assert "Needs Identification" in cols
+    assert "Needs Classification" not in cols
+    assert cols["Needs Identification"] == [
+        {"field": "has_subject", "op": "equals", "value": 0}
+    ]
+
+
+def test_migration_skips_user_customized_collection(tmp_path):
+    """If 'Needs Classification' exists with a non-default rule (the user
+    edited it), leave it alone."""
+    import json
+
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    custom = [{"field": "rating", "op": ">=", "value": 3}]
+    db.add_collection("Needs Classification", json.dumps(custom))
+    db.migrate_default_subject_collection()
+
+    cols = {c["name"]: json.loads(c["rules"]) for c in db.get_collections()}
+    assert "Needs Classification" in cols
+    assert cols["Needs Classification"] == custom
 
 
 def test_all_photos_collection_returns_all_photos(tmp_path):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1096,6 +1096,28 @@ def test_migration_skips_user_customized_collection(tmp_path):
     assert cols["Needs Classification"] == custom
 
 
+def test_default_scene_keywords_inserted(tmp_path):
+    """Database init populates the four default scene keywords."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    rows = db.conn.execute(
+        "SELECT name FROM keywords WHERE type = 'scene' ORDER BY name"
+    ).fetchall()
+    assert [r["name"] for r in rows] == ["Abstract", "Architecture", "Landscape", "Sunset"]
+
+
+def test_default_scene_keywords_idempotent(tmp_path):
+    """Calling ensure_default_scene_keywords multiple times doesn't duplicate."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.ensure_default_scene_keywords()
+    db.ensure_default_scene_keywords()
+    n = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM keywords WHERE type = 'scene'"
+    ).fetchone()["n"]
+    assert n == 4
+
+
 def test_all_photos_collection_returns_all_photos(tmp_path):
     """The default 'All Photos' collection matches every photo in the workspace."""
     from db import Database
@@ -2856,7 +2878,8 @@ def test_photo_keywords_includes_type(tmp_path):
     fid = db.add_folder('/photos', name='photos')
     pid = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
                        file_size=100, file_mtime=1.0)
-    kid = db.add_keyword('Sunset')
+    # Use a name that isn't pre-seeded as a default scene keyword.
+    kid = db.add_keyword('MyTag')
     db.tag_photo(pid, kid)
 
     keywords = db.get_photo_keywords(pid)
@@ -6472,11 +6495,12 @@ def test_add_keyword_existing_general_upgrades_to_requested_type(tmp_path):
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     db.set_active_workspace(db.create_workspace("ws"))
-    kid1 = db.add_keyword("Landscape")
+    # Use a name that isn't pre-seeded as a default scene keyword.
+    kid1 = db.add_keyword("Cityscape")
     row1 = db.conn.execute("SELECT type FROM keywords WHERE id = ?", (kid1,)).fetchone()
     assert row1["type"] == "general"
 
-    kid2 = db.add_keyword("Landscape", kw_type="scene")
+    kid2 = db.add_keyword("Cityscape", kw_type="scene")
     assert kid2 == kid1
     row2 = db.conn.execute("SELECT type FROM keywords WHERE id = ?", (kid2,)).fetchone()
     assert row2["type"] == "scene"

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1096,6 +1096,39 @@ def test_migration_skips_user_customized_collection(tmp_path):
     assert cols["Needs Classification"] == custom
 
 
+def test_upgrade_path_no_duplicate_collection(tmp_path):
+    """Regression: on an upgraded DB with the legacy 'Needs Classification'
+    default, running the startup sequence (migrate-then-seed) leaves a
+    single 'Needs Identification' collection — not a duplicate alongside
+    the legacy one."""
+    import json
+
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    # Force-create the legacy state that an upgraded DB would have.
+    db.add_collection(
+        "Needs Classification",
+        json.dumps([{"field": "has_species", "op": "equals", "value": 0}]),
+    )
+
+    # Mirror the create_app order: migrate first, then seed defaults.
+    db.migrate_default_subject_collection()
+    db.create_default_collections()
+
+    cols = {c["name"]: json.loads(c["rules"]) for c in db.get_collections()}
+    assert "Needs Classification" not in cols
+    assert "Needs Identification" in cols
+    assert cols["Needs Identification"] == [
+        {"field": "has_subject", "op": "equals", "value": 0}
+    ]
+    # Sanity: total default-collection count is 5, not 6 (no duplicate).
+    default_names = {"All Photos", "Needs Identification", "Untagged",
+                     "Flagged", "Recent Import"}
+    assert default_names.issubset(cols.keys())
+
+
 def test_default_genre_keywords_inserted(tmp_path):
     """Database init populates the default genre keywords."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7255,6 +7255,40 @@ def test_ensure_default_genre_keywords_upgrades_existing_general_wildlife(tmp_pa
     assert n >= 5  # Wildlife + Landscape + Sunset + Architecture + Abstract
 
 
+def test_init_normalizes_legacy_wildlife_before_seeding_genres(tmp_path):
+    """Regression: an upgraded DB where 'Wildlife' has a legacy type like
+    'descriptive' must end up with type='genre' after Database.__init__,
+    not stuck on 'general' (which the auto-Wildlife / backfill queries
+    can't find via WHERE name='Wildlife' AND type='genre')."""
+    from db import Database
+    # First instantiation runs the schema setup AND the seeds. Tear that
+    # down to simulate a pre-genre-feature DB: re-create the Wildlife
+    # row as 'descriptive', clear all genre rows.
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    db.conn.execute("DELETE FROM keywords WHERE type = 'genre'")
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'descriptive', 0)",
+        ("Wildlife",),
+    )
+    db.conn.commit()
+    db.conn.close()
+
+    # Re-open: __init__ runs migrate_legacy_keyword_types BEFORE
+    # ensure_default_genre_keywords, so Wildlife should be normalized to
+    # 'genre' instead of getting stuck on 'general'.
+    db2 = Database(db_path)
+    rows = db2.conn.execute(
+        "SELECT type FROM keywords WHERE name = 'Wildlife' AND parent_id IS NULL"
+    ).fetchall()
+    types = {r["type"] for r in rows}
+    assert "genre" in types, (
+        f"Legacy 'descriptive' Wildlife must end up as 'genre' after "
+        f"__init__; got types={types}. The auto-Wildlife trigger and "
+        f"backfill query depend on this."
+    )
+
+
 def test_ensure_default_genre_keywords_preserves_non_general_user_types(tmp_path):
     """If a user deliberately created e.g. an 'individual' Wildlife (a pet
     named Wildlife), ensure_default_genre_keywords must NOT clobber that."""

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6681,31 +6681,50 @@ def test_add_keyword_existing_general_upgrades_to_taxonomy_sets_is_species(tmp_p
 
 
 def test_add_keyword_taxonomy_preserves_individual_type_and_is_species(tmp_path):
-    """If an existing keyword has a deliberate non-general type (e.g. 'individual'),
-    a later add_keyword(..., kw_type='taxonomy') must NOT silently flip type or
-    stamp is_species=1. Otherwise auto-wildlife / backfill / subject filters
-    that include `OR is_species=1` would treat that individual row as a species.
+    """If an existing keyword has a deliberate non-general type (e.g.
+    'individual'), a later add_keyword(..., kw_type='taxonomy') must NOT
+    silently flip its type or stamp is_species=1. Otherwise auto-wildlife,
+    backfill, and subject filters that include `OR is_species=1` would
+    treat that individual row as a species.
+
+    The current contract: deliberate non-general rows are NOT candidates
+    for the typed-lookup. Caller asking for kw_type='taxonomy' on a name
+    that exists only as 'individual' falls through to INSERT, creating
+    a NEW taxonomy row alongside the preserved individual one
+    (duplicates by name across types are intentional; lookups
+    disambiguate by kw_type).
     """
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     db.set_active_workspace(db.create_workspace("ws"))
 
-    kid1 = db.add_keyword("Charlie", kw_type="individual")
+    kid_individual = db.add_keyword("Charlie", kw_type="individual")
     row1 = db.conn.execute(
-        "SELECT type, is_species FROM keywords WHERE id = ?", (kid1,)
+        "SELECT type, is_species FROM keywords WHERE id = ?", (kid_individual,)
     ).fetchone()
     assert row1["type"] == "individual"
     assert row1["is_species"] == 0
 
-    kid2 = db.add_keyword("Charlie", kw_type="taxonomy")
-    assert kid2 == kid1
-    row2 = db.conn.execute(
-        "SELECT type, is_species FROM keywords WHERE id = ?", (kid2,)
+    kid_taxonomy = db.add_keyword("Charlie", kw_type="taxonomy")
+    # A new row is created — the original individual row was not a
+    # candidate for the typed lookup.
+    assert kid_taxonomy != kid_individual
+
+    # Original 'individual' row is unchanged.
+    row1_after = db.conn.execute(
+        "SELECT type, is_species FROM keywords WHERE id = ?", (kid_individual,)
     ).fetchone()
-    assert row2["type"] == "individual", "deliberate type must be preserved"
-    assert row2["is_species"] == 0, (
-        "is_species must NOT be set on a non-taxonomy preserved row"
+    assert row1_after["type"] == "individual", "deliberate type must be preserved"
+    assert row1_after["is_species"] == 0, (
+        "is_species must NOT be set on a preserved non-taxonomy row"
     )
+
+    # New row has the requested taxonomy type with is_species=1.
+    row2 = db.conn.execute(
+        "SELECT type, is_species FROM keywords WHERE id = ?", (kid_taxonomy,)
+    ).fetchone()
+    assert row2["type"] == "taxonomy"
+    assert row2["is_species"] == 1
 
 
 def test_get_subject_types_returns_default(tmp_path, monkeypatch):
@@ -7399,6 +7418,46 @@ def test_ensure_default_genre_keywords_preserves_non_general_user_types(tmp_path
                 ('Landscape', 'Sunset', 'Architecture', 'Abstract')"""
     ).fetchone()[0]
     assert n_other == 4
+
+
+def test_add_keyword_kw_type_falls_through_when_only_other_types_exist(tmp_path):
+    """Regression: when kw_type is supplied but no same-type or 'general'
+    row exists, add_keyword must NOT silently return a non-promotable
+    other-typed row (e.g. 'location' or 'individual'). It must fall
+    through to INSERT a new row with the requested type, so callers
+    deterministically get back a row that matches kw_type.
+
+    Reachable via POST /api/photos/<id>/keywords and /api/batch/keyword
+    with an explicit type. Without this, the photo would be tagged with
+    a wrong-typed row and stay stuck in 'Needs Identification'."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+
+    # User has 'Backyard' typed as 'location' (a place they care about).
+    # No 'general' or 'genre' Backyard exists.
+    kid_location = db.add_keyword("Backyard", kw_type="location")
+
+    # Caller asks for genre Backyard (e.g. via the lightbox flow tagging
+    # a photo as a Backyard scene). The location row must NOT be returned.
+    kid_genre = db.add_keyword("Backyard", kw_type="genre")
+    assert kid_genre != kid_location, (
+        "add_keyword('Backyard', kw_type='genre') returned the existing "
+        "location row instead of creating a new genre row."
+    )
+
+    row = db.conn.execute(
+        "SELECT type FROM keywords WHERE id = ?", (kid_genre,)
+    ).fetchone()
+    assert row["type"] == "genre", (
+        f"Expected the new row to have type='genre'; got {row['type']!r}"
+    )
+
+    # Original 'location' Backyard is unchanged.
+    row_loc = db.conn.execute(
+        "SELECT type FROM keywords WHERE id = ?", (kid_location,)
+    ).fetchone()
+    assert row_loc["type"] == "location"
 
 
 def test_add_keyword_no_kw_type_prefers_canonical_genre_over_location(tmp_path):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7401,6 +7401,67 @@ def test_ensure_default_genre_keywords_preserves_non_general_user_types(tmp_path
     assert n_other == 4
 
 
+def test_add_keyword_no_kw_type_prefers_canonical_genre_over_location(tmp_path):
+    """Regression: when kw_type is omitted, the case-insensitive lookup
+    must prefer the most structured interpretation. A user with both a
+    hand-tagged 'location' Landscape and a canonical 'genre' Landscape
+    should get the genre row when calling add_keyword('Landscape')
+    with no kw_type — otherwise the photo would be tagged with the
+    location row and stay stuck in 'Needs Identification' under the
+    default subject_types."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    # Wipe the genre defaults; force-create a 'location' Landscape FIRST,
+    # then a 'genre' Landscape — so id-ASC alone would pick location.
+    db.conn.execute("DELETE FROM keywords WHERE type = 'genre'")
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'location', 0)",
+        ("Landscape",),
+    )
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'genre', 0)",
+        ("Landscape",),
+    )
+    db.conn.commit()
+
+    # No kw_type supplied. Must deterministically return the 'genre' row.
+    kid = db.add_keyword("Landscape")
+    row = db.conn.execute(
+        "SELECT type FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["type"] == "genre", (
+        f"add_keyword('Landscape') without kw_type must prefer 'genre' "
+        f"over 'location'; got {row['type']!r}"
+    )
+
+
+def test_add_keyword_no_kw_type_prefers_taxonomy_over_general(tmp_path):
+    """The type-priority order picks taxonomy first when present. A
+    species keyword that was once tagged plain-text and later promoted
+    via mark_species_keywords (creating a parallel 'general' row that
+    stuck around) should still be picked as the taxonomy row."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.set_active_workspace(db.create_workspace("ws"))
+    # 'general' Robin first (older id), 'taxonomy' Robin second.
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'general', 0)",
+        ("Robin",),
+    )
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES (?, 'taxonomy', 1)",
+        ("Robin",),
+    )
+    db.conn.commit()
+
+    kid = db.add_keyword("Robin")
+    row = db.conn.execute(
+        "SELECT type FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["type"] == "taxonomy"
+
+
 def test_ensure_default_genre_keywords_seeds_canonical_row_despite_typed_collision(tmp_path):
     """Regression: the seed must guarantee a canonical genre row for each
     default name even when a user has previously tagged a same-name

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -428,16 +428,16 @@ def test_add_keyword_with_type_override(app_and_db):
     pid = photos[0]['id']
 
     resp = client.post(f'/api/photos/{pid}/keywords',
-                       json={"name": "Tim", "type": "people"})
+                       json={"name": "Tim", "type": "individual"})
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["ok"] is True
     kid = data["keyword_id"]
 
-    # Verify the keyword type is "people" in the database
+    # Verify the keyword type is "individual" in the database
     row = db.conn.execute("SELECT type FROM keywords WHERE id = ?", (kid,)).fetchone()
     assert row is not None
-    assert row["type"] == "people"
+    assert row["type"] == "individual"
 
 
 def test_batch_keyword_with_type_override(app_and_db):


### PR DESCRIPTION
## Summary

Generalizes Vireo's "is this photo identified" predicate from species-only (`has_species`) to a configurable set of keyword **types**. Lets users tag landscapes / portraits / places so they drop out of "Needs Identification" and the AI classifier skips them.

## What's new

**Five-type enum** (`keywords.type`):

| Type | Meaning | Examples |
|------|---------|----------|
| `taxonomy` | Species (links to `taxa`) | Canada Goose, House Sparrow |
| `individual` | Named person or pet (face-recognition target) | Charlie, Fido |
| `location` | Named location with optional GPS | Golden Gate Park, my backyard |
| `genre` | Non-wildlife photo category | Landscape, Sunset, Wildlife |
| `general` | Catch-all untyped tags | client_A, portfolio |

**Per-workspace `subject_types` config** (default `{taxonomy, individual, genre}`) defines which types satisfy "identified."

**New `has_subject` collection rule** consults this set; default "Needs Classification" collection is renamed to **"Needs Identification"** with the new rule (idempotent migration preserves user-customized collections).

**Classifier skip-gate**: the classify job skips photos with any subject-typed keyword. `reclassify=True` bypasses for verification.

**Auto-Wildlife rule**: tagging a photo with its first taxonomy keyword auto-attaches a `Wildlife` genre keyword. Subsequent species tags don't re-add (so user removal sticks). One-shot backfill at DB init for existing species-tagged photos.

**Legacy type harmonization**: dropped the parallel `VALID_KEYWORD_TYPES` list. Migration of existing keyword rows: `people → individual`, `descriptive → general`, `event → general`. Single source of truth: `db.KEYWORD_TYPES`.

**UI**:
- Lightbox **"Not Wildlife"** button → tags with `Landscape` (genre) and advances
- Workspace settings: **"What counts as identified?"** checkbox section
- Keywords page filter buttons + bulk-type dropdown updated to the five-type enum
- Pipeline page Re-classify tooltip clarifies the new subject-tag bypass

**API**: `PUT /api/workspaces/<id>/subject-types`

**Default keywords shipped**: `Landscape`, `Sunset`, `Architecture`, `Abstract`, `Wildlife` (all `genre`).

## Design + plan docs

- `docs/plans/2026-04-25-subject-keyword-types-design.md`
- `docs/plans/2026-04-25-subject-keyword-types-plan.md`

## Test plan

- [x] Unit tests for `KEYWORD_TYPES`, `add_keyword` validation + `is_species`/type reconciliation
- [x] Tests for `get_subject_types`, `filter_out_subject_tagged`, `has_subject` rule (multiple shapes incl. empty subject_types)
- [x] API tests for `PUT /subject-types` (valid, unknown-dropped, empty allowed, non-list rejected, overrides preserved)
- [x] Default-collection migration tests (idempotent; preserves user customizations)
- [x] Default genre-keywords insertion tests (idempotent, count includes Wildlife)
- [x] Classifier skip-gate tests (skip + `reclassify=True` bypass; progress events)
- [x] Auto-Wildlife tests (first species attaches; second species doesn't re-add; user-removal sticky; re-adds after total species removal + new species; non-taxonomy types don't trigger; backfill idempotent)
- [x] Legacy type migration test (`people → individual`, `descriptive/event → general`, idempotent)
- [x] Smoke test: workspace page renders + saves subject_types via the new endpoint; browse page renders with the `Not Wildlife` button; pipeline tooltip updated

Full backend baseline: 712 tests pass on the targeted suite (`test_db.py test_app.py test_config.py test_classify_job.py test_photos_api.py test_workspaces.py test_edits_api.py test_jobs_api.py test_darktable_api.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)