### PR TITLE
Pipeline plan honesty in import mode + transient thumbnail recovery

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1304,6 +1304,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         from pipeline_plan import PipelinePlanParams, compute_plan
 
         body = request.get_json(silent=True) or {}
+        # source_paths bounds the request. A Z8 SD card can hold ~5k RAWs;
+        # 50k is a generous ceiling that keeps the JSON body well under
+        # Flask's defaults while covering realistic multi-card imports.
+        # Beyond it the plan endpoint refuses rather than truncate, since
+        # a silently-truncated list would mis-classify late files as new.
+        source_paths = body.get("source_paths") or []
+        if not isinstance(source_paths, list):
+            return json_error("source_paths must be a list", 400)
+        if len(source_paths) > 50000:
+            return json_error(
+                f"source_paths too large ({len(source_paths)} > 50000)", 400,
+            )
         params = PipelinePlanParams(
             collection_id=body.get("collection_id"),
             exclude_photo_ids=body.get("exclude_photo_ids") or [],
@@ -1316,6 +1328,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ),
             labels_files=body.get("labels_files") or [],
             reclassify=bool(body.get("reclassify")),
+            source_paths=source_paths,
         )
         db = _get_db()
         return jsonify(compute_plan(db, params, db_path))
@@ -5902,17 +5915,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/api/import/folder-preview/thumbnail")
     def api_import_folder_preview_thumbnail():
-        """Generate an on-the-fly thumbnail for a source file (not yet imported)."""
+        """Generate an on-the-fly thumbnail for a source file (not yet imported).
+
+        Cache policy: only success responses are cacheable. Failures emit
+        ``Cache-Control: no-store`` so a transient libraw I/O glitch (NAS
+        contention, network blip) doesn't pin question marks in the user's
+        preview grid for the cache lifetime — the next page load retries
+        and typically succeeds.
+        """
         file_path = request.args.get("path", "")
         if not file_path:
             return json_error("path parameter required", 400)
         if not os.path.isfile(file_path):
-            return "", 404
+            resp = make_response("", 404)
+            resp.cache_control.no_store = True
+            return resp
 
         from image_loader import load_image
         img = load_image(file_path, max_size=200)
         if img is None:
-            return "", 404
+            resp = make_response("", 404)
+            resp.cache_control.no_store = True
+            return resp
 
         import io
         buf = io.BytesIO()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1309,15 +1309,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Flask's defaults while covering realistic multi-card imports.
         # Beyond it the plan endpoint refuses rather than truncate, since
         # a silently-truncated list would mis-classify late files as new.
-        source_paths = body.get("source_paths") or []
-        if not isinstance(source_paths, list):
-            return json_error("source_paths must be a list", 400)
-        if len(source_paths) > 50000:
-            return json_error(
-                f"source_paths too large ({len(source_paths)} > 50000)", 400,
-            )
-        if not all(isinstance(p, str) for p in source_paths):
-            return json_error("source_paths entries must be strings", 400)
+        #
+        # An explicit empty list is *not* the same as a missing key: the
+        # frontend sends ``[]`` when the user is in import mode and has
+        # deselected every preview file (a genuine no-op import). Falling
+        # back to whole-workspace scope in that case would re-introduce
+        # the misleading "Already done" pills this endpoint exists to
+        # prevent. So preserve None vs [] all the way through.
+        if "source_paths" in body:
+            source_paths = body.get("source_paths")
+            if not isinstance(source_paths, list):
+                return json_error("source_paths must be a list", 400)
+            if len(source_paths) > 50000:
+                return json_error(
+                    f"source_paths too large ({len(source_paths)} > 50000)", 400,
+                )
+            if not all(isinstance(p, str) for p in source_paths):
+                return json_error("source_paths entries must be strings", 400)
+        else:
+            source_paths = None
         params = PipelinePlanParams(
             collection_id=body.get("collection_id"),
             exclude_photo_ids=body.get("exclude_photo_ids") or [],

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1328,6 +1328,26 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 return json_error("source_paths entries must be strings", 400)
         else:
             source_paths = None
+        # hash_duplicate_paths is the frontend's pre-computed set of source
+        # paths that ingest() will skip via the file_hash global-dedup gate
+        # (copy mode + skip_duplicates=True). Same shape/limits as
+        # source_paths; the planner subtracts these from new_count so the
+        # plan doesn't overstate work for hash-skipped files.
+        if "hash_duplicate_paths" in body:
+            hash_duplicate_paths = body.get("hash_duplicate_paths")
+            if not isinstance(hash_duplicate_paths, list):
+                return json_error("hash_duplicate_paths must be a list", 400)
+            if len(hash_duplicate_paths) > 50000:
+                return json_error(
+                    f"hash_duplicate_paths too large "
+                    f"({len(hash_duplicate_paths)} > 50000)", 400,
+                )
+            if not all(isinstance(p, str) for p in hash_duplicate_paths):
+                return json_error(
+                    "hash_duplicate_paths entries must be strings", 400,
+                )
+        else:
+            hash_duplicate_paths = None
         params = PipelinePlanParams(
             collection_id=body.get("collection_id"),
             exclude_photo_ids=body.get("exclude_photo_ids") or [],
@@ -1341,6 +1361,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             labels_files=body.get("labels_files") or [],
             reclassify=bool(body.get("reclassify")),
             source_paths=source_paths,
+            hash_duplicate_paths=hash_duplicate_paths,
         )
         db = _get_db()
         return jsonify(compute_plan(db, params, db_path))

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1316,6 +1316,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(
                 f"source_paths too large ({len(source_paths)} > 50000)", 400,
             )
+        if not all(isinstance(p, str) for p in source_paths):
+            return json_error("source_paths entries must be strings", 400)
         params = PipelinePlanParams(
             collection_id=body.get("collection_id"),
             exclude_photo_ids=body.get("exclude_photo_ids") or [],

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2813,6 +2813,47 @@ class Database:
                     out[os.path.join(dir_path, r["filename"])] = r["id"]
         return out
 
+    def workspace_unlinked_folder_count(self, folder_paths):
+        """Count distinct paths in ``folder_paths`` whose folders are not
+        linked to the active workspace.
+
+        A folder path is "unlinked" when either no row exists in ``folders``
+        for that path or a row exists but no ``workspace_folders`` entry
+        connects it to the active workspace.
+
+        Used by the import-mode pipeline plan to decide whether a scan over
+        already-imported files would be a real no-op for the active
+        workspace. ``scanner.scan`` calls ``_ensure_folder`` (which calls
+        ``add_folder``) for each walked directory, and ``add_folder``
+        auto-links the folder to the active workspace via
+        ``workspace_folders``. So when the user re-imports files that were
+        indexed in a different workspace, scan still mutates state by
+        attaching folders to the active workspace — and the plan must
+        report that as ``will-run`` instead of claiming ``done-prior``.
+        """
+        if not folder_paths:
+            return 0
+        ws = self._ws_id()
+        unique = list({p for p in folder_paths if p})
+        if not unique:
+            return 0
+        BATCH = 800
+        linked = set()
+        for i in range(0, len(unique), BATCH):
+            chunk = unique[i:i + BATCH]
+            placeholders = ",".join("?" for _ in chunk)
+            rows = self.conn.execute(
+                f"""SELECT f.path
+                    FROM folders f
+                    JOIN workspace_folders wf
+                      ON wf.folder_id = f.id AND wf.workspace_id = ?
+                    WHERE f.path IN ({placeholders})""",
+                (ws, *chunk),
+            ).fetchall()
+            for r in rows:
+                linked.add(r["path"])
+        return len(unique) - len(linked)
+
     def _scope_clause(self, photo_ids, table_alias="p"):
         """Build a (clause, params) pair to scope a query to photo_ids.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2777,6 +2777,42 @@ class Database:
             out.append(entry)
         return out
 
+    def photos_by_paths(self, paths):
+        """Return {abs_path: photo_id} for any of ``paths`` already in DB.
+
+        Photos are global (not workspace-scoped), so the import-mode plan
+        can ask "do these files already exist in Vireo?" without caring
+        which workspace owns the folder. Paths missing from the result are
+        genuinely new and the next pipeline run will create photo rows for
+        them — that's what makes "Will run (N)" honest in import mode.
+
+        Splits the input by directory so the SQL stays a single
+        ``WHERE f.path = ? AND p.filename IN (...)`` per directory and
+        respects SQLite's parameter cap.
+        """
+        if not paths:
+            return {}
+        by_dir = {}
+        for p in paths:
+            by_dir.setdefault(os.path.dirname(p), []).append(os.path.basename(p))
+
+        out = {}
+        BATCH = 800  # leave headroom under SQLite's default 999-param cap
+        for dir_path, fnames in by_dir.items():
+            for i in range(0, len(fnames), BATCH):
+                chunk = fnames[i:i + BATCH]
+                placeholders = ",".join("?" for _ in chunk)
+                rows = self.conn.execute(
+                    f"""SELECT p.id, p.filename
+                        FROM photos p
+                        JOIN folders f ON f.id = p.folder_id
+                        WHERE f.path = ? AND p.filename IN ({placeholders})""",
+                    (dir_path, *chunk),
+                ).fetchall()
+                for r in rows:
+                    out[os.path.join(dir_path, r["filename"])] = r["id"]
+        return out
+
     def _scope_clause(self, photo_ids, table_alias="p"):
         """Build a (clause, params) pair to scope a query to photo_ids.
 

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -39,6 +39,12 @@ def load_image(file_path, max_size=1024):
     the requested size; falls back to demosaic-based decode otherwise.
     Returns None if the file cannot be loaded.
 
+    For RAW files we retry once on transient libraw I/O errors. NAS volumes
+    occasionally fail mid-read under burst access (4 concurrent thumbnail
+    requests is enough to trip a slow share), and a single retry typically
+    succeeds — much cheaper than asking the user to refresh and recover
+    from a cached 404.
+
     Args:
         file_path: Path to the image file
         max_size: Maximum dimension (longest side). None or 0 for full resolution.
@@ -54,7 +60,7 @@ def load_image(file_path, max_size=1024):
 
     try:
         if ext in RAW_EXTENSIONS:
-            img = _load_raw(path, max_size)
+            img = _load_raw_with_retry(path, max_size)
         else:
             img = Image.open(str(path))
             img = ImageOps.exif_transpose(img)
@@ -70,6 +76,26 @@ def load_image(file_path, max_size=1024):
     except Exception as e:
         log.warning("Failed to load image: %s — %s", file_path, e)
         return None
+
+
+def _load_raw_with_retry(path, max_size):
+    """Wrap _load_raw with a single retry on transient libraw I/O errors.
+
+    Only retries on LibRawIOError — other libraw errors (UnsupportedFormat,
+    DataError) are deterministic for a given file and won't recover. The
+    retry is sequential (no backoff) since these failures are usually
+    contention-related and resolve immediately.
+    """
+    try:
+        return _load_raw(path, max_size)
+    except Exception as e:
+        # Identify libraw I/O errors by class name so we don't have to
+        # import rawpy at module scope (it's only present when a RAW
+        # actually loads). The class is rawpy._rawpy.LibRawIOError.
+        if type(e).__name__ != "LibRawIOError":
+            raise
+        log.info("Transient libraw I/O error on %s; retrying once", path)
+        return _load_raw(path, max_size)
 
 
 def _load_standard(path, max_size):

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -643,7 +643,8 @@ def _empty_import_plan():
     }
 
 
-def _scan_plan(params, new_count, known_count, unlinked_folder_count):
+def _scan_plan(params, new_count, known_count, unlinked_folder_count,
+               hash_dup_count=0):
     """Plan entry for Scan & Import — only emitted in import / new-images modes.
 
     Honest answer for the user's "what will this run do" question: how many
@@ -661,9 +662,22 @@ def _scan_plan(params, new_count, known_count, unlinked_folder_count):
     case would lie about user-visible state changes (the photos becoming
     visible in this workspace), violating CORE_PHILOSOPHY.md's
     transparency rule.
+
+    ``hash_dup_count`` covers a copy-mode-only failure mode: even when
+    ``unlinked_folder_count == 0`` for the source paths (because we
+    excluded hash-dup parents from that calculation — ingest will skip
+    those source files, so source folders aren't walked), the post-ingest
+    scan in ``run_pipeline_job`` walks the *destination* folders that hold
+    the existing copies (and walks the entire destination root if those
+    copies live elsewhere). That can still link destination folders to the
+    active workspace and surface previously-unseen photos here. So we
+    cannot claim "done-prior" when hash dups are in play, even if every
+    other signal points to a no-op — the plan must report will-run with a
+    summary that names the destination-side work the user is about to
+    trigger.
     """
     total = new_count + known_count
-    if new_count == 0 and unlinked_folder_count == 0:
+    if new_count == 0 and unlinked_folder_count == 0 and hash_dup_count == 0:
         return {
             "state": "done-prior",
             "summary": (
@@ -674,17 +688,41 @@ def _scan_plan(params, new_count, known_count, unlinked_folder_count):
                 "eligible": total, "pending": 0,
                 "new_photos": 0, "already_known": known_count,
                 "unlinked_folders": 0,
+                "hash_duplicates": 0,
             },
         }
     if new_count == 0:
-        # All files known globally but folder(s) not attached to the active
-        # workspace yet — scan will link them, making the photos visible
-        # here. That's real work, even though no new photo rows are added.
-        summary = (
-            f"All {total} file{_plural(total)} already imported elsewhere — "
-            f"scan will link {unlinked_folder_count} "
-            f"folder{_plural(unlinked_folder_count)} to this workspace"
-        )
+        # All source files already known globally. Two reasons this still
+        # isn't a no-op, either of which is enough to flip to will-run:
+        #   - unlinked_folder_count > 0: source folder(s) not yet attached
+        #     to the active workspace, scan will link them via add_folder.
+        #   - hash_dup_count > 0: copy-mode hash dedup. ingest skips the
+        #     source file but the post-ingest scan walks destination
+        #     folders (or the destination root) to attach any duplicate
+        #     destination folders here.
+        if hash_dup_count > 0 and unlinked_folder_count > 0:
+            summary = (
+                f"All {total} file{_plural(total)} already imported "
+                f"({hash_dup_count} hash-duplicate"
+                f"{_plural(hash_dup_count)}) — scan will link "
+                f"{unlinked_folder_count} source "
+                f"folder{_plural(unlinked_folder_count)} and walk the "
+                f"import destination for any duplicate folders"
+            )
+        elif hash_dup_count > 0:
+            summary = (
+                f"All {total} file{_plural(total)} already imported "
+                f"({hash_dup_count} hash-duplicate"
+                f"{_plural(hash_dup_count)}) — scan will walk the "
+                f"import destination to link any duplicate folders to "
+                f"this workspace"
+            )
+        else:
+            summary = (
+                f"All {total} file{_plural(total)} already imported "
+                f"elsewhere — scan will link {unlinked_folder_count} "
+                f"folder{_plural(unlinked_folder_count)} to this workspace"
+            )
         return {
             "state": "will-run",
             "summary": summary,
@@ -694,6 +732,7 @@ def _scan_plan(params, new_count, known_count, unlinked_folder_count):
                 "new_photos": 0,
                 "already_known": known_count,
                 "unlinked_folders": unlinked_folder_count,
+                "hash_duplicates": hash_dup_count,
             },
         }
     if known_count == 0:
