### PR TITLE
pipeline: prompt + clearly-labeled cancels for extract_masks / eye_keypoints

### DIFF
--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -841,6 +841,7 @@ def _process_photo_for_eye(db, row, folders, *, C, T, k_window):
 def detect_eye_keypoints_stage(
     db, config, progress_callback=None,
     collection_id=None, exclude_photo_ids=None,
+    abort_check=None,
 ):
     """Pipeline stage: detect eye keypoints and persist raw tenengrad.
 
@@ -866,6 +867,10 @@ def detect_eye_keypoints_stage(
             photos the user unchecked don't get eye_* values locked in (the
             stage is idempotent via eye_tenengrad IS NULL, so leaking writes
             here would survive future reruns).
+        abort_check: optional zero-arg callable returning True when the
+            run should stop. Polled once per photo; without it a user
+            cancel during a long stage is swallowed until the loop exits
+            naturally.
     """
     skip_reason = eye_keypoint_stage_preflight(config)
     if skip_reason is not None:
@@ -896,6 +901,8 @@ def detect_eye_keypoints_stage(
     total = len(photos)
 
     for i, row in enumerate(photos):
+        if abort_check is not None and abort_check():
+            break
         if progress_callback:
             progress_callback("Eye keypoints", i, total)
         try:

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -900,11 +900,11 @@ def detect_eye_keypoints_stage(
     folders = {f["id"]: f["path"] for f in db.get_folder_tree()}
     total = len(photos)
 
+    aborted = False
     for i, row in enumerate(photos):
         if abort_check is not None and abort_check():
+            aborted = True
             break
-        if progress_callback:
-            progress_callback("Eye keypoints", i, total)
         try:
             _process_photo_for_eye(
                 db, row, folders, C=C, T=T, k_window=k_window,
@@ -914,6 +914,12 @@ def detect_eye_keypoints_stage(
                 "Eye keypoint detection failed for photo %s", row["id"],
                 exc_info=True,
             )
+        # Emit AFTER processing so `current` reflects actual processed count
+        # — pipeline_job's cancel summary reads this and would lie otherwise.
+        if progress_callback:
+            progress_callback("Eye keypoints", i + 1, total)
 
-    if progress_callback:
+    # Skip the synthetic 100% emit on abort: it would poison the wrapper's
+    # `processed["count"]` to `total` and surface "Cancelled (N of N processed)".
+    if progress_callback and not aborted:
         progress_callback("Eye keypoints", total, total)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2449,6 +2449,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     variant=dinov2_variant, progress_callback=_dl_progress,
                 )
 
+            processed = 0
             for i, entry in enumerate(photos_to_process):
                 if _should_abort(abort):
                     break
@@ -2463,16 +2464,24 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     proxy = render_proxy(image_path, longest_edge=proxy_longest_edge)
                     if proxy is None:
                         skipped += 1
+                        processed = i + 1
                         continue
+                    if _should_abort(abort):
+                        break
 
                     mask = generate_mask(proxy, det_box, variant=sam2_variant)
                     if mask is None:
                         skipped += 1
+                        processed = i + 1
                         continue
+                    if _should_abort(abort):
+                        break
 
                     mask_path = save_mask(mask, masks_dir, photo_id)
                     completeness = crop_completeness(mask)
                     features = compute_all_quality_features(proxy, mask)
+                    if _should_abort(abort):
+                        break
 
                     subject_crop = crop_subject(proxy, mask, margin=0.15)
                     subj_emb_blob = None
@@ -2498,35 +2507,57 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     em_failed += 1
                     log.warning("Mask extraction failed for photo %s", photo_id, exc_info=True)
 
-                stages["extract_masks"]["count"] = i + 1
+                processed = i + 1
+                stages["extract_masks"]["count"] = processed
                 stages["extract_masks"]["total"] = total
                 runner.update_step(job["id"], "extract_masks",
-                                   progress={"current": i + 1, "total": total},
+                                   progress={"current": processed, "total": total},
                                    error_count=em_failed)
                 runner.push_event(job["id"], "progress", _progress_event(
                     stages, "extract_masks",
                     "Extracting features (SAM2 + DINOv2)",
-                    rate=round((i + 1) / max(time.time() - start_time, 0.01) * 60, 1),
+                    rate=round(processed / max(time.time() - start_time, 0.01) * 60, 1),
                 ))
 
-            final_status = "failed" if em_failed > 0 else "completed"
-            stages["extract_masks"]["status"] = final_status
-            em_rollup = (
-                f"[extract_masks] {em_failed} of {total} photos failed mask extraction"
-                if em_failed > 0 else None
-            )
-            if em_rollup:
-                errors.append(em_rollup)
-            em_summary_parts = [f"{masked} masked", f"{skipped} skipped"]
-            if em_failed:
-                em_summary_parts.append(f"{em_failed} failed")
-            runner.update_step(job["id"], "extract_masks", status=final_status,
-                               summary=", ".join(em_summary_parts),
-                               error_count=em_failed,
-                               error=em_rollup)
-            result["stages"]["extract_masks"] = {
-                "masked": masked, "skipped": skipped, "failed": em_failed, "total": total,
-            }
+            if _should_abort(abort):
+                # Distinguish a user cancel from a clean completion: pin a
+                # "Cancelled" summary on the final step update so the job
+                # tree doesn't report a half-done stage as if it ran to
+                # term. Mirrors the classify-cancel path PR #710 added.
+                stages["extract_masks"]["status"] = "completed"
+                em_summary = (
+                    f"Cancelled ({processed} of {total} processed)"
+                    if total else "Cancelled"
+                )
+                runner.update_step(
+                    job["id"], "extract_masks", status="completed",
+                    progress={"current": processed, "total": total},
+                    summary=em_summary,
+                    error_count=em_failed,
+                )
+                result["stages"]["extract_masks"] = {
+                    "masked": masked, "skipped": skipped, "failed": em_failed,
+                    "total": total, "cancelled": True,
+                }
+            else:
+                final_status = "failed" if em_failed > 0 else "completed"
+                stages["extract_masks"]["status"] = final_status
+                em_rollup = (
+                    f"[extract_masks] {em_failed} of {total} photos failed mask extraction"
+                    if em_failed > 0 else None
+                )
+                if em_rollup:
+                    errors.append(em_rollup)
+                em_summary_parts = [f"{masked} masked", f"{skipped} skipped"]
+                if em_failed:
+                    em_summary_parts.append(f"{em_failed} failed")
+                runner.update_step(job["id"], "extract_masks", status=final_status,
+                                   summary=", ".join(em_summary_parts),
+                                   error_count=em_failed,
+                                   error=em_rollup)
+                result["stages"]["extract_masks"] = {
+                    "masked": masked, "skipped": skipped, "failed": em_failed, "total": total,
+                }
         except Exception as e:
             errors.append(f"[extract_masks] Fatal: {e}")
             log.exception("Pipeline extract-masks stage failed")
@@ -2621,19 +2652,38 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 thread_db, config=pipeline_cfg, progress_callback=_progress,
                 collection_id=collection_id,
                 exclude_photo_ids=params.exclude_photo_ids,
+                abort_check=lambda: _should_abort(abort),
             )
 
             stages["eye_keypoints"]["status"] = "completed"
-            summary = (
-                f"{processed['count']} of {total} photos processed"
-                if total else "No eligible photos"
-            )
-            runner.update_step(
-                job["id"], "eye_keypoints", status="completed", summary=summary,
-            )
-            result["stages"]["eye_keypoints"] = {
-                "processed": processed["count"], "total": total,
-            }
+            if _should_abort(abort):
+                # Match the classify- and extract_masks-cancel summaries so
+                # the job tree distinguishes a user cancel from a clean
+                # finish that happened to process the same count.
+                summary = (
+                    f"Cancelled ({processed['count']} of {total} processed)"
+                    if total else "Cancelled"
+                )
+                runner.update_step(
+                    job["id"], "eye_keypoints",
+                    status="completed", summary=summary,
+                )
+                result["stages"]["eye_keypoints"] = {
+                    "processed": processed["count"], "total": total,
+                    "cancelled": True,
+                }
+            else:
+                summary = (
+                    f"{processed['count']} of {total} photos processed"
+                    if total else "No eligible photos"
+                )
+                runner.update_step(
+                    job["id"], "eye_keypoints",
+                    status="completed", summary=summary,
+                )
+                result["stages"]["eye_keypoints"] = {
+                    "processed": processed["count"], "total": total,
+                }
         except Exception as e:
             errors.append(f"[eye_keypoints] Fatal: {e}")
             log.exception("Pipeline eye-keypoints stage failed")

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -121,6 +121,10 @@
   background: var(--danger); color: #fff; border: none;
 }
 .btn-cancel:hover { opacity: 0.85; }
