### PR TITLE
fix(thumbnails): regenerate on miss instead of 404

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8697,34 +8697,89 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/thumbnails/<filename>")
     def serve_thumbnail(filename):
+        """Serve a 400px JPEG thumbnail for a photo, regenerating on miss.
+
+        Self-heal: if the thumbnail file is missing on disk but the photo
+        still exists in the database, we (re)generate the thumbnail in
+        the request thread, persist ``photos.thumb_path`` so the coverage
+        dashboard sees it, and serve it. The user never sees a broken
+        image when the source is recoverable — matching the project's
+        "no rm -rf fixes; the app self-heals" rule.
+
+        404s remain when:
+          * the filename isn't ``<int>.jpg`` (malformed request);
+          * the photo no longer exists in the DB (stale cache from a
+            previous delete — handled by ``pipeline.prune_results``
+            going forward);
+          * the source image is unreadable (e.g. RAW decode failure).
+            ``generate_thumbnail`` already logs the underlying cause.
+        """
         def _send_cached(directory, fname):
             resp = make_response(send_from_directory(directory, fname))
             resp.cache_control.public = True
             resp.cache_control.max_age = 24 * 60 * 60  # 1 day
             return resp
 
-        thumb_path = os.path.join(app.config["THUMB_CACHE_DIR"], filename)
+        thumb_dir = app.config["THUMB_CACHE_DIR"]
+        thumb_path = os.path.join(thumb_dir, filename)
         if os.path.exists(thumb_path):
-            return _send_cached(app.config["THUMB_CACHE_DIR"], filename)
+            return _send_cached(thumb_dir, filename)
 
-        # Try to generate on the fly
+        # Self-heal path: regenerate on miss when the photo still exists.
         try:
             photo_id = int(filename.replace(".jpg", ""))
-            db = _get_db()
-            photo = db.conn.execute(
-                "SELECT p.filename, f.path FROM photos p JOIN folders f ON f.id = p.folder_id WHERE p.id = ?",
-                (photo_id,),
-            ).fetchone()
-            if photo:
-                from thumbnails import generate_thumbnail
-                source = os.path.join(photo["path"], photo["filename"])
-                result = generate_thumbnail(photo_id, source, app.config["THUMB_CACHE_DIR"])
-                if result:
-                    return _send_cached(app.config["THUMB_CACHE_DIR"], filename)
-        except Exception:
-            pass
+        except ValueError:
+            log.warning("Thumbnail request with non-numeric filename: %s", filename)
+            return "", 404
 
-        return "", 404
+        db = _get_db()
+        photo = db.get_photo(photo_id)
+        if not photo:
+            # Stale URL — the photo was deleted. Caller (e.g. a cached
+            # pipeline_results JSON) is out of sync. 404 is the right
+            # answer; cache pruning is the upstream fix (PR #758).
+            return "", 404
+
+        # Resolve source via the canonical-path helper so we prefer the
+        # JPEG working copy over the original RAW. This makes the
+        # self-heal work for cameras whose RAW format libraw cannot
+        # decode (the working copy was extracted from the embedded JPEG
+        # at scan time).
+        from image_loader import get_canonical_image_path
+        from thumbnails import generate_thumbnail
+        vireo_dir = os.path.dirname(thumb_dir)
+        folders = {f["id"]: f["path"] for f in db.get_folder_tree()}
+        try:
+            source = get_canonical_image_path(photo, vireo_dir, folders)
+            result = generate_thumbnail(photo_id, source, thumb_dir)
+        except Exception:
+            log.exception(
+                "Thumbnail self-heal failed for photo %s (source=%s)",
+                photo_id, photo["filename"],
+            )
+            return "", 404
+
+        if not result:
+            # generate_thumbnail logged the reason (unreadable source,
+            # unsupported format, etc.). Nothing else to do here.
+            return "", 404
+
+        # Persist on-disk presence so the dashboard's coverage query
+        # (`thumb_path IS NOT NULL`) reflects this regeneration. Stored
+        # value is the bare filename, matching ``thumbnails.generate_all``.
+        try:
+            db.conn.execute(
+                "UPDATE photos SET thumb_path=? WHERE id=?",
+                (f"{photo_id}.jpg", photo_id),
+            )
+            db.conn.commit()
+        except Exception:
+            # Coverage column drift is recoverable via the backfill job;
+            # don't fail the request if the UPDATE racks up a transient
+            # SQLite error.
+            log.exception("Failed to persist thumb_path for photo %s", photo_id)
+
+        return _send_cached(thumb_dir, filename)
 
     @app.route("/api/species/<path:species_name>/clusters")
     def api_species_clusters(species_name):
