### PR TITLE
pipeline review: diagnostic empty state + compute-now fallback

### DIFF
--- a/docs/plans/2026-05-03-pipeline-review-fallback.md
+++ b/docs/plans/2026-05-03-pipeline-review-fallback.md
@@ -289,7 +289,7 @@ Add CSS in the `<style>` block (find an analogous block for `.empty-state` and s
 .readiness-stages .stage-missing { color: var(--text-dim); }
 .readiness-actions { margin-top: 16px; display: flex; justify-content: center; gap: 12px; }
 .readiness-actions button { padding: 8px 16px; }
-.readiness-actions .compute-btn { background: var(--accent); color: var(--bg); border: none; border-radius: 4px; cursor: pointer; }
+.readiness-actions .compute-btn { background: var(--accent); color: var(--accent-text); border: none; border-radius: 4px; cursor: pointer; }
 .readiness-actions .compute-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 ```
 
@@ -436,7 +436,7 @@ CSS:
 
 ```css
 .degraded-banner {
-  background: var(--warning-bg, #3a2e1f);
+  background: var(--warning-bg, var(--bg-secondary, #3a2e1f));
   color: var(--text);
   padding: 8px 16px;
   border-bottom: 1px solid var(--border);

--- a/docs/plans/2026-05-03-pipeline-review-fallback.md
+++ b/docs/plans/2026-05-03-pipeline-review-fallback.md
@@ -1,0 +1,558 @@
+# Pipeline Review Page Fallback Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the pipeline review page useful when features exist but the cache file doesn't — show a per-stage diagnostic, offer in-page "Compute now" using the existing in-memory pipeline, and surface a banner when results render with degraded inputs.
+
+**Architecture:** The Group stage of the pipeline is purely computational (seconds, no GPU) and reads features already in the DB. `/api/pipeline/regroup-live` already does `load_photo_features` → `run_full_pipeline` → `save_results`. The only gating signal is the per-workspace cache JSON file `pipeline_results_ws{N}.json`. We add a `review_readiness` block to `/api/pipeline/page-init` that classifies the workspace's feature state, replace the static empty state with a diagnostic + Compute-now panel, and add a degraded banner that appears when results render but enhancing features (eye keypoints, embeddings, full mask coverage) are missing for many photos.
+
+**Tech Stack:** Flask + Jinja2 + vanilla JS (no frontend framework). Tests via pytest (`vireo/tests/test_pipeline.py`, `vireo/tests/test_pipeline_api.py`). Manual verification via Playwright (per `feedback_user_first_testing` memory — drive a real browser, don't just read code).
+
+**Background reading (read first):**
+- `CORE_PHILOSOPHY.md` — "Show the user what's happening / No black boxes". The diagnostic must answer the question users actually read it as ("can I compute results from what I have?"), not a cheap proxy.
+- `vireo/pipeline.py:496-656` — `serialize_results`, `save_results`, `load_results`. The cache file format and where it lives.
+- `vireo/pipeline_plan.py` — existing per-stage plan logic (truth source for the `/pipeline` page status pills).
+- `vireo/app.py:1162-1220` — current `/api/pipeline/page-init` handler.
+- `vireo/app.py:10127-10167` — `/api/pipeline/regroup-live` (already runs full pipeline in-memory and saves cache).
+- `vireo/templates/pipeline_review.html:1054-1057, 1809-1849` — current empty state and init logic.
+
+**Out of scope:**
+- Auto-computing on page load (could be slow on large libraries; explicit button only).
+- Changing the existing `/api/pipeline/regroup-live` endpoint — we just call it.
+- Per-stage warnings on the existing `/pipeline` page — that already has its own status logic.
+
+---
+
+### Task 1: Add `compute_review_readiness` to `pipeline.py`
+
+**Files:**
+- Modify: `vireo/pipeline.py` (add new function near `load_results`, ~line 660)
+- Test: `vireo/tests/test_pipeline.py` (add test near other readiness/results tests)
+
+**Why this lives in `pipeline.py`:** It's about whether the cached pipeline results can be produced from current DB state. `pipeline_plan.py` answers "what would clicking Run do?" (takes UI selections). This answers "can the review page render meaningfully right now?" (no inputs).
+
+**Step 1: Write the failing test**
+
+In `vireo/tests/test_pipeline.py`, add:
+
+```python
+def test_compute_review_readiness_empty_workspace(tmp_db):
+    """No photos → state='empty'."""
+    from pipeline import compute_review_readiness
+    db = tmp_db  # fixture providing a Database with active workspace
+    out = compute_review_readiness(db)
+    assert out["state"] == "empty"
+    assert out["total_photos"] == 0
+
+
+def test_compute_review_readiness_no_masks(tmp_db_with_photos):
+    """Photos but no masks → state='insufficient', mask listed in missing_required."""
+    from pipeline import compute_review_readiness
+    out = compute_review_readiness(tmp_db_with_photos)
+    assert out["state"] == "insufficient"
+    assert "masks" in out["missing_required"]
+
+
+def test_compute_review_readiness_masks_present_no_eye(tmp_db_with_masks_no_eye):
+    """Masks present, no eye keypoints → state='computable', eye in enhancing_missing."""
+    from pipeline import compute_review_readiness
+    out = compute_review_readiness(tmp_db_with_masks_no_eye)
+    assert out["state"] == "computable"
+    assert out["with_masks"] > 0
+    assert "eye_keypoints" in out["enhancing_missing"]
+
+
+def test_compute_review_readiness_full_features(tmp_db_full):
+    """All features present, no cache yet → state='computable', enhancing_missing empty."""
+    from pipeline import compute_review_readiness
+    out = compute_review_readiness(tmp_db_full)
+    assert out["state"] == "computable"
+    assert out["enhancing_missing"] == []
+```
+
+You'll need to look at how existing tests in `test_pipeline.py` build the DB fixture — match that style. Reuse `db.get_coverage_stats()` (`vireo/db.py:2575`) which already counts every feature we care about.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_pipeline.py::test_compute_review_readiness_empty_workspace -v`
+Expected: FAIL with `ImportError: cannot import name 'compute_review_readiness'`
+
+**Step 3: Implement `compute_review_readiness`**
+
+In `vireo/pipeline.py`, add:
+
+```python
+def compute_review_readiness(db, mask_threshold=0.25):
+    """Classify whether the pipeline review page can render meaningful results.
+
+    The Group stage of the pipeline is purely computational and reads
+    features already cached in the DB. A "ready" workspace has the
+    grouping cache already on disk; a "computable" workspace has enough
+    features that calling /api/pipeline/regroup-live would produce a
+    useful triage view; an "insufficient" workspace has too few masks
+    for the result to be anything but a wall of REJECTs.
+
+    Args:
+        db: Database with active workspace
+        mask_threshold: minimum fraction of photos that must have masks
+            for the result to be computable (default 25%)
+
+    Returns:
+        {
+            "state": "ready" | "computable" | "insufficient" | "empty",
+            "total_photos": int,
+            "with_masks": int,
+            "with_sharpness": int,
+            "with_embeddings": int,
+            "with_eye_keypoints": int,
+            "with_predictions": int,
+            "missing_required": list[str],   # stages that block computation
+            "enhancing_missing": list[str],  # stages that would improve quality
+        }
+    """
+    cov = db.get_coverage_stats()
+    total = cov["total"]
+    out = {
+        "state": "empty",
+        "total_photos": total,
+        "with_masks": cov["mask"],
+        "with_sharpness": cov["subject_sharpness"],
+        "with_embeddings": cov["dino_embedding"],
+        "with_eye_keypoints": cov["eye"],
+        "with_predictions": cov["classified"],
+        "missing_required": [],
+        "enhancing_missing": [],
+    }
+    if total == 0:
+        return out
+
+    # Required: enough photos have masks (otherwise pipeline rejects all)
+    if cov["mask"] < max(1, int(total * mask_threshold)):
+        out["state"] = "insufficient"
+        out["missing_required"].append("masks")
+        # Still surface enhancing_missing so the diagnostic is complete
+    else:
+        out["state"] = "computable"
+
+    # Enhancing: per-stage gaps that would improve quality if filled
+    if cov["mask"] < total:
+        out["enhancing_missing"].append("masks_partial")
+    if cov["dino_embedding"] < total:
+        out["enhancing_missing"].append("embeddings")
+    if cov["eye"] < total:
+        out["enhancing_missing"].append("eye_keypoints")
+    if cov["classified"] < total:
+        out["enhancing_missing"].append("species_predictions")
+
+    return out
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest vireo/tests/test_pipeline.py -k review_readiness -v`
+Expected: 4 PASS
+
+**Step 5: Commit**
+
+```bash
+git add vireo/pipeline.py vireo/tests/test_pipeline.py
+git commit -m "pipeline: add compute_review_readiness for review-page fallback"
+```
+
+---
+
+### Task 2: Surface readiness in `/api/pipeline/page-init`
+
+**Files:**
+- Modify: `vireo/app.py:1162-1220` (the `api_pipeline_page_init` handler)
+- Test: `vireo/tests/test_pipeline_api.py` (add a test alongside `test_pipeline_page_init_includes_mask_variant_coverage`)
+
+**Step 1: Write the failing test**
+
+In `vireo/tests/test_pipeline_api.py`, add:
+
+```python
+def test_pipeline_page_init_includes_review_readiness(setup):
+    """page-init exposes review_readiness so the review page can render
+    a diagnostic empty state and decide whether to offer Compute now."""
+    app, db_path = setup
+    # Reuse _seed_workspace_with_masks or similar — it leaves photos
+    # with masks but no Group cache.
+    _seed_workspace_with_masks(db_path)
+
+    with app.test_client() as c:
+        resp = c.get("/api/pipeline/page-init")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "review_readiness" in data
+        rr = data["review_readiness"]
+        assert rr["state"] == "computable"
+        assert rr["total_photos"] >= 2
+        assert rr["with_masks"] >= 2
+
+
+def test_pipeline_page_init_review_readiness_state_ready_when_cache_exists(setup, tmp_path):
+    """When the grouping cache is already on disk, state should be 'ready'."""
+    app, db_path = setup
+    _seed_workspace_with_masks(db_path)
+
+    # Drop a minimal cache file at <db_dir>/pipeline_results_ws{N}.json
+    import os, json
+    from db import Database
+    db = Database(db_path)
+    ws = db._active_workspace_id
+    db.close()
+    cache_path = os.path.join(os.path.dirname(db_path), f"pipeline_results_ws{ws}.json")
+    with open(cache_path, "w") as f:
+        json.dump({"encounters": [], "photos": [], "summary": {}}, f)
+
+    with app.test_client() as c:
+        resp = c.get("/api/pipeline/page-init")
+        data = resp.get_json()
+        assert data["review_readiness"]["state"] == "ready"
+```
+
+**Step 2: Run to verify failure**
+
+Run: `python -m pytest vireo/tests/test_pipeline_api.py -k review_readiness -v`
+Expected: FAIL — `'review_readiness' not in data`
+
+**Step 3: Wire it into the route**
+
+Edit `vireo/app.py:1162-1220`. Inside `api_pipeline_page_init`, after `results = load_results(...)`:
+
+```python
+        from pipeline import compute_review_readiness, load_results
+        cache_dir = os.path.dirname(db_path)
+        results = load_results(cache_dir, db._active_workspace_id)
+        # ... existing flag/rating augmentation ...
+
+        review_readiness = compute_review_readiness(db)
+        if results is not None:
+            # Cache exists — even if features have changed underneath,
+            # the page can render. enhancing_missing still reflects the
+            # current gap so the degraded banner can surface accurately.
+            review_readiness["state"] = "ready"
+```
+
+And add `"review_readiness": review_readiness,` to the returned `jsonify` dict.
+
+**Step 4: Run to verify pass**
+
+Run: `python -m pytest vireo/tests/test_pipeline_api.py -k review_readiness -v`
+Expected: 2 PASS
+
+**Step 5: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_pipeline_api.py
+git commit -m "pipeline: surface review_readiness in /api/pipeline/page-init"
+```
+
+---
+
+### Task 3: Replace empty state with diagnostic + Compute-now panel
+
+**Files:**
+- Modify: `vireo/templates/pipeline_review.html:1054-1057` (the `<div class="empty-state">` block)
+- Modify: `vireo/templates/pipeline_review.html:1809-1849` (`initPipelineReviewPage`)
+
+**Step 1: Replace the static empty-state HTML**
+
+Replace lines 1054-1057 with a richer placeholder that the JS will populate:
+
+```html
+<div class="empty-state" id="emptyState" style="display:none;">
+  <h2 id="emptyStateHeading">No pipeline results yet</h2>
+  <p id="emptyStateBody"></p>
+  <div class="readiness-stages" id="readinessStages"></div>
+  <div class="readiness-actions" id="readinessActions"></div>
+</div>
+```
+
+Add CSS in the `<style>` block (find an analogous block for `.empty-state` and slot these in next to it):
+
+```css
+.readiness-stages {
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 4px 12px;
+  margin: 16px auto;
+  font-size: 13px;
+  max-width: 360px;
+  text-align: left;
+}
+.readiness-stages .stage-name { color: var(--text-dim); }
+.readiness-stages .stage-count { font-variant-numeric: tabular-nums; }
+.readiness-stages .stage-ok { color: var(--success, #4caf50); }
+.readiness-stages .stage-partial { color: var(--warning, #ff9800); }
+.readiness-stages .stage-missing { color: var(--text-dim); }
+.readiness-actions { margin-top: 16px; display: flex; justify-content: center; gap: 12px; }
+.readiness-actions button { padding: 8px 16px; }
+.readiness-actions .compute-btn { background: var(--accent); color: var(--bg); border: none; border-radius: 4px; cursor: pointer; }
+.readiness-actions .compute-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+```
+
+**Step 2: Render the diagnostic from `review_readiness`**
+
+In `pipeline_review.html`, replace the current empty-state branch (around line 1812) with a call to a new `renderEmptyState(readiness)` function. Add it nearby:
+
+```javascript
+function renderEmptyState(readiness) {
+  var heading = document.getElementById('emptyStateHeading');
+  var body = document.getElementById('emptyStateBody');
+  var stages = document.getElementById('readinessStages');
+  var actions = document.getElementById('readinessActions');
+  document.getElementById('emptyState').style.display = '';
+
+  // Per-stage rows
+  var rows = [
+    ['Photos', readiness.total_photos, readiness.total_photos],
+    ['Masks', readiness.with_masks, readiness.total_photos],
+    ['Embeddings', readiness.with_embeddings, readiness.total_photos],
+    ['Eye keypoints', readiness.with_eye_keypoints, readiness.total_photos],
+    ['Species predictions', readiness.with_predictions, readiness.total_photos],
+  ];
+  stages.innerHTML = rows.map(function(r) {
+    var name = r[0], n = r[1], total = r[2];
+    var cls = (n === total && total > 0) ? 'stage-ok'
+            : (n > 0 ? 'stage-partial' : 'stage-missing');
+    return '<span class="stage-name">' + name + '</span>'
+         + '<span class="stage-count ' + cls + '">' + n + ' / ' + total + '</span>';
+  }).join('');
+
+  if (readiness.state === 'empty') {
+    heading.textContent = 'No photos in this workspace';
+    body.textContent = 'Add folders to this workspace from the Folders page.';
+    actions.innerHTML = '';
+    return;
+  }
+
+  if (readiness.state === 'insufficient') {
+    heading.textContent = 'Not enough features to compute results yet';
+    body.textContent = 'Run mask extraction on the Pipeline page first '
+      + '— the review page needs masks to score photo quality.';
+    actions.innerHTML = '<a href="/pipeline" class="compute-btn" '
+      + 'style="text-decoration:none;display:inline-block;">Open Pipeline</a>';
+    return;
+  }
+
+  // state === 'computable'
+  heading.textContent = 'Ready to compute results';
+  var enhancing = readiness.enhancing_missing || [];
+  if (enhancing.length === 0) {
+    body.textContent = 'All upstream stages are complete. '
+      + 'Click below to group, score, and triage your photos.';
+  } else {
+    var labels = enhancing.map(function(k) {
+      return ({masks_partial: 'full mask coverage',
+               embeddings: 'embeddings',
+               eye_keypoints: 'eye keypoints',
+               species_predictions: 'species predictions'})[k] || k;
+    });
+    body.textContent = 'You can compute results now. Quality will be lower without: '
+      + labels.join(', ') + '. Re-run those stages on the Pipeline page later to improve.';
+  }
+  actions.innerHTML = '<button class="compute-btn" onclick="computeReviewNow()">'
+    + 'Compute results now</button>';
+}
+
+function computeReviewNow() {
+  var btn = document.querySelector('.readiness-actions .compute-btn');
+  if (btn) { btn.disabled = true; btn.textContent = 'Computing…'; }
+  safeFetch('/api/pipeline/regroup-live', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({})
+  }).then(function(data) {
+    if (!data || !data.encounters) {
+      if (btn) { btn.disabled = false; btn.textContent = 'Compute results now'; }
+      return;
+    }
+    // Hide empty state, render results inline
+    document.getElementById('emptyState').style.display = 'none';
+    pipelineResults = data;
+    document.getElementById('summaryBar').style.display = '';
+    updateSummaryBar(data.summary);
+    document.getElementById('filterBar').style.display = '';
+    document.getElementById('sidebarScoring').style.display = '';
+    document.getElementById('sidebarGrouping').style.display = '';
+    renderResults();
+    refreshMissesReviewBtn();
+  });
+}
+```
+
+**Step 3: Update `initPipelineReviewPage`**
+
+Replace lines 1812-1817 with:
+
+```javascript
+    if (!data || !data.results) {
+      renderEmptyState(data && data.review_readiness ? data.review_readiness
+                                                     : {state: 'empty', total_photos: 0});
+      return;
+    }
+```
+
+**Step 4: Manual verification (Playwright per user-first-testing memory)**
+
+Drive a real browser:
+
+1. Pick a workspace where the cache JSON does not exist but masks/embeddings do (or temporarily delete `~/.vireo/pipeline_results_ws{N}.json`).
+2. Visit `/pipeline/review`. Expect: per-stage diagnostic + "Compute results now" button.
+3. Click "Compute results now". Expect: button shows "Computing…", then results render inline within seconds (no page reload).
+4. Pick a workspace with no masks. Expect: "Not enough features…" with a link to `/pipeline`.
+
+Document what you saw — screenshots in PR description.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/templates/pipeline_review.html
+git commit -m "pipeline: diagnostic empty state + compute-now button on review page"
+```
+
+---
+
+### Task 4: Degraded-features banner when results render with gaps
+
+**Files:**
+- Modify: `vireo/templates/pipeline_review.html` (add banner element + render call)
+
+**Step 1: Add the banner element**
+
+In `pipeline_review.html`, add a banner near the top of the main content area (above `summaryBar`):
+
+```html
+<div class="degraded-banner" id="degradedBanner" style="display:none;">
+  <span id="degradedBannerText"></span>
+  <a href="/pipeline" class="degraded-banner-link">Open Pipeline</a>
+  <button class="degraded-banner-close" onclick="dismissDegradedBanner()" aria-label="Dismiss">&times;</button>
+</div>
+```
+
+CSS:
+
+```css
+.degraded-banner {
+  background: var(--warning-bg, #3a2e1f);
+  color: var(--text);
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.degraded-banner-link {
+  color: var(--accent);
+  margin-left: auto;
+}
+.degraded-banner-close {
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 4px;
+}
+```
+
+**Step 2: Render the banner from `review_readiness.enhancing_missing`**
+
+In `initPipelineReviewPage`, after the success branch (after `renderResults()`), add:
+
+```javascript
+    if (data.review_readiness && data.review_readiness.enhancing_missing
+        && data.review_readiness.enhancing_missing.length > 0
+        && !sessionStorage.getItem('degradedBannerDismissed')) {
+      var labels = data.review_readiness.enhancing_missing.map(function(k) {
+        return ({masks_partial: 'full mask coverage',
+                 embeddings: 'embeddings',
+                 eye_keypoints: 'eye keypoints',
+                 species_predictions: 'species predictions'})[k] || k;
+      });
+      document.getElementById('degradedBannerText').textContent =
+        'These results were computed without ' + labels.join(', ')
+        + '. Re-run those stages to improve quality.';
+      document.getElementById('degradedBanner').style.display = '';
+    }
+```
+
+And the dismiss handler:
+
+```javascript
+function dismissDegradedBanner() {
+  sessionStorage.setItem('degradedBannerDismissed', '1');
+  document.getElementById('degradedBanner').style.display = 'none';
+}
+```
+
+Session-scoped dismissal (not localStorage) — so it re-appears next session. Users should see it again if they come back to the page.
+
+**Step 3: Manual verification**
+
+1. With a workspace that has results cached but eye keypoints disabled or missing for some photos, visit `/pipeline/review`. Expect: banner shows at top with the missing-features list and a link to `/pipeline`.
+2. Click dismiss. Banner disappears. Reload page. Banner stays gone for the session.
+3. Open a fresh tab. Banner re-appears.
+
+**Step 4: Commit**
+
+```bash
+git add vireo/templates/pipeline_review.html
+git commit -m "pipeline: degraded-features banner on review page"
+```
+
+---
+
+### Task 5: Run full test suite + open PR
+
+**Step 1: Run the project test suite**
+
+Per `CLAUDE.md`:
+
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_pipeline.py vireo/tests/test_pipeline_api.py -v
+```
+
+Expected: all PASS except known-failing tests on main (see `project_preexisting_test_failures` memory). Note any unexpected failures and investigate before opening PR.
+
+**Step 2: Push and open PR**
+
+```bash
+git push -u origin claude/<branch>
+gh pr create --base main --title "pipeline review: diagnostic empty state + compute-now fallback" --body "$(cat <<'EOF'
+## Summary
+
+The pipeline review page used to bail to "No pipeline results yet" whenever the per-workspace cache JSON was absent — even when all upstream features were ready and the Group stage would have run in seconds. This PR makes the page useful in that state.
+
+- New `compute_review_readiness` classifies the workspace as `ready` / `computable` / `insufficient` / `empty` based on what's in the DB.
+- `/api/pipeline/page-init` now returns `review_readiness`.
+- The empty state shows a per-stage diagnostic and (when computable) a "Compute results now" button that calls the existing `/api/pipeline/regroup-live` endpoint and renders inline.
+- A dismissible banner appears when results render but enhancing inputs (eye keypoints, embeddings, full mask coverage, species predictions) are missing for some photos, so the user knows what would improve quality.
+
+Eye keypoints, embeddings, and species predictions are all enhancing — the Group stage degrades gracefully without them. Only masks gate computation (without masks the result is a wall of REJECTs).
+
+## Test plan
+- [ ] Backend tests: `vireo/tests/test_pipeline.py::test_compute_review_readiness_*`
+- [ ] Backend tests: `vireo/tests/test_pipeline_api.py::test_pipeline_page_init_includes_review_readiness`, `test_pipeline_page_init_review_readiness_state_ready_when_cache_exists`
+- [ ] Manual: workspace with masks but no cache → diagnostic + compute button
+- [ ] Manual: click compute → results render inline in seconds
+- [ ] Manual: workspace without masks → "Not enough features" + Pipeline link
+- [ ] Manual: results with enhancing gaps → degraded banner shows + dismisses
+EOF
+)"
+```
+
+---
+
+## Verification checklist before merge
+
+- [ ] `compute_review_readiness` correctly distinguishes empty / insufficient / computable / ready
+- [ ] `/api/pipeline/page-init` includes `review_readiness` in all responses
+- [ ] Empty state shows per-stage counts and a working Compute-now button
+- [ ] Compute-now actually populates the cache (verify file appears at `~/.vireo/pipeline_results_ws{N}.json`)
+- [ ] Degraded banner appears when expected and dismisses correctly
+- [ ] No regression in the existing happy-path (cache exists → page renders normally)
+- [ ] Note: `docs/plans/` is gitignored — commit this plan with `git add -f docs/plans/2026-05-03-pipeline-review-fallback.md` per `project_plan_docs_force_add` memory

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1183,7 +1183,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 p["flag"] = f
                 p["rating"] = r
 
-        review_readiness = compute_review_readiness(db)
+        effective_cfg = db.get_effective_config(cfg.load())
+        pipeline_cfg = effective_cfg.get("pipeline", {})
+
+        # Variant must match the active DINOv2 variant so embedding coverage
+        # reflects what /api/pipeline/regroup-live would actually consume —
+        # mismatched-variant embeddings are dropped at load time, so counting
+        # them here would lie about readiness.
+        review_readiness = compute_review_readiness(
+            db, dinov2_variant=pipeline_cfg.get("dinov2_variant"),
+        )
         if results is not None:
             # Cache exists — even if features have changed underneath,
             # the page can render. enhancing_missing still reflects the
@@ -1196,9 +1205,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 if missing == "masks" and "masks_partial" not in review_readiness["enhancing_missing"]:
                     review_readiness["enhancing_missing"].insert(0, "masks_partial")
             review_readiness["missing_required"] = []
-
-        effective_cfg = db.get_effective_config(cfg.load())
-        pipeline_cfg = effective_cfg.get("pipeline", {})
 
         ws = db.get_workspace(db._active_workspace_id)
         ws_overrides = {}

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1167,7 +1167,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         total_photos = db.count_photos()
 
         import config as cfg
-        from pipeline import load_results
+        from pipeline import compute_review_readiness, load_results
         cache_dir = os.path.dirname(db_path)
         results = load_results(cache_dir, db._active_workspace_id)
         if results and results.get("photos"):
@@ -1182,6 +1182,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 f, r = flag_map.get(p["id"], ("none", 0))
                 p["flag"] = f
                 p["rating"] = r
+
+        review_readiness = compute_review_readiness(db)
+        if results is not None:
+            # Cache exists — even if features have changed underneath,
+            # the page can render. enhancing_missing still reflects the
+            # current gap so the degraded banner can surface accurately.
+            review_readiness["state"] = "ready"
+
         effective_cfg = db.get_effective_config(cfg.load())
         pipeline_cfg = effective_cfg.get("pipeline", {})
 
@@ -1215,6 +1223,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             },
             "mask_variant_coverage": db.mask_variant_coverage(),
             "results": results,
+            "review_readiness": review_readiness,
             "workspace_overrides": ws_overrides,
             "recent_destinations": effective_cfg.get("ingest", {}).get("recent_destinations", []),
         })

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1189,6 +1189,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # the page can render. enhancing_missing still reflects the
             # current gap so the degraded banner can surface accurately.
             review_readiness["state"] = "ready"
+            # When the cache lets the page render, missing_required no
+            # longer represents a block — fold any blocking gaps into
+            # enhancing_missing so the degraded banner surfaces them.
+            for missing in review_readiness["missing_required"]:
+                if missing == "masks" and "masks_partial" not in review_readiness["enhancing_missing"]:
+                    review_readiness["enhancing_missing"].insert(0, "masks_partial")
+            review_readiness["missing_required"] = []
 
         effective_cfg = db.get_effective_config(cfg.load())
         pipeline_cfg = effective_cfg.get("pipeline", {})

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -11,6 +11,7 @@ Entry points:
 
 import json
 import logging
+import math
 import os
 from collections import defaultdict
 
@@ -713,8 +714,11 @@ def compute_review_readiness(db, mask_threshold=0.25):
     if total == 0:
         return out
 
-    # Required: enough photos have masks (otherwise pipeline rejects all)
-    if cov["mask"] < max(1, int(total * mask_threshold)):
+    # Required: enough photos have masks (otherwise pipeline rejects all).
+    # Use ceiling so the gate honors the documented minimum fraction — e.g.
+    # 1 mask out of 5 (20%) must classify as insufficient against a 25%
+    # threshold, not slip through because int() floored 1.25 down to 1.
+    if cov["mask"] < max(1, math.ceil(total * mask_threshold)):
         out["state"] = "insufficient"
         out["missing_required"].append("masks")
         # Still surface enhancing_missing so the diagnostic is complete

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -722,7 +722,7 @@ def compute_review_readiness(db, mask_threshold=0.25):
         out["state"] = "computable"
 
     # Enhancing: per-stage gaps that would improve quality if filled
-    if cov["mask"] < total:
+    if cov["mask"] < total and "masks" not in out["missing_required"]:
         out["enhancing_missing"].append("masks_partial")
     if cov["dino_embedding"] < total:
         out["enhancing_missing"].append("embeddings")

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -670,7 +670,61 @@ def load_results_raw(cache_dir, workspace_id):
         return json.load(f)
 
 
-def compute_review_readiness(db, mask_threshold=0.25):
+def _count_usable_embeddings(db, expected_variant):
+    """Count workspace photos whose stored DINO embedding is usable under
+    ``expected_variant`` — i.e. the same rule ``load_photo_features`` applies
+    via :func:`_embedding_usable`. Without ``expected_variant`` we accept any
+    non-null embedding (back-compat for callers that don't know the variant).
+    """
+    ws = db._ws_id()
+    if expected_variant is None:
+        row = db.conn.execute(
+            """SELECT COUNT(*) AS n
+               FROM photos p
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               JOIN folders f ON f.id = p.folder_id
+                             AND f.status IN ('ok', 'partial')
+               WHERE wf.workspace_id = ?
+                 AND p.dino_subject_embedding IS NOT NULL""",
+            (ws,),
+        ).fetchone()
+        return row["n"] or 0
+
+    try:
+        from dino_embed import get_embedding_dim
+        expected_bytes = get_embedding_dim(expected_variant) * 4
+    except Exception:
+        # Unknown variant — only the exact-match branch can pass.
+        row = db.conn.execute(
+            """SELECT COUNT(*) AS n
+               FROM photos p
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               JOIN folders f ON f.id = p.folder_id
+                             AND f.status IN ('ok', 'partial')
+               WHERE wf.workspace_id = ?
+                 AND p.dino_subject_embedding IS NOT NULL
+                 AND p.dino_embedding_variant = ?""",
+            (ws, expected_variant),
+        ).fetchone()
+        return row["n"] or 0
+
+    row = db.conn.execute(
+        """SELECT COUNT(*) AS n
+           FROM photos p
+           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+           JOIN folders f ON f.id = p.folder_id
+                         AND f.status IN ('ok', 'partial')
+           WHERE wf.workspace_id = ?
+             AND p.dino_subject_embedding IS NOT NULL
+             AND (p.dino_embedding_variant = ?
+                  OR (p.dino_embedding_variant IS NULL
+                      AND length(p.dino_subject_embedding) = ?))""",
+        (ws, expected_variant, expected_bytes),
+    ).fetchone()
+    return row["n"] or 0
+
+
+def compute_review_readiness(db, mask_threshold=0.25, dinov2_variant=None):
     """Classify whether the pipeline review page can render meaningful results.
 
     The Group stage of the pipeline is purely computational and reads
@@ -684,6 +738,13 @@ def compute_review_readiness(db, mask_threshold=0.25):
         db: Database with active workspace
         mask_threshold: minimum fraction of photos that must have masks
             for the result to be computable (default 25%)
+        dinov2_variant: currently configured DINOv2 variant name (e.g.
+            ``"vit-b14"``). When set, embedding coverage is computed using
+            the same variant-compatibility rule as ``load_photo_features``
+            — embeddings stored under a mismatched variant don't count.
+            Without this, after a user switches DINO variants stale
+            embeddings would be reported as complete and the review page
+            would silently render with no usable embeddings.
 
     Returns:
         {
@@ -700,12 +761,13 @@ def compute_review_readiness(db, mask_threshold=0.25):
     """
     cov = db.get_coverage_stats()
     total = cov["total"]
+    usable_embeddings = _count_usable_embeddings(db, dinov2_variant)
     out = {
         "state": "empty",
         "total_photos": total,
         "with_masks": cov["mask"],
         "with_sharpness": cov["subject_sharpness"],
-        "with_embeddings": cov["dino_embedding"],
+        "with_embeddings": usable_embeddings,
         "with_eye_keypoints": cov["eye"],
         "with_predictions": cov["classified"],
         "missing_required": [],
@@ -728,7 +790,7 @@ def compute_review_readiness(db, mask_threshold=0.25):
     # Enhancing: per-stage gaps that would improve quality if filled
     if cov["mask"] < total and "masks" not in out["missing_required"]:
         out["enhancing_missing"].append("masks_partial")
-    if cov["dino_embedding"] < total:
+    if usable_embeddings < total:
         out["enhancing_missing"].append("embeddings")
     if cov["eye"] < total:
         out["enhancing_missing"].append("eye_keypoints")

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -669,6 +669,71 @@ def load_results_raw(cache_dir, workspace_id):
         return json.load(f)
 
 
+def compute_review_readiness(db, mask_threshold=0.25):
+    """Classify whether the pipeline review page can render meaningful results.
+
+    The Group stage of the pipeline is purely computational and reads
+    features already cached in the DB. A "ready" workspace has the
+    grouping cache already on disk; a "computable" workspace has enough
+    features that calling /api/pipeline/regroup-live would produce a
+    useful triage view; an "insufficient" workspace has too few masks
+    for the result to be anything but a wall of REJECTs.
+
+    Args:
+        db: Database with active workspace
+        mask_threshold: minimum fraction of photos that must have masks
+            for the result to be computable (default 25%)
+
+    Returns:
+        {
+            "state": "ready" | "computable" | "insufficient" | "empty",
+            "total_photos": int,
+            "with_masks": int,
+            "with_sharpness": int,
+            "with_embeddings": int,
+            "with_eye_keypoints": int,
+            "with_predictions": int,
+            "missing_required": list[str],   # stages that block computation
+            "enhancing_missing": list[str],  # stages that would improve quality
+        }
+    """
+    cov = db.get_coverage_stats()
+    total = cov["total"]
+    out = {
+        "state": "empty",
+        "total_photos": total,
+        "with_masks": cov["mask"],
+        "with_sharpness": cov["subject_sharpness"],
+        "with_embeddings": cov["dino_embedding"],
+        "with_eye_keypoints": cov["eye"],
+        "with_predictions": cov["classified"],
+        "missing_required": [],
+        "enhancing_missing": [],
+    }
+    if total == 0:
+        return out
+
+    # Required: enough photos have masks (otherwise pipeline rejects all)
+    if cov["mask"] < max(1, int(total * mask_threshold)):
+        out["state"] = "insufficient"
+        out["missing_required"].append("masks")
+        # Still surface enhancing_missing so the diagnostic is complete
+    else:
+        out["state"] = "computable"
+
+    # Enhancing: per-stage gaps that would improve quality if filled
+    if cov["mask"] < total:
+        out["enhancing_missing"].append("masks_partial")
+    if cov["dino_embedding"] < total:
+        out["enhancing_missing"].append("embeddings")
+    if cov["eye"] < total:
+        out["enhancing_missing"].append("eye_keypoints")
+    if cov["classified"] < total:
+        out["enhancing_missing"].append("species_predictions")
+
+    return out
+
+
 def rebuild_species_predictions(results, photo_ids):
     """Rebuild species_predictions for a subset of photos from cached results.
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -80,7 +80,7 @@
 .readiness-stages .stage-missing { color: var(--text-dim); }
 .readiness-actions { margin-top: 16px; display: flex; justify-content: center; gap: 12px; }
 .readiness-actions button { padding: 8px 16px; }
-.readiness-actions .compute-btn { background: var(--accent); color: var(--bg); border: none; border-radius: 4px; cursor: pointer; }
+.readiness-actions .compute-btn { background: var(--accent); color: var(--accent-text); border: none; border-radius: 4px; cursor: pointer; }
 .readiness-actions .compute-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
 /* Filter bar */
@@ -1141,6 +1141,9 @@ var activeFilter = 'all';
 var minConfidence = 40;
 var speciesFilter = '';
 var hideConfirmed = false;
+// Captured from /api/pipeline/page-init so computeReviewNow() can apply
+// the same workspace-override logic the happy path uses on page load.
+var workspaceOverrides = null;
 // Survives re-renders so confirming/filtering doesn't re-expand collapsed
 // encounters. Keyed by the encounter's full sorted photo_id set so that
 // detach/regroup (which change composition) naturally invalidate the key
@@ -1900,19 +1903,33 @@ function computeReviewNow() {
     // Hide empty state, render results inline
     document.getElementById('emptyState').style.display = 'none';
     pipelineResults = data;
+    // Parity with initPipelineReviewPage's happy path:
+    collapsedEncounters = new Set();
+    if (workspaceOverrides && workspaceOverrides.review_min_confidence != null) {
+      minConfidence = workspaceOverrides.review_min_confidence;
+      document.getElementById('confSlider').value = minConfidence;
+      document.getElementById('confSliderVal').textContent = minConfidence + '%';
+    }
     document.getElementById('summaryBar').style.display = '';
     updateSummaryBar(data.summary);
     document.getElementById('filterBar').style.display = '';
     document.getElementById('sidebarScoring').style.display = '';
     document.getElementById('sidebarGrouping').style.display = '';
     renderResults();
+    checkPendingSync();
     refreshMissesReviewBtn();
+  }).catch(function() {
+    // safeFetch toasts the error; re-enable the button so the user can retry.
+    if (btn) { btn.disabled = false; btn.textContent = 'Compute results now'; }
   });
 }
 
 function initPipelineReviewPage() {
   safeFetch('/api/pipeline/page-init', {}, { toast: false })
   .then(function(data) {
+    // Capture overrides regardless of state so computeReviewNow() can apply
+    // the same review_min_confidence logic when the user clicks Compute.
+    workspaceOverrides = (data && data.workspace_overrides) || null;
     if (!data || !data.results) {
       renderEmptyState(data && data.review_readiness ? data.review_readiness
                                                      : {state: 'empty', total_photos: 0});

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -83,6 +83,29 @@
 .readiness-actions .compute-btn { background: var(--accent); color: var(--accent-text); border: none; border-radius: 4px; cursor: pointer; }
 .readiness-actions .compute-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
+.degraded-banner {
+  background: var(--warning-bg, var(--bg-secondary, #3a2e1f));
+  color: var(--text);
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.degraded-banner-link {
+  color: var(--accent);
+  margin-left: auto;
+}
+.degraded-banner-close {
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
 /* Filter bar */
 .filter-bar {
   display: flex;
@@ -1003,6 +1026,13 @@ input[type="range"]::-moz-range-thumb {
 
   <!-- Main area -->
   <div class="pipeline-main" id="mainArea">
+    <!-- Degraded-features banner (shown when results render with enhancing gaps) -->
+    <div class="degraded-banner" id="degradedBanner" style="display:none;">
+      <span id="degradedBannerText"></span>
+      <a href="/pipeline" class="degraded-banner-link">Open Pipeline</a>
+      <button class="degraded-banner-close" onclick="dismissDegradedBanner()" aria-label="Dismiss">&times;</button>
+    </div>
+
     <!-- Summary bar (hidden until data loads) -->
     <div class="summary-bar" id="summaryBar" style="display:none">
       <div class="summary-stat">
@@ -1144,6 +1174,11 @@ var hideConfirmed = false;
 // Captured from /api/pipeline/page-init so computeReviewNow() can apply
 // the same workspace-override logic the happy path uses on page load.
 var workspaceOverrides = null;
+// Captured from /api/pipeline/page-init so computeReviewNow() can re-render
+// the degraded-features banner using the current readiness snapshot
+// (regroup-live doesn't return readiness, but the missing-features set is
+// unchanged by computing the cache).
+var reviewReadiness = null;
 // Survives re-renders so confirming/filtering doesn't re-expand collapsed
 // encounters. Keyed by the encounter's full sorted photo_id set so that
 // detach/regroup (which change composition) naturally invalidate the key
@@ -1829,6 +1864,27 @@ function toggleMask() {
 
 // -- Init --
 
+function renderDegradedBanner(enhancingMissing) {
+  if (!enhancingMissing || enhancingMissing.length === 0) return;
+  if (sessionStorage.getItem('degradedBannerDismissed')) return;
+  var labelMap = {
+    masks_partial: 'full mask coverage',
+    embeddings: 'embeddings',
+    eye_keypoints: 'eye keypoints',
+    species_predictions: 'species predictions'
+  };
+  var labels = enhancingMissing.map(function(k) { return labelMap[k] || k; });
+  document.getElementById('degradedBannerText').textContent =
+    'These results were computed without ' + labels.join(', ')
+    + '. Re-run those stages to improve quality.';
+  document.getElementById('degradedBanner').style.display = '';
+}
+
+function dismissDegradedBanner() {
+  sessionStorage.setItem('degradedBannerDismissed', '1');
+  document.getElementById('degradedBanner').style.display = 'none';
+}
+
 function renderEmptyState(readiness) {
   var heading = document.getElementById('emptyStateHeading');
   var body = document.getElementById('emptyStateBody');
@@ -1918,6 +1974,7 @@ function computeReviewNow() {
     renderResults();
     checkPendingSync();
     refreshMissesReviewBtn();
+    renderDegradedBanner(reviewReadiness && reviewReadiness.enhancing_missing);
   }).catch(function() {
     // safeFetch toasts the error; re-enable the button so the user can retry.
     if (btn) { btn.disabled = false; btn.textContent = 'Compute results now'; }
@@ -1930,6 +1987,9 @@ function initPipelineReviewPage() {
     // Capture overrides regardless of state so computeReviewNow() can apply
     // the same review_min_confidence logic when the user clicks Compute.
     workspaceOverrides = (data && data.workspace_overrides) || null;
+    // Capture readiness so computeReviewNow() can re-render the degraded
+    // banner with the current missing-features set after compute completes.
+    reviewReadiness = (data && data.review_readiness) || null;
     if (!data || !data.results) {
       renderEmptyState(data && data.review_readiness ? data.review_readiness
                                                      : {state: 'empty', total_photos: 0});
@@ -1966,6 +2026,7 @@ function initPipelineReviewPage() {
     renderResults();
     checkPendingSync();
     refreshMissesReviewBtn();
+    renderDegradedBanner(data.review_readiness && data.review_readiness.enhancing_missing);
   });
 }
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -64,6 +64,24 @@
 }
 .empty-state h2 { font-size: 20px; margin-bottom: 8px; color: var(--text-secondary); }
 .empty-state p { font-size: 14px; max-width: 400px; margin: 0 auto; line-height: 1.5; }
+.readiness-stages {
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 4px 12px;
+  margin: 16px auto;
+  font-size: 13px;
+  max-width: 360px;
+  text-align: left;
+}
+.readiness-stages .stage-name { color: var(--text-dim); }
+.readiness-stages .stage-count { font-variant-numeric: tabular-nums; }
+.readiness-stages .stage-ok { color: var(--success, #4caf50); }
+.readiness-stages .stage-partial { color: var(--warning, #ff9800); }
+.readiness-stages .stage-missing { color: var(--text-dim); }
+.readiness-actions { margin-top: 16px; display: flex; justify-content: center; gap: 12px; }
+.readiness-actions button { padding: 8px 16px; }
+.readiness-actions .compute-btn { background: var(--accent); color: var(--bg); border: none; border-radius: 4px; cursor: pointer; }
+.readiness-actions .compute-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
 /* Filter bar */
 .filter-bar {
@@ -1052,8 +1070,10 @@ input[type="range"]::-moz-range-thumb {
     <div id="encountersContainer"></div>
 
     <div class="empty-state" id="emptyState" style="display:none;">
-      <h2>No pipeline results yet</h2>
-      <p>Run the pipeline from the <a href="/pipeline" style="color:var(--accent);">Pipeline</a> page first.</p>
+      <h2 id="emptyStateHeading">No pipeline results yet</h2>
+      <p id="emptyStateBody"></p>
+      <div class="readiness-stages" id="readinessStages"></div>
+      <div class="readiness-actions" id="readinessActions"></div>
     </div>
   </div>
 </div>
@@ -1806,13 +1826,96 @@ function toggleMask() {
 
 // -- Init --
 
+function renderEmptyState(readiness) {
+  var heading = document.getElementById('emptyStateHeading');
+  var body = document.getElementById('emptyStateBody');
+  var stages = document.getElementById('readinessStages');
+  var actions = document.getElementById('readinessActions');
+  document.getElementById('emptyState').style.display = '';
+
+  // Per-stage rows
+  var rows = [
+    ['Photos', readiness.total_photos, readiness.total_photos],
+    ['Masks', readiness.with_masks, readiness.total_photos],
+    ['Embeddings', readiness.with_embeddings, readiness.total_photos],
+    ['Eye keypoints', readiness.with_eye_keypoints, readiness.total_photos],
+    ['Species predictions', readiness.with_predictions, readiness.total_photos],
+  ];
+  stages.innerHTML = rows.map(function(r) {
+    var name = r[0], n = r[1], total = r[2];
+    var cls = (n === total && total > 0) ? 'stage-ok'
+            : (n > 0 ? 'stage-partial' : 'stage-missing');
+    return '<span class="stage-name">' + name + '</span>'
+         + '<span class="stage-count ' + cls + '">' + n + ' / ' + total + '</span>';
+  }).join('');
+
+  if (readiness.state === 'empty') {
+    heading.textContent = 'No photos in this workspace';
+    body.textContent = 'Add folders to this workspace from the Folders page.';
+    actions.innerHTML = '';
+    return;
+  }
+
+  if (readiness.state === 'insufficient') {
+    heading.textContent = 'Not enough features to compute results yet';
+    body.textContent = 'Run mask extraction on the Pipeline page first '
+      + '— the review page needs masks to score photo quality.';
+    actions.innerHTML = '<a href="/pipeline" class="compute-btn" '
+      + 'style="text-decoration:none;display:inline-block;">Open Pipeline</a>';
+    return;
+  }
+
+  // state === 'computable'
+  heading.textContent = 'Ready to compute results';
+  var enhancing = readiness.enhancing_missing || [];
+  if (enhancing.length === 0) {
+    body.textContent = 'All upstream stages are complete. '
+      + 'Click below to group, score, and triage your photos.';
+  } else {
+    var labels = enhancing.map(function(k) {
+      return ({masks_partial: 'full mask coverage',
+               embeddings: 'embeddings',
+               eye_keypoints: 'eye keypoints',
+               species_predictions: 'species predictions'})[k] || k;
+    });
+    body.textContent = 'You can compute results now. Quality will be lower without: '
+      + labels.join(', ') + '. Re-run those stages on the Pipeline page later to improve.';
+  }
+  actions.innerHTML = '<button class="compute-btn" onclick="computeReviewNow()">'
+    + 'Compute results now</button>';
+}
+
+function computeReviewNow() {
+  var btn = document.querySelector('.readiness-actions .compute-btn');
+  if (btn) { btn.disabled = true; btn.textContent = 'Computing…'; }
+  safeFetch('/api/pipeline/regroup-live', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({})
+  }).then(function(data) {
+    if (!data || !data.encounters) {
+      if (btn) { btn.disabled = false; btn.textContent = 'Compute results now'; }
+      return;
+    }
+    // Hide empty state, render results inline
+    document.getElementById('emptyState').style.display = 'none';
+    pipelineResults = data;
+    document.getElementById('summaryBar').style.display = '';
+    updateSummaryBar(data.summary);
+    document.getElementById('filterBar').style.display = '';
+    document.getElementById('sidebarScoring').style.display = '';
+    document.getElementById('sidebarGrouping').style.display = '';
+    renderResults();
+    refreshMissesReviewBtn();
+  });
+}
+
 function initPipelineReviewPage() {
   safeFetch('/api/pipeline/page-init', {}, { toast: false })
   .then(function(data) {
     if (!data || !data.results) {
-      // No results — show empty state
-      var empty = document.getElementById('emptyState');
-      if (empty) empty.style.display = '';
+      renderEmptyState(data && data.review_readiness ? data.review_readiness
+                                                     : {state: 'empty', total_photos: 0});
       return;
     }
     // Hide empty state, show results UI

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -84,10 +84,10 @@
 .readiness-actions .compute-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .degraded-banner {
-  background: var(--warning-bg, var(--bg-secondary, #3a2e1f));
-  color: var(--text);
+  background: var(--accent-dim, #3a2e1f);
+  color: var(--text-primary);
   padding: 8px 16px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-primary);
   font-size: 13px;
   display: flex;
   align-items: center;

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -283,6 +283,83 @@ def test_load_results_missing(tmp_path):
     assert load_results(str(tmp_path), workspace_id=999) is None
 
 
+# -- compute_review_readiness --
+
+
+def test_compute_review_readiness_empty_workspace(tmp_path):
+    """No photos in the workspace → state='empty'."""
+    from db import Database
+    from pipeline import compute_review_readiness
+
+    db = Database(str(tmp_path / "test.db"))
+    out = compute_review_readiness(db)
+    assert out["state"] == "empty"
+    assert out["total_photos"] == 0
+    assert out["missing_required"] == []
+    assert out["enhancing_missing"] == []
+
+
+def test_compute_review_readiness_no_masks(tmp_path):
+    """Photos exist but none have masks → state='insufficient',
+    'masks' listed in missing_required."""
+    from db import Database
+    from pipeline import compute_review_readiness
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+    base_time = datetime(2026, 3, 20, 10, 0, 0)
+    for i in range(5):
+        ts = base_time + timedelta(seconds=i * 2)
+        db.add_photo(
+            fid, f"photo{i}.jpg", ".jpg", 1000, 1.0,
+            timestamp=ts.isoformat(), width=4000, height=3000,
+        )
+
+    out = compute_review_readiness(db)
+    assert out["state"] == "insufficient"
+    assert "masks" in out["missing_required"]
+    assert out["total_photos"] == 5
+    assert out["with_masks"] == 0
+
+
+def test_compute_review_readiness_masks_present_no_eye(tmp_path):
+    """Masks present for all photos, no eye keypoints →
+    state='computable', 'eye_keypoints' in enhancing_missing."""
+    from pipeline import compute_review_readiness
+
+    # _setup_db_with_photos populates masks, embeddings, and predictions
+    # for every photo but does NOT set eye_x — exactly the "computable
+    # but enhancing inputs missing" state we want to assert against.
+    db, _ids = _setup_db_with_photos(tmp_path)
+    out = compute_review_readiness(db)
+    assert out["state"] == "computable"
+    assert out["with_masks"] > 0
+    assert out["with_masks"] == out["total_photos"]
+    assert "eye_keypoints" in out["enhancing_missing"]
+
+
+def test_compute_review_readiness_full_features(tmp_path):
+    """All upstream features present including eye keypoints →
+    state='computable', enhancing_missing empty."""
+    from pipeline import compute_review_readiness
+
+    db, ids = _setup_db_with_photos(tmp_path)
+    # Backfill eye keypoints for every photo so coverage is 100%.
+    for enc_ids in ids:
+        for pid in enc_ids:
+            db.update_photo_pipeline_features(
+                pid,
+                eye_x=0.5,
+                eye_y=0.5,
+                eye_conf=0.9,
+                eye_tenengrad=200.0,
+            )
+
+    out = compute_review_readiness(db)
+    assert out["state"] == "computable"
+    assert out["enhancing_missing"] == []
+
+
 def test_save_results_preserves_miss_computed_at_across_reflow(tmp_path):
     """save_results must preserve an existing miss_computed_at marker
     when the caller's results dict doesn't carry one. reflow and

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -409,6 +409,40 @@ def test_compute_review_readiness_at_mask_threshold_boundary(tmp_path):
     assert "masks_partial" not in out_below["enhancing_missing"]
 
 
+def test_compute_review_readiness_below_threshold_uses_ceiling(tmp_path):
+    """Coverage strictly below the threshold must classify as insufficient
+    even when ``int(total * threshold)`` would floor the required count
+    down to a value the actual coverage happens to meet.
+
+    Concrete case: 5 photos, 1 with a mask = 20% coverage. Against the
+    default 25% threshold, ``int(5 * 0.25) == 1`` would let 1 mask pass;
+    the ceiling form ``ceil(5 * 0.25) == 2`` correctly requires 2 and
+    classifies the workspace as insufficient.
+    """
+    from db import Database
+    from pipeline import compute_review_readiness
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+    base_time = datetime(2026, 3, 20, 10, 0, 0)
+    pids = []
+    for i in range(5):
+        ts = base_time + timedelta(seconds=i * 2)
+        pid = db.add_photo(
+            fid, f"photo{i}.jpg", ".jpg", 1000, 1.0,
+            timestamp=ts.isoformat(), width=4000, height=3000,
+        )
+        pids.append(pid)
+
+    # 1 mask out of 5 → 20% coverage, strictly below the 25% threshold.
+    db.update_photo_pipeline_features(pids[0], mask_path=f"/masks/{pids[0]}.png")
+
+    out = compute_review_readiness(db)
+    assert out["state"] == "insufficient"
+    assert out["with_masks"] == 1
+    assert "masks" in out["missing_required"]
+
+
 def test_save_results_preserves_miss_computed_at_across_reflow(tmp_path):
     """save_results must preserve an existing miss_computed_at marker
     when the caller's results dict doesn't carry one. reflow and

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -443,6 +443,51 @@ def test_compute_review_readiness_below_threshold_uses_ceiling(tmp_path):
     assert "masks" in out["missing_required"]
 
 
+def test_compute_review_readiness_variant_aware_embeddings(tmp_path):
+    """Switching DINOv2 variants must drop stale embeddings from coverage.
+
+    Pins the contract that embedding readiness mirrors the variant rule
+    in ``load_photo_features._embedding_usable``: a workspace whose
+    embeddings were all written under ``vit-b14`` (768-dim) must report
+    zero usable embeddings when readiness is asked for under ``vit-l14``
+    (1024-dim), and the user-facing ``enhancing_missing`` must surface
+    the gap so the degraded banner explains the silent quality drop.
+
+    Without this, after a variant switch the readiness pane would claim
+    full embedding coverage while ``/api/pipeline/regroup-live`` actually
+    runs without a single usable embedding.
+    """
+    from pipeline import compute_review_readiness
+
+    # _setup_db_with_photos writes 768-dim embeddings (vit-b14 shape) but
+    # leaves dino_embedding_variant NULL via update_photo_embeddings.
+    db, _ids = _setup_db_with_photos(tmp_path)
+
+    # Same variant as the stored byte-length — NULL stored variant slips
+    # through the dim-match branch, so coverage is full.
+    out_match = compute_review_readiness(db, dinov2_variant="vit-b14")
+    assert out_match["with_embeddings"] == out_match["total_photos"]
+    assert "embeddings" not in out_match["enhancing_missing"]
+
+    # Mismatched variant — 768-dim embeddings can't be reused as 1024-dim,
+    # so they must NOT count as usable and must surface in the gap list.
+    out_mismatch = compute_review_readiness(db, dinov2_variant="vit-l14")
+    assert out_mismatch["with_embeddings"] == 0
+    assert "embeddings" in out_mismatch["enhancing_missing"]
+
+    # Stamp the variant explicitly: a row marked vit-b14 must NOT count
+    # under a vit-l14 readiness check even though byte-length doesn't
+    # match either — the explicit-variant branch wins.
+    pid = _ids[0][0]
+    db.conn.execute(
+        "UPDATE photos SET dino_embedding_variant=? WHERE id=?",
+        ("vit-b14", pid),
+    )
+    db.conn.commit()
+    out_explicit_mismatch = compute_review_readiness(db, dinov2_variant="vit-l14")
+    assert out_explicit_mismatch["with_embeddings"] == 0
+
+
 def test_save_results_preserves_miss_computed_at_across_reflow(tmp_path):
     """save_results must preserve an existing miss_computed_at marker
     when the caller's results dict doesn't carry one. reflow and

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -360,6 +360,55 @@ def test_compute_review_readiness_full_features(tmp_path):
     assert out["enhancing_missing"] == []
 
 
+def test_compute_review_readiness_at_mask_threshold_boundary(tmp_path):
+    """Mask coverage exactly at the 25% threshold → state='computable'.
+
+    Pins the contract that the comparison is strict ``<`` (not ``<=``):
+    with 4 photos and 1 having a mask, coverage is 1/4 = 25%, which is
+    *at* threshold and must classify as computable. Drop one mask (0/4)
+    and the same workspace must classify as insufficient. If the
+    comparison flips to ``<=``, the boundary case becomes insufficient
+    and the first assertion below fails.
+    """
+    from db import Database
+    from pipeline import compute_review_readiness
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+    base_time = datetime(2026, 3, 20, 10, 0, 0)
+    pids = []
+    for i in range(4):
+        ts = base_time + timedelta(seconds=i * 2)
+        pid = db.add_photo(
+            fid, f"photo{i}.jpg", ".jpg", 1000, 1.0,
+            timestamp=ts.isoformat(), width=4000, height=3000,
+        )
+        pids.append(pid)
+
+    # Exactly one mask out of four → 25% coverage, at the threshold.
+    db.update_photo_pipeline_features(pids[0], mask_path=f"/masks/{pids[0]}.png")
+
+    out = compute_review_readiness(db)
+    assert out["state"] == "computable"
+    assert out["total_photos"] == 4
+    assert out["with_masks"] == 1
+    assert "masks" not in out["missing_required"]
+    # Fix 1 contract: when masks-partial would be redundant with a
+    # required-masks block we suppress it, but here masks is NOT required
+    # (we're at threshold) so the partial signal is informative and present.
+    assert "masks_partial" in out["enhancing_missing"]
+
+    # Asymmetric companion: drop the only mask → 0/4, below threshold.
+    db.update_photo_pipeline_features(pids[0], mask_path=None)
+    out_below = compute_review_readiness(db)
+    assert out_below["state"] == "insufficient"
+    assert out_below["with_masks"] == 0
+    assert "masks" in out_below["missing_required"]
+    # Fix 1 contract: when masks is in missing_required we must NOT
+    # also surface the redundant masks_partial enhancing signal.
+    assert "masks_partial" not in out_below["enhancing_missing"]
+
+
 def test_save_results_preserves_miss_computed_at_across_reflow(tmp_path):
     """save_results must preserve an existing miss_computed_at marker
     when the caller's results dict doesn't carry one. reflow and

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -764,6 +764,51 @@ def test_pipeline_page_init_review_readiness_state_ready_when_cache_exists(setup
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["review_readiness"]["state"] == "ready"
+        # The cache letting the page render does not erase enhancing_missing —
+        # the seed has masks but no embeddings, so the degraded banner should
+        # still see "embeddings" as a quality gap.
+        assert "embeddings" in data["review_readiness"]["enhancing_missing"]
+
+
+def test_pipeline_page_init_state_ready_folds_blocking_gaps_into_enhancing(setup, tmp_path):
+    """When the grouping cache is on disk but mask coverage is below the
+    25% threshold, compute_review_readiness returns missing_required=["masks"]
+    without "masks_partial" in enhancing_missing. The page-init route should
+    force state="ready" (cache lets the page render) AND fold "masks" into
+    enhancing_missing as "masks_partial" so the degraded banner surfaces it.
+    """
+    app, db_path = setup
+
+    # Seed photos but DON'T add masks — so cov["mask"] = 0 and state is
+    # "insufficient" with missing_required=["masks"] before the route fixup.
+    from db import Database
+    db = Database(db_path)
+    ws = db._active_workspace_id
+    fid = db.add_folder("/photos/seed_no_masks", name="seed_no_masks")
+    db.add_workspace_folder(ws, fid)
+    db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                 file_size=1, file_mtime=1.0)
+    db.add_photo(folder_id=fid, filename="b.jpg", extension=".jpg",
+                 file_size=1, file_mtime=1.0)
+    db.close()
+
+    # Drop a minimal cache file at <db_dir>/pipeline_results_ws{N}.json
+    import json as _json
+
+    cache_path = os.path.join(
+        os.path.dirname(db_path), f"pipeline_results_ws{ws}.json"
+    )
+    with open(cache_path, "w") as f:
+        _json.dump({"encounters": [], "photos": [], "summary": {}}, f)
+
+    with app.test_client() as c:
+        resp = c.get("/api/pipeline/page-init")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        rr = data["review_readiness"]
+        assert rr["state"] == "ready"
+        assert rr["missing_required"] == []
+        assert "masks_partial" in rr["enhancing_missing"]
 
 
 def test_active_mask_variant_endpoint_switches_workspace_photos(setup):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -723,6 +723,49 @@ def test_pipeline_page_init_includes_mask_variant_coverage(setup):
         assert cov["sam2-large"]["active_count"] == 0
 
 
+def test_pipeline_page_init_includes_review_readiness(setup):
+    """page-init exposes review_readiness so the review page can render
+    a diagnostic empty state and decide whether to offer Compute now."""
+    app, db_path = setup
+    # _seed_workspace_with_masks leaves photos with masks but no Group cache.
+    _seed_workspace_with_masks(db_path)
+
+    with app.test_client() as c:
+        resp = c.get("/api/pipeline/page-init")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "review_readiness" in data
+        rr = data["review_readiness"]
+        assert rr["state"] == "computable"
+        assert rr["total_photos"] >= 2
+        assert rr["with_masks"] >= 2
+
+
+def test_pipeline_page_init_review_readiness_state_ready_when_cache_exists(setup, tmp_path):
+    """When the grouping cache is already on disk, state should be 'ready'."""
+    app, db_path = setup
+    _seed_workspace_with_masks(db_path)
+
+    # Drop a minimal cache file at <db_dir>/pipeline_results_ws{N}.json
+    import json as _json
+
+    from db import Database
+    db = Database(db_path)
+    ws = db._active_workspace_id
+    db.close()
+    cache_path = os.path.join(
+        os.path.dirname(db_path), f"pipeline_results_ws{ws}.json"
+    )
+    with open(cache_path, "w") as f:
+        _json.dump({"encounters": [], "photos": [], "summary": {}}, f)
+
+    with app.test_client() as c:
+        resp = c.get("/api/pipeline/page-init")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["review_readiness"]["state"] == "ready"
+
+
 def test_active_mask_variant_endpoint_switches_workspace_photos(setup):
     """POST /api/pipeline/active-mask-variant flips active_mask_variant on
     every workspace photo that has a row for the requested variant."""


### PR DESCRIPTION
## Summary

The pipeline review page used to bail to "No pipeline results yet" whenever the per-workspace cache JSON file was absent — even when all upstream features were ready and the Group stage would have run in seconds. This PR makes the page useful in that state.

- New `compute_review_readiness` (`vireo/pipeline.py`) classifies the workspace as `ready` / `computable` / `insufficient` / `empty` based on per-feature counts already provided by `db.get_coverage_stats()`.
- `/api/pipeline/page-init` now returns `review_readiness`, with `state` forced to `ready` when the cache exists and any blocking gaps folded into `enhancing_missing` so the banner can still surface them.
- The empty state on `/pipeline/review` shows a per-stage diagnostic (Photos / Masks / Embeddings / Eye keypoints / Species predictions) and, when computable, a "Compute results now" button that calls the existing `/api/pipeline/regroup-live` and renders inline in seconds — no round trip to `/pipeline`.
- A session-dismissible banner appears when results render but enhancing inputs (eye keypoints, embeddings, full mask coverage, species predictions) are missing for some photos, so the user knows what would improve quality.
- Compute-now path mirrors the happy path: applies workspace overrides for `review_min_confidence`, resets `collapsedEncounters`, calls `checkPendingSync()`, and `.catch` re-enables the button on failure.

Eye keypoints, embeddings, and species predictions are all enhancing — the Group stage degrades gracefully without them. Only masks gate computation (without masks, photos hard-reject).

## Test plan

- [x] `compute_review_readiness` unit tests: empty / no_masks / masks_present_no_eye / full_features / boundary at 25% mask coverage (5 tests, `vireo/tests/test_pipeline.py`)
- [x] `/api/pipeline/page-init` API tests: `review_readiness` present, state=ready when cache exists, enhancing_missing folds blocking gaps when cache lets page render (3 tests, `vireo/tests/test_pipeline_api.py`)
- [x] Full project suite: 985 passed, 1 skipped. 2 unrelated `test_edits_api.py` flakes (keyword removal/undo — they pass in isolation, no touch from this PR)
- [ ] Manual: workspace with masks but no cache → diagnostic + compute button
- [ ] Manual: click compute → results render inline in seconds, slider reflects workspace overrides
- [ ] Manual: workspace without masks → "Not enough features" + Pipeline link
- [ ] Manual: results with enhancing gaps → degraded banner shows + dismisses + re-shows in fresh tab