### PR TITLE
SAM mask history: keep masks per variant, compare in lightbox, manage in storage

### DIFF
--- a/docs/plans/2026-05-01-sam-mask-history-plan.md
+++ b/docs/plans/2026-05-01-sam-mask-history-plan.md
@@ -1,0 +1,1257 @@
+# SAM Mask History Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Allow Vireo to keep multiple SAM masks per photo (one per SAM variant), let the user compare them in the lightbox and pick which one drives downstream scoring, and surface per-variant storage management on the stats page.
+
+**Architecture:** A new `photo_masks` table holds `(photo_id, variant) → mask path + prompt provenance + per-mask features`, with PK `(photo_id, variant)`. Mask files become `~/.vireo/masks/{photo_id}.{variant}.png`. A new `photos.active_mask_variant` column points at the row whose values are denormalized into the existing `photos.mask_path / subject_tenengrad / bg_tenengrad / crop_complete` columns, so all downstream readers (scoring, pipeline.py) keep working unchanged. The masking job skips re-running when a row already exists for `(photo_id, variant)` AND its stored detection prompt still matches the photo's current primary detection. Existing masks migrate to `variant = 'unknown'` and get regenerated on the next pipeline run.
+
+**Tech Stack:** SQLite (WAL), Flask + Jinja2, vanilla JS, pytest. ONNX Runtime for SAM2 (existing).
+
+---
+
+## Background context (for engineers with no Vireo familiarity)
+
+- `vireo/db.py` — `Database` class. The `photos` table schema is at line 223. Migrations follow the pattern at line 632 (`SELECT col FROM photos LIMIT 0` in a try/except with `ALTER TABLE photos ADD COLUMN ...` on `OperationalError`).
+- `vireo/pipeline_job.py:2310-2510` — the `extract_masks` stage of the pipeline job. Calls `generate_mask` and `save_mask` from `vireo/masking.py`, plus `update_photo_pipeline_features` and `update_photo_embeddings` on the DB.
+- `vireo/masking.py:333-349` — `save_mask` writes `~/.vireo/masks/{photo_id}.png`. The directory is `os.path.join(os.path.dirname(db_path), "masks")`.
+- `vireo/pipeline.py:24-27, 273-280` — pipeline state SELECTs read `mask_path`, `subject_tenengrad`, `bg_tenengrad`, `crop_complete` directly from the `photos` table.
+- `vireo/scoring.py` — reads `mask_path` to load per-photo masks during scoring/selection. Don't refactor; we keep `photos.mask_path` populated.
+- `vireo/templates/stats.html:220-251` — Storage section in the stats page. Existing cards: thumbnails, previews, embeddings.
+- `vireo/templates/_navbar.html` — contains the lightbox shared across pages.
+- `vireo/templates/pipeline.html` — pipeline configuration UI; `sam2_variant` dropdown is around line 3055-3093.
+- Detections schema: `vireo/db.py:348-359`. YOLO re-runs do `DELETE FROM detections WHERE photo_id=? AND detector_model=?` then re-INSERT (so detection IDs are not stable across re-runs).
+- The masking job picks `dets[0]` (highest confidence after `category != 'full-image'` filter) as the SAM prompt — see `vireo/pipeline_job.py:2347`.
+
+**Test command (run after every implementation step that changes Python):**
+
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_masking.py vireo/tests/test_pipeline.py vireo/tests/test_pipeline_api.py -v
+```
+
+**Plan-doc convention:** `docs/plans/` is gitignored. Force-add design+plan files with `git add -f docs/plans/...md` per project convention.
+
+**Workflow reminder:** All work happens on a feature branch. The branch for this plan is `sam-models-explain` (already created). Push changes to that branch and open a PR against `main` when complete.
+
+---
+
+## Phase 1 — Schema + DB methods
+
+### Task 1.1: Create `photo_masks` table on init
+
+**Files:**
+- Modify: `vireo/db.py` (insert next to existing `CREATE TABLE` blocks, near line 360 after `detections`)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write the failing test**
+
+Append to `vireo/tests/test_db.py`:
+
+```python
+def test_photo_masks_table_exists(tmp_path):
+    """photo_masks table must exist on a fresh DB."""
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    cols = {row[1] for row in db.conn.execute(
+        "PRAGMA table_info(photo_masks)"
+    ).fetchall()}
+    assert {
+        "photo_id", "variant", "path", "created_at",
+        "detector_model", "prompt_x", "prompt_y", "prompt_w", "prompt_h",
+        "subject_size", "subject_tenengrad", "bg_tenengrad", "crop_complete",
+    } <= cols
+
+
+def test_photo_masks_pk_is_photo_and_variant(tmp_path):
+    """(photo_id, variant) is the primary key — same variant twice fails."""
+    import sqlite3
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    db.conn.execute(
+        "INSERT INTO photo_masks(photo_id, variant, path, created_at, "
+        "detector_model, prompt_x, prompt_y, prompt_w, prompt_h) "
+        "VALUES (1, 'sam2-small', '/p1', 0, 'unknown', -1, -1, -1, -1)"
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        db.conn.execute(
+            "INSERT INTO photo_masks(photo_id, variant, path, created_at, "
+            "detector_model, prompt_x, prompt_y, prompt_w, prompt_h) "
+            "VALUES (1, 'sam2-small', '/p2', 1, 'unknown', -1, -1, -1, -1)"
+        )
+```
+
+**Step 2: Run failing**
+
+```
+python -m pytest vireo/tests/test_db.py::test_photo_masks_table_exists vireo/tests/test_db.py::test_photo_masks_pk_is_photo_and_variant -v
+```
+
+Expected: FAIL — `no such table: photo_masks`.
+
+**Step 3: Implement**
+
+In `vireo/db.py`, after the `CREATE TABLE IF NOT EXISTS detections (...)` block (around line 359), add:
+
+```python
+            CREATE TABLE IF NOT EXISTS photo_masks (
+                photo_id          INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
+                variant           TEXT    NOT NULL,
+                path              TEXT    NOT NULL,
+                created_at        INTEGER NOT NULL,
+                detector_model    TEXT    NOT NULL,
+                prompt_x          INTEGER NOT NULL,
+                prompt_y          INTEGER NOT NULL,
+                prompt_w          INTEGER NOT NULL,
+                prompt_h          INTEGER NOT NULL,
+                subject_size      INTEGER,
+                subject_tenengrad REAL,
+                bg_tenengrad      REAL,
+                crop_complete     REAL,
+                PRIMARY KEY (photo_id, variant)
+            );
+```
+
+**Step 4: Run passing**
+
+Same command. Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: add photo_masks table for per-variant SAM masks"
+```
+
+---
+
+### Task 1.2: Add `active_mask_variant` column to `photos`
+
+**Files:**
+- Modify: `vireo/db.py` (the migration block around line 632)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Test first**
+
+```python
+def test_photos_has_active_mask_variant_column(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("SELECT active_mask_variant FROM photos LIMIT 0")
+```
+
+**Step 2: Run failing.** Expected: PASS or FAIL depending on whether column exists. It does not yet — FAIL with `no such column`.
+
+**Step 3: Implement**
+
+In `vireo/db.py`, in the migration section that includes `working_copy_failed_at` (around line 631), add:
+
+```python
+        try:
+            self.conn.execute("SELECT active_mask_variant FROM photos LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute(
+                "ALTER TABLE photos ADD COLUMN active_mask_variant TEXT"
+            )
+```
+
+Also add `active_mask_variant TEXT` in the `CREATE TABLE photos (...)` block at line 223 right after `dino_embedding_variant TEXT,` so fresh DBs have the column natively.
+
+**Step 4: Run passing.** Same command, PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: add photos.active_mask_variant column"
+```
+
+---
+
+### Task 1.3: `upsert_photo_mask`
+
+**Files:**
+- Modify: `vireo/db.py` (add new method near `update_photo_mask` at line 3582)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Test**
+
+```python
+def test_upsert_photo_mask_inserts_and_replaces(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+
+    db.upsert_photo_mask(
+        photo_id=1, variant="sam2-small", path="/m/1.sam2-small.png",
+        detector_model="megadetector-v6",
+        prompt_x=10, prompt_y=20, prompt_w=100, prompt_h=200,
+        subject_size=20000, subject_tenengrad=1.5,
+        bg_tenengrad=0.3, crop_complete=1.0,
+    )
+    row = db.conn.execute(
+        "SELECT path, prompt_x FROM photo_masks WHERE photo_id=1 AND variant='sam2-small'"
+    ).fetchone()
+    assert row["path"] == "/m/1.sam2-small.png"
+    assert row["prompt_x"] == 10
+
+    # Re-upsert with new prompt — row replaced
+    db.upsert_photo_mask(
+        photo_id=1, variant="sam2-small", path="/m/1.sam2-small.png",
+        detector_model="megadetector-v6",
+        prompt_x=11, prompt_y=20, prompt_w=100, prompt_h=200,
+        subject_size=21000, subject_tenengrad=1.5,
+        bg_tenengrad=0.3, crop_complete=1.0,
+    )
+    row = db.conn.execute(
+        "SELECT prompt_x, subject_size FROM photo_masks WHERE photo_id=1 AND variant='sam2-small'"
+    ).fetchone()
+    assert row["prompt_x"] == 11
+    assert row["subject_size"] == 21000
+    # Still exactly one row for this (photo, variant)
+    n = db.conn.execute(
+        "SELECT COUNT(*) FROM photo_masks WHERE photo_id=1 AND variant='sam2-small'"
+    ).fetchone()[0]
+    assert n == 1
+```
+
+**Step 2: Fail.** PASS-of-fail: PASS-test fails with `AttributeError: 'Database' object has no attribute 'upsert_photo_mask'`.
+
+**Step 3: Implement** — add to `vireo/db.py` after `update_photo_mask`:
+
+```python
+    def upsert_photo_mask(
+        self, photo_id, variant, path,
+        detector_model, prompt_x, prompt_y, prompt_w, prompt_h,
+        subject_size=None, subject_tenengrad=None,
+        bg_tenengrad=None, crop_complete=None,
+    ):
+        """Insert or replace a mask row for (photo_id, variant)."""
+        import time
+        self.conn.execute(
+            """
+            INSERT INTO photo_masks (
+                photo_id, variant, path, created_at,
+                detector_model, prompt_x, prompt_y, prompt_w, prompt_h,
+                subject_size, subject_tenengrad, bg_tenengrad, crop_complete
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(photo_id, variant) DO UPDATE SET
+                path=excluded.path,
+                created_at=excluded.created_at,
+                detector_model=excluded.detector_model,
+                prompt_x=excluded.prompt_x,
+                prompt_y=excluded.prompt_y,
+                prompt_w=excluded.prompt_w,
+                prompt_h=excluded.prompt_h,
+                subject_size=excluded.subject_size,
+                subject_tenengrad=excluded.subject_tenengrad,
+                bg_tenengrad=excluded.bg_tenengrad,
+                crop_complete=excluded.crop_complete
+            """,
+            (photo_id, variant, path, int(time.time()),
+             detector_model, prompt_x, prompt_y, prompt_w, prompt_h,
+             subject_size, subject_tenengrad, bg_tenengrad, crop_complete),
+        )
+        commit_with_retry(self.conn)
+```
+
+**Step 4: Pass.**
+
+**Step 5: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: add upsert_photo_mask"
+```
+
+---
+
+### Task 1.4: `get_photo_mask` and `list_masks_for_photo`
+
+**Step 1: Test**
+
+```python
+def test_get_photo_mask_returns_row_or_none(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute("INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')")
+    assert db.get_photo_mask(1, "sam2-small") is None
+
+    db.upsert_photo_mask(
+        photo_id=1, variant="sam2-small", path="/p", detector_model="md",
+        prompt_x=1, prompt_y=2, prompt_w=3, prompt_h=4,
+    )
+    m = db.get_photo_mask(1, "sam2-small")
+    assert m["path"] == "/p"
+    assert m["detector_model"] == "md"
+    assert m["prompt_x"] == 1
+
+
+def test_list_masks_for_photo(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute("INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')")
+    db.upsert_photo_mask(photo_id=1, variant="sam2-small", path="/a",
+        detector_model="md", prompt_x=1, prompt_y=2, prompt_w=3, prompt_h=4)
+    db.upsert_photo_mask(photo_id=1, variant="sam2-large", path="/b",
+        detector_model="md", prompt_x=1, prompt_y=2, prompt_w=3, prompt_h=4)
+    variants = sorted(m["variant"] for m in db.list_masks_for_photo(1))
+    assert variants == ["sam2-large", "sam2-small"]
+```
+
+**Step 2: Fail.**
+
+**Step 3: Implement** in `vireo/db.py`:
+
+```python
+    def get_photo_mask(self, photo_id, variant):
+        row = self.conn.execute(
+            "SELECT * FROM photo_masks WHERE photo_id=? AND variant=?",
+            (photo_id, variant),
+        ).fetchone()
+        return dict(row) if row else None
+
+    def list_masks_for_photo(self, photo_id):
+        rows = self.conn.execute(
+            "SELECT * FROM photo_masks WHERE photo_id=? ORDER BY created_at DESC",
+            (photo_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+```
+
+**Step 4: Pass. Step 5: Commit.**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: add get_photo_mask and list_masks_for_photo"
+```
+
+---
+
+### Task 1.5: `set_active_mask_variant` (denormalizes into photos)
+
+This is the centerpiece for keeping downstream readers happy: when activation changes, copy that variant's path + features into the `photos` row.
+
+**Step 1: Test**
+
+```python
+def test_set_active_mask_variant_denormalizes(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute("INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')")
+    db.upsert_photo_mask(
+        photo_id=1, variant="sam2-large", path="/m/1.sam2-large.png",
+        detector_model="md", prompt_x=1, prompt_y=2, prompt_w=3, prompt_h=4,
+        subject_size=12345, subject_tenengrad=2.0,
+        bg_tenengrad=0.5, crop_complete=0.9,
+    )
+    db.set_active_mask_variant(1, "sam2-large")
+    row = db.conn.execute(
+        "SELECT mask_path, active_mask_variant, subject_size, "
+        "subject_tenengrad, bg_tenengrad, crop_complete FROM photos WHERE id=1"
+    ).fetchone()
+    assert row["mask_path"] == "/m/1.sam2-large.png"
+    assert row["active_mask_variant"] == "sam2-large"
+    assert row["subject_size"] == 12345
+    assert row["subject_tenengrad"] == 2.0
+
+
+def test_set_active_mask_variant_missing_row_raises(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute("INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')")
+    with pytest.raises(ValueError):
+        db.set_active_mask_variant(1, "sam3-small")
+```
+
+**Step 2: Fail.**
+
+**Step 3: Implement**
+
+```python
+    def set_active_mask_variant(self, photo_id, variant):
+        """Mark `variant` as active for `photo_id` and denormalize its
+        fields into the photos row (mask_path + per-mask features) so
+        downstream readers (scoring, pipeline) see the active mask."""
+        row = self.conn.execute(
+            "SELECT path, subject_size, subject_tenengrad, bg_tenengrad, "
+            "crop_complete FROM photo_masks WHERE photo_id=? AND variant=?",
+            (photo_id, variant),
+        ).fetchone()
+        if row is None:
+            raise ValueError(
+                f"No photo_masks row for photo {photo_id} variant {variant!r}"
+            )
+        self.conn.execute(
+            "UPDATE photos SET mask_path=?, active_mask_variant=?, "
+            "subject_size=?, subject_tenengrad=?, bg_tenengrad=?, "
+            "crop_complete=? WHERE id=?",
+            (row["path"], variant, row["subject_size"],
+             row["subject_tenengrad"], row["bg_tenengrad"],
+             row["crop_complete"], photo_id),
+        )
+        commit_with_retry(self.conn)
+```
+
+**Step 4: Pass. Step 5: Commit.**
+
+---
+
+### Task 1.6: `delete_masks_for_variant`, `delete_inactive_masks`, `find_stale_masks`
+
+These power the storage dashboard. Each gets its own test + implementation.
+
+**Step 1: Tests**
+
+```python
+def test_delete_masks_for_variant_removes_files_and_rows(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute("INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')")
+    db.conn.execute("INSERT INTO photos(id, folder_id, filename) VALUES (2, 1, 'b.jpg')")
+
+    masks_dir = tmp_path / "masks"
+    masks_dir.mkdir()
+    p1 = masks_dir / "1.sam2-small.png"; p1.write_bytes(b"x")
+    p2 = masks_dir / "2.sam2-small.png"; p2.write_bytes(b"y")
+    db.upsert_photo_mask(1, "sam2-small", str(p1),
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0)
+    db.upsert_photo_mask(2, "sam2-small", str(p2),
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0)
+
+    deleted = db.delete_masks_for_variant("sam2-small")
+    assert deleted == 2
+    assert not p1.exists() and not p2.exists()
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM photo_masks WHERE variant='sam2-small'"
+    ).fetchone()[0] == 0
+
+
+def test_delete_masks_for_variant_refuses_active(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute("INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')")
+    masks_dir = tmp_path / "masks"; masks_dir.mkdir()
+    p = masks_dir / "1.sam2-small.png"; p.write_bytes(b"x")
+    db.upsert_photo_mask(1, "sam2-small", str(p),
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0)
+    db.set_active_mask_variant(1, "sam2-small")
+    with pytest.raises(ValueError):
+        db.delete_masks_for_variant("sam2-small")
+
+
+def test_find_stale_masks(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute("INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')")
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (1, 'megadetector-v6', 10, 20, 100, 200, 0.9, 'animal')"
+    )
+    # Mask was made from the same prompt → not stale
+    db.upsert_photo_mask(1, "sam2-small", "/p",
+        detector_model="megadetector-v6",
+        prompt_x=10, prompt_y=20, prompt_w=100, prompt_h=200)
+    assert db.find_stale_masks() == []
+
+    # Insert a mask whose prompt no longer matches the current detection
+    db.upsert_photo_mask(1, "sam2-large", "/q",
+        detector_model="megadetector-v6",
+        prompt_x=99, prompt_y=20, prompt_w=100, prompt_h=200)
+    stale = db.find_stale_masks()
+    assert {(s["photo_id"], s["variant"]) for s in stale} == {(1, "sam2-large")}
+```
+
+**Step 2: Fail.**
+
+**Step 3: Implement** in `vireo/db.py`:
+
+```python
+    def delete_masks_for_variant(self, variant):
+        """Delete all photo_masks rows + files for a variant.
+        Refuses if the variant is active for any photo (caller must
+        switch active first)."""
+        active_count = self.conn.execute(
+            "SELECT COUNT(*) FROM photos WHERE active_mask_variant=?",
+            (variant,),
+        ).fetchone()[0]
+        if active_count > 0:
+            raise ValueError(
+                f"Variant {variant!r} is active for {active_count} photo(s); "
+                "switch active variant before deleting"
+            )
+        rows = self.conn.execute(
+            "SELECT path FROM photo_masks WHERE variant=?", (variant,),
+        ).fetchall()
+        for r in rows:
+            try:
+                if r["path"] and os.path.isfile(r["path"]):
+                    os.remove(r["path"])
+            except OSError:
+                log.warning("Failed to remove mask file %s", r["path"])
+        self.conn.execute("DELETE FROM photo_masks WHERE variant=?", (variant,))
+        commit_with_retry(self.conn)
+        return len(rows)
+
+    def delete_inactive_masks(self):
+        """Delete all photo_masks rows + files except the active variant
+        per photo. Returns the number of rows deleted."""
+        rows = self.conn.execute(
+            "SELECT pm.photo_id, pm.variant, pm.path FROM photo_masks pm "
+            "JOIN photos p ON p.id = pm.photo_id "
+            "WHERE p.active_mask_variant IS NULL "
+            "   OR p.active_mask_variant != pm.variant"
+        ).fetchall()
+        for r in rows:
+            try:
+                if r["path"] and os.path.isfile(r["path"]):
+                    os.remove(r["path"])
+            except OSError:
+                log.warning("Failed to remove mask file %s", r["path"])
+            self.conn.execute(
+                "DELETE FROM photo_masks WHERE photo_id=? AND variant=?",
+                (r["photo_id"], r["variant"]),
+            )
+        commit_with_retry(self.conn)
+        return len(rows)
+
+    def find_stale_masks(self):
+        """Return photo_masks rows whose stored prompt no longer matches
+        the photo's current primary detection (highest-confidence,
+        non full-image)."""
+        rows = self.conn.execute(
+            """
+            SELECT pm.photo_id, pm.variant, pm.path,
+                   pm.detector_model, pm.prompt_x, pm.prompt_y,
+                   pm.prompt_w, pm.prompt_h
+              FROM photo_masks pm
+             WHERE NOT EXISTS (
+                SELECT 1 FROM detections d
+                 WHERE d.photo_id = pm.photo_id
+                   AND d.detector_model = pm.detector_model
+                   AND d.detector_model != 'full-image'
+                   AND CAST(d.box_x AS INTEGER) = pm.prompt_x
+                   AND CAST(d.box_y AS INTEGER) = pm.prompt_y
+                   AND CAST(d.box_w AS INTEGER) = pm.prompt_w
+                   AND CAST(d.box_h AS INTEGER) = pm.prompt_h
+             )
+            """
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def delete_stale_masks(self):
+        """Remove rows + files for masks whose prompt no longer matches
+        the current primary detection. Skips active variants (caller can
+        re-run them through the pipeline instead of dropping the
+        currently-displayed mask)."""
+        stale = self.find_stale_masks()
+        deleted = 0
+        for s in stale:
+            is_active = self.conn.execute(
+                "SELECT 1 FROM photos WHERE id=? AND active_mask_variant=?",
+                (s["photo_id"], s["variant"]),
+            ).fetchone()
+            if is_active:
+                continue
+            try:
+                if s["path"] and os.path.isfile(s["path"]):
+                    os.remove(s["path"])
+            except OSError:
+                log.warning("Failed to remove mask file %s", s["path"])
+            self.conn.execute(
+                "DELETE FROM photo_masks WHERE photo_id=? AND variant=?",
+                (s["photo_id"], s["variant"]),
+            )
+            deleted += 1
+        commit_with_retry(self.conn)
+        return deleted
+```
+
+**Step 4: Pass. Step 5: Commit.**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: add mask deletion and staleness queries"
+```
+
+---
+
+### Task 1.7: `mask_variants_summary` (per-variant counts + bytes)
+
+**Step 1: Test**
+
+```python
+def test_mask_variants_summary(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    for pid in (1, 2, 3):
+        db.conn.execute(
+            "INSERT INTO photos(id, folder_id, filename) VALUES (?, 1, ?)",
+            (pid, f"p{pid}.jpg"),
+        )
+    md = tmp_path / "masks"; md.mkdir()
+    for pid, var, size in [(1, "sam2-small", 100), (2, "sam2-small", 200),
+                            (1, "sam2-large", 500), (3, "sam3-small", 700)]:
+        p = md / f"{pid}.{var}.png"; p.write_bytes(b"x" * size)
+        db.upsert_photo_mask(pid, var, str(p),
+            detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0)
+    db.set_active_mask_variant(1, "sam2-large")
+
+    summary = {s["variant"]: s for s in db.mask_variants_summary()}
+    assert summary["sam2-small"]["count"] == 2
+    assert summary["sam2-small"]["bytes"] == 300
+    assert summary["sam2-large"]["count"] == 1
+    assert summary["sam2-large"]["active_count"] == 1
+    assert summary["sam3-small"]["active_count"] == 0
+```
+
+**Step 2: Fail.**
+
+**Step 3: Implement** in `vireo/db.py`:
+
+```python
+    def mask_variants_summary(self):
+        """Per-variant summary: count, total bytes (best-effort, sums
+        on-disk file sizes), and active_count.
+
+        Returns: list of dicts ordered by variant name.
+        """
+        rows = self.conn.execute(
+            """
+            SELECT pm.variant,
+                   COUNT(*) AS count,
+                   SUM(CASE WHEN p.active_mask_variant = pm.variant
+                            THEN 1 ELSE 0 END) AS active_count
+              FROM photo_masks pm
+              JOIN photos p ON p.id = pm.photo_id
+             GROUP BY pm.variant
+             ORDER BY pm.variant
+            """
+        ).fetchall()
+        out = []
+        for r in rows:
+            paths = self.conn.execute(
+                "SELECT path FROM photo_masks WHERE variant=?", (r["variant"],),
+            ).fetchall()
+            total = 0
+            for pr in paths:
+                try:
+                    if pr["path"] and os.path.isfile(pr["path"]):
+                        total += os.path.getsize(pr["path"])
+                except OSError:
+                    pass
+            out.append({
+                "variant": r["variant"],
+                "count": r["count"],
+                "active_count": r["active_count"],
+                "bytes": total,
+            })
+        return out
+```
+
+**Step 4: Pass. Step 5: Commit.**
+
+---
+
+## Phase 2 — Filename + masking job integration
+
+### Task 2.1: `save_mask` writes per-variant filename
+
+**Files:**
+- Modify: `vireo/masking.py:333-349`
+- Modify: `vireo/masking.py:352-366` (load_mask)
+- Test: `vireo/tests/test_masking.py`
+
+**Step 1: Test**
+
+```python
+def test_save_mask_uses_variant_in_filename(tmp_path):
+    import numpy as np
+    from masking import save_mask
+    mask = np.array([[True, False], [False, True]], dtype=bool)
+    out = save_mask(mask, str(tmp_path), photo_id=42, variant="sam2-large")
+    assert out == str(tmp_path / "42.sam2-large.png")
+    assert (tmp_path / "42.sam2-large.png").exists()
+```
+
+**Step 2: Fail.** `save_mask()` does not yet accept a `variant` arg.
+
+**Step 3: Implement.** Change `save_mask` signature:
+
+```python
+def save_mask(mask, masks_dir, photo_id, variant):
+    """Save a boolean mask as a single-channel PNG.
+
+    Filename: ``{photo_id}.{variant}.png`` so multiple variants per photo
+    coexist on disk.
+    """
+    os.makedirs(masks_dir, exist_ok=True)
+    path = os.path.join(masks_dir, f"{photo_id}.{variant}.png")
+    mask_img = Image.fromarray((mask.astype(np.uint8) * 255), mode="L")
+    mask_img.save(path, format="PNG")
+    return path
+```
+
+Update `load_mask` to require a `variant` argument too:
+
+```python
+def load_mask(masks_dir, photo_id, variant):
+    path = os.path.join(masks_dir, f"{photo_id}.{variant}.png")
+    if not os.path.exists(path):
+        return None
+    with Image.open(path) as mask_img:
+        return np.array(mask_img.convert("L")) > 127
+```
+
+Grep for all call sites of `save_mask` and `load_mask` and add the `variant` arg:
+
+```bash
+grep -rn "save_mask\|load_mask" vireo/ tests/
+```
+
+There is one production caller of `save_mask` (`vireo/pipeline_job.py:2480`); that gets touched in Task 2.2. Tests in `vireo/tests/test_masking.py` need updating too.
+
+**Step 4: Pass.**
+
+**Step 5: Commit.**
+
+```bash
+git add vireo/masking.py vireo/tests/test_masking.py
+git commit -m "masking: include variant in mask filename"
+```
+
+---
+
+### Task 2.2: Masking job uses `photo_masks`, skips when prompt unchanged
+
+**Files:**
+- Modify: `vireo/pipeline_job.py:2310-2510`
+- Test: `vireo/tests/test_pipeline.py` and/or `vireo/tests/test_pipeline_api.py` (whichever covers the masking stage)
+
+**Step 1: Tests** — three cases.
+
+```python
+def test_masking_job_skips_when_cached_with_same_prompt(...):
+    """If photo_masks already has a row for (photo, variant) with a
+    matching prompt, generate_mask is not called and the row is left
+    alone."""
+    # Use unittest.mock.patch on masking.generate_mask; assert not called.
+
+def test_masking_job_runs_when_variant_differs(...):
+    """A row exists for sam2-small; running with sam2-large produces a
+    new row alongside it."""
+
+def test_masking_job_runs_when_prompt_changed(...):
+    """Existing row's prompt differs from current primary detection's
+    bbox → generate_mask is called and the row is replaced."""
+```
+
+(Use the existing pipeline-job test fixtures; copy patterns from `test_pipeline.py`.)
+
+**Step 2: Fail.**
+
+**Step 3: Implement.** Replace the inner mask loop body in `vireo/pipeline_job.py:2453-2509`. Logical changes:
+
+1. Determine the current primary detection's prompt for each photo (already done in the build of `photo_det_map`; persist `detector_model` and the bbox into the entry).
+2. Before calling `generate_mask`, look up `thread_db.get_photo_mask(photo_id, sam2_variant)`. If it exists and `(detector_model, prompt_x/y/w/h)` matches, skip.
+3. After `generate_mask`+`save_mask`, call `thread_db.upsert_photo_mask(...)` with all per-mask features and prompt fields.
+4. Then call `thread_db.set_active_mask_variant(photo_id, sam2_variant)` to denormalize into the photos row.
+5. Drop the call to `update_photo_pipeline_features(mask_path=..., crop_complete=..., **features)` since `set_active_mask_variant` now handles that. Embeddings call (`update_photo_embeddings`) stays as-is.
+6. Replace the existing "has_mask" precheck (line 2348-2351) with a check that doesn't short-circuit when the configured variant differs from what's already cached. Specifically: include all photos with detections; the per-photo skip happens inside the loop (step 2 above) so changing the configured variant naturally re-runs.
+
+Sketch:
+
+```python
+# Build photo_det_map (replace the existing block)
+photo_det_map = {}
+photos_with_detections = 0
+for p in photos:
+    dets = [d for d in thread_db.get_detections(p["id"])
+            if d["detector_model"] != "full-image"]
+    if dets:
+        photos_with_detections += 1
+        primary = dets[0]
+        photo_det_map[p["id"]] = {
+            "photo": p,
+            "det_box": {
+                "x": primary["box_x"], "y": primary["box_y"],
+                "w": primary["box_w"], "h": primary["box_h"],
+            },
+            "detector_model": primary["detector_model"],
+            "prompt": (
+                int(primary["box_x"]), int(primary["box_y"]),
+                int(primary["box_w"]), int(primary["box_h"]),
+            ),
+        }
+
+# Inside the loop, before generate_mask:
+existing = thread_db.get_photo_mask(photo_id, sam2_variant)
+if existing:
+    cached_prompt = (
+        existing["prompt_x"], existing["prompt_y"],
+        existing["prompt_w"], existing["prompt_h"],
+    )
+    if (existing["detector_model"] == entry["detector_model"]
+            and cached_prompt == entry["prompt"]
+            and os.path.isfile(existing["path"])):
+        # Cached + prompt unchanged → skip SAM, just (re-)activate.
+        thread_db.set_active_mask_variant(photo_id, sam2_variant)
+        masked += 1
+        processed = i + 1
+        continue
+
+# ... existing generate_mask + save_mask + features computation,
+# then:
+mask_path = save_mask(mask, masks_dir, photo_id, sam2_variant)
+completeness = crop_completeness(mask)
+features = compute_all_quality_features(proxy, mask)
+
+thread_db.upsert_photo_mask(
+    photo_id=photo_id, variant=sam2_variant, path=mask_path,
+    detector_model=entry["detector_model"],
+    prompt_x=entry["prompt"][0], prompt_y=entry["prompt"][1],
+    prompt_w=entry["prompt"][2], prompt_h=entry["prompt"][3],
+    subject_size=features.get("subject_size"),
+    subject_tenengrad=features.get("subject_tenengrad"),
+    bg_tenengrad=features.get("bg_tenengrad"),
+    crop_complete=completeness,
+)
+thread_db.set_active_mask_variant(photo_id, sam2_variant)
+
+# Embeddings unchanged:
+thread_db.update_photo_embeddings(...)
+```
+
+**Pitfall to avoid:** `compute_all_quality_features` returns `subject_tenengrad`, `bg_tenengrad`, `subject_clip_high`, `subject_clip_low`, `subject_y_median`, `noise_estimate`, `phash_crop`, `subject_size`, etc. — only the mask-derived ones (`subject_size`, `subject_tenengrad`, `bg_tenengrad`) move to `photo_masks`. The rest still need to land on the `photos` row via `update_photo_pipeline_features`. Keep that call but remove the mask-related kwargs from it.
+
+**Step 4: Pass.**
+
+**Step 5: Commit.**
+
+```bash
+git add vireo/pipeline_job.py vireo/tests/test_pipeline.py
+git commit -m "masking: cache per-variant masks and skip when prompt unchanged"
+```
+
+---
+
+### Task 2.3: `update_photo_mask` is removed (callers refactored)
+
+`update_photo_mask` (db.py:3582) is now unused. Grep:
+
+```bash
+grep -rn "update_photo_mask\b" vireo/ tests/
+```
+
+If only tests remain, delete the method and the tests that call it. Otherwise refactor remaining callers to `upsert_photo_mask` + `set_active_mask_variant`.
+
+**Commit:**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: drop unused update_photo_mask"
+```
+
+---
+
+## Phase 3 — Migration of existing data
+
+### Task 3.1: One-time migration on DB init
+
+**Files:**
+- Modify: `vireo/db.py` (add a migration step right after the `photo_masks` table is created and after the `active_mask_variant` ALTER block runs)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Test**
+
+```python
+def test_existing_masks_migrate_to_unknown_variant(tmp_path):
+    """A photos row with mask_path set on a pre-migration DB gets a
+    photo_masks row with variant='unknown' and prompt=-1."""
+    import sqlite3
+    db_path = tmp_path / "v.db"
+
+    # Build a DB with the old shape, no photo_masks table.
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT)")
+    conn.execute(
+        "CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER, "
+        "filename TEXT, mask_path TEXT, subject_size INTEGER, "
+        "subject_tenengrad REAL, bg_tenengrad REAL, crop_complete REAL)"
+    )
+    conn.execute("INSERT INTO folders(id, path) VALUES (1, '/tmp')")
+    conn.execute(
+        "INSERT INTO photos(id, folder_id, filename, mask_path, "
+        "subject_tenengrad, crop_complete) "
+        "VALUES (1, 1, 'a.jpg', '/m/1.png', 1.5, 0.9)"
+    )
+    conn.commit()
+    conn.close()
+
+    from db import Database
+    db = Database(str(db_path))
+
+    row = db.conn.execute(
+        "SELECT * FROM photo_masks WHERE photo_id=1"
+    ).fetchone()
+    assert row is not None
+    assert row["variant"] == "unknown"
+    assert row["detector_model"] == "unknown"
+    assert row["prompt_x"] == -1
+    assert row["path"] == "/m/1.png"
+    assert row["subject_tenengrad"] == 1.5
+    assert row["crop_complete"] == 0.9
+    # And photos.active_mask_variant is set
+    av = db.conn.execute(
+        "SELECT active_mask_variant FROM photos WHERE id=1"
+    ).fetchone()[0]
+    assert av == "unknown"
+```
+
+**Step 2: Fail.**
+
+**Step 3: Implement.** Add to `vireo/db.py` immediately after the `ALTER TABLE photos ADD COLUMN active_mask_variant` migration block:
+
+```python
+        # Migrate any pre-existing masks (mask_path set on photos but no
+        # photo_masks row) to variant='unknown' with sentinel prompt.
+        # Their prompt provenance is unknown, so the staleness check will
+        # treat them as stale on the next pipeline run and they'll be
+        # regenerated.
+        try:
+            already = self.conn.execute(
+                "SELECT COUNT(*) FROM photo_masks WHERE variant='unknown'"
+            ).fetchone()[0]
+        except sqlite3.OperationalError:
+            already = -1
+        if already == 0:
+            rows = self.conn.execute(
+                "SELECT id, mask_path, subject_size, subject_tenengrad, "
+                "bg_tenengrad, crop_complete FROM photos "
+                "WHERE mask_path IS NOT NULL"
+            ).fetchall()
+            now = int(time.time())  # ensure `import time` at top of db.py
+            for r in rows:
+                self.conn.execute(
+                    "INSERT OR IGNORE INTO photo_masks "
+                    "(photo_id, variant, path, created_at, detector_model, "
+                    "prompt_x, prompt_y, prompt_w, prompt_h, "
+                    "subject_size, subject_tenengrad, bg_tenengrad, crop_complete) "
+                    "VALUES (?, 'unknown', ?, ?, 'unknown', -1, -1, -1, -1, ?, ?, ?, ?)",
+                    (r["id"], r["mask_path"], now,
+                     r["subject_size"], r["subject_tenengrad"],
+                     r["bg_tenengrad"], r["crop_complete"]),
+                )
+                self.conn.execute(
+                    "UPDATE photos SET active_mask_variant='unknown' "
+                    "WHERE id=? AND active_mask_variant IS NULL",
+                    (r["id"],),
+                )
+            commit_with_retry(self.conn)
+```
+
+**Step 4: Pass. Step 5: Commit.**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: migrate existing masks to photo_masks with variant='unknown'"
+```
+
+---
+
+## Phase 4 — Storage dashboard
+
+### Task 4.1: `/api/storage/masks` endpoint
+
+**Files:**
+- Modify: `vireo/app.py` (add new route near `api_storage` at line 4513)
+- Test: `vireo/tests/test_app.py`
+
+**Step 1: Test**
+
+```python
+def test_api_storage_masks_returns_summary(client, tmp_path, db_with_masks):
+    r = client.get("/api/storage/masks")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "variants" in data
+    assert "total_bytes" in data
+    assert "stale_count" in data
+```
+
+(Use the existing app-test fixture pattern — see `vireo/tests/test_app.py` for how fixtures provision a DB and client.)
+
+**Step 2: Fail.**
+
+**Step 3: Implement** in `vireo/app.py` near line 4585:
+
+```python
+    @app.route("/api/storage/masks")
+    def api_storage_masks():
+        """Per-variant SAM mask summary (counts, bytes, active counts)
+        plus stale-mask count for the storage dashboard."""
+        db = _get_db()
+        variants = db.mask_variants_summary()
+        stale = db.find_stale_masks()
+        masks_dir = os.path.join(os.path.dirname(db_path), "masks")
+        return jsonify({
+            "variants": variants,
+            "total_bytes": sum(v["bytes"] for v in variants),
+            "stale_count": len(stale),
+            "path": masks_dir,
+        })
+```
+
+**Step 4: Pass. Step 5: Commit.**
+
+---
+
+### Task 4.2: `/api/storage/masks/delete-variant`, `/api/storage/masks/delete-inactive`, `/api/storage/masks/delete-stale`
+
+**Step 1: Tests**
+
+```python
+def test_api_delete_mask_variant(client, db_with_masks):
+    r = client.post("/api/storage/masks/delete-variant",
+                    json={"variant": "sam2-small"})
+    assert r.status_code == 200
+    assert r.get_json()["deleted"] >= 1
+
+
+def test_api_delete_mask_variant_refuses_active(client, db_with_active_variant):
+    r = client.post("/api/storage/masks/delete-variant",
+                    json={"variant": "sam2-large"})  # active
+    assert r.status_code == 400
+    assert "active" in r.get_json()["error"].lower()
+
+
+def test_api_delete_inactive_masks(client, db_with_masks):
+    r = client.post("/api/storage/masks/delete-inactive")
+    assert r.status_code == 200
+    assert "deleted" in r.get_json()
+
+
+def test_api_delete_stale_masks(client, db_with_stale_mask):
+    r = client.post("/api/storage/masks/delete-stale")
+    assert r.status_code == 200
+```
+
+**Step 2: Fail.**
+
+**Step 3: Implement** three thin wrappers around the DB methods:
+
+```python
+    @app.route("/api/storage/masks/delete-variant", methods=["POST"])
+    def api_storage_masks_delete_variant():
+        body = request.get_json(silent=True) or {}
+        variant = body.get("variant", "")
+        if not variant:
+            return json_error("variant required")
+        db = _get_db()
+        try:
+            n = db.delete_masks_for_variant(variant)
+        except ValueError as e:
+            return json_error(str(e), 400)
+        log.info("Deleted %d masks for variant %s", n, variant)
+        return jsonify({"ok": True, "deleted": n})
+
+    @app.route("/api/storage/masks/delete-inactive", methods=["POST"])
+    def api_storage_masks_delete_inactive():
+        db = _get_db()
+        n = db.delete_inactive_masks()
+        log.info("Deleted %d inactive-variant masks", n)
+        return jsonify({"ok": True, "deleted": n})
+
+    @app.route("/api/storage/masks/delete-stale", methods=["POST"])
+    def api_storage_masks_delete_stale():
+        db = _get_db()
+        n = db.delete_stale_masks()
+        log.info("Deleted %d stale masks", n)
+        return jsonify({"ok": True, "deleted": n})
+```
+
+**Step 4: Pass. Step 5: Commit.**
+
+---
+
+### Task 4.3: Masks card in `stats.html`
+
+**Files:**
+- Modify: `vireo/templates/stats.html:220-251`
+- Manual test: load /stats, verify card shows variants + counts + bytes, buttons work, refusal modal appears for active variant.
+
+**Step 1: UI scaffolding** — add a new card to the storage grid mirroring the embedding card. Show:
+
+```
+Masks (sam2-small: N1, sam2-large: N2 [active], sam3-small: N3, unknown: N4)
+                                                              [Total bytes]
+[ Manage ] [ Delete inactive ] [ Delete stale (K) ]
+```
+
+In the manage modal: list variants with `[active] [delete]` per row, where `[delete]` for the active variant is disabled with a hint "set another variant active first."
+
+**Step 2: Wire JS** — fetch from `/api/storage/masks` on card mount, POST to the three new endpoints from buttons, refresh on success.
+
+**Step 3: Manual verification**
+
+```bash
+python vireo/app.py --db ~/.vireo/vireo.db --port 8080
+```
+
+Open /stats. Confirm:
+- Masks card appears with the right counts.
+- Clicking "Delete inactive" shows correct deleted count.
+- Trying to delete the active variant shows the API error.
+- Stale count refreshes when YOLO is re-run with different settings.
+
+**Step 4: Commit.**
+
+```bash
+git add vireo/templates/stats.html
+git commit -m "stats: add Masks card with per-variant breakdown and deletion"
+```
+
+---
+
+## Phase 5 — Pipeline page (UI option C)
+
+### Task 5.1: Per-variant coverage stats in pipeline state
+
+**Files:**
+- Modify: `vireo/db.py` (extend `get_pipeline_state` or add adjacent method)
+- Modify: `vireo/app.py` (pipeline state route — find via grep)
+- Test: `vireo/tests/test_pipeline_api.py`
+
+**Step 1: Test** — assert pipeline state JSON includes `mask_variant_coverage` with per-variant counts.
+
+**Step 2-5: Implement, run tests, commit.**
+
+```bash
+git commit -m "pipeline: surface per-variant mask coverage"
+```
+
+### Task 5.2: Coverage badge + active-variant selector in pipeline.html
+
+**Files:**
+- Modify: `vireo/templates/pipeline.html` (around the SAM2 variant select at line 3055-3093)
+
+Add directly below the SAM2 variant dropdown:
+
+```
+SAM2 mask coverage:
+  sam2-small      12,400  [Set active]
+  sam2-large       8,200  [active]
+  sam3-small       3,200  [Set active]
+  unknown          ----   [legacy]
+```
+
+"Set active" calls a new endpoint: `POST /api/pipeline/active-mask-variant` with `{variant: "..."}` that loops over all photos with a mask for that variant and calls `db.set_active_mask_variant(...)`.
+
+(Test with the pipeline-state API + a manual UI check.)
+
+```bash
+git commit -m "pipeline: per-variant coverage and active-variant selector"
+```
+
+---
+
+## Phase 6 — Lightbox compare (UI option A)
+
+### Task 6.1: API to list a photo's available mask variants
+
+**Files:**
+- Modify: `vireo/app.py` — new route `/api/photos/<int:pid>/masks`
+- Test: `vireo/tests/test_photos_api.py`
+
+```python
+@app.route("/api/photos/<int:pid>/masks")
+def api_photo_masks(pid):
+    db = _get_db()
+    masks = db.list_masks_for_photo(pid)
+    active = db.conn.execute(
+        "SELECT active_mask_variant FROM photos WHERE id=?", (pid,)
+    ).fetchone()[0]
+    return jsonify({
+        "photo_id": pid,
+        "active": active,
+        "variants": [
+            {"variant": m["variant"],
+             "url": f"/api/masks/{pid}/{m['variant']}.png",
+             "created_at": m["created_at"]}
+            for m in masks
+        ],
+    })
+```
+
+Plus a static-file route to serve mask PNGs (or reuse an existing file-serving route — grep for `mask` in `app.py` to see if one exists today; today `mask_path` is read by Python only, so the file is NOT exposed over HTTP yet and a new `send_from_directory` route is required).
+
+```bash
+git commit -m "api: list and serve a photo's mask variants"
+```
+
+### Task 6.2: Lightbox variant toggle
+
+**Files:**
+- Modify: `vireo/templates/_navbar.html` (lightbox)
+
+Add a small dropdown in the lightbox controls labeled "Mask variant: [active|sam2-small|sam2-large|sam3-small]". Selecting an option:
+- Fetches the variant's PNG from `/api/masks/<pid>/<variant>.png`.
+- Replaces the current overlay image with no other side effects (does NOT change `active_mask_variant` — that's the pipeline page's job).
+- Shows "n/a" if the photo has no mask for that variant.
+
+Manual test in browser using Playwright per the user-first-testing memory.
+
+```bash
+git commit -m "lightbox: toggle mask overlay between SAM variants"
+```
+
+---
+
+## Phase 7 — Final integration check
+
+### Task 7.1: Full test sweep
+
+```bash
+python -m pytest tests/ vireo/tests/ -v
+```
+
+Expected: all SAM-related tests pass; the pre-existing-failures memo from `project_preexisting_test_failures.md` flags any unrelated flakiness.
+
+### Task 7.2: End-to-end smoke
+
+1. Start app: `python vireo/app.py --db ~/.vireo/vireo.db --port 8080`
+2. Set `pipeline.sam2_variant = sam2-small`, run pipeline on a small folder. Confirm masks appear.
+3. Set `pipeline.sam2_variant = sam2-large`, re-run. Confirm new variant gets its own files; sam2-small files still on disk; pipeline page shows two variants; lightbox toggle works.
+4. Re-run a third time without changing variant. Confirm `generate_mask` is not called for already-masked photos (check `~/.vireo/vireo.log`).
+5. In stats: "Delete inactive" leaves only the active variant; counts in the pipeline page match.
+6. Re-run YOLO with a different `detector_confidence`. After it produces different bboxes, /stats shows non-zero stale_count; pipeline rerun regenerates the affected variants.
+
+### Task 7.3: PR
+
+```bash
+gh pr create --base main --title "SAM mask history: per-variant masks, comparison UI, storage management" --body "<summary + test results>"
+```
+
+---
+
+## Open follow-ups (out of scope for this plan)
+
+- Replace the `unknown`-variant migration with a backfill from `pipeline_cfg.sam2_variant` when the user explicitly opts in via a UI button. Currently the migration is honest at the cost of one re-run.
+- Add a `prompt_hash` column for prompt types beyond bbox (e.g., point clicks) if SAM ever takes other prompt forms.
+- Consider a side-by-side-on-one-screen compare view (UI option B) once option A is in production and we know how often it gets used.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4536,9 +4536,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_storage_masks():
         """Per-variant SAM mask summary (counts, bytes, active counts)
         plus stale-mask count for the storage dashboard."""
+        import config as cfg
+
         db = _get_db()
+        # Workspace-effective detector_confidence floor — the same
+        # threshold extraction applies when picking boxes to run SAM
+        # on. Plumbing it here keeps "stale" aligned with what the
+        # pipeline would actually regenerate: a mask whose prompt only
+        # matches a now-below-threshold detection won't be re-extracted,
+        # so the storage card must surface it as stale.
+        min_detector_conf = db.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
         variants = db.mask_variants_summary()
-        stale = db.find_stale_masks()
+        stale = db.find_stale_masks(detector_confidence=min_detector_conf)
         masks_dir = os.path.join(os.path.dirname(db_path), "masks")
         return jsonify({
             "variants": variants,
@@ -4576,8 +4587,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_storage_masks_delete_stale():
         """Delete masks whose stored prompt no longer matches the current
         primary detection. Skips active variants."""
+        import config as cfg
+
         db = _get_db()
-        n = db.delete_stale_masks()
+        # Use the same workspace-effective detector_confidence floor the
+        # storage card shows, so the user deletes exactly what the count
+        # advertised.
+        min_detector_conf = db.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
+        n = db.delete_stale_masks(detector_confidence=min_detector_conf)
         log.info("Deleted %d stale masks", n)
         return jsonify({"ok": True, "deleted": n})
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1208,6 +1208,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "proxy_longest_edge": pipeline_cfg.get("proxy_longest_edge", 1536),
                 "eye_detect_enabled": pipeline_cfg.get("eye_detect_enabled", True),
             },
+            "mask_variant_coverage": db.mask_variant_coverage(),
             "results": results,
             "workspace_overrides": ws_overrides,
             "recent_destinations": effective_cfg.get("ingest", {}).get("recent_destinations", []),
@@ -10164,6 +10165,58 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             db.update_workspace(db._active_workspace_id, config_overrides=current_overrides)
 
         return jsonify({"pipeline": pipeline_section, "status": "saved"})
+
+    @app.route("/api/pipeline/active-mask-variant", methods=["POST"])
+    def api_pipeline_active_mask_variant():
+        """Switch the active mask variant for every photo in the workspace
+        that has a row for ``variant`` in ``photo_masks``.
+
+        This is the bulk version of ``Database.set_active_mask_variant``:
+        it walks the workspace's photos, finds the ones with a mask row
+        for the requested variant, and denormalizes that variant's
+        path/features into the ``photos`` row so downstream readers
+        (scoring, lightbox overlay) see the new active mask.
+
+        Body: ``{"variant": "<sam2-variant>"}``.
+        Refuses ``"unknown"`` because it's a migration sentinel, not a
+        user-selectable variant.
+        """
+        body = request.get_json(silent=True) or {}
+        variant = (body.get("variant") or "").strip()
+        if not variant:
+            return json_error("variant required")
+        if variant == "unknown":
+            return json_error(
+                "'unknown' is a migration sentinel and cannot be set active",
+                400,
+            )
+        db = _get_db()
+        ws = db._ws_id()
+        rows = db.conn.execute(
+            """
+            SELECT pm.photo_id
+              FROM photo_masks pm
+              JOIN photos p ON p.id = pm.photo_id
+              JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+             WHERE wf.workspace_id = ? AND pm.variant = ?
+            """,
+            (ws, variant),
+        ).fetchall()
+        updated = 0
+        for r in rows:
+            try:
+                db.set_active_mask_variant(r["photo_id"], variant)
+                updated += 1
+            except ValueError:
+                # Race: row was deleted between SELECT and UPDATE. Skip
+                # rather than 500 — the user just asked to "make this the
+                # active variant where possible".
+                continue
+        log.info(
+            "Switched active mask variant to %s for %d workspace photo(s)",
+            variant, updated,
+        )
+        return jsonify({"ok": True, "updated": updated})
 
     @app.route("/api/culling/results")
     def api_culling_results():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9918,13 +9918,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 if mask and mask.get("path"):
                     masks_dir_real = os.path.realpath(masks_dir)
                     abs_path = os.path.realpath(mask["path"])
-                    if (abs_path == masks_dir_real
-                            or abs_path.startswith(masks_dir_real + os.sep)):
-                        if os.path.isfile(abs_path):
-                            return send_from_directory(
-                                masks_dir_real,
-                                os.path.relpath(abs_path, masks_dir_real),
-                            )
+                    if (
+                        (abs_path == masks_dir_real
+                            or abs_path.startswith(masks_dir_real + os.sep))
+                        and os.path.isfile(abs_path)
+                    ):
+                        return send_from_directory(
+                            masks_dir_real,
+                            os.path.relpath(abs_path, masks_dir_real),
+                        )
         return "", 404
 
     @app.route("/api/photos/<int:pid>/masks")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4530,6 +4530,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             }
         )
 
+    @app.route("/api/storage/masks")
+    def api_storage_masks():
+        """Per-variant SAM mask summary (counts, bytes, active counts)
+        plus stale-mask count for the storage dashboard."""
+        db = _get_db()
+        variants = db.mask_variants_summary()
+        stale = db.find_stale_masks()
+        masks_dir = os.path.join(os.path.dirname(db_path), "masks")
+        return jsonify({
+            "variants": variants,
+            "total_bytes": sum(v["bytes"] for v in variants),
+            "stale_count": len(stale),
+            "path": masks_dir,
+        })
+
     @app.route("/api/storage/files")
     def api_storage_files():
         """List individual files in a cache directory."""

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9112,9 +9112,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                 "w": det["box_w"], "h": det["box_h"],
                             }),
                             "detection_conf": det["detector_confidence"],
+                            # Full-precision REAL prompt — see pipeline_job
+                            # for the rationale; int() would truncate the
+                            # normalized [0,1] bbox to (0,0,0,0) and break
+                            # cache invalidation on bbox change.
                             "prompt": (
-                                int(det["box_x"]), int(det["box_y"]),
-                                int(det["box_w"]), int(det["box_h"]),
+                                det["box_x"], det["box_y"],
+                                det["box_w"], det["box_h"],
                             ),
                         })
             else:
