### PR TITLE
test(e2e): fix race in palette arrow-key selection test

### DIFF
--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -185,9 +185,19 @@ def test_palette_arrow_keys_change_selection(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/browse")
     page.keyboard.press("Meta+K")
-    # Empty query → all 20 pages, selected=top
+    # openCommandPalette refreshes tab state asynchronously before rendering,
+    # so wait for the first selected row instead of querying immediately.
+    page.wait_for_selector(".cmd-palette-result.selected", timeout=3000)
     first = page.eval_on_selector(".cmd-palette-result.selected", "el => el.dataset.navId")
     page.keyboard.press("ArrowDown")
+    page.wait_for_function(
+        "prev => {"
+        "  const el = document.querySelector('.cmd-palette-result.selected');"
+        "  return el && el.dataset.navId !== prev;"
+        "}",
+        arg=first,
+        timeout=3000,
+    )
     second = page.eval_on_selector(".cmd-palette-result.selected", "el => el.dataset.navId")
     assert first != second
 


### PR DESCRIPTION
## Summary
- `test_palette_arrow_keys_change_selection` was racy: `page.eval_on_selector` doesn't auto-wait, but `openCommandPalette` renders results only after an async `refreshFromTabsState()`. The `.cmd-palette-result.selected` row often wasn't present when queried.
- Wait for the initial selected row, then `wait_for_function` for the selection to change after `ArrowDown`.

## Test plan
- [x] `pytest tests/e2e/test_navigation.py -k palette` (5 passed)
- [x] `pytest tests/e2e/test_navigation.py::test_palette_arrow_keys_change_selection` (passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)