### PR TITLE
Scanner: surface kernel-denied paths instead of silently scanning 0 photos

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -817,6 +817,25 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 job["progress"]["current"] = 0
                 job["progress"]["total"] = 0
                 _update_stages(runner, job["id"], stages)
+                # Surface kernel-level enumeration denials (macOS TCC EPERM,
+                # POSIX EACCES) into job["errors"]. Without this, scanner.scan
+                # silently skipped the subtree and the scan stage finished as
+                # "completed" with 0 photos — a black-box outcome the user
+                # reads as "no photos found here" when the truth is "Vireo
+                # was denied access". Dedup per path because the walk may
+                # signal the same dir more than once.
+                denied_seen: set[str] = set()
+                def _on_denied(path: str) -> None:
+                    if path in denied_seen:
+                        return
+                    denied_seen.add(path)
+                    errors.append(
+                        f"[scan] PERMISSION_DENIED: {path} — macOS or "
+                        f"filesystem refused enumeration. On macOS open "
+                        f"System Settings → Privacy & Security → Files "
+                        f"and Folders (or Removable/Network Volumes) and "
+                        f"grant Vireo access."
+                    )
                 scanned_roots.append(params.destination)
                 do_scan(
                     params.destination, thread_db,
@@ -828,6 +847,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     restrict_dirs=restrict,
                     vireo_dir=effective_vireo_dir,
                     thumb_cache_dir=effective_thumb_cache_dir,
+                    permission_error_callback=_on_denied,
                 )
             else:
                 # Scan-in-place: scan each source folder independently.
@@ -836,6 +856,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 job["progress"]["current"] = 0
                 job["progress"]["total"] = 0
                 _update_stages(runner, job["id"], stages)
+                # See ingest branch above — same denial-surfacing rationale.
+                denied_seen: set[str] = set()
+                def _on_denied(path: str) -> None:
+                    if path in denied_seen:
+                        return
+                    denied_seen.add(path)
+                    errors.append(
+                        f"[scan] PERMISSION_DENIED: {path} — macOS or "
+                        f"filesystem refused enumeration. On macOS open "
+                        f"System Settings → Privacy & Security → Files "
+                        f"and Folders (or Removable/Network Volumes) and "
+                        f"grant Vireo access."
+                    )
                 for src_folder in sources:
                     scanned_roots.append(src_folder)
                     try:
@@ -850,6 +883,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             recursive=params.recursive,
                             vireo_dir=effective_vireo_dir,
                             thumb_cache_dir=effective_thumb_cache_dir,
+                            permission_error_callback=_on_denied,
                         )
                     finally:
                         advance_scan_acc()

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -822,6 +822,16 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # log so we don't mask unexpected I/O problems. Defined here
     # (not nested in a branch) so the restrict_dirs path below can
     # also surface denials through the same callback.
+    #
+    # Partial-success (skip the denied dir, keep scanning siblings)
+    # is *opt-in* via permission_error_callback. Without a callback,
+    # re-raise the PermissionError: existing OSError-aware callers
+    # (e.g. pipeline_job repair scan's `except (OSError, RuntimeError)`
+    # unreachable counter) rely on the failure to surface, and silent
+    # skipping would let a denied folder be reported as successfully
+    # repaired. Callers that want to continue past denials must pass
+    # the callback to acknowledge they've taken responsibility for
+    # streaming the denial somewhere actionable.
     def _on_walk_error(err):
         if err.errno in (errno.EPERM, errno.EACCES):
             denied = err.filename or str(root_path)
@@ -831,8 +841,10 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 "→ Files and Folders / Removable Volumes) needs to "
                 "grant Vireo access.", denied,
             )
-            if permission_error_callback:
+            if permission_error_callback is not None:
                 permission_error_callback(denied)
+                return
+            raise err
         else:
             log.warning("os.walk error at %s: %s", err.filename, err)
 
