### PR TITLE
test: add pytest-timeout to fail hung tests fast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov pytest-timeout
           pip install -e .
 
       - name: Run tests with coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +27,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "pytest>=9.0",
     "pytest-cov>=6.0",
     "pytest-playwright>=0.7",
+    "pytest-timeout>=2.3",
     "ruff>=0.11",
 ]
 
@@ -60,6 +61,8 @@ include = ["vireo*"]
 testpaths = ["tests", "vireo/tests"]
 markers = ["e2e: end-to-end browser tests (require Playwright)"]
 addopts = "--ignore=tests/e2e"
+timeout = 120
+timeout_method = "thread"
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
## Summary

- Adds `pytest-timeout>=2.3` to dev deps and configures a 120s per-test timeout with thread-based cancellation in `pyproject.toml`.
- Hung tests now fail with a `Timeout` marker and stack trace instead of silently pegging CPU.

## Why

Two parallel `python -m pytest tests/...` runs (spawned by sibling Conductor workspaces following CLAUDE.md's "run tests before PR" instruction) hung at ~99% CPU for 30+ minutes today, cutting an in-progress pipeline's throughput in half (rate went from 6.1 photos/min → 3.3 photos/min on the live app, ETA jumped from ~4.6h → ~9h). Without any timeout configured, a wedged thread / `Event.wait()` / SSE generator inside a test silently burns a core forever.

`timeout_method = "thread"` matches the actual failure mode this codebase has — `signal`-based timeouts only fire if the main thread is responsive, which is exactly what's broken in the JobRunner-style hangs we see.

This doesn't fix the underlying hang in whichever test wedged today (likely something in `test_pipeline_job` / `test_scanner` / `test_new_images*`). It just makes the hang loud and bounded so we can find and fix it.

## Test plan

- [x] `pip install 'pytest-timeout>=2.3'` succeeds
- [x] `python -m pytest vireo/tests/test_config.py -q` still passes (22 passed in 4.20s)
- [x] A synthetic `time.sleep(300)` test under `--timeout=3` is killed at 3s with `+++ Timeout +++` and exit code 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)