### PR TITLE
feat(duplicates): bulk-decide UI for ambiguous group buckets

### DIFF
--- a/tests/e2e/test_duplicates_bulk_decide.py
+++ b/tests/e2e/test_duplicates_bulk_decide.py
@@ -1,0 +1,117 @@
+"""E2E test: /duplicates page renders the bulk-decide section when the
+scan result includes multi-group buckets, and a single Keep-folder click
+resolves all groups in the bucket.
+"""
+import json
+
+from playwright.sync_api import expect
+
+
+def _seed_scan_with_buckets(db, folder_a, folder_b, n_groups=3):
+    """Insert a synthetic scan result with one bucket of N groups, all
+    sharing the same {folder_a, folder_b} parent-dir set."""
+    # Need real DB rows so the bulk-resolve API can find candidates.
+    a_fid = db.add_folder(folder_a)
+    b_fid = db.add_folder(folder_b)
+    proposals = []
+    file_hashes = []
+    for i in range(n_groups):
+        h = f"BULK{i}"
+        name = f"photo{i}.jpg"
+        p_a = db.add_photo(folder_id=a_fid, filename=name, extension=".jpg",
+                           file_size=1000, file_mtime=100.0, file_hash=h)
+        p_b = db.add_photo(folder_id=b_fid, filename=name, extension=".jpg",
+                           file_size=1000, file_mtime=100.0, file_hash=h)
+        db.conn.execute("UPDATE photos SET flag='none' WHERE file_hash=?", (h,))
+        proposals.append({
+            "file_hash": h,
+            "status": "unresolved",
+            "winner": {"id": p_a, "filename": name,
+                       "path": f"{folder_a}/{name}", "file_size": 1000},
+            "losers": [{"id": p_b, "filename": name,
+                        "path": f"{folder_b}/{name}", "file_size": 1000,
+                        "reason": "shorter path"}],
+        })
+        file_hashes.append(h)
+    db.conn.commit()
+
+    result = {
+        "group_count": n_groups,
+        "loser_count": n_groups,
+        "proposals": proposals,
+        "buckets": [{
+            "folders": sorted([folder_a, folder_b]),
+            "group_count": n_groups,
+            "file_hashes": file_hashes,
+            "total_size": n_groups * 1000,
+            "example_filenames": [p["winner"]["filename"] for p in proposals[:3]],
+        }],
+    }
+    db.conn.execute(
+        """INSERT INTO job_history
+              (id, type, status, started_at, finished_at, duration, result)
+           VALUES (?, 'duplicate-scan', 'completed', ?, ?, 1.0, ?)""",
+        (
+            "duplicate-scan-bulk-test",
+            "2026-04-27T19:00:00",
+            "2026-04-27T19:00:01",
+            json.dumps(result),
+        ),
+    )
+    db.conn.commit()
+    return file_hashes, [p["winner"]["id"] for p in proposals], \
+        [p["losers"][0]["id"] for p in proposals]
+
+
+def test_duplicates_page_renders_bulk_decide_section(live_server, page):
+    """A bucket with 3 groups surfaces a 'Bulk decide' section with one
+    'Keep ... for all 3' button per folder."""
+    folder_a, folder_b = "/tmp/dupbulkdecideA", "/tmp/dupbulkdecideB"
+    _seed_scan_with_buckets(live_server["db"], folder_a, folder_b, n_groups=3)
+
+    page.goto(f"{live_server['url']}/duplicates")
+
+    expect(page.locator("h2", has_text="Bulk decide")).to_be_visible()
+    bucket = page.locator(".bucket-card").first
+    expect(bucket).to_contain_text("3")
+    expect(bucket).to_contain_text(folder_a)
+    expect(bucket).to_contain_text(folder_b)
+    # One button per folder, labeled with the folder's basename.
+    keep_buttons = bucket.locator(".keep-btn")
+    expect(keep_buttons).to_have_count(2)
+    expect(keep_buttons.nth(0)).to_contain_text("for all 3")
+
+
+def test_duplicates_bulk_decide_keep_folder_resolves_all_groups(live_server, page):
+    """Clicking 'Keep <folder> for all N' POSTs to bulk-resolve, flips the
+    DB state, and removes the bucket from the rendered page."""
+    folder_a, folder_b = "/tmp/dupbulkactA", "/tmp/dupbulkactB"
+    file_hashes, winner_ids, loser_ids = _seed_scan_with_buckets(
+        live_server["db"], folder_a, folder_b, n_groups=2
+    )
+
+    # Auto-accept the confirm() dialog. Wired before navigation so any
+    # early dialog is also handled.
+    page.on("dialog", lambda d: d.accept())
+    page.goto(f"{live_server['url']}/duplicates")
+    expect(page.locator(".bucket-card")).to_have_count(1)
+
+    # Pick the /a button (index 0; folders are sorted alphabetically).
+    page.locator(".keep-btn").first.click()
+
+    # Bucket gone post-resolution.
+    expect(page.locator(".bucket-card")).to_have_count(0)
+
+    # DB confirms /a winners kept, /b siblings rejected.
+    db = live_server["db"]
+    flags = {
+        r["id"]: r["flag"]
+        for r in db.conn.execute(
+            f"SELECT id, flag FROM photos WHERE id IN ({','.join('?' * (len(winner_ids) + len(loser_ids)))})",
+            winner_ids + loser_ids,
+        ).fetchall()
+    }
+    for wid in winner_ids:
+        assert flags[wid] == "none", f"winner {wid}"
+    for lid in loser_ids:
+        assert flags[lid] == "rejected", f"loser {lid}"

--- a/tests/e2e/test_duplicates_bulk_decide.py
+++ b/tests/e2e/test_duplicates_bulk_decide.py
@@ -10,7 +10,12 @@ from playwright.sync_api import expect
 def _seed_scan_with_buckets(db, folder_a, folder_b, n_groups=3):
     """Insert a synthetic scan result with one bucket of N groups, all
     sharing the same {folder_a, folder_b} parent-dir set."""
-    # Need real DB rows so the bulk-resolve API can find candidates.
+    # Need real DB rows so the bulk-resolve API can find candidates, and
+    # real on-disk files so bulk_resolve_by_folder's existence guard
+    # doesn't skip the hashes.
+    import os
+    os.makedirs(folder_a, exist_ok=True)
+    os.makedirs(folder_b, exist_ok=True)
     a_fid = db.add_folder(folder_a)
     b_fid = db.add_folder(folder_b)
     proposals = []
@@ -18,6 +23,10 @@ def _seed_scan_with_buckets(db, folder_a, folder_b, n_groups=3):
     for i in range(n_groups):
         h = f"BULK{i}"
         name = f"photo{i}.jpg"
+        with open(os.path.join(folder_a, name), "wb") as fh:
+            fh.write(b"x")
+        with open(os.path.join(folder_b, name), "wb") as fh:
+            fh.write(b"x")
         p_a = db.add_photo(folder_id=a_fid, filename=name, extension=".jpg",
                            file_size=1000, file_mtime=100.0, file_hash=h)
         p_b = db.add_photo(folder_id=b_fid, filename=name, extension=".jpg",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6927,6 +6927,44 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             total_rejected += result.get("rejected", 0)
         return jsonify({"rejected_count": total_rejected})
 
+    @app.route("/api/duplicates/bulk-resolve", methods=["POST"])
+    def api_duplicates_bulk_resolve():
+        """Force-resolve a batch of duplicate groups by keeping the photo
+        whose folder matches ``keep_folder``.
+
+        Body: ``{"file_hashes": [str, ...], "keep_folder": str}``. For each
+        hash, the photo in ``keep_folder`` becomes the kept winner; every
+        other non-rejected photo sharing the hash becomes rejected, with
+        rating/keywords merged onto the winner.
+
+        Returns ``{"ok": True, "resolved_count": int, "resolved":
+        [{"file_hash", "winner_id", "loser_ids"}], "skipped":
+        [{"file_hash", "reason"}]}``. ``loser_ids`` is surfaced so the UI
+        can chain into ``/api/duplicates/delete-loser-files`` when the
+        user opted in to immediate trash.
+        """
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return json_error("file_hashes and keep_folder required")
+        file_hashes = body.get("file_hashes")
+        keep_folder = body.get("keep_folder")
+        if not isinstance(file_hashes, list) or not file_hashes:
+            return json_error("file_hashes required")
+        if not isinstance(keep_folder, str) or not keep_folder:
+            return json_error("keep_folder required")
+        for h in file_hashes:
+            if not isinstance(h, str) or not h:
+                return json_error("file_hashes must be a list of non-empty strings")
+
+        db = _get_db()
+        result = db.bulk_resolve_by_folder(file_hashes, keep_folder)
+        return jsonify({
+            "ok": True,
+            "resolved_count": len(result["resolved"]),
+            "resolved": result["resolved"],
+            "skipped": result["skipped"],
+        })
+
     @app.route("/api/duplicates/delete-loser-files", methods=["POST"])
     def api_duplicates_delete_loser_files():
         """Move duplicate loser files to OS Trash and remove their DB rows.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1873,12 +1873,7 @@ class Database:
         If fewer than 2 non-rejected candidates remain, returns the no-op
         shape with ``winner_id=None``.
         """
-        from duplicates import (
-            DupCandidate,
-            PhotoMetadata,
-            merge_metadata,
-            resolve_duplicates,
-        )
+        from duplicates import DupCandidate, resolve_duplicates
 
         if not photo_ids or len(photo_ids) < 2:
             return {"winner_id": None, "loser_ids": [], "rejected": 0}
@@ -1912,6 +1907,22 @@ class Database:
             )
         winner_id, losers_with_reasons = resolve_duplicates(candidates)
         loser_ids = [lid for lid, _reason in losers_with_reasons]
