### PR TITLE
feat(library): surface photos with missing originals

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1068,8 +1068,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             stem, _ext = os.path.splitext(src)
             sized_preview = os.path.join(preview_dir, f"{pid}_{preview_size}.jpg")
             legacy_preview = os.path.join(preview_dir, f"{pid}.jpg")
+            # Working copy: the DB path wins when set, but legacy rows from
+            # before working_copy_path was tracked can still have a file at
+            # the default <vireo>/working/<id>.jpg location — and the batch
+            # delete path cleans that up regardless of the DB column. If we
+            # only consulted the column the badge would lie about what's
+            # about to be removed.
             wc_rel = row["working_copy_path"]
-            wc_abs = os.path.join(vireo_dir, wc_rel) if wc_rel else None
+            default_wc = os.path.join(working_dir, f"{pid}.jpg")
+            if wc_rel:
+                has_wc = os.path.isfile(os.path.join(vireo_dir, wc_rel))
+            else:
+                has_wc = os.path.isfile(default_wc)
             out.append({
                 "id": pid,
                 "filename": row["filename"],
@@ -1083,7 +1093,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     os.path.isfile(sized_preview) or os.path.isfile(legacy_preview)
                     or bool(_glob.glob(os.path.join(preview_dir, f"{pid}_*.jpg")))
                 ),
-                "has_working_copy": bool(wc_abs and os.path.isfile(wc_abs)),
+                "has_working_copy": has_wc,
                 "has_xmp_sidecar": (
                     os.path.isfile(stem + ".xmp")
                     or os.path.isfile(stem + ".XMP")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1050,24 +1050,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         (thumb, preview, working copy, XMP) so the user can decide whether
         anything is worth keeping before deleting the row.
         """
-        import glob as _glob
-
-        import config as cfg
-
         db = _get_db()
         thumb_dir = app.config["THUMB_CACHE_DIR"]
         vireo_dir = os.path.dirname(thumb_dir)
         preview_dir = os.path.join(vireo_dir, "previews")
         working_dir = os.path.join(vireo_dir, "working")
-        preview_size = int(cfg.load().get("preview_max_size") or 1920)
+
+        # Index preview cache once. The endpoint is polled from the navbar,
+        # so per-photo `glob(preview_dir, f"{pid}_*.jpg")` was O(missing ×
+        # cache_size) readdirs per request. Build {pid} from a single
+        # listdir and check the set in O(1) per row.
+        preview_pids: set[int] = set()
+        try:
+            for name in os.listdir(preview_dir):
+                # Match `{id}.jpg` (legacy full preview) or `{id}_{size}.jpg`
+                # (sized variant). Anything else is not part of the per-photo
+                # cache and should be ignored.
+                if not name.endswith(".jpg"):
+                    continue
+                head = name[:-4].split("_", 1)[0]
+                if head.isdigit():
+                    preview_pids.add(int(head))
+        except FileNotFoundError:
+            pass  # cache dir hasn't been created yet — no previews
 
         out = []
         for row in db.get_missing_photos():
             pid = row["id"]
             src = os.path.join(row["folder_path"], row["filename"])
             stem, _ext = os.path.splitext(src)
-            sized_preview = os.path.join(preview_dir, f"{pid}_{preview_size}.jpg")
-            legacy_preview = os.path.join(preview_dir, f"{pid}.jpg")
             # Working copy: the DB path wins when set, but legacy rows from
             # before working_copy_path was tracked can still have a file at
             # the default <vireo>/working/<id>.jpg location — and the batch
@@ -1089,10 +1100,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "timestamp": row["timestamp"],
                 "file_size": row["file_size"],
                 "has_thumb": os.path.isfile(os.path.join(thumb_dir, f"{pid}.jpg")),
-                "has_preview": (
-                    os.path.isfile(sized_preview) or os.path.isfile(legacy_preview)
-                    or bool(_glob.glob(os.path.join(preview_dir, f"{pid}_*.jpg")))
-                ),
+                "has_preview": pid in preview_pids,
                 "has_working_copy": has_wc,
                 "has_xmp_sidecar": (
                     os.path.isfile(stem + ".xmp")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1107,26 +1107,44 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_photos_missing_delete_sidecars():
         """Delete leftover .xmp sidecar files for photos whose original is gone.
 
-        Body: ``{"photos": [{"folder_path": ..., "filename": ...}, ...]}``
+        Body: ``{"photo_ids": [int, ...]}``.
 
-        Guards: only ``.xmp``/``.XMP`` extensions, only when the named
-        original is *actually* missing on disk. A sidecar whose original
-        still exists is silently skipped — that's the user's filesystem
-        and we don't want to delete files we're not sure are orphans.
+        IDs are resolved server-side against the active workspace — the
+        client never names paths directly. Earlier drafts accepted
+        ``(folder_path, filename)`` from the body and were usable to
+        unlink any ``.xmp`` on disk as long as the paired non-xmp path
+        was absent. Now we only touch sidecars whose photo row is in
+        the active workspace AND whose source is verified missing.
         """
         body = request.get_json(silent=True) or {}
-        photos = body.get("photos") or []
+        photo_ids = body.get("photo_ids") or []
+        if not isinstance(photo_ids, list):
+            return json_error("photo_ids must be a list")
+
+        db = _get_db()
+        ws_id = db._active_workspace_id
         deleted = 0
         skipped = 0
-        for entry in photos:
-            folder_path = entry.get("folder_path") or ""
-            filename = entry.get("filename") or ""
-            if not folder_path or not filename:
+        for raw_id in photo_ids:
+            try:
+                pid = int(raw_id)
+            except (TypeError, ValueError):
                 skipped += 1
                 continue
-            src = os.path.join(folder_path, filename)
+            row = db.conn.execute(
+                """SELECT p.filename, f.path AS folder_path
+                   FROM photos p
+                   JOIN folders f ON p.folder_id = f.id
+                   JOIN workspace_folders wf ON wf.folder_id = f.id
+                   WHERE p.id = ? AND wf.workspace_id = ?""",
+                (pid, ws_id),
+            ).fetchone()
+            if not row:
+                skipped += 1
+                continue
+            src = os.path.join(row["folder_path"], row["filename"])
             if os.path.exists(src):
-                # Original is present — refuse to touch the sidecar
+                # Original came back — refuse to touch the sidecar.
                 skipped += 1
                 continue
             stem, _ = os.path.splitext(src)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1042,6 +1042,57 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         missing = db.get_missing_folders()
         return jsonify([dict(f) for f in missing])
 
+    @app.route("/api/photos/missing")
+    def api_photos_missing():
+        """Return photos whose original file is gone but the folder remains.
+
+        For each ghost row we report what cached/sidecar artifacts still exist
+        (thumb, preview, working copy, XMP) so the user can decide whether
+        anything is worth keeping before deleting the row.
+        """
+        import glob as _glob
+
+        import config as cfg
+
+        db = _get_db()
+        thumb_dir = app.config["THUMB_CACHE_DIR"]
+        vireo_dir = os.path.dirname(thumb_dir)
+        preview_dir = os.path.join(vireo_dir, "previews")
+        working_dir = os.path.join(vireo_dir, "working")
+        preview_size = int(cfg.load().get("preview_max_size") or 1920)
+
+        out = []
+        for row in db.get_missing_photos():
+            pid = row["id"]
+            src = os.path.join(row["folder_path"], row["filename"])
+            stem, _ext = os.path.splitext(src)
+            sized_preview = os.path.join(preview_dir, f"{pid}_{preview_size}.jpg")
+            legacy_preview = os.path.join(preview_dir, f"{pid}.jpg")
+            wc_rel = row["working_copy_path"]
+            wc_abs = os.path.join(vireo_dir, wc_rel) if wc_rel else None
+            out.append({
+                "id": pid,
+                "filename": row["filename"],
+                "extension": row["extension"],
+                "folder_id": row["folder_id"],
+                "folder_path": row["folder_path"],
+                "timestamp": row["timestamp"],
+                "file_size": row["file_size"],
+                "has_thumb": os.path.isfile(os.path.join(thumb_dir, f"{pid}.jpg")),
+                "has_preview": (
+                    os.path.isfile(sized_preview) or os.path.isfile(legacy_preview)
+                    or bool(_glob.glob(os.path.join(preview_dir, f"{pid}_*.jpg")))
+                ),
+                "has_working_copy": bool(wc_abs and os.path.isfile(wc_abs)),
+                "has_xmp_sidecar": (
+                    os.path.isfile(stem + ".xmp")
+                    or os.path.isfile(stem + ".XMP")
+                    or os.path.isfile(src + ".xmp")
+                    or os.path.isfile(src + ".XMP")
+                ),
+            })
+        return jsonify(out)
+
     @app.route("/api/folders/check-health", methods=["POST"])
     def api_folders_check_health():
         db = _get_db()
@@ -1051,6 +1102,48 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "changed": changed,
             "missing": [dict(f) for f in missing],
         })
+
+    @app.route("/api/photos/missing/delete-sidecars", methods=["POST"])
+    def api_photos_missing_delete_sidecars():
+        """Delete leftover .xmp sidecar files for photos whose original is gone.
+
+        Body: ``{"photos": [{"folder_path": ..., "filename": ...}, ...]}``
+
+        Guards: only ``.xmp``/``.XMP`` extensions, only when the named
+        original is *actually* missing on disk. A sidecar whose original
+        still exists is silently skipped — that's the user's filesystem
+        and we don't want to delete files we're not sure are orphans.
+        """
+        body = request.get_json(silent=True) or {}
+        photos = body.get("photos") or []
+        deleted = 0
+        skipped = 0
+        for entry in photos:
+            folder_path = entry.get("folder_path") or ""
+            filename = entry.get("filename") or ""
+            if not folder_path or not filename:
+                skipped += 1
+                continue
+            src = os.path.join(folder_path, filename)
+            if os.path.exists(src):
+                # Original is present — refuse to touch the sidecar
+                skipped += 1
+                continue
+            stem, _ = os.path.splitext(src)
+            removed_one = False
+            for candidate in (stem + ".xmp", stem + ".XMP",
+                              src + ".xmp", src + ".XMP"):
+                if os.path.isfile(candidate):
+                    try:
+                        os.remove(candidate)
+                        removed_one = True
+                    except OSError as e:
+                        log.warning("Failed to delete sidecar %s: %s", candidate, e)
+            if removed_one:
+                deleted += 1
+            else:
+                skipped += 1
+        return jsonify({"deleted": deleted, "skipped": skipped})
 
     @app.route("/api/folders/<int:folder_id>", methods=["GET"])
     def api_folder_get(folder_id):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1076,6 +1076,15 @@ class Database:
         ``'missing'`` — those are surfaced by ``get_missing_folders`` and
         listing them per-photo would just duplicate that signal at high cost.
 
+        Folder DB ``status`` is updated asynchronously by a 10-minute health
+        loop, so a freshly unmounted volume can still show ``status='ok'``
+        when this query runs. To avoid surfacing thousands of "ghosts" for
+        a temporarily offline drive (and offering them up for bulk delete),
+        we also treat any folder whose root no longer resolves on disk as
+        if it were already flagged missing. Resolution is cached per folder
+        within the call so a 1000-photo folder doesn't stat the same root
+        a thousand times.
+
         Each row carries ``folder_path``, ``timestamp``, and
         ``working_copy_path`` so the caller can render rich UI without
         joining again.
@@ -1091,8 +1100,15 @@ class Database:
                ORDER BY f.path, p.filename""",
             (self._ws_id(),),
         ).fetchall()
+        folder_online: dict[int, bool] = {}
         missing = []
         for row in rows:
+            fid = row["folder_id"]
+            if fid not in folder_online:
+                folder_online[fid] = os.path.isdir(row["folder_path"])
+            if not folder_online[fid]:
+                # Whole folder is offline — surfaced by missing-folders flow.
+                continue
             src = os.path.join(row["folder_path"], row["filename"])
             if not os.path.exists(src):
                 missing.append(row)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1069,6 +1069,35 @@ class Database:
             (self._ws_id(),),
         ).fetchall()
 
