### PR TITLE
pipeline review: stop hiding mixed encounters under hide-confirmed

### DIFF
--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -521,12 +521,22 @@ def serialize_results(results):
     for enc in results["encounters"]:
         photos_list = enc.get("photos", [])
 
-        # Derive confirmed_species from photos (any confirmed photo sets encounter)
-        enc_confirmed = None
-        for p in photos_list:
-            if p.get("confirmed_species"):
-                enc_confirmed = p["confirmed_species"]
-                break
+        # An encounter is confirmed only when every photo shares the same
+        # confirmed_species. Threshold-slider regrouping can merge a confirmed
+        # encounter with an unconfirmed (or differently-confirmed) neighbor;
+        # in that case the merged encounter must stay visible for review
+        # rather than inheriting the confirmed flag from an arbitrary photo.
+        # confirmed_species is still surfaced as the dominant prior species so
+        # the /api/encounters/species endpoint can find the keyword to untag
+        # when the user re-confirms.
+        photo_species = [p.get("confirmed_species") for p in photos_list]
+        confirmed_set = {s for s in photo_species if s}
+        if photos_list and len(confirmed_set) == 1 and all(s for s in photo_species):
+            enc_confirmed = next(iter(confirmed_set))
+            species_confirmed_flag = True
+        else:
+            enc_confirmed = next(iter(confirmed_set)) if confirmed_set else None
+            species_confirmed_flag = False
 
         species_votes = _build_species_predictions(photos_list)
 
@@ -534,7 +544,7 @@ def serialize_results(results):
             "species": enc.get("species"),
             "confirmed_species": enc_confirmed,
             "species_predictions": species_votes,
-            "species_confirmed": enc_confirmed is not None,
+            "species_confirmed": species_confirmed_flag,
             "photo_count": enc.get("photo_count"),
             "burst_count": enc.get("burst_count"),
             "time_range": enc.get("time_range"),
@@ -544,10 +554,23 @@ def serialize_results(results):
             s_enc["bursts"] = []
             for burst in enc["bursts"]:
                 burst_ids = [p["id"] for p in burst]
+                # Derive species_override from per-photo confirmations so that
+                # burst-confirmed indicators survive a regroup. Previously this
+                # was always None, wiping per-burst confirmation state every
+                # time a slider moved even though the underlying tags persist.
+                burst_species = [p.get("confirmed_species") for p in burst]
+                burst_set = {s for s in burst_species if s}
+                if burst and len(burst_set) == 1 and all(s for s in burst_species):
+                    burst_override = {
+                        "species": next(iter(burst_set)),
+                        "confirmed": True,
+                    }
+                else:
+                    burst_override = None
                 s_enc["bursts"].append({
                     "photo_ids": burst_ids,
                     "species_predictions": _build_species_predictions(burst),
-                    "species_override": None,
+                    "species_override": burst_override,
                 })
         serialized_encounters.append(s_enc)
 

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -535,7 +535,24 @@ def serialize_results(results):
             enc_confirmed = next(iter(confirmed_set))
             species_confirmed_flag = True
         else:
-            enc_confirmed = next(iter(confirmed_set)) if confirmed_set else None
+            # For mixed/partial encounters, pick the most frequent confirmed
+            # species, breaking ties by first appearance in photo order. Set
+            # iteration order is not stable across processes, so iterating
+            # confirmed_set directly would feed /api/encounters/species an
+            # arbitrary previous_species and untag an unpredictable keyword
+            # on re-confirm.
+            enc_confirmed = None
+            if confirmed_set:
+                counts = defaultdict(int)
+                first_index = {}
+                for idx, s in enumerate(photo_species):
+                    if s:
+                        counts[s] += 1
+                        first_index.setdefault(s, idx)
+                enc_confirmed = max(
+                    counts,
+                    key=lambda s: (counts[s], -first_index[s]),
+                )
             species_confirmed_flag = False
 
         species_votes = _build_species_predictions(photos_list)

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -647,6 +647,68 @@ def test_serialize_results_mixed_species_not_marked_confirmed(tmp_path):
     )
 
 
