### PR TITLE
pipeline: auto-download SuperAnimal weights, drop manual readiness panel

### DIFF
--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -265,34 +265,13 @@ def test_pipeline_failed_status_clears_running_pill(live_server, page):
     expect(page.locator("#pillClassify")).not_to_contain_text("Running")
 
 
-def test_pipeline_eye_keypoints_pill_will_skip_when_no_weights(live_server, page):
-    """Eye Keypoints is gated by both the user toggle and whether SuperAnimal
-    weights are on disk. The fixture doesn't ship any keypoint models, so
-    /api/models/keypoints/status reports both as 'missing' and the pill
-    must show 'Will skip' (mirroring the backend preflight), not 'Will run',
-    even with the enable checkbox checked.
-    """
+def test_pipeline_eye_keypoints_pill_will_run_by_default(live_server, page):
+    """SuperAnimal weights are auto-downloaded by pipeline_job on first run,
+    so the pill defaults to 'Will run' even on a fresh fixture with no
+    keypoint models on disk — the user is no longer expected to click a
+    Download button before starting the pipeline."""
     url = live_server["url"]
     page.goto(f"{url}/pipeline")
-    expect(page.locator("#pillEyeKeypoints")).to_contain_text("Will skip")
-    summary = page.locator("[data-testid='pipeline-plan-summary']")
-    skip_row = summary.locator(".plan-row.will-skip .plan-stages")
-    expect(skip_row).to_contain_text("Eye Keypoints")
-    will_run_row = summary.locator(".plan-row.will-run .plan-stages")
-    expect(will_run_row).not_to_contain_text("Eye Keypoints")
-
-
-def test_pipeline_eye_keypoints_pill_will_run_when_models_ready(live_server, page):
-    """When at least one keypoint model is ready, the pill flips back to
-    'Will run'. Simulated by stubbing the status endpoint client-side and
-    re-invoking refreshKeypointsStatus."""
-    url = live_server["url"]
-    page.goto(f"{url}/pipeline")
-    expect(page.locator("#pillEyeKeypoints")).to_be_visible()
-    page.evaluate("""
-        window._keypointModelsReady = true;
-        refreshPipelineUI();
-    """)
     expect(page.locator("#pillEyeKeypoints")).to_contain_text("Will run")
 
 
@@ -301,10 +280,6 @@ def test_pipeline_eye_keypoints_toggle_off_marks_will_skip(live_server, page):
     'Will skip' without affecting Group, which doesn't depend on it."""
     url = live_server["url"]
     page.goto(f"{url}/pipeline")
-    page.evaluate("""
-        window._keypointModelsReady = true;
-        refreshPipelineUI();
-    """)
     expect(page.locator("#pillEyeKeypoints")).to_contain_text("Will run")
     page.click("#card-eyekeypoints .stage-header")
     page.uncheck("#enableEyeKeypoints")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3878,60 +3878,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "dinov2_known": dinov2_variant in DINOV2_VARIANTS,
         })
 
-    # --- Eye-focus keypoint model download (opt-in) ---
-    _ALLOWED_KEYPOINT_MODELS = (
-        "superanimal-quadruped",
-        "superanimal-bird",
-        "rtmpose-animal",
-    )
-
-    @app.route("/api/models/keypoints/status")
-    def api_keypoints_status():
-        """Return download state for each eye-focus keypoint model."""
-        import keypoints as kp
-
-        return jsonify({
-            name.replace("-", "_"): kp.weights_status(name)
-            for name in _ALLOWED_KEYPOINT_MODELS
-        })
-
-    @app.route(
-        "/api/models/keypoints/<model_name>/download",
-        methods=["POST"],
-    )
-    def api_keypoints_download(model_name):
-        """Trigger a background download of the named keypoint model.
-
-        Rejects unknown model names so a bad argument can't be coerced into
-        an arbitrary HuggingFace fetch. Returns immediately; the client
-        polls /api/models/keypoints/status to observe progress.
-        """
-        import threading
-
-        import keypoints as kp
-
-        if model_name not in _ALLOWED_KEYPOINT_MODELS:
-            return json_error(f"unknown keypoint model {model_name!r}", 400)
-
-        current = kp.weights_status(model_name)
-        if current in ("ready", "downloading"):
-            return jsonify({"status": current})
-
-        def _download():
-            kp._download_state[model_name] = "downloading"
-            try:
-                kp.ensure_keypoint_weights(model_name)
-                kp._download_state[model_name] = "idle"
-            except Exception as exc:
-                log.warning(
-                    "Keypoint weights download failed for %s: %s",
-                    model_name, exc,
-                )
-                kp._download_state[model_name] = "failed"
-
-        threading.Thread(target=_download, daemon=True).start()
-        return jsonify({"status": "downloading"})
-
     @app.route("/api/system/install-exiftool", methods=["POST"])
     def api_install_exiftool():
         """Install exiftool via Homebrew."""

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -687,13 +687,13 @@ def eye_keypoint_stage_preflight(config):
     Returns None when the stage should run. Shared between
     detect_eye_keypoints_stage and the pipeline job so the job can avoid the
     O(N) eligibility join when the stage is going to short-circuit anyway.
