### PR TITLE
taxonomy: report unavailable when file is corrupt or too small

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1193,9 +1193,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             except Exception:
                 pass
 
-        from taxonomy import find_taxonomy_json
-        taxonomy_path = find_taxonomy_json()
-        taxonomy_available = os.path.exists(taxonomy_path)
+        # "Available" must mean *usable*, not just *file exists*: a 0-byte
+        # stub from a failed download passed os.path.exists and hid the
+        # "Download taxonomy" checkbox in the pipeline page, leaving the
+        # user no in-app path to recovery. get_taxonomy_info() owns the
+        # actual integrity check.
+        from models import get_taxonomy_info
+        taxonomy_available = get_taxonomy_info()["available"]
 
         return jsonify({
             "total_photos": total_photos,

--- a/vireo/models.py
+++ b/vireo/models.py
@@ -941,8 +941,24 @@ def download_hf_model(repo_id, progress_callback=None):
     return {"model_id": model_id, "weights_path": local_dir, "name": name}
 
 
+_TAXONOMY_MIN_USABLE_BYTES = 1_000_000
+
+
 def get_taxonomy_info():
-    """Return taxonomy status info."""
+    """Return taxonomy status info.
+
+    ``available`` means *the file on disk is usable as a taxonomy*, not just
+    that a path exists. A 0-byte stub from an interrupted download or a
+    truncated write must report ``available: False`` so the UI keeps the
+    "Download taxonomy" affordance visible — the prior file-existence check
+    was hiding that affordance for unrecoverable users (CORE_PHILOSOPHY:
+    "Show the user what's happening / No black boxes").
+
+    Cheap-but-effective check: the real iNat taxonomy is hundreds of MB,
+    so anything under ~1MB is structurally broken. Full JSON parsing here
+    would dominate page-init latency for the common case where the file
+    is valid; the deeper parse happens at first ``Taxonomy(path)`` use.
+    """
     from taxonomy import find_taxonomy_json
     taxonomy_path = find_taxonomy_json()
     if not os.path.exists(taxonomy_path):
@@ -951,6 +967,17 @@ def get_taxonomy_info():
             "path": taxonomy_path,
             "taxa_count": 0,
             "last_updated": None,
+        }
+
+    size = os.path.getsize(taxonomy_path)
+    if size < _TAXONOMY_MIN_USABLE_BYTES:
+        return {
+            "available": False,
+            "path": taxonomy_path,
+            "taxa_count": 0,
+            "last_updated": None,
+            "file_size": size,
+            "corrupt": True,
         }
 
     try:
@@ -962,8 +989,6 @@ def get_taxonomy_info():
         updated_match = re.search(r'"last_updated"\s*:\s*"([^"]+)"', raw)
         last_updated = updated_match.group(1) if updated_match else None
 
-        # Get file size as a proxy for taxa count
-        size = os.path.getsize(taxonomy_path)
         # Rough estimate: ~150 bytes per taxon entry
         taxa_estimate = size // 150
 
@@ -976,8 +1001,10 @@ def get_taxonomy_info():
         }
     except Exception:
         return {
-            "available": True,
+            "available": False,
             "path": taxonomy_path,
             "taxa_count": 0,
             "last_updated": None,
+            "file_size": size,
+            "corrupt": True,
         }

--- a/vireo/models.py
+++ b/vireo/models.py
@@ -969,7 +969,23 @@ def get_taxonomy_info():
             "last_updated": None,
         }
 