@@ -714,6 +753,7 @@ def _scan_plan(params, new_count, known_count, unlinked_folder_count):
             "new_photos": new_count,
             "already_known": known_count,
             "unlinked_folders": unlinked_folder_count,
+            "hash_duplicates": hash_dup_count,
         },
     }
 
@@ -757,6 +797,7 @@ def compute_plan(db, params, db_path):
     new_count = 0
     known_count = 0
     unlinked_folder_count = 0
+    hash_dup_count = 0
     if params.collection_id is not None:
         from pipeline import _resolve_collection_photo_ids
         photo_ids = _resolve_collection_photo_ids(db, params.collection_id)
@@ -802,6 +843,7 @@ def compute_plan(db, params, db_path):
         ) - known_at_path_set
         known_count = len(known) + len(hash_dup_paths)
         new_count = len(unique_paths) - known_count
+        hash_dup_count = len(hash_dup_paths)
         # photos_by_paths is global — a path is "known" even when the
         # photo's folder belongs to a different workspace. scanner.scan
         # would still attach those folders to the active workspace via
@@ -831,6 +873,7 @@ def compute_plan(db, params, db_path):
     if params.source_paths is not None:
         stages["Scan"] = _scan_plan(
             params, new_count, known_count, unlinked_folder_count,
+            hash_dup_count,
         )
 
     return {

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -38,7 +38,13 @@ class PipelinePlanParams:
     # the next pipeline run *will* process them — replacing the old
     # behaviour of describing the whole active workspace's state, which
     # made an import into a non-empty workspace render as "Already done".
-    source_paths: list = field(default_factory=list)
+    #
+    # ``None`` = field not provided (whole-workspace scope, the existing
+    # behaviour for non-import modes). ``[]`` = import mode with every
+    # preview file deselected — a genuine no-op run, which must NOT fall
+    # back to whole-workspace scope (that would re-introduce the very
+    # misleading "Already done" pills this code exists to prevent).
+    source_paths: list | None = None
 
 
 def _plural(n, s="s"):
@@ -573,6 +579,43 @@ def _regroup_plan(db, params, db_path, ws_id, upstream_will_run, effective_cfg):
     }
 
 
+def _empty_import_plan():
+    """Per-stage plan when import mode is active but every preview file is
+    deselected. Every stage is honestly "no work" — not "Already done".
+
+    The pill copy must read as "this run will do nothing because you've
+    selected nothing", not as a status derived from the active workspace's
+    existing data.
+    """
+    no_op = {
+        "state": "will-skip",
+        "summary": "No files selected — nothing to do",
+        "detail": {"pending": 0, "eligible": 0},
+    }
+    return {
+        "stages": {
+            "Scan": {
+                "state": "will-skip",
+                "summary": "No files selected — nothing to import",
+                "detail": {
+                    "eligible": 0, "pending": 0,
+                    "new_photos": 0, "already_known": 0,
+                },
+            },
+            "Classify": dict(no_op),
+            "Extract": dict(no_op),
+            "EyeKeypoints": dict(no_op),
+            "Group": dict(no_op),
+        },
+        "scope": {
+            "collection_id": None,
+            "photo_count": 0,
+            "new_count": 0,
+            "known_count": 0,
+        },
+    }
+
+
 def _scan_plan(params, new_count, known_count):
     """Plan entry for Scan & Import — only emitted in import / new-images modes.
 
@@ -658,7 +701,14 @@ def compute_plan(db, params, db_path):
         if params.exclude_photo_ids:
             excl = set(params.exclude_photo_ids)
             photo_ids = {pid for pid in photo_ids if pid not in excl}
-    elif params.source_paths:
+    elif params.source_paths is not None:
+        if not params.source_paths:
+            # Import / new-images mode with every preview file deselected.
+            # The next pipeline run is a genuine no-op — every stage is
+            # "Nothing selected", not "Already done" derived from unrelated
+            # active-workspace state. Short-circuit so the per-stage
+            # queries don't drift back into whole-workspace summaries.
+            return _empty_import_plan()
         # Import / new-images mode. Split the file set into already-known
         # photo_ids (used as scope for real-status queries) and a count
         # of genuinely new files (fed into each stage as fresh work).
@@ -681,7 +731,7 @@ def compute_plan(db, params, db_path):
         "EyeKeypoints": eye,
         "Group": regroup,
     }
-    if params.source_paths:
+    if params.source_paths is not None:
         stages["Scan"] = _scan_plan(params, new_count, known_count)
 
     return {

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -45,6 +45,19 @@ class PipelinePlanParams:
     # back to whole-workspace scope (that would re-introduce the very
     # misleading "Already done" pills this code exists to prevent).
     source_paths: list | None = None
+    # Paths in ``source_paths`` that the import job will skip via the
+    # ``file_hash`` global-dedup gate (copy mode + ``skip_duplicates=True``).
+    # ``ingest()`` dedupes by hash, not by source path: a file whose hash
+    # already exists at *some* path in the photos table is skipped, even
+    # though the source path itself is unknown. Without this list, those
+    # files would land in ``new_count`` (their source path doesn't match
+    # any photo row), inflating Scan/Classify/Extract estimates for a run
+    # that will actually skip them. The frontend already pre-computes
+    # hash duplicates via /api/import/check-duplicates and passes the
+    # matched source paths back — we use that result instead of re-hashing
+    # at plan time, since hashing thousands of files synchronously inside
+    # a plan request would block the UI on every settings change.
+    hash_duplicate_paths: list | None = None
 
 
 def _plural(n, s="s"):
@@ -766,17 +779,39 @@ def compute_plan(db, params, db_path):
         # "will-run" misleadingly. dict.fromkeys preserves order so the
         # downstream queries see paths in the user's preview order.
         unique_paths = list(dict.fromkeys(params.source_paths))
+        unique_path_set = set(unique_paths)
         known = db.photos_by_paths(unique_paths)
         photo_ids = set(known.values())
-        known_count = len(known)
+        known_at_path_set = set(known.keys())
+        # Hash-dedup gate (copy-mode imports with skip_duplicates=True).
+        # A file flagged here exists in the global photos table at a
+        # different path; ingest() will skip the copy, so the next run
+        # creates no new photo row for it and never touches the existing
+        # one (the post-import scan walks only the destination tree).
+        # Count it as "already known", not new. Defensive intersections:
+        #   - ``& unique_path_set`` ignores stale cache entries (the
+        #     frontend's ``_duplicateResults`` survives source-folder edits
+        #     until the next check completes; a path no longer in the
+        #     selection must not influence counts).
+        #   - subtract ``known_at_path_set`` so a file that's both an
+        #     exact-path match and a hash match isn't double-counted in
+        #     ``known_count``.
+        hash_dup_paths = (
+            set(params.hash_duplicate_paths or [])
+            & unique_path_set
+        ) - known_at_path_set
+        known_count = len(known) + len(hash_dup_paths)
         new_count = len(unique_paths) - known_count
         # photos_by_paths is global — a path is "known" even when the
         # photo's folder belongs to a different workspace. scanner.scan
         # would still attach those folders to the active workspace via
         # add_folder/_ensure_folder, so a "done-prior" Scan claim would
         # be false in that case. Count parent dirs not yet linked here.
+        # Hash-dup paths are excluded: ingest skips those files, so their
+        # parent dirs aren't walked in copy mode and we mustn't claim
+        # scan would link them.
         unlinked_folder_count = db.workspace_unlinked_folder_count(
-            {os.path.dirname(p) for p in unique_paths}
+            {os.path.dirname(p) for p in unique_paths if p not in hash_dup_paths}
         )
 
     classify = _classify_plan(db, params, photo_ids, new_count)

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -630,15 +630,27 @@ def _empty_import_plan():
     }
 
 
-def _scan_plan(params, new_count, known_count):
+def _scan_plan(params, new_count, known_count, unlinked_folder_count):
     """Plan entry for Scan & Import — only emitted in import / new-images modes.
 
     Honest answer for the user's "what will this run do" question: how many