@@ -9156,8 +9160,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         }),
                         "detection_conf": r["detector_confidence"],
                         "prompt": (
-                            int(r["box_x"]), int(r["box_y"]),
-                            int(r["box_w"]), int(r["box_h"]),
+                            r["box_x"], r["box_y"],
+                            r["box_w"], r["box_h"],
                         ),
                     })
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11,6 +11,7 @@ import logging.handlers
 import math
 import os
 import queue
+import re
 import subprocess
 import sys
 import time
@@ -9888,6 +9889,60 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if os.path.exists(mask_path):
             return send_from_directory(masks_dir, filename)
         return "", 404
+
+    @app.route("/api/photos/<int:pid>/masks")
+    def api_photo_masks(pid):
+        """List a photo's available SAM mask variants and the active one.
+
+        Powers the lightbox variant-toggle dropdown: the UI fetches this
+        when opening / navigating to a photo and builds one option per
+        returned variant plus a default "active" option.
+        """
+        db = _get_db()
+        masks = db.list_masks_for_photo(pid)
+        row = db.conn.execute(
+            "SELECT active_mask_variant FROM photos WHERE id=?", (pid,)
+        ).fetchone()
+        active = row["active_mask_variant"] if row else None
+        return jsonify({
+            "photo_id": pid,
+            "active": active,
+            "variants": [
+                {
+                    "variant": m["variant"],
+                    "url": f"/api/masks/{pid}/{m['variant']}.png",
+                    "created_at": m["created_at"],
+                }
+                for m in masks
+            ],
+        })
+
+    # Variant strings live in URLs and must not be path-traversal vectors.
+    # Allow only alnum / dash / underscore — covers every variant we
+    # actually emit (sam2-small, sam2-large, sam3-small, unknown) and
+    # excludes `.`, `/`, and `..` outright.
+    _MASK_VARIANT_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+    @app.route("/api/masks/<int:pid>/<variant>.png")
+    def api_serve_mask(pid, variant):
+        """Serve ``{pid}.{variant}.png`` from the masks directory.
+
+        Defense in depth: the variant must (1) match the conservative
+        whitelist regex and (2) correspond to an actual photo_masks row,
+        not just a file on disk. This means an attacker who manages to
+        write a file matching the URL pattern still can't get it served
+        unless we also have a DB row for that (pid, variant).
+        """
+        if not _MASK_VARIANT_RE.match(variant):
+            return "", 404
+        db = _get_db()
+        if db.get_photo_mask(pid, variant) is None:
+            return "", 404
+        masks_dir = os.path.join(os.path.dirname(db_path), "masks")
+        filename = f"{pid}.{variant}.png"
+        if not os.path.isfile(os.path.join(masks_dir, filename)):
+            return "", 404
+        return send_from_directory(masks_dir, filename)
 
     @app.route("/api/pipeline/reflow", methods=["POST"])
     def api_pipeline_reflow():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9891,11 +9891,40 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/masks/<filename>")
     def serve_mask(filename):
-        """Serve mask PNG files."""
+        """Serve mask PNG files.
+
+        Legacy callers (e.g. ``openInspect`` in pipeline_review.html) still
+        request ``/masks/{photo_id}.png``. Variant-aware extraction now
+        writes ``{photo_id}.{variant}.png``, so when the literal filename
+        isn't on disk and the request looks like ``{photo_id}.png``, fall
+        back to the photo's active mask via ``photo_masks`` so the inspect
+        panel keeps working without a round-trip API call.
+        """
         masks_dir = os.path.join(os.path.dirname(db_path), "masks")
         mask_path = os.path.join(masks_dir, filename)
         if os.path.exists(mask_path):
             return send_from_directory(masks_dir, filename)
+
+        m = re.match(r"^(\d+)\.png$", filename)
+        if m:
+            pid = int(m.group(1))
+            db = _get_db()
+            row = db.conn.execute(
+                "SELECT active_mask_variant FROM photos WHERE id=?", (pid,)
+            ).fetchone()
+            active = row["active_mask_variant"] if row else None
+            if active:
+                mask = db.get_photo_mask(pid, active)
+                if mask and mask.get("path"):
+                    masks_dir_real = os.path.realpath(masks_dir)
+                    abs_path = os.path.realpath(mask["path"])
+                    if (abs_path == masks_dir_real
+                            or abs_path.startswith(masks_dir_real + os.sep)):
+                        if os.path.isfile(abs_path):
+                            return send_from_directory(
+                                masks_dir_real,
+                                os.path.relpath(abs_path, masks_dir_real),
+                            )
         return "", 404
 
     @app.route("/api/photos/<int:pid>/masks")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4545,6 +4545,40 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "path": masks_dir,
         })
 
+    @app.route("/api/storage/masks/delete-variant", methods=["POST"])
+    def api_storage_masks_delete_variant():
+        """Delete all photo_masks rows + files for the given variant.
+        Returns 400 when the variant is currently active for any photo.
+        """
+        body = request.get_json(silent=True) or {}
+        variant = body.get("variant", "")
+        if not variant:
+            return json_error("variant required")
+        db = _get_db()
+        try:
+            n = db.delete_masks_for_variant(variant)
+        except ValueError as e:
+            return json_error(str(e), 400)
+        log.info("Deleted %d masks for variant %s", n, variant)
+        return jsonify({"ok": True, "deleted": n})
+
+    @app.route("/api/storage/masks/delete-inactive", methods=["POST"])
+    def api_storage_masks_delete_inactive():
+        """Delete all non-active variant masks across all photos."""
+        db = _get_db()
+        n = db.delete_inactive_masks()
+        log.info("Deleted %d inactive-variant masks", n)
+        return jsonify({"ok": True, "deleted": n})
+
+    @app.route("/api/storage/masks/delete-stale", methods=["POST"])
+    def api_storage_masks_delete_stale():
+        """Delete masks whose stored prompt no longer matches the current
+        primary detection. Skips active variants."""
+        db = _get_db()
+        n = db.delete_stale_masks()
+        log.info("Deleted %d stale masks", n)
+        return jsonify({"ok": True, "deleted": n})
+
     @app.route("/api/storage/files")
     def api_storage_files():
         """List individual files in a cache directory."""

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4539,14 +4539,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         import config as cfg
 
         db = _get_db()
