### PR TITLE
website: update download links for v0.8.37

### DIFF
--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -6,9 +6,9 @@ const base = import.meta.env.BASE_URL;
 const releaseUrl = (v: string) => `https://github.com/jss367/vireo/releases/download/v${v}`;
 
 // Per-platform versions — updated independently by CI when each platform builds
-const macosArm64Version = '0.8.36';
-const windowsVersion = '0.8.36';
-const linuxVersion = '0.8.36';
+const macosArm64Version = '0.8.37';
+const windowsVersion = '0.8.37';
+const linuxVersion = '0.8.37';
 ---
 
 <Base title="Download — Vireo" description="Download Vireo for macOS, Windows, or Linux. Free, open source, no account required.">


### PR DESCRIPTION
Automated update of download links following the v0.8.37 release. Auto-merges once required checks pass; deploy-website.yml runs on the resulting push to main.