+
+    SuperAnimal weights are auto-downloaded by the pipeline job at stage
+    start (mirroring SAM2/DINOv2), so a missing-weights state is no longer
+    a preflight skip — only the explicit config flag is.
     """
     if not config.get("eye_detect_enabled", True):
         return "Disabled in config"
-    import keypoints as kp
-    routable = set(_EYE_KEYPOINT_MODEL_FOR_CLASS.values())
-    if not any(kp.weights_status(name) == "ready" for name in routable):
-        return "No keypoint models installed"
     return None
 
 
@@ -749,9 +749,10 @@ def _process_photo_for_eye(db, row, folders, *, C, T, k_window):
     if model_name is None:
         return
 
-    # Gate 2: weights present on disk. Stage does NOT auto-download — the
-    # user opts in via the pipeline models card. If a partial download left
-    # model.onnx but no config.json (or vice versa), skip defensively.
+    # Gate 2: weights present on disk. The pipeline job auto-downloads both
+    # SuperAnimal variants at stage start (mirroring SAM2/DINOv2), so this
+    # check is defensive — a partial download (e.g. config.json missing) is
+    # the only case where it should still trip.
     onnx_path = os.path.join(kp.MODELS_DIR, model_name, "model.onnx")
     config_path = os.path.join(kp.MODELS_DIR, model_name, "config.json")
     if not (os.path.isfile(onnx_path) and os.path.isfile(config_path)):

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2701,8 +2701,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 import keypoints as kp
                 from pipeline import _resolve_keypoint_model
 
+                # Mirror Gate 1 in _process_photo_for_eye: rows whose
+                # classifier confidence is below eye_classifier_conf_gate
+                # get skipped at run time, so they shouldn't influence
+                # which variants get downloaded — otherwise an all-low-
+                # confidence collection still pays the bandwidth cost
+                # for weights no photo can reach.
+                conf_gate = pipeline_cfg.get(
+                    "eye_classifier_conf_gate", 0.5,
+                )
                 needed_models = []
                 for row in photos_for_stage:
+                    if (row.get("species_conf") or 0.0) < conf_gate:
+                        continue
                     model_name = _resolve_keypoint_model(thread_db, row)
                     if model_name and model_name not in needed_models:
                         needed_models.append(model_name)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2729,10 +2729,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     )
 
                 # Preserve a stable order (quadruped, bird) for tests and
-                # log readability when both variants are needed.
+                # log readability when both variants are needed. Re-check
+                # abort between models so a cancel that arrives after the
+                # first weights download can short-circuit the second
+                # multi-hundred-MB fetch instead of forcing the user to
+                # wait through it.
                 for kp_model in (
                     "superanimal-quadruped", "superanimal-bird",
                 ):
+                    if _should_abort(abort):
+                        break
                     if kp_model in needed_models:
                         kp.ensure_keypoint_weights(
                             kp_model, progress_callback=_dl_progress,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2671,6 +2671,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             photos_for_stage = thread_db.list_photos_for_eye_keypoint_stage(
                 photo_ids=collection_photo_ids,
             )
+            # Defensive second filter: when collection_photo_ids is None
+            # (whole-workspace path) the DB query above returned every
+            # eligible row, so excluded IDs would otherwise still influence
+            # the download planner below and trigger weights for variants no
+            # included photo routes to.
+            if params.exclude_photo_ids:
+                photos_for_stage = [
+                    p for p in photos_for_stage
+                    if p["id"] not in params.exclude_photo_ids
+                ]
             total = len(photos_for_stage)
             start_time = time.time()
             processed = {"count": 0}

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2744,15 +2744,45 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # first weights download can short-circuit the second
                 # multi-hundred-MB fetch instead of forcing the user to
                 # wait through it.
-                for kp_model in (
-                    "superanimal-quadruped", "superanimal-bird",
-                ):
-                    if _should_abort(abort):
-                        break
-                    if kp_model in needed_models:
-                        kp.ensure_keypoint_weights(
-                            kp_model, progress_callback=_dl_progress,
-                        )
+                #
+                # Eye Keypoints is an optional stage: a transient HF /
+                # network failure must degrade to a skipped stage, not a
+                # hard pipeline failure. Without this guard the RuntimeError
+                # raised by ensure_keypoint_weights bubbles to the outer
+                # except, marks the stage 'failed', and tanks the whole
+                # run for a first-run/offline user who never opted into
+                # eye keypoints in the first place.
+                try:
+                    for kp_model in (
+                        "superanimal-quadruped", "superanimal-bird",
+                    ):
+                        if _should_abort(abort):
+                            break
+                        if kp_model in needed_models:
+                            kp.ensure_keypoint_weights(
+                                kp_model, progress_callback=_dl_progress,
+                            )
+                except Exception as dl_err:
+                    log.warning(
+                        "Eye keypoints stage skipped — weight download "
+                        "failed: %s", dl_err,
+                    )
+                    errors.append(f"[eye_keypoints] {dl_err}")
+                    stages["eye_keypoints"]["status"] = "skipped"
+                    runner.update_step(
+                        job["id"], "eye_keypoints",
+                        status="completed",
+                        summary=(
+                            f"Skipped — failed to download keypoint "
+                            f"weights: {dl_err}"
+                        ),
+                    )
+                    result["stages"]["eye_keypoints"] = {
+                        "processed": 0, "total": total,
+                        "skipped": "weight_download_failed",
+                    }
+                    _update_stages(runner, job["id"], stages)
+                    return
 
             detect_eye_keypoints_stage(
                 thread_db, config=pipeline_cfg, progress_callback=_progress,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2668,9 +2668,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     pid for pid in collection_photo_ids
                     if pid not in params.exclude_photo_ids
                 }
-            total = len(thread_db.list_photos_for_eye_keypoint_stage(
+            photos_for_stage = thread_db.list_photos_for_eye_keypoint_stage(
                 photo_ids=collection_photo_ids,
-            ))
+            )
+            total = len(photos_for_stage)
             start_time = time.time()
             processed = {"count": 0}
 
@@ -2692,18 +2693,39 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             # Auto-download SuperAnimal weights on first pipeline run.
             # Mirrors the SAM2/DINOv2 auto-download pattern in extract_masks
             # (commit 90cd0f9): without this, every photo silently skips on
-            # a fresh install. Both variants are fetched because the per-
-            # photo router picks bird vs. quadruped from taxonomy_class.
-            # Gate on total > 0 so a no-op rerun doesn't pay the download
-            # cost for zero photos.
+            # a fresh install. Only fetch variants the per-photo router
+            # would actually pick — a collection of out-of-scope classes
+            # (fish/reptiles/invertebrates) shouldn't pay the bandwidth
+            # cost for weights that will never be used.
             if total > 0:
                 import keypoints as kp
+                from pipeline import _resolve_keypoint_model
+
+                needed_models = []
+                for row in photos_for_stage:
+                    model_name = _resolve_keypoint_model(thread_db, row)
+                    if model_name and model_name not in needed_models:
+                        needed_models.append(model_name)
+
+                # Use a separate download-progress callback so a cancel
+                # during/just after weight download doesn't leak the
+                # download counter into `processed['count']` (which would
+                # surface as e.g. "Cancelled (1 of N processed)" before any
+                # photo has actually been touched).
+                def _dl_progress(phase, current, total_steps):
+                    _emit_progress(
+                        runner, job["id"], stages, "eye_keypoints", phase,
+                    )
+
+                # Preserve a stable order (quadruped, bird) for tests and
+                # log readability when both variants are needed.
                 for kp_model in (
                     "superanimal-quadruped", "superanimal-bird",
                 ):
-                    kp.ensure_keypoint_weights(
-                        kp_model, progress_callback=_progress,
-                    )
+                    if kp_model in needed_models:
+                        kp.ensure_keypoint_weights(
+                            kp_model, progress_callback=_dl_progress,
+                        )
 
             detect_eye_keypoints_stage(
                 thread_db, config=pipeline_cfg, progress_callback=_progress,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2689,6 +2689,22 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     ),
                 )
 
+            # Auto-download SuperAnimal weights on first pipeline run.
+            # Mirrors the SAM2/DINOv2 auto-download pattern in extract_masks
+            # (commit 90cd0f9): without this, every photo silently skips on
+            # a fresh install. Both variants are fetched because the per-
+            # photo router picks bird vs. quadruped from taxonomy_class.
+            # Gate on total > 0 so a no-op rerun doesn't pay the download
+            # cost for zero photos.
+            if total > 0:
+                import keypoints as kp
+                for kp_model in (
+                    "superanimal-quadruped", "superanimal-bird",
+                ):
+                    kp.ensure_keypoint_weights(
+                        kp_model, progress_callback=_progress,
+                    )
+
             detect_eye_keypoints_stage(
                 thread_db, config=pipeline_cfg, progress_callback=_progress,
                 collection_id=collection_id,

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -972,29 +972,12 @@ body { padding-bottom: 36px; }
     </div>
     <div class="stage-body">
       <p style="font-size:13px;color:var(--text-secondary);margin-bottom:12px;">
-        Per-photo eye localization via SuperAnimal keypoint models. When weights
-        are present, the pipeline refines the focus score using the windowed
-        sharpness around the eye instead of the whole subject. Fish, reptiles,
-        and invertebrates are skipped automatically.
+        Per-photo eye localization via SuperAnimal keypoint models. The pipeline
+        refines the focus score using the windowed sharpness around the eye
+        instead of the whole subject. Fish, reptiles, and invertebrates are
+        skipped automatically. SuperAnimal weights are downloaded automatically
+        on first run.
       </p>
-      <div id="eyeKeypointsReadinessPanel" style="font-size:13px;line-height:1.8;">
-        <div data-keypoint-row="superanimal-quadruped">
-          <span class="kp-state-icon"></span>
-          <span>SuperAnimal-Quadruped</span>
-          <span class="kp-state-text" style="color:var(--text-secondary);margin-left:6px;"></span>
-          <button type="button" class="btn btn-small kp-download-btn"
-                  onclick="downloadKeypointModel('superanimal-quadruped')"
-                  style="margin-left:10px;display:none;">Download</button>
-        </div>
-        <div data-keypoint-row="superanimal-bird">
-          <span class="kp-state-icon"></span>
-          <span>SuperAnimal-Bird</span>
-          <span class="kp-state-text" style="color:var(--text-secondary);margin-left:6px;"></span>
-          <button type="button" class="btn btn-small kp-download-btn"
-                  onclick="downloadKeypointModel('superanimal-bird')"
-                  style="margin-left:10px;display:none;">Download</button>
-        </div>
-      </div>
       <span class="status-msg" id="statusEyeKeypoints"></span>
       <div class="progress-wrap" id="progressEyeKeypoints" style="display:none;">
         <div class="progress-bar-track"><div class="progress-bar-fill" id="fillEyeKeypoints"></div></div>
@@ -1134,7 +1117,6 @@ function initPipelinePage() {
       updateCardStates();
       if (typeof updateReadiness === 'function') updateReadiness();
       if (typeof updateExtractReadiness === 'function') updateExtractReadiness();
-      if (typeof refreshKeypointsStatus === 'function') refreshKeypointsStatus();
 
       // Populate recent destinations
       var recents = data.recent_destinations || [];
@@ -3177,126 +3159,9 @@ function renderModelReadiness(label, info, known) {
   return frag;
 }
 
-// -- Card 7: Eye Keypoints (optional) --
-// Status polling is driven by openKeypointsCardPolling / closeKeypointsCardPolling
-// to avoid a permanent background timer that wastes cycles when the card is
-// not expanded.
-
-var _kpPollTimer = null;
-
-function _renderKeypointRow(modelName, state) {
-  // Per-model row in the Eye Keypoints card. state: 'ready' | 'missing' |
-  // 'downloading' | 'failed'. Reset disabled=false up front so a stale
-  // disable from the initial click never survives a transition to a state
-  // that re-shows the button (e.g. 'failed' → Retry).
-  var row = document.querySelector('[data-keypoint-row="' + modelName + '"]');
-  if (!row) return;
-  var iconEl = row.querySelector('.kp-state-icon');
-  var textEl = row.querySelector('.kp-state-text');
-  var btnEl  = row.querySelector('.kp-download-btn');
-  btnEl.disabled = false;
-
-  if (state === 'ready') {
-    iconEl.textContent = '\u2713';
-    iconEl.style.color = 'var(--accent,#24E5CA)';
-    textEl.textContent = 'Ready';
-    btnEl.style.display = 'none';
-  } else if (state === 'downloading') {
-    iconEl.textContent = '\u25EF';
-    iconEl.style.color = 'var(--warning,#f0c040)';
-    textEl.textContent = 'Downloading...';
-    btnEl.disabled = true;
-    btnEl.style.display = 'none';
-  } else if (state === 'failed') {
-    iconEl.textContent = '\u2717';
-    iconEl.style.color = 'var(--danger,#e74c3c)';
-    textEl.textContent = 'Download failed \u2014 retry?';
-    btnEl.textContent = 'Retry';
-    btnEl.style.display = '';
-  } else {
-    iconEl.textContent = '\u25CB';
-    iconEl.style.color = 'var(--text-faint,#5A8890)';
-    textEl.textContent = 'Not downloaded';
-    btnEl.textContent = 'Download';
-    btnEl.style.display = '';
-  }
-}
-
-async function refreshKeypointsStatus() {
-  try {
-    var s = await safeFetch(
-      '/api/models/keypoints/status', {}, { toast: false }
-    );
-    _renderKeypointRow(
-      'superanimal-quadruped', s.superanimal_quadruped || 'missing'
-    );
-    _renderKeypointRow(
-      'superanimal-bird', s.superanimal_bird || 'missing'
-    );
-    _keypointModelsReady = (
-      s.superanimal_quadruped === 'ready' ||
-      s.superanimal_bird === 'ready'
-    );
-    refreshPipelineUI();
-    // If either model is still downloading, ensure polling is running.
-    // Covers the page-reload-mid-download case where init calls
-    // refreshKeypointsStatus once and finds an in-flight download but no
-    // local timer. Otherwise stop polling — user will re-trigger via a
-    // button click that restarts it.
-    var inflight = (
-      s.superanimal_quadruped === 'downloading' ||
-      s.superanimal_bird === 'downloading'
-    );
-    if (inflight) {
-      startKeypointsPolling();
-    } else if (_kpPollTimer) {
-      clearInterval(_kpPollTimer);
-      _kpPollTimer = null;
-    }
-  } catch (e) {
-    // Initial page-load call has no timer yet, so render the fallback
-    // 'missing' state (which shows a Download button) and schedule a
-    // retry. Otherwise users see a blank row after a transient API error
-    // until they reload the page. startKeypointsPolling is idempotent,
-    // and a subsequent successful fetch with no in-flight downloads will
-    // clear the timer via the path above.
-    _renderKeypointRow('superanimal-quadruped', 'missing');
-    _renderKeypointRow('superanimal-bird', 'missing');
-    _keypointModelsReady = false;
-    refreshPipelineUI();
-    startKeypointsPolling();
-  }
-}
-
-function startKeypointsPolling() {
-  if (_kpPollTimer) return;
-  _kpPollTimer = setInterval(refreshKeypointsStatus, 2000);
-}
-
-async function downloadKeypointModel(modelName) {
-  // Disable the button immediately to prevent double-clicks; refreshKeypointsStatus
-  // will re-render with the real server state on the next poll tick.
-  var row = document.querySelector('[data-keypoint-row="' + modelName + '"]');
-  if (row) {
-    var btn = row.querySelector('.kp-download-btn');
-    if (btn) btn.disabled = true;
-  }
-  try {
-    await safeFetch(
-      '/api/models/keypoints/' + encodeURIComponent(modelName) + '/download',
-      { method: 'POST' },
-      { toast: false }
-    );
-    // Optimistic render: show 'downloading' before the first poll confirms.
-    _renderKeypointRow(modelName, 'downloading');
-    startKeypointsPolling();
-  } catch (e) {
-    if (row) {
-      var btn2 = row.querySelector('.kp-download-btn');
-      if (btn2) btn2.disabled = false;
-    }
-  }
-}
+// Card 7: Eye Keypoints — SuperAnimal weights are auto-downloaded by
+// pipeline_job.eye_keypoints_stage on first run (mirrors SAM2/DINOv2),
+// so no readiness panel, status polling, or download buttons live here.
 
 async function runExtractStep(collectionId) {
   var num = document.getElementById('numExtract');
@@ -3401,13 +3266,6 @@ var _pipelineState = {
 var _runningStages = {};  // suffix -> true while that stage is running
 var _stageOutcomes = {};  // suffix -> 'done' | 'failed' | 'will-skip' | 'done-prior'
 
-// Eye Keypoints has no enable checkbox and no `prior` flag, so without an
-// extra signal `_stageStateFor` would always show "Will run" for it. The
-// backend skips the stage when no SuperAnimal weights are on disk, so the
-// pre-run plan must reflect that. `null` means "status not yet polled" —
-// treat as runnable until we know better, to avoid flicker on page load.
-var _keypointModelsReady = null;  // true | false | null (unknown)
-
 var _STAGES = [
   { suffix: 'Scan',         label: 'Scan & Import',          enable: null,             prior: null },
   { suffix: 'Previews',     label: 'Thumbnails & Previews',  enable: null,             prior: null },
@@ -3459,14 +3317,6 @@ function _stageStateFor(stage) {
   if (stage.suffix === 'Classify') {
     var rc = document.getElementById('chkReclassify');
     reclassify = !!(rc && rc.checked);
-  }
-
-  // Eye Keypoints is also gated by whether SuperAnimal weights are on disk —
-  // backend `eye_keypoint_stage_preflight` returns a skip reason in the
-  // no-weights case, so the plan summary mirrors that pre-run regardless of
-  // the user-toggle state.
-  if (stage.suffix === 'EyeKeypoints' && _keypointModelsReady === false) {
-    return 'will-skip';
   }
 
   if (stage.enable) {

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -730,36 +730,24 @@ def test_eye_keypoint_stage_preflight_disabled(tmp_path, monkeypatch):
         == "Disabled in config"
 
 
-def test_eye_keypoint_stage_preflight_no_weights(tmp_path, monkeypatch):
-    """Preflight returns a skip reason when no routable weights are installed."""
-    import keypoints as kp
+def test_eye_keypoint_stage_preflight_enabled(tmp_path, monkeypatch):
+    """Preflight returns None when eye detection is enabled. Weights presence
+    is no longer a preflight gate — pipeline_job.eye_keypoints_stage
+    auto-downloads them at run time, so detect_eye_keypoints_stage relies
+    on the per-photo defensive check rather than a stage-level guard.
+    """
     from pipeline import eye_keypoint_stage_preflight
 
-    empty_models_dir = tmp_path / "empty"
-    empty_models_dir.mkdir()
-    monkeypatch.setattr(kp, "MODELS_DIR", str(empty_models_dir))
-
-    assert eye_keypoint_stage_preflight({}) == "No keypoint models installed"
-
-
-def test_eye_keypoint_stage_preflight_ready(tmp_path, monkeypatch):
-    """Preflight returns None when at least one routable model is ready."""
-    import keypoints as kp
-    from pipeline import eye_keypoint_stage_preflight
-
-    models_dir = tmp_path / "models"
-    models_dir.mkdir()
-    _make_fake_weights(str(models_dir), "superanimal-quadruped")
-    monkeypatch.setattr(kp, "MODELS_DIR", str(models_dir))
-
+    assert eye_keypoint_stage_preflight({"eye_detect_enabled": True}) is None
     assert eye_keypoint_stage_preflight({}) is None
 
 
-def test_eye_keypoint_stage_skips_when_weights_absent(tmp_path, monkeypatch):
-    """No routable keypoint weights installed → stage-level preflight
-    short-circuits before enumerating photos. Confirms that
-    list_photos_for_eye_keypoint_stage is never called (no O(N) DB pass)
-    and that no eye fields get written.
+def test_eye_keypoint_stage_writes_nothing_when_weights_absent(
+    tmp_path, monkeypatch,
+):
+    """When detect_eye_keypoints_stage is invoked without weights on disk
+    (e.g. someone bypasses pipeline_job's auto-download), the per-photo
+    Gate 2 check skips writing eye_* — no records get partial state.
     """
     import keypoints as kp
     from pipeline import detect_eye_keypoints_stage