@@ -844,11 +856,15 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             dp = Path(d)
             if dp.is_dir():
                 # iterdir() raises PermissionError when the kernel refuses
-                # enumeration (macOS TCC EPERM, POSIX EACCES). Without this
-                # try/except the whole pipeline scan stage aborts on the
-                # first denied dir; route through _on_walk_error so the
-                # denial is surfaced via permission_error_callback the same
-                # way the recursive path does.
+                # enumeration (macOS TCC EPERM, POSIX EACCES). Route through
+                # _on_walk_error so denials are surfaced via
+                # permission_error_callback the same way the recursive path
+                # does. _on_walk_error re-raises when no callback is
+                # registered, so callers like pipeline_job's repair scan
+                # (which counts unreachable folders via `except OSError`)
+                # keep their failure semantics; only callers that opted in
+                # to partial-success by passing the callback fall through to
+                # `continue`.
                 try:
                     entries = list(dp.iterdir())
                 except PermissionError as e:

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -812,6 +812,30 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     if status_callback:
         status_callback("Discovering files...")
     image_files = []
+
+    # os.walk + onerror, not Path.rglob: rglob silently skips any
+    # subdir that raises during enumeration, so a TCC-denied folder
+    # turns into "Found 0 images" with no signal that anything went
+    # wrong. macOS TCC raises EPERM ("Operation not permitted");
+    # POSIX mode-bit denials raise EACCES. Both must be reported,
+    # not swallowed. Other OSError flavors are still surfaced via
+    # log so we don't mask unexpected I/O problems. Defined here
+    # (not nested in a branch) so the restrict_dirs path below can
+    # also surface denials through the same callback.
+    def _on_walk_error(err):
+        if err.errno in (errno.EPERM, errno.EACCES):
+            denied = err.filename or str(root_path)
+            log.warning(
+                "Permission denied enumerating %s — skipping. "
+                "On macOS this usually means TCC (Privacy & Security "
+                "→ Files and Folders / Removable Volumes) needs to "
+                "grant Vireo access.", denied,
+            )
+            if permission_error_callback:
+                permission_error_callback(denied)
+        else:
+            log.warning("os.walk error at %s: %s", err.filename, err)
+
     if restrict_dirs is not None:
         # Only enumerate files in the specified directories (non-recursive).
         # root is still used as the folder hierarchy root for _ensure_folder.
@@ -819,7 +843,18 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         for d in restrict_dirs:
             dp = Path(d)
             if dp.is_dir():
-                for f in dp.iterdir():
+                # iterdir() raises PermissionError when the kernel refuses
+                # enumeration (macOS TCC EPERM, POSIX EACCES). Without this
+                # try/except the whole pipeline scan stage aborts on the
+                # first denied dir; route through _on_walk_error so the
+                # denial is surfaced via permission_error_callback the same
+                # way the recursive path does.
+                try:
+                    entries = list(dp.iterdir())
+                except PermissionError as e:
+                    _on_walk_error(e)
+                    continue
+                for f in entries:
                     if (f.is_file()
                             and f.suffix.lower() in SUPPORTED_EXTENSIONS
                             and not f.name.startswith(".")
@@ -828,27 +863,6 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                                  or str(f) in restrict_files_set)):
                         image_files.append(f)
     else:
-        # os.walk + onerror, not Path.rglob: rglob silently skips any
-        # subdir that raises during enumeration, so a TCC-denied folder
-        # turns into "Found 0 images" with no signal that anything went
-        # wrong. macOS TCC raises EPERM ("Operation not permitted");
-        # POSIX mode-bit denials raise EACCES. Both must be reported,
-        # not swallowed. Other OSError flavors are still surfaced via
-        # log so we don't mask unexpected I/O problems.
-        def _on_walk_error(err):
-            if err.errno in (errno.EPERM, errno.EACCES):
-                denied = err.filename or str(root_path)
-                log.warning(
-                    "Permission denied enumerating %s — skipping. "
-                    "On macOS this usually means TCC (Privacy & Security "
-                    "→ Files and Folders / Removable Volumes) needs to "
-                    "grant Vireo access.", denied,
-                )
-                if permission_error_callback:
-                    permission_error_callback(denied)
-            else:
-                log.warning("os.walk error at %s: %s", err.filename, err)
-
         if recursive:
             checked = 0
             for dirpath, _dirnames, filenames in os.walk(

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1,6 +1,7 @@
 """Scan folders, discover photos, read metadata, populate database."""
 
 import contextlib
+import errno
 import hashlib
 import json
 import logging
@@ -761,7 +762,7 @@ def backfill_working_copies(db, vireo_dir, progress_callback=None,
     }
 
 
-def scan(root, db, progress_callback=None, incremental=False, extract_full_metadata=True, photo_callback=None, skip_paths=None, status_callback=None, recursive=True, restrict_dirs=None, restrict_files=None, vireo_dir=None, thumb_cache_dir=None):
+def scan(root, db, progress_callback=None, incremental=False, extract_full_metadata=True, photo_callback=None, skip_paths=None, status_callback=None, recursive=True, restrict_dirs=None, restrict_files=None, vireo_dir=None, thumb_cache_dir=None, permission_error_callback=None):
     """Walk a folder tree, discover photos, read metadata, populate database.
 
     Args:
@@ -794,6 +795,12 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             with the configured value (Flask routes, audit entry points)
             should pass it. When omitted, falls back to
             ``vireo_dir/thumbnails``.
+        permission_error_callback: optional callable(path_str) invoked
+            once per directory the kernel refuses to enumerate (EPERM
+            from macOS TCC, EACCES from POSIX mode bits). The scan
+            continues; accessible siblings are still discovered. Without
+            this hook, a denied subdir would silently produce zero hits
+            — a "Found 0 images" black box from the user's perspective.
     """
     root_path = Path(root)
     if not root_path.is_dir():
@@ -821,15 +828,60 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                                  or str(f) in restrict_files_set)):
                         image_files.append(f)
     else:
-        candidates = root_path.rglob("*") if recursive else root_path.iterdir()
-        for checked, f in enumerate(candidates, 1):
-            if checked % 500 == 0 and status_callback:
-                status_callback(f"Discovering files... ({len(image_files)} found)")
-            if (f.is_file()
-                    and f.suffix.lower() in SUPPORTED_EXTENSIONS
-                    and not f.name.startswith(".")
-                    and (skip_paths is None or str(f) not in skip_paths)):
-                image_files.append(f)
+        # os.walk + onerror, not Path.rglob: rglob silently skips any
+        # subdir that raises during enumeration, so a TCC-denied folder
+        # turns into "Found 0 images" with no signal that anything went
+        # wrong. macOS TCC raises EPERM ("Operation not permitted");
+        # POSIX mode-bit denials raise EACCES. Both must be reported,
+        # not swallowed. Other OSError flavors are still surfaced via
+        # log so we don't mask unexpected I/O problems.
+        def _on_walk_error(err):
+            if err.errno in (errno.EPERM, errno.EACCES):
+                denied = err.filename or str(root_path)
+                log.warning(
+                    "Permission denied enumerating %s — skipping. "
+                    "On macOS this usually means TCC (Privacy & Security "
+                    "→ Files and Folders / Removable Volumes) needs to "
+                    "grant Vireo access.", denied,
+                )
+                if permission_error_callback:
+                    permission_error_callback(denied)
+            else:
+                log.warning("os.walk error at %s: %s", err.filename, err)
+
+        if recursive:
+            checked = 0
+            for dirpath, _dirnames, filenames in os.walk(
+                str(root_path), onerror=_on_walk_error,
+            ):
+                for name in filenames:
+                    checked += 1
+                    if checked % 500 == 0 and status_callback:
+                        status_callback(
+                            f"Discovering files... ({len(image_files)} found)"
+                        )
+                    ext = os.path.splitext(name)[1].lower()
+                    if (ext in SUPPORTED_EXTENSIONS
+                            and not name.startswith(".")):
+                        full = os.path.join(dirpath, name)
+                        if skip_paths is None or full not in skip_paths:
+                            image_files.append(Path(full))
+        else:
+            try:
+                entries = list(root_path.iterdir())
+            except PermissionError as e:
+                _on_walk_error(e)
+                entries = []
+            for checked, f in enumerate(entries, 1):
+                if checked % 500 == 0 and status_callback:
+                    status_callback(
+                        f"Discovering files... ({len(image_files)} found)"
+                    )
+                if (f.is_file()
+                        and f.suffix.lower() in SUPPORTED_EXTENSIONS
+                        and not f.name.startswith(".")
+                        and (skip_paths is None or str(f) not in skip_paths)):
+                    image_files.append(f)
     image_files.sort()
 
     total = len(image_files)

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -864,8 +864,18 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     if (ext in SUPPORTED_EXTENSIONS
                             and not name.startswith(".")):
                         full = os.path.join(dirpath, name)