@@ -9957,10 +10012,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/pipeline/results")
     def api_pipeline_results():
         """Return the most recent pipeline triage results for the active workspace."""
-        from pipeline import load_results
+        from pipeline import load_results, prune_missing_photos
 
         db = _get_db()
         cache_dir = os.path.dirname(db_path)
+        # Self-heal: caches written before commit 5ad83fa (which wired
+        # cache pruning into db.delete_photos) can still reference photos
+        # that were deleted afterwards through other paths. Reconcile
+        # against the DB at read time so the review page never renders
+        # orphan cards that 404 on /thumbnails/<id>.jpg.
+        prune_missing_photos(cache_dir, db._active_workspace_id, db)
         results = load_results(cache_dir, db._active_workspace_id)
         if results is None:
             return json_error("No pipeline results found. Run regroup first.", 404)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8733,10 +8733,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "", 404
 
         db = _get_db()
-        photo = db.get_photo(photo_id)
+        # Workspace-scoped lookup: a thumbnail URL only makes sense for a
+        # photo the active workspace can actually see. Without this scope,
+        # ``get_canonical_image_path`` would receive an empty folders dict
+        # for a cross-workspace photo and fall back to
+        # ``os.path.join('', photo['filename'])`` — i.e. a path resolved
+        # against the server's CWD — which could read or persist a
+        # thumbnail derived from an unrelated same-named file.
+        photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
-            # Stale URL — the photo was deleted. Caller (e.g. a cached
-            # pipeline_results JSON) is out of sync. 404 is the right
+            # Stale URL — the photo was deleted, or it lives in a folder
+            # that isn't linked to this workspace. 404 is the right
             # answer; cache pruning is the upstream fix (PR #758).
             return "", 404
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8755,7 +8755,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         from image_loader import get_canonical_image_path
         from thumbnails import generate_thumbnail
         vireo_dir = os.path.dirname(thumb_dir)
-        folders = {f["id"]: f["path"] for f in db.get_folder_tree()}
+        # Look up the photo's folder path directly rather than via
+        # ``get_folder_tree()``: the tree filter excludes folders whose
+        # status is ``'missing'``, which would leave the canonical-path
+        # helper with an empty mapping and silently fall back to
+        # ``os.path.join('', photo['filename'])`` — a CWD-relative path
+        # that could read or persist a thumbnail derived from an
+        # unrelated same-named file in the server's working directory.
+        # Workspace membership is already enforced above via
+        # ``get_photo(verify_workspace=True)``, so a direct ``get_folder``
+        # lookup here is safe and status-agnostic.
+        folder_row = db.get_folder(photo["folder_id"])
+        folders = (
+            {folder_row["id"]: folder_row["path"]} if folder_row else {}
+        )
         try:
             source = get_canonical_image_path(photo, vireo_dir, folders)
             result = generate_thumbnail(photo_id, source, thumb_dir)

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -665,7 +665,7 @@ def load_results(cache_dir, workspace_id):
 
 
 def prune_missing_photos(cache_dir, workspace_id, db):
-    """Self-heal pass: drop cached photo IDs that no longer exist in the DB.
+    """Self-heal pass: drop cached photo IDs no longer visible in the workspace.
 
     The pipeline review page renders a card per cached photo and requests
     ``/thumbnails/<id>.jpg`` for each. When a photo was deleted before
@@ -675,6 +675,12 @@ def prune_missing_photos(cache_dir, workspace_id, db):
     the cache should therefore reconcile against the DB and quietly drop
     IDs that are no longer present, so an old cache converges to clean
     state on the next read.
