### PR TITLE
fix(coverage): populate photos.thumb_path so dashboard reflects reality

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -799,6 +799,89 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     _wc_backfill_timer.daemon = True
     _wc_backfill_timer.start()
 
+    # ----- thumb_path self-healing backfill -----
+    # The dashboard's coverage card counts thumbnails by ``thumb_path IS NOT
+    # NULL``, but for a long stretch the column was never populated by
+    # production code, so libraries with 40k JPEGs cached on disk reported
+    # "0 thumbnails" forever. This pass aligns the column with disk reality
+    # for legacy rows, and clears it for photos whose cached file has since
+    # been deleted (drift correction).
+    #
+    # Same shape as the working-copy backfill above: ephemeral JobRunner
+    # job (so it shows in the bottom panel), never written to job_history,
+    # skipped entirely when a fast count check finds nothing to do.
+    def _kickoff_thumb_path_backfill():
+        from thumbnails import (
+            backfill_thumb_paths,
+            thumb_path_backfill_candidate_count,
+        )
+
+        try:
+            tpdb = Database(db_path)
+            candidate_count = thumb_path_backfill_candidate_count(
+                tpdb, app.config["THUMB_CACHE_DIR"],
+            )
+        except Exception:
+            log.exception("thumb_path backfill: candidate check failed")
+            return
+        if candidate_count == 0:
+            log.debug("thumb_path backfill: no candidates, skipping")
+            return
+
+        runner = app._job_runner
+        cache_dir = app.config["THUMB_CACHE_DIR"]
+
+        def work(job):
+            thread_db = Database(db_path)
+            active_ws = init_db._active_workspace_id
+            if active_ws is not None:
+                thread_db.set_active_workspace(active_ws)
+
+            def progress_cb(current, total):
+                job["progress"]["current"] = current
+                job["progress"]["total"] = total
+                runner.push_event(
+                    job["id"],
+                    "progress",
+                    {
+                        "current": current,
+                        "total": total,
+                        "phase": f"{current:,} / {total:,} photos reconciled",
+                    },
+                )
+
+            def status_cb(message):
+                runner.push_event(job["id"], "progress", {
+                    "phase": message,
+                    "current": job["progress"].get("current", 0),
+                    "total": job["progress"].get("total", 0),
+                })
+
+            def cancel_check():
+                return runner.is_cancelled(job["id"])
+
+            return backfill_thumb_paths(
+                thread_db, cache_dir,
+                progress_callback=progress_cb,
+                status_callback=status_cb,
+                cancel_check=cancel_check,
+            )
+
+        try:
+            runner.start(
+                "thumb_path_backfill", work,
+                ephemeral=True,
+                config={"trigger": "startup"},
+            )
+        except Exception:
+            log.exception("Failed to start thumb_path backfill job")
+
+    app._kickoff_thumb_path_backfill = _kickoff_thumb_path_backfill
+
+    _thumb_backfill_timer = threading.Timer(6.0, _kickoff_thumb_path_backfill)
+    _thumb_backfill_timer.daemon = True
+    _thumb_backfill_timer.start()
+
     # -- Page routes --
 
     @app.route("/")

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -18,7 +18,7 @@ import threading
 import time
 from dataclasses import dataclass
 
-from db import Database
+from db import Database, commit_with_retry
 
 log = logging.getLogger(__name__)
 
@@ -952,6 +952,22 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             skipped = 0
             failed = 0
 
+            # Mark photos.thumb_path so the dashboard's coverage query
+            # (`thumb_path IS NOT NULL`) reflects each freshly-generated or
+            # already-cached thumbnail. Batched so the writer lock isn't held
+            # per-row under sustained scan throughput.
+            THUMB_PATH_BATCH = 25
+            pending_thumb_paths = []
+
+            def _flush_thumb_paths():
+                if pending_thumb_paths:
+                    thread_db.conn.executemany(
+                        "UPDATE photos SET thumb_path=? WHERE id=?",
+                        pending_thumb_paths,
+                    )
+                    commit_with_retry(thread_db.conn)
+                    pending_thumb_paths.clear()
+
             while True:
                 try:
                     item = scan_to_thumb.get(timeout=1.0)
