### PR TITLE
test: shared wait_for_job helper to fix xdist-induced flakes

### DIFF
--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -193,6 +193,10 @@ class JobRunner:
             )
             if self._db_path and not job.get("ephemeral"):
                 self._persist_job(job, elapsed)
+            # Mark the in-memory job dict as fully persisted so test code
+            # can synchronize with `job_history` reads. Ephemeral jobs are
+            # also flagged so callers waiting on this don't hang.
+            job["_persisted"] = True
 
     def _persist_job(self, job, duration):
         """Persist job to history table using a thread-local connection."""

--- a/vireo/tests/conftest.py
+++ b/vireo/tests/conftest.py
@@ -2,6 +2,9 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+# Also expose the tests directory itself so test files can import shared
+# helpers (e.g. `from wait import wait_for_job_via_client`).
+sys.path.insert(0, os.path.dirname(__file__))
 
 import pytest
 from db import Database

--- a/vireo/tests/test_duplicates_api.py
+++ b/vireo/tests/test_duplicates_api.py
@@ -1,5 +1,5 @@
 """API tests for /api/duplicates/scan and /api/duplicates/apply."""
-import time
+from wait import wait_for_job_via_client
 
 
 def _seed_pair(db, file_hash, fid, name_a="x.jpg", name_b="x (2).jpg"):
@@ -43,13 +43,7 @@ def test_scan_endpoint_job_completes_with_proposals(app_and_db):
     resp = client.post("/api/duplicates/scan")
     job_id = resp.get_json()["job_id"]
 
-    for _ in range(50):
-        resp = client.get(f"/api/jobs/{job_id}")
-        data = resp.get_json()
-        if data["status"] in ("completed", "failed"):
-            break
-        time.sleep(0.1)
-
+    data = wait_for_job_via_client(client, job_id)
     assert data["status"] == "completed"
     result = data["result"]
     assert result["group_count"] >= 1
@@ -490,11 +484,7 @@ def test_last_scan_returns_completed_scan_result(app_and_db):
 
     client = app.test_client()
     job_id = client.post("/api/duplicates/scan").get_json()["job_id"]
-    for _ in range(50):
-        resp = client.get(f"/api/jobs/{job_id}")
-        if resp.get_json()["status"] in ("completed", "failed"):
-            break
-        time.sleep(0.1)
+    wait_for_job_via_client(client, job_id, wait_for_history=True)
 
     resp = client.get("/api/duplicates/last-scan")
     assert resp.status_code == 200
@@ -514,18 +504,12 @@ def test_last_scan_picks_most_recent_completed(app_and_db):
 
     client = app.test_client()
     job1 = client.post("/api/duplicates/scan").get_json()["job_id"]
-    for _ in range(50):
-        if client.get(f"/api/jobs/{job1}").get_json()["status"] in ("completed", "failed"):
-            break
-        time.sleep(0.1)
+    wait_for_job_via_client(client, job1, wait_for_history=True)
 
     # Add another duplicate group then rescan.
     _seed_pair(db, "HNEW", fid, name_a="n.jpg", name_b="n (2).jpg")
     job2 = client.post("/api/duplicates/scan").get_json()["job_id"]
-    for _ in range(50):
-        if client.get(f"/api/jobs/{job2}").get_json()["status"] in ("completed", "failed"):
-            break
-        time.sleep(0.1)
+    wait_for_job_via_client(client, job2, wait_for_history=True)
 
     body = client.get("/api/duplicates/last-scan").get_json()
     assert body["found"] is True

--- a/vireo/tests/test_job_submission_api.py
+++ b/vireo/tests/test_job_submission_api.py
@@ -4,6 +4,7 @@ import os
 import time
 
 from PIL import Image
+from wait import wait_for_job_via_client
 
 
 def test_job_thumbnails_returns_job_id(app_and_db):
@@ -108,12 +109,7 @@ def test_job_history(app_and_db, tmp_path):
     job_id = resp.get_json()["job_id"]
 
     # Poll until job completes or fails
