### PR TITLE
feat(import): pre-generate working copies on scan + backfill for existing photos

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -791,7 +791,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     # Defer the kickoff slightly so the app finishes booting before the
     # first DB-heavy background pass starts churning. Mirrors the folder
     # health loop's grace period.
-    threading.Timer(5.0, _kickoff_working_copy_backfill).start()
+    #
+    # Daemon=True so short-lived ``create_app`` callers (tests, scripts,
+    # one-shot tooling) don't get pinned waiting on the 5-second delay
+    # only to fire DB work after their real work is already done.
+    _wc_backfill_timer = threading.Timer(5.0, _kickoff_working_copy_backfill)
+    _wc_backfill_timer.daemon = True
+    _wc_backfill_timer.start()
 
     # -- Page routes --
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -709,23 +709,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     # persisting would be noise). Skipped entirely when a fast EXISTS check
     # confirms no candidates remain, so steady-state restarts pay nothing.
     def _kickoff_working_copy_backfill():
-        from scanner import backfill_working_copies
+        from scanner import (
+            backfill_working_copies,
+            working_copy_backfill_candidate_count,
+        )
 
         try:
             wcdb = Database(db_path)
-            has_candidates = wcdb.conn.execute(
-                "SELECT 1 FROM photos"
-                " WHERE working_copy_path IS NULL"
-                "   AND (working_copy_failed_at IS NULL"
-                "        OR working_copy_failed_mtime IS NULL"
-                "        OR file_mtime IS NULL"
-                "        OR working_copy_failed_mtime != file_mtime)"
-                " LIMIT 1"
-            ).fetchone()
+            # Defer to scanner's own predicate so the gate matches what
+            # ``_extract_working_copies`` will actually process. A naive
+            # ``working_copy_path IS NULL`` check would also fire on
+            # libraries of only small JPEGs (which the extractor
+            # intentionally skips), launching a no-op backfill on every
+            # restart.
+            candidate_count = working_copy_backfill_candidate_count(wcdb)
         except Exception:
             log.exception("Working-copy backfill: candidate check failed")
             return
-        if not has_candidates:
+        if candidate_count == 0:
             log.debug("Working-copy backfill: no candidates, skipping")
             return
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -695,6 +695,103 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     app._log_broadcaster = LogBroadcaster(buffer_size=500)
     app._log_broadcaster.install()
 
+    # Self-healing background backfill of missing working copies. RAW (and
+    # oversized JPEG) imports need a JPEG working copy at
+    # ``~/.vireo/working/{photo_id}.jpg`` so /photos/<id>/original can serve
+    # a static file without on-demand RAW decode (5-7s per file). The
+    # scan() path already extracts these inline for newly-discovered photos,
+    # but legacy rows (imported before the feature, or with a previous
+    # extraction failure that has since been fixed) carry NULL
+    # working_copy_path forever without this pass.
+    #
+    # Surfaced as an ephemeral JobRunner job so the bottom panel shows
+    # progress, but never written to job_history (it runs every startup —
+    # persisting would be noise). Skipped entirely when a fast EXISTS check
+    # confirms no candidates remain, so steady-state restarts pay nothing.
+    def _kickoff_working_copy_backfill():
+        from scanner import backfill_working_copies
+
+        try:
+            wcdb = Database(db_path)
+            has_candidates = wcdb.conn.execute(
+                "SELECT 1 FROM photos"
+                " WHERE working_copy_path IS NULL"
+                "   AND (working_copy_failed_at IS NULL"
+                "        OR working_copy_failed_mtime IS NULL"
+                "        OR file_mtime IS NULL"
+                "        OR working_copy_failed_mtime != file_mtime)"
+                " LIMIT 1"
+            ).fetchone()
+        except Exception:
+            log.exception("Working-copy backfill: candidate check failed")
+            return
+        if not has_candidates:
+            log.debug("Working-copy backfill: no candidates, skipping")
+            return
+
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        runner = app._job_runner
+
+        def work(job):
+            thread_db = Database(db_path)
+            # Working-copy backfill is workspace-agnostic (photos are
+            # global), but the JobRunner path leans on having an active
+            # workspace for some bookkeeping. Mirror the active workspace
+            # of init_db so any incidental ws-scoped helpers stay valid.
+            active_ws = init_db._active_workspace_id
+            if active_ws is not None:
+                thread_db.set_active_workspace(active_ws)
+
+            def progress_cb(current, total):
+                job["progress"]["current"] = current
+                job["progress"]["total"] = total
+                runner.push_event(
+                    job["id"],
+                    "progress",
+                    {
+                        "current": current,
+                        "total": total,
+                        "phase": f"{current:,} / {total:,} working copies",
+                    },
+                )
+
+            def status_cb(message):
+                runner.push_event(job["id"], "progress", {
+                    "phase": message,
+                    "current": job["progress"].get("current", 0),
+                    "total": job["progress"].get("total", 0),
+                })
+
+            def cancel_check():
+                return runner.is_cancelled(job["id"])
+
+            return backfill_working_copies(
+                thread_db, vireo_dir,
+                progress_callback=progress_cb,
+                status_callback=status_cb,
+                cancel_check=cancel_check,
+            )
+
+        try:
+            runner.start(
+                "working_copy_backfill", work,
+                ephemeral=True,
+                config={"trigger": "startup"},
+            )
+        except Exception:
+            log.exception("Failed to start working-copy backfill job")
+
+    # Expose the kickoff so tests can drive it synchronously without
+    # waiting on the Timer. Production wiring uses threading.Timer below;
+    # tests call ``app._kickoff_working_copy_backfill()`` directly and
+    # then block on the resulting JobRunner job.
+    app._kickoff_working_copy_backfill = _kickoff_working_copy_backfill
+
+    # Defer the kickoff slightly so the app finishes booting before the
+    # first DB-heavy background pass starts churning. Mirrors the folder
+    # health loop's grace period.
+    threading.Timer(5.0, _kickoff_working_copy_backfill).start()
+
     # -- Page routes --
 
     @app.route("/")

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -158,6 +158,8 @@ class Database:
                 companion_path           TEXT,
                 exif_data                TEXT,
                 working_copy_path        TEXT,
+                working_copy_failed_at   TEXT,
+                working_copy_failed_mtime REAL,
                 eye_x                    REAL,
                 eye_y                    REAL,
                 eye_conf                 REAL,
@@ -476,6 +478,22 @@ class Database:
             self.conn.execute(
                 "UPDATE workspaces SET open_tabs = ? WHERE open_tabs IS NULL",
                 (json.dumps(["settings", "workspace", "lightroom"]),),
+            )
+        # Migration: working-copy failure markers. Backfill (and the inline
+        # scan extraction) record a failure here when extract_working_copy
+        # returns False, gated by file_mtime so a user-replaced file retries
+        # on the next pass instead of being permanently skipped.
+        try:
+            self.conn.execute("SELECT working_copy_failed_at FROM photos LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute(
+                "ALTER TABLE photos ADD COLUMN working_copy_failed_at TEXT"
+            )
+        try:
+            self.conn.execute("SELECT working_copy_failed_mtime FROM photos LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute(
+                "ALTER TABLE photos ADD COLUMN working_copy_failed_mtime REAL"
             )
         self.conn.commit()
 

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -499,6 +499,15 @@ def _subtree_like_pattern(path, sep=None):
     return _escape(path) + _escape(sep) + "%"
 
 
