### PR TITLE
keymap: foundation — registry, dispatcher, Esc stack (PR 1 of 4)

### DIFF
--- a/docs/plans/2026-04-30-keymap-design.md
+++ b/docs/plans/2026-04-30-keymap-design.md
@@ -1,0 +1,155 @@
+# Keyboard Shortcut System — Design
+
+Date: 2026-04-30
+Status: Design (validated via brainstorm)
+Inspiration: [Vimium-C](https://github.com/gdh1995/vimium-c)
+
+## Goal
+
+Make Vireo more keyboard-fluent by adding two features on top of the existing per-page shortcut system:
+
+1. **Link hints** — press `f` and tiny letter labels overlay every clickable element; type the label to "click" it. Reaches anything without dedicating a memorized key to it.
+2. **Discoverability layer** — a context-aware `?` help modal plus inline badges that show the keystroke on every shortcut-able button.
+
+While we're in there, do a small cleanup sweep so existing shortcuts behave consistently across pages.
+
+## Non-goals
+
+- **Modal command sequences** (`gb`, `gp`, `yy`-style two-key combos). Deferred — single-letter nav already covers this.
+- **Vim-style movement everywhere** (`hjkl` / repeat counts). Out of scope; we add `J`/`K` for next/prev list nav (cleanup item) but no full vim motion model.
+- **Command palette** (`:` / `Cmd+K` fuzzy action search). Deferred — `?` covers the discoverability gap with much less work; revisit if shortcut count grows past ~50.
+- **First-run nudges / "shortcut of the day" toasts.** Cute, easy to make annoying. Deferred.
+- **Admin pages** (Stats, Jobs, Logs, Audit, Settings, Lightroom, Workspace). Low ROI — keep mouse-driven.
+- **Auto-detected hints on grid items.** Photo grids can have hundreds of thumbnails; auto-hinting would produce a sea of labels. Grid items are opt-in via `F` / `gf` (extended hint mode).
+
+## User-facing features
+
+### Link hints
+
+- `f` — enter hint mode for **chrome** elements (curated `data-hint` set: navbar, primary action buttons, modal controls, filter inputs, lightbox controls).
+- `F` (or `gf`) — enter **extended** hint mode that also includes `data-hint-grid` elements (photo cards, miss rows, keyword rows).
+- Type a label to trigger; `Backspace` deletes a typed character; `Esc` cancels; typing a non-matching key cancels.
+- Label alphabet (Vimium-C default): `sadfjklewcmpgh`. Two characters max. Shortest labels assigned to most prominent elements (largest bounding box, nearest viewport center).
+- Visual: small dark badge with light text, bottom-left of the target's bounding box. Reuse Vireo's tooltip color tokens (light/dark theme aware). Typed prefix bolds; non-matching candidates fade to 30% opacity.
+
+### Discoverability — `?` help modal
+
+Replace the existing `?` modal with a context-aware version backed by the keymap registry. Two columns:
+
+- **This page** — page-scoped shortcuts.
+- **Always available** — global nav, lightbox shortcuts (when open), etc.
+
+Each row: keystroke • action name • one-line description. Search box at top filters live (substring on name + description). Customizable shortcuts get a tiny pencil icon linking to `shortcuts.html`.
+
+Grouping inside each column comes from a `category` field on each registered shortcut: `Navigation`, `Edit`, `Selection`, `View`, `System`. Flat sections, no nesting.
+
+`?` again or `Esc` closes.
+
+### Discoverability — inline badges
+
+Small faint pill in the corner of any element with a registered keyboard shortcut. Same visual language as link-hint badges but lower contrast — they're "always on" so they need to recede.
+
+- Implementation: single CSS class + tiny boot script that walks `[data-shortcut]` elements and overlays the label from the registry.
+- Toggle: `\` (backslash) toggles badge visibility globally. Persisted to `config.json:show_shortcut_badges`.
+- Default: ON. Idea is the user learns the keys and turns them off after some weeks.
+- Badges only appear for elements with a *named keyboard shortcut*. Elements that are only reachable via link hints get no badge — link hints are ephemeral by design.
+
+## Architecture
+
+### Single source of truth: a JS keymap registry
+
+New file: `vireo/static/js/keymap.js`. API:
+
+```js
+Keymap.register(scope, shortcut)
+// scope: "global" | "browse" | "cull" | "review" | ... (page id)
+// shortcut: { key, name, description, category, action, customizable? }
+```
+
+A single dispatcher owns `keydown`. It:
+
+1. Suppresses single-letter / `?` / `f` / `\` keys when focus is in `<input>`, `<textarea>`, or `[contenteditable]`.
+2. If hint mode is active, routes everything to the hint engine.
+3. Otherwise, looks up the key in the registry (current scope + global) and fires the action.
+4. `Esc` is owned by the dispatcher and unwinds a single overlay stack: hint mode → modal → lightbox → bottom panel.
+
+### Why one registry
+
+Today, "what does `J` do" requires grepping templates. With a registry:
+
+- The `?` modal reads from it.
+- Inline badges read from it.
+- Hint-mode collision avoidance reads from it (though hint mode is modal, so collisions are impossible — but the registry's still the answer to "is `f` taken on this page").
+- The `shortcuts.html` editor reads from it (replacing `SHORTCUT_DEFAULTS`).
+- Per-shortcut user overrides from `config.json:keyboard_shortcuts` are merged on boot.
+
+### Hintable elements: declarative
+
+We do **not** auto-detect clickables. Anything we want hintable gets `data-hint="action-name"` in the template. Anything in the extended grid set gets `data-hint-grid`. Curated, reviewable in markup, no label sprawl.
+
+### Backwards compatibility
+
+- `config.json:keyboard_shortcuts` format unchanged.
+- `shortcuts.html` editor keeps working (now driven off the registry).
+- Existing per-page handlers are migrated incrementally. Until migrated, they coexist with the registry — the dispatcher only intercepts keys the registry knows about.
+
+## Per-page hint targets
+
+Curated `data-hint` set for each in-scope surface:
+
+- **Navbar (everywhere)** — workspace switcher, each tab, bottom-panel toggle, theme toggle.
+- **Browse** — filter chips/inputs, sort menu, selection toolbar buttons, pagination, view-mode toggle.
+- **Cull** — "Apply Culling Decisions", per-group expand/collapse, filter inputs.
+- **Review / Pipeline Review** — Accept, Skip, group-review toggle, "remove from group", filter inputs.
+- **Lightbox** — close, prev/next, zoom +/-/fit, boxes toggle, zoom mode toggle.
+- **Map / Compare / Variants / Duplicates / Misses / Keywords / Pipeline** — primary action buttons, filter inputs, view toggles. (Specific list per page during implementation — small, mechanical.)
+
+Extended grid set (`data-hint-grid`):
+
+- Photo cards in Browse, Cull, Variants, Compare.
+- Miss rows in Misses.
+- Keyword rows in Keywords.
+
+**Not** hinted: text labels inside cards, every "open" affordance on a thumbnail (use grid mode), admin pages.
+
+## Cleanup sweep (alongside)
+
+- **`J`/`K` for next/previous** in every list/grid: Browse, Cull, Review, Pipeline Review, Misses, Variants, Duplicates, Compare, Keywords. Today only Misses has it. Arrow keys keep working as a synonym.
+- **`?` on every page** — already global in `_navbar.html`; verify and document.
+- **`Esc` reliability** — currently each overlay has its own handler and they sometimes race. Dispatcher owns `Esc` with a single unwind stack.
+- **Input-focus suppression** — uniform across all global single-letter keys (currently inconsistent per page).
+
+## Edge cases
+
+- **Focused inputs**: hint mode does not activate; global single-letter shortcuts suppressed.
+- **Inside the lightbox**: hints scope to lightbox controls; thumbnails behind it are not hintable. Honor the existing `_navbar.html:3082` "active overlay" flag.
+- **Modals open**: `f` only hints elements inside the modal (visibility-aware DOM scope).
+- **Hidden / off-screen elements**: skipped (`getBoundingClientRect` + visibility check).
+- **Conflicts with letter shortcuts**: impossible. Hint mode is modal; once `f` is pressed, the dispatcher routes all keys to the hint engine until cancellation.
+
+## Testing
+
+1. **Backend test** — a small test in `vireo/tests/test_app.py` that the endpoint serving merged shortcut defaults + overrides returns correct data.
+2. **Manual checklist** (kept in this design doc — see below). For each of the 13 in-scope surfaces: press `?` and verify the modal lists the right shortcuts, press `f` and verify the curated set is hinted, press `F`/`gf` and verify grid items are hinted, press `Esc` and verify cleanup.
+3. **Playwright smoke** — one test loads Browse, presses `f`, types the label for a known navbar target, asserts navigation. Per the user-first-testing memory, drive a real browser. One path is enough to catch wiring regressions.
+
+### Manual checklist (per surface)
+
+- [ ] `?` opens modal listing correct shortcuts
+- [ ] `f` hints the curated chrome set, no grid sprawl
+- [ ] `F`/`gf` extends hints to grid items where applicable
+- [ ] `Esc` closes the topmost overlay only
+- [ ] Single-letter shortcuts suppressed inside inputs
+- [ ] Inline badges appear on shortcut-able buttons
+- [ ] `\` toggles badges; persists across reload
+
+## Rollout (PR breakdown)
+
+Each PR is independently mergeable and useful.
+
+1. **PR 1 — Foundation.** `keymap.js` registry + dispatcher + input-focus suppression + `Esc` stack. Migrate global navbar shortcuts only. No user-visible change beyond consolidated behavior.
+2. **PR 2 — Discoverability.** New `?` modal + inline badges + `\` toggle. Migrate Browse/Cull/Review/Lightbox shortcuts into the registry (highest-value pages for badges).
+3. **PR 3 — Link hints.** Hint engine (`f`/`F`), curated `data-hint` markup on PR 2's pages first.
+4. **PR 4 — Coverage.** Migrate remaining user pages (Pipeline, Map, Compare, Variants, Duplicates, Misses, Keywords) into the registry, add their `data-hint` attributes, extend `J`/`K` to grid/list pages that don't have it.
+
+If we stop after PR 2, we've still gained a unified `?` and badges. Admin pages stay untouched throughout.

--- a/docs/plans/2026-04-30-keymap-pr1-foundation.md
+++ b/docs/plans/2026-04-30-keymap-pr1-foundation.md
@@ -1,0 +1,820 @@
+# Keymap PR 1 — Foundation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extract Vireo's scattered keyboard handling into a single `keymap.js` registry + dispatcher, with a unified `Esc` stack and consistent input-focus suppression. No new user-visible features — this is plumbing for PRs 2–4.
+
+**Architecture:** New module `vireo/static/keymap.js` exposes `Keymap.register(scope, shortcut)` and `Keymap.pushEsc(handler)`. A single dispatcher owns `keydown` and routes to registered actions, suppressing single-letter keys when an `<input>`/`<textarea>`/`[contenteditable]` is focused. The existing per-page handlers in `_navbar.html` (navigation shortcuts at lines 1981–2001) and the multiple `Esc` handlers (lines 2100–2116, 3080–3129, 1389–1396) get migrated onto the registry. Per-page handlers in `browse.html`/`review.html`/etc. are NOT touched in PR 1 — they migrate in later PRs.
+
+**Tech Stack:** Vanilla JS (ES5-compatible — Vireo doesn't use ES modules in templates), Flask + Jinja2 templates, Playwright for browser-side tests, pytest for backend.
+
+**Reference design:** `docs/plans/2026-04-30-keymap-design.md`
+
+---
+
+## Pre-flight
+
+**This plan executes in a NEW worktree off `main`, not on the `keymap-design` branch.** The design branch is for the design doc only.
+
+```bash
+cd /Users/julius/git/vireo  # main checkout
+git fetch origin main
+git worktree add -b claude/keymap-foundation ../vireo-keymap-foundation origin/main
+cd ../vireo-keymap-foundation
+```
+
+All file paths below are relative to the worktree root.
+
+---
+
+## Existing code references (read these first)
+
+The plan refers back to these constantly. Read them before Task 1 so you have context.
+
+- **Existing dispatcher in navbar:** `vireo/templates/_navbar.html:1981-2001` (the `keydown` listener with `keyToHref` lookup)
+- **Existing nav defaults + config merge:** `vireo/templates/_navbar.html:1922-1935` (`NAV_ROUTES`, `NAV_DEFAULTS`) and `:2005-2018` (config fetch + merge)
+- **Existing `parseShortcut` + `matchesShortcut`:** `vireo/templates/_navbar.html:3149-3167`
+- **Existing Esc handlers (three of them):**
+  - Lightbox/overlay Esc + lightbox keys: `vireo/templates/_navbar.html:3080-3129`
+  - Shortcuts cheat sheet Esc + `?` opener: `vireo/templates/_navbar.html:2100-2116`
+  - Context menu Esc (capture-phase): `vireo/templates/_navbar.html:1389-1396`
+- **Existing JS asset loading:** `vireo/templates/_navbar.html:4951-4957`
+- **Backend `/api/config` endpoint:** `vireo/app.py:3988-4032` (no changes needed; we read from this)
+- **Existing Playwright e2e setup:** `tests/e2e/conftest.py` (provides `live_server` fixture; `page` fixture is from `pytest-playwright`)
+- **Existing page-load smoke test:** `tests/e2e/test_page_loads.py` (we extend this slightly)
+
+---
+
+## Task 1: Create `keymap.js` with helper utilities
+
+Create the module skeleton with two pure functions migrated verbatim from `_navbar.html`. Pure functions — no side effects yet.
+
+**Files:**
+- Create: `vireo/static/keymap.js`
+- Create: `tests/e2e/test_keymap.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/e2e/test_keymap.py
+"""End-to-end tests for the keymap registry and dispatcher."""
+
+import pytest
+
+
+def test_keymap_globals_exposed(live_server, page):
+    """Loading any page exposes the Keymap module on window."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    # Module is loaded
+    assert page.evaluate("typeof window.Keymap") == "object"
+
+    # Helpers are exposed
+    assert page.evaluate("typeof window.Keymap.parseShortcut") == "function"
+    assert page.evaluate("typeof window.Keymap.matchesShortcut") == "function"
+    assert page.evaluate("typeof window.Keymap.isInputFocused") == "function"
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest tests/e2e/test_keymap.py::test_keymap_globals_exposed -v
+```
+Expected: FAIL with `Keymap` undefined (script not loaded yet, file doesn't exist).
+
+**Step 3: Write minimal implementation**
+
+Create `vireo/static/keymap.js`:
+
+```javascript
+/**
+ * Vireo keymap module — single source of truth for keyboard shortcuts.
+ *
+ * Public API (this PR):
+ *   Keymap.parseShortcut(str)        -> {key, ctrl, meta, shift, alt}
+ *   Keymap.matchesShortcut(event, str)
+ *   Keymap.isInputFocused()          -> bool
+ *
+ * More API lands in subsequent tasks.
+ */
+(function (window) {
+  'use strict';
+
+  function parseShortcut(str) {
+    var parts = str.toLowerCase().split('+');
+    var key = parts.pop();
+    var mods = { ctrl: false, meta: false, shift: false, alt: false };
+    parts.forEach(function (m) { if (m in mods) mods[m] = true; });
+    return { key: key, ctrl: mods.ctrl, meta: mods.meta, shift: mods.shift, alt: mods.alt };
+  }
+
+  function matchesShortcut(e, shortcutStr) {
+    if (!shortcutStr) return false;
+    var sc = parseShortcut(shortcutStr);
+    if (e.key.toLowerCase() !== sc.key) return false;
+    var wantCtrl = sc.ctrl || sc.meta;
+    var hasCtrl = e.ctrlKey || e.metaKey;
+    if (wantCtrl !== hasCtrl) return false;
+    if (sc.shift !== e.shiftKey) return false;
+    if (sc.alt !== e.altKey) return false;
+    return true;
+  }
+
+  function isInputFocused() {
+    var el = document.activeElement;
+    if (!el) return false;
+    var tag = el.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+    if (el.isContentEditable) return true;
+    return false;
+  }
+
+  window.Keymap = {
+    parseShortcut: parseShortcut,
+    matchesShortcut: matchesShortcut,
+    isInputFocused: isInputFocused
+  };
+})(window);
+```
+
+Then add `<script src="/static/keymap.js"></script>` to `vireo/templates/_navbar.html` at line 4951 (right after `vireo-utils.js`, before `tauri-bridge.js`):
+
+```html
+<script src="/static/vireo-utils.js"></script>
+<script src="/static/keymap.js"></script>
+<script src="/static/tauri-bridge.js"></script>
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+python -m pytest tests/e2e/test_keymap.py::test_keymap_globals_exposed -v
+```
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/static/keymap.js vireo/templates/_navbar.html tests/e2e/test_keymap.py
+git commit -m "keymap: add Keymap module skeleton with parse/match/focus helpers"
+```
+
+---
+
+## Task 2: Add the registry API
+
+Add `Keymap.register(scope, shortcut)` and `Keymap.shortcutsForScope(scope)`. No dispatcher yet — just the data store.
+
+**Files:**
+- Modify: `vireo/static/keymap.js`
+- Modify: `tests/e2e/test_keymap.py`
+
+**Step 1: Write the failing test**
+
+Append to `tests/e2e/test_keymap.py`:
+
+```python
+def test_keymap_register_and_lookup(live_server, page):
+    """register() stores shortcuts; shortcutsForScope() returns them merged with global."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("""
+        window.Keymap.register('global', {
+            key: 'g', name: 'global-test', description: 'd',
+            category: 'Navigation', action: function() {}
+        });
+        window.Keymap.register('browse', {
+            key: 'b', name: 'browse-test', description: 'd',
+            category: 'Edit', action: function() {}
+        });
+    """)
+
+    global_only = page.evaluate("window.Keymap.shortcutsForScope('global').map(s => s.name)")
+    assert global_only == ["global-test"]
+
+    browse_scope = page.evaluate("window.Keymap.shortcutsForScope('browse').map(s => s.name)")
+    # browse scope returns its own shortcuts plus globals
+    assert set(browse_scope) == {"global-test", "browse-test"}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest tests/e2e/test_keymap.py::test_keymap_register_and_lookup -v
+```
+Expected: FAIL with `register is not a function`.
+
+**Step 3: Write minimal implementation**
+
+In `vireo/static/keymap.js`, inside the IIFE before the `window.Keymap = ...` assignment, add:
+
+```javascript
+  // scope -> array of shortcut definitions
+  var _registry = { global: [] };
+
+  function register(scope, shortcut) {
+    if (!_registry[scope]) _registry[scope] = [];
+    _registry[scope].push(shortcut);
+  }
+
+  function shortcutsForScope(scope) {
+    var globals = _registry.global || [];
+    if (scope === 'global' || !_registry[scope]) return globals.slice();
+    return _registry[scope].concat(globals);
+  }
+```
+
+Update the export:
+
+```javascript
+  window.Keymap = {
+    parseShortcut: parseShortcut,
+    matchesShortcut: matchesShortcut,
+    isInputFocused: isInputFocused,
+    register: register,
+    shortcutsForScope: shortcutsForScope
+  };
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+python -m pytest tests/e2e/test_keymap.py::test_keymap_register_and_lookup -v
+```
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/static/keymap.js tests/e2e/test_keymap.py
+git commit -m "keymap: add scoped shortcut registry"
+```
+
+---
+
+## Task 3: Add the central dispatcher
+
+Wire a single `keydown` listener that consults the registry, suppresses on input focus, and fires the registered `action`. Includes the page-vs-global precedence rule from the existing dispatcher (`_navbar.html:1989-1995`).
+
+**Files:**
+- Modify: `vireo/static/keymap.js`
+- Modify: `tests/e2e/test_keymap.py`
+
+**Step 1: Write the failing test**
+
+Append to `tests/e2e/test_keymap.py`:
+
+```python
+def test_dispatcher_fires_registered_action(live_server, page):
+    """Pressing a registered key fires its action; suppressed when input is focused."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("""
+        window._kmTestFired = 0;
+        window.Keymap.register('global', {
+            key: 'q', name: 'test-q', description: '', category: 'System',
+            action: function() { window._kmTestFired += 1; }
+        });
+        window.Keymap.setScope('global');
+    """)
+
+    page.keyboard.press("q")
+    assert page.evaluate("window._kmTestFired") == 1
+
+    # Focused input suppresses the shortcut
+    page.evaluate("""
+        var i = document.createElement('input');
+        i.id = '_kmTestInput';
+        document.body.appendChild(i);
+        i.focus();
+    """)
+    page.keyboard.press("q")
+    assert page.evaluate("window._kmTestFired") == 1  # unchanged
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest tests/e2e/test_keymap.py::test_dispatcher_fires_registered_action -v
+```
+Expected: FAIL — `setScope` doesn't exist and no dispatcher is wired.
+
+**Step 3: Write minimal implementation**
+
+Add to `vireo/static/keymap.js` (inside the IIFE):
+
+```javascript
+  var _currentScope = 'global';
+
+  function setScope(scope) { _currentScope = scope; }
+  function getScope() { return _currentScope; }
+
+  function _dispatch(e) {
+    if (isInputFocused()) return;
+    var candidates = shortcutsForScope(_currentScope);
+    for (var i = 0; i < candidates.length; i++) {
+      var sc = candidates[i];
+      if (matchesShortcut(e, sc.key)) {
+        e.preventDefault();
+        try { sc.action(e); } catch (err) { console.error('Keymap action error', err); }
+        return;
+      }
+    }
+  }
+
+  document.addEventListener('keydown', _dispatch);
+```
+
+Update the export to include `setScope`/`getScope`:
+
+```javascript
+  window.Keymap = {
+    parseShortcut: parseShortcut,
+    matchesShortcut: matchesShortcut,
+    isInputFocused: isInputFocused,
+    register: register,
+    shortcutsForScope: shortcutsForScope,
+    setScope: setScope,
+    getScope: getScope
+  };
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+python -m pytest tests/e2e/test_keymap.py::test_dispatcher_fires_registered_action -v
+```
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/static/keymap.js tests/e2e/test_keymap.py
+git commit -m "keymap: add central keydown dispatcher with input-focus suppression"
+```
+
+---
+
+## Task 4: Add the Esc stack
+
+Single `Esc` owner: handlers push themselves onto a stack; pressing `Esc` invokes the top handler only. Replaces the racing `Esc` listeners.
+
+**Files:**
+- Modify: `vireo/static/keymap.js`
+- Modify: `tests/e2e/test_keymap.py`
+
+**Step 1: Write the failing test**
+
+Append to `tests/e2e/test_keymap.py`:
+
+```python
+def test_esc_stack_unwinds_top_first(live_server, page):
+    """pushEsc registers handlers; Esc invokes only the top one each press."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("""
+        window._kmEscOrder = [];
+        window._kmEscToken1 = window.Keymap.pushEsc(function() { window._kmEscOrder.push('first'); });
+        window._kmEscToken2 = window.Keymap.pushEsc(function() { window._kmEscOrder.push('second'); });
+    """)
+
+    page.keyboard.press("Escape")
+    assert page.evaluate("window._kmEscOrder") == ["second"]
+
+    page.keyboard.press("Escape")
+    assert page.evaluate("window._kmEscOrder") == ["second", "first"]
+
+    page.keyboard.press("Escape")
+    assert page.evaluate("window._kmEscOrder") == ["second", "first"]  # stack empty
+
+
+def test_esc_stack_remove_by_token(live_server, page):
+    """popEsc(token) removes a specific handler regardless of position."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("""
+        window._kmEscOrder = [];
+        var t1 = window.Keymap.pushEsc(function() { window._kmEscOrder.push('first'); });
+        var t2 = window.Keymap.pushEsc(function() { window._kmEscOrder.push('second'); });
+        window.Keymap.popEsc(t2);
+    """)
+
+    page.keyboard.press("Escape")
+    assert page.evaluate("window._kmEscOrder") == ["first"]
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest tests/e2e/test_keymap.py -k esc -v
+```
+Expected: FAIL — `pushEsc` undefined.
+
+**Step 3: Write minimal implementation**
+
+Add to `vireo/static/keymap.js`:
+
+```javascript
+  var _escStack = [];
+  var _escNextToken = 1;
+
+  function pushEsc(handler) {
+    var token = _escNextToken++;
+    _escStack.push({ token: token, handler: handler });
+    return token;
+  }
+
+  function popEsc(token) {
+    for (var i = _escStack.length - 1; i >= 0; i--) {
+      if (_escStack[i].token === token) {
+        _escStack.splice(i, 1);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function _handleEsc(e) {
+    if (e.key !== 'Escape') return false;
+    if (_escStack.length === 0) return false;
+    var top = _escStack.pop();
+    e.preventDefault();
+    e.stopPropagation();
+    try { top.handler(e); } catch (err) { console.error('Esc handler error', err); }
+    return true;
+  }
+```
+
+Modify `_dispatch` to handle Esc first:
+
+```javascript
+  function _dispatch(e) {
+    if (_handleEsc(e)) return;
+    if (isInputFocused()) return;
+    // ... rest unchanged
+  }
+```
+
+Export the new methods:
+
+```javascript
+    pushEsc: pushEsc,
+    popEsc: popEsc,
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+python -m pytest tests/e2e/test_keymap.py -k esc -v
+```
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/static/keymap.js tests/e2e/test_keymap.py
+git commit -m "keymap: add Esc stack with token-based removal"
+```
+
+---
+
+## Task 5: Add page-vs-global precedence
+
+The existing dispatcher (`_navbar.html:1989-1995`) lets page-scoped shortcuts shadow global ones with the same key. Match that behavior in our dispatcher: when iterating candidates, page-scope matches win.
+
+**Files:**
+- Modify: `vireo/static/keymap.js`
+- Modify: `tests/e2e/test_keymap.py`
+
+**Step 1: Write the failing test**
+
+Append to `tests/e2e/test_keymap.py`:
+
+```python
+def test_page_scope_shadows_global_for_same_key(live_server, page):
+    """When global and page scopes register the same key, page wins."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("""
+        window._kmFired = '';
+        window.Keymap.register('global', {
+            key: 'p', name: 'g', description: '', category: 'System',
+            action: function() { window._kmFired = 'global'; }
+        });
+        window.Keymap.register('browse', {
+            key: 'p', name: 'b', description: '', category: 'Edit',
+            action: function() { window._kmFired = 'page'; }
+        });
+        window.Keymap.setScope('browse');
+    """)
+
+    page.keyboard.press("p")
+    assert page.evaluate("window._kmFired") == "page"
+```
+
+**Step 2: Run test to verify it fails**
+
+`shortcutsForScope` currently returns page first, then globals — so `_dispatch` already iterates page-first. The test should actually pass. Run it:
+
+```bash
+python -m pytest tests/e2e/test_keymap.py::test_page_scope_shadows_global_for_same_key -v
+```
+If it PASSES on first run, that's fine — the existing iteration order already implements precedence. Skip step 3 and go to step 5 (commit just the test, with a message documenting the behavior is locked in).
+
+If it FAILS (e.g., dispatcher iterates globals first), reorder the candidates list in `shortcutsForScope` so page comes first, or re-loop in `_dispatch` with a two-pass strategy.
+
+**Step 3 (if needed): Adjust ordering**
+
+`shortcutsForScope` already returns `_registry[scope].concat(globals)` so page is first. No change expected.
+
+**Step 4: Re-run**
+
+```bash
+python -m pytest tests/e2e/test_keymap.py -v
+```
+Expected: ALL PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/e2e/test_keymap.py
+git commit -m "keymap: lock in page-shadows-global precedence with test"
+```
+
+---
+
+## Task 6: Migrate global navbar nav shortcuts to the registry
+
+Replace the `keyToHref` dispatcher at `_navbar.html:1981-2001` with `Keymap.register('global', ...)` calls. Each navigation entry becomes one registered shortcut. The action fires `window.location.href = route`.
+
+**Files:**
+- Modify: `vireo/templates/_navbar.html` (replace lines 1981-2001 dispatch + extend the existing config-merge block at 2005-2018)
+- Add test: `tests/e2e/test_keymap.py`
+
+**Step 1: Write the failing test**
+
+Append to `tests/e2e/test_keymap.py`:
+
+```python
+def test_navbar_nav_shortcuts_registered_globally(live_server, page):
+    """Each NAV_ROUTES entry is registered as a global Keymap shortcut after config load."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    # After the nav shortcut bootstrap runs, every nav entry should be in the global scope.
+    names = page.evaluate("""
+        window.Keymap.shortcutsForScope('global')
+            .filter(s => s.category === 'Navigation')
+            .map(s => s.name)
+    """)
+    expected = {
+        'pipeline', 'lightroom', 'pipeline_review', 'review', 'cull',
+        'browse', 'map', 'variants', 'dashboard', 'audit', 'compare',
+        'workspace', 'shortcuts', 'settings', 'keywords'
+    }
+    assert expected.issubset(set(names))
+
+
+def test_pressing_b_navigates_to_browse(live_server, page):
+    """Pressing 'b' from a non-browse page navigates to /browse."""
+    url = live_server["url"]
+    page.goto(f"{url}/cull", timeout=5000)
+    page.wait_for_load_state("networkidle")
+    page.keyboard.press("b")
+    page.wait_for_url(f"{url}/browse", timeout=3000)
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest tests/e2e/test_keymap.py -k "navbar_nav or pressing_b" -v
+```
+Expected: at least the `shortcuts` filter test fails (no Navigation category yet); `pressing_b` may pass because the legacy dispatcher still fires — that's OK, we'll verify it still passes after migration.
+
+**Step 3: Write the migration**
+
+In `vireo/templates/_navbar.html`:
+
+Find the existing block that merges `NAV_DEFAULTS` with config (lines 2005-2018) and the dispatcher (lines 1981-2001). Replace the dispatcher with registry calls. Inside the `fetch('/api/config').then(...)` callback that merges shortcuts, add:
+
+```javascript
+// After window._vireoShortcuts.navigation is populated:
+var navMap = window._vireoShortcuts.navigation || {};
+Object.keys(NAV_ROUTES).forEach(function (action) {
+  var key = navMap[action];
+  if (!key) return;
+  var route = NAV_ROUTES[action];
+  window.Keymap.register('global', {
+    key: key,
+    name: action,
+    description: 'Go to ' + action.replace(/_/g, ' '),
+    category: 'Navigation',
+    action: function () {
+      // Don't navigate if we're already on this page (preserves existing behavior)
+      if (window.location.pathname === route) return;
+      window.location.href = route;
+    }
+  });
+});
+```
+
+Then **delete** the old `document.addEventListener('keydown', ...)` block that used `keyToHref` (lines 1981-2001). Also delete the `keyToHref` table-build code that was feeding it. **Keep** `NAV_ROUTES` and `NAV_DEFAULTS` as data (other code may still read them; we'll audit in a later PR).
+
+Set the page scope on boot. Find where `pageCtx` is determined in `_navbar.html` (search for `pageCtx`) and add right after:
+
+```javascript
+if (pageCtx) window.Keymap.setScope(pageCtx);
+```
+
+**Step 4: Run all tests + manual smoke**
+
+```bash
+python -m pytest tests/e2e/test_keymap.py -v
+python -m pytest tests/e2e/test_page_loads.py -v
+```
+Expected: ALL PASS. Then manually:
+
+- Open `http://localhost:8080/cull`. Press `b`. Should land on `/browse`.
+- Open `http://localhost:8080/browse`. Press `b`. Should NOT navigate (already there).
+- Open `http://localhost:8080/browse`. Press `m`. Should land on `/map`.
+- Open `http://localhost:8080/browse`. Click into the search input. Press `b`. Should NOT navigate (input focused).
+
+**Step 5: Commit**
+
+```bash
+git add vireo/templates/_navbar.html tests/e2e/test_keymap.py
+git commit -m "keymap: migrate navbar navigation shortcuts to registry"
+```
+
+---
+
+## Task 7: Migrate `_navbar.html` Esc handlers to the Esc stack
+
+Three current handlers (`_navbar.html:3080-3129`, `:2100-2116`, `:1389-1396`) each handle `Esc` for different overlays. Migrate each to call `Keymap.pushEsc(handler)` when the overlay opens, and `Keymap.popEsc(token)` when it closes.
+
+The lightbox handler at lines 3080-3129 also handles `ArrowLeft`/`ArrowRight`/`+`/`-`/`0`/`B`/`Z` — **leave those alone** in this task. We're only moving the `Esc` part.
+
+**Files:**
+- Modify: `vireo/templates/_navbar.html` (three regions)
+- Modify: `tests/e2e/test_keymap.py`
+
+**Step 1: Write the failing test**
+
+Append to `tests/e2e/test_keymap.py`:
+
+```python
+def test_esc_closes_shortcuts_cheat_sheet(live_server, page):
+    """Opening the cheat sheet pushes an Esc handler; pressing Esc closes it."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.keyboard.press("?")
+    sheet = page.locator("#shortcutsCheatSheet")
+    expect_open = sheet.evaluate("el => el.classList.contains('open')")
+    assert expect_open is True
+
+    page.keyboard.press("Escape")
+    expect_closed = sheet.evaluate("el => el.classList.contains('open')")
+    assert expect_closed is False
+```
+
+(Use `from playwright.sync_api import expect` if you want assertion helpers; the raw `evaluate` form above is fine.)
+
+**Step 2: Run test to verify it fails or passes**
+
+```bash
+python -m pytest tests/e2e/test_keymap.py::test_esc_closes_shortcuts_cheat_sheet -v
+```
+This test may PASS on first run since the existing handler already does this. That's fine — it locks in behavior we must preserve through the migration.
+
+**Step 3: Migrate each Esc handler**
+
+For each of the three sites, the pattern is the same.
+
+**Site 1 — Lightbox (`_navbar.html:3080-3129`):** The current handler unconditionally calls `closeLightbox`/`closePipeline`/`closeSimilar`/`closeInatModal`/`closeHelpModal`/`closeReportModal` on every `Esc`. Replace with: each `open*` function calls `Keymap.pushEsc(close*)`; each `close*` function calls `Keymap.popEsc(token)` and stores the token on a module-level variable.
+
+Example for lightbox — find `openLightbox` in `_navbar.html` and add at its top:
+
+```javascript
+if (window._lbEscToken) Keymap.popEsc(window._lbEscToken);
+window._lbEscToken = Keymap.pushEsc(function () { closeLightbox(); });
+```
+
+Find `closeLightbox` and add at its top:
+
+```javascript
+if (window._lbEscToken) { Keymap.popEsc(window._lbEscToken); window._lbEscToken = null; }
+```
+
+Repeat the pattern for `openPipeline`/`closePipeline`, `openSimilar`/`closeSimilar`, `openInatModal`/`closeInatModal`, `openHelpModal`/`closeHelpModal`, `openReportModal`/`closeReportModal`.
+
+After all six are converted, **delete** the `if (e.key === 'Escape') { closeLightbox(); ... }` lines at the top of the lightbox keydown listener (the listener stays; only the Esc cascade is removed). The other lightbox keys (arrows/+/-/0/B/Z) remain in that listener for now.
+
+**Site 2 — Shortcuts cheat sheet (`_navbar.html:2100-2116`):** This handler does two things — opens on `?` and closes on `Esc`. Convert the close path: in `openShortcutsSheet`, add `window._sheetEscToken = Keymap.pushEsc(closeShortcutsSheet);`. In `closeShortcutsSheet`, pop it. Remove the `if (e.key === 'Escape')` branch from the listener. Keep the `?` opener and the `e.preventDefault(); e.stopImmediatePropagation();` consume-all-keys behavior while sheet is open (that part isn't an Esc concern).
+
+**Site 3 — Context menu (`_navbar.html:1389-1396`):** This Esc handler is on a *capture-phase* listener — it cancels the menu without letting browse.html's Esc fire. Convert: in the function that opens the context menu, push an Esc handler. In `closeContextMenu`, pop it. Delete the capture-phase Esc listener entirely.
+
+**Step 4: Run all tests + manual smoke**
+
+```bash
+python -m pytest tests/e2e/test_keymap.py -v
+python -m pytest tests/e2e/test_page_loads.py -v
+```
+Expected: ALL PASS. Then manually:
+
+- Browse page: open lightbox on a photo, press Esc → closes lightbox.
+- Browse page: open lightbox, then open the shortcuts cheat sheet (`?`), press Esc → closes the sheet but lightbox stays open.
+- Browse page: right-click a photo card to open context menu, press Esc → closes context menu but selection stays.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/templates/_navbar.html tests/e2e/test_keymap.py
+git commit -m "keymap: migrate _navbar.html Esc handlers to Esc stack"
+```
+
+---
+
+## Task 8: Final verification
+
+Run the full test suite and execute the manual checklist. No code changes unless something breaks.
+
+**Step 1: Run the curated test command from CLAUDE.md**
+
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -v
+```
+Expected: PASS (modulo the pre-existing failures noted in memory `project_preexisting_test_failures.md` — don't block on those).
+
+**Step 2: Run all e2e tests**
+
+```bash
+python -m pytest tests/e2e/ -v
+```
+Expected: PASS.
+
+**Step 3: Manual checklist**
+
+Start the app:
+```bash
+python vireo/app.py --db ~/.vireo/vireo.db --port 8080
+```
+
+For Browse, Cull, Review, and Lightbox — verify each:
+- [ ] Page-letter nav still works (`b`, `c`, `r`, `m`, etc.)
+- [ ] No nav fires when typing in any input
+- [ ] `?` opens shortcuts cheat sheet
+- [ ] `Esc` closes the topmost overlay only
+- [ ] Lightbox arrow keys, `+`/`-`/`0`, `B`, `Z` still work
+- [ ] Browse: 0-5 ratings, P/X/U flags still work
+- [ ] Review: A accept, S skip still work
+- [ ] Misses: J/K navigation still works (untouched in this PR)
+
+**Step 4: Open the PR**
+
+```bash
+gh pr create --base main --title "keymap: foundation — Keymap registry, dispatcher, Esc stack" --body "$(cat <<'EOF'
+## Summary
+PR 1 of 4 in the keymap-design rollout. Pure plumbing — no new user-visible features.
+
+- New `vireo/static/keymap.js`: registry + central dispatcher + Esc stack
+- Migrated navbar navigation shortcuts onto the registry
+- Migrated `_navbar.html` Esc handlers (lightbox, pipeline overlay, similar, inat, help, report, shortcuts cheat sheet, context menu) to use the Esc stack
+
+Per-page handlers in browse.html / review.html / etc. are NOT touched in this PR. They migrate in PR 4.
+
+Design: `docs/plans/2026-04-30-keymap-design.md`
+Plan: `docs/plans/2026-04-30-keymap-pr1-foundation.md`
+
+## Test plan
+- [x] `pytest tests/e2e/test_keymap.py -v`
+- [x] `pytest tests/e2e/test_page_loads.py -v`
+- [x] CLAUDE.md curated test command passes
+- [x] Manual checklist (see plan section "Final verification")
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Out of scope for PR 1 (in subsequent plans)
+
+- **PR 2 — Discoverability:** new `?` modal that reads from registry, inline shortcut badges (`[data-shortcut]`), `\` toggle, migrate Browse/Cull/Review/Lightbox shortcuts into registry.
+- **PR 3 — Link hints:** hint engine (`f` / `F`), `data-hint` / `data-hint-grid` attributes.
+- **PR 4 — Coverage:** migrate remaining user pages (Pipeline, Map, Compare, Variants, Duplicates, Misses, Keywords) onto registry; extend `J`/`K` to all grid/list pages.

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -269,6 +269,48 @@ def test_two_overlays_unwind_one_esc_each(live_server, page):
     )
 
 
+def test_body_scroll_stays_locked_while_lower_overlay_open(live_server, page):
+    """With two overlays stacked, closing the top one must not unlock body
+    scroll while the lower one is still open. Regression test for the bug
+    where each close*() unconditionally cleared document.body.style.overflow,
+    letting the page behind an active overlay scroll after one Esc."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("openLightbox(1, 'hawk1.jpg')")
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=2000,
+    )
+    assert page.evaluate("document.body.style.overflow") == "hidden"
+
+    page.evaluate("openShortcutsSheet()")
+    page.wait_for_function(
+        "document.getElementById('shortcutsCheatSheet').classList.contains('open')",
+        timeout=2000,
+    )
+    assert page.evaluate("document.body.style.overflow") == "hidden"
+
+    # Closing the top overlay must NOT unlock scroll — lightbox is still open.
+    page.keyboard.press("Escape")
+    page.wait_for_function(
+        "!document.getElementById('shortcutsCheatSheet').classList.contains('open')",
+        timeout=2000,
+    )
+    assert page.evaluate("document.body.style.overflow") == "hidden", (
+        "Body scroll must remain locked while the lower overlay (lightbox) is still open"
+    )
+
+    # Closing the last overlay restores scroll.
+    page.keyboard.press("Escape")
+    page.wait_for_function(
+        "!document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=2000,
+    )
+    assert page.evaluate("document.body.style.overflow") == ""
+
+
 def test_overlay_esc_does_not_leak_to_page_handlers(live_server, page):
     """When the Esc stack handles Esc, page-level Esc handlers (e.g. browse.html
     clearing selection, lightbox close-detail) must not also fire. The capture-

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -313,6 +313,40 @@ def test_esc_closes_help_modal_via_stack(live_server, page):
     )
 
 
+def test_legacy_page_binding_shadows_global_nav(live_server, page):
+    """When the current page has bound a key in the legacy _vireoShortcuts
+    config, the global nav action yields so the page's bubble-phase listener
+    can run. Browse/review/cull page handlers don't migrate into the registry
+    until PR 4; until then this preserves user-customized collisions
+    (e.g. mapping a browse action onto the same letter as a nav shortcut)."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    # Pretend the user has remapped a browse action to 'r' (default for
+    # navigation.review). Mutating after registration is fine — the nav
+    # action reads _vireoShortcuts at dispatch time.
+    page.evaluate("""
+        window._vireoShortcuts = window._vireoShortcuts || {};
+        window._vireoShortcuts.browse = window._vireoShortcuts.browse || {};
+        window._vireoShortcuts.browse.flag = 'r';
+
+        // Bubble-phase spy mimicking a legacy page listener.
+        window.__pageHandled = 0;
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'r' && !e.defaultPrevented) window.__pageHandled += 1;
+        });
+    """)
+
+    page.keyboard.press("r")
+    page.wait_for_timeout(300)
+
+    assert page.url.endswith("/browse"), f"Expected to stay on /browse, got {page.url}"
+    assert page.evaluate("window.__pageHandled") == 1, (
+        "Legacy bubble-phase listener should have observed 'r' with defaultPrevented=false"
+    )
+
+
 def test_setscope_runs_synchronously_at_page_load(live_server, page):
     """The navbar IIFE must call Keymap.setScope(pageCtx) synchronously after
     keymap.js loads. Regression test for the script-ordering bug where

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -40,3 +40,32 @@ def test_keymap_register_and_lookup(live_server, page):
     browse_scope = page.evaluate("window.Keymap.shortcutsForScope('browse').map(s => s.name)")
     # browse scope returns its own shortcuts plus globals
     assert set(browse_scope) == {"global-test", "browse-test"}
+
+
+def test_dispatcher_fires_registered_action(live_server, page):
+    """Pressing a registered key fires its action; suppressed when input is focused."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("""
+        window._kmTestFired = 0;
+        window.Keymap.register('global', {
+            key: 'q', name: 'test-q', description: '', category: 'System',
+            action: function() { window._kmTestFired += 1; }
+        });
+        window.Keymap.setScope('global');
+    """)
+
+    page.keyboard.press("q")
+    assert page.evaluate("window._kmTestFired") == 1
+
+    # Focused input suppresses the shortcut
+    page.evaluate("""
+        var i = document.createElement('input');
+        i.id = '_kmTestInput';
+        document.body.appendChild(i);
+        i.focus();
+    """)
+    page.keyboard.press("q")
+    assert page.evaluate("window._kmTestFired") == 1  # unchanged

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -170,3 +170,43 @@ def test_pressing_b_navigates_to_browse(live_server, page):
     page.wait_for_load_state("networkidle")
     page.keyboard.press("b")
     page.wait_for_url(f"{url}/browse", timeout=3000)
+
+
+def test_nav_shortcut_suppressed_when_overlay_open(live_server, page):
+    """Pressing a nav letter while an overlay is open does not navigate."""
+    url = live_server["url"]
+    page.goto(f"{url}/cull", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    # Inject an overlay matching the OVERLAY_SELECTOR set
+    page.evaluate("""
+        var ov = document.createElement('div');
+        ov.className = 'modal-overlay open';
+        document.body.appendChild(ov);
+    """)
+
+    page.keyboard.press("b")
+    page.wait_for_timeout(400)
+    assert page.url.endswith("/cull"), f"Expected to stay on /cull, got {page.url}"
+
+
+def test_action_returning_false_does_not_preventdefault(live_server, page):
+    """Actions returning false signal 'not handled' and let next candidate run."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("""
+        window._kmCalls = [];
+        window.Keymap.register('global', {
+            key: 'y', name: 'first', description: '', category: 'System',
+            action: function() { window._kmCalls.push('first'); return false; }
+        });
+        window.Keymap.register('global', {
+            key: 'y', name: 'second', description: '', category: 'System',
+            action: function() { window._kmCalls.push('second'); }
+        });
+    """)
+
+    page.keyboard.press("y")
+    assert page.evaluate("window._kmCalls") == ["first", "second"]

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -267,3 +267,47 @@ def test_two_overlays_unwind_one_esc_each(live_server, page):
         "!document.getElementById('lightboxOverlay').classList.contains('active')",
         timeout=2000,
     )
+
+
+def test_overlay_esc_does_not_leak_to_page_handlers(live_server, page):
+    """When the Esc stack handles Esc, page-level Esc handlers (e.g. browse.html
+    clearing selection, lightbox close-detail) must not also fire. The capture-
+    phase dispatcher + stopPropagation guarantees this."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    # Add a body-level bubble Esc spy
+    page.evaluate("""
+        window.__leakCount = 0;
+        document.body.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape') window.__leakCount += 1;
+        });
+    """)
+
+    # Push an Esc handler via the stack
+    page.evaluate("""
+        window._testEscToken = window.Keymap.pushEsc(function() {});
+    """)
+
+    page.keyboard.press("Escape")
+    assert page.evaluate("window.__leakCount") == 0, "Esc must not leak to body when handled by stack"
+
+
+def test_esc_closes_help_modal_via_stack(live_server, page):
+    """Help modal opened via F1 pushes an Esc handler; Esc closes it."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.keyboard.press("F1")
+    page.wait_for_function(
+        "document.getElementById('helpModal').classList.contains('active')",
+        timeout=2000,
+    )
+
+    page.keyboard.press("Escape")
+    page.wait_for_function(
+        "!document.getElementById('helpModal').classList.contains('active')",
+        timeout=2000,
+    )

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -1,0 +1,17 @@
+"""End-to-end tests for the keymap registry and dispatcher."""
+
+
+
+def test_keymap_globals_exposed(live_server, page):
+    """Loading any page exposes the Keymap module on window."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    # Module is loaded
+    assert page.evaluate("typeof window.Keymap") == "object"
+
+    # Helpers are exposed
+    assert page.evaluate("typeof window.Keymap.parseShortcut") == "function"
+    assert page.evaluate("typeof window.Keymap.matchesShortcut") == "function"
+    assert page.evaluate("typeof window.Keymap.isInputFocused") == "function"

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -108,3 +108,26 @@ def test_esc_stack_remove_by_token(live_server, page):
 
     page.keyboard.press("Escape")
     assert page.evaluate("window._kmEscOrder") == ["first"]
+
+
+def test_page_scope_shadows_global_for_same_key(live_server, page):
+    """When global and page scopes register the same key, page wins."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("""
+        window._kmFired = '';
+        window.Keymap.register('global', {
+            key: 'p', name: 'g', description: '', category: 'System',
+            action: function() { window._kmFired = 'global'; }
+        });
+        window.Keymap.register('browse', {
+            key: 'p', name: 'b', description: '', category: 'Edit',
+            action: function() { window._kmFired = 'page'; }
+        });
+        window.Keymap.setScope('browse');
+    """)
+
+    page.keyboard.press("p")
+    assert page.evaluate("window._kmFired") == "page"

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -402,3 +402,103 @@ def test_setscope_runs_synchronously_at_page_load(live_server, page):
     page.goto(f"{url}/review", timeout=5000)
     page.wait_for_load_state("networkidle")
     assert page.evaluate("window.Keymap.getScope()") == "review"
+
+
+def test_pause_dispatch_silences_global_actions(live_server, page):
+    """While dispatch is paused, registered global actions must not fire — so
+    the /shortcuts editor's capture-phase keydown listener can claim the next
+    press without nav shortcuts navigating the user away first. resumeDispatch
+    restores normal handling."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("""
+        window._kmPausedFired = 0;
+        window.Keymap.register('global', {
+            key: 'z', name: 'pause-test', description: '', category: 'System',
+            action: function() { window._kmPausedFired += 1; }
+        });
+    """)
+
+    page.evaluate("window.Keymap.pauseDispatch()")
+    page.keyboard.press("z")
+    assert page.evaluate("window._kmPausedFired") == 0, (
+        "Paused dispatcher must not fire registered actions"
+    )
+
+    page.evaluate("window.Keymap.resumeDispatch()")
+    page.keyboard.press("z")
+    assert page.evaluate("window._kmPausedFired") == 1
+
+
+def test_shortcut_capture_does_not_navigate(live_server, page):
+    """On /shortcuts, clicking a binding button enters capture mode. Pressing
+    a key that's also a global nav letter (e.g. 'b' for browse) must be
+    captured as the new binding instead of navigating the user away. Regression
+    test for the bug where the global Keymap dispatcher won the capture-phase
+    race against the editor's own keydown listener."""
+    url = live_server["url"]
+    page.goto(f"{url}/shortcuts", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    # Start capture on the navigation.browse button — pressing 'b' is then a
+    # no-op rebind to itself (findConflict skips the current action), so we
+    # avoid touching unrelated config while still exercising the dispatcher
+    # pause path.
+    page.wait_for_function(
+        "document.querySelector('.shortcut-key-btn') !== null", timeout=2000
+    )
+    page.evaluate("""
+        (function() {
+            var btns = document.querySelectorAll('.shortcut-key-btn');
+            for (var i = 0; i < btns.length; i++) {
+                var attr = btns[i].getAttribute('onclick') || '';
+                if (attr.indexOf("'navigation', 'browse'") !== -1) {
+                    btns[i].click();
+                    return;
+                }
+            }
+            throw new Error('navigation.browse button not found');
+        })();
+    """)
+
+    page.wait_for_function(
+        "document.querySelector('.shortcut-key-btn.capturing') !== null", timeout=2000
+    )
+
+    page.keyboard.press("b")
+    page.wait_for_timeout(300)
+
+    assert page.url.endswith("/shortcuts"), (
+        f"Expected to stay on /shortcuts during capture, got {page.url}"
+    )
+
+
+def test_help_modal_unlocks_scroll_when_keymap_unavailable(live_server, page):
+    """If keymap.js fails to load (or hasn't yet), openHelpModal/closeHelpModal
+    must still pair their body-scroll lock/unlock cleanly. Regression test for
+    the bug where wasOpen was inferred from the Esc token (only set when
+    Keymap is present), so closing the modal left body scroll locked forever."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    # Simulate Keymap being unavailable (e.g. keymap.js failed to load).
+    page.evaluate("window.Keymap = undefined; window._helpEscToken = null;")
+
+    page.evaluate("openHelpModal()")
+    page.wait_for_function(
+        "document.getElementById('helpModal').classList.contains('active')",
+        timeout=2000,
+    )
+    assert page.evaluate("document.body.style.overflow") == "hidden"
+
+    page.evaluate("closeHelpModal()")
+    page.wait_for_function(
+        "!document.getElementById('helpModal').classList.contains('active')",
+        timeout=2000,
+    )
+    assert page.evaluate("document.body.style.overflow") == "", (
+        "Body scroll must unlock when help modal closes, even with Keymap unavailable"
+    )

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -34,10 +34,20 @@ def test_keymap_register_and_lookup(live_server, page):
         });
     """)
 
-    global_only = page.evaluate("window.Keymap.shortcutsForScope('global').map(s => s.name)")
+    # Filter to just the test-injected names so we don't accidentally pick up
+    # whatever globals the navbar bootstrap registered (nav shortcuts, etc.)
+    global_only = page.evaluate(
+        "window.Keymap.shortcutsForScope('global')"
+        "    .map(s => s.name)"
+        "    .filter(n => n === 'global-test' || n === 'browse-test')"
+    )
     assert global_only == ["global-test"]
 
-    browse_scope = page.evaluate("window.Keymap.shortcutsForScope('browse').map(s => s.name)")
+    browse_scope = page.evaluate(
+        "window.Keymap.shortcutsForScope('browse')"
+        "    .map(s => s.name)"
+        "    .filter(n => n === 'global-test' || n === 'browse-test')"
+    )
     # browse scope returns its own shortcuts plus globals
     assert set(browse_scope) == {"global-test", "browse-test"}
 
@@ -131,3 +141,32 @@ def test_page_scope_shadows_global_for_same_key(live_server, page):
 
     page.keyboard.press("p")
     assert page.evaluate("window._kmFired") == "page"
+
+
+def test_navbar_nav_shortcuts_registered_globally(live_server, page):
+    """Each NAV_ROUTES entry is registered as a global Keymap shortcut after config load."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    # After the nav shortcut bootstrap runs, every nav entry should be in the global scope.
+    names = page.evaluate("""
+        window.Keymap.shortcutsForScope('global')
+            .filter(s => s.category === 'Navigation')
+            .map(s => s.name)
+    """)
+    expected = {
+        'pipeline', 'lightroom', 'pipeline_review', 'review', 'cull',
+        'browse', 'map', 'variants', 'dashboard', 'audit', 'compare',
+        'workspace', 'shortcuts', 'settings', 'keywords'
+    }
+    assert expected.issubset(set(names))
+
+
+def test_pressing_b_navigates_to_browse(live_server, page):
+    """Pressing 'b' from a non-browse page navigates to /browse."""
+    url = live_server["url"]
+    page.goto(f"{url}/cull", timeout=5000)
+    page.wait_for_load_state("networkidle")
+    page.keyboard.press("b")
+    page.wait_for_url(f"{url}/browse", timeout=3000)

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -15,3 +15,28 @@ def test_keymap_globals_exposed(live_server, page):
     assert page.evaluate("typeof window.Keymap.parseShortcut") == "function"
     assert page.evaluate("typeof window.Keymap.matchesShortcut") == "function"
     assert page.evaluate("typeof window.Keymap.isInputFocused") == "function"
+
+
+def test_keymap_register_and_lookup(live_server, page):
+    """register() stores shortcuts; shortcutsForScope() returns them merged with global."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("""
+        window.Keymap.register('global', {
+            key: 'g', name: 'global-test', description: 'd',
+            category: 'Navigation', action: function() {}
+        });
+        window.Keymap.register('browse', {
+            key: 'b', name: 'browse-test', description: 'd',
+            category: 'Edit', action: function() {}
+        });
+    """)
+
+    global_only = page.evaluate("window.Keymap.shortcutsForScope('global').map(s => s.name)")
+    assert global_only == ["global-test"]
+
+    browse_scope = page.evaluate("window.Keymap.shortcutsForScope('browse').map(s => s.name)")
+    # browse scope returns its own shortcuts plus globals
+    assert set(browse_scope) == {"global-test", "browse-test"}

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -210,3 +210,60 @@ def test_action_returning_false_does_not_preventdefault(live_server, page):
 
     page.keyboard.press("y")
     assert page.evaluate("window._kmCalls") == ["first", "second"]
+
+
+def test_esc_closes_shortcuts_cheat_sheet(live_server, page):
+    """Opening the cheat sheet pushes an Esc handler; pressing Esc closes it."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.keyboard.press("?")
+    sheet = page.locator("#shortcutsCheatSheet")
+    expect_open = sheet.evaluate("el => el.classList.contains('open')")
+    assert expect_open is True
+
+    page.keyboard.press("Escape")
+    expect_closed = sheet.evaluate("el => el.classList.contains('open')")
+    assert expect_closed is False
+
+
+def test_two_overlays_unwind_one_esc_each(live_server, page):
+    """With lightbox open and cheat sheet stacked on top, each Esc closes one
+    overlay (top-of-stack first). Locks in the new one-Esc-per-overlay model
+    that replaces the legacy 'shotgun close' Esc cascade."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    # Open the lightbox on the first photo via the JS API directly
+    page.evaluate("openLightbox(1, 'hawk1.jpg')")
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=2000,
+    )
+
+    # Open the shortcuts cheat sheet on top
+    page.evaluate("openShortcutsSheet()")
+    page.wait_for_function(
+        "document.getElementById('shortcutsCheatSheet').classList.contains('open')",
+        timeout=2000,
+    )
+
+    # First Esc closes only the cheat sheet (top of stack)
+    page.keyboard.press("Escape")
+    page.wait_for_function(
+        "!document.getElementById('shortcutsCheatSheet').classList.contains('open')",
+        timeout=2000,
+    )
+    lightbox_still_open = page.evaluate(
+        "document.getElementById('lightboxOverlay').classList.contains('active')"
+    )
+    assert lightbox_still_open is True, "Lightbox should still be open after first Esc"
+
+    # Second Esc closes the lightbox
+    page.keyboard.press("Escape")
+    page.wait_for_function(
+        "!document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=2000,
+    )

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -311,3 +311,18 @@ def test_esc_closes_help_modal_via_stack(live_server, page):
         "!document.getElementById('helpModal').classList.contains('active')",
         timeout=2000,
     )
+
+
+def test_setscope_runs_synchronously_at_page_load(live_server, page):
+    """The navbar IIFE must call Keymap.setScope(pageCtx) synchronously after
+    keymap.js loads. Regression test for the script-ordering bug where
+    keymap.js loaded after the inline IIFE, leaving the dispatcher stuck on
+    'global' scope and silently breaking page-scoped shortcuts in PR 2."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+    assert page.evaluate("window.Keymap.getScope()") == "browse"
+
+    page.goto(f"{url}/review", timeout=5000)
+    page.wait_for_load_state("networkidle")
+    assert page.evaluate("window.Keymap.getScope()") == "review"

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -69,3 +69,42 @@ def test_dispatcher_fires_registered_action(live_server, page):
     """)
     page.keyboard.press("q")
     assert page.evaluate("window._kmTestFired") == 1  # unchanged
+
+
+def test_esc_stack_unwinds_top_first(live_server, page):
+    """pushEsc registers handlers; Esc invokes only the top one each press."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("""
+        window._kmEscOrder = [];
+        window._kmEscToken1 = window.Keymap.pushEsc(function() { window._kmEscOrder.push('first'); });
+        window._kmEscToken2 = window.Keymap.pushEsc(function() { window._kmEscOrder.push('second'); });
+    """)
+
+    page.keyboard.press("Escape")
+    assert page.evaluate("window._kmEscOrder") == ["second"]
+
+    page.keyboard.press("Escape")
+    assert page.evaluate("window._kmEscOrder") == ["second", "first"]
+
+    page.keyboard.press("Escape")
+    assert page.evaluate("window._kmEscOrder") == ["second", "first"]  # stack empty
+
+
+def test_esc_stack_remove_by_token(live_server, page):
+    """popEsc(token) removes a specific handler regardless of position."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=5000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("""
+        window._kmEscOrder = [];
+        var t1 = window.Keymap.pushEsc(function() { window._kmEscOrder.push('first'); });
+        var t2 = window.Keymap.pushEsc(function() { window._kmEscOrder.push('second'); });
+        window.Keymap.popEsc(t2);
+    """)
+
+    page.keyboard.press("Escape")
+    assert page.evaluate("window._kmEscOrder") == ["first"]

--- a/vireo/static/help.js
+++ b/vireo/static/help.js
@@ -78,6 +78,13 @@
 
   // Open / close
   window.openHelpModal = function() {
+    // Push an Esc handler onto the central Keymap stack so the help modal
+    // participates in the one-Esc-per-overlay model. Defensive: if keymap.js
+    // failed to load, opening still works — Esc just won't close the modal.
+    if (window.Keymap && window.Keymap.pushEsc) {
+      if (window._helpEscToken) window.Keymap.popEsc(window._helpEscToken);
+      window._helpEscToken = window.Keymap.pushEsc(function() { window.closeHelpModal(); });
+    }
     modal.classList.add('active');
     document.body.style.overflow = 'hidden';
     input.value = '';
@@ -86,6 +93,10 @@
   };
 
   window.closeHelpModal = function() {
+    if (window.Keymap && window.Keymap.popEsc && window._helpEscToken) {
+      window.Keymap.popEsc(window._helpEscToken);
+      window._helpEscToken = null;
+    }
     modal.classList.remove('active');
     document.body.style.overflow = '';
   };
@@ -95,7 +106,8 @@
     if (e.target === modal) window.closeHelpModal();
   });
 
-  // Keyboard: F1 to open, Escape to close
+  // Keyboard: F1 toggles the help modal. Esc is owned by the Keymap.pushEsc
+  // stack (registered in openHelpModal) and is intentionally NOT handled here.
   document.addEventListener('keydown', function(e) {
     if (e.key === 'F1') {
       e.preventDefault();
@@ -104,9 +116,6 @@
       } else {
         window.openHelpModal();
       }
-    }
-    if (e.key === 'Escape' && modal.classList.contains('active')) {
-      window.closeHelpModal();
     }
   });
 

--- a/vireo/static/help.js
+++ b/vireo/static/help.js
@@ -81,9 +81,11 @@
     // Push an Esc handler onto the central Keymap stack so the help modal
     // participates in the one-Esc-per-overlay model. Defensive: if keymap.js
     // failed to load, opening still works — Esc just won't close the modal.
-    var alreadyOpen = !!window._helpEscToken;
+    // Track open state via the modal's own class rather than the Esc token so
+    // the body-scroll lock pairs cleanly even when Keymap is unavailable.
+    var alreadyOpen = modal.classList.contains('active');
     if (window.Keymap && window.Keymap.pushEsc) {
-      if (alreadyOpen) window.Keymap.popEsc(window._helpEscToken);
+      if (window._helpEscToken) window.Keymap.popEsc(window._helpEscToken);
       window._helpEscToken = window.Keymap.pushEsc(function() { window.closeHelpModal(); });
     }
     modal.classList.add('active');
@@ -97,8 +99,8 @@
   };
 
   window.closeHelpModal = function() {
-    var wasOpen = !!window._helpEscToken;
-    if (window.Keymap && window.Keymap.popEsc && wasOpen) {
+    var wasOpen = modal.classList.contains('active');
+    if (window.Keymap && window.Keymap.popEsc && window._helpEscToken) {
       window.Keymap.popEsc(window._helpEscToken);
       window._helpEscToken = null;
     }

--- a/vireo/static/help.js
+++ b/vireo/static/help.js
@@ -81,24 +81,32 @@
     // Push an Esc handler onto the central Keymap stack so the help modal
     // participates in the one-Esc-per-overlay model. Defensive: if keymap.js
     // failed to load, opening still works — Esc just won't close the modal.
+    var alreadyOpen = !!window._helpEscToken;
     if (window.Keymap && window.Keymap.pushEsc) {
-      if (window._helpEscToken) window.Keymap.popEsc(window._helpEscToken);
+      if (alreadyOpen) window.Keymap.popEsc(window._helpEscToken);
       window._helpEscToken = window.Keymap.pushEsc(function() { window.closeHelpModal(); });
     }
     modal.classList.add('active');
-    document.body.style.overflow = 'hidden';
+    if (!alreadyOpen) {
+      if (window.Keymap && window.Keymap.lockBodyScroll) window.Keymap.lockBodyScroll();
+      else document.body.style.overflow = 'hidden';
+    }
     input.value = '';
     onSearch();
     input.focus();
   };
 
   window.closeHelpModal = function() {
-    if (window.Keymap && window.Keymap.popEsc && window._helpEscToken) {
+    var wasOpen = !!window._helpEscToken;
+    if (window.Keymap && window.Keymap.popEsc && wasOpen) {
       window.Keymap.popEsc(window._helpEscToken);
       window._helpEscToken = null;
     }
     modal.classList.remove('active');
-    document.body.style.overflow = '';
+    if (wasOpen) {
+      if (window.Keymap && window.Keymap.unlockBodyScroll) window.Keymap.unlockBodyScroll();
+      else document.body.style.overflow = '';
+    }
   };
 
   // Close on backdrop click

--- a/vireo/static/keymap.js
+++ b/vireo/static/keymap.js
@@ -59,7 +59,41 @@
   function setScope(scope) { _currentScope = scope; }
   function getScope() { return _currentScope; }
 
+  // Esc stack — single owner of the Escape key. Handlers push themselves
+  // onto the stack; pressing Esc invokes (and removes) the top handler only.
+  var _escStack = [];
+  var _escNextToken = 1;
+
+  function pushEsc(handler) {
+    var token = _escNextToken++;
+    _escStack.push({ token: token, handler: handler });
+    return token;
+  }
+
+  function popEsc(token) {
+    for (var i = _escStack.length - 1; i >= 0; i--) {
+      if (_escStack[i].token === token) {
+        _escStack.splice(i, 1);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function _handleEsc(e) {
+    if (e.key !== 'Escape') return false;
+    if (_escStack.length === 0) return false;
+    var top = _escStack.pop();
+    e.preventDefault();
+    e.stopPropagation();
+    try { top.handler(e); } catch (err) { console.error('Esc handler error', err); }
+    return true;
+  }
+
   function _dispatch(e) {
+    // Esc runs first — even if focus is in an input, an open modal should
+    // still be dismissable with Esc from a field inside it.
+    if (_handleEsc(e)) return;
     if (isInputFocused()) return;
     var candidates = shortcutsForScope(_currentScope);
     for (var i = 0; i < candidates.length; i++) {
@@ -81,6 +115,8 @@
     register: register,
     shortcutsForScope: shortcutsForScope,
     setScope: setScope,
-    getScope: getScope
+    getScope: getScope,
+    pushEsc: pushEsc,
+    popEsc: popEsc
   };
 })(window);

--- a/vireo/static/keymap.js
+++ b/vireo/static/keymap.js
@@ -114,7 +114,11 @@
     }
   }
 
-  document.addEventListener('keydown', _dispatch);
+  // Register in capture phase so the Esc-stack can stop propagation before any
+  // bubble-phase listeners on document.body fire (e.g. page-level Esc handlers).
+  // This preserves the "Esc dismisses overlay without leaking to page" contract
+  // that previously required individual capture-phase listeners per overlay.
+  document.addEventListener('keydown', _dispatch, true);
 
   window.Keymap = {
     parseShortcut: parseShortcut,

--- a/vireo/static/keymap.js
+++ b/vireo/static/keymap.js
@@ -59,6 +59,23 @@
   function setScope(scope) { _currentScope = scope; }
   function getScope() { return _currentScope; }
 
+  // Reference-counted body scroll lock. Stacked overlays each lock once on
+  // open and unlock once on close; only the outermost transition touches the
+  // DOM. Without this, closing a top overlay while a lower one is still open
+  // would unconditionally unlock page scroll behind the active overlay.
+  var _bodyScrollLockCount = 0;
+
+  function lockBodyScroll() {
+    if (_bodyScrollLockCount === 0) document.body.style.overflow = 'hidden';
+    _bodyScrollLockCount++;
+  }
+
+  function unlockBodyScroll() {
+    if (_bodyScrollLockCount === 0) return;
+    _bodyScrollLockCount--;
+    if (_bodyScrollLockCount === 0) document.body.style.overflow = '';
+  }
+
   // Esc stack — single owner of the Escape key. Handlers push themselves
   // onto the stack; pressing Esc invokes (and removes) the top handler only.
   var _escStack = [];
@@ -129,6 +146,8 @@
     setScope: setScope,
     getScope: getScope,
     pushEsc: pushEsc,
-    popEsc: popEsc
+    popEsc: popEsc,
+    lockBodyScroll: lockBodyScroll,
+    unlockBodyScroll: unlockBodyScroll
   };
 })(window);

--- a/vireo/static/keymap.js
+++ b/vireo/static/keymap.js
@@ -1,0 +1,48 @@
+/**
+ * Vireo keymap module — single source of truth for keyboard shortcuts.
+ *
+ * Public API (this PR):
+ *   Keymap.parseShortcut(str)        -> {key, ctrl, meta, shift, alt}
+ *   Keymap.matchesShortcut(event, str)
+ *   Keymap.isInputFocused()          -> bool
+ *
+ * More API lands in subsequent tasks.
+ */
+(function (window) {
+  'use strict';
+
+  function parseShortcut(str) {
+    var parts = str.toLowerCase().split('+');
+    var key = parts.pop();
+    var mods = { ctrl: false, meta: false, shift: false, alt: false };
+    parts.forEach(function (m) { if (m in mods) mods[m] = true; });
+    return { key: key, ctrl: mods.ctrl, meta: mods.meta, shift: mods.shift, alt: mods.alt };
+  }
+
+  function matchesShortcut(e, shortcutStr) {
+    if (!shortcutStr) return false;
+    var sc = parseShortcut(shortcutStr);
+    if (e.key.toLowerCase() !== sc.key) return false;
+    var wantCtrl = sc.ctrl || sc.meta;
+    var hasCtrl = e.ctrlKey || e.metaKey;
+    if (wantCtrl !== hasCtrl) return false;
+    if (sc.shift !== e.shiftKey) return false;
+    if (sc.alt !== e.altKey) return false;
+    return true;
+  }
+
+  function isInputFocused() {
+    var el = document.activeElement;
+    if (!el) return false;
+    var tag = el.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+    if (el.isContentEditable) return true;
+    return false;
+  }
+
+  window.Keymap = {
+    parseShortcut: parseShortcut,
+    matchesShortcut: matchesShortcut,
+    isInputFocused: isInputFocused
+  };
+})(window);

--- a/vireo/static/keymap.js
+++ b/vireo/static/keymap.js
@@ -98,11 +98,19 @@
     var candidates = shortcutsForScope(_currentScope);
     for (var i = 0; i < candidates.length; i++) {
       var sc = candidates[i];
-      if (matchesShortcut(e, sc.key)) {
+      if (!matchesShortcut(e, sc.key)) continue;
+      // Action contract: returning false means "I didn't actually handle this"
+      // (e.g. early-return because an overlay is open). In that case we do NOT
+      // preventDefault and we continue to the next candidate so another scope
+      // still has a chance to handle the key.
+      var handled;
+      try { handled = sc.action(e); }
+      catch (err) { console.error('Keymap action error', err); handled = true; }
+      if (handled !== false) {
         e.preventDefault();
-        try { sc.action(e); } catch (err) { console.error('Keymap action error', err); }
         return;
       }
+      // action returned false — try the next candidate
     }
   }
 

--- a/vireo/static/keymap.js
+++ b/vireo/static/keymap.js
@@ -40,9 +40,25 @@
     return false;
   }
 
+  // scope -> array of shortcut definitions
+  var _registry = { global: [] };
+
+  function register(scope, shortcut) {
+    if (!_registry[scope]) _registry[scope] = [];
+    _registry[scope].push(shortcut);
+  }
+
+  function shortcutsForScope(scope) {
+    var globals = _registry.global || [];
+    if (scope === 'global' || !_registry[scope]) return globals.slice();
+    return _registry[scope].concat(globals);
+  }
+
   window.Keymap = {
     parseShortcut: parseShortcut,
     matchesShortcut: matchesShortcut,
-    isInputFocused: isInputFocused
+    isInputFocused: isInputFocused,
+    register: register,
+    shortcutsForScope: shortcutsForScope
   };
 })(window);

--- a/vireo/static/keymap.js
+++ b/vireo/static/keymap.js
@@ -107,7 +107,18 @@
     return true;
   }
 
+  // Pause flag — when set, the dispatcher yields the keypress entirely so a
+  // higher-priority capture-phase listener (e.g. the /shortcuts editor's key
+  // capture) can claim the next press without nav/global actions firing first.
+  // Both listeners run in the capture phase; this dispatcher is registered at
+  // module load and would otherwise win the race.
+  var _dispatchPaused = false;
+
+  function pauseDispatch() { _dispatchPaused = true; }
+  function resumeDispatch() { _dispatchPaused = false; }
+
   function _dispatch(e) {
+    if (_dispatchPaused) return;
     // Esc runs first — even if focus is in an input, an open modal should
     // still be dismissable with Esc from a field inside it.
     if (_handleEsc(e)) return;
@@ -148,6 +159,8 @@
     pushEsc: pushEsc,
     popEsc: popEsc,
     lockBodyScroll: lockBodyScroll,
-    unlockBodyScroll: unlockBodyScroll
+    unlockBodyScroll: unlockBodyScroll,
+    pauseDispatch: pauseDispatch,
+    resumeDispatch: resumeDispatch
   };
 })(window);

--- a/vireo/static/keymap.js
+++ b/vireo/static/keymap.js
@@ -54,11 +54,33 @@
     return _registry[scope].concat(globals);
   }
 
+  var _currentScope = 'global';
+
+  function setScope(scope) { _currentScope = scope; }
+  function getScope() { return _currentScope; }
+
+  function _dispatch(e) {
+    if (isInputFocused()) return;
+    var candidates = shortcutsForScope(_currentScope);
+    for (var i = 0; i < candidates.length; i++) {
+      var sc = candidates[i];
+      if (matchesShortcut(e, sc.key)) {
+        e.preventDefault();
+        try { sc.action(e); } catch (err) { console.error('Keymap action error', err); }
+        return;
+      }
+    }
+  }
+
+  document.addEventListener('keydown', _dispatch);
+
   window.Keymap = {
     parseShortcut: parseShortcut,
     matchesShortcut: matchesShortcut,
     isInputFocused: isInputFocused,
     register: register,
-    shortcutsForScope: shortcutsForScope
+    shortcutsForScope: shortcutsForScope,
+    setScope: setScope,
+    getScope: getScope
   };
 })(window);

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4949,6 +4949,7 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
 }
 </script>
 <script src="/static/vireo-utils.js"></script>
+<script src="/static/keymap.js"></script>
 <script src="/static/tauri-bridge.js"></script>
 <script>
   /* Updater disabled — startupUpdateCheck skipped until updater is configured */

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1967,37 +1967,46 @@ function sendReport() {
     }
   }
 
-  function setupNavKeydown(navShortcuts) {
-    var keyToHref = {};
-    for (var action in navShortcuts) {
-      if (NAV_ROUTES[action]) keyToHref[navShortcuts[action]] = NAV_ROUTES[action];
-    }
+  // CSS selector for any open overlay/modal. The legacy dispatcher used this
+  // to bail out before navigating; the new Keymap dispatcher has no such
+  // built-in suppression, so each registered nav action checks it itself
+  // (Option B from the migration review). Without this, pressing 'b' while
+  // the lightbox is open would close the lightbox AND navigate.
+  var OVERLAY_SELECTOR = '.lightbox-overlay.active, .pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open, .shortcuts-overlay.open, .help-overlay.active, .report-overlay.active';
 
+  function setupNavKeydown(navShortcuts) {
     var path = location.pathname;
     var pageCtx = null;
     if (path === '/browse') pageCtx = 'browse';
     else if (path === '/review') pageCtx = 'review';
 
-    document.addEventListener('keydown', function(e) {
-      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
-      // Skip if any overlay or modal is open
-      if (document.querySelector('.lightbox-overlay.active, .pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open, .shortcuts-overlay.open, .help-overlay.active, .report-overlay.active')) return;
+    // Tell the central Keymap dispatcher what scope this page is in. Page-scoped
+    // shortcuts that share a key with a global will then shadow it (handled by
+    // shortcutsForScope's page-first ordering).
+    if (pageCtx && window.Keymap && window.Keymap.setScope) {
+      window.Keymap.setScope(pageCtx);
+    }
 
-      for (var shortcutStr in keyToHref) {
-        if (matchesShortcut(e, shortcutStr)) {
-          // Live check: does the current page claim this key?
-          if (pageCtx && window._vireoShortcuts && window._vireoShortcuts[pageCtx]) {
-            var pageShortcuts = window._vireoShortcuts[pageCtx];
-            for (var a in pageShortcuts) {
-              if (pageShortcuts[a] === shortcutStr) return; // page wins
-            }
-          }
-          if (keyToHref[shortcutStr] === path) return;
-          e.preventDefault();
-          window.location.href = keyToHref[shortcutStr];
-          return;
+    if (!window.Keymap || !window.Keymap.register) return;
+
+    Object.keys(NAV_ROUTES).forEach(function (action) {
+      var key = navShortcuts[action];
+      if (!key) return;
+      var route = NAV_ROUTES[action];
+      window.Keymap.register('global', {
+        key: key,
+        name: action,
+        description: 'Go to ' + action.replace(/_/g, ' '),
+        category: 'Navigation',
+        action: function () {
+          // Suppress while any overlay/modal is open — preserves the legacy
+          // dispatcher's overlay-aware behavior (see OVERLAY_SELECTOR comment).
+          if (document.querySelector(OVERLAY_SELECTOR)) return;
+          // Don't navigate if we're already on this page.
+          if (window.location.pathname === route) return;
+          window.location.href = route;
         }
-      }
+      });
     });
   }
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2108,17 +2108,19 @@ function sendReport() {
   }
 
   window.openShortcutsSheet = function() {
-    if (window._sheetEscToken) Keymap.popEsc(window._sheetEscToken);
+    var alreadyOpen = !!window._sheetEscToken;
+    if (alreadyOpen) Keymap.popEsc(window._sheetEscToken);
     window._sheetEscToken = Keymap.pushEsc(function() { closeShortcutsSheet(); });
     renderSheet();
     document.getElementById('shortcutsCheatSheet').classList.add('open');
-    document.body.style.overflow = 'hidden';
+    if (!alreadyOpen) Keymap.lockBodyScroll();
   };
 
   window.closeShortcutsSheet = function() {
-    if (window._sheetEscToken) { Keymap.popEsc(window._sheetEscToken); window._sheetEscToken = null; }
+    var wasOpen = !!window._sheetEscToken;
+    if (wasOpen) { Keymap.popEsc(window._sheetEscToken); window._sheetEscToken = null; }
     document.getElementById('shortcutsCheatSheet').classList.remove('open');
-    document.body.style.overflow = '';
+    if (wasOpen) Keymap.unlockBodyScroll();
   };
 
   // Listen for ? key. Esc is owned by the Keymap.pushEsc stack — this listener
@@ -2479,8 +2481,10 @@ function _lbLoadDetections(photoId) {
 }
 
 function openLightbox(photoId, filename, photoList) {
-  if (window._lbEscToken) Keymap.popEsc(window._lbEscToken);
+  var alreadyOpen = !!window._lbEscToken;
+  if (alreadyOpen) Keymap.popEsc(window._lbEscToken);
   window._lbEscToken = Keymap.pushEsc(function() { closeLightbox(); });
+  if (!alreadyOpen) Keymap.lockBodyScroll();
 
   _lightboxCurrentId = photoId;
   if (photoList) _lightboxPhotoList = photoList;
@@ -2558,7 +2562,6 @@ function openLightbox(photoId, filename, photoList) {
     }
   }
   overlay.classList.add('active');
-  document.body.style.overflow = 'hidden';
 
   // Fetch and render detection bounding boxes
   _lbLoadDetections(photoId);
@@ -2702,7 +2705,8 @@ function toggleLightboxZoom(e) {
 
 function closeLightbox(e) {
   if (e && e.target && e.target.tagName === 'IMG') return;
-  if (window._lbEscToken) { Keymap.popEsc(window._lbEscToken); window._lbEscToken = null; }
+  var wasOpen = !!window._lbEscToken;
+  if (wasOpen) { Keymap.popEsc(window._lbEscToken); window._lbEscToken = null; }
   var wrap = document.getElementById('lightboxWrap');
   if (wrap) { wrap.classList.remove('zoomed'); }
   _lbZoom = 1.0;
@@ -2716,7 +2720,7 @@ function closeLightbox(e) {
   document.getElementById('lightboxZoomBadge').style.display = 'none';
   var detContainer = document.getElementById('lightboxDetections');
   if (detContainer) detContainer.innerHTML = '';
-  document.body.style.overflow = '';
+  if (wasOpen) Keymap.unlockBodyScroll();
 }
 
 /* ---------- Lightbox right-click context menu ----------
@@ -3447,13 +3451,14 @@ function _lbScheduleSourceSwap() {
 
 <script>
 function openPipeline(photoId) {
-  if (window._pipelineEscToken) Keymap.popEsc(window._pipelineEscToken);
+  var alreadyOpen = !!window._pipelineEscToken;
+  if (alreadyOpen) Keymap.popEsc(window._pipelineEscToken);
   window._pipelineEscToken = Keymap.pushEsc(function() { closePipeline(); });
 
   var overlay = document.getElementById('pipelineOverlay');
   var content = document.getElementById('pipelineContent');
   overlay.classList.add('active');
-  document.body.style.overflow = 'hidden';
+  if (!alreadyOpen) Keymap.lockBodyScroll();
   content.innerHTML = '<p style="color:var(--text-dim);">Loading pipeline data...</p>';
 
   safeFetch('/api/photos/' + photoId + '/pipeline', {}, { toast: false })
@@ -3462,9 +3467,10 @@ function openPipeline(photoId) {
 }
 
 function closePipeline() {
-  if (window._pipelineEscToken) { Keymap.popEsc(window._pipelineEscToken); window._pipelineEscToken = null; }
+  var wasOpen = !!window._pipelineEscToken;
+  if (wasOpen) { Keymap.popEsc(window._pipelineEscToken); window._pipelineEscToken = null; }
   document.getElementById('pipelineOverlay').classList.remove('active');
-  document.body.style.overflow = '';
+  if (wasOpen) Keymap.unlockBodyScroll();
 }
 
 function renderPipeline(data, photoId) {
@@ -3598,13 +3604,14 @@ function renderPipeline(data, photoId) {
 
 <script>
 function findSimilar(photoId) {
-  if (window._similarEscToken) Keymap.popEsc(window._similarEscToken);
+  var alreadyOpen = !!window._similarEscToken;
+  if (alreadyOpen) Keymap.popEsc(window._similarEscToken);
   window._similarEscToken = Keymap.pushEsc(function() { closeSimilar(); });
 
   var overlay = document.getElementById('similarOverlay');
   var content = document.getElementById('similarContent');
   overlay.classList.add('active');
-  document.body.style.overflow = 'hidden';
+  if (!alreadyOpen) Keymap.lockBodyScroll();
   content.innerHTML = '<p style="color:var(--text-dim);">Searching for similar photos...</p>';
 
   safeFetch('/api/photos/' + photoId + '/similar?limit=40', {}, { toast: false })
@@ -3641,9 +3648,10 @@ function findSimilar(photoId) {
 }
 
 function closeSimilar() {
-  if (window._similarEscToken) { Keymap.popEsc(window._similarEscToken); window._similarEscToken = null; }
+  var wasOpen = !!window._similarEscToken;
+  if (wasOpen) { Keymap.popEsc(window._similarEscToken); window._similarEscToken = null; }
   document.getElementById('similarOverlay').classList.remove('active');
-  document.body.style.overflow = '';
+  if (wasOpen) Keymap.unlockBodyScroll();
 }
 </script>
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1992,6 +1992,18 @@ function sendReport() {
           // Return false so the dispatcher does NOT preventDefault and another
           // candidate (or the browser) can still handle the key.
           if (document.querySelector(OVERLAY_SELECTOR)) return false;
+          // Page-shadows-global precedence for legacy _vireoShortcuts bindings:
+          // browse/review page handlers still listen on document directly (they
+          // migrate into the registry in PR 4). If the current page has bound
+          // this key to one of its own actions, yield so the page's bubble-phase
+          // listener can handle it. Without this, a user who remaps e.g. browse
+          // 'flag' to 'b' would navigate away instead of flagging.
+          if (_pageCtx && window._vireoShortcuts && window._vireoShortcuts[_pageCtx]) {
+            var pageShortcuts = window._vireoShortcuts[_pageCtx];
+            for (var a in pageShortcuts) {
+              if (pageShortcuts[a] === key) return false;
+            }
+          }
           // Don't navigate if we're already on this page.
           if (window.location.pathname === route) return false;
           window.location.href = route;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1975,18 +1975,6 @@ function sendReport() {
   var OVERLAY_SELECTOR = '.lightbox-overlay.active, .pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open, .shortcuts-overlay.open, .help-overlay.active, .report-overlay.active';
 
   function setupNavKeydown(navShortcuts) {
-    var path = location.pathname;
-    var pageCtx = null;
-    if (path === '/browse') pageCtx = 'browse';
-    else if (path === '/review') pageCtx = 'review';
-
-    // Tell the central Keymap dispatcher what scope this page is in. Page-scoped
-    // shortcuts that share a key with a global will then shadow it (handled by
-    // shortcutsForScope's page-first ordering).
-    if (pageCtx && window.Keymap && window.Keymap.setScope) {
-      window.Keymap.setScope(pageCtx);
-    }
-
     if (!window.Keymap || !window.Keymap.register) return;
 
     Object.keys(NAV_ROUTES).forEach(function (action) {
@@ -2001,13 +1989,26 @@ function sendReport() {
         action: function () {
           // Suppress while any overlay/modal is open — preserves the legacy
           // dispatcher's overlay-aware behavior (see OVERLAY_SELECTOR comment).
-          if (document.querySelector(OVERLAY_SELECTOR)) return;
+          // Return false so the dispatcher does NOT preventDefault and another
+          // candidate (or the browser) can still handle the key.
+          if (document.querySelector(OVERLAY_SELECTOR)) return false;
           // Don't navigate if we're already on this page.
-          if (window.location.pathname === route) return;
+          if (window.location.pathname === route) return false;
           window.location.href = route;
         }
       });
     });
+  }
+
+  // Determine page scope and tell the Keymap dispatcher synchronously, before
+  // any /api/config fetch resolves. Otherwise page-scoped shortcuts registered
+  // by other scripts would race the fetch and dispatch on the wrong scope.
+  var _path = location.pathname;
+  var _pageCtx = null;
+  if (_path === '/browse') _pageCtx = 'browse';
+  else if (_path === '/review') _pageCtx = 'review';
+  if (_pageCtx && window.Keymap && window.Keymap.setScope) {
+    window.Keymap.setScope(_pageCtx);
   }
 
   // Fetch config and apply

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1291,6 +1291,9 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
     <div class="report-status" id="reportStatus"></div>
   </div>
 </div>
+<!-- Load keymap.js before any inline <script> blocks below so window.Keymap
+     (registry, dispatcher, Esc stack) is available when they run. -->
+<script src="/static/keymap.js"></script>
 <script>
 function openReportModal() {
   if (window._reportEscToken) Keymap.popEsc(window._reportEscToken);
@@ -4979,7 +4982,6 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
 }
 </script>
 <script src="/static/vireo-utils.js"></script>
-<script src="/static/keymap.js"></script>
 <script src="/static/tauri-bridge.js"></script>
 <script>
   /* Updater disabled — startupUpdateCheck skipped until updater is configured */

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1293,6 +1293,9 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 </div>
 <script>
 function openReportModal() {
+  if (window._reportEscToken) Keymap.popEsc(window._reportEscToken);
+  window._reportEscToken = Keymap.pushEsc(function() { closeReportModal(); });
+
   document.getElementById('reportModal').classList.add('active');
   document.getElementById('reportDescription').value = '';
   document.getElementById('reportStatus').className = 'report-status';
@@ -1301,6 +1304,7 @@ function openReportModal() {
   document.getElementById('reportDescription').focus();
 }
 function closeReportModal() {
+  if (window._reportEscToken) { Keymap.popEsc(window._reportEscToken); window._reportEscToken = null; }
   document.getElementById('reportModal').classList.remove('active');
 }
 function sendReport() {
@@ -1357,11 +1361,12 @@ function sendReport() {
 (function(){
   let _ctxEl = null;
   let _ctxDismiss = null;
+  let _ctxEscToken = null;
 
   window.closeContextMenu = function(){
+    if (_ctxEscToken !== null) { Keymap.popEsc(_ctxEscToken); _ctxEscToken = null; }
     if (_ctxEl) { _ctxEl.remove(); _ctxEl = null; }
     document.removeEventListener('mousedown', _outside, true);
-    document.removeEventListener('keydown', _keydown, true);
     window.removeEventListener('blur', closeContextMenu);
     if (_ctxDismiss) { const f = _ctxDismiss; _ctxDismiss = null; f(); }
   };
@@ -1383,16 +1388,6 @@ function sendReport() {
       // window), remove the swallow listener after a short delay so we
       // don't eat an unrelated later click.
       setTimeout(() => window.removeEventListener('click', swallow, true), 200);
-      closeContextMenu();
-    }
-  }
-  function _keydown(e){
-    if (e.key === 'Escape') {
-      // Stop propagation in the capture phase so page-level Escape handlers
-      // (e.g. browse.html's clearSelection, lightbox close) don't also fire.
-      // The user dismissed the menu, not the underlying surface.
-      e.preventDefault();
-      e.stopPropagation();
       closeContextMenu();
     }
   }
@@ -1453,7 +1448,9 @@ function sendReport() {
     _ctxEl = menu;
     _ctxDismiss = (opts && opts.onDismiss) || null;
     document.addEventListener('mousedown', _outside, true);
-    document.addEventListener('keydown', _keydown, true);
+    // Esc handling: push onto the Keymap stack so a single Esc closes only the
+    // context menu (the user dismissed the menu, not the underlying surface).
+    _ctxEscToken = Keymap.pushEsc(function() { closeContextMenu(); });
     window.addEventListener('blur', closeContextMenu);
   };
 
@@ -2096,25 +2093,29 @@ function sendReport() {
   }
 
   window.openShortcutsSheet = function() {
+    if (window._sheetEscToken) Keymap.popEsc(window._sheetEscToken);
+    window._sheetEscToken = Keymap.pushEsc(function() { closeShortcutsSheet(); });
     renderSheet();
     document.getElementById('shortcutsCheatSheet').classList.add('open');
     document.body.style.overflow = 'hidden';
   };
 
   window.closeShortcutsSheet = function() {
+    if (window._sheetEscToken) { Keymap.popEsc(window._sheetEscToken); window._sheetEscToken = null; }
     document.getElementById('shortcutsCheatSheet').classList.remove('open');
     document.body.style.overflow = '';
   };
 
-  // Listen for ? key
+  // Listen for ? key. Esc is owned by the Keymap.pushEsc stack — this listener
+  // only opens the sheet on '?' and consumes non-Esc keys while the sheet is
+  // open so page handlers (rating, navigation, etc.) don't also fire.
   document.addEventListener('keydown', function(e) {
     if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
     if (document.querySelector('.lightbox-overlay.active, .pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open, .help-overlay.active')) return;
-    // When overlay is open, consume ALL key events so page handlers don't fire
+    // When sheet is open, consume non-Esc keys so page handlers don't fire.
+    // Esc is handled by the Keymap.pushEsc stack and must reach the dispatcher.
     if (document.getElementById('shortcutsCheatSheet').classList.contains('open')) {
-      if (e.key === 'Escape') {
-        closeShortcutsSheet();
-      }
+      if (e.key === 'Escape') return;
       e.preventDefault();
       e.stopImmediatePropagation();
       return;
@@ -2463,6 +2464,9 @@ function _lbLoadDetections(photoId) {
 }
 
 function openLightbox(photoId, filename, photoList) {
+  if (window._lbEscToken) Keymap.popEsc(window._lbEscToken);
+  window._lbEscToken = Keymap.pushEsc(function() { closeLightbox(); });
+
   _lightboxCurrentId = photoId;
   if (photoList) _lightboxPhotoList = photoList;
 
@@ -2683,6 +2687,7 @@ function toggleLightboxZoom(e) {
 
 function closeLightbox(e) {
   if (e && e.target && e.target.tagName === 'IMG') return;
+  if (window._lbEscToken) { Keymap.popEsc(window._lbEscToken); window._lbEscToken = null; }
   var wrap = document.getElementById('lightboxWrap');
   if (wrap) { wrap.classList.remove('zoomed'); }
   _lbZoom = 1.0;
@@ -2979,6 +2984,9 @@ async function submitToInatBatch(photoIds) {
 }
 
 function openInatModal() {
+  if (window._inatEscToken) Keymap.popEsc(window._inatEscToken);
+  window._inatEscToken = Keymap.pushEsc(function() { closeInatModal(); });
+
   var title = inatQueue.length === 1 ? 'Submit to iNaturalist' : 'Submit ' + inatQueue.length + ' observations to iNaturalist';
   document.getElementById('inatModalTitle').textContent = title;
   document.getElementById('inatProgress').style.display = 'none';
@@ -3016,6 +3024,7 @@ function openInatModal() {
 }
 
 function closeInatModal() {
+  if (window._inatEscToken) { Keymap.popEsc(window._inatEscToken); window._inatEscToken = null; }
   document.getElementById('inatModal').classList.remove('open');
   inatQueue = [];
 }
@@ -3088,7 +3097,10 @@ async function inatDoSubmit() {
 // If adding JS-based navigation shortcuts, guard with:
 //   if (window.__TAURI_INTERNALS__) return;
 document.addEventListener('keydown', function(e) {
-  if (e.key === 'Escape') { closeLightbox(); closePipeline(); closeSimilar(); closeInatModal(); if (typeof closeHelpModal === 'function') closeHelpModal(); if (typeof closeReportModal === 'function') closeReportModal(); }
+  // Esc handling for the lightbox + overlay cascade is owned by the Keymap.pushEsc
+  // stack now: each open*() pushes its close*() and each close*() pops it. The
+  // listener below still handles arrow keys / +/-/0 / B / Z while the lightbox
+  // is open.
   if (!document.getElementById('lightboxOverlay').classList.contains('active')) return;
   if (e.key === 'ArrowRight') { lightboxNav(1); e.preventDefault(); }
   if (e.key === 'ArrowLeft') { lightboxNav(-1); e.preventDefault(); }
@@ -3420,6 +3432,9 @@ function _lbScheduleSourceSwap() {
 
 <script>
 function openPipeline(photoId) {
+  if (window._pipelineEscToken) Keymap.popEsc(window._pipelineEscToken);
+  window._pipelineEscToken = Keymap.pushEsc(function() { closePipeline(); });
+
   var overlay = document.getElementById('pipelineOverlay');
   var content = document.getElementById('pipelineContent');
   overlay.classList.add('active');
@@ -3432,6 +3447,7 @@ function openPipeline(photoId) {
 }
 
 function closePipeline() {
+  if (window._pipelineEscToken) { Keymap.popEsc(window._pipelineEscToken); window._pipelineEscToken = null; }
   document.getElementById('pipelineOverlay').classList.remove('active');
   document.body.style.overflow = '';
 }
@@ -3567,6 +3583,9 @@ function renderPipeline(data, photoId) {
 
 <script>
 function findSimilar(photoId) {
+  if (window._similarEscToken) Keymap.popEsc(window._similarEscToken);
+  window._similarEscToken = Keymap.pushEsc(function() { closeSimilar(); });
+
   var overlay = document.getElementById('similarOverlay');
   var content = document.getElementById('similarContent');
   overlay.classList.add('active');
@@ -3607,6 +3626,7 @@ function findSimilar(photoId) {
 }
 
 function closeSimilar() {
+  if (window._similarEscToken) { Keymap.popEsc(window._similarEscToken); window._similarEscToken = null; }
   document.getElementById('similarOverlay').classList.remove('active');
   document.body.style.overflow = '';
 }

--- a/vireo/templates/shortcuts.html
+++ b/vireo/templates/shortcuts.html
@@ -180,6 +180,17 @@ function startCapture(btn, ctx, action) {
   btn.classList.add('capturing');
   btn.textContent = 'Press a key...';
 
+  // Pause the global Keymap dispatcher so registered nav actions don't fire
+  // (and navigate the user away) while we're trying to capture the next key.
+  // Both this listener and the dispatcher run in the capture phase, but the
+  // dispatcher was registered at module load and wins the race otherwise.
+  if (window.Keymap && window.Keymap.pauseDispatch) window.Keymap.pauseDispatch();
+
+  function endCapture() {
+    document.removeEventListener('keydown', onKey, true);
+    if (window.Keymap && window.Keymap.resumeDispatch) window.Keymap.resumeDispatch();
+  }
+
   function onKey(e) {
     e.preventDefault();
     e.stopPropagation();
@@ -196,7 +207,7 @@ function startCapture(btn, ctx, action) {
     if (conflict) {
       btn.classList.remove('capturing');
       capturingBtn = null;
-      document.removeEventListener('keydown', onKey, true);
+      endCapture();
       btn.textContent = 'Conflict: ' + SHORTCUT_LABELS[ctx][conflict];
       btn.style.borderColor = 'var(--danger)';
       btn.style.color = 'var(--danger)';
@@ -207,7 +218,7 @@ function startCapture(btn, ctx, action) {
     currentShortcuts[ctx][action] = keyStr;
     btn.classList.remove('capturing');
     capturingBtn = null;
-    document.removeEventListener('keydown', onKey, true);
+    endCapture();
     renderShortcutsEditor();
     saveShortcuts();
   }
@@ -218,7 +229,7 @@ function startCapture(btn, ctx, action) {
     if (capturingBtn === btn) {
       btn.classList.remove('capturing');
       capturingBtn = null;
-      document.removeEventListener('keydown', onKey, true);
+      endCapture();
       renderShortcutsEditor();
     }
     btn.removeEventListener('blur', onBlur);


### PR DESCRIPTION
## Summary

PR 1 of 4 (foundation) for the keymap unification work. Pure plumbing — no new user-visible features. Sets up a single `vireo/static/keymap.js` module that owns:

- **A scoped shortcut registry** (`global` + per-page scopes) with page-shadows-global precedence.
- **A central capture-phase keydown dispatcher** with input-focus suppression and a `return false` "not handled" contract for actions that early-return.
- **An Esc stack** (`pushEsc` / `popEsc`) that owns the Escape key. One Esc closes the top overlay only — replaces the legacy shotgun-close cascade.

**Migrated:** navbar nav letters (`b`, `c`, `r`, `m`, `k`, …) onto the registry; seven `_navbar.html` overlays (lightbox, pipeline, similar, iNat, shortcuts cheat sheet, report modal, context menu) and `help.js` onto the Esc stack.

**Out of scope:** per-page handlers in `browse.html` / `review.html` / `cull.html` etc. are untouched — they migrate in PR 4. The `cfg.keyboard_shortcuts` config schema and `shortcuts.html` editor are unchanged and fully backwards-compatible.

## Intentional behavior change

The previous shotgun-close cascade closed every overlay on a single Esc press. The new Esc stack closes them one at a time, top first. Locked in by `test_two_overlays_unwind_one_esc_each`. This is the correct behavior per the design and matches every other Vireo-style app.

## Design and plan documents

- `docs/plans/2026-04-30-keymap-design.md` — full Vimium-inspired design (link hints + discoverability) covering all 4 PRs
- `docs/plans/2026-04-30-keymap-pr1-foundation.md` — task-by-task implementation plan for this PR

## Test plan

- [x] `tests/e2e/test_keymap.py` — 13 new tests (registry, dispatcher, Esc stack, precedence, navbar nav, overlay suppression, action-returns-false contract, two-overlay unwinding, no-leak-to-page, help modal Esc, setScope-on-load)
- [x] CLAUDE.md curated suite — 820 passed, 2 pre-existing failures (`test_remove_keyword_from_photo`, `test_undo_keyword_remove_clears_pending_change` — both confirmed in known-failures list, unrelated to keyboard work)
- [x] Full e2e suite — 157 passed, 1 skipped

## Coming in subsequent PRs

- **PR 2** — Discoverability layer: context-aware `?` modal driven by the registry, inline shortcut badges with a `\` toggle.
- **PR 3** — Link hints: `f` / `F` / `gf` Vimium-style link hint overlay.
- **PR 4** — Coverage: migrate the remaining per-page shortcut handlers (browse/review/cull/misses/etc.) into the registry; extend `J`/`K` to all grid/list pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)