### PR TITLE
Transparent encounter tuning: live algorithm panel + per-cut-point trace

### DIFF
--- a/docs/plans/2026-05-03-transparent-encounter-tuning-plan.md
+++ b/docs/plans/2026-05-03-transparent-encounter-tuning-plan.md
@@ -1,0 +1,1062 @@
+# Transparent Encounter Tuning Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the encounter-grouping algorithm fully visible (per-cut-point scores with component breakdown) and tunable (every weight + threshold) from the pipeline review page's left sidebar, with live re-grouping on slider change.
+
+**Architecture:** Three pieces. (1) `vireo/encounters.py` gains an opt-in `emit_trace=True` mode that records every adjacent-pair S_enc score, its 5 components, the gap, and the cut/keep decision; threaded through `pipeline.run_full_pipeline` and the existing `/api/pipeline/regroup-live` endpoint. (2) `pipeline_review.html` left sidebar exposes all ~12 grouping knobs grouped by stage (Cut / Merge / Burst), always visible, wired to existing `onGroupingChange` debounced live regroup. (3) New always-visible "Algorithm trace" panel in the sidebar shows the focused encounter's per-cut-point readout; clicking a card sets focus; new `/api/pipeline/save-grouping-defaults` persists the current weights to `~/.vireo/config.json`.
+
+**Tech Stack:** Python 3 / Flask / vanilla JS / Jinja2. Tests via `pytest`. Manual UI verification with Playwright (per `feedback_user_first_testing` memory).
+
+---
+
+## Quick reference
+
+**Existing endpoints already in place:**
+- `POST /api/pipeline/regroup-live` (`vireo/app.py:10127`) — accepts `{config: {...}}`, runs `run_full_pipeline`, returns serialized results. We extend its response.
+
+**Existing UI hooks already in place:**
+- `onGroupingChange()` (`vireo/templates/pipeline_review.html:1536`) — debounced 500ms, calls `doRegroupLive()` (line 1565) which POSTs to `/api/pipeline/regroup-live` and re-renders.
+- `getGroupingConfig()` returns the current slider values to the endpoint. We extend it to include the new sliders.
+
+**Files we will touch:**
+- `vireo/encounters.py` — add trace emission
+- `vireo/pipeline.py` — propagate trace into serialized results
+- `vireo/app.py` — add save-defaults endpoint
+- `vireo/templates/pipeline_review.html` — sidebar sliders, trace panel, focus selection, save button
+- `vireo/tests/test_encounters.py` — trace emission tests
+- `vireo/tests/test_app.py` — save-defaults endpoint test
+
+**Test command (per CLAUDE.md):**
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_encounters.py -v
+```
+
+---
+
+## Task 1: `compute_s_enc` returns components when asked
+
+**Files:**
+- Modify: `vireo/encounters.py:166-222` (`compute_s_enc`)
+- Test: `vireo/tests/test_encounters.py`
+
+**Step 1: Write the failing test**
+
+Append to `vireo/tests/test_encounters.py`:
+
+```python
+def test_compute_s_enc_returns_components_when_asked():
+    from encounters import compute_s_enc
+    photo_a = {
+        "timestamp": "2026-03-07T11:32:04",
+        "latitude": 33.7, "longitude": -118.0,
+        "focal_length": 600.0,
+    }
+    photo_b = {
+        "timestamp": "2026-03-07T11:32:09",
+        "latitude": 33.7, "longitude": -118.0,
+        "focal_length": 600.0,
+    }
+    score, components = compute_s_enc(photo_a, photo_b, return_components=True)
+    assert isinstance(score, float)
+    assert set(components.keys()) >= {"time", "subj", "global", "species", "meta"}
+    # Each component is a dict {value, weight, used}
+    assert components["time"]["value"] >= 0.0
+    assert components["time"]["weight"] == 0.35  # default w_time
+    assert components["time"]["used"] is True   # both photos have timestamps
+    assert components["species"]["used"] is False  # neither has species_top5
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/julius/conductor/workspaces/vireo/tashkent
+python -m pytest vireo/tests/test_encounters.py::test_compute_s_enc_returns_components_when_asked -v
+```
+Expected: FAIL — `compute_s_enc` does not accept `return_components` keyword.
+
+**Step 3: Modify `compute_s_enc`**
+
+Change the signature and return structure. Replace the function body (`vireo/encounters.py:166-222`) with:
+
+```python
+def compute_s_enc(photo_a, photo_b, config=None, return_components=False):
+    """Compute the combined encounter similarity score S_enc(a, b).
+
+    When return_components=True, returns (score, components_dict) where
+    components_dict maps each signal name to {value, weight, used}.
+    """
+    cfg = {**DEFAULTS, **(config or {})}
+
+    ts_a = _parse_timestamp(photo_a.get("timestamp"))
+    ts_b = _parse_timestamp(photo_b.get("timestamp"))
+    dt = _time_delta_seconds(ts_a, ts_b)
+
+    st = sim_time(dt, tau=cfg["tau_enc"])
+    ss = sim_embedding(photo_a.get("dino_subject_embedding"), photo_b.get("dino_subject_embedding"))
+    sg = sim_embedding(photo_a.get("dino_global_embedding"), photo_b.get("dino_global_embedding"))
+    sp = sim_species(photo_a.get("species_top5"), photo_b.get("species_top5"))
+    sm = sim_meta(photo_a, photo_b)
+
+    used = {
+        "time": dt != float("inf"),
+        "subj": (photo_a.get("dino_subject_embedding") is not None
+                 and photo_b.get("dino_subject_embedding") is not None),
+        "global": (photo_a.get("dino_global_embedding") is not None
+                   and photo_b.get("dino_global_embedding") is not None),
+        "species": bool(photo_a.get("species_top5") and photo_b.get("species_top5")),
+        "meta": True,
+    }
+    weight_keys = {"time": "w_time", "subj": "w_subj", "global": "w_global",
+                   "species": "w_species", "meta": "w_meta"}
+    values = {"time": st, "subj": ss, "global": sg, "species": sp, "meta": sm}
+
+    total_weight = sum(cfg[weight_keys[k]] for k, u in used.items() if u)
+    if total_weight == 0:
+        s_enc = 0.0
+    else:
+        s_enc = sum(cfg[weight_keys[k]] * values[k] for k, u in used.items() if u) / total_weight
+
+    if not return_components:
+        return s_enc
+
+    components = {
+        k: {"value": float(values[k]), "weight": float(cfg[weight_keys[k]]), "used": bool(used[k])}
+        for k in values
+    }
+    return s_enc, components
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+python -m pytest vireo/tests/test_encounters.py::test_compute_s_enc_returns_components_when_asked -v
+```
+Expected: PASS.
+
+**Step 5: Run the full encounters test file to verify no regression**
+
+```bash
+python -m pytest vireo/tests/test_encounters.py -v
+```
+Expected: all existing tests PASS. (The default code path is unchanged because `return_components` defaults to False.)
+
+**Step 6: Commit**
+
+```bash
+git add vireo/encounters.py vireo/tests/test_encounters.py
+git commit -m "encounters: opt-in component breakdown from compute_s_enc"
+```
+
+---
+
+## Task 2: `cut_microsegments` emits per-pair trace
+
+**Files:**
+- Modify: `vireo/encounters.py:228-304` (`cut_microsegments`)
+- Test: `vireo/tests/test_encounters.py`
+
+**Step 1: Write the failing test**
+
+Append:
+
+```python
+def test_cut_microsegments_emits_trace():
+    from encounters import cut_microsegments
+    # 3 photos: two close-in-time, one far apart -> hard time cut between #2 and #3
+    photos = [
+        {"timestamp": "2026-03-07T11:32:00", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+        {"timestamp": "2026-03-07T11:32:05", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+        {"timestamp": "2026-03-07T11:40:00", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+    ]
+    segments, trace = cut_microsegments(photos, emit_trace=True)
+    assert len(segments) == 2  # cut between #2 and #3
+    assert len(trace) == 2  # one entry per adjacent pair
+    # Pair 0->1: kept (small gap, no cut)
+    assert trace[0]["pair_index"] == 0
+    assert trace[0]["decision"] == "kept"
+    assert trace[0]["dt_seconds"] == 5.0
+    assert "components" in trace[0]
+    # Pair 1->2: hard time cut
+    assert trace[1]["pair_index"] == 1
+    assert trace[1]["decision"] == "cut_time"
+    assert trace[1]["dt_seconds"] == 475.0
+```
+
+**Step 2: Run test, verify it fails**
+
+```bash
+python -m pytest vireo/tests/test_encounters.py::test_cut_microsegments_emits_trace -v
+```
+Expected: FAIL — function doesn't accept `emit_trace`.
+
+**Step 3: Modify `cut_microsegments`**
+
+Replace the body of `cut_microsegments` (`vireo/encounters.py:228-304`) — keep the existing logic, add a parallel `trace` accumulator:
+
+```python
+def cut_microsegments(photos, config=None, emit_trace=False):
+    cfg = {**DEFAULTS, **(config or {})}
+
+    if len(photos) <= 1:
+        if emit_trace:
+            return ([photos] if photos else []), []
+        return [photos] if photos else []
+
+    sorted_photos = sorted(
+        photos,
+        key=lambda p: _parse_timestamp(p.get("timestamp")) or datetime.min,
+    )
+
+    cuts = set()
+    recent_scores = []
+    trace = [] if emit_trace else None
+
+    for i in range(len(sorted_photos) - 1):
+        if emit_trace:
+            score, components = compute_s_enc(
+                sorted_photos[i], sorted_photos[i + 1], config=cfg, return_components=True
+            )
+        else:
+            score = compute_s_enc(sorted_photos[i], sorted_photos[i + 1], config=cfg)
+            components = None
+
+        ts_a = _parse_timestamp(sorted_photos[i].get("timestamp"))
+        ts_b = _parse_timestamp(sorted_photos[i + 1].get("timestamp"))
+        dt = _time_delta_seconds(ts_a, ts_b)
+
+        bid_a = sorted_photos[i].get("burst_id")
+        bid_b = sorted_photos[i + 1].get("burst_id")
+        decision = None
+
+        if bid_a is not None and bid_b is not None and bid_a == bid_b:
+            decision = "burst_id_kept"
+            recent_scores.append(score)
+            if len(recent_scores) > 3:
+                recent_scores.pop(0)
+        elif dt > cfg["hard_cut_time"]:
+            cuts.add(i)
+            recent_scores = []
+            decision = "cut_time"
+        elif score < cfg["hard_cut_score"]:
+            cuts.add(i)
+            recent_scores = []
+            decision = "cut_score"
+        else:
+            recent_scores.append(score)
+            if len(recent_scores) > 3:
+                recent_scores.pop(0)
+            if len(recent_scores) >= 3:
+                below = sum(1 for s in recent_scores if s < cfg["soft_cut_score"])
+                if below >= 2:
+                    cuts.add(i)
+                    recent_scores = []
+                    decision = "cut_soft"
+            if decision is None:
+                decision = "kept"
+
+        if emit_trace:
+            trace.append({
+                "pair_index": i,
+                "score": float(score),
+                "dt_seconds": float(dt) if dt != float("inf") else None,
+                "decision": decision,
+                "components": components,
+                "thresholds": {
+                    "hard_cut_time": cfg["hard_cut_time"],
+                    "hard_cut_score": cfg["hard_cut_score"],
+                    "soft_cut_score": cfg["soft_cut_score"],
+                },
+            })
+
+    segments = []
+    start = 0
+    for i in sorted(cuts):
+        segments.append(sorted_photos[start:i + 1])
+        start = i + 1
+    segments.append(sorted_photos[start:])
+    segments = [seg for seg in segments if seg]
+
+    if emit_trace:
+        return segments, trace
+    return segments
+```
+
+**Step 4: Run test**
+
+```bash
+python -m pytest vireo/tests/test_encounters.py::test_cut_microsegments_emits_trace -v
+```
+Expected: PASS.
+
+**Step 5: Run full encounters tests for regression check**
+
+```bash
+python -m pytest vireo/tests/test_encounters.py -v
+```
+Expected: all PASS.
+
+**Step 6: Commit**
+
+```bash
+git add vireo/encounters.py vireo/tests/test_encounters.py
+git commit -m "encounters: emit per-pair cut-point trace on demand"
+```
+
+---
+
+## Task 3: `segment_encounters` propagates trace into encounter dicts
+
+**Files:**
+- Modify: `vireo/encounters.py:464-502` (`segment_encounters`)
+- Modify: `vireo/encounters.py:397-427` (`merge_microsegments`) — needs to know which microsegment each merged-segment came from so we can map trace entries to the final encounter
+- Test: `vireo/tests/test_encounters.py`
+
+**Step 1: Failing test**
+
+```python
+def test_segment_encounters_attaches_trace_to_each_encounter():
+    from encounters import segment_encounters
+    # 4 photos: two pairs separated by big time gap -> 2 encounters of 2 photos each
+    photos = [
+        {"timestamp": "2026-03-07T11:32:00", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+        {"timestamp": "2026-03-07T11:32:05", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+        {"timestamp": "2026-03-07T11:50:00", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+        {"timestamp": "2026-03-07T11:50:05", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+    ]
+    encounters = segment_encounters(photos, emit_trace=True)
+    assert len(encounters) == 2
+    for enc in encounters:
+        assert "trace" in enc
+        # 2 photos -> 1 internal pair
+        assert len(enc["trace"]) == 1
+        assert enc["trace"][0]["decision"] == "kept"
+```
+
+**Step 2: Run, verify it fails**
+
+```bash
+python -m pytest vireo/tests/test_encounters.py::test_segment_encounters_attaches_trace_to_each_encounter -v
+```
+
+**Step 3: Modify `segment_encounters`**
+
+Add `emit_trace` param. After getting microsegments and trace, mapping is straightforward: each microsegment `m` at position `j` covers a contiguous range of sorted photos `[start_j, end_j]`. The pairs *inside* it are `[start_j .. end_j - 1]`. Pairs *between* microsegments correspond to cuts.
+
+Then `merge_microsegments` may merge adjacent microsegments — when it merges, the boundary pair (a `cut_*` decision in the trace) gets re-classified as part of the final encounter. We tag it as `"merged_back"` in trace.
+
+Replace the relevant section of `segment_encounters` (`vireo/encounters.py:464-502`):
+
+```python
+def segment_encounters(photos, config=None, emit_trace=False):
+    if emit_trace:
+        microsegments, full_trace = cut_microsegments(photos, config=config, emit_trace=True)
+    else:
+        microsegments = cut_microsegments(photos, config=config)
+        full_trace = None
+    log.info("Pass 1: %d microsegments from %d photos", len(microsegments), len(photos))
+
+    # Track which microsegments get merged so we can re-tag boundary trace entries
+    if emit_trace:
+        merged, merge_map = _merge_microsegments_with_map(microsegments, config=config)
+    else:
+        merged = merge_microsegments(microsegments, config=config)
+        merge_map = None
+    log.info("Pass 2: %d encounters after merging", len(merged))
+
+    encounters = []
+    pair_cursor = 0  # index into full_trace
+    micro_cursor = 0  # index into microsegments
+
+    for enc_idx, seg in enumerate(merged):
+        species = encounter_species_label(seg)
+        first_ts = _segment_timestamp(seg, "first")
+        last_ts = _segment_timestamp(seg, "last")
+        enc = {
+            "photos": seg,
+            "species": species,
+            "photo_count": len(seg),
+            "time_range": (
+                first_ts.isoformat() if first_ts else None,
+                last_ts.isoformat() if last_ts else None,
+            ),
+        }
+        if emit_trace:
+            # Walk the microsegments that compose this merged encounter
+            n_micros = merge_map[enc_idx]
+            enc_trace = []
+            for _ in range(n_micros):
+                m = microsegments[micro_cursor]
+                # Internal pairs of this microsegment
+                for _ in range(len(m) - 1):
+                    enc_trace.append(full_trace[pair_cursor])
+                    pair_cursor += 1
+                micro_cursor += 1
+                # If there's a boundary to the next microsegment AND that next
+                # microsegment is also part of this same merged encounter,
+                # mark it merged_back.
+                if pair_cursor < len(full_trace) and micro_cursor < len(microsegments):
+                    boundary = dict(full_trace[pair_cursor])
+                    if _ < n_micros - 1:
+                        boundary["decision"] = "merged_back"
+                        enc_trace.append(boundary)
+                        pair_cursor += 1
+            enc["trace"] = enc_trace
+        encounters.append(enc)
+
+    return encounters
+
+
+def _merge_microsegments_with_map(segments, config=None):
+    """Like merge_microsegments but also returns merge_map: list[int] giving
+    the number of original microsegments fused into each final segment.
+    """
+    cfg = {**DEFAULTS, **(config or {})}
+    if len(segments) <= 1:
+        return segments, [1] * len(segments)
+    merged = [segments[0]]
+    counts = [1]
+    for seg in segments[1:]:
+        last_a = _segment_timestamp(merged[-1], "last")
+        first_b = _segment_timestamp(seg, "first")
+        gap = _time_delta_seconds(last_a, first_b)
+        did_merge = False
+        if gap <= cfg["merge_max_gap"]:
+            s_seg = compute_s_seg(merged[-1], seg, config=cfg)
+            if s_seg > cfg["merge_score"]:
+                merged[-1] = merged[-1] + seg
+                counts[-1] += 1
+                did_merge = True
+        if not did_merge:
+            merged.append(seg)
+            counts.append(1)
+    return merged, counts
+```
+
+**Step 4: Run target test**
+
+```bash
+python -m pytest vireo/tests/test_encounters.py::test_segment_encounters_attaches_trace_to_each_encounter -v
+```
+Expected: PASS.
+
+**Step 5: Add second test for the merge case**
+
+```python
+def test_segment_encounters_marks_merged_back_boundaries():
+    """When two microsegments get merged, the boundary pair should be tagged merged_back."""
+    from encounters import segment_encounters
+    # Construct a sequence that will form 2 microsegments and then merge them.
+    # We need: a soft-cut between #3 and #4 (3-of-3 below soft threshold),
+    # then a small gap so merge fires.
+    # Simplest synthetic: shared lat/lng, focal length identical, no embeddings,
+    # tight time spacing so soft-cut is unlikely. Easier path: monkey-patch
+    # config so hard_cut_score is very high (everything cuts), then a small
+    # merge_score so everything merges back.
+    photos = [
+        {"timestamp": f"2026-03-07T11:32:0{i}", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0}
+        for i in range(4)
+    ]
+    cfg = {"hard_cut_score": 1.5, "merge_score": -1.0, "merge_max_gap": 60.0}
+    encounters = segment_encounters(photos, config=cfg, emit_trace=True)
+    assert len(encounters) == 1  # all merged back
+    enc = encounters[0]
+    decisions = [t["decision"] for t in enc["trace"]]
+    # 3 internal pairs across 4 microsegments: 3 of them are boundaries that got merged_back
+    assert decisions.count("merged_back") == 3
+```
+
+```bash
+python -m pytest vireo/tests/test_encounters.py::test_segment_encounters_marks_merged_back_boundaries -v
+```
+Expected: PASS.
+
+**Step 6: Run full encounters file**
+
+```bash
+python -m pytest vireo/tests/test_encounters.py -v
+```
+Expected: all PASS.
+
+**Step 7: Commit**
+
+```bash
+git add vireo/encounters.py vireo/tests/test_encounters.py
+git commit -m "encounters: attach per-pair trace to encounter dicts"
+```
+
+---
+
+## Task 4: Pipeline + regroup-live endpoint surface the trace
+
+**Files:**
+- Modify: `vireo/pipeline.py` — `run_grouping`, `run_full_pipeline`, `serialize_results`
+- Modify: `vireo/app.py:10127-10167` (`api_pipeline_regroup_live`)
+- Test: `vireo/tests/test_app.py` (or `test_pipeline.py`)
+
+**Step 1: Find serialize_results**
+
+```bash
+grep -n "def serialize_results\|def run_grouping\|def run_full_pipeline" /Users/julius/conductor/workspaces/vireo/tashkent/vireo/pipeline.py
+```
+
+Note the line numbers; the implementing engineer should read the surrounding context.
+
+**Step 2: Failing test**
+
+In `vireo/tests/test_app.py`, add (after a similar existing endpoint test):
+
+```python
+def test_regroup_live_returns_per_encounter_trace(client_with_pipeline_results):
+    """regroup-live response should include encounter['trace'] with cut-point details."""
+    client = client_with_pipeline_results
+    resp = client.post("/api/pipeline/regroup-live", json={"config": {}})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "encounters" in data
+    for enc in data["encounters"]:
+        # Single-photo encounter has empty trace; multi-photo has one entry per internal pair
+        if enc["photo_count"] >= 2:
+            assert "trace" in enc
+            assert len(enc["trace"]) == enc["photo_count"] - 1
+            sample = enc["trace"][0]
+            assert "score" in sample
+            assert "decision" in sample
+            assert "components" in sample
+```
+
+If `client_with_pipeline_results` doesn't exist, look for existing fixtures that prepare a workspace with photos+features (search `test_app.py` for `regroup-live` and copy the fixture pattern; or use the existing `test_pipeline_job.py` fixtures and adapt).
+
+**Step 3: Run test, verify it fails**
+
+```bash
+python -m pytest vireo/tests/test_app.py::test_regroup_live_returns_per_encounter_trace -v
+```
+Expected: FAIL — `trace` not in response.
+
+**Step 4: Thread `emit_trace` through pipeline.py**
+
+Modify `run_grouping`:
+
+```python
+def run_grouping(photos, config=None, emit_trace=False):
+    from bursts import segment_bursts_for_encounters
+    from encounters import segment_encounters
+    encounters = segment_encounters(photos, config=config, emit_trace=emit_trace)
+    encounters = segment_bursts_for_encounters(encounters, config=config)
+    ...
+    return encounters
+```
+
+Modify `run_full_pipeline` to accept `emit_trace` and forward.
+
+Modify `serialize_results` (find it via grep) to pass through the `trace` field on each encounter dict — likely it's an explicit dict construction, so add `"trace": enc.get("trace")`.
+
+**Step 5: Modify the endpoint to enable trace**
+
+In `vireo/app.py:10155`:
+
+```python
+results = run_full_pipeline(photos, config=pipeline_cfg, emit_trace=True)
+```
+
+(Always emit; cost is negligible — a few hundred bytes per encounter.)
+
+**Step 6: Run target test**
+
+```bash
+python -m pytest vireo/tests/test_app.py::test_regroup_live_returns_per_encounter_trace -v
+```
+Expected: PASS.
+
+**Step 7: Run the project's full test suite per CLAUDE.md**
+
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_encounters.py -v
+```
+Expected: all PASS (or only pre-existing failures from `project_preexisting_test_failures` memory).
+
+**Step 8: Commit**
+
+```bash
+git add vireo/pipeline.py vireo/app.py vireo/tests/test_app.py
+git commit -m "pipeline: surface per-encounter cut-point trace in regroup-live"
+```
+
+---
+
+## Task 5: Save-grouping-defaults endpoint
+
+**Files:**
+- Modify: `vireo/app.py` — add new route near the regroup-live one (~line 10168)
+- Test: `vireo/tests/test_app.py`
+
+**Step 1: Failing test**
+
+```python
+def test_save_grouping_defaults_persists_to_config(tmp_path, client):
+    import config as cfg
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    payload = {"pipeline": {"w_species": 0.40, "hard_cut_score": 0.55, "tau_enc": 30.0}}
+    resp = client.post("/api/pipeline/save-grouping-defaults", json=payload)
+    assert resp.status_code == 200
+    saved = cfg.load()
+    assert saved["pipeline"]["w_species"] == 0.40
+    assert saved["pipeline"]["hard_cut_score"] == 0.55
+    assert saved["pipeline"]["tau_enc"] == 30.0
+```
+
+(Adapt to the existing `client` fixture pattern in `test_app.py`.)
+
+**Step 2: Run, fail**
+
+```bash
+python -m pytest vireo/tests/test_app.py::test_save_grouping_defaults_persists_to_config -v
+```
+
+**Step 3: Implement endpoint**
+
+After `api_pipeline_regroup_live` in `vireo/app.py`:
+
+```python
+@app.route("/api/pipeline/save-grouping-defaults", methods=["POST"])
+def api_pipeline_save_grouping_defaults():
+    """Persist current grouping weights to global config."""
+    import config as cfg
+    body = request.get_json(silent=True) or {}
+    new_pipeline = body.get("pipeline", {})
+    if not isinstance(new_pipeline, dict):
+        return json_error("pipeline must be an object")
+    # Whitelist — only allow known grouping keys
+    allowed = {
+        "w_time", "w_subj", "w_global", "w_species", "w_meta",
+        "tau_enc", "hard_cut_time", "hard_cut_score", "soft_cut_score",
+        "merge_score", "merge_max_gap", "merge_tau",
+        "burst_time_gap", "burst_phash_dist", "burst_emb_dist",
+    }
+    rejected = [k for k in new_pipeline if k not in allowed]
+    if rejected:
+        return json_error(f"unknown keys: {rejected}")
+    raw = cfg.load()
+    raw.setdefault("pipeline", {}).update(new_pipeline)
+    cfg.save(raw)
+    return jsonify({"saved": new_pipeline})
+```
+
+**Step 4: Run, pass**
+
+```bash
+python -m pytest vireo/tests/test_app.py::test_save_grouping_defaults_persists_to_config -v
+```
+
+**Step 5: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_app.py
+git commit -m "pipeline: endpoint to persist grouping defaults to config"
+```
+
+---
+
+## Task 6: Sidebar — full weight panel, always visible
+
+**Files:**
+- Modify: `vireo/templates/pipeline_review.html:940-979` (sidebar grouping section)
+- Modify: `vireo/templates/pipeline_review.html` — `getGroupingConfig()` (search for it; should be near `onGroupingChange`)
+- Modify: `vireo/templates/pipeline_review.html` — `applyGroupingDefaults()` (search; resets sliders)
+
+**Step 1: Open the sidebar always (remove the `display:none`)**
+
+Change line 940 from:
+```html
+<div class="sidebar-section" id="sidebarGrouping" style="display:none">
+```
+to:
+```html
+<div class="sidebar-section" id="sidebarGrouping">
+```
+
+**Step 2: Replace the contents with the expanded slider set**
+
+Replace lines 941-978 with three subsections. Use the same slider HTML shape as existing rows.
+
+```html
+<div class="sidebar-title">Grouping Algorithm</div>
+
+<div class="slider-section-header">Encounter cut — signal weights</div>
+<div class="slider-section-hint">How much each signal contributes to the similarity score between adjacent photos. Re-normalized over signals that have data.</div>
+<div class="slider-group">
+  <div class="slider-row">
+    <span class="slider-label" title="Weight of time-proximity in S_enc">Time</span>
+    <input type="range" min="0" max="100" value="35" step="1" id="slWTime" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valWTime">0.35</span>
+  </div>
+  <div class="slider-row">
+    <span class="slider-label" title="Weight of DINO subject embedding">Subject embed</span>
+    <input type="range" min="0" max="100" value="35" step="1" id="slWSubj" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valWSubj">0.35</span>
+  </div>
+  <div class="slider-row">
+    <span class="slider-label" title="Weight of DINO global embedding">Global embed</span>
+    <input type="range" min="0" max="100" value="15" step="1" id="slWGlobal" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valWGlobal">0.15</span>
+  </div>
+  <div class="slider-row">
+    <span class="slider-label" title="Weight of per-photo species agreement (Bhattacharyya overlap of top-5)">Species</span>
+    <input type="range" min="0" max="100" value="10" step="1" id="slWSpecies" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valWSpecies">0.10</span>
+  </div>
+  <div class="slider-row">
+    <span class="slider-label" title="Weight of GPS + focal length similarity">Meta (GPS+FL)</span>
+    <input type="range" min="0" max="100" value="5" step="1" id="slWMeta" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valWMeta">0.05</span>
+  </div>
+</div>
+
+<div class="slider-section-header">Encounter cut — thresholds</div>
+<div class="slider-group">
+  <div class="slider-row">
+    <span class="slider-label" title="Time constant for time-similarity decay (seconds). Lower = closer-in-time pairs needed.">τ time (s)</span>
+    <input type="range" min="5" max="120" value="40" step="1" id="slTauEnc" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valTauEnc">40</span>
+  </div>
+  <div class="slider-row">
+    <span class="slider-label" title="Force a cut if the gap between two photos exceeds this (seconds)">Hard cut: time</span>
+    <input type="range" min="30" max="600" value="180" step="10" id="slHardCutTime" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valHardCutTime">180</span>
+  </div>
+  <div class="slider-row">
+    <span class="slider-label" title="Force a cut if S_enc drops below this">Hard cut: score</span>
+    <input type="range" min="0" max="100" value="42" step="1" id="slEncCut" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valEncCut">0.42</span>
+  </div>
+  <div class="slider-row">
+    <span class="slider-label" title="Soft-cut threshold: 2 of last 3 scores below this triggers a cut">Soft cut: score</span>
+    <input type="range" min="0" max="100" value="52" step="1" id="slSoftCut" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valSoftCut">0.52</span>
+  </div>
+</div>
+
+<div class="slider-section-header">Encounter merge</div>
+<div class="slider-section-hint">Stitch adjacent microsegments back together if they look like the same encounter</div>
+<div class="slider-group">
+  <div class="slider-row">
+    <span class="slider-label" title="Merge if S_seg between segments exceeds this">Merge score</span>
+    <input type="range" min="0" max="100" value="62" step="1" id="slEncMerge" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valEncMerge">0.62</span>
+  </div>
+  <div class="slider-row">
+    <span class="slider-label" title="Only consider merge if time gap ≤ this (seconds)">Max gap (s)</span>
+    <input type="range" min="5" max="300" value="60" step="5" id="slMergeMaxGap" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valMergeMaxGap">60</span>
+  </div>
+  <div class="slider-row">
+    <span class="slider-label" title="Time decay constant for merge gap scoring">τ merge (s)</span>
+    <input type="range" min="5" max="120" value="20" step="1" id="slMergeTau" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valMergeTau">20</span>
+  </div>
+</div>
+
+<div class="slider-section-header">Bursts</div>
+<div class="slider-section-hint">Group rapid-fire shots within an encounter</div>
+<div class="slider-group">
+  <div class="slider-row">
+    <span class="slider-label" title="Max seconds between consecutive shots to stay in the same burst">Time gap (s)</span>
+    <input type="range" min="1" max="30" value="3" step="1" id="slBurstTime" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valBurstTime">3</span>
+  </div>
+  <div class="slider-row">
+    <span class="slider-label" title="Max perceptual hash distance — lower means more visually similar">pHash dist</span>
+    <input type="range" min="1" max="32" value="12" step="1" id="slBurstPhash" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valBurstPhash">12</span>
+  </div>
+  <div class="slider-row">
+    <span class="slider-label" title="Max embedding distance — higher tolerates more visually different shots">Emb. distance</span>
+    <input type="range" min="0" max="100" value="20" step="1" id="slBurstEmb" oninput="onGroupingChange(this)">
+    <span class="slider-val" id="valBurstEmb">0.20</span>
+  </div>
+</div>
+
+<div class="button-row">
+  <button class="reset-btn" onclick="resetGroupingDefaults()">Reset</button>
+  <button class="save-btn" onclick="saveGroupingDefaults()">Save as default</button>
+</div>
+```
+
+**Step 3: Update `getGroupingConfig`** (search for it in the same file)
+
+It currently returns the 5 existing sliders' values. Extend to include all 12. Each should map to its `pipeline.*` config key. The format the backend expects (see `regroup-live` and Task 5's whitelist):
+
+```js
+function getGroupingConfig() {
+  function pct(id) { return parseFloat(document.getElementById(id).value) / 100.0; }
+  function num(id) { return parseFloat(document.getElementById(id).value); }
+  return {
+    w_time: pct('slWTime'),
+    w_subj: pct('slWSubj'),
+    w_global: pct('slWGlobal'),
+    w_species: pct('slWSpecies'),
+    w_meta: pct('slWMeta'),
+    tau_enc: num('slTauEnc'),
+    hard_cut_time: num('slHardCutTime'),
+    hard_cut_score: pct('slEncCut'),
+    soft_cut_score: pct('slSoftCut'),
+    merge_score: pct('slEncMerge'),
+    merge_max_gap: num('slMergeMaxGap'),
+    merge_tau: num('slMergeTau'),
+    burst_time_gap: num('slBurstTime'),
+    burst_phash_dist: num('slBurstPhash'),
+    burst_emb_dist: pct('slBurstEmb'),
+  };
+}
+```
+
+**Step 4: Update `updateSliderDisplay`** (search) so each new slider shows the formatted value (`0.35`, `40`, etc.) — follow the existing pattern.
+
+**Step 5: Update `applyGroupingDefaults`** (search) to reset all 12 sliders to the defaults from `vireo/encounters.py:21-38`.
+
+**Step 6: Add `saveGroupingDefaults` function**
+
+```js
+function saveGroupingDefaults() {
+  var config = getGroupingConfig();
+  safeFetch('/api/pipeline/save-grouping-defaults', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({pipeline: config}),
+  }, { toast: 'Saved as defaults' });
+}
+```
+
+**Step 7: Manual smoke test**
+
+```bash
+python vireo/app.py --db ~/.vireo/vireo.db --port 8080
+```
+
+Open `http://localhost:8080/pipeline-review`. Verify:
+- Left sidebar shows all 12 sliders organized into 4 subsections.
+- Dragging any slider triggers a regroup (encounter cards re-render after ~500ms debounce).
+- "Save as default" button shows a toast.
+
+**Step 8: Commit**
+
+```bash
+git add vireo/templates/pipeline_review.html
+git commit -m "pipeline-review: full grouping algorithm sliders in sidebar"
+```
+
+---
+
+## Task 7: Algorithm trace panel — display focused encounter's cut-point readout
+
+**Files:**
+- Modify: `vireo/templates/pipeline_review.html` — add trace panel + focus selection
+- Add CSS for the trace rows
+
+**Step 1: Add the trace panel HTML to the sidebar**
+
+Insert after the Bursts section, before the buttons:
+
+```html
+<div class="slider-section-header">Trace — focused encounter</div>
+<div class="slider-section-hint" id="traceFocusLabel">Click an encounter to see how it was formed</div>
+<div id="algorithmTrace" class="algo-trace"></div>
+```
+
+**Step 2: Add CSS** (alongside existing sidebar styles)
+
+```css
+.algo-trace { font-size: 11px; line-height: 1.35; }
+.algo-trace .trace-row {
+  display: grid; grid-template-columns: 1fr auto auto; gap: 6px;
+  padding: 3px 4px; border-bottom: 1px solid var(--border-subtle);
+}
+.algo-trace .trace-row.cut { background: rgba(220, 50, 50, 0.08); }
+.algo-trace .trace-row.merged-back { background: rgba(80, 160, 80, 0.08); }
+.algo-trace .trace-row.kept { }
+.algo-trace .trace-decision { font-weight: 600; }
+.algo-trace .trace-components {
+  font-size: 10px; color: var(--muted); padding: 2px 4px;
+}
+.algo-trace .trace-bar {
+  height: 3px; background: var(--accent); border-radius: 2px;
+}
+```
+
+**Step 3: Add focus + render functions**
+
+```js
+var _focusedEncounterIdx = null;
+
+function setFocusedEncounter(idx) {
+  _focusedEncounterIdx = idx;
+  // Highlight the focused card
+  document.querySelectorAll('.encounter-card.focused').forEach(function(el) {
+    el.classList.remove('focused');
+  });
+  var card = document.querySelector('.encounter-card[data-encounter-index="' + idx + '"]');
+  if (card) card.classList.add('focused');
+  renderAlgorithmTrace();
+}
+
+function renderAlgorithmTrace() {
+  var panel = document.getElementById('algorithmTrace');
+  var label = document.getElementById('traceFocusLabel');
+  if (!panel) return;
+  if (_focusedEncounterIdx === null || !pipelineResults) {
+    panel.innerHTML = '';
+    label.textContent = 'Click an encounter to see how it was formed';
+    return;
+  }
+  var enc = pipelineResults.encounters[_focusedEncounterIdx];
+  if (!enc || !enc.trace || enc.trace.length === 0) {
+    panel.innerHTML = '<div class="trace-empty">Single-photo encounter — no internal cut points.</div>';
+    label.textContent = 'Encounter ' + (_focusedEncounterIdx + 1);
+    return;
+  }
+  label.textContent = 'Encounter ' + (_focusedEncounterIdx + 1) + ' — ' + enc.trace.length + ' adjacent pair' + (enc.trace.length > 1 ? 's' : '');
+  var html = '';
+  enc.trace.forEach(function(t, i) {
+    var rowCls = 'trace-row';
+    if (t.decision && t.decision.indexOf('cut_') === 0) rowCls += ' cut';
+    else if (t.decision === 'merged_back') rowCls += ' merged-back';
+    else rowCls += ' kept';
+    var dt = (t.dt_seconds === null) ? '∞' : t.dt_seconds.toFixed(1) + 's';
+    html += '<div class="' + rowCls + '">';
+    html += '<span>pair ' + (i + 1) + ' · ' + dt + '</span>';
+    html += '<span>S=' + t.score.toFixed(3) + '</span>';
+    html += '<span class="trace-decision">' + t.decision + '</span>';
+    html += '</div>';
+    // Component breakdown
+    if (t.components) {
+      var parts = [];
+      ['time','subj','global','species','meta'].forEach(function(k) {
+        var c = t.components[k];
+        if (!c) return;
+        var marker = c.used ? '' : '·'; // · means signal not available
+        parts.push(k + marker + '=' + c.value.toFixed(2) + '×' + c.weight.toFixed(2));
+      });
+      html += '<div class="trace-components">' + parts.join(' · ') + '</div>';
+    }
+  });
+  panel.innerHTML = html;
+}
+```
+
+**Step 4: Wire encounter cards to set focus on click**
+
+Find the encounter-card render function (search for `encounter-card` in the template's JS). Add `data-encounter-index="' + i + '"` to each card. Add an onclick handler — but be careful not to swallow existing photo-click handlers; use a header click region:
+
+```js
+// In the encounter card render: add to the .encounter-meta or .encounter-header element
+'<div class="encounter-header" onclick="setFocusedEncounter(' + i + ')">' + ...existing header content... + '</div>'
+```
+
+Add a CSS rule so `.encounter-card.focused` is visually distinct (e.g., `border-left: 3px solid var(--accent);`).
+
+**Step 5: Auto-focus on initial render**
+
+In `renderResults()` (search), after rendering, if `_focusedEncounterIdx === null && pipelineResults.encounters.length > 0`, call `setFocusedEncounter(0)`. After regroup, if the previously focused index is out of range, fall back to 0.
+
+**Step 6: Manual UI verification with Playwright**
+
+This is required per `feedback_user_first_testing` memory.
+
+```bash
+python vireo/app.py --db ~/.vireo/vireo.db --port 8080
+```
+
+In a separate terminal, drive Playwright:
+
+```python
+# scratch script
+from playwright.sync_api import sync_playwright
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=False)
+    page = browser.new_page()
+    page.goto("http://localhost:8080/pipeline-review")
+    # Wait for results
+    page.wait_for_selector(".encounter-card", timeout=30000)
+    # Click the second encounter card
+    page.locator(".encounter-card").nth(1).click()
+    # Verify trace panel updated
+    trace_text = page.locator("#algorithmTrace").inner_text()
+    print(trace_text[:500])
+    # Drag a slider — programmatically set value, dispatch input event
+    page.evaluate("""() => {
+      const sl = document.getElementById('slWSpecies');
+      sl.value = '40';
+      sl.dispatchEvent(new Event('input'));
+    }""")
+    # Wait for regroup
+    page.wait_for_timeout(1500)
+    # Verify the encounter list re-rendered (count probably changed)
+    new_count = page.locator(".encounter-card").count()
+    print("encounters after w_species=0.40:", new_count)
+    browser.close()
+```
+
+Hand-verify: focused card has visible left-border highlight. Trace panel shows per-pair rows with decisions. After raising w_species, the encounter that contained mixed Lesser Scaup + Ruddy Duck splits into two.
+
+**Step 7: Commit**
+
+```bash
+git add vireo/templates/pipeline_review.html
+git commit -m "pipeline-review: algorithm trace panel for focused encounter"
+```
+
+---
+
+## Task 8: Final verification + PR
+
+**Step 1: Full test run**
+
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_encounters.py -v
+```
+Note any failures against `project_preexisting_test_failures` memory; only investigate ones you introduced.
+
+**Step 2: Force-add the plan doc** (per `project_plan_docs_force_add` memory)
+
+```bash
+git add -f docs/plans/2026-05-03-transparent-encounter-tuning-plan.md
+git commit -m "docs: transparent encounter tuning plan"
+```
+
+**Step 3: Push and open PR**
+
+```bash
+git push -u origin transparent-encounter-tuning
+gh pr create --base main --title "Transparent encounter tuning" --body "$(cat <<'EOF'
+## Summary
+
+Surfaces the encounter-grouping algorithm in the pipeline review page's left sidebar:
+
+- All 12 grouping knobs (5 weights, 4 cut thresholds, 3 merge knobs) are sliders, always visible, organized by pipeline stage.
+- New "Trace" panel shows per-cut-point S_enc + component breakdown for the focused encounter — click an encounter to focus it.
+- Slider drags trigger a debounced live regroup (existing `regroup-live` endpoint).
+- "Save as default" button persists weights to `~/.vireo/config.json`.
+
+Backend changes are additive: `compute_s_enc(... return_components=True)` and `segment_encounters(... emit_trace=True)` are opt-in; default behavior unchanged.
+
+## Test plan
+
+- [x] `vireo/tests/test_encounters.py` — component breakdown, per-pair trace, merged-back tagging
+- [x] `vireo/tests/test_app.py` — regroup-live response includes trace, save-defaults persists
+- [x] Manual: open pipeline-review, drag w_species slider from 0.10 to 0.40, observe the 11-photo Bolsa Chica encounter split into two by species
+- [x] Manual: click each encounter card → trace panel updates with per-pair scores
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Notes on tradeoffs and pitfalls
+
+- **Trace serialization size.** Each pair entry is ~300 bytes. A workspace with 5000 photos and ~200 encounters of avg 25 photos = ~24 pairs/encounter × 200 = 4800 entries × 300B = ~1.5 MB extra in the regroup-live response. Acceptable. If it ever becomes a concern, add a `?include_trace=0` flag.
+- **Soft-cut tagging and merge_back.** The trace decision is the *first* decision applied. A pair that was soft-cut and then merged-back should show `merged_back` (post-merge truth). The implementation in Task 3 handles this by overwriting the decision when the merge map says so.
+- **Focus persistence across regroups.** The encounter list shape changes after regroup. Falling back to index 0 is fine for a first cut; if it feels jarring, a follow-up could try to keep focus on the encounter that contains the previously focused encounter's first photo.
+- **YAGNI guardrail.** Resist adding "advanced mode" toggle, presets, A/B comparison, or persisted per-workspace overrides. The user wants radical transparency, not yet a pro-mode UI.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -266,6 +266,10 @@ def _auto_detach_burst_for_species(results, enc_idx, burst_idx, new_species):
         for b in bursts:
             b["species_predictions"] = rebuild_species_predictions(results, b["photo_ids"])
         enc["time_range"] = _compute_time_range(photos_by_id, remaining)
+        # Pair indices in trace reference the original composition; drop it
+        # so the algorithm-trace panel renders an honest "needs recompute"
+        # state instead of stale rows.
+        enc.pop("trace", None)
 
     detached["species_predictions"] = rebuild_species_predictions(results, detached_ids)
 
@@ -279,6 +283,8 @@ def _auto_detach_burst_for_species(results, enc_idx, burst_idx, new_species):
         target["species_predictions"] = rebuild_species_predictions(
             results, target["photo_ids"]
         )
+        # Same reason as above — target's trace no longer matches its photo set.
+        target.pop("trace", None)
         t_min, t_max = target.get("time_range") or [None, None]
         d_min, d_max = detached_range
         mins = [x for x in (t_min, d_min) if x is not None]
@@ -10237,8 +10243,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             coerced[k] = v
         # Hold the same lock as the settings write paths so a concurrent
         # autosave from /api/settings doesn't clobber half of one update.
+        # Use the raw on-disk file (no DEFAULTS merge) so we only persist
+        # the keys the user actually set — otherwise cfg.save would pin
+        # every default to its current value and block future upgrades.
         with _settings_write_lock:
-            raw = cfg.load()
+            raw = _read_raw_config_file()
             raw.setdefault("pipeline", {}).update(coerced)
             cfg.save(raw)
         return jsonify({"saved": coerced})

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10169,6 +10169,33 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         return jsonify(serialize_results(results))
 
+    @app.route("/api/pipeline/save-grouping-defaults", methods=["POST"])
+    def api_pipeline_save_grouping_defaults():
+        """Persist current grouping weights/thresholds to the global config.
+
+        Whitelists known grouping keys so the endpoint can't be used to mutate
+        unrelated config. Returns the new pipeline payload that was saved.
+        """
+        import config as cfg
+
+        body = request.get_json(silent=True) or {}
+        new_pipeline = body.get("pipeline", {})
+        if not isinstance(new_pipeline, dict):
+            return json_error("pipeline must be an object")
+        allowed = {
+            "w_time", "w_subj", "w_global", "w_species", "w_meta",
+            "tau_enc", "hard_cut_time", "hard_cut_score", "soft_cut_score",
+            "merge_score", "merge_max_gap", "merge_tau",
+            "burst_time_gap", "burst_phash_dist", "burst_emb_dist",
+        }
+        rejected = [k for k in new_pipeline if k not in allowed]
+        if rejected:
+            return json_error(f"unknown keys: {rejected}")
+        raw = cfg.load()
+        raw.setdefault("pipeline", {}).update(new_pipeline)
+        cfg.save(raw)
+        return jsonify({"saved": new_pipeline})
+
     @app.route("/api/pipeline/detach-burst", methods=["POST"])
     def api_pipeline_detach_burst():
         """Detach a burst from its encounter, creating a new standalone encounter."""

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9488,7 +9488,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 {"phase": "Grouping encounters and bursts", "current": 1, "total": 3},
             )
 
-            results = run_full_pipeline(photos, config=pipeline_cfg)
+            # emit_trace=True so the pipeline-review sidebar's algorithm-trace
+            # panel can show per-cut-point details for each encounter on the
+            # very first load (not only after the user drags a live-tuning
+            # slider). Cost is negligible (~300B per adjacent pair).
+            results = run_full_pipeline(photos, config=pipeline_cfg, emit_trace=True)
             summary = results.get("summary", {})
             runner.update_step(job["id"], "group", status="completed",
                                summary=f"{summary.get('encounters', 0)} encounters")
@@ -10108,7 +10112,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not photos:
             return json_error("No photos with pipeline features", 404)
 
-        encounters = run_grouping(photos, config=pipeline_cfg)
+        # emit_trace=True so the pipeline-review sidebar's algorithm-trace
+        # panel can show per-cut-point details for each encounter on the
+        # very first load (not only after the user drags a live-tuning
+        # slider). Cost is negligible (~300B per adjacent pair).
+        encounters = run_grouping(photos, config=pipeline_cfg, emit_trace=True)
         results = reflow(encounters, config=pipeline_cfg)
 
         # Carry the miss-recomputation marker through so the review UI's

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10186,7 +10186,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "w_time", "w_subj", "w_global", "w_species", "w_meta",
             "tau_enc", "hard_cut_time", "hard_cut_score", "soft_cut_score",
             "merge_score", "merge_max_gap", "merge_tau",
-            "burst_time_gap", "burst_phash_dist", "burst_emb_dist",
+            "burst_time_gap", "burst_phash_threshold", "burst_embedding_threshold",
         }
         rejected = [k for k in new_pipeline if k not in allowed]
         if rejected:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10248,7 +10248,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # every default to its current value and block future upgrades.
         with _settings_write_lock:
             raw = _read_raw_config_file()
-            raw.setdefault("pipeline", {}).update(coerced)
+            # If a hand-edit left raw["pipeline"] as a non-dict (string, list,
+            # etc.), setdefault would return it as-is and .update would raise
+            # AttributeError. Normalize to a dict — the endpoint's job is to
+            # write a clean pipeline section, so a corrupt one should be
+            # replaced rather than crash the save.
+            if not isinstance(raw.get("pipeline"), dict):
+                raw["pipeline"] = {}
+            raw["pipeline"].update(coerced)
             cfg.save(raw)
         return jsonify({"saved": coerced})
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10199,6 +10199,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         rejected = [k for k in new_pipeline if k not in allowed]
         if rejected:
             return json_error(f"unknown keys: {rejected}")
+        # Hold the same lock as the settings write paths so a concurrent
+        # autosave from /api/settings doesn't clobber half of one update.
         with _settings_write_lock:
             raw = cfg.load()
             raw.setdefault("pipeline", {}).update(new_pipeline)
@@ -10243,6 +10245,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             enc["photo_count"] = len(enc["photo_ids"])
             enc["burst_count"] = len(bursts)
             enc["species_predictions"] = rebuild_species_predictions(results, enc["photo_ids"])
+            # Pair indices in trace reference the original photo composition;
+            # drop it so the algorithm-trace panel renders an honest "needs
+            # recompute" state instead of stale rows.
+            enc.pop("trace", None)
             # Recalculate remaining burst predictions too
             for b in bursts:
                 b["species_predictions"] = rebuild_species_predictions(results, b["photo_ids"])
@@ -10323,6 +10329,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         enc["burst_count"] = len(bursts)
         # Recalculate encounter-level predictions
         enc["species_predictions"] = rebuild_species_predictions(results, enc["photo_ids"])
+        # Encounter composition didn't change but burst structure did; trace
+        # is pair-level only, so it remains valid. No trace mutation needed.
 
         # Update summary
         results["summary"]["burst_count"] = sum(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10152,7 +10152,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not photos:
             return json_error("No photos with pipeline features", 404)
 
-        results = run_full_pipeline(photos, config=pipeline_cfg)
+        # emit_trace=True so the pipeline-review sidebar's algorithm-trace
+        # panel can show per-cut-point details for each encounter. Cost is
+        # negligible (~300B per adjacent pair).
+        results = run_full_pipeline(photos, config=pipeline_cfg, emit_trace=True)
 
         # Carry the miss-recomputation marker through so the review UI's
         # "Review misses" shortcut stays visible after a threshold

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10181,8 +10181,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_pipeline_save_grouping_defaults():
         """Persist current grouping weights/thresholds to the global config.
 
-        Whitelists known grouping keys so the endpoint can't be used to mutate
-        unrelated config. Returns the new pipeline payload that was saved.
+        Whitelists known grouping keys and validates each value's type and
+        range so a bad payload (e.g. {"hard_cut_time": "abc"}) can't poison
+        the persistent config and crash future grouping/scoring math.
+        Returns the new pipeline payload that was saved.
         """
         import config as cfg
 
@@ -10190,22 +10192,56 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         new_pipeline = body.get("pipeline", {})
         if not isinstance(new_pipeline, dict):
             return json_error("pipeline must be an object")
-        allowed = {
-            "w_time", "w_subj", "w_global", "w_species", "w_meta",
-            "tau_enc", "hard_cut_time", "hard_cut_score", "soft_cut_score",
-            "merge_score", "merge_max_gap", "merge_tau",
-            "burst_time_gap", "burst_phash_threshold", "burst_embedding_threshold",
+        # (kind, min, max). kind="unit" → 0..1 float; "score" → 0..1 float;
+        # "seconds" → non-negative float; "phash" → 0..256 int (8x8 phash =
+        # 64 bits, 256 leaves headroom for future hash sizes).
+        schema = {
+            "w_time": ("unit", 0.0, 1.0),
+            "w_subj": ("unit", 0.0, 1.0),
+            "w_global": ("unit", 0.0, 1.0),
+            "w_species": ("unit", 0.0, 1.0),
+            "w_meta": ("unit", 0.0, 1.0),
+            "tau_enc": ("seconds", 0.0, 86400.0),
+            "hard_cut_time": ("seconds", 0.0, 86400.0),
+            "hard_cut_score": ("score", 0.0, 1.0),
+            "soft_cut_score": ("score", 0.0, 1.0),
+            "merge_score": ("score", 0.0, 1.0),
+            "merge_max_gap": ("seconds", 0.0, 86400.0),
+            "merge_tau": ("seconds", 0.0, 86400.0),
+            "burst_time_gap": ("seconds", 0.0, 86400.0),
+            "burst_phash_threshold": ("phash", 0, 256),
+            "burst_embedding_threshold": ("score", 0.0, 1.0),
         }
-        rejected = [k for k in new_pipeline if k not in allowed]
+        rejected = [k for k in new_pipeline if k not in schema]
         if rejected:
             return json_error(f"unknown keys: {rejected}")
+        coerced = {}
+        for k, raw_v in new_pipeline.items():
+            kind, lo, hi = schema[k]
+            if isinstance(raw_v, bool):
+                # bool is an int subclass — reject explicitly so True/False
+                # don't silently succeed for numeric keys.
+                return json_error(f"{k} must be a number, got bool")
+            if kind == "phash":
+                if not isinstance(raw_v, int):
+                    return json_error(f"{k} must be an integer")
+                v = raw_v
+            else:
+                if not isinstance(raw_v, (int, float)):
+                    return json_error(f"{k} must be a number")
+                v = float(raw_v)
+                if v != v or v in (float("inf"), float("-inf")):
+                    return json_error(f"{k} must be finite")
+            if v < lo or v > hi:
+                return json_error(f"{k} out of range [{lo}, {hi}]")
+            coerced[k] = v
         # Hold the same lock as the settings write paths so a concurrent
         # autosave from /api/settings doesn't clobber half of one update.
         with _settings_write_lock:
             raw = cfg.load()
-            raw.setdefault("pipeline", {}).update(new_pipeline)
+            raw.setdefault("pipeline", {}).update(coerced)
             cfg.save(raw)
-        return jsonify({"saved": new_pipeline})
+        return jsonify({"saved": coerced})
 
     @app.route("/api/pipeline/detach-burst", methods=["POST"])
     def api_pipeline_detach_burst():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10199,9 +10199,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         rejected = [k for k in new_pipeline if k not in allowed]
         if rejected:
             return json_error(f"unknown keys: {rejected}")
-        raw = cfg.load()
-        raw.setdefault("pipeline", {}).update(new_pipeline)
-        cfg.save(raw)
+        with _settings_write_lock:
+            raw = cfg.load()
+            raw.setdefault("pipeline", {}).update(new_pipeline)
+            cfg.save(raw)
         return jsonify({"saved": new_pipeline})
 
     @app.route("/api/pipeline/detach-burst", methods=["POST"])

--- a/vireo/encounters.py
+++ b/vireo/encounters.py
@@ -237,19 +237,26 @@ def compute_s_enc(photo_a, photo_b, config=None, return_components=False):
 # -- Pass 1: Cut timeline into microsegments (Section 2.2) --
 
 
-def cut_microsegments(photos, config=None):
+def cut_microsegments(photos, config=None, emit_trace=False):
     """Sort photos by timestamp and cut into microsegments.
 
     Args:
         photos: list of photo dicts (see compute_s_enc for required keys)
         config: optional dict overriding DEFAULTS
+        emit_trace: when True, return (segments, trace) where each trace
+            entry is {pair_index, score, dt_seconds, decision, components,
+            thresholds}. Decisions: kept, cut_time, cut_score, cut_soft,
+            burst_id_kept.
 
     Returns:
-        list of lists (each inner list is a microsegment of photo dicts)
+        list of lists (each inner list is a microsegment of photo dicts), or
+        (segments, trace) when emit_trace is True.
     """
     cfg = {**DEFAULTS, **(config or {})}
 
     if len(photos) <= 1:
+        if emit_trace:
+            return ([photos] if photos else []), []
         return [photos] if photos else []
 
     # Sort by timestamp
@@ -258,52 +265,66 @@ def cut_microsegments(photos, config=None):
         key=lambda p: _parse_timestamp(p.get("timestamp")) or datetime.min,
     )
 
-    # Compute pairwise S_enc scores
-    scores = []
-    for i in range(len(sorted_photos) - 1):
-        s = compute_s_enc(sorted_photos[i], sorted_photos[i + 1], config=cfg)
-        scores.append(s)
-
-    # Determine cut points
     cuts = set()
     recent_scores = []  # sliding window for soft cut detection
+    trace = [] if emit_trace else None
 
-    for i, score in enumerate(scores):
+    for i in range(len(sorted_photos) - 1):
+        if emit_trace:
+            score, components = compute_s_enc(
+                sorted_photos[i], sorted_photos[i + 1], config=cfg, return_components=True
+            )
+        else:
+            score = compute_s_enc(sorted_photos[i], sorted_photos[i + 1], config=cfg)
+            components = None
+
         ts_a = _parse_timestamp(sorted_photos[i].get("timestamp"))
         ts_b = _parse_timestamp(sorted_photos[i + 1].get("timestamp"))
         dt = _time_delta_seconds(ts_a, ts_b)
 
-        # Hard rule: shared camera burst ID → no cut
         bid_a = sorted_photos[i].get("burst_id")
         bid_b = sorted_photos[i + 1].get("burst_id")
+        decision = None
+
         if bid_a is not None and bid_b is not None and bid_a == bid_b:
+            decision = "burst_id_kept"
             recent_scores.append(score)
             if len(recent_scores) > 3:
                 recent_scores.pop(0)
-            continue
-
-        # Hard cut: time gap
-        if dt > cfg["hard_cut_time"]:
+        elif dt > cfg["hard_cut_time"]:
             cuts.add(i)
             recent_scores = []
-            continue
-
-        # Hard cut: low score
-        if score < cfg["hard_cut_score"]:
+            decision = "cut_time"
+        elif score < cfg["hard_cut_score"]:
             cuts.add(i)
             recent_scores = []
-            continue
+            decision = "cut_score"
+        else:
+            recent_scores.append(score)
+            if len(recent_scores) > 3:
+                recent_scores.pop(0)
+            if len(recent_scores) >= 3:
+                below = sum(1 for s in recent_scores if s < cfg["soft_cut_score"])
+                if below >= 2:
+                    cuts.add(i)
+                    recent_scores = []
+                    decision = "cut_soft"
+            if decision is None:
+                decision = "kept"
 
-        # Soft cut: gradual drift (2 of last 3 scores below threshold)
-        recent_scores.append(score)
-        if len(recent_scores) > 3:
-            recent_scores.pop(0)
-        if len(recent_scores) >= 3:
-            below = sum(1 for s in recent_scores if s < cfg["soft_cut_score"])
-            if below >= 2:
-                cuts.add(i)
-                recent_scores = []
-                continue
+        if emit_trace:
+            trace.append({
+                "pair_index": i,
+                "score": float(score),
+                "dt_seconds": float(dt) if dt != float("inf") else None,
+                "decision": decision,
+                "components": components,
+                "thresholds": {
+                    "hard_cut_time": cfg["hard_cut_time"],
+                    "hard_cut_score": cfg["hard_cut_score"],
+                    "soft_cut_score": cfg["soft_cut_score"],
+                },
+            })
 
     # Build segments from cut points
     segments = []
@@ -312,8 +333,11 @@ def cut_microsegments(photos, config=None):
         segments.append(sorted_photos[start: i + 1])
         start = i + 1
     segments.append(sorted_photos[start:])
+    segments = [seg for seg in segments if seg]
 
-    return [seg for seg in segments if seg]
+    if emit_trace:
+        return segments, trace
+    return segments
 
 
 # -- Pass 2: Merge neighboring microsegments (Section 2.3) --

--- a/vireo/encounters.py
+++ b/vireo/encounters.py
@@ -163,7 +163,7 @@ def sim_meta(photo_a, photo_b):
         return sim_fl
 
 
-def compute_s_enc(photo_a, photo_b, config=None):
+def compute_s_enc(photo_a, photo_b, config=None, return_components=False):
     """Compute the combined encounter similarity score S_enc(a, b).
 
     Args:
@@ -176,9 +176,12 @@ def compute_s_enc(photo_a, photo_b, config=None):
             - focal_length: float or None
             - burst_id: str or None (camera burst ID)
         config: optional dict overriding DEFAULTS
+        return_components: when True, return (score, components_dict) where
+            components_dict maps each signal name to {value, weight, used}.
 
     Returns:
-        float — similarity score (higher = more likely same encounter)
+        float — similarity score (higher = more likely same encounter), or
+        (float, dict) when return_components is True.
     """
     cfg = {**DEFAULTS, **(config or {})}
 
@@ -192,34 +195,43 @@ def compute_s_enc(photo_a, photo_b, config=None):
     sp = sim_species(photo_a.get("species_top5"), photo_b.get("species_top5"))
     sm = sim_meta(photo_a, photo_b)
 
-    # Check which terms are available for renormalization
-    weights = {}
-    if dt != float("inf"):
-        weights["time"] = cfg["w_time"]
-    if photo_a.get("dino_subject_embedding") is not None and photo_b.get("dino_subject_embedding") is not None:
-        weights["subj"] = cfg["w_subj"]
-    if photo_a.get("dino_global_embedding") is not None and photo_b.get("dino_global_embedding") is not None:
-        weights["global"] = cfg["w_global"]
-    if photo_a.get("species_top5") and photo_b.get("species_top5"):
-        weights["species"] = cfg["w_species"]
-    # Meta always contributes (even if 0)
-    weights["meta"] = cfg["w_meta"]
-
-    total_weight = sum(weights.values())
-    if total_weight == 0:
-        return 0.0
-
-    scores = {
-        "time": st,
-        "subj": ss,
-        "global": sg,
-        "species": sp,
-        "meta": sm,
+    used = {
+        "time": dt != float("inf"),
+        "subj": (photo_a.get("dino_subject_embedding") is not None
+                 and photo_b.get("dino_subject_embedding") is not None),
+        "global": (photo_a.get("dino_global_embedding") is not None
+                   and photo_b.get("dino_global_embedding") is not None),
+        "species": bool(photo_a.get("species_top5") and photo_b.get("species_top5")),
+        # Meta always contributes (even if 0)
+        "meta": True,
     }
+    weight_keys = {
+        "time": "w_time",
+        "subj": "w_subj",
+        "global": "w_global",
+        "species": "w_species",
+        "meta": "w_meta",
+    }
+    values = {"time": st, "subj": ss, "global": sg, "species": sp, "meta": sm}
 
-    # Renormalized weighted sum
-    s_enc = sum(weights.get(k, 0) * scores[k] for k in scores) / total_weight
-    return s_enc
+    total_weight = sum(cfg[weight_keys[k]] for k, u in used.items() if u)
+    if total_weight == 0:
+        s_enc = 0.0
+    else:
+        s_enc = sum(cfg[weight_keys[k]] * values[k] for k, u in used.items() if u) / total_weight
+
+    if not return_components:
+        return s_enc
+
+    components = {
+        k: {
+            "value": float(values[k]),
+            "weight": float(cfg[weight_keys[k]]),
+            "used": bool(used[k]),
+        }
+        for k in values
+    }
+    return s_enc, components
 
 
 # -- Pass 1: Cut timeline into microsegments (Section 2.2) --

--- a/vireo/encounters.py
+++ b/vireo/encounters.py
@@ -440,27 +440,44 @@ def merge_microsegments(segments, config=None):
     Returns:
         list of merged segments
     """
+    merged, _ = _merge_microsegments_with_map(segments, config=config)
+    return merged
+
+
+def _merge_microsegments_with_map(segments, config=None):
+    """Like merge_microsegments but also returns a per-merged-segment count
+    of how many original microsegments were fused into it.
+
+    Returns:
+        (merged_segments, counts) where counts[i] is the number of original
+        microsegments that ended up inside merged_segments[i].
+    """
     cfg = {**DEFAULTS, **(config or {})}
 
     if len(segments) <= 1:
-        return segments
+        return list(segments), [1] * len(segments)
 
     merged = [segments[0]]
+    counts = [1]
     for seg in segments[1:]:
         last_a = _segment_timestamp(merged[-1], "last")
         first_b = _segment_timestamp(seg, "first")
         gap = _time_delta_seconds(last_a, first_b)
 
+        did_merge = False
         if gap <= cfg["merge_max_gap"]:
             s_seg = compute_s_seg(merged[-1], seg, config=cfg)
             if s_seg > cfg["merge_score"]:
                 # Merge: extend the last segment
                 merged[-1] = merged[-1] + seg
-                continue
+                counts[-1] += 1
+                did_merge = True
 
-        merged.append(seg)
+        if not did_merge:
+            merged.append(seg)
+            counts.append(1)
 
-    return merged
+    return merged, counts
 
 
 # -- Encounter-level species label (Section 2.4) --
@@ -497,12 +514,17 @@ def encounter_species_label(photos):
 # -- Full encounter segmentation pipeline --
 
 
-def segment_encounters(photos, config=None):
+def segment_encounters(photos, config=None, emit_trace=False):
     """Run the full two-pass encounter segmentation pipeline.
 
     Args:
         photos: list of photo dicts with all required features
         config: optional dict overriding DEFAULTS
+        emit_trace: when True, attach a per-encounter `trace` field — a list
+            of cut-point trace entries that fall inside that encounter (after
+            potential microsegment fusion). Boundary entries between two
+            microsegments that ended up in the same merged encounter are
+            re-tagged with decision="merged_back".
 
     Returns:
         list of encounter dicts, each with:
@@ -510,22 +532,39 @@ def segment_encounters(photos, config=None):
             - species: (name, confidence) tuple
             - photo_count: int
             - time_range: (first_timestamp, last_timestamp) or (None, None)
+            - trace: (only when emit_trace) list of trace dicts for the
+              internal adjacent pairs of this encounter
     """
     # Pass 1: Cut into microsegments
-    microsegments = cut_microsegments(photos, config=config)
+    if emit_trace:
+        microsegments, full_trace = cut_microsegments(
+            photos, config=config, emit_trace=True
+        )
+    else:
+        microsegments = cut_microsegments(photos, config=config)
+        full_trace = None
     log.info("Pass 1: %d microsegments from %d photos", len(microsegments), len(photos))
 
     # Pass 2: Merge neighbors
-    merged = merge_microsegments(microsegments, config=config)
+    if emit_trace:
+        merged, merge_counts = _merge_microsegments_with_map(
+            microsegments, config=config
+        )
+    else:
+        merged = merge_microsegments(microsegments, config=config)
+        merge_counts = None
     log.info("Pass 2: %d encounters after merging", len(merged))
 
     # Build encounter objects
     encounters = []
-    for seg in merged:
+    pair_cursor = 0  # index into full_trace
+    micro_cursor = 0  # index into microsegments
+
+    for enc_idx, seg in enumerate(merged):
         species = encounter_species_label(seg)
         first_ts = _segment_timestamp(seg, "first")
         last_ts = _segment_timestamp(seg, "last")
-        encounters.append({
+        enc = {
             "photos": seg,
             "species": species,
             "photo_count": len(seg),
@@ -533,6 +572,30 @@ def segment_encounters(photos, config=None):
                 first_ts.isoformat() if first_ts else None,
                 last_ts.isoformat() if last_ts else None,
             ),
-        })
+        }
+        if emit_trace:
+            n_micros = merge_counts[enc_idx]
+            enc_trace = []
+            for k in range(n_micros):
+                m = microsegments[micro_cursor]
+                # Internal pairs of this microsegment (one fewer than its photo count)
+                for _ in range(len(m) - 1):
+                    enc_trace.append(full_trace[pair_cursor])
+                    pair_cursor += 1
+                micro_cursor += 1
+                # Boundary pair after this microsegment
+                if pair_cursor < len(full_trace):
+                    if k < n_micros - 1:
+                        # This boundary lives inside the same merged encounter:
+                        # re-tag as merged_back (post-merge truth).
+                        boundary = dict(full_trace[pair_cursor])
+                        boundary["decision"] = "merged_back"
+                        enc_trace.append(boundary)
+                        pair_cursor += 1
+                    else:
+                        # Boundary belongs to the gap between encounters; skip.
+                        pair_cursor += 1
+            enc["trace"] = enc_trace
+        encounters.append(enc)
 
     return encounters

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -308,12 +308,13 @@ def load_photo_features(db, collection_id=None, config=None,
     return photos
 
 
-def run_grouping(photos, config=None):
+def run_grouping(photos, config=None, emit_trace=False):
     """Run encounter segmentation + burst clustering (Stages 2-3).
 
     Args:
         photos: list of photo dicts from load_photo_features()
         config: optional dict with pipeline thresholds
+        emit_trace: if True, attach per-cut-point trace to each encounter dict
 
     Returns:
         list of encounter dicts, each with 'bursts' key
@@ -321,7 +322,7 @@ def run_grouping(photos, config=None):
     from bursts import segment_bursts_for_encounters
     from encounters import segment_encounters
 
-    encounters = segment_encounters(photos, config=config)
+    encounters = segment_encounters(photos, config=config, emit_trace=emit_trace)
     encounters = segment_bursts_for_encounters(encounters, config=config)
 
     total_bursts = sum(e.get("burst_count", 0) for e in encounters)
@@ -355,12 +356,13 @@ def run_triage(encounters, config=None):
     return encounters, all_photos
 
 
-def run_full_pipeline(photos, config=None):
+def run_full_pipeline(photos, config=None, emit_trace=False):
     """Run the full pipeline: grouping → scoring → triage (Stages 2-6).
 
     Args:
         photos: list of photo dicts from load_photo_features()
         config: optional dict with all pipeline thresholds
+        emit_trace: if True, attach per-cut-point trace to each encounter dict
 
     Returns:
         dict with:
@@ -368,7 +370,7 @@ def run_full_pipeline(photos, config=None):
             photos: flat list of all photos with labels
             summary: dict with counts
     """
-    encounters = run_grouping(photos, config=config)
+    encounters = run_grouping(photos, config=config, emit_trace=emit_trace)
     encounters, all_photos = run_triage(encounters, config=config)
 
     summary = _make_summary(encounters, all_photos)
@@ -567,6 +569,11 @@ def serialize_results(results):
             "time_range": enc.get("time_range"),
             "photo_ids": [p["id"] for p in photos_list],
         }
+        # Surface per-cut-point trace when run_full_pipeline was invoked with
+        # emit_trace=True (e.g. from /api/pipeline/regroup-live so the
+        # pipeline-review sidebar can show how each encounter was formed).
+        if "trace" in enc:
+            s_enc["trace"] = enc["trace"]
         if "bursts" in enc:
             s_enc["bursts"] = []
             for burst in enc["bursts"]:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -3063,7 +3063,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                    summary="No photos to group")
                 return
 
-            results = run_full_pipeline(photos, config=pipeline_cfg)
+            results = run_full_pipeline(photos, config=pipeline_cfg, emit_trace=True)
             cache_dir = os.path.dirname(db_path)
             save_results(results, cache_dir, workspace_id)
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -390,7 +390,10 @@ input[type="range"]::-moz-range-thumb {
   font-size: 11px; color: var(--text-dim); font-style: italic; padding: 4px;
 }
 .encounter-card.focused {
-  border-left: 3px solid var(--accent);
+  /* Inset shadow instead of widening border-left from 1px → 3px:
+     keeps the 1px border on all sides so the content position and
+     rounded corners don't shift by 2px when focus changes. */
+  box-shadow: inset 3px 0 0 var(--accent);
 }
 
 /* Inspection panel */
@@ -1439,6 +1442,10 @@ function renderResults() {
   ce = document.getElementById('countReject'); if (ce) ce.textContent = ' (' + (counts.REJECT||0) + ')';
 
   var html = '';
+  // Track which encounter indices actually produced a card so focus
+  // management below can pick a *visible* encounter (not one that was
+  // filtered out by species filter, hide-confirmed, or label filter).
+  var renderedIndices = [];
   pipelineResults.encounters.forEach(function(enc, ei) {
     var timeRange = '';
     if (enc.time_range && enc.time_range[0]) {
@@ -1467,6 +1474,8 @@ function renderResults() {
       return activeFilter === 'all' || p.label === activeFilter;
     });
     if (!hasVisible) return;
+
+    renderedIndices.push(ei);
 
     var encKey = encounterKey(enc);
     var isCollapsed = encKey != null && collapsedEncounters.has(encKey);
@@ -1533,13 +1542,17 @@ function renderResults() {
 
   container.innerHTML = html;
 
-  // Focus management: auto-focus first encounter on initial render; clamp on regroup.
-  var encs = pipelineResults.encounters || [];
-  if (encs.length === 0) {
+  // Focus management: only focus encounters that are actually rendered.
+  // If we focused an index that got filtered out (species/hide-confirmed/
+  // label filter), the trace panel would show data for a card the user
+  // can't see, with no .focused highlight visible anywhere — confusing.
+  if (renderedIndices.length === 0) {
     _focusedEncounterIdx = null;
     renderAlgorithmTrace();
-  } else if (_focusedEncounterIdx === null || _focusedEncounterIdx >= encs.length) {
-    setFocusedEncounter(0);
+  } else if (_focusedEncounterIdx === null || renderedIndices.indexOf(_focusedEncounterIdx) === -1) {
+    // No focus yet, or current focus is hidden — fall back to the first
+    // visible encounter.
+    setFocusedEncounter(renderedIndices[0]);
   } else {
     // Re-apply focus highlight (DOM was rebuilt) and refresh trace panel.
     setFocusedEncounter(_focusedEncounterIdx);

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1632,8 +1632,9 @@ function getGroupingConfig() {
     merge_max_gap: num('slMergeMaxGap'),
     merge_tau: num('slMergeTau'),
     burst_time_gap: num('slBurstTime'),
-    burst_phash_dist: num('slBurstPhash'),
-    burst_emb_dist: pct('slBurstEmb'),
+    burst_phash_threshold: Math.round(num('slBurstPhash')),
+    // UI shows distance; bursts.py expects cosine similarity = 1 - distance.
+    burst_embedding_threshold: 1 - pct('slBurstEmb'),
   };
 }
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -353,6 +353,23 @@ input[type="range"]::-moz-range-thumb {
   margin-top: 8px;
 }
 .reset-btn:hover { background: var(--bg-tertiary); }
+.button-row {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+.button-row .reset-btn { margin-top: 0; }
+.save-btn {
+  display: inline-block;
+  padding: 4px 10px;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  background: var(--accent);
+  color: var(--bg-primary);
+  font-size: 11px;
+  cursor: pointer;
+}
+.save-btn:hover { filter: brightness(1.1); }
 
 /* Inspection panel */
 .inspect-overlay {
@@ -937,26 +954,85 @@ input[type="range"]::-moz-range-thumb {
       <button class="reset-btn" onclick="resetScoringDefaults()">Reset to defaults</button>
     </div>
 
-    <div class="sidebar-section" id="sidebarGrouping" style="display:none">
-      <div class="sidebar-title">Grouping Thresholds</div>
+    <div class="sidebar-section" id="sidebarGrouping">
+      <div class="sidebar-title">Grouping Algorithm</div>
 
-      <div class="slider-section-header">Encounters</div>
-      <div class="slider-section-hint">Control how photos are split and merged into encounters</div>
+      <div class="slider-section-header">Encounter cut — signal weights</div>
+      <div class="slider-section-hint">How much each signal contributes to the similarity score between adjacent photos. Re-normalized over signals that have data.</div>
       <div class="slider-group">
         <div class="slider-row">
-          <span class="slider-label" title="Similarity below this splits photos into separate encounters">Cut score</span>
+          <span class="slider-label" title="Weight of time-proximity in S_enc">Time</span>
+          <input type="range" min="0" max="100" value="35" step="1" id="slWTime" oninput="onGroupingChange(this)">
+          <span class="slider-val" id="valWTime">0.35</span>
+        </div>
+        <div class="slider-row">
+          <span class="slider-label" title="Weight of DINO subject embedding">Subject embed</span>
+          <input type="range" min="0" max="100" value="35" step="1" id="slWSubj" oninput="onGroupingChange(this)">
+          <span class="slider-val" id="valWSubj">0.35</span>
+        </div>
+        <div class="slider-row">
+          <span class="slider-label" title="Weight of DINO global embedding">Global embed</span>
+          <input type="range" min="0" max="100" value="15" step="1" id="slWGlobal" oninput="onGroupingChange(this)">
+          <span class="slider-val" id="valWGlobal">0.15</span>
+        </div>
+        <div class="slider-row">
+          <span class="slider-label" title="Weight of per-photo species agreement (Bhattacharyya overlap of top-5)">Species</span>
+          <input type="range" min="0" max="100" value="10" step="1" id="slWSpecies" oninput="onGroupingChange(this)">
+          <span class="slider-val" id="valWSpecies">0.10</span>
+        </div>
+        <div class="slider-row">
+          <span class="slider-label" title="Weight of GPS + focal length similarity">Meta (GPS+FL)</span>
+          <input type="range" min="0" max="100" value="5" step="1" id="slWMeta" oninput="onGroupingChange(this)">
+          <span class="slider-val" id="valWMeta">0.05</span>
+        </div>
+      </div>
+
+      <div class="slider-section-header">Encounter cut — thresholds</div>
+      <div class="slider-group">
+        <div class="slider-row">
+          <span class="slider-label" title="Time constant for time-similarity decay (seconds). Lower = closer-in-time pairs needed.">τ time (s)</span>
+          <input type="range" min="5" max="120" value="40" step="1" id="slTauEnc" oninput="onGroupingChange(this)">
+          <span class="slider-val" id="valTauEnc">40</span>
+        </div>
+        <div class="slider-row">
+          <span class="slider-label" title="Force a cut if the gap between two photos exceeds this (seconds)">Hard cut: time</span>
+          <input type="range" min="30" max="600" value="180" step="10" id="slHardCutTime" oninput="onGroupingChange(this)">
+          <span class="slider-val" id="valHardCutTime">180</span>
+        </div>
+        <div class="slider-row">
+          <span class="slider-label" title="Force a cut if S_enc drops below this">Hard cut: score</span>
           <input type="range" min="0" max="100" value="42" step="1" id="slEncCut" oninput="onGroupingChange(this)">
           <span class="slider-val" id="valEncCut">0.42</span>
         </div>
         <div class="slider-row">
-          <span class="slider-label" title="Similarity above this merges neighboring segments back together">Merge score</span>
+          <span class="slider-label" title="Soft-cut threshold: 2 of last 3 scores below this triggers a cut">Soft cut: score</span>
+          <input type="range" min="0" max="100" value="52" step="1" id="slSoftCut" oninput="onGroupingChange(this)">
+          <span class="slider-val" id="valSoftCut">0.52</span>
+        </div>
+      </div>
+
+      <div class="slider-section-header">Encounter merge</div>
+      <div class="slider-section-hint">Stitch adjacent microsegments back together if they look like the same encounter</div>
+      <div class="slider-group">
+        <div class="slider-row">
+          <span class="slider-label" title="Merge if S_seg between segments exceeds this">Merge score</span>
           <input type="range" min="0" max="100" value="62" step="1" id="slEncMerge" oninput="onGroupingChange(this)">
           <span class="slider-val" id="valEncMerge">0.62</span>
+        </div>
+        <div class="slider-row">
+          <span class="slider-label" title="Only consider merge if time gap ≤ this (seconds)">Max gap (s)</span>
+          <input type="range" min="5" max="300" value="60" step="5" id="slMergeMaxGap" oninput="onGroupingChange(this)">
+          <span class="slider-val" id="valMergeMaxGap">60</span>
+        </div>
+        <div class="slider-row">
+          <span class="slider-label" title="Time decay constant for merge gap scoring">τ merge (s)</span>
+          <input type="range" min="5" max="120" value="20" step="1" id="slMergeTau" oninput="onGroupingChange(this)">
+          <span class="slider-val" id="valMergeTau">20</span>
         </div>
       </div>
 
       <div class="slider-section-header">Bursts</div>
-      <div class="slider-section-hint">Group rapid-fire shots of the same subject within encounters</div>
+      <div class="slider-section-hint">Group rapid-fire shots within an encounter</div>
       <div class="slider-group">
         <div class="slider-row">
           <span class="slider-label" title="Max seconds between consecutive shots to stay in the same burst">Time gap (s)</span>
@@ -969,13 +1045,16 @@ input[type="range"]::-moz-range-thumb {
           <span class="slider-val" id="valBurstPhash">12</span>
         </div>
         <div class="slider-row">
-          <span class="slider-label" title="Max embedding distance — higher tolerates more visually different shots in the same burst">Emb. distance</span>
+          <span class="slider-label" title="Max embedding distance — higher tolerates more visually different shots">Emb. distance</span>
           <input type="range" min="0" max="100" value="20" step="1" id="slBurstEmb" oninput="onGroupingChange(this)">
           <span class="slider-val" id="valBurstEmb">0.20</span>
         </div>
       </div>
 
-      <button class="reset-btn" onclick="resetGroupingDefaults()">Reset to defaults</button>
+      <div class="button-row">
+        <button class="reset-btn" onclick="resetGroupingDefaults()">Reset</button>
+        <button class="save-btn" onclick="saveGroupingDefaults()">Save as default</button>
+      </div>
     </div>
 
     <div class="sidebar-section">
@@ -1454,7 +1533,13 @@ var SCORING_DEFAULTS = {
   burst_lambda: 85, burst_max_keep: 3, encounter_lambda: 70, encounter_max_keep: 5,
 };
 var GROUPING_DEFAULTS = {
-  hard_cut_score: 42, merge_score: 62,
+  // Weights (stored as 0-100 for slider; converted to 0..1 fraction in getGroupingConfig)
+  w_time: 35, w_subj: 35, w_global: 15, w_species: 10, w_meta: 5,
+  // Cut thresholds
+  tau_enc: 40, hard_cut_time: 180, hard_cut_score: 42, soft_cut_score: 52,
+  // Merge
+  merge_score: 62, merge_max_gap: 60, merge_tau: 20,
+  // Bursts
   burst_time_gap: 3, burst_phash_threshold: 12, burst_embedding_threshold: 20,
 };
 
@@ -1471,8 +1556,18 @@ var GROUPING_DEFAULTS = {
     SCORING_DEFAULTS.burst_max_keep = p.burst_max_keep != null ? p.burst_max_keep : 3;
     SCORING_DEFAULTS.encounter_lambda = Math.round((p.encounter_lambda != null ? p.encounter_lambda : 0.70) * 100);
     SCORING_DEFAULTS.encounter_max_keep = p.encounter_max_keep != null ? p.encounter_max_keep : 5;
+    GROUPING_DEFAULTS.w_time = Math.round((p.w_time != null ? p.w_time : 0.35) * 100);
+    GROUPING_DEFAULTS.w_subj = Math.round((p.w_subj != null ? p.w_subj : 0.35) * 100);
+    GROUPING_DEFAULTS.w_global = Math.round((p.w_global != null ? p.w_global : 0.15) * 100);
+    GROUPING_DEFAULTS.w_species = Math.round((p.w_species != null ? p.w_species : 0.10) * 100);
+    GROUPING_DEFAULTS.w_meta = Math.round((p.w_meta != null ? p.w_meta : 0.05) * 100);
+    GROUPING_DEFAULTS.tau_enc = p.tau_enc != null ? p.tau_enc : 40;
+    GROUPING_DEFAULTS.hard_cut_time = p.hard_cut_time != null ? p.hard_cut_time : 180;
     GROUPING_DEFAULTS.hard_cut_score = Math.round((p.hard_cut_score != null ? p.hard_cut_score : 0.42) * 100);
+    GROUPING_DEFAULTS.soft_cut_score = Math.round((p.soft_cut_score != null ? p.soft_cut_score : 0.52) * 100);
     GROUPING_DEFAULTS.merge_score = Math.round((p.merge_score != null ? p.merge_score : 0.62) * 100);
+    GROUPING_DEFAULTS.merge_max_gap = p.merge_max_gap != null ? p.merge_max_gap : 60;
+    GROUPING_DEFAULTS.merge_tau = p.merge_tau != null ? p.merge_tau : 20;
     GROUPING_DEFAULTS.burst_time_gap = p.burst_time_gap != null ? p.burst_time_gap : 3;
     GROUPING_DEFAULTS.burst_phash_threshold = p.burst_phash_threshold != null ? p.burst_phash_threshold : 12;
     // Stored as cosine similarity; UI shows distance = 1 - similarity.
@@ -1493,8 +1588,14 @@ function updateSliderDisplay(slider) {
   var id = slider.id;
   var valEl = document.getElementById('val' + id.substring(2));
   if (!valEl) return;
-  // Integer sliders (keep counts, time, phash)
-  if (['slBurstKeep','slEncKeep','slBurstTime','slBurstPhash'].indexOf(id) >= 0) {
+  // Integer sliders (raw values, not /100): keep counts, raw seconds, phash distance
+  var INT_SLIDERS = [
+    'slBurstKeep','slEncKeep',
+    'slBurstTime','slBurstPhash',
+    'slTauEnc','slHardCutTime',
+    'slMergeMaxGap','slMergeTau',
+  ];
+  if (INT_SLIDERS.indexOf(id) >= 0) {
     valEl.textContent = slider.value;
   } else {
     valEl.textContent = (slider.value / 100).toFixed(2);
@@ -1515,12 +1616,24 @@ function getScoringConfig() {
 }
 
 function getGroupingConfig() {
+  function pct(id) { return parseFloat(document.getElementById(id).value) / 100.0; }
+  function num(id) { return parseFloat(document.getElementById(id).value); }
   return {
-    hard_cut_score: sliderVal('slEncCut') / 100,
-    merge_score: sliderVal('slEncMerge') / 100,
-    burst_time_gap: sliderVal('slBurstTime'),
-    burst_phash_threshold: Math.round(sliderVal('slBurstPhash')),
-    burst_embedding_threshold: 1 - sliderVal('slBurstEmb') / 100,
+    w_time: pct('slWTime'),
+    w_subj: pct('slWSubj'),
+    w_global: pct('slWGlobal'),
+    w_species: pct('slWSpecies'),
+    w_meta: pct('slWMeta'),
+    tau_enc: num('slTauEnc'),
+    hard_cut_time: num('slHardCutTime'),
+    hard_cut_score: pct('slEncCut'),
+    soft_cut_score: pct('slSoftCut'),
+    merge_score: pct('slEncMerge'),
+    merge_max_gap: num('slMergeMaxGap'),
+    merge_tau: num('slMergeTau'),
+    burst_time_gap: num('slBurstTime'),
+    burst_phash_dist: num('slBurstPhash'),
+    burst_emb_dist: pct('slBurstEmb'),
   };
 }
 
@@ -1623,11 +1736,26 @@ function resetScoringDefaults() {
 }
 
 function applyGroupingDefaults() {
-  document.getElementById('slEncCut').value = GROUPING_DEFAULTS.hard_cut_score;
-  document.getElementById('slEncMerge').value = GROUPING_DEFAULTS.merge_score;
-  document.getElementById('slBurstTime').value = GROUPING_DEFAULTS.burst_time_gap;
-  document.getElementById('slBurstPhash').value = GROUPING_DEFAULTS.burst_phash_threshold;
-  document.getElementById('slBurstEmb').value = GROUPING_DEFAULTS.burst_embedding_threshold;
+  function setVal(id, v) { var el = document.getElementById(id); if (el) el.value = v; }
+  // Weights (slider values 0..100)
+  setVal('slWTime', GROUPING_DEFAULTS.w_time);
+  setVal('slWSubj', GROUPING_DEFAULTS.w_subj);
+  setVal('slWGlobal', GROUPING_DEFAULTS.w_global);
+  setVal('slWSpecies', GROUPING_DEFAULTS.w_species);
+  setVal('slWMeta', GROUPING_DEFAULTS.w_meta);
+  // Cut thresholds
+  setVal('slTauEnc', GROUPING_DEFAULTS.tau_enc);
+  setVal('slHardCutTime', GROUPING_DEFAULTS.hard_cut_time);
+  setVal('slEncCut', GROUPING_DEFAULTS.hard_cut_score);
+  setVal('slSoftCut', GROUPING_DEFAULTS.soft_cut_score);
+  // Merge
+  setVal('slEncMerge', GROUPING_DEFAULTS.merge_score);
+  setVal('slMergeMaxGap', GROUPING_DEFAULTS.merge_max_gap);
+  setVal('slMergeTau', GROUPING_DEFAULTS.merge_tau);
+  // Bursts
+  setVal('slBurstTime', GROUPING_DEFAULTS.burst_time_gap);
+  setVal('slBurstPhash', GROUPING_DEFAULTS.burst_phash_threshold);
+  setVal('slBurstEmb', GROUPING_DEFAULTS.burst_embedding_threshold);
   document.querySelectorAll('.sidebar-section input[type="range"]').forEach(function(sl) {
     updateSliderDisplay(sl);
   });
@@ -1636,6 +1764,17 @@ function applyGroupingDefaults() {
 function resetGroupingDefaults() {
   applyGroupingDefaults();
   doRegroupLive();
+}
+
+function saveGroupingDefaults() {
+  var config = getGroupingConfig();
+  safeFetch('/api/pipeline/save-grouping-defaults', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({pipeline: config}),
+  })
+  .then(function() { showToast('Saved as defaults', 'success'); })
+  .catch(function() { /* error toast already shown by safeFetch */ });
 }
 
 // -- Photo inspection --

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -371,6 +371,28 @@ input[type="range"]::-moz-range-thumb {
 }
 .save-btn:hover { filter: brightness(1.1); }
 
+/* Algorithm trace panel */
+.algo-trace { font-size: 11px; line-height: 1.35; margin-bottom: 8px; }
+.algo-trace .trace-row {
+  display: grid; grid-template-columns: 1fr auto auto; gap: 6px;
+  padding: 3px 4px; border-bottom: 1px solid var(--border-primary);
+  align-items: baseline;
+}
+.algo-trace .trace-row.cut { background: rgba(220, 50, 50, 0.10); }
+.algo-trace .trace-row.merged-back { background: rgba(80, 160, 80, 0.10); }
+.algo-trace .trace-row.kept { }
+.algo-trace .trace-decision { font-weight: 600; }
+.algo-trace .trace-components {
+  font-size: 10px; color: var(--text-dim); padding: 2px 4px 6px;
+  border-bottom: 1px solid var(--border-primary);
+}
+.algo-trace .trace-empty {
+  font-size: 11px; color: var(--text-dim); font-style: italic; padding: 4px;
+}
+.encounter-card.focused {
+  border-left: 3px solid var(--accent);
+}
+
 /* Inspection panel */
 .inspect-overlay {
   display: none;
@@ -1051,6 +1073,10 @@ input[type="range"]::-moz-range-thumb {
         </div>
       </div>
 
+      <div class="slider-section-header">Trace &mdash; focused encounter</div>
+      <div class="slider-section-hint" id="traceFocusLabel">Click an encounter to see how it was formed</div>
+      <div id="algorithmTrace" class="algo-trace"></div>
+
       <div class="button-row">
         <button class="reset-btn" onclick="resetGroupingDefaults()">Reset</button>
         <button class="save-btn" onclick="saveGroupingDefaults()">Save as default</button>
@@ -1296,6 +1322,71 @@ function encounterMatchesSpecies(enc) {
 
 // -- Rendering --
 
+var _focusedEncounterIdx = null;
+
+function setFocusedEncounter(idx) {
+  _focusedEncounterIdx = idx;
+  document.querySelectorAll('.encounter-card.focused').forEach(function(el) {
+    el.classList.remove('focused');
+  });
+  var card = document.querySelector('.encounter-card[data-encounter-index="' + idx + '"]');
+  if (card) card.classList.add('focused');
+  renderAlgorithmTrace();
+}
+
+function renderAlgorithmTrace() {
+  var panel = document.getElementById('algorithmTrace');
+  var label = document.getElementById('traceFocusLabel');
+  if (!panel) return;
+  if (_focusedEncounterIdx === null || !pipelineResults || !pipelineResults.encounters) {
+    panel.innerHTML = '';
+    if (label) label.textContent = 'Click an encounter to see how it was formed';
+    return;
+  }
+  var enc = pipelineResults.encounters[_focusedEncounterIdx];
+  if (!enc) {
+    panel.innerHTML = '';
+    if (label) label.textContent = 'Click an encounter to see how it was formed';
+    return;
+  }
+  if (!enc.trace || enc.trace.length === 0) {
+    panel.innerHTML = '<div class="trace-empty">Single-photo encounter &mdash; no internal cut points.</div>';
+    if (label) label.textContent = 'Encounter ' + (_focusedEncounterIdx + 1);
+    return;
+  }
+  if (label) {
+    label.textContent = 'Encounter ' + (_focusedEncounterIdx + 1) + ' — ' + enc.trace.length + ' adjacent pair' + (enc.trace.length > 1 ? 's' : '');
+  }
+  var html = '';
+  enc.trace.forEach(function(t, i) {
+    var rowCls = 'trace-row';
+    if (t.decision && t.decision.indexOf('cut_') === 0) rowCls += ' cut';
+    else if (t.decision === 'merged_back') rowCls += ' merged-back';
+    else rowCls += ' kept';
+    var dt = (t.dt_seconds === null || t.dt_seconds === undefined) ? '∞' : t.dt_seconds.toFixed(1) + 's';
+    var score = (typeof t.score === 'number') ? t.score.toFixed(3) : '-';
+    var decision = t.decision || '?';
+    html += '<div class="' + rowCls + '">';
+    html += '<span>pair ' + (i + 1) + ' · ' + dt + '</span>';
+    html += '<span>S=' + score + '</span>';
+    html += '<span class="trace-decision">' + decision + '</span>';
+    html += '</div>';
+    if (t.components) {
+      var parts = [];
+      ['time', 'subj', 'global', 'species', 'meta'].forEach(function(k) {
+        var c = t.components[k];
+        if (!c) return;
+        var marker = c.used ? '' : '·';
+        var v = (typeof c.value === 'number') ? c.value.toFixed(2) : '-';
+        var w = (typeof c.weight === 'number') ? c.weight.toFixed(2) : '-';
+        parts.push(k + marker + '=' + v + '×' + w);
+      });
+      html += '<div class="trace-components">' + parts.join(' · ') + '</div>';
+    }
+  });
+  panel.innerHTML = html;
+}
+
 function renderResults() {
   if (!pipelineResults) return;
   var container = document.getElementById('encountersContainer');
@@ -1379,8 +1470,9 @@ function renderResults() {
 
     var encKey = encounterKey(enc);
     var isCollapsed = encKey != null && collapsedEncounters.has(encKey);
-    html += '<div class="encounter-card">';
-    html += '<div class="encounter-header">';
+    var focusedCls = (_focusedEncounterIdx === ei) ? ' focused' : '';
+    html += '<div class="encounter-card' + focusedCls + '" data-encounter-index="' + ei + '">';
+    html += '<div class="encounter-header" onclick="setFocusedEncounter(' + ei + ')">';
     html += '<span class="encounter-chevron' + (isCollapsed ? ' collapsed' : '') + '" id="encChev' + ei + '" onclick="toggleEncounter(' + ei + ')">&#9660;</span>';
     html += renderSpeciesWidget(enc, ei, 'encounter', null);
     html += '<span class="encounter-meta" onclick="toggleEncounter(' + ei + ')" style="cursor:pointer;flex:1;">';
@@ -1440,6 +1532,18 @@ function renderResults() {
   });
 
   container.innerHTML = html;
+
+  // Focus management: auto-focus first encounter on initial render; clamp on regroup.
+  var encs = pipelineResults.encounters || [];
+  if (encs.length === 0) {
+    _focusedEncounterIdx = null;
+    renderAlgorithmTrace();
+  } else if (_focusedEncounterIdx === null || _focusedEncounterIdx >= encs.length) {
+    setFocusedEncounter(0);
+  } else {
+    // Re-apply focus highlight (DOM was rebuilt) and refresh trace panel.
+    setFocusedEncounter(_focusedEncounterIdx);
+  }
 }
 
 function renderPhotoCard(p, encIdx, burstIdx) {

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1352,8 +1352,16 @@ function renderAlgorithmTrace() {
     if (label) label.textContent = 'Click an encounter to see how it was formed';
     return;
   }
-  if (!enc.trace || enc.trace.length === 0) {
-    panel.innerHTML = '<div class="trace-empty">Single-photo encounter &mdash; no internal cut points.</div>';
+  if (!enc.trace) {
+    panel.innerHTML = '<div class="trace-empty">Trace not available &mdash; drag a slider to recompute.</div>';
+    if (label) label.textContent = 'Encounter ' + (_focusedEncounterIdx + 1);
+    return;
+  }
+  if (enc.trace.length === 0) {
+    var emptyMsg = (enc.photo_count <= 1)
+      ? 'Single-photo encounter &mdash; no internal cut points.'
+      : 'No adjacent-pair scores (encounter has no internal pairs).';
+    panel.innerHTML = '<div class="trace-empty">' + emptyMsg + '</div>';
     if (label) label.textContent = 'Encounter ' + (_focusedEncounterIdx + 1);
     return;
   }

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4051,6 +4051,38 @@ def test_save_grouping_defaults_persists_to_config(tmp_path, monkeypatch):
     assert saved["pipeline"]["tau_enc"] == 30.0
 
 
+def test_save_grouping_defaults_recovers_from_corrupt_pipeline_section(tmp_path, monkeypatch):
+    """If a hand-edit left config.json with a non-dict pipeline value, the
+    endpoint should overwrite it cleanly rather than crash with AttributeError
+    inside .update()."""
+    import json as _json
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    import models
+    from app import create_app
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    # Pre-seed config.json with a corrupt pipeline value (string, not dict).
+    with open(cfg.CONFIG_PATH, "w") as f:
+        _json.dump({"pipeline": "oops-i-edited-this-by-hand"}, f)
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="t")
+    client = app.test_client()
+
+    resp = client.post("/api/pipeline/save-grouping-defaults",
+                       json={"pipeline": {"w_species": 0.40}})
+    assert resp.status_code == 200, resp.get_json()
+    saved = cfg.load()
+    assert saved["pipeline"]["w_species"] == 0.40
+
+
 def test_save_grouping_defaults_rejects_bad_values(tmp_path, monkeypatch):
     """POST /api/pipeline/save-grouping-defaults must reject invalid types or
     out-of-range values before they corrupt the persistent config."""

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3853,3 +3853,34 @@ def test_regroup_live_returns_per_encounter_trace(tmp_path, monkeypatch):
         assert "score" in sample
         assert "decision" in sample
         assert "components" in sample
+
+
+def test_save_grouping_defaults_persists_to_config(tmp_path, monkeypatch):
+    """POST /api/pipeline/save-grouping-defaults should persist whitelisted
+    grouping keys into the global config file via cfg.save()."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    import models
+    from app import create_app
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="t")
+    client = app.test_client()
+
+    payload = {"pipeline": {"w_species": 0.40, "hard_cut_score": 0.55, "tau_enc": 30.0}}
+    resp = client.post("/api/pipeline/save-grouping-defaults", json=payload)
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    assert body.get("saved") == payload["pipeline"]
+
+    saved = cfg.load()
+    assert saved["pipeline"]["w_species"] == 0.40
+    assert saved["pipeline"]["hard_cut_score"] == 0.55
+    assert saved["pipeline"]["tau_enc"] == 30.0

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1545,6 +1545,66 @@ def test_encounter_species_auto_detaches_mixed_burst(app_and_db):
     assert eagle_enc["confirmed_species"] == "Golden Eagle"
 
 
+def test_encounter_species_auto_detach_clears_stale_trace(app_and_db):
+    """Auto-detach mutates encounter photo_ids; the trace (keyed to original
+    composition) must be dropped so the algorithm-trace panel doesn't render
+    pair indices that no longer match the post-detach photo set."""
+    import json as _json
+    app, db = app_and_db
+    client = app.test_client()
+
+    cache_dir = os.path.dirname(app.config["DB_PATH"])
+    ws_id = db._active_workspace_id
+    results = {
+        "encounters": [
+            {
+                "species": ["Bald Eagle", 0.9],
+                "confirmed_species": None,
+                "species_predictions": [{"species": "Bald Eagle", "count": 3, "models": []}],
+                "species_confirmed": False,
+                "photo_count": 3,
+                "burst_count": 2,
+                "time_range": ["2024-06-10T09:00:00", "2024-06-10T09:05:00"],
+                "photo_ids": [1, 2, 3],
+                "bursts": [
+                    {"photo_ids": [1, 2], "species_predictions": [], "species_override": None},
+                    {"photo_ids": [3], "species_predictions": [], "species_override": None},
+                ],
+                # Pre-existing trace from the original 3-photo grouping.
+                "trace": [
+                    {"pair_index": 0, "score": 0.8, "decision": "kept", "components": {},
+                     "thresholds": {}, "dt_seconds": 2.0},
+                    {"pair_index": 1, "score": 0.5, "decision": "kept", "components": {},
+                     "thresholds": {}, "dt_seconds": 298.0},
+                ],
+            }
+        ],
+        "photos": [
+            {"id": 1, "label": "KEEP", "filename": "a.jpg", "timestamp": "2024-06-10T09:00:00", "species_top5": [["Bald Eagle", 0.9, "m1"]]},
+            {"id": 2, "label": "KEEP", "filename": "b.jpg", "timestamp": "2024-06-10T09:00:02", "species_top5": [["Bald Eagle", 0.9, "m1"]]},
+            {"id": 3, "label": "REVIEW", "filename": "c.jpg", "timestamp": "2024-06-10T09:05:00", "species_top5": [["Golden Eagle", 0.6, "m1"]]},
+        ],
+        "summary": {"total_photos": 3, "encounter_count": 1, "burst_count": 2,
+                     "keep_count": 2, "review_count": 1, "reject_count": 0, "rarity_protected": 0},
+    }
+    path = os.path.join(cache_dir, f"pipeline_results_ws{ws_id}.json")
+    with open(path, "w") as f:
+        _json.dump(results, f)
+
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Golden Eagle", "photo_ids": [3], "burst_index": 1})
+    assert resp.status_code == 200
+    body = resp.get_json()
+
+    bald_enc = next(e for e in body["encounters"] if 1 in e["photo_ids"])
+    golden_enc = next(e for e in body["encounters"] if 3 in e["photo_ids"])
+    # The source encounter had its composition changed — trace must be gone.
+    assert "trace" not in bald_enc, "auto-detach left stale trace on source encounter"
+    # The new encounter created from the detached burst was never grouped, so
+    # it has no trace either (correct — would be misleading otherwise).
+    assert "trace" not in golden_enc
+
+
 def test_encounter_species_confirm_single_burst_does_not_detach(app_and_db):
     """Confirming the only burst in an encounter does not detach (nothing to split from)."""
     import json as _json

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1377,6 +1377,111 @@ def test_pipeline_detach_photo(app_and_db):
     assert "Eagle" in new_species
 
 
+def test_pipeline_detach_burst_clears_stale_trace(app_and_db):
+    """detach-burst must drop the source encounter's per-pair trace because
+    pairs involving the detached photos are no longer present in the
+    encounter — leaving the old trace would surface stale decisions in the
+    review sidebar."""
+    import json as _json
+    app, db = app_and_db
+    client = app.test_client()
+
+    cache_dir = os.path.dirname(app.config["DB_PATH"])
+    ws_id = db._active_workspace_id
+    results = {
+        "encounters": [
+            {
+                "species": ["Robin", 0.9],
+                "confirmed_species": None,
+                "species_predictions": [],
+                "species_confirmed": False,
+                "photo_count": 3,
+                "burst_count": 2,
+                "time_range": [None, None],
+                "photo_ids": [1, 2, 3],
+                "trace": [
+                    {"i": 0, "j": 1, "decision": "keep", "score": 0.7},
+                    {"i": 1, "j": 2, "decision": "keep", "score": 0.6},
+                ],
+                "bursts": [
+                    {"photo_ids": [1, 2], "species_predictions": [], "species_override": None},
+                    {"photo_ids": [3], "species_predictions": [], "species_override": None},
+                ],
+            }
+        ],
+        "photos": [
+            {"id": 1, "label": "KEEP", "filename": "a.jpg", "species_top5": [["Robin", 0.9, "m1"]]},
+            {"id": 2, "label": "KEEP", "filename": "b.jpg", "species_top5": [["Robin", 0.85, "m1"]]},
+            {"id": 3, "label": "REVIEW", "filename": "c.jpg", "species_top5": [["Eagle", 0.8, "m1"]]},
+        ],
+        "summary": {"total_photos": 3, "encounter_count": 1, "burst_count": 2,
+                     "keep_count": 2, "review_count": 1, "reject_count": 0, "rarity_protected": 0},
+    }
+    path = os.path.join(cache_dir, f"pipeline_results_ws{ws_id}.json")
+    with open(path, "w") as f:
+        _json.dump(results, f)
+
+    resp = client.post("/api/pipeline/detach-burst",
+                       json={"encounter_index": 0, "burst_index": 1})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Source encounter should no longer carry the pre-detach trace.
+    assert "trace" not in data["encounters"][0]
+    # New encounter created from detached burst has no trace either.
+    assert "trace" not in data["encounters"][1]
+
+
+def test_pipeline_detach_photo_preserves_trace(app_and_db):
+    """detach-photo only restructures bursts within the encounter — the
+    encounter's photo set and ordering is unchanged, so the per-pair trace
+    (which describes adjacent-photo decisions) remains valid and should
+    not be discarded."""
+    import json as _json
+    app, db = app_and_db
+    client = app.test_client()
+
+    cache_dir = os.path.dirname(app.config["DB_PATH"])
+    ws_id = db._active_workspace_id
+    trace = [
+        {"i": 0, "j": 1, "decision": "keep", "score": 0.7},
+        {"i": 1, "j": 2, "decision": "keep", "score": 0.6},
+    ]
+    results = {
+        "encounters": [
+            {
+                "species": ["Robin", 0.9],
+                "confirmed_species": None,
+                "species_predictions": [],
+                "species_confirmed": False,
+                "photo_count": 3,
+                "burst_count": 1,
+                "time_range": [None, None],
+                "photo_ids": [1, 2, 3],
+                "trace": trace,
+                "bursts": [
+                    {"photo_ids": [1, 2, 3], "species_predictions": [], "species_override": None},
+                ],
+            }
+        ],
+        "photos": [
+            {"id": 1, "label": "KEEP", "filename": "a.jpg", "species_top5": [["Robin", 0.9, "m1"]]},
+            {"id": 2, "label": "KEEP", "filename": "b.jpg", "species_top5": [["Robin", 0.85, "m1"]]},
+            {"id": 3, "label": "REVIEW", "filename": "c.jpg", "species_top5": [["Eagle", 0.8, "m1"]]},
+        ],
+        "summary": {"total_photos": 3, "encounter_count": 1, "burst_count": 1,
+                     "keep_count": 2, "review_count": 1, "reject_count": 0, "rarity_protected": 0},
+    }
+    path = os.path.join(cache_dir, f"pipeline_results_ws{ws_id}.json")
+    with open(path, "w") as f:
+        _json.dump(results, f)
+
+    resp = client.post("/api/pipeline/detach-photo",
+                       json={"encounter_index": 0, "burst_index": 0, "photo_id": 3})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["encounters"][0]["trace"] == trace
+
+
 def test_encounter_species_auto_detaches_mixed_burst(app_and_db):
     """Confirming a burst to a species different from its encounter auto-detaches it."""
     import json as _json
@@ -3884,3 +3989,83 @@ def test_save_grouping_defaults_persists_to_config(tmp_path, monkeypatch):
     assert saved["pipeline"]["w_species"] == 0.40
     assert saved["pipeline"]["hard_cut_score"] == 0.55
     assert saved["pipeline"]["tau_enc"] == 30.0
+
+
+def test_save_grouping_defaults_rejects_bad_values(tmp_path, monkeypatch):
+    """POST /api/pipeline/save-grouping-defaults must reject invalid types or
+    out-of-range values before they corrupt the persistent config."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    import models
+    from app import create_app
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="t")
+    client = app.test_client()
+
+    # Wrong type for a numeric field.
+    resp = client.post(
+        "/api/pipeline/save-grouping-defaults",
+        json={"pipeline": {"hard_cut_time": "abc"}},
+    )
+    assert resp.status_code == 400
+    # Out-of-range weight (must be 0..1).
+    resp = client.post(
+        "/api/pipeline/save-grouping-defaults",
+        json={"pipeline": {"w_species": 1.5}},
+    )
+    assert resp.status_code == 400
+    # Negative threshold.
+    resp = client.post(
+        "/api/pipeline/save-grouping-defaults",
+        json={"pipeline": {"hard_cut_score": -0.1}},
+    )
+    assert resp.status_code == 400
+    # bool should not satisfy "must be a number" silently.
+    resp = client.post(
+        "/api/pipeline/save-grouping-defaults",
+        json={"pipeline": {"w_time": True}},
+    )
+    assert resp.status_code == 400
+    # NaN / inf must be rejected.
+    resp = client.post(
+        "/api/pipeline/save-grouping-defaults",
+        json={"pipeline": {"tau_enc": float("inf")}},
+    )
+    assert resp.status_code == 400
+    # phash threshold must be int, not float.
+    resp = client.post(
+        "/api/pipeline/save-grouping-defaults",
+        json={"pipeline": {"burst_phash_threshold": 12.5}},
+    )
+    assert resp.status_code == 400
+
+    # No bad payload should have been written to disk — for any key we
+    # attempted to corrupt, the persisted value is still a valid number
+    # (either the default fell through, or the load merge filled it).
+    saved = cfg.load()
+    pipe = saved.get("pipeline", {})
+    if "hard_cut_time" in pipe:
+        assert isinstance(pipe["hard_cut_time"], (int, float))
+    if "w_species" in pipe:
+        assert isinstance(pipe["w_species"], (int, float))
+        assert 0.0 <= pipe["w_species"] <= 1.0
+    if "hard_cut_score" in pipe:
+        assert isinstance(pipe["hard_cut_score"], (int, float))
+        assert 0.0 <= pipe["hard_cut_score"] <= 1.0
+    if "w_time" in pipe:
+        assert isinstance(pipe["w_time"], (int, float))
+        assert pipe["w_time"] is not True  # bool guard
+    if "tau_enc" in pipe:
+        import math as _math
+        assert isinstance(pipe["tau_enc"], (int, float))
+        assert _math.isfinite(pipe["tau_enc"])
+    if "burst_phash_threshold" in pipe:
+        assert isinstance(pipe["burst_phash_threshold"], int)

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3762,3 +3762,94 @@ def test_storage_masks_uses_global_threshold_not_active_workspace(
     db.set_active_workspace(permissive)
     r = client.get("/api/storage/masks")
     assert r.get_json()["stale_count"] == 0
+
+
+def test_regroup_live_returns_per_encounter_trace(tmp_path, monkeypatch):
+    """/api/pipeline/regroup-live response should expose the per-cut-point
+    trace on each multi-photo encounter so the pipeline-review sidebar can
+    render the "how was this encounter formed" panel.
+    """
+    from datetime import datetime, timedelta
+
+    import numpy as np
+    from db import Database
+    from dino_embed import embedding_to_blob
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    import models
+    from app import create_app
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder(str(tmp_path), name="photos")
+    db.add_workspace_folder(ws_id, fid)
+
+    base_time = datetime(2026, 3, 20, 10, 0, 0)
+    # Two encounters of 3 photos each, separated by 5 minutes (hard time cut).
+    for enc_idx in range(2):
+        emb_base = np.zeros(768, dtype=np.float32)
+        emb_base[enc_idx * 100: enc_idx * 100 + 100] = 1.0
+        emb_base = emb_base / np.linalg.norm(emb_base)
+        enc_offset = enc_idx * 300
+        for i in range(3):
+            ts = base_time + timedelta(seconds=enc_offset + i * 2)
+            pid = db.add_photo(
+                fid, f"enc{enc_idx}_p{i}.jpg", ".jpg", 1000, 1.0,
+                timestamp=ts.isoformat(), width=4000, height=3000,
+            )
+            emb = emb_base + np.random.RandomState(pid).randn(768).astype(np.float32) * 0.01
+            emb = emb / np.linalg.norm(emb)
+            db.update_photo_pipeline_features(
+                pid,
+                mask_path=f"/masks/{pid}.png",
+                subject_tenengrad=200 + i * 50,
+                bg_tenengrad=30 + i * 5,
+                crop_complete=0.85 + i * 0.03,
+                bg_separation=50.0 - i * 10,
+                subject_clip_high=0.01,
+                subject_clip_low=0.01,
+                subject_y_median=120.0,
+                phash_crop=f"{pid:016x}",
+            )
+            db.update_photo_embeddings(
+                pid,
+                dino_subject_embedding=embedding_to_blob(emb),
+                dino_global_embedding=embedding_to_blob(emb),
+            )
+            db.update_photo_quality(pid, subject_size=0.08 + i * 0.02)
+            det_ids = db.save_detections(pid, [
+                {"box": {"x": 0.2, "y": 0.2, "w": 0.4, "h": 0.4}, "confidence": 0.9},
+            ], detector_model="megadetector")
+            species = "robin" if enc_idx == 0 else "eagle"
+            db.add_prediction(det_ids[0], species, 0.9 - i * 0.05, "bioclip", category="match")
+    db.close()
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="t")
+    client = app.test_client()
+
+    resp = client.post("/api/pipeline/regroup-live", json={"config": {}})
+    assert resp.status_code == 200, resp.get_json()
+    data = resp.get_json()
+    assert "encounters" in data
+    assert len(data["encounters"]) >= 1, data
+    multi_photo = [e for e in data["encounters"] if e["photo_count"] >= 2]
+    assert multi_photo, "test setup should yield at least one multi-photo encounter"
+    for enc in multi_photo:
+        assert "trace" in enc, f"trace missing on encounter: {enc.keys()}"
+        assert len(enc["trace"]) == enc["photo_count"] - 1, (
+            f"trace len {len(enc['trace'])} != photo_count-1 {enc['photo_count']-1}"
+        )
+        sample = enc["trace"][0]
+        assert "score" in sample
+        assert "decision" in sample
+        assert "components" in sample

--- a/vireo/tests/test_encounters.py
+++ b/vireo/tests/test_encounters.py
@@ -550,3 +550,68 @@ def test_cut_microsegments_emits_trace():
         else:
             expected = 0.0
         assert entry["score"] == pytest.approx(expected, abs=1e-9)
+
+
+def test_cut_microsegments_emits_cut_score_decision():
+    """A pair whose S_enc falls below hard_cut_score is tagged 'cut_score'."""
+    from encounters import cut_microsegments
+    # Two photos with tight time gap (so dt < hard_cut_time) but force the
+    # hard_cut_score above the achievable score so the cut fires.
+    photos = [
+        {"timestamp": "2026-03-07T11:32:00", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+        {"timestamp": "2026-03-07T11:32:05", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+    ]
+    segments, trace = cut_microsegments(photos, config={"hard_cut_score": 1.5}, emit_trace=True)
+    assert len(segments) == 2
+    assert len(trace) == 1
+    assert trace[0]["decision"] == "cut_score"
+
+
+def test_cut_microsegments_emits_burst_id_kept_decision():
+    """When both photos share a burst_id, the pair is tagged 'burst_id_kept'."""
+    from encounters import cut_microsegments
+    photos = [
+        {"timestamp": "2026-03-07T11:32:00", "latitude": 33.7, "longitude": -118.0,
+         "focal_length": 600.0, "burst_id": "B1"},
+        {"timestamp": "2026-03-07T11:32:05", "latitude": 33.7, "longitude": -118.0,
+         "focal_length": 600.0, "burst_id": "B1"},
+    ]
+    # Even with a punishing hard_cut_score, the burst_id short-circuit should win.
+    segments, trace = cut_microsegments(photos, config={"hard_cut_score": 1.5}, emit_trace=True)
+    assert len(segments) == 1
+    assert len(trace) == 1
+    assert trace[0]["decision"] == "burst_id_kept"
+
+
+def test_segment_encounters_attaches_trace_to_each_encounter():
+    from encounters import segment_encounters
+    # 4 photos: two pairs separated by big time gap -> 2 encounters of 2 photos each
+    photos = [
+        {"timestamp": "2026-03-07T11:32:00", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+        {"timestamp": "2026-03-07T11:32:05", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+        {"timestamp": "2026-03-07T11:50:00", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+        {"timestamp": "2026-03-07T11:50:05", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+    ]
+    encounters = segment_encounters(photos, emit_trace=True)
+    assert len(encounters) == 2
+    for enc in encounters:
+        assert "trace" in enc
+        # 2 photos -> 1 internal pair
+        assert len(enc["trace"]) == 1
+        assert enc["trace"][0]["decision"] == "kept"
+
+
+def test_segment_encounters_marks_merged_back_boundaries():
+    """When two microsegments get merged, the boundary pair should be tagged merged_back."""
+    from encounters import segment_encounters
+    photos = [
+        {"timestamp": f"2026-03-07T11:32:0{i}", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0}
+        for i in range(4)
+    ]
+    cfg = {"hard_cut_score": 1.5, "merge_score": -1.0, "merge_max_gap": 60.0}
+    encounters = segment_encounters(photos, config=cfg, emit_trace=True)
+    assert len(encounters) == 1  # all merged back
+    enc = encounters[0]
+    decisions = [t["decision"] for t in enc["trace"]]
+    # 3 internal pairs across 4 microsegments: 3 of them are boundaries that got merged_back
+    assert decisions.count("merged_back") == 3

--- a/vireo/tests/test_encounters.py
+++ b/vireo/tests/test_encounters.py
@@ -517,3 +517,36 @@ def test_compute_s_enc_returns_components_when_asked():
     assert components["time"]["weight"] == 0.35  # default w_time
     assert components["time"]["used"] is True   # both photos have timestamps
     assert components["species"]["used"] is False  # neither has species_top5
+
+
+def test_cut_microsegments_emits_trace():
+    import pytest
+    from encounters import cut_microsegments
+    # 3 photos: two close-in-time, one far apart -> hard time cut between #2 and #3
+    photos = [
+        {"timestamp": "2026-03-07T11:32:00", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+        {"timestamp": "2026-03-07T11:32:05", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+        {"timestamp": "2026-03-07T11:40:00", "latitude": 33.7, "longitude": -118.0, "focal_length": 600.0},
+    ]
+    segments, trace = cut_microsegments(photos, emit_trace=True)
+    assert len(segments) == 2  # cut between #2 and #3
+    assert len(trace) == 2  # one entry per adjacent pair
+    # Pair 0->1: kept (small gap, no cut)
+    assert trace[0]["pair_index"] == 0
+    assert trace[0]["decision"] == "kept"
+    assert trace[0]["dt_seconds"] == 5.0
+    assert "components" in trace[0]
+    # Pair 1->2: hard time cut
+    assert trace[1]["pair_index"] == 1
+    assert trace[1]["decision"] == "cut_time"
+    assert trace[1]["dt_seconds"] == 475.0
+    # Internal consistency: per-pair score == weighted sum over USED components
+    for entry in trace:
+        comps = entry["components"]
+        used_items = [c for c in comps.values() if c["used"]]
+        total_weight = sum(c["weight"] for c in used_items)
+        if total_weight > 0:
+            expected = sum(c["value"] * c["weight"] for c in used_items) / total_weight
+        else:
+            expected = 0.0
+        assert entry["score"] == pytest.approx(expected, abs=1e-9)

--- a/vireo/tests/test_encounters.py
+++ b/vireo/tests/test_encounters.py
@@ -495,3 +495,25 @@ def test_segment_encounters_with_merge():
     # Should be 1 encounter (identical embeddings, close in time)
     assert len(encounters) == 1
     assert encounters[0]["photo_count"] == 4
+
+
+def test_compute_s_enc_returns_components_when_asked():
+    from encounters import compute_s_enc
+    photo_a = {
+        "timestamp": "2026-03-07T11:32:04",
+        "latitude": 33.7, "longitude": -118.0,
+        "focal_length": 600.0,
+    }
+    photo_b = {
+        "timestamp": "2026-03-07T11:32:09",
+        "latitude": 33.7, "longitude": -118.0,
+        "focal_length": 600.0,
+    }
+    score, components = compute_s_enc(photo_a, photo_b, return_components=True)
+    assert isinstance(score, float)
+    assert set(components.keys()) >= {"time", "subj", "global", "species", "meta"}
+    # Each component is a dict {value, weight, used}
+    assert components["time"]["value"] >= 0.0
+    assert components["time"]["weight"] == 0.35  # default w_time
+    assert components["time"]["used"] is True   # both photos have timestamps
+    assert components["species"]["used"] is False  # neither has species_top5

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6215,7 +6215,7 @@ def test_pipeline_regroup_stamps_workspace_group_fingerprint(tmp_path, monkeypat
     # Stub run_full_pipeline + save_results so regroup completes deterministically.
     import pipeline as pipeline_mod
 
-    def _ok_run(photos, config=None):
+    def _ok_run(photos, config=None, emit_trace=False):
         return {"summary": {"groups": 1}, "photos": photos}
 
     def _no_save(results, cache_dir, workspace_id):
@@ -6285,7 +6285,7 @@ def test_pipeline_regroup_does_not_stamp_for_partial_run(tmp_path, monkeypatch):
 
     import pipeline as pipeline_mod
 
-    def _ok_run(photos, config=None):
+    def _ok_run(photos, config=None, emit_trace=False):
         return {"summary": {"groups": 1}, "photos": photos}
 
     monkeypatch.setattr(pipeline_mod, "run_full_pipeline", _ok_run)
@@ -6357,7 +6357,7 @@ def test_pipeline_regroup_invalidates_stamp_on_partial_run(tmp_path, monkeypatch
     import pipeline as pipeline_mod
     monkeypatch.setattr(
         pipeline_mod, "run_full_pipeline",
-        lambda photos, config=None: {"summary": {"groups": 1}, "photos": photos},
+        lambda photos, config=None, emit_trace=False: {"summary": {"groups": 1}, "photos": photos},
     )
     monkeypatch.setattr(pipeline_mod, "save_results",
                         lambda results, cache_dir, workspace_id: None)


### PR DESCRIPTION
## Summary

Surfaces the encounter-grouping algorithm in the pipeline-review page's left sidebar and makes every weight/threshold tunable with live re-grouping.

- **15 sliders, always visible**, organized into 4 stages: Encounter cut weights (5), Encounter cut thresholds (4), Encounter merge (3), Bursts (3). Drag triggers a debounced live re-group via the existing `/api/pipeline/regroup-live` endpoint.
- **"Trace — focused encounter" panel** shows every adjacent-pair S_enc score with its component breakdown (`time / subj / global / species / meta` × weight) and the cut/keep/merged_back decision. Click any encounter card to focus it.
- **Save as default** persists weights to `~/.vireo/config.json` via new `POST /api/pipeline/save-grouping-defaults` endpoint (whitelisted to grouping keys).
- Per-cut-point trace is now emitted on **all** pipeline-result entry points (background pipeline-job, regroup, reflow, regroup-live), so the trace panel populates on first page load — not only after a slider drag.

Backend changes are additive opt-in: `compute_s_enc(..., return_components=True)`, `cut_microsegments(..., emit_trace=True)`, `segment_encounters(..., emit_trace=True)`, `run_grouping/run_full_pipeline(..., emit_trace=True)`. Default behavior unchanged.

Why: see `docs/plans/2026-05-03-transparent-encounter-tuning-plan.md`. The motivating case was a single photo card displaying "Lesser Scaup 100% / Ruddy Duck 100%" without telling the user those numbers were encounter aggregates over an 11-photo group that the algorithm bundled together despite a real species split. Radical transparency: show the user the algorithm so they can reason about (and tune) why two species ended up in one encounter.

## Test plan

- [x] `vireo/tests/test_encounters.py` — component breakdown, per-pair trace, merged_back tagging, decision-label coverage (47/47 passing)
- [x] `vireo/tests/test_app.py::test_regroup_live_returns_per_encounter_trace` — endpoint integration with real DB
- [x] `vireo/tests/test_app.py::test_save_grouping_defaults_persists_to_config` — round-trip persistence
- [x] `vireo/tests/test_pipeline_job.py` — pre-existing pipeline-job tests (130/130) updated for new `emit_trace` kwarg in stub functions
- [x] Manual Playwright verification: sidebar visible, all 15 sliders render, click-to-focus works, trace panel renders per-pair rows for multi-photo encounters, slider drag triggers live regroup
- [ ] Full project test suite did not finish locally (slow + known pre-existing flakiness on main); CI will catch any genuine regression

## Notes

- Burst slider keys (`burst_phash_threshold`, `burst_embedding_threshold`) match what `vireo/bursts.py` actually consumes; the embedding slider keeps the legacy `1 - x/100` distance→similarity conversion.
- Auto-focus is filter-aware: when filters hide encounters, focus picks the first *visible* card rather than landing on a hidden one.
- Focus highlight uses `box-shadow: inset 3px 0 0` to avoid the 1px→3px border swap shifting card content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)