-    for _ in range(50):
-        status_resp = client.get(f"/api/jobs/{job_id}")
-        status_data = status_resp.get_json()
-        if status_data.get("status") in ("completed", "failed"):
-            break
-        time.sleep(0.1)
+    wait_for_job_via_client(client, job_id)
 
     history_resp = client.get("/api/jobs/history")
     assert history_resp.status_code == 200
@@ -134,12 +130,7 @@ def test_job_history_respects_limit(app_and_db, tmp_path):
     assert resp.status_code == 200
     job_id = resp.get_json()["job_id"]
 
-    for _ in range(50):
-        status_resp = client.get(f"/api/jobs/{job_id}")
-        status_data = status_resp.get_json()
-        if status_data.get("status") in ("completed", "failed"):
-            break
-        time.sleep(0.1)
+    wait_for_job_via_client(client, job_id)
 
     history_resp = client.get("/api/jobs/history?limit=1")
     assert history_resp.status_code == 200

--- a/vireo/tests/test_job_submission_api.py
+++ b/vireo/tests/test_job_submission_api.py
@@ -108,8 +108,8 @@ def test_job_history(app_and_db, tmp_path):
     assert resp.status_code == 200
     job_id = resp.get_json()["job_id"]
 
-    # Poll until job completes or fails
-    wait_for_job_via_client(client, job_id)
+    # Reads /api/jobs/history below — must wait for the row to flush.
+    wait_for_job_via_client(client, job_id, wait_for_history=True)
 
     history_resp = client.get("/api/jobs/history")
     assert history_resp.status_code == 200
@@ -130,7 +130,8 @@ def test_job_history_respects_limit(app_and_db, tmp_path):
     assert resp.status_code == 200
     job_id = resp.get_json()["job_id"]
 
-    wait_for_job_via_client(client, job_id)
+    # Reads /api/jobs/history below — must wait for the row to flush.
+    wait_for_job_via_client(client, job_id, wait_for_history=True)
 
     history_resp = client.get("/api/jobs/history?limit=1")
     assert history_resp.status_code == 200

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -5,6 +5,9 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from wait import wait_for_job_via_runner
 
 
 def test_job_runner_starts_and_completes(tmp_path):
@@ -23,14 +26,7 @@ def test_job_runner_starts_and_completes(tmp_path):
     job_id = runner.start('test', work, config={'note': 'hello'})
     assert job_id is not None
 
-    # Wait for completion
-    for _ in range(50):
-        job = runner.get(job_id)
-        if job['status'] == 'completed':
-            break
-        time.sleep(0.05)
-
-    job = runner.get(job_id)
+    job = wait_for_job_via_runner(runner, job_id)
     assert job['status'] == 'completed'
     assert job['result'] == {'items': 3}
     assert job['progress']['current'] == 3
@@ -47,13 +43,7 @@ def test_job_runner_tracks_failure(tmp_path):
 
     job_id = runner.start('test', failing_work)
 
-    for _ in range(50):
-        job = runner.get(job_id)
-        if job['status'] == 'failed':
-            break
-        time.sleep(0.05)
-
-    job = runner.get(job_id)
+    job = wait_for_job_via_runner(runner, job_id)
     assert job['status'] == 'failed'
     assert len(job['errors']) >= 1
     assert 'something broke' in job['errors'][0]
@@ -77,11 +67,7 @@ def test_job_runner_does_not_duplicate_preexisting_errors():
 
     job_id = runner.start('test', failing_work)
 
-    for _ in range(50):
-        job = runner.get(job_id)
-        if job['status'] == 'failed':
-            break
-        time.sleep(0.05)
+    wait_for_job_via_runner(runner, job_id)
 
     job = runner.get(job_id)
     assert job['status'] == 'failed'
@@ -105,11 +91,7 @@ def test_job_runner_still_records_novel_exception_text():
 
     job_id = runner.start('test', failing_work)
 
