### PR TITLE
fix(tests): update stale e2e expectations after subject keyword types

### DIFF
--- a/tests/e2e/test_keyword_context_menu.py
+++ b/tests/e2e/test_keyword_context_menu.py
@@ -5,7 +5,7 @@ Menu items (simplified per task prompt — the plan listed two redundant
 only "Show Photos with this Keyword"):
 
 - Rename                          (single only)
-- Set Type chip row (6 types)
+- Set Type chip row (5 types)
 - separator
 - Show Photos with this Keyword   (single only)
 - separator
@@ -35,9 +35,9 @@ def test_keyword_right_click_opens_menu(live_server, page):
             menu.locator(".vireo-ctx-item", has_text=label)
         ).to_be_visible()
 
-    # Six type chips for the Set Type chip row.
+    # Five type chips for the Set Type chip row (KEYWORD_TYPES in db.py).
     chips = menu.locator(".vireo-ctx-chip")
-    assert chips.count() == 6
+    assert chips.count() == 5
 
 
 def test_keyword_right_click_set_type_chip_fires_put(live_server, page):
@@ -57,7 +57,7 @@ def test_keyword_right_click_set_type_chip_fires_put(live_server, page):
         and r.request.method == "PUT"
         and r.status == 200
     ):
-        # The 'location' chip: position 3 of the 6-type chip row.
+        # The 'location' chip: one of the 5 type chips.
         menu.locator(".vireo-ctx-chip", has_text="location").click()
 
 

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -52,6 +52,16 @@ def _seed_reverse_geocode_cache(live_server, lat, lng, place_id, details):
     )
 
 
+def _wait_for_detail_loaded(page):
+    """Wait until the detail panel's photo id is set on `window`.
+
+    `_submitLocationText` (browse.html) bails silently if `_detailPhotoId` is
+    falsy, so pressing Enter before the detail finishes loading races and the
+    free-text POST is dropped. Tests must wait for this before pressing Enter.
+    """
+    page.wait_for_function("() => !!window._detailPhotoId")
+
+
 def _set_api_key(key="test-key"):
     """Write a Google Maps key into the (monkeypatched) config.json so:
       - browse.html's _cfgPromise sees `window.GOOGLE_MAPS_API_KEY` set,
@@ -88,6 +98,7 @@ def test_freetext_enter_creates_location(live_server, page):
     first = page.locator(".grid-card").first
     first.wait_for(state="visible")
     first.click()
+    _wait_for_detail_loaded(page)
 
     inp = page.locator("#locationInput")
     inp.wait_for(state="visible")
@@ -120,6 +131,7 @@ def test_enter_after_place_changed_does_not_submit_freetext(live_server, page):
     first = page.locator(".grid-card").first
     first.wait_for(state="visible")
     first.click()
+    _wait_for_detail_loaded(page)
 
     inp = page.locator("#locationInput")
     inp.wait_for(state="visible")
@@ -157,6 +169,7 @@ def test_clear_button_returns_to_empty(live_server, page):
     first = page.locator(".grid-card").first
     first.wait_for(state="visible")
     first.click()
+    _wait_for_detail_loaded(page)
 
     # Set a location first.
     inp = page.locator("#locationInput")
@@ -182,6 +195,7 @@ def test_location_persists_across_reload(live_server, page):
     first = page.locator(".grid-card").first
     first.wait_for(state="visible")
     first.click()
+    _wait_for_detail_loaded(page)
 
     inp = page.locator("#locationInput")
     inp.wait_for(state="visible")


### PR DESCRIPTION
## Summary
- `test_keyword_right_click_opens_menu` asserted **6** type chips; commit 10a3ef8 (#680) collapsed `KEYWORD_TYPES` to **5** (`taxonomy`, `individual`, `location`, `genre`, `general`). Updated docstring + count assertion + sibling comment.
- `test_clear_button_returns_to_empty` was flaky: it pressed Enter on `#locationInput` before `window._detailPhotoId` was set, and `_submitLocationText` (browse.html:2898) bails silently when the photo id is falsy — so the POST never fired and `#locationFilled` never appeared. Added a `_wait_for_detail_loaded(page)` helper and called it in all four location tests that submit via Enter.

## Test plan
- [x] `python -m pytest tests/e2e/test_keyword_context_menu.py tests/e2e/test_location_section.py -v` → 17 passed
- [x] Both originally-failing tests now pass: `test_keyword_right_click_opens_menu` and `test_clear_button_returns_to_empty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)