### PR TITLE
pipeline review: show pair photos and flag missing signals in trace

### DIFF
--- a/vireo/encounters.py
+++ b/vireo/encounters.py
@@ -195,13 +195,31 @@ def compute_s_enc(photo_a, photo_b, config=None, return_components=False):
     sp = sim_species(photo_a.get("species_top5"), photo_b.get("species_top5"))
     sm = sim_meta(photo_a, photo_b)
 
+    # Per-component missing flags: which photo (if any) lacks the signal.
+    # Used by the trace UI to surface "compute embeddings on photo B" hints
+    # without conflating a missing signal with an explicitly-zeroed weight.
+    has_subj_a = photo_a.get("dino_subject_embedding") is not None
+    has_subj_b = photo_b.get("dino_subject_embedding") is not None
+    has_global_a = photo_a.get("dino_global_embedding") is not None
+    has_global_b = photo_b.get("dino_global_embedding") is not None
+    has_species_a = bool(photo_a.get("species_top5"))
+    has_species_b = bool(photo_b.get("species_top5"))
+    has_time_a = ts_a is not None
+    has_time_b = ts_b is not None
+
+    missing = {
+        "time": (not has_time_a, not has_time_b),
+        "subj": (not has_subj_a, not has_subj_b),
+        "global": (not has_global_a, not has_global_b),
+        "species": (not has_species_a, not has_species_b),
+        "meta": (False, False),
+    }
+
     used = {
         "time": dt != float("inf"),
-        "subj": (photo_a.get("dino_subject_embedding") is not None
-                 and photo_b.get("dino_subject_embedding") is not None),
-        "global": (photo_a.get("dino_global_embedding") is not None
-                   and photo_b.get("dino_global_embedding") is not None),
-        "species": bool(photo_a.get("species_top5") and photo_b.get("species_top5")),
+        "subj": has_subj_a and has_subj_b,
+        "global": has_global_a and has_global_b,
+        "species": has_species_a and has_species_b,
         # Meta always contributes (even if 0)
         "meta": True,
     }
@@ -228,6 +246,8 @@ def compute_s_enc(photo_a, photo_b, config=None, return_components=False):
             "value": float(values[k]),
             "weight": float(cfg[weight_keys[k]]),
             "used": bool(used[k]),
+            "missing_a": bool(missing[k][0]),
+            "missing_b": bool(missing[k][1]),
         }
         for k in values
     }
