### PR TITLE
fix(duplicates): restore last scan results on page mount

### DIFF
--- a/tests/e2e/test_duplicates_restore.py
+++ b/tests/e2e/test_duplicates_restore.py
@@ -1,0 +1,69 @@
+"""E2E test: /duplicates page restores prior scan results on mount.
+
+Without restore, navigating away from /duplicates and back loses the
+in-memory proposals and forces a fresh scan. The page now hydrates from
+the most recent completed ``duplicate-scan`` row in ``job_history``.
+"""
+import json
+
+from playwright.sync_api import expect
+
+
+def _seed_prior_scan(db):
+    """Insert a synthetic completed duplicate-scan into job_history."""
+    result = {
+        "group_count": 1,
+        "loser_count": 1,
+        "proposals": [
+            {
+                "file_hash": "HFAKE",
+                "status": "unresolved",
+                "winner": {"id": 1, "filename": "a.jpg", "path": "/photos/a.jpg"},
+                "losers": [
+                    {"id": 2, "filename": "a (2).jpg", "path": "/photos/a (2).jpg"}
+                ],
+            }
+        ],
+    }
+    db.conn.execute(
+        """INSERT INTO job_history
+              (id, type, status, started_at, finished_at, duration, result)
+           VALUES (?, 'duplicate-scan', 'completed', ?, ?, 1.0, ?)""",
+        (
+            "duplicate-scan-restore-test",
+            "2026-04-27T19:00:00",
+            "2026-04-27T19:00:01",
+            json.dumps(result),
+        ),
+    )
+    db.conn.commit()
+
+
+def test_duplicates_page_restores_prior_scan(live_server, page):
+    """A prior completed scan in job_history rehydrates the page on mount."""
+    _seed_prior_scan(live_server["db"])
+    page.goto(f"{live_server['url']}/duplicates")
+
+    banner = page.locator("#restoredBanner")
+    expect(banner).to_be_visible()
+    expect(banner).to_contain_text("Showing results from your last scan")
+    expect(page.locator("#emptyState")).not_to_be_visible()
+    expect(page.locator("#results")).to_contain_text("HFAKE")
+
+
+def test_duplicates_page_no_prior_scan_shows_empty_state(live_server, page):
+    """No prior scan -> banner hidden, empty-state visible."""
+    page.goto(f"{live_server['url']}/duplicates")
+
+    expect(page.locator("#restoredBanner")).not_to_be_visible()
+    expect(page.locator("#emptyState")).to_be_visible()
+
+
+def test_duplicates_page_starting_new_scan_hides_banner(live_server, page):
+    """Clicking 'Scan' clears the restored banner."""
+    _seed_prior_scan(live_server["db"])
+    page.goto(f"{live_server['url']}/duplicates")
+    expect(page.locator("#restoredBanner")).to_be_visible()
+
+    page.click("#scanBtn")
+    expect(page.locator("#restoredBanner")).not_to_be_visible()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7086,6 +7086,46 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "failed": failed,
         })
 
