### PR TITLE
feat(duplicates): "Reveal in Finder" button on bucket cards

### DIFF
--- a/tests/e2e/test_duplicates_bulk_decide.py
+++ b/tests/e2e/test_duplicates_bulk_decide.py
@@ -76,10 +76,42 @@ def test_duplicates_page_renders_bulk_decide_section(live_server, page):
     expect(bucket).to_contain_text("3")
     expect(bucket).to_contain_text(folder_a)
     expect(bucket).to_contain_text(folder_b)
-    # One button per folder, labeled with the folder's basename.
-    keep_buttons = bucket.locator(".keep-btn")
+    # One Keep button per folder + one Reveal button. Use the negation
+    # selector so the count test isolates "Keep" buttons from "Reveal".
+    keep_buttons = bucket.locator(".keep-btn:not(.reveal-btn)")
     expect(keep_buttons).to_have_count(2)
     expect(keep_buttons.nth(0)).to_contain_text("for all 3")
+    expect(bucket.locator(".reveal-btn")).to_have_count(1)
+
+
+def test_duplicates_bulk_decide_reveal_in_finder_posts_bucket_folders(live_server, page):
+    """The 'Reveal in Finder' button posts the bucket's folder list to
+    /api/folders/reveal. We intercept the request rather than letting it
+    actually launch Finder windows in a CI/test environment."""
+    folder_a, folder_b = "/tmp/dupbulkrevealA", "/tmp/dupbulkrevealB"
+    _seed_scan_with_buckets(live_server["db"], folder_a, folder_b, n_groups=2)
+
+    # Stub /api/folders/reveal so the test doesn't actually shell out.
+    captured = {}
+
+    def handle(route):
+        req = route.request
+        captured["body"] = req.post_data_json
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ok": true, "revealed": ["' + folder_a + '", "' + folder_b +
+                 '"], "skipped": [], "failed": []}',
+        )
+
+    page.route("**/api/folders/reveal", handle)
+    page.goto(f"{live_server['url']}/duplicates")
+    expect(page.locator(".bucket-card")).to_have_count(1)
+
+    page.locator(".bucket-card .reveal-btn").click()
+    # Locator-style waiting: the request body should land before this returns.
+    expect(page.locator(".bucket-card")).to_have_count(1)  # still there
+    assert captured.get("body", {}).get("paths") == sorted([folder_a, folder_b])
 
 
 def test_duplicates_bulk_decide_keep_folder_resolves_all_groups(live_server, page):
