### PR TITLE
Pipeline UI: status pills, plan summary, and section grouping

### DIFF
--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -294,3 +294,29 @@ def test_pipeline_eye_keypoints_pill_will_run_when_models_ready(live_server, pag
         refreshPipelineUI();
     """)
     expect(page.locator("#pillEyeKeypoints")).to_contain_text("Will run")
+
+
+def test_pipeline_shared_card_not_done_until_all_substages_complete(live_server, page):
+    """model_loader and classify both map to the Classify card. The pill must
+    not flip to 'Done' when only model_loader has completed — classify still
+    has work to do. Same shape applies to thumbnails/previews on the Previews
+    card."""
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    page.evaluate("""
+        _updatePipelineStageUI({stages: {model_loader: {status: 'running'}}});
+    """)
+    expect(page.locator("#pillClassify")).to_contain_text("Running")
+    # Only model_loader has terminated; classify still has work pending.
+    page.evaluate("""
+        _updatePipelineStageUI({stages: {model_loader: {status: 'completed'}}});
+    """)
+    expect(page.locator("#pillClassify")).not_to_contain_text("Done")
+    # Both substages terminal → Done.
+    page.evaluate("""
+        _updatePipelineStageUI({stages: {
+            model_loader: {status: 'completed'},
+            classify: {status: 'completed'},
+        }});
+    """)
+    expect(page.locator("#pillClassify")).to_contain_text("Done")

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -239,6 +239,32 @@ def test_pipeline_skipped_auto_stage_shows_already_done(live_server, page):
     expect(page.locator("#pillExtract")).to_contain_text("Already done")
 
 
+def test_pipeline_failed_status_clears_running_pill(live_server, page):
+    """When a stage transitions running -> failed mid-pipeline, the pill must
+    flip to 'Failed' and stay there even after refreshPipelineUI() runs.
+
+    Regression test: _stageStateFor checks _runningStages before _stageOutcomes,
+    so without explicit failed-status handling the leftover running flag would
+    mask the failure and leave the pill stuck on 'Running…'.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    # Stage enters running state.
+    page.evaluate("""
+        _updatePipelineStageUI({stages: {classify: {status: 'running'}}});
+    """)
+    expect(page.locator("#pillClassify")).to_contain_text("Running")
+    # Stage fails mid-run.
+    page.evaluate("""
+        _updatePipelineStageUI({stages: {classify: {status: 'failed'}}});
+    """)
+    expect(page.locator("#pillClassify")).to_contain_text("Failed")
+    # A subsequent recompute must NOT flip back to Running.
+    page.evaluate("refreshPipelineUI();")
+    expect(page.locator("#pillClassify")).to_contain_text("Failed")
+    expect(page.locator("#pillClassify")).not_to_contain_text("Running")
+
+
 def test_pipeline_eye_keypoints_pill_will_skip_when_no_weights(live_server, page):
     """Eye Keypoints has no enable checkbox — it's gated by whether
     SuperAnimal weights are on disk. The fixture doesn't ship any keypoint

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -181,3 +181,59 @@ def test_pipeline_plan_summary_updates_on_toggle(live_server, page):
     expect(skip_row).to_contain_text("Classify")
     expect(skip_row).to_contain_text("Extract Features")
     expect(skip_row).to_contain_text("Group & Score")
+
+
+def test_pipeline_concurrent_running_stages_keep_running_pill(live_server, page):
+    """Multiple concurrent running stages must all keep the Running pill, even
+    after refreshPipelineUI() is invoked (e.g. via a toggle change).
+
+    Regression test for the single-string `_runningStageSuffix` bug: when the
+    pipeline ran scan + thumbnails in parallel, each running event clobbered
+    the slot, leaving only one stage pulsing while the other was recomputed
+    back to "Will run" on the next refresh.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    page.evaluate("""
+        _updatePipelineStageUI({stages: {
+            scan: {status: 'running'},
+            thumbnails: {status: 'running'},
+        }});
+    """)
+    expect(page.locator("#pillScan")).to_contain_text("Running")
+    expect(page.locator("#pillPreviews")).to_contain_text("Running")
+    # Triggering a recompute must NOT flip still-running stages back.
+    page.evaluate("refreshPipelineUI();")
+    expect(page.locator("#pillScan")).to_contain_text("Running")
+    expect(page.locator("#pillPreviews")).to_contain_text("Running")
+
+
+def test_pipeline_skipped_user_disabled_stage_keeps_will_skip_pill(live_server, page):
+    """When the user disables a stage and the backend reports it `skipped`,
+    the pill must stay "Will skip" — not flip to "Already done"."""
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    page.click("#card-classify .stage-header")
+    page.uncheck("#enableExtract")
+    expect(page.locator("#pillExtract")).to_contain_text("Will skip")
+    # Simulate the backend `skipped` status the orchestrator emits for a
+    # user-disabled stage (params.skip_extract_masks branch in pipeline_job).
+    page.evaluate("""
+        _updatePipelineStageUI({stages: {extract_masks: {status: 'skipped'}}});
+    """)
+    expect(page.locator("#pillExtract")).to_contain_text("Will skip")
+    expect(page.locator("#pillExtract")).not_to_contain_text("Already done")
+
+
+def test_pipeline_skipped_auto_stage_shows_already_done(live_server, page):
+    """When the backend reports `skipped` for a stage the user *did not*
+    disable (e.g. nothing eligible to process), the pill should show
+    "Already done" — distinguishing it from an explicit user skip."""
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    # Extract is enabled by default.
+    expect(page.locator("#pillExtract")).to_contain_text("Will run")
+    page.evaluate("""
+        _updatePipelineStageUI({stages: {extract_masks: {status: 'skipped'}}});
+    """)
+    expect(page.locator("#pillExtract")).to_contain_text("Already done")

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -237,3 +237,34 @@ def test_pipeline_skipped_auto_stage_shows_already_done(live_server, page):
         _updatePipelineStageUI({stages: {extract_masks: {status: 'skipped'}}});
     """)
     expect(page.locator("#pillExtract")).to_contain_text("Already done")
+
+
+def test_pipeline_eye_keypoints_pill_will_skip_when_no_weights(live_server, page):
+    """Eye Keypoints has no enable checkbox — it's gated by whether
+    SuperAnimal weights are on disk. The fixture doesn't ship any keypoint
+    models, so /api/models/keypoints/status reports both as 'missing' and
+    the pill must show 'Will skip' (mirroring the backend preflight),
+    not 'Will run'.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    expect(page.locator("#pillEyeKeypoints")).to_contain_text("Will skip")
+    summary = page.locator("[data-testid='pipeline-plan-summary']")
+    skip_row = summary.locator(".plan-row.will-skip .plan-stages")
+    expect(skip_row).to_contain_text("Eye Keypoints")
+    will_run_row = summary.locator(".plan-row.will-run .plan-stages")
+    expect(will_run_row).not_to_contain_text("Eye Keypoints")
+
+
+def test_pipeline_eye_keypoints_pill_will_run_when_models_ready(live_server, page):
+    """When at least one keypoint model is ready, the pill flips back to
+    'Will run'. Simulated by stubbing the status endpoint client-side and
+    re-invoking refreshKeypointsStatus."""
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    expect(page.locator("#pillEyeKeypoints")).to_be_visible()
+    page.evaluate("""
+        window._keypointModelsReady = true;
+        refreshPipelineUI();
+    """)
+    expect(page.locator("#pillEyeKeypoints")).to_contain_text("Will run")

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -110,3 +110,74 @@ def test_pipeline_preview_button_disabled_without_source_dest(live_server, page)
     page.check("[data-testid='copy-photos-toggle']")
     btn = page.locator("[data-testid='preview-folders-btn']")
     expect(btn).to_be_disabled()
+
+
+def test_pipeline_section_headers_visible(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    headers = page.locator(".stage-section-header")
+    expect(headers).to_have_count(3)
+    expect(headers.nth(0)).to_contain_text("Setup")
+    expect(headers.nth(1)).to_contain_text("Indexing")
+    expect(headers.nth(2)).to_contain_text("AI processing")
+
+
+def test_pipeline_status_pills_visible_for_processing_stages(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    # Stages 3-8 each have a pill that's populated on load.
+    for suffix in ["Scan", "Previews", "Classify", "Extract", "EyeKeypoints", "Group"]:
+        pill = page.locator(f"#pill{suffix}")
+        expect(pill).to_be_visible()
+    # Indexing stages always start at "Will run".
+    expect(page.locator("#pillScan")).to_contain_text("Will run")
+    # Seeded fixture has detections → Classify shows "Already done".
+    expect(page.locator("#pillClassify")).to_contain_text("Already done")
+    # Extract has no seeded masks → "Will run".
+    expect(page.locator("#pillExtract")).to_contain_text("Will run")
+
+
+def test_pipeline_reclassify_flips_classify_pill_to_will_run(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    expect(page.locator("#pillClassify")).to_contain_text("Already done")
+    page.click("#card-classify .stage-header")
+    page.check("#chkReclassify")
+    expect(page.locator("#pillClassify")).to_contain_text("Will run")
+
+
+def test_pipeline_toggling_classify_off_marks_downstream_will_skip(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    page.click("#card-classify .stage-header")
+    page.uncheck("#enableClassify")
+    for suffix in ["Classify", "Extract", "Group"]:
+        pill = page.locator(f"#pill{suffix}")
+        expect(pill).to_contain_text("Will skip")
+    # Indexing stages are unaffected.
+    expect(page.locator("#pillScan")).to_contain_text("Will run")
+
+
+def test_pipeline_plan_summary_lists_stages(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    summary = page.locator("[data-testid='pipeline-plan-summary']")
+    expect(summary).to_be_visible()
+    will_run = summary.locator(".plan-row.will-run .plan-stages")
+    # Extract & Group will run; Classify will not (Already done from seed).
+    expect(will_run).to_contain_text("Extract Features")
+    expect(will_run).to_contain_text("Group & Score")
+    done_prior = summary.locator(".plan-row.done-prior .plan-stages")
+    expect(done_prior).to_contain_text("Classify")
+
+
+def test_pipeline_plan_summary_updates_on_toggle(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    page.click("#card-classify .stage-header")
+    page.uncheck("#enableClassify")
+    summary = page.locator("[data-testid='pipeline-plan-summary']")
+    skip_row = summary.locator(".plan-row.will-skip .plan-stages")
+    expect(skip_row).to_contain_text("Classify")
+    expect(skip_row).to_contain_text("Extract Features")
+    expect(skip_row).to_contain_text("Group & Score")

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2381,6 +2381,19 @@ var _stageToCard = {
   regroup: 'Group',
 };
 
+// Reverse of _stageToCard: cardSuffix -> [backend stage names]. Used by
+// _updatePipelineStageUI to aggregate the per-card terminal state across
+// multi-substage cards (e.g. Previews = thumbnails + previews) so the pill
+// only flips to 'Done' once every substage has reached a terminal state.
+var _cardToStages = (function() {
+  var m = {};
+  for (var s in _stageToCard) {
+    var c = _stageToCard[s];
+    (m[c] = m[c] || []).push(s);
+  }
+  return m;
+})();
+
 // Map pipeline stage names to the progress bar element suffixes
 var _stageToProgress = {
   ingest: 'Source',
@@ -2409,52 +2422,66 @@ function _formatETA(seconds) {
 function _updatePipelineStageUI(p) {
   var stages = p.stages || {};
 
-  // Update stage number badges based on stage status. "skipped" renders
-  // as complete so cards that don't run (e.g. ingest in scan-in-place
-  // mode) still look resolved rather than pending.
+  // Aggregate backend substages per card. Multiple backend stages share a
+  // card (Previews ← thumbnails + previews; Classify ← model_loader +
+  // classify), so the card's outcome can only be decided once ALL of its
+  // substages reach a terminal state. Resolving each substage event in
+  // isolation made the pill flash 'Done' as soon as the first substage
+  // finished, even though more work was pending.
+  var cardAgg = {};  // cardSuffix -> {running, failed, completed, skipped, present}
   for (var stageName in stages) {
-    var info = stages[stageName];
     var cardSuffix = _stageToCard[stageName];
     if (!cardSuffix) continue;
+    var agg = cardAgg[cardSuffix] || (cardAgg[cardSuffix] = {
+      running: false, failed: false, completed: 0, skipped: 0, present: 0,
+    });
+    agg.present += 1;
+    var st = stages[stageName].status;
+    if (st === 'running') agg.running = true;
+    else if (st === 'failed') agg.failed = true;
+    else if (st === 'completed') agg.completed += 1;
+    else if (st === 'skipped') agg.skipped += 1;
+  }
 
-    var numEl = document.getElementById('num' + cardSuffix);
+  for (var cardSuffix2 in cardAgg) {
+    var a = cardAgg[cardSuffix2];
+    var expected = (_cardToStages[cardSuffix2] || []).length;
+    var numEl = document.getElementById('num' + cardSuffix2);
     if (!numEl) continue;
 
-    if (info.status === 'running') {
+    if (a.running) {
       numEl.className = 'stage-num running';
-      _runningStages[cardSuffix] = true;
-      _setPill(cardSuffix, 'running');
-      // Auto-expand the card
-      var card = document.getElementById('card-' + cardSuffix.toLowerCase());
+      _runningStages[cardSuffix2] = true;
+      _setPill(cardSuffix2, 'running');
+      var card = document.getElementById('card-' + cardSuffix2.toLowerCase());
       if (card) card.classList.add('expanded');
-    } else if (info.status === 'completed') {
-      numEl.className = 'stage-num complete';
-      delete _runningStages[cardSuffix];
-      _stageOutcomes[cardSuffix] = 'done';
-      _setPill(cardSuffix, 'done');
-    } else if (info.status === 'skipped') {
-      numEl.className = 'stage-num complete';
-      delete _runningStages[cardSuffix];
-      // Don't overwrite an earlier 'done' from a sibling stage in the same card
-      // (e.g. thumbnails completed, then previews skipped both map to Previews).
-      if (_stageOutcomes[cardSuffix] !== 'done') {
-        // Backend `skipped` is overloaded: it can mean the user disabled the
-        // stage via its toggle, or that the stage had nothing to do because
-        // outputs already exist. Pick the right pill so a user-disabled
-        // stage doesn't get mislabeled "Already done".
-        var skipState = _isUserDisabledStage(cardSuffix) ? 'will-skip' : 'done-prior';
-        _stageOutcomes[cardSuffix] = skipState;
-        _setPill(cardSuffix, skipState);
-      }
-    } else if (info.status === 'failed') {
+    } else if (a.failed) {
       // Must clear the running flag — _stageStateFor checks _runningStages
       // before _stageOutcomes, so a leftover running entry would mask the
       // failure and leave the pill stuck on "Running…".
       numEl.className = 'stage-num';
-      delete _runningStages[cardSuffix];
-      _stageOutcomes[cardSuffix] = 'failed';
-      _setPill(cardSuffix, 'failed');
+      delete _runningStages[cardSuffix2];
+      _stageOutcomes[cardSuffix2] = 'failed';
+      _setPill(cardSuffix2, 'failed');
+    } else if (a.completed + a.skipped >= expected && a.completed + a.skipped > 0) {
+      // All expected substages reached a non-running terminal state.
+      numEl.className = 'stage-num complete';
+      delete _runningStages[cardSuffix2];
+      if (a.completed > 0) {
+        _stageOutcomes[cardSuffix2] = 'done';
+        _setPill(cardSuffix2, 'done');
+      } else {
+        // Every substage was skipped. Backend 'skipped' covers both
+        // user-disabled stages and auto-skip; pick the right label so a
+        // user-disabled stage doesn't get mislabeled "Already done".
+        var skipState = _isUserDisabledStage(cardSuffix2) ? 'will-skip' : 'done-prior';
+        _stageOutcomes[cardSuffix2] = skipState;
+        _setPill(cardSuffix2, skipState);
+      }
     }
+    // Else: card is mid-pipeline (some substages still pending). Don't
+    // write an outcome — leave the pill at 'running' (set above when an
+    // earlier event hit the running branch) or its pre-run state.
   }
 
   // Route the progress event to the correct card via p.stage_id (set

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2446,6 +2446,14 @@ function _updatePipelineStageUI(p) {
         _stageOutcomes[cardSuffix] = skipState;
         _setPill(cardSuffix, skipState);
       }
+    } else if (info.status === 'failed') {
+      // Must clear the running flag — _stageStateFor checks _runningStages
+      // before _stageOutcomes, so a leftover running entry would mask the
+      // failure and leave the pill stuck on "Running…".
+      numEl.className = 'stage-num';
+      delete _runningStages[cardSuffix];
+      _stageOutcomes[cardSuffix] = 'failed';
+      _setPill(cardSuffix, 'failed');
     }
   }
 
@@ -2619,6 +2627,7 @@ function _onPipelineComplete(result) {
       if (cardSuffix) {
         var statusEl = document.getElementById('status' + cardSuffix);
         if (statusEl) statusEl.textContent = 'Failed: ' + errorStages[stage];
+        delete _runningStages[cardSuffix];
         _stageOutcomes[cardSuffix] = 'failed';
         _setPill(cardSuffix, 'failed');
       }

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -3139,6 +3139,11 @@ async function refreshKeypointsStatus() {
     _renderKeypointRow(
       'superanimal-bird', s.superanimal_bird || 'missing'
     );
+    _keypointModelsReady = (
+      s.superanimal_quadruped === 'ready' ||
+      s.superanimal_bird === 'ready'
+    );
+    refreshPipelineUI();
     // If either model is still downloading, ensure polling is running.
     // Covers the page-reload-mid-download case where init calls
     // refreshKeypointsStatus once and finds an in-flight download but no
@@ -3163,6 +3168,8 @@ async function refreshKeypointsStatus() {
     // clear the timer via the path above.
     _renderKeypointRow('superanimal-quadruped', 'missing');
     _renderKeypointRow('superanimal-bird', 'missing');
+    _keypointModelsReady = false;
+    refreshPipelineUI();
     startKeypointsPolling();
   }
 }
@@ -3300,6 +3307,13 @@ var _pipelineState = {
 var _runningStages = {};  // suffix -> true while that stage is running
 var _stageOutcomes = {};  // suffix -> 'done' | 'failed' | 'will-skip' | 'done-prior'
 
+// Eye Keypoints has no enable checkbox and no `prior` flag, so without an
+// extra signal `_stageStateFor` would always show "Will run" for it. The
+// backend skips the stage when no SuperAnimal weights are on disk, so the
+// pre-run plan must reflect that. `null` means "status not yet polled" —
+// treat as runnable until we know better, to avoid flicker on page load.
+var _keypointModelsReady = null;  // true | false | null (unknown)
+
 var _STAGES = [
   { suffix: 'Scan',         label: 'Scan & Import',          enable: null,             prior: null },
   { suffix: 'Previews',     label: 'Thumbnails & Previews',  enable: null,             prior: null },
@@ -3351,6 +3365,14 @@ function _stageStateFor(stage) {
   if (stage.suffix === 'Classify') {
     var rc = document.getElementById('chkReclassify');
     reclassify = !!(rc && rc.checked);
+  }
+
+  // Eye Keypoints has no enable checkbox: the stage is gated by whether
+  // SuperAnimal weights are on disk. Backend `eye_keypoint_stage_preflight`
+  // returns a skip reason in the no-weights case, so the plan summary
+  // should mirror that pre-run instead of advertising "Will run".
+  if (stage.suffix === 'EyeKeypoints' && _keypointModelsReady === false) {
+    return 'will-skip';
   }
 
   if (stage.enable) {

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -54,13 +54,104 @@ body { padding-bottom: 36px; }
   display: flex; align-items: center; justify-content: center;
   font-size: 13px; font-weight: 700;
   background: var(--bg-tertiary, #14374E);
-  color: var(--text-dim, #5A8890);
+  color: var(--text-secondary, #B0CCCC);
   flex-shrink: 0;
 }
-.stage-num.complete { background: var(--accent, #24E5CA); color: var(--accent-text); }
-.stage-num.running { background: var(--info, #12C3B5); color: var(--accent-text); animation: pulse 1.2s infinite; }
-@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
+@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.55; } }
 .stage-name { font-size: 15px; font-weight: 600; }
+
+/* Status pill — explicit text label communicating each stage's state */
+.stage-status-pill {
+  display: none;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 10px;
+  border-radius: 10px;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+}
+.stage-status-pill.visible { display: inline-block; }
+.stage-status-pill.will-run {
+  background: color-mix(in srgb, var(--accent, #24E5CA) 20%, transparent);
+  color: var(--accent, #24E5CA);
+}
+.stage-status-pill.will-skip {
+  background: var(--bg-tertiary, #14374E);
+  color: var(--text-dim, #5A8890);
+  font-style: italic;
+}
+.stage-status-pill.done-prior {
+  background: color-mix(in srgb, var(--accent, #24E5CA) 10%, transparent);
+  color: color-mix(in srgb, var(--accent, #24E5CA) 65%, var(--text-secondary, #B0CCCC));
+}
+.stage-status-pill.running {
+  background: var(--info, #12C3B5);
+  color: var(--accent-text);
+  animation: pulse 1.2s infinite;
+}
+.stage-status-pill.done {
+  background: var(--accent, #24E5CA);
+  color: var(--accent-text);
+}
+.stage-status-pill.failed {
+  background: var(--danger, #E74C3C);
+  color: #fff;
+}
+
+/* Section headers grouping the stage cards */
+.stage-section-header {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-faint, #5A8890);
+  margin: 18px 0 8px;
+  padding-left: 4px;
+}
+.stage-section-header:first-child { margin-top: 0; }
+.stage-section-sub {
+  font-size: 11px;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--text-dim, #5A8890);
+  margin-left: 6px;
+}
+
+/* Plan summary above Start button — "what will happen if I press Start" */
+.pipeline-plan-summary {
+  background: var(--bg-secondary, #0E2A3D);
+  border: 1px solid var(--border-primary, #14374E);
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-top: 16px;
+  font-size: 12px;
+  line-height: 1.7;
+}
+.pipeline-plan-summary .plan-row {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+}
+.pipeline-plan-summary .plan-label {
+  font-weight: 700;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--text-faint, #5A8890);
+  min-width: 90px;
+  flex-shrink: 0;
+}
+.pipeline-plan-summary .plan-stages { color: var(--text-secondary, #B0CCCC); }
+.pipeline-plan-summary .plan-row.will-run .plan-stages { color: var(--accent, #24E5CA); font-weight: 600; }
+.pipeline-plan-summary .plan-row.will-skip .plan-stages { color: var(--text-dim, #5A8890); font-style: italic; }
+.pipeline-plan-summary .plan-row.done-prior .plan-stages {
+  color: color-mix(in srgb, var(--accent, #24E5CA) 65%, var(--text-secondary, #B0CCCC));
+}
+.pipeline-plan-summary .plan-empty {
+  color: var(--text-faint, #5A8890);
+  font-style: italic;
+}
 .stage-summary {
   margin-left: auto;
   font-size: 12px;
@@ -462,6 +553,8 @@ body { padding-bottom: 36px; }
 <div class="pipeline-left">
   <h2 style="margin-bottom:20px;font-size:20px;">Pipeline</h2>
 
+  <div class="stage-section-header">Setup</div>
+
   <!-- Card 1: Source -->
   <div class="stage-card expanded" id="card-source" data-testid="stage-card">
     <div class="stage-header" onclick="toggleCard('source')">
@@ -706,11 +799,14 @@ body { padding-bottom: 36px; }
     </div>
   </div>
 
+  <div class="stage-section-header">Indexing<span class="stage-section-sub">always runs</span></div>
+
   <!-- Card 3: Scan & Import -->
   <div class="stage-card" id="card-scan" data-testid="stage-card">
     <div class="stage-header" onclick="toggleCard('scan')">
       <span class="stage-num" id="numScan">3</span>
       <span class="stage-name">Scan &amp; Import</span>
+      <span class="stage-status-pill" id="pillScan"></span>
       <span class="stage-summary" id="summaryScan"></span>
       <span class="stage-chevron">&#9656;</span>
     </div>
@@ -731,6 +827,7 @@ body { padding-bottom: 36px; }
     <div class="stage-header" onclick="toggleCard('previews')">
       <span class="stage-num" id="numPreviews">4</span>
       <span class="stage-name">Thumbnails &amp; Previews</span>
+      <span class="stage-status-pill" id="pillPreviews"></span>
       <span class="stage-summary" id="summaryPreviews"></span>
       <span class="stage-chevron">&#9656;</span>
     </div>
@@ -758,6 +855,8 @@ body { padding-bottom: 36px; }
     </div>
   </div>
 
+  <div class="stage-section-header">AI processing<span class="stage-section-sub">optional &mdash; toggle to include</span></div>
+
   <!-- Card 5: Classify -->
   <div class="stage-card" id="card-classify" data-testid="stage-card">
     <div class="stage-header" onclick="toggleCard('classify')">
@@ -765,6 +864,7 @@ body { padding-bottom: 36px; }
       <input type="checkbox" class="stage-enable" id="enableClassify" checked
              onchange="onStageToggle('classify')" onclick="event.stopPropagation()">
       <span class="stage-name">Classify</span>
+      <span class="stage-status-pill" id="pillClassify"></span>
       <span class="stage-summary" id="summaryClassify">
         <span id="txtDetections"></span>
       </span>
@@ -783,7 +883,7 @@ body { padding-bottom: 36px; }
       </div>
       <div class="readiness-panel" id="readinessPanel" style="display:none;"></div>
       <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;" title="Re-process photos that were already classified. Also bypasses the skip for photos already tagged with a subject keyword (taxonomy, individual, or genre) — useful for double-checking existing tags.">
-        <input type="checkbox" id="chkReclassify" style="accent-color:var(--accent);"> Re-classify
+        <input type="checkbox" id="chkReclassify" style="accent-color:var(--accent);" onchange="refreshPipelineUI()"> Re-classify
       </label>
       <div style="margin-top:8px;">
         <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;">
@@ -809,6 +909,7 @@ body { padding-bottom: 36px; }
       <input type="checkbox" class="stage-enable" id="enableExtract" checked
              onchange="onStageToggle('extract')" onclick="event.stopPropagation()">
       <span class="stage-name">Extract Features</span>
+      <span class="stage-status-pill" id="pillExtract"></span>
       <span class="stage-summary" id="summaryExtract">
         <span id="txtMasks"></span>
       </span>
@@ -861,6 +962,7 @@ body { padding-bottom: 36px; }
     <div class="stage-header" onclick="toggleCard('eyekeypoints')">
       <span class="stage-num" id="numEyeKeypoints">7</span>
       <span class="stage-name">Eye Keypoints (optional)</span>
+      <span class="stage-status-pill" id="pillEyeKeypoints"></span>
       <span class="stage-summary" id="summaryEyeKeypoints">
         <span id="txtEyeKeypoints"></span>
       </span>
@@ -906,6 +1008,7 @@ body { padding-bottom: 36px; }
       <input type="checkbox" class="stage-enable" id="enableGroup" checked
              onchange="onStageToggle('group')" onclick="event.stopPropagation()">
       <span class="stage-name">Group &amp; Score</span>
+      <span class="stage-status-pill" id="pillGroup"></span>
       <span class="stage-summary" id="summaryGroup">
         <span id="txtResults"></span>
       </span>
@@ -925,6 +1028,9 @@ body { padding-bottom: 36px; }
       <a id="viewResultsLink" href="/pipeline/review" class="view-results-btn" style="display:none;">View Results</a>
     </div>
   </div>
+
+  <!-- Plan summary: explicit "what will happen if I press Start" -->
+  <div class="pipeline-plan-summary" id="pipelinePlanSummary" data-testid="pipeline-plan-summary"></div>
 
   <!-- Pipeline action bar -->
   <div class="pipeline-action-bar">
@@ -1069,6 +1175,9 @@ function initPipelinePage() {
 }
 
 document.addEventListener('DOMContentLoaded', initPipelinePage);
+// Render pills + plan summary immediately from default toggle state, so the
+// page isn't blank while the page-init API call is in flight.
+document.addEventListener('DOMContentLoaded', refreshPipelineUI);
 
 // -- New images (Stage 1 third option) --
 var newImagesSnapshotId = null;
@@ -2055,6 +2164,7 @@ function onStageToggle(stage) {
     }
   }
   updateStartButton();
+  refreshPipelineUI();
 }
 
 // -- Pipeline orchestration --
@@ -2106,6 +2216,12 @@ async function startPipeline() {
   btn.textContent = 'Stop Pipeline';
   btn.onclick = stopPipeline;
   btn.disabled = false;
+
+  // Reset live pill state so "Done" / "Failed" from a previous run don't bleed
+  // into this one. Pills will recompute from toggles + prior data.
+  _runningStageSuffix = null;
+  _stageOutcomes = {};
+  refreshPipelineUI();
 
   // Gather config from the UI
   var body = {};
@@ -2306,11 +2422,25 @@ function _updatePipelineStageUI(p) {
 
     if (info.status === 'running') {
       numEl.className = 'stage-num running';
+      _runningStageSuffix = cardSuffix;
+      _setPill(cardSuffix, 'running');
       // Auto-expand the card
       var card = document.getElementById('card-' + cardSuffix.toLowerCase());
       if (card) card.classList.add('expanded');
-    } else if (info.status === 'completed' || info.status === 'skipped') {
+    } else if (info.status === 'completed') {
       numEl.className = 'stage-num complete';
+      if (_runningStageSuffix === cardSuffix) _runningStageSuffix = null;
+      _stageOutcomes[cardSuffix] = 'done';
+      _setPill(cardSuffix, 'done');
+    } else if (info.status === 'skipped') {
+      numEl.className = 'stage-num complete';
+      if (_runningStageSuffix === cardSuffix) _runningStageSuffix = null;
+      // Don't overwrite an earlier 'done' from a sibling stage in the same card
+      // (e.g. thumbnails completed, then previews skipped both map to Previews).
+      if (_stageOutcomes[cardSuffix] !== 'done') {
+        _stageOutcomes[cardSuffix] = 'done-prior';
+        _setPill(cardSuffix, 'done-prior');
+      }
     }
   }
 
@@ -2455,6 +2585,10 @@ function _onPipelineComplete(result) {
       // know it's a setup issue rather than an empty eligibility set.
       if (ekp.skipped) {
         ekpTxt.textContent = 'Skipped \u2014 ' + ekp.skipped;
+        // Override the 'done' outcome set above: when the backend reports
+        // skipped (e.g. no model installed), the pill should reflect that.
+        _stageOutcomes['EyeKeypoints'] = 'will-skip';
+        _setPill('EyeKeypoints', 'will-skip');
       } else {
         ekpTxt.textContent = ekpTotal
           ? (ekpProcessed + ' of ' + ekpTotal + ' processed')
@@ -2480,9 +2614,13 @@ function _onPipelineComplete(result) {
       if (cardSuffix) {
         var statusEl = document.getElementById('status' + cardSuffix);
         if (statusEl) statusEl.textContent = 'Failed: ' + errorStages[stage];
+        _stageOutcomes[cardSuffix] = 'failed';
+        _setPill(cardSuffix, 'failed');
       }
     }
   }
+
+  refreshPipelineUI();
 
   // Auto-redirect to review page on success
   if (succeeded && (!r.errors || r.errors.length === 0)) {
@@ -3143,13 +3281,92 @@ var _pipelineState = {
   hasMasks: false,
 };
 
+// --- Pipeline plan & status pills ---
+//
+// Stages 3-8 each show an explicit text pill (Will run / Will skip / Already
+// done / Running / Done / Failed) instead of relying on the colored circle.
+// `_runningStageSuffix` and `_stageOutcomes` are live overrides: while a
+// pipeline is running, they take precedence over the toggle/prior-data state.
+var _runningStageSuffix = null;
+var _stageOutcomes = {};  // suffix -> 'running' | 'done' | 'failed' | 'will-skip'
+
+var _STAGES = [
+  { suffix: 'Scan',         label: 'Scan & Import',          enable: null,             prior: null },
+  { suffix: 'Previews',     label: 'Thumbnails & Previews',  enable: null,             prior: null },
+  { suffix: 'Classify',     label: 'Classify',               enable: 'enableClassify', prior: 'hasDetections' },
+  { suffix: 'Extract',      label: 'Extract Features',       enable: 'enableExtract',  prior: 'hasMasks' },
+  { suffix: 'EyeKeypoints', label: 'Eye Keypoints',          enable: null,             prior: null },
+  { suffix: 'Group',        label: 'Group & Score',          enable: 'enableGroup',    prior: null },
+];
+
+var _PILL_LABELS = {
+  'running':    'Running…',
+  'done':       'Done',
+  'failed':     'Failed',
+  'will-run':   'Will run',
+  'will-skip':  'Will skip',
+  'done-prior': 'Already done',
+};
+
+function _setPill(suffix, state, text) {
+  var pill = document.getElementById('pill' + suffix);
+  if (!pill) return;
+  pill.className = 'stage-status-pill visible ' + state;
+  pill.textContent = text != null ? text : _PILL_LABELS[state];
+}
+
+function _stageStateFor(stage) {
+  if (_runningStageSuffix === stage.suffix) return 'running';
+  if (_stageOutcomes[stage.suffix]) return _stageOutcomes[stage.suffix];
+
+  // Re-classify bypasses the "already done" skip — Classify will run again.
+  var reclassify = false;
+  if (stage.suffix === 'Classify') {
+    var rc = document.getElementById('chkReclassify');
+    reclassify = !!(rc && rc.checked);
+  }
+
+  if (stage.enable) {
+    var cb = document.getElementById(stage.enable);
+    if (cb && !cb.checked) return 'will-skip';
+  }
+  if (stage.prior && _pipelineState[stage.prior] && !reclassify) return 'done-prior';
+  return 'will-run';
+}
+
+function _renderPlanSummary(buckets) {
+  var box = document.getElementById('pipelinePlanSummary');
+  if (!box) return;
+  function row(cls, label, names, emptyText) {
+    var inner = names.length
+      ? '<span class="plan-stages">' + names.join(', ') + '</span>'
+      : '<span class="plan-empty">' + emptyText + '</span>';
+    return '<div class="plan-row ' + cls + '">' +
+      '<span class="plan-label">' + label + '</span>' + inner + '</div>';
+  }
+  var html = row('will-run', 'Will run', buckets['will-run'], 'nothing');
+  if (buckets['will-skip'].length)  html += row('will-skip',  'Will skip',    buckets['will-skip'],  '');
+  if (buckets['done-prior'].length) html += row('done-prior', 'Already done', buckets['done-prior'], '');
+  box.innerHTML = html;
+}
+
+function refreshPipelineUI() {
+  var buckets = { 'will-run': [], 'will-skip': [], 'done-prior': [] };
+  _STAGES.forEach(function(stage) {
+    var state = _stageStateFor(stage);
+    _setPill(stage.suffix, state);
+    if (buckets[state]) buckets[state].push(stage.label);
+  });
+  _renderPlanSummary(buckets);
+}
+
 function updateCardStates() {
-  // No individual buttons to enable/disable anymore.
-  // Just auto-expand cards based on state.
+  // Auto-expand the next card based on prior data, then refresh pills + plan.
   if (_pipelineState.hasDetections && !_pipelineState.hasMasks) {
     document.getElementById('card-extract').classList.add('expanded');
   }
   updateStartButton();
+  refreshPipelineUI();
 }
 
 /* ---------- Native folder picker (Tauri only) ---------- */

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2219,7 +2219,7 @@ async function startPipeline() {
 
   // Reset live pill state so "Done" / "Failed" from a previous run don't bleed
   // into this one. Pills will recompute from toggles + prior data.
-  _runningStageSuffix = null;
+  _runningStages = {};
   _stageOutcomes = {};
   refreshPipelineUI();
 
@@ -2422,24 +2422,29 @@ function _updatePipelineStageUI(p) {
 
     if (info.status === 'running') {
       numEl.className = 'stage-num running';
-      _runningStageSuffix = cardSuffix;
+      _runningStages[cardSuffix] = true;
       _setPill(cardSuffix, 'running');
       // Auto-expand the card
       var card = document.getElementById('card-' + cardSuffix.toLowerCase());
       if (card) card.classList.add('expanded');
     } else if (info.status === 'completed') {
       numEl.className = 'stage-num complete';
-      if (_runningStageSuffix === cardSuffix) _runningStageSuffix = null;
+      delete _runningStages[cardSuffix];
       _stageOutcomes[cardSuffix] = 'done';
       _setPill(cardSuffix, 'done');
     } else if (info.status === 'skipped') {
       numEl.className = 'stage-num complete';
-      if (_runningStageSuffix === cardSuffix) _runningStageSuffix = null;
+      delete _runningStages[cardSuffix];
       // Don't overwrite an earlier 'done' from a sibling stage in the same card
       // (e.g. thumbnails completed, then previews skipped both map to Previews).
       if (_stageOutcomes[cardSuffix] !== 'done') {
-        _stageOutcomes[cardSuffix] = 'done-prior';
-        _setPill(cardSuffix, 'done-prior');
+        // Backend `skipped` is overloaded: it can mean the user disabled the
+        // stage via its toggle, or that the stage had nothing to do because
+        // outputs already exist. Pick the right pill so a user-disabled
+        // stage doesn't get mislabeled "Already done".
+        var skipState = _isUserDisabledStage(cardSuffix) ? 'will-skip' : 'done-prior';
+        _stageOutcomes[cardSuffix] = skipState;
+        _setPill(cardSuffix, skipState);
       }
     }
   }
@@ -3285,10 +3290,15 @@ var _pipelineState = {
 //
 // Stages 3-8 each show an explicit text pill (Will run / Will skip / Already
 // done / Running / Done / Failed) instead of relying on the colored circle.
-// `_runningStageSuffix` and `_stageOutcomes` are live overrides: while a
+// `_runningStages` and `_stageOutcomes` are live overrides: while a
 // pipeline is running, they take precedence over the toggle/prior-data state.
-var _runningStageSuffix = null;
-var _stageOutcomes = {};  // suffix -> 'running' | 'done' | 'failed' | 'will-skip'
+//
+// `_runningStages` is per-stage (not a single global) because the pipeline
+// allows concurrent stages — e.g. scan runs alongside thumbnails/previews —
+// and a single global would let one stage's status update clobber another's
+// "Running…" pill on the next refresh.
+var _runningStages = {};  // suffix -> true while that stage is running
+var _stageOutcomes = {};  // suffix -> 'done' | 'failed' | 'will-skip' | 'done-prior'
 
 var _STAGES = [
   { suffix: 'Scan',         label: 'Scan & Import',          enable: null,             prior: null },
@@ -3298,6 +3308,23 @@ var _STAGES = [
   { suffix: 'EyeKeypoints', label: 'Eye Keypoints',          enable: null,             prior: null },
   { suffix: 'Group',        label: 'Group & Score',          enable: 'enableGroup',    prior: null },
 ];
+
+// Lookup: cardSuffix -> enable-checkbox id (null for stages with no toggle).
+var _STAGE_ENABLE_BY_SUFFIX = (function() {
+  var m = {};
+  _STAGES.forEach(function(s) { m[s.suffix] = s.enable; });
+  return m;
+})();
+
+// Did the user disable this stage via its enable checkbox? Used to
+// distinguish backend `skipped` due to a user toggle ("Will skip") from
+// `skipped` due to prior outputs already existing ("Already done").
+function _isUserDisabledStage(cardSuffix) {
+  var enableId = _STAGE_ENABLE_BY_SUFFIX[cardSuffix];
+  if (!enableId) return false;
+  var cb = document.getElementById(enableId);
+  return !!(cb && !cb.checked);
+}
 
 var _PILL_LABELS = {
   'running':    'Running…',
@@ -3316,7 +3343,7 @@ function _setPill(suffix, state, text) {
 }
 
 function _stageStateFor(stage) {
-  if (_runningStageSuffix === stage.suffix) return 'running';
+  if (_runningStages[stage.suffix]) return 'running';
   if (_stageOutcomes[stage.suffix]) return _stageOutcomes[stage.suffix];
 
   // Re-classify bypasses the "already done" skip — Classify will run again.


### PR DESCRIPTION
## Summary

The pipeline page's numbered circles overloaded multiple meanings (step number + completion state + running indicator), and the per-stage checkboxes didn't make their effect explicit. This replaces the visual-only state with text the user can read directly.

- **Status pills on stages 3–8**: Will run / Will skip / Already done / Running… / Done / Failed. Numbered circles are now plain labels.
- **"What will happen" plan summary** above Start Pipeline lists which stages will run, skip, or are already done. Updates live with toggles and the Re-classify checkbox.
- **Section headers** group cards into Setup, Indexing (always runs), and AI processing (optional).

Pills + summary react to: prior pipeline state (`hasDetections` / `hasMasks`), enable-stage checkboxes, Re-classify, live progress events, completion outcomes, and the EyeKeypoints "skipped — no model" reason.

## Test plan

- [x] All 12 existing pipeline e2e tests still pass
- [x] 6 new e2e tests cover section headers, default pill state, Re-classify flip, toggle cascade, plan-summary rendering
- [x] Verified in headed Playwright: pills update on toggle, plan summary recomputes, "Already done" shows when prior detections exist
- [ ] Manual smoke test on a real workspace before merge (recommended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)