### PR TITLE
preview-cache: reconcile drift, raise default to 20 GB, warn when too low

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -35,7 +35,12 @@ from flask import (
 )
 from highlights import select_highlights
 from jobs import JobRunner, LogBroadcaster
-from preview_cache import evict_if_over_quota as evict_preview_cache_if_over_quota
+from preview_cache import (
+    evict_if_over_quota as evict_preview_cache_if_over_quota,
+)
+from preview_cache import (
+    reconcile_preview_cache,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
@@ -415,14 +420,20 @@ def _migrate_legacy_preview_cache(app):
 
 
 def _enforce_preview_cache_quota_at_startup(app):
-    """Run one eviction pass at startup so migration / prior runs can't
-    leave the app over quota indefinitely.
+    """Reconcile and evict at startup so prior runs / external deletes
+    can't leave the table out of sync or over quota.
+
+    Reconcile first: if a previous session left ghost rows (files
+    deleted while cache was under quota), eviction would see inflated
+    totals and stay asleep when it shouldn't, or wake up and run a
+    no-op pass over rows whose files don't exist.
     """
     from preview_cache import evict_if_over_quota
 
     vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
     db = Database(app.config["DB_PATH"])
     try:
+        reconcile_preview_cache(db, vireo_dir)
         evict_if_over_quota(db, vireo_dir)
     finally:
         try:
@@ -4698,6 +4709,31 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         log.info("Deleted %d files from %s cache", deleted, cache_type)
         return jsonify({"ok": True, "deleted": deleted})
 
+    def _recommended_preview_cache_mb(db):
+        """Recommend a quota that fits one preview per photo across the
+        whole library.
+
+        Uses the measured average bytes-per-preview from the existing
+        ``preview_cache`` rows when available, otherwise falls back to
+        500 KB (a typical 1920px JPEG at quality 90). Photos are global
+        across workspaces so this is a library-wide count, not
+        workspace-scoped.
+
+        Returns 0 when the photos table is empty (avoids a "recommended
+        0 MB" surprise on a fresh install).
+        """
+        photo_count = db.conn.execute(
+            "SELECT COUNT(*) FROM photos"
+        ).fetchone()[0]
+        if not photo_count:
+            return 0
+        avg_row = db.conn.execute(
+            "SELECT AVG(bytes) AS a FROM preview_cache WHERE bytes > 0"
+        ).fetchone()
+        avg_bytes = (avg_row["a"] if avg_row and avg_row["a"] else 500 * 1024)
+        recommended_bytes = photo_count * avg_bytes
+        return max(1, int(recommended_bytes / 1024 / 1024) + 1)
+
     @app.route("/api/preview-cache")
     def api_preview_cache():
         """Return counts and totals from the preview_cache table, plus quota."""
@@ -4707,11 +4743,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "SELECT COUNT(*) AS c FROM preview_cache"
         ).fetchone()
         total = db.preview_cache_total_bytes()
-        quota_mb = cfg.load().get("preview_cache_max_mb", 2048)
+        quota_mb = cfg.load().get("preview_cache_max_mb", 20480)
         return jsonify({
             "count": count_row["c"],
             "total_size": total,
             "quota_bytes": int(quota_mb) * 1024 * 1024,
+            "recommended_mb": _recommended_preview_cache_mb(db),
         })
 
     @app.route("/api/preview-cache/clear", methods=["POST"])

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -46,7 +46,7 @@ DEFAULTS = {
     "working_copy_max_size": 4096,
     "working_copy_quality": 92,
     "preview_quality": 90,
-    "preview_cache_max_mb": 2048,
+    "preview_cache_max_mb": 20480,
     "browse_thumb_default": 220,
     # --- Detection ---
     "detector_confidence": 0.2,

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -29,7 +29,7 @@ def evict_if_over_quota(db, vireo_dir):
     """
     import config as cfg
 
-    quota_mb = cfg.load().get("preview_cache_max_mb", 2048)
+    quota_mb = cfg.load().get("preview_cache_max_mb", 20480)
     max_bytes = int(quota_mb) * 1024 * 1024
     total = db.preview_cache_total_bytes()
     if total <= max_bytes:
@@ -37,6 +37,7 @@ def evict_if_over_quota(db, vireo_dir):
 
     preview_dir = os.path.join(vireo_dir, "previews")
     to_delete = []
+    freed_bytes = 0
     for row in db.preview_cache_oldest_first():
         if total <= max_bytes:
             break
@@ -54,6 +55,7 @@ def evict_if_over_quota(db, vireo_dir):
         if removed:
             to_delete.append((row["photo_id"], row["size"]))
             total -= row["bytes"]
+            freed_bytes += row["bytes"]
 
     if to_delete:
         db.conn.executemany(
@@ -61,3 +63,45 @@ def evict_if_over_quota(db, vireo_dir):
             to_delete,
         )
         db.conn.commit()
+        log.info(
+            "Preview cache eviction: removed %d entries, freed %.1f MB",
+            len(to_delete), freed_bytes / 1024 / 1024,
+        )
+
+
+def reconcile_preview_cache(db, vireo_dir):
+    """Drop preview_cache rows whose on-disk file is missing.
+
+    Counterpart to ``evict_if_over_quota``'s self-heal: that path only
+    cleans up ghost rows when the cache is *over* quota. If the cache
+    accounting drifts while *under* quota — e.g. files deleted by an
+    external process, or a previous eviction pass that removed files
+    after the row's ``last_access_at`` was recently touched — the
+    table keeps reporting ``total_bytes`` for files that no longer
+    exist, and eviction stays asleep. That's invisible to the user
+    until the next pipeline run regenerates everything from RAW
+    because none of the cache files actually exist.
+
+    Run at startup so a stale table can't poison the rest of the
+    session. Returns the number of rows dropped.
+    """
+    preview_dir = os.path.join(vireo_dir, "previews")
+    to_delete = []
+    for row in db.preview_cache_oldest_first():
+        path = os.path.join(
+            preview_dir, f"{row['photo_id']}_{row['size']}.jpg"
+        )
+        if not os.path.exists(path):
+            to_delete.append((row["photo_id"], row["size"]))
+
+    if to_delete:
+        db.conn.executemany(
+            "DELETE FROM preview_cache WHERE photo_id=? AND size=?",
+            to_delete,
+        )
+        db.conn.commit()
+        log.info(
+            "Preview cache reconcile: dropped %d ghost rows (files missing on disk)",
+            len(to_delete),
+        )
+    return len(to_delete)

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -296,7 +296,7 @@
         <small>Maximum disk space for cached previews (MB). Oldest entries are evicted first. Set to 0 to disable caching.</small>
       </div>
       <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;width:100%;">
-        <input type="number" id="cfgPreviewCacheMaxMb" min="0" step="128" value="2048"
+        <input type="number" id="cfgPreviewCacheMaxMb" min="0" step="128" value="20480"
                style="width:90px;background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:4px 8px;font-size:13px;text-align:center;"
                onchange="saveConfig()">
         <span style="font-size:13px;color:var(--text-dim);">MB</span>
@@ -304,6 +304,7 @@
         <button id="clearPreviewCacheBtn" onclick="clearPreviewCache()"
                 style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:4px;padding:6px 14px;font-size:12px;cursor:pointer;">Clear cache</button>
       </div>
+      <div id="previewCacheWarning" style="display:none;width:100%;font-size:12px;color:var(--accent);background:var(--bg-tertiary);border-left:3px solid var(--accent);padding:8px 12px;border-radius:4px;"></div>
     </div>
     <div class="setting-row">
       <div class="setting-label">
@@ -1215,7 +1216,7 @@ async function loadConfig() {
     var pq = cfg.preview_quality != null ? cfg.preview_quality : 90;
     document.getElementById('cfgPreviewQuality').value = pq;
     document.getElementById('cfgPreviewQualityVal').textContent = pq;
-    document.getElementById('cfgPreviewCacheMaxMb').value = cfg.preview_cache_max_mb != null ? cfg.preview_cache_max_mb : 2048;
+    document.getElementById('cfgPreviewCacheMaxMb').value = cfg.preview_cache_max_mb != null ? cfg.preview_cache_max_mb : 20480;
     var bt = cfg.browse_thumb_default != null ? cfg.browse_thumb_default : 220;
     document.getElementById('cfgBrowseThumbDefault').value = bt;
     document.getElementById('cfgBrowseThumbVal').textContent = bt + 'px';
@@ -2321,15 +2322,27 @@ async function precomputeEmbeddings(modelId, labelsFile) {
 /* ---------- Preview Cache ---------- */
 async function loadPreviewCacheStatus() {
   var statusEl = document.getElementById('previewCacheStatus');
+  var warnEl = document.getElementById('previewCacheWarning');
   if (!statusEl) return;
   try {
     var d = await safeFetch('/api/preview-cache', {}, { toast: false });
     var usedMb = (d.total_size / 1024 / 1024).toFixed(1);
-    var quotaMb = (d.quota_bytes / 1024 / 1024).toFixed(0);
+    var quotaMb = Math.round(d.quota_bytes / 1024 / 1024);
     var fileWord = d.count === 1 ? 'file' : 'files';
     statusEl.textContent = 'Current: ' + usedMb + ' / ' + quotaMb + ' MB (' + d.count + ' ' + fileWord + ')';
+    if (warnEl) {
+      var rec = d.recommended_mb || 0;
+      // Quota=0 means "disabled" — that's a deliberate user choice, not a warning case.
+      if (rec > 0 && quotaMb > 0 && quotaMb < rec) {
+        warnEl.textContent = 'Cache is smaller than your library — previews will regenerate from RAW on every pipeline run. Recommended: ' + rec.toLocaleString() + ' MB.';
+        warnEl.style.display = 'block';
+      } else {
+        warnEl.style.display = 'none';
+      }
+    }
   } catch(e) {
     statusEl.textContent = 'Failed to load';
+    if (warnEl) warnEl.style.display = 'none';
   }
 }
 

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -107,9 +107,14 @@ def test_working_copy_defaults(tmp_path, monkeypatch):
 
 
 def test_preview_cache_max_mb_default():
-    """Default config includes preview_cache_max_mb = 2048."""
+    """Default config includes preview_cache_max_mb = 20480 (20 GB).
+
+    A 2 GB cap (the prior default) only fits ~5,000 previews at 1920px,
+    so a single 22k-photo workspace would re-decode every preview from
+    RAW on every pipeline run. 20 GB comfortably covers a typical
+    library."""
     import config as cfg
-    assert cfg.DEFAULTS["preview_cache_max_mb"] == 2048
+    assert cfg.DEFAULTS["preview_cache_max_mb"] == 20480
 
 
 def test_load_returns_defaults_when_no_file(tmp_path):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1093,6 +1093,130 @@ def test_eviction_removes_oldest_files_when_over_quota(tmp_path, monkeypatch):
     assert not (preview_dir / f"{pid2}_1920.jpg").exists()
 
 
+def test_reconcile_drops_ghost_rows_when_files_missing(tmp_path):
+    """Rows whose on-disk files no longer exist must be removed so
+    accounting doesn't keep eviction asleep on phantom bytes."""
+    from db import Database
+    from preview_cache import reconcile_preview_cache
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    (vireo_dir / "previews").mkdir()
+    db = Database(str(vireo_dir / "vireo.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder(str(tmp_path / "src"), name="src")
+    pid = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                       file_size=1, file_mtime=1.0)
+
+    # Row exists in table but no file on disk — exactly the drift state
+    # observed in production (DB says ~2 GB tracked, disk has 0 bytes).
+    db.preview_cache_insert(pid, 1920, 450_000)
+    assert db.preview_cache_total_bytes() == 450_000
+
+    dropped = reconcile_preview_cache(db, str(vireo_dir))
+    assert dropped == 1
+    assert db.preview_cache_total_bytes() == 0
+    assert db.preview_cache_get(pid, 1920) is None
+
+
+def test_reconcile_keeps_live_rows(tmp_path):
+    """Rows whose on-disk file exists must survive reconcile."""
+    from db import Database
+    from PIL import Image
+    from preview_cache import reconcile_preview_cache
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    preview_dir = vireo_dir / "previews"
+    preview_dir.mkdir()
+    db = Database(str(vireo_dir / "vireo.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder(str(tmp_path / "src"), name="src")
+    pid = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                       file_size=1, file_mtime=1.0)
+
+    preview_file = preview_dir / f"{pid}_1920.jpg"
+    Image.new("RGB", (1920, 1280), (10, 20, 30)).save(str(preview_file), "JPEG")
+    db.preview_cache_insert(pid, 1920, preview_file.stat().st_size)
+
+    dropped = reconcile_preview_cache(db, str(vireo_dir))
+    assert dropped == 0
+    assert db.preview_cache_get(pid, 1920) is not None
+
+
+def test_startup_reconciles_before_eviction(tmp_path, monkeypatch):
+    """create_app must drop ghost rows so eviction sees real totals.
+
+    Regression for the production drift: 2 GB of phantom rows kept
+    eviction asleep while the previews dir was empty, and every
+    pipeline run paid the full RAW-decode cost for previews."""
+    import config as cfg
+    import models
+    from app import create_app
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vm"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    (vireo_dir / "previews").mkdir()
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir()
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder(str(tmp_path / "src"), name="src")
+    pid = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                       file_size=1, file_mtime=1.0)
+
+    # Seed a ghost row: bytes claimed but no file behind it.
+    db.preview_cache_insert(pid, 1920, 450_000)
+    db.close()
+
+    create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir),
+               api_token="test-token-123")
+
+    db2 = Database(db_path)
+    assert db2.preview_cache_total_bytes() == 0, (
+        "Startup must reconcile ghost rows so eviction operates on "
+        "real bytes, not phantom accounting."
+    )
+    db2.close()
+
+
+def test_preview_cache_endpoint_returns_recommended_mb(client_with_photo):
+    """/api/preview-cache exposes a recommendation so the UI can warn
+    when the configured cap is smaller than the photo library."""
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    # No measured rows yet → uses the 500 KB-per-preview fallback.
+    resp = client.get("/api/preview-cache")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "recommended_mb" in data
+    assert data["recommended_mb"] >= 1
+
+
+def test_recommendation_uses_measured_avg_when_rows_exist(client_with_photo):
+    """Recommendation scales with the actually-observed preview size."""
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    # Generate a real preview to populate the table with a measured size.
+    client.get(f"/photos/{photo_id}/preview?size=1920")
+    resp = client.get("/api/preview-cache")
+    data = resp.get_json()
+    # 1 photo × measured avg should round to a small positive MB value.
+    # The exact value depends on JPEG output; just assert sane bounds.
+    assert 1 <= data["recommended_mb"] <= 10
+
+
 def test_preview_cache_endpoint_uses_db(client_with_photo):
     """/api/preview-cache returns totals from preview_cache table, not filesystem."""
     app, db, photo_id = client_with_photo


### PR DESCRIPTION
## Why

Investigating slow pipeline runs uncovered preview-cache drift on this checkout: `preview_cache` table reported ~2 GB across 4,973 rows while `~/.vireo/previews/` was empty (0 files). Because the table thinks the cache is full, eviction's self-heal stays asleep — and every pipeline run regenerates previews from RAW (46 min for 22,726 photos in this workspace), so does every `/photos/<id>/preview` hit.

Two structural problems made this drift expected, not exotic:

1. The 2 GB default cap fits only ~5,000 1920px JPEG previews. A single full-workspace pipeline run generates 22k+ previews, and eviction trims back to 2 GB — meaning ~80% of generated previews get evicted immediately. With multiple workspaces, one workspace's previews evict another's. Cache thrashes.
2. `evict_if_over_quota` only reconciles ghost rows when the cache is *over* quota. If something else removes the files (quota change, manual cleanup, partial eviction whose accounting drifted), the table keeps reporting bytes for files that don't exist.

## What changes

- **`reconcile_preview_cache(db, vireo_dir)`** in `vireo/preview_cache.py` — walks all rows, drops ones whose file is missing. Logs summary.
- **Startup wiring** — `_enforce_preview_cache_quota_at_startup` in `vireo/app.py` runs reconcile *before* eviction, so eviction sees real totals.
- **Eviction logging** — `evict_if_over_quota` logs `removed N entries, freed X MB` so future drift is visible from `~/.vireo/vireo.log`.
- **Default raised 2048 → 20480 MB** in `vireo/config.py`, with matching fallback updates in `app.py`, `preview_cache.py`, and `templates/settings.html`. 20 GB comfortably covers a typical library at 1920px.
- **Settings warning** — `/api/preview-cache` now returns `recommended_mb` (photo count × measured-avg preview bytes, fallback 500 KB). The settings page shows a banner when configured cap < recommendation: "Cache is smaller than your library — previews will regenerate from RAW on every pipeline run. Recommended: X MB." Existing users on the old 2 GB value will see this immediately.

Existing user configs aren't auto-bumped (no migration); the warning makes the recommendation visible so they can opt in.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -n auto` → **827 passed, 1 skipped** (70s)
- [x] New tests cover: reconcile drops ghost rows, reconcile keeps live rows, startup integration, `/api/preview-cache` returns `recommended_mb`, recommendation uses measured avg.
- [ ] Manual: open Settings, verify low-cap warning appears when `preview_cache_max_mb` is smaller than recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)