### PR TITLE
fix(duplicates): auto-reopen resolved groups when winner file disappears

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1973,6 +1973,22 @@ class Database:
             "rejected": len(loser_ids),
         }
 
+    def reopen_duplicate_group(self, file_hash):
+        """Un-reject all rejected rows sharing this file_hash.
+
+        Used by the duplicate scan when the kept file has gone missing on
+        disk but a rejected sibling still exists — clearing the rejection
+        lets the next proposal pass run Rule 0 and promote the survivor.
+        Returns the number of rows un-rejected.
+        """
+        with self.conn:
+            cur = self.conn.execute(
+                "UPDATE photos SET flag = 'none' "
+                "WHERE file_hash = ? AND flag = 'rejected'",
+                (file_hash,),
+            )
+            return cur.rowcount
+
     # Columns to return in photo list queries (excludes large fields)
     PHOTO_COLS = """id, folder_id, filename, extension, file_size, file_mtime, xmp_mtime,
                     timestamp, width, height, rating, flag, thumb_path, sharpness,

--- a/vireo/duplicate_scan.py
+++ b/vireo/duplicate_scan.py
@@ -119,6 +119,16 @@ def _build_resolved_proposal(db, group):
         # will surface it again on the next scan.
         return None
 
+    # Auto-reopen: if the kept file is gone but a rejected sibling still
+    # exists on disk, the DB-frozen winner is now a ghost while a survivor
+    # is sitting unhandled. Un-reject the group and rebuild as unresolved
+    # so Rule 0 (present beats missing) promotes the survivor.
+    if not info_by_id[kept[0]["id"]]["exists"] and any(
+        info_by_id[r["id"]]["exists"] for r in rejected
+    ):
+        db.reopen_duplicate_group(group["file_hash"])
+        return _build_unresolved_proposal(db, group)
+
     candidates = [
         DupCandidate(id=r["id"], path=info_by_id[r["id"]]["path"],
                      mtime=r["file_mtime"] or 0.0,

--- a/vireo/tests/test_duplicates_db.py
+++ b/vireo/tests/test_duplicates_db.py
@@ -689,15 +689,15 @@ def test_run_duplicate_scan_marks_missing_files(tmp_path):
     assert prop["losers"][0]["reason"] == "file missing on disk"
 
 
-def test_run_duplicate_scan_resolved_winner_missing_keeps_kept_row(tmp_path):
-    """Resolved groups don't promote — the kept DB row stays the winner even
-    when its file is gone but a rejected sibling's file still exists.
+def test_run_duplicate_scan_reopens_resolved_when_winner_missing_and_loser_exists(tmp_path):
+    """Resolved groups auto-reopen when the kept file is gone but a rejected
+    sibling still exists. The next proposal then runs Rule 0 and promotes the
+    survivor as the new winner.
 
-    Models the scenario where auto-resolve picked a winner earlier (when both
-    files were on disk) and then the kept file was later deleted out from
-    under Vireo. The UI guards against trashing the surviving loser via the
-    warning banner + disabled trash buttons; this test locks in the proposal
-    shape so the JS can rely on ``winner.exists === false`` to detect it.
+    Without auto-reopen, the DB-frozen kept row would stay the winner forever
+    and the UI would have to disable trash on the survivor to avoid data loss.
+    With auto-reopen, the surviving sibling becomes the new winner and the
+    user can resolve normally.
     """
     from duplicate_scan import run_duplicate_scan
 
@@ -713,8 +713,8 @@ def test_run_duplicate_scan_resolved_winner_missing_keeps_kept_row(tmp_path):
     # using Rule 1 — clean filename wins).
     (a_dir / "owl.jpg").write_bytes(b"x")
     (b_dir / "owl-2.jpg").write_bytes(b"x")
-    p_kept = _add(db, a_fid, "owl.jpg", file_hash="HRESM")
-    p_loser = _add(db, b_fid, "owl-2.jpg", file_hash="HRESM")
+    p_kept = _add(db, a_fid, "owl.jpg", file_hash="HREOPEN")
+    p_loser = _add(db, b_fid, "owl-2.jpg", file_hash="HREOPEN")
 
     # Sanity: auto-resolve should have flagged p_loser as rejected.
     flags = {
@@ -725,20 +725,69 @@ def test_run_duplicate_scan_resolved_winner_missing_keeps_kept_row(tmp_path):
     }
     assert flags == {p_kept: "none", p_loser: "rejected"}
 
-    # Now the kept file disappears from disk after auto-resolve.
+    # The kept file disappears from disk after auto-resolve.
     (a_dir / "owl.jpg").unlink()
