### PR TITLE
smart collection: dropdowns for extension and folder rules

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1281,6 +1281,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         folders = db.get_folder_tree()
         return jsonify([dict(f) for f in folders])
 
+    @app.route("/api/photos/extensions")
+    def api_photos_extensions():
+        """Return the distinct lowercased file extensions present in the
+        active workspace, sorted.
+
+        The smart-collection rule editor uses this to populate the value
+        dropdown for the Extension field. Free-text was silent-failure
+        prone — typing ``JPG`` matched nothing because rows are stored as
+        ``.jpg``.
+        """
+        db = _get_db()
+        return jsonify(db.get_workspace_extensions())
+
     @app.route("/api/folders/missing")
     def api_folders_missing():
         db = _get_db()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -8026,11 +8026,16 @@ class Database:
                     conditions.append("p.timestamp >= datetime('now', ?)")
                     params.append(f"-{value} days")
             elif field == "extension":
+                # Match case-insensitively: get_workspace_extensions() returns
+                # lowercased options, but photos imported by older scans may
+                # have stored mixed-case extensions (.JPG vs .jpg). SQLite's
+                # default = / != is case-sensitive, so without LOWER() a
+                # rule saved as ".jpg" would silently miss .JPG rows.
                 if op in ("equals", "is"):
-                    conditions.append("p.extension = ?")
+                    conditions.append("LOWER(p.extension) = LOWER(?)")
                     params.append(value)
                 elif op == "is not":
-                    conditions.append("p.extension != ?")
+                    conditions.append("LOWER(p.extension) != LOWER(?)")
                     params.append(value)
             elif field in (
                 "taxonomy_kingdom",

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1218,6 +1218,30 @@ class Database:
             (workspace_id,),
         ).fetchall()
 
