### PR TITLE
fix(review): lay out burst-strip imgs at natural size for true 1:1 zoom

### DIFF
--- a/tests/e2e/test_burst_group_natural_size.py
+++ b/tests/e2e/test_burst_group_natural_size.py
@@ -1,0 +1,175 @@
+"""Verify burst-loupe strip imgs are laid out at natural source-pixel size.
+
+This guards the WKWebView quality regression: when a strip <img> is laid
+out at 180x120 and then scaled up via `transform: scale(N)`, browsers
+rasterize the layer at 180x120 first and bilinearly upscale. The fix is
+to give each <img> inline width/height equal to its served source-pixel
+dimensions and use transform-scale only to shrink it into the viewport.
+
+These tests assert the layout invariant (img CSS width == naturalWidth)
+rather than visual pixel quality, since the latter is hard to test
+deterministically across browser engines.
+"""
+import os
+
+import pytest
+from PIL import Image
+from playwright.sync_api import expect
+
+
+def _seed_burst_with_real_photos(db, thumb_dir, group_id="grp-natural-1",
+                                  model="BioCLIP-2"):
+    """Seed three Red-tailed Hawk predictions with on-disk photos that have
+    real width/height metadata. Photos are 600x400 jpeg so /photos/<id>/original
+    yields a small but real image whose naturalWidth/Height we can assert.
+    """
+    rows = db.conn.execute(
+        """SELECT pr.id, d.photo_id, p.folder_id, p.filename
+             FROM predictions pr
+             JOIN detections d ON d.id = pr.detection_id
+             JOIN photos p ON p.id = d.photo_id
+            WHERE pr.species = 'Red-tailed Hawk'
+              AND pr.classifier_model = ?""",
+        (model,),
+    ).fetchall()
+    if not rows:
+        return 0
+    total = len(rows)
+    ws_id = db._active_workspace_id
+    for i, row in enumerate(rows):
+        db.conn.execute(
+            """INSERT INTO prediction_review
+                 (prediction_id, workspace_id, status,
+                  group_id, vote_count, total_votes)
+               VALUES (?, ?, 'pending', ?, ?, ?)
+               ON CONFLICT(prediction_id, workspace_id)
+               DO UPDATE SET group_id = excluded.group_id,
+                             vote_count = excluded.vote_count,
+                             total_votes = excluded.total_votes""",
+            (row["id"], ws_id, group_id, total, total),
+        )
+        db.conn.execute(
+            """UPDATE photos
+                 SET quality_score = ?, subject_sharpness = ?,
+                     width = ?, height = ?
+               WHERE id = ?""",
+            (0.5 + 0.1 * i, 100 + 10 * i, 600, 400, row["photo_id"]),
+        )
+    db.conn.commit()
+    return total
+
+
+def _ensure_photo_files_on_disk(db, tmp_path):
+    """The /photos/<id>/original endpoint reads from disk, so we need real
+    files at the photo paths. Write 600x400 JPEGs.
+    """
+    rows = db.conn.execute(
+        """SELECT p.id, p.filename, f.path
+             FROM photos p
+             JOIN folders f ON f.id = p.folder_id
+            WHERE p.filename LIKE 'hawk%'"""
+    ).fetchall()
+    base = str(tmp_path / "hawk_photos")
+    os.makedirs(base, exist_ok=True)
+    for row in rows:
+        # The folder.path in the seed is /photos/park, but that doesn't exist
+        # on the test machine. Patch it to a real tmp dir.
+        new_dir = base
+        new_path = os.path.join(new_dir, row["filename"])
+        Image.new("RGB", (600, 400), color=(80, 120, 160)).save(new_path, "JPEG")
+        db.conn.execute(
+            "UPDATE folders SET path = ? WHERE id = (SELECT folder_id FROM photos WHERE id = ?)",
+            (new_dir, row["id"]),
+        )
+    db.conn.commit()
+
+
+def _open_burst_modal(page):
+    trigger = page.locator("button[data-group-id]").first
+    expect(trigger).to_be_visible()
+    trigger.click()
+    page.locator("#grmOverlay .grm-card[data-photo-id]").first.wait_for(
+        state="visible", timeout=2000
+    )
+
+
+def test_burst_card_img_laid_out_at_natural_size(live_server, page, tmp_path):
+    """After upgrading the strip to original (via wheel zoom), each <img>
+    should have inline CSS width/height equal to the server's served image
+    dimensions. This proves the rasterized layer is at full source size
+    instead of being upscaled from a tiny tile.
+    """
+    db = live_server["db"]
+    n = _seed_burst_with_real_photos(db, tmp_path)
+    if n < 1:
+        pytest.skip("could not seed burst group")
+    _ensure_photo_files_on_disk(db, tmp_path)
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    # Trigger a wheel zoom on the loupe so the strip upgrades to /original.
+    loupe = page.locator("#grmLoupeImg")
+    loupe.dispatch_event("wheel", {"deltaY": -100, "clientX": 200, "clientY": 200})
+
+    # Wait for at least one card img to load at the original.
+    page.wait_for_function(
+        """() => {
+          const imgs = document.querySelectorAll('.grm-card img');
+          return Array.from(imgs).some(img => img.complete && img.naturalWidth > 100);
+        }""",
+        timeout=4000,
+    )
+
+    # Assert: the card img's inline style.width matches its naturalWidth.
+    result = page.evaluate(
+        """() => {
+          const imgs = document.querySelectorAll('.grm-card img');
+          return Array.from(imgs).map(img => ({
+            inlineW: img.style.width,
+            inlineH: img.style.height,
+            naturalW: img.naturalWidth,
+            naturalH: img.naturalHeight,
+            complete: img.complete,
+          }));
+        }"""
+    )
+    assert result, "no .grm-card imgs found"
+    # At least one fully-loaded img should have inline dims matching naturalWidth.
+    matched = [
+        r for r in result
+        if r["complete"] and r["naturalW"] > 0
+        and r["inlineW"] == f"{r['naturalW']}px"
+        and r["inlineH"] == f"{r['naturalH']}px"
+    ]
+    assert matched, (
+        f"no card img has inline width matching naturalWidth — got {result}. "
+        "This means the layer is being rasterized at the wrong size, which "
+        "is the WKWebView upscaling bug this fix is meant to prevent."
+    )
+
+
+def test_burst_card_box_is_180x120(live_server, page, tmp_path):
+    """The 180x120 viewport stays the visible card box; the natural-size
+    <img> inside is clipped via overflow:hidden on .grm-card-img-box.
+    """
+    db = live_server["db"]
+    n = _seed_burst_with_real_photos(db, tmp_path)
+    if n < 1:
+        pytest.skip("could not seed burst group")
+    _ensure_photo_files_on_disk(db, tmp_path)
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    # The image-box wrapper should be exactly 180x120.
+    box = page.locator(".grm-card .grm-card-img-box").first
+    expect(box).to_be_visible()
+    bbox = box.bounding_box()
+    assert bbox is not None
+    assert abs(bbox["width"] - 180) < 1, f"box width {bbox['width']} != 180"
+    assert abs(bbox["height"] - 120) < 1, f"box height {bbox['height']} != 120"

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3158,7 +3158,14 @@ function grmCardMouseMove(e) {
   if (!_grmDragging.moved) return;
   // Use the actual displayed scale so dx/dy in screen pixels translate to
   // pre-scale offset units that, when re-scaled, follow the cursor 1:1.
-  var scale = grmBaseScale() * _grmZoomMultiplier;
+  // Must mirror _grmComputeCardTransform's hover/non-hover branch: after a
+  // zoom-in followed by mouseleave (grmLoupeReset clears _grmLastHoverX) the
+  // card is displayed at cover-fit while _grmZoomMultiplier stays >1, so a
+  // naive `coverFit * multiplier` denominator would shrink drag motion by
+  // that factor and pans would jump when hover resumes.
+  var coverFit = grmCardCoverFit(_grmDragging.card);
+  var hovering = _grmLastHoverX != null;
+  var scale = hovering ? Math.max(coverFit, coverFit * _grmZoomMultiplier) : coverFit;
   var z = scale > 0.01 ? scale : 1;
   var newTx = _grmDragging.origTx + dx / z;
   var newTy = _grmDragging.origTy + dy / z;

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -855,11 +855,24 @@ input[type="range"]::-moz-range-thumb {
 }
 .grm-reset-offsets-btn.visible { display: inline-block; }
 .grm-reset-offsets-btn:hover { color: var(--text-primary); }
-.grm-card img {
-  width: 100%;
-  aspect-ratio: 3/2;
-  object-fit: cover;
+/* Card image is laid out at its natural source-pixel size and then scaled
+ * down via CSS transform into the 180x120 viewport. Laying out at natural
+ * size forces the browser to rasterize the layer at full source resolution,
+ * so detail survives the transform — instead of being bilinearly upsampled
+ * from a tiny pre-scale bitmap (the WKWebView burst-loupe quality bug). */
+.grm-card-img-box {
+  width: 180px;
+  height: 120px;
+  position: relative;
+  overflow: hidden;
+}
+.grm-card-img-box img {
+  position: absolute;
+  top: 0;
+  left: 0;
   display: block;
+  transform-origin: 0 0;
+  /* Inline style.width / style.height set per-card in JS to natural size. */
 }
 .grm-card-info {
   padding: 6px 8px;
@@ -1338,19 +1351,30 @@ function grmUpdateResLabel() {
 
 function grmSetResolution(idx) {
   grmResolutionIdx = parseInt(idx, 10) || 0;
-  // Update card image sources in place (preserves zoom transforms so the
-  // loupe stays locked on the current region while the slider drags).
+  // Update card image sources AND natural-size layout in place. Preserving
+  // the zoom transforms keeps the loupe locked on the current region while
+  // the slider drags. Each card's <img> is laid out at the new served
+  // resolution so the rasterized layer matches what's actually being served.
   document.querySelectorAll('#grmOverlay .grm-card').forEach(function(card) {
     var pid = parseInt(card.getAttribute('data-photo-id'), 10);
     if (!pid) return;
     var img = card.querySelector('img');
-    if (img) img.src = grmPhotoUrl(pid);
+    if (!img) return;
+    var photo = grmState && grmState.items
+      ? grmState.items.find(function(p) { return p.id === pid; })
+      : null;
+    var nat = grmNaturalDims(photo);
+    card.dataset.natW = nat.w;
+    card.dataset.natH = nat.h;
+    img.style.width = nat.w + 'px';
+    img.style.height = nat.h + 'px';
+    img.src = grmPhotoUrl(pid);
   });
   if (grmState && grmState.selected) {
     var loupe = document.getElementById('grmLoupePhoto');
     if (loupe) loupe.src = grmPhotoUrl(grmState.selected);
   }
-  // Re-apply card transforms so the zoom factor matches the new 1:1 scale.
+  // Re-apply card transforms so cover-fit snaps to the new natural size.
   grmApplyCardTransforms();
   grmUpdateResLabel();
 }
@@ -2732,12 +2756,16 @@ function renderGroupModal() {
     if (p.flag === 'flagged') flagHtml = '<span class="photo-flag-badge flag-flagged" style="bottom:auto;top:4px;left:4px;">P</span>';
     else if (p.flag === 'rejected') flagHtml = '<span class="photo-flag-badge flag-rejected" style="bottom:auto;top:4px;left:4px;">X</span>';
 
+    var nat = grmNaturalDims(p);
+    var imgStyle = 'width:' + nat.w + 'px;height:' + nat.h + 'px;';
     return '<div class="' + cls + '" data-photo-id="' + p.id + '"' +
+        ' data-nat-w="' + nat.w + '" data-nat-h="' + nat.h + '"' +
         ' onmousedown="grmCardMouseDown(event)"' +
         ' onclick="grmCardClick(event, ' + p.id + ')"' +
         ' ondblclick="grmCardDblClick(event)">' +
-      '<div style="position:relative;">' +
-        '<img src="' + grmPhotoUrl(p.id) + '" loading="lazy" draggable="false">' +
+      '<div class="grm-card-img-box">' +
+        '<img src="' + grmPhotoUrl(p.id) + '" style="' + imgStyle + '"' +
+          ' onload="grmCardImgLoaded(this)" loading="lazy" draggable="false">' +
         flagHtml +
       '</div>' +
       '<div class="grm-card-info">' +
@@ -2764,14 +2792,13 @@ function renderGroupModal() {
 
   document.getElementById('grmCount').textContent = pickItems.length + ' picks, ' + rejectItems.length + ' rejects, ' + candidateItems.length + ' unsorted';
 
-  // Re-apply offset indicators and — if the loupe is currently zoomed — the
-  // per-card transforms, since innerHTML wipes them on every re-render.
+  // Re-apply offset indicators and the per-card transforms (cover-fit always
+  // needs an explicit transform now that <img>s are laid out at natural
+  // source-pixel size). innerHTML wipes inline styles on every re-render.
   document.querySelectorAll('#grmOverlay .grm-card').forEach(function(card) {
     _grmUpdateIndicator(card);
   });
-  if (_grmLastHoverX != null) {
-    grmApplyCardTransforms();
-  }
+  grmApplyCardTransforms();
   grmRefreshResetAllVisibility();
 }
 
@@ -2911,52 +2938,131 @@ var _grmOffsets = {};
 var _grmDragging = null;
 var _grmSuppressNextClick = false;
 
-function grmBaseScale() {
-  // 1:1 source-to-display scale for the current resolution stop, assuming
-  // all cards share the first photo's aspect ratio (true for a burst).
+// Compute the served image's natural dimensions for the current resolution
+// slider stop. The browser will lay the <img> out at exactly these CSS
+// pixels, so the transform-scale layer is rasterized at full source size
+// instead of upscaled from a 180x120 tile (the WKWebView quality bug).
+//
+// Returns expected dims; on image load `grmCardImgLoaded` reconciles against
+// the actual `naturalWidth/Height` (which can differ for NEFs that fall back
+// to an embedded JPEG of a different size).
+function grmNaturalDims(photo) {
   var stop = GRM_RES_STOPS[grmResolutionIdx];
-  var photo = grmState && grmState.selected
-    ? grmState.items.find(function(p) { return p.id === grmState.selected; })
-    : (grmState && grmState.items[0]);
-  if (!photo || !photo.width || !photo.height) return 4;
-  var W = photo.width, H = photo.height;
+  // Sensible defaults when photo dims are unknown — match the historical
+  // 3:2 cover-fit so the card still looks right before metadata loads.
+  var W = (photo && photo.width) ? photo.width : 1800;
+  var H = (photo && photo.height) ? photo.height : 1200;
   if (stop.kind !== 'original') {
     var longest = Math.max(W, H);
     if (longest > stop.size) {
       var r = stop.size / longest;
-      W = W * r;
-      H = H * r;
+      W = Math.round(W * r);
+      H = Math.round(H * r);
     }
   }
-  var coverRatio = Math.max(GRM_CARD_W / W, GRM_CARD_H / H);
-  return 1 / coverRatio;
+  return { w: W, h: H };
+}
+
+// Cover-fit scale for one card: the smallest scale at which the image still
+// covers the 180x120 viewport. Matches the prior "no-zoom" visible state.
+function grmCardCoverFit(card) {
+  var W = parseFloat(card.dataset.natW) || GRM_CARD_W;
+  var H = parseFloat(card.dataset.natH) || GRM_CARD_H;
+  return Math.max(GRM_CARD_W / W, GRM_CARD_H / H);
+}
+
+// Effective max for `_grmZoomMultiplier`. Multiplier=1 = cover-fit (today's
+// default visual). To reach 1:1 source-to-CSS we need multiplier ~ 1/coverFit
+// (e.g. ~30 for a 5400px-wide image). To reach 1:1 source-to-DEVICE pixels
+// (true pixel-peep on a Retina display), multiplier ~ DPR/coverFit.
+function grmMaxZoomMultiplier() {
+  var dpr = window.devicePixelRatio || 1;
+  var card = document.querySelector('#grmOverlay .grm-card');
+  if (!card) return 30 * dpr;
+  var coverFit = grmCardCoverFit(card);
+  if (!coverFit) return 30 * dpr;
+  return Math.max(3, dpr / coverFit);
+}
+
+// Compute the transform for one card. Returns the CSS transform string and
+// flags whether the user is in the zoomed (hover) state.
+function _grmComputeCardTransform(card) {
+  var W = parseFloat(card.dataset.natW) || GRM_CARD_W;
+  var H = parseFloat(card.dataset.natH) || GRM_CARD_H;
+  var coverFit = Math.max(GRM_CARD_W / W, GRM_CARD_H / H);
+  var hovering = _grmLastHoverX != null;
+  // Scale: cover-fit when not hovering; cover-fit * multiplier when hovering.
+  // Floor at coverFit so a fractional multiplier never reveals card background.
+  var s = coverFit;
+  if (hovering) {
+    s = Math.max(coverFit, coverFit * _grmZoomMultiplier);
+  }
+  // Hover-anchor: cursor at fractional position f of the loupe maps to the
+  // same fractional position in the source image. Place pixel (f*W, f*H) of
+  // the image at card pixel (f*180, f*120). Default (no hover) = centre.
+  var hx = hovering ? (_grmLastHoverX / 100) : 0.5;
+  var hy = hovering ? (_grmLastHoverY / 100) : 0.5;
+  var baseTx = hx * (GRM_CARD_W - W * s);
+  var baseTy = hy * (GRM_CARD_H - H * s);
+  var off = _grmOffsets[card.dataset.photoId] || { tx: 0, ty: 0 };
+  // User pan offsets are stored in pre-scale (image-coordinate) CSS pixels,
+  // so they translate by `off * s` in card-coordinate pixels after the scale.
+  var tx = baseTx + off.tx * s;
+  var ty = baseTy + off.ty * s;
+  return {
+    transform: 'translate(' + tx + 'px, ' + ty + 'px) scale(' + s + ')',
+    scale: s,
+    zoomed: hovering,
+  };
 }
 
 function grmApplyCardTransforms() {
-  if (_grmLastHoverX == null) return;
-  var scale = grmBaseScale() * _grmZoomMultiplier;
-  var origin = _grmLastHoverX + '% ' + _grmLastHoverY + '%';
   document.querySelectorAll('#grmOverlay .grm-card').forEach(function(card) {
     var img = card.querySelector('img');
     if (!img) return;
-    var off = _grmOffsets[card.dataset.photoId] || { tx: 0, ty: 0 };
-    img.style.transformOrigin = origin;
-    // scale × translate: translate is in pre-scale CSS pixels, so per-photo
-    // pan offsets stay correct as the shared zoom changes.
-    img.style.transform = 'scale(' + scale + ') translate(' + off.tx + 'px, ' + off.ty + 'px)';
-    img.parentElement.classList.add('zoomed');
+    var t = _grmComputeCardTransform(card);
+    img.style.transform = t.transform;
+    var box = img.parentElement;
+    if (box) box.classList.toggle('zoomed', t.zoomed);
   });
 }
 
 function _grmApplyCardTransform(card) {
-  if (_grmLastHoverX == null) return;
   var img = card.querySelector('img');
   if (!img) return;
-  var off = _grmOffsets[card.dataset.photoId] || { tx: 0, ty: 0 };
-  var scale = grmBaseScale() * _grmZoomMultiplier;
-  img.style.transformOrigin = _grmLastHoverX + '% ' + _grmLastHoverY + '%';
-  img.style.transform = 'scale(' + scale + ') translate(' + off.tx + 'px, ' + off.ty + 'px)';
-  img.parentElement.classList.add('zoomed');
+  var t = _grmComputeCardTransform(card);
+  img.style.transform = t.transform;
+  var box = img.parentElement;
+  if (box) box.classList.toggle('zoomed', t.zoomed);
+}
+
+// `grmBaseScale()` retained for any external callers / tests. Reports the
+// effective display scale for the currently selected card.
+function grmBaseScale() {
+  var card = grmState && grmState.selected
+    ? document.querySelector('#grmOverlay .grm-card[data-photo-id="' + grmState.selected + '"]')
+    : document.querySelector('#grmOverlay .grm-card');
+  if (!card) return 1;
+  return grmCardCoverFit(card);
+}
+
+// Reconcile an `<img>`'s declared size against the dimensions the browser
+// actually decoded. Some NEFs fall back to an embedded JPEG that differs
+// from the stored width/height; the natural-size layout must use the truth
+// or the rasterized layer will be the wrong resolution.
+function grmCardImgLoaded(img) {
+  if (!img || !img.naturalWidth || !img.naturalHeight) return;
+  var card = img.closest('.grm-card');
+  if (!card) return;
+  var declaredW = parseFloat(card.dataset.natW) || 0;
+  var declaredH = parseFloat(card.dataset.natH) || 0;
+  if (img.naturalWidth !== declaredW || img.naturalHeight !== declaredH) {
+    card.dataset.natW = img.naturalWidth;
+    card.dataset.natH = img.naturalHeight;
+    img.style.width = img.naturalWidth + 'px';
+    img.style.height = img.naturalHeight + 'px';
+    _grmApplyCardTransform(card);
+  }
 }
 
 function grmLoupeToggleLock(e) {
@@ -2990,8 +3096,12 @@ function grmLoupeMove(e) {
 
 function grmLoupeZoom(e) {
   e.preventDefault();
+  // Multiplier=1 = cover-fit (no zoom). Allow scaling up well past 1.0 to
+  // reach 1:1 source-to-CSS pixels and beyond to 1:1 source-to-DEVICE pixels
+  // on Retina (DPR) displays — the actual pixel-peep target.
+  var max = grmMaxZoomMultiplier();
   if (e.deltaY < 0) {
-    _grmZoomMultiplier = Math.min(3, _grmZoomMultiplier * 1.25);
+    _grmZoomMultiplier = Math.min(max, _grmZoomMultiplier * 1.25);
   } else {
     _grmZoomMultiplier = Math.max(0.33, _grmZoomMultiplier / 1.25);
   }
@@ -3003,11 +3113,10 @@ function grmLoupeReset() {
   if (_grmDragging) return;
   _grmLastHoverX = null;
   _grmLastHoverY = null;
-  document.querySelectorAll('#grmOverlay .grm-card img').forEach(function(img) {
-    img.style.transform = '';
-    img.style.transformOrigin = '';
-    img.parentElement.classList.remove('zoomed');
-  });
+  // Re-apply transforms in their default (non-hovered, cover-fit, centred)
+  // state. We can't just clear `style.transform` because the natural-size
+  // <img> needs a scale-down transform at all times to fit the 180x120 box.
+  grmApplyCardTransforms();
 }
 
 /* --- Per-photo pan (drag a thumbnail to nudge it within its panel) --- */

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1794,9 +1794,11 @@ function grmLoupeZoom(e) {
 
 function grmSnapOneToOne() {
   // Lightroom-style 1:1: zoom factor that makes one source pixel == one CSS pixel.
+  // Upgrade to original-resolution dims first so the multiplier is computed
+  // against full natW/natH, not the 400px thumbnail layout.
+  _grmUpgradeStripToOriginal();
   var mult = _grmOneToOneMultiplier();
   if (mult == null) return;
-  _grmUpgradeStripToOriginal();
   _grmZoomLevel = Math.max(1, mult);
   _grmLoupeHovering = true;
   _grmApplyAllCardTransforms(_grmLoupeLastX, _grmLoupeLastY);

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1399,6 +1399,7 @@ function openGroupReview(groupId, model) {
   _grmLoupeLastX = 50;
   _grmLoupeLastY = 50;
   _grmLoupeHovering = false;
+  _grmPendingSnap = false;
   grmRefreshResetAllVisibility();
   document.getElementById('grmOverlay').classList.add('open');
   loadGroupData(groupId);
@@ -1601,6 +1602,12 @@ var _grmLoupeLastY = 50;
 // Whether the loupe has received a real hover (vs. just the centre default).
 // Used to decide between cover-fit (no-hover) and zoom (hover) per card.
 var _grmLoupeHovering = false;
+// True when grmSnapOneToOne is awaiting the selected card's natural dims
+// (the original image is still loading and may be EXIF-rotated relative to
+// stored item.width/height). grmCardImgLoaded finishes the snap once it
+// reconciles dims so the 1:1 zoom is computed against the axes the browser
+// actually paints.
+var _grmPendingSnap = false;
 
 // Natural-size dims for one card. When the strip is still on the 400px
 // thumbnail, we use a 400px-fit; once upgraded to /original we use the
@@ -1649,7 +1656,8 @@ function _grmUpgradeStripToOriginal() {
 
 function grmCardImgLoaded(img) {
   // Reconcile declared natural dims against what the browser actually decoded
-  // (NEFs may fall back to an embedded JPEG of a different size).
+  // (NEFs may fall back to an embedded JPEG of a different size; EXIF-rotated
+  // JPEGs render with swapped axes vs. our stored pre-orientation dims).
   if (!img || !img.naturalWidth || !img.naturalHeight) return;
   var card = img.closest('.grm-card');
   if (!card) return;
@@ -1661,6 +1669,15 @@ function grmCardImgLoaded(img) {
     img.style.width = img.naturalWidth + 'px';
     img.style.height = img.naturalHeight + 'px';
     _grmApplyCardTransform(card);
+  }
+  // If the user pressed `1` before this card's natural dims were known,
+  // finish the snap now that we have the axes the browser actually paints.
+  // Without this, EXIF-rotated photos snap to a multiplier computed from
+  // pre-orientation (swapped) dims and land at the wrong zoom level.
+  if (_grmPendingSnap && grmState && grmState.selected != null
+      && String(card.dataset.photoId) === String(grmState.selected)) {
+    _grmPendingSnap = false;
+    _grmFinishSnap();
   }
 }
 
@@ -1773,6 +1790,8 @@ function _grmApplyCardTransform(card) {
 
 function grmLoupeZoom(e) {
   e.preventDefault();
+  // Wheel input is an explicit override of any pending 1:1 snap.
+  _grmPendingSnap = false;
   var max = _grmMaxZoom();
   // Multiplicative zoom: each tick scales by 1.25, so reaching 30x (a
   // typical CSS 1:1 multiplier for a 5400px image) takes ~16 ticks.
@@ -1797,6 +1816,27 @@ function grmSnapOneToOne() {
   // Upgrade to original-resolution dims first so the multiplier is computed
   // against full natW/natH, not the 400px thumbnail layout.
   _grmUpgradeStripToOriginal();
+  // For EXIF-rotated photos, item.width/height are pre-orientation while the
+  // browser paints with swapped axes. Defer the multiplier until the original
+  // <img> has loaded and grmCardImgLoaded has reconciled data-nat-w/h with
+  // naturalWidth/naturalHeight, so the snap lands at true 1:1.
+  var card = grmState.selected
+    ? document.querySelector('.grm-card[data-photo-id="' + grmState.selected + '"]')
+    : null;
+  var img = card ? card.querySelector('img') : null;
+  if (img && img.complete && img.naturalWidth && img.naturalHeight) {
+    var dw = parseFloat(card.dataset.natW) || 0;
+    var dh = parseFloat(card.dataset.natH) || 0;
+    if (img.naturalWidth === dw && img.naturalHeight === dh) {
+      _grmPendingSnap = false;
+      _grmFinishSnap();
+      return;
+    }
+  }
+  _grmPendingSnap = true;
+}
+
+function _grmFinishSnap() {
   var mult = _grmOneToOneMultiplier();
   if (mult == null) return;
   _grmZoomLevel = Math.max(1, mult);

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -438,11 +438,24 @@
   }
   .grm-reset-offsets-btn.visible { display: inline-block; }
   .grm-reset-offsets-btn:hover { color: var(--text-primary, #E0F0F0); }
-  .grm-card img {
-    width: 100%;
-    aspect-ratio: 3/2;
-    object-fit: cover;
+  /* Card image is laid out at its natural source-pixel size and then scaled
+   * down via CSS transform into the 180x120 viewport. Laying out at natural
+   * size forces the browser to rasterize the layer at full source resolution,
+   * so detail survives the transform — instead of being bilinearly upsampled
+   * from a tiny pre-scale bitmap (the WKWebView burst-loupe quality bug). */
+  .grm-card-img-box {
+    width: 180px;
+    height: 120px;
+    position: relative;
+    overflow: hidden;
+  }
+  .grm-card-img-box img {
+    position: absolute;
+    top: 0;
+    left: 0;
     display: block;
+    transform-origin: 0 0;
+    /* Inline style.width / style.height set per-card in JS to natural size. */
   }
   .grm-card-info {
     padding: 6px 8px;
@@ -1376,13 +1389,16 @@ var grmState = { groupId: null, model: null, items: [], picks: new Set(), reject
 function openGroupReview(groupId, model) {
   grmState = { groupId: groupId, model: model, items: [], picks: new Set(), rejects: new Set(), removed: new Set(), selected: null, upgraded: false };
   _grmLoupeLocked = false;
-  // Reset zoom state so a high zoom from a prior burst doesn't leak into this modal.
-  _grmZoomLevel = 4;
+  // Reset zoom state so a high zoom from a prior burst doesn't leak in. With
+  // the natural-size layout, _grmZoomLevel is now a multiplier above
+  // cover-fit (1 = no zoom).
+  _grmZoomLevel = 1;
   _grmOffsets = {};
   _grmDragging = null;
   _grmSuppressNextClick = false;
   _grmLoupeLastX = 50;
   _grmLoupeLastY = 50;
+  _grmLoupeHovering = false;
   grmRefreshResetAllVisibility();
   document.getElementById('grmOverlay').classList.add('open');
   loadGroupData(groupId);
@@ -1451,11 +1467,17 @@ function renderGroupModal() {
     var src = grmState.upgraded
       ? '/photos/' + it.photo_id + '/original'
       : '/thumbnails/' + it.photo_id + '.jpg';
+    var nat = _grmReviewNaturalDims(it, grmState.upgraded);
+    var imgStyle = 'width:' + nat.w + 'px;height:' + nat.h + 'px;';
     return '<div class="' + cls + '" data-photo-id="' + it.photo_id + '" data-pred-id="' + it.id + '"' +
+      ' data-nat-w="' + nat.w + '" data-nat-h="' + nat.h + '"' +
       ' onmousedown="grmCardMouseDown(event)"' +
       ' onclick="grmCardClick(event, ' + it.photo_id + ')"' +
       ' ondblclick="grmCardDblClick(event)">' +
-      '<img src="' + src + '" loading="lazy" draggable="false">' +
+      '<div class="grm-card-img-box">' +
+      '<img src="' + src + '" style="' + imgStyle + '"' +
+        ' onload="grmCardImgLoaded(this)" loading="lazy" draggable="false">' +
+      '</div>' +
       '<div class="grm-card-info">' +
         '<div class="grm-card-species">' + escapeHtml(it.species || '') + ' <span style="font-weight:400;color:var(--text-dim,#888);">' + confPct + '%</span></div>' +
         '<div class="grm-card-scores">Q: <span class="score-val">' + qScore + '</span> S: <span class="score-val">' + sharp + '</span></div>' +
@@ -1499,14 +1521,13 @@ function renderGroupModal() {
 
   document.getElementById('grmCount').textContent = pickItems.length + ' picks, ' + rejectItems.length + ' rejects, ' + candidateItems.length + ' unsorted';
 
-  // Re-apply offset indicators and — if the loupe is currently zoomed — the
-  // per-card transforms, since innerHTML wipes them on every re-render.
+  // Re-apply offset indicators and the per-card transforms — cover-fit
+  // always needs an explicit transform now that <img>s are laid out at
+  // natural source-pixel size. innerHTML wipes inline styles each render.
   document.querySelectorAll('.grm-card').forEach(function(card) {
     _grmUpdateIndicator(card);
   });
-  if (_grmLoupeLocked) {
-    _grmApplyAllCardTransforms(_grmLoupeLastX, _grmLoupeLastY);
-  }
+  _grmApplyAllCardTransforms(_grmLoupeLastX, _grmLoupeLastY);
   grmRefreshResetAllVisibility();
 }
 
@@ -1555,12 +1576,19 @@ function renderLoupePreds(item) {
   }).join('');
 }
 
-var _grmZoomLevel = 4;
+// Multiplier above each card's cover-fit scale. 1 = cover-fit (no zoom);
+// values past 1 zoom in towards CSS 1:1 and beyond to device 1:1 on Retina.
+var _grmZoomLevel = 1;
+// Card thumbnails are 180px wide x 120px tall (3:2). The image inside is
+// laid out at the served photo's natural pixel dimensions; transform-scale
+// shrinks it to fit the viewport.
+var GRM_CARD_W = 180;
+var GRM_CARD_H = 120;
 var _grmLoupeLocked = false;
-// Per-photo pan offsets, in pre-scale CSS pixels of the thumbnail img box.
-// Because we apply `scale(z) translate(tx, ty)`, the translate is in the
-// unscaled coordinate space, which is a fixed fraction of the underlying
-// image — so offsets remain correct as zoom level changes.
+// Per-photo pan offsets, in pre-scale CSS pixels (i.e. image-coordinate
+// pixels). Because we apply `translate(tx, ty) scale(s)` with offsets baked
+// into the translate as `off * s`, pans stay locked to the same pixel of
+// the underlying image as the shared zoom changes.
 var _grmOffsets = {};
 var _grmDragging = null;
 var _grmSuppressNextClick = false;
@@ -1570,55 +1598,93 @@ var _grmSuppressNextClick = false;
 // actions still render sensibly.
 var _grmLoupeLastX = 50;
 var _grmLoupeLastY = 50;
+// Whether the loupe has received a real hover (vs. just the centre default).
+// Used to decide between cover-fit (no-hover) and zoom (hover) per card.
+var _grmLoupeHovering = false;
+
+// Natural-size dims for one card. When the strip is still on the 400px
+// thumbnail, we use a 400px-fit; once upgraded to /original we use the
+// stored width/height.
+function _grmReviewNaturalDims(item, upgraded) {
+  if (upgraded) {
+    var W = (item && item.width) ? item.width : 1800;
+    var H = (item && item.height) ? item.height : 1200;
+    return { w: W, h: H };
+  }
+  // 400px thumbnail: longest side fits to 400 while preserving aspect ratio.
+  // Falls back to a 3:2 box when dims are unknown so the card still looks right.
+  var W2 = (item && item.width) ? item.width : 600;
+  var H2 = (item && item.height) ? item.height : 400;
+  var longest = Math.max(W2, H2);
+  if (longest > 400) {
+    var r = 400 / longest;
+    W2 = Math.round(W2 * r);
+    H2 = Math.round(H2 * r);
+  }
+  return { w: W2, h: H2 };
+}
 
 function _grmUpgradeStripToOriginal() {
   // Swap every strip card from the 400px thumbnail to the full-resolution
   // original so zoom actually reveals sensor detail. Idempotent per modal open.
+  // Also relayout each <img> at the original's natural pixel size so the
+  // browser rasterizes the layer at full resolution instead of bilinearly
+  // upsampling the 400px thumbnail bitmap (the WKWebView quality bug).
   if (grmState.upgraded) return;
   grmState.upgraded = true;
   document.querySelectorAll('.grm-card').forEach(function(card) {
     var pid = card.getAttribute('data-photo-id');
     var img = card.querySelector('img');
-    if (pid && img) img.src = '/photos/' + pid + '/original';
+    if (!pid || !img) return;
+    var item = grmState.items.find(function(it) { return String(it.photo_id) === String(pid); });
+    var nat = _grmReviewNaturalDims(item, true);
+    card.dataset.natW = nat.w;
+    card.dataset.natH = nat.h;
+    img.style.width = nat.w + 'px';
+    img.style.height = nat.h + 'px';
+    img.src = '/photos/' + pid + '/original';
   });
+  _grmApplyAllCardTransforms(_grmLoupeLastX, _grmLoupeLastY);
 }
 
-function _grmOneToOneScale() {
-  // Cards use object-fit: cover in a 3:2 box, so the on-screen base scale is
-  // max(boxW/imgW, boxH/imgH). The CSS transform factor that makes one source
-  // pixel equal one screen pixel is the inverse: min(imgW/boxW, imgH/boxH).
-  // Using width only would overshoot for images wider than 3:2 and undershoot
-  // for taller ones — misleading pixel detail either way.
-  var item = grmState.items.find(function(it) { return it.photo_id === grmState.selected; });
-  if (!item || !item.width || !item.height) return null;
-  // Prefer the selected photo's img so naturalWidth/Height (if loaded) reflect
-  // the axes the browser actually paints.
-  var sample = document.querySelector('.grm-card[data-photo-id="' + grmState.selected + '"] img')
-             || document.querySelector('.grm-card img');
-  if (!sample || !sample.offsetWidth || !sample.offsetHeight) return null;
-  // Stored item.width/height are pre-EXIF-orientation (same as in
-  // _lbRecomputeNativeZoom). For 90°-rotated JPEGs the browser swaps axes on
-  // render, so comparing stored aspect against the loaded image's aspect tells
-  // us whether to swap the stored dims before computing the 1:1 factor.
-  var imgW = item.width, imgH = item.height;
-  if (sample.naturalWidth && sample.naturalHeight) {
-    var storedAspect = item.width / item.height;
-    var renderedAspect = sample.naturalWidth / sample.naturalHeight;
-    if (Math.abs(storedAspect - renderedAspect) > Math.abs((1 / storedAspect) - renderedAspect)) {
-      imgW = item.height;
-      imgH = item.width;
-    }
+function grmCardImgLoaded(img) {
+  // Reconcile declared natural dims against what the browser actually decoded
+  // (NEFs may fall back to an embedded JPEG of a different size).
+  if (!img || !img.naturalWidth || !img.naturalHeight) return;
+  var card = img.closest('.grm-card');
+  if (!card) return;
+  var declaredW = parseFloat(card.dataset.natW) || 0;
+  var declaredH = parseFloat(card.dataset.natH) || 0;
+  if (img.naturalWidth !== declaredW || img.naturalHeight !== declaredH) {
+    card.dataset.natW = img.naturalWidth;
+    card.dataset.natH = img.naturalHeight;
+    img.style.width = img.naturalWidth + 'px';
+    img.style.height = img.naturalHeight + 'px';
+    _grmApplyCardTransform(card);
   }
-  return Math.min(imgW / sample.offsetWidth, imgH / sample.offsetHeight);
+}
+
+// Multiplier that, applied on top of cover-fit, yields a displayed scale of
+// 1.0 (i.e. one source pixel = one CSS pixel) for the selected card. With
+// the natural-size img layout, displayed scale = coverFit * multiplier, so
+// CSS 1:1 is reached at multiplier = 1 / coverFit.
+function _grmOneToOneMultiplier() {
+  if (!grmState || !grmState.selected) return null;
+  var card = document.querySelector('.grm-card[data-photo-id="' + grmState.selected + '"]');
+  if (!card) return null;
+  var coverFit = _grmCardCoverFit(card);
+  if (!coverFit) return null;
+  return 1 / coverFit;
 }
 
 function _grmMaxZoom() {
-  // Per selected photo, cap at the factor that reaches true 1:1. Falls back to
-  // 12 (the historical cap) when dimensions are unknown so we never zoom less
-  // than before.
-  var factor = _grmOneToOneScale();
-  if (factor == null) return 12;
-  return Math.max(12, Math.ceil(factor));
+  // Allow zooming past CSS 1:1 by × DPR so the user can reach one source
+  // pixel per device pixel on Retina displays — the actual pixel-peep target.
+  // Falls back to 12 when dims are unknown so we never zoom less than before.
+  var oneToOne = _grmOneToOneMultiplier();
+  var dpr = window.devicePixelRatio || 1;
+  if (oneToOne == null) return 12;
+  return Math.max(12, Math.ceil(oneToOne * dpr));
 }
 
 function grmLoupeToggleLock(e) {
@@ -1643,6 +1709,7 @@ function grmLoupeMove(e) {
   var y = ((e.clientY - rect.top) / rect.height) * 100;
   _grmLoupeLastX = x;
   _grmLoupeLastY = y;
+  _grmLoupeHovering = true;
 
   // Update crosshairs
   document.getElementById('grmCrosshairH').style.top = y + '%';
@@ -1654,35 +1721,68 @@ function grmLoupeMove(e) {
   _grmApplyAllCardTransforms(x, y);
 }
 
+function _grmCardCoverFit(card) {
+  var W = parseFloat(card.dataset.natW) || GRM_CARD_W;
+  var H = parseFloat(card.dataset.natH) || GRM_CARD_H;
+  return Math.max(GRM_CARD_W / W, GRM_CARD_H / H);
+}
+
+function _grmComputeCardTransform(card, hoverX, hoverY, hovering) {
+  var W = parseFloat(card.dataset.natW) || GRM_CARD_W;
+  var H = parseFloat(card.dataset.natH) || GRM_CARD_H;
+  var coverFit = Math.max(GRM_CARD_W / W, GRM_CARD_H / H);
+  var s = coverFit;
+  if (hovering) {
+    s = Math.max(coverFit, coverFit * _grmZoomLevel);
+  }
+  var hx = hovering ? (hoverX / 100) : 0.5;
+  var hy = hovering ? (hoverY / 100) : 0.5;
+  var baseTx = hx * (GRM_CARD_W - W * s);
+  var baseTy = hy * (GRM_CARD_H - H * s);
+  var off = _grmOffsets[card.dataset.photoId] || { tx: 0, ty: 0 };
+  // Pan offsets are in pre-scale (image-coordinate) CSS pixels; convert to
+  // card-coordinate pixels by multiplying by the displayed scale.
+  var tx = baseTx + off.tx * s;
+  var ty = baseTy + off.ty * s;
+  return {
+    transform: 'translate(' + tx + 'px, ' + ty + 'px) scale(' + s + ')',
+    scale: s,
+    zoomed: hovering,
+  };
+}
+
 function _grmApplyAllCardTransforms(x, y) {
+  var hovering = _grmLoupeHovering || _grmLoupeLocked;
   document.querySelectorAll('.grm-card').forEach(function(card) {
     var img = card.querySelector('img');
     if (!img) return;
-    var off = _grmOffsets[card.dataset.photoId] || { tx: 0, ty: 0 };
-    img.style.transformOrigin = x + '% ' + y + '%';
-    img.style.transform = 'scale(' + _grmZoomLevel + ') translate(' + off.tx + 'px, ' + off.ty + 'px)';
-    card.classList.add('zoomed');
+    var t = _grmComputeCardTransform(card, x, y, hovering);
+    img.style.transform = t.transform;
+    if (hovering) card.classList.add('zoomed');
+    else card.classList.remove('zoomed');
   });
 }
 
 function _grmApplyCardTransform(card) {
   var img = card.querySelector('img');
   if (!img) return;
-  var off = _grmOffsets[card.dataset.photoId] || { tx: 0, ty: 0 };
-  if (card.classList.contains('zoomed')) {
-    img.style.transform = 'scale(' + _grmZoomLevel + ') translate(' + off.tx + 'px, ' + off.ty + 'px)';
-  }
+  var hovering = card.classList.contains('zoomed');
+  var t = _grmComputeCardTransform(card, _grmLoupeLastX, _grmLoupeLastY, hovering);
+  img.style.transform = t.transform;
 }
 
 function grmLoupeZoom(e) {
   e.preventDefault();
   var max = _grmMaxZoom();
+  // Multiplicative zoom: each tick scales by 1.25, so reaching 30x (a
+  // typical CSS 1:1 multiplier for a 5400px image) takes ~16 ticks.
   if (e.deltaY < 0) {
-    _grmZoomLevel = Math.min(max, _grmZoomLevel + 1);
+    _grmZoomLevel = Math.min(max, _grmZoomLevel * 1.25);
   } else {
-    _grmZoomLevel = Math.max(1, _grmZoomLevel - 1);
+    _grmZoomLevel = Math.max(1, _grmZoomLevel / 1.25);
   }
   _grmUpgradeStripToOriginal();
+  _grmLoupeHovering = true;
   // Update origin from the wheel event even when locked so zoom follows cursor.
   var rect = e.currentTarget.getBoundingClientRect();
   _grmLoupeLastX = ((e.clientX - rect.left) / rect.width) * 100;
@@ -1693,22 +1793,23 @@ function grmLoupeZoom(e) {
 }
 
 function grmSnapOneToOne() {
-  // Lightroom-style 1:1: zoom factor that makes one source pixel == one screen pixel.
-  var factor = _grmOneToOneScale();
-  if (factor == null) return;
+  // Lightroom-style 1:1: zoom factor that makes one source pixel == one CSS pixel.
+  var mult = _grmOneToOneMultiplier();
+  if (mult == null) return;
   _grmUpgradeStripToOriginal();
-  _grmZoomLevel = Math.max(1, Math.round(factor));
+  _grmZoomLevel = Math.max(1, mult);
+  _grmLoupeHovering = true;
   _grmApplyAllCardTransforms(_grmLoupeLastX, _grmLoupeLastY);
 }
 
 function grmLoupeReset() {
   if (_grmLoupeLocked) return;
   if (_grmDragging) return;
-  document.querySelectorAll('.grm-card img').forEach(function(img) {
-    img.style.transform = '';
-    img.style.transformOrigin = '';
-    img.parentElement.classList.remove('zoomed');
-  });
+  // Re-apply transforms in their default (cover-fit, centred) state. We
+  // can't just clear `style.transform` because the natural-size <img> needs
+  // a scale-down transform at all times to fit the 180x120 viewport.
+  _grmLoupeHovering = false;
+  _grmApplyAllCardTransforms(_grmLoupeLastX, _grmLoupeLastY);
 }
 
 function grmCardMouseDown(e) {
@@ -1746,7 +1847,12 @@ function grmCardMouseMove(e) {
     _grmDragging.card.classList.add('dragging');
   }
   if (!_grmDragging.moved) return;
-  var z = Math.max(1, _grmZoomLevel);
+  // Convert screen-pixel drag delta to image-coordinate (pre-scale CSS)
+  // pixels by dividing by the displayed scale of the dragged card.
+  var coverFit = _grmCardCoverFit(_grmDragging.card);
+  var hovering = _grmLoupeHovering || _grmLoupeLocked;
+  var s = hovering ? Math.max(coverFit, coverFit * _grmZoomLevel) : coverFit;
+  var z = s > 0.001 ? s : 1;
   var newTx = _grmDragging.origTx + dx / z;
   var newTy = _grmDragging.origTy + dy / z;
   _grmOffsets[_grmDragging.photoId] = { tx: newTx, ty: newTy };


### PR DESCRIPTION
## Bug

The burst-loupe strip thumbnails were laid out at 180×120 CSS pixels via `width: 100%` and then scaled up via `transform: scale(N)`. Browsers (especially WKWebView, which Tauri uses on macOS) rasterize the layer at the **pre-transform** 180×120 size and then bilinearly upscale that bitmap when the transform is applied. The full-resolution image data served by `/photos/<id>/original` was thrown away before the scale ever saw it.

This had been "fixed" several times at the source-data layer (#604, #623, #624) but never at the actual culprit: the CSS rendering layer.

A secondary bug: at the slider's "1:1" position the math mapped 1 source pixel → 1 *CSS* pixel; on a Retina display (DPR=2) that's 1 source pixel → 2×2 device pixels, which is still bilinearly upscaled and looks soft.

## Fix

Each strip `<img>` is now laid out at its served photo's **natural pixel dimensions** (inline `style.width`/`style.height` set to e.g. `5392px × 3592px` at the Original slider stop). The 180×120 viewport stays the visible card box via a new `.grm-card-img-box` wrapper with `overflow: hidden`. A `transform: translate(...) scale(s)` shrinks the huge image into the viewport via cover-fit at rest, and zooms toward CSS 1:1 (and beyond, up to device 1:1 on Retina × DPR) on hover + wheel.

This forces the browser to rasterize the layer at the actual served source size, so detail survives all the way through the transform.

### Pan-offset semantics
User pan offsets continue to be stored in pre-scale (image-coordinate) CSS pixels. The new transform formula bakes `off * s` into the translate so per-photo pans stay locked to the same image pixel as zoom changes.

### NEF embedded-JPEG fallback
On `<img> load`, the actual `naturalWidth`/`naturalHeight` are checked against the declared dims and the layout re-syncs if they differ — covers the rawpy-fallback case where `/photos/<id>/original` returns an embedded JPEG smaller than `photo.width × photo.height`.

### DPR-aware max zoom
The wheel-zoom max now scales up to `DPR / coverFit`, so users can explicitly reach one source pixel per device pixel (true pixel-peep on Retina). Surfaced as a wider wheel range, not silently forced.

## Files touched

- `vireo/templates/pipeline_review.html` — Pipeline → Review Burst Group modal
- `vireo/templates/review.html` — Review page → burst loupe (older, separate impl)
- `tests/e2e/test_burst_group_natural_size.py` — new e2e regression test

The lightbox (`.lb-img`) was checked and uses a different rendering path (no transform-scale on a small layout box) — left untouched.

## Test plan

- [x] `python -m pytest tests/e2e/test_burst_group_natural_size.py tests/e2e/test_burst_group_context_menu.py -v` → 3 passed, 4 skipped
- [x] Full e2e suite: `python -m pytest tests/e2e/ -v` → **177 passed, 5 skipped**
- [x] `python -m pytest vireo/tests/test_config.py -v` → 23 passed
- [ ] Manually verify on a real burst in WKWebView (Tauri build) that pixel-peep at slider=Original now shows actual sensor detail
- [ ] Manually verify on Retina display that wheel-zoom past CSS 1:1 reaches device 1:1

## Verification details

The new e2e test asserts `img.style.width == img.naturalWidth + 'px'`, which proves the rasterized layer is at full source size instead of the 180×120 default. It also asserts `.grm-card-img-box` stays exactly 180×120 so the visible viewport is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)