### PR TITLE
pipeline-plan: uniform detail.pending + detail.eligible for Classify

### DIFF
--- a/docs/plans/2026-05-08-pipeline-pills-pr1-backend.md
+++ b/docs/plans/2026-05-08-pipeline-pills-pr1-backend.md
@@ -1,0 +1,388 @@
+# Pipeline Pills PR #1 — Backend Uniformization
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add uniform `detail.pending` + `detail.eligible` to `_classify_plan` in `vireo/pipeline_plan.py` so the upcoming UI work (PR #2) can render pill counts and progress bars without per-stage count knowledge.
+
+**Architecture:** Single function modification — every return path of `_classify_plan` gains both keys. `_extract_plan` and `_eye_keypoints_plan` already conform; `_regroup_plan` is intentionally skipped (no per-photo unit). For Classify, the unit is detection-model pairs: `eligible = total_dets * len(unblocked_models)`, `pending = pending_pairs` (or `eligible` when `params.reclassify`).
+
+**Tech Stack:** Python, pytest. Existing tests in `vireo/tests/test_pipeline_plan.py` use `_make_db` + `_add_photo_with_detection` fixtures and monkeypatch `models.get_models` / `labels.get_active_labels`.
+
+**Reference design:** `docs/plans/2026-05-08-pipeline-status-makeover-phase2-design.md`.
+
+**Test command:**
+```bash
+python -m pytest vireo/tests/test_pipeline_plan.py -v
+```
+
+---
+
+## Task 1.1: Backfill `pending` + `eligible` on every Classify return path
+
+**Files:**
+- Modify: `vireo/pipeline_plan.py:118-221` (`_classify_plan`)
+- Test: `vireo/tests/test_pipeline_plan.py`
+
+### Step 1: Read current shape
+
+`_classify_plan` has six return paths:
+
+1. `params.skip_classify` → `will-skip`, no detail (already fine; counts not meaningful for skipped stages but adding 0/0 is harmless)
+2. `not models` → `will-skip`, no detail (same)
+3. `total_dets == 0` → `will-run`, detail has `total_dets`/`photos_with_dets`/`models`
+4. `blocked and not pending_total` → `will-run`, detail has `blocked_models` only
+5. `pending_total == 0` → `done-prior`, detail has `total_dets`/`photos_with_dets`/`models`
+6. The general case → `will-run`, detail has `pending_pairs`/`per_model`/`total_dets`/`photos_with_dets`/optional `blocked_models`
+
+### Step 2: Write failing tests
+
+Add to `vireo/tests/test_pipeline_plan.py` (after `test_classify_plan_reclassify_bypasses_cache`, around line 290):
+
+```python
+def test_classify_plan_exposes_pending_and_eligible_done_prior(tmp_path, monkeypatch):
+    """Every classify return path must expose detail.pending + detail.eligible
+    so the UI's pill formatter doesn't need per-stage count knowledge.
+    Done-prior path: eligible = total_dets * num_models, pending = 0."""
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+
+    import labels as labels_mod
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=3)
+
+    plan = compute_plan(db, _params(model_ids=["m1"]), str(tmp_path / "test.db"))
+    detail = plan["stages"]["Classify"]["detail"]
+    assert detail["pending"] == 0
+    assert detail["eligible"] == 1  # 1 detection × 1 model
+
+
+def test_classify_plan_exposes_pending_and_eligible_will_run(tmp_path, monkeypatch):
+    """will-run path with new model added: eligible counts pairs across
+    all unblocked models, pending counts the unfinished ones."""
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+        {"id": "m2", "name": "BioCLIP",
+         "model_str": "hf-hub:imageomics/bioclip",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=3)
+
+    plan = compute_plan(
+        db, _params(model_ids=["m1", "m2"]), str(tmp_path / "test.db"),
+    )
+    detail = plan["stages"]["Classify"]["detail"]
+    assert detail["eligible"] == 2  # 1 detection × 2 models
+    assert detail["pending"] == 1   # only m2 is unrun
+
+
+def test_classify_plan_exposes_pending_and_eligible_reclassify(tmp_path, monkeypatch):
+    """Reclassify path: pending == eligible (everything will redo)."""
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=3)
+
+    plan = compute_plan(
+        db,
+        _params(model_ids=["m1"], reclassify=True),
+        str(tmp_path / "test.db"),
+    )
+    detail = plan["stages"]["Classify"]["detail"]
+    assert detail["eligible"] == 1
+    assert detail["pending"] == 1  # reclassify forces all pairs to redo
+
+
+def test_classify_plan_exposes_pending_and_eligible_no_detections(tmp_path, monkeypatch):
+    """No detections cached yet: eligible=0, pending=0. Bar will hide."""
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+
+    plan = compute_plan(db, _params(model_ids=["m1"]), str(tmp_path / "test.db"))
+    detail = plan["stages"]["Classify"]["detail"]
+    assert detail["eligible"] == 0
+    assert detail["pending"] == 0
+
+
+def test_classify_plan_exposes_pending_and_eligible_blocked_only(tmp_path, monkeypatch):
+    """Blocked-only path (model needs labels): eligible=0 since no model can run.
+    pending=0. UI hides the bar; the summary explains the block."""
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+
+    import labels as labels_mod
+    import models as models_mod
+    # timm models without labels are blocked. Use a non-bioclip model_str
+    # so the TOL fallback doesn't kick in.
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "SomeTimmModel",
+         "model_str": "hf-hub:other/model",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+
+    plan = compute_plan(db, _params(model_ids=["m1"]), str(tmp_path / "test.db"))
+    detail = plan["stages"]["Classify"]["detail"]
+    assert detail["eligible"] == 0  # no unblocked models
+    assert detail["pending"] == 0
+```
+
+### Step 3: Run failing
+
+```bash
+python -m pytest vireo/tests/test_pipeline_plan.py -k "exposes_pending_and_eligible" -v
+```
+
+Expected: 5 FAIL with `KeyError: 'pending'` or `KeyError: 'eligible'`.
+
+### Step 4: Implement
+
+Open `vireo/pipeline_plan.py:118-221` (`_classify_plan`). Add `pending` + `eligible` to every detail dict. The cleanest factoring is to compute `unblocked_count` once and add the two keys at each return site.
+
+The computation:
+- `unblocked_count` = number of models without `info.get("blocked")` flag.
+- `eligible = total_dets * unblocked_count` (0 when no models, no detections, or all blocked).
+- `pending` per branch:
+  - `total_dets == 0` → 0
+  - blocked-only → 0 (eligible already 0)
+  - `done-prior` → 0
+  - reclassify general case → `eligible`
+  - non-reclassify general case → `pending_total`
+
+Apply the changes directly:
+
+```python
+def _classify_plan(db, params, photo_ids):
+    if params.skip_classify:
+        return {
+            "state": "will-skip",
+            "summary": "Disabled — stage will be skipped",
+            "detail": {"pending": 0, "eligible": 0},
+        }
+
+    models = _resolve_models(params.model_ids)
+    if not models:
+        return {
+            "state": "will-skip",
+            "summary": "No models selected — stage will be skipped",
+            "detail": {"pending": 0, "eligible": 0},
+        }
+
+    label_resolution = _resolve_labels_for_models(models, params.labels_files, db)
+
+    det_counts = db.count_real_detections_in_scope(photo_ids)
+    total_dets = det_counts["total_dets"]
+    photos_with_dets = det_counts["photos_with_dets"]
+
+    unblocked_count = sum(
+        1 for m in models if not label_resolution[m["id"]].get("blocked")
+    )
+    eligible = total_dets * unblocked_count
+
+    if total_dets == 0:
+        return {
+            "state": "will-run",
+            "summary": (
+                "Will run — no detections cached yet "
+                "(MegaDetector will run first)"
+            ),
+            "detail": {
+                "total_dets": 0,
+                "photos_with_dets": 0,
+                "models": [m["name"] for m in models],
+                "pending": 0,
+                "eligible": 0,
+            },
+        }
+
+    blocked = []
+    pending_per_model = {}
+    pending_total = 0
+    for m in models:
+        info = label_resolution[m["id"]]
+        if info.get("blocked"):
+            blocked.append(m["name"])
+            continue
+        fp = info["fingerprint"]
+        if params.reclassify:
+            pending = total_dets
+        else:
+            pending = db.count_classify_pending_pairs(
+                classifier_model=m["name"],
+                labels_fingerprint=fp,
+                photo_ids=photo_ids,
+            )
+        if pending:
+            pending_per_model[m["name"]] = pending
+            pending_total += pending
+
+    if blocked and not pending_total:
+        return {
+            "state": "will-run",
+            "summary": (
+                f"Blocked — {len(blocked)} model{_plural(len(blocked))} "
+                f"need labels: {', '.join(blocked)}"
+            ),
+            "detail": {
+                "blocked_models": blocked,
+                "pending": 0,
+                "eligible": eligible,
+            },
+        }
+
+    if pending_total == 0:
+        return {
+            "state": "done-prior",
+            "summary": (
+                f"Already classified — {total_dets} "
+                f"detection{_plural(total_dets)} across "
+                f"{len(models)} model{_plural(len(models))}"
+            ),
+            "detail": {
+                "total_dets": total_dets,
+                "photos_with_dets": photos_with_dets,
+                "models": [m["name"] for m in models],
+                "pending": 0,
+                "eligible": eligible,
+            },
+        }
+
+    if params.reclassify:
+        summary = (
+            f"Re-classify — {pending_total} "
+            f"detection-model pair{_plural(pending_total)} "
+            f"({total_dets} detection{_plural(total_dets)} × "
+            f"{len(models)} model{_plural(len(models))})"
+        )
+    else:
+        breakdown = ", ".join(
+            f"{n} for {name}" for name, n in pending_per_model.items()
+        )
+        summary = (
+            f"Will classify {pending_total} new "
+            f"pair{_plural(pending_total)} ({breakdown})"
+        )
+    detail = {
+        "pending_pairs": pending_total,
+        "per_model": pending_per_model,
+        "total_dets": total_dets,
+        "photos_with_dets": photos_with_dets,
+        "pending": pending_total,
+        "eligible": eligible,
+    }
+    if blocked:
+        detail["blocked_models"] = blocked
+    return {"state": "will-run", "summary": summary, "detail": detail}
+```
+
+### Step 5: Run passing
+
+```bash
+python -m pytest vireo/tests/test_pipeline_plan.py -k "exposes_pending_and_eligible" -v
+```
+
+Expected: 5 PASS.
+
+### Step 6: Run full plan-tests for regression check
+
+```bash
+python -m pytest vireo/tests/test_pipeline_plan.py -v
+```
+
+Expected: all PASS — existing tests still green (added keys are additive, existing assertions don't check for absence).
+
+### Step 7: Commit
+
+```bash
+git add vireo/pipeline_plan.py vireo/tests/test_pipeline_plan.py
+git commit -m "pipeline-plan: uniform detail.pending + detail.eligible for Classify
+
+UI work in PR #2 needs uniform per-stage count fields so the pill
+formatter and progress bar don't have to know about pending_pairs vs
+pending vs (other stage idiosyncrasies). Extract and EyeKeypoints
+already conform; this brings Classify in line. Group is intentionally
+skipped (no per-photo unit).
+
+For Classify the work unit is detection-model pairs:
+  eligible = total_dets * unblocked_models
+  pending  = pending_pairs (or eligible when reclassify=True)
+
+5 new tests cover all six return paths."
+```
+
+---
+
+## Task 1.2: Verify focused suite + push branch
+
+**Step 1: Project's full focused suite**
+
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_pipeline.py vireo/tests/test_pipeline_job.py vireo/tests/test_pipeline_plan.py
+```
+
+Triage: the two pre-existing keyword-edit failures from `MEMORY.md` are OK (`test_remove_keyword_from_photo`, `test_undo_keyword_remove_clears_pending_change`). Anything else is on us.
+
+**Step 2: Push and open PR**
+
+```bash
+git push -u origin claude/pipeline-pills
+gh pr create --base main --title "pipeline-plan: uniform detail.pending + detail.eligible for Classify" --body "$(cat <<'EOF'
+## Summary
+
+Phase 2 PR #1 of the pipeline status makeover ([design](docs/plans/2026-05-08-pipeline-status-makeover-phase2-design.md)). Backend-only: every return path of \`_classify_plan\` now exposes uniform \`detail.pending\` + \`detail.eligible\`. \`_extract_plan\` and \`_eye_keypoints_plan\` already conform.
+
+The upcoming PR #2 (UI: pill formatter + progress bar) needs these uniform fields so the JS doesn't have to know about \`pending_pairs\` vs \`pending\` per stage.
+
+For Classify the unit is detection-model pairs:
+- \`eligible = total_dets * len(unblocked_models)\`
+- \`pending = pending_pairs\` (or \`eligible\` when \`reclassify=True\`)
+
+## Test plan
+- [x] 5 new tests in \`test_pipeline_plan.py\` cover all six return paths (skipped, no models, no detections, blocked-only, done-prior, will-run with mix; plus reclassify).
+- [x] Existing \`test_pipeline_plan.py\` tests stay green (additive change).
+- [x] Focused project suite green minus the 2 known pre-existing keyword-edit failures.
+
+EOF
+)"
+```
+
+---
+
+## Out of scope
+
+- UI consumption of these fields — that's PR #2.
+- Removing the existing `pending_pairs` / `total_dets` / `per_model` / `photos_with_dets` keys — kept for the existing summary-text builders and back-compat.
+- Group stage — design intentionally omits since it has no per-photo unit.

--- a/docs/plans/2026-05-08-pipeline-status-makeover-phase2-design.md
+++ b/docs/plans/2026-05-08-pipeline-status-makeover-phase2-design.md
@@ -1,0 +1,111 @@
+# Pipeline Status Makeover — Phase 2 Design
+
+**Date:** 2026-05-08
+**Supersedes:** the original Phase 2-4 sketches in `docs/plans/2026-05-01-pipeline-status-makeover-design.md`. PRs #745 (`/api/pipeline/plan`) and #736 (SAM mask history) shipped most of the original Phase 2-3 vision while we were in flight; this doc resets the remaining UI work.
+
+---
+
+## Why a reset
+
+Surveying `vireo/templates/pipeline.html` post-#745/#736/#739:
+
+- **Already shipped:** plan summary box (`pipelinePlanSummary`), pills driven by `/api/pipeline/plan`, SAM mask coverage table on the Extract card.
+- **Still missing:** the pills don't visually distinguish "Outdated" from "Will run", don't say "Resume (N left)" for partial completion, and don't carry counts. There's no progress bar on the cards. The fingerprint staleness signal we wired in #739 lands in `will-run` with no visual differentiation.
+
+Net: the headline UX wins from the original design (cancel-and-resume clarity, settings-change-staleness, count surfaces) are still ahead of us — but the work is much smaller than the original plan described.
+
+## Scope
+
+**In:**
+- New pill labels: "Resume (N left)", "Outdated (N to redo)", "Will run (N)", "Already done (N)" — formatted from existing plan endpoint state + detail.
+- 2-segment progress bar on Classify / Extract / Eye Keypoints cards.
+- Uniform `detail.pending` + `detail.eligible` on every stage planner so the UI doesn't need per-stage count knowledge.
+
+**Out (deferred or skipped):**
+- Live SSE counts in pills during a run ("Running… 234 / 1500"). Users still get live progress from the existing `.progress-text` lines.
+- Provenance line ("Last run 2h ago · model X").
+- Removal of legacy `has_detections` / `has_masks` / `has_sharpness` fields from `/api/pipeline/page-init`. Those still feed card "complete" badges and aren't visibly conflicting.
+
+## Section 1 — Pill text formatter
+
+State space stays at three idle states (`will-run` / `will-skip` / `done-prior`) plus running/done/failed. The UI's pill *label* changes:
+
+| Plan `state` + `detail` flags | Pill label |
+|---|---|
+| `will-skip` | "Will skip" *(unchanged)* |
+| `done-prior`, eligible=N | "Already done (N)" |
+| `will-run` AND `detail.fingerprint_outdated` or `fingerprint_invalidated` | "Outdated (N to redo)" |
+| `will-run` AND `pending < eligible` | "Resume (N left)" |
+| `will-run` AND `pending == eligible` (or no prior data) | "Will run (N)" |
+| `running` | "Running…" *(unchanged)* |
+
+N comes from `detail.pending` (`will-run` cases) or `detail.eligible` (`done-prior`).
+
+Group is special-cased — no per-photo count, pill stays text-only ("Already done" / "Will re-group …").
+
+The plan endpoint contract is unchanged — staleness flags are already there from #739. The UI gets a smarter `_setPill` formatter.
+
+## Section 2 — Progress bar
+
+Each card with a per-photo unit (Classify, Extract, Eye Keypoints) gets a slim horizontal bar above the existing `.progress-text` line.
+
+Two segments:
+- **Filled**: done = `eligible - pending`, width = `done / eligible * 100%`.
+- **Empty**: remaining = `pending`, width = `pending / eligible * 100%`.
+
+Color of the filled segment:
+- **Green** when current (no fingerprint flag set).
+- **Amber** when `detail.fingerprint_outdated` or `fingerprint_invalidated` — communicates "the done portion is actually stale".
+
+Hidden when `eligible == 0`. Not added to Group (workspace-level, no per-photo unit) or Scan/Previews (no card).
+
+CSS: flexbox with two child divs, `transition: width 200ms`. ~10 lines.
+
+JS: `_renderProgressBar(stage, planEntry)` reads `_pipelinePlan.stages[suffix].detail`, sets widths + class. Called from `refreshPipelineUI()` per stage.
+
+**Why 2 segments not 3 (done/stale/remaining):** breaking out a stale fraction would require per-stage stale counts that only Eye Keypoints exposes cheaply today (via `eye_kp_fingerprint` mismatch). Coloring the entire `done` segment amber when *anything* is outdated communicates the same thing without per-stage stale arithmetic.
+
+## Section 3 — Plan endpoint: uniform `pending` + `eligible`
+
+Each stage planner returns its own count keys today (`pending_pairs` for Classify, `pending`/`eligible` for Eye Keypoints, etc.). The UI's pill formatter and progress bar both want the same two numbers per stage — so each stage's `detail` gains:
+
+- `detail.pending` (int ≥ 0) — items still to process.
+- `detail.eligible` (int ≥ 0) — total items in scope.
+
+Existing keys stay for back-compat. The new keys are additive.
+
+Per-stage definitions:
+
+| Stage | `pending` | `eligible` |
+|---|---|---|
+| Classify | `pending_pairs` (sum across models) | `total_dets * len(models_with_resolved_labels)` |
+| Extract | photos missing masks in scope | photos with detections in scope |
+| Eye Keypoints | already conforms — keep as-is | already conforms |
+| Group | omit — UI hides bar when undefined | omit |
+
+## Section 4 — Implementation phasing
+
+**PR #1 — Backend uniformization**
+- Add `detail.pending` + `detail.eligible` to Classify and Extract planners in `pipeline_plan.py`.
+- Extend existing per-stage tests in `test_pipeline_plan.py` with assertions on the new fields.
+- ~30 lines code + ~20 lines test additions. Single commit.
+
+**PR #2 — UI: pill formatter + progress bar**
+- Replace `_PILL_LABELS` lookup with a `_formatPillLabel(stage, planEntry)` helper.
+- Add `.stage-progress-bar` CSS and `_renderProgressBar(stage, planEntry)` JS.
+- `refreshPipelineUI()` calls both per stage after the existing state-set.
+- ~80 lines JS + ~30 lines CSS in `pipeline.html`.
+- Manual browser smoke (per project's user-first-testing convention):
+  - Empty workspace → bars hidden, pills show "Will run (0)".
+  - Mid-run cancel → reopen → "Resume (N left)" with partial filled bar.
+  - Settings change after clean run → "Outdated (N to redo)" with amber bar.
+
+## What's not in scope (post-Phase-2 hygiene)
+
+- SSE live counts in pills.
+- Provenance line.
+- Removing legacy `has_*` fields.
+- Adding a "Done (N)" pill state for the just-completed stage right after a run (currently "Done").
+- Misses stage as a card.
+
+These are real gaps but not load-bearing for the cancel-resume / settings-changed UX the makeover was started for. Revisit when there's a concrete user-visible reason.

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -120,6 +120,7 @@ def _classify_plan(db, params, photo_ids):
         return {
             "state": "will-skip",
             "summary": "Disabled — stage will be skipped",
+            "detail": {"pending": 0, "eligible": 0},
         }
 
     models = _resolve_models(params.model_ids)
@@ -127,6 +128,7 @@ def _classify_plan(db, params, photo_ids):
         return {
             "state": "will-skip",
             "summary": "No models selected — stage will be skipped",
+            "detail": {"pending": 0, "eligible": 0},
         }
 
     label_resolution = _resolve_labels_for_models(models, params.labels_files, db)
@@ -134,6 +136,11 @@ def _classify_plan(db, params, photo_ids):
     det_counts = db.count_real_detections_in_scope(photo_ids)
     total_dets = det_counts["total_dets"]
     photos_with_dets = det_counts["photos_with_dets"]
+
+    unblocked_count = sum(
+        1 for m in models if not label_resolution[m["id"]].get("blocked")
+    )
+    eligible = total_dets * unblocked_count
 
     if total_dets == 0:
         return {
@@ -146,6 +153,8 @@ def _classify_plan(db, params, photo_ids):
                 "total_dets": 0,
                 "photos_with_dets": 0,
                 "models": [m["name"] for m in models],
+                "pending": 0,
+                "eligible": 0,
             },
         }
 
@@ -177,7 +186,11 @@ def _classify_plan(db, params, photo_ids):
                 f"Blocked — {len(blocked)} model{_plural(len(blocked))} "
                 f"need labels: {', '.join(blocked)}"
             ),
-            "detail": {"blocked_models": blocked},
+            "detail": {
+                "blocked_models": blocked,
+                "pending": 0,
+                "eligible": eligible,
+            },
         }
 
     if pending_total == 0:
