### PR TITLE
Dashboard: count photos in offline folders honestly

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7030,13 +7030,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # stays honest when an external drive is unmounted instead of
         # collapsing to 0. ``accessible_photo_count`` is the actionable
         # subset; when it's lower, the dashboard surfaces the gap.
+        # ``keyword_count`` likewise reports inventory-wide so the Keywords
+        # card agrees with the Top Species / Other Keywords charts (which
+        # also count photos in missing folders).
         return jsonify(
             {
                 "photo_count": db.count_photos_in_workspace(),
                 "accessible_photo_count": db.count_photos(),
                 "missing_folder_count": len(db.get_missing_folders()),
                 "folder_count": db.count_folders(),
-                "keyword_count": db.count_keywords(),
+                "keyword_count": db.count_keywords_in_workspace(),
                 "pending_changes": db.count_pending_changes(),
                 "db_size": db_size,
                 "thumb_cache_size": thumb_size,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2728,7 +2728,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_stats():
         db = _get_db()
         stats = db.get_dashboard_stats()
-        stats["total_photos"] = db.count_photos()
+        # ``total_photos`` is the workspace's full inventory (includes photos
+        # whose folders are currently flagged 'missing'), so the dashboard's
+        # headline number stays honest when a drive is unmounted.
+        # ``accessible_photos`` is the subset that's actually reachable right
+        # now — when this is lower, the UI surfaces the gap with a banner.
+        stats["total_photos"] = db.count_photos_in_workspace()
+        stats["accessible_photos"] = db.count_photos()
+        stats["missing_folder_count"] = len(db.get_missing_folders())
         return jsonify(stats)
 
     @app.route("/api/coverage")
@@ -7018,9 +7025,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 if os.path.isfile(fp):
                     thumb_size += os.path.getsize(fp)
 
+        # ``photo_count`` is the workspace's total inventory (includes photos
+        # in folders flagged 'missing'), so the dashboard's headline number
+        # stays honest when an external drive is unmounted instead of
+        # collapsing to 0. ``accessible_photo_count`` is the actionable
+        # subset; when it's lower, the dashboard surfaces the gap.
         return jsonify(
             {
-                "photo_count": db.count_photos(),
+                "photo_count": db.count_photos_in_workspace(),
+                "accessible_photo_count": db.count_photos(),
+                "missing_folder_count": len(db.get_missing_folders()),
                 "folder_count": db.count_folders(),
                 "keyword_count": db.count_keywords(),
                 "pending_changes": db.count_pending_changes(),

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2581,13 +2581,37 @@ class Database:
         ).fetchone()[0]
 
     def count_keywords(self):
-        """Return count of keywords used by photos in the active workspace."""
+        """Return count of keywords used by photos in the active workspace.
+
+        Filters out keywords whose only photos sit in folders flagged
+        ``'missing'``. For the dashboard's headline (which must agree with
+        the unfiltered top_keywords chart in ``get_dashboard_stats``), use
+        ``count_keywords_in_workspace`` instead.
+        """
         return self.conn.execute(
             """SELECT COUNT(DISTINCT pk.keyword_id)
                FROM photo_keywords pk
                JOIN photos p ON p.id = pk.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
+               WHERE wf.workspace_id = ?""",
+            (self._ws_id(),),
+        ).fetchone()[0]
+
+    def count_keywords_in_workspace(self):
+        """Return count of keywords used by photos in the active workspace,
+        including photos in folders flagged ``'missing'``.
+
+        Pairs with the unfiltered ``top_keywords`` query in
+        ``get_dashboard_stats`` so the dashboard's Keywords headline can't
+        disagree with the Top Species / Other Keywords charts when a drive
+        is unmounted (e.g. headline says 0 while charts list keywords).
+        """
+        return self.conn.execute(
+            """SELECT COUNT(DISTINCT pk.keyword_id)
+               FROM photo_keywords pk
+               JOIN photos p ON p.id = pk.photo_id
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                WHERE wf.workspace_id = ?""",
             (self._ws_id(),),
         ).fetchone()[0]

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2538,11 +2538,35 @@ class Database:
         return {row["id"]: row for row in rows}
 
     def count_photos(self):
-        """Return photo count for the active workspace."""
+        """Return photo count for the active workspace.
+
+        Filters out photos whose folder is flagged ``'missing'`` so callers
+        like browse/cull/move see only photos they can actually act on. For
+        a total inventory that survives an unmounted drive (e.g. the
+        dashboard's headline number), use ``count_photos_in_workspace``.
+        """
         return self.conn.execute(
             """SELECT COUNT(*) FROM photos p
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
+               WHERE wf.workspace_id = ?""",
+            (self._ws_id(),),
+        ).fetchone()[0]
+
+    def count_photos_in_workspace(self):
+        """Return total photo count for the active workspace, including
+        photos in folders flagged ``'missing'``.
+
+        The dashboard wants this number — when a drive unmounts, the photos
+        are still part of the workspace's inventory, just temporarily
+        inaccessible. Falling back to ``count_photos`` (which filters out
+        missing folders) makes the dashboard say "0 photos" for an
+        established workspace, hiding the fact that the data is fine and
+        only the volume is offline.
+        """
+        return self.conn.execute(
+            """SELECT COUNT(*) FROM photos p
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                WHERE wf.workspace_id = ?""",
             (self._ws_id(),),
         ).fetchone()[0]
@@ -3235,13 +3259,17 @@ class Database:
             "detector_confidence", 0.2
         )
 
+        # The four pure-metadata aggregates below (top_keywords,
+        # photos_by_month, rating_dist, flag_dist) intentionally don't filter
+        # on folder status. They read DB-resident metadata that doesn't depend
+        # on disk access, so an unmounted drive shouldn't blank the charts —
+        # the dashboard should still describe the full workspace inventory.
         top_keywords = self.conn.execute(
             """SELECT k.name, k.is_species, COUNT(pk.photo_id) as photo_count
                FROM keywords k
                JOIN photo_keywords pk ON pk.keyword_id = k.id
                JOIN photos p ON p.id = pk.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
                WHERE wf.workspace_id = ?
                GROUP BY k.id
                ORDER BY photo_count DESC
@@ -3253,7 +3281,6 @@ class Database:
             """SELECT substr(p.timestamp, 1, 7) as month, COUNT(*) as count
             FROM photos p
             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
             WHERE p.timestamp IS NOT NULL AND wf.workspace_id = ?
             GROUP BY month
             ORDER BY month""",
@@ -3264,7 +3291,6 @@ class Database:
             """SELECT p.rating, COUNT(*) as count
             FROM photos p
             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
             WHERE wf.workspace_id = ?
             GROUP BY p.rating
             ORDER BY p.rating""",
@@ -3275,7 +3301,6 @@ class Database:
             """SELECT p.flag, COUNT(*) as count
             FROM photos p
             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
             WHERE wf.workspace_id = ?
             GROUP BY p.flag""",
             (ws,),
@@ -3333,11 +3358,12 @@ class Database:
             (ws, min_conf),
         ).fetchone()[0]
 
+        # photos_by_hour and quality_dist are also pure-metadata aggregates;
+        # see the comment above the top_keywords block for the rationale.
         photos_by_hour = self.conn.execute(
             """SELECT CAST(substr(p.timestamp, 12, 2) AS INTEGER) as hour, COUNT(*) as count
             FROM photos p
             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
             WHERE p.timestamp IS NOT NULL AND length(p.timestamp) >= 13 AND wf.workspace_id = ?
             GROUP BY hour
             ORDER BY hour""",
@@ -3353,7 +3379,6 @@ class Database:
                 COUNT(*) as count
             FROM photos p
             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-            JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
             WHERE wf.workspace_id = ?
             GROUP BY bucket
             ORDER BY bucket""",
@@ -3361,12 +3386,16 @@ class Database:
         ).fetchall()
 
         # min_conf already hoisted at top of get_dashboard_stats.
+        # No folder-status filter — detections persist in the DB regardless
+        # of disk presence, and prediction_status / classified_count above
+        # don't filter either, so detected_count must match to keep the
+        # dashboard's classified-vs-detected ratio internally consistent
+        # when a folder is offline.
         detected_count = self.conn.execute(
             """SELECT COUNT(DISTINCT d.photo_id)
                FROM detections d
                JOIN photos p ON p.id = d.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
                WHERE wf.workspace_id = ?
                  AND d.detector_confidence >= ?""",
             (ws, min_conf),

--- a/vireo/templates/stats.html
+++ b/vireo/templates/stats.html
@@ -185,6 +185,7 @@ body { padding-bottom: 36px; }
       <div class="stat-card">
         <div class="stat-number" id="photoCount">-</div>
         <div class="stat-label">Photos</div>
+        <div id="offlinePhotoNote" style="display:none;font-size:11px;color:var(--warning);margin-top:4px;line-height:1.3;"></div>
       </div>
       <div class="stat-card" id="folderCard" style="cursor:pointer;" onclick="toggleFolderDetail()">
         <div class="stat-number" id="folderCount">-</div>
@@ -373,16 +374,42 @@ async function loadCoverage() {
   try {
     var data = await safeFetch('/api/coverage', {}, { toast: false });
     _coverageFolders = data.folders || [];
-    renderCoverage(container, data.overall || {total: 0});
+    var overall = data.overall || {total: 0};
+    // When ``overall.total`` is 0, we need to know whether the workspace
+    // is genuinely empty or whether all its folders are offline so we
+    // can pick the right empty-state copy. ``/api/scan/status`` carries
+    // that signal; only pay for the extra fetch on the empty branch.
+    var offlineCtx = null;
+    if ((overall.total || 0) === 0) {
+      try {
+        var status = await safeFetch('/api/scan/status', {}, { toast: false });
+        if ((status.photo_count || 0) > 0 && (status.missing_folder_count || 0) > 0) {
+          offlineCtx = {
+            offline_photos: (status.photo_count || 0) - (status.accessible_photo_count || 0),
+            missing_folders: status.missing_folder_count || 0,
+          };
+        }
+      } catch (_) { /* fall through to default empty-state */ }
+    }
+    renderCoverage(container, overall, offlineCtx);
   } catch(e) {
     container.innerHTML = '<span style="color:var(--danger);font-size:12px;">Failed to load coverage.</span>';
   }
 }
 
-function renderCoverage(container, stats) {
+function renderCoverage(container, stats, offlineCtx) {
   var total = stats.total || 0;
   if (total === 0) {
-    container.innerHTML = '<span style="color:var(--text-ghost);font-size:13px;">No photos in this workspace.</span>';
+    // ``stats.total`` counts photos in 'ok'/'partial' folders only, so it
+    // hits 0 both for an empty workspace and for one whose folders are
+    // entirely offline. ``offlineCtx`` (set by ``loadCoverage`` when
+    // ``/api/scan/status`` shows missing folders) disambiguates so the
+    // empty-state copy doesn't contradict the headline.
+    container.innerHTML = offlineCtx
+      ? '<span style="color:var(--text-ghost);font-size:13px;">'
+        + offlineCtx.offline_photos.toLocaleString()
+        + ' photos are in offline folders — mount the storage to see processing coverage.</span>'
+      : '<span style="color:var(--text-ghost);font-size:13px;">No photos in this workspace.</span>';
     return;
   }
   var html = '';
@@ -844,6 +871,22 @@ async function loadDashboard() {
     document.getElementById('folderCount').textContent = d.folder_count.toLocaleString();
     document.getElementById('keywordCount').textContent = d.keyword_count.toLocaleString();
     document.getElementById('pendingCount').textContent = d.pending_changes.toLocaleString();
+
+    // When some photos sit in offline (unmounted) folders, the headline count
+    // now includes them — surface the gap explicitly so the user knows why
+    // coverage bars dipped and what to mount to bring them back online.
+    var note = document.getElementById('offlinePhotoNote');
+    var total = d.photo_count || 0;
+    var accessible = (typeof d.accessible_photo_count === 'number') ? d.accessible_photo_count : total;
+    var missingFolders = d.missing_folder_count || 0;
+    if (accessible < total && missingFolders > 0) {
+      var offline = total - accessible;
+      var fs = missingFolders === 1 ? '' : 's';
+      note.textContent = offline.toLocaleString() + ' in ' + missingFolders + ' offline folder' + fs;
+      note.style.display = 'block';
+    } else {
+      note.style.display = 'none';
+    }
   } catch(e) {}
 }
 

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -5493,6 +5493,94 @@ def test_missing_folder_photos_hidden_from_browse(tmp_path):
     assert photos[0]["filename"] == "visible.jpg"
 
 
+def test_count_photos_in_workspace_includes_missing(tmp_path):
+    """count_photos_in_workspace counts photos regardless of folder status,
+    so the dashboard's headline total stays honest when a drive unmounts.
+
+    count_photos() filters to ok/partial folders (right for browse/cull/etc.,
+    where you can only act on accessible photos). The dashboard wants the
+    full inventory, including photos whose folders are temporarily offline.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    fid_ok = db.add_folder("/ok/folder", name="ok")
+    fid_gone = db.add_folder("/gone/folder", name="gone")
+    db.add_photo(folder_id=fid_ok, filename="visible.jpg", extension=".jpg",
+                 file_size=1000, file_mtime=1.0)
+    db.add_photo(folder_id=fid_gone, filename="hidden.jpg", extension=".jpg",
+                 file_size=1000, file_mtime=1.0)
+
+    assert db.count_photos() == 2
+    assert db.count_photos_in_workspace() == 2
+
+    db.conn.execute("UPDATE folders SET status = 'missing' WHERE id = ?", (fid_gone,))
+    db.conn.commit()
+
+    # count_photos hides missing-folder photos, but the total inventory does not
+    assert db.count_photos() == 1
+    assert db.count_photos_in_workspace() == 2
+
+
+def test_count_photos_in_workspace_scoped_to_active_workspace(tmp_path):
+    """count_photos_in_workspace is workspace-scoped — photos in other
+    workspaces' folders don't bleed into the count.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.ensure_default_workspace()
+    ws_b = db.create_workspace("OtherWS")
+
+    db.set_active_workspace(ws_a)
+    fid = db.add_folder("/some/folder", name="folder")
+    db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                 file_size=1000, file_mtime=1.0)
+
+    assert db.count_photos_in_workspace() == 1
+    db.set_active_workspace(ws_b)
+    assert db.count_photos_in_workspace() == 0
+
+
+def test_dashboard_stats_metadata_survives_missing_folders(tmp_path):
+    """get_dashboard_stats's pure-DB aggregates (top_keywords, photos_by_month,
+    rating_dist, flag_dist) read metadata that doesn't depend on disk access,
+    so they should still populate when folders are flagged 'missing'. Without
+    this, unmounting a drive blanks the entire stats page even though all the
+    underlying data is still in the database.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    fid = db.add_folder("/photos", name="photos")
+    p1 = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                      file_size=1000, file_mtime=1.0,
+                      timestamp="2024-01-15T12:00:00")
+    p2 = db.add_photo(folder_id=fid, filename="b.jpg", extension=".jpg",
+                      file_size=1000, file_mtime=1.0,
+                      timestamp="2024-02-15T12:00:00")
+    db.update_photo_rating(p1, 4)
+    db.update_photo_rating(p2, 3)
+
+    # Sanity: stats populated when folder is ok.
+    stats = db.get_dashboard_stats()
+    assert len(stats["photos_by_month"]) == 2
+    assert len(stats["rating_distribution"]) >= 1
+
+    db.conn.execute("UPDATE folders SET status = 'missing' WHERE id = ?", (fid,))
+    db.conn.commit()
+
+    # Metadata aggregates still populated — they don't depend on disk presence.
+    stats = db.get_dashboard_stats()
+    assert len(stats["photos_by_month"]) == 2, \
+        "photos_by_month went empty when folder marked missing"
+    assert len(stats["rating_distribution"]) >= 1, \
+        "rating_distribution went empty when folder marked missing"
+
+
 def test_missing_folder_hidden_from_folder_tree(tmp_path):
     """Missing folders don't appear in get_folder_tree."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -5524,6 +5524,37 @@ def test_count_photos_in_workspace_includes_missing(tmp_path):
     assert db.count_photos_in_workspace() == 2
 
 
+def test_count_keywords_in_workspace_includes_missing(tmp_path):
+    """count_keywords_in_workspace counts keywords regardless of folder
+    status, so the dashboard's Keywords headline agrees with its Top
+    Species / Other Keywords charts (both populated from photos in any
+    folder, including 'missing'). Without this, the two widgets contradict
+    each other on the same page when a drive unmounts.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    fid = db.add_folder("/photos", name="photos")
+    pid = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                       file_size=1000, file_mtime=1.0)
+    k1 = db.add_keyword("Cardinal")
+    k2 = db.add_keyword("Sparrow")
+    db.tag_photo(pid, k1)
+    db.tag_photo(pid, k2)
+
+    assert db.count_keywords() == 2
+    assert db.count_keywords_in_workspace() == 2
+
+    db.conn.execute("UPDATE folders SET status = 'missing' WHERE id = ?", (fid,))
+    db.conn.commit()
+
+    # count_keywords filters missing folders; the inventory-wide count does not
+    assert db.count_keywords() == 0
+    assert db.count_keywords_in_workspace() == 2
+
+
 def test_count_photos_in_workspace_scoped_to_active_workspace(tmp_path):
     """count_photos_in_workspace is workspace-scoped — photos in other
     workspaces' folders don't bleed into the count.

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -193,6 +193,12 @@ def test_scan_status_photo_count_includes_missing_folders(app_and_db):
         "headline photo_count must reflect inventory, not just accessible"
     assert after['accessible_photo_count'] == 0
     assert after['missing_folder_count'] >= 1
+    # Keywords headline must agree with the dashboard's top_keywords chart
+    # (which also includes photos in missing folders). The fixture tags two
+    # keywords on photos that all sit in folders we just flagged 'missing',
+    # so the unfiltered count should still see them.
+    assert after['keyword_count'] == base['keyword_count'], \
+        "keyword_count must be inventory-wide, not accessible-only"
 
 
 def test_ingest_job_starts(app_and_db, tmp_path):

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -160,6 +160,39 @@ def test_scan_status_includes_extended_stats(app_and_db):
     assert 'keyword_count' in data
     assert 'db_size' in data
     assert 'thumb_cache_size' in data
+    assert 'accessible_photo_count' in data
+    assert 'missing_folder_count' in data
+
+
+def test_scan_status_photo_count_includes_missing_folders(app_and_db):
+    """When a folder is flagged 'missing' (e.g. external drive unmounted),
+    /api/scan/status reports the workspace's full inventory in
+    ``photo_count`` and the actionable subset in ``accessible_photo_count``.
+
+    Without this split, the dashboard's headline number collapses to 0 for
+    any workspace whose photos live on an unmounted volume — even though
+    the data is intact in the DB.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    resp = client.get('/api/scan/status')
+    base = resp.get_json()
+    assert base['photo_count'] == 3
+    assert base['accessible_photo_count'] == 3
+    assert base['missing_folder_count'] == 0
+
+    # Mark every folder in the workspace as missing — simulates the
+    # external-drive-not-mounted case.
+    db.conn.execute("UPDATE folders SET status = 'missing'")
+    db.conn.commit()
+
+    resp = client.get('/api/scan/status')
+    after = resp.get_json()
+    assert after['photo_count'] == 3, \
+        "headline photo_count must reflect inventory, not just accessible"
+    assert after['accessible_photo_count'] == 0
+    assert after['missing_folder_count'] >= 1
 
 
 def test_ingest_job_starts(app_and_db, tmp_path):


### PR DESCRIPTION
## Why

When a workspace's folders are flagged `'missing'` (typical case: external drive isn't mounted), the dashboard's "Photos" card collapses to 0. The photos are still in the database, but `Database.count_photos()` filters to `status IN ('ok', 'partial')`, so it returns 0 — and from there `total_photos` poisons every chart on the page.

Reproduces by opening any workspace whose folders live on an unmounted volume — e.g. an `Apr2026` workspace with two folders under `/Volumes/Photography/...` that's currently disconnected. DB has thousands of photos, dashboard shows 0.

## What changed

- **`Database.count_photos_in_workspace()`** — new method that ignores folder status. The dashboard headline uses this; everything else (browse/cull/move) keeps using `count_photos()`, which still hides photos in missing folders so you can't try to act on what isn't reachable.
- **`/api/scan/status`** now returns `photo_count` (inventory), `accessible_photo_count` (reachable subset), and `missing_folder_count`.
- **`/api/stats`** mirrors the same split (`total_photos`, `accessible_photos`, `missing_folder_count`).
- **`get_dashboard_stats`** — drop the folder-status filter from the pure-metadata aggregates (`top_keywords`, `photos_by_month`, `rating_distribution`, `flag_distribution`, `photos_by_hour`, `quality_distribution`, `detected_count`). These read DB-resident data, so they shouldn't blank when a drive unmounts. `prediction_status`/`classified_count` already didn't filter — `detected_count` joining them keeps the classified-vs-detected ratio internally consistent.
- **`stats.html`** — Photos card shows a small "X in N offline folder(s)" note under the count when inventory > accessible. Processing Coverage's empty state explains the offline case ("All photos are in offline folders — mount the storage to see processing coverage") rather than saying "No photos in this workspace" alongside a non-zero headline.

## Out of scope (intentionally)

The ~30 other `f.status IN ('ok', 'partial')` joins across the codebase (browse/cull/classify/pipeline/etc.) are unchanged — those callers should keep filtering missing photos out so nothing tries to read pixels from an unmounted drive.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` → 916 passed, 1 skipped
- [ ] Open a workspace whose folders are on an unmounted volume; confirm the dashboard shows the inventory count with an "X in N offline folders" note rather than 0
- [ ] Mount the volume; confirm the note disappears and coverage bars repopulate
- [ ] Sanity-check a healthy workspace: counts and charts unchanged from current behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)