@@ -97,7 +129,8 @@ def test_duplicates_bulk_decide_keep_folder_resolves_all_groups(live_server, pag
     expect(page.locator(".bucket-card")).to_have_count(1)
 
     # Pick the /a button (index 0; folders are sorted alphabetically).
-    page.locator(".keep-btn").first.click()
+    # Filter out the Reveal button so we click a Keep button.
+    page.locator(".keep-btn:not(.reveal-btn)").first.click()
 
     # Bucket gone post-resolution.
     expect(page.locator(".bucket-card")).to_have_count(0)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6957,10 +6957,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         db = _get_db()
         # Look up known paths in one query rather than once-per-path.
+        # JOIN workspace_folders so paths that exist in another workspace
+        # are treated as unknown — without this gate, a caller could probe
+        # cross-workspace paths via the OS-window-opens side channel,
+        # breaking the same isolation /api/files/reveal already enforces.
         placeholders = ",".join("?" * len(paths))
         known_rows = db.conn.execute(
-            f"SELECT path FROM folders WHERE path IN ({placeholders})",
-            list(paths),
+            f"""SELECT f.path FROM folders f
+                JOIN workspace_folders wf ON wf.folder_id = f.id
+                WHERE wf.workspace_id = ? AND f.path IN ({placeholders})""",
+            [db._active_workspace_id, *paths],
         ).fetchall()
         known = {r["path"] for r in known_rows}
 
@@ -6973,21 +6979,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 continue
             try:
                 if sys.platform == "darwin":
-                    subprocess.run(["open", "-R", "--", path],
-                                   timeout=5, check=False)
+                    proc = subprocess.run(["open", "-R", "--", path],
+                                          timeout=5, check=False)
                 elif sys.platform.startswith("win"):
                     # Folder reveal opens the folder itself (no /select,)
                     # so the user sees its contents.
-                    subprocess.run(["explorer", path], timeout=5, check=False)
+                    proc = subprocess.run(["explorer", path],
+                                          timeout=5, check=False)
                 else:
                     # xdg-open doesn't honor `--`; abspath guarantees a
                     # leading slash so a crafted leading-dash path can't
                     # be parsed as a flag.
-                    subprocess.run(
+                    proc = subprocess.run(
                         ["xdg-open", os.path.abspath(path)],
                         timeout=5, check=False,
                     )
-                revealed.append(path)
+                # check=False returns a CompletedProcess for every exit
+                # code; classify non-zero as failed so the UI doesn't
+                # report success when nothing actually opened (e.g.
+                # unmounted volume, stale path).
+                if proc.returncode != 0:
+                    failed.append({
+                        "path": path,
+                        "reason": f"reveal command exited {proc.returncode}",
+                    })
+                else:
+                    revealed.append(path)
             except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
                 failed.append({"path": path, "reason": str(exc)})
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6927,6 +6927,77 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             total_rejected += result.get("rejected", 0)
         return jsonify({"rejected_count": total_rejected})
 
+    @app.route("/api/folders/reveal", methods=["POST"])
+    def api_folders_reveal():
+        """Reveal a batch of folder paths in the OS file manager.
+
+        Body: ``{"paths": [str, ...]}``. Backs the bulk-decide UI's
+        "Reveal in Finder" button, which opens every folder in a bucket
+        with a single click.
+
+        Each path must exist as a row in the ``folders`` table — refusing
+        arbitrary filesystem paths is the security boundary, otherwise
+        a malicious caller could probe paths via the side-channel of
+        whether the OS file manager opened. Unknown paths are returned
+        in ``skipped`` rather than 404'd so a single bad path doesn't
+        kill a bucket-wide batch.
+
+        Returns ``{"ok": True, "revealed": [str], "skipped":
+        [{"path", "reason"}], "failed": [{"path", "reason"}]}``.
+        """
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return json_error("paths required")
+        paths = body.get("paths")
+        if not isinstance(paths, list) or not paths:
+            return json_error("paths required")
+        for p in paths:
+            if not isinstance(p, str) or not p:
+                return json_error("paths must be a list of non-empty strings")
+
+        db = _get_db()
+        # Look up known paths in one query rather than once-per-path.
+        placeholders = ",".join("?" * len(paths))
+        known_rows = db.conn.execute(
+            f"SELECT path FROM folders WHERE path IN ({placeholders})",
+            list(paths),
+        ).fetchall()
+        known = {r["path"] for r in known_rows}
+
+        revealed = []
+        skipped = []
+        failed = []
+        for path in paths:
+            if path not in known:
+                skipped.append({"path": path, "reason": "not a known folder"})
+                continue
+            try:
+                if sys.platform == "darwin":
+                    subprocess.run(["open", "-R", "--", path],
+                                   timeout=5, check=False)
+                elif sys.platform.startswith("win"):
+                    # Folder reveal opens the folder itself (no /select,)
+                    # so the user sees its contents.
+                    subprocess.run(["explorer", path], timeout=5, check=False)
+                else:
+                    # xdg-open doesn't honor `--`; abspath guarantees a
+                    # leading slash so a crafted leading-dash path can't
+                    # be parsed as a flag.
+                    subprocess.run(
+                        ["xdg-open", os.path.abspath(path)],
+                        timeout=5, check=False,
+                    )
+                revealed.append(path)
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+                failed.append({"path": path, "reason": str(exc)})
+
+        return jsonify({
+            "ok": True,
+            "revealed": revealed,
+            "skipped": skipped,
+            "failed": failed,
+        })
+
     @app.route("/api/duplicates/bulk-resolve", methods=["POST"])
     def api_duplicates_bulk_resolve():
         """Force-resolve a batch of duplicate groups by keeping the photo

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -631,6 +631,9 @@
         'Keep ' + escapeHtml(label) + ' for all ' + bucket.group_count +
         '</button>';
     });
+    html += '<button class="keep-btn reveal-btn" onclick="revealBucketFolders(' + bi + ')" ' +
+      'title="Open all bucket folders in your OS file manager">' +
+      'Reveal in Finder</button>';
     html += '<label class="delete-toggle">' +
       '<input type="checkbox" data-bi="' + bi + '" data-delete-toggle> ' +
       'Also move extras to Trash</label>';
@@ -638,6 +641,29 @@
     html += '<div class="bucket-status" data-bi="' + bi + '" data-bucket-status></div>';
     html += '</div>';
     return html;
+  }
+
+  async function revealBucketFolders(bi) {
+    var bucket = (_lastScanResult && _lastScanResult.buckets || [])[bi];
+    if (!bucket || !bucket.folders || bucket.folders.length === 0) return;
+    try {
+      var data = await safeFetch('/api/folders/reveal', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ paths: bucket.folders }),
+      });
+      var revealed = (data.revealed || []).length;
+      var skipped = (data.skipped || []).length;
+      var failed = (data.failed || []).length;
+      if (failed > 0) {
+        showToast('Revealed ' + revealed + ', ' + failed + ' failed', 'error');
+      } else if (skipped > 0) {
+        showToast('Revealed ' + revealed + ', ' + skipped + ' unknown to Vireo', 'success');
+      }
+      // Silent on full success — Finder windows opening is feedback enough.
+    } catch (e) {
+      showToast('Reveal failed: ' + (e.message || 'error'), 'error');
+    }
   }
 
   function bulkResolveByFolderIdx(bi, fi) {

--- a/vireo/tests/test_folders_reveal_api.py
+++ b/vireo/tests/test_folders_reveal_api.py
@@ -1,0 +1,129 @@
+"""Tests for POST /api/folders/reveal — bulk reveal of folder paths in
+the OS file manager. Backs the bulk-decide UI's "Reveal in Finder" button.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+def _seed_folder(db, path):
+    """Add a folder by path so the reveal endpoint's path-validation
+    accepts it. Returns the folder id."""
+    return db.add_folder(path)
+
+
+def test_folders_reveal_single_path_macos(app_and_db):
+    """A single known folder path triggers ``open -R -- <path>`` on macOS."""
+    app, db = app_and_db
+    _seed_folder(db, "/tmp/dupreveal_one")
+
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "darwin"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0)
+        resp = c.post("/api/folders/reveal",
+                      json={"paths": ["/tmp/dupreveal_one"]})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body["revealed"] == ["/tmp/dupreveal_one"]
+        assert body["skipped"] == []
+        assert body["failed"] == []
+        # One subprocess call, with the canonical macOS argv.
+        assert run.call_count == 1
+        argv = run.call_args[0][0]
+        assert argv == ["open", "-R", "--", "/tmp/dupreveal_one"]
+
+
+def test_folders_reveal_multiple_paths_calls_each(app_and_db):
+    """Two paths in one request → two subprocess calls, both reported as
+    revealed. Lets the bulk-decide button open every folder in a bucket
+    with one click."""
+    app, db = app_and_db
+    _seed_folder(db, "/tmp/dupreveal_a")
+    _seed_folder(db, "/tmp/dupreveal_b")
+
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "darwin"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0)
+        resp = c.post("/api/folders/reveal", json={
+            "paths": ["/tmp/dupreveal_a", "/tmp/dupreveal_b"],
+        })
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert sorted(body["revealed"]) == ["/tmp/dupreveal_a", "/tmp/dupreveal_b"]
+        assert run.call_count == 2
+
+
+def test_folders_reveal_unknown_path_skipped_not_failed(app_and_db):
+    """Refusing to reveal arbitrary filesystem paths is the security
+    boundary: only paths that exist in the folders table get revealed.
+    Unknowns are reported in ``skipped`` so the UI can surface a partial-
+    success summary instead of a hard failure."""
+    app, db = app_and_db
+    _seed_folder(db, "/tmp/dupreveal_known")
+
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "darwin"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0)
+        resp = c.post("/api/folders/reveal", json={
+            "paths": ["/tmp/dupreveal_known", "/etc/passwd"],
+        })
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["revealed"] == ["/tmp/dupreveal_known"]
+        assert body["skipped"] == [
+            {"path": "/etc/passwd", "reason": "not a known folder"}
+        ]
+        # Only the known path triggers a subprocess call.
+        assert run.call_count == 1
+
+
+def test_folders_reveal_shell_failure_reports_per_path(app_and_db):
+    """If the subprocess raises for one path, the rest of the batch is
+    still attempted; the failure is surfaced per-path so the user can
+    see exactly which folder couldn't be opened."""
+    app, db = app_and_db
+    _seed_folder(db, "/tmp/dupreveal_ok")
+    _seed_folder(db, "/tmp/dupreveal_fail")
+
+    call_count = {"n": 0}
+
+    def fake_run(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise FileNotFoundError("no 'open'")
+        return MagicMock(returncode=0)
+
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "darwin"), \
+         patch("vireo.app.subprocess.run", side_effect=fake_run):
+        resp = c.post("/api/folders/reveal", json={
+            "paths": ["/tmp/dupreveal_ok", "/tmp/dupreveal_fail"],
+        })
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["revealed"] == ["/tmp/dupreveal_ok"]
+        assert len(body["failed"]) == 1
+        assert body["failed"][0]["path"] == "/tmp/dupreveal_fail"
+        assert "reason" in body["failed"][0]
+
+
+def test_folders_reveal_validates_inputs(app_and_db):
+    """Missing body / empty list / non-string entries → 400."""
+    app, _ = app_and_db
+    with app.test_client() as c:
+        # No body
+        assert c.post("/api/folders/reveal").status_code == 400
+        # Missing paths
+        assert c.post("/api/folders/reveal", json={}).status_code == 400
+        # Empty list
+        assert c.post("/api/folders/reveal",
+                      json={"paths": []}).status_code == 400
+        # Non-string entry
+        assert c.post("/api/folders/reveal",
+                      json={"paths": [123]}).status_code == 400
+        # Empty string entry
+        assert c.post("/api/folders/reveal",
+                      json={"paths": [""]}).status_code == 400