+# How long a recorded extraction failure suppresses retries when the file's
+# mtime hasn't changed. Without an upper bound, a transient failure (e.g. an
+# external drive briefly unavailable at startup) would block backfill forever
+# for unchanged files — undermining the self-healing intent. With it, a truly
+# broken file is retried at most once per ``_FAILURE_RETRY_AFTER`` hours
+# instead of every restart, and a recovered environment heals on its own.
+_FAILURE_RETRY_AFTER = "-24 hours"
+
+
 def _working_copy_candidate_predicate(wc_max_size, alias=""):
     """Build the WHERE-clause fragment selecting photos eligible for working-copy
     extraction, plus its bind parameters.
@@ -509,6 +518,13 @@ def _working_copy_candidate_predicate(wc_max_size, alias=""):
     (which the extractor intentionally skips) would still satisfy a naive
     ``working_copy_path IS NULL`` check and trigger a no-op backfill on every
     restart.
+
+    Failure suppression has two escape hatches: a content change (mtime
+    differs from the recorded ``working_copy_failed_mtime``) and a stale
+    timestamp (the failure was recorded more than ``_FAILURE_RETRY_AFTER``
+    ago). The latter prevents transient I/O / environment failures (e.g.
+    external drive temporarily disconnected at startup) from gating retries
+    forever for files whose source bytes haven't moved.
 
     ``alias`` is the table alias (e.g. ``"p"``) when the caller's query joins
     other tables; pass ``""`` when ``photos`` is unaliased.
@@ -529,8 +545,11 @@ def _working_copy_candidate_predicate(wc_max_size, alias=""):
         f" AND ({p}working_copy_failed_at IS NULL"
         f"      OR {p}working_copy_failed_mtime IS NULL"
         f"      OR {p}file_mtime IS NULL"
-        f"      OR {p}working_copy_failed_mtime != {p}file_mtime)"
+        f"      OR {p}working_copy_failed_mtime != {p}file_mtime"
+        f"      OR datetime({p}working_copy_failed_at)"
+        f"         < datetime('now', ?))"
     )
+    params.append(_FAILURE_RETRY_AFTER)
     return where, params
 
 
@@ -677,12 +696,16 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
             )
         else:
             # Mark failure gated on current file_mtime so a future content
-            # change (mtime bump) clears the gate and we retry. Logged at
-            # warning so the user sees that a specific file is the cause.
+            # change (mtime bump) clears the gate and we retry. The
+            # ``working_copy_failed_at`` timestamp also expires the gate
+            # after ``_FAILURE_RETRY_AFTER`` so transient I/O / environment
+            # failures recover even if the file itself is unchanged.
+            # Logged at warning so the user sees that a specific file is
+            # the cause.
             log.warning(
                 "Working copy extraction failed for photo %s (%s); "
-                "marked as failed and will not retry until the file changes",
-                row["id"], source,
+                "marked as failed and will retry on file change or after %s",
+                row["id"], source, _FAILURE_RETRY_AFTER.lstrip("-"),
             )
             db.conn.execute(
                 "UPDATE photos SET working_copy_failed_at=datetime('now'),"
@@ -1225,6 +1248,14 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         # Match-mode mirrors what scan() actually traversed: restrict_dirs and
         # non-recursive scans only touch direct children, so the scope uses an
         # exact-folder match; a recursive walk from `root` matches the subtree.
+        #
+        # Deliberately do NOT forward ``progress_callback`` here: callers
+        # like app.py's import job feed the scan callback into a shared
+        # ``job["progress"]`` slot that gates downstream phase totals
+        # (``scan_count = job["progress"]["total"]``). Emitting working-copy
+        # (current, total) through the same callback would overwrite the
+        # scan total with the working-copy total and visually jump the bar
+        # backward. ``status_callback`` still announces the phase.
         if vireo_dir:
             if restrict_dirs is not None:
                 wc_scope = [(str(d), "exact") for d in restrict_dirs]
@@ -1233,7 +1264,10 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             else:
                 wc_scope = [str(root_path)]
             _extract_working_copies(
-                db, vireo_dir, progress_callback, status_callback, scope=wc_scope,
+                db, vireo_dir,
+                progress_callback=None,
+                status_callback=status_callback,
+                scope=wc_scope,
             )
 
         # Batched untracked-preview sweep. One os.listdir(previews/) for

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -368,8 +368,14 @@ def _invalidate_derived_caches(db, vireo_dir, photo_id, thumb_cache_dir=None):
             os.remove(wc_file)
         except OSError:
             log.debug("Could not delete stale working copy %s", wc_file, exc_info=True)
+    # Also clear any failure markers: a content change is a meaningful
+    # input change so the next backfill / scan extraction pass should retry,
+    # not be permanently locked out by a stale failure record.
     db.conn.execute(
-        "UPDATE photos SET working_copy_path = NULL WHERE id = ?",
+        "UPDATE photos SET working_copy_path = NULL,"
+        " working_copy_failed_at = NULL,"
+        " working_copy_failed_mtime = NULL"
+        " WHERE id = ?",
         (photo_id,),
     )
 
@@ -493,7 +499,9 @@ def _subtree_like_pattern(path, sep=None):
     return _escape(path) + _escape(sep) + "%"
 
 
-def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callback=None, scope=None):
+def _extract_working_copies(db, vireo_dir, progress_callback=None,
+                            status_callback=None, scope=None,
+                            cancel_check=None):
     """Extract working copies for all RAW photos missing one.
 
     For each RAW photo without a working_copy_path, extract a JPEG working
@@ -501,6 +509,11 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
     companion JPEG (RAW+JPEG pair), the companion is used as the extraction
     source because the in-camera JPEG is higher quality than extracting from
     the RAW.
+
+    Rows that previously failed extraction (``working_copy_failed_at`` set)
+    are skipped unless ``file_mtime`` differs from the recorded
+    ``working_copy_failed_mtime`` — a user-replaced file gets a fresh
+    attempt; a permanently-broken file is not retried every pass.
 
     ``scope`` restricts which folders are considered:
       * ``None`` (default) — library-wide backfill (every missing WC).
@@ -511,6 +524,12 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
           - a ``(path, "subtree")`` tuple → explicit form of the string case.
       * empty list/tuple — no-op (used by callers that want an explicit
         "scan matched nothing" signal instead of backfilling everything).
