### PR TITLE
Dashboard: per-(model × label-set) classification inventory

### DIFF
--- a/docs/plans/2026-05-06-classification-inventory-design.md
+++ b/docs/plans/2026-05-06-classification-inventory-design.md
@@ -1,0 +1,254 @@
+# Classification Inventory — Design
+
+**Date:** 2026-05-06
+**Status:** Design validated, ready for implementation plan
+**Owner:** Julius
+
+## Problem
+
+Vireo today shows only one workspace-level classification stat: the dashboard's "X of Y photos classified" bar. This metric is per-photo and counts a photo as classified if *any* detection on it has a prediction from *any* model with *any* label set. It hides three things users need:
+
+1. **Which (model × label-set) pairs have actually been run** on this workspace.
+2. **Per-detection coverage**, which is what the classify job actually processes — a photo with five birds counts once on the dashboard but contributes five units of work.
+3. **Stale predictions** left over after a label set is edited (different fingerprint).
+
+This makes the Pipeline page's "X to classify" pending count surprising — users assume the dashboard's 67% means they're 67% done, but for a specific (model, label-set) combo they may be at 0%.
+
+## Goal
+
+Add a detailed Classification Inventory panel to the dashboard that shows, per (model × label-set) pair, exactly what has been classified, what is pending, when, with what apparent confidence, and whether there are stale leftovers from past label-set edits. Make every row a launch pad to the action that fills the gap (run classify) or inspects the result (review).
+
+## Non-goals
+
+- Not a replacement for the existing 67% summary; this sits alongside it.
+- Not a leaderboard or per-species breakdown. Species-level analysis belongs on the Review page.
+- Not retrospective analytics over time. Snapshot only.
+- Not a full audit (precise medians, etc.) — sampling is acceptable for the confidence column.
+
+## Source-of-truth definitions
+
+- **Available models:** the list returned by `/api/models/pipeline` (same source as the Pipeline page's model selector). Models found in `classifier_runs` but not in this list appear under an "Other (legacy)" group.
+- **Available label sets:** `.txt` files in `~/.vireo/labels/`, plus a synthetic "Tree of Life" entry exposed only on tol-supported models (`bioclip-2`, etc., per `vireo/classify_job.py:144`).
+- **Real detection:** `detector_model != 'full-image' AND detector_confidence >= effective_min_conf` (matches `count_classify_pending_pairs` semantics).
+- **Workspace scoping:** detections in photos whose folder is in `workspace_folders` for the active workspace.
+- **Pair identity:** `(classifier_model, labels_fingerprint)`. For Tree of Life rows, fingerprint is the literal string `tol`.
+- **Stale row:** a `(model, fingerprint)` group present in `classifier_runs` whose fingerprint does not match any current `.txt` file's fingerprint and is not the literal `tol`.
+
+## API
+
+**New endpoint:** `GET /api/workspace/classification-inventory`
+
+**Response shape:**
+
+```json
+{
+  "workspace_id": 5,
+  "workspace_name": "USA2026",
+  "min_conf": 0.2,
+  "total_real_detections": 80803,
+  "total_photos": 22709,
+  "models": [
+    {
+      "id": "bioclip-2.5",
+      "name": "BioCLIP-2.5",
+      "supports_tol": true,
+      "legacy": false,
+      "subtotal": {
+        "classified_dets": 45481,
+        "pending_dets": 196928,
+        "coverage_pct": 18.8
+      },
+      "pairs": [
+        {
+          "label_set": "california-us-birds",
+          "label_set_path": "california-us-birds-research-grade.txt",
+          "fingerprint": "dad900c8a412",
+          "is_tol": false,
+          "status": "partial",
+          "classified_dets": 22738,
+          "pending_dets": 58065,
+          "coverage_pct": 28.1,
+          "photos_covered": 9412,
+          "last_run": "2026-04-22T15:02:11Z",
+          "median_top1_conf": 0.78,
+          "median_sample_size": 2000,
+          "stale_count": 0
+        }
+      ]
+    }
+  ],
+  "stale": [
+    {
+      "model": "BioCLIP-2.5",
+      "fingerprint": "abc123def456",
+      "stale_count": 4521,
+      "last_run": "2026-03-10T08:14:22Z"
+    }
+  ],
+  "grand_total": {
+    "classified_dets": 68561,
+    "pending_dets": 565942,
+    "coverage_pct": 10.8,
+    "total_predictions_rows": 71203
+  }
+}
+```
+
+Notes:
+
+- `coverage_pct` = `classified / (classified + pending)`. The denominator equals `total_real_detections` for non-stale pairs.
+- `status` is one of `complete` (coverage_pct == 100), `partial` (>0 and <100), `never_run` (0), or `stale` (any stale_count > 0 on this row's pair).
+- `median_top1_conf` is `null` when `classified_dets < 100`; the frontend dims the column.
+- `total_predictions_rows` answers the user's original question — "how many classifications do I have?" — directly.
+
+## Query strategy
+
+Single SQL pass for the bulk of the data, scoped through a CTE:
+
+```sql
+WITH ws_dets AS (
+  SELECT d.id AS did, d.photo_id AS pid
+  FROM detections d
+  JOIN photos p ON p.id = d.photo_id
+  JOIN workspace_folders wf
+    ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+  WHERE d.detector_model != 'full-image'
+    AND d.detector_confidence >= ?
+)
+SELECT
+  cr.classifier_model,
+  cr.labels_fingerprint,
+  COUNT(DISTINCT cr.detection_id) AS classified_dets,
+  COUNT(DISTINCT ws_dets.pid)     AS photos_covered,
+  MAX(cr.created_at)              AS last_run
+FROM classifier_runs cr
+JOIN ws_dets ON ws_dets.did = cr.detection_id
+GROUP BY cr.classifier_model, cr.labels_fingerprint;
+```
+
+`total_real_detections` is one scalar (`SELECT COUNT(*) FROM ws_dets`). `pending = total - classified` per pair.
+
+**Median top-1 confidence** uses sampling for performance:
+
+```sql
+WITH top1 AS (
+  SELECT pr.detection_id, pr.classifier_model, pr.labels_fingerprint, pr.confidence
+  FROM predictions pr
+  WHERE pr.rank = 1
+    AND pr.detection_id IN (SELECT did FROM ws_dets)
+  ORDER BY RANDOM()
+  LIMIT 2000
+)
+SELECT classifier_model, labels_fingerprint, confidence
+FROM top1;
+```
+
+Python computes the median per (model, fingerprint) group from the sample. Total query budget: <80 ms on 80k detections × ~10 pairs.
+
+**Cross-product construction** is done in Python after the SQL pass:
+
+1. Read `/api/models/pipeline` model list.
+2. Read `os.listdir(~/.vireo/labels)` for `.txt` files; compute fingerprints.
+3. For each model, enumerate its label-set pairs:
+   - Closed-set / timm models (no labels needed): single virtual row keyed by an intrinsic fingerprint (e.g. iNat21's `tol`).
+   - Tol-supported models: one row per `.txt` plus one Tree of Life row.
+   - Other open-vocab models: one row per `.txt`.
+4. Merge in counts from the SQL result by `(model, fingerprint)`. Missing pairs get zeros / `never_run`.
+5. Identify stale: any `(model, fingerprint)` in the SQL result not matched by step 3.
+
+## UI
+
+**Placement:** new full-width section below the existing dashboard card grid in `vireo/templates/stats.html`, with header `<h2>Classification inventory</h2>` and a `Refresh` button.
+
+**Table layout** (8 columns + actions, grouped by model):
+
+| Column | Notes |
+|---|---|
+| Status | Pill: green `Complete`, yellow `Partial`, grey `Never run`, orange `Stale`. |
+| Label set | Filename minus `.txt`; `Tree of Life` for tol rows. |
+| Detections classified | `toLocaleString()` |
+| Pending | `toLocaleString()` |
+| Coverage | "%`.`% + thin inline bar |
+| Photos | `toLocaleString()` |
+| Last run | Relative time ("3 days ago") with absolute on hover |
+| Median top-1 | Two decimals, dimmed when sample < 100, "—" when classified = 0 |
+| Actions | ▶ Run icon (Never run / Partial / Stale rows) → `/pipeline?models=<id>&labels=<file>`. 🔍 Inspect icon (classified > 0) → `/review?model=<id>&labels_fingerprint=<fp>` |
+
+**Per-model header:**
+
+```
+BioCLIP-2.5 — 45,481 / 242,409 detections classified across 3 label sets    [▾]
+```
+
+Chevron collapses the model's pairs. Default: expanded.
+
+**Sort within a model:** alphabetical by label set, with "Tree of Life" pinned last.
+
+**Grand total row** at the bottom of the main table, visually separated by a thicker top border, includes `total_predictions_rows`.
+
+**Stale section** below the main table: collapsed by default, header reads `Outdated label-set fingerprints (N rows)`. Expanded view shows model, fingerprint prefix, stale_count, last_run, and "Reclassify with current labels" action that pre-selects the model + the current `.txt` whose name matches the legacy fingerprint's likely intent (best-effort; if no match, just opens pipeline with model preselected).
+
+**Empty / edge states:**
+
+- No models registered → "No classification models installed." with link to Settings.
+- 0 detections → "Run subject detection first to populate this view."
+- All pairs Complete and no Stale → small ✓ banner: "All combinations classified."
+
+**Refresh:**
+
+- Manual `Refresh` button.
+- Auto-refresh on classify job completion: subscribe to the existing SSE stream that `vireo/templates/_navbar.html` already wires up; on a `job.completed` event whose `job_type == 'classify'`, re-fetch.
+
+## Pipeline pre-selection
+
+`/pipeline?models=<id>&labels=<file>` — pipeline.html currently does not read query params for these. Added behavior:
+
+- On load, parse `URLSearchParams` for `models` (CSV) and `labels` (CSV).
+- If present, override the workspace's stored selection in the form state and trigger the existing "estimate" recompute (`/api/pipeline/plan`).
+- Do not persist this override unless the user actually clicks Run; query-param-driven state is transient.
+
+Affects `vireo/templates/pipeline.html` only — small JS init block.
+
+## Review pre-filtering
+
+`/review?model=<id>&labels_fingerprint=<fp>` — review.html already supports a model filter (`vireo/templates/review.html:762-805`). Add `labels_fingerprint` query param parsing the same way. If the existing filter dropdown does not surface fingerprint, the URL still applies the filter under the hood; we add a small "Filtered to fingerprint <prefix>" pill above the cards with a clear-filter X.
+
+## Tests
+
+`vireo/tests/test_classification_inventory.py` (new):
+
+1. Empty workspace: empty `models`, empty `stale`, zeroed `grand_total`.
+2. Workspace with detections but zero predictions: every available pair shows `Never run`, pending = total.
+3. Single (model, label-set) fully classified: status `complete`, pending 0, photos_covered ≤ workspace photo count.
+4. Two models × two label-sets: cross-product produces 4 pair rows; subtotals sum.
+5. Tol pair appears only on tol-supported models.
+6. Stale fingerprint: predictions on a fingerprint not on disk → row in `stale`; current-fingerprint pair shows pending = total.
+7. Detection below `min_conf` excluded from numerator and denominator.
+8. Workspace scoping: prediction on a detection in another workspace's folder not counted.
+9. Median sampling: 100 predictions all conf 0.9 → median ≈ 0.9 ± 0.02.
+10. `photos_covered` counts a photo once even with multiple classified detections.
+11. Legacy model (in `classifier_runs` but not in `/api/models/pipeline`): grouped under "Other (legacy)".
+
+Frontend: manual checks for now (Playwright TODO), covering placement, collapse/expand, action links, refresh-on-job-completion, dark+light themes.
+
+## Edge cases handled in code
+
+- Workspace with `min_conf` overridden via per-workspace config: use `db.get_effective_config(cfg.load())`.
+- Label set deleted from disk after past run: no current-fingerprint row, predictions show as stale.
+- Two label sets with the same content (same fingerprint): displayed once under whichever filename sorts first; surfaced as a soft warning ("2 files with identical content: <a>, <b>") in the inventory header.
+- `tol` fingerprint string treated as never-stale even if no tol-supported model exists currently (defensive).
+
+## Performance budget
+
+- Endpoint target: < 200 ms p95 on a workspace with 100k detections and 12 pairs.
+- Single CTE-scoped aggregation query.
+- One sampling query for medians, capped at 2000 rows.
+- One scalar `count_photos()` reuse for `total_photos`.
+- No new indices needed; existing `classifier_runs(detection_id, classifier_model, labels_fingerprint)` index covers the join.
+
+## Rollout
+
+- Single PR against `main` containing endpoint, query, frontend section, and backend tests.
+- No DB migration.
+- No feature flag.
+- Branch: `classify-pipeline-question` (already cut).

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2799,6 +2799,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "fingerprint": compute_fingerprint(species),
             })
 
+        # Dedupe by fingerprint: duplicate-content files (rename/copy) share a
+        # fingerprint and the same db_pair stats. Emitting both rows would
+        # double-count subtotals and inflate pending coverage. Keep the
+        # alphabetically-first name as the canonical representative.
+        deduped_by_fp = {}
+        for ls in sorted(label_sets, key=lambda x: x["name"].lower()):
+            deduped_by_fp.setdefault(ls["fingerprint"], ls)
+        label_sets = list(deduped_by_fp.values())
+
         # Available models: include all known classifier models even if not yet
         # downloaded — gives the user visibility into "if you downloaded iNat21
         # this would be N detections of work." Custom models registered without

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2894,8 +2894,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             })
 
         # Stale: a (current model, fingerprint) in the DB whose fingerprint