+
+        self._apply_winner_loser_merge(winner_id, loser_ids)
+
+        return {
+            "winner_id": winner_id,
+            "loser_ids": list(loser_ids),
+            "rejected": len(loser_ids),
+        }
+
+    def _apply_winner_loser_merge(self, winner_id, loser_ids):
+        """Merge rating/keywords from losers onto winner, then flag losers
+        as rejected. Single transaction. Shared between the resolver-based
+        ``apply_duplicate_resolution`` and the user-driven
+        ``bulk_resolve_by_folder``.
+        """
+        from duplicates import PhotoMetadata, merge_metadata
 
         def _meta(photo_id):
             r = self.conn.execute(
@@ -1956,22 +1967,92 @@ class Database:
             # this transaction. Rare edge case; revisit if product needs it.
             # Collections are rule-based (no junction table) so
             # merge.collection_ids_to_add has nothing to write either.
-            loser_placeholders = ",".join("?" * len(loser_ids))
-            self.conn.execute(
-                f"UPDATE photos SET flag = 'rejected' WHERE id IN ({loser_placeholders})",
-                loser_ids,
-            )
+            if loser_ids:
+                loser_placeholders = ",".join("?" * len(loser_ids))
+                self.conn.execute(
+                    f"UPDATE photos SET flag = 'rejected' WHERE id IN ({loser_placeholders})",
+                    loser_ids,
+                )
 
         logging.getLogger(__name__).info(
             "Duplicate resolved: kept id=%s, rejected id(s)=%s",
             winner_id,
             loser_ids,
         )
-        return {
-            "winner_id": winner_id,
-            "loser_ids": list(loser_ids),
-            "rejected": len(loser_ids),
-        }
+
+    def bulk_resolve_by_folder(self, file_hashes, keep_folder):
+        """Force-resolve many duplicate groups by keeping the photo whose
+        folder matches ``keep_folder``. Companion to the bulk-decide UI.
+
+        For each ``file_hash``: find non-rejected candidates, pick the one
+        whose folder path equals ``keep_folder`` as winner, mark every
+        other candidate as rejected, merge metadata. If multiple
+        candidates live in ``keep_folder`` (rare — typically only happens
+        when same-folder duplicates accumulate), runs the deterministic
+        resolver against just those to pick a single winner.
+
+        Skip reasons are surfaced rather than raised so a single bad hash
+        doesn't poison a 1000-hash batch:
+        - ``"no candidates"`` — file_hash has no DB rows (stale UI state)
+        - ``"fewer than 2 candidates"`` — only one row left, nothing to do
+        - ``"no candidate in keep_folder"`` — group exists but isn't
+          actionable from this folder choice
+
+        Returns ``{"resolved": [{"file_hash", "winner_id", "loser_ids"}],
+        "skipped": [{"file_hash", "reason"}]}``.
+        """
+        from duplicates import DupCandidate, resolve_duplicates
+
+        resolved = []
+        skipped = []
+        for file_hash in file_hashes:
+            rows = self.conn.execute(
+                """SELECT p.id, p.filename, p.file_mtime, p.rating,
+                          f.path AS folder_path
+                   FROM photos p
+                   LEFT JOIN folders f ON f.id = p.folder_id
+                   WHERE p.file_hash = ? AND p.flag != 'rejected'""",
+                (file_hash,),
+            ).fetchall()
+            if not rows:
+                skipped.append({"file_hash": file_hash, "reason": "no candidates"})
+                continue
+            if len(rows) < 2:
+                skipped.append({
+                    "file_hash": file_hash,
+                    "reason": "fewer than 2 candidates",
+                })
+                continue
+            in_folder = [r for r in rows if (r["folder_path"] or "") == keep_folder]
+            if not in_folder:
+                skipped.append({
+                    "file_hash": file_hash,
+                    "reason": "no candidate in keep_folder",
+                })
+                continue
+            if len(in_folder) == 1:
+                winner_id = in_folder[0]["id"]
+            else:
+                # Same-folder duplicates among the keep_folder candidates —
+                # let the resolver pick deterministically among them.
+                cands = []
+                for r in in_folder:
+                    path = os.path.join(r["folder_path"] or "", r["filename"] or "")
+                    cands.append(DupCandidate(
+                        id=r["id"], path=path,
+                        mtime=r["file_mtime"] or 0.0,
+                        exists=os.path.exists(path),
+                    ))
+                winner_id, _ = resolve_duplicates(cands)
+            loser_ids = [r["id"] for r in rows if r["id"] != winner_id]
+            self._apply_winner_loser_merge(winner_id, loser_ids)
+            resolved.append({
+                "file_hash": file_hash,
+                "winner_id": winner_id,
+                "loser_ids": loser_ids,
+            })
+
+        return {"resolved": resolved, "skipped": skipped}
 
     def reopen_duplicate_group(self, file_hash):
         """Un-reject all rejected rows sharing this file_hash.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2007,6 +2007,13 @@ class Database:
         """
         from duplicates import DupCandidate, resolve_duplicates
 
+        # Normalize once. The bucket UI derives folder paths from
+        # ``os.path.dirname(...)`` (never trailing-slashed), but
+        # ``folders.path`` rows can carry a trailing separator from
+        # manual relocation or legacy imports — a naive string compare
+        # silently no-ops the action for those users.
+        keep_folder_norm = os.path.normpath(keep_folder) if keep_folder else ""
+
         resolved = []
         skipped = []
         for file_hash in file_hashes:
@@ -2027,7 +2034,10 @@ class Database:
                     "reason": "fewer than 2 candidates",
                 })
                 continue
-            in_folder = [r for r in rows if (r["folder_path"] or "") == keep_folder]
+            in_folder = [
+                r for r in rows
+                if os.path.normpath(r["folder_path"] or "") == keep_folder_norm
+            ]
             if not in_folder:
                 skipped.append({
                     "file_hash": file_hash,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1997,6 +1997,10 @@ class Database:
         - ``"fewer than 2 candidates"`` — only one row left, nothing to do
         - ``"no candidate in keep_folder"`` — group exists but isn't
           actionable from this folder choice
+        - ``"keep_folder candidate missing on disk"`` — the row(s) in
+          keep_folder point at files that no longer exist; promoting them
+          would reject the only surviving sibling (and, if the caller
+          chains a delete, trash it).
 
         Returns ``{"resolved": [{"file_hash", "winner_id", "loser_ids"}],
         "skipped": [{"file_hash", "reason"}]}``.
@@ -2030,19 +2034,39 @@ class Database:
                     "reason": "no candidate in keep_folder",
                 })
                 continue