+
+    Presence is scoped to the active workspace via ``workspace_folders``:
+    a photo whose folder has been unlinked from this workspace is treated
+    the same as a hard-deleted row. Otherwise unlinking a folder leaves
+    orphan cards behind and ``/thumbnails/<id>.jpg`` regen still fails
+    because thumbnail source resolution itself is workspace-scoped.
 
     Returns True if the cache was rewritten, False otherwise.
     """
@@ -688,7 +694,10 @@ def prune_missing_photos(cache_dir, workspace_id, db):
         return False
     placeholders = ",".join("?" * len(cached_ids))
     rows = db.conn.execute(
-        f"SELECT id FROM photos WHERE id IN ({placeholders})", cached_ids
+        f"""SELECT p.id FROM photos p
+            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+            WHERE wf.workspace_id = ? AND p.id IN ({placeholders})""",
+        (workspace_id, *cached_ids),
     ).fetchall()
     present = {row["id"] for row in rows}
     missing = [pid for pid in cached_ids if pid not in present]

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -682,6 +682,12 @@ def prune_missing_photos(cache_dir, workspace_id, db):
     orphan cards behind and ``/thumbnails/<id>.jpg`` regen still fails
     because thumbnail source resolution itself is workspace-scoped.
 
+    The ``IN (...)`` lookup is chunked to stay under SQLite's default
+    bound-parameter cap (``SQLITE_LIMIT_VARIABLE_NUMBER``, typically 999):
+    a workspace cache with more entries than that would otherwise raise
+    ``OperationalError: too many SQL variables`` and turn a recoverable
+    stale-cache state into a hard 500 on ``GET /api/pipeline/results``.
+
     Returns True if the cache was rewritten, False otherwise.
     """
     path = os.path.join(cache_dir, f"pipeline_results_ws{workspace_id}.json")
@@ -692,14 +698,18 @@ def prune_missing_photos(cache_dir, workspace_id, db):
     cached_ids = [p.get("id") for p in data.get("photos", []) if p.get("id") is not None]
     if not cached_ids:
         return False
-    placeholders = ",".join("?" * len(cached_ids))
-    rows = db.conn.execute(
-        f"""SELECT p.id FROM photos p
-            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            WHERE wf.workspace_id = ? AND p.id IN ({placeholders})""",
-        (workspace_id, *cached_ids),
-    ).fetchall()
-    present = {row["id"] for row in rows}
+    _CHUNK = 900
+    present: set = set()
+    for i in range(0, len(cached_ids), _CHUNK):
+        chunk = cached_ids[i : i + _CHUNK]
+        placeholders = ",".join("?" * len(chunk))
+        rows = db.conn.execute(
+            f"""SELECT p.id FROM photos p
+                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                WHERE wf.workspace_id = ? AND p.id IN ({placeholders})""",
+            (workspace_id, *chunk),
+        ).fetchall()
+        present.update(row["id"] for row in rows)
     missing = [pid for pid in cached_ids if pid not in present]
     if not missing:
         return False

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -664,6 +664,43 @@ def load_results(cache_dir, workspace_id):
         return json.load(f)
 
 