-    files will it actually ingest (creating photo rows), and how many were
-    already in Vireo from a prior import (no-op for those).
+    files will it actually ingest (creating photo rows), how many were
+    already in Vireo from a prior import (no-op for those), and — when
+    every file is already known — whether the scan would still mutate the
+    active workspace by linking previously-unseen folders to it.
+
+    ``unlinked_folder_count`` is the count of distinct parent directories
+    of the import set whose folder rows are not yet linked to the active
+    workspace. ``scanner.scan`` calls ``_ensure_folder`` (which auto-links
+    via ``add_folder``) for every walked directory, so a non-zero value
+    means scan is *not* a no-op even when ``new_count == 0`` — it will
+    insert ``workspace_folders`` rows. Reporting "Already done" in that
+    case would lie about user-visible state changes (the photos becoming
+    visible in this workspace), violating CORE_PHILOSOPHY.md's
+    transparency rule.
     """
     total = new_count + known_count
-    if new_count == 0:
+    if new_count == 0 and unlinked_folder_count == 0:
         return {
             "state": "done-prior",
             "summary": (
@@ -648,6 +660,27 @@ def _scan_plan(params, new_count, known_count):
             "detail": {
                 "eligible": total, "pending": 0,
                 "new_photos": 0, "already_known": known_count,
+                "unlinked_folders": 0,
+            },
+        }
+    if new_count == 0:
+        # All files known globally but folder(s) not attached to the active
+        # workspace yet — scan will link them, making the photos visible
+        # here. That's real work, even though no new photo rows are added.
+        summary = (
+            f"All {total} file{_plural(total)} already imported elsewhere — "
+            f"scan will link {unlinked_folder_count} "
+            f"folder{_plural(unlinked_folder_count)} to this workspace"
+        )
+        return {
+            "state": "will-run",
+            "summary": summary,
+            "detail": {
+                "eligible": total,
+                "pending": 0,
+                "new_photos": 0,
+                "already_known": known_count,
+                "unlinked_folders": unlinked_folder_count,
             },
         }
     if known_count == 0:
@@ -667,6 +700,7 @@ def _scan_plan(params, new_count, known_count):
             "pending": new_count,
             "new_photos": new_count,
             "already_known": known_count,
+            "unlinked_folders": unlinked_folder_count,
         },
     }
 
@@ -709,6 +743,7 @@ def compute_plan(db, params, db_path):
     photo_ids = None
     new_count = 0
     known_count = 0
+    unlinked_folder_count = 0
     if params.collection_id is not None:
         from pipeline import _resolve_collection_photo_ids
         photo_ids = _resolve_collection_photo_ids(db, params.collection_id)
@@ -735,6 +770,14 @@ def compute_plan(db, params, db_path):
         photo_ids = set(known.values())
         known_count = len(known)
         new_count = len(unique_paths) - known_count
+        # photos_by_paths is global — a path is "known" even when the
+        # photo's folder belongs to a different workspace. scanner.scan
+        # would still attach those folders to the active workspace via
+        # add_folder/_ensure_folder, so a "done-prior" Scan claim would
+        # be false in that case. Count parent dirs not yet linked here.
+        unlinked_folder_count = db.workspace_unlinked_folder_count(
+            {os.path.dirname(p) for p in unique_paths}
+        )
 
     classify = _classify_plan(db, params, photo_ids, new_count)
     extract = _extract_plan(db, params, photo_ids, pipeline_cfg, new_count)
@@ -751,7 +794,9 @@ def compute_plan(db, params, db_path):
         "Group": regroup,
     }
     if params.source_paths is not None:
-        stages["Scan"] = _scan_plan(params, new_count, known_count)
+        stages["Scan"] = _scan_plan(
+            params, new_count, known_count, unlinked_folder_count,
+        )
 
     return {
         "stages": stages,

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -581,11 +581,22 @@ def _regroup_plan(db, params, db_path, ws_id, upstream_will_run, effective_cfg):
 
 def _empty_import_plan():
     """Per-stage plan when import mode is active but every preview file is
-    deselected. Every stage is honestly "no work" — not "Already done".
+    deselected.
 
-    The pill copy must read as "this run will do nothing because you've
-    selected nothing", not as a status derived from the active workspace's
-    existing data.
+    The per-photo stages (Classify/Extract/EyeKeypoints/Group) are genuine
+    no-ops because they only operate on imported photos and the import
+    set is empty. Their pill must read as "no work because you've selected
+    nothing", not status derived from the active workspace.
+
+    Scan, however, is NOT a guaranteed no-op even with an empty selection:
+    in scan-in-place mode the scanner still walks ``params.sources`` and
+    only honors per-file deselection via ``skip_paths`` (so unpreviewed
+    siblings still get scanned), and in copy mode the scanner walks the
+    destination tree when no files were copied. Reporting "will-skip" for
+    Scan would lie about substantial directory walking + hashing work the
+    next run actually performs — exactly the misleading-pill failure
+    CORE_PHILOSOPHY.md prohibits. So Scan reads as "will-run" with a
+    summary that names the gap between selection and runtime behavior.
     """
     no_op = {
         "state": "will-skip",
@@ -595,8 +606,11 @@ def _empty_import_plan():
     return {
         "stages": {
             "Scan": {
-                "state": "will-skip",
-                "summary": "No files selected — nothing to import",
+                "state": "will-run",
+                "summary": (
+                    "Will scan source folder(s) — selection only filters "
+                    "which files import"
+                ),
                 "detail": {
                     "eligible": 0, "pending": 0,
                     "new_photos": 0, "already_known": 0,
@@ -704,18 +718,23 @@ def compute_plan(db, params, db_path):
     elif params.source_paths is not None:
         if not params.source_paths:
             # Import / new-images mode with every preview file deselected.
-            # The next pipeline run is a genuine no-op — every stage is
-            # "Nothing selected", not "Already done" derived from unrelated
-            # active-workspace state. Short-circuit so the per-stage
-            # queries don't drift back into whole-workspace summaries.
+            # Per-photo stages are genuine no-ops, but Scan still walks —
+            # see _empty_import_plan() for the honesty rationale.
             return _empty_import_plan()
         # Import / new-images mode. Split the file set into already-known
         # photo_ids (used as scope for real-status queries) and a count
         # of genuinely new files (fed into each stage as fresh work).
-        known = db.photos_by_paths(params.source_paths)
+        # Deduplicate first: overlapping source roots (or a re-added folder
+        # in the preview) can land the same path in source_paths twice,
+        # and counting the duplicate as "new" would inflate Scan/Classify/
+        # Extract estimates and could flip Scan from "done-prior" to
+        # "will-run" misleadingly. dict.fromkeys preserves order so the
+        # downstream queries see paths in the user's preview order.
+        unique_paths = list(dict.fromkeys(params.source_paths))
+        known = db.photos_by_paths(unique_paths)
         photo_ids = set(known.values())
-        known_count = len(photo_ids)
-        new_count = len(params.source_paths) - known_count
+        known_count = len(known)
+        new_count = len(unique_paths) - known_count
 
     classify = _classify_plan(db, params, photo_ids, new_count)
     extract = _extract_plan(db, params, photo_ids, pipeline_cfg, new_count)

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -29,6 +29,16 @@ class PipelinePlanParams:
     model_ids: list = field(default_factory=list)
     labels_files: list = field(default_factory=list)
     reclassify: bool = False
+    # Absolute file paths for an "import" / "new_images" run — i.e. the
+    # files the user is about to ingest into the active workspace.
+    # compute_plan splits these into already-known photo_ids (used as the
+    # per-stage scope, so the existing real-status queries apply) and a
+    # count of genuinely new files. New files are treated as fresh work
+    # for every per-photo stage, which is the only honest answer when
+    # the next pipeline run *will* process them — replacing the old
+    # behaviour of describing the whole active workspace's state, which
+    # made an import into a non-empty workspace render as "Already done".
+    source_paths: list = field(default_factory=list)
 
 
 def _plural(n, s="s"):
@@ -115,7 +125,7 @@ def _resolve_labels_for_models(models, labels_files, db):
     return out
 
 
-def _classify_plan(db, params, photo_ids):
+def _classify_plan(db, params, photo_ids, new_count=0):
     if params.skip_classify:
         return {
             "state": "will-skip",
@@ -164,18 +174,26 @@ def _classify_plan(db, params, photo_ids):
     fingerprint_outdated = stale_total > 0 and not params.reclassify
 
     if total_dets == 0:
-        return {
-            "state": "will-run",
-            "summary": (
+        if new_count > 0:
+            summary = (
+                f"Will run — {new_count} new photo{_plural(new_count)} "
+                f"to detect & classify (MegaDetector runs first)"
+            )
+        else:
+            summary = (
                 "Will run — no detections cached yet "
                 "(MegaDetector will run first)"
-            ),
+            )
+        return {
+            "state": "will-run",
+            "summary": summary,
             "detail": {
                 "total_dets": 0,
                 "photos_with_dets": 0,
                 "models": [m["name"] for m in models],
-                "pending": 0,
-                "eligible": 0,
+                "pending": new_count,
+                "eligible": new_count,
+                "new_photos": new_count,
                 "stale": stale_total,
                 "fingerprint_outdated": fingerprint_outdated,
             },
@@ -224,6 +242,29 @@ def _classify_plan(db, params, photo_ids):
         }
 
     if pending_total == 0:
+        if new_count > 0:
+            # Existing scope is fully classified, but the import will pull
+            # in N new photos that need detector + classify. Honest answer
+            # is "will run", not "Already done".
+            return {
+                "state": "will-run",
+                "summary": (
+                    f"Will run on {new_count} new "
+                    f"photo{_plural(new_count)} "
+                    f"({total_dets} existing detection"
+                    f"{_plural(total_dets)} already classified)"
+                ),
+                "detail": {
+                    "total_dets": total_dets,
+                    "photos_with_dets": photos_with_dets,
+                    "models": [m["name"] for m in models],
+                    "pending": new_count,
+                    "eligible": eligible + new_count,
+                    "new_photos": new_count,
+                    "stale": stale_total,
+                    "fingerprint_outdated": fingerprint_outdated,
+                },
+            }
         return {
             "state": "done-prior",
             "summary": (
@@ -257,22 +298,31 @@ def _classify_plan(db, params, photo_ids):
             f"Will classify {pending_total} new "
             f"pair{_plural(pending_total)} ({breakdown})"
         )
+    if new_count > 0:
+        # Mixed scope: some existing detections still to classify *and*
+        # N new photos coming in (each will get its own detections + class).
+        summary += (
+            f" + {new_count} new photo{_plural(new_count)} "
+            f"to detect & classify"
+        )
     detail = {
         "pending_pairs": pending_total,
         "per_model": pending_per_model,
         "total_dets": total_dets,
         "photos_with_dets": photos_with_dets,
-        "pending": pending_total,
-        "eligible": eligible,
+        "pending": pending_total + new_count,
+        "eligible": eligible + new_count,
         "stale": stale_total,
         "fingerprint_outdated": fingerprint_outdated,
     }
+    if new_count > 0:
+        detail["new_photos"] = new_count
     if blocked:
         detail["blocked_models"] = blocked
     return {"state": "will-run", "summary": summary, "detail": detail}
 
 
-def _extract_plan(db, params, photo_ids, pipeline_cfg):
+def _extract_plan(db, params, photo_ids, pipeline_cfg, new_count=0):
     if params.skip_extract_masks:
         return {
             "state": "will-skip",
@@ -284,6 +334,26 @@ def _extract_plan(db, params, photo_ids, pipeline_cfg):
     sam2_variant = pipeline_cfg.get("sam2_variant", "sam2-small")
     stale = db.count_extract_stale(sam2_variant, photo_ids)
     if eligible == 0:
+        # Without imports: classify hasn't run yet, no photos eligible —
+        # the pill renders "Will run" with no count, which is honest.
+        # With imports: bound the count by new_count so the pill says
+        # "Will run (N)" reflecting at least N about-to-be-imported photos.
+        # (Some new photos may turn out to have no detections, so this is
+        # an upper bound on extract work, not an exact promise.)
+        if new_count > 0:
+            return {
+                "state": "will-run",
+                "summary": (
+                    f"Will run after classify produces detections "
+                    f"(up to {new_count} new "
+                    f"photo{_plural(new_count)} pending)"
+                ),
+                "detail": {
+                    "eligible": new_count, "pending": new_count,
+                    "new_photos": new_count,
+                    "stale": 0, "fingerprint_outdated": False,
+                },
+            }
         return {
             "state": "will-run",
             "summary": (
@@ -293,7 +363,7 @@ def _extract_plan(db, params, photo_ids, pipeline_cfg):
             "detail": {"eligible": 0, "pending": 0,
                        "stale": 0, "fingerprint_outdated": False},
         }
-    if pending == 0 and stale == 0:
+    if pending == 0 and stale == 0 and new_count == 0:
         return {
             "state": "done-prior",
             "summary": (
@@ -315,18 +385,36 @@ def _extract_plan(db, params, photo_ids, pipeline_cfg):
     # yet updated) would land in both buckets and inflate work past
     # eligible.
     work = pending + stale
-    return {
-        "state": "will-run",
-        "summary": (
+    if new_count > 0:
+        # Up-to-N new imports will need masks once classify produces
+        # detections for them. Treat them as eligible+pending so the pill
+        # reflects the run's full work, not just the existing-scope stragglers.
+        summary = (
+            f"Will extract masks for {work} existing + up to "
+            f"{new_count} new photo{_plural(new_count)} "
+            f"({eligible + new_count} eligible)"
+        )
+    else:
+        summary = (
             f"Will extract masks for {work} "
             f"photo{_plural(work)} ({eligible} eligible)"
-        ),
-        "detail": {"eligible": eligible, "pending": work,
-                   "stale": stale, "fingerprint_outdated": stale > 0},
+        )
+    detail = {
+        "eligible": eligible + new_count,
+        "pending": work + new_count,
+        "stale": stale,
+        "fingerprint_outdated": stale > 0,
+    }
+    if new_count > 0:
+        detail["new_photos"] = new_count
+    return {
+        "state": "will-run",
+        "summary": summary,
+        "detail": detail,
     }
 
 
-def _eye_keypoints_plan(db, params, photo_ids, pipeline_cfg):
+def _eye_keypoints_plan(db, params, photo_ids, pipeline_cfg, new_count=0):
     if params.skip_eye_keypoints or params.skip_extract_masks:
         return {
             "state": "will-skip",
@@ -347,6 +435,22 @@ def _eye_keypoints_plan(db, params, photo_ids, pipeline_cfg):
     processed = max(eligible - pending, 0)
 
     if eligible == 0:
+        if new_count > 0:
+            return {
+                "state": "will-run",
+                "summary": (
+                    f"Will run after upstream produces masks + species "
+                    f"predictions (up to {new_count} new "
+                    f"photo{_plural(new_count)} pending)"
+                ),
+                "detail": {
+                    "eligible": new_count,
+                    "pending": new_count,
+                    "new_photos": new_count,
+                    "stale": stale,
+                    "fingerprint_outdated": stale > 0,
+                },
+            }
         return {
             "state": "will-run",
             "summary": (
@@ -360,7 +464,7 @@ def _eye_keypoints_plan(db, params, photo_ids, pipeline_cfg):
                 "fingerprint_outdated": stale > 0,
             },
         }
-    if pending == 0:
+    if pending == 0 and new_count == 0:
         return {
             "state": "done-prior",
             "summary": (
@@ -375,19 +479,30 @@ def _eye_keypoints_plan(db, params, photo_ids, pipeline_cfg):
                 "fingerprint_outdated": stale > 0,
             },
         }
-    return {
-        "state": "will-run",
-        "summary": (
+    if new_count > 0:
+        summary = (
+            f"Will run on {pending} existing + up to {new_count} new "
+            f"photo{_plural(new_count)} "
+            f"({processed} of {eligible} already processed)"
+        )
+    else:
+        summary = (
             f"Will run on {pending} photo{_plural(pending)} "
             f"({processed} of {eligible} already processed)"
-        ),
-        "detail": {
-            "eligible": eligible,
-            "pending": pending,
-            "processed": processed,
-            "stale": stale,
-            "fingerprint_outdated": stale > 0,
-        },
+        )
+    detail = {
+        "eligible": eligible + new_count,
+        "pending": pending + new_count,
+        "processed": processed,
+        "stale": stale,
+        "fingerprint_outdated": stale > 0,
+    }
+    if new_count > 0:
+        detail["new_photos"] = new_count
+    return {
+        "state": "will-run",
+        "summary": summary,
+        "detail": detail,
     }
 
 
@@ -458,18 +573,74 @@ def _regroup_plan(db, params, db_path, ws_id, upstream_will_run, effective_cfg):
     }
 
 
+def _scan_plan(params, new_count, known_count):
+    """Plan entry for Scan & Import — only emitted in import / new-images modes.
+
+    Honest answer for the user's "what will this run do" question: how many
+    files will it actually ingest (creating photo rows), and how many were
+    already in Vireo from a prior import (no-op for those).
+    """
+    total = new_count + known_count
+    if new_count == 0:
+        return {
+            "state": "done-prior",
+            "summary": (
+                f"All {total} file{_plural(total)} already imported — "
+                f"scan will be a no-op"
+            ),
+            "detail": {
+                "eligible": total, "pending": 0,
+                "new_photos": 0, "already_known": known_count,
+            },
+        }
+    if known_count == 0:
+        summary = (
+            f"Will import {new_count} new file{_plural(new_count)}"
+        )
+    else:
+        summary = (
+            f"Will import {new_count} new "
+            f"file{_plural(new_count)} ({known_count} already known)"
+        )
+    return {
+        "state": "will-run",
+        "summary": summary,
+        "detail": {
+            "eligible": total,
+            "pending": new_count,
+            "new_photos": new_count,
+            "already_known": known_count,
+        },
+    }
+
+
 def compute_plan(db, params, db_path):
     """Compute the full per-stage plan for the active workspace.
