### PR TITLE
pipeline: flip burst embedding slider to distance

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -969,9 +969,9 @@ input[type="range"]::-moz-range-thumb {
           <span class="slider-val" id="valBurstPhash">12</span>
         </div>
         <div class="slider-row">
-          <span class="slider-label" title="Min embedding similarity to stay in the same burst">Emb. cosine</span>
-          <input type="range" min="0" max="100" value="80" step="1" id="slBurstEmb" oninput="onGroupingChange(this)">
-          <span class="slider-val" id="valBurstEmb">0.80</span>
+          <span class="slider-label" title="Max embedding distance — higher tolerates more visually different shots in the same burst">Emb. distance</span>
+          <input type="range" min="0" max="100" value="20" step="1" id="slBurstEmb" oninput="onGroupingChange(this)">
+          <span class="slider-val" id="valBurstEmb">0.20</span>
         </div>
       </div>
 
@@ -1455,7 +1455,7 @@ var SCORING_DEFAULTS = {
 };
 var GROUPING_DEFAULTS = {
   hard_cut_score: 42, merge_score: 62,
-  burst_time_gap: 3, burst_phash_threshold: 12, burst_embedding_threshold: 80,
+  burst_time_gap: 3, burst_phash_threshold: 12, burst_embedding_threshold: 20,
 };
 
 /* Load slider defaults from server config (overrides hard-coded values above) */
@@ -1475,7 +1475,8 @@ var GROUPING_DEFAULTS = {
     GROUPING_DEFAULTS.merge_score = Math.round((p.merge_score != null ? p.merge_score : 0.62) * 100);
     GROUPING_DEFAULTS.burst_time_gap = p.burst_time_gap != null ? p.burst_time_gap : 3;
     GROUPING_DEFAULTS.burst_phash_threshold = p.burst_phash_threshold != null ? p.burst_phash_threshold : 12;
-    GROUPING_DEFAULTS.burst_embedding_threshold = Math.round((p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.80) * 100);
+    // Stored as cosine similarity; UI shows distance = 1 - similarity.
+    GROUPING_DEFAULTS.burst_embedding_threshold = Math.round((1 - (p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.80)) * 100);
     applyScoringDefaults();
     applyGroupingDefaults();
   } catch(e) {
@@ -1519,7 +1520,7 @@ function getGroupingConfig() {
     merge_score: sliderVal('slEncMerge') / 100,
     burst_time_gap: sliderVal('slBurstTime'),
     burst_phash_threshold: Math.round(sliderVal('slBurstPhash')),
-    burst_embedding_threshold: sliderVal('slBurstEmb') / 100,
+    burst_embedding_threshold: 1 - sliderVal('slBurstEmb') / 100,
   };
 }
 

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -651,12 +651,12 @@
         </div>
       </div>
       <div class="setting-row">
-        <div class="setting-label">Embedding similarity</div>
+        <div class="setting-label">Embedding distance</div>
         <div style="display:flex;align-items:center;gap:8px;">
-          <input type="range" id="cfgBurstEmb" min="50" max="99" value="80"
+          <input type="range" id="cfgBurstEmb" min="1" max="50" value="20"
                  style="width:120px;accent-color:var(--accent);"
                  oninput="document.getElementById('cfgBurstEmbVal').textContent = this.value + '%'; saveConfig()">
-          <span style="font-size:13px;color:var(--text-primary);min-width:36px;" id="cfgBurstEmbVal">80%</span>
+          <span style="font-size:13px;color:var(--text-primary);min-width:36px;" id="cfgBurstEmbVal">20%</span>
         </div>
       </div>
 
@@ -1300,7 +1300,8 @@ async function loadConfig() {
     var bph = p.burst_phash_threshold != null ? p.burst_phash_threshold : 12;
     document.getElementById('cfgBurstPhash').value = bph;
     document.getElementById('cfgBurstPhashVal').textContent = bph;
-    var bemb = Math.round((p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.80) * 100);
+    // Stored as cosine similarity; UI shows distance = 1 - similarity.
+    var bemb = Math.round((1 - (p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.80)) * 100);
     document.getElementById('cfgBurstEmb').value = bemb;
     document.getElementById('cfgBurstEmbVal').textContent = bemb + '%';
     var bl = Math.round((p.burst_lambda != null ? p.burst_lambda : 0.85) * 100);
@@ -1453,7 +1454,7 @@ function saveConfig() {
             reject_eye_focus: parseInt(document.getElementById('cfgRejectEyeFocus').value, 10) / 100,
             burst_time_gap: parseInt(document.getElementById('cfgBurstTimeGap').value, 10) || 3,
             burst_phash_threshold: parseInt(document.getElementById('cfgBurstPhash').value, 10) || 12,
-            burst_embedding_threshold: parseInt(document.getElementById('cfgBurstEmb').value, 10) / 100,
+            burst_embedding_threshold: 1 - parseInt(document.getElementById('cfgBurstEmb').value, 10) / 100,
             burst_lambda: parseInt(document.getElementById('cfgBurstLambda').value, 10) / 100,
             burst_max_keep: parseInt(document.getElementById('cfgBurstMaxKeep').value, 10) || 3,
             encounter_lambda: parseInt(document.getElementById('cfgEncLambda').value, 10) / 100,
@@ -1484,7 +1485,7 @@ function resetPipelineDefaults() {
     cfgRejectComposite: [40, '%'],
     cfgEyeClassifierConfGate: [50, '%'], cfgEyeDetectionConfGate: [50, '%'],
     cfgRejectEyeFocus: [35, '%'],
-    cfgBurstTimeGap: [3, 's'], cfgBurstPhash: [12, ''], cfgBurstEmb: [80, '%'],
+    cfgBurstTimeGap: [3, 's'], cfgBurstPhash: [12, ''], cfgBurstEmb: [20, '%'],
     cfgBurstLambda: [85, '%'], cfgEncLambda: [70, '%'],
     cfgHardCutScore: [42, '%'], cfgSoftCutScore: [52, '%'], cfgMergeScore: [62, '%'],
   };


### PR DESCRIPTION
## Summary

The three burst-grouping sliders on Pipeline Review and Settings pointed in inconsistent directions: **time gap** and **pHash distance** moved right for looser grouping (bigger bursts), but **embedding cosine** moved left. This flips the embedding slider to a distance (`1 - cos`), so all three sliders now move the same way — right = looser grouping = bigger bursts.

- Pipeline Review slider: label `Emb. cosine` → `Emb. distance`, default `0.80` → `0.20`
- Settings slider: label `Embedding similarity` → `Embedding distance`, range flipped (`min=50,max=99,value=80` → `min=1,max=50,value=20`)
- Backend untouched: `bursts.py`, `config.py`, and `config_schema.py` still store `burst_embedding_threshold` as a cosine similarity (default 0.80). The UI inverts at load/save.

Round-trip is identity: stored `0.80` → UI shows `20` (distance 0.20) → save sends `0.80`.

## Test plan

- [x] `vireo/tests/test_bursts.py` — 16 passed
- [x] `vireo/tests/test_config.py` + `test_db.py` + `test_bursts.py` — 425 passed, 1 skipped
- [x] `vireo/tests/test_app.py` — 151 passed
- [x] `tests/test_workspaces.py` — 68 passed
- [x] `vireo/tests/test_photos_api.py` + `test_edits_api.py` + `test_jobs_api.py` + `test_darktable_api.py` — 204 passed
- [ ] Manual: open Pipeline Review, confirm slider says "Emb. distance" with default 0.20, drag right → fewer/larger bursts; check Settings page shows "Embedding distance" 20%, persists across reload