-                        if skip_paths is None or full not in skip_paths:
-                            image_files.append(Path(full))
+                        if skip_paths is not None and full in skip_paths:
+                            continue
+                        # os.walk includes broken symlinks in `filenames`,
+                        # but the pre-pass below calls image_path.stat()
+                        # which would raise FileNotFoundError and abort
+                        # the whole scan. The previous Path.rglob path
+                        # filtered these via is_file(); preserve that.
+                        # os.path.isfile follows symlinks and returns
+                        # False (not raise) for dangling targets.
+                        if not os.path.isfile(full):
+                            continue
+                        image_files.append(Path(full))
         else:
             try:
                 entries = list(root_path.iterdir())

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -8341,3 +8341,70 @@ def test_detect_eye_keypoints_stage_emits_final_100pct_on_clean_run(
     assert (last_current, last_total) == (2, 2), (
         f"Expected final emit (2, 2) on clean run; got {progress_events!r}"
     )
+
+
+import pytest
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions required")
+def test_pipeline_scan_surfaces_permission_denied(tmp_path, monkeypatch):
+    """Pipeline scan stage must surface kernel-level enumeration denials
+    (EPERM / EACCES) into job["errors"] as a typed PERMISSION_DENIED entry,
+    and accessible siblings must still be scanned. Regression: real-world
+    May2026 run on /Volumes/Photography/.../2026-05-01 reported "0 photos"
+    while macOS TCC was silently blocking the read.
+    """
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_root = tmp_path / "photos"
+    ok_dir = photo_root / "ok"
+    ok_dir.mkdir(parents=True)
+    Image.new("RGB", (16, 16), "red").save(str(ok_dir / "ok.jpg"))
+
+    locked_dir = photo_root / "locked"
+    locked_dir.mkdir()
+    Image.new("RGB", (16, 16), "blue").save(str(locked_dir / "locked.jpg"))
+    os.chmod(str(locked_dir), 0o000)
+
+    try:
+        db_path = str(tmp_path / "test.db")
+        db = Database(db_path)
+        ws_id = db._active_workspace_id
+
+        params = PipelineParams(
+            source=str(photo_root),
+            skip_classify=True,
+            skip_extract_masks=True,
+            skip_regroup=True,
+        )
+
+        runner = FakeRunner()
+        job = _make_job()
+
+        result = run_pipeline_job(job, runner, db_path, ws_id, params)
+
+        denied_errors = [
+            e for e in job["errors"] if "PERMISSION_DENIED" in e
+        ]
+        assert denied_errors, (
+            f"Expected PERMISSION_DENIED in job errors. got: {job['errors']}"
+        )
+        assert any(str(locked_dir) in e for e in denied_errors), (
+            f"Locked dir not named in denial. got: {denied_errors}"
+        )
+
+        db2 = Database(db_path)
+        db2.set_active_workspace(ws_id)
+        photos = db2.get_photos(per_page=100)
+        names = {p["filename"] for p in photos}
+        assert "ok.jpg" in names, "accessible photo must still be scanned"
+        assert "locked.jpg" not in names, "denied dir must not yield photos"
+
+        assert isinstance(result, dict)
+    finally:
+        os.chmod(str(locked_dir), 0o755)

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -2357,3 +2357,77 @@ def test_scan_restrict_dirs_surfaces_permission_denied(tmp_path, monkeypatch):
     assert any(forbidden in p for p in denied), (
         f"denied restrict_dir not reported via callback. got: {denied}"
     )
+
+
+def test_scan_restrict_dirs_raises_permission_error_without_callback(
+    tmp_path, monkeypatch,
+):
+    """Without ``permission_error_callback``, a denied restrict_dir must still
+    raise PermissionError — *not* be silently swallowed.
+
+    Regression: pipeline_job's repair scan calls ``do_scan(..., restrict_dirs=
+    [folder_path])`` without a callback and wraps it in
+    ``except (OSError, RuntimeError)`` to count unreachable folders. An
+    earlier fix caught PermissionError and unconditionally `continue`d,
+    which silently turned denied folders into "successfully repaired" —
+    a black-box regression. Partial-success is opt-in via the callback;
+    every other caller must keep the loud failure semantics they had.
+    """
+    import errno as _errno
+    from pathlib import Path as _Path
+
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'forbidden': ['hidden.jpg']})
+    forbidden = os.path.join(root, 'forbidden')
+
+    real_iterdir = _Path.iterdir
+
+    def fake_iterdir(self):
+        if str(self) == forbidden:
+            raise PermissionError(
+                _errno.EACCES, "Permission denied", str(self),
+            )
+        return real_iterdir(self)
+
+    monkeypatch.setattr(_Path, "iterdir", fake_iterdir)
+
+    db = Database(str(tmp_path / "test.db"))
+    with pytest.raises(PermissionError):
+        scan(root, db, restrict_dirs=[forbidden])
+
+
+def test_scan_recursive_raises_permission_error_without_callback(
+    tmp_path, monkeypatch,
+):
+    """Without ``permission_error_callback``, a denied subdir during a
+    recursive walk must raise PermissionError. The os.walk ``onerror``
+    callback re-raises so the failure is visible to the caller — silent
+    "Found 0 images" is the very black-box behavior this stack was
+    refactored to eliminate.
+    """
+    import errno as _errno
+
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['ok.jpg'], 'forbidden': ['hidden.jpg']})
+    forbidden = os.path.join(root, 'forbidden')
+
+    real_scandir = os.scandir
+
+    def fake_scandir(path, *args, **kwargs):
+        if os.fspath(path) == forbidden:
+            raise PermissionError(
+                _errno.EACCES, "Permission denied", forbidden,
+            )
+        return real_scandir(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "scandir", fake_scandir)
+
+    db = Database(str(tmp_path / "test.db"))
+    with pytest.raises(PermissionError):
+        scan(root, db)

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -2201,3 +2201,69 @@ def test_scan_links_restrict_dirs_when_all_files_skipped(tmp_path):
     assert sub1 in linked and sub2 in linked, (
         f"Both restrict_dirs should be linked. Linked folders: {linked}"
     )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions required")