-        # Workspace-effective detector_confidence floor — the same
-        # threshold extraction applies when picking boxes to run SAM
-        # on. Plumbing it here keeps "stale" aligned with what the
-        # pipeline would actually regenerate: a mask whose prompt only
-        # matches a now-below-threshold detection won't be re-extracted,
-        # so the storage card must surface it as stale.
-        min_detector_conf = db.get_effective_config(cfg.load()).get(
-            "detector_confidence", 0.2
+        # Storage is global across all workspaces, so the stale floor
+        # must be too. Using the active workspace's detector_confidence
+        # would make stale_count flip when the user switches workspaces
+        # and let masks valid under another workspace's lower floor
+        # show up as stale. The minimum across workspaces is the most
+        # permissive view: only mark a mask stale when no workspace
+        # would still consider it fresh.
+        min_detector_conf = db.min_detector_confidence_across_workspaces(
+            cfg.load()
         )
         variants = db.mask_variants_summary()
         stale = db.find_stale_masks(detector_confidence=min_detector_conf)
@@ -4590,11 +4591,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         import config as cfg
 
         db = _get_db()
-        # Use the same workspace-effective detector_confidence floor the
-        # storage card shows, so the user deletes exactly what the count
-        # advertised.
-        min_detector_conf = db.get_effective_config(cfg.load()).get(
-            "detector_confidence", 0.2
+        # Mirror /api/storage/masks: the deletion set must be a function
+        # of the data, not of which workspace happens to be active.
+        # Using the cross-workspace minimum keeps the count and the
+        # delete in sync and prevents deleting masks that another
+        # workspace's lower detector_confidence would still consider
+        # fresh.
+        min_detector_conf = db.min_detector_confidence_across_workspaces(
+            cfg.load()
         )
         n = db.delete_stale_masks(detector_confidence=min_detector_conf)
         log.info("Deleted %d stale masks", n)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9054,6 +9054,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         sam2_variant = pipeline_cfg.get("sam2_variant", "sam2-small")
         dinov2_variant = pipeline_cfg.get("dinov2_variant", "vit-b14")
         proxy_longest_edge = pipeline_cfg.get("proxy_longest_edge", 1536)
+        # Workspace-effective detector_confidence floor. Both the
+        # collection branch (via get_detections) and the workspace SQL
+        # below filter on this so we don't run SAM/DINO on noisy
+        # below-threshold boxes — matching get_photos_missing_masks.
+        min_detector_conf = effective_cfg.get("detector_confidence", 0.2)
 
         runner = app._job_runner
         active_ws = _get_db()._active_workspace_id
@@ -9090,7 +9095,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 photos = []
                 for p in coll_photos:
                     dets = [
-                        d for d in thread_db.get_detections(p["id"])
+                        d for d in thread_db.get_detections(
+                            p["id"], min_conf=min_detector_conf,
+                        )
                         if d["detector_model"] != "full-image"
                     ]
                     if dets:
@@ -9128,8 +9135,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                          JOIN detections d ON d.photo_id = p.id
                         WHERE wf.workspace_id = ?
                           AND d.detector_model != 'full-image'
+                          AND d.detector_confidence >= ?
                         ORDER BY p.id, d.detector_confidence DESC""",
-                    (ws_id,),
+                    (ws_id, min_detector_conf),
                 ).fetchall()
                 seen = set()
                 photos = []

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9163,7 +9163,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         WHERE wf.workspace_id = ?
                           AND d.detector_model != 'full-image'
                           AND d.detector_confidence >= ?
-                        ORDER BY p.id, d.detector_confidence DESC""",
+                        ORDER BY p.id, d.detector_confidence DESC, d.id ASC""",
                     (ws_id, min_detector_conf),
                 ).fetchall()
                 seen = set()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9008,6 +9008,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         active_ws = _get_db()._active_workspace_id
 
         def work(job):
+            import numpy as np
             from dino_embed import embed, embed_batch, embedding_to_blob
             from masking import (
                 crop_completeness,
@@ -9024,33 +9025,82 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             masks_dir = os.path.join(os.path.dirname(db_path), "masks")
             os.makedirs(masks_dir, exist_ok=True)
 
-            # Get photos that have detections but no masks
+            # Get photos that have a real (non full-image) detection. The
+            # legacy `mask_path IS NULL` gate would silently skip every
+            # photo whose stored mask was made by a *different* SAM
+            # variant — leaving photo_masks empty for the configured
+            # variant. The per-photo cache check inside the loop below
+            # against photo_masks(photo_id, sam2_variant) handles
+            # "already cached for this variant" correctly.
             if collection_id:
                 coll_photos = thread_db.get_collection_photos(
                     collection_id, per_page=999999
                 )
-                # Filter to photos with detections but no masks. Detection
-                # threshold is resolved at read time from the workspace's
-                # effective config (detections table is global now).
                 photos = []
                 for p in coll_photos:
-                    if p["mask_path"]:
-                        continue
-                    dets = thread_db.get_detections(p["id"])
+                    dets = [
+                        d for d in thread_db.get_detections(p["id"])
+                        if d["detector_model"] != "full-image"
+                    ]
                     if dets:
                         det = dets[0]
                         photos.append({
                             "id": p["id"],
                             "folder_id": p["folder_id"],
                             "filename": p["filename"],
+                            "detector_model": det["detector_model"],
                             "detection_box": json.dumps({
                                 "x": det["box_x"], "y": det["box_y"],
                                 "w": det["box_w"], "h": det["box_h"],
                             }),
                             "detection_conf": det["detector_confidence"],
+                            "prompt": (
+                                int(det["box_x"]), int(det["box_y"]),
+                                int(det["box_w"]), int(det["box_h"]),
+                            ),
                         })
             else:
-                photos = thread_db.get_photos_missing_masks()
+                # All workspace photos with at least one real
+                # (non full-image) detection. Direct SQL keeps this
+                # one round-trip to SQLite per workspace; the per-photo
+                # cache check inside the loop handles "skip when
+                # already masked for this variant".
+                ws_id = thread_db._active_workspace_id
+                rows = thread_db.conn.execute(
+                    """SELECT p.id, p.folder_id, p.filename,
+                              d.detector_model,
+                              d.box_x, d.box_y, d.box_w, d.box_h,
+                              d.detector_confidence
+                         FROM photos p
+                         JOIN workspace_folders wf
+                              ON wf.folder_id = p.folder_id
+                         JOIN detections d ON d.photo_id = p.id
+                        WHERE wf.workspace_id = ?
+                          AND d.detector_model != 'full-image'
+                        ORDER BY p.id, d.detector_confidence DESC""",
+                    (ws_id,),
+                ).fetchall()
+                seen = set()
+                photos = []
+                for r in rows:
+                    if r["id"] in seen:
+                        continue
+                    seen.add(r["id"])
+                    photos.append({
+                        "id": r["id"],
+                        "folder_id": r["folder_id"],
+                        "filename": r["filename"],
+                        "detector_model": r["detector_model"],
+                        "detection_box": json.dumps({
+                            "x": r["box_x"], "y": r["box_y"],
+                            "w": r["box_w"], "h": r["box_h"],
+                        }),
+                        "detection_conf": r["detector_confidence"],
+                        "prompt": (
+                            int(r["box_x"]), int(r["box_y"]),
+                            int(r["box_w"]), int(r["box_h"]),
+                        ),
+                    })
 
             folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
             total = len(photos)
@@ -9065,6 +9115,46 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 image_path = os.path.join(folder_path, photo["filename"])
 
                 try:
+                    # Cache hit: photo_masks already has a row for
+                    # (photo, configured variant) AND its stored prompt
+                    # + detector still match the current primary
+                    # detection AND the file is on disk. Skip SAM and
+                    # just (re-)activate the cached mask.
+                    existing = thread_db.get_photo_mask(
+                        photo_id, sam2_variant,
+                    )
+                    if existing is not None:
+                        cached_prompt = (
+                            existing["prompt_x"], existing["prompt_y"],
+                            existing["prompt_w"], existing["prompt_h"],
+                        )
+                        if (existing["detector_model"]
+                                == photo["detector_model"]
+                                and cached_prompt == photo["prompt"]
+                                and existing["path"]
+                                and os.path.isfile(existing["path"])):
+                            thread_db.set_active_mask_variant(
+                                photo_id, sam2_variant,
+                            )
+                            masked += 1
+                            runner.push_event(
+                                job["id"],
+                                "progress",
+                                {
+                                    "current": i + 1,
+                                    "total": total,
+                                    "current_file": photo["filename"],
+                                    "rate": round(
+                                        (i + 1) / max(
+                                            time.time() - job["_start_time"], 0.01,
+                                        ),
+                                        1,
+                                    ),
+                                    "phase": "Extracting features (SAM2 + DINOv2)",
+                                },
+                            )
+                            continue
+
                     # Load working-resolution proxy
                     proxy = render_proxy(image_path, longest_edge=proxy_longest_edge)
                     if proxy is None:
@@ -9108,13 +9198,51 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             embed(proxy, variant=dinov2_variant),
                         )
 
-                    # Update DB with mask path, completeness, features, and embeddings
-                    thread_db.update_photo_pipeline_features(
-                        photo_id,
-                        mask_path=mask_path,
-                        crop_complete=completeness,
-                        **features,
+                    # Per-mask features: pop them out of `features` so
+                    # they land on the photo_masks row and not on the
+                    # photos row directly. set_active_mask_variant
+                    # denormalizes them back into photos for downstream
+                    # readers.
+                    mask_subject_tenengrad = features.pop(
+                        "subject_tenengrad", None,
                     )
+                    mask_bg_tenengrad = features.pop("bg_tenengrad", None)
+                    # Mask-derived subject_size: fraction of frame
+                    # covered by the boolean mask.
+                    total_pixels = float(mask.size)
+                    if total_pixels > 0:
+                        mask_subject_size = float(
+                            np.count_nonzero(mask) / total_pixels
+                        )
+                    else:
+                        mask_subject_size = None
+
+                    thread_db.upsert_photo_mask(
+                        photo_id=photo_id,
+                        variant=sam2_variant,
+                        path=mask_path,
+                        detector_model=photo["detector_model"],
+                        prompt_x=photo["prompt"][0],
+                        prompt_y=photo["prompt"][1],
+                        prompt_w=photo["prompt"][2],
+                        prompt_h=photo["prompt"][3],
+                        subject_size=mask_subject_size,
+                        subject_tenengrad=mask_subject_tenengrad,
+                        bg_tenengrad=mask_bg_tenengrad,
+                        crop_complete=completeness,
+                    )
+                    thread_db.set_active_mask_variant(
+                        photo_id, sam2_variant,
+                    )
+                    # Remaining (non-mask) per-photo features still land
+                    # on the photos row. mask_path / crop_complete /
+                    # subject_tenengrad / bg_tenengrad / subject_size
+                    # flow via set_active_mask_variant above and are
+                    # intentionally NOT passed here.
+                    if features:
+                        thread_db.update_photo_pipeline_features(
+                            photo_id, **features,
+                        )
                     thread_db.update_photo_embeddings(
                         photo_id,
                         dino_subject_embedding=subj_emb_blob,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from urllib.parse import quote
 
 import places
-from db import KEYWORD_TYPES, Database
+from db import KEYWORD_TYPES, Database, commit_with_retry
 from flask import (
     Flask,
     Response,
@@ -10203,15 +10203,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             (ws, variant),
         ).fetchall()
         updated = 0
+        # Batch: skip the per-row commit_with_retry inside
+        # set_active_mask_variant and commit once after the loop. A
+        # workspace with 10K photos would otherwise pay 10K WAL fsyncs
+        # per request — multiple seconds with no progress indicator.
         for r in rows:
             try:
-                db.set_active_mask_variant(r["photo_id"], variant)
+                db.set_active_mask_variant(
+                    r["photo_id"], variant, _commit=False,
+                )
                 updated += 1
-            except ValueError:
+            except ValueError as e:
                 # Race: row was deleted between SELECT and UPDATE. Skip
-                # rather than 500 — the user just asked to "make this the
-                # active variant where possible".
+                # rather than 500 — the user just asked to "make this
+                # the active variant where possible". Log the skip so
+                # the cause is visible if the count looks off.
+                log.warning(
+                    "active-mask-variant skip photo %d: %s",
+                    r["photo_id"], e,
+                )
                 continue
+        commit_with_retry(db.conn)
         log.info(
             "Switched active mask variant to %s for %d workspace photo(s)",
             variant, updated,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9933,24 +9933,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/api/masks/<int:pid>/<variant>.png")
     def api_serve_mask(pid, variant):
-        """Serve ``{pid}.{variant}.png`` from the masks directory.
+        """Serve the mask file recorded on the ``photo_masks`` row.
+
+        Reads the stored ``photo_masks.path`` instead of reconstructing
+        ``{pid}.{variant}.png`` so migrated legacy masks (backfilled as
+        ``variant='unknown'`` pointing at the old ``{pid}.png`` filename)
+        remain viewable in the lightbox.
 
         Defense in depth: the variant must (1) match the conservative
-        whitelist regex and (2) correspond to an actual photo_masks row,
-        not just a file on disk. This means an attacker who manages to
-        write a file matching the URL pattern still can't get it served
-        unless we also have a DB row for that (pid, variant).
+        whitelist regex, (2) correspond to an actual ``photo_masks`` row,
+        and (3) the stored path must resolve inside the masks directory
+        (so an attacker-controlled or corrupted DB row can't escape).
         """
         if not _MASK_VARIANT_RE.match(variant):
             return "", 404
         db = _get_db()
-        if db.get_photo_mask(pid, variant) is None:
+        mask = db.get_photo_mask(pid, variant)
+        if mask is None or not mask.get("path"):
             return "", 404
-        masks_dir = os.path.join(os.path.dirname(db_path), "masks")
-        filename = f"{pid}.{variant}.png"
-        if not os.path.isfile(os.path.join(masks_dir, filename)):
+        masks_dir = os.path.realpath(
+            os.path.join(os.path.dirname(db_path), "masks")
+        )
+        abs_path = os.path.realpath(mask["path"])
+        if not (abs_path == masks_dir
+                or abs_path.startswith(masks_dir + os.sep)):
             return "", 404
-        return send_from_directory(masks_dir, filename)
+        if not os.path.isfile(abs_path):
+            return "", 404
+        return send_from_directory(
+            masks_dir, os.path.relpath(abs_path, masks_dir)
+        )
 
     @app.route("/api/pipeline/reflow", methods=["POST"])
     def api_pipeline_reflow():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9082,8 +9082,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         skipped += 1
                         continue
 
-                    # Save mask PNG
-                    mask_path = save_mask(mask, masks_dir, photo_id)
+                    # Save mask PNG (per SAM variant; one file per variant)
+                    mask_path = save_mask(
+                        mask, masks_dir, photo_id, sam2_variant,
+                    )
 
                     # Compute crop completeness + all quality features
                     completeness = crop_completeness(mask)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3611,6 +3611,20 @@ class Database:
         )
         commit_with_retry(self.conn)
 
+    def get_photo_mask(self, photo_id, variant):
+        row = self.conn.execute(
+            "SELECT * FROM photo_masks WHERE photo_id=? AND variant=?",
+            (photo_id, variant),
+        ).fetchone()
+        return dict(row) if row else None
+
+    def list_masks_for_photo(self, photo_id):
+        rows = self.conn.execute(
+            "SELECT * FROM photo_masks WHERE photo_id=? ORDER BY created_at DESC",
+            (photo_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
     def upsert_photo_mask(
         self, photo_id, variant, path,
         detector_model, prompt_x, prompt_y, prompt_w, prompt_h,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3727,12 +3727,21 @@ class Database:
 
     def delete_inactive_masks(self):
         """Delete all photo_masks rows + files except the active variant
-        per photo. Returns the number of rows deleted."""
+        per photo. Returns the number of rows deleted.
+
+        Photos whose ``active_mask_variant IS NULL`` are skipped entirely
+        (we never delete the only mask we know about). The user must
+        promote a variant to active first via the pipeline page; the
+        sentinel migration variant ``'unknown'`` is set as active for
+        legacy photos, so this is only the partial-state case where a
+        prior pipeline run wrote ``photo_masks`` but crashed before
+        ``set_active_mask_variant`` ran.
+        """
         rows = self.conn.execute(
             "SELECT pm.photo_id, pm.variant, pm.path FROM photo_masks pm "
             "JOIN photos p ON p.id = pm.photo_id "
-            "WHERE p.active_mask_variant IS NULL "
-            "   OR p.active_mask_variant != pm.variant"
+            "WHERE p.active_mask_variant IS NOT NULL "
+            "  AND p.active_mask_variant != pm.variant"
         ).fetchall()
         for r in rows:
             try:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -879,6 +879,57 @@ class Database:
         except (json.JSONDecodeError, TypeError):
             return global_config
 
+    def min_detector_confidence_across_workspaces(self, global_config):
+        """Return the minimum effective ``detector_confidence`` across all
+        workspaces.
+
+        Used by global mask-storage endpoints (``/api/storage/masks`` and
+        ``/api/storage/masks/delete-stale``). Stale-mask scoring depends
+        on the floor under which a detection is treated as too noisy to
+        re-extract from. Picking the *active* workspace's floor would
+        mean switching workspaces changes the global deletion set —
+        masks valid under another workspace's lower floor could be
+        deleted just because the user happened to be in a stricter
+        workspace at the moment. The minimum is the most permissive
+        view: a mask is only considered globally stale when **no**
+        workspace would still consider it fresh.
+        """
+        from config import _deep_merge
+
+        default = global_config.get("detector_confidence", 0.2)
+        try:
+            default = float(default)
+        except (TypeError, ValueError):
+            default = 0.2
+        workspaces = self.get_workspaces()
+        if not workspaces:
+            return default
+        values = []
+        for ws in workspaces:
+            overrides_raw = ws["config_overrides"]
+            if not overrides_raw:
+                values.append(default)
+                continue
+            try:
+                overrides = (
+                    json.loads(overrides_raw)
+                    if isinstance(overrides_raw, str)
+                    else overrides_raw
+                )
+            except (json.JSONDecodeError, TypeError):
+                values.append(default)
+                continue
+            if not isinstance(overrides, dict):
+                values.append(default)
+                continue
+            merged = _deep_merge(global_config, overrides)
+            v = merged.get("detector_confidence", default)
+            try:
+                values.append(float(v))
+            except (TypeError, ValueError):
+                values.append(default)
+        return min(values) if values else default
+
     def get_subject_types(self) -> set[str]:
         """Return the keyword types that count as 'identified' for the active
         workspace.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3611,6 +3611,40 @@ class Database:
         )
         commit_with_retry(self.conn)
 
+    def upsert_photo_mask(
+        self, photo_id, variant, path,
+        detector_model, prompt_x, prompt_y, prompt_w, prompt_h,
+        subject_size=None, subject_tenengrad=None,
+        bg_tenengrad=None, crop_complete=None,
+    ):
+        """Insert or replace a mask row for (photo_id, variant)."""
+        self.conn.execute(
+            """
+            INSERT INTO photo_masks (
+                photo_id, variant, path, created_at,
+                detector_model, prompt_x, prompt_y, prompt_w, prompt_h,
+                subject_size, subject_tenengrad, bg_tenengrad, crop_complete
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(photo_id, variant) DO UPDATE SET
+                path=excluded.path,
+                created_at=excluded.created_at,
+                detector_model=excluded.detector_model,
+                prompt_x=excluded.prompt_x,
+                prompt_y=excluded.prompt_y,
+                prompt_w=excluded.prompt_w,
+                prompt_h=excluded.prompt_h,
+                subject_size=excluded.subject_size,
+                subject_tenengrad=excluded.subject_tenengrad,
+                bg_tenengrad=excluded.bg_tenengrad,
+                crop_complete=excluded.crop_complete
+            """,
+            (photo_id, variant, path, int(time.time()),
+             detector_model, prompt_x, prompt_y, prompt_w, prompt_h,
+             subject_size, subject_tenengrad, bg_tenengrad, crop_complete),
+        )
+        commit_with_retry(self.conn)
+
     def update_photo_pipeline_features(
         self,
         photo_id,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -358,6 +358,23 @@ class Database:
                 created_at          TEXT DEFAULT (datetime('now'))
             );
 
+            CREATE TABLE IF NOT EXISTS photo_masks (
+                photo_id          INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
+                variant           TEXT    NOT NULL,
+                path              TEXT    NOT NULL,
+                created_at        INTEGER NOT NULL,
+                detector_model    TEXT    NOT NULL,
+                prompt_x          INTEGER NOT NULL,
+                prompt_y          INTEGER NOT NULL,
+                prompt_w          INTEGER NOT NULL,
+                prompt_h          INTEGER NOT NULL,
+                subject_size      INTEGER,
+                subject_tenengrad REAL,
+                bg_tenengrad      REAL,
+                crop_complete     REAL,
+                PRIMARY KEY (photo_id, variant)
+            );
+
             CREATE TABLE IF NOT EXISTS predictions (
                 id                   INTEGER PRIMARY KEY,
                 detection_id         INTEGER NOT NULL REFERENCES detections(id) ON DELETE CASCADE,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3759,7 +3759,17 @@ class Database:
     def find_stale_masks(self):
         """Return photo_masks rows whose stored prompt no longer matches
         the photo's current primary detection (highest-confidence,
-        non full-image)."""
+        non full-image).
+
+        A mask is fresh only if its stored ``(detector_model, prompt_*)``
+        equals the photo's primary detection — the single
+        highest-confidence non-``full-image`` row. Matching against any
+        detection (e.g., a low-confidence secondary box still carrying
+        the old coordinates, or another retained model's row) would
+        leave stale cache entries lingering after detector/model
+        changes, so we explicitly join the per-photo MAX confidence
+        before comparing.
+        """
         rows = self.conn.execute(
             """
             SELECT pm.photo_id, pm.variant, pm.path,
@@ -3775,6 +3785,12 @@ class Database:
                    AND CAST(d.box_y AS INTEGER) = pm.prompt_y
                    AND CAST(d.box_w AS INTEGER) = pm.prompt_w
                    AND CAST(d.box_h AS INTEGER) = pm.prompt_h
+                   AND d.detector_confidence = (
+                       SELECT MAX(d2.detector_confidence)
+                         FROM detections d2
+                        WHERE d2.photo_id = pm.photo_id
+                          AND d2.detector_model != 'full-image'
+                   )
              )
             """
         ).fetchall()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -359,6 +359,12 @@ class Database:
                 created_at          TEXT DEFAULT (datetime('now'))
             );
 
+            -- subject_size is declared REAL because compute_all_quality_features
+            -- stores it as a fraction in [0, 1]. SQLite's flexible type affinity
+            -- means existing databases that pre-date this fix (where the column
+            -- was declared INTEGER) still tolerate REAL values without an
+            -- ALTER, so we don't bother emitting a migration for the column
+            -- type — only fresh DBs see the corrected declaration.
             CREATE TABLE IF NOT EXISTS photo_masks (
                 photo_id          INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
                 variant           TEXT    NOT NULL,
@@ -369,7 +375,7 @@ class Database:
                 prompt_y          INTEGER NOT NULL,
                 prompt_w          INTEGER NOT NULL,
                 prompt_h          INTEGER NOT NULL,
-                subject_size      INTEGER,
+                subject_size      REAL,
                 subject_tenengrad REAL,
                 bg_tenengrad      REAL,
                 crop_complete     REAL,
@@ -664,6 +670,51 @@ class Database:
             self.conn.execute(
                 "ALTER TABLE photos ADD COLUMN active_mask_variant TEXT"
             )
+
+        # One-time backfill: pre-existing photos with mask_path set on the
+        # photos row but no row at all in photo_masks get migrated to
+        # variant='unknown' with a sentinel prompt. detector_model='unknown'
+        # + prompt=-1 mean the staleness check will treat these masks as
+        # stale on the next pipeline run, so they get regenerated against
+        # whatever SAM2 variant the user has configured. Idempotent on its
+        # own (skipped once any 'unknown' rows exist), and the per-photo
+        # NOT EXISTS guard means we don't shadow rows that the new code
+        # path already wrote (e.g. a photo that already has a sam2-small
+        # row from a recent pipeline run shouldn't also get an 'unknown'
+        # row appended).
+        try:
+            already = self.conn.execute(
+                "SELECT COUNT(*) FROM photo_masks WHERE variant='unknown'"
+            ).fetchone()[0]
+        except sqlite3.OperationalError:
+            already = -1
+        if already == 0:
+            rows = self.conn.execute(
+                "SELECT p.id, p.mask_path, p.subject_size, "
+                "p.subject_tenengrad, p.bg_tenengrad, p.crop_complete "
+                "FROM photos p "
+                "WHERE p.mask_path IS NOT NULL "
+                "  AND NOT EXISTS ("
+                "    SELECT 1 FROM photo_masks pm WHERE pm.photo_id = p.id"
+                "  )"
+            ).fetchall()
+            now = int(time.time())
+            for r in rows:
+                self.conn.execute(
+                    "INSERT OR IGNORE INTO photo_masks "
+                    "(photo_id, variant, path, created_at, detector_model, "
+                    "prompt_x, prompt_y, prompt_w, prompt_h, "
+                    "subject_size, subject_tenengrad, bg_tenengrad, crop_complete) "
+                    "VALUES (?, 'unknown', ?, ?, 'unknown', -1, -1, -1, -1, ?, ?, ?, ?)",
+                    (r["id"], r["mask_path"], now,
+                     r["subject_size"], r["subject_tenengrad"],
+                     r["bg_tenengrad"], r["crop_complete"]),
+                )
+                self.conn.execute(
+                    "UPDATE photos SET active_mask_variant='unknown' "
+                    "WHERE id=? AND active_mask_variant IS NULL",
+                    (r["id"],),
+                )
         self.conn.commit()
 
     # -- Workspaces --

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3603,14 +3603,6 @@ class Database:
         )
         commit_with_retry(self.conn)
 
-    def update_photo_mask(self, photo_id, mask_path):
-        """Store the mask file path for a photo."""
-        self.conn.execute(
-            "UPDATE photos SET mask_path=? WHERE id=?",
-            (mask_path, photo_id),
-        )
-        commit_with_retry(self.conn)
-
     def get_photo_mask(self, photo_id, variant):
         row = self.conn.execute(
             "SELECT * FROM photo_masks WHERE photo_id=? AND variant=?",

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -256,6 +256,7 @@ class Database:
                 phash_crop               TEXT,
                 noise_estimate           REAL,
                 dino_embedding_variant   TEXT,
+                active_mask_variant      TEXT,
                 focal_length             REAL,
                 burst_id                 TEXT,
                 file_hash                TEXT,
@@ -656,6 +657,12 @@ class Database:
         except sqlite3.OperationalError:
             self.conn.execute(
                 "ALTER TABLE photos ADD COLUMN working_copy_failed_mtime REAL"
+            )
+        try:
+            self.conn.execute("SELECT active_mask_variant FROM photos LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute(
+                "ALTER TABLE photos ADD COLUMN active_mask_variant TEXT"
             )
         self.conn.commit()
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3648,6 +3648,105 @@ class Database:
         )
         commit_with_retry(self.conn)
 
+    def delete_masks_for_variant(self, variant):
+        """Delete all photo_masks rows + files for a variant.
+        Refuses if the variant is active for any photo (caller must
+        switch active first)."""
+        active_count = self.conn.execute(
+            "SELECT COUNT(*) FROM photos WHERE active_mask_variant=?",
+            (variant,),
+        ).fetchone()[0]
+        if active_count > 0:
+            raise ValueError(
+                f"Variant {variant!r} is active for {active_count} photo(s); "
+                "switch active variant before deleting"
+            )
+        rows = self.conn.execute(
+            "SELECT path FROM photo_masks WHERE variant=?", (variant,),
+        ).fetchall()
+        for r in rows:
+            try:
+                if r["path"] and os.path.isfile(r["path"]):
+                    os.remove(r["path"])
+            except OSError:
+                log.warning("Failed to remove mask file %s", r["path"])
+        self.conn.execute("DELETE FROM photo_masks WHERE variant=?", (variant,))
+        commit_with_retry(self.conn)
+        return len(rows)
+
+    def delete_inactive_masks(self):
+        """Delete all photo_masks rows + files except the active variant
+        per photo. Returns the number of rows deleted."""
+        rows = self.conn.execute(
+            "SELECT pm.photo_id, pm.variant, pm.path FROM photo_masks pm "
+            "JOIN photos p ON p.id = pm.photo_id "
+            "WHERE p.active_mask_variant IS NULL "
+            "   OR p.active_mask_variant != pm.variant"
+        ).fetchall()
+        for r in rows:
+            try:
+                if r["path"] and os.path.isfile(r["path"]):
+                    os.remove(r["path"])
+            except OSError:
+                log.warning("Failed to remove mask file %s", r["path"])
+            self.conn.execute(
+                "DELETE FROM photo_masks WHERE photo_id=? AND variant=?",
+                (r["photo_id"], r["variant"]),
+            )
+        commit_with_retry(self.conn)
+        return len(rows)
+
+    def find_stale_masks(self):
+        """Return photo_masks rows whose stored prompt no longer matches
+        the photo's current primary detection (highest-confidence,
+        non full-image)."""
+        rows = self.conn.execute(
+            """
+            SELECT pm.photo_id, pm.variant, pm.path,
+                   pm.detector_model, pm.prompt_x, pm.prompt_y,
+                   pm.prompt_w, pm.prompt_h
+              FROM photo_masks pm
+             WHERE NOT EXISTS (
+                SELECT 1 FROM detections d
+                 WHERE d.photo_id = pm.photo_id
+                   AND d.detector_model = pm.detector_model
+                   AND d.detector_model != 'full-image'
+                   AND CAST(d.box_x AS INTEGER) = pm.prompt_x
+                   AND CAST(d.box_y AS INTEGER) = pm.prompt_y
+                   AND CAST(d.box_w AS INTEGER) = pm.prompt_w
+                   AND CAST(d.box_h AS INTEGER) = pm.prompt_h
+             )
+            """
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def delete_stale_masks(self):
+        """Remove rows + files for masks whose prompt no longer matches
+        the current primary detection. Skips active variants (caller can
+        re-run them through the pipeline instead of dropping the
+        currently-displayed mask)."""
+        stale = self.find_stale_masks()
+        deleted = 0
+        for s in stale:
+            is_active = self.conn.execute(
+                "SELECT 1 FROM photos WHERE id=? AND active_mask_variant=?",
+                (s["photo_id"], s["variant"]),
+            ).fetchone()
+            if is_active:
+                continue
+            try:
+                if s["path"] and os.path.isfile(s["path"]):
+                    os.remove(s["path"])
+            except OSError:
+                log.warning("Failed to remove mask file %s", s["path"])
+            self.conn.execute(
+                "DELETE FROM photo_masks WHERE photo_id=? AND variant=?",
+                (s["photo_id"], s["variant"]),
+            )
+            deleted += 1
+        commit_with_retry(self.conn)
+        return deleted
+
     def upsert_photo_mask(
         self, photo_id, variant, path,
         detector_model, prompt_x, prompt_y, prompt_w, prompt_h,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3668,10 +3668,17 @@ class Database:
         ).fetchall()
         return [dict(r) for r in rows]
 
-    def set_active_mask_variant(self, photo_id, variant):
+    def set_active_mask_variant(self, photo_id, variant, _commit=True):
         """Mark `variant` as active for `photo_id` and denormalize its
         fields into the photos row (mask_path + per-mask features) so
-        downstream readers (scoring, pipeline) see the active mask."""
+        downstream readers (scoring, pipeline) see the active mask.
+
+        ``_commit=False`` lets bulk callers (e.g. the
+        ``/api/pipeline/active-mask-variant`` endpoint) batch many
+        per-photo updates into a single commit, instead of paying a WAL
+        fsync per photo. Bulk callers MUST call ``commit_with_retry``
+        themselves once the loop completes.
+        """
         row = self.conn.execute(
             "SELECT path, subject_size, subject_tenengrad, bg_tenengrad, "
             "crop_complete FROM photo_masks WHERE photo_id=? AND variant=?",
@@ -3689,7 +3696,8 @@ class Database:
              row["subject_tenengrad"], row["bg_tenengrad"],
              row["crop_complete"], photo_id),
         )
-        commit_with_retry(self.conn)
+        if _commit:
+            commit_with_retry(self.conn)
 
     def delete_masks_for_variant(self, variant):
         """Delete all photo_masks rows + files for a variant.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3763,7 +3763,7 @@ class Database:
         commit_with_retry(self.conn)
         return len(rows)
 
-    def find_stale_masks(self):
+    def find_stale_masks(self, detector_confidence=None):
         """Return photo_masks rows whose stored prompt no longer matches
         the photo's current primary detection (highest-confidence,
         non full-image).
@@ -3776,9 +3776,25 @@ class Database:
         leave stale cache entries lingering after detector/model
         changes, so we explicitly join the per-photo MAX confidence
         before comparing.
