### PR TITLE
fix(lint): sort imports + add pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.8
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^(vireo|tests)/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "pytest-timeout>=2.3",
     "pytest-xdist>=3.6",
     "ruff>=0.11",
+    "pre-commit>=3.5",
 ]
 
 [tool.setuptools.packages.find]

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4283,6 +4283,7 @@ def test_collection_preview_does_not_mask_db_failures(app_and_db, monkeypatch):
     sqlite3.Error here would hide locked-DB / OperationalError incidents.
     """
     import sqlite3
+
     from db import Database
 
     app, _db = app_and_db


### PR DESCRIPTION
## Summary
- **Fix:** PR #763 merged with a ruff `I001` lint failure in `vireo/tests/test_app.py` (inline `import sqlite3` / `from db import Database` not separated). Apply `ruff check --fix`.
- **Prevent recurrence:** add `.pre-commit-config.yaml` running `ruff --fix` on staged files, and add `pre-commit` to dev deps. Reverted earlier idea of gating merges on lint via branch protection — pre-commit catches it at commit time so CI never sees it.

## One-time local setup
After pulling, run once in your local clone:
```
pip install -e '.[dev]'
pre-commit install
```
Conductor workspaces inherit `core.hooksPath` from the main checkout, so installing once there covers every workspace.

## Test plan
- [x] `python -m ruff check vireo/ tests/` → All checks passed
- [x] `pre-commit run --all-files` → ruff hook passes on the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)