-            if len(in_folder) == 1:
-                winner_id = in_folder[0]["id"]
+            # Existence-check the keep_folder candidate(s) before promoting.
+            # If the row's file has been deleted externally but a sibling in
+            # another folder still exists, force-picking the missing row as
+            # winner would reject the surviving copy — and chained delete
+            # would then trash it. Skip the hash instead.
+            in_folder_paths = [
+                (r, os.path.join(r["folder_path"] or "", r["filename"] or ""))
+                for r in in_folder
+            ]
+            present_in_folder = [
+                (r, p) for (r, p) in in_folder_paths if os.path.exists(p)
+            ]
+            if not present_in_folder:
+                skipped.append({
+                    "file_hash": file_hash,
+                    "reason": "keep_folder candidate missing on disk",
+                })
+                continue
+            if len(present_in_folder) == 1:
+                winner_id = present_in_folder[0][0]["id"]
             else:
                 # Same-folder duplicates among the keep_folder candidates —
-                # let the resolver pick deterministically among them.
-                cands = []
-                for r in in_folder:
-                    path = os.path.join(r["folder_path"] or "", r["filename"] or "")
-                    cands.append(DupCandidate(
-                        id=r["id"], path=path,
+                # let the resolver pick deterministically among them. All
+                # candidates passed in exist on disk (filtered above), so
+                # Rule 0 is a no-op here.
+                cands = [
+                    DupCandidate(
+                        id=r["id"], path=p,
                         mtime=r["file_mtime"] or 0.0,
-                        exists=os.path.exists(path),
-                    ))
+                        exists=True,
+                    )
+                    for (r, p) in present_in_folder
+                ]
                 winner_id, _ = resolve_duplicates(cands)
             loser_ids = [r["id"] for r in rows if r["id"] != winner_id]
             self._apply_winner_loser_merge(winner_id, loser_ids)

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -710,9 +710,14 @@
           var trashed = trashData.trashed || 0;
           var trashFailed = (trashData.failed || []).length;
           var msg = 'Resolved ' + resolved.length + ', moved ' + trashed + ' to Trash';
-          if (trashFailed) msg += ', ' + trashFailed + ' trash failed';
+          if (trashFailed) msg += ', ' + trashFailed + ' trash failed — rescan to retry';
           if (skippedCount) msg += ', ' + skippedCount + ' skipped';
           showToast(msg, trashFailed ? 'error' : 'success');
+          // Partial trash failure: some files are still on disk while their
+          // DB rows have been rejected. Skip the local prune so the bucket
+          // card stays visible — otherwise the user has no in-page signal
+          // that those files still need cleanup.
+          if (trashFailed) trashCallFailed = true;
         } catch (e) {
           // Trash call failed entirely — DB is resolved but the duplicate
           // files are still on disk. Surface this and skip the local prune

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -728,6 +728,22 @@
           group_count: keptHashes.length,
         });
       });
+      // renderResults reads stored aggregate counters in preference to
+      // counting from proposals, so recompute them here. Without this the
+      // summary bar still reports the pre-bulk-resolve totals (e.g. "Extras
+      // to reject" stays at the original count even after groups are gone).
+      // Mirrors the sums in vireo/duplicate_scan.py.
+      var prunedProposals = _lastScanResult.proposals;
+      _lastScanResult.group_count = prunedProposals.length;
+      _lastScanResult.loser_count = prunedProposals.reduce(function(n, p) {
+        return p.status === 'unresolved' ? n + (p.losers || []).length : n;
+      }, 0);
+      _lastScanResult.resolved_group_count = prunedProposals.reduce(function(n, p) {
+        return p.status === 'resolved' ? n + 1 : n;
+      }, 0);
+      _lastScanResult.resolved_loser_count = prunedProposals.reduce(function(n, p) {
+        return p.status === 'resolved' ? n + (p.losers || []).length : n;
+      }, 0);
       renderResults(_lastScanResult);
     } catch (e) {
       card.classList.remove('applying');

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -205,6 +205,47 @@
     background: var(--danger-bg, rgba(220, 38, 38, 0.15));
     border-left-color: var(--danger);
   }
+
+  /* Bulk-decide bucket cards. When the same dedup question repeats many
+     times across the same folder set, we surface one card per bucket so
+     the user can resolve all of them with one click. */
+  .bucket-card {
+    border: 1px solid var(--border-primary); border-radius: 8px;
+    padding: 12px 14px; margin-bottom: 10px; background: var(--bg-secondary);
+  }
+  .bucket-card .bucket-headline {
+    font-size: 13px; color: var(--text-primary); margin-bottom: 6px;
+  }
+  .bucket-card .bucket-headline b { color: var(--text-primary); }
+  .bucket-card .bucket-headline .count { color: var(--accent); font-weight: 600; }
+  .bucket-card .bucket-meta {
+    font-size: 11px; color: var(--text-dim); margin-bottom: 10px;
+  }
+  .bucket-card .bucket-actions {
+    display: flex; flex-wrap: wrap; gap: 8px; align-items: center;
+  }
+  .bucket-card .bucket-actions .keep-btn {
+    background: var(--bg-tertiary); color: var(--text-primary);
+    border: 1px solid var(--border-secondary); border-radius: 4px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .bucket-card .bucket-actions .keep-btn:hover {
+    background: var(--accent); color: var(--accent-text);
+    border-color: var(--accent);
+  }
+  .bucket-card .bucket-actions .keep-btn:disabled {
+    opacity: 0.5; cursor: not-allowed;
+  }
+  .bucket-card .delete-toggle {
+    margin-left: auto; font-size: 11px; color: var(--text-secondary);
+    display: flex; align-items: center; gap: 6px; cursor: pointer;
+    user-select: none;
+  }
+  .bucket-card .bucket-status {
+    margin-top: 8px; font-size: 11px; color: var(--text-dim);
+    font-style: italic;
+  }
+  .bucket-card.applying { opacity: 0.6; }
 </style>
 </head>
 <body>
@@ -374,10 +415,16 @@
     }
   }
 
