### PR TITLE
workspace dropdown: pin + alphabetical ordering

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3012,7 +3012,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not ws:
             return json_error("Workspace not found", 404)
         body = request.get_json(silent=True) or {}
-        pinned = bool(body.get("pinned", True))
+        pinned = body.get("pinned", True)
+        if not isinstance(pinned, bool):
+            return json_error("`pinned` must be a boolean")
         from datetime import datetime
         db.update_workspace(
             ws_id,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3005,6 +3005,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         return jsonify({"ok": True, "workspace": dict(ws), "restore_path": restore_path})
 
+    @app.route("/api/workspaces/<int:ws_id>/pin", methods=["POST"])
+    def api_pin_workspace(ws_id):
+        db = _get_db()
+        ws = db.get_workspace(ws_id)
+        if not ws:
+            return json_error("Workspace not found", 404)
+        body = request.get_json(silent=True) or {}
+        pinned = bool(body.get("pinned", True))
+        from datetime import datetime
+        db.update_workspace(
+            ws_id,
+            pinned_at=datetime.now().isoformat() if pinned else None,
+        )
+        return jsonify(dict(db.get_workspace(ws_id)))
+
     @app.route("/api/workspaces/<int:ws_id>/folders", methods=["GET"])
     def api_workspace_folders(ws_id):
         db = _get_db()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -319,7 +319,8 @@ class Database:
                 ui_state        TEXT,
                 tabs            TEXT,
                 created_at      TEXT DEFAULT (datetime('now')),
-                last_opened_at  TEXT
+                last_opened_at  TEXT,
+                pinned_at       TEXT
             );
 
             CREATE TABLE IF NOT EXISTS workspace_folders (
@@ -624,6 +625,13 @@ class Database:
             self.conn.execute("ALTER TABLE workspaces DROP COLUMN open_tabs")
         except sqlite3.OperationalError:
             pass  # column already absent (already dropped or fresh schema)
+        # Migration: add `pinned_at` for the alphabetical-with-pinned-on-top
+        # workspace dropdown. NULL means unpinned; an ISO timestamp marks the
+        # workspace as pinned.
+        try:
+            self.conn.execute("SELECT pinned_at FROM workspaces LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute("ALTER TABLE workspaces ADD COLUMN pinned_at TEXT")
         # Migration: working-copy failure markers. Backfill (and the inline
         # scan extraction) record a failure here when extract_working_copy
         # returns False, gated by file_mtime so a user-replaced file retries
@@ -740,13 +748,15 @@ class Database:
         ).fetchone()
 
     def get_workspaces(self):
-        """Return all workspaces ordered by last_opened_at desc."""
+        """Return all workspaces, pinned first then alphabetical."""
         return self.conn.execute(
-            "SELECT * FROM workspaces ORDER BY last_opened_at DESC"
+            "SELECT * FROM workspaces "
+            "ORDER BY (pinned_at IS NULL), LOWER(name)"
         ).fetchall()
 
     def update_workspace(self, workspace_id, name=None, config_overrides=_UNSET,
-                         ui_state=_UNSET, last_opened_at=None):
+                         ui_state=_UNSET, last_opened_at=None,
+                         pinned_at=_UNSET):
         """Update workspace fields. Only provided args are updated.
 
         For config_overrides and ui_state, pass None to clear the value
@@ -766,6 +776,9 @@ class Database:
         if last_opened_at is not None:
             updates.append("last_opened_at = ?")
             params.append(last_opened_at)
+        if pinned_at is not _UNSET:
+            updates.append("pinned_at = ?")
+            params.append(pinned_at)
         if not updates:
             return
         params.append(workspace_id)

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -890,11 +890,25 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 .ws-menu-item {
   display: flex; align-items: center; justify-content: space-between;
   padding: 8px 12px; cursor: pointer; font-size: 13px;
-  color: var(--text-secondary);
+  color: var(--text-secondary); gap: 8px;
 }
 .ws-menu-item:hover { background: var(--bg-tertiary); }
 .ws-menu-item.active { color: var(--accent); }
+.ws-menu-item .ws-item-name {
+  flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.ws-menu-item .ws-item-right {
+  display: flex; align-items: center; gap: 6px; flex-shrink: 0;
+}
 .ws-menu-item .ws-item-check { font-size: 14px; }
+.ws-menu-item .ws-pin-btn {
+  background: none; border: none; padding: 0 2px; cursor: pointer;
+  color: var(--text-muted); font-size: 13px; line-height: 1;
+  opacity: 0; transition: opacity 0.1s;
+}
+.ws-menu-item:hover .ws-pin-btn { opacity: 0.6; }
+.ws-menu-item .ws-pin-btn:hover { opacity: 1 !important; color: var(--accent); }
+.ws-menu-item .ws-pin-btn.is-pinned { opacity: 1; color: var(--accent); }
 .ws-menu-divider { border-top: 1px solid var(--border-primary); margin: 4px 0; }
 .ws-menu-action {
   display: block; width: 100%; text-align: left; background: none; border: none;
@@ -1307,7 +1321,6 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
       <span class="ws-arrow">&#9662;</span>
     </button>
     <div class="ws-menu" id="wsMenu">
-      <div class="ws-menu-header">Workspaces</div>
       <div id="wsMenuList"></div>
       <div class="ws-menu-divider"></div>
       <button class="ws-menu-action" onclick="showCreateWorkspaceModal()">+ New Workspace</button>
@@ -2469,23 +2482,78 @@ function closeWsDropdownOutside(e) {
   }
 }
 
+function renderWsItem(ws, activeId) {
+  var isActive = ws.id === activeId;
+  var isPinned = !!ws.pinned_at;
+  var div = document.createElement('div');
+  div.className = 'ws-menu-item' + (isActive ? ' active' : '');
+  // Title is "Unpin" if pinned, "Pin" if not. Filled star for pinned, outline for unpinned.
+  div.innerHTML =
+    '<span class="ws-item-name">' + wsEscapeHtml(ws.name) + '</span>' +
+    '<span class="ws-item-right">' +
+      (isActive ? '<span class="ws-item-check">&#10003;</span>' : '') +
+      '<button class="ws-pin-btn' + (isPinned ? ' is-pinned' : '') + '" ' +
+        'title="' + (isPinned ? 'Unpin' : 'Pin') + ' workspace" ' +
+        'data-ws-id="' + ws.id + '" data-pinned="' + (isPinned ? '1' : '0') + '">' +
+        (isPinned ? '&#9733;' : '&#9734;') +
+      '</button>' +
+    '</span>';
+  div.onclick = function(e) {
+    // Pin button clicks are handled separately and must not switch workspaces.
+    if (e.target.closest('.ws-pin-btn')) return;
+    switchWorkspace(ws.id, ws.name);
+  };
+  var pinBtn = div.querySelector('.ws-pin-btn');
+  pinBtn.onclick = function(e) {
+    e.stopPropagation();
+    toggleWorkspacePin(ws.id, !isPinned);
+  };
+  return div;
+}
+
 async function loadWorkspaceMenu() {
   try {
     var workspaces = await safeFetch('/api/workspaces', {}, { toast: false });
     var active = await safeFetch('/api/workspaces/active', {}, { toast: false });
     var list = document.getElementById('wsMenuList');
     list.innerHTML = '';
-    workspaces.forEach(function(ws) {
-      var isActive = ws.id === active.id;
-      var div = document.createElement('div');
-      div.className = 'ws-menu-item' + (isActive ? ' active' : '');
-      div.innerHTML = wsEscapeHtml(ws.name) +
-        (isActive ? ' <span class="ws-item-check">&#10003;</span>' : '');
-      div.onclick = function() { switchWorkspace(ws.id, ws.name); };
-      list.appendChild(div);
-    });
+    var pinned = workspaces.filter(function(w) { return !!w.pinned_at; });
+    var unpinned = workspaces.filter(function(w) { return !w.pinned_at; });
+    function addHeader(text) {
+      var h = document.createElement('div');
+      h.className = 'ws-menu-header';
+      h.textContent = text;
+      list.appendChild(h);
+    }
+    if (pinned.length > 0) {
+      addHeader('Pinned');
+      pinned.forEach(function(ws) { list.appendChild(renderWsItem(ws, active.id)); });
+      if (unpinned.length > 0) {
+        var divider = document.createElement('div');
+        divider.className = 'ws-menu-divider';
+        list.appendChild(divider);
+        addHeader('Workspaces');
+      }
+    } else {
+      addHeader('Workspaces');
+    }
+    unpinned.forEach(function(ws) { list.appendChild(renderWsItem(ws, active.id)); });
   } catch(e) {
     console.error('Failed to load workspaces', e);
+  }
+}
+
+async function toggleWorkspacePin(wsId, pinned) {
+  try {
+    await safeFetch('/api/workspaces/' + wsId + '/pin', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ pinned: pinned })
+    }, { toast: false });
+    // Re-render with updated grouping/order.
+    await loadWorkspaceMenu();
+  } catch(e) {
+    console.error('Failed to toggle pin', e);
   }
 }
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2500,7 +2500,10 @@ function renderWsItem(ws, activeId) {
     '</span>';
   div.onclick = function(e) {
     // Pin button clicks are handled separately and must not switch workspaces.
-    if (e.target.closest('.ws-pin-btn')) return;
+    // e.target can be a text node in some browsers; walk up to the nearest Element first.
+    var t = e.target;
+    if (t && t.nodeType !== 1) t = t.parentElement;
+    if (t && t.closest && t.closest('.ws-pin-btn')) return;
     switchWorkspace(ws.id, ws.name);
   };
   var pinBtn = div.querySelector('.ws-pin-btn');

--- a/vireo/tests/test_workspaces_api.py
+++ b/vireo/tests/test_workspaces_api.py
@@ -413,3 +413,63 @@ def test_move_folders_no_target_returns_400(app_and_db):
         "folder_ids": [1],
     })
     assert resp.status_code == 400
+
+
+# ---- Pin / unpin + ordering ----
+
+def test_pin_workspace_sets_pinned_at(app_and_db):
+    """POST /api/workspaces/<id>/pin with {pinned:true} stamps pinned_at."""
+    app, _db = app_and_db
+    client = app.test_client()
+
+    ws_id = client.post("/api/workspaces", json={"name": "Pin Me"}).get_json()["id"]
+    resp = client.post(f"/api/workspaces/{ws_id}/pin", json={"pinned": True})
+    assert resp.status_code == 200
+    assert resp.get_json()["pinned_at"] is not None
+
+
+def test_unpin_workspace_clears_pinned_at(app_and_db):
+    """POST /api/workspaces/<id>/pin with {pinned:false} clears pinned_at."""
+    app, _db = app_and_db
+    client = app.test_client()
+
+    ws_id = client.post("/api/workspaces", json={"name": "Unpin Me"}).get_json()["id"]
+    client.post(f"/api/workspaces/{ws_id}/pin", json={"pinned": True})
+    resp = client.post(f"/api/workspaces/{ws_id}/pin", json={"pinned": False})
+    assert resp.status_code == 200
+    assert resp.get_json()["pinned_at"] is None
+
+
+def test_pin_unknown_workspace_returns_404(app_and_db):
+    app, _db = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/workspaces/999999/pin", json={"pinned": True})
+    assert resp.status_code == 404
+
+
+def test_workspaces_listed_pinned_first_then_alphabetical(app_and_db):
+    """GET /api/workspaces returns pinned items first, alphabetical within
+    each group regardless of creation or last-opened order."""
+    app, _db = app_and_db
+    client = app.test_client()
+
+    # Create unpinned items in non-alphabetical order
+    for n in ["zebra", "apple", "mango"]:
+        client.post("/api/workspaces", json={"name": n})
+
+    # Pin two of them in non-alphabetical order
+    listing = client.get("/api/workspaces").get_json()
+    by_name = {w["name"]: w["id"] for w in listing}
+    client.post(f"/api/workspaces/{by_name['zebra']}/pin", json={"pinned": True})
+    client.post(f"/api/workspaces/{by_name['apple']}/pin", json={"pinned": True})
+
+    listing = client.get("/api/workspaces").get_json()
+    names = [w["name"] for w in listing]
+    # Pinned section first (alphabetical), then unpinned section (alphabetical).
+    pinned_names = [w["name"] for w in listing if w["pinned_at"]]
+    unpinned_names = [w["name"] for w in listing if not w["pinned_at"]]
+    assert pinned_names == sorted(pinned_names, key=str.lower)
+    assert unpinned_names == sorted(unpinned_names, key=str.lower)
+    # All pinned come before any unpinned in the combined order.
+    assert names.index("apple") < names.index("mango")
+    assert names.index("zebra") < names.index("mango")

--- a/vireo/tests/test_workspaces_api.py
+++ b/vireo/tests/test_workspaces_api.py
@@ -447,6 +447,23 @@ def test_pin_unknown_workspace_returns_404(app_and_db):
     assert resp.status_code == 404
 
 
+def test_pin_rejects_non_boolean_pinned_field(app_and_db):
+    """`pinned` must be a strict bool; truthy strings like "false" or "0"
+    must not be silently coerced to True (which would invert the caller's
+    intent for non-typed clients)."""
+    app, _db = app_and_db
+    client = app.test_client()
+
+    ws_id = client.post("/api/workspaces", json={"name": "Strict"}).get_json()["id"]
+    for bad in ["false", "0", "true", 0, 1, None]:
+        resp = client.post(f"/api/workspaces/{ws_id}/pin", json={"pinned": bad})
+        assert resp.status_code == 400, f"expected 400 for pinned={bad!r}"
+    # Workspace stays unpinned after all bad attempts.
+    listing = client.get("/api/workspaces").get_json()
+    ws = next(w for w in listing if w["id"] == ws_id)
+    assert ws["pinned_at"] is None
+
+
 def test_workspaces_listed_pinned_first_then_alphabetical(app_and_db):
     """GET /api/workspaces returns pinned items first, alphabetical within
     each group regardless of creation or last-opened order."""


### PR DESCRIPTION
## Summary
- Workspace dropdown now sorts pinned-first then alphabetical (was: last_opened_at desc)
- Each row has a hover-revealed star button to pin/unpin without leaving the menu; pinned items always show their star
- Pinned items render under a "Pinned" subheader above a divider; remaining items sit under "Workspaces"

## Changes
- `db.py`: new `workspaces.pinned_at TEXT` column (NULL = unpinned) + migration; `get_workspaces` orders by `(pinned_at IS NULL), LOWER(name)`; `update_workspace` accepts `pinned_at`
- `app.py`: `POST /api/workspaces/<id>/pin {pinned: bool}` toggle endpoint
- `_navbar.html`: rewrites `loadWorkspaceMenu` to render the two sections, adds CSS for the row layout + pin button hover affordance, swaps the static "Workspaces" header for JS-rendered subheaders

## Test plan
- [x] `python -m pytest vireo/tests/test_workspaces_api.py vireo/tests/test_db.py tests/test_workspaces.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` — 857 passed, 1 skipped
- [x] App boots cleanly with new migration applied
- [ ] Manually verify the dropdown UI in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)