+    def get_missing_photos(self):
+        """Return photos whose source file is missing from disk.
+
+        Scoped to the active workspace. Skips photos in folders flagged
+        ``'missing'`` — those are surfaced by ``get_missing_folders`` and
+        listing them per-photo would just duplicate that signal at high cost.
+
+        Each row carries ``folder_path``, ``timestamp``, and
+        ``working_copy_path`` so the caller can render rich UI without
+        joining again.
+        """
+        rows = self.conn.execute(
+            """SELECT p.id, p.filename, p.extension, p.file_size,
+                      p.timestamp, p.working_copy_path,
+                      f.id AS folder_id, f.path AS folder_path
+               FROM photos p
+               JOIN folders f ON p.folder_id = f.id
+               JOIN workspace_folders wf ON wf.folder_id = f.id
+               WHERE wf.workspace_id = ? AND f.status != 'missing'
+               ORDER BY f.path, p.filename""",
+            (self._ws_id(),),
+        ).fetchall()
+        missing = []
+        for row in rows:
+            src = os.path.join(row["folder_path"], row["filename"])
+            if not os.path.exists(src):
+                missing.append(row)
+        return missing
+
     def relocate_folder(self, folder_id, new_path):
         """Update folder path and set status to 'ok'.
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4881,11 +4881,19 @@ async function removeSelectedMissingPhotos() {
 }
 
 async function _deleteMissingPhotoIds(ids, deleteSidecars) {
-  const sidecarPaths = [];
+  // Sidecar cleanup must run BEFORE the batch delete: the server resolves
+  // sidecar paths from the photo row's folder + filename, so once the row
+  // is gone the lookup returns nothing and the .xmp would be left behind.
   if (deleteSidecars) {
-    for (const p of _missingPhotosCache) {
-      if (!ids.includes(p.id) || !p.has_xmp_sidecar) continue;
-      sidecarPaths.push(p);
+    const sidecarIds = _missingPhotosCache
+      .filter(p => ids.includes(p.id) && p.has_xmp_sidecar)
+      .map(p => p.id);
+    if (sidecarIds.length > 0) {
+      await safeFetch('/api/photos/missing/delete-sidecars', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({photo_ids: sidecarIds}),
+      });
     }
   }
   await safeFetch('/api/batch/delete', {
@@ -4893,15 +4901,6 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({photo_ids: ids, mode: 'vireo'}),
   });
-  if (sidecarPaths.length > 0) {
-    await safeFetch('/api/photos/missing/delete-sidecars', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({photos: sidecarPaths.map(p => ({
-        folder_path: p.folder_path, filename: p.filename,
-      }))}),
-    });
-  }
 }
 </script>
 <script src="/static/vireo-utils.js"></script>

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -994,6 +994,76 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   font-weight: 600;
   text-decoration: underline;
 }
+
+/* ---------- Missing Originals (per-photo) ---------- */
+.missing-photo-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+.missing-photo-row:last-child { border-bottom: none; }
+.missing-photo-thumb {
+  width: 56px; height: 56px; flex-shrink: 0;
+  background: var(--bg-tertiary);
+  border-radius: 4px;
+  display: flex; align-items: center; justify-content: center;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+.missing-photo-thumb img {
+  width: 100%; height: 100%; object-fit: cover;
+}
+.missing-photo-info {
+  flex: 1; min-width: 0;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.missing-photo-filename {
+  font-family: monospace;
+  font-weight: 600;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.missing-photo-path {
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-family: monospace;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.missing-photo-badges {
+  display: flex; flex-wrap: wrap; gap: 4px;
+  margin-top: 2px;
+}
+.missing-photo-badge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px dashed var(--border);
+  opacity: 0.55;
+}
+.missing-photo-badge.has {
+  background: var(--accent-soft, var(--bg-tertiary));
+  color: var(--accent, var(--text-primary));
+  border: 1px solid var(--accent, var(--border));
+  opacity: 1;
+  font-weight: 600;
+}
+.missing-photo-row .missing-folder-actions { flex-shrink: 0; }
+.missing-photos-toolbar {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 0 10px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.missing-photos-toolbar input[type="checkbox"] { margin: 0; }
+.missing-photos-toolbar .spacer { flex: 1; }
+.missing-photo-row input[type="checkbox"] { margin: 0; flex-shrink: 0; }
 .banner-dismiss {
   margin-left: auto;
   background: none;
@@ -1405,6 +1475,13 @@ function sendReport() {
   <button class="banner-dismiss" onclick="dismissMissingBanner()">&times;</button>
 </div>
 
+<!-- Missing Originals Banner -->
+<div class="missing-folders-banner" id="missingPhotosBanner" style="display:none;">
+  <span id="missingPhotosMsg"></span>
+  <a href="#" onclick="openMissingPhotosModal(); return false;">Review</a>
+  <button class="banner-dismiss" onclick="dismissMissingPhotosBanner()">&times;</button>
+</div>
+
 <!-- New Images Banner -->
 <div class="new-images-banner" id="newImagesBanner" style="display:none;">
   <span id="newImagesMsg"></span>
@@ -1430,6 +1507,28 @@ function sendReport() {
     <div class="modal-actions">
       <button class="modal-btn" onclick="loadMissingFolders()">Check Again</button>
       <button class="modal-btn modal-btn-cancel" onclick="closeMissingFoldersModal()">Close</button>
+    </div>
+  </div>
+</div>
+
+<!-- Missing Originals Modal -->
+<div class="modal-overlay" id="missingPhotosModal">
+  <div class="modal" style="max-width:780px;width:92%;max-height:80vh;display:flex;flex-direction:column;">
+    <h3>Missing Originals</h3>
+    <p style="color:var(--text-secondary);font-size:13px;margin-bottom:8px;">
+      These photos' original files can't be found on disk. Vireo may still have a cached thumbnail, preview, working copy, or XMP sidecar — review what's left, then remove the ones you no longer want in your library.
+    </p>
+    <div class="missing-photos-toolbar" id="missingPhotosToolbar" style="display:none;">
+      <label><input type="checkbox" id="missingPhotosSelectAll" onchange="toggleAllMissingPhotos(this.checked)"> Select all</label>
+      <span id="missingPhotosSelectedCount">0 selected</span>
+      <span class="spacer"></span>
+      <label title="Also delete the .xmp sidecar files left behind on disk."><input type="checkbox" id="missingPhotosDeleteSidecars"> Also delete leftover XMP sidecars</label>
+    </div>
+    <div id="missingPhotosList" style="flex:1;overflow-y:auto;"></div>
+    <div class="modal-actions">
+      <button class="modal-btn danger" id="missingPhotosRemoveBtn" onclick="removeSelectedMissingPhotos()" disabled>Remove selected</button>
+      <button class="modal-btn" onclick="loadMissingPhotos()">Check Again</button>
+      <button class="modal-btn modal-btn-cancel" onclick="closeMissingPhotosModal()">Close</button>
     </div>
   </div>
 </div>
@@ -4269,6 +4368,40 @@ function dismissMissingBanner() {
 checkMissingFolders();
 setInterval(checkMissingFolders, 600000);
 
+/* ---------- Missing Originals Banner ---------- */
+let _missingPhotosCache = [];
+let _missingPhotosBannerDismissedCount = 0;
+
+async function checkMissingPhotos() {
+  try {
+    const resp = await fetch('/api/photos/missing');
+    if (!resp.ok) return;
+    const photos = await resp.json();
+    _missingPhotosCache = photos;
+    const banner = document.getElementById('missingPhotosBanner');
+    const msg = document.getElementById('missingPhotosMsg');
+    if (photos.length > 0 && photos.length !== _missingPhotosBannerDismissedCount) {
+      const s = photos.length === 1 ? '' : 's';
+      msg.textContent = `${photos.length} photo${s} reference${photos.length === 1 ? 's' : ''} a missing original.`;
+      banner.style.display = 'flex';
+    } else if (photos.length === 0) {
+      banner.style.display = 'none';
+      _missingPhotosBannerDismissedCount = 0;
+    }
+  } catch (e) { /* ignore */ }
+}
+
+function dismissMissingPhotosBanner() {
+  document.getElementById('missingPhotosBanner').style.display = 'none';
+  _missingPhotosBannerDismissedCount = _missingPhotosCache.length;
+}
+
+// Missing-originals scan touches every photo's source path on disk; on a
+// large library that's slow over a network volume. Run on load and every
+// 30 minutes — folders disappear faster than individual files do.
+checkMissingPhotos();
+setInterval(checkMissingPhotos, 1800000);
+
 /* ---------- New Images Banner ---------- */
 // Per-workspace dismissal: one sessionStorage key per workspace id so that
 // switching workspaces doesn't clobber other workspaces' dismissal state.
@@ -4636,6 +4769,139 @@ async function startRemoveFolder(folderId, path, photoCount) {
   if (!confirm(`This will remove ${photoCount} photo${photoCount !== 1 ? 's' : ''} from Vireo.\n\nThe files on disk (if they still exist) won't be touched.\n\nRemove "${path}"?`)) return;
   await safeFetch(`/api/folders/${folderId}`, {method: 'DELETE'});
   loadMissingFolders();
+}
+
+/* ---------- Missing Originals Modal ---------- */
+let _missingPhotosSelected = new Set();
+
+function openMissingPhotosModal() {
+  document.getElementById('missingPhotosModal').classList.add('open');
+  loadMissingPhotos();
+}
+
+function closeMissingPhotosModal() {
+  document.getElementById('missingPhotosModal').classList.remove('open');
+  checkMissingPhotos();  // refresh banner
+}
+
+function _escapeAttr(s) {
+  return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+function _escapeHtml(s) { return _escapeAttr(s); }
+
+async function loadMissingPhotos() {
+  const container = document.getElementById('missingPhotosList');
+  const toolbar = document.getElementById('missingPhotosToolbar');
+  container.innerHTML = '<p style="color:var(--text-secondary);">Checking photos…</p>';
+  toolbar.style.display = 'none';
+  _missingPhotosSelected = new Set();
+  try {
+    const resp = await fetch('/api/photos/missing');
+    if (!resp.ok) throw new Error('check failed');
+    const photos = await resp.json();
+    _missingPhotosCache = photos;
+    if (photos.length === 0) {
+      container.innerHTML = '<p style="color:var(--text-secondary);">No photos with missing originals.</p>';
+      checkMissingPhotos();
+      return;
+    }
+    toolbar.style.display = 'flex';
+    document.getElementById('missingPhotosSelectAll').checked = false;
+    container.innerHTML = photos.map(p => {
+      const ts = p.timestamp ? new Date(p.timestamp).toLocaleDateString() : '';
+      const thumb = p.has_thumb
+        ? `<img src="/thumbnails/${p.id}.jpg" alt="" loading="lazy">`
+        : '<span>no thumb</span>';
+      const badges = [
+        ['thumb', p.has_thumb],
+        ['preview', p.has_preview],
+        ['working copy', p.has_working_copy],
+        ['XMP', p.has_xmp_sidecar],
+      ].map(([label, on]) =>
+        `<span class="missing-photo-badge${on ? ' has' : ''}">${on ? '✓ ' : ''}${label}</span>`
+      ).join('');
+      return `
+        <div class="missing-photo-row" data-photo-id="${p.id}">
+          <input type="checkbox" onchange="toggleMissingPhoto(${p.id}, this.checked)">
+          <div class="missing-photo-thumb">${thumb}</div>
+          <div class="missing-photo-info">
+            <div class="missing-photo-filename" title="${_escapeAttr(p.filename)}">${_escapeHtml(p.filename)}${ts ? ` <span style="font-weight:400;color:var(--text-secondary);">· ${ts}</span>` : ''}</div>
+            <div class="missing-photo-path" title="${_escapeAttr(p.folder_path)}">${_escapeHtml(p.folder_path)}</div>
+            <div class="missing-photo-badges">${badges}</div>
+          </div>
+          <div class="missing-folder-actions">
+            <button class="danger" onclick="removeOneMissingPhoto(${p.id})">Remove</button>
+          </div>
+        </div>
+      `;
+    }).join('');
+    _updateMissingPhotosBulkBtn();
+  } catch (e) {
+    container.innerHTML = '<p style="color:var(--text-secondary);">Failed to check photos.</p>';
+  }
+}
+
+function toggleMissingPhoto(id, checked) {
+  if (checked) _missingPhotosSelected.add(id);
+  else _missingPhotosSelected.delete(id);
+  _updateMissingPhotosBulkBtn();
+}
+
+function toggleAllMissingPhotos(checked) {
+  _missingPhotosSelected = new Set();
+  document.querySelectorAll('#missingPhotosList .missing-photo-row').forEach(function(row) {
+    const cb = row.querySelector('input[type="checkbox"]');
+    cb.checked = checked;
+    if (checked) _missingPhotosSelected.add(parseInt(row.dataset.photoId, 10));
+  });
+  _updateMissingPhotosBulkBtn();
+}
+
+function _updateMissingPhotosBulkBtn() {
+  const n = _missingPhotosSelected.size;
+  document.getElementById('missingPhotosSelectedCount').textContent =
+    `${n} selected`;
+  document.getElementById('missingPhotosRemoveBtn').disabled = (n === 0);
+}
+
+async function removeOneMissingPhoto(id) {
+  if (!confirm('Remove this photo from Vireo?\n\nCached thumbnail/preview/working copy (if any) will also be deleted. The XMP sidecar on disk will not be touched.')) return;
+  await _deleteMissingPhotoIds([id], false);
+  loadMissingPhotos();
+}
+
+async function removeSelectedMissingPhotos() {
+  const ids = Array.from(_missingPhotosSelected);
+  if (ids.length === 0) return;
+  const deleteSidecars = document.getElementById('missingPhotosDeleteSidecars').checked;
+  const sidecarMsg = deleteSidecars ? '\n\nLeftover XMP sidecars will also be deleted from disk.' : '';
+  if (!confirm(`Remove ${ids.length} photo${ids.length !== 1 ? 's' : ''} from Vireo?\n\nCached thumbnails/previews/working copies will be deleted.${sidecarMsg}`)) return;
+  await _deleteMissingPhotoIds(ids, deleteSidecars);
+  loadMissingPhotos();
+}
+
+async function _deleteMissingPhotoIds(ids, deleteSidecars) {
+  const sidecarPaths = [];
+  if (deleteSidecars) {
+    for (const p of _missingPhotosCache) {
+      if (!ids.includes(p.id) || !p.has_xmp_sidecar) continue;
+      sidecarPaths.push(p);
+    }
+  }
+  await safeFetch('/api/batch/delete', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({photo_ids: ids, mode: 'vireo'}),
+  });
+  if (sidecarPaths.length > 0) {
+    await safeFetch('/api/photos/missing/delete-sidecars', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photos: sidecarPaths.map(p => ({
+        folder_path: p.folder_path, filename: p.filename,
+      }))}),
+    });
+  }
 }
 </script>
 <script src="/static/vireo-utils.js"></script>

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2282,8 +2282,9 @@ def test_api_photos_missing(app_and_db, tmp_path):
 def test_api_photos_missing_delete_sidecars(app_and_db, tmp_path):
     """POST /api/photos/missing/delete-sidecars removes orphan XMP files for ghost photos.
 
