### PR TITLE
fix(workspace): summarize arrays/objects in Recent Jobs result cell

### DIFF
--- a/vireo/templates/workspace.html
+++ b/vireo/templates/workspace.html
@@ -205,7 +205,17 @@ async function loadHistory() {
         try {
           var parsed = typeof r.result === 'string' ? JSON.parse(r.result) : r.result;
           var parts = [];
-          for (var k in parsed) parts.push(k + ': ' + parsed[k]);
+          for (var k in parsed) {
+            var v = parsed[k];
+            // Arrays/objects (e.g. duplicate-scan's `proposals` list) would
+            // stringify to `[object Object],...` and blow out the cell;
+            // summarize them by length instead.
+            var disp;
+            if (Array.isArray(v)) disp = v.length + ' items';
+            else if (v !== null && typeof v === 'object') disp = '{...}';
+            else disp = String(v);
+            parts.push(k + ': ' + disp);
+          }
           result = parts.join(', ');
         } catch(e) { result = String(r.result); }
       }


### PR DESCRIPTION
## Summary

The Recent Jobs table on the Workspace settings page rendered the `Result` cell using default JS string coercion, so an array of objects (e.g. the `proposals` list a `duplicate-scan` job stores) came out as `proposals: [object Object],[object Object],…` repeated thousands of times.

`vireo/templates/workspace.html:208` — `loadHistory()` now detects arrays and objects explicitly:
- Arrays → `N items` (e.g. `proposals: 3101 items`)
- Plain objects → `{...}`
- Primitives (numbers, strings, bools) → unchanged

I considered also dropping `proposals` from the persisted job result, but `/api/duplicates/last-scan` (`vireo/app.py:7089`) reads it directly to power the duplicates-page restore-on-mount feature shipped in 62dfe0e, so removing it would be a separate refactor with behavior implications. Defensive rendering is the right scope here.

## Test plan

- [x] `python -m pytest tests/test_workspaces_api.py tests/test_jobs_api.py tests/test_app.py tests/test_config.py -q` → 239 passed
- [x] Rendered `/workspace` via Flask test client; page returns 200 and contains the new render branch
- [x] Hand-traced the actual user payload (`group_count: 3101, loser_count: 0, proposals: [...3101 objects...]`) → produces `group_count: 3101, loser_count: 0, proposals: 3101 items, …`