### PR TITLE
browse: live match count for smart collection modal

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2794,25 +2794,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         Body: {"rules": [...]}. Returns {"count": N}. Used by the smart-
         collection modal to show "Matches: N photos" as the user edits
-        rules. Returns 400 on malformed rules.
+        rules. Returns 400 on malformed rules or syntactically invalid JSON.
         """
-        import sqlite3
         db = _get_db()
-        body = request.get_json(silent=True)
+        # Parse the body manually rather than calling request.get_json(silent=True),
+        # because silent=True collapses three different states into None (no
+        # body, wrong Content-Type, malformed JSON), and we want malformed
+        # JSON to surface as a 400 rather than be silently treated as {}.
+        raw = request.get_data(cache=False)
+        if not raw:
+            body = {}
+        else:
+            try:
+                body = json.loads(raw)
+            except ValueError:
+                return json_error("request body must be valid JSON", 400)
         # Flask returns top-level JSON lists/numbers/strings as-is, so guard
         # against `body.get(...)` raising AttributeError on non-object payloads
-        # (e.g. a client posting `[]` directly). Treat missing body as {}.
-        if body is None:
-            body = {}
-        elif not isinstance(body, dict):
+        # (e.g. a client posting `[]` directly).
+        if not isinstance(body, dict):
             return json_error("request body must be a JSON object", 400)
         rules = body.get("rules", [])
         try:
             count = db.count_photos_for_rules(rules)
-        except (ValueError, TypeError, sqlite3.Error) as e:
-            # ValueError comes from explicit validation; TypeError /
-            # sqlite3.Error are belt-and-suspenders for malformed inputs that
-            # slip past validation and would otherwise surface as a 500.
+        except ValueError as e:
+            # Validation in _build_query_from_rules raises ValueError for every
+            # input shape SQLite could not bind, so we don't need to catch
+            # sqlite3 errors here — letting them surface as 5xx keeps real
+            # backend faults (locked DB, OperationalError, etc.) from being
+            # misclassified as client errors.
             return json_error(str(e), 400)
         return jsonify({"count": count})
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2788,6 +2788,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         cid = db.add_collection(name, json.dumps(rules))
         return jsonify({"ok": True, "id": cid})
 
+    @app.route("/api/collections/preview", methods=["POST"])
+    def api_collection_preview():
+        """Live count of photos that would match an unsaved rules list.
+
+        Body: {"rules": [...]}. Returns {"count": N}. Used by the smart-
+        collection modal to show "Matches: N photos" as the user edits
+        rules. Returns 400 on malformed rules.
+        """
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        rules = body.get("rules", [])
+        try:
+            count = db.count_photos_for_rules(rules)
+        except ValueError as e:
+            return json_error(str(e), 400)
+        return jsonify({"count": count})
+
     @app.route("/api/collections/<int:collection_id>", methods=["DELETE"])
     def api_delete_collection(collection_id):
         db = _get_db()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2798,7 +2798,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """
         import sqlite3
         db = _get_db()