+
+    ``progress_callback(current, total)`` is invoked once per processed row
+    so long-running backfills can stream progress to the UI.
+
+    ``cancel_check()`` is polled before each row; returning truthy aborts the
+    loop cleanly with whatever was already committed.
     """
     import config as cfg
 
@@ -561,10 +580,22 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
                 params.extend([path, _subtree_like_pattern(path)])
         scope_clause = " AND (" + " OR ".join(scope_terms) + ")"
 
+    # Skip rows whose previous extraction failed at the same file_mtime.
+    # NULL marker (never tried, or content changed via _invalidate_derived_caches)
+    # means "eligible". The IS NOT NULL on file_mtime guards the comparison
+    # itself: a row with no recorded mtime should not be permanently locked
+    # out by a stale failure marker.
+    failure_skip = (
+        " AND (p.working_copy_failed_at IS NULL"
+        "      OR p.working_copy_failed_mtime IS NULL"
+        "      OR p.file_mtime IS NULL"
+        "      OR p.working_copy_failed_mtime != p.file_mtime)"
+    )
+
     rows = db.conn.execute(
         f"""
         SELECT p.id, p.filename, p.companion_path, p.working_copy_path,
-               p.extension, p.width, p.height,
+               p.extension, p.width, p.height, p.file_mtime,
                f.path AS folder_path
           FROM photos p
           JOIN folders f ON f.id = p.folder_id
@@ -574,6 +605,7 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
                {jpeg_clause}
            )
            {scope_clause}
+           {failure_skip}
         """,
         params,
     ).fetchall()
@@ -581,10 +613,26 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
     if not rows:
         return
 
+    total = len(rows)
     if status_callback:
-        status_callback(f"Extracting {len(rows)} working copies...")
+        status_callback(f"Extracting {total} working copies...")
 
-    for _i, row in enumerate(rows):
+    # Commit in small batches so a long backfill streams progress out
+    # incrementally instead of holding a single transaction across 10k+ rows.
+    BATCH = 25
+    pending = 0
+
+    def _flush():
+        nonlocal pending
+        if pending:
+            commit_with_retry(db.conn)
+            pending = 0
+
+    for i, row in enumerate(rows, 1):
+        if cancel_check is not None and cancel_check():
+            log.info("Working-copy extraction cancelled after %d/%d rows", i - 1, total)
+            break
+
         wc_rel = f"working/{row['id']}.jpg"
         wc_abs = os.path.join(vireo_dir, wc_rel)
 
@@ -597,11 +645,87 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None, status_callba
 
         if extract_working_copy(source, wc_abs, max_size=wc_max_size, quality=wc_quality):
             db.conn.execute(
-                "UPDATE photos SET working_copy_path=? WHERE id=?",
+                "UPDATE photos SET working_copy_path=?,"
+                " working_copy_failed_at=NULL,"
+                " working_copy_failed_mtime=NULL"
+                " WHERE id=?",
                 (wc_rel, row["id"]),
             )
+        else:
+            # Mark failure gated on current file_mtime so a future content
+            # change (mtime bump) clears the gate and we retry. Logged at
+            # warning so the user sees that a specific file is the cause.
+            log.warning(
+                "Working copy extraction failed for photo %s (%s); "
+                "marked as failed and will not retry until the file changes",
+                row["id"], source,
+            )
+            db.conn.execute(
+                "UPDATE photos SET working_copy_failed_at=datetime('now'),"
+                " working_copy_failed_mtime=?"
+                " WHERE id=?",
+                (row["file_mtime"], row["id"]),
+            )
+        pending += 1
 
-    commit_with_retry(db.conn)
+        if pending >= BATCH:
+            _flush()
+        if progress_callback is not None:
+            progress_callback(i, total)
+
+    _flush()
+
+
+def backfill_working_copies(db, vireo_dir, progress_callback=None,
+                            status_callback=None, cancel_check=None):
+    """Library-wide backfill of missing working copies.
+
+    Convenience wrapper around ``_extract_working_copies`` with no folder
+    scope — used by the startup self-healing job to cover photos that
+    never went through ``scan(..., vireo_dir=...)`` (e.g. legacy rows from
+    before working-copy generation existed) or whose previous extraction
+    failed against an older mtime.
+
+    Returns a dict with ``processed`` (rows whose status changed,
+    success+failure) so callers can summarize the run. Sequential by
+    design: the bottleneck is a slow external disk where parallel reads
+    thrash. If profiling later disagrees, swap in a worker pool here.
+    """
+    before_pending = db.conn.execute(
+        "SELECT COUNT(*) FROM photos"
+        " WHERE working_copy_path IS NULL"
+        "   AND (working_copy_failed_at IS NULL"
+        "        OR working_copy_failed_mtime IS NULL"
+        "        OR file_mtime IS NULL"
+        "        OR working_copy_failed_mtime != file_mtime)"
+    ).fetchone()[0]
+
+    _extract_working_copies(
+        db, vireo_dir,
+        progress_callback=progress_callback,
+        status_callback=status_callback,
+        scope=None,
+        cancel_check=cancel_check,
+    )
+
+    after_pending = db.conn.execute(
+        "SELECT COUNT(*) FROM photos"
+        " WHERE working_copy_path IS NULL"
+        "   AND (working_copy_failed_at IS NULL"
+        "        OR working_copy_failed_mtime IS NULL"
+        "        OR file_mtime IS NULL"
+        "        OR working_copy_failed_mtime != file_mtime)"
+    ).fetchone()[0]
+
+    succeeded = db.conn.execute(
+        "SELECT COUNT(*) FROM photos WHERE working_copy_path IS NOT NULL"
+    ).fetchone()[0]
+
+    return {
+        "candidates": int(before_pending),
+        "remaining": int(after_pending),
+        "with_working_copy": int(succeeded),
+    }
 
 
 def scan(root, db, progress_callback=None, incremental=False, extract_full_metadata=True, photo_callback=None, skip_paths=None, status_callback=None, recursive=True, restrict_dirs=None, restrict_files=None, vireo_dir=None, thumb_cache_dir=None):

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -499,6 +499,57 @@ def _subtree_like_pattern(path, sep=None):
     return _escape(path) + _escape(sep) + "%"
 
 
+def _working_copy_candidate_predicate(wc_max_size, alias=""):
+    """Build the WHERE-clause fragment selecting photos eligible for working-copy
+    extraction, plus its bind parameters.
+
+    Mirrors the candidate criteria inside ``_extract_working_copies`` so the
+    startup self-healing gate and the backfill summary counts don't drift from
+    the extractor's actual SELECT — otherwise a library of only small JPEGs
+    (which the extractor intentionally skips) would still satisfy a naive
+    ``working_copy_path IS NULL`` check and trigger a no-op backfill on every
+    restart.
+
+    ``alias`` is the table alias (e.g. ``"p"``) when the caller's query joins
+    other tables; pass ``""`` when ``photos`` is unaliased.
+    """
+    p = (alias + ".") if alias else ""
+    placeholders = ",".join("?" for _ in RAW_EXTENSIONS)
+    params = list(RAW_EXTENSIONS)
+    jpeg_clause = ""
+    if wc_max_size and wc_max_size > 0:
+        jpeg_clause = (
+            f" OR (LOWER({p}extension) IN ('.jpg', '.jpeg', 'jpg', 'jpeg')"
+            f"     AND ({p}width > ? OR {p}height > ?))"
+        )
+        params.extend([wc_max_size, wc_max_size])
+    where = (
+        f"{p}working_copy_path IS NULL"
+        f" AND ({p}extension IN ({placeholders}){jpeg_clause})"
+        f" AND ({p}working_copy_failed_at IS NULL"
+        f"      OR {p}working_copy_failed_mtime IS NULL"
+        f"      OR {p}file_mtime IS NULL"
+        f"      OR {p}working_copy_failed_mtime != {p}file_mtime)"
+    )
+    return where, params
+
+
+def working_copy_backfill_candidate_count(db):
+    """Count photos that ``_extract_working_copies`` would actually process.
+
+    Used by the startup gate (skip the backfill job entirely when zero) and
+    by ``backfill_working_copies`` for accurate before/after reporting.
+    """
+    import config as cfg
+
+    user_cfg = cfg.load()
+    wc_max_size = user_cfg.get("working_copy_max_size", 4096)
+    where, params = _working_copy_candidate_predicate(wc_max_size)
+    return db.conn.execute(
+        f"SELECT COUNT(*) FROM photos WHERE {where}", params
+    ).fetchone()[0]
+
+
 def _extract_working_copies(db, vireo_dir, progress_callback=None,
                             status_callback=None, scope=None,
                             cancel_check=None):
@@ -540,22 +591,12 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
     wc_max_size = user_cfg.get("working_copy_max_size", 4096)
     wc_quality = user_cfg.get("working_copy_quality", 92)
 
-    # Select photos that need a working copy:
-    #   - All RAW files without one.
-    #   - Large JPEGs (width or height exceeds working_copy_max_size)
-    #     without one — these get a downsized working copy so every
-    #     derivative (thumbnail, preview) reads from the same canonical
-    #     image. Skipped when wc_max_size <= 0 (the "full resolution"
-    #     sentinel), where there is no cap to enforce.
-    placeholders = ",".join("?" for _ in RAW_EXTENSIONS)
-    params = list(RAW_EXTENSIONS)
-    jpeg_clause = ""
-    if wc_max_size and wc_max_size > 0:
-        jpeg_clause = (
-            " OR (LOWER(p.extension) IN ('.jpg', '.jpeg', 'jpg', 'jpeg')"
-            "     AND (p.width > ? OR p.height > ?))"
-        )
-        params.extend([wc_max_size, wc_max_size])
+    # Candidate criteria (NULL working_copy_path + RAW or oversized JPEG +
+    # not blocked by a stale failure marker) is shared with the startup gate
+    # via ``_working_copy_candidate_predicate`` so the two stay in sync.
+    candidate_where, params = _working_copy_candidate_predicate(
+        wc_max_size, alias="p"
+    )
 
     scope_clause = ""
     if scope is not None:
@@ -580,18 +621,6 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
                 params.extend([path, _subtree_like_pattern(path)])
         scope_clause = " AND (" + " OR ".join(scope_terms) + ")"
 
-    # Skip rows whose previous extraction failed at the same file_mtime.
-    # NULL marker (never tried, or content changed via _invalidate_derived_caches)
-    # means "eligible". The IS NOT NULL on file_mtime guards the comparison
-    # itself: a row with no recorded mtime should not be permanently locked
-    # out by a stale failure marker.
-    failure_skip = (
-        " AND (p.working_copy_failed_at IS NULL"
-        "      OR p.working_copy_failed_mtime IS NULL"
-        "      OR p.file_mtime IS NULL"
-        "      OR p.working_copy_failed_mtime != p.file_mtime)"
-    )
-
     rows = db.conn.execute(
         f"""
         SELECT p.id, p.filename, p.companion_path, p.working_copy_path,