+def test_serialize_results_mixed_fallback_species_is_deterministic(tmp_path):
+    """For mixed encounters, confirmed_species falls back to the most
+    frequent confirmed value so /api/encounters/species can untag a stable
+    previous keyword on re-confirm. Set iteration order is not stable
+    across processes, so the earlier next(iter(set)) fallback was
+    effectively arbitrary.
+    """
+    from pipeline import load_photo_features, run_full_pipeline, serialize_results
+
+    db, ids = _setup_db_with_photos(tmp_path)
+    robin_kid = db.add_keyword("Robin", is_species=True)
+    eagle_kid = db.add_keyword("Eagle", is_species=True)
+    # 2x Robin, 1x Eagle — Robin wins by frequency regardless of which
+    # photo happens to come first.
+    db.tag_photo(ids[0][0], eagle_kid)
+    db.tag_photo(ids[0][1], robin_kid)
+    db.tag_photo(ids[0][2], robin_kid)
+
+    photos = load_photo_features(db)
+    results = run_full_pipeline(photos)
+    serialized = serialize_results(results)
+
+    target_ids = set(ids[0])
+    target_enc = next(
+        e for e in serialized["encounters"]
+        if set(e["photo_ids"]) & target_ids
+    )
+
+    assert target_enc["species_confirmed"] is False
+    assert target_enc["confirmed_species"] == "Robin"
+
+
+def test_serialize_results_mixed_fallback_species_tiebreaks_by_first_photo(tmp_path):
+    """When confirmed-species counts tie within an encounter, the fallback
+    breaks ties by first appearance in photo order. This locks in
+    deterministic behavior so re-confirming the same encounter twice
+    untags the same previous keyword.
+    """
+    from pipeline import load_photo_features, run_full_pipeline, serialize_results
+
+    db, ids = _setup_db_with_photos(tmp_path)
+    robin_kid = db.add_keyword("Robin", is_species=True)
+    eagle_kid = db.add_keyword("Eagle", is_species=True)
+    # 1x Eagle (earliest photo), 1x Robin, 1x unconfirmed → counts tie
+    # at 1 each, so the earlier photo's species (Eagle) wins the tiebreak.
+    db.tag_photo(ids[0][0], eagle_kid)
+    db.tag_photo(ids[0][1], robin_kid)
+
+    photos = load_photo_features(db)
+    results = run_full_pipeline(photos)
+    serialized = serialize_results(results)
+
+    target_ids = set(ids[0])
+    target_enc = next(
+        e for e in serialized["encounters"]
+        if set(e["photo_ids"]) & target_ids
+    )
+
+    assert target_enc["species_confirmed"] is False
+    assert target_enc["confirmed_species"] == "Eagle"
+
+
 def test_serialize_results_uniformly_confirmed_remains_confirmed(tmp_path):
     """Sanity: an encounter where every photo shares the same confirmed
     species is still marked species_confirmed=True with confirmed_species set.

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -582,6 +582,129 @@ def test_serialize_results_has_burst_species_predictions(tmp_path):
             assert "species_override" in burst
 
 
+def test_serialize_results_partial_confirmation_not_marked_confirmed(tmp_path):
+    """An encounter with a mix of confirmed and unconfirmed photos must NOT be
+    marked species_confirmed=True. This guards the hide_confirmed UX: when
+    threshold-slider regrouping merges a confirmed encounter with an
+    unconfirmed neighbor, the merged encounter previously inherited the
+    confirmed flag and the unconfirmed photos vanished from the review list.
+    """
+    from pipeline import load_photo_features, run_full_pipeline, serialize_results
+
+    db, ids = _setup_db_with_photos(tmp_path)
+    # Confirm species on only some photos of the first encounter — the other
+    # photos in the same encounter remain unconfirmed.
+    kid = db.add_keyword("Robin", is_species=True)
+    for pid in ids[0][:1]:  # tag only the first photo
+        db.tag_photo(pid, kid)
+
+    photos = load_photo_features(db)
+    results = run_full_pipeline(photos)
+    serialized = serialize_results(results)
+
+    target_ids = set(ids[0])
+    target_enc = next(
+        e for e in serialized["encounters"]
+        if set(e["photo_ids"]) & target_ids
+    )
+
+    assert target_enc["species_confirmed"] is False, (
+        "Partially-confirmed encounter must not be marked confirmed — "
+        "otherwise hide_confirmed hides its unconfirmed photos."
+    )
+
+
+def test_serialize_results_mixed_species_not_marked_confirmed(tmp_path):
+    """An encounter where photos carry DIFFERENT confirmed species (e.g. when
+    threshold-slider regrouping merges two previously-separate confirmed
+    encounters) must not be marked species_confirmed=True with one species
+    arbitrarily winning. The mixed encounter should be visible for review.
+    """
+    from pipeline import load_photo_features, run_full_pipeline, serialize_results
+
+    db, ids = _setup_db_with_photos(tmp_path)
+    robin_kid = db.add_keyword("Robin", is_species=True)
+    eagle_kid = db.add_keyword("Eagle", is_species=True)
+    # Tag every photo in encounter 0 — but split between two species so the
+    # encounter has a genuinely mixed confirmation set.
+    db.tag_photo(ids[0][0], robin_kid)
+    db.tag_photo(ids[0][1], robin_kid)
+    db.tag_photo(ids[0][2], eagle_kid)
+
+    photos = load_photo_features(db)
+    results = run_full_pipeline(photos)
+    serialized = serialize_results(results)
+
+    target_ids = set(ids[0])
+    target_enc = next(
+        e for e in serialized["encounters"]
+        if set(e["photo_ids"]) & target_ids
+    )
+
+    assert target_enc["species_confirmed"] is False, (
+        "Encounter mixing different confirmed species must not be marked "
+        "confirmed — every photo would be hidden under hide_confirmed."
+    )
+
+
+def test_serialize_results_uniformly_confirmed_remains_confirmed(tmp_path):
+    """Sanity: an encounter where every photo shares the same confirmed
+    species is still marked species_confirmed=True with confirmed_species set.
+    """
+    from pipeline import load_photo_features, run_full_pipeline, serialize_results
+
+    db, ids = _setup_db_with_photos(tmp_path)
+    kid = db.add_keyword("Robin", is_species=True)
+    for pid in ids[0]:
+        db.tag_photo(pid, kid)
+
+    photos = load_photo_features(db)
+    results = run_full_pipeline(photos)
+    serialized = serialize_results(results)
+
+    target_ids = set(ids[0])
+    target_enc = next(
+        e for e in serialized["encounters"]
+        if set(e["photo_ids"]) <= target_ids
+    )
+
+    assert target_enc["species_confirmed"] is True
+    assert target_enc["confirmed_species"] == "Robin"
+
+
+def test_serialize_results_burst_override_derived_from_photos(tmp_path):
+    """When every photo in a burst shares the same confirmed_species, the
+    serialized burst gets a species_override matching that species. This
+    survives a regroup that previously wiped overrides to None on every call.
+    """
+    from pipeline import load_photo_features, run_full_pipeline, serialize_results
+
+    db, ids = _setup_db_with_photos(tmp_path)
+    kid = db.add_keyword("Robin", is_species=True)
+    for pid in ids[0]:
+        db.tag_photo(pid, kid)
+
+    photos = load_photo_features(db)
+    results = run_full_pipeline(photos)
+    serialized = serialize_results(results)
+
+    confirmed_burst_ids = set(ids[0])
+    saw_override = False
+    for enc in serialized["encounters"]:
+        for burst in enc.get("bursts", []):
+            burst_ids = set(burst["photo_ids"])
+            if burst_ids and burst_ids <= confirmed_burst_ids:
+                assert burst["species_override"] is not None, (
+                    "Burst whose photos are all confirmed Robin must surface a "
+                    "species_override so frontend burst-confirmed indicators "
+                    "survive a slider-driven regroup."
+                )
+                assert burst["species_override"]["species"] == "Robin"
+                assert burst["species_override"]["confirmed"] is True
+                saw_override = True
+    assert saw_override, "test setup did not produce any all-Robin burst"
+
+
 # -- DINOv2 variant filtering --
 
 


### PR DESCRIPTION
## Summary

When you nudge an encounter-grouping slider on the pipeline review page with **hide-confirmed** on, photos appear to "switch around" at the top of the list. The actual cause: a regroup can merge a confirmed encounter with an unconfirmed (or differently-confirmed) neighbor, and the serialized encounter previously inherited "confirmed" from the first photo it found with a species tag — so `hide_confirmed` swallowed the merged encounter wholesale, including its unconfirmed photos.

This made the *visible* encounter list mutate dramatically on every slider drag even though the chronological encounter list itself was stable.

### Fix

`vireo/pipeline.py:serialize_results`:

- An encounter is marked `species_confirmed=True` only when every photo shares the same `confirmed_species`. `confirmed_species` is still surfaced as the dominant prior species so `/api/encounters/species` can untag stale keywords on re-confirm.
- Burst `species_override` is derived from per-photo confirmations instead of being wiped to `None` on every regroup, so per-burst confirmation indicators survive a slider drag.

### Verification on real data (workspace ws1, 2500/3295 photos confirmed)

| | Encounters marked confirmed | Visible under hide-confirmed |
|---|---|---|
| Before | 113 / 145 | 32 |
| After  | 69 / 145 | 65 |

44 encounters un-stuck — including 4 mixed-species encounters (e.g. one labeled "Nuttall's woodpecker" that actually held 35 Nuttall's + 33 Oak titmouse photos arbitrarily flattened to one species), plus partial encounters that previously hid their unconfirmed photos.

## Test plan

- [x] `pytest vireo/tests/test_pipeline.py` — 43 passed
- [x] Required test set (`test_workspaces test_db test_app test_photos_api test_edits_api test_jobs_api test_darktable_api test_config`) — 830 passed, 1 skipped, 2 pre-existing failures (`test_remove_keyword_from_photo`, `test_undo_keyword_remove_clears_pending_change`) unrelated to this change
- [x] Real-data sanity check via worktree's `serialize_results` against ws1 cache + DB confirmations

🤖 Generated with [Claude Code](https://claude.com/claude-code)