### PR TITLE
ui(duplicates): rename "loser" → "extra copy" in user-visible strings

### DIFF
--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -216,7 +216,7 @@
   <div class="page-header">
     <div>
       <h1>Duplicate Files</h1>
-      <div class="sub">Find exact-byte duplicate photos and reject the inferior copy.</div>
+      <div class="sub">Find exact-byte duplicate photos and remove the extra copies.</div>
     </div>
     <div>
       <button id="scanBtn" class="btn-primary" onclick="startScan()">Scan for duplicate files</button>
@@ -237,7 +237,7 @@
   </div>
 
   <div id="applyBar" class="apply-bar" style="display:none;">
-    <button id="applyBtn" class="btn-primary" onclick="applyRejections()">Reject 0 losers</button>
+    <button id="applyBtn" class="btn-primary" onclick="applyRejections()">Reject 0 extra copies</button>
     <button class="btn-secondary" onclick="clearResults()">Clear results</button>
     <span id="applyStatus" style="font-size:12px;color:var(--text-dim);"></span>
   </div>
@@ -381,13 +381,13 @@
       '<div class="summary-stat"><div class="num">' + unresolvedGroupCount + '</div>' +
         '<div class="label">Need review</div></div>' +
       '<div class="summary-stat"><div class="num" style="color:var(--danger);">' + unresolvedLoserCount + '</div>' +
-        '<div class="label">Losers to reject</div></div>';
+        '<div class="label">Extras to reject</div></div>';
     if (resolvedGroupCount > 0) {
       summaryHtml +=
         '<div class="summary-stat"><div class="num">' + resolvedGroupCount + '</div>' +
           '<div class="label">Already resolved</div></div>' +
         '<div class="summary-stat"><div class="num">' + formatBytes(resolvedBytes) + '</div>' +
-          '<div class="label">Loser files on disk</div></div>';
+          '<div class="label">Extra files on disk</div></div>';
     }
     summaryHtml += '</div>';
     summary.innerHTML = summaryHtml;
@@ -419,7 +419,7 @@
           '</h2>' +
           '<div class="section-sub">' + resolvedGroupCount +
           ' group' + (resolvedGroupCount === 1 ? '' : 's') +
-          ' auto-handled during scan. Loser files (' + formatBytes(resolvedBytes) +
+          ' auto-handled during scan. Extra copies (' + formatBytes(resolvedBytes) +
           ') may still be on disk.</div>' +
         '</div>';
       // Hide the bulk button entirely when every remaining resolved group is
@@ -428,8 +428,8 @@
       html += '<div class="section-actions">';
       if (bulkTrashableLoserCount > 0) {
         html += '<button class="btn-secondary" onclick="trashAllLoserFiles()" id="trashAllBtn">' +
-            'Move ' + bulkTrashableLoserCount + ' loser file' +
-            (bulkTrashableLoserCount === 1 ? '' : 's') + ' to Trash' +
+            'Move ' + bulkTrashableLoserCount + ' extra ' +
+            (bulkTrashableLoserCount === 1 ? 'copy' : 'copies') + ' to Trash' +
           '</button>';
       }
       html += '</div></div>';
@@ -474,8 +474,8 @@
       if (group.status === 'resolved') {
         return '<div class="group-warning severe">' +
           '<b>Heads up:</b> the kept file in this resolved group is missing on disk. ' +
-          'Any surviving loser file below may be the only remaining copy — ' +
-          'trash actions on those losers are disabled to prevent data loss. ' +
+          'Any surviving extra copy below may be the only remaining copy — ' +
+          'trash actions on those extras are disabled to prevent data loss. ' +
           'Restore the kept file, or rescan the folder so Vireo can re-resolve.' +
           '</div>';
       }
@@ -488,7 +488,7 @@
     }
     if (anyLoserMissing) {
       return '<div class="group-warning">' +
-        'One or more loser files are already missing on disk. They’ll be ' +
+        'One or more extra copies are already missing on disk. They’ll be ' +
         'rejected in the DB; trash actions will skip them.' +
         '</div>';
     }
@@ -530,7 +530,8 @@
                (winnerMissing ? ' data-protected="winner-missing"' : '') + '>';
     html += '<div class="dup-group-header">';
     html += '<label style="cursor:default;">' +
