### PR TITLE
duplicates: clean up post-trash UX (rename + filter stale state)

### DIFF
--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -487,7 +487,7 @@
     if (resolvedGroupCount > 0) {
       summaryHtml +=
         '<div class="summary-stat"><div class="num">' + resolvedGroupCount + '</div>' +
-          '<div class="label">Already resolved</div></div>' +
+          '<div class="label">Cleanup pending</div></div>' +
         '<div class="summary-stat"><div class="num">' + formatBytes(resolvedBytes) + '</div>' +
           '<div class="label">Extra files on disk</div></div>';
     }
@@ -540,12 +540,12 @@
       html += '<div class="section-header">' +
         '<div>' +
           '<h2 class="' + toggleClass + '" id="resolvedToggle" onclick="toggleResolvedSection()">' +
-            '<span class="chev">&#9656;</span> Already resolved' +
+            '<span class="chev">&#9656;</span> Resolved — cleanup pending' +
           '</h2>' +
-          '<div class="section-sub">' + resolvedGroupCount +
-          ' group' + (resolvedGroupCount === 1 ? '' : 's') +
-          ' auto-handled during scan. Extra copies (' + formatBytes(resolvedBytes) +
-          ') may still be on disk.</div>' +
+          '<div class="section-sub">Vireo already picked which copy to keep for ' +
+          resolvedGroupCount + ' group' + (resolvedGroupCount === 1 ? '' : 's') +
+          ', but the extra copies (' + formatBytes(resolvedBytes) +
+          ') are still on disk. Move them to Trash to finish cleanup.</div>' +
         '</div>';
       // Hide the bulk button entirely when every remaining resolved group is
       // protected — otherwise it sticks around as a no-op that always toasts


### PR DESCRIPTION
## Summary

Two related fixes for confusion on the duplicates page after a bulk \"Move to Trash\" run.

### 1. Rename \"Already resolved\" → \"Resolved — cleanup pending\"

The label said the work was done, but the page also offered a button to delete N more files — because resolution is two-step (DB-side winner pick + disk-side cleanup), and \"already resolved\" only described the first step. New wording makes the pending action explicit.

- Section header: `Already resolved` → `Resolved — cleanup pending`
- Summary stat label: `Already resolved` → `Cleanup pending`
- Subtitle: rewritten to *\"Vireo already picked which copy to keep for N groups, but the extra copies (X MB) are still on disk. Move them to Trash to finish cleanup.\"*

### 2. Filter cleaned-up losers from the cached last-scan result

Reloading `/duplicates` after a successful bulk-trash was re-rendering the pre-trash snapshot — same groups, same \"still on disk\" stats — even though the loser photo rows had already been deleted from the DB. Root cause: `/api/duplicates/last-scan` returns the cached JSON blob from `job_history`, and the bulk-trash endpoint never rewrites it.

Filter on read instead: drop resolved-group losers whose photo rows no longer exist, drop resolved groups that lose all their losers, and recompute the aggregate counts (`group_count`, `loser_count`, `resolved_group_count`, `resolved_loser_count`) so the page reflects current state without forcing a rescan.

## Test plan

- [x] `pytest vireo/tests/test_duplicates_api.py` — 33 passed (incl. 2 new tests covering the filter behavior)
- [x] Full project test set — 820 passed; the 2 failures (`test_remove_keyword_from_photo`, `test_undo_keyword_remove_clears_pending_change`) are pre-existing on `main` and unrelated to this PR
- [ ] Manual: open `/duplicates` after a recent scan with auto-resolved groups, click \"Move to Trash\", reload — confirm the section is now empty and the stats reflect 0 / 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)