+
+    result = run_duplicate_scan({"progress": {}}, db, include_resolved=True)
+    # Auto-reopened: the group now appears as unresolved with the surviving
+    # sibling promoted to winner via Rule 0.
+    assert len(result["proposals"]) == 1
+    prop = result["proposals"][0]
+    assert prop["status"] == "unresolved"
+    assert prop["winner"]["id"] == p_loser
+    assert prop["winner"]["exists"] is True
+    assert len(prop["losers"]) == 1
+    assert prop["losers"][0]["id"] == p_kept
+    assert prop["losers"][0]["exists"] is False
+    assert prop["losers"][0]["reason"] == "file missing on disk"
+
+    # Both rows fully un-rejected so the user can apply a fresh resolution.
+    flags_after = {
+        r["id"]: r["flag"]
+        for r in db.conn.execute(
+            "SELECT id, flag FROM photos WHERE id IN (?, ?)", (p_kept, p_loser)
+        ).fetchall()
+    }
+    assert flags_after == {p_kept: "none", p_loser: "none"}
+
+
+def test_run_duplicate_scan_resolved_winner_missing_all_siblings_missing_stays_resolved(tmp_path):
+    """When the kept file AND every rejected sibling are all gone, the group
+    does NOT auto-reopen — there's no surviving copy to promote, so it still
+    surfaces as resolved with all_missing=True for orphan-row cleanup.
+    """
+    from duplicate_scan import run_duplicate_scan
+
+    db = Database(str(tmp_path / "t.db"))
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    a_dir.mkdir()
+    b_dir.mkdir()
+    a_fid = db.add_folder(str(a_dir))
+    b_fid = db.add_folder(str(b_dir))
+
+    (a_dir / "owl.jpg").write_bytes(b"x")
+    (b_dir / "owl-2.jpg").write_bytes(b"x")
+    p_kept = _add(db, a_fid, "owl.jpg", file_hash="HALLGONE")
+    p_loser = _add(db, b_fid, "owl-2.jpg", file_hash="HALLGONE")
+
+    (a_dir / "owl.jpg").unlink()
+    (b_dir / "owl-2.jpg").unlink()
 
     result = run_duplicate_scan({"progress": {}}, db, include_resolved=True)
     resolved = [p for p in result["proposals"] if p["status"] == "resolved"]
     assert len(resolved) == 1
     prop = resolved[0]
-    # Winner is still the kept DB row — _build_resolved_proposal does not
-    # promote based on existence; it surfaces the row that flag != 'rejected'.
     assert prop["winner"]["id"] == p_kept
     assert prop["winner"]["exists"] is False
-    assert prop["losers"][0]["id"] == p_loser
-    assert prop["losers"][0]["exists"] is True
-    assert prop["all_missing"] is False
+    assert prop["all_missing"] is True
+    flags_after = {
+        r["id"]: r["flag"]
+        for r in db.conn.execute(
+            "SELECT id, flag FROM photos WHERE id IN (?, ?)", (p_kept, p_loser)
+        ).fetchall()
+    }
+    assert flags_after == {p_kept: "none", p_loser: "rejected"}
 
 
 def test_run_duplicate_scan_all_missing_flag(tmp_path):


### PR DESCRIPTION
## Summary

If a duplicate group was auto-resolved earlier and the kept file is later deleted or moved off-disk while a rejected sibling's file still exists, the DB-frozen winner becomes a ghost: the proposal hardcodes the original kept row as winner, the surviving sibling stays flagged \`rejected\`, and the UI has to disable trash on the only remaining copy to prevent data loss.

[PR #696](https://github.com/jss367/vireo/pull/696) added a defensive UI warning + trash-disabling for this state, but the root cause was that scan never re-evaluated resolution correctness against current disk state.

This PR fixes the root cause:

- **\`Database.reopen_duplicate_group(file_hash)\`** — single-transaction un-reject of all rows sharing a hash.
- **\`_build_resolved_proposal\`** — when \`winner.exists\` is False but at least one rejected sibling exists on disk, calls \`reopen_duplicate_group\` and returns \`_build_unresolved_proposal\` instead. \`resolve_duplicates\` Rule 0 (present beats missing) then promotes the survivor cleanly.
- **All-missing case unaffected** — when every file is gone, the reopen branch is skipped and the existing \`all_missing=True\` orphan-cleanup path runs as before.

## User-visible behavior

- Before: kept file deleted → "Heads up: the kept file in this resolved group is missing on disk. Trash actions disabled..." with the user stuck unless they restored the file.
- After: rescan → surviving sibling promoted to KEEP. User can apply, trash, or override normally.

## Test plan

- [x] New: \`test_run_duplicate_scan_reopens_resolved_when_winner_missing_and_loser_exists\` — auto-reopen happy path (replaces the prior \`...keeps_kept_row\` test that asserted the old behavior).
- [x] New: \`test_run_duplicate_scan_resolved_winner_missing_all_siblings_missing_stays_resolved\` — pins the all-missing fallback so we don't accidentally tear down the orphan-cleanup path.
- [x] 646 tests pass across \`test_db.py\`, \`test_duplicates*.py\`, \`test_app.py\`, \`test_jobs_api.py\`.

## Follow-ups (separate PRs)

- UI cleanup: the \`if (group.status === 'resolved')\` branch in \`renderGroupWarning\` is now structurally unreachable (any resolved group with winner missing + sibling exists gets reopened during scan; only the \`all_missing\` case can leave a resolved-status group with winner missing). Punt to a follow-on once #699 (loser→extras rename) merges, to avoid the merge conflict on the warning copy.
- Bulk-decide UI for ambiguous unresolved groups (queued as PR #3 in our plan).
- Drop Rule 2 (longer-path tiebreaker) once bulk-decide is in (PR #4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)