### PR TITLE
Pipeline trace: drop redundant thumbs in pair rows

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -432,11 +432,6 @@ input[type="range"]::-moz-range-thumb {
   display: flex; gap: 6px; align-items: center;
   cursor: pointer; min-width: 0; flex: 1;
 }
-.algo-trace .trace-pair-photo img {
-  width: 36px; height: 28px; object-fit: cover;
-  border-radius: 3px; border: 1px solid var(--border-primary);
-  flex-shrink: 0;
-}
 .algo-trace .trace-pair-photo .name {
   font-size: 10px; color: var(--text-dim);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
@@ -1503,7 +1498,6 @@ function renderAlgorithmTrace() {
       return '<div class="trace-pair-photo"><span class="name">' + escapeHtml(label) + '</span></div>';
     }
     return '<div class="trace-pair-photo" onclick="openInspect(' + pid + ')" title="' + escapeHtml(p.filename || label) + '">'
-      + '<img src="/thumbnails/' + pid + '.jpg" loading="lazy" alt="">'
       + '<span class="name">' + escapeHtml(label) + '</span>'
       + '</div>';
   }
@@ -1521,8 +1515,6 @@ function renderAlgorithmTrace() {
     html += '<span>S=' + score + '</span>';
     html += '<span class="trace-decision">' + decision + '</span>';
     html += '</div>';
-    // Pair photos: filenames + tiny thumbs so the user can see *which*
-    // two photos this row scored, and click through to inspect either.
     html += '<div class="trace-pair-photos">';
     html += pairPhotoHtml(t.photo_a_id, t.photo_a_filename);
     html += '<span class="trace-pair-arrow">→</span>';


### PR DESCRIPTION
## Summary
- The encounter cards on the right already show thumbnails for every photo, so the tiny thumbs in the trace panel's pair rows were duplicating that context and adding noise to the left column.
- Drop the `<img>` from `pairPhotoHtml` and remove the now-unused `.algo-trace .trace-pair-photo img` CSS block. Filename + click-to-inspect behavior is preserved.

## Test plan
- [ ] Open Pipeline Review, click an encounter, confirm trace rows show filenames only with no thumbnails
- [ ] Confirm clicking a filename still opens the inspector for that photo
- [ ] Confirm encounter cards on the main panel still show thumbs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)