+    def get_workspace_extensions(self):
+        """Return distinct lowercased file extensions for photos in the
+        active workspace, sorted alphabetically.
+
+        Used by the smart-collection rule editor to populate the Extension
+        value dropdown — a free-text input silently failed when users typed
+        ``JPG`` instead of ``.jpg`` or vice versa. Lowercasing here means the
+        UI never has to think about case, and storing-side variations
+        (``.jpg`` vs ``.JPG`` from older imports) collapse into one option.
+        Empty/NULL extensions are skipped.
+        """
+        ws = self._ws_id()
+        rows = self.conn.execute(
+            """SELECT DISTINCT LOWER(p.extension) AS ext
+               FROM photos p
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               WHERE wf.workspace_id = ?
+                 AND p.extension IS NOT NULL
+                 AND p.extension != ''
+               ORDER BY ext""",
+            (ws,),
+        ).fetchall()
+        return [r["ext"] for r in rows]
+
     def move_folders_to_workspace(self, source_ws_id, target_ws_id, folder_ids):
         """Move folders and their workspace-scoped data to another workspace.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1228,12 +1228,21 @@ class Database:
         UI never has to think about case, and storing-side variations
         (``.jpg`` vs ``.JPG`` from older imports) collapse into one option.
         Empty/NULL extensions are skipped.
+
+        Folders whose status is not ``'ok'`` or ``'partial'`` are excluded so
+        the dropdown stays consistent with ``_build_collection_query``, which
+        joins on the same status filter. Otherwise an extension found only in
+        a missing folder would appear as a selectable option but match zero
+        photos when used in a rule — exactly the silent-failure mode this
+        change is meant to prevent.
         """
         ws = self._ws_id()
         rows = self.conn.execute(
             """SELECT DISTINCT LOWER(p.extension) AS ext
                FROM photos p
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               JOIN folders f ON f.id = p.folder_id
+                              AND f.status IN ('ok', 'partial')
                WHERE wf.workspace_id = ?
                  AND p.extension IS NOT NULL
                  AND p.extension != ''

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1518,6 +1518,12 @@ async function showCollectionModal() {
   collectionRules = [];
   document.getElementById('rulePreview').textContent = '';
   document.getElementById('collectionName').value = '';
+  // Clear the rule-row DOM before awaiting the dropdown fetches. Without
+  // this, a slow/failed fetch leaves the previous session's <select>s
+  // visible and interactive while collectionRules is already empty, so
+  // changing one fires updateRule(idx, ...) against an undefined row and
+  // throws.
+  renderRules();
   document.getElementById('collectionModal').classList.add('open');
   // Fetch the dropdown sources before adding the first rule row so the
   // initial render already has data — otherwise the user sees an empty

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1465,6 +1465,12 @@ async function filterByCollection(id) {
 
 /* ---------- Collection Modal ---------- */
 var collectionRules = [];
+// Cached dropdown sources for the rule editor. Filled on first modal open
+// and reused across rule rows so toggling field=Extension or field=Folder
+// doesn't refetch on every render. Re-fetched each time the modal opens
+// so newly-imported folders/extensions show up without a page reload.
+var collectionExtensions = [];
+var collectionFolders = [];
 
 /* Valid ops per field — must mirror vireo/db.py::_build_collection_query.
    The UI only shows ops the backend handles; non-matching combos used to
@@ -1495,6 +1501,8 @@ function defaultValueForRule(field, op) {
   if (field === 'color_label') return 'red';
   if (field === 'flag') return 'flagged';
   if (field === 'rating') return 0;
+  if (field === 'extension') return collectionExtensions[0] || '';
+  if (field === 'folder') return (collectionFolders[0] && collectionFolders[0].path) || '';
   if (field === 'timestamp') {
     if (op === 'between') return ['', ''];
     if (op === 'recent_days') return 7;
@@ -1502,16 +1510,31 @@ function defaultValueForRule(field, op) {
   return '';
 }
 
-function showCollectionModal() {
+async function showCollectionModal() {
   // Cancel any pending/in-flight preview from a previous session before
   // resetting state — otherwise a stale response can land on the DOM and
   // briefly show the previous rule set's count in the freshly opened modal.
   resetPreviewState();
   collectionRules = [];
   document.getElementById('rulePreview').textContent = '';
-  addRuleRow();
   document.getElementById('collectionName').value = '';
   document.getElementById('collectionModal').classList.add('open');
+  // Fetch the dropdown sources before adding the first rule row so the
+  // initial render already has data — otherwise the user sees an empty
+  // <select> until they click off and back on. safeFetch already parses
+  // JSON for us (see _navbar.html), so the resolved values are arrays.
+  try {
+    var [exts, folders] = await Promise.all([
+      safeFetch('/api/photos/extensions'),
+      safeFetch('/api/folders'),
+    ]);
+    collectionExtensions = Array.isArray(exts) ? exts : [];
+    collectionFolders = Array.isArray(folders) ? folders : [];
+  } catch (e) {
+    collectionExtensions = [];
+    collectionFolders = [];
+  }
+  addRuleRow();
 }
 
 function hideCollectionModal() {
@@ -1645,6 +1668,43 @@ function renderRuleValueInput(r, i) {
         '<option value="flagged"' + (r.value==='flagged'?' selected':'') + '>Pick</option>' +
         '<option value="rejected"' + (r.value==='rejected'?' selected':'') + '>Reject</option>' +
         '<option value="none"' + (r.value==='none'?' selected':'') + '>No flag</option>' +
+      '</select>';
+  }
+  if (r.field === 'extension') {
+    // Extension dropdown is sourced from /api/photos/extensions for the
+    // active workspace. If the current rule value isn't in that list
+    // (legacy rule, freshly switched field), include it as a sticky
+    // option so the user can see+keep it instead of having it silently
+    // snap to the first known extension on next render.
+    return '<select onchange="updateRule(' + i + ',\'value\',this.value)" style="flex:1;">' +
+        (collectionExtensions.length === 0
+          ? '<option value="">(no extensions yet — scan a folder)</option>'
+          : '') +
+        (r.value && collectionExtensions.indexOf(r.value) === -1
+          ? '<option value="' + escapeAttr(String(r.value)) + '" selected>' + escapeHtml(String(r.value)) + '</option>'
+          : '') +
+        collectionExtensions.map(function(ext) {
+          return '<option value="' + escapeAttr(ext) + '"' + (r.value===ext?' selected':'') + '>' + escapeHtml(ext) + '</option>';
+        }).join('') +
+      '</select>';
+  }
+  if (r.field === 'folder') {
+    // Folder dropdown shows the path (full path is the value the
+    // backend matches with f.path LIKE ?). Display is the path too —
+    // basenames collide across folders and a smart-collection author
+    // can't disambiguate "January" between /2023/January and /2024.
+    var paths = collectionFolders.map(function(f){ return f.path; });
+    var stickyFolder = (r.value && paths.indexOf(r.value) === -1)
+      ? '<option value="' + escapeAttr(String(r.value)) + '" selected>' + escapeHtml(String(r.value)) + '</option>'
+      : '';
+    return '<select onchange="updateRule(' + i + ',\'value\',this.value)" style="flex:1;">' +
+        (collectionFolders.length === 0
+          ? '<option value="">(no folders in this workspace)</option>'
+          : '') +
+        stickyFolder +
+        collectionFolders.map(function(f) {
+          return '<option value="' + escapeAttr(f.path) + '"' + (r.value===f.path?' selected':'') + '>' + escapeHtml(f.path) + '</option>';
+        }).join('') +
       '</select>';
   }
   if (r.field === 'timestamp') {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1540,6 +1540,17 @@ async function showCollectionModal() {
     collectionExtensions = [];
     collectionFolders = [];
   }
+  // Backfill any extension/folder rules added during the await: they got
+  // value '' from defaultValueForRule because the source lists were empty.
+  // After fetch, the <select> visually picks the first option but state
+  // still holds '', so save/preview would run with an empty filter.
+  collectionRules.forEach(function(r) {
+    if (r.field === 'extension' && !r.value) {
+      r.value = collectionExtensions[0] || '';
+    } else if (r.field === 'folder' && !r.value) {
+      r.value = (collectionFolders[0] && collectionFolders[0].path) || '';
+    }
+  });
   // Only seed the initial row if the user hasn't already added one (or
   // dismissed the modal) during the await. Without this guard, a user who
   // clicks "+ Add Rule" while the fetch is in flight gets a phantom

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1540,7 +1540,19 @@ async function showCollectionModal() {
     collectionExtensions = [];
     collectionFolders = [];
   }
-  addRuleRow();
+  // Only seed the initial row if the user hasn't already added one (or
+  // dismissed the modal) during the await. Without this guard, a user who
+  // clicks "+ Add Rule" while the fetch is in flight gets a phantom
+  // keyword/contains/"" row tacked on when fetches resolve, silently
+  // changing the saved collection's semantics.
+  if (collectionRules.length === 0 &&
+      document.getElementById('collectionModal').classList.contains('open')) {
+    addRuleRow();
+  } else {
+    // Re-render so any rows added during the await (which were drawn with
+    // empty extension/folder dropdowns) pick up the freshly-fetched data.
+    renderRules();
+  }
 }
 
 function hideCollectionModal() {

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -49,6 +49,43 @@ def test_api_folders(app_and_db):
     assert '/photos/2024' in paths
 
 
+def test_api_photos_extensions_returns_distinct_lowercased(app_and_db):
+    """GET /api/photos/extensions returns sorted, lowercased, workspace-scoped extensions."""
+    app, db = app_and_db
+    # Fixture seeds three .jpg photos. Add a mixed-case + raw to verify
+    # collapsing and sorting.
+    fid = db.get_folder_tree()[0]['id']
+    db.add_photo(folder_id=fid, filename='upper.JPG', extension='.JPG',
+                 file_size=1, file_mtime=99.0)
+    db.add_photo(folder_id=fid, filename='raw.nef', extension='.nef',
+                 file_size=1, file_mtime=99.0)
+
+    client = app.test_client()
+    resp = client.get('/api/photos/extensions')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == ['.jpg', '.nef']
+
+
+def test_api_photos_extensions_scoped_to_active_workspace(app_and_db):
+    """Extensions from another workspace's folders don't leak into the response."""
+    app, db = app_and_db
+    default_ws = db._active_workspace_id
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+    other_fid = db.add_folder('/other/photos', name='other')
+    db.add_photo(folder_id=other_fid, filename='only.cr2', extension='.cr2',
+                 file_size=1, file_mtime=1.0)
+    db.set_active_workspace(default_ws)
+
+    client = app.test_client()
+    resp = client.get('/api/photos/extensions')
+    assert resp.status_code == 200
+    # .cr2 belongs to "Other" workspace and must not appear here.
+    assert '.cr2' not in resp.get_json()
+    assert '.jpg' in resp.get_json()
+
+
 def test_api_coverage(app_and_db):
     """GET /api/coverage returns workspace-level and per-folder coverage."""
     app, db = app_and_db

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -10897,3 +10897,68 @@ def test_set_workspace_group_state_overwrites(tmp_path):
     ).fetchone()
     assert row["last_grouped_at"] == 2
     assert row["last_group_fingerprint"] == "new"
+
+
+def test_get_workspace_extensions_returns_distinct_lowercased(tmp_path):
+    """Extensions are returned distinct, lowercased, sorted, scoped to ws."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                 file_size=1, file_mtime=1.0)
+    db.add_photo(folder_id=fid, filename='b.JPG', extension='.JPG',
+                 file_size=1, file_mtime=1.0)
+    db.add_photo(folder_id=fid, filename='c.nef', extension='.nef',
+                 file_size=1, file_mtime=1.0)
+    db.add_photo(folder_id=fid, filename='d.cr2', extension='.cr2',
+                 file_size=1, file_mtime=1.0)
+
+    exts = db.get_workspace_extensions()
+    # Lowercased (so .jpg and .JPG collapse), distinct, sorted.
+    assert exts == ['.cr2', '.jpg', '.nef']
+
+
+def test_get_workspace_extensions_scoped_to_active_workspace(tmp_path):
+    """Extensions from another workspace's folders must not leak in."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    default_ws = db._active_workspace_id
+    f_default = db.add_folder('/a', name='a')
+    db.add_photo(folder_id=f_default, filename='x.jpg', extension='.jpg',
+                 file_size=1, file_mtime=1.0)
+
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+    f_other = db.add_folder('/b', name='b')
+    db.add_photo(folder_id=f_other, filename='y.nef', extension='.nef',
+                 file_size=1, file_mtime=1.0)
+
+    # Active = other_ws
+    assert db.get_workspace_extensions() == ['.nef']
+
+    db.set_active_workspace(default_ws)
+    assert db.get_workspace_extensions() == ['.jpg']
+
+
+def test_get_workspace_extensions_skips_null_and_empty(tmp_path):
+    """Photos with NULL/empty extension don't surface as an empty option."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/p', name='p')
+    db.add_photo(folder_id=fid, filename='ok.jpg', extension='.jpg',
+                 file_size=1, file_mtime=1.0)
+    # Force a NULL/empty row directly — add_photo doesn't normally let
+    # this happen but historical scans may have produced rows with no
+    # extension and we don't want them to render as a blank dropdown
+    # option that would silently match nothing in _build_collection_query.
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size, file_mtime) "
+        "VALUES (?, 'no_ext', NULL, 1, 1.0)", (fid,)
+    )
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size, file_mtime) "
+        "VALUES (?, 'empty_ext', '', 1, 1.0)", (fid,)
+    )
+    db.conn.commit()
+
+    assert db.get_workspace_extensions() == ['.jpg']

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -10962,3 +10962,36 @@ def test_get_workspace_extensions_skips_null_and_empty(tmp_path):
     db.conn.commit()
 
     assert db.get_workspace_extensions() == ['.jpg']