+
+        ``detector_confidence`` is an optional workspace floor (the same
+        threshold both extraction paths apply when picking detections to
+        run SAM on). When provided, detections below the floor are
+        invisible to this query, so masks whose prompt only matches a
+        below-threshold box — i.e. masks the pipeline would no longer
+        regenerate from that detection — are correctly flagged stale.
+        Without this filter, raising ``detector_confidence`` left the
+        storage card under-counting stale masks and ``delete_stale_masks``
+        leaving them on disk.
         """
+        if detector_confidence is None:
+            conf_pred = ""
+            params = ()
+        else:
+            conf_pred = " AND d{n}.detector_confidence >= ?"
+            params = (detector_confidence, detector_confidence)
         rows = self.conn.execute(
-            """
+            f"""
             SELECT pm.photo_id, pm.variant, pm.path,
                    pm.detector_model, pm.prompt_x, pm.prompt_y,
                    pm.prompt_w, pm.prompt_h
@@ -3792,23 +3808,30 @@ class Database:
                    AND d.box_y = pm.prompt_y
                    AND d.box_w = pm.prompt_w
                    AND d.box_h = pm.prompt_h
+                   {conf_pred.format(n="")}
                    AND d.detector_confidence = (
                        SELECT MAX(d2.detector_confidence)
                          FROM detections d2
                         WHERE d2.photo_id = pm.photo_id
                           AND d2.detector_model != 'full-image'
+                          {conf_pred.format(n="2")}
                    )
              )
-            """
+            """,
+            params,
         ).fetchall()
         return [dict(r) for r in rows]
 
-    def delete_stale_masks(self):
+    def delete_stale_masks(self, detector_confidence=None):
         """Remove rows + files for masks whose prompt no longer matches
         the current primary detection. Skips active variants (caller can
         re-run them through the pipeline instead of dropping the
-        currently-displayed mask)."""
-        stale = self.find_stale_masks()
+        currently-displayed mask).
+
+        ``detector_confidence`` is forwarded to :meth:`find_stale_masks`
+        so the deletion set matches the count the storage card shows.
+        """
+        stale = self.find_stale_masks(detector_confidence=detector_confidence)
         deleted = 0
         for s in stale:
             is_active = self.conn.execute(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3790,6 +3790,42 @@ class Database:
         commit_with_retry(self.conn)
         return deleted
 
+    def mask_variant_coverage(self):
+        """Per-variant photo coverage in the **active workspace**.
+
+        photo_masks rows are global (a single mask file is shared across
+        workspaces), but the pipeline page wants workspace-scoped numbers
+        so a user with a small workspace doesn't see counts dominated by
+        photos they can't see. For each variant present in photo_masks,
+        return the count of distinct workspace photos that have a row for
+        that variant, plus the count of those that also have it active.
+
+        Returns: list of dicts {variant, count, active_count} ordered by
+        variant name. Variants with zero workspace photos are omitted.
+        """
+        ws = self._ws_id()
+        rows = self.conn.execute(
+            """
+            SELECT pm.variant,
+                   COUNT(DISTINCT pm.photo_id) AS count,
+                   SUM(CASE WHEN p.active_mask_variant = pm.variant
+                            THEN 1 ELSE 0 END) AS active_count
+              FROM photo_masks pm
+              JOIN photos p ON p.id = pm.photo_id
+              JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+             WHERE wf.workspace_id = ?
+             GROUP BY pm.variant
+             ORDER BY pm.variant
+            """,
+            (ws,),
+        ).fetchall()
+        return [
+            {"variant": r["variant"],
+             "count": r["count"] or 0,
+             "active_count": r["active_count"] or 0}
+            for r in rows
+        ]
+
     def mask_variants_summary(self):
         """Per-variant summary: count, total bytes (best-effort, sums
         on-disk file sizes), and active_count.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3757,6 +3757,54 @@ class Database:
         if _commit:
             commit_with_retry(self.conn)
 
+    def _masks_dir_real(self):
+        """Realpath of the masks directory, used as the containment root
+        for cleanup deletes. Returns None for ``:memory:`` databases or
+        when the parent directory can't be resolved (in which case the
+        caller refuses to delete files by stored path).
+        """
+        if self._db_path == ":memory:":
+            return None
+        parent = os.path.dirname(self._db_path)
+        if not parent:
+            return None
+        return os.path.realpath(os.path.join(parent, "masks"))
+
+    def _safe_remove_mask_file(self, path):
+        """``os.remove`` ``path`` only if it resolves inside the masks
+        directory. The user-triggerable storage cleanup endpoints feed
+        ``photo_masks.path`` straight into this; without the realpath
+        containment check, a corrupted or migrated row pointing at
+        ``/etc/...`` could cause arbitrary file deletion. Mirrors the
+        defense already in place on ``/api/masks/<pid>/<variant>.png``.
+        """
+        if not path:
+            return
+        masks_dir = self._masks_dir_real()
+        if masks_dir is None:
+            log.warning(
+                "Refusing to remove mask file %s (no masks dir resolved)",
+                path,
+            )
+            return
+        try:
+            abs_path = os.path.realpath(path)
+        except OSError:
+            log.warning("Failed to resolve mask path %s", path)
+            return
+        if not (abs_path == masks_dir
+                or abs_path.startswith(masks_dir + os.sep)):
+            log.warning(
+                "Refusing to remove mask file %s outside masks dir %s",
+                path, masks_dir,
+            )
+            return
+        try:
+            if os.path.isfile(abs_path):
+                os.remove(abs_path)
+        except OSError:
+            log.warning("Failed to remove mask file %s", abs_path)
+
     def delete_masks_for_variant(self, variant):
         """Delete all photo_masks rows + files for a variant.
         Refuses if the variant is active for any photo (caller must
@@ -3774,11 +3822,7 @@ class Database:
             "SELECT path FROM photo_masks WHERE variant=?", (variant,),
         ).fetchall()
         for r in rows:
-            try:
-                if r["path"] and os.path.isfile(r["path"]):
-                    os.remove(r["path"])
-            except OSError:
-                log.warning("Failed to remove mask file %s", r["path"])
+            self._safe_remove_mask_file(r["path"])
         self.conn.execute("DELETE FROM photo_masks WHERE variant=?", (variant,))
         commit_with_retry(self.conn)
         return len(rows)
@@ -3802,11 +3846,7 @@ class Database:
             "  AND p.active_mask_variant != pm.variant"
         ).fetchall()
         for r in rows:
-            try:
-                if r["path"] and os.path.isfile(r["path"]):
-                    os.remove(r["path"])
-            except OSError:
-                log.warning("Failed to remove mask file %s", r["path"])
+            self._safe_remove_mask_file(r["path"])
             self.conn.execute(
                 "DELETE FROM photo_masks WHERE photo_id=? AND variant=?",
                 (r["photo_id"], r["variant"]),
@@ -3825,8 +3865,18 @@ class Database:
         detection (e.g., a low-confidence secondary box still carrying
         the old coordinates, or another retained model's row) would
         leave stale cache entries lingering after detector/model
-        changes, so we explicitly join the per-photo MAX confidence
-        before comparing.
+        changes, so we pick exactly one primary row per photo and
+        require the prompt to equal that row.
+
+        Tie-break: when multiple detections share the maximum
+        confidence, both this query and the extraction code in
+        ``api_job_extract_masks`` / ``get_detections`` resolve to the
+        smallest ``detections.id`` (insertion order). Using
+        ``MAX(detector_confidence)`` here would leave the primary
+        ambiguous on ties — a mask matching either tied row could be
+        treated as fresh even though extraction is now using the other
+        one. ``ORDER BY detector_confidence DESC, id ASC LIMIT 1`` keeps
+        stale-detection and extraction in sync.
 
         ``detector_confidence`` is an optional workspace floor (the same
         threshold both extraction paths apply when picking detections to
@@ -3842,8 +3892,8 @@ class Database:
             conf_pred = ""
             params = ()
         else:
-            conf_pred = " AND d{n}.detector_confidence >= ?"
-            params = (detector_confidence, detector_confidence)
+            conf_pred = " AND d2.detector_confidence >= ?"
+            params = (detector_confidence,)
         rows = self.conn.execute(
             f"""
             SELECT pm.photo_id, pm.variant, pm.path,
@@ -3852,21 +3902,20 @@ class Database:
               FROM photo_masks pm
              WHERE NOT EXISTS (
                 SELECT 1 FROM detections d
-                 WHERE d.photo_id = pm.photo_id
+                 WHERE d.id = (
+                       SELECT d2.id
+                         FROM detections d2
+                        WHERE d2.photo_id = pm.photo_id
+                          AND d2.detector_model != 'full-image'
+                          {conf_pred}
+                        ORDER BY d2.detector_confidence DESC, d2.id ASC
+                        LIMIT 1
+                   )
                    AND d.detector_model = pm.detector_model
-                   AND d.detector_model != 'full-image'
                    AND d.box_x = pm.prompt_x
                    AND d.box_y = pm.prompt_y
                    AND d.box_w = pm.prompt_w
                    AND d.box_h = pm.prompt_h
-                   {conf_pred.format(n="")}
-                   AND d.detector_confidence = (
-                       SELECT MAX(d2.detector_confidence)
-                         FROM detections d2
-                        WHERE d2.photo_id = pm.photo_id
-                          AND d2.detector_model != 'full-image'
-                          {conf_pred.format(n="2")}
-                   )
              )
             """,
             params,
@@ -3891,11 +3940,7 @@ class Database:
             ).fetchone()
             if is_active:
                 continue
-            try:
-                if s["path"] and os.path.isfile(s["path"]):
-                    os.remove(s["path"])
-            except OSError:
-                log.warning("Failed to remove mask file %s", s["path"])
+            self._safe_remove_mask_file(s["path"])
             self.conn.execute(
                 "DELETE FROM photo_masks WHERE photo_id=? AND variant=?",
                 (s["photo_id"], s["variant"]),
@@ -4096,7 +4141,7 @@ class Database:
                     WHERE p.folder_id IN ({placeholders})
                       AND p.mask_path IS NULL
                       AND d.detector_confidence >= ?
-                    ORDER BY p.id, d.detector_confidence DESC""",
+                    ORDER BY p.id, d.detector_confidence DESC, d.id ASC""",
                 [ws_id, *folder_ids, min_conf],
             ).fetchall()
         else:
@@ -4110,7 +4155,7 @@ class Database:
                    WHERE wf.workspace_id = ?
                      AND p.mask_path IS NULL
                      AND d.detector_confidence >= ?
-                   ORDER BY p.id, d.detector_confidence DESC""",
+                   ORDER BY p.id, d.detector_confidence DESC, d.id ASC""",
                 (ws_id, min_conf),
             ).fetchall()
 
@@ -6467,7 +6512,12 @@ class Database:
         if detector_model is not None:
             q += " AND detector_model = ?"
             params.append(detector_model)
-        q += " ORDER BY detector_confidence DESC"
+        # Explicit ``id ASC`` tie-break so callers that take the first
+        # row (mask extraction's primary detection picker) agree with
+        # ``find_stale_masks`` on which row is the primary when two
+        # detections share the maximum confidence. Without this,
+        # SQLite's row order on ties is implementation-defined.
+        q += " ORDER BY detector_confidence DESC, id ASC"
         return self.conn.execute(q, params).fetchall()
 
     def get_detections_for_photos(self, photo_ids, min_conf=None,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3747,6 +3747,44 @@ class Database:
         commit_with_retry(self.conn)
         return deleted
 
+    def mask_variants_summary(self):
+        """Per-variant summary: count, total bytes (best-effort, sums
+        on-disk file sizes), and active_count.
+
+        Returns: list of dicts ordered by variant name.
+        """
+        rows = self.conn.execute(
+            """
+            SELECT pm.variant,
+                   COUNT(*) AS count,
+                   SUM(CASE WHEN p.active_mask_variant = pm.variant
+                            THEN 1 ELSE 0 END) AS active_count
+              FROM photo_masks pm
+              JOIN photos p ON p.id = pm.photo_id
+             GROUP BY pm.variant
+             ORDER BY pm.variant
+            """
+        ).fetchall()
+        out = []
+        for r in rows:
+            paths = self.conn.execute(
+                "SELECT path FROM photo_masks WHERE variant=?", (r["variant"],),
+            ).fetchall()
+            total = 0
+            for pr in paths:
+                try:
+                    if pr["path"] and os.path.isfile(pr["path"]):
+                        total += os.path.getsize(pr["path"])
+                except OSError:
+                    pass
+            out.append({
+                "variant": r["variant"],
+                "count": r["count"],
+                "active_count": r["active_count"],
+                "bytes": total,
+            })
+        return out
+
     def upsert_photo_mask(
         self, photo_id, variant, path,
         detector_model, prompt_x, prompt_y, prompt_w, prompt_h,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3625,6 +3625,29 @@ class Database:
         ).fetchall()
         return [dict(r) for r in rows]
 
+    def set_active_mask_variant(self, photo_id, variant):
+        """Mark `variant` as active for `photo_id` and denormalize its
+        fields into the photos row (mask_path + per-mask features) so
+        downstream readers (scoring, pipeline) see the active mask."""
+        row = self.conn.execute(
+            "SELECT path, subject_size, subject_tenengrad, bg_tenengrad, "
+            "crop_complete FROM photo_masks WHERE photo_id=? AND variant=?",
+            (photo_id, variant),
+        ).fetchone()
+        if row is None:
+            raise ValueError(
+                f"No photo_masks row for photo {photo_id} variant {variant!r}"
+            )
+        self.conn.execute(
+            "UPDATE photos SET mask_path=?, active_mask_variant=?, "
+            "subject_size=?, subject_tenengrad=?, bg_tenengrad=?, "
+            "crop_complete=? WHERE id=?",
+            (row["path"], variant, row["subject_size"],
+             row["subject_tenengrad"], row["bg_tenengrad"],
+             row["crop_complete"], photo_id),
+        )
+        commit_with_retry(self.conn)
+
     def upsert_photo_mask(
         self, photo_id, variant, path,
         detector_model, prompt_x, prompt_y, prompt_w, prompt_h,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -365,16 +365,24 @@ class Database:
             -- was declared INTEGER) still tolerate REAL values without an
             -- ALTER, so we don't bother emitting a migration for the column
             -- type — only fresh DBs see the corrected declaration.
+            -- prompt_* are declared REAL because detections.box_* are
+            -- normalized values in [0, 1] and any int truncation would
+            -- collapse every prompt to (0, 0, 0, 0). SQLite's column
+            -- type affinity already accepts REAL into INTEGER-declared
+            -- columns, so older DBs created with INTEGER continue to
+            -- store the new REAL prompts verbatim — no migration is
+            -- needed; legacy rows with prompt_x = 0 will simply be
+            -- detected as stale on the next pipeline run.
             CREATE TABLE IF NOT EXISTS photo_masks (
                 photo_id          INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
                 variant           TEXT    NOT NULL,
                 path              TEXT    NOT NULL,
                 created_at        INTEGER NOT NULL,
                 detector_model    TEXT    NOT NULL,
-                prompt_x          INTEGER NOT NULL,
-                prompt_y          INTEGER NOT NULL,
-                prompt_w          INTEGER NOT NULL,
-                prompt_h          INTEGER NOT NULL,
+                prompt_x          REAL    NOT NULL,
+                prompt_y          REAL    NOT NULL,
+                prompt_w          REAL    NOT NULL,
+                prompt_h          REAL    NOT NULL,
                 subject_size      REAL,
                 subject_tenengrad REAL,
                 bg_tenengrad      REAL,
@@ -671,24 +679,21 @@ class Database:
                 "ALTER TABLE photos ADD COLUMN active_mask_variant TEXT"
             )
 
-        # One-time backfill: pre-existing photos with mask_path set on the
-        # photos row but no row at all in photo_masks get migrated to
-        # variant='unknown' with a sentinel prompt. detector_model='unknown'
+        # Backfill pre-existing photos with mask_path set on the photos
+        # row but no row in photo_masks. They get migrated to
+        # variant='unknown' with a sentinel prompt; detector_model='unknown'
         # + prompt=-1 mean the staleness check will treat these masks as
         # stale on the next pipeline run, so they get regenerated against
-        # whatever SAM2 variant the user has configured. Idempotent on its
-        # own (skipped once any 'unknown' rows exist), and the per-photo
-        # NOT EXISTS guard means we don't shadow rows that the new code
-        # path already wrote (e.g. a photo that already has a sam2-small
-        # row from a recent pipeline run shouldn't also get an 'unknown'
-        # row appended).
+        # whatever SAM2 variant the user has configured.
+        #
+        # Resumable: gating only on the per-photo NOT EXISTS clause means
+        # a startup crash partway through (e.g. after inserting some
+        # 'unknown' rows but before completing) still finishes the rest
+        # of the legacy photos on the next startup. An earlier outer
+        # ``if total_unknown_rows == 0`` guard caused remaining photos
+        # to be skipped forever, leaving orphaned mask_path values that
+        # variant-aware APIs and cleanup logic couldn't see.
         try:
-            already = self.conn.execute(
-                "SELECT COUNT(*) FROM photo_masks WHERE variant='unknown'"
-            ).fetchone()[0]
-        except sqlite3.OperationalError:
-            already = -1
-        if already == 0:
             rows = self.conn.execute(
                 "SELECT p.id, p.mask_path, p.subject_size, "
                 "p.subject_tenengrad, p.bg_tenengrad, p.crop_complete "
@@ -698,23 +703,25 @@ class Database:
                 "    SELECT 1 FROM photo_masks pm WHERE pm.photo_id = p.id"
                 "  )"
             ).fetchall()
-            now = int(time.time())
-            for r in rows:
-                self.conn.execute(
-                    "INSERT OR IGNORE INTO photo_masks "
-                    "(photo_id, variant, path, created_at, detector_model, "
-                    "prompt_x, prompt_y, prompt_w, prompt_h, "
-                    "subject_size, subject_tenengrad, bg_tenengrad, crop_complete) "
-                    "VALUES (?, 'unknown', ?, ?, 'unknown', -1, -1, -1, -1, ?, ?, ?, ?)",
-                    (r["id"], r["mask_path"], now,
-                     r["subject_size"], r["subject_tenengrad"],
-                     r["bg_tenengrad"], r["crop_complete"]),
-                )
-                self.conn.execute(
-                    "UPDATE photos SET active_mask_variant='unknown' "
-                    "WHERE id=? AND active_mask_variant IS NULL",
-                    (r["id"],),
-                )
+        except sqlite3.OperationalError:
+            rows = []
+        now = int(time.time())
+        for r in rows:
+            self.conn.execute(
+                "INSERT OR IGNORE INTO photo_masks "
+                "(photo_id, variant, path, created_at, detector_model, "
+                "prompt_x, prompt_y, prompt_w, prompt_h, "
+                "subject_size, subject_tenengrad, bg_tenengrad, crop_complete) "
+                "VALUES (?, 'unknown', ?, ?, 'unknown', -1, -1, -1, -1, ?, ?, ?, ?)",
+                (r["id"], r["mask_path"], now,
+                 r["subject_size"], r["subject_tenengrad"],
+                 r["bg_tenengrad"], r["crop_complete"]),
+            )
+            self.conn.execute(
+                "UPDATE photos SET active_mask_variant='unknown' "
+                "WHERE id=? AND active_mask_variant IS NULL",
+                (r["id"],),
+            )
         self.conn.commit()
 
     # -- Workspaces --
@@ -3781,10 +3788,10 @@ class Database:
                  WHERE d.photo_id = pm.photo_id
                    AND d.detector_model = pm.detector_model
                    AND d.detector_model != 'full-image'
-                   AND CAST(d.box_x AS INTEGER) = pm.prompt_x
-                   AND CAST(d.box_y AS INTEGER) = pm.prompt_y
-                   AND CAST(d.box_w AS INTEGER) = pm.prompt_w
-                   AND CAST(d.box_h AS INTEGER) = pm.prompt_h
+                   AND d.box_x = pm.prompt_x
+                   AND d.box_y = pm.prompt_y
+                   AND d.box_w = pm.prompt_w
+                   AND d.box_h = pm.prompt_h
                    AND d.detector_confidence = (
                        SELECT MAX(d2.detector_confidence)
                          FROM detections d2

--- a/vireo/masking.py
+++ b/vireo/masking.py
@@ -330,36 +330,41 @@ def generate_mask(image, detection_box, variant="sam2-small"):
         return None
 
 
-def save_mask(mask, masks_dir, photo_id):
+def save_mask(mask, masks_dir, photo_id, variant):
     """Save a boolean mask as a single-channel PNG.
+
+    Filename: ``{photo_id}.{variant}.png`` so multiple SAM variants per
+    photo coexist on disk (sam2-small, sam2-large, etc).
 
     Args:
         mask: numpy boolean array (H, W)
         masks_dir: directory for mask files (e.g. ~/.vireo/masks/)
         photo_id: photo ID for the filename
+        variant: SAM variant name (e.g. ``"sam2-small"``)
 
     Returns:
         path to the saved mask file
     """
     os.makedirs(masks_dir, exist_ok=True)
-    path = os.path.join(masks_dir, f"{photo_id}.png")
+    path = os.path.join(masks_dir, f"{photo_id}.{variant}.png")
     # Convert bool mask to uint8 (0 or 255)
     mask_img = Image.fromarray((mask.astype(np.uint8) * 255), mode="L")
     mask_img.save(path, format="PNG")
     return path
 
 
-def load_mask(masks_dir, photo_id):
+def load_mask(masks_dir, photo_id, variant):
     """Load a mask from disk.
 
     Args:
         masks_dir: directory containing mask files
         photo_id: photo ID
+        variant: SAM variant name (e.g. ``"sam2-small"``)
 
     Returns:
         numpy boolean array (H, W), or None if not found
     """
-    path = os.path.join(masks_dir, f"{photo_id}.png")
+    path = os.path.join(masks_dir, f"{photo_id}.{variant}.png")
     if not os.path.exists(path):
         return None
     with Image.open(path) as mask_img:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2367,6 +2367,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             # not real subject boxes and should not drive mask extraction or
             # count toward the photos_with_detections safeguard below (which
             # surfaces the "weights missing / no detections" diagnostic).
+            # Note: we intentionally do NOT short-circuit when the photo
+            # already has *some* mask in the photos table — that legacy
+            # check ignored which SAM variant produced the mask, so a
+            # config change to a different variant would never re-run.
+            # The per-photo cache check happens inside the loop below
+            # against photo_masks(photo_id, sam2_variant).
             photo_det_map = {}
             photos_with_detections = 0
             for p in photos:
@@ -2377,19 +2383,24 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 if dets:
                     photos_with_detections += 1
                     primary = dets[0]  # already ordered by confidence DESC
-                    has_mask = thread_db.conn.execute(
-                        "SELECT mask_path FROM photos WHERE id=?", (p["id"],)
-                    ).fetchone()[0]
-                    if not has_mask:
-                        photo_det_map[p["id"]] = {
-                            "photo": p,
-                            "det_box": {
-                                "x": primary["box_x"],
-                                "y": primary["box_y"],
-                                "w": primary["box_w"],
-                                "h": primary["box_h"],
-                            },
-                        }
+                    photo_det_map[p["id"]] = {
+                        "photo": p,
+                        "det_box": {
+                            "x": primary["box_x"],
+                            "y": primary["box_y"],
+                            "w": primary["box_w"],
+                            "h": primary["box_h"],
+                        },
+                        "detector_model": primary["detector_model"],
+                        # Stored prompt provenance: int-cast bbox tuple
+                        # used by photo_masks (PK column type is INTEGER).
+                        "prompt": (
+                            int(primary["box_x"]),
+                            int(primary["box_y"]),
+                            int(primary["box_w"]),
+                            int(primary["box_h"]),
+                        ),
+                    }
 
             photos_to_process = [
                 photo_det_map[pid] for pid in photo_det_map
@@ -2493,6 +2504,32 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 image_path = os.path.join(folder_path, photo["filename"])
 
                 try:
+                    # Cache hit: a row already exists for (photo, variant)
+                    # AND its stored prompt + detector still match the
+                    # current primary detection AND the file is on disk.
+                    # In that case the SAM result is unchanged, so we
+                    # only re-activate the mask (cheap denormalize) and
+                    # skip the heavy SAM + DINOv2 work.
+                    existing = thread_db.get_photo_mask(
+                        photo_id, sam2_variant,
+                    )
+                    if existing is not None:
+                        cached_prompt = (
+                            existing["prompt_x"], existing["prompt_y"],
+                            existing["prompt_w"], existing["prompt_h"],
+                        )
+                        if (existing["detector_model"]
+                                == entry["detector_model"]
+                                and cached_prompt == entry["prompt"]
+                                and existing["path"]
+                                and os.path.isfile(existing["path"])):
+                            thread_db.set_active_mask_variant(
+                                photo_id, sam2_variant,
+                            )
+                            masked += 1
+                            processed = i + 1
+                            continue
+
                     proxy = render_proxy(image_path, longest_edge=proxy_longest_edge)
                     if proxy is None:
                         skipped += 1
@@ -2517,6 +2554,28 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     if _should_abort(abort):
                         break
 
+                    # Per-mask features (move from photos row into
+                    # photo_masks; set_active_mask_variant denormalizes
+                    # them back into photos for downstream readers).
+                    mask_subject_tenengrad = features.pop(
+                        "subject_tenengrad", None,
+                    )
+                    mask_bg_tenengrad = features.pop("bg_tenengrad", None)
+                    # Mask-derived subject_size: fraction of frame
+                    # covered by the boolean mask. Replaces the
+                    # detection-bbox approximation classify uses.
+                    try:
+                        import numpy as _np
+                        total_pixels = float(mask.size)
+                        if total_pixels > 0:
+                            mask_subject_size = float(
+                                _np.count_nonzero(mask) / total_pixels
+                            )
+                        else:
+                            mask_subject_size = None
+                    except Exception:
+                        mask_subject_size = None
+
                     subject_crop = crop_subject(proxy, mask, margin=0.15)
                     if subject_crop is not None:
                         embs = embed_batch(
@@ -2530,10 +2589,32 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             embed(proxy, variant=dinov2_variant),
                         )
 
-                    thread_db.update_photo_pipeline_features(
-                        photo_id, mask_path=mask_path, crop_complete=completeness,
-                        **features,
+                    thread_db.upsert_photo_mask(
+                        photo_id=photo_id,
+                        variant=sam2_variant,
+                        path=mask_path,
+                        detector_model=entry["detector_model"],
+                        prompt_x=entry["prompt"][0],
+                        prompt_y=entry["prompt"][1],
+                        prompt_w=entry["prompt"][2],
+                        prompt_h=entry["prompt"][3],
+                        subject_size=mask_subject_size,
+                        subject_tenengrad=mask_subject_tenengrad,
+                        bg_tenengrad=mask_bg_tenengrad,
+                        crop_complete=completeness,
                     )
+                    thread_db.set_active_mask_variant(
+                        photo_id, sam2_variant,
+                    )
+                    # Remaining (non-mask) per-photo features still land
+                    # on the photos row.  mask_path / crop_complete /
+                    # subject_tenengrad / bg_tenengrad now flow via
+                    # set_active_mask_variant above, so they are
+                    # intentionally NOT passed here.
+                    if features:
+                        thread_db.update_photo_pipeline_features(
+                            photo_id, **features,
+                        )
                     thread_db.update_photo_embeddings(
                         photo_id,
                         dino_subject_embedding=subj_emb_blob,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -18,6 +18,7 @@ import threading
 import time
 from dataclasses import dataclass
 
+import numpy as np
 from db import Database, commit_with_retry
 
 log = logging.getLogger(__name__)
@@ -2056,7 +2057,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                             photo["id"], model_name,
                                         )
                                         if emb_blob:
-                                            import numpy as np
                                             embedding = np.frombuffer(
                                                 emb_blob, dtype=np.float32,
                                             )
@@ -2564,16 +2564,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     # Mask-derived subject_size: fraction of frame
                     # covered by the boolean mask. Replaces the
                     # detection-bbox approximation classify uses.
-                    try:
-                        import numpy as _np
-                        total_pixels = float(mask.size)
-                        if total_pixels > 0:
-                            mask_subject_size = float(
-                                _np.count_nonzero(mask) / total_pixels
-                            )
-                        else:
-                            mask_subject_size = None
-                    except Exception:
+                    total_pixels = float(mask.size)
+                    if total_pixels > 0:
+                        mask_subject_size = float(
+                            np.count_nonzero(mask) / total_pixels
+                        )
+                    else:
                         mask_subject_size = None
 
                     subject_crop = crop_subject(proxy, mask, margin=0.15)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2384,8 +2384,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             photos_with_detections = 0
             photos_subthreshold_only = 0
             for p in photos:
+                # Pass the captured detector_confidence explicitly so the
+                # floor matches effective_cfg (and the standalone
+                # /api/jobs/extract-masks path), not whatever cfg.load()
+                # would re-read from disk inside get_detections. With the
+                # legacy `mask_path IS NULL` prefilter gone, sub-threshold-
+                # only photos would otherwise enter SAM extraction on
+                # variant cache misses.
                 dets = [
-                    d for d in thread_db.get_detections(p["id"])
+                    d for d in thread_db.get_detections(
+                        p["id"], min_conf=detector_confidence,
+                    )
                     if d["detector_model"] != "full-image"
                 ]
                 if dets:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2509,7 +2509,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     if _should_abort(abort):
                         break
 
-                    mask_path = save_mask(mask, masks_dir, photo_id)
+                    mask_path = save_mask(
+                        mask, masks_dir, photo_id, sam2_variant,
+                    )
                     completeness = crop_completeness(mask)
                     features = compute_all_quality_features(proxy, mask)
                     if _should_abort(abort):

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2392,13 +2392,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             "h": primary["box_h"],
                         },
                         "detector_model": primary["detector_model"],
-                        # Stored prompt provenance: int-cast bbox tuple
-                        # used by photo_masks (PK column type is INTEGER).
+                        # Stored prompt provenance: full-precision bbox
+                        # tuple. detections.box_* are normalized REAL
+                        # values in [0, 1], so int()-truncating would
+                        # collapse every prompt to (0, 0, 0, 0) and the
+                        # cache/staleness check would never invalidate
+                        # on bbox change. SQLite's column type affinity
+                        # accepts REAL into the INTEGER-declared
+                        # columns and stores them verbatim.
                         "prompt": (
-                            int(primary["box_x"]),
-                            int(primary["box_y"]),
-                            int(primary["box_w"]),
-                            int(primary["box_h"]),
+                            primary["box_x"],
+                            primary["box_y"],
+                            primary["box_w"],
+                            primary["box_h"],
                         ),
                     }
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -482,6 +482,41 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   pointer-events: none;
   box-sizing: border-box;
 }
+/* SAM mask overlay sits on top of #lightboxImg inside .lightbox-transform
+   so it inherits the same transform (zoom + pan). Pointer-events disabled
+   so click-to-zoom on the underlying image still works. */
+.lb-mask-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  mix-blend-mode: multiply;
+  opacity: 0.5;
+  pointer-events: none;
+  display: none;
+}
+.lb-mask-overlay.show { display: block; }
+.lb-mask-controls {
+  display: none;
+  align-items: center;
+  gap: 6px;
+  background: rgba(0,0,0,0.6);
+  border: 1px solid var(--text-faint);
+  border-radius: 4px;
+  padding: 3px 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.lb-mask-controls.has-variants { display: inline-flex; }
+.lb-mask-controls select {
+  background: rgba(0,0,0,0.4);
+  color: var(--text-primary);
+  border: 1px solid var(--text-faint);
+  border-radius: 3px;
+  font-size: 12px;
+  padding: 1px 4px;
+}
 /* Crosshair over the detected eye keypoint. Scales with the image via
    position:% — parent .lightbox-transform absorbs the zoom transform. */
 .lb-eye-crosshair {
@@ -2584,6 +2619,7 @@ async function createWorkspace() {
     <span class="lightbox-zoom-badge" id="lightboxZoomBadge" style="display:none;">1:1</span>
     <div class="lightbox-transform" id="lightboxTransform">
       <img id="lightboxImg" src="" alt="">
+      <img id="lightboxMaskOverlay" class="lb-mask-overlay" src="" alt="">
       <div id="lightboxDetections" style="position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;"></div>
       <div id="lightboxEye" style="position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;display:none;"></div>
     </div>
@@ -2594,6 +2630,10 @@ async function createWorkspace() {
     <button id="lightboxToggleBoxes" onclick="event.stopPropagation(); toggleLightboxBoxes();" style="background:rgba(0,0,0,0.6);color:var(--text-secondary);border:1px solid var(--text-faint);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;" title="Toggle detection boxes (b)">
       Hide Boxes
     </button>
+    <span class="lb-mask-controls" id="lightboxMaskControls" onclick="event.stopPropagation();" title="SAM mask overlay">
+      <span>Mask:</span>
+      <select id="lightboxMaskSelect" onchange="event.stopPropagation(); _lbOnMaskVariantChange();"></select>
+    </span>
     <button id="lightboxNotWildlife" onclick="event.stopPropagation(); lightboxNotWildlife();" style="background:rgba(0,0,0,0.6);color:var(--warn);border:1px solid var(--warn);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;" title="Mark as Landscape — drops out of Needs Identification and stops the classifier">
       Not Wildlife
     </button>
@@ -2758,6 +2798,113 @@ function _lbLoadDetections(photoId) {
     .catch(function() {});
 }
 
+/* ---- SAM mask overlay ---------------------------------------------------
+ * The lightbox lets the user A/B-compare SAM mask variants without
+ * changing which one drives downstream scoring. The dropdown defaults
+ * to "active" (whatever photos.active_mask_variant points at) and lists
+ * one option per variant the photo has under photo_masks. Selecting a
+ * variant only swaps the overlay src; it never POSTs back to the server.
+ *
+ * Pages that don't surface masks at all (e.g. browse before the pipeline
+ * has run) still get the lightbox — the dropdown stays hidden until at
+ * least one variant comes back from /api/photos/<id>/masks, mirroring
+ * how the detection-box toggle stays present but inert when there are
+ * no detections.
+ */
+var _lbMaskActiveVariant = null;     // name of the photo's currently-active variant
+var _lbMaskAvailable = [];           // [{variant, url, created_at}, ...]
+
+function _lbResetMaskOverlay() {
+  var img = document.getElementById('lightboxMaskOverlay');
+  if (img) { img.classList.remove('show'); img.removeAttribute('src'); }
+  var ctrls = document.getElementById('lightboxMaskControls');
+  if (ctrls) ctrls.classList.remove('has-variants');
+  var sel = document.getElementById('lightboxMaskSelect');
+  if (sel) sel.innerHTML = '';
+  _lbMaskActiveVariant = null;
+  _lbMaskAvailable = [];
+}
+
+function _lbApplyMaskUrl(url) {
+  // Set the overlay's src and reveal it. If url is empty/null, hide
+  // the overlay (e.g. the photo has no mask for the chosen variant).
+  var img = document.getElementById('lightboxMaskOverlay');
+  if (!img) return;
+  if (!url) {
+    img.classList.remove('show');
+    img.removeAttribute('src');
+    return;
+  }
+  // onerror guards against the file being deleted out from under us
+  // between the /api/photos/<id>/masks call and the GET. The DB row
+  // exists but the file is gone → silently hide instead of leaving a
+  // broken-image icon over the photo.
+  img.onerror = function() { img.classList.remove('show'); };
+  img.onload = function() { img.classList.add('show'); };
+  img.src = url;
+}
+
+function _lbOnMaskVariantChange() {
+  var sel = document.getElementById('lightboxMaskSelect');
+  if (!sel) return;
+  var choice = sel.value;
+  if (choice === '__active__') {
+    if (!_lbMaskActiveVariant) {
+      // No active variant → nothing to overlay.
+      _lbApplyMaskUrl(null);
+      return;
+    }
+    var match = _lbMaskAvailable.find(function(v) {
+      return v.variant === _lbMaskActiveVariant;
+    });
+    _lbApplyMaskUrl(match ? match.url : null);
+    return;
+  }
+  var picked = _lbMaskAvailable.find(function(v) { return v.variant === choice; });
+  _lbApplyMaskUrl(picked ? picked.url : null);
+}
+
+function _lbLoadMaskVariants(photoId) {
+  // Fetch the photo's available mask variants and populate the
+  // dropdown. Defaults the selection to "active" (which displays the
+  // photo's active_mask_variant overlay if one exists).
+  var sel = document.getElementById('lightboxMaskSelect');
+  var ctrls = document.getElementById('lightboxMaskControls');
+  if (!sel || !ctrls) return;
+  // Reset before the async fetch resolves so a fast nav doesn't show
+  // stale options for the previous photo.
+  _lbResetMaskOverlay();
+
+  fetch('/api/photos/' + photoId + '/masks')
+    .then(function(r) { return r.ok ? r.json() : null; })
+    .then(function(data) {
+      // Bail if the user navigated to a different photo while the
+      // request was in flight.
+      if (!data || _lightboxCurrentId !== photoId) return;
+      _lbMaskActiveVariant = data.active || null;
+      _lbMaskAvailable = data.variants || [];
+      if (_lbMaskAvailable.length === 0) {
+        // No masks for this photo — keep the control hidden.
+        return;
+      }
+      // Build options: "active" first, then one per variant.
+      var activeLabel = _lbMaskActiveVariant
+        ? 'active (' + _lbMaskActiveVariant + ')'
+        : 'active (n/a)';
+      var html = '<option value="__active__">' + activeLabel + '</option>';
+      _lbMaskAvailable.forEach(function(v) {
+        html += '<option value="' + v.variant + '">' + v.variant + '</option>';
+      });
+      sel.innerHTML = html;
+      sel.value = '__active__';
+      ctrls.classList.add('has-variants');
+      // Apply the default ("active") overlay so the user sees something
+      // the moment masks become available.
+      _lbOnMaskVariantChange();
+    })
+    .catch(function() { /* network error → leave control hidden */ });
+}
+
 function openLightbox(photoId, filename, photoList) {
   var alreadyOpen = !!window._lbEscToken;
   if (alreadyOpen) Keymap.popEsc(window._lbEscToken);
@@ -2844,6 +2991,11 @@ function openLightbox(photoId, filename, photoList) {
   // Fetch and render detection bounding boxes
   _lbLoadDetections(photoId);
   _lbApplyBoxesVisibility();
+
+  // Fetch the photo's SAM mask variants and (if any) populate the
+  // overlay-variant dropdown. Hidden when the photo has no masks, so
+  // pages that don't run the pipeline still get the lightbox unchanged.
+  _lbLoadMaskVariants(photoId);
 
   // Show position indicator if navigating a list
   var counter = document.getElementById('lightboxCounter');
@@ -2998,6 +3150,9 @@ function closeLightbox(e) {
   document.getElementById('lightboxZoomBadge').style.display = 'none';
   var detContainer = document.getElementById('lightboxDetections');
   if (detContainer) detContainer.innerHTML = '';
+  // Drop the mask overlay too — otherwise reopening on a photo with
+  // no masks would leave the previous photo's mask painted across it.
+  _lbResetMaskOverlay();
   if (wasOpen) Keymap.unlockBodyScroll();
 }
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2887,15 +2887,24 @@ function _lbLoadMaskVariants(photoId) {
         // No masks for this photo — keep the control hidden.
         return;
       }
-      // Build options: "active" first, then one per variant.
+      // Build options: "active" first, then one per variant. Variant
+      // names come from workspace config and must be treated as
+      // untrusted — render via DOM APIs so a name containing HTML
+      // can't escape into the page as stored DOM XSS.
       var activeLabel = _lbMaskActiveVariant
         ? 'active (' + _lbMaskActiveVariant + ')'
         : 'active (n/a)';
-      var html = '<option value="__active__">' + activeLabel + '</option>';
+      sel.textContent = '';
+      var activeOpt = document.createElement('option');
+      activeOpt.value = '__active__';
+      activeOpt.textContent = activeLabel;
+      sel.appendChild(activeOpt);
       _lbMaskAvailable.forEach(function(v) {
-        html += '<option value="' + v.variant + '">' + v.variant + '</option>';
+        var opt = document.createElement('option');
+        opt.value = v.variant;
+        opt.textContent = v.variant;
+        sel.appendChild(opt);
       });
-      sel.innerHTML = html;
       sel.value = '__active__';
       ctrls.classList.add('has-variants');
       // Apply the default ("active") overlay so the user sees something

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -949,6 +949,11 @@ body { padding-bottom: 36px; }
         </div>
       </div>
       <div class="readiness-panel" id="extractReadinessPanel" style="display:none;"></div>
+      <div id="sam2CoveragePanel" style="display:none;margin-top:8px;font-size:12px;line-height:1.6;">
+        <div style="font-weight:600;color:var(--text-secondary);margin-bottom:4px;">SAM2 mask coverage</div>
+        <div id="sam2CoverageRows" style="display:flex;flex-direction:column;gap:2px;"></div>
+        <div id="sam2CoverageError" style="display:none;color:var(--danger);margin-top:4px;font-size:11px;"></div>
+      </div>
       <span class="status-msg" id="statusExtract"></span>
       <div class="progress-wrap" id="progressExtract" style="display:none;">
         <div class="progress-bar-track"><div class="progress-bar-fill" id="fillExtract"></div></div>
@@ -1117,6 +1122,9 @@ function initPipelinePage() {
       updateCardStates();
       if (typeof updateReadiness === 'function') updateReadiness();
       if (typeof updateExtractReadiness === 'function') updateExtractReadiness();
+      if (typeof renderSam2Coverage === 'function') {
+        renderSam2Coverage(data.mask_variant_coverage || []);
+      }
 
       // Populate recent destinations
       var recents = data.recent_destinations || [];
@@ -3162,6 +3170,106 @@ function renderModelReadiness(label, info, known) {
 // Card 7: Eye Keypoints — SuperAnimal weights are auto-downloaded by
 // pipeline_job.eye_keypoints_stage on first run (mirrors SAM2/DINOv2),
 // so no readiness panel, status polling, or download buttons live here.
+
+// -- SAM2 mask coverage (per-variant counts + active-variant selector) --
+//
+// Powered by /api/pipeline/page-init's mask_variant_coverage payload (a
+// list of {variant, count, active_count} for the active workspace).
+// 'unknown' is a migration sentinel: render with [legacy] tag, no button.
+function renderSam2Coverage(coverage) {
+  var panel = document.getElementById('sam2CoveragePanel');
+  var rowsEl = document.getElementById('sam2CoverageRows');
+  if (!panel || !rowsEl) return;
+  var errEl = document.getElementById('sam2CoverageError');
+  if (errEl) { errEl.textContent = ''; errEl.style.display = 'none'; }
+  rowsEl.textContent = '';
+  if (!coverage || coverage.length === 0) {
+    panel.style.display = 'none';
+    return;
+  }
+  panel.style.display = '';
+  coverage.forEach(function(row) {
+    var line = document.createElement('div');
+    line.style.cssText = 'display:flex;align-items:center;gap:10px;font-variant-numeric:tabular-nums;';
+
+    var name = document.createElement('span');
+    name.style.cssText = 'min-width:120px;color:var(--text-secondary);';
+    name.textContent = row.variant;
+    line.appendChild(name);
+
+    var count = document.createElement('span');
+    count.style.cssText = 'min-width:90px;color:var(--text-dim);';
+    var n = row.count || 0;
+    count.textContent = n.toLocaleString() + ' photo' + (n === 1 ? '' : 's');
+    line.appendChild(count);
+
+    if (row.variant === 'unknown') {
+      // Migration sentinel \u2014 never offer to set it active.
+      var legacyTag = document.createElement('span');
+      legacyTag.style.cssText = 'font-size:10px;color:var(--text-faint);background:color-mix(in srgb, var(--text-faint) 15%, transparent);border-radius:3px;padding:1px 6px;';
+      legacyTag.textContent = 'legacy';
+      line.appendChild(legacyTag);
+    } else if ((row.active_count || 0) >= (row.count || 0) && (row.count || 0) > 0) {
+      // Universally active for this variant in this workspace.
+      var activeTag = document.createElement('span');
+      activeTag.style.cssText = 'font-size:10px;color:var(--accent);background:color-mix(in srgb, var(--accent) 18%, transparent);border-radius:3px;padding:1px 6px;';
+      activeTag.textContent = 'active';
+      line.appendChild(activeTag);
+    } else {
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.style.cssText = 'background:none;color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:1px 8px;font-size:11px;cursor:pointer;';
+      btn.textContent = 'Set active';
+      var variantValue = row.variant;  // capture for click closure
+      btn.addEventListener('click', function() { setActiveMaskVariant(variantValue); });
+      line.appendChild(btn);
+      if ((row.active_count || 0) > 0) {
+        var partial = document.createElement('span');
+        partial.style.cssText = 'font-size:11px;color:var(--text-faint);';
+        partial.textContent = '(' + (row.active_count || 0).toLocaleString() + ' already active)';
+        line.appendChild(partial);
+      }
+    }
+    rowsEl.appendChild(line);
+  });
+}
+
+function _showSam2CoverageError(msg) {
+  var errEl = document.getElementById('sam2CoverageError');
+  if (!errEl) return;
+  errEl.textContent = msg;
+  errEl.style.display = '';
+}
+
+async function refreshSam2Coverage() {
+  try {
+    var data = await safeFetch('/api/pipeline/page-init', {}, { toast: false });
+    renderSam2Coverage(data.mask_variant_coverage || []);
+  } catch(e) {
+    _showSam2CoverageError('Failed to load mask coverage');
+  }
+}
+
+async function setActiveMaskVariant(variant) {
+  if (variant === 'unknown') return;  // sentinel, no button rendered
+  try {
+    var resp = await fetch('/api/pipeline/active-mask-variant', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({variant: variant}),
+    });
+    var body = await resp.json();
+    if (!resp.ok) {
+      _showSam2CoverageError(body.error || ('HTTP ' + resp.status));
+      return;
+    }
+  } catch(e) {
+    _showSam2CoverageError(String(e));
+    return;
+  }
+  await refreshSam2Coverage();
+}
+
 
 async function runExtractStep(collectionId) {
   var num = document.getElementById('numExtract');

--- a/vireo/templates/stats.html
+++ b/vireo/templates/stats.html
@@ -219,6 +219,29 @@ body { padding-bottom: 36px; }
   <div class="section">
     <div class="section-title">Storage <span id="storageTotalSize" style="font-size:12px;font-weight:400;color:var(--text-dim);margin-left:8px;">-</span></div>
     <div id="storageGrid" class="stats-grid"><span style="color:var(--text-ghost);font-size:13px;">Loading...</span></div>
+    <div id="masksCard" style="margin-top:16px;"></div>
+  </div>
+</div>
+
+<!-- Masks variant manager modal -->
+<div class="modal-overlay" id="masksModal" onclick="if(event.target===this)closeMasksModal()">
+  <div class="modal">
+    <div class="modal-header">
+      <h3>Manage Mask Variants</h3>
+      <button class="modal-close" onclick="closeMasksModal()">&times;</button>
+    </div>
+    <div class="modal-body">
+      <div class="modal-desc">
+        SAM mask files saved per photo per variant. The active variant
+        for each photo drives downstream scoring and is denormalized
+        into the photos row. Inactive variants are safe to delete.
+      </div>
+      <div id="masksModalError" style="color:var(--danger);font-size:12px;margin-bottom:10px;display:none;"></div>
+      <ul class="file-list" id="masksModalRows"></ul>
+    </div>
+    <div class="modal-footer">
+      <button class="btn-secondary" onclick="closeMasksModal()">Close</button>
+    </div>
   </div>
 </div>
 
@@ -700,6 +723,166 @@ async function loadStoragePanel() {
   } catch(e) {
     document.getElementById('storageGrid').innerHTML = '<span style="color:var(--danger);font-size:12px;">Failed to load storage info</span>';
   }
+  loadMasksCard();
+}
+
+var _masksData = null;
+
+async function loadMasksCard() {
+  var card = document.getElementById('masksCard');
+  try {
+    var data = await safeFetch('/api/storage/masks', {}, { toast: false });
+    _masksData = data;
+    var variants = data.variants || [];
+    var totalBytes = data.total_bytes || 0;
+    var stale = data.stale_count || 0;
+
+    var inner = '<div style="background:var(--bg-tertiary);border-radius:6px;padding:14px 16px;">';
+    inner += '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;">';
+    inner += '<div style="font-size:13px;font-weight:600;color:var(--text-primary);">Masks ' +
+      '<span style="font-size:11px;font-weight:400;color:var(--text-dim);margin-left:6px;">' +
+      formatBytes(totalBytes) + '</span></div>';
+    var btnEnabled = 'background:none;color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:3px 10px;font-size:11px;cursor:pointer;';
+    var btnSecondary = 'background:none;color:var(--text-dim);border:1px solid var(--border-primary);border-radius:3px;padding:3px 10px;font-size:11px;cursor:pointer;';
+    var btnDisabledStyle = 'background:none;color:var(--text-ghost);border:1px solid var(--border-primary);border-radius:3px;padding:3px 10px;font-size:11px;opacity:0.6;cursor:default;';
+    inner += '<div style="display:flex;gap:6px;">';
+    inner += '<button onclick="openMasksModal()"' +
+      (variants.length === 0
+        ? ' disabled style="' + btnDisabledStyle + '"'
+        : ' style="' + btnEnabled + '"') +
+      '>Manage</button>';
+    inner += '<button onclick="deleteInactiveMasks()"' +
+      (variants.length === 0
+        ? ' disabled style="' + btnDisabledStyle + '"'
+        : ' style="' + btnSecondary + '"') +
+      '>Delete inactive</button>';
+    if (stale > 0) {
+      inner += '<button onclick="deleteStaleMasks()" ' +
+        'style="background:none;color:var(--warning);border:1px solid var(--warning);border-radius:3px;padding:3px 10px;font-size:11px;cursor:pointer;">' +
+        'Delete stale (' + stale + ')</button>';
+    }
+    inner += '</div></div>';
+
+    if (variants.length === 0) {
+      inner += '<div style="font-size:12px;color:var(--text-ghost);">No SAM masks yet. Run the masking stage of the pipeline to populate.</div>';
+    } else {
+      inner += '<div style="display:flex;flex-direction:column;gap:4px;">';
+      variants.forEach(function(v) {
+        var isActive = (v.active_count || 0) > 0;
+        inner += '<div style="display:flex;align-items:center;gap:10px;font-size:12px;font-variant-numeric:tabular-nums;">';
+        inner += '<span style="min-width:120px;color:var(--text-secondary);">' + escapeHtml(v.variant) + '</span>';
+        inner += '<span style="min-width:80px;color:var(--text-dim);">' + (v.count || 0).toLocaleString() + ' photo' + (v.count === 1 ? '' : 's') + '</span>';
+        inner += '<span style="min-width:80px;color:var(--text-faint);">' + formatBytes(v.bytes || 0) + '</span>';
+        if (isActive) {
+          inner += '<span style="font-size:10px;color:var(--accent);background:color-mix(in srgb, var(--accent) 18%, transparent);border-radius:3px;padding:1px 6px;">active &middot; ' +
+            (v.active_count || 0).toLocaleString() + '</span>';
+        }
+        inner += '</div>';
+      });
+      inner += '</div>';
+    }
+    inner += '</div>';
+    card.innerHTML = inner;
+  } catch(e) {
+    card.innerHTML = '<div style="background:var(--bg-tertiary);border-radius:6px;padding:14px 16px;">' +
+      '<span style="color:var(--danger);font-size:12px;">Failed to load mask info</span></div>';
+  }
+}
+
+function openMasksModal() {
+  if (!_masksData) return;
+  var modal = document.getElementById('masksModal');
+  document.getElementById('masksModalError').style.display = 'none';
+  renderMasksModalRows();
+  modal.classList.add('open');
+}
+
+function closeMasksModal() {
+  document.getElementById('masksModal').classList.remove('open');
+}
+
+function renderMasksModalRows() {
+  var rows = document.getElementById('masksModalRows');
+  if (!_masksData || (_masksData.variants || []).length === 0) {
+    rows.innerHTML = '<li style="color:var(--text-ghost);font-size:13px;padding:12px 0;">No mask variants present.</li>';
+    return;
+  }
+  var html = '';
+  _masksData.variants.forEach(function(v) {
+    var isActive = (v.active_count || 0) > 0;
+    html += '<li class="file-item">';
+    html += '<label style="flex:1;">' +
+      '<strong style="color:var(--text-primary);">' + escapeHtml(v.variant) + '</strong>' +
+      ' <span style="color:var(--text-dim);">&middot; ' + (v.count || 0).toLocaleString() +
+      ' photos &middot; ' + formatBytes(v.bytes || 0) + '</span>';
+    if (isActive) {
+      html += ' <span style="font-size:10px;color:var(--accent);margin-left:6px;">[active &middot; ' +
+        (v.active_count || 0).toLocaleString() + ']</span>';
+    }
+    html += '</label>';
+    if (isActive) {
+      html += '<button class="btn-danger" disabled title="set another variant active first" ' +
+        'style="opacity:0.4;cursor:default;">Delete</button>';
+    } else {
+      html += '<button class="btn-danger" onclick="deleteMaskVariant(' + JSON.stringify(v.variant) + ')">Delete</button>';
+    }
+    html += '</li>';
+  });
+  rows.innerHTML = html;
+}
+
+function _showMasksModalError(msg) {
+  var el = document.getElementById('masksModalError');
+  el.textContent = msg;
+  el.style.display = '';
+}
+
+async function deleteMaskVariant(variant) {
+  if (!confirm('Delete all "' + variant + '" masks? Files and DB rows will be removed.')) return;
+  try {
+    var resp = await fetch('/api/storage/masks/delete-variant', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({variant: variant}),
+    });
+    var body = await resp.json();
+    if (!resp.ok) {
+      _showMasksModalError(body.error || ('HTTP ' + resp.status));
+      return;
+    }
+    document.getElementById('masksModalError').style.display = 'none';
+  } catch(e) {
+    _showMasksModalError(String(e));
+    return;
+  }
+  await loadMasksCard();
+  if (_masksData && (_masksData.variants || []).length > 0) {
+    renderMasksModalRows();
+  } else {
+    closeMasksModal();
+  }
+}
+
+async function deleteInactiveMasks() {
+  if (!confirm('Delete all non-active mask variants across photos? The active variant per photo is kept.')) return;
+  try {
+    await safeFetch('/api/storage/masks/delete-inactive', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+    });
+  } catch(e) {}
+  loadMasksCard();
+}
+
+async function deleteStaleMasks() {
+  if (!confirm('Delete masks whose detection prompt no longer matches the photo’s primary detection?')) return;
+  try {
+    await safeFetch('/api/storage/masks/delete-stale', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+    });
+  } catch(e) {}
+  loadMasksCard();
 }
 
 var _modalType = '';

--- a/vireo/templates/stats.html
+++ b/vireo/templates/stats.html
@@ -802,33 +802,66 @@ function closeMasksModal() {
 }
 
 function renderMasksModalRows() {
+  // Variant names come from workspace pipeline config and must be
+  // treated as untrusted. Build rows via DOM APIs / textContent so a
+  // crafted variant name can't escape into HTML, and so the per-row
+  // Delete button's click handler doesn't break on quote characters
+  // (a JSON-stringified variant inside onclick="..." breaks at the
+  // first inner double quote).
   var rows = document.getElementById('masksModalRows');
+  rows.textContent = '';
   if (!_masksData || (_masksData.variants || []).length === 0) {
-    rows.innerHTML = '<li style="color:var(--text-ghost);font-size:13px;padding:12px 0;">No mask variants present.</li>';
+    var empty = document.createElement('li');
+    empty.style.color = 'var(--text-ghost)';
+    empty.style.fontSize = '13px';
+    empty.style.padding = '12px 0';
+    empty.textContent = 'No mask variants present.';
+    rows.appendChild(empty);
     return;
   }
-  var html = '';
   _masksData.variants.forEach(function(v) {
     var isActive = (v.active_count || 0) > 0;
-    html += '<li class="file-item">';
-    html += '<label style="flex:1;">' +
-      '<strong style="color:var(--text-primary);">' + escapeHtml(v.variant) + '</strong>' +
-      ' <span style="color:var(--text-dim);">&middot; ' + (v.count || 0).toLocaleString() +
-      ' photos &middot; ' + formatBytes(v.bytes || 0) + '</span>';
+    var li = document.createElement('li');
+    li.className = 'file-item';
+
+    var label = document.createElement('label');
+    label.style.flex = '1';
+    var strong = document.createElement('strong');
+    strong.style.color = 'var(--text-primary)';
+    strong.textContent = v.variant;
+    label.appendChild(strong);
+    var meta = document.createElement('span');
+    meta.style.color = 'var(--text-dim)';
+    meta.textContent = ' · ' + (v.count || 0).toLocaleString() +
+      ' photos · ' + formatBytes(v.bytes || 0);
+    label.appendChild(meta);
     if (isActive) {
-      html += ' <span style="font-size:10px;color:var(--accent);margin-left:6px;">[active &middot; ' +
-        (v.active_count || 0).toLocaleString() + ']</span>';
+      var activeTag = document.createElement('span');
+      activeTag.style.fontSize = '10px';
+      activeTag.style.color = 'var(--accent)';
+      activeTag.style.marginLeft = '6px';
+      activeTag.textContent = '[active · ' +
+        (v.active_count || 0).toLocaleString() + ']';
+      label.appendChild(activeTag);
     }
-    html += '</label>';
+    li.appendChild(label);
+
+    var btn = document.createElement('button');
+    btn.className = 'btn-danger';
+    btn.textContent = 'Delete';
     if (isActive) {
-      html += '<button class="btn-danger" disabled title="set another variant active first" ' +
-        'style="opacity:0.4;cursor:default;">Delete</button>';
+      btn.disabled = true;
+      btn.title = 'set another variant active first';
+      btn.style.opacity = '0.4';
+      btn.style.cursor = 'default';
     } else {
-      html += '<button class="btn-danger" onclick="deleteMaskVariant(' + JSON.stringify(v.variant) + ')">Delete</button>';
+      btn.addEventListener('click', function() {
+        deleteMaskVariant(v.variant);
+      });
     }
-    html += '</li>';
+    li.appendChild(btn);
+    rows.appendChild(li);
   });
-  rows.innerHTML = html;
 }
 
 function _showMasksModalError(msg) {

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3693,3 +3693,72 @@ def test_api_storage_masks_delete_stale(app_and_db, tmp_path):
         "SELECT COUNT(*) FROM photo_masks WHERE variant='sam3-small'"
     ).fetchone()[0]
     assert n == 0
+
+
+def test_storage_masks_uses_global_threshold_not_active_workspace(
+    app_and_db, tmp_path
+):
+    """``/api/storage/masks`` and ``/api/storage/masks/delete-stale``
+    are global-storage endpoints, so their stale set must not depend on
+    which workspace is active. Concretely: a permissive workspace
+    (detector_confidence=0.1) has a matching low-confidence detection
+    keeping the mask fresh; a strict workspace
+    (detector_confidence=0.5) would consider that detection invisible
+    and the mask stale. Switching to the strict workspace must NOT
+    cause the storage endpoint to count or delete this mask, because
+    it's still valid under the permissive workspace's settings.
+    """
+    app, db = app_and_db
+    masks_dir = tmp_path / "masks"
+    masks_dir.mkdir(exist_ok=True)
+    pid = db.conn.execute(
+        "SELECT id FROM photos ORDER BY id LIMIT 1"
+    ).fetchone()["id"]
+    # One detection at 0.3 confidence — visible to a 0.1 floor, hidden
+    # by a 0.5 floor.
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (?, 'megadetector-v6', 0.10, 0.10, 0.10, 0.10, 0.30, 'animal')",
+        (pid,),
+    )
+    f = masks_dir / f"{pid}.sam2-small.png"
+    f.write_bytes(b"x" * 50)
+    db.upsert_photo_mask(
+        photo_id=pid, variant="sam2-small", path=str(f),
+        detector_model="megadetector-v6",
+        prompt_x=0.10, prompt_y=0.10, prompt_w=0.10, prompt_h=0.10,
+    )
+    db.conn.commit()
+    permissive = db.create_workspace(
+        "permissive", config_overrides={"detector_confidence": 0.1}
+    )
+    strict = db.create_workspace(
+        "strict", config_overrides={"detector_confidence": 0.5}
+    )
+    # Activate the strict workspace. Pre-fix this would push stale_count
+    # to 1 (and delete-stale would delete the mask) because the endpoint
+    # used the active workspace's 0.5 floor.
+    db.set_active_workspace(strict)
+    client = app.test_client()
+    r = client.get("/api/storage/masks")
+    assert r.status_code == 200
+    assert r.get_json()["stale_count"] == 0, (
+        "global storage view should not flip stale_count when the active "
+        "workspace tightens its detector threshold; another workspace "
+        "still considers the mask fresh"
+    )
+    r = client.post("/api/storage/masks/delete-stale")
+    assert r.status_code == 200
+    assert r.get_json()["deleted"] == 0
+    # Mask + DB row still there.
+    assert f.exists()
+    n = db.conn.execute(
+        "SELECT COUNT(*) FROM photo_masks WHERE photo_id=? AND variant=?",
+        (pid, "sam2-small"),
+    ).fetchone()[0]
+    assert n == 1
+    # Symmetry: switching to permissive doesn't change the answer either.
+    db.set_active_workspace(permissive)
+    r = client.get("/api/storage/masks")
+    assert r.get_json()["stale_count"] == 0

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3596,3 +3596,94 @@ def test_api_storage_masks_empty(app_and_db):
     assert data["variants"] == []
     assert data["total_bytes"] == 0
     assert data["stale_count"] == 0
+
+
+def test_api_storage_masks_delete_variant(app_and_db, tmp_path):
+    app, db = app_and_db
+    masks_dir, _p1, _p2 = _seed_masks(db, tmp_path)
+    client = app.test_client()
+    # sam2-large is not active anywhere — should delete fine.
+    r = client.post(
+        "/api/storage/masks/delete-variant",
+        json={"variant": "sam2-large"},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["ok"] is True
+    assert body["deleted"] == 1
+    # File removed
+    assert not any(p.name.endswith(".sam2-large.png") for p in masks_dir.iterdir())
+    # Row removed
+    n = db.conn.execute(
+        "SELECT COUNT(*) FROM photo_masks WHERE variant='sam2-large'"
+    ).fetchone()[0]
+    assert n == 0
+
+
+def test_api_storage_masks_delete_variant_refuses_active(app_and_db, tmp_path):
+    app, db = app_and_db
+    _seed_masks(db, tmp_path)
+    client = app.test_client()
+    # sam2-small is active for photo 1 — should refuse with 400.
+    r = client.post(
+        "/api/storage/masks/delete-variant",
+        json={"variant": "sam2-small"},
+    )
+    assert r.status_code == 400
+    body = r.get_json()
+    assert "active" in body["error"].lower()
+
+
+def test_api_storage_masks_delete_variant_requires_name(app_and_db):
+    app, _db = app_and_db
+    client = app.test_client()
+    r = client.post("/api/storage/masks/delete-variant", json={})
+    assert r.status_code == 400
+    assert "variant" in r.get_json()["error"].lower()
+
+
+def test_api_storage_masks_delete_inactive(app_and_db, tmp_path):
+    app, db = app_and_db
+    _seed_masks(db, tmp_path)
+    client = app.test_client()
+    r = client.post("/api/storage/masks/delete-inactive")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["ok"] is True
+    # We seeded 3 rows; only photo1's sam2-small is active. The other two
+    # rows (photo1 sam2-large, photo2 sam2-small) are inactive and removed.
+    assert body["deleted"] == 2
+    n = db.conn.execute("SELECT COUNT(*) FROM photo_masks").fetchone()[0]
+    assert n == 1
+
+
+def test_api_storage_masks_delete_stale(app_and_db, tmp_path):
+    app, db = app_and_db
+    masks_dir, p1, _p2 = _seed_masks(db, tmp_path)
+    # Add a detection that matches sam2-small's prompt for p1, so it's not stale.
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (?, 'megadetector-v6', 0, 0, 10, 10, 0.9, 'animal')",
+        (p1,),
+    )
+    db.conn.commit()
+    # Add a mask whose prompt does NOT match any detection — stale.
+    f = masks_dir / f"{p1}.sam3-small.png"
+    f.write_bytes(b"x" * 50)
+    db.upsert_photo_mask(
+        photo_id=p1, variant="sam3-small", path=str(f),
+        detector_model="megadetector-v6",
+        prompt_x=999, prompt_y=999, prompt_w=10, prompt_h=10,
+    )
+    client = app.test_client()
+    r = client.post("/api/storage/masks/delete-stale")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["ok"] is True
+    assert body["deleted"] >= 1
+    # The stale sam3-small row is gone.
+    n = db.conn.execute(
+        "SELECT COUNT(*) FROM photo_masks WHERE variant='sam3-small'"
+    ).fetchone()[0]
+    assert n == 0

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3564,7 +3564,13 @@ def _seed_masks(db, tmp_path):
             detector_model="megadetector-v6",
             prompt_x=0, prompt_y=0, prompt_w=10, prompt_h=10,
         )
+    # Both photos get an active variant set: this mirrors what the
+    # pipeline always does after upsert_photo_mask, so the seed reflects
+    # realistic state. delete_inactive_masks now skips photos with NULL
+    # active (the partial-state case) rather than treating them as
+    # entirely-inactive.
     db.set_active_mask_variant(p1, "sam2-small")
+    db.set_active_mask_variant(p2, "sam2-small")
     return masks_dir, p1, p2
 
 
@@ -3581,7 +3587,7 @@ def test_api_storage_masks_returns_summary(app_and_db, tmp_path):
     assert "path" in data
     by_var = {v["variant"]: v for v in data["variants"]}
     assert by_var["sam2-small"]["count"] == 2
-    assert by_var["sam2-small"]["active_count"] == 1
+    assert by_var["sam2-small"]["active_count"] == 2
     assert by_var["sam2-large"]["count"] == 1
     assert by_var["sam2-large"]["active_count"] == 0
     assert data["total_bytes"] == 100 + 200 + 150
@@ -3650,11 +3656,11 @@ def test_api_storage_masks_delete_inactive(app_and_db, tmp_path):
     assert r.status_code == 200
     body = r.get_json()
     assert body["ok"] is True
-    # We seeded 3 rows; only photo1's sam2-small is active. The other two
-    # rows (photo1 sam2-large, photo2 sam2-small) are inactive and removed.
-    assert body["deleted"] == 2
+    # We seeded 3 rows; both photos have sam2-small active. The only
+    # inactive row is photo1's sam2-large.
+    assert body["deleted"] == 1
     n = db.conn.execute("SELECT COUNT(*) FROM photo_masks").fetchone()[0]
-    assert n == 1
+    assert n == 2
 
 
 def test_api_storage_masks_delete_stale(app_and_db, tmp_path):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3531,3 +3531,68 @@ def test_precompute_embeddings_rejects_timm_models(app_and_db, monkeypatch):
     job = runner.get(job_id)
     assert job["status"] == "failed"
     assert any("fixed class head" in e for e in (job.get("errors") or []))
+
+
+# ---------------------------------------------------------------------------
+# /api/storage/masks endpoints
+# ---------------------------------------------------------------------------
+
+def _seed_masks(db, tmp_path):
+    """Insert a few photo_masks rows + on-disk files for storage tests.
+
+    Layout:
+      photo 1: sam2-small (active), sam2-large
+      photo 2: sam2-small
+    Returns the masks directory path.
+    """
+    masks_dir = tmp_path / "masks"
+    masks_dir.mkdir(exist_ok=True)
+    pids = [r["id"] for r in db.conn.execute(
+        "SELECT id FROM photos ORDER BY id LIMIT 2"
+    ).fetchall()]
+    p1, p2 = pids[0], pids[1]
+
+    for pid, var, size in [
+        (p1, "sam2-small", 100),
+        (p1, "sam2-large", 200),
+        (p2, "sam2-small", 150),
+    ]:
+        f = masks_dir / f"{pid}.{var}.png"
+        f.write_bytes(b"x" * size)
+        db.upsert_photo_mask(
+            photo_id=pid, variant=var, path=str(f),
+            detector_model="megadetector-v6",
+            prompt_x=0, prompt_y=0, prompt_w=10, prompt_h=10,
+        )
+    db.set_active_mask_variant(p1, "sam2-small")
+    return masks_dir, p1, p2
+
+
+def test_api_storage_masks_returns_summary(app_and_db, tmp_path):
+    app, db = app_and_db
+    _seed_masks(db, tmp_path)
+    client = app.test_client()
+    r = client.get("/api/storage/masks")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "variants" in data
+    assert "total_bytes" in data
+    assert "stale_count" in data
+    assert "path" in data
+    by_var = {v["variant"]: v for v in data["variants"]}
+    assert by_var["sam2-small"]["count"] == 2
+    assert by_var["sam2-small"]["active_count"] == 1
+    assert by_var["sam2-large"]["count"] == 1
+    assert by_var["sam2-large"]["active_count"] == 0
+    assert data["total_bytes"] == 100 + 200 + 150
+
+
+def test_api_storage_masks_empty(app_and_db):
+    app, _db = app_and_db
+    client = app.test_client()
+    r = client.get("/api/storage/masks")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["variants"] == []
+    assert data["total_bytes"] == 0
+    assert data["stale_count"] == 0

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -10043,6 +10043,53 @@ def test_mask_variants_summary(tmp_path):
     assert summary["sam3-small"]["active_count"] == 0
 
 
+def test_mask_variant_coverage_is_workspace_scoped(tmp_path):
+    """mask_variant_coverage returns per-variant counts of distinct photos
+    in the active workspace that have a row for that variant. Photos
+    outside the workspace are excluded even though photo_masks is global.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    ws_in = db.create_workspace("In")
+    ws_out = db.create_workspace("Out")
+
+    f_in = db.add_folder("/in", name="in")
+    f_out = db.add_folder("/out", name="out")
+    db.add_workspace_folder(ws_in, f_in)
+    db.add_workspace_folder(ws_out, f_out)
+
+    p1 = db.add_photo(folder_id=f_in, filename="a.jpg", extension=".jpg",
+                      file_size=1, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=f_in, filename="b.jpg", extension=".jpg",
+                      file_size=1, file_mtime=1.0)
+    p3 = db.add_photo(folder_id=f_out, filename="c.jpg", extension=".jpg",
+                      file_size=1, file_mtime=1.0)
+
+    db.upsert_photo_mask(p1, "sam2-small", "/p/a.small.png",
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0)
+    db.upsert_photo_mask(p1, "sam2-large", "/p/a.large.png",
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0)
+    db.upsert_photo_mask(p2, "sam2-small", "/p/b.small.png",
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0)
+    # p3 lives outside ws_in — its sam2-large row must NOT be counted.
+    db.upsert_photo_mask(p3, "sam2-large", "/p/c.large.png",
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0)
+
+    db.set_active_mask_variant(p1, "sam2-large")
+
+    db.set_active_workspace(ws_in)
+    cov = {c["variant"]: c for c in db.mask_variant_coverage()}
+    assert cov["sam2-small"]["count"] == 2
+    assert cov["sam2-small"]["active_count"] == 0
+    assert cov["sam2-large"]["count"] == 1  # p3 excluded
+    assert cov["sam2-large"]["active_count"] == 1
+
+    db.set_active_workspace(ws_out)
+    cov_out = {c["variant"]: c for c in db.mask_variant_coverage()}
+    assert cov_out["sam2-large"]["count"] == 1
+    assert "sam2-small" not in cov_out
+
+
 def test_existing_masks_migrate_to_unknown_variant(tmp_path):
     """A photos row with mask_path set on a pre-migration DB gets a
     photo_masks row with variant='unknown' and prompt=-1."""

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -10041,3 +10041,110 @@ def test_mask_variants_summary(tmp_path):
     assert summary["sam2-large"]["count"] == 1
     assert summary["sam2-large"]["active_count"] == 1
     assert summary["sam3-small"]["active_count"] == 0
+
+
+def test_existing_masks_migrate_to_unknown_variant(tmp_path):
+    """A photos row with mask_path set on a pre-migration DB gets a
+    photo_masks row with variant='unknown' and prompt=-1."""
+    import sqlite3
+    db_path = tmp_path / "v.db"
+
+    # Build a DB with the old shape, no photo_masks table. Include the
+    # columns CREATE INDEX statements reference (timestamp, file_hash) so
+    # _create_tables doesn't fail on a freshly-empty schema.
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT)")
+    conn.execute(
+        "CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER, "
+        "filename TEXT, timestamp TEXT, file_hash TEXT, rating INTEGER, "
+        "mask_path TEXT, subject_size REAL, subject_tenengrad REAL, "
+        "bg_tenengrad REAL, crop_complete REAL)"
+    )
+    conn.execute("INSERT INTO folders(id, path) VALUES (1, '/tmp')")
+    conn.execute(
+        "INSERT INTO photos(id, folder_id, filename, mask_path, "
+        "subject_tenengrad, crop_complete) "
+        "VALUES (1, 1, 'a.jpg', '/m/1.png', 1.5, 0.9)"
+    )
+    # Photo without a mask_path — should NOT get a photo_masks row.
+    conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) "
+        "VALUES (2, 1, 'b.jpg')"
+    )
+    conn.commit()
+    conn.close()
+
+    from db import Database
+    db = Database(str(db_path))
+
+    row = db.conn.execute(
+        "SELECT * FROM photo_masks WHERE photo_id=1"
+    ).fetchone()
+    assert row is not None
+    assert row["variant"] == "unknown"
+    assert row["detector_model"] == "unknown"
+    assert row["prompt_x"] == -1
+    assert row["prompt_y"] == -1
+    assert row["prompt_w"] == -1
+    assert row["prompt_h"] == -1
+    assert row["path"] == "/m/1.png"
+    assert row["subject_tenengrad"] == 1.5
+    assert row["crop_complete"] == 0.9
+    # And photos.active_mask_variant is set
+    av = db.conn.execute(
+        "SELECT active_mask_variant FROM photos WHERE id=1"
+    ).fetchone()[0]
+    assert av == "unknown"
+
+    # Photo without mask_path: no photo_masks row, no active_mask_variant.
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM photo_masks WHERE photo_id=2"
+    ).fetchone()[0] == 0
+    av2 = db.conn.execute(
+        "SELECT active_mask_variant FROM photos WHERE id=2"
+    ).fetchone()[0]
+    assert av2 is None
+
+
+def test_mask_migration_is_idempotent(tmp_path):
+    """Re-opening the DB does not re-insert migrated 'unknown' rows."""
+    import sqlite3
+    db_path = tmp_path / "v.db"
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE folders (id INTEGER PRIMARY KEY, path TEXT)")
+    conn.execute(
+        "CREATE TABLE photos (id INTEGER PRIMARY KEY, folder_id INTEGER, "
+        "filename TEXT, timestamp TEXT, file_hash TEXT, rating INTEGER, "
+        "mask_path TEXT, subject_size REAL, subject_tenengrad REAL, "
+        "bg_tenengrad REAL, crop_complete REAL)"
+    )
+    conn.execute("INSERT INTO folders(id, path) VALUES (1, '/tmp')")
+    conn.execute(
+        "INSERT INTO photos(id, folder_id, filename, mask_path) "
+        "VALUES (1, 1, 'a.jpg', '/m/1.png')"
+    )
+    conn.commit()
+    conn.close()
+
+    from db import Database
+    db = Database(str(db_path))
+    db.conn.close()
+
+    # Re-open — migration must not insert a second row.
+    db2 = Database(str(db_path))
+    n = db2.conn.execute(
+        "SELECT COUNT(*) FROM photo_masks WHERE photo_id=1"
+    ).fetchone()[0]
+    assert n == 1
+
+
+def test_photo_masks_subject_size_is_real(tmp_path):
+    """Fresh DBs declare photo_masks.subject_size as REAL since the
+    feature stores a fraction in [0, 1]."""
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    cols = {row[1]: row[2] for row in db.conn.execute(
+        "PRAGMA table_info(photo_masks)"
+    ).fetchall()}
+    assert cols["subject_size"] == "REAL"

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -9784,3 +9784,41 @@ def test_upsert_photo_mask_inserts_and_replaces(tmp_path):
         "SELECT COUNT(*) FROM photo_masks WHERE photo_id=1 AND variant='sam2-small'"
     ).fetchone()[0]
     assert n == 1
+
+
+def test_get_photo_mask_returns_row_or_none(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    assert db.get_photo_mask(1, "sam2-small") is None
+
+    db.upsert_photo_mask(
+        photo_id=1, variant="sam2-small", path="/p", detector_model="md",
+        prompt_x=1, prompt_y=2, prompt_w=3, prompt_h=4,
+    )
+    m = db.get_photo_mask(1, "sam2-small")
+    assert m["path"] == "/p"
+    assert m["detector_model"] == "md"
+    assert m["prompt_x"] == 1
+
+
+def test_list_masks_for_photo(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    db.upsert_photo_mask(
+        photo_id=1, variant="sam2-small", path="/a",
+        detector_model="md", prompt_x=1, prompt_y=2, prompt_w=3, prompt_h=4,
+    )
+    db.upsert_photo_mask(
+        photo_id=1, variant="sam2-large", path="/b",
+        detector_model="md", prompt_x=1, prompt_y=2, prompt_w=3, prompt_h=4,
+    )
+    variants = sorted(m["variant"] for m in db.list_masks_for_photo(1))
+    assert variants == ["sam2-large", "sam2-small"]

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -9743,3 +9743,44 @@ def test_photos_has_active_mask_variant_column(tmp_path):
     from db import Database
     db = Database(str(tmp_path / "v.db"))
     db.conn.execute("SELECT active_mask_variant FROM photos LIMIT 0")
+
+
+def test_upsert_photo_mask_inserts_and_replaces(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+
+    db.upsert_photo_mask(
+        photo_id=1, variant="sam2-small", path="/m/1.sam2-small.png",
+        detector_model="megadetector-v6",
+        prompt_x=10, prompt_y=20, prompt_w=100, prompt_h=200,
+        subject_size=20000, subject_tenengrad=1.5,
+        bg_tenengrad=0.3, crop_complete=1.0,
+    )
+    row = db.conn.execute(
+        "SELECT path, prompt_x FROM photo_masks WHERE photo_id=1 AND variant='sam2-small'"
+    ).fetchone()
+    assert row["path"] == "/m/1.sam2-small.png"
+    assert row["prompt_x"] == 10
+
+    # Re-upsert with new prompt — row replaced
+    db.upsert_photo_mask(
+        photo_id=1, variant="sam2-small", path="/m/1.sam2-small.png",
+        detector_model="megadetector-v6",
+        prompt_x=11, prompt_y=20, prompt_w=100, prompt_h=200,
+        subject_size=21000, subject_tenengrad=1.5,
+        bg_tenengrad=0.3, crop_complete=1.0,
+    )
+    row = db.conn.execute(
+        "SELECT prompt_x, subject_size FROM photo_masks WHERE photo_id=1 AND variant='sam2-small'"
+    ).fetchone()
+    assert row["prompt_x"] == 11
+    assert row["subject_size"] == 21000
+    # Still exactly one row for this (photo, variant)
+    n = db.conn.execute(
+        "SELECT COUNT(*) FROM photo_masks WHERE photo_id=1 AND variant='sam2-small'"
+    ).fetchone()[0]
+    assert n == 1

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -10008,3 +10008,36 @@ def test_delete_stale_masks(tmp_path):
     assert fresh.exists()
     assert not stale_path.exists()
     assert {m["variant"] for m in db.list_masks_for_photo(1)} == {"sam2-small"}
+
+
+def test_mask_variants_summary(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    for pid in (1, 2, 3):
+        db.conn.execute(
+            "INSERT INTO photos(id, folder_id, filename) VALUES (?, 1, ?)",
+            (pid, f"p{pid}.jpg"),
+        )
+    md = tmp_path / "masks"
+    md.mkdir()
+    for pid, var, size in [
+        (1, "sam2-small", 100),
+        (2, "sam2-small", 200),
+        (1, "sam2-large", 500),
+        (3, "sam3-small", 700),
+    ]:
+        p = md / f"{pid}.{var}.png"
+        p.write_bytes(b"x" * size)
+        db.upsert_photo_mask(
+            pid, var, str(p),
+            detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+        )
+    db.set_active_mask_variant(1, "sam2-large")
+
+    summary = {s["variant"]: s for s in db.mask_variants_summary()}
+    assert summary["sam2-small"]["count"] == 2
+    assert summary["sam2-small"]["bytes"] == 300
+    assert summary["sam2-large"]["count"] == 1
+    assert summary["sam2-large"]["active_count"] == 1
+    assert summary["sam3-small"]["active_count"] == 0

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -9737,3 +9737,9 @@ def test_photo_masks_pk_is_photo_and_variant(tmp_path):
             "detector_model, prompt_x, prompt_y, prompt_w, prompt_h) "
             "VALUES (1, 'sam2-small', '/p2', 1, 'unknown', -1, -1, -1, -1)"
         )
+
+
+def test_photos_has_active_mask_variant_column(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("SELECT active_mask_variant FROM photos LIMIT 0")

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -10096,6 +10096,137 @@ def test_find_stale_masks_preserves_real_precision_bbox(tmp_path):
     }
 
 
+def test_find_stale_masks_applies_detector_confidence_floor(tmp_path):
+    """The staleness check has to honor the workspace's
+    ``detector_confidence`` floor: detections below the floor are
+    invisible to extraction (it skips them), so a cached mask whose
+    prompt only matches a below-floor box must be marked stale even
+    though its coordinates technically still appear in ``detections``.
+    Otherwise raising the floor leaves stale masks active and reused.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    # Photo 1's only non-full-image detection is below the new floor.
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (1, 'megadetector-v6', 0.10, 0.20, 0.30, 0.40, 0.15, 'animal')"
+    )
+    db.upsert_photo_mask(
+        1, "sam2-small", "/p",
+        detector_model="megadetector-v6",
+        prompt_x=0.10, prompt_y=0.20, prompt_w=0.30, prompt_h=0.40,
+    )
+    # Photo 2 has a fresh, above-floor detection that matches its mask.
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (2, 1, 'b.jpg')"
+    )
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (2, 'megadetector-v6', 0.50, 0.50, 0.20, 0.20, 0.90, 'animal')"
+    )
+    db.upsert_photo_mask(
+        2, "sam2-small", "/q",
+        detector_model="megadetector-v6",
+        prompt_x=0.50, prompt_y=0.50, prompt_w=0.20, prompt_h=0.20,
+    )
+
+    # No floor: photo 1's mask matches its (low-confidence) detection,
+    # so neither mask is stale. Preserves prior behavior for callers
+    # that don't pass a threshold.
+    assert db.find_stale_masks() == []
+
+    # Floor at 0.5: photo 1's only detection (0.15) is invisible, so
+    # there's no primary detection for the mask to match against and
+    # the mask is stale. Photo 2's mask matches its 0.90 detection and
+    # stays fresh.
+    stale = db.find_stale_masks(detector_confidence=0.5)
+    assert {(s["photo_id"], s["variant"]) for s in stale} == {
+        (1, "sam2-small")
+    }
+
+
+def test_find_stale_masks_floor_drops_below_threshold_match(tmp_path):
+    """A cached mask whose prompt only matches a below-floor detection
+    (and the photo has no above-floor detections at all) must be stale
+    once the floor is applied — extraction wouldn't run for that photo
+    so the mask can never be regenerated.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    # Two below-floor detections; the cached mask's prompt matches the
+    # higher-confidence one. Without a floor it'd be the "primary" and
+    # the mask would look fresh; with the floor it disappears.
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (1, 'megadetector-v6', 0.10, 0.10, 0.10, 0.10, 0.40, 'animal')"
+    )
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (1, 'megadetector-v6', 0.20, 0.20, 0.10, 0.10, 0.30, 'animal')"
+    )
+    db.upsert_photo_mask(
+        1, "sam2-small", "/p",
+        detector_model="megadetector-v6",
+        prompt_x=0.10, prompt_y=0.10, prompt_w=0.10, prompt_h=0.10,
+    )
+    # Without floor: the 0.40 box is the primary, its prompt equals
+    # the cached one → fresh.
+    assert db.find_stale_masks() == []
+    # With floor 0.5: nothing visible, cached mask is stale.
+    stale = db.find_stale_masks(detector_confidence=0.5)
+    assert {(s["photo_id"], s["variant"]) for s in stale} == {
+        (1, "sam2-small")
+    }
+
+
+def test_delete_stale_masks_honors_detector_confidence(tmp_path):
+    """``delete_stale_masks`` has to forward the threshold so the
+    deleted set matches the count surfaced on the storage card. If it
+    didn't, the user would press *Delete stale* and end up with a
+    non-zero leftover.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (1, 'megadetector-v6', 0.10, 0.10, 0.10, 0.10, 0.20, 'animal')"
+    )
+    masks_dir = tmp_path / "masks"
+    masks_dir.mkdir()
+    p = masks_dir / "1.sam2-small.png"
+    p.write_bytes(b"x")
+    db.upsert_photo_mask(
+        1, "sam2-small", str(p),
+        detector_model="megadetector-v6",
+        prompt_x=0.10, prompt_y=0.10, prompt_w=0.10, prompt_h=0.10,
+    )
+    # Without a floor the (matching, low-confidence) detection keeps
+    # the mask fresh.
+    assert db.delete_stale_masks() == 0
+    assert p.exists()
+    # With a floor above the detection's confidence the mask becomes
+    # stale and gets removed.
+    assert db.delete_stale_masks(detector_confidence=0.5) == 1
+    assert not p.exists()
+
+
 def test_legacy_mask_backfill_is_resumable(tmp_path):
     """If startup crashes after backfilling some legacy mask rows but
     before completing, the next startup must finish the rest.  The

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -10227,6 +10227,64 @@ def test_delete_stale_masks_honors_detector_confidence(tmp_path):
     assert not p.exists()
 
 
+def test_min_detector_confidence_no_overrides(tmp_path):
+    """With no per-workspace overrides, the cross-workspace minimum is
+    just the global default. The Default workspace auto-created by
+    Database.__init__ has no config_overrides, so this is the
+    out-of-the-box state.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    assert db.min_detector_confidence_across_workspaces(
+        {"detector_confidence": 0.3}
+    ) == 0.3
+    # Falls back to 0.2 if the global config doesn't define it.
+    assert db.min_detector_confidence_across_workspaces({}) == 0.2
+
+
+def test_min_detector_confidence_picks_lowest_override(tmp_path):
+    """The global storage view must use the most permissive floor
+    across workspaces. If one workspace overrides
+    detector_confidence=0.1 and another sticks with 0.5, the global
+    minimum is 0.1 — masks valid under 0.1 must not be deleted just
+    because the active workspace happens to be the strict one.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    permissive = db.create_workspace(
+        "permissive", config_overrides={"detector_confidence": 0.1}
+    )
+    strict = db.create_workspace(
+        "strict", config_overrides={"detector_confidence": 0.5}
+    )
+    # Active workspace shouldn't matter — try both.
+    db.set_active_workspace(strict)
+    assert db.min_detector_confidence_across_workspaces(
+        {"detector_confidence": 0.3}
+    ) == 0.1
+    db.set_active_workspace(permissive)
+    assert db.min_detector_confidence_across_workspaces(
+        {"detector_confidence": 0.3}
+    ) == 0.1
+
+
+def test_min_detector_confidence_includes_unoverridden_workspaces(tmp_path):
+    """A workspace without an override still counts at the global
+    default. If global=0.2 and one workspace overrides up to 0.5 but
+    others don't override at all, the cross-workspace min is 0.2 (the
+    unoverridden workspaces' effective value), not 0.5.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.create_workspace(
+        "strict", config_overrides={"detector_confidence": 0.5}
+    )
+    # The auto-created Default workspace has no overrides → uses 0.2.
+    assert db.min_detector_confidence_across_workspaces(
+        {"detector_confidence": 0.2}
+    ) == 0.2
+
+
 def test_legacy_mask_backfill_is_resumable(tmp_path):
     """If startup crashes after backfilling some legacy mask rows but
     before completing, the next startup must finish the rest.  The

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -10002,6 +10002,58 @@ def test_find_stale_masks(tmp_path):
     assert {(s["photo_id"], s["variant"]) for s in stale} == {(1, "sam2-large")}
 
 
+def test_find_stale_masks_compares_against_primary_detection_only(tmp_path):
+    """Mask validity hangs off the *primary* detection — the
+    highest-confidence non-``full-image`` row. A leftover secondary
+    box (or a row from another retained detector model) that still
+    matches the mask's stored prompt must NOT keep the mask out of
+    the stale set; otherwise stale cache entries linger after
+    detector/model changes.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    # The current primary (highest-confidence non-full-image) is the
+    # 0.95 box at (200, 200, 50, 50). The 0.30 row at the OLD prompt
+    # coordinates is a leftover secondary that should NOT save the
+    # cached mask from being marked stale.
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (1, 'megadetector-v6', 200, 200, 50, 50, 0.95, 'animal')"
+    )
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (1, 'megadetector-v6', 10, 20, 100, 200, 0.30, 'animal')"
+    )
+    db.upsert_photo_mask(
+        1, "sam2-small", "/p",
+        detector_model="megadetector-v6",
+        prompt_x=10, prompt_y=20, prompt_w=100, prompt_h=200,
+    )
+    stale = db.find_stale_masks()
+    assert {(s["photo_id"], s["variant"]) for s in stale} == {
+        (1, "sam2-small")
+    }, (
+        "mask whose prompt only matches a secondary detection must be stale"
+    )
+
+    # Sanity: the mask for the current primary's prompt is still fresh.
+    db.upsert_photo_mask(
+        1, "sam2-large", "/q",
+        detector_model="megadetector-v6",
+        prompt_x=200, prompt_y=200, prompt_w=50, prompt_h=50,
+    )
+    stale = db.find_stale_masks()
+    assert {(s["photo_id"], s["variant"]) for s in stale} == {
+        (1, "sam2-small")
+    }
+
+
 def test_delete_stale_masks(tmp_path):
     from db import Database
     db = Database(str(tmp_path / "v.db"))

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -9822,3 +9822,39 @@ def test_list_masks_for_photo(tmp_path):
     )
     variants = sorted(m["variant"] for m in db.list_masks_for_photo(1))
     assert variants == ["sam2-large", "sam2-small"]