+
+    Scope resolution:
+      - ``collection_id`` set: scope is the collection's photo set.
+      - ``source_paths`` set (import / new-images mode): scope is the
+        already-known photos at those paths; truly new files (not yet in
+        the photos table) are counted separately and treated as fresh
+        work for every per-photo stage. A Scan plan entry describes the
+        new-vs-known split so the user can see what Scan will actually do.
+      - neither: whole-workspace scope (existing behaviour).
 
     Returns:
         {
             "stages": {
+                "Scan": {state, summary, detail?},   # only in import mode
                 "Classify": {state, summary, detail?},
                 "Extract": ...,
                 "EyeKeypoints": ...,
                 "Group": ...,
             },
-            "scope": {"collection_id": int | None, "photo_count": int | None},
+            "scope": {
+                "collection_id": int | None,
+                "photo_count": int | None,
+                "new_count": int,           # 0 unless source_paths set
+                "known_count": int,         # 0 unless source_paths set
+            },
         }
     """
     import config as cfg
@@ -479,32 +650,48 @@ def compute_plan(db, params, db_path):
     ws_id = db._ws_id()
 
     photo_ids = None
+    new_count = 0
+    known_count = 0
     if params.collection_id is not None:
         from pipeline import _resolve_collection_photo_ids
         photo_ids = _resolve_collection_photo_ids(db, params.collection_id)
         if params.exclude_photo_ids:
             excl = set(params.exclude_photo_ids)
             photo_ids = {pid for pid in photo_ids if pid not in excl}
+    elif params.source_paths:
+        # Import / new-images mode. Split the file set into already-known
+        # photo_ids (used as scope for real-status queries) and a count
+        # of genuinely new files (fed into each stage as fresh work).
+        known = db.photos_by_paths(params.source_paths)
+        photo_ids = set(known.values())
+        known_count = len(photo_ids)
+        new_count = len(params.source_paths) - known_count
 
-    classify = _classify_plan(db, params, photo_ids)
-    extract = _extract_plan(db, params, photo_ids, pipeline_cfg)
-    eye = _eye_keypoints_plan(db, params, photo_ids, pipeline_cfg)
+    classify = _classify_plan(db, params, photo_ids, new_count)
+    extract = _extract_plan(db, params, photo_ids, pipeline_cfg, new_count)
+    eye = _eye_keypoints_plan(db, params, photo_ids, pipeline_cfg, new_count)
     upstream_will_run = any(
         s["state"] == "will-run" for s in (classify, extract, eye)
     )
     regroup = _regroup_plan(db, params, db_path, ws_id, upstream_will_run, effective_cfg)
 
+    stages = {
+        "Classify": classify,
+        "Extract": extract,
+        "EyeKeypoints": eye,
+        "Group": regroup,
+    }
+    if params.source_paths:
+        stages["Scan"] = _scan_plan(params, new_count, known_count)
+
     return {
-        "stages": {
-            "Classify": classify,
-            "Extract": extract,
-            "EyeKeypoints": eye,
-            "Group": regroup,
-        },
+        "stages": stages,
         "scope": {
             "collection_id": params.collection_id,
             "photo_count": (
                 len(photo_ids) if photo_ids is not None else None
             ),
+            "new_count": new_count,
+            "known_count": known_count,
         },
     }

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1604,6 +1604,10 @@ function renderPreview() {
   updatePreviewCounts();
   // Reapply cached duplicate markers after DOM rebuild
   if (Object.keys(_duplicateResults).length > 0) applyDuplicateVisuals();
+  // Preview content drives the import-mode plan (which paths are selected).
+  // Refresh debounced — folder-level and select-all checkboxes call us in
+  // bursts, and we'd rather not POST to /api/pipeline/plan on every click.
+  schedulePlanRefresh();
 }
 
 function checkForDuplicates() {
@@ -3706,10 +3710,13 @@ function refreshPipelineUI() {
 // subset of /api/jobs/pipeline the plan needs to make accurate decisions.
 function _buildPlanBody() {
   var body = {};
-  // Source: only "existing collection" mode lets us scope the plan to a
-  // concrete photo set. For import / new-images modes the photo set
-  // doesn't exist yet, so leave collection_id null and let the plan
-  // describe whole-workspace counts.
+  // Source mode determines how the backend scopes the plan:
+  //   - 'collection': scope = collection's photo ids (real per-photo status).
+  //   - 'import' / 'new_images': send the SELECTED preview file paths so
+  //     the backend can split them into already-known-vs-new and report
+  //     truthful counts. Without this the plan falls back to whole-workspace
+  //     counts, which renders "Already done" for an import into a
+  //     non-empty workspace — exactly the bug we're fixing.
   if (_sourceMode === 'collection') {
     var picker = document.getElementById('collectionPicker');
     var cid = picker && picker.value ? parseInt(picker.value, 10) : NaN;
@@ -3720,6 +3727,20 @@ function _buildPlanBody() {
         if (!_previewSelected[f.path] && f.photo_id) excludedIds.push(f.photo_id);
       });
       if (excludedIds.length) body.exclude_photo_ids = excludedIds;
+    }
+  } else if ((_sourceMode === 'import' || _sourceMode === 'new_images')
+             && _previewData && _previewData.files && _previewSelected) {
+    // Send only the selected paths — the user can deselect duplicates
+    // or specific files in the preview, and the plan should reflect
+    // the actual run scope, not the whole-folder discovery.
+    var selectedPaths = [];
+    _previewData.files.forEach(function(f) {
+      if (_previewSelected[f.path]) selectedPaths.push(f.path);
+    });
+    // Mirror the backend cap (50k); above this the plan endpoint rejects
+    // the request rather than silently truncate, so do the same client-side.
+    if (selectedPaths.length && selectedPaths.length <= 50000) {
+      body.source_paths = selectedPaths;
     }
   }
 

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1671,6 +1671,14 @@ function checkForDuplicates() {
           if (document.getElementById('chkSkipDuplicates').checked) {
             if (data.duplicates) applyDuplicateVisuals();
             updateDuplicateSummary(data);
+            // Newly-discovered hash duplicates change the import scope —
+            // ingest() will skip those files, so the plan must shift them
+            // from "new" to "already known". Debounced via
+            // schedulePlanRefresh so the burst of SSE batches collapses
+            // into a single plan POST.
+            if (data.duplicates && data.duplicates.length) {
+              schedulePlanRefresh();
+            }
           }
         });
         read();
@@ -1748,6 +1756,10 @@ function onSkipDuplicatesToggle() {
   } else {
     checkForDuplicates();
   }
+  // Toggling the gate flips whether known-by-hash files count as
+  // "new" (gate off → ingest will copy them) or "known" (gate on →
+  // ingest will skip them). Either way the plan changes; refresh it.
+  schedulePlanRefresh();
 }
 
 function setupThumbnailObserver() {
@@ -3749,6 +3761,24 @@ function _buildPlanBody() {
     // plan. For oversized: the server returns 400 and the plan UI
     // clears — both accurate states.
     body.source_paths = selectedPaths;
+
+    // Copy-mode imports with skip_duplicates=true dedupe by file_hash, not
+    // by source path. The /api/import/check-duplicates SSE feed has
+    // already populated _duplicateResults with the hash-matched preview
+    // paths; pass that subset along so the plan counts those as already
+    // known instead of new (otherwise pills overstate work for files
+    // ingest() will silently skip). Only send when the duplicate gate is
+    // actually on; toggling it off must drop the field so the backend
+    // doesn't keep treating the cache as live.
+    var skipDup = document.getElementById('chkSkipDuplicates');
+    if (_copyMode && skipDup && skipDup.checked
+        && Object.keys(_duplicateResults).length > 0) {
+      var hashDupPaths = [];
+      selectedPaths.forEach(function(p) {
+        if (_duplicateResults[p]) hashDupPaths.push(p);
+      });
+      if (hashDupPaths.length) body.hash_duplicate_paths = hashDupPaths;
+    }
   }
 
   body.skip_classify       = !document.getElementById('enableClassify').checked;

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -3737,9 +3737,12 @@ function _buildPlanBody() {
     _previewData.files.forEach(function(f) {
       if (_previewSelected[f.path]) selectedPaths.push(f.path);
     });
-    // Mirror the backend cap (50k); above this the plan endpoint rejects
-    // the request rather than silently truncate, so do the same client-side.
-    if (selectedPaths.length && selectedPaths.length <= 50000) {
+    // Send the full list even if it exceeds the backend cap (50k).
+    // The server will respond 400 and the plan UI will clear — that's
+    // accurate. Dropping the field client-side would make the server
+    // fall back to whole-workspace scope, which is the misleading plan
+    // this code is here to prevent.
+    if (selectedPaths.length) {
       body.source_paths = selectedPaths;
     }
   }

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1919,6 +1919,13 @@ function onCopyModeChange() {
     _duplicateResults = {};
   }
   updateStartButton();
+  // Toggling copy mode flips whether _buildPlanBody sends
+  // hash_duplicate_paths (only sent when _copyMode is on with skip
+  // duplicates checked and cached results exist). Without this refresh,
+  // pills keep showing the prior mode's run estimate until some other
+  // UI action triggers a plan fetch — exactly the staleness the
+  // CORE_PHILOSOPHY transparency rule prohibits.
+  schedulePlanRefresh();
 }
 
 function getSelectedFolderTemplate() {

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1586,6 +1586,10 @@ function renderPreview() {
         e.stopPropagation();
         _previewSelected[f.path] = check.checked;
         updatePreviewCounts();
+        // Per-file toggles change the import scope (which paths the next
+        // run will touch), so refresh the plan — folder/select-all paths
+        // already get a refresh via renderPreview(); this one does not.
+        schedulePlanRefresh();
       };
       thumb.appendChild(check);
 
@@ -3737,14 +3741,14 @@ function _buildPlanBody() {
     _previewData.files.forEach(function(f) {
       if (_previewSelected[f.path]) selectedPaths.push(f.path);
     });
-    // Send the full list even if it exceeds the backend cap (50k).
-    // The server will respond 400 and the plan UI will clear — that's
-    // accurate. Dropping the field client-side would make the server
-    // fall back to whole-workspace scope, which is the misleading plan
-    // this code is here to prevent.
-    if (selectedPaths.length) {
-      body.source_paths = selectedPaths;
-    }
+    // Always send source_paths in import / new-images mode — even when
+    // the list is empty (every preview file deselected) or exceeds the
+    // backend cap (50k). Dropping the field would make the server fall
+    // back to whole-workspace scope, which is the misleading plan this
+    // code is here to prevent. For empty: the server returns a no-op
+    // plan. For oversized: the server returns 400 and the plan UI
+    // clears — both accurate states.
+    body.source_paths = selectedPaths;
   }
 
   body.skip_classify       = !document.getElementById('enableClassify').checked;

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3534,11 +3534,56 @@ def test_api_import_folder_preview_thumbnail(app_and_db, tmp_path):
 
 
 def test_api_import_folder_preview_thumbnail_missing(app_and_db):
-    """Thumbnail endpoint returns 404 for non-existent file."""
+    """Thumbnail endpoint returns 404 for non-existent file, with
+    Cache-Control: no-store so a transient libraw / NAS hiccup doesn't
+    pin question marks in the user's preview grid for the cache lifetime.
+    """
     app, _ = app_and_db
     client = app.test_client()
     resp = client.get("/api/import/folder-preview/thumbnail?path=/no/such/file.jpg")
     assert resp.status_code == 404
+    # Browsers must NOT cache this failure — next page load should retry.
+    cc = resp.headers.get("Cache-Control", "")
+    assert "no-store" in cc, f"expected no-store on 404, got {cc!r}"
+
+
+def test_api_import_folder_preview_thumbnail_unloadable_returns_404_no_store(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """When the file exists but image_loader returns None (libraw failure,
+    unsupported format, etc.), the endpoint must 404 *without* caching —
+    the failure is often transient (NAS contention) and a cached negative
+    would block recovery on next render."""
+    app, _ = app_and_db
+    src = tmp_path / "broken.nef"
+    src.write_bytes(b"not actually a NEF")  # exists, but unloadable
+    import image_loader
+    monkeypatch.setattr(image_loader, "load_image", lambda *a, **kw: None)
+
+    client = app.test_client()
+    resp = client.get(
+        "/api/import/folder-preview/thumbnail?path=" + str(src),
+    )
+    assert resp.status_code == 404
+    assert "no-store" in resp.headers.get("Cache-Control", "")
+
+
+def test_api_import_folder_preview_thumbnail_success_is_cacheable(
+    app_and_db, tmp_path,
+):
+    """Successful thumbnail responses keep the existing 5-min cache so
+    the preview doesn't re-decode RAWs on every grid scroll."""
+    app, _ = app_and_db
+    from PIL import Image
+    src = tmp_path / "ok.jpg"
+    Image.new("RGB", (300, 200), "red").save(src)
+    client = app.test_client()
+    resp = client.get(
+        "/api/import/folder-preview/thumbnail?path=" + str(src),
+    )
+    assert resp.status_code == 200
+    cc = resp.headers.get("Cache-Control", "")
+    assert "max-age" in cc and "no-store" not in cc
 
 
 def test_api_import_folder_preview_thumbnail_no_path(app_and_db):

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -446,3 +446,57 @@ def test_get_canonical_image_path_wc_missing_falls_back(tmp_path, caplog):
 
     assert result == "/some/folder/src.jpg"
     assert any("working copy missing" in r.message.lower() for r in caplog.records)
