### PR TITLE
pipeline: accurate status pills via /api/pipeline/plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@
 
 AI-powered wildlife photo organizer. Flask backend, Jinja2 templates, vanilla JS frontend. No frontend framework.
 
+## UI transparency is a hard rule
+
+Read `CORE_PHILOSOPHY.md` ("Show the user what's happening / No black boxes") before writing or reviewing any user-facing status text — pills, badges, counters, summaries, "X of Y", "Already done", "Will run", readiness panels, progress phrases. Each one must answer the question users actually read it as, not a cheaper backend proxy. A pill that says "Already done" must mean *the next run would be a no-op given current settings* — not "there exists prior output somewhere." If the accurate signal needs the current UI selections (selected models, labels, variants, reclassify, etc.), build the endpoint that takes them; don't fall back to a global `COUNT(*) > 0`.
+
 ## Running
 
 ```bash

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1213,6 +1213,38 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "recent_destinations": effective_cfg.get("ingest", {}).get("recent_destinations", []),
         })
 
+    @app.route("/api/pipeline/plan", methods=["POST"])
+    def api_pipeline_plan():
+        """Return the per-stage plan for the pipeline given current UI selections.
+
+        Truth source for the Pipeline page's status pills + plan summary —
+        each stage's state ("Will run", "Will skip", "Already done") and
+        its summary text are computed from the same gates the actual
+        pipeline job uses, so the user is never told a stage is done when
+        it isn't (or vice versa).
+
+        Body mirrors a subset of the /api/jobs/pipeline body so the page
+        can pass through the same selections the user is staging.
+        """
+        from pipeline_plan import PipelinePlanParams, compute_plan
+
+        body = request.get_json(silent=True) or {}
+        params = PipelinePlanParams(
+            collection_id=body.get("collection_id"),
+            exclude_photo_ids=body.get("exclude_photo_ids") or [],
+            skip_classify=bool(body.get("skip_classify")),
+            skip_extract_masks=bool(body.get("skip_extract_masks")),
+            skip_eye_keypoints=bool(body.get("skip_eye_keypoints")),
+            skip_regroup=bool(body.get("skip_regroup")),
+            model_ids=body.get("model_ids") or (
+                [body["model_id"]] if body.get("model_id") else []
+            ),
+            labels_files=body.get("labels_files") or [],
+            reclassify=bool(body.get("reclassify")),
+        )
+        db = _get_db()
+        return jsonify(compute_plan(db, params, db_path))
+
     @app.route("/api/folders")
     def api_folders():
         db = _get_db()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2532,6 +2532,157 @@ class Database:
             "sharpness": row["sharpness"] or 0,
         }
 
+    def _scope_clause(self, photo_ids, table_alias="p"):
+        """Build a (clause, params) pair to scope a query to photo_ids.
+
+        Returns ('', []) when photo_ids is None (whole-workspace scope).
+        Returns (' AND p.id IN (NULL)', []) for an empty set, which is the
+        intentional "no photos in scope" sentinel — callers asked for
+        "this collection" and the collection resolved to zero photos.
+        """
+        if photo_ids is None:
+            return "", []
+        ids = list(photo_ids)
+        if not ids:
+            return f" AND {table_alias}.id IN (NULL)", []
+        placeholders = ",".join("?" for _ in ids)
+        return f" AND {table_alias}.id IN ({placeholders})", ids
+
+    def count_real_detections_in_scope(self, photo_ids=None, min_conf=None):
+        """Count (photos_with_real_dets, total_real_dets) for the workspace.
+
+        "Real" excludes detector_model='full-image' synthetic anchors.
+        ``photo_ids`` scopes to a collection (set/list of ids); None = whole
+        workspace.
+
+        Used by the pipeline plan to compute classify scope.
+        """
+        ws = self._ws_id()
+        if min_conf is None:
+            import config as cfg
+            min_conf = self.get_effective_config(cfg.load()).get(
+                "detector_confidence", 0.2,
+            )
+        scope_sql, scope_params = self._scope_clause(photo_ids)
+        row = self.conn.execute(
+            f"""SELECT COUNT(*) AS total_dets,
+                       COUNT(DISTINCT d.photo_id) AS photos_with_dets
+                FROM detections d
+                JOIN photos p ON p.id = d.photo_id
+                JOIN workspace_folders wf
+                  ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                WHERE d.detector_model != 'full-image'
+                  AND d.detector_confidence >= ?{scope_sql}""",
+            (ws, min_conf, *scope_params),
+        ).fetchone()
+        return {
+            "photos_with_dets": row["photos_with_dets"] or 0,
+            "total_dets": row["total_dets"] or 0,
+        }
+
+    def count_classify_pending_pairs(
+        self, classifier_model, labels_fingerprint,
+        photo_ids=None, min_conf=None,
+    ):
+        """Count detections in scope that lack a classifier_runs row for
+        (classifier_model, labels_fingerprint).
+
+        Mirrors the gate in classify_job._classify_photos: a real detection
+        with no row in classifier_runs for the given (model, fp) is one
+        unit of pending work for the next classify run.
+        """
+        ws = self._ws_id()
+        if min_conf is None:
+            import config as cfg
+            min_conf = self.get_effective_config(cfg.load()).get(
+                "detector_confidence", 0.2,
+            )
+        scope_sql, scope_params = self._scope_clause(photo_ids)
+        row = self.conn.execute(
+            f"""SELECT COUNT(*) AS pending
+                FROM detections d
+                JOIN photos p ON p.id = d.photo_id
+                JOIN workspace_folders wf
+                  ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                LEFT JOIN classifier_runs cr
+                  ON cr.detection_id = d.id
+                 AND cr.classifier_model = ?
+                 AND cr.labels_fingerprint = ?
+                WHERE d.detector_model != 'full-image'
+                  AND d.detector_confidence >= ?
+                  AND cr.detection_id IS NULL{scope_sql}""",
+            (ws, classifier_model, labels_fingerprint, min_conf, *scope_params),
+        ).fetchone()
+        return row["pending"] or 0
+
+    def count_photos_pending_masks(self, photo_ids=None, min_conf=None):
+        """Return (pending, eligible) for the extract-masks stage.
+
+        eligible = photos in scope with at least one real detection above the
+            workspace's effective detector_confidence
+        pending  = eligible photos whose mask_path IS NULL
+
+        Mirrors extract_masks_stage's per-photo gate (which keys solely on
+        mask_path being unset for photos with non-full-image detections).
+        """
+        ws = self._ws_id()
+        if min_conf is None:
+            import config as cfg
+            min_conf = self.get_effective_config(cfg.load()).get(
+                "detector_confidence", 0.2,
+            )
+        scope_sql, scope_params = self._scope_clause(photo_ids)
+        row = self.conn.execute(
+            f"""SELECT
+                  COUNT(DISTINCT p.id) AS eligible,
+                  COUNT(DISTINCT CASE WHEN p.mask_path IS NULL THEN p.id END)
+                    AS pending
+                FROM photos p
+                JOIN workspace_folders wf
+                  ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                JOIN detections d
+                  ON d.photo_id = p.id
+                 AND d.detector_model != 'full-image'
+                 AND d.detector_confidence >= ?
+                WHERE 1=1{scope_sql}""",
+            (ws, min_conf, *scope_params),
+        ).fetchone()
+        return {
+            "eligible": row["eligible"] or 0,
+            "pending": row["pending"] or 0,
+        }
+
+    def count_eye_keypoint_eligible(self, photo_ids=None):
+        """Count photos eligible for the eye-keypoint stage, ignoring the
+        ``eye_tenengrad IS NULL`` idempotency gate.
+
+        Eligibility = mask present + at least one non-synthetic detection
+        above min_conf + at least one prediction on that detection. Matches
+        the join shape of ``list_photos_for_eye_keypoint_stage`` minus the
+        "not yet processed" filter, so the plan can distinguish "no
+        eligible photos" from "all eligible photos already processed".
+        """
+        import config as cfg
+        ws = self._ws_id()
+        min_conf = self.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2,
+        )
+        scope_sql, scope_params = self._scope_clause(photo_ids)
+        row = self.conn.execute(
+            f"""SELECT COUNT(DISTINCT p.id) AS n
+                FROM photos p
+                JOIN workspace_folders wf
+                  ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                JOIN detections d
+                  ON d.photo_id = p.id
+                 AND d.detector_model != 'full-image'
+                 AND d.detector_confidence >= ?
+                JOIN predictions pr ON pr.detection_id = d.id
+                WHERE p.mask_path IS NOT NULL{scope_sql}""",
+            (ws, min_conf, *scope_params),
+        ).fetchone()
+        return row["n"] or 0
+
     def get_dashboard_stats(self):
         """Return aggregate statistics for the dashboard."""
         ws = self._ws_id()

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -1,0 +1,386 @@
+"""Per-stage pipeline plan for the Pipeline page UI.
+
+Given the current UI selections (collection, models, labels, variants, skip
+flags, exclude IDs), return per-stage state + summary so the page renders
+accurate "Will run / Will skip / Already done" pills.
+
+This module is the truth source for the user's transparency contract
+documented in CORE_PHILOSOPHY.md ("Show the user what's happening / No
+black boxes"). The plan must match what the actual pipeline job would do
+for the same inputs — pills/summaries derive from the same gates the
+stages use, never from coarser proxies like "any prior data exists".
+"""
+
+import logging
+import os
+from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class PipelinePlanParams:
+    collection_id: int | None = None
+    exclude_photo_ids: list = field(default_factory=list)
+    skip_classify: bool = False
+    skip_extract_masks: bool = False
+    skip_eye_keypoints: bool = False
+    skip_regroup: bool = False
+    model_ids: list = field(default_factory=list)
+    labels_files: list = field(default_factory=list)
+    reclassify: bool = False
+
+
+def _plural(n, s="s"):
+    return s if n != 1 else ""
+
+
+def _resolve_models(model_ids):
+    """Resolve UI model_ids to the (id, name, model_str, model_type) entries
+    written into classifier_runs. Unknown ids are dropped — the plan reflects
+    what the classify job would actually run, and the job ignores them.
+    """
+    if not model_ids:
+        return []
+    from models import get_models
+
+    by_id = {m["id"]: m for m in get_models()}
+    out = []
+    for mid in model_ids:
+        m = by_id.get(mid)
+        if not m:
+            continue
+        out.append({
+            "id": mid,
+            "name": m.get("name") or mid,
+            "model_str": m.get("model_str") or "",
+            "model_type": m.get("model_type", "bioclip"),
+            "downloaded": m.get("downloaded", False),
+        })
+    return out
+
+
+def _resolve_labels_for_models(models, labels_files, db):
+    """Per-model: resolve the labels list and its content fingerprint.
+
+    Mirrors classify_job._load_labels' resolution order so the plan keys
+    classifier_runs lookups by the *same* (model_name, fingerprint) pair the
+    job would write. Returns: model_id -> {fingerprint, n, blocked?}.
+    """
+    from labels import get_active_labels, get_saved_labels, load_merged_labels
+    from labels_fingerprint import LEGACY_SENTINEL, TOL_SENTINEL, compute_fingerprint
+
+    saved_by_file = {s["labels_file"]: s for s in get_saved_labels()}
+
+    def _load(active_sets):
+        try:
+            return load_merged_labels(active_sets) if active_sets else []
+        except Exception as e:
+            log.warning("plan: failed to load labels %s: %s", active_sets, e)
+            return []
+
+    if labels_files:
+        active_sets = [
+            saved_by_file.get(p, {"labels_file": p}) for p in labels_files
+        ]
+        labels = _load(active_sets)
+    else:
+        ws_labels = db.get_workspace_active_labels()
+        if ws_labels is not None:
+            active_sets = [
+                saved_by_file.get(p, {"labels_file": p}) for p in ws_labels
+            ]
+            labels = _load(active_sets)
+        else:
+            labels = _load(get_active_labels())
+
+    tol_supported = {
+        "hf-hub:imageomics/bioclip",
+        "hf-hub:imageomics/bioclip-2",
+    }
+    out = {}
+    for m in models:
+        if m["model_type"] == "timm":
+            out[m["id"]] = {"fingerprint": LEGACY_SENTINEL, "n": 0}
+        elif not labels:
+            if m["model_str"] in tol_supported:
+                out[m["id"]] = {"fingerprint": TOL_SENTINEL, "n": 0}
+            else:
+                out[m["id"]] = {"fingerprint": None, "n": 0, "blocked": True}
+        else:
+            out[m["id"]] = {
+                "fingerprint": compute_fingerprint(labels),
+                "n": len(labels),
+            }
+    return out
+
+
+def _classify_plan(db, params, photo_ids):
+    if params.skip_classify:
+        return {
+            "state": "will-skip",
+            "summary": "Disabled — stage will be skipped",
+        }
+
+    models = _resolve_models(params.model_ids)
+    if not models:
+        return {
+            "state": "will-skip",
+            "summary": "No models selected — stage will be skipped",
+        }
+
+    label_resolution = _resolve_labels_for_models(models, params.labels_files, db)
+
+    det_counts = db.count_real_detections_in_scope(photo_ids)
+    total_dets = det_counts["total_dets"]
+    photos_with_dets = det_counts["photos_with_dets"]
+
+    if total_dets == 0:
+        return {
+            "state": "will-run",
+            "summary": (
+                "Will run — no detections cached yet "
+                "(MegaDetector will run first)"
+            ),
+            "detail": {
+                "total_dets": 0,
+                "photos_with_dets": 0,
+                "models": [m["name"] for m in models],
+            },
+        }
+
+    blocked = []
+    pending_per_model = {}
+    pending_total = 0
+    for m in models:
+        info = label_resolution[m["id"]]
+        if info.get("blocked"):
+            blocked.append(m["name"])
+            continue
+        fp = info["fingerprint"]
+        if params.reclassify:
+            pending = total_dets
+        else:
+            pending = db.count_classify_pending_pairs(
+                classifier_model=m["name"],
+                labels_fingerprint=fp,
+                photo_ids=photo_ids,
+            )
+        if pending:
+            pending_per_model[m["name"]] = pending
+            pending_total += pending
+
+    if blocked and not pending_total:
+        return {
+            "state": "will-run",
+            "summary": (
+                f"Blocked — {len(blocked)} model{_plural(len(blocked))} "
+                f"need labels: {', '.join(blocked)}"
+            ),
+            "detail": {"blocked_models": blocked},
+        }
+
+    if pending_total == 0:
+        return {
+            "state": "done-prior",
+            "summary": (
+                f"Already classified — {total_dets} "
+                f"detection{_plural(total_dets)} across "
+                f"{len(models)} model{_plural(len(models))}"
+            ),
+            "detail": {
+                "total_dets": total_dets,
+                "photos_with_dets": photos_with_dets,
+                "models": [m["name"] for m in models],
+            },
+        }
+
+    if params.reclassify:
+        summary = (
+            f"Re-classify — {pending_total} "
+            f"detection-model pair{_plural(pending_total)} "
+            f"({total_dets} detection{_plural(total_dets)} × "
+            f"{len(models)} model{_plural(len(models))})"
+        )
+    else:
+        breakdown = ", ".join(
+            f"{n} for {name}" for name, n in pending_per_model.items()
+        )
+        summary = (
+            f"Will classify {pending_total} new "
+            f"pair{_plural(pending_total)} ({breakdown})"
+        )
+    detail = {
+        "pending_pairs": pending_total,
+        "per_model": pending_per_model,
+        "total_dets": total_dets,
+        "photos_with_dets": photos_with_dets,
+    }
+    if blocked:
+        detail["blocked_models"] = blocked
+    return {"state": "will-run", "summary": summary, "detail": detail}
+
+
+def _extract_plan(db, params, photo_ids):
+    if params.skip_extract_masks:
+        return {
+            "state": "will-skip",
+            "summary": "Disabled — stage will be skipped",
+        }
+    counts = db.count_photos_pending_masks(photo_ids)
+    eligible = counts["eligible"]
+    pending = counts["pending"]
+    if eligible == 0:
+        return {
+            "state": "will-run",
+            "summary": (
+                "Will run after classify produces detections "
+                "(no eligible photos yet)"
+            ),
+            "detail": {"eligible": 0, "pending": 0},
+        }
+    if pending == 0:
+        return {
+            "state": "done-prior",
+            "summary": (
+                f"Masks present for all {eligible} eligible "
+                f"photo{_plural(eligible)}"
+            ),
+            "detail": {"eligible": eligible, "pending": 0},
+        }
+    return {
+        "state": "will-run",
+        "summary": (
+            f"Will extract masks for {pending} "
+            f"photo{_plural(pending)} ({eligible} eligible)"
+        ),
+        "detail": {"eligible": eligible, "pending": pending},
+    }
+
+
+def _eye_keypoints_plan(db, params, photo_ids, pipeline_cfg):
+    if params.skip_eye_keypoints or params.skip_extract_masks:
+        return {
+            "state": "will-skip",
+            "summary": "Disabled — stage will be skipped",
+        }
+    from pipeline import eye_keypoint_stage_preflight
+
+    skip_reason = eye_keypoint_stage_preflight(pipeline_cfg)
+    if skip_reason is not None:
+        return {
+            "state": "will-skip",
+            "summary": f"Will skip — {skip_reason}",
+        }
+
+    pending = len(db.list_photos_for_eye_keypoint_stage(photo_ids=photo_ids))
+    eligible = db.count_eye_keypoint_eligible(photo_ids)
+    processed = max(eligible - pending, 0)
+
+    if eligible == 0:
+        return {
+            "state": "will-run",
+            "summary": (
+                "Will run after upstream produces masks + species "
+                "predictions (no eligible photos yet)"
+            ),
+            "detail": {"eligible": 0, "pending": 0},
+        }
+    if pending == 0:
+        return {
+            "state": "done-prior",
+            "summary": (
+                f"Eye keypoints present for all {eligible} eligible "
+                f"photo{_plural(eligible)}"
+            ),
+            "detail": {"eligible": eligible, "pending": 0, "processed": processed},
+        }
+    return {
+        "state": "will-run",
+        "summary": (
+            f"Will run on {pending} photo{_plural(pending)} "
+            f"({processed} of {eligible} already processed)"
+        ),
+        "detail": {"eligible": eligible, "pending": pending, "processed": processed},
+    }
+
+
+def _regroup_plan(db, params, db_path, ws_id, upstream_will_run):
+    if params.skip_regroup:
+        return {
+            "state": "will-skip",
+            "summary": "Disabled — stage will be skipped",
+        }
+    cache_path = os.path.join(
+        os.path.dirname(db_path), f"pipeline_results_ws{ws_id}.json",
+    )
+    cache_exists = os.path.exists(cache_path)
+    if upstream_will_run:
+        return {
+            "state": "will-run",
+            "summary": "Will re-group — upstream stages have new work to do",
+            "detail": {"cache_exists": cache_exists, "upstream_will_run": True},
+        }
+    if cache_exists:
+        return {
+            "state": "done-prior",
+            "summary": "Grouping cached from prior run",
+            "detail": {"cache_exists": True, "upstream_will_run": False},
+        }
+    return {
+        "state": "will-run",
+        "summary": "Will run — no cached grouping yet",
+        "detail": {"cache_exists": False, "upstream_will_run": False},
+    }
+
+
+def compute_plan(db, params, db_path):
+    """Compute the full per-stage plan for the active workspace.
+
+    Returns:
+        {
+            "stages": {
+                "Classify": {state, summary, detail?},
+                "Extract": ...,
+                "EyeKeypoints": ...,
+                "Group": ...,
+            },
+            "scope": {"collection_id": int | None, "photo_count": int | None},
+        }
+    """
+    import config as cfg
+
+    effective_cfg = db.get_effective_config(cfg.load())
+    pipeline_cfg = effective_cfg.get("pipeline", {})
+    ws_id = db._ws_id()
+
+    photo_ids = None
+    if params.collection_id is not None:
+        from pipeline import _resolve_collection_photo_ids
+        photo_ids = _resolve_collection_photo_ids(db, params.collection_id)
+        if params.exclude_photo_ids:
+            excl = set(params.exclude_photo_ids)
+            photo_ids = {pid for pid in photo_ids if pid not in excl}
+
+    classify = _classify_plan(db, params, photo_ids)
+    extract = _extract_plan(db, params, photo_ids)
+    eye = _eye_keypoints_plan(db, params, photo_ids, pipeline_cfg)
+    upstream_will_run = any(
+        s["state"] == "will-run" for s in (classify, extract, eye)
+    )
+    regroup = _regroup_plan(db, params, db_path, ws_id, upstream_will_run)
+
+    return {
+        "stages": {
+            "Classify": classify,
+            "Extract": extract,
+            "EyeKeypoints": eye,
+            "Group": regroup,
+        },
+        "scope": {
+            "collection_id": params.collection_id,
+            "photo_count": (
+                len(photo_ids) if photo_ids is not None else None
+            ),
+        },
+    }

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -152,10 +152,48 @@ body { padding-bottom: 36px; }
   color: var(--text-faint, #5A8890);
   font-style: italic;
 }
+/* Per-stage rows: pill + summary text, one row per stage */
+.pipeline-plan-summary .plan-stage-row {
+  display: grid;
+  grid-template-columns: 140px 110px 1fr;
+  gap: 10px;
+  align-items: baseline;
+  padding: 3px 0;
+}
+.pipeline-plan-summary .plan-stage-row .plan-stage-name {
+  color: var(--text-secondary, #B0CCCC);
+  font-weight: 600;
+}
+.pipeline-plan-summary .plan-stage-row .plan-stage-pill {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  font-weight: 700;
+}
+.pipeline-plan-summary .plan-stage-row.will-run .plan-stage-pill { color: var(--accent, #24E5CA); }
+.pipeline-plan-summary .plan-stage-row.will-skip .plan-stage-pill { color: var(--text-dim, #5A8890); font-style: italic; }
+.pipeline-plan-summary .plan-stage-row.done-prior .plan-stage-pill {
+  color: color-mix(in srgb, var(--accent, #24E5CA) 65%, var(--text-secondary, #B0CCCC));
+}
+.pipeline-plan-summary .plan-stage-row .plan-stage-summary {
+  color: var(--text-dim, #5A8890);
+  font-size: 12px;
+}
+.pipeline-plan-summary .plan-loading {
+  color: var(--text-faint, #5A8890);
+  font-style: italic;
+  font-size: 12px;
+}
 .stage-summary {
   margin-left: auto;
   font-size: 12px;
   color: var(--text-dim, #5A8890);
+  text-align: right;
+  /* Plan summaries can run long ("Will classify 47 new pairs (35 for…")
+     so the span needs to wrap rather than push the chevron off the row.
+     min-width:0 lets the flex item actually shrink. */
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 .stage-chevron {
   color: var(--text-ghost, #2D5058);
@@ -883,7 +921,7 @@ body { padding-bottom: 36px; }
       </div>
       <div class="readiness-panel" id="readinessPanel" style="display:none;"></div>
       <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;" title="Re-process photos that were already classified. Also bypasses the skip for photos already tagged with a subject keyword (taxonomy, individual, or genre) — useful for double-checking existing tags.">
-        <input type="checkbox" id="chkReclassify" style="accent-color:var(--accent);" onchange="refreshPipelineUI()"> Re-classify
+        <input type="checkbox" id="chkReclassify" style="accent-color:var(--accent);" onchange="schedulePlanRefresh()"> Re-classify
       </label>
       <div style="margin-top:8px;">
         <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;">
@@ -1148,8 +1186,14 @@ function initPipelinePage() {
 
   // Load collections, models, labels, volumes in parallel
   loadCollections();
-  loadModels();
-  loadLabels();
+  // Models and labels populate the pickers the plan endpoint reads from,
+  // so chain the first plan refresh once both are in the DOM. Without
+  // this, the initial plan would key off zero models / zero labels and
+  // mislabel Classify as "No models selected" until the user clicks
+  // something.
+  Promise.all([loadModels(), loadLabels()]).then(function() {
+    refreshPipelinePlan();
+  });
   loadVolumes();
 
   // Pre-fill folders from query params (e.g., from audit panel)
@@ -2003,6 +2047,11 @@ async function selectSourceMode(mode) {
   }
 
   fetchFolderPreview();
+  // Source mode controls whether the plan body sends a collection_id, so
+  // pills/summaries can change when the user switches modes (e.g. an
+  // "Already done" Classify under whole-workspace becomes "Will run on N
+  // photos" once a partially-classified collection is selected).
+  schedulePlanRefresh();
 }
 
 function onCollectionChange() {
@@ -2012,6 +2061,7 @@ function onCollectionChange() {
     countEl.textContent = '';
     updateStartButton();
     fetchFolderPreview();
+    schedulePlanRefresh();
     return;
   }
   safeFetch('/api/collections/' + collId + '/photos?per_page=1', {}, { toast: false })
@@ -2021,6 +2071,7 @@ function onCollectionChange() {
     .catch(function() { countEl.textContent = ''; });
   updateStartButton();
   fetchFolderPreview();
+  schedulePlanRefresh();
 }
 
 async function loadVolumes() {
@@ -2172,6 +2223,7 @@ function onStageToggle(stage) {
 
   updateStartButton();
   refreshPipelineUI();
+  schedulePlanRefresh();
 }
 
 // -- Pipeline orchestration --
@@ -2374,6 +2426,10 @@ async function startPipeline() {
     btn.textContent = 'Start Pipeline';
     btn.onclick = startPipeline;
     updateStartButton();
+    // The pipeline just wrote new detections, masks, keypoints, etc. —
+    // refresh the plan so the next run's pills reflect the new state of
+    // the world (e.g. "Already done" for stages that just completed).
+    refreshPipelinePlan();
   }
 }
 
@@ -2837,7 +2893,7 @@ async function loadModels() {
         cb.value = m.id;
         cb.dataset.name = m.name;
         cb.style.cssText = 'accent-color:var(--accent);margin-right:4px;';
-        cb.onchange = updateReadiness;
+        cb.onchange = function() { updateReadiness(); schedulePlanRefresh(); };
         if (m.id === data.active_id) cb.checked = true;
         label.appendChild(cb);
         label.appendChild(document.createTextNode(m.name + ' (' + m.model_str + ')'));
@@ -2863,7 +2919,7 @@ async function loadLabels() {
         var isActive = activePaths.has(l.labels_file);
         html += '<label style="display:flex;align-items:center;gap:4px;color:var(--text-secondary);cursor:pointer;padding:2px 0;">' +
           '<input type="checkbox" class="labels-run-cb" value="' + l.labels_file.replace(/"/g, '&quot;') + '"' +
-          (isActive ? ' checked' : '') + ' onchange="updateReadiness()" style="accent-color:var(--accent);"> ' +
+          (isActive ? ' checked' : '') + ' onchange="updateReadiness(); schedulePlanRefresh();" style="accent-color:var(--accent);"> ' +
           l.name + ' (' + (l.species_count || 0) + ')</label>';
       });
       div.innerHTML = html;
@@ -3257,7 +3313,7 @@ var _pipelineState = {
 // Stages 3-8 each show an explicit text pill (Will run / Will skip / Already
 // done / Running / Done / Failed) instead of relying on the colored circle.
 // `_runningStages` and `_stageOutcomes` are live overrides: while a
-// pipeline is running, they take precedence over the toggle/prior-data state.
+// pipeline is running, they take precedence over plan-derived state.
 //
 // `_runningStages` is per-stage (not a single global) because the pipeline
 // allows concurrent stages — e.g. scan runs alongside thumbnails/previews —
@@ -3266,13 +3322,24 @@ var _pipelineState = {
 var _runningStages = {};  // suffix -> true while that stage is running
 var _stageOutcomes = {};  // suffix -> 'done' | 'failed' | 'will-skip' | 'done-prior'
 
+// Plan response from POST /api/pipeline/plan, keyed by stage suffix:
+//   { Classify: { state, summary, detail }, Extract: ..., ... }
+// Truth source for the user-visible pill state and per-stage summary text
+// when no run is active. Computed against current UI selections so the
+// page never tells the user a stage is done when, given new models or
+// labels, the next run actually has work to do (CORE_PHILOSOPHY: "No
+// black boxes" — pills must answer the question users read them as).
+var _pipelinePlan = null;
+var _planFetchSeq = 0;
+var _planDebounceTimer = null;
+
 var _STAGES = [
-  { suffix: 'Scan',         label: 'Scan & Import',          enable: null,             prior: null },
-  { suffix: 'Previews',     label: 'Thumbnails & Previews',  enable: null,             prior: null },
-  { suffix: 'Classify',     label: 'Classify',               enable: 'enableClassify', prior: 'hasDetections' },
-  { suffix: 'Extract',      label: 'Extract Features',       enable: 'enableExtract',  prior: 'hasMasks' },
-  { suffix: 'EyeKeypoints', label: 'Eye Keypoints',          enable: 'enableEyeKeypoints', prior: null },
-  { suffix: 'Group',        label: 'Group & Score',          enable: 'enableGroup',    prior: null },
+  { suffix: 'Scan',         label: 'Scan & Import',          enable: null },
+  { suffix: 'Previews',     label: 'Thumbnails & Previews',  enable: null },
+  { suffix: 'Classify',     label: 'Classify',               enable: 'enableClassify' },
+  { suffix: 'Extract',      label: 'Extract Features',       enable: 'enableExtract' },
+  { suffix: 'EyeKeypoints', label: 'Eye Keypoints',          enable: 'enableEyeKeypoints' },
+  { suffix: 'Group',        label: 'Group & Score',          enable: 'enableGroup' },
 ];
 
 // Lookup: cardSuffix -> enable-checkbox id (null for stages with no toggle).
@@ -3308,49 +3375,165 @@ function _setPill(suffix, state, text) {
   pill.textContent = text != null ? text : _PILL_LABELS[state];
 }
 
+// Map each stage suffix to the .stage-summary span it owns. The span shows
+// the plan summary text before/between runs and switches to live counts
+// during a run via the existing txtDetections/txtMasks ids.
+var _STAGE_SUMMARY_IDS = {
+  'Classify':     'txtDetections',
+  'Extract':      'txtMasks',
+  'EyeKeypoints': 'txtEyeKeypoints',
+  'Group':        'txtResults',
+};
+
+function _setStageSummaryText(suffix, text) {
+  var id = _STAGE_SUMMARY_IDS[suffix];
+  if (!id) return;
+  var el = document.getElementById(id);
+  if (el) el.textContent = text || '';
+}
+
 function _stageStateFor(stage) {
   if (_runningStages[stage.suffix]) return 'running';
   if (_stageOutcomes[stage.suffix]) return _stageOutcomes[stage.suffix];
 
-  // Re-classify bypasses the "already done" skip — Classify will run again.
-  var reclassify = false;
-  if (stage.suffix === 'Classify') {
-    var rc = document.getElementById('chkReclassify');
-    reclassify = !!(rc && rc.checked);
-  }
-
+  // User-toggled skip overrides anything the server-side plan returned —
+  // matches the user's mental model that toggling a stage off is the
+  // strongest signal of "do not run this".
   if (stage.enable) {
     var cb = document.getElementById(stage.enable);
     if (cb && !cb.checked) return 'will-skip';
   }
-  if (stage.prior && _pipelineState[stage.prior] && !reclassify) return 'done-prior';
-  return 'will-run';
+  // Stages with no plan entry (Scan, Previews) default to "will-run" —
+  // they always run when the pipeline starts.
+  if (!_pipelinePlan) return 'will-run';
+  var fromPlan = _pipelinePlan.stages && _pipelinePlan.stages[stage.suffix];
+  if (!fromPlan) return 'will-run';
+  return fromPlan.state || 'will-run';
 }
 
-function _renderPlanSummary(buckets) {
+function _stageSummaryFor(stage) {
+  if (!_pipelinePlan) return '';
+  var fromPlan = _pipelinePlan.stages && _pipelinePlan.stages[stage.suffix];
+  return (fromPlan && fromPlan.summary) || '';
+}
+
+function _renderPlanSummary() {
   var box = document.getElementById('pipelinePlanSummary');
   if (!box) return;
-  function row(cls, label, names, emptyText) {
-    var inner = names.length
-      ? '<span class="plan-stages">' + names.join(', ') + '</span>'
-      : '<span class="plan-empty">' + emptyText + '</span>';
-    return '<div class="plan-row ' + cls + '">' +
-      '<span class="plan-label">' + label + '</span>' + inner + '</div>';
+  // Per-stage rows: stage name, pill label, summary text. Mirrors the
+  // pills inside each card so the user sees the same answer in two places
+  // and can scan the whole plan at a glance before pressing Start.
+  var rows = [];
+  _STAGES.forEach(function(stage) {
+    if (!_STAGE_SUMMARY_IDS[stage.suffix]) return;  // Scan/Previews
+    var state = _stageStateFor(stage);
+    var summary = _runningStages[stage.suffix] || _stageOutcomes[stage.suffix]
+      ? ''  // live state takes the .stage-summary span; don't double up here
+      : _stageSummaryFor(stage);
+    var pillLabel = _PILL_LABELS[state] || state;
+    rows.push(
+      '<div class="plan-stage-row ' + state + '">' +
+        '<span class="plan-stage-name">' + stage.label + '</span>' +
+        '<span class="plan-stage-pill">' + pillLabel + '</span>' +
+        '<span class="plan-stage-summary">' + (summary || '') + '</span>' +
+      '</div>'
+    );
+  });
+  if (!_pipelinePlan && !Object.keys(_runningStages).length && !Object.keys(_stageOutcomes).length) {
+    box.innerHTML = '<div class="plan-loading">Loading plan…</div>';
+    return;
   }
-  var html = row('will-run', 'Will run', buckets['will-run'], 'nothing');
-  if (buckets['will-skip'].length)  html += row('will-skip',  'Will skip',    buckets['will-skip'],  '');
-  if (buckets['done-prior'].length) html += row('done-prior', 'Already done', buckets['done-prior'], '');
-  box.innerHTML = html;
+  box.innerHTML = rows.join('');
 }
 
 function refreshPipelineUI() {
-  var buckets = { 'will-run': [], 'will-skip': [], 'done-prior': [] };
   _STAGES.forEach(function(stage) {
     var state = _stageStateFor(stage);
     _setPill(stage.suffix, state);
-    if (buckets[state]) buckets[state].push(stage.label);
+    // Only paint plan summary text when no run is active for this stage,
+    // otherwise the live counts ("12/47", "Done!") get clobbered.
+    if (!_runningStages[stage.suffix] && !_stageOutcomes[stage.suffix]) {
+      _setStageSummaryText(stage.suffix, _stageSummaryFor(stage));
+    }
   });
-  _renderPlanSummary(buckets);
+  _renderPlanSummary();
+}
+
+// Build the body for /api/pipeline/plan from the current DOM. Mirrors the
+// subset of /api/jobs/pipeline the plan needs to make accurate decisions.
+function _buildPlanBody() {
+  var body = {};
+  // Source: only "existing collection" mode lets us scope the plan to a
+  // concrete photo set. For import / new-images modes the photo set
+  // doesn't exist yet, so leave collection_id null and let the plan
+  // describe whole-workspace counts.
+  if (_sourceMode === 'collection') {
+    var picker = document.getElementById('collectionPicker');
+    var cid = picker && picker.value ? parseInt(picker.value, 10) : NaN;
+    if (!isNaN(cid)) body.collection_id = cid;
+    if (_previewData && _previewSelected) {
+      var excludedIds = [];
+      _previewData.files.forEach(function(f) {
+        if (!_previewSelected[f.path] && f.photo_id) excludedIds.push(f.photo_id);
+      });
+      if (excludedIds.length) body.exclude_photo_ids = excludedIds;
+    }
+  }
+
+  body.skip_classify       = !document.getElementById('enableClassify').checked;
+  body.skip_extract_masks  = !document.getElementById('enableExtract').checked;
+  body.skip_eye_keypoints  = !document.getElementById('enableEyeKeypoints').checked;
+  body.skip_regroup        = !document.getElementById('enableGroup').checked;
+
+  if (!body.skip_classify) {
+    var modelIds = [];
+    document.querySelectorAll('.model-checkbox:checked').forEach(function(cb) {
+      modelIds.push(cb.value);
+    });
+    if (modelIds.length) body.model_ids = modelIds;
+
+    var labelsFiles = [];
+    document.querySelectorAll('.labels-run-cb:checked').forEach(function(cb) {
+      labelsFiles.push(cb.value);
+    });
+    if (labelsFiles.length) body.labels_files = labelsFiles;
+
+    var rc = document.getElementById('chkReclassify');
+    body.reclassify = !!(rc && rc.checked);
+  }
+  return body;
+}
+
+async function refreshPipelinePlan() {
+  // Don't fetch a plan while a pipeline is running — live state is
+  // authoritative, and the running stages would race the plan response.
+  if (_pipelineRunning) return;
+  var seq = ++_planFetchSeq;
+  try {
+    var data = await safeFetch('/api/pipeline/plan', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(_buildPlanBody()),
+    }, { toast: false });
+    // Drop responses that arrived after a newer request — otherwise a slow
+    // request can overwrite the result of a fresher one and the UI flickers
+    // back to stale state right after the user changed a setting.
+    if (seq !== _planFetchSeq) return;
+    _pipelinePlan = data;
+  } catch(e) {
+    if (seq !== _planFetchSeq) return;
+    _pipelinePlan = null;
+  }
+  refreshPipelineUI();
+}
+
+// Debounced version for chatty controls (label checkboxes, model picker).
+function schedulePlanRefresh() {
+  if (_planDebounceTimer) clearTimeout(_planDebounceTimer);
+  _planDebounceTimer = setTimeout(function() {
+    _planDebounceTimer = null;
+    refreshPipelinePlan();
+  }, 150);
 }
 
 function updateCardStates() {

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -1,0 +1,560 @@
+"""Tests for the pipeline plan: db helpers + compute_plan + /api/pipeline/plan.
+
+The plan is the truth source for the Pipeline page's status pills. These
+tests pin down the contract documented in CORE_PHILOSOPHY.md ("No black
+boxes"): a pill that says "Already done" must mean the next run would be a
+no-op, and a pill that says "Will run" must mean there is genuinely new
+work — independent of whether *any* prior output exists in the workspace.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+
+def _make_db(tmp_path, name="test.db"):
+    from db import Database
+    db = Database(str(tmp_path / name))
+    folder_id = db.add_folder("/tmp/p")
+    db._active_workspace_id = db.create_workspace("WS")
+    db.add_workspace_folder(db._active_workspace_id, folder_id)
+    return db, folder_id
+
+
+def _add_photo_with_detection(db, folder_id, filename, conf=0.9,
+                               detector_model="megadetector-v6"):
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename=filename, extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    det_ids = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": conf, "category": "animal"}],
+        detector_model=detector_model,
+    )
+    return photo_id, det_ids[0]
+
+
+# -------- db helpers --------
+
+def test_count_real_detections_in_scope_excludes_full_image(tmp_path):
+    """Synthetic full-image rows must not inflate the classify scope.
+
+    full-image rows exist only as FK anchors for predictions on photos
+    where MegaDetector found nothing — counting them as "real detections"
+    would let the classify pill flip to done-prior the moment a single
+    such anchor exists, even though those photos have no actual subject
+    boxes to classify.
+    """
+    db, folder_id = _make_db(tmp_path)
+    pid_real, _ = _add_photo_with_detection(db, folder_id, "real.jpg")
+    pid_synth = db.add_photo(
+        folder_id=folder_id, filename="synth.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    db.save_detections(
+        pid_synth,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+          "confidence": 1.0, "category": "anchor"}],
+        detector_model="full-image",
+    )
+
+    counts = db.count_real_detections_in_scope()
+    assert counts["total_dets"] == 1
+    assert counts["photos_with_dets"] == 1
+
+
+def test_count_real_detections_respects_min_conf(tmp_path):
+    db, folder_id = _make_db(tmp_path)
+    _add_photo_with_detection(db, folder_id, "high.jpg", conf=0.9)
+    _add_photo_with_detection(db, folder_id, "low.jpg", conf=0.05)
+
+    assert db.count_real_detections_in_scope(min_conf=0.2)["total_dets"] == 1
+    assert db.count_real_detections_in_scope(min_conf=0.0)["total_dets"] == 2
+
+
+def test_count_real_detections_scopes_to_photo_ids(tmp_path):
+    db, folder_id = _make_db(tmp_path)
+    pid_a, _ = _add_photo_with_detection(db, folder_id, "a.jpg")
+    pid_b, _ = _add_photo_with_detection(db, folder_id, "b.jpg")
+
+    counts = db.count_real_detections_in_scope(photo_ids=[pid_a])
+    assert counts["total_dets"] == 1
+    assert counts["photos_with_dets"] == 1
+
+    # Empty scope is a real "no photos" sentinel — must return zero, not
+    # the whole-workspace count.
+    counts = db.count_real_detections_in_scope(photo_ids=set())
+    assert counts == {"total_dets": 0, "photos_with_dets": 0}
+
+
+def test_count_classify_pending_excludes_recorded_runs(tmp_path):
+    """The pending-pair count must mirror the classify gate exactly: a
+    detection with a classifier_runs row for (model, fp) is done.
+    """
+    db, folder_id = _make_db(tmp_path)
+    _, did_a = _add_photo_with_detection(db, folder_id, "a.jpg")
+    _, did_b = _add_photo_with_detection(db, folder_id, "b.jpg")
+
+    # Both pending against (BioCLIP-2, fp1)
+    assert db.count_classify_pending_pairs("BioCLIP-2", "fp1") == 2
+
+    db.record_classifier_run(did_a, "BioCLIP-2", "fp1", prediction_count=1)
+    assert db.count_classify_pending_pairs("BioCLIP-2", "fp1") == 1
+
+    db.record_classifier_run(did_b, "BioCLIP-2", "fp1", prediction_count=1)
+    assert db.count_classify_pending_pairs("BioCLIP-2", "fp1") == 0
+
+    # A different (model, fp) must NOT see those rows as done — adding a
+    # new model is the headline failure mode the plan must catch.
+    assert db.count_classify_pending_pairs("BioCLIP-2", "fp2") == 2
+    assert db.count_classify_pending_pairs("OtherModel", "fp1") == 2
+
+
+def test_count_photos_pending_masks(tmp_path):
+    db, folder_id = _make_db(tmp_path)
+    pid_unmasked, _ = _add_photo_with_detection(db, folder_id, "no_mask.jpg")
+    pid_masked, _ = _add_photo_with_detection(db, folder_id, "masked.jpg")
+    db.conn.execute(
+        "UPDATE photos SET mask_path=? WHERE id=?",
+        ("/masks/x.png", pid_masked),
+    )
+    db.conn.commit()
+
+    counts = db.count_photos_pending_masks()
+    assert counts == {"eligible": 2, "pending": 1}
+
+
+def test_count_photos_pending_masks_ignores_photos_without_real_detections(tmp_path):
+    """A photo with only a synthetic full-image anchor should not be
+    counted as eligible for mask extraction — the actual stage skips it.
+    """
+    db, folder_id = _make_db(tmp_path)
+    pid = db.add_photo(
+        folder_id=folder_id, filename="anchor_only.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+          "confidence": 1.0, "category": "anchor"}],
+        detector_model="full-image",
+    )
+    counts = db.count_photos_pending_masks()
+    assert counts == {"eligible": 0, "pending": 0}
+
+
+def test_count_eye_keypoint_eligible_requires_mask_and_prediction(tmp_path):
+    db, folder_id = _make_db(tmp_path)
+    # Photo A: real det, mask, prediction → eligible
+    pid_a, did_a = _add_photo_with_detection(db, folder_id, "a.jpg")
+    db.conn.execute("UPDATE photos SET mask_path='/m/a.png' WHERE id=?", (pid_a,))
+    db.conn.execute(
+        """INSERT INTO predictions
+            (detection_id, classifier_model, labels_fingerprint,
+             species, confidence)
+           VALUES (?, ?, ?, ?, ?)""",
+        (did_a, "BioCLIP-2", "fp1", "robin", 0.9),
+    )
+    # Photo B: real det, NO mask → NOT eligible
+    pid_b, did_b = _add_photo_with_detection(db, folder_id, "b.jpg")
+    db.conn.execute(
+        """INSERT INTO predictions
+            (detection_id, classifier_model, labels_fingerprint,
+             species, confidence)
+           VALUES (?, ?, ?, ?, ?)""",
+        (did_b, "BioCLIP-2", "fp1", "sparrow", 0.8),
+    )
+    # Photo C: real det, mask, no prediction → NOT eligible
+    pid_c, _ = _add_photo_with_detection(db, folder_id, "c.jpg")
+    db.conn.execute("UPDATE photos SET mask_path='/m/c.png' WHERE id=?", (pid_c,))
+    db.conn.commit()
+
+    assert db.count_eye_keypoint_eligible() == 1
+
+
+# -------- compute_plan: classify --------
+
+def _params(**kwargs):
+    from pipeline_plan import PipelinePlanParams
+    return PipelinePlanParams(**kwargs)
+
+
+def test_classify_plan_will_skip_when_disabled(tmp_path):
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    plan = compute_plan(db, _params(skip_classify=True), str(tmp_path / "test.db"))
+    assert plan["stages"]["Classify"]["state"] == "will-skip"
+
+
+def test_classify_plan_will_skip_when_no_models_selected(tmp_path):
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    plan = compute_plan(db, _params(model_ids=[]), str(tmp_path / "test.db"))
+    assert plan["stages"]["Classify"]["state"] == "will-skip"
+    assert "No models selected" in plan["stages"]["Classify"]["summary"]
+
+
+def test_classify_plan_will_run_when_no_detections_yet(tmp_path, monkeypatch):
+    """Empty workspace → Classify must show "will run" so the user knows
+    MegaDetector + classifiers will both run on the next press.
+    """
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    plan = compute_plan(db, _params(model_ids=["m1"]), str(tmp_path / "test.db"))
+    assert plan["stages"]["Classify"]["state"] == "will-run"
+
+
+def test_classify_plan_done_prior_when_all_pairs_recorded(tmp_path, monkeypatch):
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+
+    import labels as labels_mod
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    # Pin label resolution: no labels_files passed and no workspace
+    # overrides → TOL fallback for bioclip-2. The dev's real
+    # ~/.vireo/labels_active.json must not bleed into this test.
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=3)
+
+    plan = compute_plan(db, _params(model_ids=["m1"]), str(tmp_path / "test.db"))
+    classify = plan["stages"]["Classify"]
+    assert classify["state"] == "done-prior"
+    assert "Already classified" in classify["summary"]
+
+
+def test_classify_plan_will_run_when_new_model_added(tmp_path, monkeypatch):
+    """The headline bug from the user report: classifying with model A
+    must NOT make the pill say "Already done" once the user adds model B
+    to the run.
+    """
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+        {"id": "m2", "name": "BioCLIP",
+         "model_str": "hf-hub:imageomics/bioclip",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    # Only m1 has been run — the new m2 has zero coverage.
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=3)
+
+    plan = compute_plan(
+        db, _params(model_ids=["m1", "m2"]), str(tmp_path / "test.db"),
+    )
+    classify = plan["stages"]["Classify"]
+    assert classify["state"] == "will-run"
+    # Per-model breakdown surfaces the *new* model so the user sees why.
+    assert "BioCLIP" in classify["summary"]
+
+
+def test_classify_plan_reclassify_bypasses_cache(tmp_path, monkeypatch):
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=3)
+
+    plan = compute_plan(
+        db,
+        _params(model_ids=["m1"], reclassify=True),
+        str(tmp_path / "test.db"),
+    )
+    classify = plan["stages"]["Classify"]
+    assert classify["state"] == "will-run"
+    assert "Re-classify" in classify["summary"]
+
+
+# -------- compute_plan: extract --------
+
+def test_extract_plan_will_skip_when_disabled(tmp_path):
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    plan = compute_plan(
+        db, _params(skip_extract_masks=True), str(tmp_path / "test.db"),
+    )
+    assert plan["stages"]["Extract"]["state"] == "will-skip"
+
+
+def test_extract_plan_done_prior_when_all_masks_present(tmp_path):
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    pid, _ = _add_photo_with_detection(db, folder_id, "a.jpg")
+    db.conn.execute("UPDATE photos SET mask_path='/m/a.png' WHERE id=?", (pid,))
+    db.conn.commit()
+    plan = compute_plan(db, _params(), str(tmp_path / "test.db"))
+    extract = plan["stages"]["Extract"]
+    assert extract["state"] == "done-prior"
+    assert "1" in extract["summary"]
+
+
+def test_extract_plan_will_run_when_some_photos_missing_masks(tmp_path):
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    pid_done, _ = _add_photo_with_detection(db, folder_id, "done.jpg")
+    db.conn.execute(
+        "UPDATE photos SET mask_path='/m/done.png' WHERE id=?", (pid_done,),
+    )
+    _add_photo_with_detection(db, folder_id, "todo.jpg")
+    db.conn.commit()
+
+    plan = compute_plan(db, _params(), str(tmp_path / "test.db"))
+    extract = plan["stages"]["Extract"]
+    assert extract["state"] == "will-run"
+    assert extract["detail"]["pending"] == 1
+    assert extract["detail"]["eligible"] == 2
+
+
+# -------- compute_plan: eye keypoints --------
+
+def test_eye_keypoints_plan_will_skip_when_disabled(tmp_path):
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    plan = compute_plan(
+        db, _params(skip_eye_keypoints=True), str(tmp_path / "test.db"),
+    )
+    assert plan["stages"]["EyeKeypoints"]["state"] == "will-skip"
+
+
+def test_eye_keypoints_plan_will_skip_when_extract_disabled(tmp_path):
+    """Eye keypoints depends on masks — disabling extract must propagate."""
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    plan = compute_plan(
+        db, _params(skip_extract_masks=True), str(tmp_path / "test.db"),
+    )
+    assert plan["stages"]["EyeKeypoints"]["state"] == "will-skip"
+
+
+def test_eye_keypoints_plan_will_skip_when_preflight_fails(tmp_path, monkeypatch):
+    import pipeline as pipeline_mod
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight",
+        lambda config: "disabled in config",
+    )
+    plan = compute_plan(db, _params(), str(tmp_path / "test.db"))
+    eye = plan["stages"]["EyeKeypoints"]
+    assert eye["state"] == "will-skip"
+    assert "disabled in config" in eye["summary"]
+
+
+def test_eye_keypoints_plan_done_prior_when_all_processed(tmp_path, monkeypatch):
+    """The headline bug case: every eligible photo has eye_tenengrad set,
+    so the next run is a no-op. The pill must say so.
+    """
+    import pipeline as pipeline_mod
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight",
+        lambda config: None,
+    )
+    pid, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+    db.conn.execute(
+        "UPDATE photos SET mask_path='/m/a.png', eye_tenengrad=0.5 WHERE id=?",
+        (pid,),
+    )
+    db.conn.execute(
+        """INSERT INTO predictions
+            (detection_id, classifier_model, labels_fingerprint,
+             species, confidence)
+           VALUES (?, ?, ?, ?, ?)""",
+        (did, "BioCLIP-2", "fp1", "robin", 0.9),
+    )
+    db.conn.commit()
+
+    plan = compute_plan(db, _params(), str(tmp_path / "test.db"))
+    eye = plan["stages"]["EyeKeypoints"]
+    assert eye["state"] == "done-prior"
+
+
+def test_eye_keypoints_plan_will_run_when_some_pending(tmp_path, monkeypatch):
+    import pipeline as pipeline_mod
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight",
+        lambda config: None,
+    )
+    pid_done, did_done = _add_photo_with_detection(db, folder_id, "done.jpg")
+    pid_todo, did_todo = _add_photo_with_detection(db, folder_id, "todo.jpg")
+    db.conn.execute(
+        "UPDATE photos SET mask_path='/m/d.png', eye_tenengrad=0.5 WHERE id=?",
+        (pid_done,),
+    )
+    db.conn.execute(
+        "UPDATE photos SET mask_path='/m/t.png' WHERE id=?", (pid_todo,),
+    )
+    for did in (did_done, did_todo):
+        db.conn.execute(
+            """INSERT INTO predictions
+                (detection_id, classifier_model, labels_fingerprint,
+                 species, confidence)
+               VALUES (?, ?, ?, ?, ?)""",
+            (did, "BioCLIP-2", "fp1", "robin", 0.9),
+        )
+    db.conn.commit()
+
+    plan = compute_plan(db, _params(), str(tmp_path / "test.db"))
+    eye = plan["stages"]["EyeKeypoints"]
+    assert eye["state"] == "will-run"
+    assert eye["detail"]["pending"] == 1
+    assert eye["detail"]["eligible"] == 2
+
+
+# -------- compute_plan: regroup --------
+
+def test_regroup_plan_will_skip_when_disabled(tmp_path):
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    plan = compute_plan(
+        db, _params(skip_regroup=True), str(tmp_path / "test.db"),
+    )
+    assert plan["stages"]["Group"]["state"] == "will-skip"
+
+
+def test_regroup_plan_done_prior_when_cache_exists_and_no_upstream_work(tmp_path, monkeypatch):
+    """The other headline bug: Group & Score had no signal at all and
+    always said "Will run." When the cache exists and no upstream stage
+    has work, the next press is a no-op — say so.
+    """
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    # Make Classify and Extract done-prior so upstream_will_run is False.
+    pid, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+    db.conn.execute("UPDATE photos SET mask_path='/m/a.png' WHERE id=?", (pid,))
+    db.conn.commit()
+    from labels_fingerprint import TOL_SENTINEL
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=1)
+
+    cache_path = os.path.join(
+        str(tmp_path), f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(cache_path, "w") as f:
+        f.write('{"photos": []}')
+
+    import labels as labels_mod
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+    plan = compute_plan(
+        db,
+        # Skip eye keypoints so it doesn't surface as upstream "will-run".
+        _params(model_ids=["m1"], skip_eye_keypoints=True),
+        str(tmp_path / "test.db"),
+    )
+
+    assert plan["stages"]["Group"]["state"] == "done-prior"
+
+
+def test_regroup_plan_will_run_when_upstream_has_work(tmp_path):
+    """If any upstream stage is going to run, regroup must too — even if
+    a stale cache file exists, the grouping needs to be redone.
+    """
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _add_photo_with_detection(db, folder_id, "todo.jpg")
+
+    cache_path = os.path.join(
+        str(tmp_path), f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(cache_path, "w") as f:
+        f.write('{"photos": []}')
+
+    plan = compute_plan(db, _params(), str(tmp_path / "test.db"))
+    # Extract has pending work → upstream_will_run = True
+    assert plan["stages"]["Extract"]["state"] == "will-run"
+    assert plan["stages"]["Group"]["state"] == "will-run"
+
+
+def test_regroup_plan_will_run_when_no_cache(tmp_path):
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    # Skip everything else so upstream is all will-skip and cache is the
+    # only signal.
+    plan = compute_plan(
+        db,
+        _params(
+            skip_classify=True, skip_extract_masks=True,
+            skip_eye_keypoints=True,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    assert plan["stages"]["Group"]["state"] == "will-run"
+    assert "no cached" in plan["stages"]["Group"]["summary"].lower()
+
+
+# -------- /api/pipeline/plan endpoint --------
+
+def test_api_pipeline_plan_returns_per_stage_state(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={
+            "skip_classify": True, "skip_extract_masks": True,
+            "skip_eye_keypoints": True, "skip_regroup": True,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["stages"]["Classify"]["state"] == "will-skip"
+    assert data["stages"]["Extract"]["state"] == "will-skip"
+    assert data["stages"]["EyeKeypoints"]["state"] == "will-skip"
+    assert data["stages"]["Group"]["state"] == "will-skip"
+
+
+def test_api_pipeline_plan_collection_scope(app_and_db):
+    """Passing a collection_id must scope the plan to that collection's
+    photos — the endpoint's headline transparency contract.
+    """
+    app, db = app_and_db
+    # No detections in app_and_db fixture, so Extract should report
+    # "no eligible photos yet" rather than will-skip.
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={
+            "skip_classify": True,  # short-circuit to keep test simple
+            "skip_eye_keypoints": True, "skip_regroup": True,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["stages"]["Extract"]["state"] == "will-run"
+    assert data["stages"]["Extract"]["detail"]["eligible"] == 0


### PR DESCRIPTION
## Summary

The Pipeline page's status pills were lying in both directions:

- **Classify** and **Extract Features** said "Already done" the moment any single detection or mask existed in the workspace, even after adding new models/labels with zero coverage.
- **Eye Keypoints** and **Group & Score** said "Will run" forever because they had no prior-data signal at all.

Root cause: pills were driven by `_pipelineState.hasDetections` / `hasMasks`, populated from `db.get_pipeline_feature_counts()` (`COUNT(*) > 0` over the workspace) — a much weaker signal than "will the next run be a no-op."

## What changes

- New `POST /api/pipeline/plan` endpoint — takes a subset of the `/api/jobs/pipeline` body (`collection_id`, `model_ids`, `labels_files`, `reclassify`, skip flags, exclude IDs) and returns per-stage `state` (`will-run` / `will-skip` / `done-prior`) plus a verbose `summary` string.
- New `vireo/pipeline_plan.py` mirrors each stage's actual gate against current UI selections:
  - Classify: per-(detection, model_name, labels_fingerprint) lookup against `classifier_runs` — adds a per-model pending breakdown.
  - Extract: photos with real detections lacking `mask_path`.
  - Eye Keypoints: `list_photos_for_eye_keypoint_stage` (already applies the `eye_tenengrad IS NULL` gate) vs eligible population.
  - Group & Score: `done-prior` when cache exists and no upstream stage has work.
- Four new `db.py` helpers backing the plan: `count_real_detections_in_scope`, `count_classify_pending_pairs`, `count_photos_pending_masks`, `count_eye_keypoint_eligible`.
- Pipeline page: `_pipelinePlan` populated by debounced fetches on every relevant control change (model picker, labels, reclassify toggle, stage enable, source mode, collection, post-run). Plan summary block now shows one row per AI stage with name + pill + summary, mirroring the per-card pills.
- `CLAUDE.md` gains a "UI transparency is a hard rule" section pointing reviewers at `CORE_PHILOSOPHY.md` "No black boxes" — forcing function for this class of bug at review time.

## Test plan

- [x] `vireo/tests/test_pipeline_plan.py` — 27 new tests passing
- [x] Project regression suite (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_pipeline_plan.py`) — 859 passed, 1 skipped
- [x] `vireo/tests/test_pipeline_job.py` — 122 passed
- [x] Smoke-test: `GET /pipeline` returns 200 with the new JS hooks present
- [ ] Manual: add a new model after a successful classify run; confirm Classify pill flips from "Already done" to "Will run" with per-model breakdown
- [ ] Manual: run pipeline through Group & Score; reload page; confirm Group pill says "Already done" with no upstream changes
- [ ] Manual: re-classify checkbox flips Classify pill to "Will run — Re-classify all N detections..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)