-            losers.length + ' loser' + (losers.length === 1 ? '' : 's') +
+            losers.length + ' extra ' +
+            (losers.length === 1 ? 'copy' : 'copies') +
             ' rejected during scan</label>';
     html += '<span class="hash">' + escapeHtml(hash.substring(0, 16)) + '...</span>';
     html += '</div>';
@@ -661,8 +662,8 @@
     if (!confirm('Move ' + ids.length + ' file' + (ids.length === 1 ? '' : 's') +
                  ' to Trash and remove their entries from Vireo?\n\n' +
                  'Files go to your OS Trash (recoverable from there). The ' +
-                 'corresponding loser records (and their thumbnails/previews) ' +
-                 'are deleted from Vireo. Winners keep all merged keywords ' +
+                 'corresponding extra-copy records (and their thumbnails/previews) ' +
+                 'are deleted from Vireo. Kept copies retain all merged keywords ' +
                  'and ratings.')) {
       return;
     }
@@ -743,8 +744,8 @@
         });
         if (remaining > 0) {
           btn.disabled = false;
-          btn.textContent = 'Move ' + remaining + ' loser file' +
-                            (remaining === 1 ? '' : 's') + ' to Trash';
+          btn.textContent = 'Move ' + remaining + ' extra ' +
+                            (remaining === 1 ? 'copy' : 'copies') + ' to Trash';
         } else {
           // Mirror the initial render: when there's nothing left that the
           // bulk action would actually touch, drop the button rather than
@@ -753,7 +754,7 @@
         }
       }
     } catch (e) {
-      if (btn) { btn.disabled = false; btn.textContent = 'Move loser files to Trash'; }
+      if (btn) { btn.disabled = false; btn.textContent = 'Move extra copies to Trash'; }
     }
   }
 
@@ -781,7 +782,7 @@
     var loserCount = 0;
     checked.forEach(function(g) { loserCount += (g.losers || []).length; });
     var btn = document.getElementById('applyBtn');
-    btn.textContent = 'Reject ' + loserCount + ' loser' + (loserCount === 1 ? '' : 's');
+    btn.textContent = 'Reject ' + loserCount + ' extra ' + (loserCount === 1 ? 'copy' : 'copies');
     btn.disabled = loserCount === 0;
   }
 


### PR DESCRIPTION
## Summary

The duplicates page exposed internal "loser" jargon throughout: button labels, summary stats, group headers, the bulk-trash confirm dialog, and warning banners. "Loser" is accurate dedup-tooling terminology, but in a personal photo app it reads as a value judgment about a file the user took.

Switch user-visible copy to **"extra copy"** / **"extras"** — natural language pair for "Keep" (Keep / Extra) without the connotation. Internal naming (CSS `.loser` class, JS variables/functions, API URL `/api/duplicates/delete-loser-files`, Python field names) is intentionally **unchanged** — pure UI rename, no behavior change, minimal blast radius.

### Strings changed (all in `vireo/templates/duplicates.html`)

- "Reject N losers" → "Reject N extra copies"
- "Losers to reject" → "Extras to reject"
- "Loser files on disk" → "Extra files on disk"
- "Loser files (...) auto-handled" → "Extra copies (...) auto-handled"
- "Move N loser file(s) to Trash" → "Move N extra cop{y,ies} to Trash"
- "Any surviving loser file below" → "Any surviving extra copy below"
- "trash actions on those losers" → "trash actions on those extras"
- "One or more loser files are already missing" → "One or more extra copies are already missing"
- "N loser(s) rejected during scan" → "N extra cop{y,ies} rejected during scan"
- "corresponding loser records" → "corresponding extra-copy records"
- Page sub-header: "reject the inferior copy" → "remove the extra copies"
- Bulk-confirm: "Winners keep all merged keywords" → "Kept copies retain all merged keywords"

## Test plan

- [x] Jinja template parses
- [x] Duplicates test suite passes (76/76 — `test_duplicates.py`, `test_duplicates_db.py`, `test_duplicates_api.py`)
- [x] grep confirms no remaining user-visible "loser" strings; only internal CSS/JS/Python identifiers and code comments remain

## Follow-ups (separate PRs)

- Auto-reopen resolved groups on scan when the kept file goes missing — eliminates the "this resolved group's kept file is missing" warning state entirely
- Bulk-decide UI for ambiguous duplicate groups (group by parent-dir set; one decision per bucket, with mark-vs-delete toggle and "Reveal all in Finder")
- Drop the longer-path tiebreaker from the resolver (depends on the bulk-decide UI shipping first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)