### PR TITLE
fix(new-images): suppress JPG companions of already-imported RAWs

### DIFF
--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -9,6 +9,14 @@ from image_loader import SUPPORTED_EXTENSIONS
 
 log = logging.getLogger(__name__)
 
+# Mirror ``vireo/scanner.py`` ``_pair_raw_jpeg_companions``: a JPG sitting next
+# to a RAW with the same basename in the same folder is the RAW's working-copy
+# companion, not a separate photo. Keeping these sets in sync with the scanner
+# is what guarantees the detector and the ingest path agree on what counts as
+# a new image.
+_RAW_EXTS = {".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf"}
+_JPEG_EXTS = {".jpg", ".jpeg"}
+
 
 def _known_paths_for_workspace(db, workspace_id):
     """Return the set of absolute paths of photos already ingested into the workspace."""
@@ -21,6 +29,22 @@ def _known_paths_for_workspace(db, workspace_id):
         (workspace_id,),
     ).fetchall()
     return {os.path.join(r["folder_path"], r["filename"]) for r in rows}
+
+
+def _known_raw_stems_for_workspace(db, workspace_id):
+    """Return the set of ``(folder_path, stem)`` pairs for already-imported
+    RAW photos in the workspace, used to suppress JPG working-copy companions
+    from the "new images" count."""
+    rows = db.conn.execute(
+        """SELECT f.path AS folder_path, p.filename
+           FROM photos p
+           JOIN folders f ON f.id = p.folder_id
+           JOIN workspace_folders wf ON wf.folder_id = f.id
+           WHERE wf.workspace_id = ?
+             AND lower(p.extension) IN ('.nef','.cr2','.cr3','.arw','.raf','.dng','.rw2','.orf')""",
+        (workspace_id,),
+    ).fetchall()
+    return {(r["folder_path"], Path(r["filename"]).stem) for r in rows}
 
 
 def mapped_roots(db, workspace_id):
