### PR TITLE
fix(stats): scale Other Keywords bars to their own max

### DIFF
--- a/vireo/templates/stats.html
+++ b/vireo/templates/stats.html
@@ -165,6 +165,12 @@ body { padding-bottom: 36px; }
     <div class="bar-chart" id="speciesChart"><span style="color:var(--text-ghost);font-size:13px;">Loading...</span></div>
   </div>
 
+  <!-- Other Keywords -->
+  <div class="section" id="otherKeywordsSection" style="display:none;">
+    <div class="section-title">Other Keywords</div>
+    <div class="bar-chart" id="otherKeywordsChart"></div>
+  </div>
+
   <div class="grid-2col">
     <!-- Rating Distribution -->
     <div class="section">
@@ -357,21 +363,28 @@ function renderSpecies(keywords) {
       '<span class="bar-value">' + k.photo_count.toLocaleString() + '</span>' +
     '</div>';
   });
+  container.innerHTML = html;
 
-  // Also show top non-species keywords
+  // Render top non-species keywords in their own section
   var nonSpecies = keywords.filter(function(k) { return !k.is_species; }).slice(0, 10);
+  var otherSection = document.getElementById('otherKeywordsSection');
+  var otherChart = document.getElementById('otherKeywordsChart');
   if (nonSpecies.length > 0) {
-    html += '<div style="margin-top:16px;font-size:11px;color:var(--text-faint);text-transform:uppercase;margin-bottom:8px;">Other Keywords</div>';
+    var nonSpeciesMax = nonSpecies[0].photo_count;
+    var otherHtml = '';
     nonSpecies.forEach(function(k) {
-      var pct = Math.round((k.photo_count / max) * 100);
-      html += '<div class="bar-row">' +
+      var pct = Math.round((k.photo_count / nonSpeciesMax) * 100);
+      otherHtml += '<div class="bar-row">' +
         '<span class="bar-label">' + escapeHtml(k.name) + '</span>' +
         '<div class="bar-track"><div class="bar-fill" style="width:' + pct + '%;background:var(--text-ghost);"></div></div>' +
         '<span class="bar-value">' + k.photo_count.toLocaleString() + '</span>' +
       '</div>';
     });
+    otherChart.innerHTML = otherHtml;
+    otherSection.style.display = '';
+  } else {
+    otherSection.style.display = 'none';
   }
-  container.innerHTML = html;
 }
 
 function renderMonths(months) {


### PR DESCRIPTION
## Summary

- The Other Keywords bars on the dashboard were normalized against `species[0].photo_count`, so when a non-species keyword (e.g. \"Bird\", \"Wildlife\") had more photos than the top species, the bars overflowed and most appeared to span the entire row.
- Switched the denominator to the top non-species count so the leading Other Keyword sits at 100% and the rest scale relative to it.
- Promoted Other Keywords to its own `section` with a `section-title` heading so it matches the Top Species styling (title case, same font/border) instead of the small uppercase label.

## Test plan

- [ ] Open the dashboard on a workspace where a non-species keyword (e.g. \"Bird\") has more photos than the top species — Other Keywords bars should scale relative to each other, not overflow.
- [ ] Confirm Other Keywords section header matches Top Species in size, weight, and border.
- [ ] Confirm the section is hidden when there are no non-species keywords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)