### PR TITLE
pipeline review: default resolution slider to Original

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1107,7 +1107,7 @@ input[type="range"]::-moz-range-thumb {
     <button onclick="grmRemoveFromGroup()" style="background:var(--bg-tertiary);color:var(--text-muted);border:none;border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;">Remove from group</button>
     <div class="grm-res-control" title="Image resolution — higher = slower but better for pixel-peeping">
       <label style="font-size:12px;color:var(--text-muted);">Res:</label>
-      <input type="range" id="grmResSlider" min="0" max="3" step="1" value="0" oninput="grmSetResolution(this.value)">
+      <input type="range" id="grmResSlider" min="0" max="3" step="1" value="3" oninput="grmSetResolution(this.value)">
       <span id="grmResLabel" style="font-size:11px;color:var(--text-dim);min-width:140px;">1920 · preview</span>
     </div>
     <span class="grm-hint">↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
@@ -1140,7 +1140,7 @@ var GRM_RES_STOPS = [
   {size: 3840, label: '4K',   kind: 'preview'},
   {size: 0,    label: 'Original', kind: 'original'}
 ];
-var grmResolutionIdx = 0;
+var grmResolutionIdx = 3;
 
 function grmPhotoUrl(photoId) {
   var stop = GRM_RES_STOPS[grmResolutionIdx];


### PR DESCRIPTION
## Summary
- Pipeline review's resolution slider was defaulting to **1920px preview at JPEG q=90**, well below 1:1 for any modern camera. That undermines pixel-peeping, which is core to culling.
- Flipped the default to **Original** (slider index 3). Classifiers load the source independently, so this only changes what the user sees during review — not classifier input.

## Files
- `vireo/templates/pipeline_review.html` — slider initial `value` and `grmResolutionIdx` default both 0 → 3.

## Tradeoff
First view of a photo triggers a working-copy extract (~5–7s if not already cached); subsequent loads are cached. Cache lives in `~/.vireo/previews/` / working-copy paths.

## Test plan
- [x] `python -m pytest vireo/tests/test_app.py -q` → 151 passed
- [ ] Open pipeline review on a workspace; confirm slider sits on "Original" and dimensions label shows the photo's native size
- [ ] Drag slider down to 1920 and back — labels and image swap correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)