-        body = request.get_json(silent=True) or {}
+        body = request.get_json(silent=True)
+        # Flask returns top-level JSON lists/numbers/strings as-is, so guard
+        # against `body.get(...)` raising AttributeError on non-object payloads
+        # (e.g. a client posting `[]` directly). Treat missing body as {}.
+        if body is None:
+            body = {}
+        elif not isinstance(body, dict):
+            return json_error("request body must be a JSON object", 400)
         rules = body.get("rules", [])
         try:
             count = db.count_photos_for_rules(rules)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2796,12 +2796,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         collection modal to show "Matches: N photos" as the user edits
         rules. Returns 400 on malformed rules.
         """
+        import sqlite3
         db = _get_db()
         body = request.get_json(silent=True) or {}
         rules = body.get("rules", [])
         try:
             count = db.count_photos_for_rules(rules)
-        except ValueError as e:
+        except (ValueError, TypeError, sqlite3.Error) as e:
+            # ValueError comes from explicit validation; TypeError /
+            # sqlite3.Error are belt-and-suspenders for malformed inputs that
+            # slip past validation and would otherwise surface as a 500.
             return json_error(str(e), 400)
         return jsonify({"count": count})
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7801,6 +7801,21 @@ class Database:
             return None
 
         rules = json.loads(row["rules"])
+        return self._build_query_from_rules(rules)
+
+    def _build_query_from_rules(self, rules):
+        """Build SQL clauses from a rules list (not yet persisted).
+
+        Returns (folder_join, join_clause, where, params). Raises ValueError on
+        malformed input — callers that accept rules from untrusted sources
+        (e.g. the live-preview API) should catch and surface a 400.
+        """
+        if not isinstance(rules, list):
+            raise ValueError("rules must be a list")
+        for r in rules:
+            if not isinstance(r, dict) or "field" not in r:
+                raise ValueError("each rule must be an object with a 'field'")
+
         conditions = []
         params = []
         need_keyword_join = False
@@ -8048,6 +8063,22 @@ class Database:
             return 0
 
         folder_join, join_clause, where, params = parts
+        query = f"""
+            SELECT COUNT(DISTINCT p.id) FROM photos p
+            {folder_join}
+            {join_clause}
+            {where}
+        """
+        return self.conn.execute(query, params).fetchone()[0]
+
+    def count_photos_for_rules(self, rules):
+        """Return the number of photos in the active workspace that match
+        an unsaved rules list. Used by the smart-collection modal preview.
+
+        Raises ValueError on malformed input (propagated from
+        ``_build_query_from_rules``).
+        """
+        folder_join, join_clause, where, params = self._build_query_from_rules(rules)
         query = f"""
             SELECT COUNT(DISTINCT p.id) FROM photos p
             {folder_join}

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7812,22 +7812,28 @@ class Database:
         """
         if not isinstance(rules, list):
             raise ValueError("rules must be a list")
+        # Only photo_ids and timestamp/between consume list values; every other
+        # field binds `value` as a single SQL parameter, so a list there raises
+        # sqlite3.ProgrammingError ("type 'list' is not supported"). Without
+        # this distinction the preview route would surface those as 500s on
+        # inputs like {"field":"rating","value":[4]}.
         for r in rules:
             if not isinstance(r, dict) or "field" not in r:
                 raise ValueError("each rule must be an object with a 'field'")
-            # Values are bound directly as SQL parameters, so reject anything
-            # SQLite can't bind (dicts, nested lists). Without this the preview
-            # route would surface a sqlite3.InterfaceError as a 500 on inputs
-            # like {"value": {"foo": 1}}.
+            field = r.get("field")
+            op = r.get("op")
             val = r.get("value")
-            if val is None or isinstance(val, (str, int, float, bool)):
-                continue
+            list_allowed = field == "photo_ids" or (field == "timestamp" and op == "between")
             if isinstance(val, list):
+                if not list_allowed:
+                    raise ValueError(f"rule field {field!r} does not accept a list value")
                 for item in val:
                     if item is not None and not isinstance(item, (str, int, float, bool)):
                         raise ValueError("rule list values must be scalars")
                 continue
-            raise ValueError("rule value must be a scalar or list of scalars")
+            if val is None or isinstance(val, (str, int, float, bool)):
+                continue
+            raise ValueError("rule value must be a scalar")
 
         conditions = []
         params = []

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7815,6 +7815,19 @@ class Database:
         for r in rules:
             if not isinstance(r, dict) or "field" not in r:
                 raise ValueError("each rule must be an object with a 'field'")
+            # Values are bound directly as SQL parameters, so reject anything
+            # SQLite can't bind (dicts, nested lists). Without this the preview
+            # route would surface a sqlite3.InterfaceError as a 500 on inputs
+            # like {"value": {"foo": 1}}.
+            val = r.get("value")
+            if val is None or isinstance(val, (str, int, float, bool)):
+                continue
+            if isinstance(val, list):
+                for item in val:
+                    if item is not None and not isinstance(item, (str, int, float, bool)):
+                        raise ValueError("rule list values must be scalars")
+                continue
+            raise ValueError("rule value must be a scalar or list of scalars")
 
         conditions = []
         params = []

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1519,10 +1519,10 @@ async function updatePreviewNow() {
   _previewTimer = null;
   var el = document.getElementById('rulePreview');
   if (!el) return;
-  if (!collectionRules.length) {
-    el.textContent = '';
-    return;
-  }
+  // An empty rules list is a valid save state — it matches every photo in
+  // the workspace — so we still query the API rather than blanking the
+  // preview text. Otherwise removing all rule rows would hide the count
+  // for what is actually a "match all photos" save.
   // Coerce numeric fields the same way saveCollection() does, so the
   // preview matches what would be saved.
   var rules = collectionRules.map(function(r) {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1467,6 +1467,10 @@ async function filterByCollection(id) {
 var collectionRules = [];
 
 function showCollectionModal() {
+  // Cancel any pending/in-flight preview from a previous session before
+  // resetting state — otherwise a stale response can land on the DOM and
+  // briefly show the previous rule set's count in the freshly opened modal.
+  resetPreviewState();
   collectionRules = [];
   document.getElementById('rulePreview').textContent = '';
   addRuleRow();
@@ -1475,6 +1479,7 @@ function showCollectionModal() {
 }
 
 function hideCollectionModal() {
+  resetPreviewState();
   document.getElementById('collectionModal').classList.remove('open');
 }
 
@@ -1513,6 +1518,17 @@ var _previewSeq = 0;
 function schedulePreviewUpdate() {
   if (_previewTimer) clearTimeout(_previewTimer);
   _previewTimer = setTimeout(updatePreviewNow, 250);
+}
+
+function resetPreviewState() {
+  // Bump the sequence so any in-flight fetch's response is discarded as
+  // stale, and cancel any pending debounced call. Used when the modal
+  // opens or closes so a previous session can't write into a new one.
+  if (_previewTimer) {
+    clearTimeout(_previewTimer);
+    _previewTimer = null;
+  }
+  _previewSeq++;
 }
 
 async function updatePreviewNow() {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1468,6 +1468,7 @@ var collectionRules = [];
 
 function showCollectionModal() {
   collectionRules = [];
+  document.getElementById('rulePreview').textContent = '';
   addRuleRow();
   document.getElementById('collectionName').value = '';
   document.getElementById('collectionModal').classList.add('open');
@@ -1498,6 +1499,52 @@ function updateRule(idx, key, val) {
       collectionRules[idx].op = 'is';
     }
     renderRules();
+  } else {
+    // Field changes already trigger renderRules() above (which schedules a
+    // preview); for op/value changes, just refresh the count.
+    schedulePreviewUpdate();
+  }
+}
+
+/* ---------- Live match-count preview ---------- */
+var _previewTimer = null;
+var _previewSeq = 0;
+
+function schedulePreviewUpdate() {
+  if (_previewTimer) clearTimeout(_previewTimer);
+  _previewTimer = setTimeout(updatePreviewNow, 250);
+}
+
+async function updatePreviewNow() {
+  _previewTimer = null;
+  var el = document.getElementById('rulePreview');
+  if (!el) return;
+  if (!collectionRules.length) {
+    el.textContent = '';
+    return;
+  }
+  // Coerce numeric fields the same way saveCollection() does, so the
+  // preview matches what would be saved.
+  var rules = collectionRules.map(function(r) {
+    var val = r.value;
+    if (r.field === 'rating') val = parseInt(val, 10) || 0;
+    return {field: r.field, op: r.op, value: val};
+  });
+  var seq = ++_previewSeq;
+  try {
+    var data = await safeFetch('/api/collections/preview', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({rules: rules}),
+    }, {toast: false});
+    if (seq !== _previewSeq) return;  // stale response
+    if (data && typeof data.count === 'number') {
+      el.textContent = 'Matches: ' + data.count + ' photo' + (data.count === 1 ? '' : 's');
+    } else {
+      el.textContent = '';
+    }
+  } catch (e) {
+    if (seq === _previewSeq) el.textContent = '';
   }
 }
 
@@ -1537,6 +1584,7 @@ function renderRules() {
     '</div>';
   });
   document.getElementById('ruleRows').innerHTML = html;
+  schedulePreviewUpdate();
 }
 
 async function saveCollection() {

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4224,3 +4224,14 @@ def test_collection_preview_rejects_malformed_rules(app_and_db):
     )
     assert resp.status_code == 400
     assert "error" in resp.get_json()
+
+    # Top-level JSON that isn't an object (list, number, string) must also
+    # return 400 — the route reads `body.get("rules", ...)`, which would
+    # otherwise raise AttributeError and surface as a 500.
+    for bad_body in ([], [1, 2, 3], 5, "hello"):
+        resp = client.post(
+            "/api/collections/preview",
+            json=bad_body,
+        )
+        assert resp.status_code == 400, f"expected 400 for body {bad_body!r}"
+        assert "error" in resp.get_json()

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4225,6 +4225,19 @@ def test_collection_preview_rejects_malformed_rules(app_and_db):
     assert resp.status_code == 400
     assert "error" in resp.get_json()
 
+    # Scalar-only fields must reject list values up front; otherwise SQLite
+    # raises ProgrammingError at bind time and the route would 500.
+    for field, op in [("rating", ">="), ("flag", "is"),
+                      ("extension", "is"), ("color_label", "is")]:
+        resp = client.post(
+            "/api/collections/preview",
+            json={"rules": [{"field": field, "op": op, "value": [1]}]},
+        )
+        assert resp.status_code == 400, (
+            f"expected 400 for list value on {field!r}/{op!r}"
+        )
+        assert "error" in resp.get_json()
+
     # Top-level JSON that isn't an object (list, number, string) must also
     # return 400 — the route reads `body.get("rules", ...)`, which would
     # otherwise raise AttributeError and surface as a 500.

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4170,3 +4170,48 @@ def test_save_grouping_defaults_rejects_bad_values(tmp_path, monkeypatch):
         assert _math.isfinite(pipe["tau_enc"])
     if "burst_phash_threshold" in pipe:
         assert isinstance(pipe["burst_phash_threshold"], int)
+
+
+def test_collection_preview_returns_match_count(app_and_db):
+    """POST /api/collections/preview returns the count of photos that
+    would match an unsaved rules list. Powers the smart-collection
+    modal's live "Matches: N photos" readout.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+    collections_before = len(db.get_collections())
+
+    # The fixture creates 3 photos; p1 has rating=3, p3 has rating=5.
+    # Empty rules -> all photos in workspace.
+    resp = client.post("/api/collections/preview", json={"rules": []})
+    assert resp.status_code == 200
+    assert resp.get_json()["count"] == 3
+
+    # rating >= 4 -> only p3 (rating=5).
+    resp = client.post(
+        "/api/collections/preview",
+        json={"rules": [{"field": "rating", "op": ">=", "value": 4}]},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["count"] == 1
+
+    # No collection row was persisted as a side effect of previewing.
+    assert len(db.get_collections()) == collections_before
+
+
+def test_collection_preview_rejects_malformed_rules(app_and_db):
+    """Malformed rules return 400, not 500 — the route must not crash on
+    untrusted input from the modal.
+    """
+    app, _db = app_and_db
+    client = app.test_client()
+
+    resp = client.post("/api/collections/preview", json={"rules": "not a list"})
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+    resp = client.post(
+        "/api/collections/preview",
+        json={"rules": [{"op": "is", "value": 5}]},  # missing 'field'
+    )
+    assert resp.status_code == 400

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4235,3 +4235,56 @@ def test_collection_preview_rejects_malformed_rules(app_and_db):
         )
         assert resp.status_code == 400, f"expected 400 for body {bad_body!r}"
         assert "error" in resp.get_json()