-    for _ in range(50):
-        job = runner.get(job_id)
-        if job['status'] == 'failed':
-            break
-        time.sleep(0.05)
+    wait_for_job_via_runner(runner, job_id)
 
     job = runner.get(job_id)
     assert job['status'] == 'failed'
@@ -238,11 +220,7 @@ def test_job_progress_events():
 
     job_id = runner.start('scan', work)
 
-    for _ in range(50):
-        job = runner.get(job_id)
-        if job['status'] == 'completed':
-            break
-        time.sleep(0.05)
+    wait_for_job_via_runner(runner, job_id)
 
     events = runner.get_events(job_id)
     assert len(events) >= 2
@@ -307,11 +285,7 @@ def test_job_history_persistence(tmp_path):
 
     job_id = runner.start('scan', work, config={'root': '/photos'})
 
-    for _ in range(50):
-        job = runner.get(job_id)
-        if job['status'] == 'completed':
-            break
-        time.sleep(0.05)
+    wait_for_job_via_runner(runner, job_id)
 
     # Give it a moment to persist
     time.sleep(0.1)
@@ -335,11 +309,7 @@ def test_ephemeral_job_skips_history_persistence(tmp_path):
 
     job_id = runner.start("new_images_walk", work, ephemeral=True)
 
-    for _ in range(50):
-        job = runner.get(job_id)
-        if job and job["status"] == "completed":
-            break
-        time.sleep(0.05)
+    wait_for_job_via_runner(runner, job_id)
     time.sleep(0.1)
 
     job = runner.get(job_id)
@@ -365,11 +335,7 @@ def test_ephemeral_failed_job_skips_history_persistence(tmp_path):
 
     job_id = runner.start("new_images_walk", work, ephemeral=True)
 