+.btn-cancel.cancelling,
+.btn-cancel:disabled {
+  background: var(--text-muted); cursor: progress; opacity: 0.7;
+}
 .btn-retry {
   font-size: 11px; padding: 2px 8px; border-radius: 3px; cursor: pointer;
   background: var(--accent); color: var(--accent-text); border: none;
@@ -262,6 +266,11 @@
   var sseSource = null;
   var leafBuffers = {};
   var LEAF_MAX = 20;
+  // Job ids the user has clicked Cancel on but the server hasn't yet
+  // moved out of the active list. Tracked here so subsequent renders
+  // (every 2s poll) keep showing the optimistic "Cancelling…" state
+  // instead of reverting to a fresh "Cancel" button.
+  var cancellingJobIds = {};
   var collapsedSteps = {};
   var activeWsId = null;
   var workspaceNames = {};
@@ -324,7 +333,11 @@
     }
     html += '<span class="job-detail-status ' + job.status + '">' + job.status + '</span>';
     if (isLive) {
-      html += '<button class="btn-cancel" data-cancel-job="' + esc(job.id) + '">Cancel</button>';
+      if (cancellingJobIds[job.id]) {
+        html += '<button class="btn-cancel cancelling" disabled>Cancelling…</button>';
+      } else {
+        html += '<button class="btn-cancel" data-cancel-job="' + esc(job.id) + '">Cancel</button>';
+      }
     }
     html += '</div>';
 
