### PR TITLE
fix(photos): trust working copy on /original, skip RAW re-extract

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9504,48 +9504,56 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
 
-        # Working copy is the canonical asset *unless* it was deliberately
-        # capped below the original. The cheap signal is config + stored
-        # dims; the precise signal is the wc's actual dims on disk. Use
-        # the cheap signal first and only open the wc when capping is
-        # plausible — burst-review zoom fires this endpoint per card, so
-        # the common path must avoid PIL altogether.
+        # Decide whether to trust the working copy as the full-res asset
+        # by reading its actual on-disk dimensions, NOT the current
+        # ``working_copy_max_size`` config — the cap may have changed
+        # since the wc was generated, leaving stale capped wcs that
+        # config-based logic would misclassify as full-res.
         #
-        # Cases:
-        #   - cap <= 0 (full-res config): wc is never downsized → serve it.
-        #   - cap > 0 and orig_long <= cap: wc reflects the full source
-        #     (e.g. RAW embedded-JPEG fallback whose dims are slightly
-        #     smaller than the sensor area) → serve it.
-        #   - orig dims unknown: can't detect capping; trust the wc rather
-        #     than pay 5–7s for a speculative RAW re-extract per request.
-        #   - cap > 0 and orig_long > cap: wc *might* be capped, but might
-        #     already have been upgraded in a previous request (the
-        #     extraction below overwrites wc at full-res). Read the wc's
-        #     actual long side via the JPEG header and trust it when close
-        #     to orig_long — this both detects post-upgrade wcs and avoids
-        #     re-extract loops for RAWs whose embedded-JPEG fallback is
-        #     slightly smaller than the sensor area.
+        # PIL.Image.open is lazy: it reads the JPEG SOF marker for
+        # ``.size`` without decoding pixels (sub-millisecond), so this
+        # is safe to do per request even during burst-review zoom. The
+        # expensive path we must avoid is the RAW re-extract below
+        # (5–7s per photo), not the header read.
         if photo["working_copy_path"]:
             wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
             if os.path.exists(wc_path):
-                effective_cfg = db.get_effective_config(cfg.load())
-                wc_max_size = int(effective_cfg.get("working_copy_max_size", 4096) or 0)
-                orig_long = max(photo["width"] or 0, photo["height"] or 0)
-                wc_might_be_capped = wc_max_size > 0 and orig_long > wc_max_size
-                if not wc_might_be_capped:
-                    return send_file(wc_path, mimetype="image/jpeg")
-                # Capping is plausible — confirm with a JPEG header read.
-                # 1% tolerance covers RAW embedded-JPEG fallbacks (e.g.
-                # Nikon NEFs report sensor dims 8280×5520 but the embedded
-                # JPEG is 8256×5504).
+                from PIL import Image as _PILImage
                 try:
-                    from PIL import Image as _PILImage
                     with _PILImage.open(wc_path) as _wc_img:
-                        wc_long = max(_wc_img.size)
-                    if wc_long >= orig_long * 0.99:
-                        return send_file(wc_path, mimetype="image/jpeg")
+                        wc_w, wc_h = _wc_img.size
                 except Exception:
-                    pass  # unreadable wc — fall through to re-extract
+                    wc_w = wc_h = 0
+                orig_w = photo["width"] or 0
+                orig_h = photo["height"] or 0
+                # Trust the wc when it meets/exceeds the believed
+                # original dims, or when those dims are unknown (no
+                # basis to declare the wc stale and a speculative RAW
+                # re-extract would just thrash the disk).
+                if wc_w and wc_h and (
+                    (wc_w >= orig_w and wc_h >= orig_h)
+                    or not (orig_w and orig_h)
+                ):
+                    return send_file(wc_path, mimetype="image/jpeg")
+                # The wc is smaller than the believed original. For RAW
+                # sources this often means rawpy.postprocess() failed
+                # and we fell back to the embedded JPEG, which can be a
+                # few pixels shy of the full sensor area (e.g. Nikon
+                # NEFs report 8280×5520 but the embedded JPEG is
+                # 8256×5504). Re-extracting would yield the same
+                # fallback image, just slower — so trust the wc when
+                # it is within 1% of the believed dims. This tolerance
+                # is RAW-only: for JPEG/PNG/etc., the wc being smaller
+                # means the cap downsized it, and re-extracting WILL
+                # produce more pixels.
+                from image_loader import RAW_EXTENSIONS
+                ext = os.path.splitext(photo["filename"])[1].lower()
+                if ext in RAW_EXTENSIONS and wc_w and wc_h:
+                    wc_long = max(wc_w, wc_h)
+                    orig_long = max(orig_w, orig_h)
+                    if orig_long and wc_long >= orig_long * 0.99:
+                        return send_file(wc_path, mimetype="image/jpeg")
+                # Fall through to on-demand re-extract.
 
         # Resolve original file path
         folder = db.conn.execute(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9504,21 +9504,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
 
-        # Check if working copy is full-res
+        # Working copy is the canonical full-res asset — serve it if present.
         if photo["working_copy_path"]:
             wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
             if os.path.exists(wc_path):
-                from PIL import Image as _PILImage
-                with _PILImage.open(wc_path) as wc_img:
-                    wc_w, wc_h = wc_img.size
-                orig_w = photo["width"]
-                orig_h = photo["height"]
-                # If working copy matches original dimensions, serve it directly.
-                # Skip shortcut when original dimensions are unknown (None) to
-                # avoid serving a capped working copy as full-res.
-                if orig_w and orig_h and wc_w >= orig_w and wc_h >= orig_h:
-                    return send_file(wc_path, mimetype="image/jpeg")
-                # Otherwise: need full-res extraction (on-demand upgrade)
+                return send_file(wc_path, mimetype="image/jpeg")
 
         # Resolve original file path
         folder = db.conn.execute(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9504,11 +9504,48 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
 
-        # Working copy is the canonical full-res asset — serve it if present.
+        # Working copy is the canonical asset *unless* it was deliberately
+        # capped below the original. The cheap signal is config + stored
+        # dims; the precise signal is the wc's actual dims on disk. Use
+        # the cheap signal first and only open the wc when capping is
+        # plausible — burst-review zoom fires this endpoint per card, so
+        # the common path must avoid PIL altogether.
+        #
+        # Cases:
+        #   - cap <= 0 (full-res config): wc is never downsized → serve it.
+        #   - cap > 0 and orig_long <= cap: wc reflects the full source
+        #     (e.g. RAW embedded-JPEG fallback whose dims are slightly
+        #     smaller than the sensor area) → serve it.
+        #   - orig dims unknown: can't detect capping; trust the wc rather
+        #     than pay 5–7s for a speculative RAW re-extract per request.
+        #   - cap > 0 and orig_long > cap: wc *might* be capped, but might
+        #     already have been upgraded in a previous request (the
+        #     extraction below overwrites wc at full-res). Read the wc's
+        #     actual long side via the JPEG header and trust it when close
+        #     to orig_long — this both detects post-upgrade wcs and avoids
+        #     re-extract loops for RAWs whose embedded-JPEG fallback is
+        #     slightly smaller than the sensor area.
         if photo["working_copy_path"]:
             wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
             if os.path.exists(wc_path):
-                return send_file(wc_path, mimetype="image/jpeg")
+                effective_cfg = db.get_effective_config(cfg.load())
+                wc_max_size = int(effective_cfg.get("working_copy_max_size", 4096) or 0)
+                orig_long = max(photo["width"] or 0, photo["height"] or 0)
+                wc_might_be_capped = wc_max_size > 0 and orig_long > wc_max_size
+                if not wc_might_be_capped:
+                    return send_file(wc_path, mimetype="image/jpeg")
+                # Capping is plausible — confirm with a JPEG header read.
+                # 1% tolerance covers RAW embedded-JPEG fallbacks (e.g.
+                # Nikon NEFs report sensor dims 8280×5520 but the embedded
+                # JPEG is 8256×5504).
+                try:
+                    from PIL import Image as _PILImage
+                    with _PILImage.open(wc_path) as _wc_img:
+                        wc_long = max(_wc_img.size)
+                    if wc_long >= orig_long * 0.99:
+                        return send_file(wc_path, mimetype="image/jpeg")
+                except Exception:
+                    pass  # unreadable wc — fall through to re-extract
 
         # Resolve original file path
         folder = db.conn.execute(

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -628,15 +628,22 @@ def test_original_serves_full_res_working_copy(app_and_db):
 
 
 def test_original_trusts_working_copy_even_when_smaller_than_stored_dims(app_and_db):
-    """Original endpoint trusts working copy as the canonical full-res asset.
+    """Original endpoint trusts working copy when stored dims slightly exceed wc.
 
-    The working copy is the full-res asset; stored RAW sensor dimensions can
-    legitimately exceed embedded-JPEG-derived working copy dimensions (Nikon
-    NEFs that fall back to the embedded JPEG are a known case). The endpoint
-    must serve the working copy directly without re-extracting from RAW.
+    Stored RAW sensor dimensions can legitimately exceed embedded-JPEG-derived
+    working copy dimensions (Nikon NEFs that fall back to the embedded JPEG
+    are a known case). When the configured cap is large enough that the wc
+    on disk reaches it, the endpoint must serve the working copy directly
+    without re-extracting from RAW.
     """
+    import config as cfg
+
     app, db = app_and_db
     client = app.test_client()
+
+    # Full-res working copies (NEF case implies the user has lifted the cap;
+    # otherwise the embedded JPEG of 8256 would have been thumbnailed to 4096).
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 0})
 
     photos = db.get_photos()
     pid = photos[0]["id"]
@@ -662,6 +669,101 @@ def test_original_trusts_working_copy_even_when_smaller_than_stored_dims(app_and
     assert resp.status_code == 200
 
     # Body must be exactly the working copy bytes — no re-extraction.
+    with open(wc_path, "rb") as f:
+        assert resp.data == f.read()
+
+
+def test_original_upgrades_capped_working_copy_to_full_res(app_and_db, tmp_path):
+    """Original endpoint re-extracts when working copy was capped below original.
+
+    With the default ``working_copy_max_size`` (4096), a 6000×4000 JPEG gets a
+    4096-px working copy. Serving that directly for /original would break 1:1
+    zoom — the endpoint must trigger the on-demand full-res upgrade.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    photos = db.get_photos()
+    pid = photos[0]["id"]
+
+    # Stored dimensions exceed the default cap (4096).
+    db.conn.execute("UPDATE photos SET width=6000, height=4000 WHERE id=?", (pid,))
+    db.conn.commit()
+
+    # Capped working copy: 4096-px long side.
+    from PIL import Image
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_path = os.path.join(working_dir, f"{pid}.jpg")
+    Image.new("RGB", (4096, 2731), color=(10, 20, 30)).save(wc_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (f"working/{pid}.jpg", pid),
+    )
+    db.conn.commit()
+
+    # Real 6000×4000 source on disk so the on-demand upgrade can run.
+    photo_dir = tmp_path / "photo_files"
+    photo_dir.mkdir()
+    db.conn.execute(
+        "UPDATE folders SET path=? WHERE id=?",
+        (str(photo_dir), photos[0]["folder_id"]),
+    )
+    db.conn.commit()
+    img_path = os.path.join(str(photo_dir), photos[0]["filename"])
+    Image.new("RGB", (6000, 4000), color=(40, 50, 60)).save(img_path, "JPEG")
+
+    resp = client.get(f"/photos/{pid}/original")
+    assert resp.status_code == 200
+
+    # The served image must be full-res (6000×4000), not the capped 4096-px wc.
+    import io
+    with Image.open(io.BytesIO(resp.data)) as served:
+        assert max(served.size) == 6000
+
+
+def test_original_serves_post_upgrade_working_copy_without_reextracting(app_and_db, tmp_path):
+    """After the on-demand upgrade overwrites wc at full-res, subsequent
+    requests must serve the upgraded wc directly — not loop into another
+    re-extract on every burst-review zoom click.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    photos = db.get_photos()
+    pid = photos[0]["id"]
+
+    # Stored dims still exceed the default cap (4096), but the wc on disk
+    # has already been upgraded to full-res by an earlier request.
+    db.conn.execute("UPDATE photos SET width=6000, height=4000 WHERE id=?", (pid,))
+    db.conn.commit()
+
+    from PIL import Image
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_path = os.path.join(working_dir, f"{pid}.jpg")
+    # Upgraded wc: matches stored dims.
+    Image.new("RGB", (6000, 4000), color=(70, 80, 90)).save(wc_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (f"working/{pid}.jpg", pid),
+    )
+    db.conn.commit()
+
+    # Source file does NOT exist — so if the endpoint tried to re-extract,
+    # the test would fail with a 5xx. Serving the wc directly succeeds.
+    photo_dir = tmp_path / "photo_files_missing"
+    photo_dir.mkdir()
+    db.conn.execute(
+        "UPDATE folders SET path=? WHERE id=?",
+        (str(photo_dir), photos[0]["folder_id"]),
+    )
+    db.conn.commit()
+
+    resp = client.get(f"/photos/{pid}/original")
+    assert resp.status_code == 200
     with open(wc_path, "rb") as f:
         assert resp.data == f.read()
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -627,14 +627,15 @@ def test_original_serves_full_res_working_copy(app_and_db):
     assert resp.status_code == 200
 
 
-def test_original_trusts_working_copy_even_when_smaller_than_stored_dims(app_and_db):
-    """Original endpoint trusts working copy when stored dims slightly exceed wc.
+def test_original_trusts_raw_working_copy_even_when_smaller_than_stored_dims(app_and_db):
+    """Original endpoint trusts RAW working copy when sensor dims slightly exceed wc.
 
     Stored RAW sensor dimensions can legitimately exceed embedded-JPEG-derived
     working copy dimensions (Nikon NEFs that fall back to the embedded JPEG
-    are a known case). When the configured cap is large enough that the wc
-    on disk reaches it, the endpoint must serve the working copy directly
-    without re-extracting from RAW.
+    are a known case: sensor 8280×5520 vs embedded JPEG 8256×5504). The
+    endpoint must serve the working copy directly without re-extracting,
+    because re-extraction would just produce the same embedded JPEG —
+    just slower — and burst-review zoom would loop on every request.
     """
     import config as cfg
 
@@ -648,8 +649,13 @@ def test_original_trusts_working_copy_even_when_smaller_than_stored_dims(app_and
     photos = db.get_photos()
     pid = photos[0]["id"]
 
-    # Stored dimensions are larger than the working copy on disk.
-    db.conn.execute("UPDATE photos SET width=8280, height=5520 WHERE id=?", (pid,))
+    # Mark this photo as a RAW source so the embedded-JPEG-fallback
+    # tolerance applies. Plain JPEGs do NOT get the tolerance — for them
+    # any wc smaller than the original means the cap downsized it.
+    db.conn.execute(
+        "UPDATE photos SET filename=?, extension=?, width=8280, height=5520 WHERE id=?",
+        ("DSC_0001.NEF", ".nef", pid),
+    )
     db.conn.commit()
 
     # Working copy is slightly smaller (e.g. embedded-JPEG fallback).
@@ -671,6 +677,111 @@ def test_original_trusts_working_copy_even_when_smaller_than_stored_dims(app_and
     # Body must be exactly the working copy bytes — no re-extraction.
     with open(wc_path, "rb") as f:
         assert resp.data == f.read()
+
+
+def test_original_reextracts_stale_capped_jpeg_wc_after_cap_raised(app_and_db, tmp_path):
+    """Stale working copies generated under a smaller cap must be re-extracted
+    after the cap is raised — the endpoint must not trust the wc just
+    because the *current* cap is larger than the original.
+
+    Scenario: an existing 4096-px wc was generated for a 6000-px JPEG when
+    ``working_copy_max_size`` was 4096. The user later sets the cap to 0
+    (no cap). The next ``/original`` request must produce the full 6000 px,
+    not silently serve the stale 4096-px wc.
+    """
+    import config as cfg
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    # User has lifted the cap.
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 0})
+
+    photos = db.get_photos()
+    pid = photos[0]["id"]
+
+    db.conn.execute("UPDATE photos SET width=6000, height=4000 WHERE id=?", (pid,))
+    db.conn.commit()
+
+    # Stale 4096-px wc from an older, smaller cap.
+    from PIL import Image
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_path = os.path.join(working_dir, f"{pid}.jpg")
+    Image.new("RGB", (4096, 2731), color=(10, 20, 30)).save(wc_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (f"working/{pid}.jpg", pid),
+    )
+    db.conn.commit()
+
+    # Real 6000×4000 source on disk so the on-demand upgrade can run.
+    photo_dir = tmp_path / "photo_files"
+    photo_dir.mkdir()
+    db.conn.execute(
+        "UPDATE folders SET path=? WHERE id=?",
+        (str(photo_dir), photos[0]["folder_id"]),
+    )
+    db.conn.commit()
+    img_path = os.path.join(str(photo_dir), photos[0]["filename"])
+    Image.new("RGB", (6000, 4000), color=(40, 50, 60)).save(img_path, "JPEG")
+
+    resp = client.get(f"/photos/{pid}/original")
+    assert resp.status_code == 200
+
+    # The served image must be full-res, not the stale 4096-px wc.
+    import io
+    with Image.open(io.BytesIO(resp.data)) as served:
+        assert max(served.size) == 6000
+
+
+def test_original_reextracts_jpeg_just_above_cap(app_and_db, tmp_path):
+    """A capped wc whose long side is just slightly below the original must
+    not be misclassified as full-res. Specifically: a 4100-px JPEG with the
+    default 4096 cap produces a 4096-px wc — that wc is genuinely capped,
+    not a near-match, and ``/original`` must re-extract.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    photos = db.get_photos()
+    pid = photos[0]["id"]
+
+    # Original is 4 pixels above the default 4096 cap.
+    db.conn.execute("UPDATE photos SET width=4100, height=2733 WHERE id=?", (pid,))
+    db.conn.commit()
+
+    from PIL import Image
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_path = os.path.join(working_dir, f"{pid}.jpg")
+    # Capped wc at the cap value.
+    Image.new("RGB", (4096, 2731), color=(10, 20, 30)).save(wc_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (f"working/{pid}.jpg", pid),
+    )
+    db.conn.commit()
+
+    photo_dir = tmp_path / "photo_files"
+    photo_dir.mkdir()
+    db.conn.execute(
+        "UPDATE folders SET path=? WHERE id=?",
+        (str(photo_dir), photos[0]["folder_id"]),
+    )
+    db.conn.commit()
+    img_path = os.path.join(str(photo_dir), photos[0]["filename"])
+    Image.new("RGB", (4100, 2733), color=(40, 50, 60)).save(img_path, "JPEG")
+
+    resp = client.get(f"/photos/{pid}/original")
+    assert resp.status_code == 200
+
+    # Must serve the true 4100-px original, not the 4096-px capped wc.
+    import io
+    with Image.open(io.BytesIO(resp.data)) as served:
+        assert max(served.size) == 4100
 
 
 def test_original_upgrades_capped_working_copy_to_full_res(app_and_db, tmp_path):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -627,44 +627,43 @@ def test_original_serves_full_res_working_copy(app_and_db):
     assert resp.status_code == 200
 
 
-def test_original_endpoint_upgrades_working_copy_to_full_res(app_and_db, tmp_path):
-    """Original endpoint extracts full-res when working copy is capped."""
+def test_original_trusts_working_copy_even_when_smaller_than_stored_dims(app_and_db):
+    """Original endpoint trusts working copy as the canonical full-res asset.
+
+    The working copy is the full-res asset; stored RAW sensor dimensions can
+    legitimately exceed embedded-JPEG-derived working copy dimensions (Nikon
+    NEFs that fall back to the embedded JPEG are a known case). The endpoint
+    must serve the working copy directly without re-extracting from RAW.
+    """
     app, db = app_and_db
     client = app.test_client()
 
     photos = db.get_photos()
     pid = photos[0]["id"]
 
-    # Set dimensions larger than working copy
-    db.conn.execute("UPDATE photos SET width=6000, height=4000 WHERE id=?", (pid,))
+    # Stored dimensions are larger than the working copy on disk.
+    db.conn.execute("UPDATE photos SET width=8280, height=5520 WHERE id=?", (pid,))
     db.conn.commit()
 
-    # Create a capped working copy (smaller than original dimensions)
+    # Working copy is slightly smaller (e.g. embedded-JPEG fallback).
     from PIL import Image
     vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
     working_dir = os.path.join(vireo_dir, "working")
     os.makedirs(working_dir, exist_ok=True)
     wc_path = os.path.join(working_dir, f"{pid}.jpg")
-    Image.new("RGB", (4096, 2731)).save(wc_path, "JPEG")
+    Image.new("RGB", (8256, 5504), color=(123, 45, 67)).save(wc_path, "JPEG")
     db.conn.execute(
         "UPDATE photos SET working_copy_path=? WHERE id=?",
         (f"working/{pid}.jpg", pid),
     )
     db.conn.commit()
 
-    # Point folder to a writable tmp location and create a real source image
-    photo_dir = tmp_path / "photo_files"
-    photo_dir.mkdir()
-    db.conn.execute(
-        "UPDATE folders SET path=? WHERE id=?",
-        (str(photo_dir), photos[0]["folder_id"]),
-    )
-    db.conn.commit()
-    img_path = os.path.join(str(photo_dir), photos[0]["filename"])
-    Image.new("RGB", (6000, 4000)).save(img_path, "JPEG")
-
     resp = client.get(f"/photos/{pid}/original")
     assert resp.status_code == 200
+
+    # Body must be exactly the working copy bytes — no re-extraction.
+    with open(wc_path, "rb") as f:
+        assert resp.data == f.read()
 
 
 def test_original_serves_native_jpeg_directly(app_and_db, tmp_path):


### PR DESCRIPTION
## Summary

The `/photos/{id}/original` endpoint was opening every cached working copy with PIL just to compare its pixel dimensions against the RAW sensor dims stored in `photos.width/height`, and re-extracting from RAW whenever the working copy was even slightly smaller. For Nikon NEFs (and any RAW where `rawpy.postprocess()` fails and Vireo falls back to the embedded JPEG), the embedded JPEG is a few pixels smaller than the full sensor area — so the check failed on every request and a fresh RAW decode ran each time (5–7s per photo).

This is the bug behind burst-review zoom stalls: opening a burst fires `/photos/{id}/original` for every card simultaneously; concurrent re-extractions thrash the disk and a few requests get stuck in the browser indefinitely.

The working copy *is* the canonical full-res asset (per `all pixel ops use working copy`). Serve it directly when present and skip the comparison.

## Changes

- `vireo/app.py` — in `serve_original_photo`, drop the `wc_w >= orig_w` dimension check and the per-request `PIL.Image.open` overhead. If `working_copy_path` is set and the file exists, send it.
- `vireo/tests/test_photos_api.py` — replace `test_original_endpoint_upgrades_working_copy_to_full_res` (which asserted the broken upgrade behavior) with `test_original_trusts_working_copy_even_when_smaller_than_stored_dims`, which uses an 8256×5504 working copy against stored 8280×5520 dims (the Nikon-NEF case) and asserts the response bytes equal the working-copy bytes — proving no re-extraction happened.

## Test plan

- [x] `pytest vireo/tests/test_photos_api.py -v` — 62 passed
- [x] Full required suite (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py`) — exit 0

## Notes

A separate PR is in flight to pre-generate working copies on import so the on-demand extraction path is rarely taken at all. This change is independent and lands the immediate fix for already-imported photos.