+
+
+def test_set_active_mask_variant_denormalizes(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    db.upsert_photo_mask(
+        photo_id=1, variant="sam2-large", path="/m/1.sam2-large.png",
+        detector_model="md", prompt_x=1, prompt_y=2, prompt_w=3, prompt_h=4,
+        subject_size=12345, subject_tenengrad=2.0,
+        bg_tenengrad=0.5, crop_complete=0.9,
+    )
+    db.set_active_mask_variant(1, "sam2-large")
+    row = db.conn.execute(
+        "SELECT mask_path, active_mask_variant, subject_size, "
+        "subject_tenengrad, bg_tenengrad, crop_complete FROM photos WHERE id=1"
+    ).fetchone()
+    assert row["mask_path"] == "/m/1.sam2-large.png"
+    assert row["active_mask_variant"] == "sam2-large"
+    assert row["subject_size"] == 12345
+    assert row["subject_tenengrad"] == 2.0
+
+
+def test_set_active_mask_variant_missing_row_raises(tmp_path):
+    import pytest
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    with pytest.raises(ValueError):
+        db.set_active_mask_variant(1, "sam3-small")

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -9699,3 +9699,41 @@ def test_default_tabs_is_the_curated_nine():
         "review", "cull", "jobs",
         "highlights", "misses", "settings",
     ]
+
+
+def test_photo_masks_table_exists(tmp_path):
+    """photo_masks table must exist on a fresh DB."""
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    cols = {row[1] for row in db.conn.execute(
+        "PRAGMA table_info(photo_masks)"
+    ).fetchall()}
+    assert {
+        "photo_id", "variant", "path", "created_at",
+        "detector_model", "prompt_x", "prompt_y", "prompt_w", "prompt_h",
+        "subject_size", "subject_tenengrad", "bg_tenengrad", "crop_complete",
+    } <= cols
+
+
+def test_photo_masks_pk_is_photo_and_variant(tmp_path):
+    """(photo_id, variant) is the primary key — same variant twice fails."""
+    import sqlite3
+
+    import pytest
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    db.conn.execute(
+        "INSERT INTO photo_masks(photo_id, variant, path, created_at, "
+        "detector_model, prompt_x, prompt_y, prompt_w, prompt_h) "
+        "VALUES (1, 'sam2-small', '/p1', 0, 'unknown', -1, -1, -1, -1)"
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        db.conn.execute(
+            "INSERT INTO photo_masks(photo_id, variant, path, created_at, "
+            "detector_model, prompt_x, prompt_y, prompt_w, prompt_h) "
+            "VALUES (1, 'sam2-small', '/p2', 1, 'unknown', -1, -1, -1, -1)"
+        )

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -10054,6 +10054,110 @@ def test_find_stale_masks_compares_against_primary_detection_only(tmp_path):
     }
 
 