-    for _ in range(50):
-        job = runner.get(job_id)
-        if job and job["status"] == "failed":
-            break
-        time.sleep(0.05)
+    wait_for_job_via_runner(runner, job_id)
     time.sleep(0.1)
 
     rows = db.conn.execute(
@@ -393,7 +359,6 @@ def test_job_history_stores_tree_and_summary(tmp_path):
 
 def test_job_steps_tracking(tmp_path):
     """Jobs can define and update execution steps."""
-    import time
 
     from db import Database
     from jobs import JobRunner
@@ -415,11 +380,7 @@ def test_job_steps_tracking(tmp_path):
 
     job_id = runner.start("scan", work, workspace_id=1)
 
-    for _ in range(50):
-        j = runner.get(job_id)
-        if j and j["status"] != "running":
-            break
-        time.sleep(0.1)
+    wait_for_job_via_runner(runner, job_id)
 
     j = runner.get(job_id)
     assert j["status"] == "completed"
@@ -457,11 +418,7 @@ def test_job_history_persists_steps_tree(tmp_path):
 
     job_id = runner.start("scan", work, workspace_id=ws_id)
 
-    for _ in range(50):
-        j = runner.get(job_id)
-        if j and j["status"] != "running":
-            break
-        time.sleep(0.1)
+    wait_for_job_via_runner(runner, job_id)
 
     time.sleep(0.5)
 
@@ -502,11 +459,7 @@ def test_job_history_prunes_to_100(tmp_path):
         return {}
 
     job_id = runner.start("test", work, workspace_id=ws_id)
-    for _ in range(50):
-        j = runner.get(job_id)
-        if j and j["status"] != "running":
-            break
-        time.sleep(0.1)
+    wait_for_job_via_runner(runner, job_id)
     time.sleep(0.5)
 
     count = db.conn.execute(
@@ -517,7 +470,6 @@ def test_job_history_prunes_to_100(tmp_path):
 
 def test_progress_events_include_steps(tmp_path):
     """Progress events include the steps array when steps are defined."""
-    import time
 
     from db import Database
     from jobs import JobRunner
@@ -540,11 +492,7 @@ def test_progress_events_include_steps(tmp_path):
 
     job_id = runner.start("test", work, workspace_id=1)
 
-    for _ in range(50):
-        j = runner.get(job_id)
-        if j and j["status"] != "running":
-            break
-        time.sleep(0.1)
+    wait_for_job_via_runner(runner, job_id)
 
     events = runner.get_events(job_id)
     progress_events = [e for e in events if e["type"] == "progress"]

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2,6 +2,7 @@ import os
 import time
 
 from PIL import Image
+from wait import wait_for_job_via_client, wait_for_job_via_runner
 
 
 def test_job_scan_returns_job_id(app_and_db, tmp_path):
@@ -41,12 +42,7 @@ def test_job_status_endpoint(app_and_db, tmp_path):
     resp = client.post('/api/jobs/scan', json={'root': scan_dir})
     job_id = resp.get_json()['job_id']
 
-    for _ in range(50):
-        resp = client.get(f'/api/jobs/{job_id}')
-        data = resp.get_json()
-        if data['status'] in ('completed', 'failed'):
-            break
-        time.sleep(0.1)
+    data = wait_for_job_via_client(client, job_id)
 
     assert resp.status_code == 200
     assert data['status'] == 'completed'
@@ -189,7 +185,6 @@ def test_bottom_panel_has_compact_jobs(app_and_db):
 
 def test_scan_job_has_steps(app_and_db, tmp_path):
     """Scan job defines steps for the jobs page tree view."""
-    import time
     app, _ = app_and_db
     client = app.test_client()
 
@@ -200,12 +195,7 @@ def test_scan_job_has_steps(app_and_db, tmp_path):
     resp = client.post('/api/jobs/scan', json={'root': scan_dir})
     job_id = resp.get_json()['job_id']
 
-    for _ in range(50):
-        resp = client.get(f'/api/jobs/{job_id}')
-        data = resp.get_json()
-        if data['status'] in ('completed', 'failed'):
-            break
-        time.sleep(0.1)
+    data = wait_for_job_via_client(client, job_id)
 
     assert data['status'] == 'completed'
     assert 'steps' in data
@@ -216,7 +206,6 @@ def test_scan_job_has_steps(app_and_db, tmp_path):
 
 def test_job_history_includes_parsed_tree(app_and_db, tmp_path):
     """GET /api/jobs/history returns parsed tree data for completed jobs."""
-    import time
     app, _ = app_and_db
     client = app.test_client()
 
@@ -227,14 +216,7 @@ def test_job_history_includes_parsed_tree(app_and_db, tmp_path):
     resp = client.post('/api/jobs/scan', json={'root': scan_dir})
     job_id = resp.get_json()['job_id']
 
-    for _ in range(80):
-        resp = client.get(f'/api/jobs/{job_id}')
-        data = resp.get_json()
-        if data['status'] in ('completed', 'failed'):
-            break
-        time.sleep(0.1)
-
-    time.sleep(0.5)
+    wait_for_job_via_client(client, job_id, wait_for_history=True)
 
     resp = client.get('/api/jobs/history?limit=5')
     assert resp.status_code == 200
@@ -387,7 +369,6 @@ def test_update_step_current_file(app_and_db):
 
 def test_scan_step_has_progress(app_and_db, tmp_path):
     """Scan step reports step-level progress with current/total."""
-    import time
     app, _ = app_and_db
     client = app.test_client()
 
@@ -399,12 +380,7 @@ def test_scan_step_has_progress(app_and_db, tmp_path):
     resp = client.post('/api/jobs/scan', json={'root': scan_dir})
     job_id = resp.get_json()['job_id']
 
-    for _ in range(50):
-        resp = client.get(f'/api/jobs/{job_id}')
-        data = resp.get_json()
-        if data['status'] in ('completed', 'failed'):
-            break
-        time.sleep(0.1)
+    data = wait_for_job_via_client(client, job_id)
 
     assert data['status'] == 'completed'
     scan_step = data['steps'][0]
@@ -417,7 +393,6 @@ def test_scan_step_has_progress(app_and_db, tmp_path):
 
 def test_pipeline_thumbnail_step_has_progress(app_and_db, tmp_path):
     """Thumbnail step in pipeline reports step-level progress."""
-    import time
     app, _ = app_and_db
     client = app.test_client()
 
@@ -433,12 +408,7 @@ def test_pipeline_thumbnail_step_has_progress(app_and_db, tmp_path):
     })
     job_id = resp.get_json()['job_id']
 