@@ -192,6 +205,8 @@ def _classify_plan(db, params, photo_ids):
                 "total_dets": total_dets,
                 "photos_with_dets": photos_with_dets,
                 "models": [m["name"] for m in models],
+                "pending": 0,
+                "eligible": eligible,
             },
         }
 
@@ -215,6 +230,8 @@ def _classify_plan(db, params, photo_ids):
         "per_model": pending_per_model,
         "total_dets": total_dets,
         "photos_with_dets": photos_with_dets,
+        "pending": pending_total,
+        "eligible": eligible,
     }
     if blocked:
         detail["blocked_models"] = blocked

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -180,6 +180,11 @@ def _classify_plan(db, params, photo_ids):
             pending_total += pending
 
     if blocked and not pending_total:
+        # eligible=0 here even when some unblocked models happen to be
+        # fully cached — the stage is functionally blocked on missing
+        # labels and the summary text already explains that. Returning
+        # eligible>0 with pending=0 would let the UI render
+        # "Resume (0 left)" against a state that's actually "Blocked".
         return {
             "state": "will-run",
             "summary": (
@@ -189,7 +194,7 @@ def _classify_plan(db, params, photo_ids):
             "detail": {
                 "blocked_models": blocked,
                 "pending": 0,
-                "eligible": eligible,
+                "eligible": 0,
             },
         }
 

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -293,6 +293,130 @@ def test_classify_plan_reclassify_bypasses_cache(tmp_path, monkeypatch):
     assert "Re-classify" in classify["summary"]
 
 
+def test_classify_plan_exposes_pending_and_eligible_done_prior(tmp_path, monkeypatch):
+    """Every classify return path must expose detail.pending + detail.eligible
+    so the UI's pill formatter doesn't need per-stage count knowledge.
+    Done-prior path: eligible = total_dets * num_models, pending = 0."""
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+
+    import labels as labels_mod
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=3)
+
+    plan = compute_plan(db, _params(model_ids=["m1"]), str(tmp_path / "test.db"))
+    detail = plan["stages"]["Classify"]["detail"]
+    assert detail["pending"] == 0
+    assert detail["eligible"] == 1  # 1 detection × 1 model
+
+
+def test_classify_plan_exposes_pending_and_eligible_will_run(tmp_path, monkeypatch):
+    """will-run path with new model added: eligible counts pairs across
+    all unblocked models, pending counts the unfinished ones."""
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+
+    import labels as labels_mod
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+        {"id": "m2", "name": "BioCLIP",
+         "model_str": "hf-hub:imageomics/bioclip",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=3)
+
+    plan = compute_plan(
+        db, _params(model_ids=["m1", "m2"]), str(tmp_path / "test.db"),
+    )
+    detail = plan["stages"]["Classify"]["detail"]
+    assert detail["eligible"] == 2  # 1 detection × 2 models
+    assert detail["pending"] == 1   # only m2 is unrun
+
+
+def test_classify_plan_exposes_pending_and_eligible_reclassify(tmp_path, monkeypatch):
+    """Reclassify path: pending == eligible (everything will redo)."""
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=3)
+
+    plan = compute_plan(
+        db,
+        _params(model_ids=["m1"], reclassify=True),
+        str(tmp_path / "test.db"),
+    )
+    detail = plan["stages"]["Classify"]["detail"]
+    assert detail["eligible"] == 1
+    assert detail["pending"] == 1  # reclassify forces all pairs to redo
+
+
+def test_classify_plan_exposes_pending_and_eligible_no_detections(tmp_path, monkeypatch):
+    """No detections cached yet: eligible=0, pending=0. Bar will hide."""
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+
+    plan = compute_plan(db, _params(model_ids=["m1"]), str(tmp_path / "test.db"))
+    detail = plan["stages"]["Classify"]["detail"]
+    assert detail["eligible"] == 0
+    assert detail["pending"] == 0
+
+
+def test_classify_plan_exposes_pending_and_eligible_blocked_only(tmp_path, monkeypatch):
+    """Blocked-only path (model needs labels): eligible=0 since no model can run.
+    pending=0. UI hides the bar; the summary explains the block."""
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+
+    import labels as labels_mod
+    import models as models_mod
+    # timm models without labels are blocked. Use a non-bioclip model_str
+    # so the TOL fallback doesn't kick in.
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "SomeTimmModel",
+         "model_str": "hf-hub:other/model",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+
+    plan = compute_plan(db, _params(model_ids=["m1"]), str(tmp_path / "test.db"))
+    detail = plan["stages"]["Classify"]["detail"]
+    assert detail["eligible"] == 0  # no unblocked models
+    assert detail["pending"] == 0
+
+
 # -------- compute_plan: extract --------
 
 def test_extract_plan_will_skip_when_disabled(tmp_path):

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -417,6 +417,53 @@ def test_classify_plan_exposes_pending_and_eligible_blocked_only(tmp_path, monke
     assert detail["pending"] == 0
 
 
+
+def test_classify_plan_exposes_pending_and_eligible_mixed_blocked_and_done(
+    tmp_path, monkeypatch,
+):
+    """Mixed path: one unblocked model is fully cached AND another model is
+    blocked-needs-labels. The blocked-only return branch fires (pending_total
+    is 0 from the cached model + the blocked one was skipped via continue).
+    eligible must be 0/0 since the stage is functionally blocked — returning
+    eligible>0 with pending=0 here would let the UI render "Resume (0 left)"
+    which is contradictory with the "Blocked" summary text."""
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+
+    import labels as labels_mod
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+        {"id": "m2", "name": "OtherModel",
+         "model_str": "hf-hub:other/model",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+    # m1 is fully cached under the TOL fallback. m2 is blocked (no labels,
+    # not a TOL-supported model_str).
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=3)
+
+    plan = compute_plan(
+        db, _params(model_ids=["m1", "m2"]), str(tmp_path / "test.db"),
+    )
+    classify = plan["stages"]["Classify"]
+    assert classify["state"] == "will-run"
+    assert "Blocked" in classify["summary"]
+    detail = classify["detail"]
+    assert detail["pending"] == 0
+    assert detail["eligible"] == 0, (
+        "blocked-only branch must return eligible=0 even when some unblocked "
+        "models happen to be fully cached — otherwise pending=0/eligible>0 "
+        "lets the UI show 'Resume (0 left)' against a stage that's actually "
+        "blocked on missing labels"
+    )
+
+
 # -------- compute_plan: extract --------
 
 def test_extract_plan_will_skip_when_disabled(tmp_path):


### PR DESCRIPTION
## Summary

Phase 2 PR #1 of the pipeline status makeover ([phase 2 design](docs/plans/2026-05-08-pipeline-status-makeover-phase2-design.md), [PR1 plan](docs/plans/2026-05-08-pipeline-pills-pr1-backend.md)). Backend-only.

Every return path of \`_classify_plan\` now exposes uniform \`detail.pending\` + \`detail.eligible\`. \`_extract_plan\` and \`_eye_keypoints_plan\` already conform; \`_regroup_plan\` is intentionally omitted (no per-photo unit). The upcoming PR #2 (UI: pill formatter + progress bar) reads these uniform fields so the JS doesn't need per-stage count knowledge.

For Classify the work unit is detection-model pairs:
- \`eligible = total_dets * len(unblocked_models)\`
- \`pending = pending_pairs\` (or \`eligible\` when \`reclassify=True\`)

Existing keys (\`pending_pairs\`, \`per_model\`, \`total_dets\`, \`photos_with_dets\`, \`blocked_models\`) stay for back-compat with the existing summary-text builders.

## Test plan
- [x] 5 new tests in \`test_pipeline_plan.py\` cover all six return paths (skip, no models, no detections, blocked-only, done-prior, will-run-with-mix; plus reclassify).
- [x] Existing 30 tests in \`test_pipeline_plan.py\` stay green (additive change).
- [x] Focused project suite: 1106 passed, 2 failed (the 2 pre-existing keyword-edit failures listed in \`MEMORY.md\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)