+
+
+def test_collection_preview_rejects_invalid_json(app_and_db):
+    """Syntactically broken JSON returns 400 — silent=True would otherwise
+    coerce it to None and the route would happily return a 200 match count
+    for a request the client never actually made successfully.
+    """
+    app, _db = app_and_db
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/collections/preview",
+        data="{not valid json",
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+    # An empty body, however, is still valid — equivalent to {} — and should
+    # match every photo in the workspace (the same behavior as {"rules": []}).
+    resp = client.post(
+        "/api/collections/preview",
+        data="",
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert "count" in resp.get_json()
+
+
+def test_collection_preview_does_not_mask_db_failures(app_and_db, monkeypatch):
+    """Real backend faults from sqlite3 must surface as 5xx — not be
+    rewritten as 400 by the route's exception handler. Catching the base
+    sqlite3.Error here would hide locked-DB / OperationalError incidents.
+    """
+    import sqlite3
+    from db import Database
+
+    app, _db = app_and_db
+    client = app.test_client()
+
+    # Patch the class so the per-request Database instance built by
+    # _get_db() is affected too — the route does not share the fixture's
+    # instance.
+    def boom(self, _rules):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(Database, "count_photos_for_rules", boom)
+
+    resp = client.post("/api/collections/preview", json={"rules": []})
+    # Flask's default for an unhandled exception is 500; the important thing
+    # is that it's *not* a 400, which would mislabel a backend fault as a
+    # client error.
+    assert resp.status_code >= 500

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4215,3 +4215,12 @@ def test_collection_preview_rejects_malformed_rules(app_and_db):
         json={"rules": [{"op": "is", "value": 5}]},  # missing 'field'
     )
     assert resp.status_code == 400