+    @app.route("/api/duplicates/last-scan", methods=["GET"])
+    def api_duplicates_last_scan():
+        """Return the most recent completed duplicate-scan's result.
+
+        The /duplicates page only holds proposals in JS memory, so
+        navigating away and back used to require a full rescan. This
+        lets the page restore prior results from ``job_history`` instead.
+
+        Library-wide on purpose: duplicate detection itself ignores
+        workspace scope (photos are global), so the result of any
+        completed scan is valid for any active workspace — even though
+        the row carries the triggering workspace's id.
+
+        Response: ``{found: false}`` or
+        ``{found: true, job_id, started_at, finished_at, result}``.
+        """
+        db = _get_db()
+        row = db.conn.execute(
+            """SELECT id, started_at, finished_at, result
+                 FROM job_history
+                WHERE type = 'duplicate-scan'
+                  AND status = 'completed'
+                  AND result IS NOT NULL
+                ORDER BY finished_at DESC
+                LIMIT 1"""
+        ).fetchone()
+        if row is None:
+            return jsonify({"found": False})
+        try:
+            result = json.loads(row["result"])
+        except (json.JSONDecodeError, TypeError):
+            return jsonify({"found": False})
+        return jsonify({
+            "found": True,
+            "job_id": row["id"],
+            "started_at": row["started_at"],
+            "finished_at": row["finished_at"],
+            "result": result,
+        })
+
     @app.route("/api/duplicates/disk-cleanup-summary", methods=["GET"])
     def api_duplicates_disk_cleanup_summary():
         """Return counts of duplicate-loser files that may still be on disk.

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -228,6 +228,11 @@
     <span class="status" id="progressStatus">Starting scan...</span>
   </div>
 
+  <div id="restoredBanner" class="group-warning" style="display:none;">
+    Showing results from your last scan (<span id="restoredAgo"></span>).
+    Click <b>Scan for duplicate files</b> above for a fresh scan.
+  </div>
+
   <div id="summary" style="display:none;"></div>
 
   <div id="results"></div>
@@ -272,9 +277,38 @@
     document.getElementById('emptyState').style.display = visible ? '' : 'none';
   }
 
+  function hideRestoredBanner() {
+    document.getElementById('restoredBanner').style.display = 'none';
+  }
+
+  function formatTimeAgo(isoStr) {
+    if (!isoStr) return '';
+    var d = new Date(isoStr.endsWith('Z') ? isoStr : isoStr + 'Z');
+    var sec = Math.floor((new Date() - d) / 1000);
+    if (sec < 60) return 'just now';
+    if (sec < 3600) return Math.floor(sec / 60) + 'm ago';
+    if (sec < 86400) return Math.floor(sec / 3600) + 'h ago';
+    return d.toLocaleString();
+  }
+
+  async function tryRestoreLastScan() {
+    try {
+      var data = await safeFetch('/api/duplicates/last-scan', undefined, { toast: false });
+      if (!data || !data.found) return;
+      renderResults(data.result || {});
+      var banner = document.getElementById('restoredBanner');
+      document.getElementById('restoredAgo').textContent =
+        formatTimeAgo(data.finished_at);
+      banner.style.display = '';
+    } catch (e) {
+      // best-effort; fall through to the normal empty-state UI
+    }
+  }
+
   async function startScan() {
     var scanBtn = document.getElementById('scanBtn');
     scanBtn.disabled = true;
+    hideRestoredBanner();
     setEmptyVisible(false);
     document.getElementById('results').innerHTML = '';
     document.getElementById('summary').style.display = 'none';
@@ -820,8 +854,11 @@
     document.getElementById('summary').style.display = 'none';
     document.getElementById('applyBar').style.display = 'none';
     document.getElementById('applyStatus').textContent = '';
+    hideRestoredBanner();
     setEmptyVisible(true);
   }
+
+  document.addEventListener('DOMContentLoaded', tryRestoreLastScan);
 </script>
 </body>
 </html>

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -286,7 +286,11 @@
 
   function formatTimeAgo(isoStr) {
     if (!isoStr) return '';
-    var d = new Date(isoStr.endsWith('Z') ? isoStr : isoStr + 'Z');
+    // job_history timestamps are naive local-time ISO strings written by
+    // datetime.now().isoformat() in vireo/jobs.py. Pass them through as-is so
+    // JS parses them as local time; appending 'Z' would shift the displayed
+    // age by the local UTC offset (e.g. a fresh scan appearing hours old).
+    var d = new Date(isoStr);
     var sec = Math.floor((new Date() - d) / 1000);
     if (sec < 60) return 'just now';
     if (sec < 3600) return Math.floor(sec / 60) + 'm ago';

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -252,6 +252,9 @@
 <script>
   var _proposals = [];
   var _currentJobId = null;
+  // Set synchronously at the top of startScan() so the async tryRestoreLastScan
+  // can detect that a fresh scan is already underway and skip its render.
+  var _scanInProgress = false;
 
   function escapeHtml(s) {
     if (s == null) return '';
@@ -292,8 +295,13 @@
   }
 
   async function tryRestoreLastScan() {
+    if (_scanInProgress) return;
     try {
       var data = await safeFetch('/api/duplicates/last-scan', undefined, { toast: false });
+      // The user may have clicked Scan while we were awaiting the response.
+      // Don't clobber the in-progress scan's UI with stale results — that
+      // would re-enable the scan button and risk overlapping scan jobs.
+      if (_scanInProgress) return;
       if (!data || !data.found) return;
       renderResults(data.result || {});
       var banner = document.getElementById('restoredBanner');
@@ -307,6 +315,7 @@
 
   async function startScan() {
     var scanBtn = document.getElementById('scanBtn');
+    _scanInProgress = true;
     scanBtn.disabled = true;
     hideRestoredBanner();
     setEmptyVisible(false);

--- a/vireo/tests/test_duplicates_api.py
+++ b/vireo/tests/test_duplicates_api.py
@@ -465,3 +465,87 @@ def test_disk_cleanup_summary_zero_when_clean(app_and_db):
     body = resp.get_json()
     assert body["count"] == 0
     assert body["total_size"] == 0
+
+
+# ---------------------------------------------------------------------------
+# /api/duplicates/last-scan — restore the most recent completed scan's result
+# so navigating away from /duplicates and back doesn't force a rescan.
+# ---------------------------------------------------------------------------
+
+
+def test_last_scan_returns_not_found_when_no_history(app_and_db):
+    """No prior scan -> {found: false}."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/duplicates/last-scan")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"found": False}
+
+
+def test_last_scan_returns_completed_scan_result(app_and_db):
+    """After a scan completes, last-scan returns its proposals."""
+    app, db = app_and_db
+    fid = db.add_folder("/tmp/duplastscan1")
+    _seed_pair(db, "HLAST", fid)
+
+    client = app.test_client()
+    job_id = client.post("/api/duplicates/scan").get_json()["job_id"]
+    for _ in range(50):
+        resp = client.get(f"/api/jobs/{job_id}")
+        if resp.get_json()["status"] in ("completed", "failed"):
+            break
+        time.sleep(0.1)
+
+    resp = client.get("/api/duplicates/last-scan")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["found"] is True
+    assert body["job_id"] == job_id
+    assert body["finished_at"]
+    hashes = [p["file_hash"] for p in body["result"]["proposals"]]
+    assert "HLAST" in hashes
+
+
+def test_last_scan_picks_most_recent_completed(app_and_db):
+    """Two scans -> last-scan reflects the newer one."""
+    app, db = app_and_db
+    fid = db.add_folder("/tmp/duplastscan2")
+    _seed_pair(db, "HOLD", fid)
+
+    client = app.test_client()
+    job1 = client.post("/api/duplicates/scan").get_json()["job_id"]
+    for _ in range(50):
+        if client.get(f"/api/jobs/{job1}").get_json()["status"] in ("completed", "failed"):
+            break
+        time.sleep(0.1)
+
+    # Add another duplicate group then rescan.
+    _seed_pair(db, "HNEW", fid, name_a="n.jpg", name_b="n (2).jpg")
+    job2 = client.post("/api/duplicates/scan").get_json()["job_id"]
+    for _ in range(50):
+        if client.get(f"/api/jobs/{job2}").get_json()["status"] in ("completed", "failed"):
+            break
+        time.sleep(0.1)
+
+    body = client.get("/api/duplicates/last-scan").get_json()
+    assert body["found"] is True
+    assert body["job_id"] == job2
+    hashes = [p["file_hash"] for p in body["result"]["proposals"]]
+    assert "HNEW" in hashes
+    assert "HOLD" in hashes  # still present in the library
+
+
+def test_last_scan_ignores_failed_jobs(app_and_db):
+    """A failed scan in history must not be served as the 'last' result."""
+    app, db = app_and_db
+    # Insert a synthetic 'failed' duplicate-scan row directly into history.
+    db.conn.execute(
+        """INSERT INTO job_history
+              (id, type, status, started_at, finished_at, duration, result)
+           VALUES (?, 'duplicate-scan', 'failed', ?, ?, 0.0, NULL)""",
+        ("duplicate-scan-failed-1", "2026-01-01T00:00:00", "2026-01-01T00:00:01"),
+    )
+    db.conn.commit()
+
+    body = app.test_client().get("/api/duplicates/last-scan").get_json()
+    assert body == {"found": False}