@@ -500,6 +513,14 @@
         activeJobs = data.active || [];
         activeWsId = data.active_workspace_id || null;
         workspaceNames = data.workspace_names || {};
+        // Drop optimistic-cancel state for jobs that have left the active
+        // list (server has finalized them; their next render comes from
+        // historyJobs which never shows a cancel button).
+        var stillActive = {};
+        activeJobs.forEach(function(j) { stillActive[j.id] = true; });
+        Object.keys(cancellingJobIds).forEach(function(id) {
+          if (!stillActive[id]) delete cancellingJobIds[id];
+        });
         updateList();
         updateRunningBadge();
         if (currentView === 'active') renderActiveOverview();
@@ -695,7 +716,15 @@
     var cancelBtn = e.target.closest('[data-cancel-job]');
     if (cancelBtn) {
       var jobId = cancelBtn.getAttribute('data-cancel-job');
+      // Optimistic UI: flip the button to a disabled "Cancelling…" pill
+      // immediately so the click feels live. The server cancel just sets
+      // a flag; the running stage may take seconds to actually exit. Track
+      // jobId in cancellingJobIds so subsequent fetchJobs re-renders keep
+      // the state until the job moves out of active.
       cancelBtn.disabled = true;
+      cancelBtn.textContent = 'Cancelling…';
+      cancelBtn.classList.add('cancelling');
+      cancellingJobIds[jobId] = true;
       fetch('/api/jobs/' + encodeURIComponent(jobId) + '/cancel', { method: 'POST' })
         .then(function(r) {
           if (r.ok) {
@@ -705,13 +734,19 @@
             return r.json().then(function(data) {
               var msg = (data && data.error) || 'Unable to cancel job';
               if (typeof showToast === 'function') showToast(msg, 'error');
+              delete cancellingJobIds[jobId];
               cancelBtn.disabled = false;
+              cancelBtn.textContent = 'Cancel';
+              cancelBtn.classList.remove('cancelling');
             });
           }
         })
         .catch(function() {
           if (typeof showToast === 'function') showToast('Unable to cancel job', 'error');
+          delete cancellingJobIds[jobId];
           cancelBtn.disabled = false;
+          cancelBtn.textContent = 'Cancel';
+          cancelBtn.classList.remove('cancelling');
         });
     }
   });

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6345,3 +6345,114 @@ def test_detect_eye_keypoints_stage_honors_abort_check(tmp_path, monkeypatch):
         f"detect_eye_keypoints_stage must break on abort_check; "
         f"got {process_calls[0]} _process_photo_for_eye calls (expected 1)."
     )