@@ -599,13 +628,8 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
                f.path AS folder_path
           FROM photos p
           JOIN folders f ON f.id = p.folder_id
-         WHERE p.working_copy_path IS NULL
-           AND (
-               p.extension IN ({placeholders})
-               {jpeg_clause}
-           )
+         WHERE {candidate_where}
            {scope_clause}
-           {failure_skip}
         """,
         params,
     ).fetchall()
@@ -691,14 +715,7 @@ def backfill_working_copies(db, vireo_dir, progress_callback=None,
     design: the bottleneck is a slow external disk where parallel reads
     thrash. If profiling later disagrees, swap in a worker pool here.
     """
-    before_pending = db.conn.execute(
-        "SELECT COUNT(*) FROM photos"
-        " WHERE working_copy_path IS NULL"
-        "   AND (working_copy_failed_at IS NULL"
-        "        OR working_copy_failed_mtime IS NULL"
-        "        OR file_mtime IS NULL"
-        "        OR working_copy_failed_mtime != file_mtime)"
-    ).fetchone()[0]
+    before_pending = working_copy_backfill_candidate_count(db)
 
     _extract_working_copies(
         db, vireo_dir,
@@ -708,14 +725,7 @@ def backfill_working_copies(db, vireo_dir, progress_callback=None,
         cancel_check=cancel_check,
     )
 
-    after_pending = db.conn.execute(
-        "SELECT COUNT(*) FROM photos"
-        " WHERE working_copy_path IS NULL"
-        "   AND (working_copy_failed_at IS NULL"
-        "        OR working_copy_failed_mtime IS NULL"
-        "        OR file_mtime IS NULL"
-        "        OR working_copy_failed_mtime != file_mtime)"
-    ).fetchone()[0]
+    after_pending = working_copy_backfill_candidate_count(db)
 
     succeeded = db.conn.execute(
         "SELECT COUNT(*) FROM photos WHERE working_copy_path IS NOT NULL"

--- a/vireo/tests/test_scanner_working_copy.py
+++ b/vireo/tests/test_scanner_working_copy.py
@@ -393,6 +393,94 @@ def test_no_working_copy_for_small_jpeg(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Candidate-count helper (drives the startup gate + before/after totals)
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_count_excludes_small_jpegs(tmp_path, monkeypatch):
+    """A row that the extractor would skip must not show up as a candidate.
+
+    Small JPEGs (under ``working_copy_max_size``) are intentionally left
+    without working copies, so a library of only small JPEGs has zero
+    backfill work to do.
+    """
+    import config as cfg
+    from db import Database
+    from scanner import working_copy_backfill_candidate_count
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    src = folder / "small.jpg"
+    _make_jpeg(str(src), 800, 600)
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(folder))
+    db.add_photo(
+        folder_id, "small.jpg", ".jpg",
+        file_size=os.path.getsize(str(src)),
+        file_mtime=os.path.getmtime(str(src)),
+        width=800, height=600,
+    )
+
+    assert working_copy_backfill_candidate_count(db) == 0
+
+
+def test_candidate_count_includes_large_jpeg(tmp_path, monkeypatch):
+    """An oversized JPEG is a real backfill candidate."""
+    import config as cfg
+    from db import Database
+    from scanner import working_copy_backfill_candidate_count
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    src = folder / "big.jpg"
+    _make_jpeg(str(src), 2000, 1500)
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(folder))
+    db.add_photo(
+        folder_id, "big.jpg", ".jpg",
+        file_size=os.path.getsize(str(src)),
+        file_mtime=os.path.getmtime(str(src)),
+        width=2000, height=1500,
+    )
+
+    assert working_copy_backfill_candidate_count(db) == 1
+
+
+def test_candidate_count_includes_raw(tmp_path, monkeypatch):
+    """RAW photos are always candidates regardless of recorded dimensions."""
+    import config as cfg
+    from db import Database
+    from scanner import working_copy_backfill_candidate_count
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    raw = folder / "shot.nef"
+    raw.write_bytes(b"\x00" * 16)  # contents irrelevant for the SELECT
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(folder))
+    db.add_photo(
+        folder_id, "shot.nef", ".nef",
+        file_size=os.path.getsize(str(raw)),
+        file_mtime=os.path.getmtime(str(raw)),
+        width=None, height=None,
+    )
+
+    assert working_copy_backfill_candidate_count(db) == 1
+
+
+# ---------------------------------------------------------------------------
 # Library-wide backfill (used by the startup self-healing job)
 # ---------------------------------------------------------------------------
 