+
+
+# -------- transient libraw I/O retry --------
+
+def test_load_image_retries_once_on_libraw_io_error(tmp_path, monkeypatch):
+    """A NAS hiccup that fails one rawpy.imread() call typically clears
+    on retry. load_image must give the file a second chance — without it
+    the user is stuck with cached question marks until they refresh."""
+    import image_loader
+    import rawpy
+
+    src = tmp_path / "DSC_0001.NEF"
+    src.write_bytes(b"placeholder")  # need an existing file path
+
+    embedded = _jpeg_bytes((1024, 768))
+    fake = _FakeRaw(embedded_jpeg=embedded,
+                    postprocess_error=rawpy.LibRawFileUnsupportedError(
+                        b"unsupported"))
+
+    calls = {"n": 0}
+
+    def imread_flaky(_path):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise rawpy.LibRawIOError(b"Input/output error")
+        return fake
+
+    monkeypatch.setattr(rawpy, "imread", imread_flaky)
+
+    img = image_loader.load_image(str(src), max_size=200)
+    assert img is not None
+    assert calls["n"] == 2  # initial + one retry
+
+
+def test_load_image_does_not_retry_on_unsupported_format(tmp_path, monkeypatch):
+    """Non-I/O libraw errors are deterministic — retrying is wasted work
+    and would slow down legitimately-bad files."""
+    import image_loader
+    import rawpy
+
+    src = tmp_path / "DSC_0002.NEF"
+    src.write_bytes(b"placeholder")
+
+    calls = {"n": 0}
+
+    def imread_unsupported(_path):
+        calls["n"] += 1
+        raise rawpy.LibRawFileUnsupportedError(b"truly bad file")
+
+    monkeypatch.setattr(rawpy, "imread", imread_unsupported)
+
+    img = image_loader.load_image(str(src), max_size=200)
+    assert img is None
+    assert calls["n"] == 1  # no retry

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -1610,6 +1610,54 @@ def test_import_plan_partial_overlap_counts_only_truly_new(tmp_path, monkeypatch
     assert plan["stages"]["Scan"]["detail"]["already_known"] == 2
 
 
+def test_import_plan_deduplicates_source_paths(tmp_path, monkeypatch):
+    """Overlapping source roots can land the same path in source_paths
+    twice. Counting the duplicate as 'new' would inflate Scan/Classify/
+    Extract estimates and could flip Scan from done-prior to will-run
+    misleadingly. Dedup must happen before the new-vs-known split.
+    """
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _stub_models(monkeypatch)
+    fid_card = db.add_folder("/cards/A")
+    db.add_photo(folder_id=fid_card, filename="IMG_001.NEF",
+                 extension=".nef", file_size=1, file_mtime=1.0)
+
+    # All-known with duplicates: same known path repeated must NOT count
+    # as new work; Scan stays done-prior.
+    plan_all_known = compute_plan(
+        db,
+        _import_params(
+            ["/cards/A/IMG_001.NEF", "/cards/A/IMG_001.NEF"],
+            model_ids=["m1"],
+        ),
+        str(tmp_path / "test.db"),
+    )
+    assert plan_all_known["scope"]["new_count"] == 0
+    assert plan_all_known["scope"]["known_count"] == 1
+    assert plan_all_known["stages"]["Scan"]["state"] == "done-prior"
+
+    # Mixed with duplicates: 1 unique known + 1 unique new (each repeated).
+    # Without dedup, new_count would be 4 - 1 = 3 (wrong).
+    plan_mixed = compute_plan(
+        db,
+        _import_params(
+            [
+                "/cards/A/IMG_001.NEF",   # known
+                "/cards/A/IMG_001.NEF",   # known dup
+                "/cards/A/IMG_NEW.NEF",   # new
+                "/cards/A/IMG_NEW.NEF",   # new dup
+            ],
+            model_ids=["m1"],
+        ),
+        str(tmp_path / "test.db"),
+    )
+    assert plan_mixed["scope"]["new_count"] == 1
+    assert plan_mixed["scope"]["known_count"] == 1
+    assert plan_mixed["stages"]["Scan"]["detail"]["new_photos"] == 1
+    assert plan_mixed["stages"]["Scan"]["detail"]["already_known"] == 1
+
+
 def test_import_plan_all_known_scan_is_done_prior(tmp_path):
     """If every preview file is already in the DB, Scan reports done-prior
     (the run will be a no-op for the scan step). Other stages reflect
@@ -1702,14 +1750,17 @@ def test_api_pipeline_plan_rejects_non_string_source_paths_elements(app_and_db):
 
 
 def test_import_plan_empty_source_paths_is_no_op(tmp_path, monkeypatch):
-    """Import / new-images mode with every preview file deselected: the
-    next run is a genuine no-op. Every stage must read as "no work" —
-    NOT fall through to whole-workspace scope and report unrelated
-    "Already done" / "Will run" status from the active workspace.
+    """Import / new-images mode with every preview file deselected.
 
-    Regression guard for the misleading-pill bug Codex flagged: silently
-    dropping the empty source_paths field would re-introduce exactly the
-    cross-workspace status leak this code exists to prevent.
+    Per-photo stages (Classify, Extract, ...) are genuine no-ops because
+    they only operate on imported photos and the import set is empty —
+    they must not leak active-workspace state.
+
+    Scan, however, must NOT report "will-skip": the runtime still walks
+    the source/destination tree regardless of selection, so claiming a
+    no-op there violates CORE_PHILOSOPHY.md's "show what's happening"
+    rule. Scan reads as "will-run" with a summary explaining that
+    selection only affects which files import.
     """
     from labels_fingerprint import TOL_SENTINEL
     from pipeline_plan import compute_plan
@@ -1729,12 +1780,17 @@ def test_import_plan_empty_source_paths_is_no_op(tmp_path, monkeypatch):
         _import_params([], model_ids=["m1"]),
         str(tmp_path / "test.db"),
     )
-    # Every stage reports "no work" — none leak active-workspace state.
-    for name in ("Scan", "Classify", "Extract"):
+    # Per-photo stages are no-ops — none leak active-workspace state.
+    for name in ("Classify", "Extract"):
         assert plan["stages"][name]["state"] == "will-skip", (
             f"{name} leaked workspace state: {plan['stages'][name]}"
         )
         assert "no files selected" in plan["stages"][name]["summary"].lower()
+    # Scan honestly reports it will still run (directory walk + hashing),
+    # not "will-skip", since the runtime doesn't actually no-op here.
+    scan = plan["stages"]["Scan"]
+    assert scan["state"] == "will-run", scan
+    assert "scan" in scan["summary"].lower()
     assert plan["scope"]["new_count"] == 0
     assert plan["scope"]["known_count"] == 0
     assert plan["scope"]["photo_count"] == 0
@@ -1767,8 +1823,9 @@ def test_compute_plan_distinguishes_none_from_empty_source_paths(tmp_path, monke
     assert "Scan" not in whole_ws["stages"]  # not import mode
     assert whole_ws["stages"]["Extract"]["state"] == "done-prior"
 
-    # source_paths=[] → import mode, no-op run. Scan emitted; Extract
-    # is "will-skip — No files selected", NOT "done-prior".
+    # source_paths=[] → import mode. Scan emitted as will-run (runtime
+    # still walks); Extract is "will-skip — No files selected", NOT
+    # "done-prior" (would leak active-workspace state).
     empty_import = compute_plan(
         db,
         PipelinePlanParams(
@@ -1778,6 +1835,7 @@ def test_compute_plan_distinguishes_none_from_empty_source_paths(tmp_path, monke
         str(tmp_path / "test.db"),
     )
     assert "Scan" in empty_import["stages"]
+    assert empty_import["stages"]["Scan"]["state"] == "will-run"
     assert empty_import["stages"]["Extract"]["state"] == "will-skip"
 
 
@@ -1803,9 +1861,11 @@ def test_api_pipeline_plan_empty_source_paths_does_not_fall_back(app_and_db):
     )
     assert resp.status_code == 200
     data = resp.get_json()
-    # Scan stage emitted (= import mode active) and reports nothing to do.
+    # Scan stage emitted (= import mode active). It reads as "will-run"
+    # because the runtime still walks the tree regardless of selection;
+    # claiming "will-skip" would lie about substantial directory work.
     assert "Scan" in data["stages"]
-    assert data["stages"]["Scan"]["state"] == "will-skip"
+    assert data["stages"]["Scan"]["state"] == "will-run"
     assert data["scope"]["new_count"] == 0
     assert data["scope"]["known_count"] == 0
 

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -1682,3 +1682,20 @@ def test_api_pipeline_plan_rejects_non_list_source_paths(app_and_db):
         },
     )
     assert resp.status_code == 400
