### PR TITLE
fix(duplicates): auto-create .Trashes/<uid>/ on external volumes

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -100,6 +100,33 @@ def _chunked(seq, size=_SQL_PARAM_CHUNK):
         yield seq[i:i + size]
 
 
+def _ensure_volume_trashes_dir(filepath, ensured_volumes):
+    """Make sure ``/Volumes/<X>/.Trashes/<uid>/`` exists when ``filepath`` is on
+    an external/network mount. macOS ``send2trash`` legacy mode raises
+    ``OSError: Directory not found`` on volumes where this directory was never
+    created (fresh SMB shares, NAS mounts, USB drives) — without it the caller
+    falls back to AppleScript Finder, which then times out under load (-1712)
+    and stalls the whole bulk trash for hours.
+
+    No-op for paths outside ``/Volumes/`` (the system Trash already handles
+    those) and for volumes already ensured this request. ``OSError`` from
+    ``makedirs`` (read-only mount, ACL block) is swallowed so the actual
+    trash call surfaces a more specific error than "could not mkdir".
+    """
+    parts = filepath.split(os.sep)
+    if len(parts) < 4 or parts[0] != "" or parts[1] != "Volumes":
+        return
+    volume_root = os.sep.join(parts[:3])
+    if volume_root in ensured_volumes:
+        return
+    ensured_volumes.add(volume_root)
+    trashes_dir = os.path.join(volume_root, ".Trashes", str(os.getuid()))
+    try:
+        os.makedirs(trashes_dir, mode=0o700, exist_ok=True)
+    except OSError as exc:
+        log.debug("could not ensure %s: %s", trashes_dir, exc)
+
+
 def _trash_via_finder(filepath):
     """Trash a file via Finder using AppleScript.
 
@@ -7267,6 +7294,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         trashed_pids = []
         skipped = []
         failed = []
+        ensured_volumes = set()
         for pid in photo_ids:
             row = rows_by_id.get(pid)
             if row is None:
@@ -7292,6 +7320,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 skipped.append({"id": pid, "reason": "file already missing"})
                 trashed_pids.append(pid)
                 continue
+            _ensure_volume_trashes_dir(filepath, ensured_volumes)
             try:
                 from send2trash import send2trash as _trash
                 _trash(filepath)

--- a/vireo/tests/test_duplicates_api.py
+++ b/vireo/tests/test_duplicates_api.py
@@ -660,3 +660,89 @@ def test_last_scan_ignores_failed_jobs(app_and_db):
 
     body = app.test_client().get("/api/duplicates/last-scan").get_json()
     assert body == {"found": False}
+
+
+# -----------------------------------------------------------------------------
+# _ensure_volume_trashes_dir — pre-trash hook that creates the per-user
+# .Trashes directory on external/network volumes so send2trash legacy mode
+# stops falling back to AppleScript Finder (which times out for hours).
+# -----------------------------------------------------------------------------
+
+def test_ensure_volume_trashes_dir_creates_dir_under_volume(monkeypatch):
+    """Path under /Volumes/X triggers makedirs for /Volumes/X/.Trashes/$UID."""
+    import os
+
+    from app import _ensure_volume_trashes_dir
+
+    calls = []
+    def fake_makedirs(path, mode=None, exist_ok=False):
+        calls.append((path, mode, exist_ok))
+    monkeypatch.setattr("os.makedirs", fake_makedirs)
+
+    seen = set()
+    _ensure_volume_trashes_dir("/Volumes/Photography/sub/file.NEF", seen)
+
+    assert len(calls) == 1
+    path, mode, exist_ok = calls[0]
+    assert path == f"/Volumes/Photography/.Trashes/{os.getuid()}"
+    assert mode == 0o700
+    assert exist_ok is True
+    assert "/Volumes/Photography" in seen
+
+
+def test_ensure_volume_trashes_dir_idempotent_per_volume(monkeypatch):
+    """Repeated calls for files on the same volume only run makedirs once."""
+    from app import _ensure_volume_trashes_dir
+
+    calls = []
+    monkeypatch.setattr("os.makedirs", lambda *a, **k: calls.append((a, k)))
+
+    seen = set()
+    _ensure_volume_trashes_dir("/Volumes/Photography/a.NEF", seen)
+    _ensure_volume_trashes_dir("/Volumes/Photography/b.NEF", seen)
+    _ensure_volume_trashes_dir("/Volumes/Photography/sub/c.NEF", seen)
+
+    assert len(calls) == 1
+
+
+def test_ensure_volume_trashes_dir_creates_per_distinct_volume(monkeypatch):
+    """Files on different volumes each get their own .Trashes dir created."""
+    from app import _ensure_volume_trashes_dir
+
+    calls = []
+    monkeypatch.setattr("os.makedirs", lambda p, **k: calls.append(p))
+
+    seen = set()
+    _ensure_volume_trashes_dir("/Volumes/Photography/a.NEF", seen)
+    _ensure_volume_trashes_dir("/Volumes/Backup/a.NEF", seen)
+
+    assert len(calls) == 2
+    assert "/Volumes/Photography/.Trashes/" in calls[0]
+    assert "/Volumes/Backup/.Trashes/" in calls[1]
+
+
+def test_ensure_volume_trashes_dir_skips_non_volume_paths(monkeypatch):
+    """System-Trash-managed paths (~, /tmp, /private) don't need this hook."""
+    from app import _ensure_volume_trashes_dir
+
+    calls = []
+    monkeypatch.setattr("os.makedirs", lambda *a, **k: calls.append(a))
+
+    _ensure_volume_trashes_dir("/Users/julius/photo.NEF", set())
+    _ensure_volume_trashes_dir("/private/tmp/photo.NEF", set())
+    _ensure_volume_trashes_dir("relative/path.NEF", set())
+    _ensure_volume_trashes_dir("/Volumes", set())  # bare /Volumes, no mount
+
+    assert calls == []
+
+
+def test_ensure_volume_trashes_dir_swallows_oserror(monkeypatch):
+    """Read-only mount or ACL block must not break the bulk trash — let the
+    actual send2trash call surface the more specific error."""
+    from app import _ensure_volume_trashes_dir
+
+    def boom(*a, **k):
+        raise OSError("read-only file system")
+    monkeypatch.setattr("os.makedirs", boom)
+
+    _ensure_volume_trashes_dir("/Volumes/X/photo.NEF", set())  # must not raise


