### PR TITLE
Make classify cancel responsive

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4961,7 +4961,7 @@ class Database:
         self.conn.commit()
 
     def clear_predictions(self, model=None, collection_photo_ids=None,
-                          labels_fingerprint=None):
+                          labels_fingerprint=None, clear_run_keys=True):
         """Clear predictions, optionally filtered by model, photo set, and fingerprint.
 
         The ``predictions`` table is now global (no workspace_id).  This
@@ -4978,6 +4978,15 @@ class Database:
         leave those detections unclassified until forced. With
         ``labels_fingerprint`` passed, we delete only A's rows AND the
         matching ``classifier_runs`` rows so A's next pass actually re-runs.
+
+        ``clear_run_keys=False`` is for callers that have just written fresh
+        ``classifier_runs`` rows for these detections and are about to
+        replace the predictions in the same transaction (e.g. the pipeline's
+        deferred reclassify clear that runs after the per-photo
+        ``record_classifier_run`` calls).  Wiping the run keys in that case
+        would force the next non-reclassify pass to re-infer the entire
+        collection.  Default ``True`` matches the long-standing safety
+        behavior — only opt out if the caller guarantees fresh run keys.
         """
         ws = self._ws_id()
         # Build a reusable (cond, params) pair for the predictions subquery.
@@ -5007,6 +5016,10 @@ class Database:
             )""",
             [ws, *extra_params],
         )
+
+        if not clear_run_keys:
+            self.conn.commit()
+            return
 
         # Also clear matching classifier_runs rows so the next pass actually
         # re-runs the classifier. Without this, the skip gate at

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1864,6 +1864,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 raw_results: list = []
                 failed = 0
                 skipped_existing = 0
+                # Photos actually iterated past the inner abort check, used to
+                # correct the per-batch progress claim on a mid-batch cancel
+                # (the per-batch event below pre-advances count by len(batch)).
+                processed_in_loop = 0
                 start_time = time.time()
                 batch_size = 32  # classification batch granularity
 
@@ -1906,6 +1910,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         # then break out of the batch loop entirely.
                         if _should_abort(abort):
                             break
+                        processed_in_loop += 1
                         # Record this photo as classify-processed for the first
                         # successful model. Used by the stale-detection purge to
                         # restrict deletions to photos actually reclassified.
@@ -2050,10 +2055,28 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # for this model (see the comment on the purge below), which
                 # is the safe default when classify didn't finish.
                 if _should_abort(abort):
+                    # The per-batch progress event above pre-advances the
+                    # count by the full batch length BEFORE the inner loop
+                    # runs. On a mid-batch cancel that leaves the UI showing
+                    # a count higher than what was actually classified — emit
+                    # a corrected progress event and step update so the job
+                    # tree reflects the true partial state.
+                    stages["classify"]["count"] = (
+                        spec_idx * total + processed_in_loop
+                    )
+                    stages["classify"]["total"] = (
+                        total * len(resolved_specs_local)
+                    )
+                    runner.push_event(job["id"], "progress", _progress_event(
+                        stages, "classify",
+                        f"Cancelled — {processed_in_loop} of {total} photos",
+                        step_id=step_id,
+                    ))
                     runner.update_step(
                         job["id"], step_id,
                         status="completed",
-                        summary=f"Cancelled ({len(raw_results)} of {total} photos)",
+                        progress={"current": processed_in_loop, "total": total},
+                        summary=f"Cancelled ({processed_in_loop} of {total} photos)",
                     )
                     continue
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1842,17 +1842,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # the reclassify clear so the clear can scope by fingerprint.
                 spec_fp = loaded_models.get("labels_fingerprint", "legacy")
 
-                if params.reclassify:
-                    photo_ids = [p["id"] for p in photos]
-                    # Scope by labels_fingerprint so reclassifying one
-                    # workspace's label set doesn't wipe another
-                    # workspace's cached predictions on the same photos
-                    # under its own fingerprint (shared-folder setups).
-                    thread_db.clear_predictions(
-                        model=model_name,
-                        collection_photo_ids=photo_ids,
-                        labels_fingerprint=spec_fp,
-                    )
+                # The reclassify clear (wipes prior predictions for this
+                # model+fingerprint) is intentionally deferred to just before
+                # _store_grouped_predictions below — clearing here and then
+                # cancelling mid-classify would leave the predictions table
+                # empty for this model with no replacement, erasing the
+                # user's prior classifications instead of preserving them.
 
                 # No photo-level short-circuit: it would hide detections
                 # that newly cross the workspace's detector_confidence
@@ -2079,6 +2074,20 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         summary=f"Cancelled ({processed_in_loop} of {total} photos)",
                     )
                     continue
+
+                # Reclassify clear, deferred from the top of the per-spec body
+                # so a mid-batch cancel above leaves the user's prior
+                # predictions intact (Codex P1 review on #710).  Scope by
+                # labels_fingerprint so reclassifying one workspace's label
+                # set doesn't wipe another workspace's cached predictions on
+                # the same photos under its own fingerprint (shared-folder
+                # setups).
+                if params.reclassify:
+                    thread_db.clear_predictions(
+                        model=model_name,
+                        collection_photo_ids=[p["id"] for p in photos],
+                        labels_fingerprint=spec_fp,
+                    )
 
                 group_result = _store_grouped_predictions(
                     raw_results, job["id"], model_name,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2081,12 +2081,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # labels_fingerprint so reclassifying one workspace's label
                 # set doesn't wipe another workspace's cached predictions on
                 # the same photos under its own fingerprint (shared-folder
-                # setups).
+                # setups).  ``clear_run_keys=False`` because the per-photo
+                # ``record_classifier_run`` calls inside the loop above
+                # already wrote fresh classifier_runs rows for processed
+                # detections — wiping them here would strand the gate and
+                # force the next non-reclassify pass to re-infer everything.
                 if params.reclassify:
                     thread_db.clear_predictions(
                         model=model_name,
                         collection_photo_ids=[p["id"] for p in photos],
                         labels_fingerprint=spec_fp,
+                        clear_run_keys=False,
                     )
 
                 group_result = _store_grouped_predictions(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1899,6 +1899,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     )
 
                     for photo in batch:
+                        # Per-photo abort check so cancel takes effect within
+                        # one inference (~seconds) instead of waiting for the
+                        # next batch boundary (~32 photos). The outer batch
+                        # loop's check at the top of the next iteration will
+                        # then break out of the batch loop entirely.
+                        if _should_abort(abort):
+                            break
                         # Record this photo as classify-processed for the first
                         # successful model. Used by the stale-detection purge to
                         # restrict deletions to photos actually reclassified.
@@ -2035,6 +2042,20 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 primary_det["id"], model_name, spec_fp,
                                 prediction_count=new_count,
                             )
+
+                # Skip the grouping/storage finalization on cancel — it can
+                # take a minute on large collections and the user has already
+                # asked us to stop. Leaving models_succeeded at its current
+                # value also keeps the reclassify stale-row purge from firing
+                # for this model (see the comment on the purge below), which
+                # is the safe default when classify didn't finish.
+                if _should_abort(abort):
+                    runner.update_step(
+                        job["id"], step_id,
+                        status="completed",
+                        summary=f"Cancelled ({len(raw_results)} of {total} photos)",
+                    )
+                    continue
 
                 group_result = _store_grouped_predictions(
                     raw_results, job["id"], model_name,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2122,7 +2122,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     summary=", ".join(parts),
                 )
 
-            if models_succeeded == 0 and skipped_model_names:
+            # Cancellation takes precedence over the all-models-failed-to-load
+            # signal: if the user cancelled mid-classify after a prior model
+            # had already been added to skipped_model_names, raising here
+            # would misclassify the cancel as a fatal load failure and
+            # overwrite the per-model 'Cancelled' summary in the exception
+            # handler.
+            if (
+                models_succeeded == 0
+                and skipped_model_names
+                and not _should_abort(abort)
+            ):
                 raise RuntimeError(
                     f"All {len(skipped_model_names)} model(s) failed to load: "
                     + ", ".join(skipped_model_names)

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -3138,6 +3138,167 @@ def test_pipeline_classify_mid_batch_cancel_skips_storage(tmp_path, monkeypatch)
     )
 
 
+def test_pipeline_classify_cancel_does_not_raise_when_earlier_model_load_failed(
+    tmp_path, monkeypatch,
+):
+    """If model 0 failed to load (populating skipped_model_names) and model 1
+    is then cancelled mid-classify, the post-loop
+    `if models_succeeded == 0 and skipped_model_names: raise` check must
+    NOT fire — cancellation takes precedence over the all-models-failed
+    signal. Without this guard, a user cancel gets misclassified as a
+    fatal load failure (Codex P2 review).
+    """
+    import threading
+
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    import pipeline_job as pj
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    for i in range(3):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 2000 + i, 2_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    model_ids = _setup_two_fake_downloaded_models(tmp_path, monkeypatch)
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            existing = db_.get_detections(p["id"])
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in existing if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    from PIL import Image as _PILImage
+
+    def fake_prepare_image(photo, folders, detection, vireo_dir=None):
+        folder_path = folders.get(photo["folder_id"], "")
+        image_path = os.path.join(folder_path, photo["filename"])
+        return _PILImage.new("RGB", (16, 16), "black"), folder_path, image_path
+
+    monkeypatch.setattr(classify_job, "_prepare_image", fake_prepare_image)
+
+    abort_after_classify = threading.Event()
+
+    def spy_flush_batch(batch, clf, model_type, model_name, db_, raw_results,
+                        top_k=1):
+        for entry in batch:
+            raw_results.append({
+                "photo": entry["photo"],
+                "detection_id": entry.get("detection_id"),
+                "folder_path": entry["folder_path"],
+                "image_path": entry["image_path"],
+                "prediction": "Robin",
+                "confidence": 0.9,
+                "timestamp": None,
+                "filename": entry["photo"]["filename"],
+                "embedding": None,
+                "taxonomy": None,
+            })
+        abort_after_classify.set()
+        return 0
+
+    monkeypatch.setattr(classify_job, "_flush_batch", spy_flush_batch)
+    monkeypatch.setattr(
+        classify_job, "_store_grouped_predictions",
+        lambda *a, **k: {"predictions_stored": 0, "burst_groups": 0,
+                         "already_labeled": 0},
+    )
+
+    original_should_abort = pj._should_abort
+
+    def patched_should_abort(event):
+        if abort_after_classify.is_set():
+            return True
+        return original_should_abort(event)
+
+    monkeypatch.setattr(pj, "_should_abort", patched_should_abort)
+
+    # Make model 0 fail to load (so skipped_model_names gets populated) and
+    # model 1 succeed. The pipeline tries model 0 twice — once in
+    # model_loader_stage's preload, once in classify_stage's spec_idx==0
+    # branch — so the first 2 Classifier() calls fail; call 3 (model 1)
+    # succeeds.
+    classifier_calls = [0]
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            classifier_calls[0] += 1
+            if classifier_calls[0] <= 2:
+                raise RuntimeError(
+                    "simulated load failure for model 0"
+                )
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    # Order matters: model 0 fails, model 1 must come second so it actually
+    # runs classify and is the one we cancel. Pass them explicitly to lock
+    # the order against any reordering inside the pipeline.
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=model_ids,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    # Pre-fix, this would raise RuntimeError("All 1 model(s) failed to load: ...")
+    # because models_succeeded=0 and skipped_model_names=[model 0 name].
+    # With the guard, the cancel takes precedence and the call returns cleanly.
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # Sanity: the cancelled model 1 step has a 'Cancelled' summary.
+    classify_step_id = f"classify:{model_ids[1]}"
+    cancelled_updates = [
+        kw for (_, sid, kw) in runner.step_updates
+        if sid == classify_step_id and "Cancelled" in (kw.get("summary") or "")
+    ]
+    assert cancelled_updates, (
+        f"Expected {classify_step_id!r} to finalize as 'Cancelled'; "
+        f"got step_updates={runner.step_updates!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Sentinel written on ONNX load failure
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -3319,6 +3319,182 @@ def test_pipeline_reclassify_cancel_preserves_existing_predictions(
     )
 
 
+def test_pipeline_reclassify_success_preserves_classifier_run_keys(
+    tmp_path, monkeypatch,
+):
+    """A successful reclassify must leave fresh classifier_runs rows in
+    place for the processed detections so the next non-reclassify pass
+    hits the skip gate.  The deferred reclassify clear runs AFTER the
+    per-photo ``record_classifier_run`` calls; without ``clear_run_keys=False``
+    it wipes the just-written run keys, forcing the next normal classify to
+    re-infer the entire collection.  Codex P1 review on #710.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    detection_ids = []
+    for i in range(3):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        det_ids = db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+        detection_ids.append(det_ids[0])
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "legacy")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            existing = db_.get_detections(p["id"])
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in existing if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    from PIL import Image as _PILImage
+
+    def fake_prepare_image(photo, folders, detection, vireo_dir=None):
+        folder_path = folders.get(photo["folder_id"], "")
+        image_path = os.path.join(folder_path, photo["filename"])
+        return _PILImage.new("RGB", (16, 16), "black"), folder_path, image_path
+
+    monkeypatch.setattr(classify_job, "_prepare_image", fake_prepare_image)
+
+    # Wrap clear_predictions to verify the deferred reclassify clear runs
+    # with clear_run_keys=False AND that the just-written classifier_runs
+    # rows survive that clear.  We can't assert via the final post-pipeline
+    # state because the reclassify stale-detection purge runs after
+    # _store_grouped_predictions and FK-cascades the run keys away — but
+    # that's pre-existing reclassify behavior, unrelated to the deferred
+    # clear's scope.  The fix is about the clear itself, so test the clear.
+    from db import Database as _Db
+    original_clear = _Db.clear_predictions
+    clear_calls = []
+
+    def wrapped_clear(self, model=None, collection_photo_ids=None,
+                     labels_fingerprint=None, clear_run_keys=True):
+        before = self.conn.execute(
+            "SELECT COUNT(*) FROM classifier_runs"
+        ).fetchone()[0]
+        result = original_clear(
+            self, model=model,
+            collection_photo_ids=collection_photo_ids,
+            labels_fingerprint=labels_fingerprint,
+            clear_run_keys=clear_run_keys,
+        )
+        after = self.conn.execute(
+            "SELECT COUNT(*) FROM classifier_runs"
+        ).fetchone()[0]
+        clear_calls.append({
+            "model": model,
+            "fp": labels_fingerprint,
+            "clear_run_keys": clear_run_keys,
+            "runs_before": before,
+            "runs_after": after,
+        })
+        return result
+
+    monkeypatch.setattr(_Db, "clear_predictions", wrapped_clear)
+
+    def fake_flush_batch(batch, clf, model_type, model_name, db_, raw_results,
+                        top_k=1):
+        for entry in batch:
+            raw_results.append({
+                "photo": entry["photo"],
+                "detection_id": entry.get("detection_id"),
+                "folder_path": entry["folder_path"],
+                "image_path": entry["image_path"],
+                "prediction": "Robin",
+                "confidence": 0.9,
+                "timestamp": None,
+                "filename": entry["photo"]["filename"],
+                "embedding": None,
+                "taxonomy": None,
+            })
+        return 0
+
+    monkeypatch.setattr(classify_job, "_flush_batch", fake_flush_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        reclassify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # Find the deferred reclassify clear (the only call inside classify_stage
+    # that scopes by model+fingerprint+photos).  It must have been invoked
+    # with clear_run_keys=False so the per-photo record_classifier_run
+    # writes survive into _store_grouped_predictions.
+    deferred = [c for c in clear_calls if c["model"] == "BioCLIP"
+                and c["fp"] == "legacy"]
+    assert len(deferred) == 1, (
+        f"Expected exactly one deferred reclassify clear; got "
+        f"{len(deferred)}: {clear_calls!r}"
+    )
+    call = deferred[0]
+    assert call["clear_run_keys"] is False, (
+        f"Deferred reclassify clear must run with clear_run_keys=False so "
+        f"the just-written classifier_runs survive into the next "
+        f"non-reclassify pass.  Got clear_run_keys={call['clear_run_keys']!r}."
+    )
+    assert call["runs_before"] >= 3 and call["runs_after"] == call["runs_before"], (
+        f"clear_predictions(clear_run_keys=False) must NOT touch "
+        f"classifier_runs. Got runs_before={call['runs_before']}, "
+        f"runs_after={call['runs_after']}."
+    )
+
+
 def test_pipeline_classify_cancel_does_not_raise_when_earlier_model_load_failed(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -3153,6 +3153,172 @@ def test_pipeline_classify_mid_batch_cancel_skips_storage(tmp_path, monkeypatch)
     )
 
 
+def test_pipeline_reclassify_cancel_preserves_existing_predictions(
+    tmp_path, monkeypatch,
+):
+    """A reclassify cancelled mid-classify must NOT erase the user's prior
+    predictions. The reclassify clear runs only once we're committed to
+    storing fresh results — Codex P1 review on #710. Without this guard,
+    `clear_predictions` had already wiped the predictions table when the
+    cancel guard skipped `_store_grouped_predictions`, leaving the model
+    with no predictions for the entire collection.
+    """
+    import threading
+
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    import pipeline_job as pj
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    detection_ids = []
+    for i in range(3):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 3000 + i, 3_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        det_ids = db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+        detection_ids.append(det_ids[0])
+
+    # Insert pre-existing predictions for each detection under the model
+    # name and fingerprint the pipeline will use ('BioCLIP' / 'legacy' for
+    # the test stubs).  These are what must survive the cancelled reclassify.
+    for det_id in detection_ids:
+        db.add_prediction(
+            detection_id=det_id,
+            species="Pre-existing Sparrow",
+            confidence=0.95,
+            model="BioCLIP",
+            labels_fingerprint="legacy",
+        )
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    model_id = _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    # Force the bundle's labels_fingerprint to 'legacy' so it matches the
+    # add_prediction calls above.
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "legacy")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            existing = db_.get_detections(p["id"])
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in existing if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    from PIL import Image as _PILImage
+
+    def fake_prepare_image(photo, folders, detection, vireo_dir=None):
+        folder_path = folders.get(photo["folder_id"], "")
+        image_path = os.path.join(folder_path, photo["filename"])
+        return _PILImage.new("RGB", (16, 16), "black"), folder_path, image_path
+
+    monkeypatch.setattr(classify_job, "_prepare_image", fake_prepare_image)
+
+    abort_after_classify = threading.Event()
+
+    def spy_flush_batch(batch, clf, model_type, model_name, db_, raw_results,
+                        top_k=1):
+        for entry in batch:
+            raw_results.append({
+                "photo": entry["photo"],
+                "detection_id": entry.get("detection_id"),
+                "folder_path": entry["folder_path"],
+                "image_path": entry["image_path"],
+                "prediction": "Robin",
+                "confidence": 0.9,
+                "timestamp": None,
+                "filename": entry["photo"]["filename"],
+                "embedding": None,
+                "taxonomy": None,
+            })
+        abort_after_classify.set()
+        return 0
+
+    monkeypatch.setattr(classify_job, "_flush_batch", spy_flush_batch)
+
+    original_should_abort = pj._should_abort
+
+    def patched_should_abort(event):
+        if abort_after_classify.is_set():
+            return True
+        return original_should_abort(event)
+
+    monkeypatch.setattr(pj, "_should_abort", patched_should_abort)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        reclassify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    verify_db = Database(db_path)
+    verify_db.set_active_workspace(ws_id)
+
+    # All three pre-existing predictions must still be in the table.
+    # Before the fix, clear_predictions ran at the top of the per-spec body
+    # and wiped them; the cancel guard skipped _store_grouped_predictions,
+    # leaving the predictions table empty for this model.
+    surviving = verify_db.conn.execute(
+        "SELECT COUNT(*) FROM predictions "
+        "WHERE classifier_model = ? AND labels_fingerprint = ? "
+        "AND species = ?",
+        ("BioCLIP", "legacy", "Pre-existing Sparrow"),
+    ).fetchone()[0]
+    assert surviving == 3, (
+        f"A cancelled reclassify must NOT wipe the user's prior "
+        f"predictions. Expected all 3 'Pre-existing Sparrow' rows to "
+        f"survive; found {surviving}."
+    )
+
+
 def test_pipeline_classify_cancel_does_not_raise_when_earlier_model_load_failed(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -3137,6 +3137,21 @@ def test_pipeline_classify_mid_batch_cancel_skips_storage(tmp_path, monkeypatch)
         f"'Cancelled' summary; got step_updates={runner.step_updates!r}"
     )
 
