### PR TITLE
Pin sidebar on pipeline review so thresholds stay reachable

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3681,6 +3681,7 @@ function formatDuration(seconds) {
       panel.style.height = savedH + 'px';
       document.getElementById('bottomToggle').classList.add('open');
       document.body.style.paddingBottom = (savedH + 28) + 'px';
+      document.body.style.setProperty('--bottom-offset', (savedH + 28) + 'px');
     }
     var savedTab = localStorage.getItem('vireo_panel_tab') || 'jobs';
     switchBpTab(savedTab);
@@ -3913,7 +3914,9 @@ function formatDuration(seconds) {
     localStorage.setItem('vireo_panel_open', isOpen);
     var h = isOpen ? (parseInt(localStorage.getItem('vireo_panel_height')) || 240) : 0;
     panel.style.height = h + 'px';
-    document.body.style.paddingBottom = isOpen ? (h + 28) + 'px' : '28px';
+    var newPad = isOpen ? (h + 28) + 'px' : '28px';
+    document.body.style.paddingBottom = newPad;
+    document.body.style.setProperty('--bottom-offset', newPad);
     // Start/stop SSE and polling based on panel visibility
     if (isOpen) {
       startLogStream();
@@ -3950,6 +3953,7 @@ function formatDuration(seconds) {
       var newH = Math.max(100, Math.min(window.innerHeight - 100, startH + (startY - e.clientY)));
       panel.style.height = newH + 'px';
       document.body.style.paddingBottom = (newH + 28) + 'px';
+      document.body.style.setProperty('--bottom-offset', (newH + 28) + 'px');
     });
 
     document.addEventListener('mouseup', function() {

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -8,12 +8,11 @@
 <link rel="stylesheet" href="/static/vireo-base.css">
 <title>Vireo - Pipeline Review</title>
 <style>
-body { padding-bottom: 36px; }
-
 /* Layout: sidebar + main */
 .pipeline-layout {
   display: flex;
-  min-height: calc(100vh - 44px);
+  height: calc(100vh - 48px - 28px);
+  overflow: hidden;
 }
 
 /* -- Sidebar -- */

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -11,7 +11,7 @@
 /* Layout: sidebar + main */
 .pipeline-layout {
   display: flex;
-  height: calc(100vh - 48px - 28px);
+  height: calc(100vh - 48px - var(--bottom-offset, 28px));
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- The pipeline review layout used `min-height: calc(100vh - 44px)` on the flex container, so the whole page scrolled as one unit and the scoring/grouping threshold sliders disappeared once you scrolled past them.
- Switched to a fixed `height: calc(100vh - 48px - 28px)` (navbar + bottom toggle) with `overflow: hidden`, matching the pattern already used in `jobs.html`. The sidebar and main pane already had `overflow-y: auto`, so they now scroll independently and the thresholds stay pinned.
- Removed the now-unneeded `body { padding-bottom: 36px; }` since the body no longer scrolls.

## Test plan
- [ ] Open the pipeline review page, scroll the photo grid — sliders in the left sidebar remain visible and adjustable.
- [ ] Sidebar itself scrolls when its contents overflow (many threshold sections expanded).
- [ ] Inspect modal (position: fixed) still opens correctly over the layout.
- [ ] `python -m pytest vireo/tests/test_app.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)