--- a/vireo/tests/test_folders_reveal_api.py
+++ b/vireo/tests/test_folders_reveal_api.py
@@ -110,6 +110,59 @@ def test_folders_reveal_shell_failure_reports_per_path(app_and_db):
         assert "reason" in body["failed"][0]
 
 
+def test_folders_reveal_skips_path_outside_active_workspace(app_and_db):
+    """A folder that exists in the ``folders`` table but isn't linked to
+    the active workspace must be treated as unknown — otherwise this
+    endpoint becomes a cross-workspace path oracle / open-action gadget,
+    breaking the workspace isolation /api/files/reveal already enforces.
+    """
+    app, db = app_and_db
+    default_ws = db._active_workspace_id
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+    db.add_folder("/secret/cross-ws-only")
+    db.set_active_workspace(default_ws)
+
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "darwin"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0)
+        resp = c.post("/api/folders/reveal",
+                      json={"paths": ["/secret/cross-ws-only"]})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        # Skipped, not revealed — and no subprocess call leaks the path
+        # to the OS file manager.
+        assert body["revealed"] == []
+        assert body["skipped"] == [
+            {"path": "/secret/cross-ws-only", "reason": "not a known folder"}
+        ]
+        assert run.call_count == 0
+
+
+def test_folders_reveal_non_zero_exit_reports_failure(app_and_db):
+    """``subprocess.run(..., check=False)`` returns a CompletedProcess for
+    every exit code, success or not. The endpoint must inspect
+    ``returncode`` so a path that fails to open (e.g. unmounted volume,
+    disappeared on disk) lands in ``failed`` instead of ``revealed`` —
+    otherwise the UI shows nothing happened but reports success."""
+    app, db = app_and_db
+    _seed_folder(db, "/tmp/dupreveal_nonzero")
+
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "darwin"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=1)
+        resp = c.post("/api/folders/reveal",
+                      json={"paths": ["/tmp/dupreveal_nonzero"]})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["revealed"] == []
+        assert len(body["failed"]) == 1
+        assert body["failed"][0]["path"] == "/tmp/dupreveal_nonzero"
+        assert "reason" in body["failed"][0]
+
+
 def test_folders_reveal_validates_inputs(app_and_db):
     """Missing body / empty list / non-string entries → 400."""
     app, _ = app_and_db