@@ -748,6 +836,59 @@ def test_startup_backfill_skips_when_no_candidates(tmp_path, monkeypatch):
         if j["type"] == "working_copy_backfill"
     ]
     assert backfill_jobs == []
+
+
+def test_startup_backfill_skips_for_small_jpeg_only_library(tmp_path, monkeypatch):
+    """Small JPEGs (under working_copy_max_size) are intentionally not extracted.
+
+    The startup gate must skip them rather than launching a no-op backfill on
+    every restart. Regression test for a library that contains only small
+    JPEGs — naive ``working_copy_path IS NULL`` check would fire forever.
+    """
+    import os
+
+    import config as cfg
+    import models
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    from app import create_app
+    from db import Database
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir()
+    db_path = str(vireo_dir / "test.db")
+
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    src = photos_dir / "small.jpg"
+    _make_jpeg(str(src), 800, 600)  # below the 1000 cap
+
+    db = Database(db_path)
+    folder_id = db.add_folder(str(photos_dir))
+    db.add_photo(
+        folder_id, "small.jpg", ".jpg",
+        file_size=os.path.getsize(str(src)),
+        file_mtime=os.path.getmtime(str(src)),
+        width=800, height=600,
+    )
+    db.conn.close()
+
+    app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir), api_token="t")
+    app._kickoff_working_copy_backfill()
+
+    backfill_jobs = [
+        j for j in app._job_runner.list_jobs()
+        if j["type"] == "working_copy_backfill"
+    ]
+    assert backfill_jobs == [], (
+        "small-JPEG-only library should not trigger working_copy_backfill"
+    )
 
 
 def test_startup_backfill_runs_when_candidates_exist(tmp_path, monkeypatch):

--- a/vireo/tests/test_scanner_working_copy.py
+++ b/vireo/tests/test_scanner_working_copy.py
@@ -389,3 +389,493 @@ def test_no_working_copy_for_small_jpeg(tmp_path, monkeypatch):
         "SELECT working_copy_path FROM photos WHERE id=?", (photo_id,)
     ).fetchone()
     assert row["working_copy_path"] is None