-    Safety guards: only deletes .xmp/.XMP, only when the corresponding original
-    is actually missing on disk. Anything else gets skipped.
+    Safety guards:
+    - Only acts on photo_ids that exist in the active workspace.
+    - Only deletes .xmp/.XMP, only when the source is genuinely missing.
     """
     app, db = app_and_db
     client = app.test_client()
@@ -2299,11 +2300,14 @@ def test_api_photos_missing_delete_sidecars(app_and_db, tmp_path):
     decoy_xmp = real_dir / "decoy.xmp"
     decoy_xmp.write_text("<x:xmpmeta/>")
 
+    fid = db.add_folder(str(real_dir), name="live")
+    pid_ghost = db.add_photo(folder_id=fid, filename="ghost.NEF",
+                             extension=".nef", file_size=1, file_mtime=1.0)
+    pid_decoy = db.add_photo(folder_id=fid, filename="decoy.jpg",
+                             extension=".jpg", file_size=1, file_mtime=1.0)
+
     resp = client.post("/api/photos/missing/delete-sidecars", json={
-        "photos": [
-            {"folder_path": str(real_dir), "filename": "ghost.NEF"},
-            {"folder_path": str(real_dir), "filename": "decoy.jpg"},
-        ],
+        "photo_ids": [pid_ghost, pid_decoy],
     })
     assert resp.status_code == 200
     data = resp.get_json()
@@ -2311,6 +2315,35 @@ def test_api_photos_missing_delete_sidecars(app_and_db, tmp_path):
     assert data["skipped"] == 1
     assert not ghost_xmp.exists(), "ghost sidecar should be deleted"
     assert decoy_xmp.exists(), "sidecar with present original must not be deleted"
+
+
+def test_api_photos_missing_delete_sidecars_rejects_untracked_paths(app_and_db, tmp_path):
+    """Endpoint must not delete .xmp files outside the active workspace.
+
+    Regression: an earlier draft accepted client-supplied (folder_path, filename)
+    pairs and unlinked any matching .xmp on disk as long as the named "original"
+    was absent. That allowed a crafted request to delete arbitrary .xmp files.
+    The fix: only act on photo_ids that resolve to a row in the active workspace.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    # An attacker-controlled directory entirely outside Vireo's library —
+    # we drop a sidecar there to confirm the endpoint won't touch it.
+    untracked_dir = tmp_path / "outside"
+    untracked_dir.mkdir()
+    poached = untracked_dir / "victim.xmp"
+    poached.write_text("<x:xmpmeta/>")
+
+    # A high photo id that doesn't exist in the DB (active workspace).
+    resp = client.post("/api/photos/missing/delete-sidecars", json={
+        "photo_ids": [999_999],
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["deleted"] == 0
+    assert data["skipped"] == 1
+    assert poached.exists(), "untracked sidecar must not be touched"
 
 
 def test_api_photos_missing_excludes_present_files(app_and_db, tmp_path):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2232,6 +2232,110 @@ def test_api_folders_check_health(app_and_db):
     assert isinstance(data["missing"], list)
 
 
+def test_api_photos_missing(app_and_db, tmp_path):
+    """GET /api/photos/missing returns photos with absent source files."""
+    from PIL import Image
+    app, db = app_and_db
+    client = app.test_client()
+
+    # Replace the seed folder with one that exists on disk and seed one
+    # real file + one ghost row so missing detection has something to find.
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    Image.new("RGB", (10, 10)).save(real_dir / "here.jpg")
+    fid = db.add_folder(str(real_dir), name="live")
+    pid_present = db.add_photo(folder_id=fid, filename="here.jpg",
+                               extension=".jpg", file_size=1, file_mtime=1.0)
+    pid_ghost = db.add_photo(folder_id=fid, filename="ghost.NEF",
+                             extension=".nef", file_size=42, file_mtime=2.0,
+                             timestamp="2024-03-08T10:00:00")
+    # Pre-existing seed photos in /photos/2024 also have absent sources;
+    # simplify the assertion by removing them from the workspace.
+    db.delete_photos([
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id != ?", (fid,)
+        ).fetchall()
+    ])
+
+    # Cache a thumb for the ghost so the UI can still preview it.
+    Image.new("RGB", (10, 10)).save(
+        os.path.join(app.config["THUMB_CACHE_DIR"], f"{pid_ghost}.jpg"),
+    )
+    # Drop an XMP sidecar next to the ghost.
+    (real_dir / "ghost.xmp").write_text("<x:xmpmeta/>")
+
+    resp = client.get("/api/photos/missing")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert [row["id"] for row in data] == [pid_ghost]
+    row = data[0]
+    assert row["filename"] == "ghost.NEF"
+    assert row["folder_path"] == str(real_dir)
+    assert row["timestamp"] == "2024-03-08T10:00:00"
+    assert row["has_thumb"] is True
+    assert row["has_preview"] is False
+    assert row["has_working_copy"] is False
+    assert row["has_xmp_sidecar"] is True
+
+
+def test_api_photos_missing_delete_sidecars(app_and_db, tmp_path):
+    """POST /api/photos/missing/delete-sidecars removes orphan XMP files for ghost photos.
+
+    Safety guards: only deletes .xmp/.XMP, only when the corresponding original
+    is actually missing on disk. Anything else gets skipped.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    # Ghost: NEF gone, XMP remains
+    ghost_xmp = real_dir / "ghost.xmp"
+    ghost_xmp.write_text("<x:xmpmeta/>")
+    # Decoy: original still there — endpoint must refuse to touch its sidecar
+    decoy_jpg = real_dir / "decoy.jpg"
+    decoy_jpg.write_bytes(b"jpeg")
+    decoy_xmp = real_dir / "decoy.xmp"
+    decoy_xmp.write_text("<x:xmpmeta/>")
+
+    resp = client.post("/api/photos/missing/delete-sidecars", json={
+        "photos": [
+            {"folder_path": str(real_dir), "filename": "ghost.NEF"},
+            {"folder_path": str(real_dir), "filename": "decoy.jpg"},
+        ],
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["deleted"] == 1
+    assert data["skipped"] == 1
+    assert not ghost_xmp.exists(), "ghost sidecar should be deleted"
+    assert decoy_xmp.exists(), "sidecar with present original must not be deleted"
+
+
+def test_api_photos_missing_excludes_present_files(app_and_db, tmp_path):
+    """A photo whose source still exists must not show up as missing."""
+    from PIL import Image
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "ok"
+    real_dir.mkdir()
+    Image.new("RGB", (10, 10)).save(real_dir / "still_here.jpg")
+    fid = db.add_folder(str(real_dir), name="ok")
+    db.add_photo(folder_id=fid, filename="still_here.jpg", extension=".jpg",
+                 file_size=1, file_mtime=1.0)
+    db.delete_photos([
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id != ?", (fid,)
+        ).fetchall()
+    ])
+
+    resp = client.get("/api/photos/missing")
+    assert resp.status_code == 200
+    assert resp.get_json() == []
+
+
 def test_api_folder_relocate(app_and_db, tmp_path):
     """POST /api/folders/<id>/relocate updates path and status."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2346,6 +2346,49 @@ def test_api_photos_missing_delete_sidecars_rejects_untracked_paths(app_and_db, 
     assert poached.exists(), "untracked sidecar must not be touched"
 
 
+def test_api_photos_missing_detects_preview_variants(app_and_db, tmp_path):
+    """has_preview must catch both `{id}_{size}.jpg` and legacy `{id}.jpg`.
+
+    Indexing the cache once per request (instead of per-photo glob) is the
+    perf optimization; this test proves both filename shapes still land as
+    True so the behavior change is invisible to callers.
+    """
+    from PIL import Image
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    fid = db.add_folder(str(real_dir), name="live")
+    pid_sized = db.add_photo(folder_id=fid, filename="sized.NEF",
+                             extension=".nef", file_size=1, file_mtime=1.0)
+    pid_legacy = db.add_photo(folder_id=fid, filename="legacy.NEF",
+                              extension=".nef", file_size=1, file_mtime=1.0)
+    pid_no_preview = db.add_photo(folder_id=fid, filename="bare.NEF",
+                                  extension=".nef", file_size=1, file_mtime=1.0)
+    db.delete_photos([
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id != ?", (fid,)
+        ).fetchall()
+    ])
+
+    thumb_dir = app.config["THUMB_CACHE_DIR"]
+    vireo_dir = os.path.dirname(thumb_dir)
+    preview_dir = os.path.join(vireo_dir, "previews")
+    os.makedirs(preview_dir, exist_ok=True)
+    Image.new("RGB", (10, 10)).save(os.path.join(preview_dir, f"{pid_sized}_1920.jpg"))
+    Image.new("RGB", (10, 10)).save(os.path.join(preview_dir, f"{pid_legacy}.jpg"))
+    # Stray non-numeric filename in the cache must not crash the indexer.
+    Image.new("RGB", (10, 10)).save(os.path.join(preview_dir, "stray.jpg"))
+
+    resp = client.get("/api/photos/missing")
+    assert resp.status_code == 200
+    by_id = {r["id"]: r for r in resp.get_json()}
+    assert by_id[pid_sized]["has_preview"] is True
+    assert by_id[pid_legacy]["has_preview"] is True
+    assert by_id[pid_no_preview]["has_preview"] is False
+
+
 def test_api_photos_missing_reports_default_working_copy(app_and_db, tmp_path):
     """has_working_copy must reflect on-disk reality even when working_copy_path is NULL.
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2346,6 +2346,45 @@ def test_api_photos_missing_delete_sidecars_rejects_untracked_paths(app_and_db, 
     assert poached.exists(), "untracked sidecar must not be touched"
 
 
+def test_api_photos_missing_reports_default_working_copy(app_and_db, tmp_path):
+    """has_working_copy must reflect on-disk reality even when working_copy_path is NULL.
+
+    Legacy rows backfilled before working_copy_path was tracked still have a
+    file at <vireo>/working/<id>.jpg, and the batch-delete path removes it
+    on row removal. If the modal said no working copy existed, users would
+    decide to delete based on stale info.
+    """
+    from PIL import Image
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    fid = db.add_folder(str(real_dir), name="live")
+    pid = db.add_photo(folder_id=fid, filename="ghost.NEF",
+                       extension=".nef", file_size=1, file_mtime=1.0)
+    db.delete_photos([
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id != ?", (fid,)
+        ).fetchall()
+    ])
+
+    # Drop a working-copy file at the default location, leave the DB
+    # column NULL — same shape legacy/backfill state has.
+    thumb_dir = app.config["THUMB_CACHE_DIR"]
+    vireo_dir = os.path.dirname(thumb_dir)
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    Image.new("RGB", (10, 10)).save(os.path.join(working_dir, f"{pid}.jpg"))
+    assert db.get_photo(pid)["working_copy_path"] is None
+
+    resp = client.get("/api/photos/missing")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]["has_working_copy"] is True
+
+
 def test_api_photos_missing_excludes_present_files(app_and_db, tmp_path):
     """A photo whose source still exists must not show up as missing."""
     from PIL import Image

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4218,6 +4218,32 @@ def test_get_missing_photos_excludes_photos_in_missing_folders(tmp_path):
     assert db.get_missing_photos() == []
 
 
+def test_get_missing_photos_skips_folder_whose_root_is_offline(tmp_path):
+    """Folders whose path no longer resolves on disk must be skipped wholesale.
+
+    Regression: folder status only flips to 'missing' when the 10-minute
+    health loop runs. When a volume is unmounted, get_missing_photos used
+    to classify every photo in that folder as a ghost, and the UI offered
+    bulk delete — which would wipe library rows for a drive that's just
+    temporarily offline. Treat 'folder root missing on disk' the same as
+    'folder marked missing in DB' so we never surface those rows.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    # Folder is 'ok' in DB but its path doesn't exist (unmounted volume).
+    fid = db.add_folder("/Volumes/never_mounted/dir", name="offline")
+    assert db.conn.execute(
+        "SELECT status FROM folders WHERE id = ?", (fid,)
+    ).fetchone()["status"] == "ok"
+    db.add_photo(folder_id=fid, filename="bird.NEF", extension=".nef",
+                 file_size=1, file_mtime=1.0)
+
+    assert db.get_missing_photos() == []
+
+
 def test_get_missing_photos_scoped_to_active_workspace(tmp_path):
     """Missing photos in other workspaces don't leak into the active one."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4173,6 +4173,79 @@ def test_get_missing_folders_scoped_to_active_workspace(tmp_path):
     assert [row["path"] for row in missing] == ["/gone/in_b"]
 
 
+def test_get_missing_photos_returns_photos_with_missing_source(tmp_path):
+    """get_missing_photos returns photos whose source file is gone but folder remains."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    fid = db.add_folder(str(folder), name="photos")
+
+    here = folder / "present.jpg"
+    here.write_bytes(b"x")
+    pid_present = db.add_photo(folder_id=fid, filename="present.jpg",
+                               extension=".jpg", file_size=1, file_mtime=1.0)
+    pid_gone = db.add_photo(folder_id=fid, filename="gone.NEF",
+                            extension=".nef", file_size=1, file_mtime=1.0,
+                            timestamp="2024-03-08T10:00:00")
+
+    missing = db.get_missing_photos()
+    ids = [row["id"] for row in missing]
+    assert ids == [pid_gone]
+    row = missing[0]
+    assert row["filename"] == "gone.NEF"
+    assert row["folder_path"] == str(folder)
+    assert row["timestamp"] == "2024-03-08T10:00:00"
+
+
+def test_get_missing_photos_excludes_photos_in_missing_folders(tmp_path):
+    """Photos in folders flagged 'missing' are surfaced by get_missing_folders;
+    don't double-count them here."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    fid = db.add_folder("/gone/folder", name="gone")
+    db.add_photo(folder_id=fid, filename="bird.jpg", extension=".jpg",
+                 file_size=1, file_mtime=1.0)
+    db.conn.execute("UPDATE folders SET status = 'missing' WHERE id = ?", (fid,))
+    db.conn.commit()
+
+    assert db.get_missing_photos() == []
+
+
+def test_get_missing_photos_scoped_to_active_workspace(tmp_path):
+    """Missing photos in other workspaces don't leak into the active one."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.ensure_default_workspace()
+    ws_b = db.create_workspace("Other")
+
+    folder_a = tmp_path / "a"
+    folder_a.mkdir()
+    folder_b = tmp_path / "b"
+    folder_b.mkdir()
+
+    db.set_active_workspace(ws_a)
+    fid_a = db.add_folder(str(folder_a), name="a")
+    db.add_photo(folder_id=fid_a, filename="ghost_a.jpg", extension=".jpg",
+                 file_size=1, file_mtime=1.0)
+
+    db.set_active_workspace(ws_b)
+    fid_b = db.add_folder(str(folder_b), name="b")
+    db.add_photo(folder_id=fid_b, filename="ghost_b.jpg", extension=".jpg",
+                 file_size=1, file_mtime=1.0)
+
+    db.set_active_workspace(ws_a)
+    assert [row["filename"] for row in db.get_missing_photos()] == ["ghost_a.jpg"]
+    db.set_active_workspace(ws_b)
+    assert [row["filename"] for row in db.get_missing_photos()] == ["ghost_b.jpg"]
+
+
 def test_relocate_folder(tmp_path):
     """relocate_folder updates path and sets status to 'ok'."""
     from db import Database