+def test_find_stale_masks_preserves_real_precision_bbox(tmp_path):
+    """detections.box_* are normalized REAL values in [0, 1].  An older
+    revision int()-truncated those to populate prompt_*, which collapsed
+    every prompt to (0, 0, 0, 0) and meant the staleness query matched
+    any cached mask against any current detection.  A REAL prompt that
+    matches the current primary detection must be fresh; a REAL prompt
+    that doesn't match must be stale.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    # Normalized bbox (x, y, w, h) — typical detector output.
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (1, 'megadetector-v6', 0.123, 0.456, 0.300, 0.400, 0.9, 'animal')"
+    )
+    # Mask was made from the same REAL prompt → not stale.
+    db.upsert_photo_mask(
+        1, "sam2-small", "/p",
+        detector_model="megadetector-v6",
+        prompt_x=0.123, prompt_y=0.456, prompt_w=0.300, prompt_h=0.400,
+    )
+    assert db.find_stale_masks() == []
+
+    # Mask whose prompt matches what the prior int() truncation would
+    # have written. The actual detection has moved (any normalized
+    # value), so this mask must be stale.
+    db.upsert_photo_mask(
+        1, "sam2-large", "/q",
+        detector_model="megadetector-v6",
+        prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+    )
+    stale = db.find_stale_masks()
+    assert {(s["photo_id"], s["variant"]) for s in stale} == {
+        (1, "sam2-large")
+    }
+
+
+def test_legacy_mask_backfill_is_resumable(tmp_path):
+    """If startup crashes after backfilling some legacy mask rows but
+    before completing, the next startup must finish the rest.  The
+    earlier outer ``if total_unknown_rows == 0`` guard caused the
+    remaining photos to be skipped forever, leaving orphan mask_path
+    values that the variant-aware APIs and cleanup logic couldn't see.
+    """
+    from db import Database
+    db_path = str(tmp_path / "v.db")
+    db = Database(db_path)
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename, mask_path) "
+        "VALUES (1, 1, 'a.jpg', '/m/1.png')"
+    )
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename, mask_path) "
+        "VALUES (2, 1, 'b.jpg', '/m/2.png')"
+    )
+    db.conn.commit()
+    db.close()
+
+    # First open: everything backfills.
+    db = Database(db_path)
+    backfilled = {
+        r[0] for r in db.conn.execute(
+            "SELECT photo_id FROM photo_masks WHERE variant='unknown'"
+        )
+    }
+    assert backfilled == {1, 2}
+
+    # Simulate a partial crash: one of the unknown rows was inserted
+    # but the other never made it (rolled back, killed mid-loop, etc.).
+    db.conn.execute(
+        "DELETE FROM photo_masks WHERE photo_id=2 AND variant='unknown'"
+    )
+    db.conn.execute(
+        "UPDATE photos SET active_mask_variant=NULL WHERE id=2"
+    )
+    db.conn.commit()
+    db.close()
+
+    # Next startup must finish the missing photo, not stop just because
+    # *some* unknown rows already exist.
+    db = Database(db_path)
+    backfilled = {
+        r[0] for r in db.conn.execute(
+            "SELECT photo_id FROM photo_masks WHERE variant='unknown'"
+        )
+    }
+    assert backfilled == {1, 2}, (
+        "second startup must re-finish the legacy mask backfill for "
+        "photos missing photo_masks rows"
+    )
+    active = {
+        r[0]: r[1] for r in db.conn.execute(
+            "SELECT id, active_mask_variant FROM photos"
+        )
+    }
+    assert active == {1: "unknown", 2: "unknown"}
+
+
 def test_delete_stale_masks(tmp_path):
     from db import Database
     db = Database(str(tmp_path / "v.db"))

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -10382,6 +10382,121 @@ def test_delete_stale_masks(tmp_path):
     assert {m["variant"] for m in db.list_masks_for_photo(1)} == {"sam2-small"}
 
 
+def test_find_stale_masks_breaks_primary_ties_deterministically(tmp_path):
+    """When two non-full-image detections share the maximum confidence,
+    extraction (``ORDER BY detector_confidence DESC, id ASC``) picks the
+    smaller-id row as the primary. ``find_stale_masks`` has to agree —
+    otherwise a mask whose prompt matches the *other* tied row could be
+    treated as fresh while extraction is regenerating from the chosen
+    primary, leaving stale cache entries that drift between the two
+    paths.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    # Two detections tied on detector_confidence. Insertion order makes
+    # det id=1 the deterministic primary (smaller id wins on tie).
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (1, 'megadetector-v6', 0.10, 0.10, 0.10, 0.10, 0.80, 'animal')"
+    )
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (1, 'megadetector-v6', 0.20, 0.20, 0.20, 0.20, 0.80, 'animal')"
+    )
+
+    # Mask matching the LATER tied row (the one extraction does NOT
+    # pick) must be stale: extraction would not regenerate from it.
+    db.upsert_photo_mask(
+        1, "sam2-small", "/p",
+        detector_model="megadetector-v6",
+        prompt_x=0.20, prompt_y=0.20, prompt_w=0.20, prompt_h=0.20,
+    )
+    stale = db.find_stale_masks()
+    assert {(s["photo_id"], s["variant"]) for s in stale} == {
+        (1, "sam2-small")
+    }
+
+    # Mask matching the FIRST tied row (the deterministic primary) is
+    # fresh.
+    db.upsert_photo_mask(
+        1, "sam2-large", "/q",
+        detector_model="megadetector-v6",
+        prompt_x=0.10, prompt_y=0.10, prompt_w=0.10, prompt_h=0.10,
+    )
+    stale = db.find_stale_masks()
+    assert {(s["photo_id"], s["variant"]) for s in stale} == {
+        (1, "sam2-small")
+    }
+
+
+def test_delete_masks_refuses_paths_outside_masks_dir(tmp_path):
+    """``delete_masks_for_variant`` / ``delete_inactive_masks`` /
+    ``delete_stale_masks`` feed ``photo_masks.path`` straight into
+    ``os.remove``. A corrupted or migrated row pointing outside the
+    masks directory must not let the user-triggerable storage cleanup
+    endpoints unlink arbitrary files. Mirrors the realpath containment
+    already enforced by ``/api/masks/<pid>/<variant>.png``.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    masks_dir = tmp_path / "masks"
+    masks_dir.mkdir()
+
+    # File outside the masks directory — must be untouched.
+    outside = tmp_path / "evil.png"
+    outside.write_bytes(b"important")
+    db.upsert_photo_mask(
+        1, "sam2-small", str(outside),
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+    )
+
+    db.delete_masks_for_variant("sam2-small")
+    assert outside.exists(), "file outside masks dir was deleted"
+
+    # Same protection on delete_inactive_masks.
+    db.upsert_photo_mask(
+        1, "sam2-small", str(outside),
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+    )
+    inside = masks_dir / "1.sam2-large.png"
+    inside.write_bytes(b"in")
+    db.upsert_photo_mask(
+        1, "sam2-large", str(inside),
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+    )
+    db.set_active_mask_variant(1, "sam2-large")
+    db.delete_inactive_masks()
+    assert outside.exists(), "delete_inactive_masks unlinked outside path"
+    # Active variant inside masks dir is preserved.
+    assert inside.exists()
+
+    # And on delete_stale_masks: a stale row pointing outside is
+    # unlinked from the DB but the file is left alone.
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (1, 'md', 9, 9, 9, 9, 0.9, 'animal')"
+    )
+    stale_outside = tmp_path / "stale.png"
+    stale_outside.write_bytes(b"stale")
+    db.upsert_photo_mask(
+        1, "sam2-small", str(stale_outside),
+        detector_model="md", prompt_x=1, prompt_y=1, prompt_w=1, prompt_h=1,
+    )
+    db.delete_stale_masks()
+    assert stale_outside.exists(), "delete_stale_masks unlinked outside path"
+
+
 def test_mask_variants_summary(tmp_path):
     from db import Database
     db = Database(str(tmp_path / "v.db"))

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -9858,3 +9858,153 @@ def test_set_active_mask_variant_missing_row_raises(tmp_path):
     )
     with pytest.raises(ValueError):
         db.set_active_mask_variant(1, "sam3-small")
+
+
+def test_delete_masks_for_variant_removes_files_and_rows(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (2, 1, 'b.jpg')"
+    )
+
+    masks_dir = tmp_path / "masks"
+    masks_dir.mkdir()
+    p1 = masks_dir / "1.sam2-small.png"
+    p1.write_bytes(b"x")
+    p2 = masks_dir / "2.sam2-small.png"
+    p2.write_bytes(b"y")
+    db.upsert_photo_mask(
+        1, "sam2-small", str(p1),
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+    )
+    db.upsert_photo_mask(
+        2, "sam2-small", str(p2),
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+    )
+
+    deleted = db.delete_masks_for_variant("sam2-small")
+    assert deleted == 2
+    assert not p1.exists() and not p2.exists()
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM photo_masks WHERE variant='sam2-small'"
+    ).fetchone()[0] == 0
+
+
+def test_delete_masks_for_variant_refuses_active(tmp_path):
+    import pytest
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    masks_dir = tmp_path / "masks"
+    masks_dir.mkdir()
+    p = masks_dir / "1.sam2-small.png"
+    p.write_bytes(b"x")
+    db.upsert_photo_mask(
+        1, "sam2-small", str(p),
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+    )
+    db.set_active_mask_variant(1, "sam2-small")
+    with pytest.raises(ValueError):
+        db.delete_masks_for_variant("sam2-small")
+
+
+def test_delete_inactive_masks(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    masks_dir = tmp_path / "masks"
+    masks_dir.mkdir()
+    pa = masks_dir / "1.sam2-small.png"
+    pa.write_bytes(b"a")
+    pb = masks_dir / "1.sam2-large.png"
+    pb.write_bytes(b"b")
+    db.upsert_photo_mask(
+        1, "sam2-small", str(pa),
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+    )
+    db.upsert_photo_mask(
+        1, "sam2-large", str(pb),
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+    )
+    db.set_active_mask_variant(1, "sam2-large")
+    n = db.delete_inactive_masks()
+    assert n == 1
+    assert not pa.exists()
+    assert pb.exists()
+    remaining = {m["variant"] for m in db.list_masks_for_photo(1)}
+    assert remaining == {"sam2-large"}
+
+
+def test_find_stale_masks(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (1, 'megadetector-v6', 10, 20, 100, 200, 0.9, 'animal')"
+    )
+    # Mask was made from the same prompt → not stale
+    db.upsert_photo_mask(
+        1, "sam2-small", "/p",
+        detector_model="megadetector-v6",
+        prompt_x=10, prompt_y=20, prompt_w=100, prompt_h=200,
+    )
+    assert db.find_stale_masks() == []
+
+    # Insert a mask whose prompt no longer matches the current detection
+    db.upsert_photo_mask(
+        1, "sam2-large", "/q",
+        detector_model="megadetector-v6",
+        prompt_x=99, prompt_y=20, prompt_w=100, prompt_h=200,
+    )
+    stale = db.find_stale_masks()
+    assert {(s["photo_id"], s["variant"]) for s in stale} == {(1, "sam2-large")}
+
+
+def test_delete_stale_masks(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    db.conn.execute(
+        "INSERT INTO detections(photo_id, detector_model, box_x, box_y, "
+        "box_w, box_h, detector_confidence, category) "
+        "VALUES (1, 'megadetector-v6', 10, 20, 100, 200, 0.9, 'animal')"
+    )
+    masks_dir = tmp_path / "masks"
+    masks_dir.mkdir()
+    fresh = masks_dir / "1.sam2-small.png"
+    fresh.write_bytes(b"f")
+    stale_path = masks_dir / "1.sam2-large.png"
+    stale_path.write_bytes(b"s")
+    db.upsert_photo_mask(
+        1, "sam2-small", str(fresh),
+        detector_model="megadetector-v6",
+        prompt_x=10, prompt_y=20, prompt_w=100, prompt_h=200,
+    )
+    db.upsert_photo_mask(
+        1, "sam2-large", str(stale_path),
+        detector_model="megadetector-v6",
+        prompt_x=99, prompt_y=20, prompt_w=100, prompt_h=200,
+    )
+    deleted = db.delete_stale_masks()
+    assert deleted == 1
+    assert fresh.exists()
+    assert not stale_path.exists()
+    assert {m["variant"] for m in db.list_masks_for_photo(1)} == {"sam2-small"}

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -9945,6 +9945,33 @@ def test_delete_inactive_masks(tmp_path):
     assert remaining == {"sam2-large"}
 
 
+def test_delete_inactive_masks_skips_photos_with_no_active(tmp_path):
+    """Photos whose active_mask_variant IS NULL must not lose their
+    masks to delete-inactive: that's the partial-state case where a
+    prior pipeline crashed between upsert_photo_mask and
+    set_active_mask_variant. The user has to promote a variant to
+    active first before the cleanup will touch the photo."""
+    from db import Database
+    db = Database(str(tmp_path / "v.db"))
+    db.conn.execute("INSERT INTO folders(path) VALUES ('/tmp')")
+    db.conn.execute(
+        "INSERT INTO photos(id, folder_id, filename) VALUES (1, 1, 'a.jpg')"
+    )
+    masks_dir = tmp_path / "masks"
+    masks_dir.mkdir()
+    p = masks_dir / "1.sam2-small.png"
+    p.write_bytes(b"x")
+    db.upsert_photo_mask(
+        1, "sam2-small", str(p),
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+    )
+    # Note: NO set_active_mask_variant call — leaves active NULL.
+    n = db.delete_inactive_masks()
+    assert n == 0
+    assert p.exists()
+    assert {m["variant"] for m in db.list_masks_for_photo(1)} == {"sam2-small"}
+
+
 def test_find_stale_masks(tmp_path):
     from db import Database
     db = Database(str(tmp_path / "v.db"))

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -1371,12 +1371,12 @@ def _patch_extract_masks_deps(monkeypatch, generate_mask_calls):
         },
     )
     monkeypatch.setattr(
-        dino_embed, "embed_global",
+        dino_embed, "embed",
         lambda p, variant=None: np.zeros(384, dtype=np.float32),
     )
     monkeypatch.setattr(
-        dino_embed, "embed_subject",
-        lambda c, variant=None: np.zeros(384, dtype=np.float32),
+        dino_embed, "embed_batch",
+        lambda imgs, variant=None: np.zeros((len(imgs), 384), dtype=np.float32),
     )
     monkeypatch.setattr(dino_embed, "embedding_to_blob", lambda e: b"")
 

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -1542,3 +1542,71 @@ def test_extract_masks_route_skips_sam_when_cached(
         (pid,),
     ).fetchone()[0]
     assert n == 1
+
+
+def test_extract_masks_route_workspace_branch_respects_detector_confidence(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """Without a ``collection_id``, the workspace SQL branch must filter
+    detections by the workspace-effective ``detector_confidence`` floor —
+    matching the collection branch (which goes through
+    ``get_detections``) and the legacy ``get_photos_missing_masks``
+    path. Otherwise SAM/DINO runs on noisy below-threshold boxes and
+    activates masks the user shouldn't see."""
+    import config as cfg
+    cfg.save({
+        "pipeline": {
+            "sam2_variant": "sam2-small",
+            "dinov2_variant": "vit-b14",
+        },
+        "detector_confidence": 0.5,
+    })
+
+    app, db = app_and_db
+
+    # Two photos in the workspace, both with a non-full-image detection.
+    # Photo A's detection clears the 0.5 floor; Photo B's does not.
+    pid_high = _seed_photo_with_detection(
+        db, tmp_path, "above.jpg", (10, 20, 100, 200), "MegaDetector",
+    )
+    pid_low = _seed_photo_with_detection(
+        db, tmp_path, "below.jpg", (30, 40, 80, 90), "MegaDetector",
+    )
+    # _seed_photo_with_detection hardcodes confidence=0.9, so override
+    # the low-confidence row directly.
+    db.conn.execute(
+        "UPDATE detections SET detector_confidence=0.05 WHERE photo_id=?",
+        (pid_low,),
+    )
+    db.conn.commit()
+
+    calls = []
+    _patch_extract_masks_deps(monkeypatch, calls)
+
+    client = app.test_client()
+    resp = client.post("/api/jobs/extract-masks", json={})
+    assert resp.status_code == 200
+    data = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert data["status"] == "completed", data
+
+    # SAM was invoked exactly once — for the above-threshold photo only.
+    assert len(calls) == 1, calls
+
+    # photo_masks row exists for the above-threshold photo.
+    high_row = db.conn.execute(
+        "SELECT variant FROM photo_masks WHERE photo_id=?", (pid_high,),
+    ).fetchone()
+    assert high_row is not None, "above-threshold photo must be masked"
+
+    # Below-threshold photo is skipped: no photo_masks row, no
+    # active variant denormalized onto photos.
+    low_row = db.conn.execute(
+        "SELECT variant FROM photo_masks WHERE photo_id=?", (pid_low,),
+    ).fetchone()
+    assert low_row is None, (
+        "below-threshold photo must not get a mask"
+    )
+    low_active = db.conn.execute(
+        "SELECT active_mask_variant FROM photos WHERE id=?", (pid_low,),
+    ).fetchone()
+    assert low_active["active_mask_variant"] is None

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -1,3 +1,4 @@
+import json
 import os
 import time
 
@@ -1314,3 +1315,230 @@ def test_pipeline_repair_respects_excluded_photo_ids(
     ).fetchone()
     assert row["timestamp"] is None
     assert row["exif_data"] is None
