### PR TITLE
test: parallelize pytest with xdist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov pytest-xdist
           pip install -e .
 
       - name: Run tests with coverage
-        run: python -m pytest tests/ vireo/tests/ -v --tb=short --cov=vireo --cov-report=term-missing --cov-fail-under=40
+        run: python -m pytest tests/ vireo/tests/ -n auto -v --tb=short --cov=vireo --cov-report=term-missing --cov-fail-under=40
 
   lint:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "pytest>=9.0",
     "pytest-cov>=6.0",
     "pytest-playwright>=0.7",
+    "pytest-xdist>=3.6",
     "ruff>=0.11",
 ]
 


### PR DESCRIPTION
## Summary

- Adds `pytest-xdist>=3.6` to dev deps and to the CI install line.
- Adds `-n auto` to the pytest invocation so the suite runs on all available cores.

## Why

The full test suite takes **~45 minutes** on GitHub Actions' 2-core runner. Investigation shows it's not slow tests — locally the same suite runs in **~3 minutes** with no changes. The runtime is dominated by per-test Flask app fixture overhead (sqlite setup, monkeypatching, app creation) compounded by GHA's slow shared-disk I/O. Parallelism is the right lever.

`pytest-cov` auto-detects xdist and merges coverage across workers — no extra config needed.

## Local benchmark (this branch)

- `python -m pytest vireo/tests/ -n auto --no-cov`: **2405 passed in 145s** (used ~5 cores at ~480% CPU)
- `python -m pytest <3 files> -n auto --cov=vireo`: 106 passed in 5.24s, coverage report merges correctly

CI is 2-core so realistic outcome is **~22 min** instead of 45.

## Notes

- The 1 test that fails under xdist (`test_misses_scenario`) **also fails serially on main** at 8d5244e — pre-existing `TypeError` in `vireo/testing/userfirst/seeds.py:175` calling `save_detections` with the wrong signature. Out of scope for this PR.
- Stacks cleanly with #709 (pytest-timeout); independent change.

## Test plan

- [x] Confirmed locally: `pytest vireo/tests/ -n auto --no-cov` runs in 2m25s vs ~3 min sequential
- [x] Confirmed locally with `--cov`: coverage report merges across workers, no missing data
- [ ] CI completes in <30 min on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)