-        # is not currently on disk and isn't TOL.
+        # is not currently on disk and isn't TOL. Single-file fingerprints
+        # come from the label_sets above; merged-set fingerprints come from
+        # the labels_fingerprints sidecar (one row per distinct merge the
+        # classify job has ever produced). A merged row is current if all
+        # its sources still exist and re-merging them reproduces the same
+        # fingerprint; otherwise the contents drifted and it's stale.
         current_fps = {ls["fingerprint"] for ls in label_sets} | {TOL_SENTINEL}
+        for row in db.get_labels_fingerprints():
+            sources = row.get("sources") or []
+            if len(sources) <= 1:
+                continue  # single-file already covered by label_sets
+            if not all(os.path.exists(s) for s in sources):
+                continue
+            try:
+                merged = []
+                for s in sources:
+                    with open(s) as fh:
+                        merged.extend(ln.strip() for ln in fh if ln.strip())
+            except OSError:
+                continue
+            if compute_fingerprint(merged) == row["fingerprint"]:
+                current_fps.add(row["fingerprint"])
         stale = []
         for (model_name, fp), p in db_pairs.items():
             if model_name not in registry_names:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2801,10 +2801,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Available models: include all known classifier models even if not yet
         # downloaded — gives the user visibility into "if you downloaded iNat21
-        # this would be N detections of work."
+        # this would be N detections of work." Custom models registered without
+        # an explicit model_type default to bioclip (same as classify/pipeline).
         all_models = [
             m for m in get_models()
-            if m.get("model_type") in ("bioclip", "timm")
+            if m.get("model_type", "bioclip") in ("bioclip", "timm")
         ]
 
         models_out = []

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -238,6 +238,51 @@ def _find_merge_target(encounters, detached_range, target_species):
     return None
 
 