+
+
+
+# ---------------------------------------------------------------------------
+# Library-wide backfill (used by the startup self-healing job)
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_processes_legacy_null_working_copy_path(tmp_path, monkeypatch):
+    """``backfill_working_copies`` covers photos imported before the feature.
+
+    Simulates a row that exists with ``working_copy_path=NULL`` from a prior
+    scan that never had ``vireo_dir`` passed in. The new startup pass must
+    pick it up library-wide (no ``scope`` argument).
+    """
+    import config as cfg
+    from db import Database
+    from scanner import backfill_working_copies
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    folder_a = tmp_path / "a"
+    folder_a.mkdir()
+    folder_b = tmp_path / "b"
+    folder_b.mkdir()
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+    a_id = _seed_large_jpeg(db, folder_a, "a.jpg")
+    b_id = _seed_large_jpeg(db, folder_b, "b.jpg")
+
+    result = backfill_working_copies(db, str(vireo_dir))
+
+    # Both photos should now have a working copy on disk and in the DB.
+    assert (vireo_dir / "working" / f"{a_id}.jpg").exists()
+    assert (vireo_dir / "working" / f"{b_id}.jpg").exists()
+
+    rows = {
+        r["id"]: r["working_copy_path"]
+        for r in db.conn.execute(
+            "SELECT id, working_copy_path FROM photos WHERE id IN (?, ?)",
+            (a_id, b_id),
+        ).fetchall()
+    }
+    assert rows[a_id] == f"working/{a_id}.jpg"
+    assert rows[b_id] == f"working/{b_id}.jpg"
+
+    assert result["candidates"] == 2
+    assert result["remaining"] == 0
+    assert result["with_working_copy"] == 2
+
+
+def test_backfill_skips_already_extracted(tmp_path, monkeypatch):
+    """A photo that already has working_copy_path is not re-processed."""
+    import config as cfg
+    from db import Database
+    from scanner import backfill_working_copies
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    folder = tmp_path / "a"
+    folder.mkdir()
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+    pid = _seed_large_jpeg(db, folder, "a.jpg")
+
+    # First pass creates the working copy.
+    backfill_working_copies(db, str(vireo_dir))
+    wc_path = vireo_dir / "working" / f"{pid}.jpg"
+    first_mtime = wc_path.stat().st_mtime
+
+    # Second pass: the row is no longer a candidate.
+    result = backfill_working_copies(db, str(vireo_dir))
+    assert result["candidates"] == 0
+    # File is untouched (no rewrite).
+    assert wc_path.stat().st_mtime == first_mtime
+
+
+def test_backfill_failure_marker_prevents_retry_loop(tmp_path, monkeypatch):
+    """A row whose extraction fails is marked and skipped on the next pass.
+
+    Without this guard, every startup would re-attempt every broken file —
+    an O(N) waste on each restart.
+    """
+    import config as cfg
+    from db import Database
+    from scanner import backfill_working_copies
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    folder = tmp_path / "a"
+    folder.mkdir()
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+
+    # Register a row whose source file does NOT exist on disk —
+    # extract_working_copy will fail.
+    folder_id = db.add_folder(str(folder))
+    pid = db.add_photo(
+        folder_id, "missing.jpg", ".jpg",
+        file_size=1000, file_mtime=42.0,
+        width=2000, height=1500,
+    )
+
+    calls = {"n": 0}
+    real = None
+
+    import scanner as _scanner_mod
+
+    def counting_extract(*args, **kwargs):
+        calls["n"] += 1
+        return False  # always fail
+
+    monkeypatch.setattr(_scanner_mod, "extract_working_copy", counting_extract)
+
+    backfill_working_copies(db, str(vireo_dir))
+    assert calls["n"] == 1, "first pass should call extract once"
+
+    row = db.conn.execute(
+        "SELECT working_copy_path, working_copy_failed_at,"
+        " working_copy_failed_mtime FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert row["working_copy_path"] is None
+    assert row["working_copy_failed_at"] is not None
+    assert row["working_copy_failed_mtime"] == 42.0
+
+    # Second pass: candidate query must skip this row.
+    backfill_working_copies(db, str(vireo_dir))
+    assert calls["n"] == 1, "second pass must NOT retry a marked failure"
+
+
+def test_backfill_failure_retries_when_mtime_changes(tmp_path, monkeypatch):
+    """A user-replaced file (different mtime) clears the failure gate."""
+    import config as cfg
+    from db import Database
+    from scanner import backfill_working_copies
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    folder = tmp_path / "a"
+    folder.mkdir()
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+    folder_id = db.add_folder(str(folder))
+    pid = db.add_photo(
+        folder_id, "missing.jpg", ".jpg",
+        file_size=1000, file_mtime=42.0,
+        width=2000, height=1500,
+    )
+
+    calls = {"n": 0}
+
+    import scanner as _scanner_mod
+
+    def counting_extract(*args, **kwargs):
+        calls["n"] += 1
+        return False
+
+    monkeypatch.setattr(_scanner_mod, "extract_working_copy", counting_extract)
+
+    backfill_working_copies(db, str(vireo_dir))
+    assert calls["n"] == 1
+
+    # Simulate the user replacing the file: mtime changes.
+    db.conn.execute(
+        "UPDATE photos SET file_mtime=? WHERE id=?", (99.0, pid),
+    )
+    db.conn.commit()
+
+    backfill_working_copies(db, str(vireo_dir))
+    assert calls["n"] == 2, "mtime change must clear the failure gate"
+
+
+def test_backfill_success_clears_prior_failure_marker(tmp_path, monkeypatch):
+    """After a successful extraction, failure columns are reset."""
+    import config as cfg
+    from db import Database
+    from scanner import backfill_working_copies
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    folder = tmp_path / "a"
+    folder.mkdir()
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+
+    pid = _seed_large_jpeg(db, folder, "a.jpg")
+    # Pretend a previous backfill failed against an older mtime.
+    db.conn.execute(
+        "UPDATE photos SET working_copy_failed_at=datetime('now'),"
+        " working_copy_failed_mtime=?"
+        " WHERE id=?",
+        (1.0, pid),
+    )
+    db.conn.commit()
+
+    backfill_working_copies(db, str(vireo_dir))
+
+    row = db.conn.execute(
+        "SELECT working_copy_path, working_copy_failed_at,"
+        " working_copy_failed_mtime FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert row["working_copy_path"] == f"working/{pid}.jpg"
+    assert row["working_copy_failed_at"] is None
+    assert row["working_copy_failed_mtime"] is None
+
+
+def test_backfill_progress_callback_streams_per_row(tmp_path, monkeypatch):
+    """``progress_callback`` is invoked once per row with (current, total)."""
+    import config as cfg
+    from db import Database
+    from scanner import backfill_working_copies
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    folder = tmp_path / "a"
+    folder.mkdir()
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+
+    ids = [_seed_large_jpeg(db, folder, f"p{i}.jpg") for i in range(3)]
+
+    events = []
+    backfill_working_copies(
+        db, str(vireo_dir),
+        progress_callback=lambda c, t: events.append((c, t)),
+    )
+
+    assert events == [(1, 3), (2, 3), (3, 3)]
+    for pid in ids:
+        assert (vireo_dir / "working" / f"{pid}.jpg").exists()
+
+
+def test_backfill_cancel_check_aborts_loop(tmp_path, monkeypatch):
+    """``cancel_check`` returning True stops the loop after the current row."""
+    import config as cfg
+    from db import Database
+    from scanner import backfill_working_copies
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    folder = tmp_path / "a"
+    folder.mkdir()
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+
+    ids = [_seed_large_jpeg(db, folder, f"p{i}.jpg") for i in range(5)]
+
+    # Cancel on second iteration. cancel_check fires *before* the row, so
+    # row 0 runs, cancel is requested, row 1 sees cancel and aborts.
+    state = {"n": 0}
+
+    def cancel_check():
+        state["n"] += 1
+        return state["n"] >= 2
+
+    backfill_working_copies(db, str(vireo_dir), cancel_check=cancel_check)
+
+    completed = sum(
+        1 for pid in ids
+        if (vireo_dir / "working" / f"{pid}.jpg").exists()
+    )
+    assert completed == 1, f"expected 1 completion before cancel, got {completed}"
+
+
+# ---------------------------------------------------------------------------
+# scan() inline extraction — the new-imports path
+# ---------------------------------------------------------------------------
+
+
+def test_scan_records_failure_marker_for_unreadable_file(tmp_path, monkeypatch):
+    """When inline extraction fails during scan(), the row carries a marker.
+
+    Confirms the inline path (not just backfill) records failures, so the
+    next backfill pass will respect the marker rather than retrying.
+    """
+    import config as cfg
+    from db import Database
+    from scanner import scan
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+
+    root = tmp_path / "scan"
+    root.mkdir()
+    src = root / "big.jpg"
+    _make_jpeg(str(src), 2000, 1500)
+
+    # Force extraction to fail on the post-scan pass.
+    import scanner as _scanner_mod
+    monkeypatch.setattr(_scanner_mod, "extract_working_copy", lambda *a, **k: False)
+
+    scan(str(root), db, vireo_dir=str(vireo_dir))
+
+    row = db.conn.execute(
+        "SELECT working_copy_path, working_copy_failed_at,"
+        " working_copy_failed_mtime, file_mtime FROM photos"
+        " WHERE filename='big.jpg'"
+    ).fetchone()
+    assert row["working_copy_path"] is None
+    assert row["working_copy_failed_at"] is not None
+    assert row["working_copy_failed_mtime"] == row["file_mtime"]
+
+
+
+# ---------------------------------------------------------------------------
+# Startup self-healing kickoff (app.create_app -> ephemeral JobRunner job)
+# ---------------------------------------------------------------------------
+
+
+def test_startup_backfill_skips_when_no_candidates(tmp_path, monkeypatch):
+    """If no photo needs work, no working_copy_backfill job is started."""
+    import os
+
+    import config as cfg
+    import models
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    from app import create_app
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+    Database(db_path)  # create empty DB with workspace
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="t")
+
+    # Drive the kickoff synchronously instead of waiting for the 5s Timer.
+    app._kickoff_working_copy_backfill()
+
+    backfill_jobs = [
+        j for j in app._job_runner.list_jobs()
+        if j["type"] == "working_copy_backfill"
+    ]
+    assert backfill_jobs == []
+
+
+def test_startup_backfill_runs_when_candidates_exist(tmp_path, monkeypatch):
+    """A photo with NULL working_copy_path triggers an ephemeral backfill job
+    that produces the working copy and completes successfully.
+    """
+    import os
+    import time
+
+    import config as cfg
+    import models
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    from app import create_app
+    from db import Database
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir()
+    db_path = str(vireo_dir / "test.db")
+
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    src = photos_dir / "big.jpg"
+    _make_jpeg(str(src), 2000, 1500)
+
+    db = Database(db_path)
+    folder_id = db.add_folder(str(photos_dir))
+    pid = db.add_photo(
+        folder_id, "big.jpg", ".jpg",
+        file_size=os.path.getsize(str(src)),
+        file_mtime=os.path.getmtime(str(src)),
+        width=2000, height=1500,
+    )
+    db.conn.close()
+
+    app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir), api_token="t")
+    app._kickoff_working_copy_backfill()
+
+    runner = app._job_runner
+    deadline = time.time() + 5
+    job = None
+    while time.time() < deadline:
+        backfill_jobs = [
+            j for j in runner.list_jobs()
+            if j["type"] == "working_copy_backfill"
+        ]
+        if backfill_jobs and backfill_jobs[0]["status"] in ("completed", "failed"):
+            job = backfill_jobs[0]
+            break
+        time.sleep(0.05)
+
+    assert job is not None, "backfill job should have been started"
+    assert job["status"] == "completed", f"job: {job}"
+    assert job.get("ephemeral") is True
+
+    # The working copy actually exists.
+    assert (vireo_dir / "working" / f"{pid}.jpg").exists()
+
+    # The DB row was updated with the working copy path.
+    db2 = Database(db_path)
+    row = db2.conn.execute(
+        "SELECT working_copy_path FROM photos WHERE id=?", (pid,)
+    ).fetchone()
+    assert row["working_copy_path"] == f"working/{pid}.jpg"
+
+
+def test_startup_backfill_does_not_persist_to_history(tmp_path, monkeypatch):
+    """Ephemeral backfill job must NOT land in job_history.
+
+    Otherwise every restart adds a noise row.
+    """
+    import os
+    import time
+
+    import config as cfg
+    import models
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    from app import create_app
+    from db import Database
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir()
+    db_path = str(vireo_dir / "test.db")
+
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    src = photos_dir / "big.jpg"
+    _make_jpeg(str(src), 2000, 1500)
+
+    db = Database(db_path)
+    folder_id = db.add_folder(str(photos_dir))
+    db.add_photo(
+        folder_id, "big.jpg", ".jpg",
+        file_size=os.path.getsize(str(src)),
+        file_mtime=os.path.getmtime(str(src)),
+        width=2000, height=1500,
+    )
+    db.conn.close()
+
+    app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir), api_token="t")
+    app._kickoff_working_copy_backfill()
+
+    runner = app._job_runner
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        backfill_jobs = [
+            j for j in runner.list_jobs()
+            if j["type"] == "working_copy_backfill"
+        ]
+        if backfill_jobs and backfill_jobs[0]["status"] in ("completed", "failed"):
+            break
+        time.sleep(0.05)
+
+    db2 = Database(db_path)
+    rows = db2.conn.execute(
+        "SELECT id FROM job_history WHERE type='working_copy_backfill'"
+    ).fetchall()
+    assert rows == [], "ephemeral job must not persist to history"