@@ -972,8 +988,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         failed += 1
                     elif already_exists:
                         skipped += 1
+                        pending_thumb_paths.append((f"{photo_id}.jpg", photo_id))
                     else:
                         generated += 1
+                        pending_thumb_paths.append((f"{photo_id}.jpg", photo_id))
+                    if len(pending_thumb_paths) >= THUMB_PATH_BATCH:
+                        _flush_thumb_paths()
                 except Exception:
                     failed += 1
                     log.debug("Thumbnail failed for photo %s", photo_id)
@@ -1025,8 +1045,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             failed += 1
                         elif already_exists:
                             skipped += 1
+                            pending_thumb_paths.append((f"{photo_id}.jpg", photo_id))
                         else:
                             generated += 1
+                            pending_thumb_paths.append((f"{photo_id}.jpg", photo_id))
+                        if len(pending_thumb_paths) >= THUMB_PATH_BATCH:
+                            _flush_thumb_paths()
                     except Exception:
                         failed += 1
                         log.debug("Thumbnail failed for photo %s", photo_id)
@@ -1045,6 +1069,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         current_file=os.path.basename(photo_path),
                         rate=rate,
                     ))
+
+            # Flush any thumb_path updates from the final partial batch.
+            _flush_thumb_paths()
 
             from thumbnails import format_summary as thumb_summary
             thumb_result = {"generated": generated, "skipped": skipped, "failed": failed}

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -5240,6 +5240,51 @@ def test_weighted_progress_monotonic_through_pipeline():
     assert last_pct == 100.0
 
 
