### PR TITLE
fix(release): abort on failed push instead of printing fake success

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -123,7 +123,11 @@ echo ""
 if $PUBLISH; then
     echo "==> Tagging v$NEW_VERSION..."
     git tag "v$NEW_VERSION"
-    git push && git push origin "v$NEW_VERSION"
+    # Separate commands so `set -e` aborts on a failed `git push`. Inside an
+    # `&&` chain, `set -e` is suppressed for the LHS, so a rejected main push
+    # would silently fall through and the script would still print success.
+    git push
+    git push origin "v$NEW_VERSION"
     echo ""
     echo "Tag pushed. CI will build all platforms and create a draft release."
     echo "Monitor: https://github.com/jss367/vireo/actions"


### PR DESCRIPTION
## Summary
- During the v0.8.34 release, the main push was rejected (non-fast-forward) but the script still printed "Tag pushed" and exited 0. The tag was never actually pushed, so no CI build ran. Recovered manually by pushing the tag.
- Root cause: `git push && git push origin "$tag"` (scripts/release.sh:126). `set -e` is suppressed for the LHS of an `&&` chain, so a failing first push silently falls through to the success messages.
- Fix: split the two pushes onto separate lines so `set -e` aborts the script on a failed main push.

## Test plan
- [x] `bash -n scripts/release.sh` passes
- [ ] Next release run uses the fixed script — failure path is hard to dry-run without forging a non-FF state, but the change is a small, isolated control-flow fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)