### PR TITLE
feat(duplicates): bucket unresolved groups by parent-dir set

### DIFF
--- a/vireo/duplicate_buckets.py
+++ b/vireo/duplicate_buckets.py
@@ -1,0 +1,52 @@
+"""Bucket unresolved duplicate proposals by parent-dir set.
+
+When the same dedup question repeats hundreds of times — same two folders,
+different filenames — the UI lets the user decide once for the whole bucket
+instead of clicking through every group. Pure function: input is the
+``proposals`` list from :func:`duplicate_scan.run_duplicate_scan`, output is
+a list of bucket dicts ready for the UI.
+"""
+import os
+from collections import defaultdict
+
+
+def bucket_unresolved_proposals(proposals):
+    """Group unresolved proposals by the set of parent directories of their
+    candidates. Returns a list of bucket dicts sorted by ``group_count`` desc.
+
+    A bucket dict has:
+
+    - ``folders``: sorted list of parent directory paths
+    - ``group_count``: number of duplicate groups in this bucket
+    - ``file_hashes``: list of file_hashes belonging to this bucket
+    - ``total_size``: bytes recoverable if the user picks any one folder
+      (``sum_per_group(n_candidates - 1) * file_size``)
+    - ``example_filenames``: up to 3 sample filenames for UI preview
+
+    Resolved proposals are filtered out — they're already done.
+    """
+    by_key = defaultdict(list)
+    for p in proposals:
+        if p.get("status") != "unresolved":
+            continue
+        paths = [p["winner"]["path"]] + [l["path"] for l in p["losers"]]
+        key = frozenset(os.path.dirname(path) for path in paths)
+        by_key[key].append(p)
+
+    buckets = []
+    for key, group_proposals in by_key.items():
+        total_size = sum(
+            len(p["losers"]) * p["winner"]["file_size"]
+            for p in group_proposals
+        )
+        examples = [p["winner"]["filename"] for p in group_proposals[:3]]
+        buckets.append({
+            "folders": sorted(key),
+            "group_count": len(group_proposals),
+            "file_hashes": [p["file_hash"] for p in group_proposals],
+            "total_size": total_size,
+            "example_filenames": examples,
+        })
+
+    buckets.sort(key=lambda b: -b["group_count"])
+    return buckets

