### PR TITLE
db: prune pipeline review cache when photos are deleted

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3979,6 +3979,19 @@ class Database:
             # files should re-surface as "new" on the next read.
             if affected_folder_ids:
                 self.invalidate_new_images_cache_for_folders(affected_folder_ids)
+
+        # Prune the pipeline review cache so deleted photos don't render as
+        # blank cards on the pipeline review page.
+        if all_ids and self._db_path != ":memory:" and self._active_workspace_id:
+            try:
+                from pipeline import prune_results
+                prune_results(
+                    os.path.dirname(self._db_path),
+                    self._active_workspace_id,
+                    all_ids,
+                )
+            except Exception:
+                log.exception("Failed to prune pipeline cache after delete")
         return {"deleted": len(all_ids), "files": files}
 
     # ------------------------------------------------------------------

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -664,6 +664,73 @@ def load_results(cache_dir, workspace_id):
         return json.load(f)
 
 
+def prune_results(cache_dir, workspace_id, deleted_ids):
+    """Remove deleted photo IDs from the cached pipeline results in place.
+
+    Strips the IDs from the top-level photos list, every encounter's
+    photo_ids, and every burst's photo_ids. Encounters and bursts that
+    end up empty are dropped. photo_count, burst_count, and the
+    top-level summary are recomputed from survivors so the review page
+    reflects the current state.
+
+    Returns True if the cache was rewritten, False if nothing changed
+    (no cache file, empty input, or no overlap with the cache).
+    """
+    if not deleted_ids:
+        return False
+    path = os.path.join(cache_dir, f"pipeline_results_ws{workspace_id}.json")
+    if not os.path.exists(path):
+        return False
+    with open(path) as f:
+        data = json.load(f)
+
+    deleted = set(deleted_ids)
+    cached_ids = {p.get("id") for p in data.get("photos", [])}
+    if cached_ids.isdisjoint(deleted):
+        return False
+
+    data["photos"] = [p for p in data.get("photos", []) if p.get("id") not in deleted]
+
+    pruned_encounters = []
+    for enc in data.get("encounters", []):
+        enc["photo_ids"] = [pid for pid in enc.get("photo_ids", []) if pid not in deleted]
+        if "bursts" in enc:
+            kept_bursts = []
+            for burst in enc["bursts"]:
+                burst["photo_ids"] = [
+                    pid for pid in burst.get("photo_ids", []) if pid not in deleted
+                ]
+                if burst["photo_ids"]:
+                    kept_bursts.append(burst)
+            enc["bursts"] = kept_bursts
+            enc["burst_count"] = len(kept_bursts)
+        if not enc["photo_ids"]:
+            continue
+        enc["photo_count"] = len(enc["photo_ids"])
+        pruned_encounters.append(enc)
+    data["encounters"] = pruned_encounters
+
+    photos = data["photos"]
+    summary = data.get("summary") or {}
+    summary["total_photos"] = len(photos)
+    summary["encounter_count"] = len(pruned_encounters)
+    summary["burst_count"] = sum(e.get("burst_count", 0) for e in pruned_encounters)
+    summary["keep_count"] = sum(1 for p in photos if p.get("label") == "KEEP")
+    summary["review_count"] = sum(1 for p in photos if p.get("label") == "REVIEW")
+    summary["reject_count"] = sum(1 for p in photos if p.get("label") == "REJECT")
+    summary["rarity_protected"] = sum(1 for p in photos if p.get("rarity_protected"))
+    data["summary"] = summary
+
+    with open(path, "w") as f:
+        json.dump(data, f)
+    log.info(
+        "Pipeline cache pruned at %s: removed %d photo(s)",
+        path,
+        len(cached_ids & deleted),
+    )
+    return True
+
+
 def load_results_raw(cache_dir, workspace_id):
     """Load raw (already serialized) pipeline results JSON dict.
 

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -453,3 +453,68 @@ def test_api_batch_delete_disk_permanent_with_photo_ids(app_and_db, tmp_path):
     assert data["trashed"] == 1
     assert not os.path.exists(real_file)
     assert db.get_photo(pid) is None
+
+
+def test_delete_photos_prunes_pipeline_cache(app_and_db):
+    """Deleting photos strips them from the pipeline review cache so
+    they don't render as blank cards on the pipeline review page."""
+    app, db = app_and_db
+    photos = db.get_photos()
+    pid_to_delete = photos[0]["id"]
+    surviving_ids = [p["id"] for p in photos[1:]]
+
+    cache_dir = os.path.dirname(db._db_path)
+    cache_path = os.path.join(
+        cache_dir, f"pipeline_results_ws{db._active_workspace_id}.json"
+    )
+    cache = {
+        "encounters": [{
+            "species": None,
+            "photo_count": len(photos),
+            "burst_count": 1,
+            "photo_ids": [p["id"] for p in photos],
+            "bursts": [{
+                "photo_ids": [p["id"] for p in photos],
+                "species_predictions": [],
+                "species_override": None,
+            }],
+        }],
+        "photos": [{"id": p["id"], "label": "KEEP"} for p in photos],
+        "summary": {
+            "total_photos": len(photos),
+            "encounter_count": 1,
+            "burst_count": 1,
+            "keep_count": len(photos),
+            "review_count": 0,
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    with open(cache_path, "w") as f:
+        json.dump(cache, f)
+
+    db.delete_photos([pid_to_delete])
+
+    with open(cache_path) as f:
+        pruned = json.load(f)
+    assert [p["id"] for p in pruned["photos"]] == surviving_ids
+    assert pruned["encounters"][0]["photo_ids"] == surviving_ids
+    assert pruned["encounters"][0]["bursts"][0]["photo_ids"] == surviving_ids
+    assert pruned["encounters"][0]["photo_count"] == len(surviving_ids)
+    assert pruned["summary"]["total_photos"] == len(surviving_ids)
+    assert pruned["summary"]["keep_count"] == len(surviving_ids)
+
+
+def test_delete_photos_no_pipeline_cache_does_not_raise(app_and_db):
+    """delete_photos succeeds even when no pipeline cache file exists."""
+    app, db = app_and_db
+    photos = db.get_photos()
+
+    cache_dir = os.path.dirname(db._db_path)
+    cache_path = os.path.join(
+        cache_dir, f"pipeline_results_ws{db._active_workspace_id}.json"
+    )
+    assert not os.path.exists(cache_path)
+
+    result = db.delete_photos([photos[0]["id"]])
+    assert result["deleted"] == 1

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -283,6 +283,152 @@ def test_load_results_missing(tmp_path):
     assert load_results(str(tmp_path), workspace_id=999) is None
 
 
+# -- prune_results --
+
+
+def _write_cache(cache_dir, workspace_id, data):
+    path = os.path.join(cache_dir, f"pipeline_results_ws{workspace_id}.json")
+    with open(path, "w") as f:
+        json.dump(data, f)
+    return path
+
+
+def _sample_cache():
+    return {
+        "encounters": [
+            {
+                "species": "American Robin",
+                "confirmed_species": None,
+                "species_predictions": [],
+                "species_confirmed": False,
+                "photo_count": 3,
+                "burst_count": 2,
+                "time_range": ["2026-03-20T10:00:00", "2026-03-20T10:00:04"],
+                "photo_ids": [1, 2, 3],
+                "bursts": [
+                    {"photo_ids": [1, 2], "species_predictions": [], "species_override": None},
+                    {"photo_ids": [3], "species_predictions": [], "species_override": None},
+                ],
+            },
+            {
+                "species": "Blue Jay",
+                "confirmed_species": None,
+                "species_predictions": [],
+                "species_confirmed": False,
+                "photo_count": 2,
+                "burst_count": 1,
+                "time_range": ["2026-03-20T10:05:00", "2026-03-20T10:05:02"],
+                "photo_ids": [4, 5],
+                "bursts": [
+                    {"photo_ids": [4, 5], "species_predictions": [], "species_override": None},
+                ],
+            },
+        ],
+        "photos": [
+            {"id": 1, "label": "KEEP", "rarity_protected": False},
+            {"id": 2, "label": "REJECT", "rarity_protected": False},
+            {"id": 3, "label": "REVIEW", "rarity_protected": True},
+            {"id": 4, "label": "KEEP", "rarity_protected": False},
+            {"id": 5, "label": "REJECT", "rarity_protected": False},
+        ],
+        "summary": {
+            "total_photos": 5,
+            "encounter_count": 2,
+            "burst_count": 3,
+            "keep_count": 2,
+            "review_count": 1,
+            "reject_count": 2,
+            "rarity_protected": 1,
+        },
+    }
+
+
+def test_prune_results_removes_deleted_ids(tmp_path):
+    """Deleted photo IDs are stripped from photos and encounter/burst photo_ids."""
+    from pipeline import load_results, prune_results
+
+    _write_cache(str(tmp_path), 1, _sample_cache())
+    changed = prune_results(str(tmp_path), 1, [2, 5])
+
+    assert changed is True
+    loaded = load_results(str(tmp_path), 1)
+    assert [p["id"] for p in loaded["photos"]] == [1, 3, 4]
+    assert loaded["encounters"][0]["photo_ids"] == [1, 3]
+    assert loaded["encounters"][1]["photo_ids"] == [4]
+    assert loaded["encounters"][0]["bursts"][0]["photo_ids"] == [1]
+    assert loaded["encounters"][0]["bursts"][1]["photo_ids"] == [3]
+    assert loaded["encounters"][1]["bursts"][0]["photo_ids"] == [4]
+
+
+def test_prune_results_drops_empty_encounters_and_bursts(tmp_path):
+    """An encounter (or burst) whose every photo was deleted is dropped."""
+    from pipeline import load_results, prune_results
+
+    _write_cache(str(tmp_path), 1, _sample_cache())
+    # Delete the entire second encounter and the second burst of the first.
+    prune_results(str(tmp_path), 1, [3, 4, 5])
+
+    loaded = load_results(str(tmp_path), 1)
+    assert len(loaded["encounters"]) == 1
+    assert loaded["encounters"][0]["photo_ids"] == [1, 2]
+    assert len(loaded["encounters"][0]["bursts"]) == 1
+    assert loaded["encounters"][0]["bursts"][0]["photo_ids"] == [1, 2]
+
+
+def test_prune_results_recomputes_counts(tmp_path):
+    """photo_count, burst_count, and summary are recomputed from survivors."""
+    from pipeline import load_results, prune_results
+
+    _write_cache(str(tmp_path), 1, _sample_cache())
+    prune_results(str(tmp_path), 1, [2, 5])
+
+    loaded = load_results(str(tmp_path), 1)
+    assert loaded["encounters"][0]["photo_count"] == 2
+    assert loaded["encounters"][0]["burst_count"] == 2
+    assert loaded["encounters"][1]["photo_count"] == 1
+    assert loaded["encounters"][1]["burst_count"] == 1
+
+    summary = loaded["summary"]
+    assert summary["total_photos"] == 3
+    assert summary["encounter_count"] == 2
+    assert summary["burst_count"] == 3
+    assert summary["keep_count"] == 2
+    assert summary["review_count"] == 1
+    assert summary["reject_count"] == 0
+    assert summary["rarity_protected"] == 1
+
+
+def test_prune_results_no_overlap_returns_false(tmp_path):
+    """If no deleted IDs intersect the cache, the file is unchanged."""
+    from pipeline import prune_results
+
+    path = _write_cache(str(tmp_path), 1, _sample_cache())
+    mtime = os.path.getmtime(path)
+
+    changed = prune_results(str(tmp_path), 1, [99, 100])
+
+    assert changed is False
+    assert os.path.getmtime(path) == mtime
+
+
+def test_prune_results_missing_cache_is_noop(tmp_path):
+    """No cache file → prune_results returns False, does not raise."""
+    from pipeline import prune_results
+
+    assert prune_results(str(tmp_path), 1, [1, 2, 3]) is False
+
+
+def test_prune_results_empty_id_list(tmp_path):
+    """Empty deleted-id list → no-op."""
+    from pipeline import prune_results
+
+    path = _write_cache(str(tmp_path), 1, _sample_cache())
+    mtime = os.path.getmtime(path)
+
+    assert prune_results(str(tmp_path), 1, []) is False
+    assert os.path.getmtime(path) == mtime
+
+
 # -- compute_review_readiness --
 
 


### PR DESCRIPTION
## Summary
- Deleting photos on the browse page was leaving stale entries in `pipeline_results_ws{N}.json`, so the pipeline review page kept rendering cards for photos whose thumbnails were gone — the user saw blank cards.
- Added `pipeline.prune_results(cache_dir, workspace_id, deleted_ids)` which strips deleted IDs from the cached `photos` list, every encounter's `photo_ids`, every burst's `photo_ids`, drops empty encounters/bursts, and recomputes `photo_count` / `burst_count` / `summary` from survivors.
- `db.delete_photos` calls it after the commit, matching the existing new-images-cache invalidation pattern (`vireo/db.py:3982`). Pruning preserves the rest of the expensive pipeline output (masks, embeddings, species predictions for surviving photos), so culling a few photos doesn't force a full pipeline rerun.

## Test plan
- [x] New unit tests in `vireo/tests/test_pipeline.py` cover: removes deleted IDs from photos/encounters/bursts, drops empty encounters and bursts, recomputes counts and summary, no-op on empty input / missing cache / no overlap.
- [x] New integration tests in `vireo/tests/test_delete_api.py` cover: `db.delete_photos` prunes the cache, and succeeds when no cache exists.
- [x] Full required suite (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_pipeline.py vireo/tests/test_delete_api.py`) — **981 passed, 1 skipped, 2 failed** in 47:36.
- [x] The two failures (`test_edits_api.py::test_remove_keyword_from_photo`, `test_undo_keyword_remove_clears_pending_change`) are pre-existing test-suite pollution: `test_edits_api.py` passes 41/41 in isolation against this branch, and both tests pass when run in isolation against `main`. Not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)