### PR TITLE
pipeline: split classify counter into inferred vs cached

### DIFF
--- a/docs/plans/2026-04-29-pipeline-classify-counter-design.md
+++ b/docs/plans/2026-04-29-pipeline-classify-counter-design.md
@@ -1,0 +1,174 @@
+# Pipeline classify progress counter — design
+
+## Problem
+
+The pipeline classify stage shows `Classifying species: 1,056 / 24,647` — a single counter that ticks for every photo regardless of whether the classifier actually ran. Cache hits (photos with an existing `classifier_runs` row matching the active model + label fingerprint) skip inference entirely, but advance the same counter. This makes a half-cached run look as slow as a full run during the early minutes, before cache hits start arriving in bulk, and produces misleading ETAs from the rate calculation.
+
+In the run that motivated this design (USA2026 workspace, 24,647 photos, BioCLIP‑2.5 / fingerprint `916d13ffb4a2`):
+
+- 13,421 photos already had cached predictions for the active model + fingerprint (54%).
+- 11,226 photos required fresh inference (46%).
+- The counter advanced for both kinds at the same rate, so the user could not tell that more than half of the work was a fast cache lookup.
+
+## Goal
+
+Surface inferred vs cached photo counts in the live progress UI for the classify stage, and add a one-shot pre-flight estimate so the ETA is honest from the first second of the run.
+
+## Non-goals
+
+- No changes to other stages. Only the `classify` stage's progress payload populates the new fields. UI handles the new fields generically so future stages can adopt them, but no retroactive change.
+- No split rates ("inference rate" + "cache hit rate"). Current single rate is good enough.
+- No change to `reclassify=True` semantics. When the gate is bypassed, `cached` is naturally 0.
+- No per-photo cache-hit log lines. The aggregate counter is what matters.
+
+## Architecture
+
+The progress event already flows from `pipeline_job.py` → `JobRunner` (SSE stream) → pipeline page JS. We add two optional integer fields to the per-stage payload:
+
+- `cached` — count of photos that hit the cache and skipped inference.
+- `cached_estimate` — pre-flight estimate of cache hits, set once at stage start.
+
+```
+classify loop (pipeline_job.py)
+  ├─ on cache hit:   stages["classify"]["cached"] += 1
+  └─ on inference:   stages["classify"]["count"] += 1
+
+stage state shape (back-compat — both new fields optional):
+  {
+    status: "running",
+    count: 718,                # photos that ran inference (semantic change)
+    cached: 338,               # photos that hit the cache (NEW)
+    total: 24647,              # total photos in the run
+    cached_estimate: 13421,    # pre-flight estimate (NEW, set once)
+    label: "Classifying species",
+  }
+
+UI rule (pipeline.html):
+  if cached_estimate is set, show pre-flight banner once at stage start
+  if cached > 0, render "718 inferred · 338 cached / 24,647"
+  else, render existing "718 / 24,647"
+  bar fill uses (count + cached) / total so completion percent is honest
+```
+
+### Semantic change to `count`
+
+Today `count` represents "photos seen" — pre-advanced by the full batch length at batch start (`pipeline_job.py:1885`). After this change, `count` represents "photos that ran inference" only, and `cached` covers the skipped photos. The sum `count + cached` equals the old "photos seen" semantics, so the progress bar percentage stays correct.
+
+### `cached_estimate` is a hint, not a guarantee
+
+The estimate counts detections with a `classifier_runs` row matching the active `(model, fingerprint)`. The classify loop's gate also checks that `get_predictions_for_detection` returns rows; if a run-key exists with no cached predictions (e.g. a prior pass stored only `category == 'match'`), it falls through to inference (`pipeline_job.py:2000-2004`). So actual `cached` final value can be lower than `cached_estimate`. UI treats the estimate as approximate.
+
+## Backend changes (`vireo/pipeline_job.py`)
+
+### Pre-flight estimate (per spec, before each model's batch loop, ~line 1830)
+
+```python
+cached_est = thread_db.count_classifier_runs(
+    photo_ids=[p["id"] for p in photos],
+    classifier_model=model_name,
+    labels_fingerprint=spec_fp,
+)
+stages["classify"]["cached_estimate"] = (
+    stages["classify"].get("cached_estimate", 0) + cached_est
+)
+runner.push_event(job["id"], "progress", _progress_event(
+    stages, "classify", phase_label, step_id=step_id,
+))
+```
+
+Cumulative across multiple specs in a multi-model run, mirroring how `count` and `total` already span `[0, total * len(resolved_specs)]`.
+
+### Per-photo counter increments
+
+Replace the per-batch pre-advance at line 1885. After the cache-skip block at line 1999, increment `stages["classify"]["cached"]` and continue. After successful inference at line 2044, increment `stages["classify"]["count"]`. Both counters span `[0, total * len(resolved_specs)]`.
+
+### Progress event cadence
+
+Keep one event per batch (~750 events for 24k photos at batch size 32). Push at batch *end* now instead of batch start, with both fields populated.
+
+### Mid-batch cancel cleanup
+
+The corrective fixup at lines 2059-2064 goes away. `count` is per-photo accurate now, so the cancel path just pushes final state and updates the step.
+
+## Database change (`vireo/db.py`)
+
+New method:
+
+```python
+def count_classifier_runs(
+    self,
+    photo_ids: list[int],
+    classifier_model: str,
+    labels_fingerprint: str,
+) -> int:
+    """Count distinct photos in `photo_ids` that have at least one
+    detection with a classifier_runs row matching (model, fingerprint).
+    """
+```
+
+Joins `detections` + `classifier_runs`, filtered by `photo_id IN (...)` and the model + fingerprint pair. Chunks `photo_ids` to stay under SQLITE_MAX_VARIABLE_NUMBER (999).
+
+## Frontend changes (`vireo/templates/pipeline.html`, around line 2293)
+
+```javascript
+var si = stages[p.stage_id] || {};
+var stageCurrent = si.count || 0;
+var stageCached = si.cached || 0;
+var stageCachedEst = si.cached_estimate || 0;
+var stageTotal = si.total || 0;
+
+var parts = [];
+if (p.phase) parts.push(p.phase);
+
+if (stageTotal > 0 && (stageCurrent > 0 || stageCached > 0)) {
+  if (stageCached > 0) {
+    parts.push(
+      stageCurrent.toLocaleString() + ' inferred · ' +
+      stageCached.toLocaleString() + ' cached / ' +
+      stageTotal.toLocaleString()
+    );
+  } else {
+    parts.push(stageCurrent.toLocaleString() + ' / ' + stageTotal.toLocaleString());
+  }
+}
+
+if (stageCachedEst > 0 && stageCurrent === 0 && stageCached === 0) {
+  parts.push(
+    '~' + stageCachedEst.toLocaleString() + ' cached, ~' +
+    (stageTotal - stageCachedEst).toLocaleString() + ' to classify'
+  );
+}
+
+// Bar fill must reflect both inferred AND cached photos so the bar
+// tracks honest completion, not just inferences.
+var pct = Math.round((stageCurrent + stageCached) / stageTotal * 100);
+```
+
+Other stages render unchanged: they don't set `cached`, so the new branches are never taken.
+
+## Tests
+
+### `test_db.py::test_count_classifier_runs_filters_by_model_and_fingerprint`
+
+3 photos, 1 detection each. Insert `classifier_runs` rows for:
+- detection 1 → (BioCLIP-2.5, `fp-a`)
+- detection 2 → (BioCLIP-2.5, `fp-b`)
+- detection 3 → (iNat21, `fp-a`)
+
+Assert `count_classifier_runs([1,2,3], "BioCLIP-2.5", "fp-a") == 1`. Also test the empty case returns 0 and the "photo with multiple detections, only one cached" case still counts as 1 photo.
+
+### `test_db.py::test_count_classifier_runs_chunks_large_id_lists`
+
+1500 photos with cached runs. Assert the count returns 1500, verifying chunking works above SQLITE_MAX_VARIABLE_NUMBER.
+
+### `test_pipeline_job.py::test_classify_progress_reports_cached_separately`
+
+Use existing pipeline test scaffolding (collection mode, monkeypatched classifier). 4 photos, 2 with pre-existing `classifier_runs` rows for the test model+fingerprint, 2 without. Run the pipeline classify stage and inspect captured progress events:
+
+- An early event has `stages["classify"]["cached_estimate"] == 2`.
+- The final classify event has `stages["classify"]["cached"] == 2` and `stages["classify"]["count"] == 2`.
+- `count + cached == total`.
+
+### Manual verification
+
+Drive the running browser. Start a small classify job in a workspace with mixed cached/uncached photos. Confirm UI shows "X inferred · Y cached / Total" and the pre-flight banner appears at stage start.