### PR DESCRIPTION
## Problem

Scan for duplicates, navigate away, come back to /duplicates → forced to rescan from scratch, even though the prior scan's full proposal list was already persisted in `job_history.result` (~2 MB blob with all winners/losers).

The page only held results in a JS variable (`_proposals`) and had no logic to query for or restore prior scans on mount.

## Fix

- New endpoint `GET /api/duplicates/last-scan` returns the most recent completed `duplicate-scan` row from `job_history`, including its parsed `result`. Library-wide on purpose: duplicate detection itself ignores workspace scope, so a prior scan's result is valid for any active workspace.
- `duplicates.html` now calls this endpoint on `DOMContentLoaded` and, if a result is found, renders it and shows a small "Showing results from your last scan (Nm ago). Click Scan for duplicate files above for a fresh scan." banner. The banner is cleared when the user starts a new scan or applies/clears results.

## Test plan

- [x] `vireo/tests/test_duplicates_api.py` — 4 new endpoint tests (no history, after one completed scan, picks most recent, ignores failed jobs)
- [x] `tests/e2e/test_duplicates_restore.py` — 3 new browser tests (banner restored on mount, no banner when no prior scan, banner clears on new scan)
- [x] All 172 tests in `test_duplicates_api.py` + `test_app.py` + new e2e: pass
- [x] All 111 tests in `test_duplicates*` + `test_jobs_api.py`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)