-    for _ in range(100):
-        resp = client.get(f'/api/jobs/{job_id}')
-        data = resp.get_json()
-        if data['status'] in ('completed', 'failed'):
-            break
-        time.sleep(0.1)
+    data = wait_for_job_via_client(client, job_id)
 
     assert data['status'] == 'completed'
     thumb_step = next(s for s in data['steps'] if s['id'] == 'thumbnails')
@@ -448,7 +418,6 @@ def test_pipeline_thumbnail_step_has_progress(app_and_db, tmp_path):
 
 def test_pipeline_preview_step_has_progress(app_and_db, tmp_path):
     """Preview step in pipeline reports step-level progress."""
-    import time
     app, _ = app_and_db
     client = app.test_client()
 
@@ -464,12 +433,7 @@ def test_pipeline_preview_step_has_progress(app_and_db, tmp_path):
     })
     job_id = resp.get_json()['job_id']
 
-    for _ in range(100):
-        resp = client.get(f'/api/jobs/{job_id}')
-        data = resp.get_json()
-        if data['status'] in ('completed', 'failed'):
-            break
-        time.sleep(0.1)
+    data = wait_for_job_via_client(client, job_id)
 
     assert data['status'] == 'completed'
     preview_step = next(s for s in data['steps'] if s['id'] == 'previews')
@@ -631,14 +595,7 @@ def test_job_cancel_running_job_marks_cancelled(app_and_db):
         assert data.get("cancelled") is True
 
     # Wait for the work function to observe cancellation and exit.
-    for _ in range(50):
-        job = runner.get(job_id)
-        if job and job["status"] in ("completed", "failed", "cancelled"):
-            break
-        time.sleep(0.05)
-
-    job = runner.get(job_id)
-    assert job is not None
+    job = wait_for_job_via_runner(runner, job_id)
     assert job["status"] == "cancelled"
 
 
@@ -652,11 +609,7 @@ def test_job_cancel_finished_job_returns_404(app_and_db):
 
     job_id = runner.start("test", quick_work)
 
-    for _ in range(50):
-        job = runner.get(job_id)
-        if job and job["status"] == "completed":
-            break
-        time.sleep(0.05)
+    wait_for_job_via_runner(runner, job_id)
 
     with app.test_client() as c:
         resp = c.post(f"/api/jobs/{job_id}/cancel")
@@ -914,12 +867,7 @@ def test_pipeline_with_healthy_collection_skips_scan(app_and_db):
         assert resp.status_code == 200
         job_id = resp.get_json()["job_id"]
 
-        for _ in range(100):
-            resp = client.get(f"/api/jobs/{job_id}")
-            data = resp.get_json()
-            if data["status"] in ("completed", "failed"):
-                break
-            time.sleep(0.1)
+        data = wait_for_job_via_client(client, job_id)
 
         scan_step = next(s for s in data["steps"] if s["id"] == "scan")
         assert scan_step.get("summary") == "Skipped (using collection)"