+def _inventory_pair(label_set, label_set_path, fingerprint, is_tol,
+                    is_intrinsic, db_pair, total):
+    """Build one (model × label-set) row for the classification inventory."""
+    classified = db_pair.get("classified_dets", 0)
+    pending = max(0, total - classified) if not is_intrinsic else max(
+        0, total - classified
+    )
+    if classified == 0:
+        status = "never_run"
+    elif pending == 0:
+        status = "complete"
+    else:
+        status = "partial"
+    denom = classified + pending
+    coverage = round(100.0 * classified / denom, 1) if denom > 0 else 0.0
+    return {
+        "label_set": label_set,
+        "label_set_path": label_set_path,
+        "fingerprint": fingerprint,
+        "is_tol": is_tol,
+        "is_intrinsic": is_intrinsic,
+        "status": status,
+        "classified_dets": classified,
+        "pending_dets": pending,
+        "coverage_pct": coverage,
+        "photos_covered": db_pair.get("photos_covered", 0),
+        "last_run": db_pair.get("last_run"),
+        "median_top1_conf": db_pair.get("median_top1_conf"),
+        "median_sample_size": db_pair.get("median_sample_size", 0),
+    }
+
+
+def _inventory_subtotal(pairs):
+    """Sum classified/pending across a model's pairs into a subtotal dict."""
+    classified = sum(p["classified_dets"] for p in pairs)
+    pending = sum(p["pending_dets"] for p in pairs)
+    denom = classified + pending
+    coverage = round(100.0 * classified / denom, 1) if denom > 0 else 0.0
+    return {
+        "classified_dets": classified,
+        "pending_dets": pending,
+        "coverage_pct": coverage,
+    }
+
+
 def _auto_detach_burst_for_species(results, enc_idx, burst_idx, new_species):
     """Detach the burst at (enc_idx, burst_idx) from its encounter. If an adjacent
     encounter already has new_species as its confirmed species, merge the burst
@@ -2698,6 +2743,190 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         return jsonify({
             "overall": db.get_coverage_stats(),
             "folders": db.get_folder_coverage_stats(),
+        })
+
+    @app.route("/api/workspace/classification-inventory")
+    def api_workspace_classification_inventory():
+        """Per-(model × label-set) classification coverage for the active workspace.
+
+        Builds a cross-product of available classifier models × label sets on
+        disk, merges in per-pair counts from `classifier_runs`, identifies
+        stale rows (predictions whose fingerprint no longer matches any
+        label file) and legacy rows (predictions from a model not in the
+        current registry), and returns a structured payload for the
+        dashboard inventory panel. See
+        ``docs/plans/2026-05-06-classification-inventory-design.md``.
+        """
+        import config as cfg
+        from labels import LABELS_DIR, get_saved_labels  # noqa: F401
+        from labels_fingerprint import TOL_SENTINEL, compute_fingerprint
+        from models import get_models
+
+        db = _get_db()
+        ws_id = db._active_workspace_id
+        if not ws_id:
+            return json_error("No active workspace", status=400)
+        ws = db.get_workspace(ws_id)
+        min_conf = db.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2,
+        )
+
+        db_inv = db.get_classification_inventory(ws_id, min_conf=min_conf)
+        total_dets = db_inv["total_real_detections"]
+        db_pairs = {
+            (p["classifier_model"], p["labels_fingerprint"]): p
+            for p in db_inv["pairs"]
+        }
+
+        # Available label sets: read each saved .txt and recompute fingerprint
+        # so the inventory's identity matches what the classify job would use.
+        label_sets = []
+        seen_paths = set()
+        for ls in get_saved_labels():
+            path = ls.get("labels_file", "")
+            if not path or not os.path.exists(path) or path in seen_paths:
+                continue
+            seen_paths.add(path)
+            try:
+                with open(path) as fh:
+                    species = [ln.strip() for ln in fh if ln.strip()]
+            except OSError:
+                continue
+            label_sets.append({
+                "name": ls.get("name") or os.path.splitext(os.path.basename(path))[0],
+                "path": path,
+                "filename": os.path.basename(path),
+                "fingerprint": compute_fingerprint(species),
+            })
+
+        # Available models: include all known classifier models even if not yet
+        # downloaded — gives the user visibility into "if you downloaded iNat21
+        # this would be N detections of work."
+        all_models = [
+            m for m in get_models()
+            if m.get("model_type") in ("bioclip", "timm")
+        ]
+
+        models_out = []
+        seen_keys = set()  # (model_name, fingerprint) we've placed in models_out
+
+        for m in all_models:
+            model_name = m.get("name") or m.get("id")
+            supports_tol = "tol_embeddings.npy" in m.get("files", [])
+            is_closed_set = m.get("model_type") == "timm"
+
+            pairs = []
+            if is_closed_set:
+                key = (model_name, TOL_SENTINEL)
+                pairs.append(_inventory_pair(
+                    label_set="(intrinsic)", label_set_path=None,
+                    fingerprint=TOL_SENTINEL, is_tol=False, is_intrinsic=True,
+                    db_pair=db_pairs.get(key, {}), total=total_dets,
+                ))
+                seen_keys.add(key)
+            else:
+                for ls in sorted(label_sets, key=lambda x: x["name"].lower()):
+                    key = (model_name, ls["fingerprint"])
+                    pairs.append(_inventory_pair(
+                        label_set=ls["name"], label_set_path=ls["filename"],
+                        fingerprint=ls["fingerprint"], is_tol=False,
+                        is_intrinsic=False,
+                        db_pair=db_pairs.get(key, {}), total=total_dets,
+                    ))
+                    seen_keys.add(key)
+                if supports_tol:
+                    key = (model_name, TOL_SENTINEL)
+                    pairs.append(_inventory_pair(
+                        label_set="Tree of Life", label_set_path=None,
+                        fingerprint=TOL_SENTINEL, is_tol=True,
+                        is_intrinsic=False,
+                        db_pair=db_pairs.get(key, {}), total=total_dets,
+                    ))
+                    seen_keys.add(key)
+
+            models_out.append({
+                "id": m.get("id"),
+                "name": model_name,
+                "supports_tol": supports_tol,
+                "downloaded": bool(m.get("downloaded")),
+                "legacy": False,
+                "subtotal": _inventory_subtotal(pairs),
+                "pairs": pairs,
+            })
+
+        # Legacy: a (model, fp) in the DB whose model isn't in the current
+        # registry. Group those rows under one entry per legacy model name.
+        registry_names = {m.get("name") or m.get("id") for m in all_models}
+        legacy_groups = {}
+        for (model_name, fp), p in db_pairs.items():
+            if model_name in registry_names:
+                continue
+            legacy_groups.setdefault(model_name, []).append((fp, p))
+        for model_name, fp_pairs in sorted(legacy_groups.items()):
+            pairs = []
+            for fp, p in sorted(fp_pairs, key=lambda x: x[0]):
+                pairs.append(_inventory_pair(
+                    label_set=("Tree of Life" if fp == TOL_SENTINEL
+                               else "fp:" + fp[:8]),
+                    label_set_path=None, fingerprint=fp,
+                    is_tol=(fp == TOL_SENTINEL), is_intrinsic=False,
+                    db_pair=p, total=total_dets,
+                ))
+                seen_keys.add((model_name, fp))
+            models_out.append({
+                "id": None,
+                "name": model_name,
+                "supports_tol": False,
+                "downloaded": False,
+                "legacy": True,
+                "subtotal": _inventory_subtotal(pairs),
+                "pairs": pairs,
+            })
+
+        # Stale: a (current model, fingerprint) in the DB whose fingerprint
+        # is not currently on disk and isn't TOL.
+        current_fps = {ls["fingerprint"] for ls in label_sets} | {TOL_SENTINEL}
+        stale = []
+        for (model_name, fp), p in db_pairs.items():
+            if model_name not in registry_names:
+                continue  # legacy, already grouped
+            if fp in current_fps:
+                continue
+            stale.append({
+                "model": model_name,
+                "fingerprint": fp,
+                "stale_count": p.get("classified_dets", 0),
+                "last_run": p.get("last_run"),
+            })
+
+        # Grand total: classified across all rows (including stale/legacy);
+        # pending across the current cross-product only (forward-looking work).
+        grand_classified_all = sum(
+            p.get("classified_dets", 0) for p in db_inv["pairs"]
+        )
+        grand_pending = sum(
+            pp["pending_dets"] for m in models_out
+            for pp in m["pairs"] if not m["legacy"]
+        )
+        denom = grand_classified_all + grand_pending
+        grand_coverage = (
+            round(100.0 * grand_classified_all / denom, 1) if denom > 0 else 0.0
+        )
+
+        return jsonify({
+            "workspace_id": ws_id,
+            "workspace_name": ws["name"] if ws else None,
+            "min_conf": min_conf,
+            "total_real_detections": total_dets,
+            "total_photos": db.count_photos(),
+            "models": models_out,
+            "stale": stale,
+            "grand_total": {
+                "classified_dets": grand_classified_all,
+                "pending_dets": grand_pending,
+                "coverage_pct": grand_coverage,
+                "total_predictions_rows": db_inv["total_predictions_rows"],
+            },
         })
 
     @app.route("/api/sync/status")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2902,10 +2902,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 continue  # legacy, already grouped
             if fp in current_fps:
                 continue
+            # The stale UI labels this column "Predictions", so report rows
+            # from `predictions` (one per species) rather than distinct
+            # detection IDs from `classifier_runs`. A top-k run with k species
+            # per detection would otherwise undercount stale work.
             stale.append({
                 "model": model_name,
                 "fingerprint": fp,
-                "stale_count": p.get("classified_dets", 0),
+                "stale_count": p.get("predictions_count", 0),
                 "last_run": p.get("last_run"),
             })
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2858,6 +2858,175 @@ class Database:
         ).fetchone()
         return row["n"] or 0
 
+    def get_classification_inventory(self, workspace_id, min_conf=None,
+                                     median_sample_per_pair=2000):
+        """Per-(model × fingerprint) coverage stats for ``workspace_id``.
+
+        Returns::
+
+            {
+              "total_real_detections": int,
+              "pairs": [
+                {
+                  "classifier_model": str,
+                  "labels_fingerprint": str,
+                  "classified_dets": int,
+                  "photos_covered": int,
+                  "last_run": str | None,
+                  "predictions_count": int,
+                  "median_top1_conf": float | None,
+                  "median_sample_size": int,
+                }
+              ],
+              "total_predictions_rows": int,
+            }
+
+        Caller (the endpoint) is responsible for joining this against the
+        on-disk model registry / label files to identify never-run, stale,
+        and legacy combinations.
+        """
+        if min_conf is None:
+            import config as cfg
+            saved_active = self._active_workspace_id
+            try:
+                self._active_workspace_id = workspace_id
+                min_conf = self.get_effective_config(cfg.load()).get(
+                    "detector_confidence", 0.2,
+                )
+            finally:
+                self._active_workspace_id = saved_active
+
+        # Scalar: total real detections in scope.
+        total_row = self.conn.execute(
+            """SELECT COUNT(*) AS n
+               FROM detections d
+               JOIN photos p ON p.id = d.photo_id
+               JOIN workspace_folders wf
+                 ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+               WHERE d.detector_model != 'full-image'
+                 AND d.detector_confidence >= ?""",
+            (workspace_id, min_conf),
+        ).fetchone()
+        total_real_detections = total_row["n"] or 0
+
+        # Per-pair aggregates from classifier_runs joined to in-scope detections.
+        pair_rows = self.conn.execute(
+            """SELECT cr.classifier_model      AS classifier_model,
+                      cr.labels_fingerprint    AS labels_fingerprint,
+                      COUNT(DISTINCT cr.detection_id) AS classified_dets,
+                      COUNT(DISTINCT d.photo_id)      AS photos_covered,
+                      MAX(cr.run_at)           AS last_run
+               FROM classifier_runs cr
+               JOIN detections d ON d.id = cr.detection_id
+               JOIN photos p ON p.id = d.photo_id
+               JOIN workspace_folders wf
+                 ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+               WHERE d.detector_model != 'full-image'
+                 AND d.detector_confidence >= ?
+               GROUP BY cr.classifier_model, cr.labels_fingerprint""",
+            (workspace_id, min_conf),
+        ).fetchall()
+
+        # Per-pair predictions row count (so the grand total can sum it).
+        pred_count_rows = self.conn.execute(
+            """SELECT pr.classifier_model      AS classifier_model,
+                      pr.labels_fingerprint    AS labels_fingerprint,
+                      COUNT(*)                 AS n
+               FROM predictions pr
+               JOIN detections d ON d.id = pr.detection_id
+               JOIN photos p ON p.id = d.photo_id
+               JOIN workspace_folders wf
+                 ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+               WHERE d.detector_model != 'full-image'
+                 AND d.detector_confidence >= ?
+               GROUP BY pr.classifier_model, pr.labels_fingerprint""",
+            (workspace_id, min_conf),
+        ).fetchall()
+        pred_counts = {
+            (r["classifier_model"], r["labels_fingerprint"]): r["n"]
+            for r in pred_count_rows
+        }
+
+        # Median top-1 confidence per pair, via a sampled top-1-per-detection set.
+        # Bounded by median_sample_per_pair to keep total work small.
+        medians = self._sampled_top1_medians(
+            workspace_id, min_conf, median_sample_per_pair,
+        )
+
+        pairs = []
+        for r in pair_rows:
+            key = (r["classifier_model"], r["labels_fingerprint"])
+            med, sample_size = medians.get(key, (None, 0))
+            pairs.append({
+                "classifier_model": r["classifier_model"],
+                "labels_fingerprint": r["labels_fingerprint"],
+                "classified_dets": r["classified_dets"] or 0,
+                "photos_covered": r["photos_covered"] or 0,
+                "last_run": r["last_run"],
+                "predictions_count": pred_counts.get(key, 0),
+                "median_top1_conf": med,
+                "median_sample_size": sample_size,
+            })
+
+        total_pred_rows = sum(pred_counts.values())
+
+        return {
+            "total_real_detections": total_real_detections,
+            "pairs": pairs,
+            "total_predictions_rows": total_pred_rows,
+        }
+
+    def _sampled_top1_medians(self, workspace_id, min_conf, sample_per_pair):
+        """Return {(model, fingerprint): (median, sample_size)} from a sampled
+        set of top-1-per-detection prediction confidences.
+
+        SQLite has no built-in median; we pull a per-pair sample (at most
+        ``sample_per_pair`` rows) of the max confidence per (detection, model,
+        fingerprint) tuple and median in Python. Sampling is fine for the UX
+        signal — if classified_dets is small, the sample is the whole set.
+        """
+        # Top-1 per (detection, model, fp) — predictions UNIQUE on
+        # (detection_id, classifier_model, labels_fingerprint, species), so
+        # MAX(confidence) within that group is the top-1 confidence.
+        rows = self.conn.execute(
+            """SELECT pr.classifier_model      AS classifier_model,
+                      pr.labels_fingerprint    AS labels_fingerprint,
+                      MAX(pr.confidence)       AS top1
+               FROM predictions pr
+               JOIN detections d ON d.id = pr.detection_id
+               JOIN photos p ON p.id = d.photo_id
+               JOIN workspace_folders wf
+                 ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+               WHERE d.detector_model != 'full-image'
+                 AND d.detector_confidence >= ?
+                 AND pr.confidence IS NOT NULL
+               GROUP BY pr.classifier_model, pr.labels_fingerprint, pr.detection_id""",
+            (workspace_id, min_conf),
+        ).fetchall()
+
+        # Bucket by pair, cap each bucket at sample_per_pair.
+        buckets = {}
+        for r in rows:
+            key = (r["classifier_model"], r["labels_fingerprint"])
+            bucket = buckets.setdefault(key, [])
+            if len(bucket) < sample_per_pair:
+                bucket.append(r["top1"])
+
+        out = {}
+        for key, vals in buckets.items():
+            if not vals:
+                out[key] = (None, 0)
+                continue
+            vals_sorted = sorted(vals)
+            n = len(vals_sorted)
+            mid = n // 2
+            if n % 2 == 1:
+                med = vals_sorted[mid]
+            else:
+                med = (vals_sorted[mid - 1] + vals_sorted[mid]) / 2.0
+            out[key] = (float(med), n)
+        return out
+
     def count_photos_pending_masks(self, photo_ids=None, min_conf=None):
         """Return (pending, eligible) for the extract-masks stage.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2987,7 +2987,10 @@ class Database:
         """
         # Top-1 per (detection, model, fp) — predictions UNIQUE on
         # (detection_id, classifier_model, labels_fingerprint, species), so
-        # MAX(confidence) within that group is the top-1 confidence.
+        # MAX(confidence) within that group is the top-1 confidence. The
+        # outer window orders by RANDOM() so the per-pair cap picks an
+        # unbiased sample rather than the oldest detection IDs (which would
+        # under-represent recent reclassifications and bias the median).
         # Cap rows per (model, fp) pair in SQL via ROW_NUMBER so a workspace
         # with millions of predictions doesn't materialize them all in Python.
         rows = self.conn.execute(
@@ -2998,7 +3001,7 @@ class Database:
                         top1,
                         ROW_NUMBER() OVER (
                           PARTITION BY classifier_model, labels_fingerprint
-                          ORDER BY detection_id
+                          ORDER BY RANDOM()
                         ) AS rn
                  FROM (
                    SELECT pr.classifier_model      AS classifier_model,
@@ -6955,6 +6958,34 @@ class Database:
             for r in rows:
                 matched.add(r["photo_id"])
         return len(matched)
+
+    def get_labels_fingerprints(self):
+        """Return all rows from the labels_fingerprints sidecar.
+
+        Each row records the (fingerprint, sources, label_count) triple a
+        classify run wrote — single-file runs list one source, merged-set
+        runs list several. Used by the inventory endpoint to identify
+        merged fingerprints that are still current (sources on disk and
+        unchanged) so they don't get marked stale.
+        """
+        import json
+        rows = self.conn.execute(
+            "SELECT fingerprint, display_name, sources_json, label_count "
+            "FROM labels_fingerprints"
+        ).fetchall()
+        out = []
+        for r in rows:
+            try:
+                sources = json.loads(r["sources_json"] or "[]")
+            except (TypeError, ValueError):
+                sources = []
+            out.append({
+                "fingerprint": r["fingerprint"],
+                "display_name": r["display_name"],
+                "sources": sources,
+                "label_count": r["label_count"],
+            })
+        return out
 
     def upsert_labels_fingerprint(self, fingerprint, display_name, sources, label_count):
         import json

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2988,29 +2988,45 @@ class Database:
         # Top-1 per (detection, model, fp) — predictions UNIQUE on
         # (detection_id, classifier_model, labels_fingerprint, species), so
         # MAX(confidence) within that group is the top-1 confidence.
+        # Cap rows per (model, fp) pair in SQL via ROW_NUMBER so a workspace
+        # with millions of predictions doesn't materialize them all in Python.
         rows = self.conn.execute(
-            """SELECT pr.classifier_model      AS classifier_model,
-                      pr.labels_fingerprint    AS labels_fingerprint,
-                      MAX(pr.confidence)       AS top1
-               FROM predictions pr
-               JOIN detections d ON d.id = pr.detection_id
-               JOIN photos p ON p.id = d.photo_id
-               JOIN workspace_folders wf
-                 ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
-               WHERE d.detector_model != 'full-image'
-                 AND d.detector_confidence >= ?
-                 AND pr.confidence IS NOT NULL
-               GROUP BY pr.classifier_model, pr.labels_fingerprint, pr.detection_id""",
-            (workspace_id, min_conf),
+            """SELECT classifier_model, labels_fingerprint, top1
+               FROM (
+                 SELECT classifier_model,
+                        labels_fingerprint,
+                        top1,
+                        ROW_NUMBER() OVER (
+                          PARTITION BY classifier_model, labels_fingerprint
+                          ORDER BY detection_id
+                        ) AS rn
+                 FROM (
+                   SELECT pr.classifier_model      AS classifier_model,
+                          pr.labels_fingerprint    AS labels_fingerprint,
+                          pr.detection_id          AS detection_id,
+                          MAX(pr.confidence)       AS top1
+                   FROM predictions pr
+                   JOIN detections d ON d.id = pr.detection_id
+                   JOIN photos p ON p.id = d.photo_id
+                   JOIN workspace_folders wf
+                     ON wf.folder_id = p.folder_id
+                    AND wf.workspace_id = ?
+                   WHERE d.detector_model != 'full-image'
+                     AND d.detector_confidence >= ?
+                     AND pr.confidence IS NOT NULL
+                   GROUP BY pr.classifier_model, pr.labels_fingerprint,
+                            pr.detection_id
+                 )
+               )
+               WHERE rn <= ?""",
+            (workspace_id, min_conf, sample_per_pair),
         ).fetchall()
 
-        # Bucket by pair, cap each bucket at sample_per_pair.
+        # Bucket by pair (already capped at sample_per_pair by SQL).
         buckets = {}
         for r in rows:
             key = (r["classifier_model"], r["labels_fingerprint"])
-            bucket = buckets.setdefault(key, [])
-            if len(bucket) < sample_per_pair:
-                bucket.append(r["top1"])
+            buckets.setdefault(key, []).append(r["top1"])
 
         out = {}
         for key, vals in buckets.items():

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1226,17 +1226,21 @@ function initPipelinePage() {
 // actually clicks Run.
 function applyClassifyQueryParams() {
   var qs = new URLSearchParams(window.location.search);
-  var qsModels = qs.get('models');
-  var qsLabels = qs.get('labels');
-  if (!qsModels && !qsLabels) return;
-  if (qsModels) {
-    var wantModels = new Set(qsModels.split(',').map(function(s) { return s.trim(); }).filter(Boolean));
+  // Use getAll() so multiple selections come through as repeated params
+  // (?models=a&models=b). Splitting a single decoded value on commas would
+  // mishandle filenames or IDs that contain a literal comma — get() decodes
+  // %2C back to ',' before any split would run.
+  var qsModels = qs.getAll('models').filter(Boolean);
+  var qsLabels = qs.getAll('labels').filter(Boolean);
+  if (qsModels.length === 0 && qsLabels.length === 0) return;
+  if (qsModels.length > 0) {
+    var wantModels = new Set(qsModels);
     document.querySelectorAll('.model-checkbox').forEach(function(cb) {
       cb.checked = wantModels.has(cb.value);
     });
   }
-  if (qsLabels) {
-    var wantLabels = new Set(qsLabels.split(',').map(function(s) { return s.trim(); }).filter(Boolean));
+  if (qsLabels.length > 0) {
+    var wantLabels = new Set(qsLabels);
     document.querySelectorAll('.labels-run-cb').forEach(function(cb) {
       // Match by full path or by basename (the inventory passes basenames).
       // Split on both POSIX (/) and Windows (\) separators so deep links work

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1239,7 +1239,10 @@ function applyClassifyQueryParams() {
     var wantLabels = new Set(qsLabels.split(',').map(function(s) { return s.trim(); }).filter(Boolean));
     document.querySelectorAll('.labels-run-cb').forEach(function(cb) {
       // Match by full path or by basename (the inventory passes basenames).
-      var base = cb.value.split('/').pop();
+      // Split on both POSIX (/) and Windows (\) separators so deep links work
+      // regardless of OS.
+      var parts = cb.value.split(/[/\\]/);
+      var base = parts[parts.length - 1];
       cb.checked = wantLabels.has(cb.value) || wantLabels.has(base);
     });
   }

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1203,6 +1203,7 @@ function initPipelinePage() {
   // mislabel Classify as "No models selected" until the user clicks
   // something.
   Promise.all([loadModels(), loadLabels()]).then(function() {
+    applyClassifyQueryParams();
     refreshPipelinePlan();
   });
   loadVolumes();
@@ -1216,6 +1217,31 @@ function initPipelinePage() {
     selectSourceMode('import');
     updateStartButton();
     fetchFolderPreview();
+  }
+}
+
+// Pre-select classify model and label set from query params (e.g. dashboard
+// inventory's ▶ links). Runs after loadModels()/loadLabels() so the
+// checkboxes exist. Transient: state is not persisted unless the user
+// actually clicks Run.
+function applyClassifyQueryParams() {
+  var qs = new URLSearchParams(window.location.search);
+  var qsModels = qs.get('models');
+  var qsLabels = qs.get('labels');
+  if (!qsModels && !qsLabels) return;
+  if (qsModels) {
+    var wantModels = new Set(qsModels.split(',').map(function(s) { return s.trim(); }).filter(Boolean));
+    document.querySelectorAll('.model-checkbox').forEach(function(cb) {
+      cb.checked = wantModels.has(cb.value);
+    });
+  }
+  if (qsLabels) {
+    var wantLabels = new Set(qsLabels.split(',').map(function(s) { return s.trim(); }).filter(Boolean));
+    document.querySelectorAll('.labels-run-cb').forEach(function(cb) {
+      // Match by full path or by basename (the inventory passes basenames).
+      var base = cb.value.split('/').pop();
+      cb.checked = wantLabels.has(cb.value) || wantLabels.has(base);
+    });
   }
 }
 

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -671,6 +671,7 @@ var currentModel = 'all';
 var currentCollection = 'all';
 var currentSort = 'filename';
 var minConfidence = 0;
+var currentLabelsFingerprint = null;  // set from ?labels_fingerprint= URL param
 var availableModels = [];
 var collectionPhotoIds = null;  // null = no filter
 var thumbSize = 400;
@@ -742,8 +743,42 @@ async function switchCollection(val) {
 }
 
 /* ---------- Bootstrap ---------- */
+applyReviewQueryParams();
 loadPredictions();
 loadCollectionFilter();
+
+function applyReviewQueryParams() {
+  var qs = new URLSearchParams(window.location.search);
+  var qsModel = qs.get('model');
+  var qsFp = qs.get('labels_fingerprint');
+  if (qsModel) currentModel = qsModel;
+  if (qsFp) currentLabelsFingerprint = qsFp;
+}
+
+function renderFingerprintFilterPill() {
+  var existing = document.getElementById('fpFilterPill');
+  if (existing) existing.remove();
+  if (!currentLabelsFingerprint) return;
+  var bar = document.querySelector('.toolbar') || document.body;
+  var pill = document.createElement('div');
+  pill.id = 'fpFilterPill';
+  pill.style.cssText = 'display:inline-flex;align-items:center;gap:6px;padding:3px 10px;' +
+    'border-radius:12px;background:color-mix(in srgb,var(--accent) 15%,transparent);' +
+    'color:var(--accent);font-size:12px;margin:6px 0;';
+  pill.innerHTML = 'Filtered to fingerprint <code>' +
+    currentLabelsFingerprint.substring(0, 12) +
+    '</code> <a href="#" id="fpFilterClear" style="color:inherit;text-decoration:none;">×</a>';
+  bar.parentNode.insertBefore(pill, bar.nextSibling);
+  document.getElementById('fpFilterClear').addEventListener('click', function(e) {
+    e.preventDefault();
+    currentLabelsFingerprint = null;
+    var url = new URL(window.location.href);
+    url.searchParams.delete('labels_fingerprint');
+    window.history.replaceState({}, '', url.toString());
+    pill.remove();
+    renderAll();
+  });
+}
 
 async function loadPredictions() {
   document.getElementById('loading').style.display = 'block';
@@ -783,6 +818,7 @@ async function loadPredictions() {
 /* ---------- Render ---------- */
 function renderAll() {
   renderModelFilter();
+  renderFingerprintFilterPill();
   renderStats();
   renderTabs();
   renderButtons();
@@ -881,6 +917,13 @@ function getVisibleItems() {
   // Filter by model
   if (currentModel !== 'all') {
     filtered = filtered.filter(function(p) { return p.model === currentModel; });
+  }
+
+  // Filter by label-set fingerprint (from dashboard inventory's Inspect link)
+  if (currentLabelsFingerprint) {
+    filtered = filtered.filter(function(p) {
+      return p.labels_fingerprint === currentLabelsFingerprint;
+    });
   }
 
   // Filter by status tab

--- a/vireo/templates/stats.html
+++ b/vireo/templates/stats.html
@@ -556,7 +556,10 @@ function renderInvPairRow(model, p, mi) {
       p.median_top1_conf.toFixed(2) + '</span>';
   }
   var actions = '';
-  if (model.id && (p.status === 'never_run' || p.status === 'partial' || p.status === 'stale')) {
+  // Only render the Run deep-link if the model is downloaded — pipeline
+  // model checkboxes are populated from downloaded models only, so a deep
+  // link to a not-downloaded model is a dead end (nothing to pre-select).
+  if (model.id && model.downloaded && (p.status === 'never_run' || p.status === 'partial' || p.status === 'stale')) {
     var labelsParam = '';
     if (p.label_set_path) {
       labelsParam = '&labels=' + encodeURIComponent(p.label_set_path);

--- a/vireo/templates/stats.html
+++ b/vireo/templates/stats.html
@@ -55,6 +55,59 @@ body { padding-bottom: 36px; }
 .grid-2col { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
 @media (max-width: 768px) { .grid-2col { grid-template-columns: 1fr; } }
 
+/* Classification inventory */
+#classInvSection .content-table {
+  width: 100%; border-collapse: collapse; font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+#classInvSection .content-table th, #classInvSection .content-table td {
+  padding: 6px 8px; text-align: left; border-bottom: 1px solid var(--border-subtle);
+  white-space: nowrap;
+}
+#classInvSection .content-table th {
+  color: var(--text-dim); font-weight: 600; font-size: 11px;
+  text-transform: uppercase; letter-spacing: 0.4px;
+}
+#classInvSection .content-table td.num { text-align: right; }
+#classInvSection .group-header td {
+  background: var(--bg-tertiary); padding: 8px 10px; font-weight: 600;
+  cursor: pointer;
+}
+#classInvSection .group-header .chev { color: var(--text-ghost); margin-right: 6px; }
+#classInvSection .group-header.muted td { color: var(--text-dim); }
+#classInvSection .grand-total td {
+  border-top: 2px solid var(--border-primary); font-weight: 600;
+  background: var(--bg-tertiary);
+}
+#classInvSection .pill {
+  display: inline-block; padding: 1px 7px; border-radius: 9px; font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.4px; font-weight: 600;
+}
+#classInvSection .pill.complete { background: color-mix(in srgb, var(--accent) 18%, transparent); color: var(--accent); }
+#classInvSection .pill.partial  { background: color-mix(in srgb, var(--warning) 18%, transparent); color: var(--warning); }
+#classInvSection .pill.never_run { background: var(--bg-secondary); color: var(--text-dim); }
+#classInvSection .pill.stale    { background: color-mix(in srgb, #f97316 18%, transparent); color: #f97316; }
+#classInvSection .cov-mini {
+  display: inline-block; width: 60px; height: 6px; background: var(--bg-tertiary);
+  border-radius: 3px; vertical-align: middle; margin-left: 6px; overflow: hidden;
+}
+#classInvSection .cov-mini-fill { height: 100%; background: var(--accent); }
+#classInvSection .act-link {
+  color: var(--text-dim); text-decoration: none; padding: 2px 6px; border-radius: 4px;
+}
+#classInvSection .act-link:hover { background: var(--bg-tertiary); color: var(--accent); }
+#classInvSection .median-dim { color: var(--text-faint); }
+#classInvSection .stale-section {
+  margin-top: 14px; padding: 10px; background: var(--bg-secondary); border-radius: 6px;
+}
+#classInvSection .stale-section summary {
+  cursor: pointer; font-size: 13px; color: var(--text-secondary);
+}
+#classInvSection .all-good {
+  padding: 10px 12px; background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border-radius: 6px; color: var(--accent); font-size: 13px;
+}
+
 .stat-big { text-align: center; padding: 16px; }
 .stat-big .number { font-size: 36px; font-weight: 700; color: var(--accent); }
 .stat-big .label { font-size: 12px; color: var(--text-dim); margin-top: 4px; }
@@ -197,6 +250,17 @@ body { padding-bottom: 36px; }
     </div>
   </div>
 
+  <!-- Classification Inventory: per (model × label-set) coverage -->
+  <div class="section" id="classInvSection">
+    <div class="section-title" style="display:flex;align-items:center;gap:10px;">
+      <span>Classification Inventory</span>
+      <span id="classInvSummary" style="font-size:12px;font-weight:400;color:var(--text-dim);"></span>
+      <button id="classInvRefresh" onclick="loadClassificationInventory()" class="btn-secondary"
+              style="margin-left:auto;font-size:12px;padding:3px 10px;">Refresh</button>
+    </div>
+    <div id="classInvBody"><span style="color:var(--text-ghost);font-size:13px;">Loading...</span></div>
+  </div>
+
   <!-- Quality Score Distribution -->
   <div class="section">
     <div class="section-title">Quality Score Distribution</div>
@@ -278,6 +342,7 @@ loadStats();
 loadStoragePanel();
 loadDashboard();
 loadCoverage();
+loadClassificationInventory();
 
 // Order matches the pipeline roughly: ingest → metadata → pixel ops → AI → review.
 var COVERAGE_FIELDS = [
@@ -367,6 +432,180 @@ async function loadStats() {
   } catch(e) {
     document.getElementById('speciesChart').textContent = 'Failed to load statistics.';
   }
+}
+
+async function loadClassificationInventory() {
+  var body = document.getElementById('classInvBody');
+  var summary = document.getElementById('classInvSummary');
+  body.innerHTML = '<span style="color:var(--text-ghost);font-size:13px;">Loading...</span>';
+  try {
+    var data = await safeFetch('/api/workspace/classification-inventory', {}, { toast: false });
+    renderClassificationInventory(data);
+    if (data && data.grand_total) {
+      summary.textContent =
+        data.grand_total.total_predictions_rows.toLocaleString() + ' predictions • ' +
+        data.grand_total.classified_dets.toLocaleString() + ' / ' +
+        (data.grand_total.classified_dets + data.grand_total.pending_dets).toLocaleString() +
+        ' detection-pairs (' + data.grand_total.coverage_pct + '%)';
+    }
+  } catch(e) {
+    body.innerHTML = '<span style="color:var(--danger);font-size:13px;">Failed to load inventory.</span>';
+  }
+}
+
+function renderClassificationInventory(data) {
+  var body = document.getElementById('classInvBody');
+  if (!data || !data.models || data.models.length === 0) {
+    body.innerHTML = '<div style="color:var(--text-ghost);font-size:13px;">' +
+      'No classification models registered. <a href="/settings" style="color:var(--accent);">Settings</a></div>';
+    return;
+  }
+  if (data.total_real_detections === 0) {
+    body.innerHTML = '<div style="color:var(--text-ghost);font-size:13px;">' +
+      'No subject detections yet in this workspace. Run detection first.</div>';
+    return;
+  }
+
+  var html = '<table class="content-table"><thead><tr>' +
+    '<th style="width:90px;">Status</th>' +
+    '<th>Label set</th>' +
+    '<th class="num">Classified</th>' +
+    '<th class="num">Pending</th>' +
+    '<th class="num">Coverage</th>' +
+    '<th class="num">Photos</th>' +
+    '<th>Last run</th>' +
+    '<th class="num">Median top-1</th>' +
+    '<th style="width:70px;">Actions</th>' +
+    '</tr></thead><tbody>';
+
+  data.models.forEach(function(m, mi) {
+    var headerCls = 'group-header' + (m.legacy || !m.downloaded ? ' muted' : '');
+    var headerNote = '';
+    if (m.legacy) headerNote = ' <span style="color:var(--text-ghost);font-weight:400;">(legacy — model no longer in registry)</span>';
+    else if (!m.downloaded) headerNote = ' <span style="color:var(--text-ghost);font-weight:400;">(not downloaded)</span>';
+    html += '<tr class="' + headerCls + '" onclick="toggleInvModel(' + mi + ')">' +
+      '<td colspan="9">' +
+        '<span class="chev" id="chev-' + mi + '">▾</span>' +
+        escapeHtml(m.name) + headerNote +
+        ' — <span style="font-weight:400;color:var(--text-secondary);">' +
+          m.subtotal.classified_dets.toLocaleString() + ' / ' +
+          (m.subtotal.classified_dets + m.subtotal.pending_dets).toLocaleString() +
+          ' (' + m.subtotal.coverage_pct + '%)' +
+          ' across ' + m.pairs.length + ' label set' + (m.pairs.length === 1 ? '' : 's') +
+        '</span>' +
+      '</td></tr>';
+    m.pairs.forEach(function(p) {
+      html += renderInvPairRow(m, p, mi);
+    });
+  });
+
+  // Grand total
+  html += '<tr class="grand-total">' +
+    '<td></td>' +
+    '<td>Total</td>' +
+    '<td class="num">' + data.grand_total.classified_dets.toLocaleString() + '</td>' +
+    '<td class="num">' + data.grand_total.pending_dets.toLocaleString() + '</td>' +
+    '<td class="num">' + data.grand_total.coverage_pct + '%</td>' +
+    '<td class="num"></td>' +
+    '<td></td>' +
+    '<td class="num"></td>' +
+    '<td></td>' +
+    '</tr>';
+  html += '</tbody></table>';
+
+  // Stale section
+  if (data.stale && data.stale.length > 0) {
+    html += '<details class="stale-section"><summary>' +
+      'Outdated label-set fingerprints (' + data.stale.length + ' row' +
+      (data.stale.length === 1 ? '' : 's') + ')</summary>' +
+      '<table class="content-table" style="margin-top:8px;"><thead><tr>' +
+        '<th>Model</th><th>Fingerprint</th><th class="num">Predictions</th>' +
+        '<th>Last run</th><th>Action</th>' +
+      '</tr></thead><tbody>';
+    data.stale.forEach(function(s) {
+      html += '<tr>' +
+        '<td>' + escapeHtml(s.model) + '</td>' +
+        '<td><code style="font-size:11px;">' + escapeHtml(s.fingerprint.substring(0,12)) + '</code></td>' +
+        '<td class="num">' + (s.stale_count || 0).toLocaleString() + '</td>' +
+        '<td>' + (s.last_run ? formatRelative(s.last_run) : '—') + '</td>' +
+        '<td><a class="act-link" href="/pipeline" title="Open pipeline to reclassify with current labels">Reclassify</a></td>' +
+      '</tr>';
+    });
+    html += '</tbody></table></details>';
+  } else {
+    var allComplete = data.models.every(function(m) {
+      return m.legacy || m.pairs.every(function(p) { return p.status === 'complete'; });
+    });
+    if (allComplete && data.total_real_detections > 0) {
+      html += '<div class="all-good" style="margin-top:14px;">✓ All combinations classified.</div>';
+    }
+  }
+
+  body.innerHTML = html;
+}
+
+function renderInvPairRow(model, p, mi) {
+  var statusLabel = p.status.replace('_', ' ');
+  var coverage = p.coverage_pct + '%' +
+    '<span class="cov-mini"><span class="cov-mini-fill" style="width:' + p.coverage_pct + '%;"></span></span>';
+  var lastRun = p.last_run ? formatRelative(p.last_run) : '—';
+  var medianHtml = '—';
+  if (p.median_top1_conf !== null && p.median_top1_conf !== undefined) {
+    var dim = p.median_sample_size < 100 ? ' median-dim' : '';
+    medianHtml = '<span class="' + dim.trim() + '" title="sample size: ' + p.median_sample_size + '">' +
+      p.median_top1_conf.toFixed(2) + '</span>';
+  }
+  var actions = '';
+  if (model.id && (p.status === 'never_run' || p.status === 'partial' || p.status === 'stale')) {
+    var labelsParam = '';
+    if (p.label_set_path) {
+      labelsParam = '&labels=' + encodeURIComponent(p.label_set_path);
+    }
+    actions += '<a class="act-link" href="/pipeline?models=' + encodeURIComponent(model.id) +
+      labelsParam + '" title="Run classify with this combination">▶</a>';
+  }
+  if (p.classified_dets > 0) {
+    actions += ' <a class="act-link" href="/review?model=' + encodeURIComponent(model.name) +
+      '&labels_fingerprint=' + encodeURIComponent(p.fingerprint) +
+      '" title="Inspect predictions for this combination">\u{1F50D}</a>';
+  }
+  return '<tr class="inv-row inv-row-m' + mi + '">' +
+    '<td><span class="pill ' + p.status + '">' + statusLabel + '</span></td>' +
+    '<td>' + escapeHtml(p.label_set) + '</td>' +
+    '<td class="num">' + p.classified_dets.toLocaleString() + '</td>' +
+    '<td class="num">' + p.pending_dets.toLocaleString() + '</td>' +
+    '<td class="num">' + coverage + '</td>' +
+    '<td class="num">' + p.photos_covered.toLocaleString() + '</td>' +
+    '<td>' + lastRun + '</td>' +
+    '<td class="num">' + medianHtml + '</td>' +
+    '<td>' + actions + '</td>' +
+    '</tr>';
+}
+
+function toggleInvModel(mi) {
+  var rows = document.querySelectorAll('.inv-row-m' + mi);
+  var chev = document.getElementById('chev-' + mi);
+  var hidden = rows.length > 0 && rows[0].style.display === 'none';
+  rows.forEach(function(r) { r.style.display = hidden ? '' : 'none'; });
+  if (chev) chev.textContent = hidden ? '▾' : '▸';
+}
+
+function formatRelative(iso) {
+  if (!iso) return '—';
+  var t = new Date(iso.endsWith('Z') || iso.includes('+') ? iso : iso + 'Z');
+  var ms = Date.now() - t.getTime();
+  if (isNaN(ms) || ms < 0) return iso;
+  var s = Math.floor(ms / 1000);
+  if (s < 60) return s + 's ago';
+  var m = Math.floor(s / 60);
+  if (m < 60) return m + 'm ago';
+  var h = Math.floor(m / 60);
+  if (h < 24) return h + 'h ago';
+  var d = Math.floor(h / 24);
+  if (d < 30) return d + 'd ago';
+  var mo = Math.floor(d / 30);
+  if (mo < 12) return mo + 'mo ago';
+  return Math.floor(mo / 12) + 'y ago';
 }
 
 function renderSpecies(keywords) {

--- a/vireo/tests/test_classification_inventory.py
+++ b/vireo/tests/test_classification_inventory.py
@@ -201,6 +201,40 @@ def test_median_top1_confidence_sample(db):
     assert pair["median_sample_size"] >= 1
 
 
+def test_median_top1_sample_is_unbiased_by_detection_id(db):
+    """The capped median sample must not deterministically pick the oldest
+    detection IDs. Detection IDs are auto-incremented chronologically, so
+    a deterministic-by-ID sample under-represents recent runs and biases
+    the median.
+
+    Setup: 50 low-conf detections (older IDs) followed by 200 high-conf
+    (newer IDs). Sample 50 per pair.
+      - Deterministic-by-ID: picks the 50 oldest → all conf 0.1 →
+        median 0.1.
+      - Random: ~20% of population is low, so ~10 of 50 sampled are
+        low → median 0.9.
+    """
+    ws_id, photos = _seed_workspace(db, n_photos=1)
+    photo = photos[0]
+    for _ in range(50):
+        d = _add_detection(db, photo)
+        _record_run(db, d, "M", "fp")
+        _add_prediction(db, d, "M", "fp", "X", 0.1)
+    for _ in range(200):
+        d = _add_detection(db, photo)
+        _record_run(db, d, "M", "fp")
+        _add_prediction(db, d, "M", "fp", "X", 0.9)
+
+    inv = db.get_classification_inventory(ws_id, min_conf=0.2,
+                                           median_sample_per_pair=50)
+    pair = inv["pairs"][0]
+    # Random median is 0.9 with overwhelming probability; deterministic-by-ID
+    # bias would pin it at 0.1.
+    assert pair["median_top1_conf"] > 0.5, (
+        f"median {pair['median_top1_conf']} indicates biased sampling"
+    )
+
+
 def test_median_top1_uses_max_per_detection(db):
     """A detection with multiple species predictions: median uses the top-1 (max conf)."""
     ws_id, photos = _seed_workspace(db, n_photos=1)
@@ -391,6 +425,41 @@ def test_endpoint_dedupes_label_files_with_same_fingerprint(
         for p in m["pairs"]:
             if p["fingerprint"] == fp:
                 assert p["classified_dets"] <= 1
+
+
+def test_endpoint_merged_fingerprint_not_stale(app_and_db, tmp_path, monkeypatch):
+    """A classify run with multiple label files merged produces a fingerprint
+    of the union — that fingerprint matches no single ``.txt`` file but is
+    still current as long as the source files exist and their content
+    matches what was hashed. The labels_fingerprints sidecar records
+    the (fingerprint, sources) pair; the inventory must consult it so
+    merged-labels runs don't get marked stale.
+    """
+    from labels_fingerprint import compute_fingerprint
+    app, db = app_and_db
+    photo_row = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()
+    det = _add_detection(db, photo_row["id"])
+
+    paths = _setup_labels_dir(tmp_path, monkeypatch, [
+        ("birds", ["Robin", "Sparrow"]),
+        ("reptiles", ["Lizard"]),
+    ])
+    merged = sorted({"Robin", "Sparrow", "Lizard"})
+    merged_fp = compute_fingerprint(merged)
+    _record_run(db, det, "BioCLIP-2.5", merged_fp)
+    _add_prediction(db, det, "BioCLIP-2.5", merged_fp, "Robin", 0.7)
+    db.upsert_labels_fingerprint(
+        fingerprint=merged_fp,
+        display_name="birds.txt, reptiles.txt",
+        sources=[paths["birds"], paths["reptiles"]],
+        label_count=len(merged),
+    )
+
+    client = app.test_client()
+    resp = client.get("/api/workspace/classification-inventory")
+    body = resp.get_json()
+    stale_fps = {s["fingerprint"] for s in body["stale"]}
+    assert merged_fp not in stale_fps
 
 
 def test_endpoint_stale_count_uses_prediction_rows(app_and_db, tmp_path, monkeypatch):

--- a/vireo/tests/test_classification_inventory.py
+++ b/vireo/tests/test_classification_inventory.py
@@ -391,3 +391,30 @@ def test_endpoint_dedupes_label_files_with_same_fingerprint(
         for p in m["pairs"]:
             if p["fingerprint"] == fp:
                 assert p["classified_dets"] <= 1
+
+
+def test_endpoint_stale_count_uses_prediction_rows(app_and_db, tmp_path, monkeypatch):
+    """Stale rows are rendered with a "Predictions" column header in the UI,
+    so ``stale_count`` must reflect prediction rows (which can be multiple
+    per detection — one per species in a top-k result), not distinct
+    detection IDs.
+    """
+    app, db = app_and_db
+    photo_row = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()
+    det = _add_detection(db, photo_row["id"])
+    # Run on a fingerprint that does not match any current label file →
+    # this becomes a stale entry. Three species predictions on the one
+    # detection: prediction count = 3, distinct detection count = 1.
+    _record_run(db, det, "BioCLIP-2.5", "obsolete_fp")
+    _add_prediction(db, det, "BioCLIP-2.5", "obsolete_fp", "Robin", 0.7)
+    _add_prediction(db, det, "BioCLIP-2.5", "obsolete_fp", "Sparrow", 0.2)
+    _add_prediction(db, det, "BioCLIP-2.5", "obsolete_fp", "Wren", 0.1)
+
+    _setup_labels_dir(tmp_path, monkeypatch, [("birds", ["Robin"])])
+
+    client = app.test_client()
+    resp = client.get("/api/workspace/classification-inventory")
+    body = resp.get_json()
+    stale = [s for s in body["stale"] if s["fingerprint"] == "obsolete_fp"]
+    assert len(stale) == 1
+    assert stale[0]["stale_count"] == 3

--- a/vireo/tests/test_classification_inventory.py
+++ b/vireo/tests/test_classification_inventory.py
@@ -342,3 +342,52 @@ def test_endpoint_grand_total(app_and_db, tmp_path, monkeypatch):
     gt = body["grand_total"]
     assert gt["classified_dets"] >= 1
     assert gt["total_predictions_rows"] >= 1
+
+
+def test_endpoint_dedupes_label_files_with_same_fingerprint(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """Two label files with identical content (same fingerprint) must produce
+    one inventory row per model — emitting both would double-count the shared
+    db_pair stats in subtotals and grand totals.
+    """
+    app, db = app_and_db
+    photo_row = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()
+    det = _add_detection(db, photo_row["id"])
+
+    # Two label files with identical species → identical fingerprint.
+    _setup_labels_dir(tmp_path, monkeypatch, [
+        ("birds", ["Robin", "Sparrow"]),
+        ("birds_copy", ["Robin", "Sparrow"]),
+    ])
+
+    # Pre-record a run + prediction against the shared fingerprint so the
+    # double-count would be observable in the totals.
+    from labels_fingerprint import compute_fingerprint
+    fp = compute_fingerprint(["Robin", "Sparrow"])
+    _record_run(db, det, "BioCLIP-2.5", fp)
+    _add_prediction(db, det, "BioCLIP-2.5", fp, "Robin", 0.9)
+
+    client = app.test_client()
+    resp = client.get("/api/workspace/classification-inventory")
+    body = resp.get_json()
+
+    # For each non-legacy model, the duplicate fingerprint should appear only
+    # once across that model's label-set rows.
+    for m in body["models"]:
+        if m.get("legacy"):
+            continue
+        non_intrinsic = [p for p in m["pairs"] if not p.get("is_intrinsic")]
+        fps = [p["fingerprint"] for p in non_intrinsic]
+        assert len(fps) == len(set(fps)), (
+            f"{m['name']} has duplicate fingerprints: {fps}"
+        )
+
+    # The grand total counts each detection at most once per (model, fp);
+    # without dedup, classified_dets would be inflated by the duplicate row.
+    for m in body["models"]:
+        if m.get("legacy"):
+            continue
+        for p in m["pairs"]:
+            if p["fingerprint"] == fp:
+                assert p["classified_dets"] <= 1

--- a/vireo/tests/test_classification_inventory.py
+++ b/vireo/tests/test_classification_inventory.py
@@ -1,0 +1,344 @@
+"""Tests for the classification inventory feature.
+
+Covers `Database.get_classification_inventory()` (per-pair aggregates over the
+active workspace) and the `/api/workspace/classification-inventory` endpoint
+that builds the cross-product, identifies stale rows, and computes medians.
+"""
+import json
+import os
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _add_detection(db, photo_id, model="megadetector-v6", conf=0.9, category="animal"):
+    cur = db.conn.execute(
+        "INSERT INTO detections (photo_id, detector_model, detector_confidence, category, "
+        "box_x, box_y, box_w, box_h) VALUES (?, ?, ?, ?, 0.1, 0.1, 0.5, 0.5)",
+        (photo_id, model, conf, category),
+    )
+    db.conn.commit()
+    return cur.lastrowid
+
+
+def _record_run(db, detection_id, model_name, fingerprint, run_at=None):
+    """Insert a classifier_runs row + a single prediction row.
+
+    A real classify pass writes both. Tests should mirror that so coverage
+    queries (which use classifier_runs) and median queries (which use
+    predictions) line up.
+    """
+    if run_at:
+        db.conn.execute(
+            "INSERT INTO classifier_runs (detection_id, classifier_model, "
+            "labels_fingerprint, run_at, prediction_count) VALUES (?, ?, ?, ?, 1)",
+            (detection_id, model_name, fingerprint, run_at),
+        )
+    else:
+        db.conn.execute(
+            "INSERT INTO classifier_runs (detection_id, classifier_model, "
+            "labels_fingerprint, prediction_count) VALUES (?, ?, ?, 1)",
+            (detection_id, model_name, fingerprint),
+        )
+    db.conn.commit()
+
+
+def _add_prediction(db, detection_id, model_name, fingerprint, species, confidence):
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, labels_fingerprint, "
+        "species, confidence) VALUES (?, ?, ?, ?, ?)",
+        (detection_id, model_name, fingerprint, species, confidence),
+    )
+    db.conn.commit()
+
+
+def _seed_workspace(db, name="WS1", folder_path="/photos/ws1", n_photos=2):
+    """Create a workspace with N photos in one folder. Returns (ws_id, photo_ids)."""
+    ws_id = db.create_workspace(name) if hasattr(db, "create_workspace") else None
+    if ws_id is None:
+        cur = db.conn.execute("INSERT INTO workspaces (name) VALUES (?)", (name,))
+        ws_id = cur.lastrowid
+        db.conn.commit()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder(folder_path, name=os.path.basename(folder_path))
+    photo_ids = []
+    for i in range(n_photos):
+        pid = db.add_photo(
+            folder_id=fid,
+            filename=f"p{i}.jpg",
+            extension=".jpg",
+            file_size=1000 + i,
+            file_mtime=float(i),
+            timestamp=f"2026-01-{i+1:02d}T10:00:00",
+        )
+        photo_ids.append(pid)
+    return ws_id, photo_ids
+
+
+# ---------------------------------------------------------------------------
+# DB-level tests: Database.get_classification_inventory()
+# ---------------------------------------------------------------------------
+
+def test_empty_workspace_returns_zero_pairs(db):
+    ws_id, _ = _seed_workspace(db, n_photos=0)
+    inv = db.get_classification_inventory(ws_id, min_conf=0.2)
+    assert inv["total_real_detections"] == 0
+    assert inv["pairs"] == []
+
+
+def test_no_predictions_returns_zero_classified(db):
+    ws_id, photos = _seed_workspace(db, n_photos=2)
+    for p in photos:
+        _add_detection(db, p)
+    inv = db.get_classification_inventory(ws_id, min_conf=0.2)
+    assert inv["total_real_detections"] == 2
+    assert inv["pairs"] == []
+
+
+def test_single_pair_fully_classified(db):
+    ws_id, photos = _seed_workspace(db, n_photos=2)
+    for p in photos:
+        det = _add_detection(db, p)
+        _record_run(db, det, "BioCLIP-2.5", "fp_birds")
+        _add_prediction(db, det, "BioCLIP-2.5", "fp_birds", "Robin", 0.85)
+
+    inv = db.get_classification_inventory(ws_id, min_conf=0.2)
+    assert inv["total_real_detections"] == 2
+    assert len(inv["pairs"]) == 1
+    pair = inv["pairs"][0]
+    assert pair["classifier_model"] == "BioCLIP-2.5"
+    assert pair["labels_fingerprint"] == "fp_birds"
+    assert pair["classified_dets"] == 2
+    assert pair["photos_covered"] == 2
+    assert pair["last_run"] is not None
+
+
+def test_two_pairs_independent(db):
+    ws_id, photos = _seed_workspace(db, n_photos=3)
+    dets = [_add_detection(db, p) for p in photos]
+    # All 3 detections classified by BioCLIP-2.5 with fp_birds
+    for d in dets:
+        _record_run(db, d, "BioCLIP-2.5", "fp_birds")
+    # Only 1 detection classified by iNat21 with tol
+    _record_run(db, dets[0], "iNat21 (EVA-02 Large)", "tol")
+
+    inv = db.get_classification_inventory(ws_id, min_conf=0.2)
+    pair_map = {(p["classifier_model"], p["labels_fingerprint"]): p for p in inv["pairs"]}
+    assert pair_map[("BioCLIP-2.5", "fp_birds")]["classified_dets"] == 3
+    assert pair_map[("iNat21 (EVA-02 Large)", "tol")]["classified_dets"] == 1
+
+
+def test_below_threshold_excluded(db):
+    ws_id, photos = _seed_workspace(db, n_photos=2)
+    high = _add_detection(db, photos[0], conf=0.9)
+    low = _add_detection(db, photos[1], conf=0.05)
+    _record_run(db, high, "M", "fp")
+    _record_run(db, low, "M", "fp")
+
+    inv = db.get_classification_inventory(ws_id, min_conf=0.2)
+    assert inv["total_real_detections"] == 1  # low excluded
+    assert inv["pairs"][0]["classified_dets"] == 1
+
+
+def test_full_image_detections_excluded(db):
+    ws_id, photos = _seed_workspace(db, n_photos=2)
+    real = _add_detection(db, photos[0], model="megadetector-v6")
+    full = _add_detection(db, photos[1], model="full-image")
+    _record_run(db, real, "M", "fp")
+    _record_run(db, full, "M", "fp")
+
+    inv = db.get_classification_inventory(ws_id, min_conf=0.2)
+    assert inv["total_real_detections"] == 1
+    assert inv["pairs"][0]["classified_dets"] == 1
+
+
+def test_workspace_scoping_excludes_other_workspaces(db):
+    ws1_id, photos1 = _seed_workspace(db, name="WS1", folder_path="/photos/ws1", n_photos=1)
+    det1 = _add_detection(db, photos1[0])
+    _record_run(db, det1, "M", "fp")
+
+    ws2_id, photos2 = _seed_workspace(db, name="WS2", folder_path="/photos/ws2", n_photos=1)
+    det2 = _add_detection(db, photos2[0])
+    _record_run(db, det2, "M", "fp")
+
+    # Inventory for ws1 should see only its own detection
+    inv1 = db.get_classification_inventory(ws1_id, min_conf=0.2)
+    assert inv1["total_real_detections"] == 1
+    assert inv1["pairs"][0]["classified_dets"] == 1
+
+    inv2 = db.get_classification_inventory(ws2_id, min_conf=0.2)
+    assert inv2["total_real_detections"] == 1
+    assert inv2["pairs"][0]["classified_dets"] == 1
+
+
+def test_photos_covered_dedupes(db):
+    ws_id, photos = _seed_workspace(db, n_photos=1)
+    # 5 detections on one photo
+    dets = [_add_detection(db, photos[0]) for _ in range(5)]
+    for d in dets:
+        _record_run(db, d, "M", "fp")
+
+    inv = db.get_classification_inventory(ws_id, min_conf=0.2)
+    pair = inv["pairs"][0]
+    assert pair["classified_dets"] == 5
+    assert pair["photos_covered"] == 1
+
+
+def test_median_top1_confidence_sample(db):
+    ws_id, photos = _seed_workspace(db, n_photos=10)
+    # Each photo: one detection, one prediction with conf 0.9
+    for p in photos:
+        d = _add_detection(db, p)
+        _record_run(db, d, "M", "fp")
+        _add_prediction(db, d, "M", "fp", "X", 0.9)
+
+    inv = db.get_classification_inventory(ws_id, min_conf=0.2)
+    pair = inv["pairs"][0]
+    # When all confidences are 0.9, median must be 0.9 regardless of sampling.
+    assert pair["median_top1_conf"] == pytest.approx(0.9, abs=0.001)
+    assert pair["median_sample_size"] >= 1
+
+
+def test_median_top1_uses_max_per_detection(db):
+    """A detection with multiple species predictions: median uses the top-1 (max conf)."""
+    ws_id, photos = _seed_workspace(db, n_photos=1)
+    d = _add_detection(db, photos[0])
+    _record_run(db, d, "M", "fp")
+    _add_prediction(db, d, "M", "fp", "Robin", 0.85)
+    _add_prediction(db, d, "M", "fp", "Sparrow", 0.10)
+
+    inv = db.get_classification_inventory(ws_id, min_conf=0.2)
+    pair = inv["pairs"][0]
+    assert pair["median_top1_conf"] == pytest.approx(0.85, abs=0.001)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint-level tests: /api/workspace/classification-inventory
+# ---------------------------------------------------------------------------
+
+def _setup_labels_dir(tmp_path, monkeypatch, sets):
+    """Write label files under a temp dir and patch labels.LABELS_DIR.
+
+    sets: list of (name, [species]). Writes name.json + name.txt.
+    """
+    import labels as labels_mod
+    labels_dir = os.path.join(str(tmp_path), ".vireo", "labels")
+    os.makedirs(labels_dir, exist_ok=True)
+    monkeypatch.setattr(labels_mod, "LABELS_DIR", labels_dir)
+    paths = {}
+    for name, species in sets:
+        txt = os.path.join(labels_dir, f"{name}.txt")
+        with open(txt, "w") as f:
+            f.write("\n".join(species))
+        meta = {
+            "name": name,
+            "place_name": name,
+            "taxon_groups": [],
+            "species_count": len(species),
+            "labels_file": txt,
+        }
+        with open(os.path.join(labels_dir, f"{name}.json"), "w") as f:
+            json.dump(meta, f)
+        paths[name] = txt
+    return paths
+
+
+def test_endpoint_cross_product_includes_never_run(app_and_db, tmp_path, monkeypatch):
+    from labels_fingerprint import compute_fingerprint  # noqa: F401
+    app, db = app_and_db
+    # Seed a single detection in workspace's first photo
+    ws_id = db._active_workspace_id
+    photo_row = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()
+    _add_detection(db, photo_row["id"])
+
+    # Two label sets on disk, no runs at all
+    _setup_labels_dir(tmp_path, monkeypatch, [
+        ("birds", ["Robin", "Sparrow"]),
+        ("reptiles", ["Lizard"]),
+    ])
+
+    client = app.test_client()
+    resp = client.get("/api/workspace/classification-inventory")
+    assert resp.status_code == 200
+    body = resp.get_json()
+
+    # Cross-product: every (model × label-set) pair appears, each "never_run"
+    assert body["total_real_detections"] == 1
+    assert len(body["models"]) >= 1
+    seen_pairs = []
+    for m in body["models"]:
+        for p in m["pairs"]:
+            seen_pairs.append((m["name"], p["label_set"]))
+            assert p["status"] in ("never_run", "complete", "partial", "stale")
+    # There should be at least one (model, "birds") pair and one (model, "reptiles") pair
+    label_sets_seen = {ls for _, ls in seen_pairs}
+    assert "birds" in label_sets_seen
+    assert "reptiles" in label_sets_seen
+
+
+def test_endpoint_identifies_stale(app_and_db, tmp_path, monkeypatch):
+    app, db = app_and_db
+    photo_row = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()
+    det = _add_detection(db, photo_row["id"])
+    # A prior run on a fingerprint that does not match any current label file
+    _record_run(db, det, "BioCLIP-2.5", "obsolete_fp_xyz")
+
+    _setup_labels_dir(tmp_path, monkeypatch, [("birds", ["Robin"])])
+
+    client = app.test_client()
+    resp = client.get("/api/workspace/classification-inventory")
+    body = resp.get_json()
+    stale_fps = {s["fingerprint"] for s in body["stale"]}
+    assert "obsolete_fp_xyz" in stale_fps
+
+
+def test_endpoint_tol_only_for_supported_models(app_and_db, tmp_path, monkeypatch):
+    app, db = app_and_db
+    _setup_labels_dir(tmp_path, monkeypatch, [("birds", ["Robin"])])
+
+    client = app.test_client()
+    resp = client.get("/api/workspace/classification-inventory")
+    body = resp.get_json()
+
+    for m in body["models"]:
+        tol_pairs = [p for p in m["pairs"] if p.get("is_tol")]
+        if m["supports_tol"]:
+            assert len(tol_pairs) == 1, f"{m['name']} should have one Tree of Life pair"
+        else:
+            assert tol_pairs == [], f"{m['name']} should not have a Tree of Life pair"
+
+
+def test_endpoint_legacy_model_grouped(app_and_db, tmp_path, monkeypatch):
+    app, db = app_and_db
+    photo_row = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()
+    det = _add_detection(db, photo_row["id"])
+    # A run from a model not in the registry
+    _record_run(db, det, "AncientModel-v0", "fp")
+
+    _setup_labels_dir(tmp_path, monkeypatch, [("birds", ["Robin"])])
+
+    client = app.test_client()
+    resp = client.get("/api/workspace/classification-inventory")
+    body = resp.get_json()
+    legacy_models = [m for m in body["models"] if m.get("legacy")]
+    legacy_names = {m["name"] for m in legacy_models}
+    assert "AncientModel-v0" in legacy_names
+
+
+def test_endpoint_grand_total(app_and_db, tmp_path, monkeypatch):
+    app, db = app_and_db
+    photo_row = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()
+    det = _add_detection(db, photo_row["id"])
+    _record_run(db, det, "BioCLIP-2.5", "fp_birds")
+    _add_prediction(db, det, "BioCLIP-2.5", "fp_birds", "Robin", 0.9)
+
+    _setup_labels_dir(tmp_path, monkeypatch, [("birds", ["Robin"])])
+
+    client = app.test_client()
+    resp = client.get("/api/workspace/classification-inventory")
+    body = resp.get_json()
+    gt = body["grand_total"]
+    assert gt["classified_dets"] >= 1
+    assert gt["total_predictions_rows"] >= 1


### PR DESCRIPTION
## Summary

Adds a Classification Inventory section to the dashboard so users can see, per (classifier model × label set), exactly what's been classified and what's pending in the active workspace. Closes the gap between the dashboard's per-photo "67% classified" summary and the pipeline page's per-detection pending count, which can otherwise look contradictory.

## Why

The existing 67% summary counts a photo as classified if **any** detection on it has **any** prediction by **any** model with **any** label set. That hides three things:

1. Which (model × label-set) pairs have actually been run on the workspace.
2. Per-detection coverage — a photo with five birds is one unit on the dashboard but five units of classify work.
3. Stale predictions left over after a label set is edited (different fingerprint).

This makes the pipeline page's "X to classify" estimate surprising. The new section gives the user a complete picture and a launch pad to fill gaps.

## What's in the table

| Column | Meaning |
|---|---|
| Status | Complete / Partial / Never run / Stale pill |
| Label set | Filename (or "Tree of Life", or "(intrinsic)" for closed-set models) |
| Classified | Detections classified for this pair |
| Pending | Detections in scope without a row in `classifier_runs` for this pair |
| Coverage | classified / (classified + pending), with inline mini-bar |
| Photos | Distinct photos with ≥1 classified detection for this pair |
| Last run | Relative time |
| Median top-1 | Sampled median of top-1 confidence (dimmed when sample <100) |
| Actions | ▶ deep-links to `/pipeline?models=&labels=` pre-selected; 🔍 deep-links to `/review?model=&labels_fingerprint=` filtered |

Per-model subtotals, grand total at the bottom, collapsible "Outdated label-set fingerprints" section for stale rows, and a "Legacy" group for predictions from models no longer in the registry.

## Backend

- `Database.get_classification_inventory(workspace_id, min_conf)` — single CTE-scoped aggregate over `classifier_runs` for per-pair counts + last_run, plus a sampled top-1 median (max 2,000 rows per pair) for the median column.
- `/api/workspace/classification-inventory` — composes the cross-product of available models × label sets on disk, merges in DB results, identifies stale and legacy rows, returns the structured payload defined in the design doc.
- No DB migration; reads existing tables only.

## Frontend

- New full-width section in `vireo/templates/stats.html` under the existing card grid, with refresh button, grouped table, status pills, collapse/expand, grand total, stale section.
- `vireo/templates/pipeline.html` reads `?models=` / `?labels=` query params on load to pre-select the corresponding checkboxes (transient — not persisted unless the user clicks Run).
- `vireo/templates/review.html` reads `?labels_fingerprint=` and applies it as a client-side filter, with a clearable "Filtered to fingerprint <prefix>" pill.

## Trade-offs

- **Manual refresh, not SSE auto-refresh.** The design considered subscribing to the existing job SSE stream for live updates, but opted for a Refresh button to avoid competing with the navbar's SSE thread pool (Flask single-process). Easy to add later if needed.
- **All known classifier models shown, even if not yet downloaded.** Surfaces "if you downloaded iNat21 this is N detections of work" — the user explicitly wanted maximum information density.
- **Sampled median.** The median top-1 confidence is computed from at most 2,000 rows per pair. SQLite has no native median; precise computation would slow the endpoint significantly without changing what the column says (a fuzzy "is this model giving confident answers" signal).

## Test plan

- [x] `python -m pytest vireo/tests/test_classification_inventory.py -v` — 15/15 pass (10 DB-level + 5 endpoint).
- [x] Primary test suite (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py`) — green, no regressions.
- [x] Live verification against USA2026 in a browser (Playwright headless): correct numbers, status pills, collapse/expand, grand total, action links wire up to `/pipeline` and `/review` with the right pre-selection.
- [x] Dark mode renders legibly (CSS uses theme variables).
- [ ] Manual user check on real data after merge.

## Design doc

See `docs/plans/2026-05-06-classification-inventory-design.md` (committed in the previous commit on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)