+def test_scan_surfaces_permission_denied_subdirs(tmp_path):
+    """A subdir the kernel won't let us enter must surface as a denied path,
+    not silently disappear into a 'Found 0 images' lie. Accessible siblings
+    must still be discovered.
+
+    Regression: the scan of /Volumes/Photography/.../2026-05-01 returned
+    'Found 0 images' for a folder containing 1122 NEFs because macOS TCC
+    blocked Vireo's process. Path.rglob("*") swallows PermissionError per
+    directory; switching to os.walk(onerror=...) lets us see them.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {
+        '': ['ok.jpg'],
+        'forbidden': ['hidden.jpg'],
+    })
+
+    forbidden = os.path.join(root, 'forbidden')
+    os.chmod(forbidden, 0o000)
+    try:
+        db = Database(str(tmp_path / "test.db"))
+        denied = []
+        scan(root, db, permission_error_callback=denied.append)
+
+        photos = {p['filename'] for p in db.get_photos(per_page=100)}
+        assert 'ok.jpg' in photos, "accessible files must still be scanned"
+        assert 'hidden.jpg' not in photos, "denied dir must not yield photos"
+        assert any(forbidden in p for p in denied), (
+            f"denied path not reported via callback. got: {denied}"
+        )
+    finally:
+        os.chmod(forbidden, 0o755)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions required")
+def test_scan_continues_after_permission_denied(tmp_path):
+    """A denied subtree must not abort the scan — sibling subtrees keep being
+    walked. This is the partial-discovery property: a single locked-down
+    folder shouldn't poison an entire run."""
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {
+        'a': ['a.jpg'],
+        'b': ['b.jpg'],
+        'c': ['c.jpg'],
+    })
+
+    locked = os.path.join(root, 'b')
+    os.chmod(locked, 0o000)
+    try:
+        db = Database(str(tmp_path / "test.db"))
+        denied = []
+        scan(root, db, permission_error_callback=denied.append)
+
+        photos = {p['filename'] for p in db.get_photos(per_page=100)}
+        assert photos == {'a.jpg', 'c.jpg'}
+        assert any(locked in p for p in denied)
+    finally:
+        os.chmod(locked, 0o755)

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -2267,3 +2267,33 @@ def test_scan_continues_after_permission_denied(tmp_path):
         assert any(locked in p for p in denied)
     finally:
         os.chmod(locked, 0o755)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks required")