@@ -983,12 +931,7 @@ def test_pipeline_with_broken_collection_repairs_metadata(app_and_db, tmp_path, 
         assert resp.status_code == 200
         job_id = resp.get_json()["job_id"]
 
-        for _ in range(100):
-            resp = client.get(f"/api/jobs/{job_id}")
-            data = resp.get_json()
-            if data["status"] in ("completed", "failed"):
-                break
-            time.sleep(0.1)
+        data = wait_for_job_via_client(client, job_id)
 
         assert data["status"] == "completed", data
         scan_step = next(s for s in data["steps"] if s["id"] == "scan")
@@ -1062,12 +1005,7 @@ def test_pipeline_repair_does_not_ingest_untracked_files(app_and_db, tmp_path, m
         assert resp.status_code == 200
         job_id = resp.get_json()["job_id"]
 
-        for _ in range(100):
-            resp = client.get(f"/api/jobs/{job_id}")
-            data = resp.get_json()
-            if data["status"] in ("completed", "failed"):
-                break
-            time.sleep(0.1)
+        data = wait_for_job_via_client(client, job_id)
 
     # Tracked photo repaired: timestamp populated.
     tracked_row = db.conn.execute(
@@ -1121,12 +1059,7 @@ def test_pipeline_with_broken_collection_handles_unreachable_folder(app_and_db):
         assert resp.status_code == 200
         job_id = resp.get_json()["job_id"]
 
-        for _ in range(100):
-            resp = client.get(f"/api/jobs/{job_id}")
-            data = resp.get_json()
-            if data["status"] in ("completed", "failed"):
-                break
-            time.sleep(0.1)
+        data = wait_for_job_via_client(client, job_id)
 
         # The scan step should have completed without error. With the
         # broken row's file missing on disk, the repair-target filter
@@ -1208,12 +1141,7 @@ def test_pipeline_repair_does_not_double_process_thumbnails(
         assert resp.status_code == 200
         job_id = resp.get_json()["job_id"]
 
-        for _ in range(100):
-            resp = client.get(f"/api/jobs/{job_id}")
-            data = resp.get_json()
-            if data["status"] in ("completed", "failed"):
-                break
-            time.sleep(0.1)
+        data = wait_for_job_via_client(client, job_id)
 
         assert data["status"] == "completed", data
 
@@ -1282,12 +1210,7 @@ def test_pipeline_repair_respects_excluded_photo_ids(
         assert resp.status_code == 200
         job_id = resp.get_json()["job_id"]
 
-        for _ in range(100):
-            resp = client.get(f"/api/jobs/{job_id}")
-            data = resp.get_json()
-            if data["status"] in ("completed", "failed"):
-                break
-            time.sleep(0.1)
+        data = wait_for_job_via_client(client, job_id)
 
         # The scan step should have reported the "Skipped" fast path
         # because the only broken photo was excluded from the run.

--- a/vireo/tests/wait.py
+++ b/vireo/tests/wait.py
@@ -1,0 +1,103 @@
+"""Shared polling helpers for tests that wait on background-job completion.
+
+Many tests spawn a job (scan, classify, import, ...) and need to block until
+it reaches a terminal state. The historical pattern was to inline a poll
+loop:
+
+    for _ in range(50):
+        if client.get(f'/api/jobs/{job_id}').get_json()['status'] in (
+            'completed', 'failed'):
+            break
+        time.sleep(0.1)
+
+That gives a 5s budget, which is fine on an unloaded developer machine but
+flakes under `pytest -n auto` where xdist workers contend for I/O. These
+helpers replace that pattern with a generous default timeout (30s) and a
+clear failure message that surfaces the last observed job state, so a real
+hang is diagnosable instead of just a silent assertion failure on
+"completed" later in the test.
+"""
+
+import time
+
+import pytest
+
+_DEFAULT_TERMINAL = ("completed", "failed", "cancelled")
+
+
+def wait_for_job(fetch, *, timeout=30.0, poll=0.05,
+                 terminal=_DEFAULT_TERMINAL, description=None):
+    """Block until ``fetch()`` returns a job dict with a terminal ``status``.
+
+    Args:
+        fetch: zero-arg callable returning a job dict (or ``None`` if the
+            job is not yet visible). Typically wraps a Flask client GET or a
+            direct ``JobRunner.get`` call.
+        timeout: max seconds to poll. Default 30s — generous enough for
+            xdist parallel runs where workers contend for I/O.
+        poll: sleep between polls.
+        terminal: iterable of terminal status strings.
+        description: human-readable label for the timeout message.
+
+    Returns:
+        The terminal job dict.
+
+    Raises:
+        pytest.fail.Exception when the job does not reach a terminal state
+        before ``timeout``. The message includes the last observed state so
+        a real hang is diagnosable.
+    """
+    deadline = time.monotonic() + timeout
+    last = None
+    while True:
+        last = fetch()
+        if last is not None and last.get("status") in terminal:
+            return last
+        if time.monotonic() >= deadline:
+            label = description or "job"
+            pytest.fail(
+                f"{label} did not reach a terminal state within {timeout}s; "
+                f"last={last!r}"
+            )
+        time.sleep(poll)
+
+
+def wait_for_job_via_client(client, job_id, *, wait_for_history=False, **kwargs):
+    """Wait for a job to terminate by polling the HTTP /api/jobs/<id> route.
+
+    JobRunner sets ``job["status"]`` to a terminal value before persisting to
+    the ``job_history`` table. Callers that immediately read history-backed
+    endpoints (e.g. ``/api/duplicates/last-scan``, ``/api/jobs/history``)
+    must pass ``wait_for_history=True`` to also block until the worker
+    thread has flushed the row to SQLite — otherwise the next query may
+    return stale or empty data.
+    """
+    def _fetch():
+        return client.get(f"/api/jobs/{job_id}").get_json()
+    job = wait_for_job(_fetch, description=f"job {job_id}", **kwargs)
+    if wait_for_history:
+        def _persisted():
+            data = client.get(f"/api/jobs/{job_id}").get_json()
+            return data if data and data.get("_persisted") else None
+        job = wait_for_job(_persisted,
+                           description=f"job {job_id} persistence",
+                           **kwargs)
+    return job
+
+
+def wait_for_job_via_runner(runner, job_id, *, wait_for_history=False, **kwargs):
+    """Wait for a job to terminate by polling JobRunner.get directly.
+
+    See :func:`wait_for_job_via_client` for the meaning of ``wait_for_history``.
+    """
+    def _fetch():
+        return runner.get(job_id)
+    job = wait_for_job(_fetch, description=f"job {job_id}", **kwargs)
+    if wait_for_history:
+        def _persisted():
+            data = runner.get(job_id)
+            return data if data and data.get("_persisted") else None
+        job = wait_for_job(_persisted,
+                           description=f"job {job_id} persistence",
+                           **kwargs)
+    return job


### PR DESCRIPTION
## Summary

Many job-completion tests inlined a 5-second polling loop. That budget is fine on an unloaded developer machine but flakes under \`pytest -n auto\` where workers contend for I/O — the test asserts on a still-running scan and fails. \`test_last_scan_picks_most_recent_completed\` was the most visible offender (failed CI on PR #718), and several other tests in \`test_jobs_api.py\` / \`test_jobs.py\` / \`test_job_submission_api.py\` shared the same pattern.

- New shared helper at \`vireo/tests/wait.py\` with \`wait_for_job_via_client\` (HTTP) and \`wait_for_job_via_runner\` (direct \`JobRunner.get\`). Default 30s timeout (vs the inlined 5s); raises \`pytest.fail\` with the last observed job state on hang.
- Replaced ~17 inlined polling sites across 4 test files. Net diff: −44 lines of test code despite +104 lines of helper + docstrings.
- Found a deeper race while testing the helper: \`JobRunner._run_job\` sets \`job["status"]\` to a terminal value BEFORE flushing to the \`job_history\` table. Tests that immediately read history-backed endpoints (e.g. \`/api/duplicates/last-scan\`) saw stale data. Added a \`_persisted\` flag set after the SQLite INSERT, and a \`wait_for_history=True\` opt-in on the helpers. Replaces the prior \`time.sleep(0.5)\` band-aid in \`test_jobs_api\`.

## Test plan

- [x] All 109 tests in the four touched files pass under \`pytest -n auto\` (16 workers).
- [x] Stress-tested \`test_duplicates_api.py\` 20× under \`pytest -n auto\` — 0/20 failures (was reproducibly flaky before; ~1/8 failure rate).
- [x] Broader sweep \`test_workspaces / test_db / test_app / test_photos_api / test_edits_api / test_jobs_api / test_darktable_api / test_config\` under \`pytest -n auto\` — 819 passed, 1 skipped.
- [ ] CI green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)