--- a/docs/plans/2026-04-29-pipeline-classify-counter.md
+++ b/docs/plans/2026-04-29-pipeline-classify-counter.md
@@ -1,0 +1,581 @@
+# Pipeline Classify Counter Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Split the classify stage's progress counter into "inferred" vs "cached" and add a one-shot pre-flight estimate so the user sees honest progress and ETA from the first second.
+
+**Architecture:** Add an optional `cached` integer (incremented on cache-hit) and a `cached_estimate` integer (set once at stage start) to the per-stage progress payload. Backend populates them in `vireo/pipeline_job.py`'s classify loop. UI in `vireo/templates/pipeline.html` renders the new fields when present, falling back to the existing single-number display when absent. New DB method `count_classifier_runs` provides the pre-flight count.
+
+**Tech Stack:** Python 3.10+, SQLite via `sqlite3`, Flask + Jinja2, vanilla JS.
+
+**Design doc:** see the matching `*-design.md` in this directory (cherry-picked from `current-job-status` branch where it was authored, commit b0ee9a6).
+
+**Working directory:** `/Users/julius/git/vireo/.worktrees/classify-counter` (branch `claude/classify-counter`, branched from `origin/main`).
+
+**Test command (full suite per CLAUDE.md):**
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_pipeline_job.py -v
+```
+
+For incremental TDD use the targeted commands inside each task.
+
+---
+
+## Task 1: Add `count_classifier_runs` DB method (TDD)
+
+**Files:**
+- Modify: `vireo/db.py` (add method near `get_classifier_run_keys` at line 5802)
+- Modify: `vireo/tests/test_db.py` (append two tests at end)
+
+### Step 1: Verify `add_detection` signature
+
+Before writing the test, run:
+
+```bash
+grep -n "def add_detection" vireo/db.py
+```
+
+Read the function signature so the test setup matches. Adjust the test calls in Step 2 if the signature differs from `(photo_id, box_x, box_y, box_w, box_h, detector_confidence, category, detector_model)`.
+
+### Step 2: Write the first failing test
+
+Append to `vireo/tests/test_db.py`:
+
+```python
+def test_count_classifier_runs_filters_by_model_and_fingerprint(tmp_path):
+    """count_classifier_runs returns the number of distinct photos in the
+    given id list that have at least one detection with a classifier_runs
+    row matching the given (model, fingerprint)."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos", name="photos")
+    p1 = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                     file_size=1, file_mtime=1.0, timestamp=None,
+                     width=1, height=1)
+    p2 = db.add_photo(folder_id=fid, filename="b.jpg", extension=".jpg",
+                     file_size=1, file_mtime=1.0, timestamp=None,
+                     width=1, height=1)
+    p3 = db.add_photo(folder_id=fid, filename="c.jpg", extension=".jpg",
+                     file_size=1, file_mtime=1.0, timestamp=None,
+                     width=1, height=1)
+
+    d1 = db.add_detection(p1, 0.0, 0.0, 1.0, 1.0, 0.9, "animal", "test-det")
+    d2 = db.add_detection(p2, 0.0, 0.0, 1.0, 1.0, 0.9, "animal", "test-det")
+    d3 = db.add_detection(p3, 0.0, 0.0, 1.0, 1.0, 0.9, "animal", "test-det")
+
+    db.record_classifier_run(d1, "BioCLIP-2.5", "fp-a", prediction_count=1)
+    db.record_classifier_run(d2, "BioCLIP-2.5", "fp-b", prediction_count=1)
+    db.record_classifier_run(d3, "iNat21", "fp-a", prediction_count=1)
+
+    # Only p1 matches (BioCLIP-2.5 + fp-a).
+    assert db.count_classifier_runs(
+        [p1, p2, p3], "BioCLIP-2.5", "fp-a"
+    ) == 1
+
+    # Empty input returns 0.
+    assert db.count_classifier_runs([], "BioCLIP-2.5", "fp-a") == 0
+
+    # Photo with multiple detections, only one cached, still counts as 1.
+    d2b = db.add_detection(p2, 0.0, 0.0, 1.0, 1.0, 0.9, "animal", "test-det")
+    db.record_classifier_run(d2b, "BioCLIP-2.5", "fp-a", prediction_count=1)
+    assert db.count_classifier_runs(
+        [p1, p2, p3], "BioCLIP-2.5", "fp-a"
+    ) == 2  # p1 and p2
+```
+
+### Step 3: Run the test, verify it fails
+
+```bash
+cd /Users/julius/git/vireo/.worktrees/classify-counter
+python -m pytest vireo/tests/test_db.py::test_count_classifier_runs_filters_by_model_and_fingerprint -v
+```
+
+**Expected:** FAIL with `AttributeError: 'Database' object has no attribute 'count_classifier_runs'`.
+
+### Step 4: Implement `count_classifier_runs` in `vireo/db.py`
+
+Insert after `get_classifier_run_keys` (line 5810):
+
+```python
+def count_classifier_runs(self, photo_ids, classifier_model, labels_fingerprint):
+    """Count distinct photos in `photo_ids` that have at least one
+    detection with a classifier_runs row matching the given
+    (classifier_model, labels_fingerprint).
+
+    Used by the streaming pipeline's classify stage to pre-flight how
+    many photos will hit the cache vs. require fresh inference.
+    """
+    if not photo_ids:
+        return 0
+    # Chunk to stay under SQLITE_MAX_VARIABLE_NUMBER (default 999).
+    # Match the 500-element chunks used elsewhere in this file.
+    CHUNK = 500
+    matched = set()
+    for i in range(0, len(photo_ids), CHUNK):
+        chunk = photo_ids[i:i + CHUNK]
+        placeholders = ",".join("?" * len(chunk))
+        rows = self.conn.execute(
+            f"SELECT DISTINCT d.photo_id "
+            f"FROM detections d "
+            f"JOIN classifier_runs cr ON cr.detection_id = d.id "
+            f"WHERE cr.classifier_model = ? "
+            f"  AND cr.labels_fingerprint = ? "
+            f"  AND d.photo_id IN ({placeholders})",
+            [classifier_model, labels_fingerprint, *chunk],
+        ).fetchall()
+        for r in rows:
+            matched.add(r["photo_id"])
+    return len(matched)
+```
+
+### Step 5: Run the test, verify it passes
+
+```bash
+python -m pytest vireo/tests/test_db.py::test_count_classifier_runs_filters_by_model_and_fingerprint -v
+```
+
+**Expected:** PASS.
+
+### Step 6: Write the chunking test
+
+Append to `vireo/tests/test_db.py`:
+
+```python
+def test_count_classifier_runs_chunks_large_id_lists(tmp_path):
+    """count_classifier_runs returns the correct count even when the
+    photo id list exceeds SQLITE_MAX_VARIABLE_NUMBER (default 999)."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos", name="photos")
+
+    # 1500 photos, each with one detection and one classifier_runs row
+    # for (BioCLIP-2.5, fp-a). Above the 999 SQLite variable cap.
+    photo_ids = []
+    for i in range(1500):
+        pid = db.add_photo(
+            folder_id=fid, filename=f"p_{i:05d}.jpg", extension=".jpg",
+            file_size=1, file_mtime=1.0, timestamp=None,
+            width=1, height=1,
+        )
+        did = db.add_detection(pid, 0.0, 0.0, 1.0, 1.0, 0.9, "animal", "test-det")
+        db.record_classifier_run(did, "BioCLIP-2.5", "fp-a", prediction_count=1)
+        photo_ids.append(pid)
+
+    assert db.count_classifier_runs(
+        photo_ids, "BioCLIP-2.5", "fp-a"
+    ) == 1500
+```
+
+### Step 7: Run the chunking test, verify it passes
+
+```bash
+python -m pytest vireo/tests/test_db.py::test_count_classifier_runs_chunks_large_id_lists -v
+```
+
+**Expected:** PASS.
+
+### Step 8: Commit
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "$(cat <<'EOF2'
+db: add count_classifier_runs for classify pre-flight
+
+Returns the number of distinct photos in a given id list that have at
+least one cached classifier_runs row for the active model+fingerprint.
+Chunked over SQLITE_MAX_VARIABLE_NUMBER (999) to handle large
+collections.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF2
+)"
+```
+
+---
+
+## Task 2: Add pre-flight estimate in pipeline_job classify loop
+
+**Files:**
+- Modify: `vireo/pipeline_job.py` (insert at top of per-spec block, ~line 1859)
+
+### Step 1: Insert the pre-flight call
+
+In `vireo/pipeline_job.py`, find the block that starts at line 1859 (`raw_results: list = []`). Just BEFORE that line, and AFTER line 1858's comment block ends, insert:
+
+```python
+                # Pre-flight cache estimate. One indexed query per spec
+                # so the UI can display "~M cached, ~K to classify" before
+                # the first inference runs and ETAs are honest from the
+                # start. The estimate may overcount if a run-key exists
+                # but no cached predictions do (see lines ~2000-2004); the
+                # live `cached` counter reflects actual skips.
+                cached_est = thread_db.count_classifier_runs(
+                    [p["id"] for p in photos],
+                    model_name,
+                    spec_fp,
+                )
+                stages["classify"]["cached_estimate"] = (
+                    stages["classify"].get("cached_estimate", 0) + cached_est
+                )
+                runner.push_event(job["id"], "progress", _progress_event(
+                    stages, "classify",
+                    f"Classifying with {active_spec['name']}",
+                    step_id=step_id,
+                ))
+```
+
+The placement matters: this must run AFTER `spec_fp` is set (line 1843) and BEFORE the batch loop. Insert it between lines 1858 and 1859.
+
+### Step 2: Run a smoke test to ensure the pipeline still loads
+
+```bash
+python -c "import sys; sys.path.insert(0, 'vireo'); import pipeline_job; print('ok')"
+```
+
+**Expected:** `ok` printed, no traceback.
+
+### Step 3: Run the existing pipeline_job test suite
+
+```bash
+python -m pytest vireo/tests/test_pipeline_job.py -v
+```
+
+**Expected:** All existing tests still pass. The new pre-flight query is harmless for existing tests since they all use `skip_classify=True`.
+
+### Step 4: Commit
+
+```bash
+git add vireo/pipeline_job.py
+git commit -m "$(cat <<'EOF2'
+pipeline_job: pre-flight classify cache estimate
+
+Before each model's batch loop, count how many photos already have a
+classifier_runs row for the active (model, fingerprint) and surface
+the count as stages.classify.cached_estimate. Lets the UI show
+"~M cached, ~K to classify" before any inference runs.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF2
+)"
+```
+
+---
+
+## Task 3: Replace per-batch counter pre-advance with per-photo increments
+
+**Files:**
+- Modify: `vireo/pipeline_job.py` (classify loop body, lines 1869-1898 and 1944-2076)
+
+### Step 1: Initialize cached counter at stage start
+
+Find line 1861 (`skipped_existing = 0`). Just below it, ensure `stages["classify"]["cached"]` starts at 0 for this spec (cumulative across multi-spec runs). Insert AFTER line 1861:
+
+```python
+                stages["classify"].setdefault("cached", 0)
+```
+
+### Step 2: Remove per-batch pre-advance
+
+In the for-loop starting at line 1869, locate lines 1882-1898 (the `# Aggregate classify progress across models...` block plus the `runner.push_event(...)` and `runner.update_step(...)` calls).
+
+**Delete lines 1882-1898 entirely.** That block was the per-batch pre-advance. We will push events at batch *end* now, after the inner loop has incremented per-photo counters.
+
+### Step 3: Increment cached counter on cache hit
+
+Find line 1964 (`skipped_existing += 1`, inside the `if cached:` block). Add a sibling line:
+
+```python
+                                    stages["classify"]["cached"] += 1
+```
+
+Final shape:
+
+```python
+                                if cached:
+                                    skipped_existing += 1
+                                    stages["classify"]["cached"] += 1
+                                    top = cached[0]
+                                    ...
+```
+
+### Step 4: Increment count counter on successful inference
+
+Find lines 2040-2044 (the `if new_count > 0:` block where `record_classifier_run` is called). Add a sibling that increments classify count:
+
+```python
+                        new_count = len(raw_results) - pre_len
+                        if new_count > 0:
+                            thread_db.record_classifier_run(
+                                primary_det["id"], model_name, spec_fp,
+                                prediction_count=new_count,
+                            )
+                            stages["classify"]["count"] = (
+                                stages["classify"].get("count", 0) + 1
+                            )
+```
+
+### Step 5: Push progress event at batch end
+
+After the inner `for photo in batch:` loop closes (just before line 2046's `# Skip the grouping/storage finalization on cancel` block), add a batch-boundary event push:
+
+```python
+                    # Batch boundary: surface the per-photo accumulated
+                    # count + cached to the UI. Replaces the old per-batch
+                    # pre-advance which lied about progress when batches
+                    # contained cache hits.
+                    stages["classify"]["total"] = total * len(resolved_specs_local)
+                    elapsed = max(time.time() - start_time, 0.01)
+                    seen = stages["classify"]["count"] + stages["classify"]["cached"]
+                    runner.push_event(job["id"], "progress", _progress_event(
+                        stages, "classify",
+                        f"Classifying with {active_spec['name']}"
+                        + (
+                            f" ({spec_idx + 1}/{len(resolved_specs_local)})"
+                            if len(resolved_specs_local) > 1 else ""
+                        ),
+                        step_id=step_id,
+                        rate=round(seen / elapsed * 60, 1),
+                    ))
+                    runner.update_step(
+                        job["id"], step_id,
+                        progress={
+                            "current": stages["classify"]["count"],
+                            "total": total,
+                        },
+                    )
+```
+
+### Step 6: Simplify mid-batch cancel cleanup
+
+Lines 2059-2076 contain the corrective fixup that adjusts `count` after a mid-batch cancel because of the old pre-advance. With per-photo accuracy this fixup is no longer needed — `count` and `cached` are already correct.
+
+Replace the entire block from `if _should_abort(abort):` at line 2052 through line 2076 with:
+
+```python
+                # Skip the grouping/storage finalization on cancel — it can
+                # take a minute on large collections and the user has already
+                # asked us to stop. Per-photo counters are accurate, no
+                # corrective fixup needed.
+                if _should_abort(abort):
+                    runner.update_step(
+                        job["id"], step_id,
+                        status="completed",
+                        progress={
+                            "current": stages["classify"]["count"],
+                            "total": total,
+                        },
+                        summary=(
+                            f"Cancelled "
+                            f"({stages['classify']['count']} classified, "
+                            f"{stages['classify']['cached']} cached "
+                            f"of {total})"
+                        ),
+                    )
+                    continue
+```
+
+### Step 7: Run pipeline_job tests
+
+```bash
+python -m pytest vireo/tests/test_pipeline_job.py -v
+```
+
+**Expected:** All existing tests pass.
+
+### Step 8: Run full suite per CLAUDE.md
+
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_pipeline_job.py -v
+```
+
+**Expected:** All pass.
+
+### Step 9: Commit
+
+```bash
+git add vireo/pipeline_job.py
+git commit -m "$(cat <<'EOF2'
+pipeline_job: track classify cached vs inferred per photo
+
+Replaces the per-batch counter pre-advance with per-photo increments
+so the live progress event distinguishes cache hits (cached) from
+fresh inferences (count). Removes the mid-batch cancel fixup since
+counters are now accurate at every photo boundary.
+
+stages.classify shape:
+  count           - photos that ran inference
+  cached          - photos that hit the classifier_runs cache
+  total           - photos in the run (x number of specs)
+  cached_estimate - pre-flight estimate from prior task
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF2
+)"
+```
+
+---
+
+## Task 4: Render `cached` and `cached_estimate` in pipeline.html
+
+**Files:**
+- Modify: `vireo/templates/pipeline.html` (function `_updatePipelineStageUI`, around line 2293)
+
+### Step 1: Update the JS render block
+
+In `vireo/templates/pipeline.html`, locate `_updatePipelineStageUI` (line 2293). Find the block at lines 2334-2360. Replace the existing logic with:
+
+```javascript
+  var si = stages[p.stage_id] || {};
+  var stageCurrent = si.count || 0;
+  var stageCached = si.cached || 0;
+  var stageCachedEst = si.cached_estimate || 0;
+  var stageTotal = si.total || 0;
+
+  var parts = [];
+  if (p.phase) parts.push(p.phase);
+
+  // Count line: split when we have actually seen cache hits, otherwise
+  // fall back to single-number display so non-classify stages render
+  // unchanged.
+  if (stageTotal > 0 && (stageCurrent > 0 || stageCached > 0)) {
+    if (stageCached > 0) {
+      parts.push(
+        stageCurrent.toLocaleString() + ' inferred · ' +
+        stageCached.toLocaleString() + ' cached / ' +
+        stageTotal.toLocaleString()
+      );
+    } else {
+      parts.push(stageCurrent.toLocaleString() + ' / ' + stageTotal.toLocaleString());
+    }
+  }
+
+  // Pre-flight banner: shown once when the stage starts and we have an
+  // estimate but no actual progress yet.
+  if (stageCachedEst > 0 && stageCurrent === 0 && stageCached === 0) {
+    parts.push(
+      '~' + stageCachedEst.toLocaleString() + ' cached, ~' +
+      (stageTotal - stageCachedEst).toLocaleString() + ' to classify'
+    );
+  }
+
+  if (p.rate) parts.push(Math.round(p.rate) + ' files/min');
+  if (p.eta_seconds != null && p.eta_seconds > 0) {
+    parts.push('~' + _formatETA(p.eta_seconds) + ' remaining');
+  } else if (stageTotal > 0 && stageCurrent > 0 && stageCurrent < 10) {
+    parts.push('Estimating...');
+  }
+  if (p.current_file) parts.push(p.current_file);
+  var label = parts.join(' — ');
+
+  if (status) status.textContent = label;
+
+  if (stageTotal > 0) {
+    if (progressWrap) progressWrap.style.display = '';
+    // Bar fill must reflect both inferred AND cached photos so the bar
+    // tracks honest completion, not just inferences.
+    var pct = Math.round((stageCurrent + stageCached) / stageTotal * 100);
+    if (fill) fill.style.width = pct + '%';
+```
+
+(Keep whatever lines come after `if (fill) fill.style.width = pct + '%';` unchanged.)
+
+### Step 2: Commit
+
+```bash
+git add vireo/templates/pipeline.html
+git commit -m "$(cat <<'EOF2'
+pipeline UI: render classify cached vs inferred counts
+
+Splits the classify stage's count line into "X inferred . Y cached / N"
+when cache hits exist. Shows a pre-flight banner ("~M cached, ~K to
+classify") before any photos process. Bar fill reflects (count + cached)
+/ total so percentage matches honest completion.
+
+Other stages render unchanged - they don't set cached, so the new
+branches are never taken.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF2
+)"
+```
+
+---
+
+## Task 5: Manual browser verification
+
+**Why manual:** The change is primarily UX. Per CLAUDE.md "user-first testing", drive a real browser for UI changes.
+
+### Step 1: Start a Vireo dev instance from the worktree
+
+```bash
+cd /Users/julius/git/vireo/.worktrees/classify-counter
+python vireo/app.py --db ~/.vireo/vireo-classify-counter-test.db --port 8090 &
+```
+
+Open http://127.0.0.1:8090 in a browser.
+
+### Step 2: Set up test data
+
+In the test DB, create a workspace with a small folder (~20 photos). Run a full pipeline once to populate detections + classifier_runs. Stop after classify completes.
+
+### Step 3: Re-run classify on the same collection
+
+This time, every photo should hit the cache. Expected UI behavior:
+
+- Pre-flight banner appears at stage start: `Classifying species - ~20 cached, ~0 to classify`.
+- During the run, count line shows: `Classifying species - 0 inferred . 20 cached / 20`.
+- Bar fills 0% to 100% smoothly as cached counter ticks.
+- Final state: `0 inferred . 20 cached / 20` with bar at 100%.
+
+### Step 4: Add a small new folder, re-run on a mixed collection
+
+Add 5 fresh photos (no detections yet). Run the full pipeline. After detect completes, the classify stage should show:
+
+- Pre-flight: `~20 cached, ~5 to classify`.
+- Mid-run: numbers split between cached (climbing fast through old photos) and inferred (climbing slowly through new ones).
+- Final: `5 inferred . 20 cached / 25`.
+
+### Step 5: Sanity-check non-classify stages
+
+Confirm thumbnails, previews, detect, regroup all still render their existing single-number progress (no `inferred . cached` split, no banner).
+
+### Step 6: Stop the dev instance
+
+```bash
+kill %1
+```
+
+### Step 7: Push the branch and open a PR
+
+```bash
+git push -u origin claude/classify-counter
+gh pr create --base main --title "pipeline: split classify counter into inferred vs cached" \
+  --body "$(cat <<'EOF2'
+## Summary
+
+Splits the classify stage's progress counter into "inferred" vs "cached" and adds a one-shot pre-flight estimate so users see honest progress and ETA from the first second of the run.
+
+Motivated by a 24,647-photo classify run where ~54% of photos already had cached predictions but the counter advanced for both kinds at the same rate, making a half-cached run look as slow as a full one.
+
+## Changes
+
+- db.count_classifier_runs(photo_ids, model, fingerprint) - pre-flight count.
+- pipeline_job.py - per-photo increments (count for inference, cached for skip), pre-flight estimate at stage start, simpler mid-batch cancel cleanup.
+- pipeline.html - renders "X inferred . Y cached / N", pre-flight banner, honest bar fill.
+
+## Test plan
+
+- [x] DB tests: count_classifier_runs filters by model+fingerprint, chunks > 999 ids.
+- [x] All existing pipeline_job tests still pass.
+- [x] Manual: re-run classify on fully-cached collection - banner + counter render correctly.
+- [x] Manual: run on mixed cached/uncached collection - both counters climb honestly.
+- [x] Manual: other stages (thumbnails, detect, regroup) render unchanged.
+EOF2
+)"
+```
+
+---
+
+## Done
+
+When all five tasks complete and the PR is open, hand control back. Implementation done.

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -361,6 +361,19 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                             "box_h": d["box_h"],
                             "confidence": d["detector_confidence"],
                             "category": d["category"],
+                            # sqlite3.Row supports [key] but not .get(); use try
+                            # so test mocks (plain dicts without detector_model)
+                            # don't crash this path.
+                            # sqlite3.Row supports [key] but lacks .get(),
+                            # and `key in row` is not supported either; .keys()
+                            # is the documented contains-check. Fallback to None
+                            # so test mocks (plain dicts without detector_model)
+                            # don't crash this path.
+                            "detector_model": (
+                                d["detector_model"]
+                                if "detector_model" in d.keys()  # noqa: SIM118
+                                else None
+                            ),
                         })
                     detection_map[photo["id"]] = det_list
                     detected += 1
@@ -418,6 +431,7 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                         "box_h": det["box"]["h"],
                         "confidence": det["confidence"],
                         "category": det.get("category", "animal"),
+                        "detector_model": "megadetector-v6",
                     })
                 detection_map[photo["id"]] = det_list
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -5810,14 +5810,29 @@ class Database:
 
     def count_classifier_runs(self, photo_ids, classifier_model, labels_fingerprint):
         """Count distinct photos in `photo_ids` that have at least one
-        detection with a classifier_runs row matching the given
-        (classifier_model, labels_fingerprint).
+        non-full-image detection above the active workspace's
+        ``detector_confidence`` threshold with a classifier_runs row
+        matching the given (classifier_model, labels_fingerprint).
 
         Used by the streaming pipeline's classify stage to pre-flight how
         many photos will hit the cache vs. require fresh inference.
+
+        Mirrors the runtime gate's photo selection (see pipeline_job.py,
+        the ``primary_det = photo_dets[0]`` block in the classify loop):
+        full-image rows are excluded and below-threshold detections are
+        ignored, so prior full-image classifier_runs and low-confidence
+        secondary boxes don't inflate the cached_estimate. May still
+        overcount for photos with multiple above-threshold non-full-image
+        detections where a non-primary one happens to carry the matching
+        run key — exact mirroring would require a window function over
+        every photo's detection set.
         """
         if not photo_ids:
             return 0
+        import config as cfg
+        min_conf = self.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2,
+        )
         # Chunk to stay under SQLITE_MAX_VARIABLE_NUMBER (default 999).
         # Match the 500-element chunks used elsewhere in this file.
         CHUNK = 500
@@ -5831,8 +5846,10 @@ class Database:
                 f"JOIN classifier_runs cr ON cr.detection_id = d.id "
                 f"WHERE cr.classifier_model = ? "
                 f"  AND cr.labels_fingerprint = ? "
+                f"  AND d.detector_model != 'full-image' "
+                f"  AND d.detector_confidence >= ? "
                 f"  AND d.photo_id IN ({placeholders})",
-                [classifier_model, labels_fingerprint, *chunk],
+                [classifier_model, labels_fingerprint, min_conf, *chunk],
             ).fetchall()
             for r in rows:
                 matched.add(r["photo_id"])

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -5808,6 +5808,36 @@ class Database:
         ).fetchall()
         return {(r["classifier_model"], r["labels_fingerprint"]) for r in rows}
 
+    def count_classifier_runs(self, photo_ids, classifier_model, labels_fingerprint):
+        """Count distinct photos in `photo_ids` that have at least one
+        detection with a classifier_runs row matching the given
+        (classifier_model, labels_fingerprint).
+
+        Used by the streaming pipeline's classify stage to pre-flight how
+        many photos will hit the cache vs. require fresh inference.
+        """
+        if not photo_ids:
+            return 0
+        # Chunk to stay under SQLITE_MAX_VARIABLE_NUMBER (default 999).
+        # Match the 500-element chunks used elsewhere in this file.
+        CHUNK = 500
+        matched = set()
+        for i in range(0, len(photo_ids), CHUNK):
+            chunk = photo_ids[i:i + CHUNK]
+            placeholders = ",".join("?" * len(chunk))
+            rows = self.conn.execute(
+                f"SELECT DISTINCT d.photo_id "
+                f"FROM detections d "
+                f"JOIN classifier_runs cr ON cr.detection_id = d.id "
+                f"WHERE cr.classifier_model = ? "
+                f"  AND cr.labels_fingerprint = ? "
+                f"  AND d.photo_id IN ({placeholders})",
+                [classifier_model, labels_fingerprint, *chunk],
+            ).fetchall()
+            for r in rows:
+                matched.add(r["photo_id"])
+        return len(matched)
+
     def upsert_labels_fingerprint(self, fingerprint, display_name, sources, label_count):
         import json
         self.conn.execute(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1879,10 +1879,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 failed = 0
                 skipped_existing = 0
                 stages["classify"].setdefault("cached", 0)
-                # Photos actually iterated past the inner abort check, used to
-                # correct the per-batch progress claim on a mid-batch cancel
-                # (the per-batch event below pre-advances count by len(batch)).
-                processed_in_loop = 0
                 start_time = time.time()
                 batch_size = 32  # classification batch granularity
 
@@ -1899,7 +1895,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         # then break out of the batch loop entirely.
                         if _should_abort(abort):
                             break
-                        processed_in_loop += 1
                         # Record this photo as classify-processed for the first
                         # successful model. Used by the stale-detection purge to
                         # restrict deletions to photos actually reclassified.
@@ -2071,6 +2066,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # asked us to stop. Per-photo counters are accurate, no
                 # corrective fixup needed.
                 if _should_abort(abort):
+                    runner.push_event(job["id"], "progress", _progress_event(
+                        stages, "classify",
+                        f"Cancelled — {stages['classify']['count']} of "
+                        f"{total} classified",
+                        step_id=step_id,
+                    ))
                     runner.update_step(
                         job["id"], step_id,
                         status="completed",

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2113,9 +2113,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         },
                         summary=(
                             f"Cancelled "
-                            f"({stages['classify']['count']} classified, "
-                            f"{stages['classify']['cached']} cached "
-                            f"of {total})"
+                            f"({processed_in_spec} of {total} processed)"
                         ),
                     )
                     continue

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1871,17 +1871,25 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # classifier_runs gate below handles skipping correctly
                 # and still surfaces cached results into raw_results so
                 # grouping sees them.
-                # Pre-flight cache estimate. One indexed query per spec
-                # so the UI can display "~M cached, ~K to classify" before
-                # the first inference runs and ETAs are honest from the
-                # start. The estimate may overcount if a run-key exists
-                # but no cached predictions do (see lines ~2000-2004); the
-                # live `cached` counter reflects actual skips.
+                # Pre-flight cache estimate. One indexed query so the UI
+                # can display "~M cached, ~K to classify" before the first
+                # inference runs and ETAs are honest from the start. The
+                # estimate may overcount if a run-key exists but no cached
+                # predictions do (see lines ~2000-2004); the live `cached`
+                # counter reflects actual skips.
                 #
-                # Skipped on reclassify runs: the gate below is bypassed
-                # in that mode, so every photo will be re-inferred and
-                # showing "~N cached" would mislead the user.
-                if not params.reclassify:
+                # Skipped on reclassify runs (the gate below is bypassed
+                # so every photo is re-inferred regardless of cache state)
+                # and on multi-spec runs (the estimate would only cover
+                # the current spec while ``total`` already spans every
+                # spec, producing a banner that undercounts cache and
+                # overstates remaining work — and since the UI hides the
+                # banner once any photo lands, there's no correction
+                # window). The single-spec case is the common one.
+                if (
+                    not params.reclassify
+                    and len(resolved_specs_local) == 1
+                ):
                     cached_est = thread_db.count_classifier_runs(
                         [p["id"] for p in photos],
                         model_name,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1957,7 +1957,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         # skipped entirely; pipeline classify is detection-
                         # driven and won't synthesize full-image boxes.
                         if photo["id"] in cached_detections:
-                            photo_dets = cached_detections[photo["id"]]
+                            # cached_detections from _detect_batch can include
+                            # full-image rows when an earlier pass synthesized
+                            # them (legacy db state); filter to match the
+                            # fallback-query branch below so primary_det never
+                            # lands on a full-image box. Pipeline classify is
+                            # detection-driven and won't classify full-image.
+                            photo_dets = [
+                                d for d in cached_detections[photo["id"]]
+                                if d.get("detector_model") != "full-image"
+                            ]
                         else:
                             photo_dets = [
                                 {

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -355,7 +355,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         "previews": {"status": "pending", "count": 0, "label": "Generating previews"},
         "model_loader": {"status": "pending", "label": "Loading models"},
         "detect": {"status": "pending", "count": 0, "label": "Detecting subjects"},
-        "classify": {"status": "pending", "count": 0, "label": "Classifying species"},
+        "classify": {"status": "pending", "count": 0, "cached": 0, "seen": 0, "label": "Classifying species"},
         "extract_masks": {"status": "pending", "count": 0, "label": "Extracting features"},
         "eye_keypoints": {"status": "pending", "count": 0, "label": "Detecting eye keypoints"},
         "regroup": {"status": "pending", "label": "Grouping encounters"},
@@ -1886,6 +1886,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 failed = 0
                 skipped_existing = 0
                 stages["classify"].setdefault("cached", 0)
+                stages["classify"].setdefault("seen", 0)
+                # Photos that iterated past the inner abort check IN THIS spec.
+                # Used for the per-spec ``runner.update_step`` progress (which
+                # is bounded by ``total``, not the multi-spec stage total) and
+                # for the batch-end rate calc.  Captures every branch — cache
+                # hit, successful inference, no-detection, image decode fail,
+                # inference fail — so spec-level progress reaches ``total`` at
+                # the end of the spec regardless of outcome mix.
+                processed_in_spec = 0
                 start_time = time.time()
                 batch_size = 32  # classification batch granularity
 
@@ -1902,6 +1911,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         # then break out of the batch loop entirely.
                         if _should_abort(abort):
                             break
+                        processed_in_spec += 1
+                        stages["classify"]["seen"] = (
+                            stages["classify"].get("seen", 0) + 1
+                        )
                         # Record this photo as classify-processed for the first
                         # successful model. Used by the stale-detection purge to
                         # restrict deletions to photos actually reclassified.
@@ -2049,7 +2062,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     # contained cache hits.
                     stages["classify"]["total"] = total * len(resolved_specs_local)
                     elapsed = max(time.time() - start_time, 0.01)
-                    seen = stages["classify"]["count"] + stages["classify"]["cached"]
                     runner.push_event(job["id"], "progress", _progress_event(
                         stages, "classify",
                         f"Classifying with {active_spec['name']}"
@@ -2058,12 +2070,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             if len(resolved_specs_local) > 1 else ""
                         ),
                         step_id=step_id,
-                        rate=round(seen / elapsed * 60, 1),
+                        rate=round(processed_in_spec / elapsed * 60, 1),
                     ))
                     runner.update_step(
                         job["id"], step_id,
                         progress={
-                            "current": stages["classify"]["count"],
+                            "current": processed_in_spec,
                             "total": total,
                         },
                     )
@@ -2075,15 +2087,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 if _should_abort(abort):
                     runner.push_event(job["id"], "progress", _progress_event(
                         stages, "classify",
-                        f"Cancelled — {stages['classify']['count']} of "
-                        f"{total} classified",
+                        f"Cancelled — {processed_in_spec} of "
+                        f"{total} processed",
                         step_id=step_id,
                     ))
                     runner.update_step(
                         job["id"], step_id,
                         status="completed",
                         progress={
-                            "current": stages["classify"]["count"],
+                            "current": processed_in_spec,
                             "total": total,
                         },
                         summary=(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1877,14 +1877,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # start. The estimate may overcount if a run-key exists
                 # but no cached predictions do (see lines ~2000-2004); the
                 # live `cached` counter reflects actual skips.
-                cached_est = thread_db.count_classifier_runs(
-                    [p["id"] for p in photos],
-                    model_name,
-                    spec_fp,
-                )
-                stages["classify"]["cached_estimate"] = (
-                    stages["classify"].get("cached_estimate", 0) + cached_est
-                )
+                #
+                # Skipped on reclassify runs: the gate below is bypassed
+                # in that mode, so every photo will be re-inferred and
+                # showing "~N cached" would mislead the user.
+                if not params.reclassify:
+                    cached_est = thread_db.count_classifier_runs(
+                        [p["id"] for p in photos],
+                        model_name,
+                        spec_fp,
+                    )
+                    stages["classify"]["cached_estimate"] = (
+                        stages["classify"].get("cached_estimate", 0) + cached_est
+                    )
                 # Set total BEFORE the pre-flight event so the UI's
                 # ``stageTotal - stageCachedEst`` subtraction renders the
                 # real "to classify" count on the first event the user

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1878,6 +1878,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 raw_results: list = []
                 failed = 0
                 skipped_existing = 0
+                stages["classify"].setdefault("cached", 0)
                 # Photos actually iterated past the inner abort check, used to
                 # correct the per-batch progress claim on a mid-batch cancel
                 # (the per-batch event below pre-advances count by len(batch)).
@@ -1889,32 +1890,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     if _should_abort(abort):
                         break
                     batch = photos[batch_start:batch_start + batch_size]
-                    batch_idx = batch_start + len(batch)
-
-                    phase_label = (
-                        f"Classifying with {active_spec['name']}"
-                        + (
-                            f" ({spec_idx + 1}/{len(resolved_specs_local)})"
-                            if len(resolved_specs_local) > 1 else ""
-                        )
-                    )
-                    # Aggregate classify progress across models: count spans
-                    # [0, total*N] so the overall bar advances smoothly through
-                    # a multi-model run instead of snapping to 100% per model.
-                    stages["classify"]["count"] = spec_idx * total + batch_idx
-                    stages["classify"]["total"] = total * len(resolved_specs_local)
-                    runner.push_event(job["id"], "progress", _progress_event(
-                        stages, "classify", phase_label,
-                        step_id=step_id,
-                        rate=round(
-                            batch_idx / max(time.time() - start_time, 0.01) * 60,
-                            1,
-                        ),
-                    ))
-                    runner.update_step(
-                        job["id"], step_id,
-                        progress={"current": batch_idx, "total": total},
-                    )
 
                     for photo in batch:
                         # Per-photo abort check so cancel takes effect within
@@ -1981,6 +1956,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 )
                                 if cached:
                                     skipped_existing += 1
+                                    stages["classify"]["cached"] += 1
                                     top = cached[0]
                                     folder_path = folders.get(photo["folder_id"], "")
                                     image_path = os.path.join(
@@ -2061,36 +2037,53 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 primary_det["id"], model_name, spec_fp,
                                 prediction_count=new_count,
                             )
+                            stages["classify"]["count"] = (
+                                stages["classify"].get("count", 0) + 1
+                            )
 
-                # Skip the grouping/storage finalization on cancel — it can
-                # take a minute on large collections and the user has already
-                # asked us to stop. Leaving models_succeeded at its current
-                # value also keeps the reclassify stale-row purge from firing
-                # for this model (see the comment on the purge below), which
-                # is the safe default when classify didn't finish.
-                if _should_abort(abort):
-                    # The per-batch progress event above pre-advances the
-                    # count by the full batch length BEFORE the inner loop
-                    # runs. On a mid-batch cancel that leaves the UI showing
-                    # a count higher than what was actually classified — emit
-                    # a corrected progress event and step update so the job
-                    # tree reflects the true partial state.
-                    stages["classify"]["count"] = (
-                        spec_idx * total + processed_in_loop
-                    )
-                    stages["classify"]["total"] = (
-                        total * len(resolved_specs_local)
-                    )
+                    # Batch boundary: surface the per-photo accumulated
+                    # count + cached to the UI. Replaces the old per-batch
+                    # pre-advance which lied about progress when batches
+                    # contained cache hits.
+                    stages["classify"]["total"] = total * len(resolved_specs_local)
+                    elapsed = max(time.time() - start_time, 0.01)
+                    seen = stages["classify"]["count"] + stages["classify"]["cached"]
                     runner.push_event(job["id"], "progress", _progress_event(
                         stages, "classify",
-                        f"Cancelled — {processed_in_loop} of {total} photos",
+                        f"Classifying with {active_spec['name']}"
+                        + (
+                            f" ({spec_idx + 1}/{len(resolved_specs_local)})"
+                            if len(resolved_specs_local) > 1 else ""
+                        ),
                         step_id=step_id,
+                        rate=round(seen / elapsed * 60, 1),
                     ))
                     runner.update_step(
                         job["id"], step_id,
+                        progress={
+                            "current": stages["classify"]["count"],
+                            "total": total,
+                        },
+                    )
+
+                # Skip the grouping/storage finalization on cancel — it can
+                # take a minute on large collections and the user has already
+                # asked us to stop. Per-photo counters are accurate, no
+                # corrective fixup needed.
+                if _should_abort(abort):
+                    runner.update_step(
+                        job["id"], step_id,
                         status="completed",
-                        progress={"current": processed_in_loop, "total": total},
-                        summary=f"Cancelled ({processed_in_loop} of {total} photos)",
+                        progress={
+                            "current": stages["classify"]["count"],
+                            "total": total,
+                        },
+                        summary=(
+                            f"Cancelled "
+                            f"({stages['classify']['count']} classified, "
+                            f"{stages['classify']['cached']} cached "
+                            f"of {total})"
+                        ),
                     )
                     continue
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -163,23 +163,31 @@ STAGE_WEIGHTS = {
 def _stage_fraction(info):
     """Return a 0..1 completion fraction for one stage entry.
 
-    'failed' stages still contribute their partial (count/total) progress:
-    heavy stages like classify and extract_masks often process most items
-    before marking themselves failed due to per-item errors, and dropping
-    their weight to 0 would make the overall bar lurch backward when that
-    failure surfaces."""
+    'failed' stages still contribute their partial progress: heavy stages
+    like classify and extract_masks often process most items before marking
+    themselves failed due to per-item errors, and dropping their weight to
+    0 would make the overall bar lurch backward when that failure surfaces.
+
+    Prefer ``seen`` (every photo the stage iterated past, regardless of
+    outcome) when present; fall back to ``count`` for stages that don't
+    surface seen. Without this, classify's per-photo split into ``count``
+    (inferred) + ``cached`` would leave the overall pipeline bar stuck on
+    cached-heavy runs, since count alone stops growing once the cache
+    starts hitting."""
     status = info.get("status", "pending")
     if status in ("completed", "skipped"):
         return 1.0
     if status not in ("running", "failed"):
         return 0.0
     total = info.get("total") or 0
-    count = info.get("count") or 0
+    progressed = info.get("seen")
+    if progressed is None:
+        progressed = info.get("count") or 0
     if total <= 0:
         return 0.0
-    if count >= total:
+    if progressed >= total:
         return 1.0
-    return count / total
+    return progressed / total
 
 
 def _weighted_progress(stages):
@@ -1877,6 +1885,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 stages["classify"]["cached_estimate"] = (
                     stages["classify"].get("cached_estimate", 0) + cached_est
                 )
+                # Set total BEFORE the pre-flight event so the UI's
+                # ``stageTotal - stageCachedEst`` subtraction renders the
+                # real "to classify" count on the first event the user
+                # sees, not 0.
+                stages["classify"]["total"] = total * len(resolved_specs_local)
                 runner.push_event(job["id"], "progress", _progress_event(
                     stages, "classify",
                     f"Classifying with {active_spec['name']}",

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1797,7 +1797,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     model_type = loaded_models["model_type"]
                     model_name = loaded_models["model_name"]
                 else:
-                    stages["classify"]["count"] = spec_idx * total
+                    # Don't reset stages["classify"]["count"] here — it now
+                    # accumulates real inferences per-photo (Task 3); jumping
+                    # it to spec_idx * total would silently double-count the
+                    # cached hits from prior specs.  total is left at its
+                    # multi-spec value (set by the batch-end push of the
+                    # previous spec, or unchanged on first entry); explicitly
+                    # restate it so the "Loading next model..." event always
+                    # carries the multi-spec total.
                     stages["classify"]["total"] = total * len(resolved_specs_local)
                     runner.push_event(job["id"], "progress", _progress_event(
                         stages, "classify", f"Loading {active_spec['name']}...",

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1856,6 +1856,25 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # classifier_runs gate below handles skipping correctly
                 # and still surfaces cached results into raw_results so
                 # grouping sees them.
+                # Pre-flight cache estimate. One indexed query per spec
+                # so the UI can display "~M cached, ~K to classify" before
+                # the first inference runs and ETAs are honest from the
+                # start. The estimate may overcount if a run-key exists
+                # but no cached predictions do (see lines ~2000-2004); the
+                # live `cached` counter reflects actual skips.
+                cached_est = thread_db.count_classifier_runs(
+                    [p["id"] for p in photos],
+                    model_name,
+                    spec_fp,
+                )
+                stages["classify"]["cached_estimate"] = (
+                    stages["classify"].get("cached_estimate", 0) + cached_est
+                )
+                runner.push_event(job["id"], "progress", _progress_event(
+                    stages, "classify",
+                    f"Classifying with {active_spec['name']}",
+                    step_id=step_id,
+                ))
                 raw_results: list = []
                 failed = 0
                 skipped_existing = 0

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2504,6 +2504,7 @@ function _updatePipelineStageUI(p) {
   var si = stages[p.stage_id] || {};
   var stageCurrent = si.count || 0;
   var stageCached = si.cached || 0;
+  var stageSeen = si.seen || 0;
   var stageCachedEst = si.cached_estimate || 0;
   var stageTotal = si.total || 0;
 
@@ -2549,9 +2550,13 @@ function _updatePipelineStageUI(p) {
 
   if (stageTotal > 0) {
     if (progressWrap) progressWrap.style.display = '';
-    // Bar fill must reflect both inferred AND cached photos so the bar
-    // tracks honest completion, not just inferences.
-    var pct = Math.min(100, Math.round((stageCurrent + stageCached) / stageTotal * 100));
+    // Bar fill: classify surfaces ``seen`` which counts every photo the
+    // loop iterated past (cached, inferred, no-detection, decode-failed,
+    // inference-failed); use it so the bar reaches 100% on collections that
+    // contain non-classifiable photos. Other stages fall back to
+    // count + cached.
+    var stageProcessed = stageSeen || (stageCurrent + stageCached);
+    var pct = Math.min(100, Math.round(stageProcessed / stageTotal * 100));
     if (fill) fill.style.width = pct + '%';
     if (text) text.textContent = label;
   }

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2530,7 +2530,7 @@ function _updatePipelineStageUI(p) {
   if (stageCachedEst > 0 && stageCurrent === 0 && stageCached === 0) {
     parts.push(
       '~' + stageCachedEst.toLocaleString() + ' cached, ~' +
-      (stageTotal - stageCachedEst).toLocaleString() + ' to classify'
+      Math.max(0, stageTotal - stageCachedEst).toLocaleString() + ' to classify'
     );
   }
 
@@ -2543,13 +2543,15 @@ function _updatePipelineStageUI(p) {
   if (p.current_file) parts.push(p.current_file);
   var label = parts.join(' — ');
 
+  // Always update the status line so indeterminate phases like
+  // "Discovering files..." are visible even before the bar has a total.
   if (status) status.textContent = label;
 
   if (stageTotal > 0) {
     if (progressWrap) progressWrap.style.display = '';
     // Bar fill must reflect both inferred AND cached photos so the bar
     // tracks honest completion, not just inferences.
-    var pct = Math.round((stageCurrent + stageCached) / stageTotal * 100);
+    var pct = Math.min(100, Math.round((stageCurrent + stageCached) / stageTotal * 100));
     if (fill) fill.style.width = pct + '%';
     if (text) text.textContent = label;
   }

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2503,13 +2503,37 @@ function _updatePipelineStageUI(p) {
   // individual cards (it would make every card read the same %).
   var si = stages[p.stage_id] || {};
   var stageCurrent = si.count || 0;
+  var stageCached = si.cached || 0;
+  var stageCachedEst = si.cached_estimate || 0;
   var stageTotal = si.total || 0;
 
   var parts = [];
   if (p.phase) parts.push(p.phase);
-  if (stageTotal > 0 && stageCurrent > 0) {
-    parts.push(stageCurrent.toLocaleString() + ' / ' + stageTotal.toLocaleString());
+
+  // Count line: split when we have actually seen cache hits, otherwise
+  // fall back to single-number display so non-classify stages render
+  // unchanged.
+  if (stageTotal > 0 && (stageCurrent > 0 || stageCached > 0)) {
+    if (stageCached > 0) {
+      parts.push(
+        stageCurrent.toLocaleString() + ' inferred · ' +
+        stageCached.toLocaleString() + ' cached / ' +
+        stageTotal.toLocaleString()
+      );
+    } else {
+      parts.push(stageCurrent.toLocaleString() + ' / ' + stageTotal.toLocaleString());
+    }
   }
+
+  // Pre-flight banner: shown once when the stage starts and we have an
+  // estimate but no actual progress yet.
+  if (stageCachedEst > 0 && stageCurrent === 0 && stageCached === 0) {
+    parts.push(
+      '~' + stageCachedEst.toLocaleString() + ' cached, ~' +
+      (stageTotal - stageCachedEst).toLocaleString() + ' to classify'
+    );
+  }
+
   if (p.rate) parts.push(Math.round(p.rate) + ' files/min');
   if (p.eta_seconds != null && p.eta_seconds > 0) {
     parts.push('~' + _formatETA(p.eta_seconds) + ' remaining');
@@ -2517,15 +2541,15 @@ function _updatePipelineStageUI(p) {
     parts.push('Estimating...');
   }
   if (p.current_file) parts.push(p.current_file);
-  var label = parts.join(' \u2014 ');
+  var label = parts.join(' — ');
 
-  // Always update the status line so indeterminate phases like
-  // "Discovering files..." are visible even before the bar has a total.
   if (status) status.textContent = label;
 
   if (stageTotal > 0) {
     if (progressWrap) progressWrap.style.display = '';
-    var pct = Math.round(stageCurrent / stageTotal * 100);
+    // Bar fill must reflect both inferred AND cached photos so the bar
+    // tracks honest completion, not just inferences.
+    var pct = Math.round((stageCurrent + stageCached) / stageTotal * 100);
     if (fill) fill.style.width = pct + '%';
     if (text) text.textContent = label;
   }

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2528,7 +2528,7 @@ function _updatePipelineStageUI(p) {
 
   // Pre-flight banner: shown once when the stage starts and we have an
   // estimate but no actual progress yet.
-  if (stageCachedEst > 0 && stageCurrent === 0 && stageCached === 0) {
+  if (stageCachedEst > 0 && stageCurrent === 0 && stageCached === 0 && stageSeen === 0) {
     parts.push(
       '~' + stageCachedEst.toLocaleString() + ' cached, ~' +
       Math.max(0, stageTotal - stageCachedEst).toLocaleString() + ' to classify'

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -9561,7 +9561,7 @@ def test_add_photo_retries_on_database_is_locked(tmp_path):
     assert photo["filename"] == "DSC_0001.NEF"
 
 
-def _add_one_detection(db, photo_id, detector_model="test-det"):
+def _add_one_detection(db, photo_id, detector_model="test-det", conf=0.9):
     """Append a single detection without wiping prior rows for the same
     (photo, model). save_detections is destructive per (photo, model), so
     use direct SQL when we want multiple detections on one photo.
@@ -9570,8 +9570,8 @@ def _add_one_detection(db, photo_id, detector_model="test-det"):
         """INSERT INTO detections
              (photo_id, detector_model, box_x, box_y, box_w, box_h,
               detector_confidence, category)
-           VALUES (?, ?, 0.0, 0.0, 1.0, 1.0, 0.9, 'animal')""",
-        (photo_id, detector_model),
+           VALUES (?, ?, 0.0, 0.0, 1.0, 1.0, ?, 'animal')""",
+        (photo_id, detector_model, conf),
     )
     db.conn.commit()
     return cur.lastrowid
@@ -9641,3 +9641,40 @@ def test_count_classifier_runs_chunks_large_id_lists(tmp_path):
     assert db.count_classifier_runs(
         photo_ids, "BioCLIP-2.5", "fp-a"
     ) == 1500
+
+
+def test_count_classifier_runs_excludes_full_image_and_below_threshold(tmp_path):
+    """count_classifier_runs mirrors the runtime gate: full-image rows and
+    sub-threshold detections are excluded so prior full-image classifier
+    runs and stale low-confidence boxes don't inflate cached_estimate."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos", name="photos")
+    p1 = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                     file_size=1, file_mtime=1.0, timestamp=None,
+                     width=1, height=1)
+    p2 = db.add_photo(folder_id=fid, filename="b.jpg", extension=".jpg",
+                     file_size=1, file_mtime=1.0, timestamp=None,
+                     width=1, height=1)
+    p3 = db.add_photo(folder_id=fid, filename="c.jpg", extension=".jpg",
+                     file_size=1, file_mtime=1.0, timestamp=None,
+                     width=1, height=1)
+
+    # p1: only a full-image detection has a matching run key. Should NOT
+    # be counted (runtime gate skips full-image rows when picking primary).
+    d1_full = _add_one_detection(db, p1, detector_model="full-image", conf=0.9)
+    db.record_classifier_run(d1_full, "BioCLIP-2.5", "fp-a", prediction_count=1)
+
+    # p2: only a below-threshold detection has a matching run key. Should
+    # NOT be counted (runtime gate filters at detector_confidence >= 0.2).
+    d2_low = _add_one_detection(db, p2, conf=0.05)
+    db.record_classifier_run(d2_low, "BioCLIP-2.5", "fp-a", prediction_count=1)
+
+    # p3: a normal above-threshold non-full-image detection has a matching
+    # run key. Should be counted.
+    d3 = _add_one_detection(db, p3, conf=0.9)
+    db.record_classifier_run(d3, "BioCLIP-2.5", "fp-a", prediction_count=1)
+
+    assert db.count_classifier_runs(
+        [p1, p2, p3], "BioCLIP-2.5", "fp-a",
+    ) == 1

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -9559,3 +9559,85 @@ def test_add_photo_retries_on_database_is_locked(tmp_path):
     assert fail_remaining["n"] == 0, "the flaky executor should have been hit"
     photo = db.get_photo(pid)
     assert photo["filename"] == "DSC_0001.NEF"
+
+
+def _add_one_detection(db, photo_id, detector_model="test-det"):
+    """Append a single detection without wiping prior rows for the same
+    (photo, model). save_detections is destructive per (photo, model), so
+    use direct SQL when we want multiple detections on one photo.
+    """
+    cur = db.conn.execute(
+        """INSERT INTO detections
+             (photo_id, detector_model, box_x, box_y, box_w, box_h,
+              detector_confidence, category)
+           VALUES (?, ?, 0.0, 0.0, 1.0, 1.0, 0.9, 'animal')""",
+        (photo_id, detector_model),
+    )
+    db.conn.commit()
+    return cur.lastrowid
+
+
+def test_count_classifier_runs_filters_by_model_and_fingerprint(tmp_path):
+    """count_classifier_runs returns the number of distinct photos in the
+    given id list that have at least one detection with a classifier_runs
+    row matching the given (model, fingerprint)."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos", name="photos")
+    p1 = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                     file_size=1, file_mtime=1.0, timestamp=None,
+                     width=1, height=1)
+    p2 = db.add_photo(folder_id=fid, filename="b.jpg", extension=".jpg",
+                     file_size=1, file_mtime=1.0, timestamp=None,
+                     width=1, height=1)
+    p3 = db.add_photo(folder_id=fid, filename="c.jpg", extension=".jpg",
+                     file_size=1, file_mtime=1.0, timestamp=None,
+                     width=1, height=1)
+
+    d1 = _add_one_detection(db, p1)
+    d2 = _add_one_detection(db, p2)
+    d3 = _add_one_detection(db, p3)
+
+    db.record_classifier_run(d1, "BioCLIP-2.5", "fp-a", prediction_count=1)
+    db.record_classifier_run(d2, "BioCLIP-2.5", "fp-b", prediction_count=1)
+    db.record_classifier_run(d3, "iNat21", "fp-a", prediction_count=1)
+
+    # Only p1 matches (BioCLIP-2.5 + fp-a).
+    assert db.count_classifier_runs(
+        [p1, p2, p3], "BioCLIP-2.5", "fp-a"
+    ) == 1
+
+    # Empty input returns 0.
+    assert db.count_classifier_runs([], "BioCLIP-2.5", "fp-a") == 0
+
+    # Photo with multiple detections, only one cached, still counts as 1.
+    d2b = _add_one_detection(db, p2)
+    db.record_classifier_run(d2b, "BioCLIP-2.5", "fp-a", prediction_count=1)
+    assert db.count_classifier_runs(
+        [p1, p2, p3], "BioCLIP-2.5", "fp-a"
+    ) == 2  # p1 and p2
+
+
+def test_count_classifier_runs_chunks_large_id_lists(tmp_path):
+    """count_classifier_runs returns the correct count even when the
+    photo id list exceeds SQLITE_MAX_VARIABLE_NUMBER (default 999)."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos", name="photos")
+
+    # 1500 photos, each with one detection and one classifier_runs row
+    # for (BioCLIP-2.5, fp-a). Above the 999 SQLite variable cap.
+    photo_ids = []
+    for i in range(1500):
+        pid = db.add_photo(
+            folder_id=fid, filename=f"p_{i:05d}.jpg", extension=".jpg",
+            file_size=1, file_mtime=1.0, timestamp=None,
+            width=1, height=1,
+        )
+        did = _add_one_detection(db, pid)
+        db.record_classifier_run(did, "BioCLIP-2.5", "fp-a", prediction_count=1)
+        photo_ids.append(pid)
+
+    assert db.count_classifier_runs(
+        photo_ids, "BioCLIP-2.5", "fp-a"
+    ) == 1500

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -3147,8 +3147,7 @@ def test_pipeline_classify_mid_batch_cancel_skips_storage(tmp_path, monkeypatch)
         f"the pre-emptive batch claim (3/3). Got progress="
         f"{cancelled_kw.get('progress')!r}"
     )
-    assert "1 classified" in (cancelled_kw.get("summary") or "") and \
-        "of 3" in (cancelled_kw.get("summary") or ""), (
+    assert "1 of 3 processed" in (cancelled_kw.get("summary") or ""), (
         f"Cancelled summary should report actual processed count; got "
         f"{cancelled_kw.get('summary')!r}"
     )

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -3147,7 +3147,8 @@ def test_pipeline_classify_mid_batch_cancel_skips_storage(tmp_path, monkeypatch)
         f"the pre-emptive batch claim (3/3). Got progress="
         f"{cancelled_kw.get('progress')!r}"
     )
-    assert "1 of 3" in (cancelled_kw.get("summary") or ""), (
+    assert "1 classified" in (cancelled_kw.get("summary") or "") and \
+        "of 3" in (cancelled_kw.get("summary") or ""), (
         f"Cancelled summary should report actual processed count; got "
         f"{cancelled_kw.get('summary')!r}"
     )


### PR DESCRIPTION
## Summary

Splits the classify stage's progress counter into "inferred" vs "cached" and adds a one-shot pre-flight estimate so users see honest progress and ETA from the first second of the run.

Motivated by a 24,647-photo classify run where ~54% of photos already had cached predictions but the counter advanced for both kinds at the same rate, making a half-cached run look as slow as a full one.

## Changes

- `db.count_classifier_runs(photo_ids, model, fingerprint)` — pre-flight count of photos already in `classifier_runs` for the active (model, fingerprint).
- `pipeline_job.py` — per-photo increments (`count` for inference, `cached` for skip), pre-flight estimate at stage start, simpler mid-batch cancel cleanup. Also drops a multi-spec `count` reset that would have double-counted cached hits across specs after the per-photo refactor.
- `pipeline.html` — renders "X inferred · Y cached / N", pre-flight banner ("~M cached, ~K to classify"), bar fill driven by `count + cached` so percentage matches honest completion.

## Architecture

`stages.classify` payload gains two optional fields:

- `count` (semantic change): photos that ran inference (was: photos seen).
- `cached`: photos that hit the `classifier_runs` cache.
- `cached_estimate`: pre-flight count from the new DB query, set once at stage start.
- `total`: unchanged.

UI guards new branches on the new fields, so other stages render unchanged.

## Test plan

- [x] DB tests: `count_classifier_runs` filters by model+fingerprint, chunks > 999 ids.
- [x] All 102 existing pipeline_job tests still pass.
- [x] Pre-existing flaky `test_edits_api.py` keyword tests fail under full-suite cross-file pollution (pre-existing, pass in isolation, unrelated to this PR).
- [ ] Manual: re-run classify on fully-cached collection — banner + counter render correctly.
- [ ] Manual: run on mixed cached/uncached collection — both counters climb honestly.
- [ ] Manual: multi-spec run — bar advances smoothly across specs without backward jumps.
- [ ] Manual: other stages (thumbnails, detect, regroup) render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)