### PR TITLE
Pipeline review: recover pair photos from old caches

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1521,16 +1521,24 @@ function renderAlgorithmTrace() {
     html += '<span>S=' + score + '</span>';
     html += '<span class="trace-decision">' + decision + '</span>';
     html += '</div>';
+    // Caches written before commit 82b3144 lack photo_a_id/photo_b_id on
+    // trace entries. Within an encounter the i-th adjacent-pair row is
+    // photo_ids[i] → photo_ids[i+1] (cut_microsegments sorts by timestamp
+    // and segment_encounters preserves that order), so we can recover the
+    // IDs from the encounter without forcing a regroup.
+    var encPhotoIds = enc.photo_ids || [];
+    var aId = (t.photo_a_id != null) ? t.photo_a_id : (encPhotoIds[i] != null ? encPhotoIds[i] : null);
+    var bId = (t.photo_b_id != null) ? t.photo_b_id : (encPhotoIds[i + 1] != null ? encPhotoIds[i + 1] : null);
     // Pair photos: filenames + tiny thumbs so the user can see *which*
     // two photos this row scored, and click through to inspect either.
     html += '<div class="trace-pair-photos">';
-    html += pairPhotoHtml(t.photo_a_id, t.photo_a_filename);
+    html += pairPhotoHtml(aId, t.photo_a_filename);
     html += '<span class="trace-pair-arrow">→</span>';
-    html += pairPhotoHtml(t.photo_b_id, t.photo_b_filename);
+    html += pairPhotoHtml(bId, t.photo_b_filename);
     html += '</div>';
     if (t.components) {
-      var nameA = shortName((photoMap[t.photo_a_id] || {}).filename || t.photo_a_filename || 'A');
-      var nameB = shortName((photoMap[t.photo_b_id] || {}).filename || t.photo_b_filename || 'B');
+      var nameA = shortName((photoMap[aId] || {}).filename || t.photo_a_filename || 'A');
+      var nameB = shortName((photoMap[bId] || {}).filename || t.photo_b_filename || 'B');
       var parts = [];
       ['time', 'subj', 'global', 'species', 'meta'].forEach(function(k) {
         var c = t.components[k];

--- a/vireo/tests/test_encounters.py
+++ b/vireo/tests/test_encounters.py
@@ -620,6 +620,48 @@ def test_trace_includes_pair_photo_ids_and_filenames():
     assert trace[0]["photo_b_filename"] == "DSC_1385.NEF"
 
 
+def test_trace_position_aligns_with_encounter_photo_order():
+    """Within an encounter, the i-th trace entry must describe the pair
+    (photos[i], photos[i+1]) in encounter-photo order. The pipeline-review
+    UI relies on this to recover pair photos from old caches that were
+    written before photo_a_id/photo_b_id were added to trace entries —
+    falling back to enc.photo_ids[i] / enc.photo_ids[i+1].
+    """
+    from encounters import segment_encounters
+
+    # Three encounters of varying sizes, separated by big time gaps so
+    # cut_microsegments produces distinct microsegments. Within each
+    # encounter the photos remain in timestamp order.
+    photos = [
+        # Encounter A: 3 photos
+        {"id": 100, "timestamp": "2026-03-07T10:00:00", "focal_length": 600.0},
+        {"id": 101, "timestamp": "2026-03-07T10:00:02", "focal_length": 600.0},
+        {"id": 102, "timestamp": "2026-03-07T10:00:04", "focal_length": 600.0},
+        # Encounter B: 2 photos
+        {"id": 200, "timestamp": "2026-03-07T11:00:00", "focal_length": 600.0},
+        {"id": 201, "timestamp": "2026-03-07T11:00:03", "focal_length": 600.0},
+        # Encounter C: 4 photos
+        {"id": 300, "timestamp": "2026-03-07T12:00:00", "focal_length": 600.0},
+        {"id": 301, "timestamp": "2026-03-07T12:00:02", "focal_length": 600.0},
+        {"id": 302, "timestamp": "2026-03-07T12:00:04", "focal_length": 600.0},
+        {"id": 303, "timestamp": "2026-03-07T12:00:06", "focal_length": 600.0},
+    ]
+    encounters = segment_encounters(photos, emit_trace=True)
+    assert len(encounters) == 3
+
+    for enc in encounters:
+        photo_ids = [p["id"] for p in enc["photos"]]
+        trace = enc["trace"]
+        assert len(trace) == len(photo_ids) - 1
+        for i, t in enumerate(trace):
+            assert t["photo_a_id"] == photo_ids[i], (
+                f"trace[{i}].photo_a_id={t['photo_a_id']} != photo_ids[{i}]={photo_ids[i]}"
+            )
+            assert t["photo_b_id"] == photo_ids[i + 1], (
+                f"trace[{i}].photo_b_id={t['photo_b_id']} != photo_ids[{i+1}]={photo_ids[i + 1]}"
+            )
+
+
 def test_components_flag_which_photo_is_missing_each_signal():
     """Each component tags missing_a / missing_b so the UI can say
     "missing on DSC_1385" instead of just rendering a bare dot. This is


### PR DESCRIPTION
## Summary

- The pipeline-review algorithm-trace panel showed `Photo ? → Photo ?` for every adjacent pair when the cached `pipeline_results_ws<id>.json` was written before `photo_a_id`/`photo_b_id` were added to trace entries (PR #770). Old caches are read from disk on `/pipeline/review`, so restarting the app picks up the new template but not the new data — and the panel was useless until the user manually re-ran a regroup.
- Within a merged encounter, the i-th adjacent-pair trace entry always describes `(photo_ids[i], photo_ids[i+1])` — `cut_microsegments` sorts by timestamp and `segment_encounters` preserves that order. So when `photo_a_id`/`photo_b_id` are missing, fall back to `enc.photo_ids[i]` / `enc.photo_ids[i+1]` and look up filenames + thumbs from the photo map. Old caches self-heal in the UI without forcing a regroup.
- Adds `test_trace_position_aligns_with_encounter_photo_order` so a future change that reorders an encounter's photos vs. its trace fails loudly instead of silently misrendering pairs.

## Repro

Hit by Julius on the **Apr2026** workspace today: pair 1 and following all rendered as `photo? → photo?`. The cache at `~/.vireo/pipeline_results_ws12.json` was last regrouped 8 minutes after PR #770 merged, by a Vireo instance still running the old `encounters.py` (Flask `debug=False`, no auto-reloader).

## Test plan

- [x] `pytest vireo/tests/test_encounters.py` — 45 passed (incl. new alignment test)
- [x] `pytest vireo/tests/test_pipeline.py` — passed
- [x] `pytest vireo/tests/test_app.py vireo/tests/test_build_static.py` — 175 passed
- [x] `pytest tests/test_workspaces.py vireo/tests/test_db.py` — passed
- [x] **Browser verification:** ran Vireo against a copy of the Apr2026 cache with `photo_a_id`/`photo_b_id`/`photo_a_filename`/`photo_b_filename` stripped from every trace entry (17,508 fields removed) — Playwright loaded `/pipeline/review`, opened the algorithm-trace panel, and confirmed the rendered pair-photo names were real filenames (`DSC_1090`, `DSC_1092`, …) and thumb `src` URLs were `/thumbnails/<real-id>.jpg`, not the `Photo ?` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)