### PR TITLE
chore(raw): reword fallback log + clarify resolution label with crop mode

### DIFF
--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -193,7 +193,10 @@ def _load_raw(path, max_size):
 
     1. Try the embedded JPEG preview; use it if it's big enough for max_size.
     2. Otherwise demosaic via rawpy.postprocess().
-    3. If postprocess fails, fall back to the embedded JPEG (even if small).
+    3. If libraw can't decode this RAW variant (e.g. Nikon HE*/TicoRAW on
+       libraw 0.22), use the embedded JPEG. Modern Nikon bodies write the
+       full camera-output JPEG as the embedded preview, so this is not a
+       degradation — it's the same pixels the camera produced.
     """
     import rawpy
 
@@ -213,8 +216,9 @@ def _load_raw(path, max_size):
         except Exception as e:
             if embedded is not None:
                 log.info(
-                    "RAW decode failed for %s, using embedded JPEG (%dx%d): %s",
-                    path, embedded.size[0], embedded.size[1], e,
+                    "libraw cannot decode %s (%s); using embedded JPEG "
+                    "(%dx%d, full camera output)",
+                    path, e, embedded.size[0], embedded.size[1],
                 )
                 return embedded
             raise

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -193,10 +193,8 @@ def _load_raw(path, max_size):
 
     1. Try the embedded JPEG preview; use it if it's big enough for max_size.
     2. Otherwise demosaic via rawpy.postprocess().
-    3. If libraw can't decode this RAW variant (e.g. Nikon HE*/TicoRAW on
-       libraw 0.22), use the embedded JPEG. Modern Nikon bodies write the
-       full camera-output JPEG as the embedded preview, so this is not a
-       degradation — it's the same pixels the camera produced.
+    3. If postprocess raises (e.g. libraw 0.22 can't decode Nikon HE*/TicoRAW),
+       fall back to the embedded JPEG even if smaller than max_size.
     """
     import rawpy
 
@@ -215,10 +213,20 @@ def _load_raw(path, max_size):
             return _postprocess_raw(raw, max_size)
         except Exception as e:
             if embedded is not None:
+                # Only claim "full camera output" when the embedded JPEG
+                # actually matches the sensor's active dimensions (e.g.
+                # Nikon HE*/TicoRAW). For other failures the embedded may
+                # be a smaller preview and the fallback is a real
+                # degradation — don't paper over it.
+                sensor_long = max(raw.sizes.width, raw.sizes.height)
+                embedded_long = max(embedded.size)
+                qualifier = (", full camera output"
+                             if sensor_long and embedded_long >= sensor_long
+                             else "")
                 log.info(
                     "libraw cannot decode %s (%s); using embedded JPEG "
-                    "(%dx%d, full camera output)",
-                    path, e, embedded.size[0], embedded.size[1],
+                    "(%dx%d%s)",
+                    path, e, embedded.size[0], embedded.size[1], qualifier,
                 )
                 return embedded
             raise

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -214,15 +214,21 @@ def _load_raw(path, max_size):
         except Exception as e:
             if embedded is not None:
                 # Only claim "full camera output" when the embedded JPEG
