### PR TITLE
feat: location autocomplete with Google Places

### DIFF
--- a/docs/plans/2026-04-25-location-autocomplete-design.md
+++ b/docs/plans/2026-04-25-location-autocomplete-design.md
@@ -1,0 +1,91 @@
+# Location Autocomplete — Design
+
+**Date**: 2026-04-25
+**Status**: Approved, ready for implementation plan
+
+## Problem
+
+Vireo's location keywords are free-text strings entered in the same input as every other keyword. There's no autocomplete, no link to a real-world place, no coords, no map presence for non-EXIF photos. The `keywords` table already has `latitude`/`longitude` columns and a `parent_id` for hierarchy, but the UI never uses them.
+
+We want iNaturalist's pattern: type a place, pick from a Google Places dropdown, get coords + a parent chain (city → state → country), have it show on the map.
+
+## Decisions
+
+### UX
+
+- **Dedicated Location section** in the photo detail panel, separate from the keyword pill area. Single input bound to Google's `places.Autocomplete` widget. Always visible.
+- **Single leaf per photo** with auto-rolled-up parents derived from Google's `address_components`. The user picks "Central Park"; the system implicitly tags it with Manhattan / NY / NYS / USA via `parent_id` chain.
+- **Free-text fallback**: if the user hits Enter on text Google didn't match, create a `type='location'` keyword with no `place_id` and no coords. No manual pin-drop in v1.
+- **EXIF GPS suggest-on-open**: when a photo has lat/lng but no location keyword, the section shows an inline reverse-geocoded suggestion ("EXIF says: Central Park, Manhattan, NY [Accept]"). Click to attach. No background mass-tagging.
+- **Filled state** shows the leaf place bold + parent breadcrumbs muted, plus an × to clear.
+- **Existing coordless location keywords** stay as-is; `keywords.html` gains a per-row "📍 Link…" button that opens an autocomplete modal and attaches `place_id`/coords/parent chain to the existing row. No bulk auto-match (silent mistagging risk).
+
+### Data model
+
+- **Add column**: `keywords.place_id TEXT` (nullable).
+- **Add index**: `CREATE UNIQUE INDEX idx_keywords_place_id ON keywords(place_id) WHERE place_id IS NOT NULL`.
+- Existing free-text rows keep deduping by `UNIQUE(name, parent_id)`.
+- `parent_id` chain is populated from `address_components` returned by Google Place Details. Each level becomes its own keyword row, deduped by `place_id` when Google supplies one for the component.
+- **No data migration.** Existing `type='location'` keywords keep working; the Link button upgrades them on demand.
+- **New table** for reverse-geocode caching (server-side):
+
+  ```sql
+  CREATE TABLE IF NOT EXISTS place_reverse_geocode_cache (
+    lat_grid    INTEGER NOT NULL,   -- round(lat * 1000), ~110m grid
+    lng_grid    INTEGER NOT NULL,
+    place_id    TEXT,               -- NULL = "Google had no match"
+    response    TEXT NOT NULL,      -- raw JSON
+    fetched_at  INTEGER NOT NULL,
+    PRIMARY KEY (lat_grid, lng_grid)
+  );
+  ```
+
+### Architecture
+
+Hybrid client/server:
+
+- **Client-side** (Google Maps JS Places library, key embedded in page): the per-keystroke autocomplete dropdown in the Location section and in the Link modal. Uses Google's native UI widget, not reskinned.
+- **Server-side proxy** (key in `~/.vireo/config.json`, never sent to browser): Place Details lookup on user pick (so we can do parent-chain upserts atomically) and reverse-geocoding for EXIF suggestions (cached in SQLite).
+
+### Server endpoints (all in `vireo/app.py`)
+
+- `POST /api/photos/<int:photo_id>/location` — body `{place_id}`. Fetches Place Details, builds parent chain, upserts keywords, swaps the photo's location keyword. Returns rendered Location-section HTML fragment.
+- `POST /api/photos/<int:photo_id>/location/text` — body `{name}`. Free-text fallback path. Same return shape.
+- `DELETE /api/photos/<int:photo_id>/location` — clears the photo's `type='location'` keyword links (does not delete keyword rows).
+- `GET /api/places/reverse-geocode?lat=&lng=` — server proxy, cached. Returns `{place_id, summary}` or `{place_id: null}`.
+- `POST /api/keywords/<int:keyword_id>/link-place` — body `{place_id}`. Attaches Google data to an existing free-text keyword. Detects unique-index conflict and merges photo associations into the canonical row.
+
+All endpoints that talk to Google read the key at request time. Empty key returns `{"error": "no_api_key"}` with HTTP 400; frontend translates into "Add a Google Maps key in Settings".
+
+### Config
+
+- New field `google_maps_api_key` in `vireo/config.py` `DEFAULTS` (empty default).
+- Settings page gets a password-style input + one-line help linking to Google Cloud console.
+- One-line note: add HTTP referrer restriction in Google Cloud console (`localhost:8080/*`) for key safety.
+- Empty key = feature degrades gracefully (free-text only, no autocomplete dropdown, no EXIF suggestion).
+
+### Map page (`vireo/templates/map.html`)
+
+- Modify the photo-feed query: prefer `photos.latitude/longitude` (EXIF), fall back to the deepest `type='location'` keyword's coords. Photos with neither still don't appear.
+- Each marker carries a `source` field (`'exif'` or `'keyword'`); the popup shows a one-line provenance footer.
+- No new layer for places-as-markers (deferred to v1.5).
+
+## Out of scope (YAGNI)
+
+- Manual pin-drop on a Leaflet picker for free-text places.
+- Background bulk reverse-geocode of all GPS-tagged photos.
+- "Locations" layer on the map (places themselves as clickable markers with photo counts).
+- Place metadata blob (viewport bbox, place types, etc.).
+- Multi-location-per-photo tagging.
+- Privacy / location obscuring.
+- Re-pointing an already-linked keyword's `place_id`.
+
+## Cost
+
+Solo-user volume is comfortably free under Google's Essentials tier (10k events/month per SKU, three relevant SKUs: Autocomplete, Place Details, Geocoding). Reverse-geocode is heavily cached (a 200-photo trip = one call). HTTP referrer restriction is the meaningful safeguard, not in-app rate limiting.
+
+## Open implementation questions
+
+- Exact JS approach for embedding Google's autocomplete widget while keeping `browse.html` snappy (lazy-load the Maps JS library on first focus of the input).
+- How to render the parent breadcrumb in the filled state without overflowing in narrow panels — likely truncate middle parents on hover.
+- Whether the "Link" modal in `keywords.html` should also offer to merge if the picked place_id already exists, or just silently merge.