### PR DESCRIPTION
## Why

Pipeline runs were silently failing on photos whose source files had been deleted from disk. In the user's library: 126 ghost rows across two folders (`2026-03-08`, `2026-03-09`) produced **126 preview errors** and **61 thumbnail errors** per pipeline run. Only XMP sidecars remained on disk; the NEFs were gone.

The existing missing-folders flow didn't catch these because the parent folders were still mounted — only the individual files were missing. Users had no way to find or clean up these ghost rows short of running the pipeline and reading error rollups.

## What

A navbar banner + modal that mirrors the existing missing-folders pattern, but at the per-photo level. Each row shows what Vireo still has cached for the ghost (thumbnail, preview, working copy, XMP sidecar), so the user can decide whether anything is worth keeping before removing the row.

### Backend
- `Database.get_missing_photos()` — returns photos in active workspace whose source file is missing on disk. Skips photos in folders that are already flagged `missing` (the existing folders flow handles those).
- `GET /api/photos/missing` — enriches each ghost with `has_thumb` / `has_preview` / `has_working_copy` / `has_xmp_sidecar` so the UI can render meaningful badges.
- `POST /api/photos/missing/delete-sidecars` — opt-in cleanup of orphan `.xmp` files. Refuses to touch sidecars whose original is still present on disk.