+
+    # A value that SQLite can't bind as a parameter (e.g. a nested object)
+    # must also surface as 400 rather than a 500 from sqlite3.InterfaceError.
+    resp = client.post(
+        "/api/collections/preview",
+        json={"rules": [{"field": "rating", "op": ">=", "value": {"x": 1}}]},
+    )
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -642,6 +642,16 @@ def test_count_photos_for_rules_rejects_malformed_input(tmp_path):
         db.count_photos_for_rules([{"op": "is", "value": 5}])  # missing field
     with pytest.raises(ValueError):
         db.count_photos_for_rules(["not a dict"])
+    # Reject value types SQLite cannot bind as a parameter — without this
+    # the preview route surfaces a sqlite3.InterfaceError as a 500.
+    with pytest.raises(ValueError):
+        db.count_photos_for_rules(
+            [{"field": "rating", "op": ">=", "value": {"nested": 1}}]
+        )
+    with pytest.raises(ValueError):
+        db.count_photos_for_rules(
+            [{"field": "photo_ids", "op": "is", "value": [1, {"nested": 1}]}]
+        )
 
 
 def test_collection_untagged_rule(tmp_path):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -594,6 +594,56 @@ def test_collection_photos_keyword_rule(tmp_path):
     assert photos[0]['filename'] == 'hawk.jpg'
 
 