### PR DESCRIPTION
## Summary

When the user is staring at a bucket of "247 photos in /A also exist in /B" they often want to look at the actual contents of both folders before deciding which to keep. The new "Reveal in Finder" button opens every folder in the bucket at once.

**Stacked on top of #703** (bulk-decide UI). #703 in turn is stacked on #701. Once both merge, this PR retargets to \`main\` automatically.

### Backend

- **\`POST /api/folders/reveal\`** takes \`{"paths": [str, ...]}\`. Reuses the cross-platform reveal pattern from \`/api/files/reveal\` (macOS \`open -R --\`, Windows \`explorer\`, Linux \`xdg-open <abspath>\`). Per-path reveals so one failure (e.g. unmounted folder) doesn't kill the batch.
- **Security boundary**: every path must exist as a row in the \`folders\` table; otherwise it lands in \`skipped\` rather than being revealed. Refusing arbitrary filesystem paths prevents path-probing via the OS-window-opens side channel.

### UI

- New **\`.reveal-btn\`** on each bucket card alongside the per-folder Keep buttons. Posts \`bucket.folders\` to the new endpoint.
- Silent on full success — Finder windows opening is feedback enough. Toast only fires on partial/full failure.

## Test plan

- [x] 5 unit tests for the endpoint (single path, multi-path batch, unknown-path skip, per-path failure surfacing, input validation).
- [x] E2E test stubs \`/api/folders/reveal\` via Playwright's \`page.route\` and asserts the button click posts the bucket's folder list.
- [x] Existing bulk-decide E2E tests updated to the \`.keep-btn:not(.reveal-btn)\` / \`.reveal-btn\` split selectors.
- [x] All 127 duplicate-related tests pass.

## Manual verification needed

- Click the button on a real bucket card and confirm Finder/Explorer windows open for each folder. Test on macOS at minimum; cross-platform code is unchanged from the proven \`/api/files/reveal\` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)