### PR TITLE
jobs: title-case job-type identifiers shown to the user

### DIFF
--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -295,7 +295,12 @@ class JobRunner:
             if parts:
                 return ", ".join(parts[:3])
 
-        return job["type"] + " " + job["status"]
+        # Final fallback: title-case the job type (e.g. "duplicate-scan" →
+        # "Duplicate Scan") so the summary line is presentable to the user.
+        pretty_type = " ".join(
+            w.capitalize() for w in job["type"].replace("_", " ").replace("-", " ").split()
+        )
+        return f"{pretty_type} {job['status']}"
 
     def get(self, job_id):
         """Get a job by id. Returns a shallow copy so callers don't mutate shared state."""

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4538,7 +4538,7 @@ function formatDuration(seconds) {
       var lastDone = activeJobs.filter(function(j) { return j.status !== 'running'; })[0];
       if (lastDone) {
         container.innerHTML = '<div style="font-size:12px;color:var(--text-muted);padding:4px 0;">No active jobs. Last run: ' +
-          bpEscape(lastDone.type) + ' ' + (lastDone.status === 'completed' ? '\u2713' : '\u2717') +
+          bpEscape(window.formatJobType(lastDone.type)) + ' ' + (lastDone.status === 'completed' ? '\u2713' : '\u2717') +
           ' <a href="/jobs" style="color:var(--accent);text-decoration:none;">View history \u2192</a></div>';
       } else {
         container.innerHTML = '<div style="font-size:12px;color:var(--text-muted);padding:4px 0;">No active jobs. ' +
@@ -4580,7 +4580,7 @@ function formatDuration(seconds) {
       }
       html += '<div class="bp-compact-job" style="display:flex;align-items:center;gap:8px;padding:4px 0;font-size:12px;">';
       html += '<span style="width:6px;height:6px;border-radius:50%;background:var(--accent);flex-shrink:0;"></span>';
-      html += '<span style="font-weight:600;text-transform:capitalize;">' + bpEscape(j.type) + '</span>';
+      html += '<span style="font-weight:600;">' + bpEscape(window.formatJobType(j.type)) + '</span>';
       if (phase) html += '<span style="color:var(--text-muted);">\u2014 ' + bpEscape(phase) + '</span>';
       if (detail) html += '<span style="color:var(--text-muted);font-variant-numeric:tabular-nums;">' + detail + '</span>';
       html += '<a href="/jobs" style="margin-left:auto;color:var(--accent);text-decoration:none;font-size:11px;white-space:nowrap;">View \u2192</a>';
@@ -4602,7 +4602,7 @@ function formatDuration(seconds) {
 
     summary.classList.remove('idle');
     var j = running[0];
-    var text = j.type;
+    var text = window.formatJobType(j.type);
     if (j.progress && j.progress.phase) {
       text += ' — ' + j.progress.phase;
     }
@@ -4682,6 +4682,18 @@ function formatDuration(seconds) {
     div.appendChild(document.createTextNode(String(str)));
     return div.innerHTML;
   }
+
+  // Convert internal job-type identifiers like "new_images_walk" or
+  // "duplicate-scan" into a user-facing label ("New Images Walk", "Duplicate
+  // Scan"). Exposed on window so per-page scripts (e.g. jobs.html) can reuse it.
+  window.formatJobType = function(type) {
+    if (!type) return '';
+    return String(type)
+      .split(/[-_]+/)
+      .filter(function(w) { return w.length > 0; })
+      .map(function(w) { return w.charAt(0).toUpperCase() + w.slice(1); })
+      .join(' ');
+  };
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', init);

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -327,7 +327,7 @@
 
     // Header: type, workspace label, status, cancel
     html += '<div class="job-card-header">';
-    html += '<span class="job-detail-title">' + esc(job.type) + '</span>';
+    html += '<span class="job-detail-title">' + esc(window.formatJobType(job.type)) + '</span>';
     if (options.workspaceName) {
       html += '<span class="job-card-workspace">' + esc(options.workspaceName) + '</span>';
     }
@@ -556,7 +556,7 @@
     var current = sel.value;
     sel.innerHTML = '<option value="">All types</option>';
     Object.keys(types).sort().forEach(function(t) {
-      sel.innerHTML += '<option value="' + esc(t) + '">' + esc(t) + '</option>';
+      sel.innerHTML += '<option value="' + esc(t) + '">' + esc(window.formatJobType(t)) + '</option>';
     });
     sel.value = current;
   }
@@ -614,7 +614,7 @@
     var html = '<div class="job-list-item' + selected + '" data-job-id="' + esc(j.id) + '" data-job-source="' + source + '">';
     html += '<div class="job-list-item-header">';
     html += '<span class="job-list-item-dot ' + dot + '"></span>';
-    html += '<span class="job-list-item-type">' + esc(j.type) + '</span>';
+    html += '<span class="job-list-item-type">' + esc(window.formatJobType(j.type)) + '</span>';
     html += '<span class="job-list-item-time">' + time + '</span>';
     html += '</div>';
     if (detail) html += '<div class="job-list-item-detail">' + detail + '</div>';


### PR DESCRIPTION
## Summary
- Internal job-type strings like `new_images_walk` and `duplicate-scan` were leaking into the UI. Now displayed as "New Images Walk" / "Duplicate Scan".
- Added a `window.formatJobType` helper in `_navbar.html` (shared by all pages) and applied it at every render site:
  - Bottom-panel running-jobs list, idle "Last run: …" line, bottom-toolbar summary
  - Jobs page detail title, sidebar list items, type filter dropdown labels (filter `value=` is still the raw type so filtering keeps working)
- Updated `JobRunner._build_summary` so the persisted `job_history.summary` fallback reads "Duplicate Scan completed" instead of "duplicate-scan completed".

API responses and DB rows still use the raw type — only the display layer changed.

## Test plan
- [x] `python -m pytest vireo/tests/test_jobs.py vireo/tests/test_jobs_api.py vireo/tests/test_db.py vireo/tests/test_config.py -q` → 481 passed, 1 skipped
- [x] Verified `/jobs` and `/browse` render with `window.formatJobType` defined and called
- [ ] Manually open the Jobs page with at least one running job and confirm names look right
- [ ] Manually open the bottom panel and confirm the running-jobs list / summary read nicely

🤖 Generated with [Claude Code](https://claude.com/claude-code)