@@ -83,6 +107,7 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5,
     needing to refactor the walk.
     """
     known = _known_paths_for_workspace(db, workspace_id)
+    known_raw_stems = _known_raw_stems_for_workspace(db, workspace_id)
     roots = mapped_roots(db, workspace_id)
 
     per_root = []
@@ -122,6 +147,14 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5,
                     continue
                 full = os.path.join(dirpath, name)
                 if full in known:
+                    _maybe_emit()
+                    continue
+                # Suppress JPG working-copy companions of already-imported
+                # RAWs in the same folder. The scanner pairs them as
+                # ``companion_path`` rather than create a new primary photo,
+                # so flagging them as "new" misleads the user into thinking
+                # there's something to ingest.
+                if ext in _JPEG_EXTS and (dirpath, Path(name).stem) in known_raw_stems:
                     _maybe_emit()
                     continue
                 root_new += 1

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -226,6 +226,137 @@ def test_count_new_images_basename_collision_across_subdirs(db_with_workspace):
     assert any("day2" in s for s in result["sample"])
 
 
+def test_count_new_images_skips_jpg_companion_of_existing_raw(db_with_workspace):
+    """A JPG sitting next to an already-imported RAW with the same basename
+    is the RAW's working-copy companion, not a new image. The scanner's
+    ``_pair_raw_jpeg_companions`` would attach it as ``companion_path``
+    rather than create a new primary photo, so the detector must not flag
+    it in the "N new images" banner.
+    """
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    # NEF is already in the database; the .jpg sidecar is on disk only.
+    _touch_image(str(root / "_D851928.jpg"))
+    root_id = db.add_folder(str(root), name="shoot")
+    db.add_photo(
+        folder_id=root_id, filename="_D851928.NEF", extension=".nef",
+        file_size=1, file_mtime=0.0,
+    )
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+
+    assert result["new_count"] == 0, (
+        f"JPG companion of existing RAW should not be flagged as new; "
+        f"got new_count={result['new_count']} sample={result['sample']}"
+    )
+
+
+def test_count_new_images_skips_jpg_companion_for_all_raw_extensions(db_with_workspace):
+    """The suppression must cover the same RAW extension set the scanner
+    pairs against (vireo/scanner.py: ``_pair_raw_jpeg_companions``)."""
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    raw_exts = [".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf"]
+    root_id = db.add_folder(str(root), name="shoot")
+    for i, ext in enumerate(raw_exts):
+        stem = f"IMG_{i:04d}"
+        _touch_image(str(root / f"{stem}.jpg"))
+        db.add_photo(
+            folder_id=root_id, filename=f"{stem}{ext.upper()}", extension=ext,
+            file_size=1, file_mtime=0.0,
+        )
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+
+    assert result["new_count"] == 0, (
+        f"All JPG companions of known RAWs should be suppressed; "
+        f"got new_count={result['new_count']} sample={result['sample']}"
+    )
+
+
+def test_count_new_images_skips_jpeg_extension_companion(db_with_workspace):
+    """``.jpeg`` (long form) is a JPEG too — must be suppressed when paired
+    with an existing RAW."""
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG_0001.jpeg"))
+    root_id = db.add_folder(str(root), name="shoot")
+    db.add_photo(
+        folder_id=root_id, filename="IMG_0001.CR3", extension=".cr3",
+        file_size=1, file_mtime=0.0,
+    )
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+
+    assert result["new_count"] == 0
+
+
+def test_count_new_images_counts_jpg_without_raw_companion(db_with_workspace):
+    """A JPG with no matching RAW in the database is genuinely new — the
+    suppression must NOT swallow it."""
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG_0001.jpg"))
+    db.add_folder(str(root), name="shoot")
+    # No photos added — workspace is empty.
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+
+    assert result["new_count"] == 1
+    assert result["sample"] == [str(root / "IMG_0001.jpg")]
+
+
+def test_count_new_images_counts_raw_alongside_existing_jpg(db_with_workspace):
+    """Asymmetric: only JPG-paired-with-existing-RAW is suppressed. A new
+    RAW alongside an already-imported JPG with the same stem is still a
+    new image (the scanner will pair them but keep the RAW as primary —
+    so the user genuinely needs to ingest it)."""
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG_0001.NEF"))
+    root_id = db.add_folder(str(root), name="shoot")
+    db.add_photo(
+        folder_id=root_id, filename="IMG_0001.jpg", extension=".jpg",
+        file_size=1, file_mtime=0.0,
+    )
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+
+    assert result["new_count"] == 1, (
+        "Asymmetric suppression: a new RAW next to an existing JPG must "
+        "still appear as new — the scanner will promote the RAW to primary."
+    )
+
+
+def test_count_new_images_jpg_companion_in_different_folder_is_new(db_with_workspace):
+    """Pairing matches on (folder, stem), not stem alone. A JPG in a
+    different folder than the RAW with the same stem must still count as
+    new — the scanner won't pair them across folders either."""
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "shoot"
+    day1 = root / "day1"
+    day2 = root / "day2"
+    _touch_image(str(day2 / "IMG_0001.jpg"))
+    root_id = db.add_folder(str(root), name="shoot")
+    day1_id = db.add_folder(str(day1), name="day1", parent_id=root_id)
+    db.add_folder(str(day2), name="day2", parent_id=root_id)
+    db.add_photo(
+        folder_id=day1_id, filename="IMG_0001.NEF", extension=".nef",
+        file_size=1, file_mtime=0.0,
+    )
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+
+    assert result["new_count"] == 1
+    assert any("day2" in s for s in result["sample"])
+
+
 def test_db_get_new_images_for_workspace_caches_result(db_with_workspace, monkeypatch):
     db, ws_id, tmp_path = db_with_workspace
     root = tmp_path / "shoot"


### PR DESCRIPTION
## Summary

The "N new images detected" banner counts files by full path, so a JPG sitting next to an already-imported RAW with the same basename — the RAW's working-copy companion — was flagged as new. The scanner's `_pair_raw_jpeg_companions` would later attach it as `companion_path` rather than create a separate primary photo, so the banner was misleading: it claimed there was something to ingest when there wasn't.

Concrete trigger: the Feb2026 workspace banner showed "62 new images detected"; all 62 turned out to be `.jpg` files paired with existing `.NEF` rows.

## Change

`count_new_images_for_workspace` (`vireo/new_images.py`) now suppresses a JPG candidate when an already-imported RAW exists at the same `(folder_path, stem)`. The RAW extension set mirrors the scanner's `_pair_raw_jpeg_companions` so detection and ingest agree on what counts as a companion.

Asymmetric on purpose: a new RAW alongside an already-imported JPG is *still* flagged as new — the scanner promotes the RAW to primary, so the user genuinely needs to ingest it.

## Test plan

- [x] New tests cover: JPG companion suppressed for every RAW extension; `.jpeg` long-form also suppressed; JPG with no RAW companion still counted; RAW alongside existing JPG still counted (asymmetry); folder boundaries respected (different folder ⇒ not paired).
- [x] `vireo/tests/test_new_images.py` — 36 passed.
- [x] `vireo/tests/test_new_images.py vireo/tests/test_new_images_api.py vireo/tests/test_new_images_cache.py vireo/tests/test_scanner.py` — 144 passed.
- [x] CLAUDE.md standard set (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py`) — 803 passed, 2 pre-existing failures in `test_edits_api.py` (`test_remove_keyword_from_photo`, `test_undo_keyword_remove_clears_pending_change`) confirmed on main at eb32f3d, unrelated to this change.
- [x] Live verification on the real Feb2026 workspace: `new_count` went from 62 → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)