+  // Latest scan-result snapshot. Used for client-side bucket pruning
+  // after a successful bulk-resolve so we don't have to round-trip a
+  // full re-scan to refresh the UI.
+  var _lastScanResult = null;
+
   function renderResults(result) {
     hideProgress();
     document.getElementById('scanBtn').disabled = false;
 
+    _lastScanResult = result;
     _proposals = result.proposals || [];
 
     // Split proposals so the two sections render independently. Unresolved
@@ -441,6 +488,22 @@
 
     // Render each section.
     var html = '';
+    var buckets = (result.buckets || []).filter(function(b) {
+      // Only show buckets that have at least 2 groups — a 1-group bucket
+      // is just an individual group and the per-group UI handles it more
+      // expressively (per-photo cards, ratings, etc.).
+      return b.group_count >= 2;
+    });
+    if (buckets.length > 0) {
+      html += '<div class="section-header"><div>' +
+        '<h2>Bulk decide</h2>' +
+        '<div class="section-sub">' +
+        'The same dedup question repeats across multiple groups. Decide ' +
+        'once per bucket to clear them all at once.</div></div></div>';
+      buckets.forEach(function(bucket, bi) {
+        html += renderBucket(bucket, bi);
+      });
+    }
     if (unresolvedGroupCount > 0) {
       html += '<div class="section-header"><div>' +
         '<h2>Needs review</h2>' +
@@ -540,6 +603,138 @@
         '</div>';
     }
     return '';
+  }
+
+  function renderBucket(bucket, bi) {
+    var folders = bucket.folders || [];
+    var folderListHtml = folders.map(function(f) {
+      return '<code>' + escapeHtml(f) + '</code>';
+    }).join(' &middot; ');
+    var examples = (bucket.example_filenames || []).map(escapeHtml).join(', ');
+    var sizeStr = formatBytes(bucket.total_size || 0);
+    var html = '<div class="bucket-card" data-bi="' + bi + '">';
+    html += '<div class="bucket-headline">' +
+      '<span class="count">' + bucket.group_count + '</span> ' +
+      'duplicate group' + (bucket.group_count === 1 ? '' : 's') +
+      ' shared between: ' + folderListHtml + '</div>';
+    var metaParts = [];
+    if (examples) metaParts.push('Examples: ' + examples);
+    if (bucket.total_size) metaParts.push(sizeStr + ' recoverable');
+    if (metaParts.length) {
+      html += '<div class="bucket-meta">' + metaParts.join(' &middot; ') + '</div>';
+    }
+    html += '<div class="bucket-actions">';
+    folders.forEach(function(folder, fi) {
+      var label = folder.split('/').filter(Boolean).pop() || folder;
+      html += '<button class="keep-btn" onclick="bulkResolveByFolderIdx(' +
+              bi + ', ' + fi + ')">' +
+        'Keep ' + escapeHtml(label) + ' for all ' + bucket.group_count +
+        '</button>';
+    });
+    html += '<label class="delete-toggle">' +
+      '<input type="checkbox" data-bi="' + bi + '" data-delete-toggle> ' +
+      'Also move extras to Trash</label>';
+    html += '</div>';
+    html += '<div class="bucket-status" data-bi="' + bi + '" data-bucket-status></div>';
+    html += '</div>';
+    return html;
+  }
+
+  function bulkResolveByFolderIdx(bi, fi) {
+    var bucket = (_lastScanResult && _lastScanResult.buckets || [])[bi];
+    if (!bucket) return;
+    var folder = (bucket.folders || [])[fi];
+    if (folder == null) return;
+    return bulkResolveByFolder(bi, folder);
+  }
+
+  async function bulkResolveByFolder(bi, keepFolder) {
+    var card = document.querySelector('.bucket-card[data-bi="' + bi + '"]');
+    if (!card) return;
+    var bucket = (_lastScanResult && _lastScanResult.buckets || [])[bi];
+    if (!bucket) return;
+
+    var deleteToggle = card.querySelector('input[data-delete-toggle]');
+    var deleteFiles = !!(deleteToggle && deleteToggle.checked);
+    var status = card.querySelector('[data-bucket-status]');
+    var btns = card.querySelectorAll('.keep-btn');
+
+    var n = bucket.group_count;
+    var label = keepFolder.split('/').filter(Boolean).pop() || keepFolder;
+    var confirmMsg = 'Keep all ' + n + ' photo' + (n === 1 ? '' : 's') +
+      ' in ' + label + ' and reject the duplicates' +
+      (deleteFiles ? ', then move the duplicate files to Trash' : '') + '?';
+    if (!confirm(confirmMsg)) return;
+
+    card.classList.add('applying');
+    btns.forEach(function(b) { b.disabled = true; });
+    if (status) status.textContent = 'Resolving ' + n + ' group' + (n === 1 ? '' : 's') + '...';
+
+    try {
+      var data = await safeFetch('/api/duplicates/bulk-resolve', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          file_hashes: bucket.file_hashes,
+          keep_folder: keepFolder,
+        }),
+      });
+      var resolved = data.resolved || [];
+      var skippedCount = (data.skipped || []).length;
+      var loserIds = [];
+      resolved.forEach(function(r) {
+        (r.loser_ids || []).forEach(function(id) { loserIds.push(id); });
+      });
+
+      if (deleteFiles && loserIds.length > 0) {
+        if (status) status.textContent = 'Moving ' + loserIds.length +
+          ' file' + (loserIds.length === 1 ? '' : 's') + ' to Trash...';
+        try {
+          var trashData = await safeFetch('/api/duplicates/delete-loser-files', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ photo_ids: loserIds }),
+          });
+          var trashed = trashData.trashed || 0;
+          var trashFailed = (trashData.failed || []).length;
+          var msg = 'Resolved ' + resolved.length + ', moved ' + trashed + ' to Trash';
+          if (trashFailed) msg += ', ' + trashFailed + ' trash failed';
+          if (skippedCount) msg += ', ' + skippedCount + ' skipped';
+          showToast(msg, trashFailed ? 'error' : 'success');
+        } catch (e) {
+          showToast('Resolved DB but trash failed: ' + (e.message || 'error'), 'error');
+        }
+      } else {
+        var msg = 'Resolved ' + resolved.length + ' group' +
+          (resolved.length === 1 ? '' : 's');
+        if (skippedCount) msg += ', ' + skippedCount + ' skipped';
+        showToast(msg, 'success');
+      }
+
+      // Locally prune the resolved hashes from _lastScanResult so the next
+      // render drops this bucket and the matching unresolved groups. Avoids
+      // an expensive re-scan round-trip on libraries with thousands of dups.
+      var resolvedHashes = new Set(resolved.map(function(r) { return r.file_hash; }));
+      _lastScanResult.proposals = (_lastScanResult.proposals || []).filter(
+        function(p) { return !resolvedHashes.has(p.file_hash); }
+      );
+      _lastScanResult.buckets = (_lastScanResult.buckets || []).map(function(b) {
+        var keptHashes = (b.file_hashes || []).filter(
+          function(h) { return !resolvedHashes.has(h); }
+        );
+        if (keptHashes.length === b.file_hashes.length) return b;
+        return Object.assign({}, b, {
+          file_hashes: keptHashes,
+          group_count: keptHashes.length,
+        });
+      });
+      renderResults(_lastScanResult);
+    } catch (e) {
+      card.classList.remove('applying');
+      btns.forEach(function(b) { b.disabled = false; });
+      if (status) status.textContent = '';
+      showToast('Bulk resolve failed: ' + (e.message || 'error'), 'error');
+    }
   }
 
   function renderUnresolvedGroup(group) {

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -686,6 +686,7 @@
         (r.loser_ids || []).forEach(function(id) { loserIds.push(id); });
       });
 
+      var trashCallFailed = false;
       if (deleteFiles && loserIds.length > 0) {
         if (status) status.textContent = 'Moving ' + loserIds.length +
           ' file' + (loserIds.length === 1 ? '' : 's') + ' to Trash...';
@@ -702,13 +703,30 @@
           if (skippedCount) msg += ', ' + skippedCount + ' skipped';
           showToast(msg, trashFailed ? 'error' : 'success');
         } catch (e) {
-          showToast('Resolved DB but trash failed: ' + (e.message || 'error'), 'error');
+          // Trash call failed entirely — DB is resolved but the duplicate
+          // files are still on disk. Surface this and skip the local prune
+          // so the bucket card stays visible; otherwise the user thinks
+          // cleanup completed and has no path to retry without a rescan.
+          trashCallFailed = true;
+          showToast('Resolved DB but trash failed: ' + (e.message || 'error') +
+                    ' — rescan to retry trash', 'error');
         }
       } else {
         var msg = 'Resolved ' + resolved.length + ' group' +
           (resolved.length === 1 ? '' : 's');
         if (skippedCount) msg += ', ' + skippedCount + ' skipped';
         showToast(msg, 'success');
+      }
+
+      if (trashCallFailed) {
+        // Restore the card UI so the failure is visible and not stuck in
+        // the spinner state. We deliberately do not prune _lastScanResult
+        // here: a rescan is required to reconcile DB-rejected rows with
+        // the on-disk files that still need trashing.
+        card.classList.remove('applying');
+        btns.forEach(function(b) { b.disabled = false; });
+        if (status) status.textContent = 'Trash failed — rescan to retry';
+        return;
       }
 
       // Locally prune the resolved hashes from _lastScanResult so the next

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -797,7 +797,14 @@
       _lastScanResult.resolved_loser_count = prunedProposals.reduce(function(n, p) {
         return p.status === 'resolved' ? n + (p.losers || []).length : n;
       }, 0);