+def test_pipeline_thumbnail_stage_records_thumb_path_in_db(tmp_path, monkeypatch):
+    """Each successful generate_thumbnail in the pipeline thumbnail_stage must
+    set photos.thumb_path so the dashboard's coverage query reflects it.
+    Without this, scanning produces JPEGs on disk but the column stays NULL
+    and "0 of N thumbnails made" is reported forever."""
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    photo_dir = _make_photo_dir(tmp_path, 3)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    job = _make_job()
+    runner = FakeRunner()
+
+    with contextlib.suppress(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # Re-open the DB connection — the pipeline runs on a thread with its
+    # own connection and we want the committed view.
+    db2 = Database(db_path)
+    rows = db2.conn.execute(
+        "SELECT id, thumb_path FROM photos ORDER BY id"
+    ).fetchall()
+    assert len(rows) == 3
+    for r in rows:
+        assert r["thumb_path"] is not None, (
+            f"photo {r['id']} has thumb_path=NULL after pipeline ran"
+        )
+        assert r["thumb_path"] == f"{r['id']}.jpg", (
+            f"thumb_path should be the bare filename '{r['id']}.jpg', "
+            f"got {r['thumb_path']!r}"
+        )
+
+
 def test_update_stages_emits_weighted_current_total():
     """_update_stages must send the weighted overall to push_event instead
     of hardcoded 0/0. This is what makes the 'Overall %' visible in the UI."""

--- a/vireo/tests/test_thumb_path_backfill.py
+++ b/vireo/tests/test_thumb_path_backfill.py
@@ -1,0 +1,157 @@
+"""Startup self-healing for photos.thumb_path.
+
+The dashboard's coverage card reads ``thumb_path IS NOT NULL`` to count how
+many photos have a generated thumbnail. Until PR #6xx the column was never
+populated by production code, so the dashboard always reported "0 of N
+thumbnails made" even when 40k JPEGs sat on disk in ``~/.vireo/thumbnails/``.
+
+These tests exercise the ephemeral startup job that:
+
+* sets ``thumb_path`` for legacy photos whose JPEG already exists on disk, and
+* clears ``thumb_path`` if the file has since been deleted (drift correction).
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from PIL import Image
+
+
+def _make_jpeg(path, w=200, h=150):
+    Image.new("RGB", (w, h), (100, 100, 100)).save(str(path), "JPEG", quality=85)
+
+
+def _wait_for_job(runner, job_type, deadline_s=5):
+    deadline = time.time() + deadline_s
+    while time.time() < deadline:
+        jobs = [j for j in runner.list_jobs() if j["type"] == job_type]
+        if jobs and jobs[0]["status"] in ("completed", "failed"):
+            return jobs[0]
+        time.sleep(0.05)
+    return None
+
+
+def test_startup_thumb_path_backfill_skips_when_synced(tmp_path, monkeypatch):
+    """If every photo's thumb_path matches disk reality, no ephemeral
+    thumb_path_backfill job is started — steady-state restarts pay nothing."""
+    import config as cfg
+    import models
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    from app import create_app
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+    Database(db_path)  # create empty DB with workspace
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="t")
+    app._kickoff_thumb_path_backfill()
+
+    backfill_jobs = [
+        j for j in app._job_runner.list_jobs()
+        if j["type"] == "thumb_path_backfill"
+    ]
+    assert backfill_jobs == []
+
+
+def test_startup_thumb_path_backfill_sets_unsynced_rows(tmp_path, monkeypatch):
+    """A photo with NULL thumb_path whose JPEG exists in the cache must have
+    its column populated by the startup ephemeral job. This is the production
+    repair path: 40k thumbnails on disk reported as 0/40k forever."""
+    import config as cfg
+    import models
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    from app import create_app
+    from db import Database
+
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    src = photos_dir / "a.jpg"
+    _make_jpeg(str(src))
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = tmp_path / "thumbs"
+    thumb_dir.mkdir()
+
+    db = Database(db_path)
+    folder_id = db.add_folder(str(photos_dir))
+    pid = db.add_photo(
+        folder_id, "a.jpg", ".jpg",
+        file_size=os.path.getsize(str(src)),
+        file_mtime=os.path.getmtime(str(src)),
+        width=200, height=150,
+    )
+    # Pre-existing on-disk thumbnail (the legacy state).
+    _make_jpeg(thumb_dir / f"{pid}.jpg")
+    db.conn.close()
+
+    app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir), api_token="t")
+    app._kickoff_thumb_path_backfill()
+
+    job = _wait_for_job(app._job_runner, "thumb_path_backfill")
+    assert job is not None, "backfill job should have been started"
+    assert job["status"] == "completed", f"job: {job}"
+    assert job.get("ephemeral") is True
+
+    db2 = Database(db_path)
+    row = db2.conn.execute(
+        "SELECT thumb_path FROM photos WHERE id=?", (pid,)
+    ).fetchone()
+    assert row["thumb_path"] == f"{pid}.jpg"
+
+
+def test_startup_thumb_path_backfill_does_not_persist_to_history(tmp_path, monkeypatch):
+    """Ephemeral job must NOT land in job_history — every restart would
+    otherwise add a noise row."""
+    import config as cfg
+    import models
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    from app import create_app
+    from db import Database
+
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    src = photos_dir / "a.jpg"
+    _make_jpeg(str(src))
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = tmp_path / "thumbs"
+    thumb_dir.mkdir()
+
+    db = Database(db_path)
+    folder_id = db.add_folder(str(photos_dir))
+    pid = db.add_photo(
+        folder_id, "a.jpg", ".jpg",
+        file_size=os.path.getsize(str(src)),
+        file_mtime=os.path.getmtime(str(src)),
+        width=200, height=150,
+    )
+    _make_jpeg(thumb_dir / f"{pid}.jpg")
+    db.conn.close()
+
+    app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir), api_token="t")
+    app._kickoff_thumb_path_backfill()
+
+    _wait_for_job(app._job_runner, "thumb_path_backfill")
+
+    db2 = Database(db_path)
+    rows = db2.conn.execute(
+        "SELECT id FROM job_history WHERE type='thumb_path_backfill'"
+    ).fetchall()
+    assert rows == [], "ephemeral job must not persist to history"

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -163,3 +163,177 @@ def test_generate_all_creates_missing(tmp_path):
     assert len(progress) == 2
     assert os.path.exists(os.path.join(cache_dir, "1.jpg"))
     assert os.path.exists(os.path.join(cache_dir, "2.jpg"))
+
+
+def test_generate_all_records_thumb_path_in_db(tmp_path):
+    """After generate_all, photos.thumb_path must reflect the generated file
+    so the dashboard's coverage query (`thumb_path IS NOT NULL`) shows the
+    thumbnail as produced. The on-disk JPEG alone is not enough."""
+    from db import Database
+    from thumbnails import generate_all
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name='root')
+    for name in ['a.jpg', 'b.jpg']:
+        Image.new('RGB', (300, 200)).save(str(tmp_path / name))
+        db.add_photo(folder_id=fid, filename=name, extension='.jpg',
+                     file_size=100, file_mtime=1.0)
+
+    cache_dir = str(tmp_path / "thumbs")
+    os.makedirs(cache_dir)
+    generate_all(db, cache_dir)
+
+    rows = db.conn.execute(
+        "SELECT id, thumb_path FROM photos ORDER BY id"
+    ).fetchall()
+    assert all(r["thumb_path"] is not None for r in rows), (
+        f"All photos should have thumb_path set; got {[dict(r) for r in rows]}"
+    )
+    # Stored value should identify the file by photo id, not as a brittle
+    # absolute path that breaks if cache_dir moves.
+    assert rows[0]["thumb_path"] == "1.jpg"
+    assert rows[1]["thumb_path"] == "2.jpg"
+
+
+def test_generate_all_does_not_record_thumb_path_on_failure(tmp_path, monkeypatch):
+    """If generate_thumbnail returns None (failure), thumb_path stays NULL —
+    we don't want the dashboard to falsely report coverage."""
+    import thumbnails as thumbnails_mod
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name='root')
+    Image.new('RGB', (300, 200)).save(str(tmp_path / "a.jpg"))
+    db.add_photo(folder_id=fid, filename="a.jpg", extension='.jpg',
+                 file_size=100, file_mtime=1.0)
+
+    monkeypatch.setattr(
+        thumbnails_mod, "generate_thumbnail",
+        lambda photo_id, src, cache_dir, size=400, quality=85: None,
+    )
+
+    cache_dir = str(tmp_path / "thumbs")
+    os.makedirs(cache_dir)
+    thumbnails_mod.generate_all(db, cache_dir)
+
+    row = db.conn.execute("SELECT thumb_path FROM photos").fetchone()
+    assert row["thumb_path"] is None
+
+
+def test_backfill_thumb_paths_sets_path_for_existing_files(tmp_path):
+    """Library-wide backfill should mark photos whose thumbnail JPEG exists on
+    disk but whose thumb_path is NULL (the dashboard-coverage repair pass)."""
+    from db import Database
+    from thumbnails import backfill_thumb_paths
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name='root')
+    for name in ['a.jpg', 'b.jpg', 'c.jpg']:
+        db.add_photo(folder_id=fid, filename=name, extension='.jpg',
+                     file_size=100, file_mtime=1.0)
+
+    cache_dir = str(tmp_path / "thumbs")
+    os.makedirs(cache_dir)
+    # Only photos 1 and 3 have on-disk thumbnails.
+    Image.new('RGB', (50, 50)).save(str(tmp_path / "thumbs" / "1.jpg"))
+    Image.new('RGB', (50, 50)).save(str(tmp_path / "thumbs" / "3.jpg"))
+
+    result = backfill_thumb_paths(db, cache_dir)
+
+    rows = {r["id"]: r["thumb_path"] for r in db.conn.execute(
+        "SELECT id, thumb_path FROM photos"
+    ).fetchall()}
+    assert rows[1] == "1.jpg"
+    assert rows[2] is None
+    assert rows[3] == "3.jpg"
+    assert result["set"] == 2
+
+
+def test_backfill_thumb_paths_clears_path_for_missing_files(tmp_path):
+    """If a photo has thumb_path set but the file is gone (user wiped the
+    cache), the backfill should clear the column so the dashboard reflects
+    on-disk reality. Otherwise drift persists between disk and DB."""
+    from db import Database
+    from thumbnails import backfill_thumb_paths
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name='root')
+    db.add_photo(folder_id=fid, filename="a.jpg", extension='.jpg',
+                 file_size=100, file_mtime=1.0)
+    # Pretend a previous run set this; the file no longer exists on disk.
+    db.conn.execute("UPDATE photos SET thumb_path='1.jpg' WHERE id=1")
+    db.conn.commit()
+
+    cache_dir = str(tmp_path / "thumbs")
+    os.makedirs(cache_dir)
+
+    result = backfill_thumb_paths(db, cache_dir)
+
+    row = db.conn.execute("SELECT thumb_path FROM photos").fetchone()
+    assert row["thumb_path"] is None
+    assert result["cleared"] == 1
+
+
+def test_backfill_thumb_paths_skips_when_already_synced(tmp_path):
+    """No-op when every photo's thumb_path matches disk — the steady-state
+    case after the first backfill run."""
+    from db import Database
+    from thumbnails import backfill_thumb_paths
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name='root')
+    db.add_photo(folder_id=fid, filename="a.jpg", extension='.jpg',
+                 file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET thumb_path='1.jpg' WHERE id=1")
+    db.conn.commit()
+
+    cache_dir = str(tmp_path / "thumbs")
+    os.makedirs(cache_dir)
+    Image.new('RGB', (50, 50)).save(str(tmp_path / "thumbs" / "1.jpg"))
+
+    result = backfill_thumb_paths(db, cache_dir)
+    assert result["set"] == 0
+    assert result["cleared"] == 0
+
+
+def test_thumb_path_backfill_candidate_count_zero_when_synced(tmp_path):
+    """Startup gate count: returns 0 when nothing needs work, so the kickoff
+    can skip spawning a job entirely."""
+    from db import Database
+    from thumbnails import thumb_path_backfill_candidate_count
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name='root')
+    db.add_photo(folder_id=fid, filename="a.jpg", extension='.jpg',
+                 file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET thumb_path='1.jpg' WHERE id=1")
+    db.conn.commit()
+
+    cache_dir = str(tmp_path / "thumbs")
+    os.makedirs(cache_dir)
+    Image.new('RGB', (50, 50)).save(str(tmp_path / "thumbs" / "1.jpg"))
+
+    assert thumb_path_backfill_candidate_count(db, cache_dir) == 0
+
+
+def test_thumb_path_backfill_candidate_count_counts_unsynced(tmp_path):
+    """Both stale-NULL (file exists but column empty) and stale-NOT-NULL
+    (column set but file missing) photos count as candidates."""
+    from db import Database
+    from thumbnails import thumb_path_backfill_candidate_count
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name='root')
+    for name in ['a.jpg', 'b.jpg']:
+        db.add_photo(folder_id=fid, filename=name, extension='.jpg',
+                     file_size=100, file_mtime=1.0)
+
+    cache_dir = str(tmp_path / "thumbs")
+    os.makedirs(cache_dir)
+    # Photo 1: file exists, column NULL  -> needs setting.
+    Image.new('RGB', (50, 50)).save(str(tmp_path / "thumbs" / "1.jpg"))
+    # Photo 2: column set, file missing  -> needs clearing.
+    db.conn.execute("UPDATE photos SET thumb_path='2.jpg' WHERE id=2")
+    db.conn.commit()
+
+    assert thumb_path_backfill_candidate_count(db, cache_dir) == 2

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -101,17 +101,131 @@ def generate_all(db, cache_dir, progress_callback=None, config=None, vireo_dir=N
             source_path = os.path.join(folder_path, photo["filename"])
         if generate_thumbnail(photo["id"], source_path, cache_dir, size=thumb_size, quality=thumb_quality) is not None:
             generated += 1
+            # Record on-disk presence in the photos table so the dashboard's
+            # coverage query (`thumb_path IS NOT NULL`) reflects this run.
+            # Stored value is the bare filename ({id}.jpg) so the column
+            # stays correct even if the thumbnail cache dir is later moved.
+            db.conn.execute(
+                "UPDATE photos SET thumb_path=? WHERE id=?",
+                (f"{photo['id']}.jpg", photo["id"]),
+            )
         else:
             failed += 1
 
         if progress_callback:
             progress_callback(i + 1, total)
 
+    db.conn.commit()
     if failed:
         log.warning("Thumbnail generation: %d of %d failed", failed, total)
     result = {"generated": generated, "skipped": skipped, "failed": failed}
     result["summary"] = format_summary(result)
     return result
+
+
+def thumb_path_backfill_candidate_count(db, cache_dir):
+    """Count photos that ``backfill_thumb_paths`` would actually update.
+
+    A photo is a candidate when its ``thumb_path`` does not match disk
+    reality:
+
+    * ``thumb_path IS NULL`` but ``<cache_dir>/<id>.jpg`` exists, or
+    * ``thumb_path IS NOT NULL`` but the file no longer exists (drift after
+      a manual cache wipe).
+
+    Used by the startup gate in ``app.py`` to skip spawning a backfill job
+    when nothing needs work, and after a backfill run for "remaining"
+    reporting.
+    """
+    rows = db.conn.execute(
+        "SELECT id, thumb_path FROM photos"
+    ).fetchall()
+    candidates = 0
+    for row in rows:
+        photo_id = row["id"]
+        on_disk = os.path.exists(os.path.join(cache_dir, f"{photo_id}.jpg"))
+        if row["thumb_path"] is None and on_disk or row["thumb_path"] is not None and not on_disk:
+            candidates += 1
+    return candidates
+
+
+def backfill_thumb_paths(db, cache_dir, progress_callback=None,
+                         status_callback=None, cancel_check=None):
+    """Library-wide self-healing pass that aligns ``photos.thumb_path`` with
+    on-disk reality.
+
+    Two corrections:
+
+    * For each photo with ``thumb_path IS NULL`` whose JPEG exists on disk,
+      set ``thumb_path = '<id>.jpg'`` so the dashboard's coverage query
+      reports it. This is the path that fired in production: thumbnails
+      generated before the column was wired up reported 0 forever.
+    * For each photo whose ``thumb_path`` is set but the file is gone,
+      clear the column — otherwise the dashboard claims coverage that no
+      longer exists after a manual cache wipe.
+
+    Returns a summary dict ``{"set": N, "cleared": M, "remaining": K}``.
+
+    Sequential by design — each row is a stat() plus at most one tiny
+    UPDATE, so single-threaded throughput is fine even on tens of
+    thousands of photos.
+    """
+    rows = db.conn.execute(
+        "SELECT id, thumb_path FROM photos"
+    ).fetchall()
+    total = len(rows)
+    if status_callback:
+        status_callback(f"Reconciling thumb_path for {total:,} photos")
+
+    set_count = 0
+    cleared_count = 0
+    BATCH = 500
+    pending_set = []
+    pending_clear = []
+
+    def _flush():
+        if pending_set:
+            db.conn.executemany(
+                "UPDATE photos SET thumb_path=? WHERE id=?",
+                pending_set,
+            )
+            pending_set.clear()
+        if pending_clear:
+            db.conn.executemany(
+                "UPDATE photos SET thumb_path=NULL WHERE id=?",
+                pending_clear,
+            )
+            pending_clear.clear()
+        db.conn.commit()
+
+    for i, row in enumerate(rows):
+        if cancel_check is not None and cancel_check():
+            break
+        photo_id = row["id"]
+        on_disk = os.path.exists(os.path.join(cache_dir, f"{photo_id}.jpg"))
+        if row["thumb_path"] is None and on_disk:
+            pending_set.append((f"{photo_id}.jpg", photo_id))
+            set_count += 1
+        elif row["thumb_path"] is not None and not on_disk:
+            pending_clear.append((photo_id,))
+            cleared_count += 1
+
+        if (len(pending_set) + len(pending_clear)) >= BATCH:
+            _flush()
+        if progress_callback is not None:
+            progress_callback(i + 1, total)
+
+    _flush()
+
+    log.info(
+        "thumb_path backfill: set=%d cleared=%d (of %d photos)",
+        set_count, cleared_count, total,
+    )
+    return {
+        "set": set_count,
+        "cleared": cleared_count,
+        "remaining": thumb_path_backfill_candidate_count(db, cache_dir),
+    }
 
 
 def format_summary(result):


### PR DESCRIPTION
## Summary

Reported as: USA2026 workspace shows "0 of 26k thumbnails made" on the dashboard while ~40k thumbnail JPEGs already exist on disk in `~/.vireo/thumbnails/`.

Root cause: the dashboard's Processing Coverage card counts thumbnails by `photos.thumb_path IS NOT NULL` (`vireo/db.py:1821`), but **no production code path ever wrote that column**. Verified directly against the live DB:

| signal | count |
|---|---|
| photos in DB | 39,823 |
| photos with `thumb_path` set | **0** |
| JPEGs in `~/.vireo/thumbnails/` | **40,896** |
| photos with `working_copy_path` set | 3,703 |
| photos with `phash` set | 27,711 |

So thumbnails exist for almost every photo — the column they're tracked in is just empty. The coverage card was added in #632 (Apr 23) and assumed `thumb_path` was being populated like the others.

## What changed

- `thumbnails.generate_all` and `pipeline_job.thumbnail_stage` now `UPDATE photos SET thumb_path = '<id>.jpg'` after each successful generation. The pipeline path batches via `commit_with_retry` (BATCH=25) to avoid extra writer-lock pressure during scan throughput.
- New `thumbnails.backfill_thumb_paths(db, cache_dir, ...)` self-heals the column against on-disk reality: sets `thumb_path` for photos whose JPEG already exists, and clears it for photos whose cached file has since been deleted (drift correction). Plus `thumb_path_backfill_candidate_count` for the startup gate.
- New `_kickoff_thumb_path_backfill` in `app.py` runs the helper as an ephemeral JobRunner job at startup (5s daemon Timer; same shape as `_kickoff_working_copy_backfill` from #689). Skipped entirely when the count gate is 0 so steady-state restarts pay nothing. Never written to `job_history`.

Storage convention: just the bare filename `<id>.jpg`, not an absolute path. No reader currently uses the column for path lookup (the serve route builds its own path from `THUMB_CACHE_DIR + id`), and storing only the filename keeps the column correct if the cache dir is later moved.

## Test plan

- [x] New: `vireo/tests/test_thumbnails.py` adds 7 cases covering `generate_all` set + skip-on-failure, `backfill_thumb_paths` set + clear + skip-when-synced, candidate count zero/non-zero.
- [x] New: `vireo/tests/test_pipeline_job.py::test_pipeline_thumbnail_stage_records_thumb_path_in_db` asserts the column is populated after `run_pipeline_job`.
- [x] New: `vireo/tests/test_thumb_path_backfill.py` (3 cases) for the startup kickoff: skip when synced, set unsynced rows, never persist to `job_history`.
- [x] CLAUDE.md test command + touched modules: **813 passed** in 19m16s.
- [ ] Manual: restart app on the affected DB, confirm bottom panel shows the ephemeral backfill job, confirm the dashboard's thumbnails coverage flips from 0 to ~40k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)