-                # actually matches the sensor's active dimensions (e.g.
-                # Nikon HE*/TicoRAW). For other failures the embedded may
-                # be a smaller preview and the fallback is a real
-                # degradation — don't paper over it.
-                sensor_long = max(raw.sizes.width, raw.sizes.height)
-                embedded_long = max(embedded.size)
-                qualifier = (", full camera output"
-                             if sensor_long and embedded_long >= sensor_long
-                             else "")
+                # actually matches the sensor's active dimensions on both
+                # axes (e.g. Nikon HE*/TicoRAW). A long-edge-only check
+                # would still mislabel cropped/aspect-mismatched previews
+                # like 6000×3376 against a 6000×4000 sensor.
+                sensor_dims = sorted(
+                    (raw.sizes.width, raw.sizes.height), reverse=True
+                )
+                embedded_dims = sorted(embedded.size, reverse=True)
+                qualifier = (
+                    ", full camera output"
+                    if sensor_dims[0]
+                    and embedded_dims[0] >= sensor_dims[0]
+                    and embedded_dims[1] >= sensor_dims[1]
+                    else ""
+                )
                 log.info(
                     "libraw cannot decode %s (%s); using embedded JPEG "
                     "(%dx%d%s)",

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1332,12 +1332,18 @@ function grmUpdateResLabel() {
   if (!el) return;
   var stop = GRM_RES_STOPS[grmResolutionIdx];
   var dims = '';
+  var mpStr = '';
   var photo = grmState && grmState.selected
     ? grmState.items.find(function(p) { return p.id === grmState.selected; })
     : (grmState && grmState.items[0]);
   if (photo && photo.width && photo.height) {
     if (stop.kind === 'original') {
       dims = photo.width + '×' + photo.height;
+      // Show megapixels alongside the dimensions so users can tell at a
+      // glance why two shots in the same library zoom to different
+      // "Original" sizes — e.g. Nikon DX-crop ~19 MP vs FX ~45 MP.
+      var mp = (photo.width * photo.height) / 1e6;
+      mpStr = (mp >= 10 ? mp.toFixed(0) : mp.toFixed(1)) + ' MP';
     } else {
       var longest = Math.max(photo.width, photo.height);
       var scale = longest > stop.size ? stop.size / longest : 1;
@@ -1346,7 +1352,8 @@ function grmUpdateResLabel() {
       dims = w + '×' + h;
     }
   }
-  el.textContent = (dims ? dims + ' · ' : stop.label + ' · ') + stop.kind;
+  var prefix = dims ? dims : stop.label;
+  el.textContent = prefix + ' · ' + (mpStr ? mpStr + ' · ' : '') + stop.kind;
 }
 
 function grmSetResolution(idx) {

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -214,6 +214,21 @@ def test_raw_fallback_log_claims_full_output_only_when_embedded_matches_sensor(
     msgs = [r.message for r in caplog.records]
     assert not any("full camera output" in m for m in msgs), msgs
 
+    # Case 3: embedded shares the sensor's long edge but is cropped on the
+    # short edge (e.g. 6000×3376 preview against a 6000×4000 sensor). A
+    # long-edge-only check would mislabel this as full output; we want
+    # both axes verified.
+    _install_fake_raw(monkeypatch, _FakeRaw(
+        embedded_jpeg=_jpeg_bytes((6000, 3376)),
+        sensor_size=(6000, 4000),
+        postprocess_error=rawpy.LibRawFileUnsupportedError(b'unsupported'),
+    ))
+    with caplog.at_level(logging.INFO, logger='image_loader'):
+        caplog.clear()
+        load_image(str(nef), max_size=8000)
+    msgs = [r.message for r in caplog.records]
+    assert not any("full camera output" in m for m in msgs), msgs
+
 
 def test_raw_uses_postprocess_when_embedded_too_small(tmp_path, monkeypatch):
     """When embedded JPEG is smaller than max_size, RAW decode is used."""

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -172,6 +172,49 @@ def test_raw_falls_back_to_embedded_on_postprocess_failure(tmp_path, monkeypatch
     assert max(result.size) == 1600, "should return the embedded JPEG as-is"
 
 
+def test_raw_fallback_log_claims_full_output_only_when_embedded_matches_sensor(
+    tmp_path, monkeypatch, caplog
+):
+    """The fallback log line must only claim "full camera output" when the
+    embedded JPEG actually matches the sensor's reported dimensions.
+
+    Regression guard for PR #764: an earlier revision asserted "full camera
+    output" unconditionally, which is misleading when the embedded preview
+    is genuinely smaller than the sensor (a real degradation).
+    """
+    import logging
+
+    import rawpy
+    from image_loader import load_image
+
+    nef = tmp_path / "test.nef"
+    nef.write_bytes(b"fake NEF content")
+
+    # Case 1: embedded JPEG matches sensor (HE*/TicoRAW shape) → claim it.
+    _install_fake_raw(monkeypatch, _FakeRaw(
+        embedded_jpeg=_jpeg_bytes((5392, 3592)),
+        sensor_size=(5392, 3592),
+        postprocess_error=rawpy.LibRawFileUnsupportedError(b'unsupported'),
+    ))
+    with caplog.at_level(logging.INFO, logger='image_loader'):
+        caplog.clear()
+        load_image(str(nef), max_size=8000)
+    msgs = [r.message for r in caplog.records]
+    assert any("full camera output" in m for m in msgs), msgs
+
+    # Case 2: embedded JPEG smaller than sensor → don't claim it.
+    _install_fake_raw(monkeypatch, _FakeRaw(
+        embedded_jpeg=_jpeg_bytes((1600, 1067)),
+        sensor_size=(6000, 4000),
+        postprocess_error=rawpy.LibRawFileUnsupportedError(b'unsupported'),
+    ))
+    with caplog.at_level(logging.INFO, logger='image_loader'):
+        caplog.clear()
+        load_image(str(nef), max_size=2048)
+    msgs = [r.message for r in caplog.records]
+    assert not any("full camera output" in m for m in msgs), msgs
+
+
 def test_raw_uses_postprocess_when_embedded_too_small(tmp_path, monkeypatch):
     """When embedded JPEG is smaller than max_size, RAW decode is used."""
     from image_loader import load_image


### PR DESCRIPTION
## Summary

Two cosmetic fixes around the libraw HE*/TicoRAW fallback. Together they would have prevented the real-user diagnosis session that chased a non-bug.

### 1. Reword the misleading log line (`vireo/image_loader.py`)

For Nikon Z 8 (and other bodies) shooting in High Efficiency* (TicoRAW) mode, libraw 0.22 can't decode the RAW. We fall back to the camera's embedded JPEG, which on modern Nikon bodies IS the full camera-output for that shot. The old log message:

> `RAW decode failed for /path/file.NEF, using embedded JPEG (5392x3592): Unsupported file format or not RAW file`

reads as a degradation and misled a diagnosis session into hunting for "missing pixels." The new wording is honest about what's actually happening:

> `libraw cannot decode /path/file.NEF (Unsupported file format or not RAW file); using embedded JPEG (5392x3592, full camera output)`

`_load_raw` docstring updated to match.

### 2. Show megapixels in the GRM resolution-slider label (`vireo/templates/pipeline_review.html`)

The user shoots with a body that toggles between FX (~45 MP) and DX-crop (~19 MP). Currently two shots in the same library zoom to different "Original" sizes (8256×5504 vs 5392×3592) with no UI hint as to why. Adding the MP figure to the slider label answers the unspoken question without requiring crop-mode EXIF extraction.

Per CORE_PHILOSOPHY.md "No black boxes" rule: pills/labels should answer the question users actually read them as. New label format: `5392×3592 · 19.4 MP · original` (vs. `8256×5504 · 45 MP · original` for FX).

Pure JS change in `grmUpdateResLabel`. No schema change, no scanner change. `review.html` was checked and has no parallel slider label, so only `pipeline_review.html` needed the change.

## Test plan

- [x] `pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_config.py` — 514 passed, 1 skipped
- [x] `pytest vireo/tests/test_app.py -k "raw or _load_raw or thumbnail"` — 3 passed
- [ ] Manual: open a burst with mixed FX/DX shots in pipeline review, drag resolution slider to Original, verify each card's label shows correct MP (FX shows ~45 MP, DX shows ~19 MP)
- [ ] Manual: trigger an HE* RAW load, verify log line no longer contains "failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)