### PR TITLE
pipeline: surface sub-threshold detections in extract_masks diagnostic

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2367,8 +2367,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             # not real subject boxes and should not drive mask extraction or
             # count toward the photos_with_detections safeguard below (which
             # surfaces the "weights missing / no detections" diagnostic).
+            #
+            # Track sub-threshold-only photos separately so the silent-
+            # completion guard can distinguish "no detection rows at all"
+            # from "rows exist but every confidence is below
+            # detector_confidence" — the user's remediation differs (download
+            # weights vs lower the threshold).
+            detector_confidence = effective_cfg.get("detector_confidence", 0.2)
             photo_det_map = {}
             photos_with_detections = 0
+            photos_subthreshold_only = 0
             for p in photos:
                 dets = [
                     d for d in thread_db.get_detections(p["id"])
@@ -2390,6 +2398,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 "h": primary["box_h"],
                             },
                         }
+                else:
+                    raw_dets = [
+                        d for d in thread_db.get_detections(p["id"], min_conf=0)
+                        if d["detector_model"] != "full-image"
+                    ]
+                    if raw_dets:
+                        has_mask = thread_db.conn.execute(
+                            "SELECT mask_path FROM photos WHERE id=?", (p["id"],)
+                        ).fetchone()[0]
+                        if not has_mask:
+                            photos_subthreshold_only += 1
 
             photos_to_process = [
                 photo_det_map[pid] for pid in photo_det_map
@@ -2423,7 +2442,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 except ImportError:
                     weights_present = False
 
-                if weights_present:
+                if photos_subthreshold_only > 0:
+                    reason = (
+                        f"{photos_subthreshold_only} photo(s) have detections but every "
+                        f"detection is below the current detector_confidence threshold "
+                        f"({detector_confidence}). The pipeline will reject these photos "
+                        "with `no_subject_mask`. Lower `detector_confidence` in workspace "
+                        "settings to extract masks for them."
+                    )
+                    summary = (
+                        f"Skipped — {photos_subthreshold_only} photo(s) below "
+                        f"detector_confidence threshold ({detector_confidence})"
+                    )
+                elif weights_present:
                     reason = (
                         f"No detections produced for {len(photos)} photo(s). MegaDetector ran but "
                         "found no animals meeting the confidence threshold. The pipeline will "
@@ -2450,9 +2481,51 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     job["id"], "extract_masks", status="completed",
                     summary=summary,
                 )
+                if photos_subthreshold_only > 0:
+                    em_reason = "all_subthreshold"
+                elif weights_present:
+                    em_reason = "no_detections"
+                else:
+                    em_reason = "weights_missing"
                 result["stages"]["extract_masks"] = {
                     "masked": 0, "skipped": 0, "failed": 0, "total": 0,
-                    "reason": "weights_missing" if not weights_present else "no_detections",
+                    "subthreshold": photos_subthreshold_only,
+                    "reason": em_reason,
+                }
+                _update_stages(runner, job["id"], stages)
+                return
+
+            # Mixed-state guard: photos_with_detections > 0 (some photos have
+            # qualifying detections — already masked from a prior run) but
+            # there are also unmasked photos whose only detections are below
+            # the threshold. Without this branch the stage completes silently
+            # with "0 masked, 0 skipped" and the user has no way to discover
+            # why the unmasked photos were never processed. Production hit
+            # this when 4166 of 5054 photos were already masked and the
+            # remaining 727 had only sub-threshold detections.
+            if total == 0 and photos_subthreshold_only > 0 and classify_ran:
+                reason = (
+                    f"{photos_subthreshold_only} photo(s) have detections but every "
+                    f"detection is below the current detector_confidence threshold "
+                    f"({detector_confidence}). The pipeline will reject these photos "
+                    "with `no_subject_mask`. Lower `detector_confidence` in workspace "
+                    "settings to extract masks for them."
+                )
+                summary = (
+                    f"Skipped — {photos_subthreshold_only} photo(s) below "
+                    f"detector_confidence threshold ({detector_confidence})"
+                )
+                log.warning("Pipeline extract-masks: %s", reason)
+                errors.append(f"[extract_masks] {reason}")
+                stages["extract_masks"]["status"] = "skipped"
+                runner.update_step(
+                    job["id"], "extract_masks", status="completed",
+                    summary=summary,
+                )
+                result["stages"]["extract_masks"] = {
+                    "masked": 0, "skipped": 0, "failed": 0, "total": 0,
+                    "subthreshold": photos_subthreshold_only,
+                    "reason": "all_subthreshold",
                 }
                 _update_stages(runner, job["id"], stages)
                 return
@@ -2587,12 +2660,18 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 em_summary_parts = [f"{masked} masked", f"{skipped} skipped"]
                 if em_failed:
                     em_summary_parts.append(f"{em_failed} failed")
+                if photos_subthreshold_only > 0:
+                    em_summary_parts.append(
+                        f"{photos_subthreshold_only} below detector_confidence "
+                        f"({detector_confidence})"
+                    )
                 runner.update_step(job["id"], "extract_masks", status=final_status,
                                    summary=", ".join(em_summary_parts),
                                    error_count=em_failed,
                                    error=em_rollup)
                 result["stages"]["extract_masks"] = {
-                    "masked": masked, "skipped": skipped, "failed": em_failed, "total": total,
+                    "masked": masked, "skipped": skipped, "failed": em_failed,
+                    "total": total, "subthreshold": photos_subthreshold_only,
                 }
         except Exception as e:
             errors.append(f"[extract_masks] Fatal: {e}")

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -4394,6 +4394,212 @@ def test_extract_masks_stage_ignores_synthetic_full_image_detections(
     )
 
 
+def test_extract_masks_stage_warns_when_all_detections_below_threshold(
+    tmp_path, monkeypatch
+):
+    """If a photo has detections but every one is below detector_confidence,
+    extract_masks silently completes with masked=0 and the user has no way to
+    discover why their unmasked photos were skipped — get_detections returns
+    [] at the workspace threshold, so the photo never enters photo_det_map.
+
+    Regression observed in production: 727 of 5054 photos had only
+    sub-threshold detections, so extract_masks finished in 0.5s with
+    "0 masked, 0 skipped" and no error. Surface a clear diagnostic that
+    names the threshold and points at the workaround.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_id = db.add_photo(folder_id, "lowconf.jpg", ".jpg", 12345, 1_000_000.0)
+    _drop_jpeg(folder_path, "lowconf.jpg")
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": [photo_id]}]),
+    )
+
+    # Real MegaDetector hit, but at confidence 0.05 — well below the default
+    # 0.2 detector_confidence threshold. The detection row is real, but
+    # get_detections() filters it out at read time.
+    db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 100, "h": 100},
+          "confidence": 0.05, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    # Mark the photo as already detected so the detect stage reuses the
+    # cached row instead of re-running MegaDetector against the stub jpeg.
+    db.record_detector_run(photo_id, "megadetector-v6", box_count=1)
+
+    model_id = _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        return {}, 0, {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            emb = np.zeros(512, dtype=np.float32)
+            return [
+                ([{"species": "Unknown", "score": 0.5}], emb)
+                for _ in images
+            ]
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=[model_id],
+        skip_extract_masks=False,  # exercise extract_masks_stage
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    extract_summaries = [
+        kwargs.get("summary", "")
+        for (_, step_id, kwargs) in runner.step_updates
+        if step_id == "extract_masks" and kwargs.get("status") in (
+            "completed", "failed", "skipped",
+        )
+    ]
+    joined = " ".join(extract_summaries).lower()
+    assert "below" in joined and (
+        "threshold" in joined or "detector_confidence" in joined
+    ), (
+        f"extract_masks_stage should explain why nothing was masked when all "
+        f"detections are sub-threshold; got summaries: {extract_summaries}"
+    )
+
+
+def test_extract_masks_stage_warns_on_mixed_already_masked_and_subthreshold(
+    tmp_path, monkeypatch
+):
+    """Production hit: 4166/5054 photos already had masks (photos_with_detections
+    > 0), and the remaining 727 had only sub-threshold detections. The
+    existing "no detections" guard requires photos_with_detections == 0, so
+    it didn't fire — extract_masks completed silently with "0 masked, 0
+    skipped" while 727 unmasked photos sat untouched. The mixed-state guard
+    must fire instead.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+
+    # Photo A: already has a mask AND a qualifying detection — drives
+    # photos_with_detections > 0 so the existing no-detections guard does
+    # NOT fire.
+    masked_id = db.add_photo(folder_id, "masked.jpg", ".jpg", 12345, 1_000_000.0)
+    _drop_jpeg(folder_path, "masked.jpg")
+    db.save_detections(
+        masked_id,
+        [{"box": {"x": 0, "y": 0, "w": 100, "h": 100},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    db.record_detector_run(masked_id, "megadetector-v6", box_count=1)
+    db.update_photo_pipeline_features(
+        masked_id, mask_path=str(tmp_path / "mask_a.png"),
+    )
+
+    # Photo B: no mask, only sub-threshold detection → should be flagged.
+    lowconf_id = db.add_photo(folder_id, "lowconf.jpg", ".jpg", 23456, 1_000_001.0)
+    _drop_jpeg(folder_path, "lowconf.jpg")
+    db.save_detections(
+        lowconf_id,
+        [{"box": {"x": 0, "y": 0, "w": 50, "h": 50},
+          "confidence": 0.05, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    db.record_detector_run(lowconf_id, "megadetector-v6", box_count=1)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": [masked_id, lowconf_id]}]),
+    )
+
+    model_id = _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        return {}, 0, {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            emb = np.zeros(512, dtype=np.float32)
+            return [
+                ([{"species": "Unknown", "score": 0.5}], emb)
+                for _ in images
+            ]
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=[model_id],
+        skip_extract_masks=False,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    extract_summaries = [
+        kwargs.get("summary", "")
+        for (_, step_id, kwargs) in runner.step_updates
+        if step_id == "extract_masks" and kwargs.get("status") in (
+            "completed", "failed", "skipped",
+        )
+    ]
+    joined = " ".join(extract_summaries).lower()
+    assert "below" in joined and (
+        "threshold" in joined or "detector_confidence" in joined
+    ), (
+        f"extract_masks_stage should flag the sub-threshold photo even when "
+        f"another photo already has a mask; got summaries: {extract_summaries}"
+    )
+
+
 def test_pipeline_rerun_with_existing_prediction_and_bursts_does_not_crash(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

`extract_masks_stage` silently completed with "0 masked, 0 skipped" when
unmasked photos had detection rows whose confidence was all below
`detector_confidence`. `db.get_detections()` filters at the workspace
threshold, so those photos looked detection-less — they never entered
`photo_det_map`, were never counted toward the existing no-detections guard,
and the run finished with no error or hint.

**Production hit (workspace 13, 5054-photo collection):**
- 4166 photos already had masks (from a prior run)
- 161 photos had no detection rows at all
- **727 photos had only sub-threshold detections** → silently dropped
- `extract_masks` stage finished in 0.5s with `summary="0 masked, 0 skipped"`
- No error, no log, no UI hint

## What changed

`vireo/pipeline_job.py` — in the `extract_masks_stage` photo loop, also
inspect raw (`min_conf=0`) detections for photos that have no qualifying
detections, and count those that lack a mask as `photos_subthreshold_only`.
Three downstream paths now surface the count:

1. **Existing no-detections guard** (`photos_with_detections == 0`) now
   distinguishes "no detection rows at all" from "rows exist but all
   sub-threshold" — the user's remediation differs (download MegaDetector
   weights vs lower the threshold).
2. **New mixed-state guard** for the production case: `total == 0` AND
   sub-threshold candidates exist, even when `photos_with_detections > 0`
   (i.e. some photos already have masks). Without this branch the stage
   returns silently.
3. **Normal completion summary** gains a `"N below detector_confidence (T)"`
   clause whenever sub-threshold photos exist, so partial runs are
   auditable in the job tree.

The result dict also gains a `subthreshold` count and a new
`reason="all_subthreshold"` for downstream consumers.

## Test plan

- [x] `python -m pytest vireo/tests/test_pipeline_job.py -q` — **122 passed** (122 prior + 2 new tests below; one prior test reorganized)
- [x] `test_extract_masks_stage_warns_when_all_detections_below_threshold` — pure sub-threshold case (every photo's detection < threshold)
- [x] `test_extract_masks_stage_warns_on_mixed_already_masked_and_subthreshold` — production case (one already-masked photo + one sub-threshold photo)
- [x] `test_extract_masks_stage_ignores_synthetic_full_image_detections` (existing) still passes — confirms `full-image` rows in raw_dets are still filtered
- [ ] Re-run the affected pipeline on workspace 13 with the build that includes this fix — expect `extract_masks` to report `"Skipped — 727 photo(s) below detector_confidence threshold (0.2)"` instead of `"0 masked, 0 skipped"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)