+
+
+def test_detect_eye_keypoints_stage_skips_synthetic_100pct_on_abort(
+    tmp_path, monkeypatch,
+):
+    """When abort fires mid-loop, detect_eye_keypoints_stage must NOT emit
+    the unconditional final progress(total, total) callback. That synthetic
+    100% signal corrupts the wrapping eye_keypoints_stage's processed['count']
+    and surfaces "Cancelled (N of N processed)" — indistinguishable from a
+    clean run that processed N photos.
+    """
+    import pipeline as pipeline_mod
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    monkeypatch.setattr(
+        Database, "list_photos_for_eye_keypoint_stage",
+        lambda self, **k: [{"id": 1}, {"id": 2}, {"id": 3}],
+    )
+    monkeypatch.setattr(
+        Database, "get_folder_tree",
+        lambda self: [],
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "_process_photo_for_eye", lambda *a, **kw: None,
+    )
+
+    progress_events = []
+
+    def progress_callback(phase, current, total):
+        progress_events.append((current, total))
+
+    abort_after_first = [False]
+
+    def abort_check():
+        # First poll returns False (photo 1 runs), subsequent polls True.
+        result = abort_after_first[0]
+        abort_after_first[0] = True
+        return result
+
+    pipeline_mod.detect_eye_keypoints_stage(
+        db, config={},
+        progress_callback=progress_callback,
+        abort_check=abort_check,
+    )
+
+    # Stage processed exactly one photo before aborting; the wrapper must see
+    # current < total on the final emit, not current == total.
+    assert progress_events, "Expected at least one progress event"
+    last_current, last_total = progress_events[-1]
+    assert last_total == 3, f"Unexpected total in last emit: {progress_events!r}"
+    assert last_current < last_total, (
+        f"detect_eye_keypoints_stage must not emit progress({last_current}, "
+        f"{last_total}) after abort — that 100% signal would mask the cancel "
+        f"in the wrapper. Events: {progress_events!r}"
+    )
+    # And the count should reflect the actual photo processed (1), not 0.
+    assert last_current == 1, (
+        f"Expected 1 photo to be reported processed before abort; "
+        f"got events={progress_events!r}"
+    )
+
+
+def test_detect_eye_keypoints_stage_emits_final_100pct_on_clean_run(
+    tmp_path, monkeypatch,
+):
+    """On a clean (non-aborted) run, detect_eye_keypoints_stage must finish
+    by reporting current == total so the wrapping stage's processed['count']
+    matches reality.
+    """
+    import pipeline as pipeline_mod
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    monkeypatch.setattr(
+        Database, "list_photos_for_eye_keypoint_stage",
+        lambda self, **k: [{"id": 1}, {"id": 2}],
+    )
+    monkeypatch.setattr(
+        Database, "get_folder_tree",
+        lambda self: [],
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "_process_photo_for_eye", lambda *a, **kw: None,
+    )
+
+    progress_events = []
+
+    def progress_callback(phase, current, total):
+        progress_events.append((current, total))
+
+    pipeline_mod.detect_eye_keypoints_stage(
+        db, config={},
+        progress_callback=progress_callback,
+    )
+
+    assert progress_events, "Expected at least one progress event"
+    last_current, last_total = progress_events[-1]
+    assert (last_current, last_total) == (2, 2), (
+        f"Expected final emit (2, 2) on clean run; got {progress_events!r}"
+    )

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -5996,3 +5996,352 @@ def test_update_stages_emits_weighted_current_total():
     assert data["total"] == sum(STAGE_WEIGHTS.values())
     # ingest (2) + scan half (4) = 6
     assert data["current"] == 6