-    size = os.path.getsize(taxonomy_path)
+    # Wrap the stat in the same fault path as the read: the file existed
+    # at the exists() check above, but a concurrent taxonomy refresh can
+    # remove or replace it between calls. Without this guard, getsize()
+    # would raise FileNotFoundError/OSError straight out of the helper
+    # and 500 every caller (including /api/pipeline/page-init) in exactly
+    # the transient window where we should degrade to "unavailable".
+    try:
+        size = os.path.getsize(taxonomy_path)
+    except OSError:
+        return {
+            "available": False,
+            "path": taxonomy_path,
+            "taxa_count": 0,
+            "last_updated": None,
+            "corrupt": True,
+        }
+
     if size < _TAXONOMY_MIN_USABLE_BYTES:
         return {
             "available": False,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1462,10 +1462,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             first_name = resolved_specs[0]["name"]
             runner.update_step(job["id"], "model_loader", current_file=first_name)
 
-            # Download taxonomy if missing and requested
+            # Download taxonomy if missing/unusable and requested. Mirrors the
+            # availability check used by /api/pipeline/page-init: a 0-byte stub
+            # from an interrupted download "exists" but is not a usable
+            # taxonomy, and the user opted into a download to recover from
+            # exactly that state.
+            from models import get_taxonomy_info
             from taxonomy import TAXONOMY_JSON_PATH, find_taxonomy_json
             taxonomy_path = find_taxonomy_json()
-            if params.download_taxonomy and not os.path.exists(taxonomy_path):
+            if params.download_taxonomy and not get_taxonomy_info().get("available"):
                 try:
                     from taxonomy import download_taxonomy
                     _emit_progress(

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -378,21 +378,57 @@ def test_get_taxonomy_info_no_file(monkeypatch):
 
 
 def test_get_taxonomy_info_with_file(tmp_path, monkeypatch):
-    """Returns correct info when taxonomy.json exists."""
+    """Returns correct info when taxonomy.json exists and is plausibly sized."""
     import models
     import taxonomy
 
     tax_path = tmp_path / "taxonomy.json"
-    # Make the file large enough for taxa_count estimation (size // 150)
     tax_data = {"last_updated": "2024-01-15", "taxa": [{"name": f"Species {i}"} for i in range(100)]}
     tax_path.write_text(json.dumps(tax_data))
 
     monkeypatch.setattr(taxonomy, "find_taxonomy_json", lambda: str(tax_path))
+    # The fixture file is far smaller than the production taxonomy; lower
+    # the usability floor so the integrity check passes for the test.
+    monkeypatch.setattr(models, "_TAXONOMY_MIN_USABLE_BYTES", 100)
 
     info = models.get_taxonomy_info()
     assert info["available"] is True
     assert info["last_updated"] == "2024-01-15"
     assert info["taxa_count"] > 0
+
+
+def test_get_taxonomy_info_zero_byte_stub_unavailable(tmp_path, monkeypatch):
+    """A truncated/0-byte file from a failed download must report
+    available=False so the UI keeps the "Download taxonomy" affordance
+    visible — the prior os.path.exists check hid it for unrecoverable users.
+    """
+    import models
+    import taxonomy
+
+    tax_path = tmp_path / "taxonomy.json"
+    tax_path.write_bytes(b"")
+    monkeypatch.setattr(taxonomy, "find_taxonomy_json", lambda: str(tax_path))
+
+    info = models.get_taxonomy_info()
+    assert info["available"] is False
+    assert info.get("corrupt") is True
+
+
+def test_get_taxonomy_info_undersized_stub_unavailable(tmp_path, monkeypatch):
+    """A multi-KB stub (e.g. an HTML error page from a misrouted CDN
+    response saved as taxonomy.json) is structurally too small to be a
+    real taxonomy and must report available=False.
+    """
+    import models
+    import taxonomy
+
+    tax_path = tmp_path / "taxonomy.json"
+    tax_path.write_text('{"error": "404 Not Found"}')
+    monkeypatch.setattr(taxonomy, "find_taxonomy_json", lambda: str(tax_path))
+
+    info = models.get_taxonomy_info()
+    assert info["available"] is False
+    assert info.get("corrupt") is True
 
 
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -437,8 +437,9 @@ def test_get_taxonomy_info_race_after_exists_check(tmp_path, monkeypatch):
     available=False rather than letting OSError bubble up and 500 the
     /api/pipeline/page-init endpoint.
     """
-    import models
     import os as os_mod
+
+    import models
     import taxonomy
 
     tax_path = tmp_path / "taxonomy.json"

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -431,6 +431,31 @@ def test_get_taxonomy_info_undersized_stub_unavailable(tmp_path, monkeypatch):
     assert info.get("corrupt") is True
 
 
+def test_get_taxonomy_info_race_after_exists_check(tmp_path, monkeypatch):
+    """If the taxonomy file is removed between os.path.exists() and the
+    stat call (e.g. a concurrent refresh), the helper must degrade to
+    available=False rather than letting OSError bubble up and 500 the
+    /api/pipeline/page-init endpoint.
+    """
+    import models
+    import os as os_mod
+    import taxonomy
+
+    tax_path = tmp_path / "taxonomy.json"
+    monkeypatch.setattr(taxonomy, "find_taxonomy_json", lambda: str(tax_path))
+
+    # Pretend the file exists at the entry check, but the stat call
+    # races with a delete/replace and raises.
+    monkeypatch.setattr(os_mod.path, "exists", lambda p: True)
+    def _raise(_):
+        raise FileNotFoundError(_)
+    monkeypatch.setattr(os_mod.path, "getsize", _raise)
+
+    info = models.get_taxonomy_info()
+    assert info["available"] is False
+    assert info.get("corrupt") is True
+
+
 # ---------------------------------------------------------------------------
 # download_model (validation only — no actual downloads)
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -2204,6 +2204,139 @@ def test_pipeline_model_ids_back_compat_with_model_id(tmp_path, monkeypatch):
     )
 
 
+def test_pipeline_redownloads_taxonomy_when_existing_file_is_corrupt(
+    tmp_path, monkeypatch
+):
+    """A 0-byte stub from an interrupted download "exists" on disk but is
+    not a usable taxonomy. /api/pipeline/page-init reports unavailable in
+    that case (so the "Download taxonomy if missing" checkbox stays
+    visible), and the runner must honor the same gate — otherwise checking
+    the box from the UI silently no-ops on the exact corruption case the
+    page-init change targets, leaving users with no in-app recovery path.
+    """
+    import classifier as classifier_mod
+    import config as cfg
+    import taxonomy as taxonomy_mod
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    fake_path = tmp_path / "taxonomy.json"
+    fake_path.write_bytes(b"")  # 0-byte stub from an interrupted download
+    monkeypatch.setattr(taxonomy_mod, "TAXONOMY_JSON_PATH", str(fake_path))
+    monkeypatch.setattr(
+        taxonomy_mod, "find_taxonomy_json", lambda: str(fake_path)
+    )
+    monkeypatch.setattr(taxonomy_mod, "load_local_taxonomy", lambda: None)
+
+    download_calls = []
+
+    def fake_download(output_path, progress_callback=None):
+        download_calls.append(output_path)
+
+    monkeypatch.setattr(taxonomy_mod, "download_taxonomy", fake_download)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        download_taxonomy=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert download_calls, (
+        "Pipeline must trigger taxonomy download when the existing file is "
+        "corrupt/undersized; gate must match get_taxonomy_info() availability"
+    )
+
+
+def test_pipeline_skips_taxonomy_download_when_file_is_usable(
+    tmp_path, monkeypatch
+):
+    """Converse of the corruption case: a valid taxonomy file (>= 1MB) on
+    disk must NOT trigger a re-download even when download_taxonomy=True is
+    set, otherwise the checkbox would silently re-download on every run.
+    """
+    import classifier as classifier_mod
+    import config as cfg
+    import taxonomy as taxonomy_mod
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    fake_path = tmp_path / "taxonomy.json"
+    with open(fake_path, "wb") as f:
+        f.truncate(2_000_000)
+    monkeypatch.setattr(taxonomy_mod, "TAXONOMY_JSON_PATH", str(fake_path))
+    monkeypatch.setattr(
+        taxonomy_mod, "find_taxonomy_json", lambda: str(fake_path)
+    )
+    monkeypatch.setattr(taxonomy_mod, "load_local_taxonomy", lambda: None)
+
+    download_calls = []
+    monkeypatch.setattr(
+        taxonomy_mod,
+        "download_taxonomy",
+        lambda output_path, progress_callback=None: download_calls.append(
+            output_path
+        ),
+    )
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        download_taxonomy=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert not download_calls, (
+        "Valid (>= 1MB) taxonomy must not be redundantly redownloaded"
+    )
+
+
 def test_pipeline_reclassify_multimodel_ignores_stale_detection_ids(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

`taxonomy_available` on the pipeline page came from `os.path.exists` over the taxonomy.json path. A 0-byte stub from an interrupted/failed download passed that check and hid the "Download taxonomy if missing" checkbox in `pipeline.html`, leaving the user no in-app path to recovery.

Found during the post-#745 audit for other places where the transparency rule (`CORE_PHILOSOPHY.md` "No black boxes") is silently violated.

## What changes

- `models.py:get_taxonomy_info()` now reports `available: false` (with `corrupt: true`) when the file is missing, under ~1MB, or unreadable. The real iNat taxonomy is hundreds of MB, so anything under 1MB is structurally too small to be one. Full JSON parsing would dominate page-init latency for the common valid case; deeper parse happens at first `Taxonomy(path)` use.
- `app.py:/api/pipeline/page-init` routes through `get_taxonomy_info()` instead of duplicating the existence check.
- Fixes a pre-existing silent-corruption bug in `get_taxonomy_info`'s `except Exception` branch — it previously returned `available: True` even when reading failed.

## Test plan

- [x] `vireo/tests/test_models.py` — 51 passed (including 2 new tests for 0-byte stub + undersized stub)
- [x] Project regression suite (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_models.py vireo/tests/test_pipeline_plan.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py`) — 962 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)