@@ -315,6 +335,10 @@ def cut_microsegments(photos, config=None, emit_trace=False):
         if emit_trace:
             trace.append({
                 "pair_index": i,
+                "photo_a_id": sorted_photos[i].get("id"),
+                "photo_b_id": sorted_photos[i + 1].get("id"),
+                "photo_a_filename": sorted_photos[i].get("filename"),
+                "photo_b_filename": sorted_photos[i + 1].get("filename"),
                 "score": float(score),
                 "dt_seconds": float(dt) if dt != float("inf") else None,
                 "decision": decision,

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -416,16 +416,41 @@ input[type="range"]::-moz-range-thumb {
 .algo-trace { font-size: 11px; line-height: 1.35; margin-bottom: 8px; }
 .algo-trace .trace-row {
   display: grid; grid-template-columns: 1fr auto auto; gap: 6px;
-  padding: 3px 4px; border-bottom: 1px solid var(--border-primary);
+  padding: 3px 4px;
   align-items: baseline;
 }
 .algo-trace .trace-row.cut { background: rgba(220, 50, 50, 0.10); }
 .algo-trace .trace-row.merged-back { background: rgba(80, 160, 80, 0.10); }
 .algo-trace .trace-row.kept { }
 .algo-trace .trace-decision { font-weight: 600; }
+.algo-trace .trace-pair-photos {
+  display: flex; gap: 8px; align-items: center;
+  padding: 4px 4px 6px;
+  border-bottom: 1px solid var(--border-primary);
+}
+.algo-trace .trace-pair-photo {
+  display: flex; gap: 6px; align-items: center;
+  cursor: pointer; min-width: 0; flex: 1;
+}
+.algo-trace .trace-pair-photo img {
+  width: 36px; height: 28px; object-fit: cover;
+  border-radius: 3px; border: 1px solid var(--border-primary);
+  flex-shrink: 0;
+}
+.algo-trace .trace-pair-photo .name {
+  font-size: 10px; color: var(--text-dim);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.algo-trace .trace-pair-photo:hover .name { color: var(--text-primary); }
+.algo-trace .trace-pair-arrow {
+  color: var(--text-muted); font-size: 11px; flex-shrink: 0;
+}
 .algo-trace .trace-components {
   font-size: 10px; color: var(--text-dim); padding: 2px 4px 6px;
-  border-bottom: 1px solid var(--border-primary);
+}
+.algo-trace .trace-component-missing {
+  color: rgba(220, 140, 60, 0.85);
+  font-style: italic;
 }
 .algo-trace .trace-empty {
   font-size: 11px; color: var(--text-dim); font-style: italic; padding: 4px;
@@ -1457,6 +1482,31 @@ function renderAlgorithmTrace() {
   if (label) {
     label.textContent = 'Encounter ' + (_focusedEncounterIdx + 1) + ' — ' + enc.trace.length + ' adjacent pair' + (enc.trace.length > 1 ? 's' : '');
   }
+  var photoMap = {};
+  (pipelineResults.photos || []).forEach(function(p) { photoMap[p.id] = p; });
+  function escapeHtml(s) {
+    if (s == null) return '';
+    var d = document.createElement('div');
+    d.textContent = String(s);
+    return d.innerHTML;
+  }
+  function shortName(fname) {
+    if (!fname) return '';
+    var dot = fname.lastIndexOf('.');
+    return dot > 0 ? fname.slice(0, dot) : fname;
+  }
+  function pairPhotoHtml(pid, fallbackName) {
+    var p = photoMap[pid] || {};
+    var name = shortName(p.filename || fallbackName || '');
+    var label = name || ('Photo ' + (pid != null ? pid : '?'));
+    if (pid == null) {
+      return '<div class="trace-pair-photo"><span class="name">' + escapeHtml(label) + '</span></div>';
+    }
+    return '<div class="trace-pair-photo" onclick="openInspect(' + pid + ')" title="' + escapeHtml(p.filename || label) + '">'
+      + '<img src="/thumbnails/' + pid + '.jpg" loading="lazy" alt="">'
+      + '<span class="name">' + escapeHtml(label) + '</span>'
+      + '</div>';
+  }
   var html = '';
   enc.trace.forEach(function(t, i) {
     var rowCls = 'trace-row';
@@ -1471,15 +1521,43 @@ function renderAlgorithmTrace() {
     html += '<span>S=' + score + '</span>';
     html += '<span class="trace-decision">' + decision + '</span>';
     html += '</div>';
+    // Pair photos: filenames + tiny thumbs so the user can see *which*
+    // two photos this row scored, and click through to inspect either.
+    html += '<div class="trace-pair-photos">';
+    html += pairPhotoHtml(t.photo_a_id, t.photo_a_filename);
+    html += '<span class="trace-pair-arrow">→</span>';
+    html += pairPhotoHtml(t.photo_b_id, t.photo_b_filename);
+    html += '</div>';
     if (t.components) {
+      var nameA = shortName((photoMap[t.photo_a_id] || {}).filename || t.photo_a_filename || 'A');
+      var nameB = shortName((photoMap[t.photo_b_id] || {}).filename || t.photo_b_filename || 'B');
       var parts = [];
       ['time', 'subj', 'global', 'species', 'meta'].forEach(function(k) {
         var c = t.components[k];
         if (!c) return;
-        var marker = c.used ? '' : '·';
         var v = (typeof c.value === 'number') ? c.value.toFixed(2) : '-';
         var w = (typeof c.weight === 'number') ? c.weight.toFixed(2) : '-';
-        parts.push(k + marker + '=' + v + '×' + w);
+        if (!c.used) {
+          // Distinguish "missing data" from a zero-weighted component.
+          // Both are unused, but only the former is actionable (compute
+          // the missing signal); the latter means the user dialled it out.
+          var weightZero = !(c.weight > 0);
+          if (weightZero) {
+            // Component is intentionally turned off — render in muted form
+            // without a "missing" annotation.
+            parts.push(k + '=' + v + '×' + w);
+          } else {
+            var who;
+            if (c.missing_a && c.missing_b) who = 'both';
+            else if (c.missing_a) who = nameA;
+            else if (c.missing_b) who = nameB;
+            else who = '?';
+            parts.push('<span class="trace-component-missing">' + escapeHtml(k)
+              + '=missing on ' + escapeHtml(who) + ' (w=' + w + ')</span>');
+          }
+        } else {
+          parts.push(k + '=' + v + '×' + w);
+        }
       });
       html += '<div class="trace-components">' + parts.join(' · ') + '</div>';
     }

--- a/vireo/tests/test_encounters.py
+++ b/vireo/tests/test_encounters.py
@@ -601,6 +601,65 @@ def test_segment_encounters_attaches_trace_to_each_encounter():
         assert enc["trace"][0]["decision"] == "kept"
 
 
+def test_trace_includes_pair_photo_ids_and_filenames():
+    """Trace entries surface which two photos formed the pair, so the
+    review UI can render filenames + thumbs and let the user click through.
+    """
+    from encounters import cut_microsegments
+    photos = [
+        {"id": 11, "filename": "DSC_1384.NEF",
+         "timestamp": "2026-03-07T11:32:00", "focal_length": 600.0},
+        {"id": 22, "filename": "DSC_1385.NEF",
+         "timestamp": "2026-03-07T11:32:05", "focal_length": 600.0},
+    ]
+    _, trace = cut_microsegments(photos, emit_trace=True)
+    assert len(trace) == 1
+    assert trace[0]["photo_a_id"] == 11
+    assert trace[0]["photo_b_id"] == 22
+    assert trace[0]["photo_a_filename"] == "DSC_1384.NEF"
+    assert trace[0]["photo_b_filename"] == "DSC_1385.NEF"
+
+
+def test_components_flag_which_photo_is_missing_each_signal():
+    """Each component tags missing_a / missing_b so the UI can say
+    "missing on DSC_1385" instead of just rendering a bare dot. This is
+    what makes the half-processed-photo case actionable in the trace.
+    """
+    import numpy as np
+    from encounters import compute_s_enc
+
+    subj_emb = np.ones(128, dtype=np.float32)
+    photo_a = {
+        "id": 1, "filename": "A.NEF",
+        "timestamp": "2026-03-07T11:32:00",
+        "focal_length": 600.0,
+        "dino_subject_embedding": subj_emb,
+        "dino_global_embedding": subj_emb,
+        "species_top5": [("Western Bluebird", 0.9)],
+    }
+    photo_b = {
+        "id": 2, "filename": "B.NEF",
+        "timestamp": "2026-03-07T11:32:05",
+        "focal_length": 600.0,
+        # subj/global embeddings + species deliberately absent on B
+    }
+    _, components = compute_s_enc(photo_a, photo_b, return_components=True)
+    # Subj signal present on A, missing on B
+    assert components["subj"]["used"] is False
+    assert components["subj"]["missing_a"] is False
+    assert components["subj"]["missing_b"] is True
+    # Same for global and species
+    assert components["global"]["missing_a"] is False
+    assert components["global"]["missing_b"] is True
+    assert components["species"]["missing_a"] is False
+    assert components["species"]["missing_b"] is True
+    # Time and meta both present on both photos
+    assert components["time"]["missing_a"] is False
+    assert components["time"]["missing_b"] is False
+    assert components["meta"]["missing_a"] is False
+    assert components["meta"]["missing_b"] is False
+
+
 def test_segment_encounters_marks_merged_back_boundaries():
     """When two microsegments get merged, the boundary pair should be tagged merged_back."""
     from encounters import segment_encounters


### PR DESCRIPTION
## Summary

The algorithm-trace panel on the pipeline review page printed a bare `pair N · 32.4s · S=… kept` line and a components string where unused signals collapsed to a single dot (`subj·=…`). That hid the most important failure mode: a pair whose score is propped up by `time + meta` because one of the two photos is half-processed (no DINO embedding, no species predictions). The trace looked confident even when most of the signal was missing, and there was no way to tell *which* photos the row was about.

This PR makes the trace honest about both:

- Each trace row now shows **both filenames + tiny clickable thumbs** for the pair, so you can see at a glance whether the row is comparing two views of the same bird or — as in the case that surfaced this — a Western Bluebird on a twig vs. a (likely) Steller's Jay on a log 32 seconds later.
- For unused components, the row renders `subj=missing on DSC_1385 (w=0.35)` in muted italics instead of `subj·=0.00×0.35`. A component with weight=0 is rendered normally (no "missing" annotation), so "you turned this off" reads differently from "this photo doesn't have the data."

## Changes

**Backend — `vireo/encounters.py`**
- `compute_s_enc(... return_components=True)` now emits `missing_a` and `missing_b` per component (which photo lacks the signal). Score math is unchanged.
- Each `cut_microsegments` trace entry carries `photo_a_id`, `photo_b_id`, `photo_a_filename`, `photo_b_filename`. `segment_encounters` already forwards `enc["trace"]` unmodified.

**Frontend — `vireo/templates/pipeline_review.html`**
- New `.trace-pair-photos` block under each pair header: filename + 36×28 thumb for each photo, clickable to open the existing inspect panel. Uses the existing `pipelineResults.photos` lookup; no extra fetches.
- Components line: distinguishes missing-data from zero-weight; bare `·` marker is gone.
- Local `escapeHtml` helper added (this template didn't define one).

**Tests — `vireo/tests/test_encounters.py`**
- `test_trace_includes_pair_photo_ids_and_filenames` — covers the trace shape addition.
- `test_components_flag_which_photo_is_missing_each_signal` — covers the missing-on-which-side flagging using exactly the A-has-everything / B-has-nothing setup we hit on a real encounter.

## Follow-up (not in this PR)

The other half of the surfaced-state idea — a "compute the missing signals for these photos" action button right on the trace row — would need a new endpoint that runs the right pipeline step(s) for a photo-id list, plus a job-rollup story for it. Worth designing rather than guessing; happy to spec that as a separate PR.

## Test plan

- [x] `python -m pytest vireo/tests/test_encounters.py vireo/tests/test_pipeline.py` — 112 passed (incl. 2 new tests).
- [x] Full recommended set (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_encounters.py vireo/tests/test_pipeline.py`) — 1022 passed, 1 skipped, 2 pre-existing keyword failures. The 2 failures pass in isolation on both clean main and this branch (pre-existing test-ordering pollution; documented in memory).
- [ ] Visual smoke: open the pipeline review page, focus an encounter that contains a half-processed photo, confirm the row shows both filenames + thumbs and the unused-component line says "missing on \<filename\> (w=0.xx)" in muted orange italics.