+
+
+def test_collection_extension_rule_matches_case_insensitively(tmp_path):
+    """Extension rule must match photos regardless of stored case.
+
+    The dropdown only offers lowercased options, but older imports can
+    leave .JPG (mixed case) in the photos table. SQLite's = is
+    case-sensitive, so without LOWER() on both sides a rule saved as
+    .jpg silently misses .JPG photos.
+    """
+    import json
+
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    db.add_photo(folder_id=fid, filename='lower.jpg', extension='.jpg',
+                 file_size=1, file_mtime=1.0)
+    db.add_photo(folder_id=fid, filename='upper.JPG', extension='.JPG',
+                 file_size=1, file_mtime=1.0)
+    db.add_photo(folder_id=fid, filename='raw.nef', extension='.nef',
+                 file_size=1, file_mtime=1.0)
+
+    cid = db.add_collection(
+        'JPGs', json.dumps([{"field": "extension", "op": "is", "value": ".jpg"}])
+    )
+    names = sorted(p['filename'] for p in db.get_collection_photos(cid))
+    assert names == ['lower.jpg', 'upper.JPG']
+
+    cid_not = db.add_collection(
+        'NotJPG', json.dumps([{"field": "extension", "op": "is not", "value": ".jpg"}])
+    )
+    names_not = sorted(p['filename'] for p in db.get_collection_photos(cid_not))
+    assert names_not == ['raw.nef']

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -10995,3 +10995,28 @@ def test_collection_extension_rule_matches_case_insensitively(tmp_path):
     )
     names_not = sorted(p['filename'] for p in db.get_collection_photos(cid_not))
     assert names_not == ['raw.nef']