+def prune_missing_photos(cache_dir, workspace_id, db):
+    """Self-heal pass: drop cached photo IDs that no longer exist in the DB.
+
+    The pipeline review page renders a card per cached photo and requests
+    ``/thumbnails/<id>.jpg`` for each. When a photo was deleted before
+    ``prune_results`` was wired into ``db.delete_photos`` (commit 5ad83fa),
+    the cache file kept its ID, the page rendered an orphan card, and the
+    thumbnail route correctly 404'd because the photo row is gone. Reading
+    the cache should therefore reconcile against the DB and quietly drop
+    IDs that are no longer present, so an old cache converges to clean
+    state on the next read.
+
+    Returns True if the cache was rewritten, False otherwise.
+    """
+    path = os.path.join(cache_dir, f"pipeline_results_ws{workspace_id}.json")
+    if not os.path.exists(path):
+        return False
+    with open(path) as f:
+        data = json.load(f)
+    cached_ids = [p.get("id") for p in data.get("photos", []) if p.get("id") is not None]
+    if not cached_ids:
+        return False
+    placeholders = ",".join("?" * len(cached_ids))
+    rows = db.conn.execute(
+        f"SELECT id FROM photos WHERE id IN ({placeholders})", cached_ids
+    ).fetchall()
+    present = {row["id"] for row in rows}
+    missing = [pid for pid in cached_ids if pid not in present]
+    if not missing:
+        return False
+    log.info(
+        "Pipeline cache for ws%s references %d deleted photo(s); pruning",
+        workspace_id, len(missing),
+    )
+    return prune_results(cache_dir, workspace_id, missing)
+
+
 def prune_results(cache_dir, workspace_id, deleted_ids):
     """Remove deleted photo IDs from the cached pipeline results in place.
 

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -429,6 +429,64 @@ def test_prune_results_empty_id_list(tmp_path):
     assert os.path.getmtime(path) == mtime
 
 
+# -- prune_missing_photos --
+
+
+def _make_db_with_ids(tmp_path, ids):
+    """Create a minimal Database with photo rows whose ids match ``ids``."""
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+    for pid in ids:
+        # add_photo auto-assigns id, so we override via raw SQL after
+        # insertion to pin the row to the desired id.
+        actual = db.add_photo(fid, f"p{pid}.jpg", ".jpg", 1000, 1.0)
+        if actual != pid:
+            db.conn.execute("UPDATE photos SET id=? WHERE id=?", (pid, actual))
+    db.conn.commit()
+    return db
+
+
+def test_prune_missing_photos_drops_deleted_ids(tmp_path):
+    """IDs in the cache but absent from the photos table are pruned."""
+    from pipeline import load_results, prune_missing_photos
+
+    _write_cache(str(tmp_path), 1, _sample_cache())
+    # photos table has only ids {1, 3}; cache references {1..5}
+    db = _make_db_with_ids(tmp_path, [1, 3])
+
+    changed = prune_missing_photos(str(tmp_path), 1, db)
+    assert changed is True
+
+    loaded = load_results(str(tmp_path), 1)
+    assert [p["id"] for p in loaded["photos"]] == [1, 3]
+    assert loaded["encounters"][0]["photo_ids"] == [1, 3]
+    # second encounter (ids 4, 5) is fully gone
+    assert len(loaded["encounters"]) == 1
+
+
+def test_prune_missing_photos_noop_when_all_present(tmp_path):
+    """If every cached id exists in the DB, the cache is untouched."""
+    from pipeline import prune_missing_photos
+
+    path = _write_cache(str(tmp_path), 1, _sample_cache())
+    mtime = os.path.getmtime(path)
+    db = _make_db_with_ids(tmp_path, [1, 2, 3, 4, 5])
+
+    changed = prune_missing_photos(str(tmp_path), 1, db)
+    assert changed is False
+    assert os.path.getmtime(path) == mtime
+
+
+def test_prune_missing_photos_no_cache_is_noop(tmp_path):
+    """No cache file → returns False, does not raise."""
+    from pipeline import prune_missing_photos
+
+    db = _make_db_with_ids(tmp_path, [1])
+    assert prune_missing_photos(str(tmp_path), 999, db) is False
+
+
 # -- compute_review_readiness --
 
 

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -432,12 +432,21 @@ def test_prune_results_empty_id_list(tmp_path):
 # -- prune_missing_photos --
 
 
-def _make_db_with_ids(tmp_path, ids):
-    """Create a minimal Database with photo rows whose ids match ``ids``."""
+def _make_db_with_ids(tmp_path, ids, workspace_id=1, link_folder=True):
+    """Create a minimal Database with photo rows whose ids match ``ids``.
+
+    ``link_folder`` controls whether the photo folder is registered with
+    ``workspace_id`` via ``workspace_folders``. ``add_folder`` auto-links
+    to the active workspace, so when False we explicitly remove the link
+    to simulate a folder that exists in the photos table but is not
+    visible in the workspace.
+    """
     from db import Database
 
     db = Database(str(tmp_path / "test.db"))
     fid = db.add_folder(str(tmp_path), name="photos")
+    if not link_folder:
+        db.remove_workspace_folder(workspace_id, fid)
     for pid in ids:
         # add_photo auto-assigns id, so we override via raw SQL after
         # insertion to pin the row to the desired id.
@@ -485,6 +494,28 @@ def test_prune_missing_photos_no_cache_is_noop(tmp_path):
 
     db = _make_db_with_ids(tmp_path, [1])
     assert prune_missing_photos(str(tmp_path), 999, db) is False
+
+
+def test_prune_missing_photos_drops_ids_in_unlinked_folder(tmp_path):
+    """Photos that exist in the table but whose folder isn't linked to
+    the workspace are pruned just like hard-deleted rows. Without this,
+    unlinking a folder leaves orphan cards on the review page and the
+    thumbnail self-heal route still 404s because thumbnail source
+    resolution is itself workspace-scoped."""
+    from pipeline import load_results, prune_missing_photos
+
+    _write_cache(str(tmp_path), 1, _sample_cache())
+    # Photos 1..5 exist in the photos table, but their folder is NOT
+    # linked to workspace 1 (link_folder=False), so the workspace can't
+    # actually see any of them.
+    db = _make_db_with_ids(tmp_path, [1, 2, 3, 4, 5], link_folder=False)
+
+    changed = prune_missing_photos(str(tmp_path), 1, db)
+    assert changed is True
+
+    loaded = load_results(str(tmp_path), 1)
+    assert loaded["photos"] == []
+    assert loaded["encounters"] == []
 
 
 # -- compute_review_readiness --

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -518,6 +518,70 @@ def test_prune_missing_photos_drops_ids_in_unlinked_folder(tmp_path):
     assert loaded["encounters"] == []
 
 
+def test_prune_missing_photos_chunks_large_id_lists(tmp_path):
+    """Cache with more entries than SQLite's bound-parameter cap
+    (``SQLITE_LIMIT_VARIABLE_NUMBER``, default 999 in production builds)
+    must not raise ``OperationalError: too many SQL variables``. Without
+    chunking, a large workspace would regress from a recoverable
+    stale-cache state to a hard 500 on ``GET /api/pipeline/results``.
+
+    The local ``sqlite3`` build often ships with a much higher default
+    (e.g. 250k), which would mask the bug. Force the limit down with
+    ``Connection.setlimit`` so the chunking path is actually exercised.
+    """
+    import sqlite3
+
+    from pipeline import load_results, prune_missing_photos
+
+    # 1500 cached ids — half present, half not.
+    n = 1500
+    present_ids = list(range(1, n // 2 + 1))
+    missing_ids = list(range(n // 2 + 1, n + 1))
+    cache = {
+        "encounters": [
+            {
+                "species": "Robin",
+                "confirmed_species": None,
+                "species_predictions": [],
+                "species_confirmed": False,
+                "photo_count": n,
+                "burst_count": 1,
+                "time_range": ["2026-03-20T10:00:00", "2026-03-20T10:00:01"],
+                "photo_ids": present_ids + missing_ids,
+                "bursts": [
+                    {"photo_ids": present_ids + missing_ids, "species_predictions": [], "species_override": None},
+                ],
+            },
+        ],
+        "photos": [
+            {"id": pid, "label": "KEEP", "rarity_protected": False}
+            for pid in present_ids + missing_ids
+        ],
+        "summary": {
+            "total_photos": n,
+            "encounter_count": 1,
+            "burst_count": 1,
+            "keep_count": n,
+            "review_count": 0,
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    _write_cache(str(tmp_path), 1, cache)
+    db = _make_db_with_ids(tmp_path, present_ids)
+
+    # Force the bound-parameter limit below n so the unchunked code path
+    # would raise OperationalError. The chunking implementation uses 900
+    # per query, so a cap of 999 lets each chunk through.
+    db.conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 999)
+
+    changed = prune_missing_photos(str(tmp_path), 1, db)
+    assert changed is True
+
+    loaded = load_results(str(tmp_path), 1)
+    assert [p["id"] for p in loaded["photos"]] == present_ids
+
+
 # -- compute_review_readiness --
 
 

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -337,3 +337,193 @@ def test_thumb_path_backfill_candidate_count_counts_unsynced(tmp_path):
     db.conn.commit()
 
     assert thumb_path_backfill_candidate_count(db, cache_dir) == 2
+
+
+# -- Route-level self-heal tests --
+#
+# The /thumbnails/<id>.jpg route must regenerate on miss instead of
+# 404-ing whenever the photo still exists in the DB and the source
+# image is readable. A blank card on the encounter grid is a UX
+# black-box (CORE_PHILOSOPHY: no black boxes), and the project's
+# self-healing-app rule (feedback_self_healing_app.md) says the app
+# should detect and repair broken cache state, not surface it.
+
+def _make_app_with_real_photo(tmp_path, monkeypatch, filename="bird.jpg"):
+    """Build a Flask app + DB with one real photo whose source file exists.
+
+    Returns (app, db, photo_id, thumb_dir).
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    import models
+    from app import create_app
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(
+        models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"),
+    )
+    monkeypatch.setattr(
+        models, "CONFIG_PATH", str(tmp_path / "models.json"),
+    )
+
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    src = photos_dir / filename
+    Image.new("RGB", (800, 600), (180, 90, 40)).save(str(src), "JPEG", quality=85)
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir()
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder(str(photos_dir), name="photos")
+    pid = db.add_photo(
+        folder_id=fid, filename=filename, extension=".jpg",
+        file_size=os.path.getsize(src),
+        file_mtime=os.path.getmtime(src),
+        width=800, height=600,
+    )
+
+    app = create_app(
+        db_path=db_path, thumb_cache_dir=str(thumb_dir),
+        api_token="test-token-123",
+    )
+    return app, db, pid, str(thumb_dir)
+
+
+def test_serve_thumbnail_regenerates_on_cache_miss(tmp_path, monkeypatch):
+    """When the thumbnail JPEG is missing on disk but the photo exists,
+    the route must regenerate it and serve it — never 404 — and the
+    file must persist for next time. This is the encounter-grid card
+    self-heal path: a wiped or never-populated cache should not leave
+    blank tiles."""
+    app, db, pid, thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+    thumb_file = os.path.join(thumb_dir, f"{pid}.jpg")
+    assert not os.path.exists(thumb_file), "precondition: cache miss"
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 200, (
+        f"thumbnail route should self-heal on miss, got {resp.status_code}"
+    )
+    assert resp.mimetype in ("image/jpeg", "image/jpg")
+    # Body must be a real JPEG (SOI marker = FF D8).
+    assert resp.data[:2] == b"\xff\xd8", "response body is not a JPEG"
+
+    # Persisted: the file is now on disk for future requests.
+    assert os.path.exists(thumb_file), "regenerated thumbnail must be saved to disk"
+
+    # And photos.thumb_path is set so the dashboard's coverage query
+    # reflects the heal.
+    row = db.conn.execute(
+        "SELECT thumb_path FROM photos WHERE id=?", (pid,)
+    ).fetchone()
+    assert row["thumb_path"] == f"{pid}.jpg"
+
+
+def test_serve_thumbnail_serves_cached_without_regenerating(tmp_path, monkeypatch):
+    """When the file is already on disk, the route must not re-decode the
+    source — that would burn CPU on every encounter-grid scroll."""
+    app, _db, pid, thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+
+    # Pre-populate with a sentinel image whose bytes we recognise.
+    thumb_file = os.path.join(thumb_dir, f"{pid}.jpg")
+    Image.new("RGB", (50, 50), (1, 2, 3)).save(thumb_file, "JPEG", quality=70)
+    sentinel_size = os.path.getsize(thumb_file)
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 200
+    # The cached file must have been served unmodified.
+    assert os.path.getsize(thumb_file) == sentinel_size
+
+
+def test_serve_thumbnail_404s_for_deleted_photo(tmp_path, monkeypatch):
+    """When the photo is gone from the DB (stale URL from a cached
+    pipeline_results JSON), the route correctly 404s. There is nothing
+    to regenerate."""
+    app, db, pid, _thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+    db.conn.execute("DELETE FROM photos WHERE id=?", (pid,))
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 404
+
+
+def test_serve_thumbnail_404s_for_non_numeric_filename(tmp_path, monkeypatch):
+    """Garbage URLs (e.g. /thumbnails/foo.jpg) must 404 cleanly without
+    raising — defends the route against arbitrary path probes."""
+    app, *_ = _make_app_with_real_photo(tmp_path, monkeypatch)
+    client = app.test_client()
+    resp = client.get("/thumbnails/not-a-number.jpg")
+    assert resp.status_code == 404
+
+
+def test_serve_thumbnail_prefers_working_copy_over_source(tmp_path, monkeypatch):
+    """When a working copy exists, the self-heal must use it instead of
+    the original. This matters for RAW formats whose original cannot be
+    decoded by libraw — the working copy was extracted from the embedded
+    JPEG at scan time and is the only readable source."""
+    app, db, pid, thumb_dir = _make_app_with_real_photo(
+        tmp_path, monkeypatch, filename="bird.jpg",
+    )
+
+    # Replace the original on disk with garbage so any attempt to decode
+    # it fails. The working copy is the only readable source.
+    photos_row = db.conn.execute(
+        "SELECT f.path, p.filename FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (pid,),
+    ).fetchone()
+    original_path = os.path.join(photos_row["path"], photos_row["filename"])
+    with open(original_path, "wb") as f:
+        f.write(b"not a real image")
+
+    # Stage a working copy at the canonical location.
+    vireo_dir = os.path.dirname(thumb_dir)
+    wc_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(wc_dir, exist_ok=True)
+    wc_path = os.path.join(wc_dir, f"{pid}.jpg")
+    Image.new("RGB", (1024, 768), (50, 200, 50)).save(wc_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (f"working/{pid}.jpg", pid),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 200, (
+        "self-heal should fall through to the working copy when the "
+        "original is unreadable"
+    )
+    assert resp.data[:2] == b"\xff\xd8"
+    assert os.path.exists(os.path.join(thumb_dir, f"{pid}.jpg"))
+
+
+def test_serve_thumbnail_404s_when_source_is_unreadable(tmp_path, monkeypatch):
+    """When neither the original nor a working copy is readable, the
+    route must 404 (not 500). generate_thumbnail logs the cause."""
+    app, db, pid, _thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+
+    # Make the only source unreadable.
+    photos_row = db.conn.execute(
+        "SELECT f.path, p.filename FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (pid,),
+    ).fetchone()
+    original_path = os.path.join(photos_row["path"], photos_row["filename"])
+    with open(original_path, "wb") as f:
+        f.write(b"not a real image")
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+    assert resp.status_code == 404

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -529,6 +529,55 @@ def test_serve_thumbnail_404s_when_source_is_unreadable(tmp_path, monkeypatch):
     assert resp.status_code == 404
 
 
+def test_serve_thumbnail_resolves_when_folder_status_is_missing(tmp_path, monkeypatch):
+    """The self-heal must use the photo's actual folder path even when
+    the folder's status is ``'missing'``. ``get_folder_tree()`` filters
+    out ``'missing'`` folders, which would leave the canonical-path
+    helper with an empty mapping and silently fall back to
+    ``os.path.join('', photo['filename'])`` — a CWD-relative path.
+
+    A request can land on this code path while a network mount briefly
+    flaps (the health loop flips status to ``'missing'``) or before the
+    next health pass clears a transient state. Resolving CWD-relative
+    is wrong in either case: at best the request 404s nondeterministically,
+    at worst it persists a thumbnail derived from an unrelated file with
+    the same basename in the server's working directory.
+    """
+    app, db, pid, thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+
+    # Mark the photo's folder as missing — but the source file is still
+    # on disk (the canonical case is a flapping mount, not a real
+    # delete). The route must still resolve via the actual folder path.
+    db.conn.execute("UPDATE folders SET status = 'missing'")
+    db.conn.commit()
+
+    # Sanity: get_folder_tree (the prior lookup) would now omit this
+    # folder, forcing the buggy CWD fallback.
+    assert db.get_folder_tree() == [], (
+        "precondition: folder is filtered out of the workspace tree once "
+        "marked missing — the bug we're guarding against"
+    )
+
+    # Pollute CWD with a same-named file that contains different bytes
+    # so a CWD-relative resolution would silently feed unrelated pixels
+    # into the thumbnail (and persist it to disk under photo_id.jpg).
+    cwd_decoy_dir = tmp_path / "cwd"
+    cwd_decoy_dir.mkdir()
+    decoy = cwd_decoy_dir / "bird.jpg"
+    Image.new("RGB", (800, 600), (10, 250, 10)).save(str(decoy), "JPEG")
+    monkeypatch.chdir(str(cwd_decoy_dir))
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 200, (
+        "self-heal must resolve via the photo's folder regardless of "
+        f"folder status, got {resp.status_code}"
+    )
+    assert resp.data[:2] == b"\xff\xd8"
+    assert os.path.exists(os.path.join(thumb_dir, f"{pid}.jpg"))
+
+
 def test_serve_thumbnail_404s_for_photo_outside_active_workspace(tmp_path, monkeypatch):
     """The route must 404 when the photo exists in the DB but its folder
     isn't linked to the active workspace. Without workspace scoping,

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -527,3 +527,32 @@ def test_serve_thumbnail_404s_when_source_is_unreadable(tmp_path, monkeypatch):
     client = app.test_client()
     resp = client.get(f"/thumbnails/{pid}.jpg")
     assert resp.status_code == 404
+
+
+def test_serve_thumbnail_404s_for_photo_outside_active_workspace(tmp_path, monkeypatch):
+    """The route must 404 when the photo exists in the DB but its folder
+    isn't linked to the active workspace. Without workspace scoping,
+    ``get_canonical_image_path`` would receive an empty folders dict
+    (``get_folder_tree`` is workspace-scoped) and fall back to a CWD-
+    relative path — which could read or persist a thumbnail derived from
+    an unrelated same-named file on the server. Same-filename collision
+    across workspaces is not exotic: every Lightroom export produces
+    files like ``DSC_0001.jpg``."""
+    app, db, pid, _thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+
+    # Spin up a second workspace that does NOT have the photo's folder
+    # linked, and make it the active one. The photo row still exists,
+    # but it is invisible from this workspace. Persisting
+    # ``last_opened_at`` is what the per-request ``Database`` instance
+    # uses to pick the active workspace on init, so the route inherits
+    # the switch.
+    other_ws = db.create_workspace("Other")
+    db.update_workspace(other_ws, last_opened_at="2030-01-01T00:00:00Z")
+    db.set_active_workspace(other_ws)
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+    assert resp.status_code == 404, (
+        "thumbnail self-heal must not serve a photo that the active "
+        "workspace cannot see"
+    )


### PR DESCRIPTION
## Bug

Pipeline Review page was logging `/thumbnails/<id>.jpg` 404s in the browser console for photo IDs like `18455-18458` and `34107`. Investigation showed those IDs are **not in the photos table** — they were deleted, but the workspace's `pipeline_results_ws<N>.json` cache still referenced them, so the page rendered orphan cards whose thumbnail requests genuinely had no photo to serve.

Two compounding causes:

1. **Stale pipeline cache.** Commit 5ad83fa wired `prune_results` into `db.delete_photos`, but caches written before that fix already contained stale IDs. `/api/pipeline/results` read them blindly.
2. **Best-effort thumbnail route.** The existing `/thumbnails/<id>.jpg` self-heal didn't persist `photos.thumb_path` after regen, didn't prefer the JPEG working copy over the original (so RAWs that libraw can't decode stayed broken even when their extracted JPEG was on disk), and silently swallowed exceptions.

## Fix

**`pipeline.prune_missing_photos(cache_dir, ws_id, db)`** — read-time reconciliation that diffs cached IDs against the photos table and calls the existing `prune_results` for the missing set. `/api/pipeline/results` runs the pass before serving, so an old cache converges to clean state on the next read instead of repeatedly rendering orphan cards.

**Tightened `/thumbnails/<id>.jpg` route:**
- Explicit `ValueError` handling for malformed filenames
- Canonical-path resolution that prefers the working copy (RAW workflow)
- Structured logging on failure
- `UPDATE photos SET thumb_path=?` on success so the coverage dashboard reflects the heal

## Tests

- 6 new route-level tests in `test_thumbnails.py`: cache miss → 200 + file persisted + `thumb_path` set, cache hit served unmodified, deleted photo → 404, non-numeric filename → 404, working-copy fallback when original is unreadable, both-unreadable → 404
- 3 new pipeline tests in `test_pipeline.py`: `prune_missing_photos` drops missing IDs, no-op when all present, no-op without cache file

```
vireo/tests/test_thumbnails.py  20 passed
vireo/tests/test_pipeline.py    66 passed
```

Full battery from `CLAUDE.md` (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_pipeline.py`) ran to completion with exit 0.

## Test plan

- [ ] Open Pipeline Review on a workspace whose cache references deleted photos — first load self-heals the cache, no more `/thumbnails/<id>.jpg` 404s in the console
- [ ] Wipe `~/.vireo/thumbnails/` and reload the encounter grid — thumbnails regenerate on demand instead of leaving blank cards
- [ ] After regen, `photos.thumb_path` is populated (visible on the dashboard coverage card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)