### Frontend (`vireo/templates/_navbar.html`)
- Warning banner with dismissable count.
- Modal lists each ghost with its cached thumbnail (when available), filename + date, folder path, and four ON/OFF artifact badges.
- Per-row remove + select-all + bulk remove via existing `/api/batch/delete` (which already deletes the cached thumb/preview/working-copy).
- Opt-in "Also delete leftover XMP sidecars" checkbox for the bulk path.

### Safety / scope
- No changes to existing endpoints or DB schema.
- `delete-sidecars` only deletes `.xmp`/`.XMP` and only when the original is verified missing — won't touch other extensions or active sidecars.
- Banner check runs every 30 min (vs. 10 min for folders) since the per-file existence scan is more expensive on a network volume.

## Tests

- 6 new unit tests, all TDD (RED before GREEN):
  - `test_get_missing_photos_returns_photos_with_missing_source`
  - `test_get_missing_photos_excludes_photos_in_missing_folders`
  - `test_get_missing_photos_scoped_to_active_workspace`
  - `test_api_photos_missing`
  - `test_api_photos_missing_excludes_present_files`
  - `test_api_photos_missing_delete_sidecars`
- Full project test suite (CLAUDE.md command): **445 passed, 1 warning, 0 failed** in 10:06.
- Playwright smoke against a live Flask app: banner shows, modal renders, badges differentiate present/absent artifacts, bulk delete + sidecar removal flow works end-to-end.

## Test plan

- [ ] Open the app on a library that has at least one photo whose source file is missing.
- [ ] Confirm the "X photo(s) reference a missing original" banner appears.
- [ ] Open the modal — verify cached thumb renders, badges accurately reflect what's on disk.
- [ ] Remove one row; confirm it disappears from the modal and the cached thumb/preview/working-copy are gone.
- [ ] Bulk select with "Also delete leftover XMP sidecars" — confirm the orphan `.xmp` files are removed from disk.
- [ ] Verify a sidecar whose original *is* present is **not** deleted by the bulk path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)