--- a/vireo/duplicate_scan.py
+++ b/vireo/duplicate_scan.py
@@ -5,6 +5,7 @@ Read-only. Does not apply — the UI shows the preview and a user action (the
 """
 import os
 
+from duplicate_buckets import bucket_unresolved_proposals
 from duplicates import DupCandidate, resolve_duplicates
 
 # SQLite's legacy ``SQLITE_MAX_VARIABLE_NUMBER`` cap is 999 on older builds.
@@ -188,6 +189,7 @@ def run_duplicate_scan(job, db, include_resolved=True):
 
     return {
         "proposals": proposals,
+        "buckets": bucket_unresolved_proposals(proposals),
         "group_count": total,
         "loser_count": sum(
             len(p["losers"]) for p in proposals if p["status"] == "unresolved"

--- a/vireo/tests/test_duplicate_buckets.py
+++ b/vireo/tests/test_duplicate_buckets.py
@@ -1,0 +1,147 @@
+"""Tests for the unresolved-proposal bucketing helper.
+
+Bucketing groups unresolved duplicate proposals that share the same set of
+parent directories so the user can decide once for many groups instead of
+clicking through each. See docs/plans/duplicates-bulk-decide.md.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from duplicate_buckets import bucket_unresolved_proposals
+
+
+def _proposal(file_hash, paths, file_size=1000):
+    """Build a minimal unresolved-proposal dict with given paths.
+
+    First path is the winner; remaining are losers. The function under test
+    only reads ``status``, ``file_hash``, ``winner.path``, ``winner.file_size``,
+    and ``losers[].path`` / ``losers[].file_size`` so the rest is omitted.
+    """
+    return {
+        "status": "unresolved",
+        "file_hash": file_hash,
+        "winner": {"path": paths[0], "filename": os.path.basename(paths[0]),
+                   "file_size": file_size},
+        "losers": [
+            {"path": p, "filename": os.path.basename(p), "file_size": file_size}
+            for p in paths[1:]
+        ],
+    }
+
+
+def test_empty_input_returns_empty_buckets():
+    assert bucket_unresolved_proposals([]) == []
+
+
+def test_single_proposal_returns_one_bucket():
+    proposals = [_proposal("h1", ["/a/owl.jpg", "/b/owl.jpg"], file_size=500)]
+    buckets = bucket_unresolved_proposals(proposals)
+    assert len(buckets) == 1
+    bucket = buckets[0]
+    assert bucket["folders"] == ["/a", "/b"]
+    assert bucket["group_count"] == 1
+    assert bucket["file_hashes"] == ["h1"]
+    # Savings = (n_candidates - 1) * file_size = 1 * 500.
+    assert bucket["total_size"] == 500
+
+
+def test_proposals_with_same_parent_dirs_collapse_into_one_bucket():
+    proposals = [
+        _proposal("h1", ["/a/owl.jpg", "/b/owl.jpg"]),
+        _proposal("h2", ["/a/hawk.jpg", "/b/hawk.jpg"]),
+        _proposal("h3", ["/a/finch.jpg", "/b/finch.jpg"]),
+    ]
+    buckets = bucket_unresolved_proposals(proposals)
+    assert len(buckets) == 1
+    bucket = buckets[0]
+    assert bucket["folders"] == ["/a", "/b"]
+    assert bucket["group_count"] == 3
+    assert sorted(bucket["file_hashes"]) == ["h1", "h2", "h3"]
+    assert bucket["total_size"] == 3 * 1000
+
+
+def test_winner_and_loser_order_does_not_affect_bucketing():
+    """Bucket key uses the *set* of parent dirs across winner+losers, so
+    swapping which file Rule 0/1 picked as winner shouldn't split a bucket."""
+    proposals = [
+        _proposal("h1", ["/a/owl.jpg", "/b/owl.jpg"]),
+        _proposal("h2", ["/b/hawk.jpg", "/a/hawk.jpg"]),
+    ]
+    buckets = bucket_unresolved_proposals(proposals)
+    assert len(buckets) == 1
+    assert buckets[0]["group_count"] == 2
+
+
+def test_proposals_with_different_parent_dirs_split_into_separate_buckets():
+    proposals = [
+        _proposal("h1", ["/a/owl.jpg", "/b/owl.jpg"]),
+        _proposal("h2", ["/c/hawk.jpg", "/d/hawk.jpg"]),
+    ]
+    buckets = bucket_unresolved_proposals(proposals)
+    assert len(buckets) == 2
+    folders_seen = {tuple(b["folders"]) for b in buckets}
+    assert folders_seen == {("/a", "/b"), ("/c", "/d")}
+
+
+def test_three_way_groups_form_distinct_buckets_from_two_way():
+    """A {a, b, c} bucket and an {a, b} bucket are different shapes — the
+    user has different choices to make for each."""
+    proposals = [
+        _proposal("h1", ["/a/owl.jpg", "/b/owl.jpg", "/c/owl.jpg"]),
+        _proposal("h2", ["/a/hawk.jpg", "/b/hawk.jpg"]),
+    ]
+    buckets = bucket_unresolved_proposals(proposals)
+    assert len(buckets) == 2
+    by_size = {len(b["folders"]): b for b in buckets}
+    assert sorted(by_size[3]["folders"]) == ["/a", "/b", "/c"]
+    assert sorted(by_size[2]["folders"]) == ["/a", "/b"]
+    # 3-way bucket savings = (3 - 1) * 1000.
+    assert by_size[3]["total_size"] == 2000
+
+
+def test_resolved_proposals_are_filtered_out():
+    proposals = [
+        _proposal("h1", ["/a/owl.jpg", "/b/owl.jpg"]),
+        {**_proposal("h2", ["/a/hawk.jpg", "/b/hawk.jpg"]), "status": "resolved"},
+    ]
+    buckets = bucket_unresolved_proposals(proposals)
+    assert len(buckets) == 1
+    assert buckets[0]["group_count"] == 1
+    assert buckets[0]["file_hashes"] == ["h1"]
+
+
+def test_buckets_sorted_by_group_count_descending():
+    """Most-impactful buckets first so the UI can lead with them."""
+    proposals = (
+        [_proposal(f"sm{i}", ["/c/x.jpg", "/d/x.jpg"]) for i in range(2)]
+        + [_proposal(f"lg{i}", ["/a/x.jpg", "/b/x.jpg"]) for i in range(5)]
+    )
+    buckets = bucket_unresolved_proposals(proposals)
+    assert [b["group_count"] for b in buckets] == [5, 2]
+
+
+def test_bucket_includes_example_filenames_for_ui_preview():
+    """UI shows up to 3 sample filenames per bucket so the user can sanity-
+    check before bulk-resolving."""
+    proposals = [
+        _proposal(f"h{i}", [f"/a/photo{i}.jpg", f"/b/photo{i}.jpg"])
+        for i in range(5)
+    ]
+    buckets = bucket_unresolved_proposals(proposals)
+    assert len(buckets) == 1
+    examples = buckets[0]["example_filenames"]
+    assert len(examples) == 3
+    assert all(name.startswith("photo") and name.endswith(".jpg") for name in examples)
+
+
+def test_same_folder_duplicates_form_a_single_folder_bucket():
+    """Two copies in the same folder (rare but possible) → bucket with one
+    folder. UI can render this as 'X duplicates within folder Y'."""
+    proposals = [
+        _proposal("h1", ["/a/owl.jpg", "/a/owl-2.jpg"]),
+    ]
+    buckets = bucket_unresolved_proposals(proposals)
+    assert len(buckets) == 1
+    assert buckets[0]["folders"] == ["/a"]

--- a/vireo/tests/test_duplicates_db.py
+++ b/vireo/tests/test_duplicates_db.py
@@ -433,6 +433,37 @@ def test_run_duplicate_scan_excludes_resolved_when_opt_out(tmp_path):
     assert result["resolved_group_count"] == 0
 
 
+def test_run_duplicate_scan_emits_buckets_for_unresolved_groups(tmp_path):
+    """Scan response includes pre-computed buckets so the UI can offer one
+    decision per (folder-set) bucket instead of per-group. Three unresolved
+    groups all sharing the same {folderA, folderB} parent-dir set should
+    collapse to a single bucket with group_count=3."""
+    from duplicate_scan import run_duplicate_scan
+
+    db = Database(str(tmp_path / "t.db"))
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    a_dir.mkdir()
+    b_dir.mkdir()
+    a_fid = db.add_folder(str(a_dir))
+    b_fid = db.add_folder(str(b_dir))
+
+    # Three groups, each with one file in /a and one in /b. Reset flags so
+    # the auto-resolve hook doesn't pre-pick a winner — we want unresolved.
+    for h, name in [("HBKT1", "owl.jpg"), ("HBKT2", "hawk.jpg"), ("HBKT3", "finch.jpg")]:
+        _add(db, a_fid, name, file_hash=h)
+        _add(db, b_fid, name, file_hash=h)
+        _reset_flags(db, h)
+
+    result = run_duplicate_scan({"progress": {}}, db, include_resolved=False)
+    assert "buckets" in result
+    assert len(result["buckets"]) == 1
+    bucket = result["buckets"][0]
+    assert sorted(bucket["folders"]) == [str(a_dir), str(b_dir)]
+    assert bucket["group_count"] == 3
+    assert sorted(bucket["file_hashes"]) == ["HBKT1", "HBKT2", "HBKT3"]
+
+
 def test_run_duplicate_scan_chunks_large_groups(tmp_path, monkeypatch):
     """A single resolved group with more than ``_SQL_PARAM_CHUNK`` photo_ids
     must not raise ``OperationalError`` on SQLite builds with the legacy


### PR DESCRIPTION
## Summary

When the same dedup question repeats hundreds of times — same two folders, different filenames — clicking through every group one at a time is a miserable workflow. Bucketing lets the UI offer one decision per (folder-set) bucket and apply it to every group in the bucket.

This PR is the **backend-only foundation**. The bulk-resolve endpoint and the bulk-decide UI that consume this data land in a follow-on PR — they are tightly coupled to each other, but neither requires touching this layer once it's in.

### Changes

- **New \`vireo/duplicate_buckets.py\`** — pure function \`bucket_unresolved_proposals(proposals)\`. Bucket key is \`frozenset(parent_dirs)\` across winner+losers, so two-way and three-way buckets are naturally distinct and winner/loser order doesn't fragment a bucket.
- **\`run_duplicate_scan\`** now returns \`buckets\` alongside \`proposals\` so the UI can render the summary section without a second pass.

### Bucket dict shape

\`\`\`python
{
  "folders": ["/a", "/b"],          # sorted parent dirs
  "group_count": 247,                # number of groups in this bucket
  "file_hashes": ["abc...", ...],    # all hashes in this bucket
  "total_size": 24700000,            # bytes recoverable if user picks any one folder
  "example_filenames": ["owl.jpg", "hawk.jpg", "finch.jpg"],  # up to 3 preview names
}
\`\`\`

Buckets are sorted by \`group_count\` desc so the most-impactful surface first.

## Test plan

- [x] 10 unit tests in \`test_duplicate_buckets.py\` cover: empty input, single proposal, same/different parent-dir collapse, winner/loser-order independence, 2-way vs 3-way splitting, resolved-proposal filtering, group_count sort, example filenames, same-folder duplicates.
- [x] 1 integration test in \`test_duplicates_db.py\` exercises end-to-end through \`run_duplicate_scan\`.
- [x] All 92 duplicate-related tests pass.

## Follow-ups

- PR 3b: \`/api/duplicates/bulk-resolve\` endpoint + bulk-decide UI section. Endpoint contract: \`{file_hashes, keep_folder, delete_files: bool}\` → resolves all groups by forcing winner = photo whose folder matches \`keep_folder\`, optionally trashes the extras.
- PR 3c: \`/api/folders/reveal\` endpoint + "Reveal all in Finder" button (reuses existing cross-platform reveal logic at \`vireo/app.py:1671\`).
- PR 4: Drop Rule 2 (longer-path tiebreaker) once the bulk-decide UI exists to absorb the resulting ambiguous groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)