+
+
+# ---------------------------------------------------------------------------
+# Cancel responsiveness in extract_masks / eye_keypoints
+#
+# PR #710 fixed mid-batch cancel for the classify stage. The same hang shape
+# (cancel takes minutes, stage finalizes as plain "completed") still affected
+# extract_masks and eye_keypoints. These tests pin the corrected behavior:
+#   - The per-photo loop in extract_masks breaks promptly on abort.
+#   - extract_masks finalizes with a "Cancelled (X of N processed)" summary.
+#   - eye_keypoints finalizes with a "Cancelled" summary, not the
+#     misleading default "X of N photos processed".
+#   - detect_eye_keypoints_stage in pipeline.py honors an abort_check
+#     callable so a stuck mid-stage cancel can take effect within one
+#     keypoint inference, not at end of stage.
+# ---------------------------------------------------------------------------
+
+
+def _stub_extract_masks_heavy_ops(monkeypatch):
+    """Stub the SAM2 + DINOv2 helpers extract_masks_stage imports so the loop
+    body runs in microseconds. Returns a dict with the proxy-call counter so
+    the test can assert how many photos the loop touched.
+    """
+    import dino_embed
+    import masking
+    import numpy as np
+    import quality
+    from db import Database
+
+    state = {"proxy_calls": 0}
+
+    def fake_render_proxy(image_path, longest_edge=None):
+        state["proxy_calls"] += 1
+        return np.zeros((16, 16, 3), dtype=np.uint8)
+
+    monkeypatch.setattr(masking, "render_proxy", fake_render_proxy)
+    monkeypatch.setattr(
+        masking, "generate_mask",
+        lambda *a, **k: np.ones((16, 16), dtype=np.uint8),
+    )
+    monkeypatch.setattr(
+        masking, "save_mask",
+        lambda mask, dir_, pid_: os.path.join(dir_, f"{pid_}.png"),
+    )
+    monkeypatch.setattr(masking, "crop_completeness", lambda m: 1.0)
+    monkeypatch.setattr(masking, "crop_subject", lambda p, m, margin=0.15: None)
+    monkeypatch.setattr(masking, "ensure_sam2_weights", lambda **k: None)
+    monkeypatch.setattr(quality, "compute_all_quality_features", lambda p, m: {})
+    monkeypatch.setattr(
+        dino_embed, "embed_global",
+        lambda p, variant=None: np.zeros(384, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        dino_embed, "embed_subject",
+        lambda c, variant=None: np.zeros(384, dtype=np.float32),
+    )
+    monkeypatch.setattr(dino_embed, "embedding_to_blob", lambda e: b"")
+    monkeypatch.setattr(dino_embed, "ensure_dinov2_weights", lambda **k: None)
+    monkeypatch.setattr(
+        Database, "update_photo_pipeline_features",
+        lambda self, *a, **k: None,
+    )
+    monkeypatch.setattr(
+        Database, "update_photo_embeddings",
+        lambda self, *a, **k: None,
+    )
+    return state
+
+
+def test_pipeline_extract_masks_cancel_marks_stage_cancelled(
+    tmp_path, monkeypatch,
+):
+    """An abort triggered during extract_masks must finalize the stage with
+    a 'Cancelled (X of N processed)' summary, not as plain 'completed' (or
+    'failed') as if the full set was processed.
+
+    Pre-fix shape: stages["extract_masks"]["status"] was unconditionally set
+    to "completed" or "failed" based only on em_failed, regardless of
+    abort. The user saw a green "completed" summary on a stage that had
+    only processed 173 of 11,285 photos.
+    """
+    import config as cfg
+    import pipeline_job as pj
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+
+    photo_ids = []
+    for i in range(3):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(
+            folder_id, name, ".jpg", 1000 + i, 1_000_000.0 + i,
+        )
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    state = _stub_extract_masks_heavy_ops(monkeypatch)
+
+    # Trigger abort once the first photo's render_proxy fires. The next
+    # iteration's top-of-loop abort check (and the new intra-photo checks)
+    # must catch it before any further photo-level work runs.
+    abort_after_first = threading.Event()
+    real_render = state.get("real_render")  # placeholder; we override below
+
+    import masking
+    import numpy as np
+
+    def render_then_abort(image_path, longest_edge=None):
+        state["proxy_calls"] += 1
+        if state["proxy_calls"] == 1:
+            abort_after_first.set()
+        return np.zeros((16, 16, 3), dtype=np.uint8)
+
+    state["proxy_calls"] = 0  # reset for the override
+    monkeypatch.setattr(masking, "render_proxy", render_then_abort)
+
+    original_should_abort = pj._should_abort
+
+    def patched_should_abort(event):
+        if abort_after_first.is_set():
+            return True
+        return original_should_abort(event)
+
+    monkeypatch.setattr(pj, "_should_abort", patched_should_abort)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # Without the intra-photo / top-of-loop abort honoring, all 3 photos
+    # would render their proxies. With the fix, the loop bails after photo 1
+    # (and at most one more iteration if abort lands between sub-steps).
+    assert 1 <= state["proxy_calls"] <= 2, (
+        f"Expected extract_masks to stop within ~1 photo of abort; got "
+        f"{state['proxy_calls']} render_proxy calls."
+    )
+
+    # The final extract_masks step update must carry a 'Cancelled' summary,
+    # not the default 'X masked, Y skipped'.
+    em_finals = [
+        kw for (_, sid, kw) in runner.step_updates
+        if sid == "extract_masks" and kw.get("status") in (
+            "completed", "failed",
+        ) and "summary" in kw
+    ]
+    assert em_finals, (
+        f"Expected at least one final extract_masks update; got "
+        f"step_updates={runner.step_updates!r}"
+    )
+    final_kw = em_finals[-1]
+    final_summary = final_kw.get("summary") or ""
+    assert "Cancelled" in final_summary, (
+        f"extract_masks final summary must reflect cancellation; got "
+        f"{final_summary!r}"
+    )
+    # The status must NOT be 'failed' on a clean cancel — failure status
+    # would inflate the job rollup's error count.
+    assert final_kw.get("status") == "completed", (
+        f"Cancelled extract_masks should finalize as 'completed'; got "
+        f"status={final_kw.get('status')!r}"
+    )
+
+
+def test_pipeline_eye_keypoints_cancel_marks_stage_cancelled(
+    tmp_path, monkeypatch,
+):
+    """An abort during eye_keypoints must finalize the stage with a
+    'Cancelled' summary, not the default 'X of N photos processed' which
+    looks indistinguishable from a clean run that happened to process X.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    import pipeline_job as pj
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    # Stub extract_masks heavies so it sails through (eye_keypoints is
+    # gated on extract_masks running). We do NOT trigger abort during
+    # extract_masks — only during eye_keypoints.
+    _stub_extract_masks_heavy_ops(monkeypatch)
+
+    # Make eye_keypoints reachable: preflight returns None.
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    # The wrapping stage uses list_photos_for_eye_keypoint_stage to compute
+    # `total`. Force a simple list of one photo.
+    monkeypatch.setattr(
+        Database, "list_photos_for_eye_keypoint_stage",
+        lambda self, **k: [{"id": pid}],
+    )
+
+    abort_now = [False]
+
+    def fake_detect_eye_keypoints_stage(
+        db_, config, progress_callback=None,
+        collection_id=None, exclude_photo_ids=None,
+        abort_check=None,
+    ):
+        # Mid-stage: emit a progress event then trigger abort. The wrapping
+        # stage must notice and finalize with a "Cancelled" summary.
+        if progress_callback:
+            progress_callback("Eye keypoints", 0, 1)
+        abort_now[0] = True
+
+    monkeypatch.setattr(
+        pipeline_mod, "detect_eye_keypoints_stage",
+        fake_detect_eye_keypoints_stage,
+    )
+
+    original_should_abort = pj._should_abort
+
+    def patched_should_abort(event):
+        if abort_now[0]:
+            return True
+        return original_should_abort(event)
+
+    monkeypatch.setattr(pj, "_should_abort", patched_should_abort)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    ek_finals = [
+        kw for (_, sid, kw) in runner.step_updates
+        if sid == "eye_keypoints" and kw.get("status") in (
+            "completed", "failed",
+        ) and "summary" in kw
+    ]
+    assert ek_finals, (
+        f"Expected eye_keypoints final update; got "
+        f"step_updates={runner.step_updates!r}"
+    )
+    summary = ek_finals[-1].get("summary") or ""
+    assert "Cancelled" in summary, (
+        f"eye_keypoints final summary must reflect cancellation; got "
+        f"{summary!r}"
+    )
+
+
+def test_detect_eye_keypoints_stage_honors_abort_check(tmp_path, monkeypatch):
+    """detect_eye_keypoints_stage must accept an `abort_check` callable and
+    break the per-photo loop the first time it returns True. Without this
+    hook, a long eye_keypoints run swallows the user's cancel for many
+    inferences.
+    """
+    import pipeline as pipeline_mod
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+
+    # Drive the loop with a controlled photos list. Bypass eligibility and
+    # the route check by stubbing helpers; we only care that the abort_check
+    # parameter is honored before per-photo work fires.
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    monkeypatch.setattr(
+        Database, "list_photos_for_eye_keypoint_stage",
+        lambda self, **k: [
+            {"id": 1}, {"id": 2}, {"id": 3},
+        ],
+    )
+    monkeypatch.setattr(
+        Database, "get_folder_tree",
+        lambda self: [],
+    )
+
+    process_calls = [0]
+
+    def spy_process(*args, **kwargs):
+        process_calls[0] += 1
+
+    monkeypatch.setattr(pipeline_mod, "_process_photo_for_eye", spy_process)
+
+    abort_after_first = [False]
+
+    def abort_check():
+        # Returns False on first poll, True on every subsequent poll. The
+        # loop polls once per photo at the top of each iteration. So the
+        # first photo runs, the second iteration's check breaks.
+        result = abort_after_first[0]
+        abort_after_first[0] = True
+        return result
+
+    pipeline_mod.detect_eye_keypoints_stage(
+        db, config={}, abort_check=abort_check,
+    )
+
+    assert process_calls[0] == 1, (
+        f"detect_eye_keypoints_stage must break on abort_check; "
+        f"got {process_calls[0]} _process_photo_for_eye calls (expected 1)."
+    )


### PR DESCRIPTION
## Summary

Cancel during `extract_masks` or `eye_keypoints` was both **slow to react** and **mislabeled** in the job tree. PR #710 fixed this for `classify`; this PR finishes the job for the other two heavy stages and adds optimistic UI.

Concretely, today's run showed:

- User clicked Cancel during `extract_masks` (stage was at photo 173 of 11,285)
- POST returned 200 immediately
- Job didn't actually stop for **3 min 15 s**
- Final stage status was reported as `completed` (count 173/11,285) — looks identical to a clean run that processed 173 photos

## Changes

### Backend — `vireo/pipeline_job.py` (`extract_masks_stage`)
- **Intra-photo abort checks.** The loop already had `if _should_abort(abort): break` at the top of each iteration, but a single photo runs SAM2 + DINOv2 + quality features (~15 s typical, much longer if SAM2 hangs on a tough RAW). Added abort checks between sub-steps (after `render_proxy`, after `generate_mask`, after `compute_all_quality_features`) so a stuck inference no longer swallows cancel for many seconds. Each check is `event.is_set()`, ns-scale.
- **Cancel-aware finalization.** When the loop exits with abort set, finalize the stage with `summary="Cancelled (X of N processed)"` and `result["stages"]["extract_masks"]["cancelled"] = True` instead of the default `"X masked, Y skipped"`. Mirrors the per-model classify-cancel summary added in PR #710.

### Backend — `vireo/pipeline.py` + `pipeline_job.py` (`eye_keypoints`)
- Added `abort_check=None` parameter to `detect_eye_keypoints_stage` (optional, default preserves existing behavior). The per-photo loop polls it before each keypoint inference and breaks on True.
- The wrapping `eye_keypoints_stage` in `pipeline_job.py` passes `abort_check=lambda: _should_abort(abort)` and, when abort is set after the call returns, finalizes with `summary="Cancelled (X of N processed)"` instead of the default `"X of N photos processed"`.

### UI — `vireo/templates/jobs.html`
- Optimistic "Cancelling…" pill on the cancel button. The moment the user clicks, the button text changes to **Cancelling…**, gets disabled, and gains a `.cancelling` class (greyed background, `cursor: progress`).
- A `cancellingJobIds` map persists the optimistic state across the 2 s `fetchJobs` poll. The button stays "Cancelling…" until the job actually leaves the active list (typically when the stage notices the abort and exits).
- On error response or fetch failure, the optimistic state is rolled back so the user can retry.

## Why this matters

Before: click Cancel → silence for up to 3 min → "completed" status that looks like a clean run.
After: click Cancel → button shows "Cancelling…" instantly → stage exits within ~one inference (seconds, not minutes) → step finalizes as `Cancelled (X of N processed)` with `cancelled=True` on the result payload.

## Test plan

- [x] New tests in `vireo/tests/test_pipeline_job.py`:
  - `test_pipeline_extract_masks_cancel_marks_stage_cancelled` — verifies the per-photo loop bails within ~1 photo of abort and the step is finalized with a `Cancelled` summary, status `completed` (not `failed`).
  - `test_pipeline_eye_keypoints_cancel_marks_stage_cancelled` — verifies the wrapping stage emits a `Cancelled` summary when abort fires during/after `detect_eye_keypoints_stage`.
  - `test_detect_eye_keypoints_stage_honors_abort_check` — unit test on `pipeline.detect_eye_keypoints_stage` that the new `abort_check` callable breaks the loop the first time it returns True.
- [x] `python -m pytest vireo/tests/test_pipeline_job.py` → **105 passed** (155 s)
- [x] `python -m pytest vireo/tests/test_pipeline.py -k eye_keypoint` → **7 passed**
- [x] CLAUDE.md test set: **819 passed, 1 skipped, 3 pre-existing flakes** unrelated to this PR (`test_remove_keyword_from_photo`, `test_undo_keyword_remove_clears_pending_change`, `test_post_keyword_link_place_returns_400_on_wrong_keyword_type` — last one passes in isolation; first two are documented in pre-existing-failures memory).
- [x] JS syntax validated via `node --check` on the inline `<script>` body.
- [ ] Manual UI verification deferred to post-merge (blocked locally by app port-lock — Vireo.app already running on 61546).

🤖 Generated with [Claude Code](https://claude.com/claude-code)