+    # Progress on the cancelled step must reflect what was *actually*
+    # classified (1 photo), not what the per-batch progress event claimed
+    # (the entire batch).  Without the corrected progress emit, the step
+    # would show 3/3 even though only 1 photo was inferred — Codex P2.
+    cancelled_kw = cancelled_updates[-1]
+    assert cancelled_kw.get("progress") == {"current": 1, "total": 3}, (
+        f"Cancelled step must show actual processed count (1/3), not "
+        f"the pre-emptive batch claim (3/3). Got progress="
+        f"{cancelled_kw.get('progress')!r}"
+    )
+    assert "1 of 3" in (cancelled_kw.get("summary") or ""), (
+        f"Cancelled summary should report actual processed count; got "
+        f"{cancelled_kw.get('summary')!r}"
+    )
+
 
 def test_pipeline_classify_cancel_does_not_raise_when_earlier_model_load_failed(
     tmp_path, monkeypatch,

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -2964,6 +2964,180 @@ def test_pipeline_reclassify_partial_batch_exception_preserves_detections(
     )
 
 
+def test_pipeline_classify_mid_batch_cancel_skips_storage(tmp_path, monkeypatch):
+    """A mid-classify cancel must take effect within roughly one photo's
+    worth of work (not at the next 32-photo batch boundary), and must skip
+    _store_grouped_predictions, which can take a minute on large
+    collections.  The per-model step is finalized with a 'Cancelled'
+    summary so the user sees the partial state in the job tree.
+    """
+    import threading
+
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    import pipeline_job as pj
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    for i in range(3):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 1000 + i, 1_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    model_id = _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    # detect_stage stub: surface the prior-run detection rows we inserted
+    # above as if MegaDetector just produced them, so classify_stage's
+    # cached_detections lookup hits with real DB ids (record_classifier_run
+    # has a FK to detections.id).
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            existing = db_.get_detections(p["id"])
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in existing if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    # _prepare_image opens the real image and crops it. Stub it to a fake
+    # PIL image so the per-photo loop progresses to _flush_batch regardless
+    # of the dummy 16x16 black JPEGs on disk.
+    from PIL import Image as _PILImage
+
+    def fake_prepare_image(photo, folders, detection, vireo_dir=None):
+        folder_path = folders.get(photo["folder_id"], "")
+        image_path = os.path.join(folder_path, photo["filename"])
+        return _PILImage.new("RGB", (16, 16), "black"), folder_path, image_path
+
+    monkeypatch.setattr(classify_job, "_prepare_image", fake_prepare_image)
+
+    # Spy on _flush_batch: count calls, populate raw_results with a fake
+    # prediction so the per-model step has something to report, and trigger
+    # abort after the FIRST call so the inner-loop abort check is exercised
+    # on the second photo.
+    abort_after_classify = threading.Event()
+    flush_calls = [0]
+
+    def spy_flush_batch(batch, clf, model_type, model_name, db_, raw_results,
+                        top_k=1):
+        flush_calls[0] += 1
+        for entry in batch:
+            raw_results.append({
+                "photo": entry["photo"],
+                "detection_id": entry.get("detection_id"),
+                "folder_path": entry["folder_path"],
+                "image_path": entry["image_path"],
+                "prediction": "Robin",
+                "confidence": 0.9,
+                "timestamp": None,
+                "filename": entry["photo"]["filename"],
+                "embedding": None,
+                "taxonomy": None,
+            })
+        abort_after_classify.set()
+        return 0
+
+    monkeypatch.setattr(classify_job, "_flush_batch", spy_flush_batch)
+
+    # Spy on _store_grouped_predictions to verify the cancel path skips it.
+    store_calls = [0]
+
+    def spy_store(*args, **kwargs):
+        store_calls[0] += 1
+        return {"predictions_stored": 0, "burst_groups": 0,
+                "already_labeled": 0}
+
+    monkeypatch.setattr(classify_job, "_store_grouped_predictions", spy_store)
+
+    original_should_abort = pj._should_abort
+
+    def patched_should_abort(event):
+        if abort_after_classify.is_set():
+            return True
+        return original_should_abort(event)
+
+    monkeypatch.setattr(pj, "_should_abort", patched_should_abort)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        reclassify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # Without the fix, all 3 photos are classified before the next outer
+    # batch boundary fires (batch_size=32 > 3 photos). With the fix, the
+    # inner-loop check catches abort on photo 2.
+    assert 1 <= flush_calls[0] <= 2, (
+        f"Expected classify to stop within ~1 photo of abort; got "
+        f"{flush_calls[0]} _flush_batch calls. Without the inner-loop "
+        f"abort check this would be 3."
+    )
+
+    # _store_grouped_predictions is the slow tail that the user reported
+    # as 'still going' after cancel.  The cancel path must skip it.
+    assert store_calls[0] == 0, (
+        f"_store_grouped_predictions must NOT run on a mid-batch cancel; "
+        f"got {store_calls[0]} calls."
+    )
+
+    classify_step_id = f"classify:{model_id}"
+    cancelled_updates = [
+        kw for (_, sid, kw) in runner.step_updates
+        if sid == classify_step_id and "Cancelled" in (kw.get("summary") or "")
+    ]
+    assert cancelled_updates, (
+        f"Expected at least one update on {classify_step_id!r} with a "
+        f"'Cancelled' summary; got step_updates={runner.step_updates!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Sentinel written on ONNX load failure
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Cancel of a long classify run could appear to hang for minutes. Two problems combined inside `classify_stage` (`vireo/pipeline_job.py`):

1. The abort check fired only **between batches of 32 photos**. With ~5s per inference, that's up to ~3 minutes before cancel registered.
2. After the batch loop broke out, `_store_grouped_predictions` still ran to finalize partial results — another ~minute on large collections, during which classify-related logs kept streaming and made the job look like it was still going.

This PR adds an abort check inside the per-photo loop so cancel takes effect within roughly one inference, and skips `_store_grouped_predictions` on cancel. The per-model step is finalized with a `Cancelled (X of N photos)` summary so the user sees the partial state in the job tree.

**Reclassify safety:** leaving `models_succeeded` at 0 keeps the stale-row purge from firing on a cancelled model — same guarantee as the existing per-spec abort path at the top of the per-spec loop.

**Performance:** the new check is `abort_event.is_set()`, ~tens of ns. Each photo's inference takes seconds. Overhead is unmeasurable.

## Test plan

- [x] `python -m pytest vireo/tests/test_pipeline_job.py` → 99 passed
- [x] New test `test_pipeline_classify_mid_batch_cancel_skips_storage`:
  - Without the fix: classify processes all 3 photos before noticing abort, `_store_grouped_predictions` runs.
  - With the fix: classify stops after 1 photo, `_store_grouped_predictions` is skipped, per-model step has `Cancelled (1 of 3 photos)` summary.
- [x] CLAUDE.md test set passes (1 pre-existing flake in `test_jobs_api`/`test_pipeline_auto_skips_classify_when_no_model` documented under `project_preexisting_test_failures` — unrelated, passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)