### PR DESCRIPTION
## What

`send2trash` legacy mode raises `OSError: Directory not found` on external/network volumes (SMB shares, NAS mounts, USB drives) that don't have a `.Trashes/$UID/` directory yet. The bulk-trash endpoint then falls back to `_trash_via_finder` (AppleScript), which under load times out with `-1712: AppleEvent timed out`.

A real-world cleanup of 1,471 duplicate files on a Synology SMB share triggered exactly this path:

```
File "app.py", line 7297, in api_duplicates_delete_loser_files
File "send2trash/mac/legacy.py", line 52, in send2trash
OSError: Directory not found

[fallback to AppleScript]

File "app.py", line 7303, in _trash_via_finder
OSError: 109:123: execution error: Finder got an error: AppleEvent timed out. (-1712)
```

The single `delete-loser-files` request returned **HTTP 200 after 36,651.6 seconds (10h 11m)**. 1,167 files squeaked through Finder; 304 failed to a hung Finder process. The whole app effectively locked up overnight.

The volume itself was perfectly writable — it just didn't have `.Trashes/<uid>/` yet (the standard macOS per-user external-volume trash directory).

## Fix

Add `_ensure_volume_trashes_dir(filepath, ensured_volumes)` and call it once per distinct `/Volumes/<X>/` mount inside the bulk-trash loop, before invoking `send2trash`:

```python
ensured_volumes = set()
for pid in photo_ids:
    ...
    _ensure_volume_trashes_dir(filepath, ensured_volumes)
    try:
        from send2trash import send2trash as _trash
        _trash(filepath)
        ...
```

The helper:
- Detects `/Volumes/<X>/...` paths (no-op for `/Users/`, `/private/tmp/`, etc — system Trash already handles those)
- Calls `os.makedirs(.Trashes/<uid>/, mode=0o700, exist_ok=True)` once per volume per request
- Caches by volume root so a 1,000-file bulk action only stats each volume once
- Swallows `OSError` (read-only mount, ACL block) so the actual `send2trash` call surfaces a more specific error than "could not mkdir"

Standard macOS convention; this is what Finder itself does on first-trash to an external volume.

## Tests

5 new unit tests in `vireo/tests/test_duplicates_api.py` (monkeypatching `os.makedirs`):

- creates `.Trashes/$UID/` with mode `0o700` and `exist_ok=True` for files under `/Volumes/X/`
- idempotent: repeated calls for the same volume only `makedirs` once
- creates a separate `.Trashes` for each distinct volume in a single bulk request
- skips paths outside `/Volumes/` (system Trash handles those)
- swallows `OSError` from `makedirs` (read-only volume, ACL block)

```
$ python -m pytest vireo/tests/test_duplicates_api.py vireo/tests/test_duplicates_bulk.py vireo/tests/test_duplicates_db.py vireo/tests/test_duplicate_buckets.py vireo/tests/test_duplicates.py
======================== 114 passed in 2.02s =========================
```

## Impact

User who triggered the 10-hour hang should now be able to retry "Move N extras to Trash" on the same Synology share and have it complete in minutes instead of hanging on Finder. No DB-state changes — purely fixes the trash path.

## Out of scope

- Per-file timeout on `send2trash` / Finder (separate guard)
- Batched progress feedback to the UI for long-running trash operations (separate enhancement)
- The bulk-decide bucket card UX makeover (separate PR)