--- a/docs/plans/2026-04-25-location-autocomplete-plan.md
+++ b/docs/plans/2026-04-25-location-autocomplete-plan.md
@@ -1,0 +1,604 @@
+# Location Autocomplete Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wire iNaturalist-style Google Places autocomplete into Vireo's location keyword flow, populate `keywords.latitude/longitude`, build a parent chain via `parent_id`, and surface coords on the existing Leaflet map.
+
+**Architecture:** Hybrid client/server. Per-keystroke autocomplete uses the Google Maps JS Places library client-side with the API key embedded (referrer-restricted by the user in Google Cloud console). Place Details on user pick + reverse-geocode for EXIF go through Flask proxy endpoints (key in `~/.vireo/config.json`, never sent to browser). Reverse-geocode results are cached in SQLite by ~110m grid.
+
+**Tech Stack:** Flask, Jinja2, vanilla JS, SQLite (no ORM, no migration system), Leaflet (existing), Google Maps Places (new), pytest + Playwright e2e.
+
+**Design doc:** `docs/plans/2026-04-25-location-autocomplete-design.md`
+
+---
+
+## Conventions (read first)
+
+- DB access in routes: `db = _get_db()` (`vireo/app.py:484`).
+- JSON request body: `request.get_json(silent=True) or {}`.
+- JSON errors: `return json_error("msg", status=400)` (`vireo/app.py:480`).
+- JSON success: `return jsonify({...})`.
+- Schema changes: no migrations system. New tables use `CREATE TABLE IF NOT EXISTS` in `Database._create_tables()`. New columns on existing tables use a guarded `ALTER TABLE ... ADD COLUMN` pattern (check `PRAGMA table_info(<table>)` first).
+- Test harness: `tests/conftest.py` provides a `db` fixture (Database with tmp_path). API tests use the Flask test client. E2E uses `tests/e2e/` with Playwright + `live_server`.
+- Pre-existing test failures on main as of 2026-04-22 should not block — see `~/.claude/projects/-Users-julius-git-vireo/memory/project_preexisting_test_failures.md`.
+
+Each task ends with a commit. Frequent commits.
+
+---
+
+## Task 1: Schema — `place_id` column + unique index
+
+**Files:**
+- Modify: `vireo/db.py` (the `Database._create_tables()` method)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write the failing test**
+
+Add to `vireo/tests/test_db.py`:
+```python
+def test_keywords_has_place_id_column_and_unique_index(db):
+    cols = {row[1] for row in db._conn.execute("PRAGMA table_info(keywords)").fetchall()}
+    assert "place_id" in cols
+
+    db._conn.execute(
+        "INSERT INTO keywords (name, type, place_id) VALUES (?, ?, ?)",
+        ("Central Park", "location", "ChIJ_test_1"),
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        db._conn.execute(
+            "INSERT INTO keywords (name, type, place_id) VALUES (?, ?, ?)",
+            ("Different Name", "location", "ChIJ_test_1"),
+        )
+
+    db._conn.execute(
+        "INSERT INTO keywords (name, type, place_id) VALUES (?, ?, NULL)",
+        ("free text 1", "location"),
+    )
+    db._conn.execute(
+        "INSERT INTO keywords (name, type, place_id) VALUES (?, ?, NULL)",
+        ("free text 2", "location"),
+    )
+```
+
+**Step 2: Run test to verify it fails**
+
+`python -m pytest vireo/tests/test_db.py::test_keywords_has_place_id_column_and_unique_index -v`
+Expected: FAIL (column missing).
+
+**Step 3: Implement**
+
+In `Database._create_tables()` (after the `keywords` table is created), add a guarded column add and the partial unique index:
+```python
+cur.execute("PRAGMA table_info(keywords)")
+kw_cols = {row[1] for row in cur.fetchall()}
+if "place_id" not in kw_cols:
+    cur.execute("ALTER TABLE keywords ADD COLUMN place_id TEXT")
+cur.execute(
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_keywords_place_id "
+    "ON keywords(place_id) WHERE place_id IS NOT NULL"
+)
+```
+
+**Step 4: Re-run test → PASS**
+
+**Step 5: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "feat(db): add place_id column + unique index to keywords"
+```
+
+---
+
+## Task 2: Schema — `place_reverse_geocode_cache` table
+
+**Files:**
+- Modify: `vireo/db.py`
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Failing test**
+
+```python
+def test_place_reverse_geocode_cache_table_exists(db):
+    cols = {row[1] for row in db._conn.execute(
+        "PRAGMA table_info(place_reverse_geocode_cache)"
+    ).fetchall()}
+    assert cols >= {"lat_grid", "lng_grid", "place_id", "response", "fetched_at"}
+```
+
+**Step 2: Run → FAIL**
+
+**Step 3: Implement**
+
+Add to `_create_tables()`:
+```sql
+CREATE TABLE IF NOT EXISTS place_reverse_geocode_cache (
+    lat_grid    INTEGER NOT NULL,
+    lng_grid    INTEGER NOT NULL,
+    place_id    TEXT,
+    response    TEXT NOT NULL,
+    fetched_at  INTEGER NOT NULL,
+    PRIMARY KEY (lat_grid, lng_grid)
+)
+```
+
+**Step 4: Run → PASS**
+
+**Step 5: Commit**
+```bash
+git commit -am "feat(db): add place_reverse_geocode_cache table"
+```
+
+---
+
+## Task 3: Config — `google_maps_api_key`
+
+**Files:**
+- Modify: `vireo/config.py`
+- Test: `vireo/tests/test_config.py`
+
+**Step 1: Failing test**
+```python
+def test_google_maps_api_key_default_is_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    assert cfg.load().get("google_maps_api_key") == ""
+```
+
+**Step 2: Run → FAIL**
+
+**Step 3: Implement** — add `"google_maps_api_key": ""` to `DEFAULTS` in `vireo/config.py`.
+
+**Step 4: Run → PASS**
+
+**Step 5: Commit**
+```bash
+git commit -am "feat(config): add google_maps_api_key field"
+```
+
+---
+
+## Task 4: Google Places API wrapper module
+
+**Files:**
+- Create: `vireo/places.py`
+- Test: `vireo/tests/test_places.py`
+
+**Goal:** Thin wrapper around Google's HTTP APIs. Two functions:
+- `place_details(place_id, api_key) -> dict | None` — calls Place Details API; returns dict with `name`, `lat`, `lng`, `place_id`, `address_components` (list of `{place_id?, name, types[], short_name}`).
+- `reverse_geocode(lat, lng, api_key) -> dict | None` — calls Geocoding API; returns same shape (or None for no match).
+
+Use `urllib.request` (no new dependency). Endpoints:
+- Place Details: `https://maps.googleapis.com/maps/api/place/details/json?place_id=...&key=...&fields=place_id,name,geometry/location,address_components`
+- Reverse geocode: `https://maps.googleapis.com/maps/api/geocode/json?latlng=lat,lng&key=...`
+
+**Step 1: Failing tests**
+
+Mock `urllib.request.urlopen` with fixed JSON. Three tests:
+1. `test_place_details_parses_response` — feed canned JSON, assert returned dict has expected keys.
+2. `test_place_details_returns_none_on_zero_results` — Google returns `{"status": "ZERO_RESULTS"}` → `None`.
+3. `test_reverse_geocode_parses_response` — same shape.
+
+**Step 2: Run → FAIL** (`ModuleNotFoundError`).
+
+**Step 3: Implement** `vireo/places.py` with the two functions + a small `_get_json(url)` helper. No retry, no caching at this layer.
+
+**Step 4: Run → PASS**
+
+**Step 5: Commit**
+```bash
+git add vireo/places.py vireo/tests/test_places.py
+git commit -m "feat(places): add Google Places HTTP wrapper"
+```
+
+---
+
+## Task 5: DB — place keyword upsert (parent chain)
+
+**Files:**
+- Modify: `vireo/db.py` (add `Database.upsert_place_chain`)
+- Test: `vireo/tests/test_db.py`
+
+**Goal:** Given a Place Details dict (from `places.place_details`), upsert the leaf keyword + a parent-chain of keywords from `address_components`. Returns the leaf keyword `id`.
+
+**Behavior:**
+- Walk `address_components` from broadest (`country`) → narrowest, building parents one at a time.
+- For each level, dedupe by `place_id` if Google supplied one for the component, else by `(name, parent_id)`.
+- Set `type='location'`, `latitude`/`longitude` (only on leaf for v1), `place_id` where available.
+- Final leaf = the place itself (using top-level `name` + `place_id` + `geometry.location`).
+
+**Step 1: Failing test**
+
+Feed a canned Place Details dict (Central Park-style with country/state/city components). Assert:
+- Leaf keyword exists with correct name, place_id, lat, lng, type='location'.
+- Parent chain walks 4 levels (country → state → city → leaf).
+- Calling twice returns the same leaf id (idempotent).
+
+**Step 2: Run → FAIL**
+
+**Step 3: Implement** the method. Helper `_upsert_one_keyword(name, parent_id, place_id) -> int` that does the conflict-tolerant insert.
+
+**Step 4: Run → PASS**
+
+**Step 5: Commit**
+```bash
+git commit -am "feat(db): add upsert_place_chain for Google Places"
+```
+
+---
+
+## Task 6: DB — set/clear photo location, free-text location, link existing keyword
+
+**Files:**
+- Modify: `vireo/db.py`
+- Test: `vireo/tests/test_db.py`
+
+Three new methods:
+- `set_photo_location(photo_id, leaf_keyword_id)` — removes any existing `type='location'` keyword links for the photo, inserts the new link.
+- `clear_photo_location(photo_id)` — removes `type='location'` keyword links.
+- `get_or_create_text_location(name) -> int` — finds or creates a `type='location'` keyword with no `place_id`, returns its id.
+- `link_keyword_to_place(keyword_id, details)` — attaches `place_id`, coords, and parent chain to an existing keyword. Detects unique conflict on `place_id` and merges (re-points `photo_keywords` rows from old → canonical, deletes old).
+
+**Step 1: Failing tests** — one per method. Cover the merge case for `link_keyword_to_place`.
+
+**Step 2: Run → FAIL**
+
+**Step 3: Implement**
+
+**Step 4: Run → PASS**
+
+**Step 5: Commit**
+```bash
+git commit -am "feat(db): photo location set/clear + keyword link-place"
+```
+
+---
+
+## Task 7: DB — reverse-geocode cache get/put
+
+**Files:**
+- Modify: `vireo/db.py`
+- Test: `vireo/tests/test_db.py`
+
+Methods:
+- `reverse_geocode_cache_get(lat, lng) -> dict | None` — looks up by rounded grid; returns `{place_id, response}` or `None`.
+- `reverse_geocode_cache_put(lat, lng, place_id, response_json)` — upsert at grid cell.
+
+Grid: `int(round(lat * 1000))`, `int(round(lng * 1000))`.
+
+**Step 1-5:** Standard TDD. Test that put-then-get round-trips, that two coords in the same ~110m grid hit the same cell, that negative results (`place_id=None`) are also cached.
+
+```bash
+git commit -am "feat(db): reverse-geocode cache get/put"
+```
+
+---
+
+## Task 8: API — `POST/DELETE /api/photos/<id>/location`
+
+**Files:**
+- Modify: `vireo/app.py`
+- Test: `vireo/tests/test_photos_api.py` (or new `test_location_api.py`)
+
+**Endpoints:**
+
+`POST /api/photos/<int:photo_id>/location`:
+1. Parse body `{place_id}`.
+2. Read `google_maps_api_key` from config; if empty, return `json_error("no_api_key", 400)`.
+3. `details = places.place_details(place_id, key)`; if `None`, return `json_error("place_not_found", 404)`.
+4. `leaf_id = db.upsert_place_chain(details)`.
+5. `db.set_photo_location(photo_id, leaf_id)`.
+6. Return JSON: `{"location": {...rendered fields for the section UI...}}`.
+
+`DELETE /api/photos/<int:photo_id>/location`:
+1. `db.clear_photo_location(photo_id)`.
+2. Return `{"ok": true}`.
+
+**Step 1: Failing tests**
+
+Use Flask test client. Mock `places.place_details` (monkeypatch). Two tests:
+- POST with valid place_id → 200, photo has `type='location'` keyword link with correct lat/lng.
+- DELETE → 200, no `type='location'` keyword links remain.
+- POST with empty config key → 400 with `error: "no_api_key"`.
+
+**Step 2-4: Standard TDD.**
+
+**Step 5: Commit**
+```bash
+git commit -am "feat(api): POST/DELETE photo location"
+```
+
+---
+
+## Task 9: API — `POST /api/photos/<id>/location/text`
+
+**Files:**
+- Modify: `vireo/app.py`
+- Test: same test file as Task 8
+
+Body: `{name}`. Path: free-text fallback. No Google call.
+
+1. `leaf_id = db.get_or_create_text_location(name)`.
+2. `db.set_photo_location(photo_id, leaf_id)`.
+3. Return `{"location": {...}}`.
+
+**TDD as above.** Commit:
+```bash
+git commit -am "feat(api): POST photo location text fallback"
+```
+
+---
+
+## Task 10: API — `GET /api/places/reverse-geocode`
+
+**Files:**
+- Modify: `vireo/app.py`
+- Test: same file
+
+Query params: `lat`, `lng`. Behavior:
+1. Validate floats.
+2. `cached = db.reverse_geocode_cache_get(lat, lng)`. If hit, return `{place_id, summary}` (summary derived from cached `response`).
+3. Miss: read API key from config; if empty, return cached miss as `{place_id: null}` (don't 400 — degrade gracefully so the UI can just hide the suggestion).
+4. `details = places.reverse_geocode(lat, lng, key)`.
+5. `db.reverse_geocode_cache_put(lat, lng, details and details["place_id"], json.dumps(details or {}))`.
+6. Return `{place_id, summary}` (or `{place_id: null}` if Google had no match).
+
+**Summary string** — derived from `details`: leaf name + first 2 parent names. Helper `_summarize_details(details) -> str`.
+
+**TDD:** monkeypatch `places.reverse_geocode`. Cache hit, cache miss, no-API-key paths.
+
+```bash
+git commit -am "feat(api): reverse-geocode proxy with SQLite cache"
+```
+
+---
+
+## Task 11: API — `POST /api/keywords/<id>/link-place`
+
+**Files:**
+- Modify: `vireo/app.py`
+- Test: same file
+
+Body: `{place_id}`. Steps:
+1. Read API key; empty → 400.
+2. `details = places.place_details(place_id, key)`; None → 404.
+3. `result = db.link_keyword_to_place(keyword_id, details)`. Returns `{keyword_id, merged: bool}` (merged=True means an existing place_id-bearing keyword absorbed the link target).
+4. Return JSON with the resulting keyword fields.
+
+**TDD:** test the link, test the merge case. Commit:
+```bash
+git commit -am "feat(api): link existing keyword to Google place"
+```
+
+---
+
+## Task 12: UI — Settings page Google Maps key input
+
+**Files:**
+- Modify: `vireo/templates/settings.html`
+- Test: `tests/e2e/test_settings.py` (extend if exists, else create)
+
+**Steps:**
+- Add a section "Google Maps" with a password-style input bound to `cfg.google_maps_api_key`. Same wiring pattern as existing `inat_token` (read on render, POST on save to `/api/config`).
+- One-line help: "Used for location autocomplete. Add an HTTP referrer restriction in Google Cloud console (e.g. `localhost:8080/*`)."
+
+**Manual verification (no e2e required for v1):**
+1. `python vireo/app.py --db ~/.vireo/vireo.db --port 8080`
+2. Open http://localhost:8080/settings.
+3. Enter a key, save, reload. Confirm it persists in `~/.vireo/config.json`.
+
+```bash
+git commit -am "feat(settings): add Google Maps API key input"
+```
+
+---
+
+## Task 13: UI — Location section in photo detail panel
+
+**Files:**
+- Modify: `vireo/templates/browse.html`
+
+This is the biggest UI task. Break it into substeps with a single commit at the end.
+
+**Substep 13.1: HTML scaffold**
+
+In the photo detail panel (above or just below the Keywords pill area), add:
+```html
+<div class="location-section">
+  <div class="location-label">Location</div>
+  <div id="locationFilled" hidden></div>
+  <div id="locationEmpty">
+    <input id="locationInput" class="add-kw-input" placeholder="📍 Add location..." />
+    <div id="locationExifSuggestion" hidden></div>
+  </div>
+</div>
+```
+
+**Substep 13.2: Lazy-load Google Maps JS**
+
+Helper `loadGoogleMapsJs()` that, on first call, injects `<script src="https://maps.googleapis.com/maps/api/js?key={{ google_maps_api_key }}&libraries=places&loading=async">` and resolves a Promise when ready. Memoize. Pass the API key from the route into the template context (extend the existing browse route in `app.py` to include `google_maps_api_key=cfg.load().get('google_maps_api_key', '')`).
+
+If the key is empty, skip loading and leave the input as plain text (Enter creates a free-text location).
+
+**Substep 13.3: Bind autocomplete on focus**
+
+When `locationInput` first gains focus, call `loadGoogleMapsJs()`, then `new google.maps.places.Autocomplete(input, {types: ['geocode', 'establishment']})`. On `place_changed` event, grab `place.place_id`, POST to `/api/photos/<id>/location`, render filled state from response.
+
+**Substep 13.4: Free-text Enter fallback**
+
+If user hits Enter without picking from the dropdown (`autocomplete.getPlace().place_id` is undefined or input value doesn't match a picked place), POST to `/api/photos/<id>/location/text` with `{name: input.value}`.
+
+**Substep 13.5: Filled state**
+
+Renders leaf name (bold) + parent breadcrumbs (muted, `·` separated) + clear button (×). Clear → DELETE `/api/photos/<id>/location` → swap back to empty state.
+
+**Substep 13.6: Render server-side on initial load**
+
+When the photo detail panel renders for a photo that already has a `type='location'` keyword link, server-side resolve the leaf + parent chain and pre-render the filled state (no client roundtrip needed).
+
+**Manual test:**
+1. Run app, set API key in Settings.
+2. Open a photo, focus Location input, type "Central". Confirm Google dropdown appears.
+3. Pick "Central Park, NY". Confirm filled state renders with breadcrumbs.
+4. Reload the page; confirm location is still filled.
+5. Click ×; confirm cleared.
+6. Type "the dog park behind my house" + Enter; confirm a free-text location is created (no breadcrumbs).
+7. Clear the API key; confirm autocomplete is gone but free-text + Enter still works.
+
+```bash
+git commit -am "feat(ui): add Location section with Places autocomplete"
+```
+
+---
+
+## Task 14: UI — EXIF GPS suggest-on-open
+
+**Files:**
+- Modify: `vireo/templates/browse.html`
+
+When opening a photo:
+- If photo has `latitude/longitude` (EXIF) AND no `type='location'` keyword link AND `google_maps_api_key` is set:
+  - Fire `GET /api/places/reverse-geocode?lat=...&lng=...`.
+  - On `{place_id, summary}`, render `<div id="locationExifSuggestion">💡 EXIF says: {summary} <button>Accept</button></div>` below the input.
+  - On Accept click, POST `/api/photos/<id>/location` with that `place_id` (same path as autocomplete pick).
+  - On `{place_id: null}`, hide the suggestion silently.
+
+**Manual test:**
+- Open a GPS-tagged photo with no location keyword. Confirm suggestion appears within ~1s.
+- Click Accept. Confirm location is filled, suggestion disappears.
+- Re-open the same photo. Confirm no suggestion (already has location).
+
+```bash
+git commit -am "feat(ui): EXIF reverse-geocode suggest-on-open"
+```
+
+---
+
+## Task 15: UI — `keywords.html` Link-to-Google button
+
+**Files:**
+- Modify: `vireo/templates/keywords.html`
+
+For each row where `type='location' AND place_id IS NULL`, render a `📍 Link…` button. Click opens a small modal:
+- Single autocomplete input (same `places.Autocomplete` widget; reuse `loadGoogleMapsJs()` from browse.html or extract to a small shared `static/js/places.js`).
+- Pre-fill input value with the keyword's current name.
+- On pick → `POST /api/keywords/<id>/link-place` with `place_id` → close modal, re-render row with breadcrumb + linked badge.
+- If response says `merged: true`, show a small toast: "Merged into existing 'Central Park'".
+
+Add a filter chip "Locations · N unlinked" near the existing keyword filters.
+
+**Manual test:**
+- Create a free-text location keyword via the existing keyword flow.
+- Visit /keywords, find it, click Link, pick a Google match.
+- Confirm coords + breadcrumb appear, button disappears.
+- Confirm photos previously tagged with that keyword now show on /map.
+
+```bash
+git commit -am "feat(ui): link existing location keywords to Google places"
+```
+
+---
+
+## Task 16: Map — fall back to keyword coords + provenance
+
+**Files:**
+- Modify: `vireo/db.py` (`get_geolocated_photos`)
+- Modify: `vireo/templates/map.html`
+- Test: `vireo/tests/test_db.py`
+
+**DB change:** Modify `get_geolocated_photos` to also return photos that lack EXIF coords but have a `type='location'` keyword with non-null lat/lng. Use a `COALESCE` pattern with a subquery:
+
+```sql
+SELECT
+  p.id,
+  COALESCE(p.latitude, kl.latitude)  AS latitude,
+  COALESCE(p.longitude, kl.longitude) AS longitude,
+  CASE WHEN p.latitude IS NOT NULL THEN 'exif' ELSE 'keyword' END AS coord_source,
+  kl.name AS keyword_location_name,
+  ...
+FROM photos p
+LEFT JOIN (
+  SELECT pk.photo_id, k.latitude, k.longitude, k.name, k.id,
+         ROW_NUMBER() OVER (PARTITION BY pk.photo_id ORDER BY k.parent_id IS NULL, k.id) AS rn
+  FROM photo_keywords pk
+  JOIN keywords k ON k.id = pk.keyword_id
+  WHERE k.type='location' AND k.latitude IS NOT NULL
+) kl ON kl.photo_id = p.id AND kl.rn = 1
+WHERE COALESCE(p.latitude, kl.latitude) IS NOT NULL
+  AND COALESCE(p.longitude, kl.longitude) IS NOT NULL
+  AND ...workspace/folder filters...
+```
+
+(Choosing leaf via `parent_id IS NULL` proxy isn't perfect; for v1, picking the lowest-id row with non-null coords is acceptable. A cleaner "deepest in chain" picker can come in v1.5.)
+
+**Step 1: Failing test** — insert a photo with no EXIF GPS but with a `type='location'` keyword that has coords; assert `get_geolocated_photos` returns it with `coord_source='keyword'`.
+
+**Step 2-4: Standard TDD.**
+
+**map.html change:** Read `coord_source` and `keyword_location_name` from the marker payload. Append a one-line provenance footer to the popup: `📍 from EXIF GPS` or `📍 from location: {name}`.
+
+**Manual test:**
+- Tag a non-GPS photo with a location keyword that has coords.
+- Open /map; confirm the photo appears at the keyword's coords with the right provenance footer.
+
+**Step 5: Commit**
+```bash
+git commit -am "feat(map): fall back to keyword coords + provenance footer"
+```
+
+---
+
+## Task 17: Final integration test pass
+
+Run the full test suite per `CLAUDE.md`:
+
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -v
+```
+
+Manual end-to-end smoke test:
+1. Start app, set API key in Settings.
+2. Open a photo with EXIF GPS, accept the suggestion. Confirm location fills.
+3. Open a photo without EXIF GPS, type a location, pick from dropdown. Confirm location fills + breadcrumbs render.
+4. Open a photo without EXIF GPS, type a free-text location, hit Enter. Confirm it's created without coords.
+5. Visit /keywords, link a free-text location to Google. Confirm coords + breadcrumb appear.
+6. Visit /map, confirm both EXIF-source and keyword-source markers appear with correct provenance.
+7. Clear the key in Settings, reload a photo, confirm autocomplete gracefully degrades (free-text + Enter still works).
+8. Open /map, /keywords, /settings — no console errors.
+
+If everything passes:
+```bash
+gh pr create --base main --title "feat: location autocomplete with Google Places" --body "$(cat <<'EOF'
+## Summary
+- Adds iNaturalist-style Google Places autocomplete on the location keyword.
+- Single-leaf-with-parent-chain data model; `keywords.place_id` column dedupes Google places.
+- Hybrid client/server: JS Places library client-side; Place Details + reverse-geocode (with SQLite cache) server-side.
+- EXIF GPS reverse-geocode "suggest on open" with Accept button.
+- Existing free-text location keywords get a "📍 Link..." button on `/keywords` to attach Google data.
+- `/map` falls back to keyword coords for photos without EXIF GPS.
+- Graceful degrade when no API key configured.
+
+Design: `docs/plans/2026-04-25-location-autocomplete-design.md`
+Plan: `docs/plans/2026-04-25-location-autocomplete-plan.md`
+
+## Test plan
+- [ ] Unit: db schema, places wrapper, photo location set/clear, keyword link-place, reverse-geocode cache
+- [ ] API: POST/DELETE photo location, free-text fallback, reverse-geocode proxy, link-keyword
+- [ ] Manual: 8-step smoke test in plan Task 17
+EOF
+)"
+```
+
+---
+
+## Task ordering / dependencies
+
+- Tasks 1-3 are independent and can be done in any order (but commit each separately).
+- Task 4 depends on nothing (pure module).
+- Tasks 5-7 depend on Task 1 (`place_id` column).
+- Tasks 8-11 depend on 5-7 + 4.
+- Task 12 is independent (just a settings input).
+- Tasks 13-15 depend on 8-11 (UI talks to API).
+- Task 16 depends on 5-7 (data has to exist before map can render it).
+- Task 17 is final.
+
+Recommended order: 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 10 → 11 → 12 → 13 → 14 → 15 → 16 → 17.

--- a/tests/e2e/test_keywords_link.py
+++ b/tests/e2e/test_keywords_link.py
@@ -1,0 +1,238 @@
+"""E2E tests for the /keywords page Link-to-Google-place flow (Task 15).
+
+These tests cover the **non-Google** parts of the flow:
+  - The 📍 Link... button only appears on `type='location'` keywords with
+    no `place_id` (and is hidden otherwise).
+  - The modal opens on click and closes on Cancel / Escape.
+  - The link API path itself wires through correctly when triggered via the
+    test-only `window.__linkPlaceForTest` hook (which simulates "user picked
+    a Google suggestion" without driving the Google Places UI).
+
+We deliberately don't drive `google.maps.places.Autocomplete` here — that
+needs a real API key + network roundtrip. Tests instead call the JS test
+hook OR `/api/keywords/<id>/link-place` directly, with `places.place_details`
+monkeypatched.
+"""
+
+from playwright.sync_api import expect
+
+# Canned Place Details response for the link-place call. Shape matches
+# `places.place_details` (see vireo/places.py).
+#
+# Note: address_components in real Google responses do NOT typically include
+# the leaf place itself — only its containing administrative parents. We
+# follow that here so the parent-chain upsert creates exactly 2 new unlinked
+# keyword rows (California, United States) on top of the linked leaf.
+_CANNED_PLACE_ID = "ChIJTestKeywordsLink"
+_CANNED_DETAILS = {
+    "place_id": _CANNED_PLACE_ID,
+    "name": "Yosemite National Park",
+    "lat": 37.8651,
+    "lng": -119.5383,
+    "address_components": [
+        {"name": "California", "types": ["administrative_area_level_1"]},
+        {"name": "United States", "types": ["country"]},
+    ],
+}
+
+
+def _seed_location_keyword(live_server, name, place_id=None):
+    """Create a `type='location'` keyword and tag the first photo with it so
+    it shows up in /api/keywords/all (which is workspace-scoped via tagged
+    photos + ancestors). Returns the keyword id."""
+    db = live_server["db"]
+    photo_id = live_server["data"]["photos"][0]
+    if place_id:
+        # Use upsert path so place_id flows through normally.
+        cur = db.conn.execute(
+            "INSERT INTO keywords (name, type, place_id) VALUES (?, 'location', ?)",
+            (name, place_id),
+        )
+        kw_id = cur.lastrowid
+        db.conn.commit()
+    else:
+        kw_id = db.get_or_create_text_location(name)
+    db.tag_photo(photo_id, kw_id)
+    return kw_id
+
+
+def _set_api_key(key="test-key"):
+    """Write a Google Maps key into the (monkeypatched) config.json."""
+    import config as cfg
+
+    current = cfg.load()
+    current["google_maps_api_key"] = key
+    cfg.save(current)
+
+
+def test_link_button_visible_on_unlinked_location_keyword(live_server, page):
+    """A type='location' keyword with no place_id renders a 📍 Link... button."""
+    kw_id = _seed_location_keyword(live_server, "the meadow")
+
+    page.goto(f"{live_server['url']}/keywords")
+    row = page.locator(f"tr[data-id='{kw_id}']")
+    row.wait_for(state="visible")
+
+    btn = row.locator(".kw-link-btn")
+    expect(btn).to_be_visible()
+    expect(btn).to_contain_text("Link")
+
+
+def test_link_button_hidden_on_linked_location_keyword(live_server, page):
+    """A type='location' keyword that already has a place_id shows a linked
+    badge instead of the Link button."""
+    kw_id = _seed_location_keyword(
+        live_server, "Yosemite Valley", place_id="ChIJSeedExisting"
+    )
+
+    page.goto(f"{live_server['url']}/keywords")
+    row = page.locator(f"tr[data-id='{kw_id}']")
+    row.wait_for(state="visible")
+
+    expect(row.locator(".kw-link-btn")).to_have_count(0)
+    expect(row.locator(".kw-linked-badge")).to_be_visible()
+
+
+def test_link_button_hidden_on_non_location_keyword(live_server, page):
+    """Non-location keywords (e.g. taxonomy) do not get a Link button."""
+    page.goto(f"{live_server['url']}/keywords")
+    # The seed includes 'Red-tailed Hawk' as a species/taxonomy keyword.
+    row = page.locator("tr[data-id]", has_text="Red-tailed Hawk").first
+    row.wait_for(state="visible")
+    expect(row.locator(".kw-link-btn")).to_have_count(0)
+
+
+def test_link_modal_opens_and_closes(live_server, page):
+    """Clicking the Link button opens the modal; Cancel hides it again."""
+    kw_id = _seed_location_keyword(live_server, "the cabin")
+
+    page.goto(f"{live_server['url']}/keywords")
+    row = page.locator(f"tr[data-id='{kw_id}']")
+    row.wait_for(state="visible")
+    row.locator(".kw-link-btn").click()
+
+    modal = page.locator("#linkPlaceModal")
+    expect(modal).to_have_class("modal-overlay open")
+    # Pre-fills the input with the keyword's current name.
+    expect(page.locator("#linkPlaceInput")).to_have_value("the cabin")
+
+    page.locator("#linkPlaceCancel").click()
+    # The .open class drives display:flex; without it the modal is hidden.
+    expect(modal).not_to_have_class("modal-overlay open")
+
+
+def test_link_modal_closes_on_escape(live_server, page):
+    """Escape key closes the link modal."""
+    kw_id = _seed_location_keyword(live_server, "the trailhead")
+
+    page.goto(f"{live_server['url']}/keywords")
+    row = page.locator(f"tr[data-id='{kw_id}']")
+    row.wait_for(state="visible")
+    row.locator(".kw-link-btn").click()
+
+    modal = page.locator("#linkPlaceModal")
+    expect(modal).to_have_class("modal-overlay open")
+
+    page.keyboard.press("Escape")
+    expect(modal).not_to_have_class("modal-overlay open")
+
+
+def test_link_modal_shows_no_key_error_when_unconfigured(live_server, page):
+    """With no Google Maps API key in config, the modal opens but surfaces an
+    inline error instead of trying to load Google Maps JS."""
+    kw_id = _seed_location_keyword(live_server, "free text place")
+
+    page.goto(f"{live_server['url']}/keywords")
+    row = page.locator(f"tr[data-id='{kw_id}']")
+    row.wait_for(state="visible")
+    row.locator(".kw-link-btn").click()
+
+    err = page.locator("#linkPlaceError")
+    expect(err).to_be_visible()
+    expect(err).to_contain_text("API key")
+
+    # And no Google Maps script tag should have been injected.
+    count = page.evaluate(
+        "document.querySelectorAll('script[src*=\"maps.googleapis.com\"]').length"
+    )
+    assert count == 0
+
+
+def test_unlinked_locations_filter_chip_count_and_filter(live_server, page):
+    """The 'Unlinked locations' chip shows the count of type='location'
+    keywords with no place_id, and clicking it narrows the table to only
+    those rows."""
+    kw_unlinked_id = _seed_location_keyword(live_server, "the unlinked field")
+    kw_linked_id = _seed_location_keyword(
+        live_server, "Already Linked", place_id="ChIJAlreadyLinked"
+    )
+
+    page.goto(f"{live_server['url']}/keywords")
+    page.locator(f"tr[data-id='{kw_unlinked_id}']").wait_for(state="visible")
+
+    # Chip count reflects the one unlinked location (the linked one doesn't
+    # count, taxonomy keywords don't count).
+    expect(page.locator("#kwUnlinkedCount")).to_have_text("1")
+
+    page.locator("#kwFilterUnlinked").click()
+    # Only the unlinked row remains visible.
+    expect(page.locator(f"tr[data-id='{kw_unlinked_id}']")).to_be_visible()
+    expect(page.locator(f"tr[data-id='{kw_linked_id}']")).to_have_count(0)
+
+
+def test_link_attaches_place_id_via_test_hook(live_server, page, monkeypatch):
+    """Driving the JS submit hook (the same path the place_changed listener
+    takes once a Google suggestion is picked) should:
+      * POST /api/keywords/<id>/link-place
+      * Update the row to show a linked badge instead of the Link button
+      * Decrement the unlinked-locations chip count
+      * Persist the place_id on the keyword row in the DB
+    """
+    import places
+
+    monkeypatch.setattr(places, "place_details", lambda pid, key: _CANNED_DETAILS)
+    _set_api_key()
+
+    kw_id = _seed_location_keyword(live_server, "to-be-linked")
+
+    page.goto(f"{live_server['url']}/keywords")
+    row = page.locator(f"tr[data-id='{kw_id}']")
+    row.wait_for(state="visible")
+
+    expect(row.locator(".kw-link-btn")).to_be_visible()
+    expect(page.locator("#kwUnlinkedCount")).to_have_text("1")
+
+    # Trigger the submit path the place_changed listener would take. We pass
+    # a non-empty place_id; the canned monkeypatched place_details returns
+    # _CANNED_DETAILS regardless of the argument.
+    page.evaluate(
+        "([id, pid]) => window.__linkPlaceForTest(id, pid)",
+        [kw_id, _CANNED_PLACE_ID],
+    )
+
+    # Wait for the row to re-render (loadKeywords resolves async). Use the
+    # linked badge as the readiness signal.
+    expect(
+        page.locator(f"tr[data-id='{kw_id}'] .kw-linked-badge")
+    ).to_be_visible()
+    expect(
+        page.locator(f"tr[data-id='{kw_id}'] .kw-link-btn")
+    ).to_have_count(0)
+    # Linking the leaf decreases the unlinked count by one (the original
+    # free-text leaf was the only unlinked location pre-link). The parent
+    # chain spawns its own location rows (California, USA), but those are
+    # not visible in /api/keywords/all unless they're ancestors of a tagged
+    # keyword. Since the leaf is tagged, its parents ARE ancestors — so the
+    # chip count rises again. The user-facing invariant we DO care about is
+    # that the originally-linked row is no longer counted.
+    final_count = int(page.locator("#kwUnlinkedCount").inner_text())
+    assert final_count == 2, f"expected 2 (parent chain), got {final_count}"
+
+    # Sanity-check the DB row got place_id + coords.
+    row_db = live_server["db"].conn.execute(
+        "SELECT place_id, latitude, longitude FROM keywords WHERE id = ?",
+        (kw_id,),
+    ).fetchone()
+    assert row_db["place_id"] == _CANNED_PLACE_ID
+    assert row_db["latitude"] == _CANNED_DETAILS["lat"]
+    assert row_db["longitude"] == _CANNED_DETAILS["lng"]

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -104,6 +104,51 @@ def test_freetext_enter_creates_location(live_server, page):
     expect(page.locator("#locationEmpty")).to_be_hidden()
 
 
+def test_enter_after_place_changed_does_not_submit_freetext(live_server, page):
+    """Regression for the keyboard-selected-autocomplete race: when the
+    user presses Enter to pick a highlighted Google suggestion, the
+    keydown event fires SYNCHRONOUSLY before place_changed. Without the
+    deferred-cancel logic, the keydown handler would POST a free-text
+    submit before place_changed could route the place_id POST.
+
+    We simulate place_changed firing (by bumping _locationLastPickedAt
+    just before pressing Enter) and verify NO free-text POST is sent.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click()
+
+    inp = page.locator("#locationInput")
+    inp.wait_for(state="visible")
+    inp.fill("Central Park")
+
+    # Track network calls so we can assert the text endpoint never fires.
+    text_posts = []
+    page.on("request", lambda req: text_posts.append(req.url) if (
+        req.method == "POST" and "/location/text" in req.url
+    ) else None)
+
+    # Simulate place_changed having just fired — like a keyboard pick.
+    page.evaluate("window._locationLastPickedAt = Date.now();")
+    inp.press("Enter")
+
+    # Wait past the 300ms defer window plus margin.
+    page.wait_for_timeout(600)
+
+    # No free-text POST should have happened. (We didn't simulate a real
+    # place_id submit either, so the input remains in the empty state —
+    # that's expected for this regression test.)
+    assert text_posts == [], (
+        f"keydown handler must defer to place_changed when "
+        f"_locationLastPickedAt is recent; got POSTs: {text_posts}"
+    )
+    # Sanity: we should still be in the empty state (no submit happened).
+    expect(page.locator("#locationEmpty")).to_be_visible()
+
+
 def test_clear_button_returns_to_empty(live_server, page):
     """The × button on the filled state clears the location server-side."""
     url = live_server["url"]

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -1,0 +1,127 @@
+"""E2E tests for the photo detail Location section in browse.html.
+
+These tests exercise the section in the no-Google-API-key branch (the live_server
+fixture starts with an empty config), so they cover the free-text Enter path
+and the server-side initial render. They do NOT test Google Places autocomplete
+itself — that requires a real key and a network round-trip we don't want in CI.
+"""
+
+from playwright.sync_api import expect
+
+
+def test_location_section_renders_empty(live_server, page):
+    """Opening a photo with no location shows the empty input."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click()
+
+    section = page.locator("#locationSection")
+    expect(section).to_be_visible()
+    expect(page.locator("#locationInput")).to_be_visible()
+    expect(page.locator("#locationFilled")).to_be_hidden()
+
+
+def test_freetext_enter_creates_location(live_server, page):
+    """Typing a free-text location and pressing Enter swaps to the filled state."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click()
+
+    inp = page.locator("#locationInput")
+    inp.wait_for(state="visible")
+    inp.fill("the meadow behind the cabin")
+    inp.press("Enter")
+
+    filled = page.locator("#locationFilled")
+    expect(filled).to_be_visible()
+    expect(page.locator("#locationFilled .filled-place")).to_have_text(
+        "the meadow behind the cabin"
+    )
+    # Free-text locations have no parent chain.
+    expect(page.locator("#locationFilled .filled-parents")).to_have_count(0)
+    expect(page.locator("#locationEmpty")).to_be_hidden()
+
+
+def test_clear_button_returns_to_empty(live_server, page):
+    """The × button on the filled state clears the location server-side."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click()
+
+    # Set a location first.
+    inp = page.locator("#locationInput")
+    inp.wait_for(state="visible")
+    inp.fill("test location")
+    inp.press("Enter")
+
+    expect(page.locator("#locationFilled")).to_be_visible()
+
+    # Clear it.
+    page.locator("#locationFilled .clear-location").click()
+
+    expect(page.locator("#locationFilled")).to_be_hidden()
+    expect(page.locator("#locationEmpty")).to_be_visible()
+
+
+def test_location_persists_across_reload(live_server, page):
+    """Server-side initial render: re-opening the photo after a reload shows the
+    saved location without any client-side roundtrip beyond /api/photos/<id>."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click()
+
+    inp = page.locator("#locationInput")
+    inp.wait_for(state="visible")
+    inp.fill("Persistent Place")
+    inp.press("Enter")
+
+    expect(page.locator("#locationFilled .filled-place")).to_have_text(
+        "Persistent Place"
+    )
+
+    # Reload the whole page; the section should re-render filled when the
+    # photo is reopened.
+    page.reload()
+    page.locator(".grid-card").first.wait_for(state="visible")
+    page.locator(".grid-card").first.click()
+
+    expect(page.locator("#locationFilled")).to_be_visible()
+    expect(page.locator("#locationFilled .filled-place")).to_have_text(
+        "Persistent Place"
+    )
+
+
+def test_no_gmaps_script_when_key_empty(live_server, page):
+    """With no API key configured, focusing the input must NOT inject the
+    Google Maps script tag — we shouldn't ping Google with an empty key."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click()
+
+    inp = page.locator("#locationInput")
+    inp.wait_for(state="visible")
+    inp.focus()
+
+    # Give any binding a moment to fire (sync; no real network expected).
+    page.wait_for_timeout(100)
+
+    # No <script src> pointing at maps.googleapis.com should exist.
+    count = page.evaluate(
+        "document.querySelectorAll('script[src*=\"maps.googleapis.com\"]').length"
+    )
+    assert count == 0

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -4,9 +4,65 @@ These tests exercise the section in the no-Google-API-key branch (the live_serve
 fixture starts with an empty config), so they cover the free-text Enter path
 and the server-side initial render. They do NOT test Google Places autocomplete
 itself — that requires a real key and a network round-trip we don't want in CI.
+
+The EXIF-suggestion tests below seed `place_reverse_geocode_cache` directly so
+the server's `/api/places/reverse-geocode` proxy serves a hit without ever
+calling Google. The Accept-button test additionally monkeypatches
+`places.place_details` so the POST /api/photos/<id>/location call returns canned
+data without a live API call.
 """
 
+import json
+
 from playwright.sync_api import expect
+
+# Canned reverse-geocode response: shape matches what `places.reverse_geocode`
+# produces (see vireo/places.py). `_summarize_details` reads `name` plus the
+# last 1-2 entries of `address_components`.
+_CANNED_PLACE_ID = "ChIJTestCentralPark"
+_CANNED_DETAILS = {
+    "place_id": _CANNED_PLACE_ID,
+    "name": "Central Park, New York, NY, USA",
+    "lat": 40.785091,
+    "lng": -73.968285,
+    "address_components": [
+        {"name": "Central Park", "types": ["park"]},
+        {"name": "New York", "types": ["locality"]},
+        {"name": "United States", "types": ["country"]},
+    ],
+}
+
+
+def _seed_exif_photo(live_server, lat=40.785091, lng=-73.968285):
+    """Set lat/lng on the first seeded photo and return its id."""
+    db = live_server["db"]
+    photo_id = live_server["data"]["photos"][0]
+    with db.conn:
+        db.conn.execute(
+            "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+            (lat, lng, photo_id),
+        )
+    return photo_id
+
+
+def _seed_reverse_geocode_cache(live_server, lat, lng, place_id, details):
+    """Pre-populate `place_reverse_geocode_cache` so the proxy serves a hit."""
+    live_server["db"].reverse_geocode_cache_put(
+        lat, lng, place_id=place_id, response_json=json.dumps(details),
+    )
+
+
+def _set_api_key(key="test-key"):
+    """Write a Google Maps key into the (monkeypatched) config.json so:
+      - browse.html's _cfgPromise sees `window.GOOGLE_MAPS_API_KEY` set,
+        which gates the `maybeShowExifSuggestion` fetch path; AND
+      - the server's reverse-geocode + set-location routes accept the request.
+    """
+    import config as cfg
+
+    current = cfg.load()
+    current["google_maps_api_key"] = key
+    cfg.save(current)
 
 
 def test_location_section_renders_empty(live_server, page):
@@ -125,3 +181,107 @@ def test_no_gmaps_script_when_key_empty(live_server, page):
         "document.querySelectorAll('script[src*=\"maps.googleapis.com\"]').length"
     )
     assert count == 0
+
+
+def test_exif_suggestion_appears_when_photo_has_gps_and_no_location(live_server, page):
+    """A photo with EXIF GPS + no location keyword + a configured API key
+    should trigger the reverse-geocode proxy and render the suggestion line.
+
+    We pre-populate `place_reverse_geocode_cache` so the proxy serves a hit
+    without ever calling Google.
+    """
+    photo_id = _seed_exif_photo(live_server)
+    _seed_reverse_geocode_cache(
+        live_server, 40.785091, -73.968285, _CANNED_PLACE_ID, _CANNED_DETAILS,
+    )
+    _set_api_key()
+
+    page.goto(f"{live_server['url']}/browse")
+    card = page.locator(f".grid-card[data-id='{photo_id}']")
+    card.wait_for(state="visible")
+    card.click()
+
+    sugg = page.locator("#locationExifSuggestion")
+    expect(sugg).to_be_visible()
+    expect(sugg).to_contain_text("EXIF says:")
+    expect(sugg).to_contain_text("Central Park")
+    expect(sugg.locator("button.accept-btn")).to_have_text("Accept")
+
+
+def test_exif_suggestion_hidden_when_no_gps(live_server, page):
+    """A photo with no lat/lng must NOT trigger the suggestion line, even if
+    a key is configured."""
+    _set_api_key()
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+    page.locator(".grid-card").first.click()
+
+    page.locator("#locationInput").wait_for(state="visible")
+    # Give the no-op JS path a moment in case anything would fire.
+    page.wait_for_timeout(150)
+
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+
+
+def test_exif_suggestion_hidden_when_already_has_location(live_server, page):
+    """Photos that already have a location keyword render the filled state,
+    so the empty container (and the suggestion line within it) stays hidden."""
+    db = live_server["db"]
+    photo_id = _seed_exif_photo(live_server)
+    # Pre-tag with a free-text location.
+    leaf_id = db.get_or_create_text_location("Pre-existing Location")
+    db.set_photo_location(photo_id, leaf_id)
+    _seed_reverse_geocode_cache(
+        live_server, 40.785091, -73.968285, _CANNED_PLACE_ID, _CANNED_DETAILS,
+    )
+    _set_api_key()
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+    page.locator(".grid-card").first.click()
+
+    expect(page.locator("#locationFilled")).to_be_visible()
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+
+
+def test_exif_accept_button_attaches_location(live_server, page, monkeypatch):
+    """Clicking Accept POSTs the place_id and switches to the filled state.
+
+    POST /api/photos/<id>/location calls `places.place_details` (Google), so we
+    monkeypatch that to return our canned details.
+    """
+    photo_id = _seed_exif_photo(live_server)
+    _seed_reverse_geocode_cache(
+        live_server, 40.785091, -73.968285, _CANNED_PLACE_ID, _CANNED_DETAILS,
+    )
+    _set_api_key()
+
+    import places
+    monkeypatch.setattr(
+        places, "place_details", lambda pid, key: _CANNED_DETAILS,
+    )
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+    page.locator(".grid-card").first.click()
+
+    accept = page.locator("#locationExifSuggestion button.accept-btn")
+    expect(accept).to_be_visible()
+    accept.click()
+
+    filled = page.locator("#locationFilled")
+    expect(filled).to_be_visible()
+    expect(page.locator("#locationFilled .filled-place")).to_have_text(
+        _CANNED_DETAILS["name"]
+    )
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+
+    # Sanity-check server state: the leaf keyword is now linked.
+    row = live_server["db"].conn.execute(
+        "SELECT 1 FROM photo_keywords pk "
+        "JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE pk.photo_id = ? AND k.type = 'location' AND k.place_id = ?",
+        (photo_id, _CANNED_PLACE_ID),
+    ).fetchone()
+    assert row is not None

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1115,6 +1115,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         keywords = db.get_photo_keywords(photo_id)
         result["keywords"] = [dict(k) for k in keywords]
 
+        # Location section: pre-resolved leaf + parent chain so the photo
+        # detail panel can render the filled state without a second roundtrip.
+        result["location"] = _serialize_photo_location(db, photo_id)
+
         # Read XMP sidecar keywords
         folder = db.conn.execute(
             "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1701,7 +1701,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("place_not_found", 404)
 
         db = _get_db()
-        leaf_id = db.upsert_place_chain(details)
+        try:
+            leaf_id = db.upsert_place_chain(details)
+        except RuntimeError as err:
+            # _upsert_one_keyword raises RuntimeError when the parent-chain
+            # build hits an existing keyword of a different type at the same
+            # (name, parent_id). Mirror /api/keywords/<id>/link-place's 409.
+            return jsonify({
+                "error": "name_conflict",
+                "error_detail": str(err),
+            }), 409
         db.set_photo_location(photo_id, leaf_id)
         db.record_edit(
             'location_set',
@@ -1798,7 +1807,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # Don't cache here — see docstring.
             return jsonify({"place_id": None, "summary": None})
 
-        details = places.reverse_geocode(lat, lng, key)
+        try:
+            details = places.reverse_geocode(lat, lng, key)
+        except places.PlacesTransientError:
+            # OVER_QUERY_LIMIT / REQUEST_DENIED / network blip — Google
+            # may answer this later, so do NOT cache. Returning null here
+            # just suppresses the EXIF suggestion for this request; the
+            # next request will retry Google.
+            app.logger.warning(
+                "reverse_geocode transient failure for lat=%s lng=%s — not caching",
+                lat, lng,
+            )
+            return jsonify({"place_id": None, "summary": None})
+
         cache_place_id = details.get("place_id") if details else None
         db.reverse_geocode_cache_put(
             lat, lng,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8,6 +8,7 @@ import argparse
 import json
 import logging
 import logging.handlers
+import math
 import os
 import queue
 import subprocess
@@ -1783,6 +1784,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             lat = float(request.args.get("lat", ""))
             lng = float(request.args.get("lng", ""))
         except (TypeError, ValueError):
+            return json_error("invalid coords", 400)
+        # float() accepts "nan" and "inf"; both blow up downstream in
+        # _reverse_geocode_grid's int(round(...)). Reject explicitly.
+        if not (math.isfinite(lat) and math.isfinite(lng)):
             return json_error("invalid coords", 400)
 
         db = _get_db()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1542,7 +1542,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         parents = []
         current_parent_id = leaf["parent_id"]
-        while current_parent_id is not None:
+        # Depth cap of 10 — chains are bounded ~5 in practice, but guard
+        # against pathological/malformed cycles (link_keyword_to_place
+        # already prevents creating cycles, but a corrupted DB could).
+        for _ in range(10):
+            if current_parent_id is None:
+                break
             row = db.conn.execute(
                 "SELECT id, name, parent_id FROM keywords WHERE id = ?",
                 (current_parent_id,),
@@ -1563,6 +1568,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "parent_chain": parents,
         }
 
+    # Location keywords don't propagate to dc:subject sidecars — structured XMP (exif:GPS*, Iptc4xmpCore:Location) is a future feature.
     @app.route("/api/photos/<int:photo_id>/location", methods=["POST"])
     def api_set_photo_location(photo_id):
         """Attach a Google place to ``photo_id`` via the autocomplete flow.
@@ -1589,6 +1595,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         leaf_id = db.upsert_place_chain(details)
         db.set_photo_location(photo_id, leaf_id)
+        db.record_edit(
+            'location_set',
+            f"set location: {details.get('name', 'unknown')}",
+            str(leaf_id),
+            [{'photo_id': photo_id, 'old_value': '', 'new_value': str(leaf_id)}],
+        )
         return jsonify({"location": _serialize_photo_location(db, photo_id)})
 
     @app.route("/api/photos/<int:photo_id>/location", methods=["DELETE"])
@@ -1596,6 +1608,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """Remove all ``type='location'`` keyword links for ``photo_id``."""
         db = _get_db()
         db.clear_photo_location(photo_id)
+        db.record_edit(
+            'location_clear',
+            "cleared location",
+            '',
+            [{'photo_id': photo_id, 'old_value': '', 'new_value': ''}],
+        )
         return jsonify({"ok": True})
 
     # -- Batch operations --

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1697,11 +1697,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not key:
             return json_error("no_api_key", 400)
 
+        db = _get_db()
+        # Guard against stale clients (e.g. tab open after photo deleted).
+        # Without this, set_photo_location's INSERT into photo_keywords
+        # raises a FK IntegrityError that surfaces as a 500.
+        if db.conn.execute(
+            "SELECT 1 FROM photos WHERE id = ?", (photo_id,)
+        ).fetchone() is None:
+            return json_error("photo_not_found", 404)
+
         details = places.place_details(place_id, key)
         if details is None:
             return json_error("place_not_found", 404)
 
-        db = _get_db()
         try:
             leaf_id = db.upsert_place_chain(details)
         except RuntimeError as err:
@@ -1737,6 +1745,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         stripped = name.strip()
 
         db = _get_db()
+        if db.conn.execute(
+            "SELECT 1 FROM photos WHERE id = ?", (photo_id,)
+        ).fetchone() is None:
+            return json_error("photo_not_found", 404)
         try:
             leaf_id = db.get_or_create_text_location(stripped)
         except ValueError:
@@ -1755,6 +1767,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_clear_photo_location(photo_id):
         """Remove all ``type='location'`` keyword links for ``photo_id``."""
         db = _get_db()
+        if db.conn.execute(
+            "SELECT 1 FROM photos WHERE id = ?", (photo_id,)
+        ).fetchone() is None:
+            return json_error("photo_not_found", 404)
         db.clear_photo_location(photo_id)
         db.record_edit(
             'location_clear',
@@ -1880,8 +1896,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         try:
             result = db.link_keyword_to_place(keyword_id, details)
-        except ValueError:
-            # Database raises ValueError when the keyword id doesn't exist.
+        except ValueError as err:
+            # Database raises ValueError both for "missing id" and "wrong
+            # type". Distinguish so callers can tell a 404 from a 400.
+            msg = str(err)
+            if "is type" in msg:
+                return jsonify({
+                    "error": "wrong_keyword_type",
+                    "error_detail": msg,
+                }), 400
             return json_error("keyword_not_found", 404)
         except RuntimeError as err:
             # _upsert_one_keyword raises RuntimeError when the parent-chain

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1549,6 +1549,34 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return ""
         return " · ".join(parts)
 
+    def _walk_parent_chain(db, leaf_parent_id):
+        """Walk ``parent_id`` upward from ``leaf_parent_id`` to the root.
+
+        Returns a list of ``{"id": int, "name": str}`` dicts in broadest →
+        narrowest order, EXCLUDING the leaf itself. Pass the leaf's
+        ``parent_id`` (i.e. the *first* parent), not the leaf's own id.
+
+        Depth cap of 10 — chains are bounded ~5 in practice, but guard
+        against pathological/malformed cycles (link_keyword_to_place
+        already prevents creating cycles, but a corrupted DB could).
+        """
+        parents = []
+        current_parent_id = leaf_parent_id
+        for _ in range(10):
+            if current_parent_id is None:
+                break
+            row = db.conn.execute(
+                "SELECT id, name, parent_id FROM keywords WHERE id = ?",
+                (current_parent_id,),
+            ).fetchone()
+            if row is None:
+                break
+            parents.append({"id": row["id"], "name": row["name"]})
+            current_parent_id = row["parent_id"]
+        # Reverse so broadest (e.g. country) comes first, narrowest last.
+        parents.reverse()
+        return parents
+
     def _serialize_photo_location(db, photo_id):
         """Return a summary dict for the photo's current location keyword.
 
@@ -1564,8 +1592,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             }
 
         Returns ``None`` if the photo has no ``type='location'`` keyword link.
-        Walks ``parent_id`` upward via repeated SELECTs — fine for v1 since the
-        chain is bounded (~5 deep).
         """
         leaf = db.conn.execute(
             "SELECT k.id, k.name, k.place_id, k.latitude, k.longitude, k.parent_id "
@@ -1578,32 +1604,39 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if leaf is None:
             return None
 
-        parents = []
-        current_parent_id = leaf["parent_id"]
-        # Depth cap of 10 — chains are bounded ~5 in practice, but guard
-        # against pathological/malformed cycles (link_keyword_to_place
-        # already prevents creating cycles, but a corrupted DB could).
-        for _ in range(10):
-            if current_parent_id is None:
-                break
-            row = db.conn.execute(
-                "SELECT id, name, parent_id FROM keywords WHERE id = ?",
-                (current_parent_id,),
-            ).fetchone()
-            if row is None:
-                break
-            parents.append({"id": row["id"], "name": row["name"]})
-            current_parent_id = row["parent_id"]
-        # Reverse so broadest (e.g. country) comes first, narrowest last.
-        parents.reverse()
-
         return {
             "keyword_id": leaf["id"],
             "name": leaf["name"],
             "place_id": leaf["place_id"],
             "latitude": leaf["latitude"],
             "longitude": leaf["longitude"],
-            "parent_chain": parents,
+            "parent_chain": _walk_parent_chain(db, leaf["parent_id"]),
+        }
+
+    def _serialize_keyword(db, keyword_id):
+        """Return a summary dict for a single ``type='location'`` keyword row.
+
+        Same shape as :func:`_serialize_photo_location` (leaf fields + a
+        broadest-first parent chain), but keyed on the keyword id directly
+        rather than via a photo. Used by the ``link-place`` route, which
+        operates on a keyword and isn't tied to a photo.
+
+        Returns ``None`` if the keyword does not exist.
+        """
+        leaf = db.conn.execute(
+            "SELECT id, name, place_id, latitude, longitude, parent_id "
+            "FROM keywords WHERE id = ?",
+            (keyword_id,),
+        ).fetchone()
+        if leaf is None:
+            return None
+        return {
+            "keyword_id": leaf["id"],
+            "name": leaf["name"],
+            "place_id": leaf["place_id"],
+            "latitude": leaf["latitude"],
+            "longitude": leaf["longitude"],
+            "parent_chain": _walk_parent_chain(db, leaf["parent_id"]),
         }
 
     # Location keywords don't propagate to dc:subject sidecars — structured XMP (exif:GPS*, Iptc4xmpCore:Location) is a future feature.
@@ -1740,6 +1773,83 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         return jsonify({
             "place_id": cache_place_id,
             "summary": _summarize_details(details),
+        })
+
+    @app.route("/api/keywords/<int:keyword_id>/link-place", methods=["POST"])
+    def api_link_keyword_to_place(keyword_id):
+        """Attach Google place data to an existing keyword.
+
+        Body: ``{"place_id": "ChIJ..."}``. Looks up the place via
+        :func:`places.place_details` and delegates to
+        :meth:`Database.link_keyword_to_place`, which UPDATEs the target row
+        in-place — or, if another keyword already owns this ``place_id``,
+        re-points the target's ``photo_keywords`` rows onto the canonical row
+        and deletes the now-empty target.
+
+        Response: ``{"keyword": <serialized leaf+chain>, "merged": <bool>}``.
+        ``merged`` is True when an existing place-bearing row absorbed the
+        target.
+
+        Error modes:
+        - 400 ``missing place_id`` — empty body.
+        - 400 ``no_api_key`` — config has no ``google_maps_api_key``.
+        - 404 ``place_not_found`` — Google had no record of ``place_id``.
+        - 404 ``keyword_not_found`` — ``keyword_id`` doesn't exist.
+        - 409 ``name_conflict`` — the parent chain would clash with an
+          existing keyword of a different ``type`` at the same
+          ``(name, parent_id)``. Carries an ``error_detail`` string from the
+          underlying RuntimeError for debugging.
+        """
+        body = request.get_json(silent=True) or {}
+        place_id = (body.get("place_id") or "").strip()
+        if not place_id:
+            return json_error("missing place_id", 400)
+
+        import config as cfg
+        key = cfg.load().get("google_maps_api_key", "")
+        if not key:
+            return json_error("no_api_key", 400)
+
+        details = places.place_details(place_id, key)
+        if details is None:
+            return json_error("place_not_found", 404)
+
+        db = _get_db()
+        try:
+            result = db.link_keyword_to_place(keyword_id, details)
+        except ValueError:
+            # Database raises ValueError when the keyword id doesn't exist.
+            return json_error("keyword_not_found", 404)
+        except RuntimeError as err:
+            # _upsert_one_keyword raises RuntimeError when the parent-chain
+            # build hits an existing keyword of a different type at the same
+            # (name, parent_id). Surface the message for debugging.
+            return jsonify({
+                "error": "name_conflict",
+                "error_detail": str(err),
+            }), 409
+
+        # Audit log: this action isn't tied to a single photo (it operates on
+        # a keyword), so we omit the per-photo items list. ``photo_id`` in
+        # ``edit_history_items`` is FK-constrained to ``photos.id``, so a
+        # placeholder like 0 would IntegrityError. The ``new_value`` column on
+        # the parent ``edit_history`` row carries the canonical keyword id;
+        # the ``description`` carries the place name and the source-id pair.
+        db.record_edit(
+            'location_link',
+            (
+                f"linked keyword {keyword_id} to place: "
+                f"{details.get('name', 'unknown')} "
+                f"(canonical keyword_id={result['keyword_id']}, "
+                f"merged={result['merged']})"
+            ),
+            str(result['keyword_id']),
+            [],
+        )
+
+        return jsonify({
+            "keyword": _serialize_keyword(db, result["keyword_id"]),
+            "merged": result["merged"],
         })
 
     # -- Batch operations --

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18,6 +18,7 @@ from datetime import UTC
 from pathlib import Path
 from urllib.parse import quote
 
+import places
 from db import Database
 from flask import (
     Flask,
@@ -1508,6 +1509,93 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db.conn.execute("DELETE FROM photo_keywords WHERE keyword_id = ?", (keyword_id,))
         db.conn.execute("DELETE FROM keywords WHERE id = ?", (keyword_id,))
         db.conn.commit()
+        return jsonify({"ok": True})
+
+    def _serialize_photo_location(db, photo_id):
+        """Return a summary dict for the photo's current location keyword.
+
+        The shape matches the JSON the location section UI expects::
+
+            {
+                "keyword_id":   int,
+                "name":         str,
+                "place_id":     str | None,
+                "latitude":     float | None,
+                "longitude":    float | None,
+                "parent_chain": [{"id": int, "name": str}, ...],  # broadest -> narrowest, EXCLUDES leaf
+            }
+
+        Returns ``None`` if the photo has no ``type='location'`` keyword link.
+        Walks ``parent_id`` upward via repeated SELECTs — fine for v1 since the
+        chain is bounded (~5 deep).
+        """
+        leaf = db.conn.execute(
+            "SELECT k.id, k.name, k.place_id, k.latitude, k.longitude, k.parent_id "
+            "FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location' "
+            "LIMIT 1",
+            (photo_id,),
+        ).fetchone()
+        if leaf is None:
+            return None
+
+        parents = []
+        current_parent_id = leaf["parent_id"]
+        while current_parent_id is not None:
+            row = db.conn.execute(
+                "SELECT id, name, parent_id FROM keywords WHERE id = ?",
+                (current_parent_id,),
+            ).fetchone()
+            if row is None:
+                break
+            parents.append({"id": row["id"], "name": row["name"]})
+            current_parent_id = row["parent_id"]
+        # Reverse so broadest (e.g. country) comes first, narrowest last.
+        parents.reverse()
+
+        return {
+            "keyword_id": leaf["id"],
+            "name": leaf["name"],
+            "place_id": leaf["place_id"],
+            "latitude": leaf["latitude"],
+            "longitude": leaf["longitude"],
+            "parent_chain": parents,
+        }
+
+    @app.route("/api/photos/<int:photo_id>/location", methods=["POST"])
+    def api_set_photo_location(photo_id):
+        """Attach a Google place to ``photo_id`` via the autocomplete flow.
+
+        Body: ``{"place_id": "ChIJ..."}``. Looks up the place via
+        :func:`places.place_details`, upserts the leaf + parent chain into
+        ``keywords``, and links the leaf to the photo (replacing any existing
+        ``type='location'`` link).
+        """
+        body = request.get_json(silent=True) or {}
+        place_id = (body.get("place_id") or "").strip()
+        if not place_id:
+            return json_error("missing place_id", 400)
+
+        import config as cfg
+        key = cfg.load().get("google_maps_api_key", "")
+        if not key:
+            return json_error("no_api_key", 400)
+
+        details = places.place_details(place_id, key)
+        if details is None:
+            return json_error("place_not_found", 404)
+
+        db = _get_db()
+        leaf_id = db.upsert_place_chain(details)
+        db.set_photo_location(photo_id, leaf_id)
+        return jsonify({"location": _serialize_photo_location(db, photo_id)})
+
+    @app.route("/api/photos/<int:photo_id>/location", methods=["DELETE"])
+    def api_clear_photo_location(photo_id):
+        """Remove all ``type='location'`` keyword links for ``photo_id``."""
+        db = _get_db()
+        db.clear_photo_location(photo_id)
         return jsonify({"ok": True})
 
     # -- Batch operations --

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1603,6 +1603,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         return jsonify({"location": _serialize_photo_location(db, photo_id)})
 
+    @app.route("/api/photos/<int:photo_id>/location/text", methods=["POST"])
+    def api_set_photo_location_text(photo_id):
+        """Attach a free-text location keyword (no Google data) to ``photo_id``.
+
+        Body: ``{"name": "the meadow behind the cabin"}``. Used when the user
+        types a name and hits Enter without picking a Google suggestion, or
+        when no API key is configured. Reuses the ``location_set`` audit
+        action_type so the audit log filters consistently across both paths.
+        """
+        body = request.get_json(silent=True) or {}
+        name = body.get("name") or ""
+        if not name.strip():
+            return json_error("missing name", 400)
+        stripped = name.strip()
+
+        db = _get_db()
+        try:
+            leaf_id = db.get_or_create_text_location(stripped)
+        except ValueError:
+            # Defensive: validation above should already catch empty input.
+            return json_error("missing name", 400)
+        db.set_photo_location(photo_id, leaf_id)
+        db.record_edit(
+            'location_set',
+            f"set location: {stripped}",
+            str(leaf_id),
+            [{'photo_id': photo_id, 'old_value': '', 'new_value': str(leaf_id)}],
+        )
+        return jsonify({"location": _serialize_photo_location(db, photo_id)})
+
     @app.route("/api/photos/<int:photo_id>/location", methods=["DELETE"])
     def api_clear_photo_location(photo_id):
         """Remove all ``type='location'`` keyword links for ``photo_id``."""

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1511,6 +1511,44 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db.conn.commit()
         return jsonify({"ok": True})
 
+    def _summarize_details(details):
+        """Build a short human-friendly summary string from a Place Details dict.
+
+        Format: ``"<leaf name> · <broadest 1-2 parents>"``. Google's
+        ``address_components`` are ordered narrowest-first, so the broadest
+        parents (country, state) sit at the END of the list. We pick at most
+        the last two, dedupe against the leaf name, and join with " · ".
+
+        Examples::
+
+            "Central Park · New York · United States"
+            "Some Lighthouse · Iceland"
+            "JustALeaf"  # if no usable parent components
+        """
+        leaf = (details or {}).get("name", "") or ""
+        components = (details or {}).get("address_components") or []
+
+        # Broadest 1-2 parents = last two components (Google orders broad-last).
+        tail = components[-2:] if len(components) >= 2 else components[-1:]
+        # Walk in reverse so we render broadest-first to broader-second
+        # ("New York · United States" reads better than "United States · New York"
+        # given the leaf comes first; iNaturalist uses leaf-then-narrowest-up).
+        # Actually: leaf · narrowest-parent · ... · broadest-parent reads most
+        # naturally for breadcrumbs. So reverse the tail so the closest parent
+        # is first.
+        parts = [leaf] if leaf else []
+        for comp in reversed(tail):
+            name = (comp or {}).get("name") or (comp or {}).get("long_name") or ""
+            if not name:
+                continue
+            if name == leaf or name in parts:
+                continue
+            parts.append(name)
+
+        if not parts:
+            return ""
+        return " · ".join(parts)
+
     def _serialize_photo_location(db, photo_id):
         """Return a summary dict for the photo's current location keyword.
 
@@ -1645,6 +1683,64 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             [{'photo_id': photo_id, 'old_value': '', 'new_value': ''}],
         )
         return jsonify({"ok": True})
+
+    @app.route("/api/places/reverse-geocode", methods=["GET"])
+    def api_reverse_geocode():
+        """Reverse-geocode (lat, lng) via Google, with a SQLite grid cache.
+
+        Query params: ``lat``, ``lng`` (floats). Returns
+        ``{"place_id": <str|null>, "summary": <str|null>}``.
+
+        Cache layer is keyed on ~110m grid (see ``Database._reverse_geocode_grid``).
+        A row with ``place_id=None`` is a cached negative — Google was previously
+        asked and had no match, and we serve null without re-asking.
+
+        When no ``google_maps_api_key`` is configured we degrade to ``null``
+        WITHOUT writing to the cache. Caching null in that branch would make
+        already-asked grids stay null forever once the user finally adds a
+        key, which is exactly the wrong UX.
+        """
+        try:
+            lat = float(request.args.get("lat", ""))
+            lng = float(request.args.get("lng", ""))
+        except (TypeError, ValueError):
+            return json_error("invalid coords", 400)
+
+        db = _get_db()
+        cached = db.reverse_geocode_cache_get(lat, lng)
+        if cached is not None:
+            if cached["place_id"] is None:
+                # Cached negative — Google previously had no match here.
+                return jsonify({"place_id": None, "summary": None})
+            try:
+                details = json.loads(cached["response"])
+            except (ValueError, TypeError):
+                details = {}
+            return jsonify({
+                "place_id": cached["place_id"],
+                "summary": _summarize_details(details),
+            })
+
+        # Cache miss.
+        import config as cfg
+        key = cfg.load().get("google_maps_api_key", "")
+        if not key:
+            # Don't cache here — see docstring.
+            return jsonify({"place_id": None, "summary": None})
+
+        details = places.reverse_geocode(lat, lng, key)
+        cache_place_id = details.get("place_id") if details else None
+        db.reverse_geocode_cache_put(
+            lat, lng,
+            place_id=cache_place_id,
+            response_json=json.dumps(details or {}),
+        )
+        if details is None:
+            return jsonify({"place_id": None, "summary": None})
+        return jsonify({
+            "place_id": cache_place_id,
+            "summary": _summarize_details(details),
+        })
 
     # -- Batch operations --
 

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -23,6 +23,7 @@ DEFAULTS = {
     "max_edit_history": 1000,
     "inat_token": "",
     "hf_token": "",
+    "google_maps_api_key": "",
     "scan_roots": [],
     "scan_workers": 0,
     "setup_complete": False,

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -255,6 +255,12 @@ SCHEMA = {
         "label": "Hugging Face token",
         "desc": "API token for Hugging Face (used for model downloads).",
     },
+    "google_maps_api_key": {
+        "type": "secret",
+        "category": "Integrations", "scope": "global",
+        "label": "Google Maps API key",
+        "desc": "Used for location autocomplete on photo keywords. Add an HTTP referrer restriction in the Google Cloud console (e.g. localhost:8080/*).",
+    },
     "report_url": {
         "type": "string",
         "category": "Integrations", "scope": "global",

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3417,7 +3417,7 @@ class Database:
         id.
         """
         if place_id is not None:
-            cur = self.conn.execute(
+            insert_sql = (
                 "INSERT INTO keywords "
                 "(name, parent_id, type, place_id, latitude, longitude) "
                 "VALUES (?, ?, 'location', ?, ?, ?) "
@@ -3426,10 +3426,35 @@ class Database:
                 "  parent_id = excluded.parent_id, "
                 "  latitude = excluded.latitude, "
                 "  longitude = excluded.longitude "
-                "RETURNING id",
-                (name, parent_id, place_id, latitude, longitude),
+                "RETURNING id"
             )
-            return cur.fetchone()["id"]
+            try:
+                cur = self.conn.execute(
+                    insert_sql, (name, parent_id, place_id, latitude, longitude),
+                )
+                return cur.fetchone()["id"]
+            except sqlite3.IntegrityError:
+                # ON CONFLICT(place_id) handles same-place-id re-picks. The
+                # remaining failure mode is the table-level UNIQUE(name,
+                # parent_id): a *different* keyword (different place_id, or
+                # NULL place_id) already occupies this slot. Disambiguate the
+                # new row's name by appending a short place_id suffix and
+                # retry. Realistic case: two distinct Google places with the
+                # same name under the same parent (e.g. two parks named
+                # "Riverside Park" in the same state).
+                suffix = place_id[-8:]
+                disambiguated = f"{name} ({suffix})"
+                try:
+                    cur = self.conn.execute(
+                        insert_sql,
+                        (disambiguated, parent_id, place_id, latitude, longitude),
+                    )
+                    return cur.fetchone()["id"]
+                except sqlite3.IntegrityError as inner_err:
+                    raise RuntimeError(
+                        f"keyword '{name}' (parent_id={parent_id}) collides "
+                        f"with an existing row even after disambiguation"
+                    ) from inner_err
 
         if parent_id is None:
             existing = self.conn.execute(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3331,10 +3331,13 @@ class Database:
     def _upsert_location_parent_chain(self, components):
         """Upsert a chain of parent location keywords from ``address_components``.
 
-        Walks broadest → narrowest, returning the deepest parent's id (or
-        ``None`` if ``components`` is empty / all entries lack a name).
-        Caller is responsible for the surrounding transaction.
+        Walks broadest → narrowest, returning the list of visited keyword ids
+        in broadest → narrowest order. Returns an empty list if ``components``
+        is empty / all entries lack a name. The deepest (narrowest) parent is
+        ``chain[-1]`` if non-empty. Caller is responsible for the surrounding
+        transaction.
         """
+        chain: list[int] = []
         parent_id = None
         # Reverse Google's narrowest-first list to walk broadest → narrowest.
         for comp in reversed(components or []):
@@ -3347,7 +3350,8 @@ class Database:
                 latitude=None,
                 longitude=None,
             )
-        return parent_id
+            chain.append(parent_id)
+        return chain
 
     def upsert_place_chain(self, details):
         """Upsert a Google Place + its parent chain. Returns the leaf id.
@@ -3374,7 +3378,8 @@ class Database:
         components = details.get("address_components") or []
 
         with self.conn:
-            parent_id = self._upsert_location_parent_chain(components)
+            chain = self._upsert_location_parent_chain(components)
+            parent_id = chain[-1] if chain else None
             leaf_id = self._upsert_one_keyword(
                 name=name,
                 parent_id=parent_id,
@@ -3389,7 +3394,22 @@ class Database:
 
         Removes any existing ``type='location'`` keyword links for the photo,
         then inserts the new link. Atomic.
+
+        Raises ``ValueError`` if ``leaf_keyword_id`` does not exist or its
+        keyword type is not ``'location'`` — otherwise the DELETE would strip
+        real location links and replace them with a non-location link that
+        :meth:`clear_photo_location` could not clean up.
         """
+        row = self.conn.execute(
+            "SELECT type FROM keywords WHERE id = ?", (leaf_keyword_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"keyword id {leaf_keyword_id} does not exist")
+        if row["type"] != "location":
+            raise ValueError(
+                f"keyword {leaf_keyword_id} has type={row['type']!r}, "
+                f"not 'location'"
+            )
         with self.conn:
             self.conn.execute(
                 "DELETE FROM photo_keywords WHERE photo_id = ? "
@@ -3454,6 +3474,12 @@ class Database:
         if not details.get("place_id"):
             raise ValueError("link_keyword_to_place requires details['place_id']")
 
+        row = self.conn.execute(
+            "SELECT 1 FROM keywords WHERE id = ?", (keyword_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"keyword id {keyword_id} does not exist")
+
         place_id = details["place_id"]
         new_name = details.get("name", "")
         lat = details.get("lat")
@@ -3461,17 +3487,19 @@ class Database:
         components = details.get("address_components") or []
 
         with self.conn:
-            parent_id = self._upsert_location_parent_chain(components)
+            chain = self._upsert_location_parent_chain(components)
+            parent_id = chain[-1] if chain else None
 
-            # If the chain itself ended up choosing this very keyword (e.g.,
-            # a free-text "United States" keyword that we just promoted to
-            # the country parent), the UPDATE below would reparent it onto
-            # itself or a descendant. Guard against that by treating it the
-            # same as the merge case — the chain row is the canonical one.
-            if parent_id == keyword_id:
-                # The keyword we were asked to "link" got reused as a parent
-                # in the chain. Nothing to merge from photo_keywords (it is
-                # already the canonical row for its slot), so just return it.
+            # If the chain itself reused this very keyword anywhere — as the
+            # deepest parent OR as a non-leaf ancestor (e.g. a free-text
+            # "United States" promoted into the country slot while deeper
+            # levels like NY/Manhattan were also discovered) — the UPDATE
+            # below would create a cycle by reparenting the row onto a
+            # descendant of itself. Guard by checking the full visited chain.
+            if keyword_id in chain:
+                # The keyword we were asked to "link" got reused inside the
+                # chain. Nothing to merge from photo_keywords (it is already
+                # the canonical row for its slot), so just return it.
                 return {"keyword_id": keyword_id, "merged": False}
 
             try:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3248,6 +3248,16 @@ class Database:
           whose ``place_id`` is also NULL. SELECT-then-INSERT (rather than
           ``INSERT OR IGNORE``) so we never collide a coordless parent row
           with a place_id-bearing leaf that happens to share a name+parent.
+
+        TODO(task-6): Cross-type (name, parent_id) collision. The table-level
+        UNIQUE(name, parent_id) constraint doesn't filter by `type`, so the
+        narrow SELECT here (which only matches type='location' rows) can miss
+        a row of a different type, then the INSERT fails. Realistically rare
+        (general/people/event keywords don't usually collide with country/
+        city/admin names), but Task 6's get_or_create_text_location faces the
+        same issue and should fix both — likely by replacing the table-level
+        UNIQUE with partial unique indexes scoped by type, or by catching the
+        IntegrityError and re-SELECTing without the type filter.
         """
         if place_id is not None:
             cur = self.conn.execute(
@@ -3305,6 +3315,13 @@ class Database:
         Idempotent: calling twice with the same ``details`` returns the same
         leaf id and does not create duplicate rows.
         """
+        if not details.get("place_id"):
+            raise ValueError("upsert_place_chain requires details['place_id']")
+
+        name = details.get("name", "")
+        lat = details.get("lat")
+        lng = details.get("lng")
+
         # Reverse Google's narrowest-first list to walk broadest → narrowest.
         # Don't sort by type — trust Google's ordering (per plan).
         components = list(reversed(details.get("address_components") or []))
@@ -3312,6 +3329,8 @@ class Database:
         with self.conn:
             parent_id = None
             for comp in components:
+                if not comp.get("name"):
+                    continue
                 parent_id = self._upsert_one_keyword(
                     name=comp["name"],
                     parent_id=parent_id,
@@ -3321,11 +3340,11 @@ class Database:
                 )
 
             leaf_id = self._upsert_one_keyword(
-                name=details["name"],
+                name=name,
                 parent_id=parent_id,
                 place_id=details["place_id"],
-                latitude=details.get("lat"),
-                longitude=details.get("lng"),
+                latitude=lat,
+                longitude=lng,
             )
         return leaf_id
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2525,10 +2525,13 @@ class Database:
         and ``keyword_location_name`` (the location keyword's name when EXIF is
         absent, NULL otherwise) so the map can show provenance.
         """
+        # Paired fallback: either BOTH EXIF axes win, or BOTH keyword axes win.
+        # Per-axis COALESCE would let a photo with partial EXIF (only one axis
+        # populated) emit a mixed pair, producing wrong markers.
         conditions = [
             "wf.workspace_id = ?",
-            "COALESCE(p.latitude, kl.latitude) IS NOT NULL",
-            "COALESCE(p.longitude, kl.longitude) IS NOT NULL",
+            "((p.latitude IS NOT NULL AND p.longitude IS NOT NULL) "
+            " OR (kl.latitude IS NOT NULL AND kl.longitude IS NOT NULL))",
         ]
         params = [self._ws_id()]
 
@@ -2612,8 +2615,10 @@ class Database:
 
         query = f"""
             SELECT p.id,
-                   COALESCE(p.latitude, kl.latitude) AS latitude,
-                   COALESCE(p.longitude, kl.longitude) AS longitude,
+                   CASE WHEN p.latitude IS NOT NULL AND p.longitude IS NOT NULL
+                        THEN p.latitude ELSE kl.latitude END AS latitude,
+                   CASE WHEN p.latitude IS NOT NULL AND p.longitude IS NOT NULL
+                        THEN p.longitude ELSE kl.longitude END AS longitude,
                    CASE WHEN p.latitude IS NOT NULL AND p.longitude IS NOT NULL
                         THEN 'exif' ELSE 'keyword' END AS coord_source,
                    CASE WHEN p.latitude IS NOT NULL AND p.longitude IS NOT NULL

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -384,6 +384,15 @@ class Database:
               PRIMARY KEY (snapshot_id, file_path)
             );
 
+            CREATE TABLE IF NOT EXISTS place_reverse_geocode_cache (
+                lat_grid    INTEGER NOT NULL,
+                lng_grid    INTEGER NOT NULL,
+                place_id    TEXT,
+                response    TEXT NOT NULL,
+                fetched_at  INTEGER NOT NULL,
+                PRIMARY KEY (lat_grid, lng_grid)
+            );
+
             CREATE INDEX IF NOT EXISTS idx_taxa_parent ON taxa(parent_id);
             CREATE INDEX IF NOT EXISTS idx_taxa_rank ON taxa(rank);
             CREATE INDEX IF NOT EXISTS idx_taxa_name ON taxa(name);

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3233,6 +3233,102 @@ class Database:
             self.conn.commit()
         return cur.lastrowid
 
+    def _upsert_one_keyword(
+        self, name, parent_id, place_id=None, latitude=None, longitude=None,
+    ):
+        """Insert-or-fetch a single ``type='location'`` keyword row.
+
+        Two dedupe modes:
+
+        * ``place_id`` is given: dedupe on the partial unique index over
+          ``place_id``. If a row with that ``place_id`` already exists, update
+          its name/parent/coords (the user just re-picked the same Google
+          place) and return its id.
+        * ``place_id`` is ``None``: dedupe on ``(name, parent_id)`` among rows
+          whose ``place_id`` is also NULL. SELECT-then-INSERT (rather than
+          ``INSERT OR IGNORE``) so we never collide a coordless parent row
+          with a place_id-bearing leaf that happens to share a name+parent.
+        """
+        if place_id is not None:
+            cur = self.conn.execute(
+                "INSERT INTO keywords "
+                "(name, parent_id, type, place_id, latitude, longitude) "
+                "VALUES (?, ?, 'location', ?, ?, ?) "
+                "ON CONFLICT(place_id) WHERE place_id IS NOT NULL DO UPDATE SET "
+                "  name = excluded.name, "
+                "  parent_id = excluded.parent_id, "
+                "  latitude = excluded.latitude, "
+                "  longitude = excluded.longitude "
+                "RETURNING id",
+                (name, parent_id, place_id, latitude, longitude),
+            )
+            return cur.fetchone()["id"]
+
+        if parent_id is None:
+            existing = self.conn.execute(
+                "SELECT id FROM keywords "
+                "WHERE name = ? AND parent_id IS NULL "
+                "  AND type = 'location' AND place_id IS NULL",
+                (name,),
+            ).fetchone()
+        else:
+            existing = self.conn.execute(
+                "SELECT id FROM keywords "
+                "WHERE name = ? AND parent_id = ? "
+                "  AND type = 'location' AND place_id IS NULL",
+                (name, parent_id),
+            ).fetchone()
+        if existing:
+            return existing["id"]
+
+        cur = self.conn.execute(
+            "INSERT INTO keywords "
+            "(name, parent_id, type, place_id, latitude, longitude) "
+            "VALUES (?, ?, 'location', NULL, ?, ?)",
+            (name, parent_id, latitude, longitude),
+        )
+        return cur.lastrowid
+
+    def upsert_place_chain(self, details):
+        """Upsert a Google Place + its parent chain. Returns the leaf id.
+
+        ``details`` is the normalized dict produced by
+        :func:`vireo.places.place_details`: ``place_id``, ``name``, ``lat``,
+        ``lng``, ``address_components`` (Google's narrowest-first order).
+
+        Each ``address_component`` becomes a parent ``type='location'``
+        keyword chained via ``parent_id``. Per Task 4's finding, Google's
+        standard responses do NOT carry a per-component ``place_id``, so
+        parents dedupe on ``(name, parent_id)`` and only the leaf carries
+        ``place_id``/coords.
+
+        Idempotent: calling twice with the same ``details`` returns the same
+        leaf id and does not create duplicate rows.
+        """
+        # Reverse Google's narrowest-first list to walk broadest → narrowest.
+        # Don't sort by type — trust Google's ordering (per plan).
+        components = list(reversed(details.get("address_components") or []))
+
+        with self.conn:
+            parent_id = None
+            for comp in components:
+                parent_id = self._upsert_one_keyword(
+                    name=comp["name"],
+                    parent_id=parent_id,
+                    place_id=None,
+                    latitude=None,
+                    longitude=None,
+                )
+
+            leaf_id = self._upsert_one_keyword(
+                name=details["name"],
+                parent_id=parent_id,
+                place_id=details["place_id"],
+                latitude=details.get("lat"),
+                longitude=details.get("lng"),
+            )
+        return leaf_id
+
     def merge_duplicate_keywords(self):
         """Find and merge case-insensitive duplicate keywords in active workspace.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3249,15 +3249,16 @@ class Database:
           ``INSERT OR IGNORE``) so we never collide a coordless parent row
           with a place_id-bearing leaf that happens to share a name+parent.
 
-        TODO(task-6): Cross-type (name, parent_id) collision. The table-level
-        UNIQUE(name, parent_id) constraint doesn't filter by `type`, so the
-        narrow SELECT here (which only matches type='location' rows) can miss
-        a row of a different type, then the INSERT fails. Realistically rare
-        (general/people/event keywords don't usually collide with country/
-        city/admin names), but Task 6's get_or_create_text_location faces the
-        same issue and should fix both — likely by replacing the table-level
-        UNIQUE with partial unique indexes scoped by type, or by catching the
-        IntegrityError and re-SELECTing without the type filter.
+        Cross-type collision handling: the table-level ``UNIQUE(name,
+        parent_id)`` constraint doesn't filter by ``type``, so a pre-existing
+        keyword of a *different* type with the same ``(name, parent_id)`` can
+        cause our INSERT to raise ``sqlite3.IntegrityError``. Rather than
+        silently merging into an unrelated keyword (which would corrupt the
+        user's existing tags), we catch that error, re-SELECT to confirm
+        what's actually there, and raise a descriptive ``RuntimeError``. If
+        the existing row turns out to be a coordless ``type='location'``
+        row that our narrow SELECT somehow missed, we defensively return its
+        id.
         """
         if place_id is not None:
             cur = self.conn.execute(
@@ -3291,13 +3292,62 @@ class Database:
         if existing:
             return existing["id"]
 
-        cur = self.conn.execute(
-            "INSERT INTO keywords "
-            "(name, parent_id, type, place_id, latitude, longitude) "
-            "VALUES (?, ?, 'location', NULL, ?, ?)",
-            (name, parent_id, latitude, longitude),
-        )
-        return cur.lastrowid
+        try:
+            cur = self.conn.execute(
+                "INSERT INTO keywords "
+                "(name, parent_id, type, place_id, latitude, longitude) "
+                "VALUES (?, ?, 'location', NULL, ?, ?)",
+                (name, parent_id, latitude, longitude),
+            )
+            return cur.lastrowid
+        except sqlite3.IntegrityError as integrity_err:
+            # UNIQUE(name, parent_id) violated by a row our type-filtered
+            # SELECT didn't see. Find out what's actually there.
+            if parent_id is None:
+                clash = self.conn.execute(
+                    "SELECT id, type, place_id FROM keywords "
+                    "WHERE name = ? AND parent_id IS NULL",
+                    (name,),
+                ).fetchone()
+            else:
+                clash = self.conn.execute(
+                    "SELECT id, type, place_id FROM keywords "
+                    "WHERE name = ? AND parent_id = ?",
+                    (name, parent_id),
+                ).fetchone()
+            if clash is None:
+                # Should be unreachable — re-raise the original error
+                # rather than swallow it.
+                raise
+            if clash["type"] == "location" and clash["place_id"] is None:
+                # Defensive: our narrow SELECT missed it (shouldn't happen,
+                # but reusing it is safe and idempotent).
+                return clash["id"]
+            raise RuntimeError(
+                f"keyword '{name}' (parent_id={parent_id}) exists with "
+                f"type={clash['type']!r}, can't reuse for location chain"
+            ) from integrity_err
+
+    def _upsert_location_parent_chain(self, components):
+        """Upsert a chain of parent location keywords from ``address_components``.
+
+        Walks broadest → narrowest, returning the deepest parent's id (or
+        ``None`` if ``components`` is empty / all entries lack a name).
+        Caller is responsible for the surrounding transaction.
+        """
+        parent_id = None
+        # Reverse Google's narrowest-first list to walk broadest → narrowest.
+        for comp in reversed(components or []):
+            if not comp.get("name"):
+                continue
+            parent_id = self._upsert_one_keyword(
+                name=comp["name"],
+                parent_id=parent_id,
+                place_id=None,
+                latitude=None,
+                longitude=None,
+            )
+        return parent_id
 
     def upsert_place_chain(self, details):
         """Upsert a Google Place + its parent chain. Returns the leaf id.
@@ -3321,24 +3371,10 @@ class Database:
         name = details.get("name", "")
         lat = details.get("lat")
         lng = details.get("lng")
-
-        # Reverse Google's narrowest-first list to walk broadest → narrowest.
-        # Don't sort by type — trust Google's ordering (per plan).
-        components = list(reversed(details.get("address_components") or []))
+        components = details.get("address_components") or []
 
         with self.conn:
-            parent_id = None
-            for comp in components:
-                if not comp.get("name"):
-                    continue
-                parent_id = self._upsert_one_keyword(
-                    name=comp["name"],
-                    parent_id=parent_id,
-                    place_id=None,
-                    latitude=None,
-                    longitude=None,
-                )
-
+            parent_id = self._upsert_location_parent_chain(components)
             leaf_id = self._upsert_one_keyword(
                 name=name,
                 parent_id=parent_id,
@@ -3347,6 +3383,133 @@ class Database:
                 longitude=lng,
             )
         return leaf_id
+
+    def set_photo_location(self, photo_id, leaf_keyword_id):
+        """Set ``photo_id``'s location to ``leaf_keyword_id``.
+
+        Removes any existing ``type='location'`` keyword links for the photo,
+        then inserts the new link. Atomic.
+        """
+        with self.conn:
+            self.conn.execute(
+                "DELETE FROM photo_keywords WHERE photo_id = ? "
+                "AND keyword_id IN (SELECT id FROM keywords WHERE type='location')",
+                (photo_id,),
+            )
+            self.conn.execute(
+                "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) "
+                "VALUES (?, ?)",
+                (photo_id, leaf_keyword_id),
+            )
+
+    def clear_photo_location(self, photo_id):
+        """Remove any ``type='location'`` keyword links for ``photo_id``.
+
+        Does NOT delete the keyword rows themselves — other photos may still
+        reference them, and even if they don't, free-text/place-id keywords
+        are part of the user's vocabulary.
+        """
+        with self.conn:
+            self.conn.execute(
+                "DELETE FROM photo_keywords WHERE photo_id = ? "
+                "AND keyword_id IN (SELECT id FROM keywords WHERE type='location')",
+                (photo_id,),
+            )
+
+    def get_or_create_text_location(self, name):
+        """Find or create a free-text ``type='location'`` keyword.
+
+        No ``place_id``, no coords, no parent. Whitespace is stripped from
+        ``name``; raises ``ValueError`` if the stripped result is empty.
+        Returns the keyword id.
+        """
+        if name is None:
+            raise ValueError("location name must not be empty")
+        stripped = name.strip()
+        if not stripped:
+            raise ValueError("location name must not be empty")
+        with self.conn:
+            return self._upsert_one_keyword(
+                name=stripped,
+                parent_id=None,
+                place_id=None,
+                latitude=None,
+                longitude=None,
+            )
+
+    def link_keyword_to_place(self, keyword_id, details):
+        """Attach Google place data to an existing keyword.
+
+        ``details`` has the same shape as :meth:`upsert_place_chain`'s input.
+        Builds the parent chain, then tries to UPDATE the target keyword with
+        ``place_id``, coords, name, and the deepest parent's id. If another
+        keyword already has the target ``place_id`` (UNIQUE collision on the
+        partial index), the existing canonical row absorbs all
+        ``photo_keywords`` rows from the target, and the now-empty target
+        row is deleted.
+
+        Returns ``{"keyword_id": <final id>, "merged": <bool>}``. ``merged``
+        is True when an existing place-bearing row absorbed the target.
+        """
+        if not details.get("place_id"):
+            raise ValueError("link_keyword_to_place requires details['place_id']")
+
+        place_id = details["place_id"]
+        new_name = details.get("name", "")
+        lat = details.get("lat")
+        lng = details.get("lng")
+        components = details.get("address_components") or []
+
+        with self.conn:
+            parent_id = self._upsert_location_parent_chain(components)
+
+            # If the chain itself ended up choosing this very keyword (e.g.,
+            # a free-text "United States" keyword that we just promoted to
+            # the country parent), the UPDATE below would reparent it onto
+            # itself or a descendant. Guard against that by treating it the
+            # same as the merge case — the chain row is the canonical one.
+            if parent_id == keyword_id:
+                # The keyword we were asked to "link" got reused as a parent
+                # in the chain. Nothing to merge from photo_keywords (it is
+                # already the canonical row for its slot), so just return it.
+                return {"keyword_id": keyword_id, "merged": False}
+
+            try:
+                self.conn.execute(
+                    "UPDATE keywords SET "
+                    "  place_id = ?, "
+                    "  latitude = ?, "
+                    "  longitude = ?, "
+                    "  name = ?, "
+                    "  parent_id = ? "
+                    "WHERE id = ?",
+                    (place_id, lat, lng, new_name, parent_id, keyword_id),
+                )
+                return {"keyword_id": keyword_id, "merged": False}
+            except sqlite3.IntegrityError:
+                # Another keyword already owns this place_id. Merge.
+                canonical = self.conn.execute(
+                    "SELECT id FROM keywords WHERE place_id = ?", (place_id,),
+                ).fetchone()
+                if canonical is None:
+                    # Shouldn't happen — re-raise so we don't lose info.
+                    raise
+                canonical_id = canonical["id"]
+                # Re-point photo_keywords from old → canonical.
+                self.conn.execute(
+                    "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) "
+                    "SELECT photo_id, ? FROM photo_keywords WHERE keyword_id = ?",
+                    (canonical_id, keyword_id),
+                )
+                self.conn.execute(
+                    "DELETE FROM photo_keywords WHERE keyword_id = ?",
+                    (keyword_id,),
+                )
+                # Delete the now-empty old keyword row.
+                self.conn.execute(
+                    "DELETE FROM keywords WHERE id = ?", (keyword_id,),
+                )
+                return {"keyword_id": canonical_id, "merged": True}
 
     def merge_duplicate_keywords(self):
         """Find and merge case-insensitive duplicate keywords in active workspace.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2400,14 +2400,21 @@ class Database:
     ):
         """Return all geolocated photos with optional species, scoped to active workspace.
 
-        Returns photos that have non-null latitude and longitude. No pagination —
-        returns all matching photos for map rendering. Includes the photo's
-        species keyword (or NULL if none), derived from photo_keywords joined to
-        keywords where is_species = 1.
+        Returns photos that have either non-null EXIF latitude/longitude OR a
+        ``type='location'`` keyword link whose keyword has non-null coords. No
+        pagination — returns all matching photos for map rendering. Includes
+        the photo's species keyword (or NULL if none), derived from
+        photo_keywords joined to keywords where is_species = 1.
+
+        Output columns include ``coord_source`` (``'exif'`` or ``'keyword'``)
+        and ``keyword_location_name`` (the location keyword's name when EXIF is
+        absent, NULL otherwise) so the map can show provenance.
         """
-        conditions = ["wf.workspace_id = ?",
-                      "p.latitude IS NOT NULL",
-                      "p.longitude IS NOT NULL"]
+        conditions = [
+            "wf.workspace_id = ?",
+            "COALESCE(p.latitude, kl.latitude) IS NOT NULL",
+            "COALESCE(p.longitude, kl.longitude) IS NOT NULL",
+        ]
         params = [self._ws_id()]
 
         if folder_id is not None:
@@ -2425,8 +2432,30 @@ class Database:
             conditions.append("p.timestamp <= ?")
             params.append(_inclusive_date_to(date_to))
 
-        join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
-                       "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
+        # Pick one location keyword per photo. Ordering: prefer the deepest-
+        # in-chain row (parent_id NOT NULL ranks before parent_id IS NULL),
+        # tie-break by largest id (most recently inserted, typically the leaf).
+        location_subquery = """
+            LEFT JOIN (
+                SELECT pk_loc.photo_id, k_loc.id AS id, k_loc.name AS name,
+                       k_loc.latitude AS latitude, k_loc.longitude AS longitude,
+                       ROW_NUMBER() OVER (
+                         PARTITION BY pk_loc.photo_id
+                         ORDER BY (k_loc.parent_id IS NULL) ASC, k_loc.id DESC
+                       ) AS rn
+                FROM photo_keywords pk_loc
+                JOIN keywords k_loc ON k_loc.id = pk_loc.keyword_id
+                WHERE k_loc.type = 'location'
+                  AND k_loc.latitude IS NOT NULL
+                  AND k_loc.longitude IS NOT NULL
+            ) kl ON kl.photo_id = p.id AND kl.rn = 1
+        """
+
+        join_clause = (
+            "JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
+            "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')"
+            f"\n{location_subquery}"
+        )
         if keyword is not None:
             join_clause += """
                 LEFT JOIN photo_keywords pk ON pk.photo_id = p.id
@@ -2467,7 +2496,14 @@ class Database:
             species_col_params = []
 
         query = f"""
-            SELECT p.id, p.latitude, p.longitude, p.thumb_path, p.filename,
+            SELECT p.id,
+                   COALESCE(p.latitude, kl.latitude) AS latitude,
+                   COALESCE(p.longitude, kl.longitude) AS longitude,
+                   CASE WHEN p.latitude IS NOT NULL AND p.longitude IS NOT NULL
+                        THEN 'exif' ELSE 'keyword' END AS coord_source,
+                   CASE WHEN p.latitude IS NOT NULL AND p.longitude IS NOT NULL
+                        THEN NULL ELSE kl.name END AS keyword_location_name,
+                   p.thumb_path, p.filename,
                    p.timestamp, p.rating, p.folder_id,
                    {species_col_sql}
             FROM photos p

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -433,6 +433,15 @@ class Database:
                 ON pending_changes(workspace_id);
         """
         )
+        cur = self.conn.cursor()
+        cur.execute("PRAGMA table_info(keywords)")
+        kw_cols = {row[1] for row in cur.fetchall()}
+        if "place_id" not in kw_cols:
+            cur.execute("ALTER TABLE keywords ADD COLUMN place_id TEXT")
+        cur.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_keywords_place_id "
+            "ON keywords(place_id) WHERE place_id IS NOT NULL"
+        )
         # Phase 1 storage-philosophy migration: classifier embeddings move
         # from single-slot photos.(embedding, embedding_model) columns into
         # the per-(photo, model, variant) photo_embeddings table. Rows whose

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3858,7 +3858,7 @@ class Database:
                    WHERE k.parent_id IS NOT NULL
                )
                SELECT k.id, k.name, k.parent_id, k.type, k.taxon_id,
-                      k.latitude, k.longitude,
+                      k.latitude, k.longitude, k.place_id,
                       t.name AS taxon_name, t.common_name AS taxon_common_name,
                       COUNT(ws_photo.photo_id) AS photo_count
                FROM keywords k

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3539,6 +3539,55 @@ class Database:
                 )
                 return {"keyword_id": canonical_id, "merged": True}
 
+    @staticmethod
+    def _reverse_geocode_grid(lat, lng):
+        """Round (lat, lng) to a ~110m grid cell.
+
+        Used as the cache key for reverse-geocode lookups so two coords from
+        the same neighborhood share one Google call.
+        """
+        return int(round(lat * 1000)), int(round(lng * 1000))
+
+    def reverse_geocode_cache_get(self, lat, lng):
+        """Look up cached reverse-geocode response for (lat, lng).
+
+        Returns ``{"place_id": <str|None>, "response": <str>}`` on hit
+        (``response`` is the raw JSON string the put-side stashed). A row
+        with ``place_id=None`` is a cached negative result — Google was
+        asked and returned no match — and is still a hit. Returns ``None``
+        only on a true miss (the cell was never populated).
+        """
+        lat_grid, lng_grid = self._reverse_geocode_grid(lat, lng)
+        row = self.conn.execute(
+            "SELECT place_id, response FROM place_reverse_geocode_cache "
+            "WHERE lat_grid = ? AND lng_grid = ?",
+            (lat_grid, lng_grid),
+        ).fetchone()
+        if row is None:
+            return None
+        return {"place_id": row["place_id"], "response": row["response"]}
+
+    def reverse_geocode_cache_put(self, lat, lng, place_id, response_json):
+        """Upsert reverse-geocode result at the (lat, lng) grid cell.
+
+        ``place_id`` may be ``None`` to cache a negative result (Google
+        returned no match). ``response_json`` is already a JSON string —
+        the caller serializes; we don't re-encode.
+        """
+        lat_grid, lng_grid = self._reverse_geocode_grid(lat, lng)
+        fetched_at = int(time.time())
+        with self.conn:
+            self.conn.execute(
+                "INSERT INTO place_reverse_geocode_cache "
+                "  (lat_grid, lng_grid, place_id, response, fetched_at) "
+                "VALUES (?, ?, ?, ?, ?) "
+                "ON CONFLICT(lat_grid, lng_grid) DO UPDATE SET "
+                "  place_id   = excluded.place_id, "
+                "  response   = excluded.response, "
+                "  fetched_at = excluded.fetched_at",
+                (lat_grid, lng_grid, place_id, response_json, fetched_at),
+            )
+
     def merge_duplicate_keywords(self):
         """Find and merge case-insensitive duplicate keywords in active workspace.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2637,9 +2637,12 @@ class Database:
     def get_accepted_species(self):
         """Return distinct marker species from geolocated photos in the active workspace.
 
-        Uses the same derivation as get_geolocated_photos: species keywords
-        (is_species = 1) tagged on the photo.  Only considers photos that have
-        GPS coordinates, so every returned species can actually produce a map marker.
+        Uses the same "geolocated" definition as get_geolocated_photos: a
+        photo is included if it has EXIF coords OR a ``type='location'``
+        keyword with coords. That keeps the species filter dropdown in sync
+        with which photos can actually appear as markers — otherwise photos
+        placed via location-keyword coords would render on the map but their
+        species would be missing from the filter.
         """
         ws = self._ws_id()
         return [
@@ -2653,8 +2656,18 @@ class Database:
                 JOIN photo_keywords pk ON pk.photo_id = p.id
                 JOIN keywords k ON k.id = pk.keyword_id AND k.is_species = 1
                 WHERE wf.workspace_id = ?
-                  AND p.latitude IS NOT NULL
-                  AND p.longitude IS NOT NULL
+                  AND (
+                    (p.latitude IS NOT NULL AND p.longitude IS NOT NULL)
+                    OR EXISTS (
+                      SELECT 1
+                      FROM photo_keywords pk_loc
+                      JOIN keywords k_loc ON k_loc.id = pk_loc.keyword_id
+                      WHERE pk_loc.photo_id = p.id
+                        AND k_loc.type = 'location'
+                        AND k_loc.latitude IS NOT NULL
+                        AND k_loc.longitude IS NOT NULL
+                    )
+                  )
                 ORDER BY k.name ASC
                 """,
                 (ws,),
@@ -3656,10 +3669,19 @@ class Database:
             raise ValueError("link_keyword_to_place requires details['place_id']")
 
         row = self.conn.execute(
-            "SELECT 1 FROM keywords WHERE id = ?", (keyword_id,),
+            "SELECT type FROM keywords WHERE id = ?", (keyword_id,),
         ).fetchone()
         if row is None:
             raise ValueError(f"keyword id {keyword_id} does not exist")
+        # Reject non-location keywords. place_id is globally unique, so
+        # attaching one to (say) a species or general keyword would let later
+        # location upserts resolve to a non-location row, after which
+        # set_photo_location rejects it and the place is effectively unusable
+        # until the row is manually cleaned up.
+        if row["type"] != "location":
+            raise ValueError(
+                f"keyword id {keyword_id} is type '{row['type']}', not 'location'"
+            )
 
         place_id = details["place_id"]
         new_name = details.get("name", "")

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3723,42 +3723,93 @@ class Database:
                 # the canonical row for its slot), so just return it.
                 return {"keyword_id": keyword_id, "merged": False}
 
+            update_sql = (
+                "UPDATE keywords SET "
+                "  place_id = ?, "
+                "  latitude = ?, "
+                "  longitude = ?, "
+                "  name = ?, "
+                "  parent_id = ? "
+                "WHERE id = ?"
+            )
             try:
                 self.conn.execute(
-                    "UPDATE keywords SET "
-                    "  place_id = ?, "
-                    "  latitude = ?, "
-                    "  longitude = ?, "
-                    "  name = ?, "
-                    "  parent_id = ? "
-                    "WHERE id = ?",
+                    update_sql,
                     (place_id, lat, lng, new_name, parent_id, keyword_id),
                 )
                 return {"keyword_id": keyword_id, "merged": False}
             except sqlite3.IntegrityError:
-                # Another keyword already owns this place_id. Merge.
+                # Two distinct constraints can fail here:
+                #   (a) UNIQUE(place_id) — another row already has this
+                #       place_id → merge case.
+                #   (b) UNIQUE(name, parent_id) — another row already
+                #       owns this (name, parent_id) slot with a different
+                #       (or NULL) place_id → name-collision case.
+                # Disambiguate by checking which.
                 canonical = self.conn.execute(
                     "SELECT id FROM keywords WHERE place_id = ?", (place_id,),
                 ).fetchone()
-                if canonical is None:
-                    # Shouldn't happen — re-raise so we don't lose info.
+                if canonical is not None and canonical["id"] != keyword_id:
+                    # Case (a): merge.
+                    canonical_id = canonical["id"]
+                    # FK on keywords.parent_id is enforced (foreign_keys=ON),
+                    # so any descendants of the old keyword would block the
+                    # final DELETE FROM keywords. Reparent them onto the
+                    # canonical row first — the canonical row represents the
+                    # same place, so its descendants inherit cleanly.
+                    self.conn.execute(
+                        "UPDATE keywords SET parent_id = ? WHERE parent_id = ?",
+                        (canonical_id, keyword_id),
+                    )
+                    # Re-point photo_keywords from old → canonical.
+                    self.conn.execute(
+                        "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) "
+                        "SELECT photo_id, ? FROM photo_keywords WHERE keyword_id = ?",
+                        (canonical_id, keyword_id),
+                    )
+                    self.conn.execute(
+                        "DELETE FROM photo_keywords WHERE keyword_id = ?",
+                        (keyword_id,),
+                    )
+                    # Delete the now-empty old keyword row.
+                    self.conn.execute(
+                        "DELETE FROM keywords WHERE id = ?", (keyword_id,),
+                    )
+                    return {"keyword_id": canonical_id, "merged": True}
+
+                # Case (b): name collision — a *different* keyword already
+                # holds the (new_name, parent_id) slot. Disambiguate the
+                # name by appending a short place_id suffix and retry.
+                # Same approach as _upsert_one_keyword's leaf-collision path.
+                if parent_id is None:
+                    name_clash = self.conn.execute(
+                        "SELECT id FROM keywords "
+                        "WHERE name = ? AND parent_id IS NULL AND id != ?",
+                        (new_name, keyword_id),
+                    ).fetchone()
+                else:
+                    name_clash = self.conn.execute(
+                        "SELECT id FROM keywords "
+                        "WHERE name = ? AND parent_id = ? AND id != ?",
+                        (new_name, parent_id, keyword_id),
+                    ).fetchone()
+                if name_clash is None:
+                    # Neither place_id nor name conflict — shouldn't happen
+                    # but re-raise rather than swallow.
                     raise
-                canonical_id = canonical["id"]
-                # Re-point photo_keywords from old → canonical.
-                self.conn.execute(
-                    "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) "
-                    "SELECT photo_id, ? FROM photo_keywords WHERE keyword_id = ?",
-                    (canonical_id, keyword_id),
-                )
-                self.conn.execute(
-                    "DELETE FROM photo_keywords WHERE keyword_id = ?",
-                    (keyword_id,),
-                )
-                # Delete the now-empty old keyword row.
-                self.conn.execute(
-                    "DELETE FROM keywords WHERE id = ?", (keyword_id,),
-                )
-                return {"keyword_id": canonical_id, "merged": True}
+                suffix = place_id[-8:]
+                disambiguated = f"{new_name} ({suffix})"
+                try:
+                    self.conn.execute(
+                        update_sql,
+                        (place_id, lat, lng, disambiguated, parent_id, keyword_id),
+                    )
+                    return {"keyword_id": keyword_id, "merged": False}
+                except sqlite3.IntegrityError as inner_err:
+                    raise RuntimeError(
+                        f"keyword '{new_name}' (parent_id={parent_id}) "
+                        f"collides with an existing row even after disambiguation"
+                    ) from inner_err
 
     @staticmethod
     def _reverse_geocode_grid(lat, lng):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3757,10 +3757,37 @@ class Database:
                     # final DELETE FROM keywords. Reparent them onto the
                     # canonical row first — the canonical row represents the
                     # same place, so its descendants inherit cleanly.
-                    self.conn.execute(
-                        "UPDATE keywords SET parent_id = ? WHERE parent_id = ?",
-                        (canonical_id, keyword_id),
-                    )
+                    # Per-child reparent so a UNIQUE(name, parent_id) clash
+                    # in the canonical's existing subtree (a child with the
+                    # same name) doesn't blow up the bulk UPDATE. On clash,
+                    # disambiguate the migrating child's name with a short
+                    # id suffix — preserves both rows' photo links rather
+                    # than losing data.
+                    children = self.conn.execute(
+                        "SELECT id, name FROM keywords WHERE parent_id = ?",
+                        (keyword_id,),
+                    ).fetchall()
+                    for child in children:
+                        try:
+                            self.conn.execute(
+                                "UPDATE keywords SET parent_id = ? WHERE id = ?",
+                                (canonical_id, child["id"]),
+                            )
+                        except sqlite3.IntegrityError:
+                            disambiguated = f"{child['name']} (id-{child['id']})"
+                            try:
+                                self.conn.execute(
+                                    "UPDATE keywords SET parent_id = ?, name = ? "
+                                    "WHERE id = ?",
+                                    (canonical_id, disambiguated, child["id"]),
+                                )
+                            except sqlite3.IntegrityError as inner_err:
+                                raise RuntimeError(
+                                    f"child keyword '{child['name']}' "
+                                    f"(id={child['id']}) collides with the "
+                                    f"canonical row's subtree even after "
+                                    f"disambiguation"
+                                ) from inner_err
                     # Re-point photo_keywords from old → canonical.
                     self.conn.execute(
                         "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) "
@@ -5678,7 +5705,14 @@ class Database:
         return [dict(r) for r in rows]
 
     # Action types that appear in history but cannot be reversed
-    _NON_UNDOABLE = ('prediction_reject', 'discard')
+    _NON_UNDOABLE = (
+        'prediction_reject', 'discard',
+        # Location edits (set/clear/link) are auditable but not undoable
+        # in v1 — _apply_undo has no handlers for them, so including them
+        # would silently advance the undo cursor without reverting state.
+        # Adding undo support is a follow-up if it becomes important.
+        'location_set', 'location_clear', 'location_link',
+    )
 
     def undo_last_edit(self):
         """Undo the most recent undoable edit. Returns the undone entry dict, or None.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2675,7 +2675,17 @@ class Database:
         ]
 
     def count_photos_without_gps(self):
-        """Count photos in active workspace that lack GPS coordinates."""
+        """Count photos in the active workspace that the map can't plot.
+
+        A photo IS plottable when either its EXIF lat/lng are both present
+        OR it carries a ``type='location'`` keyword whose lat/lng are both
+        present (matches :meth:`get_geolocated_photos`'s paired-fallback
+        semantics). This counter excludes those.
+
+        Used by the ``/api/photos/geo`` response to drive the map's
+        "Showing N of M geolocated photos" label — keeping the two
+        definitions in lockstep so M is never less than N.
+        """
         row = self.conn.execute(
             """
             SELECT COUNT(*) FROM photos p
@@ -2683,6 +2693,14 @@ class Database:
             JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
             WHERE wf.workspace_id = ?
               AND (p.latitude IS NULL OR p.longitude IS NULL)
+              AND NOT EXISTS (
+                SELECT 1 FROM photo_keywords pk
+                JOIN keywords k ON k.id = pk.keyword_id
+                WHERE pk.photo_id = p.id
+                  AND k.type = 'location'
+                  AND k.latitude IS NOT NULL
+                  AND k.longitude IS NOT NULL
+              )
             """,
             (self._ws_id(),),
         ).fetchone()

--- a/vireo/places.py
+++ b/vireo/places.py
@@ -1,0 +1,203 @@
+"""Thin HTTP wrappers around Google's Places + Geocoding APIs.
+
+This module is intentionally minimal:
+
+* No retries — callers can decide policy.
+* No caching — that lives in the DB layer (see ``Database`` reverse-geocode
+  cache).
+* No new dependencies — only ``urllib`` + stdlib.
+
+Both public functions normalize Google's response into a single shape::
+
+    {
+        "place_id":            str,
+        "name":                str,
+        "lat":                 float,
+        "lng":                 float,
+        "address_components":  [
+            {
+                "name":        str,   # Google's ``long_name``
+                "short_name":  str,
+                "types":       list[str],
+                # ``place_id`` may be present if Google returned one for the
+                # component — the standard Place Details / Geocoding responses
+                # generally do *not* include per-component place_ids, so
+                # absence is the common case.
+            },
+            ...
+        ],
+    }
+
+Returns ``None`` whenever Google reports ``ZERO_RESULTS`` / ``NOT_FOUND`` / no
+results, or any error status (logged at WARNING).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.parse
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_PLACE_DETAILS_URL = "https://maps.googleapis.com/maps/api/place/details/json"
+_GEOCODE_URL = "https://maps.googleapis.com/maps/api/geocode/json"
+
+# Google statuses that mean "no match" — we return ``None`` silently.
+_EMPTY_STATUSES = {"ZERO_RESULTS", "NOT_FOUND"}
+
+# Google statuses that mean "something went wrong" — we log a warning and
+# still return ``None`` (callers should not raise on transient API failures).
+_ERROR_STATUSES = {
+    "OVER_QUERY_LIMIT",
+    "REQUEST_DENIED",
+    "INVALID_REQUEST",
+    "UNKNOWN_ERROR",
+}
+
+
+def _get_json(url: str) -> dict:
+    """Fetch ``url`` and parse the response as JSON.
+
+    Kept tiny so tests can monkeypatch ``urllib.request.urlopen`` directly.
+    """
+    with urllib.request.urlopen(url) as f:
+        body = f.read()
+    return json.loads(body)
+
+
+def _normalize_components(components: list[dict] | None) -> list[dict]:
+    """Convert Google's ``address_components`` into our shape."""
+    out: list[dict] = []
+    for c in components or []:
+        comp = {
+            "name": c.get("long_name", ""),
+            "short_name": c.get("short_name", ""),
+            "types": list(c.get("types", []) or []),
+        }
+        # The standard Place Details / Geocoding endpoints don't return a
+        # per-component place_id, but pass it through if Google ever does.
+        if "place_id" in c:
+            comp["place_id"] = c["place_id"]
+        out.append(comp)
+    return out
+
+
+def _check_status(status: str, where: str) -> bool:
+    """Return True if ``status == 'OK'``. Otherwise log + return False."""
+    if status == "OK":
+        return True
+    if status in _EMPTY_STATUSES:
+        return False
+    if status in _ERROR_STATUSES:
+        logger.warning("%s: Google API returned status=%s", where, status)
+        return False
+    # Unknown status — treat as error.
+    logger.warning("%s: Google API returned unexpected status=%s", where, status)
+    return False
+
+
+def place_details(place_id: str, api_key: str) -> dict | None:
+    """Look up a Google place by its ``place_id``.
+
+    Returns the normalized dict described in the module docstring, or ``None``
+    if Google returns no result / an error status.
+    """
+    params = {
+        "place_id": place_id,
+        "key": api_key,
+        "fields": "place_id,name,geometry/location,address_components",
+    }
+    url = f"{_PLACE_DETAILS_URL}?{urllib.parse.urlencode(params)}"
+
+    try:
+        payload = _get_json(url)
+    except Exception:  # noqa: BLE001 — log + degrade
+        logger.warning("place_details: HTTP/JSON failure for place_id=%s", place_id, exc_info=True)
+        return None
+
+    status = payload.get("status", "")
+    if not _check_status(status, "place_details"):
+        return None
+
+    result = payload.get("result") or {}
+    if not result:
+        return None
+
+    location = (result.get("geometry") or {}).get("location") or {}
+    try:
+        lat = float(location["lat"])
+        lng = float(location["lng"])
+    except (KeyError, TypeError, ValueError):
+        logger.warning(
+            "place_details: missing/invalid geometry.location for place_id=%s",
+            place_id,
+        )
+        return None
+
+    return {
+        "place_id": result.get("place_id", place_id),
+        "name": result.get("name", ""),
+        "lat": lat,
+        "lng": lng,
+        "address_components": _normalize_components(result.get("address_components")),
+    }
+
+
+def reverse_geocode(lat: float, lng: float, api_key: str) -> dict | None:
+    """Reverse-geocode a (lat, lng) pair via the Geocoding API.
+
+    Returns the normalized dict for the first result, or ``None`` if Google
+    has no match / returned an error status.
+    """
+    params = {
+        "latlng": f"{lat},{lng}",
+        "key": api_key,
+    }
+    url = f"{_GEOCODE_URL}?{urllib.parse.urlencode(params)}"
+
+    try:
+        payload = _get_json(url)
+    except Exception:  # noqa: BLE001 — log + degrade
+        logger.warning(
+            "reverse_geocode: HTTP/JSON failure for latlng=%s,%s", lat, lng, exc_info=True
+        )
+        return None
+
+    status = payload.get("status", "")
+    if not _check_status(status, "reverse_geocode"):
+        return None
+
+    results = payload.get("results") or []
+    if not results:
+        return None
+
+    result = results[0]
+
+    location = (result.get("geometry") or {}).get("location") or {}
+    try:
+        out_lat = float(location["lat"])
+        out_lng = float(location["lng"])
+    except (KeyError, TypeError, ValueError):
+        logger.warning(
+            "reverse_geocode: missing/invalid geometry.location for latlng=%s,%s",
+            lat,
+            lng,
+        )
+        return None
+
+    # ``name`` for reverse-geocode results: prefer formatted_address, fall back
+    # to the broadest address component's long_name.
+    name = result.get("formatted_address", "")
+    components = result.get("address_components") or []
+    if not name and components:
+        name = components[0].get("long_name", "")
+
+    return {
+        "place_id": result.get("place_id", ""),
+        "name": name,
+        "lat": out_lat,
+        "lng": out_lng,
+        "address_components": _normalize_components(components),
+    }

--- a/vireo/places.py
+++ b/vireo/places.py
@@ -62,7 +62,7 @@ def _get_json(url: str) -> dict:
 
     Kept tiny so tests can monkeypatch ``urllib.request.urlopen`` directly.
     """
-    with urllib.request.urlopen(url) as f:
+    with urllib.request.urlopen(url, timeout=10) as f:
         body = f.read()
     return json.loads(body)
 

--- a/vireo/places.py
+++ b/vireo/places.py
@@ -145,11 +145,25 @@ def place_details(place_id: str, api_key: str) -> dict | None:
     }
 
 
+class PlacesTransientError(Exception):
+    """Raised by :func:`reverse_geocode` on transient Google API failures
+    (rate limits, request denied, malformed response, network/JSON errors).
+
+    Distinguishes "Google said no match" (return ``None``) from "we couldn't
+    ask Google right now" (raise this) so callers that cache negative
+    results don't poison the cache with transient failures.
+    """
+
+
 def reverse_geocode(lat: float, lng: float, api_key: str) -> dict | None:
     """Reverse-geocode a (lat, lng) pair via the Geocoding API.
 
-    Returns the normalized dict for the first result, or ``None`` if Google
-    has no match / returned an error status.
+    - Returns the normalized dict on success.
+    - Returns ``None`` only when Google reports a true no-match
+      (``ZERO_RESULTS`` / ``NOT_FOUND`` / empty results list).
+    - Raises :class:`PlacesTransientError` on transient failures
+      (``OVER_QUERY_LIMIT``, ``REQUEST_DENIED``, network/JSON errors).
+      Callers that cache results MUST NOT cache when this is raised.
     """
     params = {
         "latlng": f"{lat},{lng}",
@@ -159,15 +173,20 @@ def reverse_geocode(lat: float, lng: float, api_key: str) -> dict | None:
 
     try:
         payload = _get_json(url)
-    except Exception:  # noqa: BLE001 — log + degrade
+    except Exception as e:  # noqa: BLE001 — log + raise transient
         logger.warning(
             "reverse_geocode: HTTP/JSON failure for latlng=%s,%s", lat, lng, exc_info=True
         )
-        return None
+        raise PlacesTransientError("HTTP/JSON failure") from e
 
     status = payload.get("status", "")
-    if not _check_status(status, "reverse_geocode"):
+    if status in _EMPTY_STATUSES:
         return None
+    if status != "OK":
+        # _ERROR_STATUSES (OVER_QUERY_LIMIT, REQUEST_DENIED, INVALID_REQUEST,
+        # UNKNOWN_ERROR) and any other unexpected status are transient.
+        logger.warning("reverse_geocode: Google API returned status=%s", status)
+        raise PlacesTransientError(f"Google API status={status}")
 
     results = payload.get("results") or []
     if not results:

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -403,6 +403,66 @@ body {
   outline: none;
 }
 .add-kw-input:focus { border-color: var(--accent); }
+.location-section .filled-place {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 13px;
+}
+.location-section .filled-parents {
+  display: block;
+  font-size: 11px;
+  color: var(--text-dim);
+  opacity: 0.8;
+  margin-top: 2px;
+  word-break: break-word;
+}
+.location-section .clear-location {
+  background: transparent;
+  border: none;
+  color: var(--text-ghost);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 4px;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+.location-section .clear-location:hover { color: var(--danger, var(--warning)); }
+.location-section .filled-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 6px;
+}
+.location-section .filled-text { flex: 1; min-width: 0; }
+.location-section .location-suggestion {
+  margin-top: 6px;
+  padding: 6px 8px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.location-section .location-suggestion .accept-btn {
+  background: var(--accent);
+  color: var(--bg-primary);
+  border: none;
+  border-radius: 3px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
+}
+.location-section .location-error {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--warning);
+}
+/* Google Places autocomplete dropdown z-index — must sit above the detail panel. */
+.pac-container { z-index: 10000 !important; }
 .detail-summary {
   font-size: 12px;
   color: var(--text-dim);
@@ -937,6 +997,16 @@ body {
         </div>
       </div>
 
+      <div class="detail-section location-section" id="locationSection">
+        <div class="detail-section-title">Location</div>
+        <div id="locationFilled" hidden></div>
+        <div id="locationEmpty">
+          <input type="text" id="locationInput" class="add-kw-input" placeholder="📍 Add location..." autocomplete="off">
+          <div id="locationExifSuggestion" class="location-suggestion" hidden></div>
+          <div id="locationError" class="location-error" hidden></div>
+        </div>
+      </div>
+
       <div class="detail-section">
         <div class="detail-section-title">Keywords</div>
         <div id="detailKeywords"></div>
@@ -1021,6 +1091,11 @@ body {
 
 
 <script>
+/* Google Maps API key — populated from /api/config below (window._cfgPromise).
+   Empty string when no key is configured; the Location section then
+   degrades to free-text-only (no autocomplete, no script injection). */
+window.GOOGLE_MAPS_API_KEY = '';
+
 /* ---------- State ---------- */
 var photos = [];
 var totalPhotos = 0;
@@ -1057,6 +1132,7 @@ var _cfgPromise = (async function() {
     var saved = (cfg.keyboard_shortcuts || {}).browse || {};
     _shortcuts = Object.assign({}, _BROWSE_SC_DEFAULTS, saved);
     window._vireoShortcuts = cfg.keyboard_shortcuts || {};
+    window.GOOGLE_MAPS_API_KEY = cfg.google_maps_api_key || '';
     return cfg;
   } catch(e) {
     _shortcuts = Object.assign({}, _BROWSE_SC_DEFAULTS);
@@ -2343,6 +2419,13 @@ function renderDetail(photo) {
   });
   document.getElementById('detailKeywords').innerHTML = kwHtml;
 
+  // Location section
+  if (photo.location) {
+    renderLocationFilled(photo.location);
+  } else {
+    renderLocationEmpty();
+  }
+
   // XMP sidecar
   var xmpEl = document.getElementById('detailXmp');
   if (photo.xmp_exists === false) {
@@ -2701,6 +2784,194 @@ async function removeKeyword(photoId, keywordId) {
     loadDetail(photoId);
   } catch(e) {}
 }
+
+/* ---------- Location section ---------- */
+let googleMapsLoadPromise = null;
+function loadGoogleMapsJs() {
+  if (googleMapsLoadPromise) return googleMapsLoadPromise;
+  const apiKey = window.GOOGLE_MAPS_API_KEY || '';
+  if (!apiKey) {
+    googleMapsLoadPromise = Promise.reject(new Error('no_api_key'));
+    return googleMapsLoadPromise;
+  }
+  googleMapsLoadPromise = new Promise(function(resolve, reject) {
+    window._gmapsCallback = function() { resolve(window.google); };
+    var s = document.createElement('script');
+    s.src = 'https://maps.googleapis.com/maps/api/js?key=' +
+      encodeURIComponent(apiKey) +
+      '&libraries=places&loading=async&callback=_gmapsCallback';
+    s.async = true;
+    s.onerror = function() { reject(new Error('gmaps_load_failed')); };
+    document.head.appendChild(s);
+  });
+  return googleMapsLoadPromise;
+}
+
+// Per-input autocomplete state. Keyed by `input` element so we can detect
+// whether a `place_changed` event recently fired (and thus the Enter
+// handler should defer to it).
+var _locationAutocomplete = null;
+var _locationLastPickedAt = 0;
+var _locationAutocompleteBound = false;
+
+function _showLocationError(msg) {
+  var el = document.getElementById('locationError');
+  if (!el) return;
+  el.textContent = msg;
+  el.hidden = false;
+  setTimeout(function() {
+    if (el.textContent === msg) el.hidden = true;
+  }, 4000);
+}
+
+function _hideLocationError() {
+  var el = document.getElementById('locationError');
+  if (el) el.hidden = true;
+}
+
+async function bindLocationAutocomplete() {
+  if (_locationAutocompleteBound) return;
+  // Wait for the /api/config fetch to resolve so window.GOOGLE_MAPS_API_KEY
+  // is populated. The user can focus the input before _cfgPromise has
+  // resolved on a slow page load — without this await we'd take the
+  // empty-key branch permanently.
+  try { await _cfgPromise; } catch(e) {}
+  if (!window.GOOGLE_MAPS_API_KEY) return;  // no key -> free-text only
+  _locationAutocompleteBound = true;
+  var input = document.getElementById('locationInput');
+  if (!input) return;
+  loadGoogleMapsJs().then(function(google) {
+    if (!google || !google.maps || !google.maps.places) return;
+    _locationAutocomplete = new google.maps.places.Autocomplete(input, {
+      types: ['geocode', 'establishment'],
+      fields: ['place_id', 'name', 'formatted_address'],
+    });
+    _locationAutocomplete.addListener('place_changed', function() {
+      var place = _locationAutocomplete.getPlace();
+      if (!place || !place.place_id) return;
+      _locationLastPickedAt = Date.now();
+      _submitLocationPlace(place.place_id);
+    });
+  }).catch(function(err) {
+    console.warn('Google Maps load failed:', err);
+    // Don't disable the input — free-text Enter still works.
+  });
+}
+
+async function _submitLocationPlace(placeId) {
+  var photoId = window._detailPhotoId;
+  if (!photoId) return;
+  _hideLocationError();
+  try {
+    var resp = await safeFetch('/api/photos/' + photoId + '/location', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ place_id: placeId }),
+    });
+    if (resp && resp.location) {
+      renderLocationFilled(resp.location);
+      // The location keyword may also appear in the Keywords list; refresh.
+      loadDetail(photoId);
+    }
+  } catch(e) {
+    _showLocationError('Could not save location.');
+  }
+}
+
+async function _submitLocationText(name) {
+  var photoId = window._detailPhotoId;
+  if (!photoId) return;
+  _hideLocationError();
+  try {
+    var resp = await safeFetch('/api/photos/' + photoId + '/location/text', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: name }),
+    });
+    if (resp && resp.location) {
+      renderLocationFilled(resp.location);
+      loadDetail(photoId);
+    }
+  } catch(e) {
+    _showLocationError('Could not save location.');
+  }
+}
+
+async function clearPhotoLocation() {
+  var photoId = window._detailPhotoId;
+  if (!photoId) return;
+  _hideLocationError();
+  try {
+    await safeFetch('/api/photos/' + photoId + '/location', { method: 'DELETE' });
+    renderLocationEmpty();
+    loadDetail(photoId);
+  } catch(e) {
+    _showLocationError('Could not clear location.');
+  }
+}
+
+function renderLocationFilled(loc) {
+  var filled = document.getElementById('locationFilled');
+  var empty = document.getElementById('locationEmpty');
+  if (!filled || !empty) return;
+  if (!loc) { renderLocationEmpty(); return; }
+  var parents = (loc.parent_chain || [])
+    .map(function(p) { return p && p.name ? p.name : ''; })
+    .filter(Boolean);
+  var parentsHtml = parents.length
+    ? '<span class="filled-parents">' + parents.map(escapeHtml).join(' · ') + '</span>'
+    : '';
+  filled.innerHTML =
+    '<div class="filled-row">' +
+      '<div class="filled-text">' +
+        '<span class="filled-place">' + escapeHtml(loc.name || '') + '</span>' +
+        parentsHtml +
+      '</div>' +
+      '<button class="clear-location" type="button" title="Clear location" onclick="clearPhotoLocation()">×</button>' +
+    '</div>';
+  filled.hidden = false;
+  empty.hidden = true;
+  // Reset the input value for next time.
+  var input = document.getElementById('locationInput');
+  if (input) input.value = '';
+}
+
+function renderLocationEmpty() {
+  var filled = document.getElementById('locationFilled');
+  var empty = document.getElementById('locationEmpty');
+  if (!filled || !empty) return;
+  filled.innerHTML = '';
+  filled.hidden = true;
+  empty.hidden = false;
+  var input = document.getElementById('locationInput');
+  if (input) input.value = '';
+}
+
+function _onLocationInputFocus() {
+  bindLocationAutocomplete();
+}
+
+function _onLocationInputKeydown(e) {
+  if (e.key !== 'Enter') return;
+  e.preventDefault();
+  // If a Google place was just picked (within ~500ms), the place_changed
+  // listener already submitted it; ignore the redundant Enter.
+  if (Date.now() - _locationLastPickedAt < 500) return;
+  var input = e.target;
+  var val = (input.value || '').trim();
+  if (!val) return;
+  _submitLocationText(val);
+}
+
+// Wire up listeners once on initial script load. The input element exists
+// in the DOM unconditionally (server renders the section), so we don't need
+// to re-bind on every photo load.
+document.addEventListener('DOMContentLoaded', function() {
+  var input = document.getElementById('locationInput');
+  if (!input) return;
+  input.addEventListener('focus', _onLocationInputFocus);
+  input.addEventListener('keydown', _onLocationInputKeydown);
+});
 
 /* ---------- Keyword Type Dropdown ---------- */
 function toggleTypeDropdown(indicator, kwId) {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -447,6 +447,10 @@ body {
   align-items: center;
   gap: 6px;
 }
+/* Specificity-match the rule above so the `hidden` attribute actually
+   hides the element. Without this, `display: flex` wins over the UA's
+   `[hidden] { display: none }` rule. */
+.location-section .location-suggestion[hidden] { display: none; }
 .location-section .location-suggestion .accept-btn {
   background: var(--accent);
   color: var(--bg-primary);
@@ -2424,6 +2428,7 @@ function renderDetail(photo) {
     renderLocationFilled(photo.location);
   } else {
     renderLocationEmpty();
+    maybeShowExifSuggestion(photo);
   }
 
   // XMP sidecar
@@ -2945,6 +2950,86 @@ function renderLocationEmpty() {
   empty.hidden = false;
   var input = document.getElementById('locationInput');
   if (input) input.value = '';
+  // Reset any prior EXIF suggestion. The caller (renderDetail) re-runs
+  // maybeShowExifSuggestion(photo) after this, which decides whether to
+  // populate the line for the new photo.
+  var sugg = document.getElementById('locationExifSuggestion');
+  if (sugg) {
+    sugg.hidden = true;
+    sugg.innerHTML = '';
+  }
+}
+
+/* When a photo with EXIF GPS but no location keyword is opened, fetch a
+   reverse-geocode suggestion and offer it as an inline Accept line. Bails
+   silently when there's no key or no coords; the proxy returns null when
+   Google has no match for the cell. */
+async function maybeShowExifSuggestion(photo) {
+  var sugg = document.getElementById('locationExifSuggestion');
+  if (!sugg) return;
+  sugg.hidden = true;
+  sugg.innerHTML = '';
+
+  if (!photo) return;
+  if (photo.location) return;
+  if (photo.latitude == null || photo.longitude == null) return;
+
+  await _cfgPromise;
+  var apiKey = (window.GOOGLE_MAPS_API_KEY || '').trim();
+  if (!apiKey) return;
+
+  // Capture the photo id at request time so a slow reverse-geocode for an
+  // older photo doesn't paint into the suggestion line for a newer one.
+  var requestPhotoId = photo.id;
+  try {
+    var params = new URLSearchParams({lat: photo.latitude, lng: photo.longitude});
+    var r = await fetch('/api/places/reverse-geocode?' + params.toString());
+    if (!r.ok) return;
+    var data = await r.json();
+    if (!data || !data.place_id || !data.summary) return;
+    if (window._detailPhotoId !== requestPhotoId) return;
+
+    sugg.innerHTML = '';
+    var text = document.createElement('span');
+    text.textContent = '💡 EXIF says: ' + data.summary + '  ';
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'accept-btn';
+    btn.textContent = 'Accept';
+    btn.dataset.placeId = data.place_id;
+    btn.addEventListener('click', function() {
+      acceptExifSuggestion(data.place_id);
+    });
+    sugg.appendChild(text);
+    sugg.appendChild(btn);
+    sugg.hidden = false;
+  } catch (e) {
+    console.warn('reverse-geocode suggestion failed:', e);
+  }
+}
+
+async function acceptExifSuggestion(placeId) {
+  var photoId = window._detailPhotoId;
+  if (!photoId || !placeId) return;
+  _hideLocationError();
+  try {
+    var resp = await safeFetch('/api/photos/' + photoId + '/location', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ place_id: placeId }),
+    });
+    if (resp && resp.location) {
+      renderLocationFilled(resp.location);
+      loadDetail(photoId);
+    }
+    var sugg = document.getElementById('locationExifSuggestion');
+    if (sugg) {
+      sugg.hidden = true;
+      sugg.innerHTML = '';
+    }
+  } catch(e) {
+    _showLocationError('Could not save location.');
+  }
 }
 
 function _onLocationInputFocus() {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2818,6 +2818,10 @@ function loadGoogleMapsJs() {
 var _locationAutocomplete = null;
 var _locationLastPickedAt = 0;
 var _locationAutocompleteBound = false;
+// Pending free-text submit triggered by Enter. Held for ~300ms so a
+// keyboard-selected autocomplete suggestion (where place_changed fires
+// AFTER the keydown event) gets a chance to cancel the text path.
+var _locationPendingTextSubmit = null;
 
 function _showLocationError(msg) {
   var el = document.getElementById('locationError');
@@ -2855,6 +2859,13 @@ async function bindLocationAutocomplete() {
       var place = _locationAutocomplete.getPlace();
       if (!place || !place.place_id) return;
       _locationLastPickedAt = Date.now();
+      // Cancel any pending free-text submit from the Enter that triggered
+      // this place_changed event — keydown fires synchronously BEFORE
+      // place_changed, so the text path's setTimeout is still queued.
+      if (_locationPendingTextSubmit) {
+        clearTimeout(_locationPendingTextSubmit);
+        _locationPendingTextSubmit = null;
+      }
       _submitLocationPlace(place.place_id);
     });
   }).catch(function(err) {
@@ -3038,14 +3049,28 @@ function _onLocationInputFocus() {
 
 function _onLocationInputKeydown(e) {
   if (e.key !== 'Enter') return;
-  e.preventDefault();
-  // If a Google place was just picked (within ~500ms), the place_changed
-  // listener already submitted it; ignore the redundant Enter.
+  // DO NOT preventDefault — Google's autocomplete listens for Enter to
+  // pick the highlighted suggestion. Suppressing the event would block
+  // keyboard place selection. The input has no surrounding form, so
+  // letting Enter through has no native side effect.
+  // If a place was JUST picked (e.g. mouse click within ~500ms ago),
+  // skip outright.
   if (Date.now() - _locationLastPickedAt < 500) return;
   var input = e.target;
   var val = (input.value || '').trim();
   if (!val) return;
-  _submitLocationText(val);
+  // Defer the free-text submit. If a Google suggestion was highlighted
+  // and the user pressed Enter to pick it, place_changed will fire after
+  // this keydown (synchronously, but still after the event-loop tick) and
+  // cancel our pending timeout. If place_changed never fires (no
+  // suggestion highlighted), the text submit goes through after 300ms.
+  if (_locationPendingTextSubmit) clearTimeout(_locationPendingTextSubmit);
+  _locationPendingTextSubmit = setTimeout(function() {
+    _locationPendingTextSubmit = null;
+    // Final guard: place_changed may have raced in just before this fired.
+    if (Date.now() - _locationLastPickedAt < 1000) return;
+    _submitLocationText(val);
+  }, 300);
 }
 
 // Wire up listeners once on initial script load. The input element exists

--- a/vireo/templates/keywords.html
+++ b/vireo/templates/keywords.html
@@ -144,6 +144,27 @@
   .kw-coords { font-size: 11px; color: var(--text-dim); font-family: monospace; }
   .kw-taxon { font-size: 12px; color: var(--text-muted); font-style: italic; }
   .kw-parent { font-size: 12px; color: var(--text-dim); }
+
+  /* Link-to-Google button on unlinked location keywords */
+  .kw-link-btn {
+    padding: 2px 8px; border-radius: 10px; font-size: 11px;
+    border: 1px solid var(--border-secondary);
+    background: transparent; color: var(--text-secondary);
+    cursor: pointer; white-space: nowrap;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+  }
+  .kw-link-btn:hover {
+    background: var(--accent-dim); border-color: var(--accent); color: var(--accent);
+  }
+  .kw-linked-badge {
+    display: inline-block; font-size: 11px; color: var(--accent);
+    margin-left: 4px;
+  }
+
+  /* Link-place modal: reuses .modal-overlay/.modal classes from _navbar.html */
+  #linkPlaceModal .modal-help {
+    font-size: 12px; color: var(--text-muted); margin-bottom: 12px;
+  }
 </style>
 </head>
 <body>
@@ -165,6 +186,10 @@
       <button class="kw-filter-btn" data-type="descriptive">Descriptive</button>
       <button class="kw-filter-btn" data-type="people">People</button>
       <button class="kw-filter-btn" data-type="event">Event</button>
+      <button class="kw-filter-btn" id="kwFilterUnlinked" data-type="unlinked-location"
+              title="Show only location keywords without a Google place link">
+        Unlinked locations <span id="kwUnlinkedCount">0</span>
+      </button>
       <span class="kw-stats" id="kwStats">Loading...</span>
     </div>
 
@@ -197,6 +222,7 @@
             <th data-col="taxon">Taxon <span class="sort-arrow">&#9650;</span></th>
             <th data-col="photo_count">Photos <span class="sort-arrow">&#9650;</span></th>
             <th data-col="coords">Coords <span class="sort-arrow">&#9650;</span></th>
+            <th data-col="link">Link</th>
           </tr>
         </thead>
         <tbody id="kwBody"></tbody>
@@ -205,6 +231,23 @@
     </div>
   </div>
 
+</div>
+
+<!-- Link-to-Google-place modal -->
+<div class="modal-overlay" id="linkPlaceModal">
+  <div class="modal">
+    <h3>Link keyword to Google place</h3>
+    <p class="modal-help">
+      Pick the Google place this location keyword represents.
+      Coordinates and the parent chain (city, state, country) will be attached.
+    </p>
+    <input type="text" id="linkPlaceInput" class="modal-input"
+           placeholder="Type a place name..." autocomplete="off" />
+    <div id="linkPlaceError" class="modal-error"></div>
+    <div class="modal-actions">
+      <button class="modal-btn modal-btn-cancel" id="linkPlaceCancel" type="button">Cancel</button>
+    </div>
+  </div>
 </div>
 
 <script>
@@ -237,7 +280,9 @@
 
   function getFiltered() {
     let list = allKeywords;
-    if (filterType !== 'all') {
+    if (filterType === 'unlinked-location') {
+      list = list.filter(k => (k.type || 'general') === 'location' && !k.place_id);
+    } else if (filterType !== 'all') {
       list = list.filter(k => (k.type || 'general') === filterType);
     }
     if (searchTerm) {
@@ -245,6 +290,12 @@
       list = list.filter(k => k.name.toLowerCase().includes(s));
     }
     return list;
+  }
+
+  function unlinkedLocationCount() {
+    return allKeywords.reduce(function(n, k) {
+      return n + (((k.type || 'general') === 'location' && !k.place_id) ? 1 : 0);
+    }, 0);
   }
 
   function sortList(list) {
@@ -280,6 +331,8 @@
     const stats = document.getElementById('kwStats');
 
     stats.textContent = filtered.length + ' of ' + allKeywords.length + ' keywords';
+    const unlinkedEl = document.getElementById('kwUnlinkedCount');
+    if (unlinkedEl) unlinkedEl.textContent = unlinkedLocationCount();
 
     if (!filtered.length) {
       tbody.innerHTML = '';
@@ -299,6 +352,20 @@
       const coordStr = (k.latitude != null && k.longitude != null)
                        ? k.latitude.toFixed(4) + ', ' + k.longitude.toFixed(4) : '';
 
+      // Per-row Link cell:
+      //   * type='location' AND no place_id  -> 📍 Link... button
+      //   * type='location' AND has place_id -> 📍 linked badge
+      //   * other types                      -> empty
+      let linkCell = '';
+      if (t === 'location') {
+        if (k.place_id) {
+          linkCell = '<span class="kw-linked-badge" title="Linked to Google place">📍 linked</span>';
+        } else {
+          linkCell = '<button class="kw-link-btn" data-link-id="' + k.id + '" type="button">' +
+            '📍 Link…</button>';
+        }
+      }
+
       return '<tr data-id="' + k.id + '">' +
         '<td class="cb-cell"><input type="checkbox" class="kw-cb" data-id="' + k.id + '" ' + checked + '></td>' +
         '<td class="kw-name-cell"><span class="name-text" data-id="' + k.id + '">' + escapeHtml(k.name) + '</span></td>' +
@@ -307,6 +374,7 @@
         '<td><span class="kw-taxon">' + escapeHtml(taxonStr) + '</span></td>' +
         '<td>' + (k.photo_count || 0) + '</td>' +
         '<td><span class="kw-coords">' + coordStr + '</span></td>' +
+        '<td>' + linkCell + '</td>' +
         '</tr>';
     });
     tbody.innerHTML = rows.join('');
@@ -587,6 +655,184 @@
     render();
     openContextMenu(e, buildKeywordContextMenu(ids));
   });
+
+  // -- Link-to-Google-place flow ---------------------------------------------
+
+  // Cached promise for the Google Maps JS loader (memoized).
+  let _gmapsLoadPromise = null;
+  function loadGoogleMapsJs() {
+    if (_gmapsLoadPromise) return _gmapsLoadPromise;
+    const apiKey = window.GOOGLE_MAPS_API_KEY || '';
+    if (!apiKey) {
+      _gmapsLoadPromise = Promise.reject(new Error('no_api_key'));
+      return _gmapsLoadPromise;
+    }
+    _gmapsLoadPromise = new Promise(function(resolve, reject) {
+      window._gmapsCallback = function() { resolve(window.google); };
+      const s = document.createElement('script');
+      s.src = 'https://maps.googleapis.com/maps/api/js?key=' +
+        encodeURIComponent(apiKey) +
+        '&libraries=places&loading=async&callback=_gmapsCallback';
+      s.async = true;
+      s.onerror = function() { reject(new Error('gmaps_load_failed')); };
+      document.head.appendChild(s);
+    });
+    return _gmapsLoadPromise;
+  }
+
+  // Fetch /api/config once on page load to populate window.GOOGLE_MAPS_API_KEY.
+  // Mirrors browse.html's _cfgPromise pattern. The modal awaits this promise
+  // before deciding whether to bind autocomplete vs. show the empty-key error.
+  const _cfgPromise = (async function() {
+    try {
+      const r = await fetch('/api/config');
+      const cfg = await r.json();
+      window.GOOGLE_MAPS_API_KEY = cfg.google_maps_api_key || '';
+      return cfg;
+    } catch(e) {
+      window.GOOGLE_MAPS_API_KEY = '';
+      return null;
+    }
+  })();
+
+  let _activeLinkAutocomplete = null;
+  let _activeLinkKeywordId = null;
+
+  function _showLinkError(msg) {
+    const el = document.getElementById('linkPlaceError');
+    if (!el) return;
+    el.textContent = msg;
+    el.style.display = 'block';
+  }
+
+  function _hideLinkError() {
+    const el = document.getElementById('linkPlaceError');
+    if (el) el.style.display = 'none';
+  }
+
+  async function openLinkPlaceModal(keywordId, currentName) {
+    const modal = document.getElementById('linkPlaceModal');
+    const input = document.getElementById('linkPlaceInput');
+    if (!modal || !input) return;
+
+    _hideLinkError();
+    _activeLinkKeywordId = keywordId;
+    input.value = currentName || '';
+    modal.classList.add('open');
+    // Defer focus so the modal is laid out first.
+    setTimeout(function() { input.focus(); input.select(); }, 0);
+
+    // Wait for /api/config so window.GOOGLE_MAPS_API_KEY is populated even
+    // on a slow first paint.
+    try { await _cfgPromise; } catch(e) {}
+
+    if (!window.GOOGLE_MAPS_API_KEY) {
+      _showLinkError(
+        'Google Maps API key not configured. Add one in Settings to enable autocomplete.'
+      );
+      return;
+    }
+
+    try {
+      const google = await loadGoogleMapsJs();
+      if (!google || !google.maps || !google.maps.places) {
+        _showLinkError('Google Maps unavailable.');
+        return;
+      }
+      // Detach any previous listener by replacing the autocomplete instance
+      // (Google's API doesn't expose a clean detach for the binding to
+      // `input`; binding twice triggers two `place_changed` events).
+      _activeLinkAutocomplete = new google.maps.places.Autocomplete(input, {
+        types: ['geocode', 'establishment'],
+        fields: ['place_id', 'name', 'formatted_address'],
+      });
+      _activeLinkAutocomplete.addListener('place_changed', function() {
+        const place = _activeLinkAutocomplete.getPlace();
+        if (place && place.place_id && _activeLinkKeywordId) {
+          submitLinkPlace(_activeLinkKeywordId, place.place_id);
+        }
+      });
+    } catch(err) {
+      _showLinkError('Failed to load Google Maps: ' + (err && err.message || err));
+    }
+  }
+
+  function closeLinkPlaceModal() {
+    const modal = document.getElementById('linkPlaceModal');
+    if (modal) modal.classList.remove('open');
+    _activeLinkKeywordId = null;
+    _activeLinkAutocomplete = null;
+    _hideLinkError();
+  }
+
+  async function submitLinkPlace(keywordId, placeId) {
+    _hideLinkError();
+    let resp;
+    try {
+      resp = await fetch('/api/keywords/' + keywordId + '/link-place', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({place_id: placeId}),
+      });
+    } catch(err) {
+      _showLinkError('Network error: ' + (err && err.message || err));
+      return;
+    }
+    if (!resp.ok) {
+      let body = {};
+      try { body = await resp.json(); } catch(e) {}
+      _showLinkError(body.error || ('Failed (HTTP ' + resp.status + ')'));
+      return;
+    }
+    let data = {};
+    try { data = await resp.json(); } catch(e) {}
+
+    closeLinkPlaceModal();
+
+    if (data.merged && typeof showToast === 'function') {
+      const mergedName = (data.keyword && data.keyword.name) || 'existing keyword';
+      showToast('Merged into existing "' + mergedName + '"', 'success');
+    } else if (typeof showToast === 'function') {
+      const linkedName = (data.keyword && data.keyword.name) || 'place';
+      showToast('Linked to ' + linkedName, 'success');
+    }
+
+    // Re-fetch to pick up new place_id / coords / parent_id, and so the
+    // unlinked-locations chip count updates.
+    await loadKeywords();
+  }
+
+  // Per-row "Link..." button click handler. Bound on the body via delegation
+  // because rows are re-rendered by render().
+  document.getElementById('kwBody').addEventListener('click', function(e) {
+    const btn = e.target.closest('.kw-link-btn');
+    if (!btn) return;
+    e.stopPropagation();
+    const kwId = parseInt(btn.dataset.linkId, 10);
+    if (!kwId) return;
+    const kw = allKeywords.find(k => k.id === kwId);
+    openLinkPlaceModal(kwId, kw ? kw.name : '');
+  });
+
+  // Modal: cancel button + click-on-overlay + Escape key.
+  document.getElementById('linkPlaceCancel').addEventListener(
+    'click', closeLinkPlaceModal
+  );
+  document.getElementById('linkPlaceModal').addEventListener('click', function(e) {
+    // Click on the overlay (outside .modal) closes it.
+    if (e.target === this) closeLinkPlaceModal();
+  });
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+      const modal = document.getElementById('linkPlaceModal');
+      if (modal && modal.classList.contains('open')) closeLinkPlaceModal();
+    }
+  });
+
+  // Test hook: lets e2e tests trigger the API path without driving the
+  // Google Places UI (which Playwright can't reasonably exercise without a
+  // live network round-trip).
+  window.__linkPlaceForTest = submitLinkPlace;
 
   // -- Init --
   loadKeywords();

--- a/vireo/templates/map.html
+++ b/vireo/templates/map.html
@@ -199,6 +199,14 @@ body { padding-bottom: 36px; }
 }
 .photo-popup .popup-link:hover { text-decoration: underline; }
 
+.photo-popup .popup-provenance {
+  font-size: 10px;
+  color: var(--text-dim, #888);
+  margin-top: 4px;
+  border-top: 1px solid var(--border, #1a4a5a);
+  padding-top: 4px;
+}
+
 .popup-stars { color: var(--warning); font-size: 11px; }
 
 /* Species legend control */
@@ -574,12 +582,21 @@ async function loadPhotos() {
         ? '<div class="popup-species">' + escapeHtml(p.species) + '</div>'
         : '';
 
+      var provenanceLine = '';
+      if (p.coord_source === 'keyword' && p.keyword_location_name) {
+        provenanceLine = '<div class="popup-provenance">\u{1F4CD} from location: '
+          + escapeHtml(p.keyword_location_name) + '</div>';
+      } else if (p.coord_source === 'exif') {
+        provenanceLine = '<div class="popup-provenance">\u{1F4CD} from EXIF GPS</div>';
+      }
+
       var popup = '<div class="photo-popup">'
         + imgTag
         + '<div class="popup-title">' + escapeHtml(p.filename) + '</div>'
         + '<div class="popup-meta">' + escapeHtml(formatDate(p.timestamp)) + ' ' + buildStars(p.rating) + '</div>'
         + speciesLine
         + '<a class="popup-link" href="/browse?photo_id=' + p.id + '">View in Browse &rarr;</a>'
+        + provenanceLine
         + '</div>';
 
       var color = getSpeciesColor(p.species);

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -794,6 +794,26 @@
     <div id="inatTokenStatus" style="font-size:12px;margin-top:4px;min-height:18px;"></div>
   </div>
 
+  <!-- Google Maps -->
+  <div class="section">
+    <div class="section-title">Google Maps</div>
+    <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+      Used for location autocomplete on photo keywords. Get a key from the Google Cloud console (Maps JavaScript API + Places API + Geocoding API enabled). Add an HTTP referrer restriction in the console (e.g. <code>localhost:8080/*</code>) so the key can only be used from your machine.
+    </p>
+    <div class="setting-row">
+      <div class="setting-label">
+        API Key
+        <small>Stored in <code>~/.vireo/config.json</code>. The key is embedded in the browse page when set so the Google Maps JS library can call autocomplete client-side.</small>
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;">
+        <input type="password" id="cfgGoogleMapsApiKey" placeholder="AIza..."
+               style="width:260px;background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:12px;font-family:monospace;"
+               onchange="saveConfig()">
+        <button onclick="toggleGoogleMapsKeyVisibility()" style="background:var(--bg-tertiary);color:var(--text-dim);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:11px;cursor:pointer;">Show</button>
+      </div>
+    </div>
+  </div>
+
   <!-- External Editor -->
   <div class="section">
     <div class="section-title">External Editor</div>
@@ -1121,6 +1141,7 @@ async function loadConfig() {
     document.getElementById('cfgHfToken').value = cfg.hf_token || '';
     document.getElementById('cfgInatToken').value = cfg.inat_token || '';
     if (cfg.inat_token) validateInatToken();
+    document.getElementById('cfgGoogleMapsApiKey').value = cfg.google_maps_api_key || '';
     document.getElementById('cfgKeywordCase').value = cfg.keyword_case || 'auto';
     document.getElementById('cfgMaxEditHistory').value = cfg.max_edit_history != null ? cfg.max_edit_history : 1000;
     // Load darktable settings
@@ -1314,6 +1335,7 @@ function saveConfig() {
           max_edit_history: maxEditHistory,
           hf_token: hfToken,
           inat_token: document.getElementById('cfgInatToken').value.trim(),
+          google_maps_api_key: document.getElementById('cfgGoogleMapsApiKey').value.trim(),
           external_editor: document.getElementById('cfgExternalEditor').value.trim(),
           darktable_bin: document.getElementById('cfgDarktableBin').value.trim(),
           darktable_style: document.getElementById('cfgDarktableStyle').value.trim(),
@@ -1446,6 +1468,11 @@ function resetPipelineDefaults() {
 
 function toggleInatTokenVisibility() {
   var inp = document.getElementById('cfgInatToken');
+  inp.type = inp.type === 'password' ? 'text' : 'password';
+}
+
+function toggleGoogleMapsKeyVisibility() {
+  var inp = document.getElementById('cfgGoogleMapsApiKey');
   inp.type = inp.type === 'password' ? 'text' : 'password';
 }
 

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -270,3 +270,9 @@ def test_miss_defaults_present():
     assert d["miss_bbox_area_min"] == 0.005
     assert d["miss_bbox_area_min_singleton"] == 0.002
     assert d["miss_oof_ratio"] == 0.5
+
+
+def test_google_maps_api_key_default_is_empty(tmp_path, monkeypatch):
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    assert cfg.load().get("google_maps_api_key") == ""

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6417,3 +6417,264 @@ def test_upsert_place_chain_shares_parents_across_leaves(db):
         "SELECT COUNT(*) AS n FROM keywords WHERE type='location'"
     ).fetchone()["n"]
     assert total == 6
+
+
+def _make_photo(db, filename="loc.jpg"):
+    """Helper: create a folder + a single photo, return its id."""
+    fid = db.add_folder(f"/photos/{filename}-folder", name="loc")
+    return db.add_photo(
+        folder_id=fid, filename=filename, extension=".jpg",
+        file_size=1000, file_mtime=1.0,
+    )
+
+
+def test_set_photo_location_replaces_existing(db):
+    """set_photo_location removes any existing 'location' link before inserting."""
+    pid = _make_photo(db)
+    # Pre-existing location keyword link.
+    old_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES (?, 'location')",
+        ("Old Park",),
+    ).lastrowid
+    new_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES (?, 'location')",
+        ("New Park",),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, old_id),
+    )
+    db.conn.commit()
+
+    db.set_photo_location(pid, new_id)
+
+    rows = db.conn.execute(
+        "SELECT keyword_id FROM photo_keywords WHERE photo_id = ?", (pid,),
+    ).fetchall()
+    keyword_ids = {r["keyword_id"] for r in rows}
+    assert keyword_ids == {new_id}, "old location link must be removed; new one present"
+
+
+def test_set_photo_location_preserves_non_location_keywords(db):
+    """set_photo_location must only touch 'location' links, not other tag types."""
+    pid = _make_photo(db)
+    general_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES (?, 'general')",
+        ("Bird",),
+    ).lastrowid
+    loc_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES (?, 'location')",
+        ("Park",),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, general_id),
+    )
+    db.conn.commit()
+
+    db.set_photo_location(pid, loc_id)
+
+    rows = db.conn.execute(
+        "SELECT keyword_id FROM photo_keywords WHERE photo_id = ?", (pid,),
+    ).fetchall()
+    keyword_ids = {r["keyword_id"] for r in rows}
+    assert keyword_ids == {general_id, loc_id}
+
+
+def test_clear_photo_location_removes_links_but_keeps_keyword_rows(db):
+    """clear_photo_location deletes the link only, never the keyword row."""
+    pid = _make_photo(db)
+    loc_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES (?, 'location')",
+        ("Park",),
+    ).lastrowid
+    general_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES (?, 'general')",
+        ("Bird",),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, loc_id),
+    )
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, general_id),
+    )
+    db.conn.commit()
+
+    db.clear_photo_location(pid)
+
+    # Location link gone, general link survives.
+    rows = db.conn.execute(
+        "SELECT keyword_id FROM photo_keywords WHERE photo_id = ?", (pid,),
+    ).fetchall()
+    assert {r["keyword_id"] for r in rows} == {general_id}
+
+    # Both keyword rows still exist.
+    kept = db.conn.execute(
+        "SELECT id FROM keywords WHERE id IN (?, ?)", (loc_id, general_id),
+    ).fetchall()
+    assert len(kept) == 2
+
+
+def test_get_or_create_text_location_creates_new(db):
+    """First call creates, second with same name returns same id."""
+    first = db.get_or_create_text_location("the dog park")
+    row = db.conn.execute(
+        "SELECT name, type, place_id, parent_id, latitude, longitude "
+        "FROM keywords WHERE id = ?",
+        (first,),
+    ).fetchone()
+    assert row["name"] == "the dog park"
+    assert row["type"] == "location"
+    assert row["place_id"] is None
+    assert row["parent_id"] is None
+    assert row["latitude"] is None
+    assert row["longitude"] is None
+
+    second = db.get_or_create_text_location("the dog park")
+    assert second == first
+
+
+def test_get_or_create_text_location_strips_whitespace_and_rejects_empty(db):
+    """Whitespace stripped; empty/whitespace-only raises ValueError."""
+    import pytest
+
+    a = db.get_or_create_text_location("  Café Park  ")
+    b = db.get_or_create_text_location("Café Park")
+    assert a == b
+    row = db.conn.execute(
+        "SELECT name FROM keywords WHERE id = ?", (a,),
+    ).fetchone()
+    assert row["name"] == "Café Park"
+
+    with pytest.raises(ValueError):
+        db.get_or_create_text_location("")
+    with pytest.raises(ValueError):
+        db.get_or_create_text_location("   ")
+
+
+def test_link_keyword_to_place_attaches_metadata(db):
+    """An existing free-text keyword gets place_id, coords, and parent chain."""
+    # Create a free-text "Central Park" with a photo tagged.
+    pid = _make_photo(db)
+    free_id = db.get_or_create_text_location("Central Park")
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, free_id),
+    )
+    db.conn.commit()
+
+    details = _central_park_details()
+    result = db.link_keyword_to_place(free_id, details)
+
+    assert result["merged"] is False
+    assert result["keyword_id"] == free_id
+
+    row = db.conn.execute(
+        "SELECT name, type, place_id, latitude, longitude, parent_id "
+        "FROM keywords WHERE id = ?",
+        (free_id,),
+    ).fetchone()
+    assert row["place_id"] == details["place_id"]
+    assert row["latitude"] == details["lat"]
+    assert row["longitude"] == details["lng"]
+    assert row["name"] == "Central Park"
+    # Parent chain attached.
+    assert row["parent_id"] is not None
+
+    # Photo link preserved.
+    pk = db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
+        (pid, free_id),
+    ).fetchone()
+    assert pk is not None
+
+
+def test_link_keyword_to_place_merges_on_existing_place_id(db):
+    """If the place_id already belongs to another keyword, merge into it."""
+    # First: create the canonical place-bearing keyword via upsert_place_chain.
+    details = _central_park_details()
+    canonical_id = db.upsert_place_chain(details)
+
+    # Tag photo A with the canonical row.
+    pid_a = _make_photo(db, "a.jpg")
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid_a, canonical_id),
+    )
+
+    # Now: a separate free-text "Central Park (free)" keyword, tagged on photo B.
+    pid_b = _make_photo(db, "b.jpg")
+    free_id = db.get_or_create_text_location("Central Park (free)")
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid_b, free_id),
+    )
+    db.conn.commit()
+
+    # Link the free-text keyword to the same place_id → should merge into canonical.
+    result = db.link_keyword_to_place(free_id, details)
+
+    assert result["merged"] is True
+    assert result["keyword_id"] == canonical_id
+
+    # Old free-text row gone.
+    gone = db.conn.execute(
+        "SELECT id FROM keywords WHERE id = ?", (free_id,),
+    ).fetchone()
+    assert gone is None
+
+    # Both photos now linked to canonical.
+    rows = db.conn.execute(
+        "SELECT photo_id FROM photo_keywords WHERE keyword_id = ?",
+        (canonical_id,),
+    ).fetchall()
+    photo_ids = {r["photo_id"] for r in rows}
+    assert photo_ids == {pid_a, pid_b}
+
+    # No leftover links to the old free-text id.
+    stale = db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE keyword_id = ?", (free_id,),
+    ).fetchone()
+    assert stale is None
+
+
+def test_upsert_place_chain_raises_on_cross_type_collision(db):
+    """A pre-existing non-location keyword on the same (name, parent_id) must
+    raise a clear error rather than silently merging or surfacing a raw
+    sqlite3.IntegrityError. The user's existing tags must not be corrupted.
+
+    Note: SQLite's UNIQUE(name, parent_id) doesn't fire when parent_id is
+    NULL (NULL != NULL in SQL), so the collision can only occur on
+    non-root chain levels. We pre-build the "United States" → "New York"
+    (state) → "New York" (locality) location parents directly, then plant
+    a 'general' keyword "Manhattan" under the locality. The next
+    upsert_place_chain walk will try to INSERT a 'location' "Manhattan"
+    in the same slot, triggering the UNIQUE(name, parent_id) collision.
+    """
+    import pytest
+
+    us_id = db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES (?, 'location', NULL)",
+        ("United States",),
+    ).lastrowid
+    state_id = db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES (?, 'location', ?)",
+        ("New York", us_id),
+    ).lastrowid
+    locality_id = db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES (?, 'location', ?)",
+        ("New York", state_id),
+    ).lastrowid
+    # Plant a 'general' "Manhattan" under the locality New York row.
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES (?, 'general', ?)",
+        ("Manhattan", locality_id),
+    )
+    db.conn.commit()
+
+    # Chain walk wants a 'location' "Manhattan" under the same locality →
+    # UNIQUE(name, parent_id) blows up; we must surface a clear RuntimeError.
+    with pytest.raises(RuntimeError, match="Manhattan"):
+        db.upsert_place_chain(_central_park_details())

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2776,6 +2776,59 @@ def test_count_photos_without_gps(tmp_path):
     assert db.count_photos_without_gps() == 2
 
 
+def test_count_photos_without_gps_excludes_keyword_coord_photos(tmp_path):
+    """A photo with no EXIF GPS but a coord-bearing location keyword IS
+    plottable on the map — count_photos_without_gps must not count it,
+    so total_with_gps stays >= len(get_geolocated_photos())."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    db.add_workspace_folder(db._active_workspace_id, fid)
+
+    # Photo 1: full EXIF GPS — definitely plottable.
+    db.add_photo(folder_id=fid, filename='exif.jpg', extension='.jpg',
+                 file_size=100, file_mtime=1.0)
+    db.conn.execute(
+        "UPDATE photos SET latitude=37.0, longitude=-122.0 WHERE filename='exif.jpg'"
+    )
+    # Photo 2: no EXIF, but tagged with a coord-bearing location keyword.
+    p2 = db.add_photo(folder_id=fid, filename='via_keyword.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type, latitude, longitude) "
+        "VALUES ('Central Park', 'location', 40.78, -73.96)",
+    )
+    kid = cur.lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p2, kid),
+    )
+    # Photo 3: no EXIF, tagged with a free-text (coordless) location keyword.
+    p3 = db.add_photo(folder_id=fid, filename='free_text.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES ('the dog park', 'location')",
+    )
+    free_kid = cur.lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p3, free_kid),
+    )
+    # Photo 4: nothing — truly without GPS.
+    db.add_photo(folder_id=fid, filename='lonely.jpg', extension='.jpg',
+                 file_size=100, file_mtime=1.0)
+    db.conn.commit()
+
+    # Photos 3 and 4 are not plottable (no EXIF, no coord-bearing keyword).
+    assert db.count_photos_without_gps() == 2
+
+    # Sanity: get_geolocated_photos returns the two plottable photos
+    # (Photo 1 via EXIF, Photo 2 via keyword fallback). Total of plottable
+    # (= 4 photos - 2 without_gps = 2) matches len(get_geolocated_photos).
+    geo = db.get_geolocated_photos()
+    assert len(geo) == 2
+
+
 def test_taxa_table_exists(tmp_path):
     """The taxa table is created with expected columns."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6890,6 +6890,84 @@ def test_upsert_place_chain_raises_on_cross_type_collision(db):
         db.upsert_place_chain(_central_park_details())
 
 
+def test_upsert_one_keyword_handles_homonymous_places(db):
+    """Two distinct Google places with different place_ids that share the
+    same (name, parent_id) chain slot must both succeed. The current
+    ON CONFLICT(place_id) handler doesn't catch the (name, parent_id)
+    UNIQUE constraint, so the second insert previously surfaced as a 500
+    from the API. Disambiguate by appending a short place_id suffix to
+    the second row's name.
+    """
+    # Realistic-ish setup: two Google places that share the same name AND
+    # the same parent. Rare in practice (parents usually disambiguate), but
+    # Google can return the same address_components for distinct points.
+    state_id = db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES (?, 'location', NULL)",
+        ("New York",),
+    ).lastrowid
+    db.conn.commit()
+
+    first_id = db._upsert_one_keyword(
+        name="Riverside Park",
+        parent_id=state_id,
+        place_id="ChIJ_Riverside_A",
+        latitude=40.80,
+        longitude=-73.97,
+    )
+    second_id = db._upsert_one_keyword(
+        name="Riverside Park",
+        parent_id=state_id,
+        place_id="ChIJ_Riverside_B",
+        latitude=40.85,
+        longitude=-73.95,
+    )
+    assert first_id != second_id, "homonymous places must be distinct rows"
+    rows = db.conn.execute(
+        "SELECT id, name, place_id FROM keywords "
+        "WHERE place_id IN ('ChIJ_Riverside_A', 'ChIJ_Riverside_B') "
+        "ORDER BY id"
+    ).fetchall()
+    assert len(rows) == 2
+    # First row keeps its plain name; second is disambiguated.
+    assert rows[0]["name"] == "Riverside Park"
+    assert rows[0]["place_id"] == "ChIJ_Riverside_A"
+    assert rows[1]["place_id"] == "ChIJ_Riverside_B"
+    # Disambiguated name should be different from the first; format is an
+    # implementation detail, but it must contain enough of the place_id to
+    # make collisions astronomically unlikely.
+    assert rows[1]["name"] != "Riverside Park"
+    assert "Riverside Park" in rows[1]["name"]
+
+
+def test_upsert_one_keyword_homonymous_idempotent(db):
+    """Re-upserting the SAME (place_id) after disambiguation still hits
+    the ON CONFLICT(place_id) path and returns the same id (no extra rows)."""
+    state_id = db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES (?, 'location', NULL)",
+        ("New York",),
+    ).lastrowid
+    db.conn.commit()
+    db._upsert_one_keyword(
+        name="Riverside Park", parent_id=state_id,
+        place_id="ChIJ_Riverside_A", latitude=40.80, longitude=-73.97,
+    )
+    second_id = db._upsert_one_keyword(
+        name="Riverside Park", parent_id=state_id,
+        place_id="ChIJ_Riverside_B", latitude=40.85, longitude=-73.95,
+    )
+    # Re-upsert with the same place_id (B) — should hit ON CONFLICT(place_id)
+    # and return the SAME id without trying the disambiguation path again.
+    second_id_again = db._upsert_one_keyword(
+        name="Riverside Park", parent_id=state_id,
+        place_id="ChIJ_Riverside_B", latitude=40.85, longitude=-73.95,
+    )
+    assert second_id == second_id_again
+    n_rows = db.conn.execute(
+        "SELECT COUNT(*) FROM keywords WHERE place_id LIKE 'ChIJ_Riverside_%'"
+    ).fetchone()[0]
+    assert n_rows == 2, "no extra rows from idempotent re-upsert"
+
+
 # --- Task 7: reverse-geocode cache get/put -----------------------------------
 
 

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2694,6 +2694,71 @@ def test_get_accepted_species_multiple_species_per_photo(tmp_path):
     assert species == ["Cooper's Hawk", 'Red-tailed Hawk']
 
 
+def test_get_accepted_species_includes_keyword_coord_photos(tmp_path):
+    """A photo without EXIF GPS but with a 'location'-type keyword that has
+    coords must still surface its species in the dropdown — get_geolocated_photos
+    renders such photos as map markers, so the filter list has to match."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    db.add_workspace_folder(db._active_workspace_id, fid)
+    p1 = db.add_photo(folder_id=fid, filename='hawk.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    # No EXIF GPS — only a location keyword with coords.
+    loc_id = db.conn.execute(
+        "INSERT INTO keywords (name, type, latitude, longitude) "
+        "VALUES (?, 'location', ?, ?)",
+        ("Central Park", 40.785091, -73.968285),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p1, loc_id),
+    )
+    db.conn.commit()
+
+    det_ids = db.save_detections(p1, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")
+    db.add_prediction(det_ids[0], 'Red-tailed Hawk', 0.95, 'bioclip')
+    preds = db.get_predictions(photo_ids=[p1])
+    for pr in preds:
+        db.accept_prediction(pr['id'])
+
+    assert db.get_accepted_species() == ['Red-tailed Hawk']
+
+
+def test_get_accepted_species_ignores_coordless_location_keywords(tmp_path):
+    """A 'location'-type keyword *without* coords (free-text "the meadow")
+    is not enough — get_geolocated_photos won't render the photo, so the
+    species filter shouldn't list it either."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    db.add_workspace_folder(db._active_workspace_id, fid)
+    p1 = db.add_photo(folder_id=fid, filename='hawk.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    # Free-text location keyword: no coords.
+    loc_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES (?, 'location')",
+        ("the meadow behind the cabin",),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p1, loc_id),
+    )
+    db.conn.commit()
+
+    det_ids = db.save_detections(p1, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="MDV6")
+    db.add_prediction(det_ids[0], 'Red-tailed Hawk', 0.95, 'bioclip')
+    preds = db.get_predictions(photo_ids=[p1])
+    for pr in preds:
+        db.accept_prediction(pr['id'])
+
+    assert db.get_accepted_species() == []
+
+
 def test_count_photos_without_gps(tmp_path):
     """count_photos_without_gps counts photos missing GPS coordinates."""
     from db import Database
@@ -6827,6 +6892,38 @@ def test_link_keyword_to_place_raises_on_missing_id(db):
     details = _central_park_details()
     with pytest.raises(ValueError, match="999999"):
         db.link_keyword_to_place(999999, details)
+
+
+def test_link_keyword_to_place_rejects_non_location_keyword(db):
+    """Linking a place to a non-'location' keyword must raise ValueError.
+    Otherwise the globally-unique place_id would get attached to (say) a
+    species or general keyword, and later location upserts would resolve to
+    that non-location row, after which set_photo_location rejects it and
+    the place is stuck until manual cleanup."""
+    import pytest
+
+    general_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES (?, 'general')",
+        ("Bird",),
+    ).lastrowid
+    db.conn.commit()
+
+    details = _central_park_details()
+    with pytest.raises(ValueError, match="not 'location'"):
+        db.link_keyword_to_place(general_id, details)
+
+    # The non-location keyword must be left untouched — no place_id, no
+    # coords, no reparenting onto a freshly-created chain.
+    row = db.conn.execute(
+        "SELECT type, place_id, latitude, longitude, parent_id "
+        "FROM keywords WHERE id = ?",
+        (general_id,),
+    ).fetchone()
+    assert row["type"] == "general"
+    assert row["place_id"] is None
+    assert row["latitude"] is None
+    assert row["longitude"] is None
+    assert row["parent_id"] is None
 
 
 def test_set_photo_location_rejects_non_location_keyword(db):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6288,3 +6288,132 @@ def test_place_reverse_geocode_cache_table_exists(db):
         ).fetchall()
     }
     assert cols >= {"lat_grid", "lng_grid", "place_id", "response", "fetched_at"}
+
+
+def _central_park_details():
+    """Canned Place Details payload (matches places.place_details() shape)."""
+    return {
+        "place_id": "ChIJ4zGFAZpYwokRGUGph3Mf37k",
+        "name": "Central Park",
+        "lat": 40.7829,
+        "lng": -73.9654,
+        "address_components": [
+            # Google's response order: narrowest → broadest.
+            {"name": "Manhattan", "short_name": "Manhattan",
+             "types": ["sublocality_level_1", "sublocality", "political"]},
+            {"name": "New York", "short_name": "New York",
+             "types": ["locality", "political"]},
+            {"name": "New York", "short_name": "NY",
+             "types": ["administrative_area_level_1", "political"]},
+            {"name": "United States", "short_name": "US",
+             "types": ["country", "political"]},
+        ],
+    }
+
+
+def test_upsert_place_chain_creates_leaf_with_coords_and_place_id(db):
+    details = _central_park_details()
+    leaf_id = db.upsert_place_chain(details)
+    leaf = db.conn.execute(
+        "SELECT name, type, place_id, latitude, longitude, parent_id "
+        "FROM keywords WHERE id = ?",
+        (leaf_id,),
+    ).fetchone()
+    assert leaf is not None
+    assert leaf["name"] == "Central Park"
+    assert leaf["type"] == "location"
+    assert leaf["place_id"] == details["place_id"]
+    assert leaf["latitude"] == details["lat"]
+    assert leaf["longitude"] == details["lng"]
+    # Parent chain populated, so leaf must have a non-null parent_id.
+    assert leaf["parent_id"] is not None
+
+
+def test_upsert_place_chain_walks_full_parent_chain(db):
+    details = _central_park_details()
+    leaf_id = db.upsert_place_chain(details)
+
+    # Walk leaf → root, collecting names + place_ids.
+    chain = []
+    cur_id = leaf_id
+    while cur_id is not None:
+        row = db.conn.execute(
+            "SELECT id, name, parent_id, type, place_id, latitude, longitude "
+            "FROM keywords WHERE id = ?",
+            (cur_id,),
+        ).fetchone()
+        chain.append(row)
+        cur_id = row["parent_id"]
+
+    # Leaf + 4 address_components → 5 total.
+    assert len(chain) == 5
+    # Order is leaf → narrowest parent → … → broadest.
+    names = [r["name"] for r in chain]
+    assert names == [
+        "Central Park",
+        "Manhattan",
+        "New York",       # locality
+        "New York",       # state (admin_area_1)
+        "United States",
+    ]
+    # Only the leaf carries place_id and coords.
+    leaf, *parents = chain
+    assert leaf["place_id"] == details["place_id"]
+    assert leaf["latitude"] == details["lat"]
+    for p in parents:
+        assert p["type"] == "location"
+        assert p["place_id"] is None
+        assert p["latitude"] is None
+        assert p["longitude"] is None
+    # Root (broadest) must have NULL parent_id.
+    assert chain[-1]["parent_id"] is None
+
+
+def test_upsert_place_chain_is_idempotent(db):
+    details = _central_park_details()
+    first_id = db.upsert_place_chain(details)
+    before_count = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM keywords"
+    ).fetchone()["n"]
+
+    second_id = db.upsert_place_chain(details)
+    after_count = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM keywords"
+    ).fetchone()["n"]
+
+    assert second_id == first_id
+    assert after_count == before_count
+
+
+def test_upsert_place_chain_shares_parents_across_leaves(db):
+    """Two leaves under the same NY/USA chain must reuse parent rows."""
+    central_park = _central_park_details()
+    times_square = {
+        "place_id": "ChIJmQJIxlVYwokRLgeuocVOGVU",
+        "name": "Times Square",
+        "lat": 40.7580,
+        "lng": -73.9855,
+        "address_components": list(central_park["address_components"]),
+    }
+    cp_leaf = db.upsert_place_chain(central_park)
+    ts_leaf = db.upsert_place_chain(times_square)
+
+    assert cp_leaf != ts_leaf
+
+    # Both leaves should chain up to the same broadest ancestor (United States).
+    def root_of(kid):
+        cur = kid
+        while True:
+            row = db.conn.execute(
+                "SELECT parent_id FROM keywords WHERE id = ?", (cur,),
+            ).fetchone()
+            if row["parent_id"] is None:
+                return cur
+            cur = row["parent_id"]
+
+    assert root_of(cp_leaf) == root_of(ts_leaf)
+    # Total keywords: 4 shared parents + 2 leaves = 6 (no duplicate parents).
+    total = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM keywords WHERE type='location'"
+    ).fetchone()["n"]
+    assert total == 6

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6250,3 +6250,31 @@ def test_get_folder_tree_includes_partial_folders_with_status(tmp_path):
     assert missing_id not in rows, "missing folder must not appear in tree"
     assert rows[ok_id]["status"] == "ok"
     assert rows[partial_id]["status"] == "partial"
+
+
+def test_keywords_has_place_id_column_and_unique_index(db):
+    import sqlite3
+
+    import pytest
+
+    cols = {row[1] for row in db.conn.execute("PRAGMA table_info(keywords)").fetchall()}
+    assert "place_id" in cols
+
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, place_id) VALUES (?, ?, ?)",
+        ("Central Park", "location", "ChIJ_test_1"),
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        db.conn.execute(
+            "INSERT INTO keywords (name, type, place_id) VALUES (?, ?, ?)",
+            ("Different Name", "location", "ChIJ_test_1"),
+        )
+
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, place_id) VALUES (?, ?, NULL)",
+        ("free text 1", "location"),
+    )
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, place_id) VALUES (?, ?, NULL)",
+        ("free text 2", "location"),
+    )

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6979,6 +6979,119 @@ def test_link_keyword_to_place_rejects_non_location_keyword(db):
     assert row["parent_id"] is None
 
 
+def test_link_keyword_to_place_disambiguates_name_collision(db):
+    """The UPDATE in link_keyword_to_place can fail on UNIQUE(name,
+    parent_id) — not just UNIQUE(place_id) — when a different row with the
+    same (name, parent_id) already exists (e.g., an earlier upsert created
+    one homonymous place at the slot). The handler must distinguish from
+    a place_id collision and disambiguate the new row's name rather than
+    re-raising as 500."""
+    # First, upsert a place chain that creates "Riverside Park" with
+    # place_id=A under "New York" (state).
+    details_a = {
+        "place_id": "ChIJ_Park_A",
+        "name": "Riverside Park",
+        "lat": 40.80, "lng": -73.97,
+        "address_components": [
+            {"name": "New York", "short_name": "NY",
+             "types": ["administrative_area_level_1", "political"]},
+        ],
+    }
+    leaf_a = db.upsert_place_chain(details_a)
+
+    # Now create a free-text "Riverside Park" with no parent (different
+    # slot, so the upsert above didn't touch it).
+    free_id = db.get_or_create_text_location("Riverside Park")
+    assert free_id != leaf_a
+
+    # Link the free-text row to a DIFFERENT Google place (B) whose chain
+    # ALSO lands under "New York" — the UPDATE will try to set the same
+    # (name="Riverside Park", parent_id=NY) as A and collide.
+    details_b = {
+        "place_id": "ChIJ_Park_B",
+        "name": "Riverside Park",
+        "lat": 40.85, "lng": -73.95,
+        "address_components": [
+            {"name": "New York", "short_name": "NY",
+             "types": ["administrative_area_level_1", "political"]},
+        ],
+    }
+    result = db.link_keyword_to_place(free_id, details_b)
+
+    # Should NOT have re-raised. Should NOT have merged (A and B are
+    # distinct places). free_id keeps its identity but with a
+    # disambiguated name.
+    assert result["merged"] is False
+    assert result["keyword_id"] == free_id
+
+    free_row = db.conn.execute(
+        "SELECT name, place_id FROM keywords WHERE id = ?", (free_id,),
+    ).fetchone()
+    assert free_row["place_id"] == "ChIJ_Park_B"
+    # Disambiguated name keeps the original name as a prefix.
+    assert "Riverside Park" in free_row["name"]
+    assert free_row["name"] != "Riverside Park", \
+        "name must have been disambiguated, not left as the colliding value"
+
+    # The original "Riverside Park" (place A) is untouched.
+    a_row = db.conn.execute(
+        "SELECT name, place_id FROM keywords WHERE id = ?", (leaf_a,),
+    ).fetchone()
+    assert a_row["name"] == "Riverside Park"
+    assert a_row["place_id"] == "ChIJ_Park_A"
+
+
+def test_link_keyword_to_place_merge_reparents_descendants(db):
+    """When the merge path fires (place_id already owned by a canonical
+    row), the old keyword may have descendants pointing to it via
+    parent_id. SQLite's self-referential FK on keywords.parent_id (with
+    foreign_keys=ON) blocks DELETE FROM keywords if any child still
+    references the old row. The merge must reparent descendants onto the
+    canonical row before deleting."""
+
+    # Step 1: pre-create a canonical place row Q with a known place_id.
+    q_details = {
+        "place_id": "ChIJ_Q",
+        "name": "Q Park",
+        "lat": 40.0, "lng": -73.0,
+        "address_components": [],
+    }
+    canonical_id = db.upsert_place_chain(q_details)
+
+    # Step 2: create a free-text keyword P (no place_id), and give it a
+    # child keyword C that points to P via parent_id.
+    p_id = db.get_or_create_text_location("Q Park")
+    c_id = db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES (?, 'location', ?)",
+        ("Q Park West", p_id),
+    ).lastrowid
+    db.conn.commit()
+
+    # Step 3: link P to the same place_id as the canonical row Q.
+    # This triggers the merge path — P's photos (none here) move onto Q,
+    # and P must be deleted. With descendants still pointing to P, the
+    # naive DELETE fails on the self-FK. After the fix, C is reparented
+    # to Q first.
+    result = db.link_keyword_to_place(p_id, q_details)
+
+    assert result["merged"] is True
+    assert result["keyword_id"] == canonical_id
+
+    # P must be gone.
+    p_row = db.conn.execute(
+        "SELECT id FROM keywords WHERE id = ?", (p_id,),
+    ).fetchone()
+    assert p_row is None, "old keyword should have been deleted post-merge"
+
+    # C must still exist and now point to Q (the canonical row).
+    c_row = db.conn.execute(
+        "SELECT name, parent_id FROM keywords WHERE id = ?", (c_id,),
+    ).fetchone()
+    assert c_row is not None, "child keyword must survive the merge"
+    assert c_row["parent_id"] == canonical_id, \
+        "child must be reparented onto the canonical row"
+
+
 def test_set_photo_location_rejects_non_location_keyword(db):
     """Passing a non-'location' keyword must raise ValueError; otherwise the
     DELETE would strip real location links and the INSERT would add a

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2461,6 +2461,99 @@ def test_get_geolocated_photos_species_filter_multi_species(tmp_path):
     assert db.get_geolocated_photos(species='Cardinal') == []
 
 
+def test_get_geolocated_photos_falls_back_to_keyword_coords(tmp_path):
+    """Photos without EXIF GPS but tagged with a location keyword that has
+    coords are returned with the keyword's coords and coord_source='keyword'."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    db.add_workspace_folder(db._active_workspace_id, fid)
+    pid = db.add_photo(folder_id=fid, filename='no_gps.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    # No EXIF GPS — leave latitude/longitude as NULL.
+
+    # Create a type='location' keyword with coords.
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type, latitude, longitude) VALUES (?, 'location', ?, ?)",
+        ('Central Park', 40.7829, -73.9654),
+    )
+    kid = cur.lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, kid),
+    )
+    db.conn.commit()
+
+    rows = db.get_geolocated_photos()
+    assert len(rows) == 1
+    r = rows[0]
+    assert r['filename'] == 'no_gps.jpg'
+    assert r['latitude'] == 40.7829
+    assert r['longitude'] == -73.9654
+    assert r['coord_source'] == 'keyword'
+    assert r['keyword_location_name'] == 'Central Park'
+
+
+def test_get_geolocated_photos_prefers_exif_over_keyword(tmp_path):
+    """When a photo has both EXIF coords AND a location keyword, EXIF wins."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    db.add_workspace_folder(db._active_workspace_id, fid)
+    pid = db.add_photo(folder_id=fid, filename='both.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET latitude=?, longitude=? WHERE id=?",
+                    (37.7749, -122.4194, pid))
+
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type, latitude, longitude) VALUES (?, 'location', ?, ?)",
+        ('New York', 40.7128, -74.0060),
+    )
+    kid = cur.lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, kid),
+    )
+    db.conn.commit()
+
+    rows = db.get_geolocated_photos()
+    assert len(rows) == 1
+    r = rows[0]
+    assert r['latitude'] == 37.7749
+    assert r['longitude'] == -122.4194
+    assert r['coord_source'] == 'exif'
+    assert r['keyword_location_name'] is None
+
+
+def test_get_geolocated_photos_excludes_photos_with_neither(tmp_path):
+    """Photos with neither EXIF coords nor a coord-bearing location keyword
+    should not appear in results."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    db.add_workspace_folder(db._active_workspace_id, fid)
+    # Photo 1: no GPS, no keyword link at all.
+    p1 = db.add_photo(folder_id=fid, filename='lonely.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    # Photo 2: no GPS, has a location keyword but the keyword has no coords
+    # (free-text fallback).
+    p2 = db.add_photo(folder_id=fid, filename='free_text.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES (?, 'location')",
+        ('the dog park',),
+    )
+    kid = cur.lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (p2, kid),
+    )
+    db.conn.commit()
+
+    rows = db.get_geolocated_photos()
+    assert rows == []
+
+
 def test_get_accepted_species(tmp_path):
     """get_accepted_species returns distinct marker species from geolocated photos."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6755,3 +6755,72 @@ def test_upsert_place_chain_raises_on_cross_type_collision(db):
     # UNIQUE(name, parent_id) blows up; we must surface a clear RuntimeError.
     with pytest.raises(RuntimeError, match="Manhattan"):
         db.upsert_place_chain(_central_park_details())
+
+
+# --- Task 7: reverse-geocode cache get/put -----------------------------------
+
+
+def test_reverse_geocode_cache_round_trips_put_then_get(db):
+    """Putting a value and then getting it back returns matching fields."""
+    response_json = '{"place_id": "ChIJN1t_tDeuEmsRUsoyG83frY4", "name": "Sydney"}'
+    db.reverse_geocode_cache_put(
+        -33.8688, 151.2093, "ChIJN1t_tDeuEmsRUsoyG83frY4", response_json,
+    )
+    hit = db.reverse_geocode_cache_get(-33.8688, 151.2093)
+    assert hit is not None
+    assert hit["place_id"] == "ChIJN1t_tDeuEmsRUsoyG83frY4"
+    assert hit["response"] == response_json
+
+
+def test_reverse_geocode_cache_returns_none_on_miss(db):
+    """Getting a never-put coord returns None (distinct from cached negative)."""
+    assert db.reverse_geocode_cache_get(40.0, -73.0) is None
+
+
+def test_reverse_geocode_cache_grid_collapses_nearby_coords(db):
+    """Coords that round to the same ~110m grid cell share a cache entry,
+    while coords that round to a different cell are kept separate."""
+    db.reverse_geocode_cache_put(
+        40.7820, -73.9650, "ChIJ_central_park", '{"name":"Central Park"}',
+    )
+    # 40.7821, -73.9648 → both round to the same int(round(x*1000)) cell
+    hit = db.reverse_geocode_cache_get(40.7821, -73.9648)
+    assert hit is not None
+    assert hit["place_id"] == "ChIJ_central_park"
+    assert hit["response"] == '{"name":"Central Park"}'
+
+    # 40.7830, -73.9650 → different lat_grid (40783 vs 40782)
+    db.reverse_geocode_cache_put(
+        40.7830, -73.9650, "ChIJ_other", '{"name":"Other"}',
+    )
+    other_hit = db.reverse_geocode_cache_get(40.7830, -73.9650)
+    assert other_hit is not None
+    assert other_hit["place_id"] == "ChIJ_other"
+    # Original cell unchanged.
+    orig_hit = db.reverse_geocode_cache_get(40.7820, -73.9650)
+    assert orig_hit["place_id"] == "ChIJ_central_park"
+
+
+def test_reverse_geocode_cache_caches_negative_result(db):
+    """A null place_id (Google returned no match) is still cached. The
+    cache must distinguish 'we asked Google and got no match' from 'we
+    never asked' — get returns the row, not None."""
+    db.reverse_geocode_cache_put(0.0, 0.0, None, "{}")
+    hit = db.reverse_geocode_cache_get(0.0, 0.0)
+    assert hit is not None
+    assert hit["place_id"] is None
+    assert hit["response"] == "{}"
+
+
+def test_reverse_geocode_cache_put_overwrites_existing(db):
+    """Re-putting at the same grid cell overwrites the prior value."""
+    db.reverse_geocode_cache_put(
+        12.345, 67.890, "ChIJ_first", '{"v":1}',
+    )
+    db.reverse_geocode_cache_put(
+        12.345, 67.890, "ChIJ_second", '{"v":2}',
+    )
+    hit = db.reverse_geocode_cache_get(12.345, 67.890)
+    assert hit is not None
+    assert hit["place_id"] == "ChIJ_second"
+    assert hit["response"] == '{"v":2}'

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6640,6 +6640,83 @@ def test_link_keyword_to_place_merges_on_existing_place_id(db):
     assert stale is None
 
 
+def test_link_keyword_to_place_self_merge_via_non_leaf_parent(db):
+    """If the chain reuses the target keyword as a non-leaf ancestor, the
+    link must be a no-op (returning ``merged=False``) rather than reparenting
+    the keyword onto one of its own descendants and creating a cycle.
+
+    Scenario: user has a free-text "United States" keyword and tries to link
+    it to Central Park. The chain walk discovers and reuses the user's
+    "United States" row at the country (broadest) level, then walks deeper
+    through NY-state, NY-city, Manhattan. Without the full-chain self-merge
+    guard, the UPDATE would set the user's row to ``name='Central Park',
+    parent_id=Manhattan_id`` — making the user's row a child of its own
+    great-grandchild.
+    """
+    pid = _make_photo(db)
+    free_us_id = db.get_or_create_text_location("United States")
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, free_us_id),
+    )
+    db.conn.commit()
+
+    details = _central_park_details()
+    result = db.link_keyword_to_place(free_us_id, details)
+
+    # No-op result.
+    assert result == {"keyword_id": free_us_id, "merged": False}
+
+    # Original keyword unchanged: still "United States", no place_id, no parent.
+    row = db.conn.execute(
+        "SELECT name, type, place_id, parent_id FROM keywords WHERE id = ?",
+        (free_us_id,),
+    ).fetchone()
+    assert row is not None
+    assert row["name"] == "United States"
+    assert row["type"] == "location"
+    assert row["place_id"] is None
+    assert row["parent_id"] is None
+
+    # Photo still tagged with the original keyword.
+    pk = db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
+        (pid, free_us_id),
+    ).fetchone()
+    assert pk is not None
+
+
+def test_link_keyword_to_place_raises_on_missing_id(db):
+    """A non-existent keyword id must raise ValueError, not silently no-op
+    while leaving orphan parent rows behind."""
+    import pytest
+
+    details = _central_park_details()
+    with pytest.raises(ValueError, match="999999"):
+        db.link_keyword_to_place(999999, details)
+
+
+def test_set_photo_location_rejects_non_location_keyword(db):
+    """Passing a non-'location' keyword must raise ValueError; otherwise the
+    DELETE would strip real location links and the INSERT would add a
+    keyword that clear_photo_location can't clean up."""
+    import pytest
+
+    pid = _make_photo(db)
+    general_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES (?, 'general')",
+        ("Bird",),
+    ).lastrowid
+    db.conn.commit()
+
+    with pytest.raises(ValueError, match="not 'location'"):
+        db.set_photo_location(pid, general_id)
+
+    # Also a missing id must raise.
+    with pytest.raises(ValueError, match="does not exist"):
+        db.set_photo_location(pid, 999999)
+
+
 def test_upsert_place_chain_raises_on_cross_type_collision(db):
     """A pre-existing non-location keyword on the same (name, parent_id) must
     raise a clear error rather than silently merging or surfacing a raw

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2554,6 +2554,46 @@ def test_get_geolocated_photos_excludes_photos_with_neither(tmp_path):
     assert rows == []
 
 
+def test_get_geolocated_photos_with_partial_exif_uses_keyword_pair(tmp_path):
+    """A photo with only one EXIF axis populated must NOT mix EXIF lat with
+    keyword lng (or vice versa) — that produces a wrong marker location.
+    The fallback decision is paired: either both EXIF axes win, or both
+    keyword axes win."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    db.add_workspace_folder(db._active_workspace_id, fid)
+    pid = db.add_photo(folder_id=fid, filename='partial.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    # Partial EXIF: latitude present, longitude missing (sometimes seen on
+    # corrupt EXIF or when only one half of GPS lat/lng was decoded).
+    db.conn.execute(
+        "UPDATE photos SET latitude=?, longitude=NULL WHERE id=?",
+        (37.7749, pid),
+    )
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type, latitude, longitude) "
+        "VALUES (?, 'location', ?, ?)",
+        ('Central Park', 40.7829, -73.9654),
+    )
+    kid = cur.lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, kid),
+    )
+    db.conn.commit()
+
+    rows = db.get_geolocated_photos()
+    assert len(rows) == 1
+    r = rows[0]
+    # Coords must come as a pair from the keyword (not 37.7749 + -73.9654,
+    # which would put the marker in the middle of the Pacific).
+    assert r['latitude'] == 40.7829, "expected paired keyword lat, got mixed"
+    assert r['longitude'] == -73.9654, "expected paired keyword lng, got mixed"
+    assert r['coord_source'] == 'keyword'
+    assert r['keyword_location_name'] == 'Central Park'
+
+
 def test_get_accepted_species(tmp_path):
     """get_accepted_species returns distinct marker species from geolocated photos."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6278,3 +6278,13 @@ def test_keywords_has_place_id_column_and_unique_index(db):
         "INSERT INTO keywords (name, type, place_id) VALUES (?, ?, NULL)",
         ("free text 2", "location"),
     )
+
+
+def test_place_reverse_geocode_cache_table_exists(db):
+    cols = {
+        row[1]
+        for row in db.conn.execute(
+            "PRAGMA table_info(place_reverse_geocode_cache)"
+        ).fetchall()
+    }
+    assert cols >= {"lat_grid", "lng_grid", "place_id", "response", "fetched_at"}

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7041,7 +7041,82 @@ def test_link_keyword_to_place_disambiguates_name_collision(db):
     assert a_row["place_id"] == "ChIJ_Park_A"
 
 
-def test_link_keyword_to_place_merge_reparents_descendants(db):
+def test_link_keyword_to_place_merge_reparents_with_child_name_collision(db):
+    """During the merge path's reparent of children onto the canonical row,
+    a child whose (name) collides with an existing child of the canonical
+    would violate UNIQUE(name, parent_id) on a bulk UPDATE. Disambiguate
+    the migrating child's name on clash rather than 500ing."""
+    # Canonical place row Q, with an existing child "Boathouse".
+    q_details = {
+        "place_id": "ChIJ_Q",
+        "name": "Q Park",
+        "lat": 40.0, "lng": -73.0,
+        "address_components": [],
+    }
+    canonical_id = db.upsert_place_chain(q_details)
+    canonical_child_id = db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES ('Boathouse', 'location', ?)",
+        (canonical_id,),
+    ).lastrowid
+
+    # Old keyword P (free-text), with its own "Boathouse" child.
+    p_id = db.get_or_create_text_location("Q Park")
+    p_child_id = db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES ('Boathouse', 'location', ?)",
+        (p_id,),
+    ).lastrowid
+    db.conn.commit()
+
+    # Link P → triggers merge. The reparent step would naively try to set
+    # both Boathouse rows' parent_id = canonical_id, colliding on
+    # UNIQUE(name, parent_id). Fix: per-child loop with disambiguation.
+    result = db.link_keyword_to_place(p_id, q_details)
+    assert result["merged"] is True
+    assert result["keyword_id"] == canonical_id
+
+    # The original canonical child keeps its name; the migrating child got
+    # disambiguated.
+    canonical_child = db.conn.execute(
+        "SELECT name, parent_id FROM keywords WHERE id = ?", (canonical_child_id,),
+    ).fetchone()
+    assert canonical_child["name"] == "Boathouse"
+    assert canonical_child["parent_id"] == canonical_id
+
+    migrated_child = db.conn.execute(
+        "SELECT name, parent_id FROM keywords WHERE id = ?", (p_child_id,),
+    ).fetchone()
+    assert migrated_child is not None, "migrating child must survive"
+    assert migrated_child["parent_id"] == canonical_id
+    assert migrated_child["name"] != "Boathouse", \
+        "migrating child must have been disambiguated, not left to clash"
+    assert "Boathouse" in migrated_child["name"]
+
+
+def test_location_edits_are_non_undoable(db):
+    """location_set / location_clear / location_link entries land in the
+    edit history (auditable) but are skipped by undo so the user doesn't
+    click Undo and see no state change while older edits become the next
+    undo target."""
+    # Pre-record one undoable edit so the undo cursor can be tested.
+    pid = _make_photo(db)
+    db.record_edit('rating', 'First edit', '1',
+                   [{'photo_id': pid, 'old_value': '0', 'new_value': '1'}])
+
+    # Now record location_set / clear / link audit entries (newest = link).
+    db.record_edit('location_set', 'set location: Test', '1',
+                   [{'photo_id': pid, 'old_value': '', 'new_value': '1'}])
+    db.record_edit('location_clear', 'cleared location', '',
+                   [{'photo_id': pid, 'old_value': '', 'new_value': ''}])
+    db.record_edit('location_link', 'linked', '1', [])
+
+    # Undo MUST step over the three location_* entries straight to the
+    # rating edit, even though they're newer.
+    entry = db.undo_last_edit()
+    assert entry is not None
+    assert entry['action_type'] == 'rating', (
+        "undo must skip location_* entries; "
+        f"got action_type={entry['action_type']!r} instead"
+    )
     """When the merge path fires (place_id already owned by a canonical
     row), the old keyword may have descendants pointing to it via
     parent_id. SQLite's self-referential FK on keywords.parent_id (with

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1898,3 +1898,210 @@ def test_post_photo_location_text_records_edit(app_and_db):
     entry = post_history[0]
     assert entry["action_type"] == "location_set"
     assert "the meadow" in entry["description"]
+
+
+# --- GET /api/places/reverse-geocode ----------------------------------------
+#
+# Server-side proxy for the Google Geocoding API with a SQLite cache layer
+# keyed on the (lat, lng) ~110m grid. The route exists so the API key never
+# leaves the server (the autocomplete JS library is the one client-facing
+# Google call we make). Tests monkeypatch ``places.reverse_geocode`` so no
+# HTTP traffic happens.
+
+def _central_park_geocode_response():
+    """Canned reverse-geocode response stored in the cache for hit tests.
+
+    Same shape as ``places.reverse_geocode`` returns — i.e. the value the
+    route serializes via ``json.dumps(details)`` before stashing. Reusing the
+    Central Park place_id for symmetry with the autocomplete tests above.
+    """
+    return {
+        "place_id": "ChIJ4zGFAZpYwokRGUGph3Mf37k",
+        "name": "Central Park",
+        "lat": 40.7828,
+        "lng": -73.9654,
+        "address_components": [
+            {"name": "New York", "short_name": "New York", "types": ["locality"]},
+            {"name": "New York", "short_name": "NY", "types": ["administrative_area_level_1"]},
+            {"name": "United States", "short_name": "US", "types": ["country"]},
+        ],
+    }
+
+
+def test_reverse_geocode_cache_hit_returns_summary(app_and_db, monkeypatch):
+    """Pre-populated cache: route serves from SQLite, no Google call."""
+    import json
+
+    import places
+    app, db = app_and_db
+
+    lat, lng = 40.7828, -73.9654
+    db.reverse_geocode_cache_put(
+        lat, lng,
+        place_id="ChIJ4zGFAZpYwokRGUGph3Mf37k",
+        response_json=json.dumps(_central_park_geocode_response()),
+    )
+
+    # Counter-mock proves we never reached out to Google.
+    calls = {"n": 0}
+
+    def fake_reverse_geocode(lat_, lng_, key):
+        calls["n"] += 1
+        raise AssertionError("places.reverse_geocode should not be called on cache hit")
+
+    monkeypatch.setattr(places, "reverse_geocode", fake_reverse_geocode)
+
+    client = app.test_client()
+    resp = client.get(f"/api/places/reverse-geocode?lat={lat}&lng={lng}")
+    assert resp.status_code == 200, resp.get_json()
+    data = resp.get_json()
+    assert data["place_id"] == "ChIJ4zGFAZpYwokRGUGph3Mf37k"
+    # Summary: leaf + the 1-2 broadest parents (end-of-list components).
+    assert "Central Park" in data["summary"]
+    assert "United States" in data["summary"]
+    assert calls["n"] == 0
+
+
+def test_reverse_geocode_cache_negative_hit_returns_null(app_and_db, monkeypatch):
+    """Cached negative (place_id=None): route returns null without calling Google."""
+    import places
+    app, db = app_and_db
+
+    lat, lng = 12.345, 67.890
+    # Negative cache entry — Google was previously asked and returned no match.
+    db.reverse_geocode_cache_put(lat, lng, place_id=None, response_json="{}")
+
+    calls = {"n": 0}
+
+    def fake_reverse_geocode(lat_, lng_, key):
+        calls["n"] += 1
+        raise AssertionError("places.reverse_geocode should not be called on negative cache hit")
+
+    monkeypatch.setattr(places, "reverse_geocode", fake_reverse_geocode)
+
+    client = app.test_client()
+    resp = client.get(f"/api/places/reverse-geocode?lat={lat}&lng={lng}")
+    assert resp.status_code == 200, resp.get_json()
+    assert resp.get_json() == {"place_id": None, "summary": None}
+    assert calls["n"] == 0
+
+
+def test_reverse_geocode_cache_miss_calls_google_and_caches(app_and_db, monkeypatch):
+    """Empty cache: hit Google, cache the result, second call hits cache."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+
+    calls = {"n": 0}
+
+    def fake_reverse_geocode(lat_, lng_, key):
+        calls["n"] += 1
+        return _central_park_geocode_response()
+
+    monkeypatch.setattr(places, "reverse_geocode", fake_reverse_geocode)
+
+    client = app.test_client()
+    lat, lng = 40.7828, -73.9654
+
+    r1 = client.get(f"/api/places/reverse-geocode?lat={lat}&lng={lng}")
+    assert r1.status_code == 200, r1.get_json()
+    data1 = r1.get_json()
+    assert data1["place_id"] == "ChIJ4zGFAZpYwokRGUGph3Mf37k"
+    assert "Central Park" in data1["summary"]
+    assert calls["n"] == 1
+
+    # Second call against the same coords should hit the cache, NOT Google.
+    r2 = client.get(f"/api/places/reverse-geocode?lat={lat}&lng={lng}")
+    assert r2.status_code == 200
+    data2 = r2.get_json()
+    assert data2["place_id"] == data1["place_id"]
+    assert data2["summary"] == data1["summary"]
+    assert calls["n"] == 1  # unchanged — second call was served from cache
+
+
+def test_reverse_geocode_cache_miss_caches_negative_when_google_returns_none(
+    app_and_db, monkeypatch,
+):
+    """Google returns None: cache the negative so future calls don't hit the API."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+
+    calls = {"n": 0}
+
+    def fake_reverse_geocode(lat_, lng_, key):
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr(places, "reverse_geocode", fake_reverse_geocode)
+
+    client = app.test_client()
+    lat, lng = 0.123, 0.456
+
+    r1 = client.get(f"/api/places/reverse-geocode?lat={lat}&lng={lng}")
+    assert r1.status_code == 200, r1.get_json()
+    assert r1.get_json() == {"place_id": None, "summary": None}
+    assert calls["n"] == 1
+
+    # Negative was cached — second call must NOT re-ask Google.
+    r2 = client.get(f"/api/places/reverse-geocode?lat={lat}&lng={lng}")
+    assert r2.status_code == 200
+    assert r2.get_json() == {"place_id": None, "summary": None}
+    assert calls["n"] == 1
+
+
+def test_reverse_geocode_returns_null_when_no_api_key_and_does_not_cache(
+    app_and_db, monkeypatch,
+):
+    """No API key: degrade to ``{place_id: null}`` AND don't pollute the cache.
+
+    Caching a negative when the user has no key would mean that once they add
+    a key, already-asked grid cells would forever return null. So we skip the
+    cache write entirely and just return the null shape.
+    """
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": ""})
+
+    calls = {"n": 0}
+
+    def fake_reverse_geocode(lat_, lng_, key):
+        calls["n"] += 1
+        raise AssertionError("places.reverse_geocode should not be called when no API key")
+
+    monkeypatch.setattr(places, "reverse_geocode", fake_reverse_geocode)
+
+    lat, lng = 51.5074, -0.1278  # somewhere in London — fresh coords
+
+    client = app.test_client()
+    resp = client.get(f"/api/places/reverse-geocode?lat={lat}&lng={lng}")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"place_id": None, "summary": None}
+    assert calls["n"] == 0
+
+    # Critically: the cache must be empty for this grid, so once the user
+    # eventually adds a key, the next call will actually reach Google.
+    cached = db.reverse_geocode_cache_get(lat, lng)
+    assert cached is None
+
+
+def test_reverse_geocode_400_on_invalid_coords(app_and_db):
+    """Missing or unparseable lat/lng is a 400."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    # No query params at all.
+    r1 = client.get("/api/places/reverse-geocode")
+    assert r1.status_code == 400
+    assert r1.get_json()["error"] == "invalid coords"
+
+    # Garbage lat.
+    r2 = client.get("/api/places/reverse-geocode?lat=foo&lng=1.0")
+    assert r2.status_code == 400
+    assert r2.get_json()["error"] == "invalid coords"

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2105,3 +2105,255 @@ def test_reverse_geocode_400_on_invalid_coords(app_and_db):
     r2 = client.get("/api/places/reverse-geocode?lat=foo&lng=1.0")
     assert r2.status_code == 400
     assert r2.get_json()["error"] == "invalid coords"
+
+
+# --- POST /api/keywords/<id>/link-place -------------------------------------
+#
+# Attach Google place data to an existing free-text location keyword. Builds
+# the parent chain server-side and either UPDATEs the target row or merges it
+# into a pre-existing canonical place_id-bearing row. ``places.place_details``
+# is monkeypatched so no HTTP traffic happens.
+
+def test_post_keyword_link_place_attaches_metadata(app_and_db, monkeypatch):
+    """Successful link: target keyword gains place_id + coords + parent chain."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+    monkeypatch.setattr(places, "place_details",
+                        lambda place_id, key: _central_park_details())
+
+    # Pre-create a free-text "Central Park" keyword and tag a photo with it.
+    kw_id = db.get_or_create_text_location("Central Park")
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+    db.set_photo_location(pid, kw_id)
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/keywords/{kw_id}/link-place",
+        json={"place_id": "ChIJ_x"},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    data = resp.get_json()
+
+    assert data["merged"] is False
+    kw = data["keyword"]
+    assert kw["keyword_id"] == kw_id  # canonical row is the original
+    assert kw["place_id"] == "ChIJ4zGFAZpYwokRGUGph3Mf37k"
+    assert kw["latitude"] == 40.7828
+    assert kw["longitude"] == -73.9654
+    assert kw["name"] == "Central Park"
+    # Parent chain: broadest -> narrowest, EXCLUDES leaf.
+    assert [p["name"] for p in kw["parent_chain"]] == [
+        "United States", "New York", "New York County", "New York",
+    ]
+
+    # DB-level: original keyword row now has place_id + coords.
+    row = db.conn.execute(
+        "SELECT name, place_id, latitude, longitude FROM keywords WHERE id = ?",
+        (kw_id,),
+    ).fetchone()
+    assert row["place_id"] == "ChIJ4zGFAZpYwokRGUGph3Mf37k"
+    assert row["latitude"] == 40.7828
+    assert row["longitude"] == -73.9654
+
+    # Photo is still tagged with the same row.
+    rows = db.conn.execute(
+        "SELECT k.id FROM photo_keywords pk "
+        "JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE pk.photo_id = ? AND k.type = 'location'",
+        (pid,),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["id"] == kw_id
+
+
+def test_post_keyword_link_place_merges_when_place_id_already_taken(
+    app_and_db, monkeypatch,
+):
+    """Second link to the same Google place merges into the canonical row."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+    monkeypatch.setattr(places, "place_details",
+                        lambda place_id, key: _central_park_details())
+
+    # Distinct names so they're separate rows in keywords.
+    kw_a = db.get_or_create_text_location("Central Park A")
+    kw_b = db.get_or_create_text_location("Central Park B")
+
+    client = app.test_client()
+    # First link -> kw_a becomes the place_id-bearing canonical row.
+    r1 = client.post(
+        f"/api/keywords/{kw_a}/link-place",
+        json={"place_id": "ChIJ_x"},
+    )
+    assert r1.status_code == 200, r1.get_json()
+    assert r1.get_json()["merged"] is False
+
+    # Second link to the SAME place_id -> kw_b should be absorbed by kw_a.
+    r2 = client.post(
+        f"/api/keywords/{kw_b}/link-place",
+        json={"place_id": "ChIJ_x"},
+    )
+    assert r2.status_code == 200, r2.get_json()
+    data = r2.get_json()
+    assert data["merged"] is True
+    assert data["keyword"]["keyword_id"] == kw_a  # canonical wins
+
+    # kw_b is gone from the DB after the merge.
+    row = db.conn.execute(
+        "SELECT 1 FROM keywords WHERE id = ?", (kw_b,),
+    ).fetchone()
+    assert row is None
+
+
+def test_post_keyword_link_place_returns_404_on_missing_keyword(
+    app_and_db, monkeypatch,
+):
+    """Unknown keyword id -> 404 keyword_not_found."""
+    import config as cfg
+    import places
+    app, _ = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+    monkeypatch.setattr(places, "place_details",
+                        lambda place_id, key: _central_park_details())
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/keywords/999999/link-place",
+        json={"place_id": "ChIJ_x"},
+    )
+    assert resp.status_code == 404
+    assert resp.get_json()["error"] == "keyword_not_found"
+
+
+def test_post_keyword_link_place_returns_400_on_missing_place_id(app_and_db):
+    """Empty body / missing place_id -> 400 (never reaches Google)."""
+    app, db = app_and_db
+    kw_id = db.get_or_create_text_location("Central Park")
+
+    client = app.test_client()
+    resp = client.post(f"/api/keywords/{kw_id}/link-place", json={})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "missing place_id"
+
+
+def test_post_keyword_link_place_returns_400_on_empty_api_key(app_and_db):
+    """No API key configured -> 400 no_api_key."""
+    import config as cfg
+    app, db = app_and_db
+    cfg.save({**cfg.load(), "google_maps_api_key": ""})
+    kw_id = db.get_or_create_text_location("Central Park")
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/keywords/{kw_id}/link-place",
+        json={"place_id": "ChIJ_x"},
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "no_api_key"
+
+
+def test_post_keyword_link_place_returns_404_when_google_returns_none(
+    app_and_db, monkeypatch,
+):
+    """Google returns None -> 404 place_not_found."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+    monkeypatch.setattr(places, "place_details", lambda place_id, key: None)
+
+    kw_id = db.get_or_create_text_location("Central Park")
+    client = app.test_client()
+    resp = client.post(
+        f"/api/keywords/{kw_id}/link-place",
+        json={"place_id": "ChIJ_unknown"},
+    )
+    assert resp.status_code == 404
+    assert resp.get_json()["error"] == "place_not_found"
+
+
+def test_post_keyword_link_place_returns_409_on_cross_type_collision(
+    app_and_db, monkeypatch,
+):
+    """Pre-existing non-location keyword in a non-root chain slot -> 409.
+
+    SQLite's UNIQUE(name, parent_id) doesn't fire when ``parent_id`` is NULL
+    (NULL != NULL), so collisions can only occur on non-root chain levels.
+    We pre-build a ``location`` chain ``United States -> New York`` directly,
+    then plant a ``general`` ``"New York County"`` under the state. The
+    chain walk will try to INSERT a ``location`` ``"New York County"`` in
+    the same slot, hitting UNIQUE(name, parent_id) and surfacing as 409.
+    """
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+    monkeypatch.setattr(places, "place_details",
+                        lambda place_id, key: _central_park_details())
+
+    us_id = db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES (?, 'location', NULL)",
+        ("United States",),
+    ).lastrowid
+    state_id = db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES (?, 'location', ?)",
+        ("New York", us_id),
+    ).lastrowid
+    # Plant a 'general' "New York County" under the state — the chain walk
+    # wants a 'location' row in this exact slot.
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES (?, 'general', ?)",
+        ("New York County", state_id),
+    )
+    db.conn.commit()
+
+    kw_id = db.get_or_create_text_location("Central Park")
+    client = app.test_client()
+    resp = client.post(
+        f"/api/keywords/{kw_id}/link-place",
+        json={"place_id": "ChIJ_x"},
+    )
+    assert resp.status_code == 409, resp.get_json()
+    body = resp.get_json()
+    assert body["error"] == "name_conflict"
+    # The exception detail should mention the offending name for debugging.
+    assert "New York County" in body.get("error_detail", "")
+
+
+def test_post_keyword_link_place_records_edit(app_and_db, monkeypatch):
+    """Successful link adds an audit-log entry under action_type='location_link'."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+    monkeypatch.setattr(places, "place_details",
+                        lambda place_id, key: _central_park_details())
+
+    kw_id = db.get_or_create_text_location("Central Park")
+
+    pre_history = db.get_edit_history()
+    pre_count = len(pre_history)
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/keywords/{kw_id}/link-place",
+        json={"place_id": "ChIJ_x"},
+    )
+    assert resp.status_code == 200, resp.get_json()
+
+    post_history = db.get_edit_history()
+    assert len(post_history) == pre_count + 1
+    entry = post_history[0]
+    assert entry["action_type"] == "location_link"
+    assert "Central Park" in entry["description"]

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1668,6 +1668,53 @@ def test_post_photo_location_returns_404_when_google_returns_none(app_and_db, mo
     assert resp.get_json()["error"] == "place_not_found"
 
 
+def test_post_photo_location_returns_409_on_name_conflict(app_and_db, monkeypatch):
+    """When upsert_place_chain raises RuntimeError (cross-type collision in
+    the parent chain), the route must return 409 with name_conflict — same
+    contract as /api/keywords/<id>/link-place. Previously the RuntimeError
+    propagated and surfaced as a 500."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+
+    # Pre-build the location parent chain through the state level, then
+    # plant a 'general' keyword whose (name, parent_id) collides with one of
+    # the components in _central_park_details (which uses New York / New
+    # York County / New York / United States). Planting 'general'
+    # "New York County" under the state row triggers the cross-type
+    # collision when the chain walk tries to INSERT 'location' "New York
+    # County" at the same slot.
+    us_id = db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES ('United States', 'location', NULL)",
+    ).lastrowid
+    state_id = db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES ('New York', 'location', ?)",
+        (us_id,),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, parent_id) VALUES ('New York County', 'general', ?)",
+        (state_id,),
+    )
+    db.conn.commit()
+
+    monkeypatch.setattr(places, "place_details",
+                        lambda place_id, key: _central_park_details())
+
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/location",
+        json={"place_id": "ChIJ_anything"},
+    )
+    assert resp.status_code == 409
+    body = resp.get_json()
+    assert body["error"] == "name_conflict"
+    assert "New York County" in body["error_detail"]
+
+
 def test_delete_photo_location_clears_links(app_and_db):
     """DELETE removes location keyword links but leaves the keyword row intact."""
     app, db = app_and_db
@@ -2089,6 +2136,39 @@ def test_reverse_geocode_returns_null_when_no_api_key_and_does_not_cache(
     # eventually adds a key, the next call will actually reach Google.
     cached = db.reverse_geocode_cache_get(lat, lng)
     assert cached is None
+
+
+def test_reverse_geocode_does_not_cache_transient_errors(app_and_db, monkeypatch):
+    """When ``places.reverse_geocode`` raises ``PlacesTransientError``
+    (rate limit, network blip, etc.), the route MUST return null without
+    writing to the cache. Otherwise the next request for the same grid
+    would hit a stale negative-cache entry and silently suppress the EXIF
+    suggestion until manual cache cleanup."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+
+    def transient(lat_, lng_, key):
+        raise places.PlacesTransientError("simulated OVER_QUERY_LIMIT")
+
+    monkeypatch.setattr(places, "reverse_geocode", transient)
+
+    lat, lng = 35.6762, 139.6503  # Tokyo — fresh coords
+
+    client = app.test_client()
+    resp = client.get(f"/api/places/reverse-geocode?lat={lat}&lng={lng}")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"place_id": None, "summary": None}
+
+    # The cache MUST NOT have been written. A subsequent request will
+    # retry Google.
+    cached = db.reverse_geocode_cache_get(lat, lng)
+    assert cached is None, (
+        "transient failures must not be cached — the cache row must "
+        "stay absent so the next request retries Google"
+    )
 
 
 def test_reverse_geocode_400_on_invalid_coords(app_and_db):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1706,3 +1706,55 @@ def test_delete_photo_location_clears_links(app_and_db):
     ).fetchone()
     assert leaf_row is not None
     assert leaf_row["name"] == "Central Park"
+def test_post_photo_location_records_edit(app_and_db, monkeypatch):
+    """POST adds an entry to the audit log so the action is undoable/visible."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+    monkeypatch.setattr(places, "place_details",
+                        lambda place_id, key: _central_park_details())
+
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    pre_history = db.get_edit_history()
+    pre_count = len(pre_history)
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/location",
+        json={"place_id": "ChIJ_x"},
+    )
+    assert resp.status_code == 200, resp.get_json()
+
+    post_history = db.get_edit_history()
+    assert len(post_history) == pre_count + 1
+    # Most recent first.
+    entry = post_history[0]
+    assert entry["action_type"] == "location_set"
+    assert "Central Park" in entry["description"]
+
+
+def test_delete_photo_location_records_edit(app_and_db):
+    """DELETE adds an entry to the audit log even though it doesn't write a sidecar."""
+    app, db = app_and_db
+
+    leaf_id = db.upsert_place_chain(_central_park_details())
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+    db.set_photo_location(pid, leaf_id)
+
+    pre_history = db.get_edit_history()
+    pre_count = len(pre_history)
+
+    client = app.test_client()
+    resp = client.delete(f"/api/photos/{pid}/location")
+    assert resp.status_code == 200
+
+    post_history = db.get_edit_history()
+    assert len(post_history) == pre_count + 1
+    entry = post_history[0]
+    assert entry["action_type"] == "location_clear"
+    assert entry["description"] == "cleared location"

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1715,6 +1715,49 @@ def test_post_photo_location_returns_409_on_name_conflict(app_and_db, monkeypatc
     assert "New York County" in body["error_detail"]
 
 
+def test_post_photo_location_returns_404_on_missing_photo(app_and_db, monkeypatch):
+    """A stale client (e.g. tab open after the photo was deleted) hitting
+    POST /api/photos/<id>/location must get a clean 404, not a 500 from
+    set_photo_location's FK violation on photo_keywords."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+    monkeypatch.setattr(places, "place_details",
+                        lambda place_id, key: _central_park_details())
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/photos/999999/location",
+        json={"place_id": "ChIJ_x"},
+    )
+    assert resp.status_code == 404
+    assert resp.get_json()["error"] == "photo_not_found"
+
+
+def test_post_photo_location_text_returns_404_on_missing_photo(app_and_db):
+    """Same FK guard for the free-text fallback path."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/photos/999999/location/text",
+        json={"name": "the meadow"},
+    )
+    assert resp.status_code == 404
+    assert resp.get_json()["error"] == "photo_not_found"
+
+
+def test_delete_photo_location_returns_404_on_missing_photo(app_and_db):
+    """DELETE on a missing photo returns 404 for consistency with the
+    POST routes (was previously a silent 200 because the underlying
+    DELETE matched nothing)."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.delete("/api/photos/999999/location")
+    assert resp.status_code == 404
+    assert resp.get_json()["error"] == "photo_not_found"
+
+
 def test_delete_photo_location_clears_links(app_and_db):
     """DELETE removes location keyword links but leaves the keyword row intact."""
     app, db = app_and_db
@@ -2327,6 +2370,37 @@ def test_post_keyword_link_place_returns_404_on_missing_keyword(
     )
     assert resp.status_code == 404
     assert resp.get_json()["error"] == "keyword_not_found"
+
+
+def test_post_keyword_link_place_returns_400_on_wrong_keyword_type(
+    app_and_db, monkeypatch,
+):
+    """Linking a non-'location' keyword should be a 400 wrong_keyword_type
+    (the id exists, but it's the wrong kind), not a 404 keyword_not_found
+    that misleadingly tells callers the id doesn't exist."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+    monkeypatch.setattr(places, "place_details",
+                        lambda place_id, key: _central_park_details())
+
+    # Create a 'general' keyword (not 'location').
+    kw_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES ('Bird', 'general')",
+    ).lastrowid
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/keywords/{kw_id}/link-place",
+        json={"place_id": "ChIJ_x"},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["error"] == "wrong_keyword_type"
+    assert "general" in body["error_detail"]
 
 
 def test_post_keyword_link_place_returns_400_on_missing_place_id(app_and_db):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1758,3 +1758,143 @@ def test_delete_photo_location_records_edit(app_and_db):
     entry = post_history[0]
     assert entry["action_type"] == "location_clear"
     assert entry["description"] == "cleared location"
+
+
+# --- POST /api/photos/<id>/location/text ------------------------------------
+#
+# Free-text fallback path: user types a name and hits Enter without picking a
+# Google suggestion (or no API key is configured). No Google round-trip.
+
+def test_post_photo_location_text_creates_keyword_and_links(app_and_db):
+    """Free-text POST creates a no-place_id keyword and links it to the photo."""
+    app, db = app_and_db
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/location/text",
+        json={"name": "the meadow"},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    data = resp.get_json()
+
+    loc = data["location"]
+    assert loc["name"] == "the meadow"
+    assert loc["place_id"] is None
+    assert loc["parent_chain"] == []
+
+    # DB-level: photo has exactly one type='location' keyword link, on a row
+    # with no place_id (free-text).
+    rows = db.conn.execute(
+        "SELECT k.id, k.name, k.place_id FROM photo_keywords pk "
+        "JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE pk.photo_id = ? AND k.type = 'location'",
+        (pid,),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["name"] == "the meadow"
+    assert rows[0]["place_id"] is None
+
+
+def test_post_photo_location_text_strips_whitespace(app_and_db):
+    """Surrounding whitespace is stripped before the keyword is created."""
+    app, db = app_and_db
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/location/text",
+        json={"name": "  the meadow  "},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    data = resp.get_json()
+    assert data["location"]["name"] == "the meadow"
+
+    rows = db.conn.execute(
+        "SELECT k.name FROM photo_keywords pk "
+        "JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE pk.photo_id = ? AND k.type = 'location'",
+        (pid,),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["name"] == "the meadow"
+
+
+def test_post_photo_location_text_400_on_missing_name(app_and_db):
+    """Empty body / missing name is a 400."""
+    app, db = app_and_db
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    client = app.test_client()
+    resp = client.post(f"/api/photos/{pid}/location/text", json={})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "missing name"
+
+
+def test_post_photo_location_text_400_on_empty_name(app_and_db):
+    """Whitespace-only name is rejected as 400."""
+    app, db = app_and_db
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/location/text",
+        json={"name": "   "},
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "missing name"
+
+
+def test_post_photo_location_text_replaces_existing_location(app_and_db):
+    """A second free-text POST replaces (not adds to) the existing location link."""
+    app, db = app_and_db
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    client = app.test_client()
+    r1 = client.post(
+        f"/api/photos/{pid}/location/text",
+        json={"name": "first place"},
+    )
+    assert r1.status_code == 200
+    r2 = client.post(
+        f"/api/photos/{pid}/location/text",
+        json={"name": "second place"},
+    )
+    assert r2.status_code == 200
+
+    rows = db.conn.execute(
+        "SELECT k.name FROM photo_keywords pk "
+        "JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE pk.photo_id = ? AND k.type = 'location'",
+        (pid,),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["name"] == "second place"
+
+
+def test_post_photo_location_text_records_edit(app_and_db):
+    """Free-text POST adds an audit-log entry under the same 'location_set' type."""
+    app, db = app_and_db
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    pre_history = db.get_edit_history()
+    pre_count = len(pre_history)
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/location/text",
+        json={"name": "the meadow"},
+    )
+    assert resp.status_code == 200, resp.get_json()
+
+    post_history = db.get_edit_history()
+    assert len(post_history) == pre_count + 1
+    entry = post_history[0]
+    assert entry["action_type"] == "location_set"
+    assert "the meadow" in entry["description"]

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2171,6 +2171,22 @@ def test_reverse_geocode_does_not_cache_transient_errors(app_and_db, monkeypatch
     )
 
 
+def test_reverse_geocode_400_on_non_finite_coords(app_and_db):
+    """float() accepts 'nan' and 'inf' but they blow up downstream when
+    we round to the grid (int(round(NaN)) raises ValueError). Reject them
+    at the boundary as 400, same as other invalid coords."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    for bad in ["nan", "NaN", "inf", "-inf", "Infinity"]:
+        r = client.get(f"/api/places/reverse-geocode?lat={bad}&lng=0")
+        assert r.status_code == 400, f"lat={bad} should be rejected"
+        assert r.get_json()["error"] == "invalid coords"
+
+        r = client.get(f"/api/places/reverse-geocode?lat=0&lng={bad}")
+        assert r.status_code == 400, f"lng={bad} should be rejected"
+
+
 def test_reverse_geocode_400_on_invalid_coords(app_and_db):
     """Missing or unparseable lat/lng is a 400."""
     app, _ = app_and_db

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1526,3 +1526,183 @@ def test_zero_byte_cache_file_is_regenerated(client_with_photo):
     row = db.preview_cache_get(photo_id, 1920)
     assert row is not None
     assert row["bytes"] > 0
+
+
+# --- POST/DELETE /api/photos/<id>/location ----------------------------------
+#
+# The autocomplete pick path: client sends a Google ``place_id``, server
+# looks it up via the Places HTTP wrapper and writes a leaf+parent-chain of
+# ``type='location'`` keywords. ``places.place_details`` is monkeypatched
+# so no HTTP traffic happens during tests.
+
+def _central_park_details():
+    """Canned Place Details dict shaped like ``vireo.places.place_details``.
+
+    Mirrors what Google would return for Central Park, NYC: a leaf with
+    coords + a four-level parent chain (city -> county -> state -> country).
+    Google's ``address_components`` order is narrowest-first, which the
+    upsert logic in ``Database._upsert_location_parent_chain`` reverses
+    when chaining ``parent_id`` upward.
+    """
+    return {
+        "place_id": "ChIJ4zGFAZpYwokRGUGph3Mf37k",
+        "name": "Central Park",
+        "lat": 40.7828,
+        "lng": -73.9654,
+        "address_components": [
+            {"name": "New York", "short_name": "New York", "types": ["locality"]},
+            {"name": "New York County", "short_name": "New York County",
+             "types": ["administrative_area_level_2"]},
+            {"name": "New York", "short_name": "NY", "types": ["administrative_area_level_1"]},
+            {"name": "United States", "short_name": "US", "types": ["country"]},
+        ],
+    }
+
+
+def test_post_photo_location_with_valid_place_id(app_and_db, monkeypatch):
+    """Valid pick: route stores leaf + parents and returns the serialized location."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    # API key must be present or the route short-circuits with no_api_key.
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+
+    captured = {}
+
+    def fake_place_details(place_id, key):
+        captured["place_id"] = place_id
+        captured["key"] = key
+        return _central_park_details()
+
+    # The route imports ``places`` at module level via ``import places``.
+    monkeypatch.setattr(places, "place_details", fake_place_details)
+
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/location",
+        json={"place_id": "ChIJ_x"},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    data = resp.get_json()
+
+    # Response shape — leaf fields + parent chain (broadest -> narrowest, no leaf).
+    loc = data["location"]
+    assert loc["name"] == "Central Park"
+    assert loc["place_id"] == "ChIJ4zGFAZpYwokRGUGph3Mf37k"
+    assert loc["latitude"] == 40.7828
+    assert loc["longitude"] == -73.9654
+    assert [p["name"] for p in loc["parent_chain"]] == [
+        "United States", "New York", "New York County", "New York",
+    ]
+
+    # And the route actually called Google with the body's place_id + config key.
+    assert captured == {"place_id": "ChIJ_x", "key": "FAKE-KEY"}
+
+    # Photo now has exactly one type='location' keyword link, pointing at the
+    # leaf row that carries the place_id.
+    rows = db.conn.execute(
+        "SELECT k.id, k.name, k.place_id FROM photo_keywords pk "
+        "JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE pk.photo_id = ? AND k.type = 'location'",
+        (pid,),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["place_id"] == "ChIJ4zGFAZpYwokRGUGph3Mf37k"
+    assert rows[0]["name"] == "Central Park"
+
+
+def test_post_photo_location_returns_400_on_missing_place_id(app_and_db):
+    """Empty body / missing place_id is a 400 — never reaches Google."""
+    app, db = app_and_db
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    client = app.test_client()
+    resp = client.post(f"/api/photos/{pid}/location", json={})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "missing place_id"
+
+
+def test_post_photo_location_returns_400_on_empty_api_key(app_and_db):
+    """No configured API key: degrade to a 400 ``no_api_key`` error."""
+    import config as cfg
+    app, db = app_and_db
+    # Explicitly clear the key so the route hits the empty-key branch even
+    # if a previous test left one behind in the same temp config file.
+    cfg.save({**cfg.load(), "google_maps_api_key": ""})
+
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/location",
+        json={"place_id": "ChIJ_x"},
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "no_api_key"
+
+
+def test_post_photo_location_returns_404_when_google_returns_none(app_and_db, monkeypatch):
+    """Google returns ZERO_RESULTS / NOT_FOUND -> wrapper returns None -> 404."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+    monkeypatch.setattr(places, "place_details", lambda place_id, key: None)
+
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/location",
+        json={"place_id": "ChIJ_unknown"},
+    )
+    assert resp.status_code == 404
+    assert resp.get_json()["error"] == "place_not_found"
+
+
+def test_delete_photo_location_clears_links(app_and_db):
+    """DELETE removes location keyword links but leaves the keyword row intact."""
+    app, db = app_and_db
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    # Set up an existing location link directly via DB methods (no Google
+    # round-trip needed for the delete path).
+    leaf_id = db.upsert_place_chain(_central_park_details())
+    db.set_photo_location(pid, leaf_id)
+    # Sanity: the link exists before DELETE.
+    pre_links = db.conn.execute(
+        "SELECT 1 FROM photo_keywords pk JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE pk.photo_id = ? AND k.type = 'location'",
+        (pid,),
+    ).fetchall()
+    assert len(pre_links) == 1
+
+    client = app.test_client()
+    resp = client.delete(f"/api/photos/{pid}/location")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True}
+
+    # No location links remain on the photo.
+    post_links = db.conn.execute(
+        "SELECT 1 FROM photo_keywords pk JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE pk.photo_id = ? AND k.type = 'location'",
+        (pid,),
+    ).fetchall()
+    assert post_links == []
+
+    # The keyword row itself is preserved — other photos / future links may
+    # still reference it.
+    leaf_row = db.conn.execute(
+        "SELECT id, name FROM keywords WHERE id = ?", (leaf_id,),
+    ).fetchone()
+    assert leaf_row is not None
+    assert leaf_row["name"] == "Central Park"

--- a/vireo/tests/test_places.py
+++ b/vireo/tests/test_places.py
@@ -1,0 +1,180 @@
+"""Tests for vireo.places — Google Maps HTTP wrappers.
+
+The tests do NOT hit the network. They monkeypatch
+``vireo.places.urllib.request.urlopen`` with a fake that returns canned JSON
+responses. This means the implementation must call ``urlopen`` through
+``urllib.request.urlopen`` (e.g. via ``with urlopen(url) as f:``) so that the
+patch resolves to the fake.
+"""
+
+import io
+import json
+
+import pytest
+
+
+class _FakeResponse:
+    """Minimal stand-in for the object returned by ``urllib.request.urlopen``.
+
+    Supports the context-manager protocol (``with urlopen(url) as f:``) and
+    a ``read()`` method that returns bytes — same surface our wrapper uses.
+    """
+
+    def __init__(self, payload: dict):
+        self._buf = io.BytesIO(json.dumps(payload).encode("utf-8"))
+
+    def read(self):
+        return self._buf.read()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._buf.close()
+        return False
+
+
+def _make_fake_urlopen(payload: dict, captured_urls: list | None = None):
+    def fake_urlopen(url, *args, **kwargs):
+        if captured_urls is not None:
+            captured_urls.append(url)
+        return _FakeResponse(payload)
+
+    return fake_urlopen
+
+
+def test_place_details_parses_response(monkeypatch):
+    """Place Details OK response is normalized into the wrapper's dict shape."""
+    from vireo import places
+
+    canned = {
+        "status": "OK",
+        "result": {
+            "place_id": "ChIJ4zGFAZpYwokRGUGph3Mf37k",
+            "name": "Central Park",
+            "geometry": {"location": {"lat": 40.7828647, "lng": -73.9653551}},
+            "address_components": [
+                {
+                    "long_name": "Manhattan",
+                    "short_name": "Manhattan",
+                    "types": ["political", "sublocality", "sublocality_level_1"],
+                },
+                {
+                    "long_name": "New York",
+                    "short_name": "New York",
+                    "types": ["locality", "political"],
+                },
+                {
+                    "long_name": "New York",
+                    "short_name": "NY",
+                    "types": ["administrative_area_level_1", "political"],
+                },
+                {
+                    "long_name": "United States",
+                    "short_name": "US",
+                    "types": ["country", "political"],
+                },
+            ],
+        },
+    }
+
+    captured = []
+    monkeypatch.setattr(
+        "vireo.places.urllib.request.urlopen",
+        _make_fake_urlopen(canned, captured),
+    )
+
+    out = places.place_details("ChIJ4zGFAZpYwokRGUGph3Mf37k", "FAKE_KEY")
+
+    assert out is not None
+    assert out["place_id"] == "ChIJ4zGFAZpYwokRGUGph3Mf37k"
+    assert out["name"] == "Central Park"
+    assert isinstance(out["lat"], float)
+    assert isinstance(out["lng"], float)
+    assert out["lat"] == pytest.approx(40.7828647)
+    assert out["lng"] == pytest.approx(-73.9653551)
+    assert isinstance(out["address_components"], list)
+    assert len(out["address_components"]) == 4
+
+    # Components should expose normalized keys.
+    leaf_country = out["address_components"][-1]
+    assert leaf_country["name"] == "United States"
+    assert leaf_country["short_name"] == "US"
+    assert "country" in leaf_country["types"]
+
+    # The URL must include the place_id and the key (passed through urlencode).
+    assert len(captured) == 1
+    url = captured[0]
+    assert "place_id=ChIJ4zGFAZpYwokRGUGph3Mf37k" in url
+    assert "key=FAKE_KEY" in url
+
+
+def test_place_details_returns_none_on_zero_results(monkeypatch):
+    """ZERO_RESULTS / NOT_FOUND / empty result → ``None``, no raise."""
+    from vireo import places
+
+    monkeypatch.setattr(
+        "vireo.places.urllib.request.urlopen",
+        _make_fake_urlopen({"status": "ZERO_RESULTS"}),
+    )
+
+    assert places.place_details("ChIJ_does_not_exist", "FAKE_KEY") is None
+
+
+def test_reverse_geocode_parses_response(monkeypatch):
+    """Geocoding OK response is normalized into the wrapper's dict shape."""
+    from vireo import places
+
+    canned = {
+        "status": "OK",
+        "results": [
+            {
+                "place_id": "ChIJOwg_06VPwokRYv534QaPC8g",
+                "formatted_address": "New York, NY, USA",
+                "geometry": {"location": {"lat": 40.7127753, "lng": -74.0059728}},
+                "address_components": [
+                    {
+                        "long_name": "New York",
+                        "short_name": "New York",
+                        "types": ["locality", "political"],
+                    },
+                    {
+                        "long_name": "New York",
+                        "short_name": "NY",
+                        "types": ["administrative_area_level_1", "political"],
+                    },
+                    {
+                        "long_name": "United States",
+                        "short_name": "US",
+                        "types": ["country", "political"],
+                    },
+                ],
+            }
+        ],
+    }
+
+    captured = []
+    monkeypatch.setattr(
+        "vireo.places.urllib.request.urlopen",
+        _make_fake_urlopen(canned, captured),
+    )
+
+    out = places.reverse_geocode(40.7127753, -74.0059728, "FAKE_KEY")
+
+    assert out is not None
+    assert out["place_id"] == "ChIJOwg_06VPwokRYv534QaPC8g"
+    assert out["name"] == "New York, NY, USA"
+    assert isinstance(out["lat"], float)
+    assert isinstance(out["lng"], float)
+    assert out["lat"] == pytest.approx(40.7127753)
+    assert out["lng"] == pytest.approx(-74.0059728)
+    assert isinstance(out["address_components"], list)
+    assert len(out["address_components"]) == 3
+
+    # latlng=lat,lng should be in the URL — comma may be percent-encoded.
+    assert len(captured) == 1
+    url = captured[0]
+    assert ("latlng=40.7127753%2C-74.0059728" in url) or (
+        "latlng=40.7127753,-74.0059728" in url
+    )
+    assert "key=FAKE_KEY" in url

--- a/vireo/tests/test_places.py
+++ b/vireo/tests/test_places.py
@@ -9,6 +9,7 @@ patch resolves to the fake.
 
 import io
 import json
+import urllib.error
 
 import pytest
 
@@ -178,3 +179,58 @@ def test_reverse_geocode_parses_response(monkeypatch):
         "latlng=40.7127753,-74.0059728" in url
     )
     assert "key=FAKE_KEY" in url
+
+
+def test_reverse_geocode_returns_none_on_zero_results(monkeypatch):
+    """ZERO_RESULTS is a true no-match — return ``None`` so callers may
+    cache the negative result."""
+    from vireo import places
+
+    monkeypatch.setattr(
+        "vireo.places.urllib.request.urlopen",
+        _make_fake_urlopen({"status": "ZERO_RESULTS"}),
+    )
+
+    assert places.reverse_geocode(0.0, 0.0, "FAKE_KEY") is None
+
+
+def test_reverse_geocode_raises_transient_on_over_query_limit(monkeypatch):
+    """OVER_QUERY_LIMIT is a transient API failure, not a real no-match.
+    Wrapper raises PlacesTransientError so callers can avoid caching."""
+    from vireo import places
+
+    monkeypatch.setattr(
+        "vireo.places.urllib.request.urlopen",
+        _make_fake_urlopen({"status": "OVER_QUERY_LIMIT"}),
+    )
+
+    with pytest.raises(places.PlacesTransientError):
+        places.reverse_geocode(40.0, -73.0, "FAKE_KEY")
+
+
+def test_reverse_geocode_raises_transient_on_request_denied(monkeypatch):
+    """REQUEST_DENIED (e.g. bad key, referrer mismatch) is also transient
+    from the cache's perspective — the user may fix it and retry."""
+    from vireo import places
+
+    monkeypatch.setattr(
+        "vireo.places.urllib.request.urlopen",
+        _make_fake_urlopen({"status": "REQUEST_DENIED"}),
+    )
+
+    with pytest.raises(places.PlacesTransientError):
+        places.reverse_geocode(40.0, -73.0, "FAKE_KEY")
+
+
+def test_reverse_geocode_raises_transient_on_network_failure(monkeypatch):
+    """Transport errors (URLError, socket timeout, malformed JSON) are
+    transient — wrapper raises PlacesTransientError chained from the cause."""
+    from vireo import places
+
+    def boom(url, timeout=10):
+        raise urllib.error.URLError("simulated network failure")
+
+    monkeypatch.setattr("vireo.places.urllib.request.urlopen", boom)
+
+    with pytest.raises(places.PlacesTransientError):
+        places.reverse_geocode(40.0, -73.0, "FAKE_KEY")


### PR DESCRIPTION
## Summary
- iNaturalist-style Google Places autocomplete on the location keyword. Pick a place from a dropdown, get coords + a parent chain (city → state → country), have the photo show on the map.
- Free-text fallback for places Google doesn't know ("the meadow behind the cabin"); creates a coordless location keyword.
- EXIF GPS reverse-geocode "suggest on open" — opening a GPS-tagged photo with no location keyword shows an inline `💡 EXIF says: ... [Accept]` suggestion.
- Existing free-text location keywords get a `📍 Link…` button on `/keywords` to opportunistically attach Google data + parents (with merge-on-existing-place_id handling).
- `/map` falls back to a `type='location'` keyword's coords when EXIF GPS is missing; popup shows a provenance footer (`from EXIF GPS` vs `from location: <name>`).
- Graceful degrade when no API key is configured — free-text + Enter still works; autocomplete and EXIF suggestions silently disable.

## Architecture
Hybrid client/server. Per-keystroke autocomplete uses Google's JS Places library with the API key embedded (referrer-restricted by the user in Google Cloud console). Place Details lookups (on user pick) and reverse-geocoding (for EXIF suggestions) are proxied through Flask, with the key in `~/.vireo/config.json` and reverse-geocode results cached in SQLite by ~110m grid cell.

Data model: single leaf location per photo with auto-rolled-up parents derived from Google's `address_components`. New `keywords.place_id` column with a unique partial index dedupes Google places deterministically; existing `UNIQUE(name, parent_id)` still dedupes free-text keywords. New `place_reverse_geocode_cache` table for the EXIF lookup cache.

## Test plan
- [x] DB schema migrations + new methods (`vireo/tests/test_db.py`)
- [x] Google Places HTTP wrapper (`vireo/tests/test_places.py`)
- [x] Photo location set/clear/text/link/reverse-geocode API (`vireo/tests/test_photos_api.py`)
- [x] Config field round-trip (`vireo/tests/test_config.py`)
- [x] Settings page key input (manual round-trip via isolated HOME)
- [x] Browse panel Location section, EXIF suggest, free-text fallback, clear (`tests/e2e/test_location_section.py`)
- [x] Keywords page Link button + modal + filter chip (`tests/e2e/test_keywords_link.py`)
- [x] Map fallback to keyword coords + provenance footer (`vireo/tests/test_db.py`)
- [x] Full required suite (`test_workspaces`, `test_db`, `test_app`, `test_photos_api`, `test_edits_api`, `test_jobs_api`, `test_darktable_api`, `test_config`, `test_places`): **710 tests, all passing**

## Out of scope (YAGNI for v1)
- Manual pin-drop on a Leaflet picker for free-text places (defer until a "place behind the cabin" actually wants to be on the map).
- Background bulk reverse-geocode of all GPS-tagged photos (suggest-on-open proves the geocoding first; bulk becomes a one-button job later).
- "Locations" layer on the map showing places themselves as clickable markers with photo counts (v1.5).
- Place metadata blob (viewport bbox, place types, opening hours, etc.).
- Multi-location-per-photo tagging — single leaf only; rollup is via parent chain.
- Privacy / location obscuring for sensitive species.
- Re-pointing an already-linked keyword's `place_id` (the `📍 Link…` button only acts on unlinked rows).
- Structured XMP location sidecar writes (`exif:GPS*`, `Iptc4xmpCore:Location`). Location keywords intentionally bypass the `dc:subject` sidecar queue.
- The location keyword still also appears in the regular keyword pill area on the photo detail panel (design called for it to be hidden there); left as a small follow-up.

## References
- Design: \`docs/plans/2026-04-25-location-autocomplete-design.md\`
- Plan: \`docs/plans/2026-04-25-location-autocomplete-plan.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)