+def test_scan_skips_broken_symlinks(tmp_path):
+    """A dangling symlink with a supported extension must not abort the scan.
+
+    Regression: switching from Path.rglob (which used is_file() — False for
+    broken symlinks) to os.walk (which lists broken symlinks in `filenames`)
+    caused dangling *.jpg symlinks to be queued for processing. The pre-pass
+    then called image_path.stat() and raised FileNotFoundError, killing the
+    whole scan. os.walk-mode must filter non-files like the rglob path did.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['real.jpg']})
+    # Create a dangling symlink whose target does not exist.
+    os.symlink(
+        os.path.join(root, "missing-target.jpg"),
+        os.path.join(root, "broken.jpg"),
+    )
+
+    db = Database(str(tmp_path / "test.db"))
+    # Must not raise FileNotFoundError; must still scan the real file.
+    scan(root, db)
+
+    photos = {p['filename'] for p in db.get_photos(per_page=100)}
+    assert 'real.jpg' in photos
+    assert 'broken.jpg' not in photos

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -2297,3 +2297,63 @@ def test_scan_skips_broken_symlinks(tmp_path):
     photos = {p['filename'] for p in db.get_photos(per_page=100)}
     assert 'real.jpg' in photos
     assert 'broken.jpg' not in photos
+
+
+def test_scan_restrict_dirs_surfaces_permission_denied(tmp_path, monkeypatch):
+    """The pipeline copy-mode path drives scan() with restrict_dirs. A denied
+    directory in that list must surface via permission_error_callback and not
+    abort the whole scan — accessible siblings must still be discovered.
+
+    Regression: permission_error_callback was only wired into the os.walk
+    branch (restrict_dirs is None). With restrict_dirs set, dp.iterdir()
+    raised PermissionError unhandled and the entire pipeline scan stage
+    failed with no PERMISSION_DENIED entry in job["errors"].
+
+    Mocks Path.iterdir for the locked subtree (rather than chmod 0o000) so
+    the assertion holds regardless of test-runner uid: chmod-based denial
+    silently bypasses for root, which would let the locked file slip in.
+    """
+    import errno as _errno
+    from pathlib import Path as _Path
+
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {
+        'allowed': ['ok.jpg'],
+        'forbidden': ['hidden.jpg'],
+    })
+    allowed = os.path.join(root, 'allowed')
+    forbidden = os.path.join(root, 'forbidden')
+
+    real_iterdir = _Path.iterdir
+
+    def fake_iterdir(self):
+        if str(self) == forbidden:
+            raise PermissionError(
+                _errno.EACCES, "Permission denied", str(self),
+            )
+        return real_iterdir(self)
+
+    monkeypatch.setattr(_Path, "iterdir", fake_iterdir)
+
+    db = Database(str(tmp_path / "test.db"))
+    denied = []
+    # Must not raise; must surface the denied dir via the callback.
+    scan(
+        root, db,
+        restrict_dirs=[allowed, forbidden],
+        permission_error_callback=denied.append,
+    )
+
+    photos = {p['filename'] for p in db.get_photos(per_page=100)}
+    assert 'ok.jpg' in photos, (
+        "accessible restrict_dir entries must still be scanned"
+    )
+    assert 'hidden.jpg' not in photos, (
+        "denied restrict_dir must not yield photos"
+    )
+    assert any(forbidden in p for p in denied), (
+        f"denied restrict_dir not reported via callback. got: {denied}"
+    )


### PR DESCRIPTION
## Summary

- `scanner.scan()` switches from `Path.rglob` to `os.walk(onerror=...)` so directories the kernel refuses to enumerate (macOS TCC EPERM, POSIX EACCES) get reported instead of silently dropped. Accessible siblings are still discovered (partial-success, not all-or-nothing).
- New optional `permission_error_callback(path)` parameter on `scanner.scan()` lets callers stream denied paths somewhere actionable.
- `pipeline_job.py` wires the callback into the scan stage so denied paths appear in `job[\"errors\"]` as typed `PERMISSION_DENIED: <path>` entries (deduped), with a hint to grant access in System Settings → Privacy & Security → Files and Folders.

## Why

Real-world bug: a pipeline run scanning `/Volumes/Photography/Raw Files/USA/2026/2026-05-01` (1122 NEFs on disk) reported `\"Found 0 images\"` and finished as `completed`. The cause was macOS TCC silently blocking Vireo's process; `Path.rglob(\"*\")` swallowed the per-directory `PermissionError` and returned an empty iterator. The user got a black-box success that had imported nothing — exactly the failure mode CORE_PHILOSOPHY's \"No black boxes\" rule exists to prevent.

This PR is the detection layer. Follow-ups (separate PRs):
1. New `/api/folders/denied` health endpoint + extension to `/api/folders/check-health`.
2. Navbar banner with a deep-link button to the right TCC pane.

## Test plan

- [x] `python -m pytest vireo/tests/test_scanner.py -v` — 70 passed (2 new, 68 existing).
- [x] New: `test_scan_surfaces_permission_denied_subdirs` — chmod 000 a subdir, scan parent, assert accessible photo is found, denied dir is not, callback fires.
- [x] New: `test_scan_continues_after_permission_denied` — partial-discovery property: locked sibling doesn't poison other subtrees.
- [x] New: `test_pipeline_scan_surfaces_permission_denied` — full pipeline run with a chmod-000 subtree; asserts `job[\"errors\"]` contains a `PERMISSION_DENIED` entry naming the locked path AND that the accessible photo was scanned.
- [x] Project standard suite (`tests/test_workspaces.py vireo/tests/{test_db,test_app,test_photos_api,test_edits_api,test_jobs_api,test_darktable_api,test_config,test_scanner,test_pipeline_job}.py`): 1117 passed, 2 failed, 1 skipped. Both failures (`test_remove_keyword_from_photo`, `test_undo_keyword_remove_clears_pending_change`) are pre-existing on main and unrelated to scanner/pipeline.