### PR TITLE
feat: open-in-browser mode (skip Tauri window)

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,0 +1,107 @@
+//! Read a small subset of Vireo's user config (`~/.vireo/config.json`).
+//!
+//! The Python side owns the full schema and writes the file. Rust only needs
+//! to read a couple of launch-time booleans, so we deserialize defensively
+//! into a struct with all-optional fields and fall back to defaults if the
+//! file is missing, unreadable, or malformed.
+
+use serde::Deserialize;
+use std::path::PathBuf;
+
+/// Subset of `~/.vireo/config.json` the Tauri wrapper cares about.
+///
+/// Everything is `Option<T>` so a missing key, an extra key, or a totally
+/// empty file all parse cleanly and let us apply our own defaults.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct LaunchConfig {
+    /// If true, the desktop wrapper opens the UI in the user's default
+    /// browser on launch instead of creating a WKWebView window.
+    pub open_in_browser: Option<bool>,
+}
+
+impl LaunchConfig {
+    /// True if browser-launch mode is enabled (defaults to false).
+    pub fn open_in_browser(&self) -> bool {
+        self.open_in_browser.unwrap_or(false)
+    }
+}
+
+/// Resolve the path to `~/.vireo/config.json`.
+pub fn config_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".vireo").join("config.json"))
+}
+
+/// Read and parse the config file, returning defaults on any failure.
+///
+/// Failure modes (file missing, unreadable, invalid JSON, unexpected shape)
+/// all silently fall back to defaults so a corrupt file never blocks app
+/// launch — the worst it does is skip the user's preference for one run.
+pub fn load_launch_config() -> LaunchConfig {
+    let Some(path) = config_path() else {
+        return LaunchConfig::default();
+    };
+    let Ok(bytes) = std::fs::read(&path) else {
+        return LaunchConfig::default();
+    };
+    match serde_json::from_slice::<LaunchConfig>(&bytes) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            log::warn!(
+                "Failed to parse {} for launch config ({e}); using defaults",
+                path.display()
+            );
+            LaunchConfig::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_yields_defaults() {
+        // We can't easily redirect the home dir in unit tests, so just
+        // verify the parser is defensive on empty / missing input.
+        let cfg: LaunchConfig = serde_json::from_str("{}").unwrap();
+        assert!(!cfg.open_in_browser());
+    }
+
+    #[test]
+    fn explicit_true_round_trips() {
+        let cfg: LaunchConfig =
+            serde_json::from_str(r#"{"open_in_browser": true}"#).unwrap();
+        assert!(cfg.open_in_browser());
+    }
+
+    #[test]
+    fn explicit_false_round_trips() {
+        let cfg: LaunchConfig =
+            serde_json::from_str(r#"{"open_in_browser": false}"#).unwrap();
+        assert!(!cfg.open_in_browser());
+    }
+
+    #[test]
+    fn unknown_keys_are_tolerated() {
+        // The Python side has dozens of keys we don't care about — they
+        // must not break parsing.
+        let json = r#"{
+            "open_in_browser": true,
+            "classification_threshold": 0.4,
+            "pipeline": {"w_focus": 0.45},
+            "scan_roots": ["/tmp/photos"]
+        }"#;
+        let cfg: LaunchConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.open_in_browser());
+    }
+
+    #[test]
+    fn malformed_json_is_handled_by_caller() {
+        // load_launch_config swallows parse errors; here we just confirm
+        // that serde itself reports the error so the caller's match arm
+        // is exercised in real use.
+        let result = serde_json::from_str::<LaunchConfig>("not json {{");
+        assert!(result.is_err());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod config;
 mod menu;
 mod sidecar;
 mod tray;
@@ -5,6 +6,20 @@ mod updater;
 use sidecar::SidecarState;
 use tauri::{Manager, RunEvent};
 use tauri::window::{ProgressBarState, ProgressBarStatus};
+use tauri_plugin_opener::OpenerExt;
+
+/// Open the given URL in the user's default web browser.
+///
+/// Logs failures rather than propagating them — failing to open a browser
+/// shouldn't crash the app; the user can still reach the UI by clicking
+/// the tray icon menu item.
+fn open_in_browser(app: &tauri::AppHandle, url: &str) {
+    if let Err(e) = app.opener().open_url(url, None::<&str>) {
+        log::error!("Failed to open browser at {}: {}", url, e);
+    } else {
+        log::info!("Opened default browser at {}", url);
+    }
+}
 
 #[tauri::command]
 fn get_server_port(state: tauri::State<'_, SidecarState>) -> u16 {
@@ -44,6 +59,11 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
+            // Read the user's launch-time config (~/.vireo/config.json).
+            // Failures fall back to defaults — see config::load_launch_config.
+            let launch_cfg = config::load_launch_config();
+            let browser_mode = launch_cfg.open_in_browser();
+
             if cfg!(debug_assertions) {
                 // In dev mode, don't spawn sidecar — developer runs Flask manually
                 app.handle().plugin(
@@ -62,9 +82,14 @@ pub fn run() {
                     Ok(state) => {
                         let port = state.port;
                         app.manage(state);
-                        if let Some(window) = app.get_webview_window("main") {
-                            let url = format!("http://127.0.0.1:{}", port);
-                            let _ = window.navigate(url.parse().unwrap());
+                        // Only navigate the WKWebView when we're actually
+                        // going to show it. In browser mode the window is
+                        // about to be hidden/closed anyway.
+                        if !browser_mode {
+                            if let Some(window) = app.get_webview_window("main") {
+                                let url = format!("http://127.0.0.1:{}", port);
+                                let _ = window.navigate(url.parse().unwrap());
+                            }
                         }
                     }
                     Err(e) => {
@@ -80,7 +105,22 @@ pub fn run() {
             app.set_menu(menu)?;
 
             let port = app.state::<SidecarState>().port;
-            tray::create_tray(app.handle(), port)?;
+            tray::create_tray(app.handle(), port, browser_mode)?;
+
+            // The main window is created with `visible: false` (see
+            // tauri.conf.json) so we can decide here whether to show it
+            // (classic mode) or leave it hidden (browser mode) — avoids a
+            // visible flash before we'd otherwise hide it.
+            if browser_mode {
+                // Sidecar is healthy by this point — start_sidecar blocks
+                // on /api/health in production, and in dev the developer's
+                // Flask is presumed already running.
+                let url = format!("http://127.0.0.1:{}", port);
+                open_in_browser(app.handle(), &url);
+            } else if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
 
             // Background update checks (production only)
             if !cfg!(debug_assertions) {
@@ -127,9 +167,18 @@ pub fn run() {
                 return;
             }
 
-            // Navigation items — evaluate JS in the main webview
+            // Navigation items — evaluate JS in the main webview, or in
+            // browser mode open the route in the user's default browser.
             if let Some(route) = menu::route_for_id(id) {
-                if let Some(window) = app.get_webview_window("main") {
+                let browser_mode = app
+                    .try_state::<tray::TrayMode>()
+                    .map(|m| m.browser_mode)
+                    .unwrap_or(false);
+                if browser_mode {
+                    let port = app.state::<SidecarState>().port;
+                    let url = format!("http://127.0.0.1:{}{}", port, route);
+                    open_in_browser(app, &url);
+                } else if let Some(window) = app.get_webview_window("main") {
                     let js = format!("window.location.href = '{}'", route);
                     if let Err(e) = window.eval(&js) {
                         log::error!("Failed to navigate to {}: {}", route, e);

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -7,6 +7,7 @@ use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
 };
+use tauri_plugin_opener::OpenerExt;
 
 #[derive(Deserialize)]
 struct JobsResponse {
@@ -25,15 +26,31 @@ pub struct TrayPollState {
     pub stop: Arc<AtomicBool>,
 }
 
+/// Whether the app launched in browser mode. Stored in Tauri state so the
+/// menu-event handler (which only gets an `AppHandle`) can branch correctly
+/// without re-reading the config file.
+pub struct TrayMode {
+    pub browser_mode: bool,
+    /// Sidecar port — used to construct the URL we hand to the browser.
+    pub port: u16,
+}
+
 /// Menu item IDs
 const SHOW_WINDOW: &str = "show_window";
 const HIDE_WINDOW: &str = "hide_window";
+const OPEN_IN_BROWSER: &str = "open_in_browser";
 const JOB_STATUS: &str = "job_status";
 const QUIT: &str = "quit";
 
 /// Build the tray icon with its context menu and start job polling.
-pub fn create_tray(app: &AppHandle, port: u16) -> tauri::Result<()> {
-    let menu = build_menu(app, "No active jobs")?;
+///
+/// `browser_mode` swaps the "Show / Hide Window" pair for a single
+/// "Open in browser" item, since the WKWebView window is intentionally
+/// hidden in that mode and showing it would be confusing.
+pub fn create_tray(app: &AppHandle, port: u16, browser_mode: bool) -> tauri::Result<()> {
+    app.manage(TrayMode { browser_mode, port });
+
+    let menu = build_menu(app, "No active jobs", browser_mode)?;
 
     TrayIconBuilder::with_id("main-tray")
         .icon(app.default_window_icon().unwrap().clone())
@@ -44,7 +61,8 @@ pub fn create_tray(app: &AppHandle, port: u16) -> tauri::Result<()> {
             handle_menu_event(app, event.id().as_ref());
         })
         .on_tray_icon_event(|tray, event| {
-            // Left-click on the tray icon: show and focus the window
+            // Left-click on the tray icon: show and focus the window, or
+            // re-open the browser if we're in browser mode.
             if let TrayIconEvent::Click {
                 button: MouseButton::Left,
                 button_state: MouseButtonState::Up,
@@ -52,7 +70,7 @@ pub fn create_tray(app: &AppHandle, port: u16) -> tauri::Result<()> {
             } = event
             {
                 let app = tray.app_handle();
-                show_main_window(app);
+                activate_ui(app);
             }
         })
         .build(app)?;
@@ -66,15 +84,33 @@ pub fn create_tray(app: &AppHandle, port: u16) -> tauri::Result<()> {
 }
 
 /// Build (or rebuild) the tray context menu with a given job status string.
-pub fn build_menu(app: &AppHandle, job_status: &str) -> tauri::Result<Menu<tauri::Wry>> {
-    let show = MenuItem::with_id(app, SHOW_WINDOW, "Show Window", true, None::<&str>)?;
-    let hide = MenuItem::with_id(app, HIDE_WINDOW, "Hide Window", true, None::<&str>)?;
+pub fn build_menu(
+    app: &AppHandle,
+    job_status: &str,
+    browser_mode: bool,
+) -> tauri::Result<Menu<tauri::Wry>> {
     let sep1 = PredefinedMenuItem::separator(app)?;
     let jobs = MenuItem::with_id(app, JOB_STATUS, job_status, false, None::<&str>)?;
     let sep2 = PredefinedMenuItem::separator(app)?;
     let quit = MenuItem::with_id(app, QUIT, "Quit Vireo", true, None::<&str>)?;
 
-    Menu::with_items(app, &[&show, &hide, &sep1, &jobs, &sep2, &quit])
+    if browser_mode {
+        // Browser-launch mode: there is no app window to show or hide, so
+        // we offer a single "Open in browser" item that re-opens the URL
+        // (handy if the user closed the tab).
+        let open = MenuItem::with_id(
+            app,
+            OPEN_IN_BROWSER,
+            "Open in browser",
+            true,
+            None::<&str>,
+        )?;
+        Menu::with_items(app, &[&open, &sep1, &jobs, &sep2, &quit])
+    } else {
+        let show = MenuItem::with_id(app, SHOW_WINDOW, "Show Window", true, None::<&str>)?;
+        let hide = MenuItem::with_id(app, HIDE_WINDOW, "Hide Window", true, None::<&str>)?;
+        Menu::with_items(app, &[&show, &hide, &sep1, &jobs, &sep2, &quit])
+    }
 }
 
 /// Handle a menu item click.
@@ -82,6 +118,7 @@ fn handle_menu_event(app: &AppHandle, id: &str) {
     match id {
         SHOW_WINDOW => show_main_window(app),
         HIDE_WINDOW => hide_main_window(app),
+        OPEN_IN_BROWSER => open_ui_in_browser(app),
         QUIT => {
             // Stop the polling thread
             if let Some(poll_state) = app.try_state::<TrayPollState>() {
@@ -113,6 +150,40 @@ fn hide_main_window(app: &AppHandle) {
     }
 }
 
+/// Open (or re-open) the UI in the user's default browser.
+///
+/// In browser mode this is what the tray's left-click and "Open in browser"
+/// menu item do. Most browsers will focus an existing tab pointed at the
+/// same origin rather than opening a duplicate; if not, the user gets a
+/// fresh tab — either way they end up looking at the UI.
+fn open_ui_in_browser(app: &AppHandle) {
+    let port = match app.try_state::<TrayMode>() {
+        Some(mode) => mode.port,
+        None => {
+            log::error!("TrayMode not initialised; cannot open browser");
+            return;
+        }
+    };
+    let url = format!("http://127.0.0.1:{}", port);
+    if let Err(e) = app.opener().open_url(&url, None::<&str>) {
+        log::error!("Failed to open browser at {}: {}", url, e);
+    }
+}
+
+/// Activate the UI: show the main window, or open the browser, depending
+/// on which launch mode we're in.
+fn activate_ui(app: &AppHandle) {
+    let browser_mode = app
+        .try_state::<TrayMode>()
+        .map(|m| m.browser_mode)
+        .unwrap_or(false);
+    if browser_mode {
+        open_ui_in_browser(app);
+    } else {
+        show_main_window(app);
+    }
+}
+
 /// Query the Flask backend for running jobs.
 fn fetch_running_job_count(port: u16) -> usize {
     let url = format!("http://127.0.0.1:{}/api/jobs", port);
@@ -139,8 +210,12 @@ fn fetch_running_job_count(port: u16) -> usize {
 
 /// Rebuild the tray menu with updated job status text.
 fn update_tray_menu(app: &AppHandle, job_status: &str) {
+    let browser_mode = app
+        .try_state::<TrayMode>()
+        .map(|m| m.browser_mode)
+        .unwrap_or(false);
     if let Some(tray) = app.tray_by_id("main-tray") {
-        match build_menu(app, job_status) {
+        match build_menu(app, job_status, browser_mode) {
             Ok(menu) => {
                 let _ = tray.set_menu(Some(menu));
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,8 @@
         "minWidth": 800,
         "minHeight": 600,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "visible": false
       }
     ],
     "security": {

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -33,6 +33,11 @@ DEFAULTS = {
     "darktable_style": "",
     "darktable_output_format": "jpg",
     "darktable_output_dir": "",
+    # When true, the Tauri desktop wrapper opens this UI in the user's
+    # default web browser on launch instead of creating its WKWebView
+    # window. The Flask sidecar and tray icon still run as usual.
+    # Read by `src-tauri/src/lib.rs` at startup; takes effect after restart.
+    "open_in_browser": False,
     # --- Subject identification ---
     # Keyword types that count as "identifying" a photo for queue/classifier
     # purposes. Photos with at least one keyword of one of these types drop

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -167,6 +167,17 @@ SCHEMA = {
         "label": "Browse card fields",
         "desc": "Which metadata badges appear on each photo card in browse.",
     },
+    "open_in_browser": {
+        "type": "bool",
+        "category": "Display", "scope": "global",
+        "label": "Open in default browser on launch (skip the app window)",
+        "desc": (
+            "Desktop app only. When enabled, launching Vireo opens this UI "
+            "in your default web browser instead of the in-app window. "
+            "The Flask backend and tray icon keep running. "
+            "Takes effect after restart."
+        ),
+    },
 
     # --- Subject identification -------------------------------------------
     # Workspace-overridable. Photos with at least one keyword of one of

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -318,6 +318,16 @@
         <span style="font-size:13px;color:var(--text-primary);min-width:42px;" id="cfgBrowseThumbVal">220px</span>
       </div>
     </div>
+    <div class="setting-row">
+      <div class="setting-label">
+        Open in default browser on launch (skip the app window)
+        <small>When enabled, launching Vireo opens this UI in your default web browser. The app keeps running as a menu-bar/tray icon. Takes effect after restart. (Only meaningful in the desktop app build.)</small>
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;">
+        <input type="checkbox" id="cfgOpenInBrowser"
+               onchange="saveConfig()" style="accent-color:var(--accent);">
+      </div>
+    </div>
   </div>
 
   <!-- Browse Grid -->
@@ -1220,6 +1230,7 @@ async function loadConfig() {
     var bt = cfg.browse_thumb_default != null ? cfg.browse_thumb_default : 220;
     document.getElementById('cfgBrowseThumbDefault').value = bt;
     document.getElementById('cfgBrowseThumbVal').textContent = bt + 'px';
+    document.getElementById('cfgOpenInBrowser').checked = cfg.open_in_browser === true;
     // Load browse card fields
     loadCardFieldCheckboxes(cfg.browse_card_fields || ["filename", "rating", "flag", "sharpness"]);
     // Load detection settings
@@ -1402,6 +1413,7 @@ function saveConfig() {
           preview_quality: parseInt(document.getElementById('cfgPreviewQuality').value, 10) || 90,
           preview_cache_max_mb: Math.max(0, parseInt(document.getElementById('cfgPreviewCacheMaxMb').value, 10) || 0),
           browse_thumb_default: parseInt(document.getElementById('cfgBrowseThumbDefault').value, 10) || 220,
+          open_in_browser: document.getElementById('cfgOpenInBrowser').checked,
           browse_card_fields: getSelectedCardFields(),
           detector_confidence: parseInt(document.getElementById('cfgDetectorConf').value, 10) / 100,
           detection_padding: parseInt(document.getElementById('cfgDetectionPadding').value, 10) / 100,

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -361,3 +361,34 @@ def test_google_maps_api_key_default_is_empty(tmp_path, monkeypatch):
     import config as cfg
     monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
     assert cfg.load().get("google_maps_api_key") == ""
+
+
+def test_open_in_browser_default_is_false(tmp_path, monkeypatch):
+    """open_in_browser defaults to False so the Tauri wrapper keeps its
+    classic in-window behavior unless the user opts in."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    assert cfg.DEFAULTS["open_in_browser"] is False
+    assert cfg.load().get("open_in_browser") is False
+
+
+def test_open_in_browser_round_trip(tmp_path, monkeypatch):
+    """Setting open_in_browser persists to disk and reloads as a real bool.
+
+    The Rust side reads ~/.vireo/config.json directly with serde_json, so the
+    value must round-trip as a JSON boolean (not a truthy int or string)."""
+    import json as _json
+
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.set("open_in_browser", True)
+    assert cfg.get("open_in_browser") is True
+
+    # Confirm it serialises as a bare JSON boolean — what Rust's serde_json
+    # will deserialise into bool.
+    with open(cfg.CONFIG_PATH) as f:
+        on_disk = _json.load(f)
+    assert on_disk["open_in_browser"] is True
+
+    cfg.set("open_in_browser", False)
+    assert cfg.get("open_in_browser") is False


### PR DESCRIPTION
## Summary

Adds an opt-in `open_in_browser` config flag (default `false`). When enabled, launching the desktop app skips creating the WKWebView main window and opens the Flask sidecar URL in the user's default browser instead. The sidecar and tray icon keep running.

## Why

WKWebView (the macOS embedded browser Tauri uses) rasterizes transformed/large images at visibly worse quality than Chromium-family browsers — same problem motivating PR #756's burst-strip fix, but at a more general level. This gives users an escape hatch: keep the Vireo backend / tray, but view the UI in a browser whose image rendering you prefer.

## What changed

- **Config plumbing** — `vireo/config.py`, `vireo/config_schema.py`, `vireo/templates/settings.html`: new `open_in_browser` boolean (default `false`), surfaced on the /settings page under the Display category.
- **Rust config reader** — new `src-tauri/src/config.rs`: defensive serde struct that parses just the keys the wrapper needs from `~/.vireo/config.json`. All-optional fields, falls back to defaults on missing file / unreadable / malformed JSON, and tolerates the dozens of unrelated keys Python writes.
- **Launch branching** — `src-tauri/src/lib.rs`: reads launch config in `setup`. In browser mode, skips navigating the WKWebView and calls `opener.open_url` on `http://127.0.0.1:<port>`. Menu navigation items (Browse, Cull, Settings, etc.) also open in the browser instead of `window.eval`-ing in WKWebView.
- **Window stays hidden until decided** — `tauri.conf.json` sets `visible: false`. Setup explicitly `.show()`s it in classic mode; browser mode leaves it hidden, so we never flash a window before closing it.
- **Tray** — `src-tauri/src/tray.rs`: in browser mode the tray menu shows a single "Open in browser" item instead of "Show Window / Hide Window" (the WKWebView is intentionally not user-visible in browser mode). Tray left-click also re-opens the browser. New `TrayMode` resource in app state so the menu-event handler can branch without re-reading the config file.

## Tests

- New `test_open_in_browser_default_is_false` and `test_open_in_browser_round_trip` in `vireo/tests/test_config.py` (the round-trip test verifies the value lands as a real JSON `bool` on disk, since the Rust side reads it with `serde_json`).
- New Rust unit tests in `src-tauri/src/config.rs::tests` (5 tests covering defaults, true/false, unknown-key tolerance, malformed JSON).
- `cargo build` / `cargo test --lib config` clean.
- `python -m pytest vireo/tests/test_config.py -v` → 25/25 pass (incl. the 2 new ones).
- Standard battery (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py`): each file passes in isolation. The 2 known-pre-existing `test_edits_api` failures (`test_remove_keyword_from_photo`, `test_undo_keyword_remove_clears_pending_change`) reproduce on `main` and are not regressions.

## Manual-test notes (not yet run by me)

- Toggle the setting on /settings, restart the desktop app: should land in the user's default browser at `http://127.0.0.1:<port>`. Tray icon stays in the menu bar.
- Tray left-click → re-opens the browser tab. Tray menu items (Browse, Cull, etc.) → open the corresponding route in the browser.
- Toggle off, restart: classic in-window behaviour.
- Corrupt `~/.vireo/config.json` (e.g. truncate to half a brace): app still launches in classic mode, log warns.

## Caveats / follow-ups

- Setting takes effect after restart only — there's no live "switch the running app to browser mode" path. Documented in the schema description.
- The flag is desktop-only-meaningful (no-op when running Flask directly via `python vireo/app.py`); the settings page label says so but it's still shown to all users.
- Did not implement an "Open in browser" affordance in classic mode (e.g. a tray menu item that just opens the URL once without persisting the preference). Reasonable follow-up if useful.