+
+
+# ---------------------------------------------------------------------------
+# /api/jobs/extract-masks — standalone masking route writes photo_masks rows.
+#
+# Phase 2 of the SAM mask history plan migrated the unified pipeline's
+# masking stage to write photo_masks rows. The standalone route in
+# api_job_extract_masks is a separate code path and must follow the
+# same flow: write a per-variant photo_masks row, denormalize via
+# set_active_mask_variant, and skip SAM when the cached row's prompt
+# still matches the photo's primary detection.
+# ---------------------------------------------------------------------------
+
+
+def _patch_extract_masks_deps(monkeypatch, generate_mask_calls):
+    """Stub out the heavy SAM2 / DINOv2 / proxy / quality modules so the
+    extract-masks route runs deterministically without ONNX weights.
+
+    `generate_mask_calls` is a list mutated in place — every fake
+    generate_mask call appends a (variant, det_box_tuple) tuple. Tests
+    assert against this list to check whether SAM was invoked.
+    """
+    import dino_embed
+    import masking
+    import numpy as np
+    import quality
+
+    def fake_render_proxy(image_path, longest_edge=None):
+        return np.zeros((4, 4, 3), dtype=np.uint8)
+
+    def fake_generate_mask(proxy, det_box, variant=None):
+        generate_mask_calls.append(
+            (variant, tuple(sorted(det_box.items())))
+        )
+        return np.ones((4, 4), dtype=bool)
+
+    monkeypatch.setattr(masking, "render_proxy", fake_render_proxy)
+    monkeypatch.setattr(masking, "generate_mask", fake_generate_mask)
+    monkeypatch.setattr(masking, "crop_completeness", lambda m: 0.9)
+    monkeypatch.setattr(
+        masking, "crop_subject", lambda p, m, margin=0.15: None,
+    )
+    monkeypatch.setattr(
+        quality, "compute_all_quality_features",
+        lambda p, m: {
+            "subject_tenengrad": 1.5,
+            "bg_tenengrad": 0.3,
+            "subject_clip_high": 0.01,
+            "subject_clip_low": 0.01,
+            "subject_y_median": 100.0,
+            "bg_separation": 50.0,
+            "phash_crop": "deadbeef",
+            "noise_estimate": 5.0,
+        },
+    )
+    monkeypatch.setattr(
+        dino_embed, "embed_global",
+        lambda p, variant=None: np.zeros(384, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        dino_embed, "embed_subject",
+        lambda c, variant=None: np.zeros(384, dtype=np.float32),
+    )
+    monkeypatch.setattr(dino_embed, "embedding_to_blob", lambda e: b"")
+
+
+def _seed_photo_with_detection(db, tmp_path, filename, box, model):
+    """Create a folder + photo + JPEG on disk + a single detection row.
+    Returns the photo_id."""
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = None
+    existing = db.conn.execute(
+        "SELECT id FROM folders WHERE path=?", (folder_path,)
+    ).fetchone()
+    if existing:
+        folder_id = existing["id"]
+    else:
+        folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, filename, ".jpg", 1000, 1.0)
+    Image.new("RGB", (16, 16), "black").save(
+        os.path.join(folder_path, filename)
+    )
+    x, y, w, h = box
+    db.save_detections(
+        pid,
+        [{"box": {"x": x, "y": y, "w": w, "h": h},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model=model,
+    )
+    return pid
+
+
+def test_extract_masks_route_writes_photo_masks_row(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """POSTing /api/jobs/extract-masks must write a photo_masks row for
+    the configured variant with the right prompt, AND set
+    photos.active_mask_variant. Before the Phase 2 fix-up the route
+    only updated photos.mask_path and left photo_masks empty."""
+    import config as cfg
+    cfg.save({
+        "pipeline": {
+            "sam2_variant": "sam2-small",
+            "dinov2_variant": "vit-b14",
+        },
+    })
+
+    app, db = app_and_db
+    pid = _seed_photo_with_detection(
+        db, tmp_path, "bird.jpg", (10, 20, 100, 200), "MegaDetector",
+    )
+
+    calls = []
+    _patch_extract_masks_deps(monkeypatch, calls)
+
+    col_id = db.add_collection(
+        "extract-masks-test",
+        json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/jobs/extract-masks", json={"collection_id": col_id},
+    )
+    assert resp.status_code == 200
+    job_id = resp.get_json()["job_id"]
+    data = wait_for_job_via_client(client, job_id)
+    assert data["status"] == "completed", data
+
+    # SAM was invoked exactly once.
+    assert len(calls) == 1, calls
+
+    # photo_masks row exists with the right variant + prompt.
+    row = db.conn.execute(
+        "SELECT variant, detector_model, prompt_x, prompt_y, "
+        "prompt_w, prompt_h, path FROM photo_masks WHERE photo_id=?",
+        (pid,),
+    ).fetchone()
+    assert row is not None, "photo_masks row must be written"
+    assert row["variant"] == "sam2-small"
+    assert row["detector_model"] == "MegaDetector"
+    assert row["prompt_x"] == 10
+    assert row["prompt_y"] == 20
+    assert row["prompt_w"] == 100
+    assert row["prompt_h"] == 200
+    assert row["path"] and os.path.isfile(row["path"]), (
+        "mask PNG must be on disk"
+    )
+
+    # photos.active_mask_variant was denormalized.
+    pr = db.conn.execute(
+        "SELECT active_mask_variant, mask_path FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert pr["active_mask_variant"] == "sam2-small"
+    assert pr["mask_path"] == row["path"]
+
+
+def test_extract_masks_route_skips_sam_when_cached(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """Re-hitting /api/jobs/extract-masks with the same configured
+    variant + unchanged detection prompt must skip generate_mask: the
+    cached photo_masks row is reused and active_mask_variant is
+    re-applied. Before the Phase 2 fix-up the route's `mask_path
+    IS NULL` gate skipped these photos entirely instead, so the cache
+    short-circuit was never tested for this route."""
+    import config as cfg
+    cfg.save({
+        "pipeline": {
+            "sam2_variant": "sam2-small",
+            "dinov2_variant": "vit-b14",
+        },
+    })
+
+    app, db = app_and_db
+    pid = _seed_photo_with_detection(
+        db, tmp_path, "bird.jpg", (10, 20, 100, 200), "MegaDetector",
+    )
+
+    calls = []
+    _patch_extract_masks_deps(monkeypatch, calls)
+
+    col_id = db.add_collection(
+        "extract-masks-cache-test",
+        json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    client = app.test_client()
+
+    # First run: SAM is called once.
+    resp = client.post(
+        "/api/jobs/extract-masks", json={"collection_id": col_id},
+    )
+    assert resp.status_code == 200
+    data = wait_for_job_via_client(
+        client, resp.get_json()["job_id"],
+    )
+    assert data["status"] == "completed"
+    assert len(calls) == 1, (
+        f"first run should call generate_mask once; got {calls}"
+    )
+
+    # Second run with the same config + same detection: SAM must NOT
+    # be called again. The cache hit re-applies active_mask_variant
+    # and counts the photo as masked without re-running SAM.
+    calls.clear()
+    resp2 = client.post(
+        "/api/jobs/extract-masks", json={"collection_id": col_id},
+    )
+    assert resp2.status_code == 200
+    data2 = wait_for_job_via_client(
+        client, resp2.get_json()["job_id"],
+    )
+    assert data2["status"] == "completed"
+    assert calls == [], (
+        f"second run with cached prompt must skip generate_mask; got {calls}"
+    )
+
+    # Still exactly one row for this (photo, variant).
+    n = db.conn.execute(
+        "SELECT COUNT(*) FROM photo_masks "
+        "WHERE photo_id=? AND variant='sam2-small'",
+        (pid,),
+    ).fetchone()[0]
+    assert n == 1

--- a/vireo/tests/test_masking.py
+++ b/vireo/tests/test_masking.py
@@ -33,22 +33,6 @@ def test_pipeline_columns_exist(tmp_path):
     assert row is None  # empty table
 
 
-def test_update_photo_mask(tmp_path):
-    """update_photo_mask stores the mask path for a photo."""
-    from db import Database
-
-    db = Database(str(tmp_path / "test.db"))
-    fid = db.add_folder(str(tmp_path), name="root")
-    pid = db.add_photo(fid, "bird.jpg", ".jpg", 100, 1.0)
-
-    db.update_photo_mask(pid, "/masks/1.png")
-
-    row = db.conn.execute(
-        "SELECT mask_path FROM photos WHERE id=?", (pid,)
-    ).fetchone()
-    assert row[0] == "/masks/1.png"
-
-
 # -- update_photo_pipeline_features --
 
 
@@ -102,7 +86,7 @@ def test_get_photos_missing_masks(tmp_path):
     db.save_detections(pid3, [
         {"box": {"x": 0.2, "y": 0.2, "w": 0.3, "h": 0.3}, "confidence": 0.8},
     ], detector_model="megadetector")
-    db.update_photo_mask(pid3, "/masks/3.png")
+    db.update_photo_pipeline_features(pid3, mask_path="/masks/3.png")
 
     photos = db.get_photos_missing_masks()
     assert len(photos) == 1

--- a/vireo/tests/test_masking.py
+++ b/vireo/tests/test_masking.py
@@ -120,11 +120,11 @@ def test_mask_save_load_roundtrip(tmp_path):
     mask = np.zeros((100, 150), dtype=bool)
     mask[20:60, 30:90] = True  # rectangular subject
 
-    path = save_mask(mask, masks_dir, photo_id=42)
+    path = save_mask(mask, masks_dir, photo_id=42, variant="sam2-small")
     assert os.path.exists(path)
-    assert path.endswith("42.png")
+    assert path.endswith("42.sam2-small.png")
 
-    loaded = load_mask(masks_dir, photo_id=42)
+    loaded = load_mask(masks_dir, photo_id=42, variant="sam2-small")
     assert loaded is not None
     assert loaded.shape == (100, 150)
     assert loaded.dtype == bool
@@ -135,8 +135,35 @@ def test_load_mask_missing(tmp_path):
     """load_mask returns None when mask file doesn't exist."""
     from masking import load_mask
 
-    result = load_mask(str(tmp_path), photo_id=999)
+    result = load_mask(str(tmp_path), photo_id=999, variant="sam2-small")
     assert result is None
+
+
+def test_save_mask_uses_variant_in_filename(tmp_path):
+    """save_mask writes ``{photo_id}.{variant}.png`` so multiple SAM
+    variants for the same photo coexist on disk."""
+    from masking import save_mask
+
+    mask = np.array([[True, False], [False, True]], dtype=bool)
+    out = save_mask(
+        mask, str(tmp_path), photo_id=42, variant="sam2-large",
+    )
+    assert out == str(tmp_path / "42.sam2-large.png")
+    assert (tmp_path / "42.sam2-large.png").exists()
+
+
+def test_save_mask_per_variant_files_coexist(tmp_path):
+    """Saving the same photo under two different variants leaves both
+    files on disk side-by-side."""
+    from masking import save_mask
+
+    mask = np.zeros((4, 4), dtype=bool)
+    mask[1:3, 1:3] = True
+
+    p_small = save_mask(mask, str(tmp_path), photo_id=7, variant="sam2-small")
+    p_large = save_mask(mask, str(tmp_path), photo_id=7, variant="sam2-large")
+    assert p_small != p_large
+    assert os.path.isfile(p_small) and os.path.isfile(p_large)
 
 
 # -- crop_subject --

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2985,3 +2985,52 @@ def test_api_serve_mask_rejects_path_traversal(app_and_db):
     # Backslash variants should also fail validation.
     resp = client.get(f"/api/masks/{pid}/sam2..small.png")
     assert resp.status_code == 404
+
+
+def test_api_serve_mask_uses_stored_db_path_for_legacy_filename(app_and_db):
+    """Migrated legacy masks (filename ``{pid}.png``, no variant suffix)
+    must still serve under their backfilled ``variant='unknown'`` row.
+
+    The DB-init backfill inserts a ``photo_masks`` row pointing at the
+    pre-existing ``{pid}.png`` file; reconstructing ``{pid}.unknown.png``
+    would 404 even though the row and file are both present.
+    """
+    import os as _os
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    masks_dir = _os.path.join(_os.path.dirname(db._db_path), "masks")
+    _os.makedirs(masks_dir, exist_ok=True)
+    legacy_path = _os.path.join(masks_dir, f"{pid}.png")
+    with open(legacy_path, "wb") as fh:
+        fh.write(b"LEGACYPNG")
+    db.upsert_photo_mask(
+        photo_id=pid, variant="unknown", path=legacy_path,
+        detector_model="unknown",
+        prompt_x=-1, prompt_y=-1, prompt_w=-1, prompt_h=-1,
+    )
+
+    client = app.test_client()
+    resp = client.get(f"/api/masks/{pid}/unknown.png")
+    assert resp.status_code == 200
+    assert resp.data == b"LEGACYPNG"
+
+
+def test_api_serve_mask_rejects_path_outside_masks_dir(app_and_db, tmp_path):
+    """A DB row whose ``path`` resolves outside the masks dir must 404.
+
+    Defense in depth: even if the file exists and the ``photo_masks`` row
+    looks valid, serving an arbitrary on-disk file from a corrupted /
+    attacker-controlled DB row would be a directory-escape primitive.
+    """
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    outside = tmp_path / "outside.png"
+    outside.write_bytes(b"SECRET")
+    db.upsert_photo_mask(
+        photo_id=pid, variant="sam2-small", path=str(outside),
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+    )
+
+    client = app.test_client()
+    resp = client.get(f"/api/masks/{pid}/sam2-small.png")
+    assert resp.status_code == 404

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3015,6 +3015,55 @@ def test_api_serve_mask_uses_stored_db_path_for_legacy_filename(app_and_db):
     assert resp.data == b"LEGACYPNG"
 
 
+def test_legacy_serve_mask_falls_back_to_active_variant(app_and_db):
+    """``/masks/{pid}.png`` must keep working after variant-aware extraction.
+
+    Callers like ``openInspect`` in pipeline_review.html still request
+    the legacy URL. New masks are written as ``{pid}.{variant}.png`` and
+    the DB ``active_mask_variant`` points at one of them, so the route
+    must look up the active variant and serve from the stored path
+    when the literal ``{pid}.png`` file no longer exists.
+    """
+    import os as _os
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    masks_dir = _os.path.join(_os.path.dirname(db._db_path), "masks")
+    _seed_mask(db, masks_dir, pid, "sam2-small", body=b"ACTIVEPNG")
+    db.set_active_mask_variant(pid, "sam2-small")
+    # No literal `{pid}.png` on disk.
+    assert not _os.path.exists(_os.path.join(masks_dir, f"{pid}.png"))
+
+    client = app.test_client()
+    resp = client.get(f"/masks/{pid}.png")
+    assert resp.status_code == 200
+    assert resp.data == b"ACTIVEPNG"
+
+
+def test_legacy_serve_mask_404_when_no_active_variant(app_and_db):
+    """No file, no active variant → 404 (don't leak by serving any mask)."""
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    client = app.test_client()
+    resp = client.get(f"/masks/{pid}.png")
+    assert resp.status_code == 404
+
+
+def test_legacy_serve_mask_direct_file_still_served(app_and_db):
+    """A literal ``{pid}.png`` on disk (legacy backfill) is served as-is."""
+    import os as _os
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    masks_dir = _os.path.join(_os.path.dirname(db._db_path), "masks")
+    _os.makedirs(masks_dir, exist_ok=True)
+    with open(_os.path.join(masks_dir, f"{pid}.png"), "wb") as fh:
+        fh.write(b"LEGACYDIRECT")
+
+    client = app.test_client()
+    resp = client.get(f"/masks/{pid}.png")
+    assert resp.status_code == 200
+    assert resp.data == b"LEGACYDIRECT"
+
+
 def test_api_serve_mask_rejects_path_outside_masks_dir(app_and_db, tmp_path):
     """A DB row whose ``path`` resolves outside the masks dir must 404.
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2863,3 +2863,125 @@ def test_post_keyword_link_place_records_edit(app_and_db, monkeypatch):
     entry = post_history[0]
     assert entry["action_type"] == "location_link"
     assert "Central Park" in entry["description"]
+
+
+# --- /api/photos/<id>/masks and /api/masks/<pid>/<variant>.png --------------
+
+def _seed_mask(db, masks_dir, pid, variant, body=b"PNGBYTES"):
+    """Helper: write a mask file on disk and insert a photo_masks row.
+
+    Centralizes the bookkeeping the lightbox-variant tests need so each
+    test only declares what's interesting (which variants exist for which
+    photo, and which one is active).
+    """
+    import os as _os
+    _os.makedirs(masks_dir, exist_ok=True)
+    path = _os.path.join(masks_dir, f"{pid}.{variant}.png")
+    with open(path, "wb") as fh:
+        fh.write(body)
+    db.upsert_photo_mask(
+        photo_id=pid, variant=variant, path=path,
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+    )
+    return path
+
+
+def test_api_photo_masks_lists_variants_and_active(app_and_db):
+    """GET /api/photos/<id>/masks returns the photo's variants and the active one."""
+    import os as _os
+    app, db = app_and_db
+    photos = db.get_photos()
+    pid = photos[0]["id"]
+    masks_dir = _os.path.join(_os.path.dirname(db._db_path), "masks")
+
+    _seed_mask(db, masks_dir, pid, "sam2-small")
+    _seed_mask(db, masks_dir, pid, "sam2-large")
+    db.set_active_mask_variant(pid, "sam2-large")
+
+    client = app.test_client()
+    resp = client.get(f"/api/photos/{pid}/masks")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["photo_id"] == pid
+    assert data["active"] == "sam2-large"
+    variants = {v["variant"]: v for v in data["variants"]}
+    assert set(variants) == {"sam2-small", "sam2-large"}
+    assert variants["sam2-small"]["url"] == f"/api/masks/{pid}/sam2-small.png"
+    assert "created_at" in variants["sam2-small"]
+
+
+def test_api_photo_masks_empty_when_no_masks(app_and_db):
+    """GET /api/photos/<id>/masks returns an empty list and null active."""
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    client = app.test_client()
+    resp = client.get(f"/api/photos/{pid}/masks")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["variants"] == []
+    assert data["active"] is None
+
+
+def test_api_serve_mask_png(app_and_db):
+    """GET /api/masks/<pid>/<variant>.png serves the on-disk mask."""
+    import os as _os
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    masks_dir = _os.path.join(_os.path.dirname(db._db_path), "masks")
+    _seed_mask(db, masks_dir, pid, "sam2-small", body=b"\x89PNGFAKE")
+
+    client = app.test_client()
+    resp = client.get(f"/api/masks/{pid}/sam2-small.png")
+    assert resp.status_code == 200
+    assert resp.data == b"\x89PNGFAKE"
+
+
+def test_api_serve_mask_404_when_no_db_row(app_and_db):
+    """Even if a file matching the pattern is on disk, no row → 404.
+
+    Defense in depth: mask file existence alone must not be enough to
+    serve an arbitrary file matching the URL pattern.
+    """
+    import os as _os
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    masks_dir = _os.path.join(_os.path.dirname(db._db_path), "masks")
+    _os.makedirs(masks_dir, exist_ok=True)
+    # File on disk, but no photo_masks row.
+    with open(_os.path.join(masks_dir, f"{pid}.sam2-small.png"), "wb") as fh:
+        fh.write(b"x")
+
+    client = app.test_client()
+    resp = client.get(f"/api/masks/{pid}/sam2-small.png")
+    assert resp.status_code == 404
+
+
+def test_api_serve_mask_404_when_file_missing(app_and_db):
+    """DB row exists but file missing → 404."""
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    db.upsert_photo_mask(
+        photo_id=pid, variant="sam2-small", path="/nope/missing.png",
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+    )
+    client = app.test_client()
+    resp = client.get(f"/api/masks/{pid}/sam2-small.png")
+    assert resp.status_code == 404
+
+
+def test_api_serve_mask_rejects_path_traversal(app_and_db):
+    """`..` segments and slashes must not allow escaping the masks dir.
+
+    Flask's int converter on <pid> already blocks tricks at that segment,
+    but the variant segment is a string. Any URL whose variant contains
+    ``..`` or path separators must 404 — never reach the file system.
+    """
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    client = app.test_client()
+    # `..%2F` would decode to `../` — must not let us climb out.
+    resp = client.get(f"/api/masks/{pid}/..%2Fevil.png")
+    assert resp.status_code == 404
+    # Backslash variants should also fail validation.
+    resp = client.get(f"/api/masks/{pid}/sam2..small.png")
+    assert resp.status_code == 404

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -54,7 +54,6 @@ def _setup_db_with_photos(tmp_path, n_encounters=2, photos_per_encounter=3):
             emb = emb_base + np.random.RandomState(pid).randn(768).astype(np.float32) * 0.01
             emb = emb / np.linalg.norm(emb)
 
-            db.update_photo_mask(pid, f"/masks/{pid}.png")
             db.update_photo_pipeline_features(
                 pid,
                 mask_path=f"/masks/{pid}.png",

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -679,3 +679,85 @@ def test_pipeline_rejects_non_integer_snapshot_id(setup, bad_id):
             f"bad snapshot id {bad_id!r} must be rejected with 4xx, "
             f"got {resp.status_code}: {resp.get_json()}"
         )
+
+
+def _seed_workspace_with_masks(db_path):
+    """Build a workspace with two photos and a few mask variants so the
+    pipeline coverage endpoint has something to report."""
+    from db import Database
+    db = Database(db_path)
+    ws_id = db._active_workspace_id  # Default workspace, auto-created
+    fid = db.add_folder("/photos/seed", name="seed")
+    db.add_workspace_folder(ws_id, fid)
+    p1 = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                      file_size=1, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename="b.jpg", extension=".jpg",
+                      file_size=1, file_mtime=1.0)
+    db.upsert_photo_mask(p1, "sam2-small", "/m/a.small.png",
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0)
+    db.upsert_photo_mask(p2, "sam2-small", "/m/b.small.png",
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0)
+    db.upsert_photo_mask(p1, "sam2-large", "/m/a.large.png",
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0)
+    db.set_active_mask_variant(p1, "sam2-small")
+    db.set_active_mask_variant(p2, "sam2-small")
+    db.close()
+    return p1, p2
+
+
+def test_pipeline_page_init_includes_mask_variant_coverage(setup):
+    """page-init exposes mask_variant_coverage so the SAM2 dropdown card
+    can render per-variant counts and an active-variant selector."""
+    app, db_path = setup
+    _seed_workspace_with_masks(db_path)
+
+    with app.test_client() as c:
+        resp = c.get("/api/pipeline/page-init")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "mask_variant_coverage" in data
+        cov = {row["variant"]: row for row in data["mask_variant_coverage"]}
+        assert cov["sam2-small"]["count"] == 2
+        assert cov["sam2-small"]["active_count"] == 2
+        assert cov["sam2-large"]["count"] == 1
+        assert cov["sam2-large"]["active_count"] == 0
+
+
+def test_active_mask_variant_endpoint_switches_workspace_photos(setup):
+    """POST /api/pipeline/active-mask-variant flips active_mask_variant on
+    every workspace photo that has a row for the requested variant."""
+    app, db_path = setup
+    p1, p2 = _seed_workspace_with_masks(db_path)
+
+    with app.test_client() as c:
+        resp = c.post(
+            "/api/pipeline/active-mask-variant",
+            json={"variant": "sam2-large"},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        # Only p1 has a sam2-large row, so only p1 is updated.
+        assert body["updated"] == 1
+
+        # p2 stays on sam2-small (no sam2-large row to switch to).
+        from db import Database
+        db = Database(db_path)
+        try:
+            row = db.conn.execute(
+                "SELECT id, active_mask_variant FROM photos WHERE id IN (?, ?) "
+                "ORDER BY id",
+                (p1, p2),
+            ).fetchall()
+            by_id = {r["id"]: r["active_mask_variant"] for r in row}
+            assert by_id[p1] == "sam2-large"
+            assert by_id[p2] == "sam2-small"
+        finally:
+            db.close()
+
+
+def test_active_mask_variant_endpoint_requires_variant(setup):
+    app, _ = setup
+    with app.test_client() as c:
+        resp = c.post("/api/pipeline/active-mask-variant", json={})
+        assert resp.status_code == 400

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -756,6 +756,73 @@ def test_active_mask_variant_endpoint_switches_workspace_photos(setup):
             db.close()
 
 
+def test_active_mask_variant_endpoint_is_workspace_scoped(setup):
+    """Switching the active mask variant in workspace A must not affect
+    photos that live in workspace B. ``photo_masks`` and ``photos`` are
+    global tables — the endpoint relies on a workspace_folders join to
+    scope the UPDATE. Regression guard: a buggy version that drops the
+    join would silently flip every photo in the DB.
+    """
+    app, db_path = setup
+
+    from db import Database
+    db = Database(db_path)
+    try:
+        ws_a = db.create_workspace("A")
+        ws_b = db.create_workspace("B")
+
+        f_a = db.add_folder("/a", name="a")
+        f_b = db.add_folder("/b", name="b")
+        db.add_workspace_folder(ws_a, f_a)
+        db.add_workspace_folder(ws_b, f_b)
+
+        p_a = db.add_photo(folder_id=f_a, filename="a.jpg",
+                           extension=".jpg", file_size=1, file_mtime=1.0)
+        p_b = db.add_photo(folder_id=f_b, filename="b.jpg",
+                           extension=".jpg", file_size=1, file_mtime=1.0)
+
+        # Seed the same variant in both workspaces so the only thing
+        # keeping ws_b out of the update is the workspace join.
+        db.upsert_photo_mask(p_a, "sam2-small", "/m/a.small.png",
+            detector_model="md", prompt_x=0, prompt_y=0,
+            prompt_w=0, prompt_h=0)
+        db.upsert_photo_mask(p_b, "sam2-small", "/m/b.small.png",
+            detector_model="md", prompt_x=0, prompt_y=0,
+            prompt_w=0, prompt_h=0)
+
+        # Mark ws_a as the most-recently-opened so a fresh Database()
+        # inside _get_db() picks it as the active workspace.
+        db.update_workspace(ws_b, last_opened_at="2026-01-01T00:00:00")
+        db.update_workspace(ws_a, last_opened_at="2026-05-01T00:00:00")
+    finally:
+        db.close()
+
+    with app.test_client() as c:
+        resp = c.post(
+            "/api/pipeline/active-mask-variant",
+            json={"variant": "sam2-small"},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        # Only the workspace-A photo should have been updated.
+        assert body["updated"] == 1
+
+    db = Database(db_path)
+    try:
+        rows = db.conn.execute(
+            "SELECT id, active_mask_variant FROM photos WHERE id IN (?, ?)",
+            (p_a, p_b),
+        ).fetchall()
+        by_id = {r["id"]: r["active_mask_variant"] for r in rows}
+        assert by_id[p_a] == "sam2-small"
+        # ws_b's photo MUST be untouched — it lives in a different
+        # workspace, even though it has the same variant in photo_masks.
+        assert by_id[p_b] is None
+    finally:
+        db.close()
+
+
 def test_active_mask_variant_endpoint_requires_variant(setup):
     app, _ = setup
     with app.test_client() as c:

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6255,6 +6255,406 @@ def test_pipeline_extract_masks_cancel_marks_stage_cancelled(
     )
 
 
+# ---------------------------------------------------------------------------
+# extract_masks per-variant cache (photo_masks)
+#
+# Phase 2 of the SAM mask history plan stops the masking stage from re-running
+# SAM when a row already exists in `photo_masks` for (photo, configured
+# variant) AND its stored prompt + detector still matches the photo's current
+# primary detection.  Three regression tests pin the contract:
+#
+#   - cached_with_same_prompt → generate_mask NOT called, photo_masks
+#     unchanged, masked counter still increments (cache hit is a successful
+#     outcome, not a "skipped" SAM failure).
+#   - variant_differs → switching `pipeline.sam2_variant` re-runs SAM, leaves
+#     the previous variant's row in place, adds a new row.
+#   - prompt_changed → if the detection bbox shifts (e.g. YOLO re-run with a
+#     different threshold), the cached row is replaced with the new prompt.
+# ---------------------------------------------------------------------------
+
+
+def _run_extract_masks_for_test(
+    tmp_path, monkeypatch, sam2_variant, photo_specs,
+):
+    """Drive a single pipeline run with extract_masks enabled and the heavy
+    SAM2/DINOv2 calls stubbed.  Returns (db, runner, generate_mask_calls)
+    where generate_mask_calls is a list of (photo_id, variant) tuples
+    capturing every call the patched generate_mask saw.
+
+    `photo_specs` is a list of dicts:
+        [{"filename": "a.jpg", "box": (x, y, w, h), "model": "MegaDetector"}]
+
+    Each photo gets a unique 1x1 mask whose pixel pattern depends on
+    photo_id, so different photos cannot accidentally collide.
+    """
+    import config as cfg
+    import dino_embed
+    import masking
+    import numpy as np
+    import quality
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    cfg.save({
+        "pipeline": {"sam2_variant": sam2_variant, "dinov2_variant": "vit-b14"},
+    })
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+
+    photo_ids = []
+    for spec in photo_specs:
+        pid = db.add_photo(folder_id, spec["filename"], ".jpg", 1000, 1.0)
+        _drop_jpeg(folder_path, spec["filename"])
+        x, y, w, h = spec["box"]
+        db.save_detections(
+            pid,
+            [{"box": {"x": x, "y": y, "w": w, "h": h},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model=spec["model"],
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    generate_mask_calls = []
+
+    def fake_render_proxy(image_path, longest_edge=None):
+        return np.zeros((4, 4, 3), dtype=np.uint8)
+
+    def fake_generate_mask(proxy, det_box, variant=None):
+        # Track every (variant, det_box) we get asked about — the cache
+        # short-circuit must skip past this entirely on a hit.
+        generate_mask_calls.append((variant, tuple(sorted(det_box.items()))))
+        return np.ones((4, 4), dtype=bool)
+
+    monkeypatch.setattr(masking, "render_proxy", fake_render_proxy)
+    monkeypatch.setattr(masking, "generate_mask", fake_generate_mask)
+    monkeypatch.setattr(masking, "crop_completeness", lambda m: 0.9)
+    monkeypatch.setattr(masking, "crop_subject", lambda p, m, margin=0.15: None)
+    monkeypatch.setattr(masking, "ensure_sam2_weights", lambda **k: None)
+    monkeypatch.setattr(
+        quality, "compute_all_quality_features",
+        lambda p, m: {
+            "subject_tenengrad": 1.5,
+            "bg_tenengrad": 0.3,
+            "subject_clip_high": 0.01,
+            "subject_clip_low": 0.01,
+            "subject_y_median": 100.0,
+            "bg_separation": 50.0,
+            "phash_crop": "deadbeef",
+            "noise_estimate": 5.0,
+        },
+    )
+    monkeypatch.setattr(
+        dino_embed, "embed_global",
+        lambda p, variant=None: np.zeros(384, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        dino_embed, "embed_subject",
+        lambda c, variant=None: np.zeros(384, dtype=np.float32),
+    )
+    monkeypatch.setattr(dino_embed, "embedding_to_blob", lambda e: b"")
+    monkeypatch.setattr(dino_embed, "ensure_dinov2_weights", lambda **k: None)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    return db, runner, generate_mask_calls, photo_ids
+
+
+def test_extract_masks_skips_sam_when_cached_with_same_prompt(
+    tmp_path, monkeypatch,
+):
+    """Second pipeline pass over the same photo + same detection must NOT
+    call generate_mask: the photo_masks row is already there for the
+    configured variant and the cached prompt still matches.  The
+    photo_masks row remains intact (one row, same path)."""
+    spec = {"filename": "a.jpg", "box": (10, 20, 100, 200),
+            "model": "MegaDetector"}
+
+    db, _, calls_first, photo_ids = _run_extract_masks_for_test(
+        tmp_path, monkeypatch, "sam2-small", [spec],
+    )
+    pid = photo_ids[0]
+    assert len(calls_first) == 1, (
+        f"first run should call generate_mask once; got {calls_first}"
+    )
+    rows_first = db.list_masks_for_photo(pid)
+    assert len(rows_first) == 1
+    assert rows_first[0]["variant"] == "sam2-small"
+    first_path = rows_first[0]["path"]
+
+    # Re-run the stage in the same workspace with the same DB.  Reuse the
+    # helper to drive a *second* pass — but we want the same DB, so call
+    # run_pipeline_job again directly.
+    import config as cfg
+    import dino_embed
+    import masking
+    import numpy as np
+    import quality
+
+    calls_second = []
+
+    def fake_generate_mask_2(proxy, det_box, variant=None):
+        calls_second.append((variant, tuple(sorted(det_box.items()))))
+        return np.ones((4, 4), dtype=bool)
+
+    monkeypatch.setattr(
+        masking, "render_proxy",
+        lambda *a, **k: np.zeros((4, 4, 3), dtype=np.uint8),
+    )
+    monkeypatch.setattr(masking, "generate_mask", fake_generate_mask_2)
+    monkeypatch.setattr(masking, "crop_completeness", lambda m: 0.9)
+    monkeypatch.setattr(masking, "crop_subject", lambda p, m, margin=0.15: None)
+    monkeypatch.setattr(masking, "ensure_sam2_weights", lambda **k: None)
+    monkeypatch.setattr(
+        quality, "compute_all_quality_features",
+        lambda p, m: {
+            "subject_tenengrad": 1.5, "bg_tenengrad": 0.3,
+            "subject_clip_high": 0.01, "subject_clip_low": 0.01,
+            "subject_y_median": 100.0, "bg_separation": 50.0,
+            "phash_crop": "deadbeef", "noise_estimate": 5.0,
+        },
+    )
+    monkeypatch.setattr(
+        dino_embed, "embed_global",
+        lambda p, variant=None: np.zeros(384, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        dino_embed, "embed_subject",
+        lambda c, variant=None: np.zeros(384, dtype=np.float32),
+    )
+    monkeypatch.setattr(dino_embed, "embedding_to_blob", lambda e: b"")
+    monkeypatch.setattr(dino_embed, "ensure_dinov2_weights", lambda **k: None)
+
+    cfg.save({
+        "pipeline": {"sam2_variant": "sam2-small", "dinov2_variant": "vit-b14"},
+    })
+    # The mask file must exist on disk for the cache check to fire — the
+    # first run wrote it, but ensure it's still there.
+    assert os.path.isfile(first_path)
+
+    col_id = db.conn.execute(
+        "SELECT id FROM collections ORDER BY id LIMIT 1"
+    ).fetchone()[0]
+    params = PipelineParams(
+        collection_id=col_id, skip_classify=True,
+        skip_extract_masks=False, skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(
+        job, runner, str(tmp_path / "test.db"), db._active_workspace_id, params,
+    )
+
+    assert calls_second == [], (
+        f"cache hit must skip generate_mask entirely; got {calls_second}"
+    )
+    rows_after = db.list_masks_for_photo(pid)
+    assert len(rows_after) == 1
+    assert rows_after[0]["path"] == first_path
+
+
+def test_extract_masks_runs_for_new_variant_keeps_old(tmp_path, monkeypatch):
+    """A first pass with sam2-small writes one row; switching the
+    configured variant to sam2-large adds a second row — both
+    variants for the photo are listed in photo_masks.  Active variant
+    on the photos row tracks the most recent run."""
+    spec = {"filename": "a.jpg", "box": (10, 20, 100, 200),
+            "model": "MegaDetector"}
+
+    db, _, calls_first, photo_ids = _run_extract_masks_for_test(
+        tmp_path, monkeypatch, "sam2-small", [spec],
+    )
+    pid = photo_ids[0]
+    assert len(calls_first) == 1
+    assert calls_first[0][0] == "sam2-small"
+
+    rows = db.list_masks_for_photo(pid)
+    assert {r["variant"] for r in rows} == {"sam2-small"}
+
+    # Switch the configured variant.  Re-run.
+    import config as cfg
+    import dino_embed
+    import masking
+    import numpy as np
+    import quality
+
+    cfg.save({
+        "pipeline": {"sam2_variant": "sam2-large", "dinov2_variant": "vit-b14"},
+    })
+
+    calls_second = []
+
+    def fake_generate_mask_2(proxy, det_box, variant=None):
+        calls_second.append((variant, tuple(sorted(det_box.items()))))
+        return np.ones((4, 4), dtype=bool)
+
+    monkeypatch.setattr(
+        masking, "render_proxy",
+        lambda *a, **k: np.zeros((4, 4, 3), dtype=np.uint8),
+    )
+    monkeypatch.setattr(masking, "generate_mask", fake_generate_mask_2)
+    monkeypatch.setattr(masking, "crop_completeness", lambda m: 0.9)
+    monkeypatch.setattr(masking, "crop_subject", lambda p, m, margin=0.15: None)
+    monkeypatch.setattr(masking, "ensure_sam2_weights", lambda **k: None)
+    monkeypatch.setattr(
+        quality, "compute_all_quality_features",
+        lambda p, m: {
+            "subject_tenengrad": 2.0, "bg_tenengrad": 0.4,
+            "subject_clip_high": 0.0, "subject_clip_low": 0.0,
+            "subject_y_median": 110.0, "bg_separation": 60.0,
+            "phash_crop": "cafef00d", "noise_estimate": 5.0,
+        },
+    )
+    monkeypatch.setattr(
+        dino_embed, "embed_global",
+        lambda p, variant=None: np.zeros(384, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        dino_embed, "embed_subject",
+        lambda c, variant=None: np.zeros(384, dtype=np.float32),
+    )
+    monkeypatch.setattr(dino_embed, "embedding_to_blob", lambda e: b"")
+    monkeypatch.setattr(dino_embed, "ensure_dinov2_weights", lambda **k: None)
+
+    col_id = db.conn.execute(
+        "SELECT id FROM collections ORDER BY id LIMIT 1"
+    ).fetchone()[0]
+    params = PipelineParams(
+        collection_id=col_id, skip_classify=True,
+        skip_extract_masks=False, skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(
+        job, runner, str(tmp_path / "test.db"), db._active_workspace_id, params,
+    )
+
+    assert len(calls_second) == 1 and calls_second[0][0] == "sam2-large", (
+        f"new variant must trigger generate_mask once for sam2-large; "
+        f"got {calls_second}"
+    )
+    rows = db.list_masks_for_photo(pid)
+    assert {r["variant"] for r in rows} == {"sam2-small", "sam2-large"}, (
+        f"expected both variants present after re-run; got {rows}"
+    )
+    active = db.conn.execute(
+        "SELECT active_mask_variant FROM photos WHERE id=?", (pid,),
+    ).fetchone()[0]
+    assert active == "sam2-large"
+
+
+def test_extract_masks_re_runs_when_prompt_changed(tmp_path, monkeypatch):
+    """If the photo's primary detection's bbox changes between runs, the
+    cached photo_masks row's prompt no longer matches and SAM has to
+    re-run.  The row is replaced with the new prompt + path; the
+    photo_masks set still has exactly one row for that variant."""
+    spec = {"filename": "a.jpg", "box": (10, 20, 100, 200),
+            "model": "MegaDetector"}
+
+    db, _, calls_first, photo_ids = _run_extract_masks_for_test(
+        tmp_path, monkeypatch, "sam2-small", [spec],
+    )
+    pid = photo_ids[0]
+    assert len(calls_first) == 1
+    rows = db.list_masks_for_photo(pid)
+    assert len(rows) == 1
+    assert (rows[0]["prompt_x"], rows[0]["prompt_w"]) == (10, 100)
+
+    # Mutate the detection so it carries a new bbox (mimics YOLO re-run
+    # with a different confidence threshold producing a slightly
+    # different box).
+    db.conn.execute(
+        "UPDATE detections SET box_x = 99 WHERE photo_id=?", (pid,),
+    )
+    db.conn.commit()
+
+    # Re-run — generate_mask must be called and the row must be replaced.
+    import config as cfg
+    import dino_embed
+    import masking
+    import numpy as np
+    import quality
+
+    cfg.save({
+        "pipeline": {"sam2_variant": "sam2-small", "dinov2_variant": "vit-b14"},
+    })
+
+    calls_second = []
+
+    def fake_generate_mask_2(proxy, det_box, variant=None):
+        calls_second.append((variant, tuple(sorted(det_box.items()))))
+        return np.ones((4, 4), dtype=bool)
+
+    monkeypatch.setattr(
+        masking, "render_proxy",
+        lambda *a, **k: np.zeros((4, 4, 3), dtype=np.uint8),
+    )
+    monkeypatch.setattr(masking, "generate_mask", fake_generate_mask_2)
+    monkeypatch.setattr(masking, "crop_completeness", lambda m: 0.95)
+    monkeypatch.setattr(masking, "crop_subject", lambda p, m, margin=0.15: None)
+    monkeypatch.setattr(masking, "ensure_sam2_weights", lambda **k: None)
+    monkeypatch.setattr(
+        quality, "compute_all_quality_features",
+        lambda p, m: {
+            "subject_tenengrad": 1.5, "bg_tenengrad": 0.3,
+            "subject_clip_high": 0.01, "subject_clip_low": 0.01,
+            "subject_y_median": 100.0, "bg_separation": 50.0,
+            "phash_crop": "deadbeef", "noise_estimate": 5.0,
+        },
+    )
+    monkeypatch.setattr(
+        dino_embed, "embed_global",
+        lambda p, variant=None: np.zeros(384, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        dino_embed, "embed_subject",
+        lambda c, variant=None: np.zeros(384, dtype=np.float32),
+    )
+    monkeypatch.setattr(dino_embed, "embedding_to_blob", lambda e: b"")
+    monkeypatch.setattr(dino_embed, "ensure_dinov2_weights", lambda **k: None)
+
+    col_id = db.conn.execute(
+        "SELECT id FROM collections ORDER BY id LIMIT 1"
+    ).fetchone()[0]
+    params = PipelineParams(
+        collection_id=col_id, skip_classify=True,
+        skip_extract_masks=False, skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(
+        job, runner, str(tmp_path / "test.db"), db._active_workspace_id, params,
+    )
+
+    assert len(calls_second) == 1, (
+        f"prompt change must re-run generate_mask; got {calls_second}"
+    )
+    rows_after = db.list_masks_for_photo(pid)
+    assert len(rows_after) == 1, (
+        f"row should be replaced (upsert), not duplicated; got {rows_after}"
+    )
+    assert rows_after[0]["prompt_x"] == 99
+
+
 def test_pipeline_eye_keypoints_cancel_marks_stage_cancelled(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6105,7 +6105,9 @@ def _stub_extract_masks_heavy_ops(monkeypatch):
     )
     monkeypatch.setattr(
         masking, "save_mask",
-        lambda mask, dir_, pid_: os.path.join(dir_, f"{pid_}.png"),
+        lambda mask, dir_, pid_, variant: os.path.join(
+            dir_, f"{pid_}.{variant}.png",
+        ),
     )
     monkeypatch.setattr(masking, "crop_completeness", lambda m: 1.0)
     monkeypatch.setattr(masking, "crop_subject", lambda p, m, margin=0.15: None)

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6356,12 +6356,12 @@ def _run_extract_masks_for_test(
         },
     )
     monkeypatch.setattr(
-        dino_embed, "embed_global",
+        dino_embed, "embed",
         lambda p, variant=None: np.zeros(384, dtype=np.float32),
     )
     monkeypatch.setattr(
-        dino_embed, "embed_subject",
-        lambda c, variant=None: np.zeros(384, dtype=np.float32),
+        dino_embed, "embed_batch",
+        lambda imgs, variant=None: np.zeros((len(imgs), 384), dtype=np.float32),
     )
     monkeypatch.setattr(dino_embed, "embedding_to_blob", lambda e: b"")
     monkeypatch.setattr(dino_embed, "ensure_dinov2_weights", lambda **k: None)
@@ -6434,12 +6434,12 @@ def test_extract_masks_skips_sam_when_cached_with_same_prompt(
         },
     )
     monkeypatch.setattr(
-        dino_embed, "embed_global",
+        dino_embed, "embed",
         lambda p, variant=None: np.zeros(384, dtype=np.float32),
     )
     monkeypatch.setattr(
-        dino_embed, "embed_subject",
-        lambda c, variant=None: np.zeros(384, dtype=np.float32),
+        dino_embed, "embed_batch",
+        lambda imgs, variant=None: np.zeros((len(imgs), 384), dtype=np.float32),
     )
     monkeypatch.setattr(dino_embed, "embedding_to_blob", lambda e: b"")
     monkeypatch.setattr(dino_embed, "ensure_dinov2_weights", lambda **k: None)
@@ -6525,12 +6525,12 @@ def test_extract_masks_runs_for_new_variant_keeps_old(tmp_path, monkeypatch):
         },
     )
     monkeypatch.setattr(
-        dino_embed, "embed_global",
+        dino_embed, "embed",
         lambda p, variant=None: np.zeros(384, dtype=np.float32),
     )
     monkeypatch.setattr(
-        dino_embed, "embed_subject",
-        lambda c, variant=None: np.zeros(384, dtype=np.float32),
+        dino_embed, "embed_batch",
+        lambda imgs, variant=None: np.zeros((len(imgs), 384), dtype=np.float32),
     )
     monkeypatch.setattr(dino_embed, "embedding_to_blob", lambda e: b"")
     monkeypatch.setattr(dino_embed, "ensure_dinov2_weights", lambda **k: None)
@@ -6622,12 +6622,12 @@ def test_extract_masks_re_runs_when_prompt_changed(tmp_path, monkeypatch):
         },
     )
     monkeypatch.setattr(
-        dino_embed, "embed_global",
+        dino_embed, "embed",
         lambda p, variant=None: np.zeros(384, dtype=np.float32),
     )
     monkeypatch.setattr(
-        dino_embed, "embed_subject",
-        lambda c, variant=None: np.zeros(384, dtype=np.float32),
+        dino_embed, "embed_batch",
+        lambda imgs, variant=None: np.zeros((len(imgs), 384), dtype=np.float32),
     )
     monkeypatch.setattr(dino_embed, "embedding_to_blob", lambda e: b"")
     monkeypatch.setattr(dino_embed, "ensure_dinov2_weights", lambda **k: None)

--- a/vireo/tests/test_reflow.py
+++ b/vireo/tests/test_reflow.py
@@ -27,7 +27,6 @@ def _setup_db(tmp_path):
             fid, f"photo{i}.jpg", ".jpg", 1000, 1.0,
             timestamp=ts.isoformat(), width=4000, height=3000,
         )
-        db.update_photo_mask(pid, f"/masks/{pid}.png")
         db.update_photo_pipeline_features(
             pid,
             mask_path=f"/masks/{pid}.png",


### PR DESCRIPTION
## Summary

Vireo previously stored a single SAM mask per photo. Running `sam2-large` after `sam2-small` overwrote the previous mask, with no way to compare them or recover the prior result.

This branch keeps masks per `(photo, SAM variant)` so multiple variants coexist, and adds three places to interact with them:

- **Pipeline page** — per-variant coverage (`sam2-small: 12,400 photos`, `sam2-large: 8,200 photos`) with a "Set active" button per variant. Setting active is what flips which mask drives downstream scoring/selection.
- **Lightbox** — a "Mask:" dropdown to toggle which variant's overlay is shown for the current photo (does NOT change the active variant — that's strictly the pipeline page's job).
- **Stats / Storage** — a Masks card showing per-variant counts and bytes, plus "Delete inactive" and "Delete stale" actions. Stale = the cached mask's prompt no longer matches the current primary detection (e.g., after re-running YOLO with a different threshold).

## Schema

- New `photo_masks` table: PK `(photo_id, variant)`, columns for path + detection prompt provenance (detector_model + bbox) + per-mask features (`subject_size`, `subject_tenengrad`, `bg_tenengrad`, `crop_complete`).
- New `photos.active_mask_variant TEXT` column.
- Mask files are now `~/.vireo/masks/{photo_id}.{variant}.png`.
- `photos.mask_path` and the per-mask feature columns are now denormalized mirrors of the active variant's `photo_masks` row, so all existing readers (`scoring.py`, `pipeline.py`) keep working unchanged.

## Skip-when-cached

Both the unified pipeline (`pipeline_job.py`) and the standalone `/api/jobs/extract-masks` endpoint skip SAM when a row exists for `(photo_id, variant)` AND its stored prompt still matches the photo's current primary detection. Re-running with the same config and same detection bboxes is a no-op; switching detectors or thresholds invalidates affected masks (visible as `stale_count > 0` on the stats page).

## Migration

Existing masks (`photos.mask_path` set, no `photo_masks` row yet) are backfilled on DB init as `variant='unknown'` with sentinel prompt `(-1,-1,-1,-1)`. The staleness check naturally treats them as stale, so the next pipeline run regenerates them with real provenance. Idempotent and crash-safe.

## Workspace scoping (intentional asymmetry, calling it out)

- `/api/storage/masks` and the stats card are **global** (storage = system level).
- `/api/pipeline/page-init` mask coverage and `/api/pipeline/active-mask-variant` are **workspace-scoped** (pipeline = workspace level).

This matches how the rest of the app treats those pages.

## Test plan

- [x] Phase-level pytest sweep at every step (TDD-style: each method/route has a paired test).
- [x] Skip-when-cached: 3 cache tests + 2 standalone-route cache tests.
- [x] Migration: idempotency + correctness + the `INTEGER → REAL` column-type fix for `subject_size`.
- [x] Storage dashboard: 7 endpoint tests including the "refuses to delete the active variant" case.
- [x] Pipeline coverage + active switch: workspace-scoping test for both the read and the bulk write.
- [x] Lightbox file route: path-traversal rejection + 404-when-no-row defense in depth.
- [x] Final whole-branch review: passed (one important fix applied — `delete_inactive_masks` no longer deletes masks for photos with `active_mask_variant IS NULL`).
- [x] Full focused suite (`test_db.py + test_app.py + test_photos_api.py + test_jobs_api.py + test_masking.py + test_pipeline.py + test_pipeline_api.py + test_pipeline_job.py + test_workspaces.py + test_edits_api.py + test_darktable_api.py + test_config.py`): **1077 passed, 1 skipped**, 2 failures (`test_remove_keyword_from_photo`, `test_undo_keyword_remove_clears_pending_change`) — both listed in the pre-existing-failures memo and unrelated to this PR.
- [ ] Browser smoke (manual): open lightbox, toggle variants; pipeline page → set active variant; stats page → delete inactive.

## Open follow-ups (out of scope here)

- Side-by-side compare view (UI option B from the design discussion).
- `prompt_hash` column for non-bbox prompt types (point clicks, etc.).
- Self-heal pass on startup that nulls `photos.mask_path` when the file is missing AND no `photo_masks` row covers it.
- Tighten the legacy `/masks/<filename>` route with the same DB-row-required defense the new `/api/masks/<pid>/<variant>.png` route uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)