--- a/vireo/tests/test_scanner_working_copy.py
+++ b/vireo/tests/test_scanner_working_copy.py
@@ -659,6 +659,111 @@ def test_backfill_failure_retries_when_mtime_changes(tmp_path, monkeypatch):
     assert calls["n"] == 2, "mtime change must clear the failure gate"
 
 
+def test_backfill_failure_retries_after_grace_period_elapses(tmp_path, monkeypatch):
+    """A stale failure marker is bypassed even when the file mtime is unchanged.
+
+    Regression: gating retries solely on ``working_copy_failed_mtime ==
+    file_mtime`` permanently suppressed retries for transient failures
+    (external drive temporarily disconnected at startup, brief I/O
+    blip, etc.). Files whose source bytes never change would never get a
+    second chance once that first failure was recorded — undermining the
+    self-healing intent. The predicate now also bypasses the gate when the
+    failure timestamp is older than the configured grace period.
+    """
+    import config as cfg
+    from db import Database
+    from scanner import backfill_working_copies
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    folder = tmp_path / "a"
+    folder.mkdir()
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+
+    pid = _seed_large_jpeg(db, folder, "a.jpg")
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+
+    # Pretend the previous failure was recorded 48 hours ago against the
+    # SAME file_mtime. Mtime equality alone would suppress the retry
+    # forever; the time-based escape should override it.
+    db.conn.execute(
+        "UPDATE photos SET working_copy_failed_at = datetime('now', '-48 hours'),"
+        " working_copy_failed_mtime = ?"
+        " WHERE id = ?",
+        (file_mtime, pid),
+    )
+    db.conn.commit()
+
+    backfill_working_copies(db, str(vireo_dir))
+
+    row = db.conn.execute(
+        "SELECT working_copy_path, working_copy_failed_at,"
+        " working_copy_failed_mtime FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert row["working_copy_path"] == f"working/{pid}.jpg"
+    assert row["working_copy_failed_at"] is None
+    assert row["working_copy_failed_mtime"] is None
+    assert (vireo_dir / "working" / f"{pid}.jpg").exists()
+
+
+def test_backfill_failure_does_not_retry_within_grace_period(tmp_path, monkeypatch):
+    """A recent failure with unchanged mtime is still suppressed.
+
+    Counterpart to ``test_backfill_failure_retries_after_grace_period_elapses``:
+    the time-based escape must only trigger once enough time has passed —
+    otherwise we'd be back to the original retry-loop problem on every
+    restart.
+    """
+    import config as cfg
+    from db import Database
+    from scanner import backfill_working_copies
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    folder = tmp_path / "a"
+    folder.mkdir()
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+    folder_id = db.add_folder(str(folder))
+    pid = db.add_photo(
+        folder_id, "missing.jpg", ".jpg",
+        file_size=1000, file_mtime=42.0,
+        width=2000, height=1500,
+    )
+    # Record a very recent failure (~1 minute ago) against the same mtime.
+    db.conn.execute(
+        "UPDATE photos SET working_copy_failed_at = datetime('now', '-1 minute'),"
+        " working_copy_failed_mtime = ?"
+        " WHERE id = ?",
+        (42.0, pid),
+    )
+    db.conn.commit()
+
+    calls = {"n": 0}
+
+    import scanner as _scanner_mod
+
+    def counting_extract(*args, **kwargs):
+        calls["n"] += 1
+        return False
+
+    monkeypatch.setattr(_scanner_mod, "extract_working_copy", counting_extract)
+
+    backfill_working_copies(db, str(vireo_dir))
+
+    assert calls["n"] == 0, (
+        "fresh failure marker (within grace period) must suppress retry"
+    )
+
+
 def test_backfill_success_clears_prior_failure_marker(tmp_path, monkeypatch):
     """After a successful extraction, failure columns are reset."""
     import config as cfg
@@ -800,6 +905,64 @@ def test_scan_records_failure_marker_for_unreadable_file(tmp_path, monkeypatch):
     assert row["working_copy_failed_at"] is not None
     assert row["working_copy_failed_mtime"] == row["file_mtime"]
 
+
+def test_scan_progress_callback_not_clobbered_by_working_copy_phase(tmp_path, monkeypatch):
+    """The post-scan WC phase must not overwrite scan totals via progress_callback.
+
+    Regression: ``_extract_working_copies`` was called with the same
+    ``progress_callback`` the scan loop used to report per-file totals. In
+    callers like the import job (vireo/app.py) the callback writes
+    ``current``/``total`` into a shared ``job["progress"]`` dict that
+    downstream phases read for the scan count. Passing the callback in
+    again caused the WC phase to overwrite that total with the
+    working-copy total — visually jumping the bar backward and feeding
+    the wrong scan_count to later phases.
+    """
+    import config as cfg
+    from db import Database
+    from scanner import scan
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 1000, "working_copy_quality": 90})
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+
+    root = tmp_path / "scan"
+    root.mkdir()
+    # Two scanned files; only one is large enough to need a working copy.
+    # Without the fix, the WC phase emits (1, 1) and would clobber the
+    # scan's final (2, 2).
+    _make_jpeg(str(root / "small.jpg"), 600, 400)
+    _make_jpeg(str(root / "big.jpg"), 2000, 1500)
+
+    events = []
+
+    def progress_cb(current, total):
+        events.append((current, total))
+
+    scan(str(root), db, progress_callback=progress_cb, vireo_dir=str(vireo_dir))
+
+    assert events, "scan should report progress for the scan loop"
+    # The last reported total must be the SCAN total (2 files), not the
+    # working-copy total (1 file). Any (_, 1) appearing after a (_, 2)
+    # would mean the WC phase overwrote the scan totals.
+    seen_scan_total = False
+    for _current, total in events:
+        if total == 2:
+            seen_scan_total = True
+        elif seen_scan_total and total == 1:
+            raise AssertionError(
+                f"Working-copy phase clobbered scan totals: {events}"
+            )
+    assert seen_scan_total, f"never observed scan total of 2: {events}"
+
+    # Sanity check: the working copy itself was still produced.
+    big_row = db.conn.execute(
+        "SELECT id, working_copy_path FROM photos WHERE filename='big.jpg'"
+    ).fetchone()
+    assert big_row["working_copy_path"] == f"working/{big_row['id']}.jpg"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Goal