-      renderResults(_lastScanResult);
+      // Don't clobber an in-flight scan's UI: if the user clicked Scan
+      // while bulk-resolve was awaiting, ``renderResults`` would hide the
+      // progress spinner, re-enable the scan button, and paint stale
+      // pre-scan results — risking overlapping scan jobs. Same guard
+      // tryRestoreLastScan uses.
+      if (!_scanInProgress) {
+        renderResults(_lastScanResult);
+      }
     } catch (e) {
       card.classList.remove('applying');
       btns.forEach(function(b) { b.disabled = false; });

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -752,14 +752,33 @@
       _lastScanResult.proposals = (_lastScanResult.proposals || []).filter(
         function(p) { return !resolvedHashes.has(p.file_hash); }
       );
+      // Recompute total_size and example_filenames from the surviving
+      // proposals so a partially-pruned bucket card doesn't keep
+      // advertising the pre-resolution recoverable size or stale sample
+      // filenames. Mirrors bucket_unresolved_proposals in Python.
+      var proposalsByHash = {};
+      (_lastScanResult.proposals || []).forEach(function(p) {
+        proposalsByHash[p.file_hash] = p;
+      });
       _lastScanResult.buckets = (_lastScanResult.buckets || []).map(function(b) {
         var keptHashes = (b.file_hashes || []).filter(
           function(h) { return !resolvedHashes.has(h); }
         );
         if (keptHashes.length === b.file_hashes.length) return b;
+        var keptProposals = keptHashes
+          .map(function(h) { return proposalsByHash[h]; })
+          .filter(function(p) { return p != null; });
+        var newTotalSize = keptProposals.reduce(function(n, p) {
+          return n + ((p.losers || []).length * ((p.winner || {}).file_size || 0));
+        }, 0);
+        var newExamples = keptProposals.slice(0, 3).map(function(p) {
+          return (p.winner || {}).filename || '';
+        });
         return Object.assign({}, b, {
           file_hashes: keptHashes,
           group_count: keptHashes.length,
+          total_size: newTotalSize,
+          example_filenames: newExamples,
         });
       });
       // renderResults reads stored aggregate counters in preference to

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -488,19 +488,26 @@
 
     // Render each section.
     var html = '';
-    var buckets = (result.buckets || []).filter(function(b) {
-      // Only show buckets that have at least 2 groups — a 1-group bucket
-      // is just an individual group and the per-group UI handles it more
-      // expressively (per-photo cards, ratings, etc.).
+    // Iterate over the unfiltered bucket list so `bi` stays a stable index
+    // into ``_lastScanResult.buckets``. Filtering with ``.filter`` first and
+    // re-indexing the result would let a partial bulk-resolve (which can drop
+    // a bucket to ``group_count === 1`` without removing it from the array)
+    // shift later indexes, so subsequent button clicks would resolve the
+    // wrong bucket — and with delete enabled, potentially trash the wrong
+    // files. Skip 1-group buckets inline instead — the per-group UI handles
+    // them more expressively (per-photo cards, ratings, etc.).
+    var allBuckets = result.buckets || [];
+    var hasVisibleBuckets = allBuckets.some(function(b) {
       return b.group_count >= 2;
     });
-    if (buckets.length > 0) {
+    if (hasVisibleBuckets) {
       html += '<div class="section-header"><div>' +
         '<h2>Bulk decide</h2>' +
         '<div class="section-sub">' +
         'The same dedup question repeats across multiple groups. Decide ' +
         'once per bucket to clear them all at once.</div></div></div>';
-      buckets.forEach(function(bucket, bi) {
+      allBuckets.forEach(function(bucket, bi) {
+        if (bucket.group_count < 2) return;
         html += renderBucket(bucket, bi);
       });
     }
@@ -643,6 +650,10 @@
   function bulkResolveByFolderIdx(bi, fi) {
     var bucket = (_lastScanResult && _lastScanResult.buckets || [])[bi];
     if (!bucket) return;
+    // After a partial prune a bucket can drop to ``group_count < 2`` and be
+    // filtered out of the next render. A button left in the DOM from a stale
+    // render must not be allowed to act on it.
+    if (!bucket.file_hashes || bucket.file_hashes.length < 2) return;
     var folder = (bucket.folders || [])[fi];
     if (folder == null) return;
     return bulkResolveByFolder(bi, folder);

--- a/vireo/tests/test_duplicates_api.py
+++ b/vireo/tests/test_duplicates_api.py
@@ -535,15 +535,22 @@ def test_last_scan_picks_most_recent_completed(app_and_db):
     assert "HOLD" in hashes  # still present in the library
 
 
-def test_bulk_resolve_endpoint_resolves_by_folder(app_and_db):
+def test_bulk_resolve_endpoint_resolves_by_folder(app_and_db, tmp_path):
     """POST /api/duplicates/bulk-resolve forces winners by keep_folder for
     every supplied hash and returns a summary."""
     app, db = app_and_db
-    a_fid = db.add_folder("/tmp/dupbulka")
-    b_fid = db.add_folder("/tmp/dupbulkb")
-    # Seed three groups with one file in each folder.
+    a_dir = tmp_path / "dupbulka"
+    b_dir = tmp_path / "dupbulkb"
+    a_dir.mkdir()
+    b_dir.mkdir()
+    a_fid = db.add_folder(str(a_dir))
+    b_fid = db.add_folder(str(b_dir))
+    # Seed three groups with one file in each folder. Real on-disk files so
+    # the existence guard in bulk_resolve_by_folder is satisfied.
     pairs = []
     for h, name in [("HBA1", "owl.jpg"), ("HBA2", "hawk.jpg"), ("HBA3", "finch.jpg")]:
+        (a_dir / name).write_bytes(b"x")
+        (b_dir / name).write_bytes(b"x")
         p_a = db.add_photo(folder_id=a_fid, filename=name, extension=".jpg",
                            file_size=1000, file_mtime=100.0, file_hash=h)
         p_b = db.add_photo(folder_id=b_fid, filename=name, extension=".jpg",
@@ -554,7 +561,7 @@ def test_bulk_resolve_endpoint_resolves_by_folder(app_and_db):
 
     resp = app.test_client().post("/api/duplicates/bulk-resolve", json={
         "file_hashes": ["HBA1", "HBA2", "HBA3"],
-        "keep_folder": "/tmp/dupbulkb",
+        "keep_folder": str(b_dir),
     })
     assert resp.status_code == 200
     body = resp.get_json()
@@ -577,18 +584,25 @@ def test_bulk_resolve_endpoint_resolves_by_folder(app_and_db):
     assert surfaced_loser_ids == sorted(p_a for _, p_a, _ in pairs)
 
 
-def test_bulk_resolve_endpoint_skips_hash_with_no_candidate_in_folder(app_and_db):
+def test_bulk_resolve_endpoint_skips_hash_with_no_candidate_in_folder(app_and_db, tmp_path):
     """A hash whose candidates all live outside keep_folder is reported in
     skipped, not as a fatal error — the rest of the batch still resolves."""
     app, db = app_and_db
-    a_fid = db.add_folder("/tmp/dupbulkskipa")
-    b_fid = db.add_folder("/tmp/dupbulkskipb")
-    c_fid = db.add_folder("/tmp/dupbulkskipc")
+    a_dir = tmp_path / "dupbulkskipa"
+    b_dir = tmp_path / "dupbulkskipb"
+    c_dir = tmp_path / "dupbulkskipc"
+    for d in (a_dir, b_dir, c_dir):
+        d.mkdir()
+    a_fid = db.add_folder(str(a_dir))
+    b_fid = db.add_folder(str(b_dir))
+    c_fid = db.add_folder(str(c_dir))
+    folder_by_id = {a_fid: a_dir, b_fid: b_dir, c_fid: c_dir}
     # Distinct filenames per group so the UNIQUE(folder_id, filename) on
     # photos doesn't collide when both groups share folder /b.
     for h, fids, name in [("OK", (a_fid, b_fid), "ok.jpg"),
                           ("SKIP", (b_fid, c_fid), "skip.jpg")]:
         for fid in fids:
+            (folder_by_id[fid] / name).write_bytes(b"x")
             db.add_photo(folder_id=fid, filename=name, extension=".jpg",
                          file_size=1000, file_mtime=100.0, file_hash=h)
         db.conn.execute("UPDATE photos SET flag='none' WHERE file_hash=?", (h,))
@@ -596,7 +610,7 @@ def test_bulk_resolve_endpoint_skips_hash_with_no_candidate_in_folder(app_and_db
 
     resp = app.test_client().post("/api/duplicates/bulk-resolve", json={
         "file_hashes": ["OK", "SKIP"],
-        "keep_folder": "/tmp/dupbulkskipa",
+        "keep_folder": str(a_dir),
     })
     assert resp.status_code == 200
     body = resp.get_json()

--- a/vireo/tests/test_duplicates_api.py
+++ b/vireo/tests/test_duplicates_api.py
@@ -535,6 +535,103 @@ def test_last_scan_picks_most_recent_completed(app_and_db):
     assert "HOLD" in hashes  # still present in the library
 
 
+def test_bulk_resolve_endpoint_resolves_by_folder(app_and_db):
+    """POST /api/duplicates/bulk-resolve forces winners by keep_folder for
+    every supplied hash and returns a summary."""
+    app, db = app_and_db
+    a_fid = db.add_folder("/tmp/dupbulka")
+    b_fid = db.add_folder("/tmp/dupbulkb")
+    # Seed three groups with one file in each folder.
+    pairs = []
+    for h, name in [("HBA1", "owl.jpg"), ("HBA2", "hawk.jpg"), ("HBA3", "finch.jpg")]:
+        p_a = db.add_photo(folder_id=a_fid, filename=name, extension=".jpg",
+                           file_size=1000, file_mtime=100.0, file_hash=h)
+        p_b = db.add_photo(folder_id=b_fid, filename=name, extension=".jpg",
+                           file_size=1000, file_mtime=100.0, file_hash=h)
+        db.conn.execute("UPDATE photos SET flag='none' WHERE file_hash=?", (h,))
+        pairs.append((h, p_a, p_b))
+    db.conn.commit()
+
+    resp = app.test_client().post("/api/duplicates/bulk-resolve", json={
+        "file_hashes": ["HBA1", "HBA2", "HBA3"],
+        "keep_folder": "/tmp/dupbulkb",
+    })
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["resolved_count"] == 3
+    assert body["skipped"] == []
+    # All /b photos kept; all /a photos rejected.
+    for h, p_a, p_b in pairs:
+        flags = {
+            r["id"]: r["flag"]
+            for r in db.conn.execute(
+                "SELECT id, flag FROM photos WHERE id IN (?, ?)", (p_a, p_b)
+            ).fetchall()
+        }
+        assert flags == {p_a: "rejected", p_b: "none"}, f"hash {h}"
+    # Loser ids surfaced so the UI can pipe them to delete-loser-files.
+    surfaced_loser_ids = sorted(
+        lid for r in body["resolved"] for lid in r["loser_ids"]
+    )
+    assert surfaced_loser_ids == sorted(p_a for _, p_a, _ in pairs)
+
+
+def test_bulk_resolve_endpoint_skips_hash_with_no_candidate_in_folder(app_and_db):
+    """A hash whose candidates all live outside keep_folder is reported in
+    skipped, not as a fatal error — the rest of the batch still resolves."""
+    app, db = app_and_db
+    a_fid = db.add_folder("/tmp/dupbulkskipa")
+    b_fid = db.add_folder("/tmp/dupbulkskipb")
+    c_fid = db.add_folder("/tmp/dupbulkskipc")
+    # Distinct filenames per group so the UNIQUE(folder_id, filename) on
+    # photos doesn't collide when both groups share folder /b.
+    for h, fids, name in [("OK", (a_fid, b_fid), "ok.jpg"),
+                          ("SKIP", (b_fid, c_fid), "skip.jpg")]:
+        for fid in fids:
+            db.add_photo(folder_id=fid, filename=name, extension=".jpg",
+                         file_size=1000, file_mtime=100.0, file_hash=h)
+        db.conn.execute("UPDATE photos SET flag='none' WHERE file_hash=?", (h,))
+    db.conn.commit()
+
+    resp = app.test_client().post("/api/duplicates/bulk-resolve", json={
+        "file_hashes": ["OK", "SKIP"],
+        "keep_folder": "/tmp/dupbulkskipa",
+    })
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["resolved_count"] == 1
+    assert body["resolved"][0]["file_hash"] == "OK"
+    assert body["skipped"] == [
+        {"file_hash": "SKIP", "reason": "no candidate in keep_folder"}
+    ]
+
+
+def test_bulk_resolve_endpoint_validates_inputs(app_and_db):
+    app, _db = app_and_db
+    client = app.test_client()
+    # Missing body
+    assert client.post("/api/duplicates/bulk-resolve").status_code == 400
+    # Missing file_hashes
+    assert client.post("/api/duplicates/bulk-resolve",
+                       json={"keep_folder": "/x"}).status_code == 400
+    # Empty file_hashes
+    assert client.post("/api/duplicates/bulk-resolve",
+                       json={"file_hashes": [], "keep_folder": "/x"}
+                       ).status_code == 400
+    # Missing keep_folder
+    assert client.post("/api/duplicates/bulk-resolve",
+                       json={"file_hashes": ["H"]}).status_code == 400
+    # Bad type for keep_folder
+    assert client.post("/api/duplicates/bulk-resolve",
+                       json={"file_hashes": ["H"], "keep_folder": 123}
+                       ).status_code == 400
+    # Bad entry in file_hashes
+    assert client.post("/api/duplicates/bulk-resolve",
+                       json={"file_hashes": [123], "keep_folder": "/x"}
+                       ).status_code == 400
+
+
 def test_last_scan_ignores_failed_jobs(app_and_db):
     """A failed scan in history must not be served as the 'last' result."""
     app, db = app_and_db

--- a/vireo/tests/test_duplicates_bulk.py
+++ b/vireo/tests/test_duplicates_bulk.py
@@ -271,6 +271,36 @@ def test_bulk_resolve_skips_when_keep_folder_candidate_missing_on_disk(tmp_path)
     assert _flags(db, [p_a, p_b]) == {p_a: "none", p_b: "none"}
 
 
+def test_bulk_resolve_normalizes_keep_folder_trailing_slash(tmp_path):
+    """The bucket UI passes folder paths derived from ``os.path.dirname(...)``
+    — never trailing-slashed. But ``folders.path`` rows in the DB can carry
+    a trailing separator (manual relocation, legacy imports). A naive
+    ``folder_path == keep_folder`` comparison would silently no-op the
+    bulk action for affected users; the lookup must normalize."""
+    db = Database(str(tmp_path / "t.db"))
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    a_dir.mkdir()
+    b_dir.mkdir()
+    # Folder stored WITH a trailing slash (simulates legacy/relocated rows).
+    a_fid = db.add_folder(str(a_dir) + "/")
+    b_fid = db.add_folder(str(b_dir))
+    p_a = _add(db, a_fid, "owl.jpg", file_hash="HSLASH")
+    p_b = _add(db, b_fid, "owl.jpg", file_hash="HSLASH")
+    _touch(a_dir, "owl.jpg")
+    _touch(b_dir, "owl.jpg")
+    _reset_flags(db, "HSLASH")
+
+    # Caller passes the un-slashed form — the form the bucket UI derives.
+    result = db.bulk_resolve_by_folder(["HSLASH"], str(a_dir))
+
+    assert result["skipped"] == []
+    assert result["resolved"] == [
+        {"file_hash": "HSLASH", "winner_id": p_a, "loser_ids": [p_b]}
+    ]
+    assert _flags(db, [p_a, p_b]) == {p_a: "none", p_b: "rejected"}
+
+
 def test_bulk_resolve_skips_when_all_keep_folder_candidates_missing(tmp_path):
     """Same protection when there are multiple stale rows in keep_folder:
     don't fall through to the resolver and pick a missing winner."""

--- a/vireo/tests/test_duplicates_bulk.py
+++ b/vireo/tests/test_duplicates_bulk.py
@@ -28,6 +28,16 @@ def _add(db, folder_id, filename, file_hash=None, file_mtime=100.0, rating=0):
     return pid
 
 
+def _touch(folder, filename):
+    """Materialize ``filename`` inside ``folder`` so the existence check in
+    ``bulk_resolve_by_folder`` doesn't trip. Tests that exercise the
+    'keep_folder candidate missing on disk' branch deliberately skip this.
+    """
+    p = folder / filename
+    p.write_bytes(b"x")
+    return p
+
+
 def _reset_flags(db, file_hash):
     db.conn.execute(
         "UPDATE photos SET flag = 'none' WHERE file_hash = ?", (file_hash,)
@@ -57,6 +67,8 @@ def test_bulk_resolve_single_hash_picks_photo_in_keep_folder(tmp_path):
     b_fid = db.add_folder(str(b_dir))
     p_a = _add(db, a_fid, "owl.jpg", file_hash="HBR1")
     p_b = _add(db, b_fid, "owl.jpg", file_hash="HBR1")
+    _touch(a_dir, "owl.jpg")
+    _touch(b_dir, "owl.jpg")
     _reset_flags(db, "HBR1")  # make group unresolved
 
     result = db.bulk_resolve_by_folder(["HBR1"], str(b_dir))
@@ -83,6 +95,8 @@ def test_bulk_resolve_multiple_hashes_share_keep_folder(tmp_path):
     for h, name in [("H1", "owl.jpg"), ("H2", "hawk.jpg"), ("H3", "finch.jpg")]:
         p_a = _add(db, a_fid, name, file_hash=h)
         p_b = _add(db, b_fid, name, file_hash=h)
+        _touch(a_dir, name)
+        _touch(b_dir, name)
         _reset_flags(db, h)
         pairs.append((h, p_a, p_b))
 
@@ -116,6 +130,10 @@ def test_bulk_resolve_skips_hash_with_no_photo_in_keep_folder(tmp_path):
     h1_b = _add(db, b_fid, "owl.jpg", file_hash="H1")
     h2_b = _add(db, b_fid, "hawk.jpg", file_hash="H2")
     h2_c = _add(db, c_fid, "hawk.jpg", file_hash="H2")
+    _touch(a_dir, "owl.jpg")
+    _touch(b_dir, "owl.jpg")
+    _touch(b_dir, "hawk.jpg")
+    _touch(c_dir, "hawk.jpg")
     _reset_flags(db, "H1")
     _reset_flags(db, "H2")
 
@@ -213,6 +231,8 @@ def test_bulk_resolve_merges_metadata_onto_forced_winner(tmp_path):
     # Winner has rating=2; loser has rating=5. Bulk-resolve should merge to 5.
     p_a = _add(db, a_fid, "owl.jpg", file_hash="HMERGE", rating=2)
     p_b = _add(db, b_fid, "owl.jpg", file_hash="HMERGE", rating=5)
+    _touch(a_dir, "owl.jpg")
+    _touch(b_dir, "owl.jpg")
     _reset_flags(db, "HMERGE")
 
     db.bulk_resolve_by_folder(["HMERGE"], str(a_dir))
@@ -221,3 +241,59 @@ def test_bulk_resolve_merges_metadata_onto_forced_winner(tmp_path):
         "SELECT rating FROM photos WHERE id = ?", (p_a,)
     ).fetchone()
     assert row["rating"] == 5
+
+
+def test_bulk_resolve_skips_when_keep_folder_candidate_missing_on_disk(tmp_path):
+    """If the keep_folder row points at a file that's been deleted externally,
+    skip the hash rather than promoting a missing winner. Force-rejecting the
+    surviving sibling in another folder, followed by the chained
+    delete-loser-files, would otherwise trash the only remaining copy."""
+    db = Database(str(tmp_path / "t.db"))
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    a_dir.mkdir()
+    b_dir.mkdir()
+    a_fid = db.add_folder(str(a_dir))
+    b_fid = db.add_folder(str(b_dir))
+    p_a = _add(db, a_fid, "owl.jpg", file_hash="HGONE")
+    p_b = _add(db, b_fid, "owl.jpg", file_hash="HGONE")
+    # Only the /b copy exists on disk; the /a row is stale.
+    _touch(b_dir, "owl.jpg")
+    _reset_flags(db, "HGONE")
+
+    result = db.bulk_resolve_by_folder(["HGONE"], str(a_dir))
+
+    assert result["resolved"] == []
+    assert result["skipped"] == [
+        {"file_hash": "HGONE", "reason": "keep_folder candidate missing on disk"}
+    ]
+    # Both rows untouched — the surviving /b file MUST remain selectable.
+    assert _flags(db, [p_a, p_b]) == {p_a: "none", p_b: "none"}
+
+
+def test_bulk_resolve_skips_when_all_keep_folder_candidates_missing(tmp_path):
+    """Same protection when there are multiple stale rows in keep_folder:
+    don't fall through to the resolver and pick a missing winner."""
+    db = Database(str(tmp_path / "t.db"))
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    a_dir.mkdir()
+    b_dir.mkdir()
+    a_fid = db.add_folder(str(a_dir))
+    b_fid = db.add_folder(str(b_dir))
+    p_a1 = _add(db, a_fid, "owl.jpg", file_hash="HALLGONE")
+    p_a2 = _add(db, a_fid, "owl-2.jpg", file_hash="HALLGONE")
+    p_b = _add(db, b_fid, "owl.jpg", file_hash="HALLGONE")
+    # Neither /a copy on disk; only /b survives.
+    _touch(b_dir, "owl.jpg")
+    _reset_flags(db, "HALLGONE")
+
+    result = db.bulk_resolve_by_folder(["HALLGONE"], str(a_dir))
+
+    assert result["resolved"] == []
+    assert result["skipped"] == [
+        {"file_hash": "HALLGONE", "reason": "keep_folder candidate missing on disk"}
+    ]
+    assert _flags(db, [p_a1, p_a2, p_b]) == {
+        p_a1: "none", p_a2: "none", p_b: "none",
+    }

--- a/vireo/tests/test_duplicates_bulk.py
+++ b/vireo/tests/test_duplicates_bulk.py
@@ -1,0 +1,223 @@
+"""Tests for ``Database.bulk_resolve_by_folder``.
+
+Backs the bulk-decide UI: when the user looks at a bucket of N duplicate
+groups all sharing the same {folderA, folderB} parent-dir set, clicking
+"Keep folderA for all N" resolves every group at once with the photo in
+folderA forced as the winner.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from db import Database
+
+
+def _add(db, folder_id, filename, file_hash=None, file_mtime=100.0, rating=0):
+    pid = db.add_photo(
+        folder_id=folder_id,
+        filename=filename,
+        extension=os.path.splitext(filename)[1] or ".jpg",
+        file_size=1000,
+        file_mtime=file_mtime,
+        file_hash=file_hash,
+    )
+    if rating:
+        db.conn.execute("UPDATE photos SET rating = ? WHERE id = ?", (rating, pid))
+        db.conn.commit()
+    return pid
+
+
+def _reset_flags(db, file_hash):
+    db.conn.execute(
+        "UPDATE photos SET flag = 'none' WHERE file_hash = ?", (file_hash,)
+    )
+    db.conn.commit()
+
+
+def _flags(db, ids):
+    return {
+        r["id"]: r["flag"]
+        for r in db.conn.execute(
+            f"SELECT id, flag FROM photos WHERE id IN ({','.join('?' * len(ids))})",
+            list(ids),
+        ).fetchall()
+    }
+
+
+def test_bulk_resolve_single_hash_picks_photo_in_keep_folder(tmp_path):
+    """For one hash with two candidates, the photo in keep_folder becomes
+    the winner; the other gets flagged rejected."""
+    db = Database(str(tmp_path / "t.db"))
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    a_dir.mkdir()
+    b_dir.mkdir()
+    a_fid = db.add_folder(str(a_dir))
+    b_fid = db.add_folder(str(b_dir))
+    p_a = _add(db, a_fid, "owl.jpg", file_hash="HBR1")
+    p_b = _add(db, b_fid, "owl.jpg", file_hash="HBR1")
+    _reset_flags(db, "HBR1")  # make group unresolved
+
+    result = db.bulk_resolve_by_folder(["HBR1"], str(b_dir))
+
+    assert result["resolved"] == [
+        {"file_hash": "HBR1", "winner_id": p_b, "loser_ids": [p_a]}
+    ]
+    assert result["skipped"] == []
+    assert _flags(db, [p_a, p_b]) == {p_a: "rejected", p_b: "none"}
+
+
+def test_bulk_resolve_multiple_hashes_share_keep_folder(tmp_path):
+    """The whole point of bulk: 3 hashes, one call, all resolved by keeping
+    the candidates in one folder."""
+    db = Database(str(tmp_path / "t.db"))
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    a_dir.mkdir()
+    b_dir.mkdir()
+    a_fid = db.add_folder(str(a_dir))
+    b_fid = db.add_folder(str(b_dir))
+
+    pairs = []
+    for h, name in [("H1", "owl.jpg"), ("H2", "hawk.jpg"), ("H3", "finch.jpg")]:
+        p_a = _add(db, a_fid, name, file_hash=h)
+        p_b = _add(db, b_fid, name, file_hash=h)
+        _reset_flags(db, h)
+        pairs.append((h, p_a, p_b))
+
+    result = db.bulk_resolve_by_folder(["H1", "H2", "H3"], str(a_dir))
+
+    assert len(result["resolved"]) == 3
+    assert result["skipped"] == []
+    # Every /a photo wins; every /b photo loses.
+    for h, p_a, p_b in pairs:
+        flags = _flags(db, [p_a, p_b])
+        assert flags == {p_a: "none", p_b: "rejected"}, f"hash {h}"
+
+
+def test_bulk_resolve_skips_hash_with_no_photo_in_keep_folder(tmp_path):
+    """A hash whose candidates all live outside keep_folder is skipped
+    cleanly — the rest of the batch still resolves."""
+    db = Database(str(tmp_path / "t.db"))
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    c_dir = tmp_path / "c"
+    a_dir.mkdir()
+    b_dir.mkdir()
+    c_dir.mkdir()
+    a_fid = db.add_folder(str(a_dir))
+    b_fid = db.add_folder(str(b_dir))
+    c_fid = db.add_folder(str(c_dir))
+
+    # H1 has files in /a and /b; H2 has files in /b and /c. Picking /a as
+    # keep_folder resolves H1 but skips H2 (no candidate in /a).
+    h1_a = _add(db, a_fid, "owl.jpg", file_hash="H1")
+    h1_b = _add(db, b_fid, "owl.jpg", file_hash="H1")
+    h2_b = _add(db, b_fid, "hawk.jpg", file_hash="H2")
+    h2_c = _add(db, c_fid, "hawk.jpg", file_hash="H2")
+    _reset_flags(db, "H1")
+    _reset_flags(db, "H2")
+
+    result = db.bulk_resolve_by_folder(["H1", "H2"], str(a_dir))
+
+    assert len(result["resolved"]) == 1
+    assert result["resolved"][0]["file_hash"] == "H1"
+    assert result["resolved"][0]["winner_id"] == h1_a
+    assert result["skipped"] == [
+        {"file_hash": "H2", "reason": "no candidate in keep_folder"}
+    ]
+    # H1 resolved, H2 untouched.
+    assert _flags(db, [h1_a, h1_b]) == {h1_a: "none", h1_b: "rejected"}
+    assert _flags(db, [h2_b, h2_c]) == {h2_b: "none", h2_c: "none"}
+
+
+def test_bulk_resolve_unknown_hash_skipped(tmp_path):
+    """A hash with no DB rows at all is reported as skipped, not as a fatal
+    error — the user might be acting on stale scan results."""
+    db = Database(str(tmp_path / "t.db"))
+    a_dir = tmp_path / "a"
+    a_dir.mkdir()
+    db.add_folder(str(a_dir))
+
+    result = db.bulk_resolve_by_folder(["DOES_NOT_EXIST"], str(a_dir))
+
+    assert result["resolved"] == []
+    assert result["skipped"] == [
+        {"file_hash": "DOES_NOT_EXIST", "reason": "no candidates"}
+    ]
+
+
+def test_bulk_resolve_singleton_hash_skipped(tmp_path):
+    """A hash with only one non-rejected candidate (others already rejected
+    by an earlier resolution) has nothing to resolve — skip."""
+    db = Database(str(tmp_path / "t.db"))
+    a_dir = tmp_path / "a"
+    a_dir.mkdir()
+    a_fid = db.add_folder(str(a_dir))
+    # Single candidate.
+    _add(db, a_fid, "owl.jpg", file_hash="HSOLO")
+    _reset_flags(db, "HSOLO")
+
+    result = db.bulk_resolve_by_folder(["HSOLO"], str(a_dir))
+
+    assert result["resolved"] == []
+    assert result["skipped"] == [
+        {"file_hash": "HSOLO", "reason": "fewer than 2 candidates"}
+    ]
+
+
+def test_bulk_resolve_multiple_in_keep_folder_resolves_among_them(tmp_path):
+    """Edge case: two candidates share a hash AND both are in keep_folder
+    (e.g., owl.jpg and owl-2.jpg). The resolver picks one of them as
+    winner; the other inside-folder copy AND the outside-folder copies
+    all become losers."""
+    db = Database(str(tmp_path / "t.db"))
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    a_dir.mkdir()
+    b_dir.mkdir()
+    a_fid = db.add_folder(str(a_dir))
+    b_fid = db.add_folder(str(b_dir))
+
+    # Need files on disk so resolve_duplicates Rule 0 doesn't bias picks.
+    (a_dir / "owl.jpg").write_bytes(b"x")
+    (a_dir / "owl-2.jpg").write_bytes(b"x")
+    (b_dir / "owl.jpg").write_bytes(b"x")
+    p_clean = _add(db, a_fid, "owl.jpg", file_hash="HMULTI")
+    p_dirty = _add(db, a_fid, "owl-2.jpg", file_hash="HMULTI")
+    p_b = _add(db, b_fid, "owl.jpg", file_hash="HMULTI")
+    _reset_flags(db, "HMULTI")
+
+    result = db.bulk_resolve_by_folder(["HMULTI"], str(a_dir))
+
+    assert len(result["resolved"]) == 1
+    res = result["resolved"][0]
+    # Rule 1 (clean filename) picks p_clean over p_dirty within /a.
+    assert res["winner_id"] == p_clean
+    assert sorted(res["loser_ids"]) == sorted([p_dirty, p_b])
+    flags = _flags(db, [p_clean, p_dirty, p_b])
+    assert flags == {p_clean: "none", p_dirty: "rejected", p_b: "rejected"}
+
+
+def test_bulk_resolve_merges_metadata_onto_forced_winner(tmp_path):
+    """Forced winner inherits the max rating from losers, same as the normal
+    apply_duplicate_resolution path."""
+    db = Database(str(tmp_path / "t.db"))
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    a_dir.mkdir()
+    b_dir.mkdir()
+    a_fid = db.add_folder(str(a_dir))
+    b_fid = db.add_folder(str(b_dir))
+    # Winner has rating=2; loser has rating=5. Bulk-resolve should merge to 5.
+    p_a = _add(db, a_fid, "owl.jpg", file_hash="HMERGE", rating=2)
+    p_b = _add(db, b_fid, "owl.jpg", file_hash="HMERGE", rating=5)
+    _reset_flags(db, "HMERGE")
+
+    db.bulk_resolve_by_folder(["HMERGE"], str(a_dir))
+
+    row = db.conn.execute(
+        "SELECT rating FROM photos WHERE id = ?", (p_a,)
+    ).fetchone()
+    assert row["rating"] == 5


### PR DESCRIPTION
## Summary

When a duplicate scan returns hundreds of unresolved groups all sharing the same {folderA, folderB} parent-dir set (the "1000 photos in two folders" case), forcing the user to click through every group is miserable. The bulk-decide section lets them pick a folder once and resolve every group in the bucket with one click.

**Stacked on top of #701** (backend bucketing). Once #701 merges, retarget this PR to \`main\`.

### Backend

- **\`Database._apply_winner_loser_merge(winner_id, loser_ids)\`** extracted from \`apply_duplicate_resolution\` so the metadata-merge + reject path can be reused without re-running the resolver.
- **\`Database.bulk_resolve_by_folder(file_hashes, keep_folder)\`** — per hash, finds the candidate in \`keep_folder\` and forces it as winner. Surfaces skip reasons (\`no candidates\`, \`fewer than 2 candidates\`, \`no candidate in keep_folder\`) so a single bad hash doesn't poison a 1000-hash batch. Same-folder duplicates among the keep_folder candidates fall back to the deterministic resolver.
- **\`POST /api/duplicates/bulk-resolve\`** thin wrapper. Returns \`loser_ids\` so the UI can chain into \`/api/duplicates/delete-loser-files\` when the user opted in to immediate trash.

### UI

- New "Bulk decide" section above "Needs review", rendered for each bucket with \`group_count >= 2\`.
- Per bucket: folder list, example filenames, recoverable size, one **"Keep \<folder> for all N"** button per folder, plus a **"Also move extras to Trash"** toggle that triggers the chained delete after bulk-resolve succeeds.
- After successful bulk-resolve, locally prunes the resolved hashes from \`_lastScanResult\` and re-renders — avoids a full re-scan round-trip on libraries with thousands of duplicates.

## Test plan

- [x] **7 unit tests** for \`bulk_resolve_by_folder\` (single hash, multi-hash, no-candidate-in-folder skip, unknown hash skip, singleton skip, multiple-in-keep-folder fallback to resolver, metadata merge).
- [x] **3 API tests** for \`/api/duplicates/bulk-resolve\` (happy path with multi-hash batch, partial skip, input validation).
- [x] **2 Playwright E2E tests** seed a scan result with a 3-group bucket and verify (a) the "Bulk decide" section renders with the right folder buttons, (b) clicking "Keep <folder> for all N" flips DB state and removes the bucket from the page.
- [x] All 104 duplicate-related tests pass (98 backend + 4 API + 2 E2E).

## Manual verification needed before merge

- Run with a real library that has many duplicates across two folders. Confirm the bucket card readably summarizes the situation, the "Keep" buttons resolve quickly, and the "Also move extras to Trash" toggle behaves sanely on partial failures.

## Follow-ups (separate PRs)

- **PR 3c**: \`/api/folders/reveal\` endpoint + "Reveal all in Finder" button on each bucket card (reuses existing cross-platform reveal logic at \`vireo/app.py:1671\`).
- **PR 4**: Drop Rule 2 (longer-path tiebreaker) from \`resolve_duplicates\` so genuinely ambiguous groups flow into the bulk-decide UI instead of being arbitrarily auto-resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)