+
+
+def test_get_workspace_extensions_excludes_missing_folders(tmp_path):
+    """An extension only present in a missing folder must not appear in the
+    dropdown.
+
+    `_build_collection_query` joins folders with `status IN ('ok',
+    'partial')`, so an extension surfaced from a missing-folder photo
+    would silently match zero rows when used in a rule — exactly the
+    failure mode this dropdown exists to prevent.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid_ok = db.add_folder('/ok', name='ok')
+    fid_gone = db.add_folder('/gone', name='gone')
+    db.add_photo(folder_id=fid_ok, filename='a.jpg', extension='.jpg',
+                 file_size=1, file_mtime=1.0)
+    db.add_photo(folder_id=fid_gone, filename='b.cr2', extension='.cr2',
+                 file_size=1, file_mtime=1.0)
+
+    db.conn.execute("UPDATE folders SET status = 'missing' WHERE id = ?", (fid_gone,))
+    db.conn.commit()
+
+    # .cr2 lives only in the missing folder — must be filtered out.
+    assert db.get_workspace_extensions() == ['.jpg']


### PR DESCRIPTION
## Summary

Final piece of the smart-collection rule editor cleanup. Same failure mode as the others: free-text inputs let you type values the backend won't match — \"JPG\" instead of \".jpg\", or a folder path with a typo — and you silently get zero matches.

- New \`Database.get_workspace_extensions()\` returns distinct, lowercased, sorted extensions for photos in the active workspace. Empty/NULL extensions are filtered out.
- New endpoint \`GET /api/photos/extensions\`.
- Modal fetches \`/api/photos/extensions\` and the existing \`/api/folders\` once when it opens (parallel, cached for the modal's lifetime).
- Extension and Folder rule values render as \`<select>\` dropdowns matching the color_label / flag pattern. If a legacy rule's value isn't in the current list, it appears as a sticky option so the user sees it and can keep it instead of having it silently snap to the first known value.

## Test plan
- [x] New backend tests in \`vireo/tests/test_db.py\` and \`vireo/tests/test_app.py\` for the new method and endpoint, including workspace scoping and the empty/NULL extension filtering.
- [x] Full required suite passes (901 passed; 2 pre-existing test_edits_api flakies documented in main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)