+def test_count_photos_for_rules_unsaved(tmp_path):
+    """count_photos_for_rules evaluates a rules list directly (without
+    persisting it to the collections table) so the smart-collection modal
+    can show a live match count as the user edits rules.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='good.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='ok.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    p3 = db.add_photo(folder_id=fid, filename='bad.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    db.update_photo_rating(p1, 5)
+    db.update_photo_rating(p2, 4)
+    db.update_photo_rating(p3, 1)
+
+    # No rules -> matches every photo in the workspace.
+    assert db.count_photos_for_rules([]) == 3
+
+    # rating >= 4 -> two of three.
+    assert db.count_photos_for_rules(
+        [{"field": "rating", "op": ">=", "value": 4}]
+    ) == 2
+
+    # No saved collection row was created.
+    assert len(db.get_collections()) == 0
+
+
+def test_count_photos_for_rules_rejects_malformed_input(tmp_path):
+    """The preview helper raises on input that isn't a list of rule dicts —
+    the API route relies on this to return a 400 instead of 500.
+    """
+    import pytest
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    with pytest.raises(ValueError):
+        db.count_photos_for_rules("not a list")
+    with pytest.raises(ValueError):
+        db.count_photos_for_rules([{"op": "is", "value": 5}])  # missing field
+    with pytest.raises(ValueError):
+        db.count_photos_for_rules(["not a dict"])
+
+
 def test_collection_untagged_rule(tmp_path):
     """get_collection_photos filters by keyword_count equals 0."""
     import json

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -652,6 +652,26 @@ def test_count_photos_for_rules_rejects_malformed_input(tmp_path):
         db.count_photos_for_rules(
             [{"field": "photo_ids", "op": "is", "value": [1, {"nested": 1}]}]
         )
+    # Scalar-only fields must reject list values; otherwise SQLite raises
+    # ProgrammingError ("type 'list' is not supported") at bind time.
+    for field, op in [
+        ("rating", ">="),
+        ("flag", "is"),
+        ("extension", "is"),
+        ("color_label", "is"),
+    ]:
+        with pytest.raises(ValueError):
+            db.count_photos_for_rules(
+                [{"field": field, "op": op, "value": [1]}]
+            )
+    # ...but list-accepting fields still work.
+    assert db.count_photos_for_rules(
+        [{"field": "photo_ids", "op": "is", "value": [1, 2, 3]}]
+    ) == 0
+    assert db.count_photos_for_rules(
+        [{"field": "timestamp", "op": "between",
+          "value": ["2020-01-01", "2020-12-31"]}]
+    ) == 0
 
 
 def test_collection_untagged_rule(tmp_path):


### PR DESCRIPTION
## Summary

Wires up the previously-empty `<div id=\"rulePreview\">` in the Browse smart-collection modal so the user sees a live, debounced **Matches: N photos** count as they edit rules. The signal is the *real* result of the same query that would run if the user clicked Save (no proxy / global count) -- consistent with the UI-transparency rule in `CORE_PHILOSOPHY.md`.

- **Backend refactor**: `Database._build_collection_query(collection_id)` now loads rules from the DB and delegates to a new `_build_query_from_rules(rules)` helper. Existing callers (`count_collection_photos`, `get_collection_photos`, `collection_photo_ids`) are unchanged.
- **New method**: `Database.count_photos_for_rules(rules)` -> `int`. Raises `ValueError` on malformed input.
- **New route**: `POST /api/collections/preview` with `{\"rules\": [...]}` -> `{\"count\": N}`. Returns 400 (not 500) on bad input.
- **Frontend**: 250 ms debounce on every rule mutation (`renderRules`, `addRuleRow`, `updateRule`, `removeRule`); sequence guard discards stale responses; `toast: false` so transient preview failures don't nag the user. Modal also clears the preview text on open. The pre-existing `.modal-preview` CSS rule already had appropriate styling -- no CSS changes needed.

## Test plan

Required suite (run in parallel):

\`\`\`
python -m pytest vireo/tests/test_db.py vireo/tests/test_app.py -n 4
# 591 passed, 1 skipped

python -m pytest tests/test_workspaces.py vireo/tests/test_photos_api.py \
  vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py \
  vireo/tests/test_darktable_api.py vireo/tests/test_config.py -n 4
# 309 passed
\`\`\`

New tests:
- `vireo/tests/test_db.py::test_count_photos_for_rules_unsaved` -- empty rules match all workspace photos; `rating >= 4` matches 2 of 3; no collection row is persisted.
- `vireo/tests/test_db.py::test_count_photos_for_rules_rejects_malformed_input` -- non-list, missing-field, and non-dict inputs all raise.
- `vireo/tests/test_app.py::test_collection_preview_returns_match_count` -- route returns expected counts and persists no collection.
- `vireo/tests/test_app.py::test_collection_preview_rejects_malformed_rules` -- 400 (not 500) on bad payloads.

## Notes on parallel PRs

Two other PRs are touching this same modal. Conflicts will be resolved at merge time. The `_build_collection_query` -> `_build_query_from_rules` refactor will benefit them automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)