### PR TITLE
feat(pipeline-review): right-click photo to open in browse view

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1335,7 +1335,7 @@ function renderPhotoCard(p, encIdx, burstIdx) {
   var label = (p.label || '').toLowerCase();
   var q = p.quality_composite || 0;
   var qPct = Math.round(q * 100);
-  var html = '<div class="photo-card ' + label + '">';
+  var html = '<div class="photo-card ' + label + '" data-photo-id="' + p.id + '">';
   html += '<img src="/thumbnails/' + p.id + '.jpg" loading="lazy" alt="" onclick="openInspect(' + p.id + ')">';
   if (p.label) html += '<span class="photo-label ' + label + '">' + p.label + '</span>';
   if (p.rarity_protected) html += '<span class="photo-rarity">protected</span>';
@@ -2715,6 +2715,19 @@ document.addEventListener('keydown', function(e) {
   }
   if (e.key === 'Delete' || e.key === 'Backspace') { grmRemoveFromGroup(); e.preventDefault(); return; }
   if (e.key === ' ') { grmMoveCandidate(); e.preventDefault(); return; }
+});
+
+/* --- Right-click → open in Browse view ---
+ * Catches contextmenu on photo cards (main grid) and grm-cards (group review
+ * modal). Opens /browse?photo_id=<id> in a new tab so the user keeps their
+ * pipeline-review state intact. */
+document.addEventListener('contextmenu', function(e) {
+  var card = e.target.closest('.photo-card[data-photo-id], .grm-card[data-photo-id]');
+  if (!card) return;
+  var pid = parseInt(card.dataset.photoId, 10);
+  if (!pid) return;
+  e.preventDefault();
+  window.open('/browse?photo_id=' + pid, '_blank', 'noopener');
 });
 
 /* --- Apply & Close --- */


### PR DESCRIPTION
## Summary
- Adds a document-level `contextmenu` handler in `pipeline_review.html` that catches right-clicks on `.photo-card` (main grid) and `.grm-card` (group-review modal) and opens `/browse?photo_id=<id>` in a new tab.
- `renderPhotoCard` now emits `data-photo-id` on the card div so the handler can resolve the id from the element.
- New tab (vs. same-tab navigation) keeps pipeline-review state intact while peeking at a photo in browse.

## Test plan
- [x] Live-browser Playwright check against a sandboxed Vireo instance:
  - Right-click `.photo-card` → opens `/browse?photo_id=42` in a new tab
  - Right-click `.grm-card` → opens `/browse?photo_id=99` in a new tab
  - Right-click empty area → falls through to native browser context menu
  - `renderPhotoCard` output now contains `data-photo-id="<id>"`
- [x] Full project test suite from `CLAUDE.md` passes.
- [ ] Verify in app: open `/pipeline/review`, right-click any thumbnail in the main grid and in the burst-group modal, confirm a new tab opens scrolled to that photo in browse.