@@ -770,18 +758,8 @@ def test_eye_keypoint_stage_skips_when_weights_absent(tmp_path, monkeypatch):
 
     db, pid = _setup_eligible_mammal_photo(tmp_path)
 
-    called = {"listed": False}
-    orig = db.list_photos_for_eye_keypoint_stage
-
-    def _spy(*args, **kwargs):
-        called["listed"] = True
-        return orig(*args, **kwargs)
-
-    monkeypatch.setattr(db, "list_photos_for_eye_keypoint_stage", _spy)
-
     detect_eye_keypoints_stage(db, config={"eye_detect_enabled": True})
 
-    assert called["listed"] is False
     row = db.conn.execute(
         "SELECT eye_x, eye_y, eye_conf, eye_tenengrad FROM photos WHERE id=?",
         (pid,),

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6302,6 +6302,13 @@ def test_pipeline_eye_keypoints_cancel_marks_stage_cancelled(
         Database, "list_photos_for_eye_keypoint_stage",
         lambda self, **k: [{"id": pid}],
     )
+    # Stub ensure_keypoint_weights so the auto-download path doesn't try to
+    # hit HuggingFace from a unit test. Pretend weights are already there.
+    import keypoints as _kp_mod
+    monkeypatch.setattr(
+        _kp_mod, "ensure_keypoint_weights",
+        lambda name, progress_callback=None: "/fake/model.onnx",
+    )
 
     abort_now = [False]
 
@@ -6355,6 +6362,148 @@ def test_pipeline_eye_keypoints_cancel_marks_stage_cancelled(
     assert "Cancelled" in summary, (
         f"eye_keypoints final summary must reflect cancellation; got "
         f"{summary!r}"
+    )
+
+
+def test_pipeline_eye_keypoints_stage_auto_downloads_superanimal_weights(
+    tmp_path, monkeypatch,
+):
+    """The eye_keypoints stage must call ensure_keypoint_weights for both
+    SuperAnimal models before iterating photos. Without this auto-download,
+    a fresh install would silently produce zero eye keypoints because the
+    per-photo Gate 2 check would skip every photo.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    _stub_extract_masks_heavy_ops(monkeypatch)
+
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    monkeypatch.setattr(
+        Database, "list_photos_for_eye_keypoint_stage",
+        lambda self, **k: [{"id": pid}],
+    )
+    # detect_eye_keypoints_stage stub — we're testing the wrapping stage's
+    # download orchestration, not per-photo inference.
+    monkeypatch.setattr(
+        pipeline_mod, "detect_eye_keypoints_stage",
+        lambda *a, **k: None,
+    )
+
+    downloaded = []
+    import keypoints as _kp_mod
+
+    def _spy_ensure(name, progress_callback=None):
+        downloaded.append(name)
+        return "/fake/model.onnx"
+
+    monkeypatch.setattr(_kp_mod, "ensure_keypoint_weights", _spy_ensure)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert downloaded == ["superanimal-quadruped", "superanimal-bird"], (
+        f"Expected stage to auto-download both SuperAnimal variants in order; "
+        f"got {downloaded!r}"
+    )
+
+
+def test_pipeline_eye_keypoints_stage_skips_download_when_no_eligible_photos(
+    tmp_path, monkeypatch,
+):
+    """When no photos are eligible (total == 0), the stage must NOT trigger
+    a multi-hundred-MB download — gate matches the SAM2/DINOv2 pattern."""
+    import config as cfg
+    import pipeline as pipeline_mod
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    _stub_extract_masks_heavy_ops(monkeypatch)
+
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    # Force "no eligible photos" — preflight passes but the eligibility
+    # query returns nothing.
+    monkeypatch.setattr(
+        Database, "list_photos_for_eye_keypoint_stage",
+        lambda self, **k: [],
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "detect_eye_keypoints_stage",
+        lambda *a, **k: None,
+    )
+
+    downloaded = []
+    import keypoints as _kp_mod
+    monkeypatch.setattr(
+        _kp_mod, "ensure_keypoint_weights",
+        lambda name, progress_callback=None: downloaded.append(name) or "/fake",
+    )
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_regroup=True,
+    )
+    run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
+
+    assert downloaded == [], (
+        f"Expected no auto-download when 0 photos are eligible; got {downloaded!r}"
     )
 
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6369,7 +6369,8 @@ def test_pipeline_eye_keypoints_stage_auto_downloads_superanimal_weights(
     tmp_path, monkeypatch,
 ):
     """The eye_keypoints stage must call ensure_keypoint_weights for both
-    SuperAnimal models before iterating photos. Without this auto-download,
+    SuperAnimal models before iterating photos when the eligible set
+    contains both bird and quadruped subjects. Without this auto-download,
     a fresh install would silently produce zero eye keypoints because the
     per-photo Gate 2 check would skip every photo.
     """
@@ -6404,9 +6405,14 @@ def test_pipeline_eye_keypoints_stage_auto_downloads_superanimal_weights(
     monkeypatch.setattr(
         pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
     )
+    # Provide one bird and one quadruped row so the routing-aware download
+    # picks both SuperAnimal variants.
     monkeypatch.setattr(
         Database, "list_photos_for_eye_keypoint_stage",
-        lambda self, **k: [{"id": pid}],
+        lambda self, **k: [
+            {"id": pid, "taxonomy_class": "Mammalia"},
+            {"id": pid + 1000, "taxonomy_class": "Aves"},
+        ],
     )
     # detect_eye_keypoints_stage stub — we're testing the wrapping stage's
     # download orchestration, not per-photo inference.
@@ -6437,6 +6443,269 @@ def test_pipeline_eye_keypoints_stage_auto_downloads_superanimal_weights(
     assert downloaded == ["superanimal-quadruped", "superanimal-bird"], (
         f"Expected stage to auto-download both SuperAnimal variants in order; "
         f"got {downloaded!r}"
+    )
+
+
+def test_pipeline_eye_keypoints_stage_only_downloads_routable_variants(
+    tmp_path, monkeypatch,
+):
+    """When every eligible photo routes to bird, the stage must skip the
+    quadruped variant download (and vice versa). Otherwise a bird-only
+    collection pays the full quadruped download cost for weights it would
+    never use.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    _stub_extract_masks_heavy_ops(monkeypatch)
+
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    # Bird-only eligible set.
+    monkeypatch.setattr(
+        Database, "list_photos_for_eye_keypoint_stage",
+        lambda self, **k: [
+            {"id": pid, "taxonomy_class": "Aves"},
+        ],
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "detect_eye_keypoints_stage",
+        lambda *a, **k: None,
+    )
+
+    downloaded = []
+    import keypoints as _kp_mod
+    monkeypatch.setattr(
+        _kp_mod, "ensure_keypoint_weights",
+        lambda name, progress_callback=None: downloaded.append(name) or "/fake",
+    )
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_regroup=True,
+    )
+    run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
+
+    assert downloaded == ["superanimal-bird"], (
+        f"Expected only superanimal-bird to download for a bird-only "
+        f"eligible set; got {downloaded!r}"
+    )
+
+
+def test_pipeline_eye_keypoints_stage_skips_download_for_out_of_scope_only(
+    tmp_path, monkeypatch,
+):
+    """A collection of only out-of-scope subjects (fish/reptiles/inverts)
+    must not trigger any SuperAnimal download. Without routing-awareness,
+    the prior `if total > 0` guard would still pull both ~hundreds-of-MB
+    variants even though `_resolve_keypoint_model` skips every photo.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    _stub_extract_masks_heavy_ops(monkeypatch)
+
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    # Eligible photos exist (total > 0) but every row carries an
+    # out-of-scope taxonomy_class — the per-photo router will return None
+    # for each, so no SuperAnimal model is needed.
+    monkeypatch.setattr(
+        Database, "list_photos_for_eye_keypoint_stage",
+        lambda self, **k: [
+            {"id": pid, "taxonomy_class": "Reptilia"},
+            {"id": pid + 1, "taxonomy_class": "Actinopterygii"},
+        ],
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "detect_eye_keypoints_stage",
+        lambda *a, **k: None,
+    )
+
+    downloaded = []
+    import keypoints as _kp_mod
+    monkeypatch.setattr(
+        _kp_mod, "ensure_keypoint_weights",
+        lambda name, progress_callback=None: downloaded.append(name) or "/fake",
+    )
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_regroup=True,
+    )
+    run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
+
+    assert downloaded == [], (
+        f"Expected zero downloads for an out-of-scope-only eligible set; "
+        f"got {downloaded!r}"
+    )
+
+
+def test_pipeline_eye_keypoints_stage_download_progress_isolated_from_photo_count(
+    tmp_path, monkeypatch,
+):
+    """The download progress callback must NOT advance the photo
+    `processed` counter. Otherwise a cancel during/just after weight
+    download surfaces e.g. "Cancelled (1 of N processed)" before any
+    photo has actually been touched, misreporting stage outcomes.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    import pipeline_job as pj
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    _stub_extract_masks_heavy_ops(monkeypatch)
+
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    # Three quadruped rows so total=3 — large enough to make the bug
+    # observable if the download callback bumps the photo counter.
+    monkeypatch.setattr(
+        Database, "list_photos_for_eye_keypoint_stage",
+        lambda self, **k: [
+            {"id": pid, "taxonomy_class": "Mammalia"},
+            {"id": pid + 1, "taxonomy_class": "Mammalia"},
+            {"id": pid + 2, "taxonomy_class": "Mammalia"},
+        ],
+    )
+
+    abort_now = [False]
+
+    # Stub ensure_keypoint_weights to (a) invoke the progress callback the
+    # way the real implementation does — phase, current=0/total=1 then
+    # current=1/total=1 — and (b) trigger an abort, so detect_*_stage
+    # exits before any real photo work happens.
+    import keypoints as _kp_mod
+
+    def _ensure_with_progress(name, progress_callback=None):
+        if progress_callback is not None:
+            progress_callback(f"Downloading {name}...", 0, 1)
+            progress_callback(f"{name} ready", 1, 1)
+        abort_now[0] = True
+        return "/fake/model.onnx"
+
+    monkeypatch.setattr(
+        _kp_mod, "ensure_keypoint_weights", _ensure_with_progress,
+    )
+    # Make detect_eye_keypoints_stage a no-op — the abort fires before it
+    # would touch a photo and we want to assert what the wrapping stage
+    # reports for processed['count'].
+    monkeypatch.setattr(
+        pipeline_mod, "detect_eye_keypoints_stage",
+        lambda *a, **k: None,
+    )
+
+    original_should_abort = pj._should_abort
+
+    def patched_should_abort(event):
+        if abort_now[0]:
+            return True
+        return original_should_abort(event)
+
+    monkeypatch.setattr(pj, "_should_abort", patched_should_abort)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    ek_finals = [
+        kw for (_, sid, kw) in runner.step_updates
+        if sid == "eye_keypoints" and kw.get("status") in (
+            "completed", "failed",
+        ) and "summary" in kw
+    ]
+    assert ek_finals, (
+        f"Expected eye_keypoints final update; got "
+        f"step_updates={runner.step_updates!r}"
+    )
+    summary = ek_finals[-1].get("summary") or ""
+    # Cancel summary must report 0 processed (no photo ran), not 1 — the
+    # download callback must not bleed into the photo counter.
+    assert "Cancelled (0 of 3 processed)" in summary, (
+        f"Download progress callback leaked into the photo counter; "
+        f"expected 'Cancelled (0 of 3 processed)', got {summary!r}"
     )
 
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6406,12 +6406,14 @@ def test_pipeline_eye_keypoints_stage_auto_downloads_superanimal_weights(
         pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
     )
     # Provide one bird and one quadruped row so the routing-aware download
-    # picks both SuperAnimal variants.
+    # picks both SuperAnimal variants. species_conf is above the default
+    # eye_classifier_conf_gate (0.5) so the conf-gate filter doesn't drop
+    # them before _resolve_keypoint_model runs.
     monkeypatch.setattr(
         Database, "list_photos_for_eye_keypoint_stage",
         lambda self, **k: [
-            {"id": pid, "taxonomy_class": "Mammalia"},
-            {"id": pid + 1000, "taxonomy_class": "Aves"},
+            {"id": pid, "taxonomy_class": "Mammalia", "species_conf": 0.9},
+            {"id": pid + 1000, "taxonomy_class": "Aves", "species_conf": 0.9},
         ],
     )
     # detect_eye_keypoints_stage stub — we're testing the wrapping stage's
@@ -6485,11 +6487,13 @@ def test_pipeline_eye_keypoints_stage_only_downloads_routable_variants(
     monkeypatch.setattr(
         pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
     )
-    # Bird-only eligible set.
+    # Bird-only eligible set; species_conf above eye_classifier_conf_gate
+    # (default 0.5) so the conf-gate filter doesn't drop the row before
+    # routing.
     monkeypatch.setattr(
         Database, "list_photos_for_eye_keypoint_stage",
         lambda self, **k: [
-            {"id": pid, "taxonomy_class": "Aves"},
+            {"id": pid, "taxonomy_class": "Aves", "species_conf": 0.9},
         ],
     )
     monkeypatch.setattr(
@@ -6559,12 +6563,15 @@ def test_pipeline_eye_keypoints_stage_skips_download_for_out_of_scope_only(
     )
     # Eligible photos exist (total > 0) but every row carries an
     # out-of-scope taxonomy_class — the per-photo router will return None
-    # for each, so no SuperAnimal model is needed.
+    # for each, so no SuperAnimal model is needed. species_conf is above
+    # the conf-gate threshold to isolate the routing skip from the
+    # confidence skip.
     monkeypatch.setattr(
         Database, "list_photos_for_eye_keypoint_stage",
         lambda self, **k: [
-            {"id": pid, "taxonomy_class": "Reptilia"},
-            {"id": pid + 1, "taxonomy_class": "Actinopterygii"},
+            {"id": pid, "taxonomy_class": "Reptilia", "species_conf": 0.9},
+            {"id": pid + 1, "taxonomy_class": "Actinopterygii",
+             "species_conf": 0.9},
         ],
     )
     monkeypatch.setattr(
@@ -6635,12 +6642,14 @@ def test_pipeline_eye_keypoints_stage_download_progress_isolated_from_photo_coun
     )
     # Three quadruped rows so total=3 — large enough to make the bug
     # observable if the download callback bumps the photo counter.
+    # species_conf above the conf-gate so they reach the download
+    # planner.
     monkeypatch.setattr(
         Database, "list_photos_for_eye_keypoint_stage",
         lambda self, **k: [
-            {"id": pid, "taxonomy_class": "Mammalia"},
-            {"id": pid + 1, "taxonomy_class": "Mammalia"},
-            {"id": pid + 2, "taxonomy_class": "Mammalia"},
+            {"id": pid, "taxonomy_class": "Mammalia", "species_conf": 0.9},
+            {"id": pid + 1, "taxonomy_class": "Mammalia", "species_conf": 0.9},
+            {"id": pid + 2, "taxonomy_class": "Mammalia", "species_conf": 0.9},
         ],
     )
 
@@ -6773,6 +6782,80 @@ def test_pipeline_eye_keypoints_stage_skips_download_when_no_eligible_photos(
 
     assert downloaded == [], (
         f"Expected no auto-download when 0 photos are eligible; got {downloaded!r}"
+    )
+
+
+def test_pipeline_eye_keypoints_stage_skips_download_when_all_below_conf_gate(
+    tmp_path, monkeypatch,
+):
+    """When every eligible row has species_conf below
+    eye_classifier_conf_gate, _process_photo_for_eye skips it at Gate 1
+    before any keypoint inference. The download planner must mirror that
+    threshold so an all-low-confidence collection doesn't pull
+    multi-hundred-MB SuperAnimal weights that no photo can use.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    _stub_extract_masks_heavy_ops(monkeypatch)
+
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    # Default eye_classifier_conf_gate is 0.5; both rows sit below it.
+    monkeypatch.setattr(
+        Database, "list_photos_for_eye_keypoint_stage",
+        lambda self, **k: [
+            {"id": pid, "taxonomy_class": "Mammalia", "species_conf": 0.2},
+            {"id": pid + 1, "taxonomy_class": "Aves", "species_conf": 0.4},
+        ],
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "detect_eye_keypoints_stage",
+        lambda *a, **k: None,
+    )
+
+    downloaded = []
+    import keypoints as _kp_mod
+    monkeypatch.setattr(
+        _kp_mod, "ensure_keypoint_weights",
+        lambda name, progress_callback=None: downloaded.append(name) or "/fake",
+    )
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_regroup=True,
+    )
+    run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
+
+    assert downloaded == [], (
+        f"Expected no downloads for an all-below-conf-gate set; "
+        f"got {downloaded!r}"
     )
 
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6950,6 +6950,117 @@ def test_pipeline_eye_keypoints_stage_aborts_between_keypoint_downloads(
     )
 
 
+def test_pipeline_eye_keypoints_stage_download_failure_skips_stage_not_pipeline(
+    tmp_path, monkeypatch,
+):
+    """A transient HuggingFace/network failure inside
+    ensure_keypoint_weights must degrade Eye Keypoints to a skipped stage
+    rather than failing the whole pipeline run. Without this, first-run /
+    offline users who never asked to opt out of eye keypoints get a hard
+    RuntimeError out of run_pipeline_job for an optional stage.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    _stub_extract_masks_heavy_ops(monkeypatch)
+
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    monkeypatch.setattr(
+        Database, "list_photos_for_eye_keypoint_stage",
+        lambda self, **k: [
+            {"id": pid, "taxonomy_class": "Mammalia", "species_conf": 0.9},
+        ],
+    )
+
+    detect_called = [False]
+
+    def fake_detect_eye_keypoints_stage(*a, **k):
+        detect_called[0] = True
+
+    monkeypatch.setattr(
+        pipeline_mod, "detect_eye_keypoints_stage",
+        fake_detect_eye_keypoints_stage,
+    )
+
+    import keypoints as _kp_mod
+
+    def _ensure_raises(name, progress_callback=None):
+        raise RuntimeError(
+            f"Failed to download {name} weights: connection reset. "
+            "Check your network connection and retry."
+        )
+
+    monkeypatch.setattr(_kp_mod, "ensure_keypoint_weights", _ensure_raises)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+    # Must NOT raise: an optional stage's download failure cannot tank
+    # the whole pipeline run.
+    result = run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert detect_called[0] is False, (
+        "detect_eye_keypoints_stage must be skipped when weight download "
+        "fails; running it would crash on missing weights."
+    )
+
+    ek_finals = [
+        kw for (_, sid, kw) in runner.step_updates
+        if sid == "eye_keypoints" and "summary" in kw
+    ]
+    assert ek_finals, (
+        f"Expected eye_keypoints final update; got "
+        f"step_updates={runner.step_updates!r}"
+    )
+    final = ek_finals[-1]
+    assert final.get("status") == "completed", (
+        f"eye_keypoints must finalize as completed (skipped variant), not "
+        f"failed; got {final!r}"
+    )
+    summary = final.get("summary") or ""
+    assert "Skipped" in summary and "download" in summary.lower(), (
+        f"eye_keypoints summary must explain the download was skipped; "
+        f"got {summary!r}"
+    )
+
+    ek_result = result.get("stages", {}).get("eye_keypoints", {})
+    assert ek_result.get("skipped") == "weight_download_failed", (
+        f"result.stages.eye_keypoints must record the skip reason; "
+        f"got {ek_result!r}"
+    )
+
+
 def test_pipeline_eye_keypoints_stage_excluded_photos_do_not_influence_downloads(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6859,6 +6859,97 @@ def test_pipeline_eye_keypoints_stage_skips_download_when_all_below_conf_gate(
     )
 
 
+def test_pipeline_eye_keypoints_stage_aborts_between_keypoint_downloads(
+    tmp_path, monkeypatch,
+):
+    """A cancel that arrives after the first SuperAnimal weights download
+    must short-circuit the second. Without the abort check between models
+    the user waits through tens-to-hundreds of MB of unwanted bandwidth
+    before the stage exits.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    import pipeline_job as pj
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    _stub_extract_masks_heavy_ops(monkeypatch)
+
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    # One mammal + one bird so the planner queues both variants.
+    monkeypatch.setattr(
+        Database, "list_photos_for_eye_keypoint_stage",
+        lambda self, **k: [
+            {"id": pid, "taxonomy_class": "Mammalia", "species_conf": 0.9},
+            {"id": pid + 1, "taxonomy_class": "Aves", "species_conf": 0.9},
+        ],
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "detect_eye_keypoints_stage",
+        lambda *a, **k: None,
+    )
+
+    abort_now = [False]
+    downloaded = []
+    import keypoints as _kp_mod
+
+    def _ensure_then_abort(name, progress_callback=None):
+        downloaded.append(name)
+        # Trigger abort the moment the first download "finishes" so the
+        # next iteration's abort check fires.
+        abort_now[0] = True
+        return "/fake/model.onnx"
+
+    monkeypatch.setattr(
+        _kp_mod, "ensure_keypoint_weights", _ensure_then_abort,
+    )
+
+    original_should_abort = pj._should_abort
+
+    def patched_should_abort(event):
+        if abort_now[0]:
+            return True
+        return original_should_abort(event)
+
+    monkeypatch.setattr(pj, "_should_abort", patched_should_abort)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_regroup=True,
+    )
+    run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
+
+    assert downloaded == ["superanimal-quadruped"], (
+        f"Cancel after the first weights download must short-circuit the "
+        f"second; expected ['superanimal-quadruped'], got {downloaded!r}"
+    )
+
+
 def test_detect_eye_keypoints_stage_honors_abort_check(tmp_path, monkeypatch):
     """detect_eye_keypoints_stage must accept an `abort_check` callable and
     break the per-photo loop the first time it returns True. Without this

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6950,6 +6950,85 @@ def test_pipeline_eye_keypoints_stage_aborts_between_keypoint_downloads(
     )
 
 
+def test_pipeline_eye_keypoints_stage_excluded_photos_do_not_influence_downloads(
+    tmp_path, monkeypatch,
+):
+    """Photos in params.exclude_photo_ids must not influence which
+    SuperAnimal variants are downloaded. detect_eye_keypoints_stage already
+    skips them per-photo, so pulling weights to satisfy a deselected row
+    wastes bandwidth on a variant that no included photo will use.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    _stub_extract_masks_heavy_ops(monkeypatch)
+
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    # One bird (kept) + one mammal (excluded). After exclusion, only the
+    # bird variant should be downloaded — the mammal row would route to
+    # quadruped, but it's deselected so that variant is wasted bandwidth.
+    excluded_id = pid + 7
+    monkeypatch.setattr(
+        Database, "list_photos_for_eye_keypoint_stage",
+        lambda self, **k: [
+            {"id": pid, "taxonomy_class": "Aves", "species_conf": 0.9},
+            {"id": excluded_id, "taxonomy_class": "Mammalia",
+             "species_conf": 0.9},
+        ],
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "detect_eye_keypoints_stage",
+        lambda *a, **k: None,
+    )
+
+    downloaded = []
+    import keypoints as _kp_mod
+    monkeypatch.setattr(
+        _kp_mod, "ensure_keypoint_weights",
+        lambda name, progress_callback=None: downloaded.append(name) or "/fake",
+    )
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_regroup=True,
+        exclude_photo_ids={excluded_id},
+    )
+    run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
+
+    assert downloaded == ["superanimal-bird"], (
+        f"Expected only superanimal-bird to download — the mammal row was "
+        f"excluded and shouldn't influence the download planner; "
+        f"got {downloaded!r}"
+    )
+
+
 def test_detect_eye_keypoints_stage_honors_abort_check(tmp_path, monkeypatch):
     """detect_eye_keypoints_stage must accept an `abort_check` callable and
     break the per-photo loop the first time it returns True. Without this


### PR DESCRIPTION
## Summary

Follow-up to #734 — reconciles the Eye Keypoints stage with how every other ML model in Vireo handles weights.

Until now, eye keypoints was the only stage that required users to click a Download button in a per-card readiness panel before it would run. MegaDetector, SAM2, and DINOv2 all auto-download on first pipeline run. After this PR, SuperAnimal weights do too.

### Backend
- `eye_keypoints_stage` calls `keypoints.ensure_keypoint_weights` for both SuperAnimal variants before iterating photos (mirrors the SAM2/DINOv2 download block in `extract_masks`). Gated on `total > 0` so a no-op rerun doesn't pay the download cost.
- `eye_keypoint_stage_preflight` drops the `No keypoint models installed` branch — only the `eye_detect_enabled` config flag remains as a preflight gate.
- Per-photo Gate 2 stays as a defensive check against partial downloads (config.json missing, etc).
- Removed `/api/models/keypoints/status` and `/api/models/keypoints/<name>/download` and `_ALLOWED_KEYPOINT_MODELS` — no callers left after the readiness panel went away.

### Frontend
- Stripped `eyeKeypointsReadinessPanel` + per-model download rows from the Eye Keypoints stage card.
- Removed `_renderKeypointRow`, `refreshKeypointsStatus`, `startKeypointsPolling`, `downloadKeypointModel`, `_keypointModelsReady`, and the related branch in `_stageStateFor`.
- Updated the card description to say weights are downloaded automatically.

### Tests
- New `test_pipeline_eye_keypoints_stage_auto_downloads_superanimal_weights` pins that both SuperAnimal variants are fetched in order before iteration.
- New skip-when-zero-photos test mirroring the SAM2/DINOv2 cost-gate pattern.
- Replaced the stale "Will skip when no weights" e2e test with `test_pipeline_eye_keypoints_pill_will_run_by_default` reflecting the new UX.
- Loosened the preflight test (`test_eye_keypoint_stage_preflight_enabled`) to match the new contract.
- Existing `test_pipeline_eye_keypoints_cancel_marks_stage_cancelled` now stubs `ensure_keypoint_weights` so unit tests don't hit HuggingFace.

## Test plan

- [x] `python -m pytest vireo/tests/test_pipeline.py vireo/tests/test_pipeline_job.py tests/e2e/test_pipeline.py -k "eye_keypoint or eye_keypoints or skip_eye or preflight or auto_download or extract"` — 20 passed
- [x] `python -m pytest vireo/tests/test_keypoints.py vireo/tests/test_pipeline.py vireo/tests/test_pipeline_job.py` — 157 passed
- [x] `python -m pytest tests/e2e/test_pipeline.py` — 26 passed
- [x] Verified `/pipeline` HTML no longer renders the readiness panel and `/api/models/keypoints/status` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)