### PR TITLE
e2e: fix 4 pipeline pill tests after plan-driven UI rework

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 import threading
@@ -7,6 +8,38 @@ from PIL import Image
 from werkzeug.serving import make_server
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'vireo'))
+
+
+def _seed_classifier_model(home_dir):
+    """Stage a fake bioclip-2 model on disk + active selection in models.json.
+
+    The pipeline page's plan endpoint resolves model state via models.get_models(),
+    which only reports a model as "downloaded" when its files are actually
+    present. With no model registered, _classify_plan returns "Will skip"
+    regardless of seeded predictions — masking the user-facing intent the
+    tests verify ("Already done" when classifications exist). bioclip-2's
+    model_str is in tol_supported, so the plan resolves the labels
+    fingerprint to TOL_SENTINEL even with no label sets configured.
+    """
+    model_dir = os.path.join(home_dir, ".vireo", "models", "bioclip-2")
+    os.makedirs(model_dir)
+    for fname in (
+        "image_encoder.onnx",
+        "image_encoder.onnx.data",
+        "text_encoder.onnx",
+        "text_encoder.onnx.data",
+        "tokenizer.json",
+        "config.json",
+        "tol_embeddings.npy",
+        "tol_classes.json",
+    ):
+        with open(os.path.join(model_dir, fname), "w") as f:
+            f.write("")
+    # Mark verify-skipped so get_models() reports state="unverified" → downloaded.
+    with open(os.path.join(model_dir, ".verify_skipped"), "w") as f:
+        f.write("test")
+    with open(os.path.join(home_dir, ".vireo", "models.json"), "w") as f:
+        json.dump({"models": [], "active_model": "bioclip-2"}, f)
 
 
 def seed_e2e_data(db, thumb_dir):
@@ -43,7 +76,10 @@ def seed_e2e_data(db, thumb_dir):
 
     db.create_workspace("Field Work")
 
-    # Add detections and predictions so the review page has content
+    # Add detections and predictions so the review page has content. Also
+    # record classifier_runs so the pipeline plan reports Classify as
+    # "Already done" — the table the plan consults, distinct from predictions.
+    from labels_fingerprint import TOL_SENTINEL
     species_for_photo = [
         "Red-tailed Hawk", "Red-tailed Hawk", "Red-tailed Hawk",
         "American Robin", "American Robin",
@@ -57,7 +93,14 @@ def seed_e2e_data(db, thumb_dir):
             detection_id=det_ids[0],
             species=species,
             confidence=0.92,
-            model="test-classifier",
+            model="BioCLIP-2",
+            labels_fingerprint=TOL_SENTINEL,
+        )
+        db.record_classifier_run(
+            detection_id=det_ids[0],
+            classifier_model="BioCLIP-2",
+            labels_fingerprint=TOL_SENTINEL,
+            prediction_count=1,
         )
 
     return {"photos": photos, "folders": [f1, f2]}
@@ -74,6 +117,17 @@ def live_server(tmp_path, monkeypatch):
     from db import Database
 
     monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    # Pin models.py paths to tmp_path so a model staged for the test is
+    # resolvable regardless of when models.py was first imported in the session.
+    import models
+    monkeypatch.setattr(
+        models, "CONFIG_PATH", str(tmp_path / ".vireo" / "models.json"),
+    )
+    monkeypatch.setattr(
+        models, "DEFAULT_MODELS_DIR", str(tmp_path / ".vireo" / "models"),
+    )
+    _seed_classifier_model(str(tmp_path))
 
     db_path = str(tmp_path / "test.db")
     thumb_dir = str(tmp_path / "thumbs")

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -163,12 +163,16 @@ def test_pipeline_plan_summary_lists_stages(live_server, page):
     page.goto(f"{url}/pipeline")
     summary = page.locator("[data-testid='pipeline-plan-summary']")
     expect(summary).to_be_visible()
-    will_run = summary.locator(".plan-row.will-run .plan-stages")
-    # Extract & Group will run; Classify will not (Already done from seed).
-    expect(will_run).to_contain_text("Extract Features")
-    expect(will_run).to_contain_text("Group & Score")
-    done_prior = summary.locator(".plan-row.done-prior .plan-stages")
-    expect(done_prior).to_contain_text("Classify")
+    # Extract & Group will run; Classify is done-prior (seed has classifier_runs).
+    expect(
+        summary.locator(".plan-stage-row.will-run", has_text="Extract Features")
+    ).to_be_visible()
+    expect(
+        summary.locator(".plan-stage-row.will-run", has_text="Group & Score")
+    ).to_be_visible()
+    expect(
+        summary.locator(".plan-stage-row.done-prior", has_text="Classify")
+    ).to_be_visible()
 
 
 def test_pipeline_plan_summary_updates_on_toggle(live_server, page):
@@ -177,10 +181,10 @@ def test_pipeline_plan_summary_updates_on_toggle(live_server, page):
     page.click("#card-classify .stage-header")
     page.uncheck("#enableClassify")
     summary = page.locator("[data-testid='pipeline-plan-summary']")
-    skip_row = summary.locator(".plan-row.will-skip .plan-stages")
-    expect(skip_row).to_contain_text("Classify")
-    expect(skip_row).to_contain_text("Extract Features")
-    expect(skip_row).to_contain_text("Group & Score")
+    for label in ("Classify", "Extract Features", "Group & Score"):
+        expect(
+            summary.locator(".plan-stage-row.will-skip", has_text=label)
+        ).to_be_visible()
 
 
 def test_pipeline_concurrent_running_stages_keep_running_pill(live_server, page):


### PR DESCRIPTION
## Summary

Four e2e pipeline tests started failing after the recent pill rework — they asserted on user-facing intent (Classify shows \"Already done\" with seeded data, plan summary lists stages by state) but the test seed didn't satisfy the new plan endpoint's gates.

- The plan endpoint resolves \`Classify\` via \`models.get_models()\` + \`classifier_runs\`. With no model registered, it correctly returned \"Will skip\" — but the seed only added \`predictions\` rows, leaving \`classifier_runs\` empty and no model on disk.
- The plan-summary tests still selected \`.plan-row\` against the new \`.plan-stage-row\` per-stage markup added in #748.

Fix:
- Stage a fake \`bioclip-2\` model directory under \`tmp_path\` with the \`.verify_skipped\` sentinel so \`get_models()\` reports it downloaded, set it active in \`models.json\`. \`bioclip-2\`'s \`model_str\` is in \`tol_supported\`, so the labels fingerprint resolves to \`TOL_SENTINEL\` without configuring label sets.
- \`record_classifier_run\` for each seeded detection so \`count_classify_pending_pairs\` returns 0 → state=done-prior.
- Update the two plan-summary tests to the new per-stage row markup.

## Test plan

- [x] \`tests/e2e/test_pipeline.py\` — all 26 tests pass
- [x] \`tests/e2e/\` (full suite) — 175 passed, 5 skipped (pre-existing)
- [x] \`vireo/tests/test_db.py\`, \`vireo/tests/test_app.py\` — 583 passed, 1 skipped (no regressions from conftest changes)