Eliminate the on-demand RAW decode that stalls burst-zoom in the review/culling
workflow. Today, opening a burst and zooming triggers `/photos/{id}/original`
for each card; for RAW (NEF/CR2/etc.) photos without a working copy on disk,
each request triggers a fresh 5-7s extraction. Multiple concurrent extractions
thrash CPU + slow external disk and stall some images in the browser.

The architectural fix is: **always have a JPEG working copy at
`~/.vireo/working/{photo_id}.jpg` before the user views the photo.** Then
`/photos/{id}/original` serves a static file — no on-demand decode.

## What changed

`scanner.scan(..., vireo_dir=...)` already extracts working copies inline at
the end of every scan. That covers freshly-imported photos. This PR closes
two gaps:

1. **Library-wide backfill** for already-imported photos with
   `working_copy_path IS NULL` (legacy rows from before WC generation
   existed, or rows whose previous extraction failed and has since been
   fixed). New `scanner.backfill_working_copies(db, vireo_dir, ...)` walks
   the full library and produces working copies sequentially.
2. **Self-healing kickoff at app startup.** `create_app` runs a fast
   `EXISTS` check; if any rows still need work, it kicks off an **ephemeral
   `JobRunner` job** named `working_copy_backfill`. The job streams progress
   to the bottom panel via SSE, but is never written to `job_history` (it
   runs every restart — persisting would be noise). When nothing needs
   work, no thread spawns.

Failures don't loop:

- New nullable columns `working_copy_failed_at TEXT` and
  `working_copy_failed_mtime REAL` on `photos`. Migrated lazily via
  `ALTER TABLE` on startup.
- When `extract_working_copy` returns False, the row is marked. Subsequent
  passes skip it **until `file_mtime` differs** — a user-replaced file
  retries automatically; a permanently-broken file is not re-attempted
  every startup.
- `_invalidate_derived_caches` (called when a content change is detected
  during scan) clears the failure markers along with `working_copy_path`,
  so a content change is a meaningful retry signal.

## Design choices

- **Where pre-generation hooks in:** Inline in `scan()` (already done) for
  new imports, plus a new ephemeral `JobRunner` job at startup for backfill.
  Mirrors the recent `new_images_walk` ephemeral pattern (commit e280377).
- **Concurrency:** Sequential. The bottleneck is a slow external/USB disk
  where parallel reads thrash. Easy to swap in a worker pool later if
  profiling later disagrees.
- **Failure tracking:** Two columns on `photos` rather than a sidecar
  marker file — single source of truth, joins cleanly into the same
  candidate SELECT, no extra cleanup sweep step.
- **Why startup not on-demand:** Self-healing is the project's stated
  preference (auto-memory: `App self-heals broken state`). Doing it lazily
  at view time is exactly the lag we're trying to remove.

## What this PR does NOT touch (per task constraints)

- `serve_original_photo` in `vireo/app.py`. Pre-generation must produce
  something useful even if that route still has its dimension-check bug.
  That's a separate PR's domain.
- Working-copy file naming / storage layout (`~/.vireo/working/{photo_id}.jpg`
  unchanged).
- `image_loader.extract_working_copy()` — reused, not rewritten.

## Tests

`vireo/tests/test_scanner_working_copy.py` — 13 existing + 11 new cases:

- **Backfill correctness**
  - `test_backfill_processes_legacy_null_working_copy_path`
  - `test_backfill_skips_already_extracted`
- **Failure handling**
  - `test_backfill_failure_marker_prevents_retry_loop`
  - `test_backfill_failure_retries_when_mtime_changes`
  - `test_backfill_success_clears_prior_failure_marker`
  - `test_scan_records_failure_marker_for_unreadable_file`
- **Streaming + cancellation**
  - `test_backfill_progress_callback_streams_per_row`
  - `test_backfill_cancel_check_aborts_loop`
- **Startup hook**
  - `test_startup_backfill_skips_when_no_candidates`
  - `test_startup_backfill_runs_when_candidates_exist`
  - `test_startup_backfill_does_not_persist_to_history`

### Test results

- `vireo/tests/test_scanner_working_copy.py`: **24 passed**
- Scanner-adjacent suite (`test_multi_root_scan.py`, `test_scanner.py`,
  `test_scanner_callback.py`, `test_scanner_working_copy.py`,
  `test_folder_rescan_api.py`, `test_image_loader.py`): **133 passed**
- Jobs / new-images suite (`test_jobs.py`, `test_new_images.py`,
  `test_new_images_api.py`): **72 passed**
- Full CLAUDE.md project suite (`tests/test_workspaces.py`,
  `vireo/tests/test_db.py`, `test_app.py`, `test_photos_api.py`,
  `test_edits_api.py`, `test_jobs_api.py`, `test_darktable_api.py`,
  `test_config.py`): **662 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)