### PR TITLE
fix(cull,scan): cull holds writer lock too long, breaking concurrent scans

### DIFF
--- a/vireo/culling.py
+++ b/vireo/culling.py
@@ -149,6 +149,12 @@ def analyze_for_culling(
             ).fetchone()
             if not row:
                 continue
+            # Scope the broad except narrowly to the image-loading + hash step:
+            # those have a legitimate "skip this photo" failure mode
+            # (corrupt RAW, missing working copy, decode error). DB errors on
+            # the UPDATE/commit below must propagate — masking them would
+            # silently drop pHash writes AND leave the writer transaction
+            # open, defeating the per-photo commit's lock-release purpose.
             try:
                 img = None
                 if vireo_dir:
@@ -163,20 +169,21 @@ def analyze_for_culling(
                 if img is None:
                     continue
                 h = imagehash.phash(img)
-                phashes[pid] = h
-                db.conn.execute(
-                    "UPDATE photos SET phash = ? WHERE id = ?",
-                    (str(h), pid),
-                )
-                # Commit per photo so the writer lock is released between
-                # iterations. Otherwise this loop holds the lock for the entire
-                # backfill (potentially many minutes on a fresh import where
-                # thousands of photos still need pHashes), starving any
-                # concurrent writer (e.g. a pipeline scan whose next
-                # ``add_photo`` INSERT will time out past the 30s busy_timeout).
-                db.conn.commit()
             except Exception:
                 log.debug("Could not compute pHash for photo %d", pid, exc_info=True)
+                continue
+            phashes[pid] = h
+            db.conn.execute(
+                "UPDATE photos SET phash = ? WHERE id = ?",
+                (str(h), pid),
+            )
+            # Commit per photo so the writer lock is released between
+            # iterations. Otherwise this loop holds the lock for the entire
+            # backfill (potentially many minutes on a fresh import where
+            # thousands of photos still need pHashes), starving any
+            # concurrent writer (e.g. a pipeline scan whose next
+            # ``add_photo`` INSERT will time out past the 30s busy_timeout).
+            db.conn.commit()
 
     # Classify extensions as RAW or non-RAW
     from image_loader import RAW_EXTENSIONS

--- a/vireo/culling.py
+++ b/vireo/culling.py
@@ -168,9 +168,15 @@ def analyze_for_culling(
                     "UPDATE photos SET phash = ? WHERE id = ?",
                     (str(h), pid),
                 )
+                # Commit per photo so the writer lock is released between
+                # iterations. Otherwise this loop holds the lock for the entire
+                # backfill (potentially many minutes on a fresh import where
+                # thousands of photos still need pHashes), starving any
+                # concurrent writer (e.g. a pipeline scan whose next
+                # ``add_photo`` INSERT will time out past the 30s busy_timeout).
+                db.conn.commit()
             except Exception:
                 log.debug("Could not compute pHash for photo %d", pid, exc_info=True)
-        db.conn.commit()
 
     # Classify extensions as RAW or non-RAW
     from image_loader import RAW_EXTENSIONS

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -40,6 +40,28 @@ def commit_with_retry(conn, max_retries=5, base_delay=0.1):
             time.sleep(base_delay * (2 ** attempt))
 
 
+def execute_with_retry(conn, sql, params=(), max_retries=5, base_delay=0.1):
+    """Run ``conn.execute(sql, params)`` with retry on transient
+    "locked"/"busy" errors. Returns the cursor.
+
+    The 30s ``busy_timeout`` PRAGMA covers both INSERT/UPDATE statements
+    and commits, but a single 30s wait isn't enough when another writer
+    holds the lock for longer (observed: a cull job's pHash backfill held
+    the writer lock for the entire backfill loop and an active scan's next
+    ``add_photo`` INSERT timed out, killing the scan stage). This helper
+    extends ``busy_timeout`` with bounded retry/backoff so brief contention
+    bursts don't abort callers mid-write.
+    """
+    for attempt in range(max_retries + 1):
+        try:
+            return conn.execute(sql, params)
+        except sqlite3.OperationalError as e:
+            msg = str(e).lower()
+            if ("locked" not in msg and "busy" not in msg) or attempt == max_retries:
+                raise
+            time.sleep(base_delay * (2 ** attempt))
+
+
 def _inclusive_date_to(date_to):
     """Pad a date_to bound so it includes sub-second timestamps.
 
@@ -1447,7 +1469,8 @@ class Database:
         The hook is wrapped in try/except so resolver bugs never break
         inserts.
         """
-        cur = self.conn.execute(
+        cur = execute_with_retry(
+            self.conn,
             """INSERT OR IGNORE INTO photos
                (folder_id, filename, extension, file_size, file_mtime, xmp_mtime,
                 timestamp, width, height, file_hash)

--- a/vireo/tests/test_culling.py
+++ b/vireo/tests/test_culling.py
@@ -719,3 +719,76 @@ def test_analyze_for_culling_falls_back_to_source_when_working_copy_corrupt(tmp_
     assert result["photos_missing_phash"] == 0
     row = db.conn.execute("SELECT phash FROM photos WHERE id = ?", (pid,)).fetchone()
     assert row["phash"], "phash should fall back to the valid source JPEG"
+
+
+def test_phash_backfill_commits_per_photo(tmp_path):
+    """The pHash backfill must commit per-photo so its writer lock doesn't
+    starve concurrent jobs (e.g. an in-progress scan).
+
+    Observed in production: a cull run held the writer lock for the entire
+    backfill loop (one commit at the end) and an active pipeline scan timed
+    out on its next ``add_photo`` INSERT past the 30s ``busy_timeout``.
+    """
+    from culling import analyze_for_culling
+    from db import Database
+    from PIL import Image
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    fid = db.add_folder(folder_path, name="photos")
+
+    pids = []
+    for i in range(3):
+        fname = f"bird{i}.jpg"
+        Image.new("RGB", (50, 50), color=(50 + i * 30, 120, 80)).save(
+            os.path.join(folder_path, fname)
+        )
+        pid = db.add_photo(
+            fid, fname, ".jpg", 1000, 1.0,
+            timestamp=f"2024-01-01T10:00:0{i}",
+        )
+        det_ids = db.save_detections(pid, [
+            {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4},
+             "confidence": 0.9, "category": "animal"},
+        ], detector_model="MDV6")
+        db.add_prediction(det_ids[0], "Robin", 0.95, "test-model")
+        pids.append(pid)
+    db.conn.commit()
+
+    # Wrap the connection so we can count commits. A single commit at the
+    # end of the backfill loop means the writer lock was held the whole time;
+    # per-photo commits release it between iterations so other writers can
+    # interleave.
+    real_conn = db.conn
+    commit_count = {"n": 0}
+
+    class _CountingConn:
+        def __init__(self, real):
+            self._real = real
+        def commit(self):
+            commit_count["n"] += 1
+            return self._real.commit()
+        def __enter__(self):
+            return self._real.__enter__()
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return self._real.__exit__(exc_type, exc_val, exc_tb)
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    db.conn = _CountingConn(real_conn)
+    pre_count = commit_count["n"]
+    try:
+        analyze_for_culling(db, vireo_dir=str(tmp_path))
+    finally:
+        db.conn = real_conn
+
+    backfill_commits = commit_count["n"] - pre_count
+    assert backfill_commits >= len(pids), (
+        f"phash backfill must commit per-photo to release the writer lock "
+        f"between iterations; got {backfill_commits} commits for "
+        f"{len(pids)} photos"
+    )

--- a/vireo/tests/test_culling.py
+++ b/vireo/tests/test_culling.py
@@ -14,6 +14,7 @@ import sys
 from datetime import datetime
 
 import numpy as np
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -792,3 +793,63 @@ def test_phash_backfill_commits_per_photo(tmp_path):
         f"between iterations; got {backfill_commits} commits for "
         f"{len(pids)} photos"
     )
+
+
+def test_phash_backfill_does_not_swallow_commit_errors(tmp_path):
+    """Commit failures during the pHash backfill must propagate, not be
+    silently swallowed.
+
+    Codex review on PR #690: with the commit inside ``try/except Exception``,
+    a transient SQLite lock or I/O failure on commit gets logged as
+    "could not compute pHash" and the loop continues against an open
+    transaction — defeating the very lock-release fix this PR introduced.
+    """
+    import sqlite3
+
+    from culling import analyze_for_culling
+    from db import Database
+    from PIL import Image
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    fid = db.add_folder(folder_path, name="photos")
+
+    fname = "bird.jpg"
+    Image.new("RGB", (50, 50), color=(50, 120, 80)).save(
+        os.path.join(folder_path, fname)
+    )
+    pid = db.add_photo(fid, fname, ".jpg", 1000, 1.0,
+                       timestamp="2024-01-01T10:00:00")
+    det_ids = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4},
+         "confidence": 0.9, "category": "animal"},
+    ], detector_model="MDV6")
+    db.add_prediction(det_ids[0], "Robin", 0.95, "test-model")
+    db.conn.commit()
+
+    real_conn = db.conn
+
+    class _BrokenCommitConn:
+        """Proxy that raises on every commit. Mirrors a sustained writer-lock
+        contention scenario where commit times out past busy_timeout."""
+        def __init__(self, real):
+            self._real = real
+        def commit(self):
+            raise sqlite3.OperationalError("database is locked")
+        def __enter__(self):
+            return self._real.__enter__()
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return self._real.__exit__(exc_type, exc_val, exc_tb)
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    db.conn = _BrokenCommitConn(real_conn)
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            analyze_for_culling(db, vireo_dir=str(tmp_path))
+    finally:
+        db.conn = real_conn

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6599,3 +6599,54 @@ def test_update_keyword_idempotent_name_update_does_not_auto_retype(tmp_path):
         "no actual name change — auto-detection must not fire"
     )
     assert row["taxon_id"] is None
+
+
+def test_add_photo_retries_on_database_is_locked(tmp_path):
+    """The INSERT inside add_photo must retry transient 'database is locked'.
+
+    Observed in production: a long-running cull held the writer lock for
+    minutes; the active scan's next ``add_photo`` call timed out at the
+    INSERT (not the commit), aborting the whole pipeline. ``commit_with_retry``
+    only protects the commit phase; statement-level retries cover the
+    INSERT itself.
+    """
+    import sqlite3
+
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos", name="photos")
+
+    real_conn = db.conn
+    fail_remaining = {"n": 2}
+
+    class _LockyExecuteConn:
+        """Proxy that injects 'database is locked' on the photos INSERT a few
+        times. sqlite3.Connection.execute is read-only at the instance level
+        so we must wrap the whole connection."""
+        def __init__(self, real):
+            self._real = real
+        def execute(self, sql, params=()):
+            if fail_remaining["n"] > 0 and "INSERT OR IGNORE INTO photos" in sql:
+                fail_remaining["n"] -= 1
+                raise sqlite3.OperationalError("database is locked")
+            return self._real.execute(sql, params)
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    db.conn = _LockyExecuteConn(real_conn)
+    try:
+        pid = db.add_photo(
+            folder_id=fid,
+            filename="DSC_0001.NEF",
+            extension=".nef",
+            file_size=1000,
+            file_mtime=1.0,
+        )
+    finally:
+        db.conn = real_conn
+
+    assert pid is not None, "add_photo must succeed after transient lock retries"
+    assert fail_remaining["n"] == 0, "the flaky executor should have been hit"
+    photo = db.get_photo(pid)
+    assert photo["filename"] == "DSC_0001.NEF"


### PR DESCRIPTION
## Summary

Today's pipeline scan failed at ~89% through a 26k-photo import with `[scan] Fatal: database is locked` raised inside `db.add_photo` ~63 seconds after a cull job was kicked off. Logs show the cull held the writer lock for the entire duration of its pHash backfill — minutes — and the scan's next INSERT timed out past the 30s `busy_timeout`. PR #679's commit-retry fix didn't catch this because the failure was on the INSERT statement, not the commit.

Two compounding bugs, both fixed here.

### 1. Root cause: `culling.py` pHash backfill is one giant transaction

`analyze_for_culling` loops through every photo missing a pHash, doing slow image loading + an `UPDATE photos SET phash = ?` per photo, then commits **once at the end**. Python's sqlite3 starts an implicit write transaction on the first UPDATE and holds the writer lock until commit. On a fresh import where downstream pipeline stages haven't run yet (so thousands of photos still need pHashes), this lock-hold can run for many minutes — long enough to starve a concurrent scan past `busy_timeout` even with retries.

**Fix:** commit per photo so the writer lock is released between iterations.

### 2. Defense in depth: `add_photo` INSERT had no statement-level retry

`add_photo`'s INSERT used a bare `conn.execute`. `commit_with_retry` (PR #679) only protects commits. `busy_timeout` covers statement execution too, but a single 30s wait isn't enough when the lock-holder runs longer than that.

**Fix:** add an `execute_with_retry()` helper (same shape as `commit_with_retry`) and use it for the INSERT in `add_photo`.

## Tests

Two new regression tests, both verified RED → GREEN:

- `test_phash_backfill_commits_per_photo` — wraps `db.conn` in a counting proxy, runs the backfill on 3 photos, asserts ≥3 commits during the loop. Fails on `main` (got 1 commit), passes after the cull fix.
- `test_add_photo_retries_on_database_is_locked` — wraps `db.conn` in a proxy that injects `OperationalError("database is locked")` twice on the photos INSERT. Fails on `main` (the bare execute raises), passes after `execute_with_retry`.

## Test plan

- [x] New regression tests fail without the fix, pass with it
- [x] `python -m pytest vireo/tests/test_culling.py vireo/tests/test_db.py vireo/tests/test_scanner.py vireo/tests/test_pipeline.py vireo/tests/test_pipeline_job.py vireo/tests/test_classify_job.py vireo/tests/test_misses.py vireo/tests/test_app.py -q` → 723 passed
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_culling.py -q` → 679 passed

## What this still doesn't solve

If a different long-write-transaction offender shows up (or someone adds one), retries only buy ~3-6s of extra grace past `busy_timeout`. The structural fix is to either (a) audit every loop-with-execute-then-commit pattern and force per-iteration commits, or (b) add a UI/API guard that prevents starting writer-heavy jobs (cull, sync, etc.) while a pipeline is running. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)