### PR TITLE
fix(duplicates): hide bulk-decide folders with no existing candidates

### DIFF
--- a/vireo/duplicate_buckets.py
+++ b/vireo/duplicate_buckets.py
@@ -35,13 +35,21 @@ def bucket_unresolved_proposals(proposals):
 
     buckets = []
     for key, group_proposals in by_key.items():
+        folders_with_existing = set()
+        for p in group_proposals:
+            for cand in [p["winner"]] + list(p["losers"]):
+                if cand.get("exists", True):
+                    folders_with_existing.add(os.path.dirname(cand["path"]))
+        folders = sorted(f for f in key if f in folders_with_existing)
+        if not folders:
+            continue
         total_size = sum(
             len(p["losers"]) * p["winner"]["file_size"]
             for p in group_proposals
         )
         examples = [p["winner"]["filename"] for p in group_proposals[:3]]
         buckets.append({
-            "folders": sorted(key),
+            "folders": folders,
             "group_count": len(group_proposals),
             "file_hashes": [p["file_hash"] for p in group_proposals],
             "total_size": total_size,

--- a/vireo/tests/test_duplicate_buckets.py
+++ b/vireo/tests/test_duplicate_buckets.py
@@ -12,22 +12,33 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from duplicate_buckets import bucket_unresolved_proposals
 
 
-def _proposal(file_hash, paths, file_size=1000):
+def _proposal(file_hash, paths, file_size=1000, exists=None):
     """Build a minimal unresolved-proposal dict with given paths.
 
     First path is the winner; remaining are losers. The function under test
     only reads ``status``, ``file_hash``, ``winner.path``, ``winner.file_size``,
-    and ``losers[].path`` / ``losers[].file_size`` so the rest is omitted.
+    ``winner.exists``, and ``losers[].path`` / ``losers[].file_size`` /
+    ``losers[].exists`` so the rest is omitted.
+
+    ``exists``, if given, must be a list of booleans matching ``paths``.
+    Pass ``None`` to omit the key entirely (preserves pre-existence-aware
+    behavior, treated as present by the helper).
     """
+    def _candidate(idx, path):
+        cand = {
+            "path": path,
+            "filename": os.path.basename(path),
+            "file_size": file_size,
+        }
+        if exists is not None:
+            cand["exists"] = exists[idx]
+        return cand
+
     return {
         "status": "unresolved",
         "file_hash": file_hash,
-        "winner": {"path": paths[0], "filename": os.path.basename(paths[0]),
-                   "file_size": file_size},
-        "losers": [
-            {"path": p, "filename": os.path.basename(p), "file_size": file_size}
-            for p in paths[1:]
-        ],
+        "winner": _candidate(0, paths[0]),
+        "losers": [_candidate(i + 1, p) for i, p in enumerate(paths[1:])],
     }
 
 
@@ -145,3 +156,49 @@ def test_same_folder_duplicates_form_a_single_folder_bucket():
     buckets = bucket_unresolved_proposals(proposals)
     assert len(buckets) == 1
     assert buckets[0]["folders"] == ["/a"]
+
+
+def test_folder_with_only_missing_candidates_dropped_from_folders():
+    """A folder whose every candidate has ``exists=False`` would render a
+    bulk-decide button that the backend skip-guard refuses, so hide it."""
+    proposals = [
+        _proposal("h1", ["/a/owl.jpg", "/b/owl.jpg"], exists=[True, False]),
+    ]
+    buckets = bucket_unresolved_proposals(proposals)
+    assert len(buckets) == 1
+    assert buckets[0]["folders"] == ["/a"]
+
+
+def test_folder_with_one_existing_candidate_across_groups_stays():
+    """If a folder has at least one real file across the bucket's groups,
+    keep it — the backend will skip the missing hashes per-row."""
+    proposals = [
+        _proposal("h1", ["/a/owl.jpg", "/b/owl.jpg"], exists=[True, True]),
+        _proposal("h2", ["/a/hawk.jpg", "/b/hawk.jpg"], exists=[True, False]),
+    ]
+    buckets = bucket_unresolved_proposals(proposals)
+    assert len(buckets) == 1
+    assert buckets[0]["folders"] == ["/a", "/b"]
+
+
+def test_bucket_dropped_when_every_folder_only_has_missing_candidates():
+    """Pathological case: every candidate is missing. Bucket has nothing
+    actionable, so don't surface it at all — the per-group review path
+    handles those rows."""
+    proposals = [
+        _proposal("h1", ["/a/owl.jpg", "/b/owl.jpg"], exists=[False, False]),
+    ]
+    assert bucket_unresolved_proposals(proposals) == []
+
+
+def test_proposals_without_exists_key_preserve_all_folders():
+    """Backwards compat: proposals built before existence-aware bucketing
+    didn't carry an ``exists`` flag. Treat absent as present so pre-fix data
+    (and tests that don't bother with the flag) keep working."""
+    proposals = [
+        _proposal("h1", ["/a/owl.jpg", "/b/owl.jpg"]),
+        _proposal("h2", ["/a/hawk.jpg", "/b/hawk.jpg"]),
+    ]
+    buckets = bucket_unresolved_proposals(proposals)
+    assert len(buckets) == 1
+    assert buckets[0]["folders"] == ["/a", "/b"]

--- a/vireo/tests/test_duplicates_db.py
+++ b/vireo/tests/test_duplicates_db.py
@@ -450,7 +450,11 @@ def test_run_duplicate_scan_emits_buckets_for_unresolved_groups(tmp_path):
 
     # Three groups, each with one file in /a and one in /b. Reset flags so
     # the auto-resolve hook doesn't pre-pick a winner — we want unresolved.
+    # Touch the files on disk so the bucket builder's existence check
+    # (which drops folders with only missing candidates) keeps the bucket.
     for h, name in [("HBKT1", "owl.jpg"), ("HBKT2", "hawk.jpg"), ("HBKT3", "finch.jpg")]:
+        (a_dir / name).touch()
+        (b_dir / name).touch()
         _add(db, a_fid, name, file_hash=h)
         _add(db, b_fid, name, file_hash=h)
         _reset_flags(db, h)


### PR DESCRIPTION
## What

The bulk-decide bucket card on the Duplicates page listed every distinct parent folder across the bucket's groups, including folders whose every candidate row pointed at a missing file (e.g., a renamed/moved folder where stale DB rows still exist).

This produced misleading **"Keep \<folder\> for all N"** buttons. The backend (`Database.bulk_resolve_by_folder`) has an existence guard that skips per-hash with \`\"keep_folder candidate missing on disk\"\`, so clicking the bad button is non-destructive — but the user still sees a button that looks live and offers a choice that does nothing.

Real-world example from a user with 1,471 unresolved groups: the bucket listed both \`/Volumes/.../USA/2026/04-04\` (folder no longer exists; all 1,471 candidates have \`exists: False\`) and \`/Volumes/.../USA/2026/2026-04-04\` (folder exists; both candidates per group present). The \`04-04\` button was offered as a peer of the real choice.

## Fix

In \`vireo/duplicate_buckets.py:bucket_unresolved_proposals\`, filter \`bucket[\"folders\"]\` to parent dirs where **at least one candidate (winner or loser) across the bucket's groups** has \`exists\` truthy. The bucket key (the grouping) stays unchanged — only the displayed folder list is filtered. Drop the bucket entirely when no folder qualifies — per-group review still surfaces those groups for individual handling.

## Backwards compat

Proposals without an \`exists\` key are treated as present (the safe default). Existing tests that didn't set \`exists\` in their fixtures keep working without modification.

One existing scan-integration test (\`test_run_duplicate_scan_emits_buckets_for_unresolved_groups\`) was relying on \"bucket survives without files on disk\" by coincidence — updated it to actually \`touch()\` the candidate files, which is more realistic anyway.

## Tests

Added four new cases in \`vireo/tests/test_duplicate_buckets.py\`:

- folder with all-missing candidates dropped from \`folders\`
- folder with at least one existing candidate across groups stays
- bucket dropped entirely when every folder has only missing candidates
- backwards compat: proposals without \`exists\` key preserve all folders

\`\`\`
$ python -m pytest vireo/tests/test_duplicate_buckets.py vireo/tests/test_duplicates.py vireo/tests/test_duplicates_api.py vireo/tests/test_duplicates_bulk.py vireo/tests/test_duplicates_db.py
======================== 109 passed in 1.99s =========================

$ python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py
======== 803 passed, 2 failed in 2115s =========
\`\`\`

The two failures are pre-existing on main at \`eb32f3d\` and unrelated to this change:
- \`test_edits_api.py::test_remove_keyword_from_photo\`
- \`test_edits_api.py::test_undo_keyword_remove_clears_pending_change\`

## Out of scope

A bigger UX makeover of the bucket card (per-button preview of what each "Keep" does, clearer "Move extras to Trash" copy explaining file count + size + DB-row impact) is being tracked separately.