+
+
+def test_api_pipeline_plan_rejects_non_string_source_paths_elements(app_and_db):
+    """A payload like {"source_paths": [123]} would otherwise reach
+    photos_by_paths and crash os.path.dirname with TypeError, surfacing
+    as a 500. Catch it at the boundary as a 400 instead."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={
+            "source_paths": ["/ok/path.nef", 123],  # mixed types
+            "skip_classify": True, "skip_extract_masks": True,
+            "skip_eye_keypoints": True, "skip_regroup": True,
+        },
+    )
+    assert resp.status_code == 400

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -2004,3 +2004,181 @@ def test_api_pipeline_plan_missing_source_paths_uses_whole_workspace(app_and_db)
     assert resp.status_code == 200
     data = resp.get_json()
     assert "Scan" not in data["stages"]
+
+
+# -------- compute_plan: copy-mode hash-dedup honesty --------
+#
+# Copy-mode imports run with skip_duplicates=True dedupe by file_hash via
+# ingest(), not by source path. The frontend pre-computes hash matches via
+# /api/import/check-duplicates and passes them back in hash_duplicate_paths.
+# These paths must count as "already known", not "new" — otherwise pills
+# overstate work for files ingest() will silently skip (the common case:
+# a card was already imported once into a different destination folder).
+
+def test_import_plan_hash_duplicates_count_as_known(tmp_path, monkeypatch):
+    """Hash-matched source paths shift from new_count to known_count, so
+    Scan/Classify/Extract estimates reflect what ingest will actually do.
+
+    Setup mirrors a real copy-mode re-import: the library has one photo at
+    a destination path; the user is re-importing two source files, one of
+    which is byte-identical to the existing photo (same hash, different
+    source path) and one of which is genuinely new. The frontend's prior
+    check-duplicates pass has flagged the matching source path.
+    """
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    _stub_models(monkeypatch)
+
+    plan = compute_plan(
+        db,
+        _import_params(
+            ["/cards/SD/IMG_DUP.NEF", "/cards/SD/IMG_NEW.NEF"],
+            hash_duplicate_paths=["/cards/SD/IMG_DUP.NEF"],
+            model_ids=["m1"],
+        ),
+        str(tmp_path / "test.db"),
+    )
+    assert plan["scope"]["new_count"] == 1, plan["scope"]
+    assert plan["scope"]["known_count"] == 1, plan["scope"]
+    scan = plan["stages"]["Scan"]
+    assert scan["detail"]["new_photos"] == 1
+    assert scan["detail"]["already_known"] == 1
+
+
+def test_import_plan_hash_duplicates_outside_selection_ignored(tmp_path, monkeypatch):
+    """``_duplicateResults`` survives source-folder edits; a path in
+    hash_duplicate_paths that's no longer in source_paths is a stale
+    cache entry and must NOT influence counts.
+    """
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    _stub_models(monkeypatch)
+
+    plan = compute_plan(
+        db,
+        _import_params(
+            ["/cards/SD/IMG_NEW.NEF"],  # one selected, all new
+            hash_duplicate_paths=[
+                "/cards/SD/IMG_NEW.NEF",      # NOT a dup but in cache (stale)
+                "/cards/SD/IMG_OLD.NEF",      # not even in source_paths
+            ],
+            model_ids=["m1"],
+        ),
+        str(tmp_path / "test.db"),
+    )
+    # IMG_NEW is in source_paths AND in hash_duplicate_paths, so it's
+    # counted as known. IMG_OLD isn't in source_paths so it's ignored.
+    assert plan["scope"]["new_count"] == 0
+    assert plan["scope"]["known_count"] == 1
+
+
+def test_import_plan_hash_dup_also_known_at_path_not_double_counted(tmp_path, monkeypatch):
+    """A file already known at its exact source path (re-pointing at an
+    already-imported folder) is also a hash match. It must count toward
+    known_count exactly once — double-counting would push known_count
+    past the total file count.
+    """
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    _stub_models(monkeypatch)
+    fid = db.add_folder("/cards/A")
+    db.add_photo(folder_id=fid, filename="IMG_001.NEF",
+                 extension=".nef", file_size=1, file_mtime=1.0)
+
+    plan = compute_plan(
+        db,
+        _import_params(
+            ["/cards/A/IMG_001.NEF"],
+            hash_duplicate_paths=["/cards/A/IMG_001.NEF"],  # also a hash match
+            model_ids=["m1"],
+        ),
+        str(tmp_path / "test.db"),
+    )
+    assert plan["scope"]["new_count"] == 0
+    assert plan["scope"]["known_count"] == 1  # not 2
+
+
+def test_import_plan_hash_duplicate_does_not_link_source_folder(tmp_path, monkeypatch):
+    """In copy mode, ingest skips a hash-matched source file entirely —
+    its source folder is never walked by the post-import scan (only the
+    destination is). So Scan must NOT report the source folder as
+    "needs linking" for hash-dup-only paths.
+    """
+    from db import Database
+    from pipeline_plan import compute_plan
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.create_workspace("WorkspaceA")
+    db._active_workspace_id = ws_a
+    # Photo lives at /library/2025 in WorkspaceA. Folder /cards/SD has
+    # never been seen by the DB, so it would normally count as "unlinked".
+    fid = db.add_folder("/library/2025")
+    db.add_photo(folder_id=fid, filename="dest.NEF",
+                 extension=".nef", file_size=1, file_mtime=1.0)
+    db._active_workspace_id = db.create_workspace("WorkspaceB")
+
+    plan = compute_plan(
+        db,
+        _import_params(
+            ["/cards/SD/IMG_HASH.NEF"],  # only file is a hash dup
+            hash_duplicate_paths=["/cards/SD/IMG_HASH.NEF"],
+            skip_classify=True, skip_extract_masks=True,
+            skip_eye_keypoints=True, skip_regroup=True,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    scan = plan["stages"]["Scan"]
+    # Every file is hash-skipped → scan is genuinely a no-op (ingest
+    # walks nothing new and links no source folder).
+    assert scan["detail"]["unlinked_folders"] == 0, scan
+    assert scan["state"] == "done-prior", scan
+
+
+def test_api_pipeline_plan_rejects_oversized_hash_duplicate_paths(app_and_db):
+    """Same 50k cap as source_paths. Without this, a misbehaving client
+    could OOM the server by passing arbitrarily large hash-dup lists."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={
+            "source_paths": ["/x/0"],
+            "hash_duplicate_paths": ["/x/" + str(i) for i in range(50001)],
+            "skip_classify": True, "skip_extract_masks": True,
+            "skip_eye_keypoints": True, "skip_regroup": True,
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_api_pipeline_plan_rejects_non_list_hash_duplicate_paths(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={
+            "source_paths": ["/x/0"],
+            "hash_duplicate_paths": "/single/path.nef",
+            "skip_classify": True, "skip_extract_masks": True,
+            "skip_eye_keypoints": True, "skip_regroup": True,
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_api_pipeline_plan_rejects_non_string_hash_duplicate_paths_elements(app_and_db):
+    """Mixed-type list must be rejected at the API boundary; otherwise
+    set membership in compute_plan would behave unpredictably for
+    non-hashable / non-string entries.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={
+            "source_paths": ["/x/0"],
+            "hash_duplicate_paths": ["/ok/path.nef", 123],
+            "skip_classify": True, "skip_extract_masks": True,
+            "skip_eye_keypoints": True, "skip_regroup": True,
+        },
+    )
+    assert resp.status_code == 400

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -38,6 +38,57 @@ def _add_photo_with_detection(db, folder_id, filename, conf=0.9,
 
 # -------- db helpers --------
 
+def test_photos_by_paths_returns_known_and_omits_unknown(tmp_path):
+    """photos_by_paths is the lookup that lets import-mode plan split a
+    preview file list into 'already in DB' vs 'truly new'. Known paths
+    must come back keyed by absolute path; unknown paths must be absent.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid_a = db.add_folder("/cards/a")
+    fid_b = db.add_folder("/cards/b")
+    pid_a1 = db.add_photo(folder_id=fid_a, filename="IMG_001.NEF",
+                          extension=".nef", file_size=1, file_mtime=1.0)
+    pid_b1 = db.add_photo(folder_id=fid_b, filename="IMG_900.JPG",
+                          extension=".jpg", file_size=1, file_mtime=1.0)
+
+    result = db.photos_by_paths([
+        "/cards/a/IMG_001.NEF",         # known
+        "/cards/a/IMG_NEW.NEF",         # unknown (new file, same folder)
+        "/cards/b/IMG_900.JPG",         # known (different folder)
+        "/cards/never/IMG_000.JPG",     # unknown (folder not in DB)
+    ])
+    assert result == {
+        "/cards/a/IMG_001.NEF": pid_a1,
+        "/cards/b/IMG_900.JPG": pid_b1,
+    }
+
+
+def test_photos_by_paths_handles_empty_input(tmp_path):
+    """Empty list must short-circuit, not run a SELECT with zero
+    placeholders (which is malformed SQL)."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    assert db.photos_by_paths([]) == {}
+
+
+def test_photos_by_paths_ignores_workspace_membership(tmp_path):
+    """Photos are global; the lookup must find a known photo even when
+    its folder is not in the active workspace. Otherwise re-importing
+    into a different workspace would mis-classify already-imported
+    files as 'new'.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/cards/a")
+    pid = db.add_photo(folder_id=fid, filename="x.jpg",
+                       extension=".jpg", file_size=1, file_mtime=1.0)
+    # Active workspace has no folders (the import target is a fresh ws).
+    db._active_workspace_id = db.create_workspace("Other")
+
+    assert db.photos_by_paths(["/cards/a/x.jpg"]) == {"/cards/a/x.jpg": pid}
+
+
 def test_count_real_detections_in_scope_excludes_full_image(tmp_path):
     """Synthetic full-image rows must not inflate the classify scope.
 
@@ -1365,3 +1416,269 @@ def test_api_pipeline_plan_collection_scope(app_and_db):
     data = resp.get_json()
     assert data["stages"]["Extract"]["state"] == "will-run"
     assert data["stages"]["Extract"]["detail"]["eligible"] == 0
+
+
+# -------- compute_plan: import-mode honesty --------
+#
+# These tests pin the core bug fix: when the user is about to import a
+# brand-new SD card, every per-photo stage must report "will run" with a
+# count that reflects the about-to-be-imported files — *not* "Already
+# done" derived from the active workspace's existing photos. A pill that
+# says "Already done" must mean the next run is genuinely a no-op.
+
+def _import_params(paths, **kwargs):
+    """Helper: compute_plan params for an import run with the given paths.
+
+    Defaults skip eye-keypoints + regroup so tests can focus on the
+    classify/extract scope without setting up label fixtures."""
+    from pipeline_plan import PipelinePlanParams
+    return PipelinePlanParams(
+        source_paths=list(paths),
+        skip_eye_keypoints=kwargs.pop("skip_eye_keypoints", True),
+        skip_regroup=kwargs.pop("skip_regroup", True),
+        **kwargs,
+    )
+
+
+def _stub_models(monkeypatch):
+    import labels as labels_mod
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+
+
+def test_import_plan_all_new_files_flips_classify_to_will_run(tmp_path, monkeypatch):
+    """The bug we're fixing: workspace has fully-classified detections,
+    user points at a brand-new folder. Classify must say "will run", not
+    "Already done"."""
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _stub_models(monkeypatch)
+    # Existing scope: one detection, already classified — would be
+    # "done-prior" without imports.
+    _, did = _add_photo_with_detection(db, folder_id, "existing.jpg")
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=1)
+
+    new_paths = ["/cards/A/IMG_001.NEF", "/cards/A/IMG_002.NEF"]
+    plan = compute_plan(
+        db,
+        _import_params(new_paths, model_ids=["m1"]),
+        str(tmp_path / "test.db"),
+    )
+    classify = plan["stages"]["Classify"]
+    assert classify["state"] == "will-run"
+    assert classify["detail"]["new_photos"] == 2
+    assert classify["detail"]["pending"] == 2
+    assert "2 new" in classify["summary"]
+
+
+def test_import_plan_all_new_files_flips_extract_to_will_run(tmp_path):
+    """Extract pill on a brand-new import: every file is a new photo that
+    will need a mask once the detector produces detections, so the pill
+    must show "Will run (N)" with N = the import count, not 0 or "Already
+    done"."""
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    # Background: workspace has a fully-masked photo. Without source_paths
+    # the plan would report this as "done-prior". With source_paths, the
+    # scope is the import only — so the existing photo doesn't pollute the
+    # numbers (it's not what this run is touching).
+    pid, _ = _add_photo_with_detection(db, folder_id, "existing.jpg")
+    db.conn.execute("UPDATE photos SET mask_path='/m/x.png' WHERE id=?", (pid,))
+    db.conn.commit()
+
+    plan = compute_plan(
+        db,
+        _import_params(
+            ["/cards/A/IMG_001.NEF", "/cards/A/IMG_002.NEF",
+             "/cards/A/IMG_003.NEF"],
+            skip_classify=True,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    extract = plan["stages"]["Extract"]
+    assert extract["state"] == "will-run"
+    assert extract["detail"]["new_photos"] == 3
+    # Scope = import (3 new) only. The unrelated existing photo isn't
+    # being processed by this run and must not be included.
+    assert extract["detail"]["eligible"] == 3
+    assert extract["detail"]["pending"] == 3
+
+
+def test_import_plan_known_files_with_pending_masks_combine(tmp_path):
+    """Mixed scope: the user re-points at a partly-imported folder where
+    one already-known photo has a detection but no mask yet, plus a
+    new file. Extract must report the combined work — masks for the
+    pending known + masks for the new — so the pill is honest about
+    what the run will actually do.
+    """
+    from pipeline_plan import compute_plan
+    db, _folder = _make_db(tmp_path)
+    fid_card = db.add_folder("/cards/A")
+    db.add_workspace_folder(db._active_workspace_id, fid_card)
+    pid_known, _ = _add_photo_with_detection(db, fid_card, "IMG_001.NEF")
+    # IMG_001.NEF: known, has detection, no mask → eligible=1, pending=1.
+    paths = ["/cards/A/IMG_001.NEF", "/cards/A/IMG_002.NEF"]
+    plan = compute_plan(
+        db,
+        _import_params(paths, skip_classify=True),
+        str(tmp_path / "test.db"),
+    )
+    extract = plan["stages"]["Extract"]
+    assert extract["state"] == "will-run"
+    assert extract["detail"]["eligible"] == 2  # 1 known + 1 new
+    assert extract["detail"]["pending"] == 2   # both need masks
+    assert extract["detail"]["new_photos"] == 1
+
+
+def test_import_plan_does_not_leak_active_workspace_state(tmp_path):
+    """The headline bug: active workspace has tons of "done" work, and
+    the user starts an import. Without source_paths the plan describes
+    the active workspace (→ "Already done"). With source_paths the plan
+    describes the import — every per-photo stage flips to will-run.
+
+    This is the regression guard for the user-reported bug.
+    """
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    # Fully-classified detection + masked photo in the active workspace.
+    pid, did = _add_photo_with_detection(db, folder_id, "old.jpg")
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=1)
+    db.conn.execute("UPDATE photos SET mask_path='/m/old.png' WHERE id=?", (pid,))
+    db.conn.commit()
+
+    # Without source_paths → plan is whole-workspace (the old buggy
+    # behaviour), so Extract reports done-prior.
+    baseline = compute_plan(
+        db,
+        _params(skip_classify=True, skip_eye_keypoints=True, skip_regroup=True),
+        str(tmp_path / "test.db"),
+    )
+    assert baseline["stages"]["Extract"]["state"] == "done-prior"
+
+    # With source_paths for a fresh import → plan is scoped to those
+    # paths, Extract flips to will-run.
+    fixed = compute_plan(
+        db,
+        _import_params(
+            ["/cards/A/IMG_001.NEF", "/cards/A/IMG_002.NEF"],
+            skip_classify=True,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    assert fixed["stages"]["Extract"]["state"] == "will-run"
+    assert fixed["stages"]["Extract"]["detail"]["pending"] == 2
+
+
+def test_import_plan_partial_overlap_counts_only_truly_new(tmp_path, monkeypatch):
+    """If half the preview's files are already in the DB (the user
+    re-pointed at an SD card they previously imported), the plan must
+    count only the truly-new ones as new work — re-importing an existing
+    file is a no-op."""
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _stub_models(monkeypatch)
+    # Two existing photos in DB at /cards/A/...
+    fid_card = db.add_folder("/cards/A")
+    db.add_photo(folder_id=fid_card, filename="IMG_001.NEF",
+                 extension=".nef", file_size=1, file_mtime=1.0)
+    db.add_photo(folder_id=fid_card, filename="IMG_002.NEF",
+                 extension=".nef", file_size=1, file_mtime=1.0)
+
+    paths = [
+        "/cards/A/IMG_001.NEF",  # known
+        "/cards/A/IMG_002.NEF",  # known
+        "/cards/A/IMG_003.NEF",  # new
+        "/cards/A/IMG_004.NEF",  # new
+    ]
+    plan = compute_plan(
+        db,
+        _import_params(paths, model_ids=["m1"]),
+        str(tmp_path / "test.db"),
+    )
+    assert plan["scope"]["new_count"] == 2
+    assert plan["scope"]["known_count"] == 2
+    assert plan["stages"]["Scan"]["state"] == "will-run"
+    assert plan["stages"]["Scan"]["detail"]["new_photos"] == 2
+    assert plan["stages"]["Scan"]["detail"]["already_known"] == 2
+
+
+def test_import_plan_all_known_scan_is_done_prior(tmp_path):
+    """If every preview file is already in the DB, Scan reports done-prior
+    (the run will be a no-op for the scan step). Other stages reflect
+    real status of those known photos as scope."""
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    fid_card = db.add_folder("/cards/A")
+    db.add_photo(folder_id=fid_card, filename="IMG_001.NEF",
+                 extension=".nef", file_size=1, file_mtime=1.0)
+
+    plan = compute_plan(
+        db,
+        _import_params(
+            ["/cards/A/IMG_001.NEF"],
+            skip_classify=True,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    scan = plan["stages"]["Scan"]
+    assert scan["state"] == "done-prior"
+    assert scan["detail"]["new_photos"] == 0
+    assert scan["detail"]["already_known"] == 1
+
+
+def test_import_plan_emits_scan_only_for_import_mode(tmp_path):
+    """Scan plan entry is import/new-images specific. Whole-workspace and
+    collection-scoped plans must not emit it (the JS renders a default
+    'will run' for unknown stages, which is fine for those modes)."""
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+
+    plan = compute_plan(
+        db,
+        _params(
+            skip_classify=True, skip_extract_masks=True,
+            skip_eye_keypoints=True, skip_regroup=True,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    assert "Scan" not in plan["stages"]
+    assert plan["scope"]["new_count"] == 0
+
+
+def test_api_pipeline_plan_rejects_oversized_source_paths(app_and_db):
+    """Defense in depth at the API boundary — a misbehaving client that
+    POSTs hundreds of thousands of paths should get 400, not silent
+    truncation (which would mis-classify the dropped files as new)."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={
+            "source_paths": ["/x/" + str(i) for i in range(50001)],
+            "skip_classify": True, "skip_extract_masks": True,
+            "skip_eye_keypoints": True, "skip_regroup": True,
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_api_pipeline_plan_rejects_non_list_source_paths(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={
+            "source_paths": "/single/path.nef",  # str, not list
+            "skip_classify": True, "skip_extract_masks": True,
+            "skip_eye_keypoints": True, "skip_regroup": True,
+        },
+    )
+    assert resp.status_code == 400

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -2103,6 +2103,14 @@ def test_import_plan_hash_duplicate_does_not_link_source_folder(tmp_path, monkey
     its source folder is never walked by the post-import scan (only the
     destination is). So Scan must NOT report the source folder as
     "needs linking" for hash-dup-only paths.
+
+    BUT: scan is still not a no-op. The post-ingest scan walks the
+    destination folders that hold the existing copies (and walks the
+    entire destination root if those copies live elsewhere), which can
+    link previously-unseen destination folders to the active workspace.
+    The plan must report will-run with a summary that names this
+    destination-side work — claiming "done-prior" would lie about real
+    state changes the user is about to trigger.
     """
     from db import Database
     from pipeline_plan import compute_plan
@@ -2127,10 +2135,53 @@ def test_import_plan_hash_duplicate_does_not_link_source_folder(tmp_path, monkey
         str(tmp_path / "test.db"),
     )
     scan = plan["stages"]["Scan"]
-    # Every file is hash-skipped → scan is genuinely a no-op (ingest
-    # walks nothing new and links no source folder).
+    # Source folder isn't walked (ingest skips the file entirely), so
+    # ``unlinked_folders`` for source paths stays 0.
     assert scan["detail"]["unlinked_folders"] == 0, scan
-    assert scan["state"] == "done-prior", scan
+    # But the destination is walked, so plan must surface will-run.
+    assert scan["state"] == "will-run", scan
+    assert scan["detail"]["hash_duplicates"] == 1, scan
+    assert "hash-duplicate" in scan["summary"], scan
+    assert "destination" in scan["summary"], scan
+
+
+def test_import_plan_hash_duplicate_with_unlinked_source_folder(tmp_path, monkeypatch):
+    """Mixed signal: some import paths are hash dups (copy mode skips them
+    + walks destination), and one path resolves to an existing photo whose
+    source folder isn't linked to the active workspace yet (scan will link
+    it). The plan must surface BOTH reasons in the summary so the user
+    sees what mutates and isn't told a misleading "Already done".
+    """
+    from db import Database
+    from pipeline_plan import compute_plan
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.create_workspace("WorkspaceA")
+    db._active_workspace_id = ws_a
+    # Existing photo at /cards/A/IMG_OLD.NEF — its folder is in WorkspaceA
+    # only. Re-importing into WorkspaceB will link /cards/A here.
+    fid_a = db.add_folder("/cards/A")
+    db.add_photo(folder_id=fid_a, filename="IMG_OLD.NEF",
+                 extension=".nef", file_size=1, file_mtime=1.0)
+    db._active_workspace_id = db.create_workspace("WorkspaceB")
+
+    plan = compute_plan(
+        db,
+        _import_params(
+            ["/cards/A/IMG_OLD.NEF", "/cards/B/IMG_HASH.NEF"],
+            hash_duplicate_paths=["/cards/B/IMG_HASH.NEF"],
+            skip_classify=True, skip_extract_masks=True,
+            skip_eye_keypoints=True, skip_regroup=True,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    scan = plan["stages"]["Scan"]
+    assert scan["state"] == "will-run", scan
+    assert scan["detail"]["unlinked_folders"] >= 1, scan
+    assert scan["detail"]["hash_duplicates"] == 1, scan
+    # Summary must mention both the source-link work and the
+    # destination-walk work, so the user knows what's about to mutate.
+    assert "hash-duplicate" in scan["summary"], scan
+    assert "destination" in scan["summary"], scan
 
 
 def test_api_pipeline_plan_rejects_oversized_hash_duplicate_paths(app_and_db):

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -1699,3 +1699,133 @@ def test_api_pipeline_plan_rejects_non_string_source_paths_elements(app_and_db):
         },
     )
     assert resp.status_code == 400
+
+
+def test_import_plan_empty_source_paths_is_no_op(tmp_path, monkeypatch):
+    """Import / new-images mode with every preview file deselected: the
+    next run is a genuine no-op. Every stage must read as "no work" —
+    NOT fall through to whole-workspace scope and report unrelated
+    "Already done" / "Will run" status from the active workspace.
+
+    Regression guard for the misleading-pill bug Codex flagged: silently
+    dropping the empty source_paths field would re-introduce exactly the
+    cross-workspace status leak this code exists to prevent.
+    """
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _stub_models(monkeypatch)
+    # Active-workspace state that would otherwise dominate the plan:
+    # one fully-classified, fully-masked photo. Without our fix this
+    # would render as "done-prior" for Classify and Extract.
+    pid, did = _add_photo_with_detection(db, folder_id, "old.jpg")
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=1)
+    db.conn.execute("UPDATE photos SET mask_path='/m/old.png' WHERE id=?", (pid,))
+    db.conn.commit()
+
+    # Empty source_paths = import mode, all files deselected.
+    plan = compute_plan(
+        db,
+        _import_params([], model_ids=["m1"]),
+        str(tmp_path / "test.db"),
+    )
+    # Every stage reports "no work" — none leak active-workspace state.
+    for name in ("Scan", "Classify", "Extract"):
+        assert plan["stages"][name]["state"] == "will-skip", (
+            f"{name} leaked workspace state: {plan['stages'][name]}"
+        )
+        assert "no files selected" in plan["stages"][name]["summary"].lower()
+    assert plan["scope"]["new_count"] == 0
+    assert plan["scope"]["known_count"] == 0
+    assert plan["scope"]["photo_count"] == 0
+
+
+def test_compute_plan_distinguishes_none_from_empty_source_paths(tmp_path, monkeypatch):
+    """source_paths=None (whole-workspace) and source_paths=[] (empty
+    import) must produce different plans. Conflating them re-introduces
+    the cross-workspace status leak the import-mode plan exists to fix.
+    """
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import PipelinePlanParams, compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _stub_models(monkeypatch)
+    pid, did = _add_photo_with_detection(db, folder_id, "old.jpg")
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=1)
+    db.conn.execute("UPDATE photos SET mask_path='/m/old.png' WHERE id=?", (pid,))
+    db.conn.commit()
+
+    # source_paths=None → whole-workspace fallback (Extract sees the
+    # masked photo and reports "done-prior").
+    whole_ws = compute_plan(
+        db,
+        PipelinePlanParams(
+            source_paths=None, model_ids=["m1"],
+            skip_eye_keypoints=True, skip_regroup=True,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    assert "Scan" not in whole_ws["stages"]  # not import mode
+    assert whole_ws["stages"]["Extract"]["state"] == "done-prior"
+
+    # source_paths=[] → import mode, no-op run. Scan emitted; Extract
+    # is "will-skip — No files selected", NOT "done-prior".
+    empty_import = compute_plan(
+        db,
+        PipelinePlanParams(
+            source_paths=[], model_ids=["m1"],
+            skip_eye_keypoints=True, skip_regroup=True,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    assert "Scan" in empty_import["stages"]
+    assert empty_import["stages"]["Extract"]["state"] == "will-skip"
+
+
+def test_api_pipeline_plan_empty_source_paths_does_not_fall_back(app_and_db):
+    """API-level guard: posting an explicit empty source_paths list (the
+    frontend's signal for "import mode, every preview file deselected")
+    must produce the no-op import plan, not whole-workspace fallback.
+
+    Codex flagged this exact regression — dropping the field client-side
+    when no files are selected made /api/pipeline/plan describe the
+    unrelated active workspace, which is the misleading behaviour the
+    import-mode scope is meant to prevent.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={
+            "source_paths": [],  # explicit empty == import mode, no files
+            "skip_classify": True, "skip_extract_masks": True,
+            "skip_eye_keypoints": True, "skip_regroup": True,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Scan stage emitted (= import mode active) and reports nothing to do.
+    assert "Scan" in data["stages"]
+    assert data["stages"]["Scan"]["state"] == "will-skip"
+    assert data["scope"]["new_count"] == 0
+    assert data["scope"]["known_count"] == 0
+
+
+def test_api_pipeline_plan_missing_source_paths_uses_whole_workspace(app_and_db):
+    """The mirror of the empty-list case: when the client doesn't send
+    source_paths at all (e.g. collection or workspace mode), the API
+    must fall through to whole-workspace scope. No Scan entry is
+    emitted because the run isn't an import.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={
+            # no source_paths key at all
+            "skip_classify": True, "skip_extract_masks": True,
+            "skip_eye_keypoints": True, "skip_regroup": True,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "Scan" not in data["stages"]

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -89,6 +89,48 @@ def test_photos_by_paths_ignores_workspace_membership(tmp_path):
     assert db.photos_by_paths(["/cards/a/x.jpg"]) == {"/cards/a/x.jpg": pid}
 
 
+def test_workspace_unlinked_folder_count_counts_unlinked(tmp_path):
+    """The helper must report folders not linked to the active workspace.
+
+    Three cases must all count as "unlinked":
+      - folder row exists but is linked only to a different workspace,
+      - folder row exists and is linked to no workspace,
+      - folder row does not exist at all (a brand-new directory).
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_other = db.create_workspace("Other")
+    ws_active = db.create_workspace("Active")
+
+    fid_other = db.add_folder("/cards/other-ws-only")
+    db.add_workspace_folder(ws_other, fid_other)
+    db.add_folder("/cards/orphan")  # no workspace link at all
+    fid_shared = db.add_folder("/cards/shared")
+    db.add_workspace_folder(ws_other, fid_shared)
+    db.add_workspace_folder(ws_active, fid_shared)
+
+    db._active_workspace_id = ws_active
+
+    assert db.workspace_unlinked_folder_count([
+        "/cards/other-ws-only",  # linked only to Other
+        "/cards/orphan",         # linked to nothing
+        "/cards/shared",         # linked to Active
+        "/cards/never-seen",     # no folder row at all
+    ]) == 3
+
+
+def test_workspace_unlinked_folder_count_dedupes_and_handles_empty(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db._active_workspace_id = db.create_workspace("Active")
+    fid = db.add_folder("/cards/a")
+    db.add_workspace_folder(db._active_workspace_id, fid)
+
+    assert db.workspace_unlinked_folder_count([]) == 0
+    assert db.workspace_unlinked_folder_count(["/cards/a", "/cards/a"]) == 0
+    assert db.workspace_unlinked_folder_count(["/cards/x", "/cards/x"]) == 1
+
+
 def test_count_real_detections_in_scope_excludes_full_image(tmp_path):
     """Synthetic full-image rows must not inflate the classify scope.
 
@@ -1680,6 +1722,79 @@ def test_import_plan_all_known_scan_is_done_prior(tmp_path):
     assert scan["state"] == "done-prior"
     assert scan["detail"]["new_photos"] == 0
     assert scan["detail"]["already_known"] == 1
+    assert scan["detail"]["unlinked_folders"] == 0
+
+
+def test_import_plan_all_known_but_folder_unlinked_to_active_workspace(tmp_path):
+    """Files known globally but whose folder is not yet linked to the
+    active workspace must NOT report Scan as done-prior.
+
+    Re-importing files that were indexed in another workspace lands in
+    this branch. ``scanner.scan`` calls ``_ensure_folder`` for every
+    walked directory, and ``add_folder`` auto-links to the active
+    workspace via ``workspace_folders`` — so the next pipeline run will
+    mutate workspace state by attaching the folder (and thereby making
+    those photos visible here). Claiming "Already done" hides that work
+    from the user, exactly the misleading-pill failure
+    CORE_PHILOSOPHY.md prohibits.
+    """
+    from db import Database
+    from pipeline_plan import compute_plan
+    db = Database(str(tmp_path / "test.db"))
+
+    # Photos imported under workspace A.
+    ws_a = db.create_workspace("WorkspaceA")
+    db._active_workspace_id = ws_a
+    fid = db.add_folder("/cards/A")  # auto-linked to WorkspaceA
+    db.add_photo(folder_id=fid, filename="IMG_001.NEF",
+                 extension=".nef", file_size=1, file_mtime=1.0)
+
+    # Switch active workspace to a fresh B that has no link to /cards/A.
+    db._active_workspace_id = db.create_workspace("WorkspaceB")
+
+    plan = compute_plan(
+        db,
+        _import_params(
+            ["/cards/A/IMG_001.NEF"],
+            skip_classify=True, skip_extract_masks=True,
+            skip_eye_keypoints=True, skip_regroup=True,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    scan = plan["stages"]["Scan"]
+    # Scan must run — it will INSERT INTO workspace_folders for /cards/A.
+    assert scan["state"] == "will-run", scan
+    assert scan["detail"]["new_photos"] == 0
+    assert scan["detail"]["already_known"] == 1
+    assert scan["detail"]["unlinked_folders"] == 1
+    # Summary must name the linking work, not pretend it's a no-op.
+    assert "elsewhere" in scan["summary"].lower()
+    assert "link" in scan["summary"].lower()
+
+
+def test_import_plan_all_known_with_folder_linked_stays_done_prior(tmp_path):
+    """Same workspace re-import: folder is linked to the active workspace,
+    so scan really is a no-op. The unlinked-folder check must not flip
+    these into will-run.
+    """
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    fid = db.add_folder("/cards/A")  # auto-links to active WS
+    db.add_photo(folder_id=fid, filename="IMG_001.NEF",
+                 extension=".nef", file_size=1, file_mtime=1.0)
+
+    plan = compute_plan(
+        db,
+        _import_params(
+            ["/cards/A/IMG_001.NEF"],
+            skip_classify=True, skip_extract_masks=True,
+            skip_eye_keypoints=True, skip_regroup=True,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    scan = plan["stages"]["Scan"]
+    assert scan["state"] == "done-prior", scan
+    assert scan["detail"]["unlinked_folders"] == 0
 
 
 def test_import_plan_emits_scan_only_for_import_mode(tmp_path):


### PR DESCRIPTION
## Summary

Two related bugs that surface when starting an import on the Pipeline page:

1. **Status pills lied about what an import would do.** Pointing at a brand-new SD card (or NAS folder) while the active workspace already had fully-processed photos rendered every per-photo stage as **"Already done"** or **"Resume"** — derived from the active workspace's existing state, not the about-to-be-imported files. Truthfully, those new files have no detections, masks, keypoints, or classifier runs yet, so every stage will run on them. This violated CORE_PHILOSOPHY.md's transparency rule (a pill that says "Already done" must mean the next run is a no-op).

2. **Question-mark thumbnails persisted across page reloads.** A transient libraw I/O glitch (NAS contention during burst preview reads of Z8 HE* NEFs) made the thumbnail endpoint 404, and the 404 was cached for 5 minutes. Even after the underlying issue cleared, the user stayed stuck looking at broken-image glyphs until the cache expired.

## Changes

### Bug 1: Plan honesty
- New DB helper `db.photos_by_paths(paths)`: maps a list of absolute file paths → existing `photo_id`s (or omits unknown paths). Photos are global, so the lookup ignores workspace membership.
- `PipelinePlanParams` gains `source_paths: list`. `compute_plan` splits the list into already-known photo ids (used as the per-stage scope, so existing real-status queries apply) and a count of genuinely new files. New files are treated as fresh work for every per-photo stage — pills flip from "Already done" to "Will run (N)" for an import that will actually produce N new units of work.
- New `Scan` plan entry, emitted only in import / new-images modes: "Will import N new (M already known)" or "All N already imported — scan will be a no-op" when the user re-points at an already-imported folder.
- Frontend `_buildPlanBody` sends the selected preview file paths as `source_paths` in import / new-images modes; refresh hooked into `renderPreview()` (debounced).
- API guards: `source_paths` must be a list and ≤ 50 000 entries (rejected with 400 rather than silently truncated, since a dropped file would be mis-classified as new).

### Bug 2: Thumbnail recovery
- `/api/import/folder-preview/thumbnail` emits `Cache-Control: no-store` on 404 responses; 200s keep the existing 5-min cache.
- `image_loader._load_raw_with_retry` catches `LibRawIOError` once and retries. Other libraw errors (UnsupportedFormat, DataError) are deterministic for a given file and still fail fast.
- A future PR can bundle exiftool via Tauri's `externalBin` to add a non-libraw embedded-JPEG fallback for RAW formats libraw genuinely can't open. The existing `_extract_embedded_jpeg` path already handles HE*/TicoRAW correctly when libraw can read the file at all, so that's a separate enhancement, not a fix for this bug.

## Tests

- `test_pipeline_plan.py`: new tests for `photos_by_paths` (known/unknown/empty/cross-workspace), `compute_plan` import-mode honesty (all-new flips classify + extract to will-run; partial overlap counts only truly-new; all-known scan is done-prior; non-import modes don't emit Scan), and API param validation (oversized + non-list `source_paths`).
- `test_image_loader.py`: retry once on `LibRawIOError`; do not retry on `LibRawFileUnsupportedError`.
- `test_app.py`: thumbnail endpoint emits `no-store` on 404 (path missing or `load_image` returned None); 200s remain cacheable.

Test command per CLAUDE.md ran clean across `tests/test_workspaces.py`, `vireo/tests/test_db.py`, `test_app.py`, `test_photos_api.py`, `test_edits_api.py`, `test_jobs_api.py`, `test_darktable_api.py`, `test_config.py`, `test_pipeline_plan.py`, `test_pipeline_api.py`, and `test_image_loader.py` — 1049 tests, all passing.

## Test plan

- [ ] On April 2026 (existing) workspace, point pipeline at a brand-new folder. Pills should read "Will run (N)" for Classify/Extract/Keypoints, not "Already done". Scan should read "Will import N new".
- [ ] Re-point at the same folder after import: Scan reads "All N already imported"; downstream stages reflect real status of those imported photos.
- [ ] Point at a partly-imported folder: Scan reads "Will import K new (M already known)".
- [ ] Open a folder of Z8 HE* NEFs over a slow NAS share. If a thumbnail fails (transient I/O), refreshing the page should retry — no 5-minute lockout on broken images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)