### PR TITLE
Thumbnails: regenerate stale cache from photo-ID reuse

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9145,37 +9145,53 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "", 404
 
         db = _get_db()
-        # Collapse the existence + freshness probe into a single
-        # ``getmtime`` so a concurrent ``Clear cache`` (or parallel
-        # regeneration) that unlinks the file between two separate
-        # syscalls can't surface as a 500 to the user. ``FileNotFoundError``
-        # here is the cache-miss signal and falls through to the regen
-        # path below; nothing else should be silently swallowed, so we
-        # bind the exception narrowly.
+        # Workspace-scoped lookup hoisted before any cache mutation. A
+        # thumbnail URL only makes sense for a photo the active
+        # workspace can actually see, and the staleness branch below
+        # may unlink the cached file — that mutation must not run for
+        # a photo outside the active workspace, otherwise an ill-aimed
+        # request from workspace B can wipe workspace A's cache as a
+        # side effect. Doing this lookup once also lets the freshness
+        # check use ``photo["file_mtime"]`` directly instead of a
+        # separate SELECT. (Without this scope,
+        # ``get_canonical_image_path`` would also receive an empty
+        # folders dict for a cross-workspace photo and fall back to
+        # ``os.path.join('', photo['filename'])`` — a CWD-relative
+        # path that could read or persist a thumbnail derived from an
+        # unrelated same-named file.)
+        photo = db.get_photo(photo_id, verify_workspace=True)
+        if not photo:
+            # Stale URL — the photo was deleted, or it lives in a folder
+            # that isn't linked to this workspace. 404 is the right
+            # answer; cache pruning is the upstream fix (PR #758). We
+            # do NOT touch the cached file here — another workspace may
+            # legitimately own it.
+            return "", 404
+
+        # Collapse existence + freshness probe into a single ``getmtime``
+        # so a concurrent ``Clear cache`` (or parallel regeneration) that
+        # unlinks the file between two separate syscalls can't surface as
+        # a 500. ``FileNotFoundError`` is the cache-miss signal; bind the
+        # exception narrowly so unrelated OSErrors still surface.
         try:
             cached_mtime = os.path.getmtime(thumb_path)
         except FileNotFoundError:
             cached_mtime = None
         if cached_mtime is not None:
-            row = db.conn.execute(
-                "SELECT file_mtime FROM photos WHERE id=?", (photo_id,),
-            ).fetchone()
-            # Treat as fresh if either the photo row is gone (the existing
-            # 404-on-deleted-photo behavior takes over below) or its
-            # ``file_mtime`` is unknown (legacy rows pre-mtime tracking
-            # — we have no signal to invalidate against, so prefer the
-            # fast path over false-positive regeneration).
+            # Treat as fresh if ``file_mtime`` is unknown (legacy rows
+            # pre-mtime tracking — we have no signal to invalidate
+            # against, so prefer the fast path over false-positive
+            # regeneration).
             fresh = (
-                not row
-                or row["file_mtime"] is None
-                or cached_mtime >= row["file_mtime"]
+                photo["file_mtime"] is None
+                or cached_mtime >= photo["file_mtime"]
             )
             if fresh:
                 return _send_cached(thumb_dir, filename)
             log.info(
                 "Thumbnail for photo %s is stale (cached mtime %.0f < "
                 "source file_mtime %.0f) — regenerating",
-                photo_id, cached_mtime, row["file_mtime"],
+                photo_id, cached_mtime, photo["file_mtime"],
             )
             # ``generate_thumbnail`` short-circuits when the destination
             # file already exists (an "already done" optimization), so a
@@ -9185,26 +9201,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             try:
                 os.remove(thumb_path)
             except OSError:
-                log.debug(
-                    "Could not unlink stale thumbnail %s before regen",
+                # If we can't unlink the stale file (Windows lock,
+                # permissions, antivirus quarantine), do NOT proceed to
+                # regen+utime: ``generate_thumbnail`` would short-circuit
+                # on the existing file and the subsequent ``os.utime``
+                # below would mark the stale image as fresh forever.
+                # Serve what's on disk this once and leave the mtime
+                # alone — next request will retry the unlink.
+                log.warning(
+                    "Could not unlink stale thumbnail %s; serving stale "
+                    "file once. Next request will retry the unlink.",
                     thumb_path, exc_info=True,
                 )
+                return _send_cached(thumb_dir, filename)
 
         # Self-heal path: regenerate on miss (or stale) when the photo
         # still exists.
-        # Workspace-scoped lookup: a thumbnail URL only makes sense for a
-        # photo the active workspace can actually see. Without this scope,
-        # ``get_canonical_image_path`` would receive an empty folders dict
-        # for a cross-workspace photo and fall back to
-        # ``os.path.join('', photo['filename'])`` — i.e. a path resolved
-        # against the server's CWD — which could read or persist a
-        # thumbnail derived from an unrelated same-named file.
-        photo = db.get_photo(photo_id, verify_workspace=True)
-        if not photo:
-            # Stale URL — the photo was deleted, or it lives in a folder
-            # that isn't linked to this workspace. 404 is the right
-            # answer; cache pruning is the upstream fix (PR #758).
-            return "", 404
 
         # Resolve source via the canonical-path helper so we prefer the
         # JPEG working copy over the original RAW. This makes the

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9233,6 +9233,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # unsupported format, etc.). Nothing else to do here.
             return "", 404
 
+        # Peg the regenerated thumbnail's mtime to the source file_mtime
+        # so the staleness invariant — ``cached_mtime >= file_mtime`` —
+        # holds on the next request. ``generate_thumbnail`` writes with
+        # the current wall clock; if ``file_mtime`` is in the future
+        # (clock skew on the source machine, archives that preserve
+        # future filesystem timestamps), the next request would compare
+        # ``time.time() < file_mtime`` and treat the just-written file
+        # as stale, triggering a regeneration loop on every fetch. The
+        # ``photo`` dict was loaded from the row above, so its
+        # ``file_mtime`` is the canonical source-of-truth value.
+        if photo["file_mtime"] is not None:
+            try:
+                os.utime(result, (photo["file_mtime"], photo["file_mtime"]))
+            except OSError:
+                # Best-effort: a touch failure is non-fatal; the worst
+                # case is the next request regenerates again. We don't
+                # 404 the user over a chmod / quota issue.
+                log.debug(
+                    "Could not align thumb mtime to source for photo %s",
+                    photo_id, exc_info=True,
+                )
+
         # Persist on-disk presence so the dashboard's coverage query
         # (`thumb_path IS NOT NULL`) reflects this regeneration. Stored
         # value is the bare filename, matching ``thumbnails.generate_all``.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6031,13 +6031,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/api/audit/remove-orphans", methods=["POST"])
     def api_audit_remove_orphans():
+        """Drop DB rows for photos whose source file is gone from disk,
+        and unlink the cached thumbnails / previews / working copies that
+        were derived from them.
+
+        Routed through ``db.delete_photos`` rather than the older
+        ``audit.remove_orphans`` so all the FK-cascading cleanup
+        (detections, predictions, collection rules, iNat submissions)
+        runs and ``_cleanup_cached_files_for_deleted_photos`` unlinks
+        the on-disk derivatives. Skipping the cache cleanup is what
+        leaves stale ``<id>.jpg`` thumbnails behind that then attach to
+        whatever new photo later inherits the freed rowid.
+        """
         db = _get_db()
         body = request.get_json(silent=True) or {}
         photo_ids = body.get("photo_ids", [])
-        from audit import remove_orphans
+        if not photo_ids:
+            return jsonify({"ok": True, "removed": 0})
 
-        remove_orphans(db, photo_ids)
-        return jsonify({"ok": True, "removed": len(photo_ids)})
+        result = db.delete_photos(photo_ids)
+        _cleanup_cached_files_for_deleted_photos(result.get("files", []))
+        return jsonify({"ok": True, "removed": result.get("deleted", 0)})
 
     @app.route("/api/audit/import-untracked", methods=["POST"])
     def api_audit_import_untracked():
@@ -9094,6 +9108,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         image when the source is recoverable — matching the project's
         "no rm -rf fixes; the app self-heals" rule.
 
+        Stale-cache guard: ``photos.id`` is INTEGER PRIMARY KEY *without*
+        AUTOINCREMENT, so SQLite reuses the highest freed rowids on the
+        next insert. Combined with delete paths that don't unlink cached
+        files (``audit.remove_orphans``, folder consolidation in
+        ``Database.consolidate_folders``, companion-pair dedup in
+        ``scanner._merge_companion_pair``), a JPEG at ``<id>.jpg`` can
+        outlive its original photo and then be served as the thumbnail
+        for an entirely different photo that later inherits that ID.
+        Compare the cached file's mtime against the photo's
+        ``file_mtime`` and treat predates-source as a miss so the regen
+        path produces a fresh JPEG. This is correctness rooted in the
+        data, independent of whether every delete site cleans up.
+
         404s remain when:
           * the filename isn't ``<int>.jpg`` (malformed request);
           * the photo no longer exists in the DB (stale cache from a
@@ -9110,10 +9137,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         thumb_dir = app.config["THUMB_CACHE_DIR"]
         thumb_path = os.path.join(thumb_dir, filename)
-        if os.path.exists(thumb_path):
-            return _send_cached(thumb_dir, filename)
 
-        # Self-heal path: regenerate on miss when the photo still exists.
         try:
             photo_id = int(filename.replace(".jpg", ""))
         except ValueError:
@@ -9121,6 +9145,43 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "", 404
 
         db = _get_db()
+        if os.path.exists(thumb_path):
+            cached_mtime = os.path.getmtime(thumb_path)
+            row = db.conn.execute(
+                "SELECT file_mtime FROM photos WHERE id=?", (photo_id,),
+            ).fetchone()
+            # Treat as fresh if either the photo row is gone (the existing
+            # 404-on-deleted-photo behavior takes over below) or its
+            # ``file_mtime`` is unknown (legacy rows pre-mtime tracking
+            # — we have no signal to invalidate against, so prefer the
+            # fast path over false-positive regeneration).
+            fresh = (
+                not row
+                or row["file_mtime"] is None
+                or cached_mtime >= row["file_mtime"]
+            )
+            if fresh:
+                return _send_cached(thumb_dir, filename)
+            log.info(
+                "Thumbnail for photo %s is stale (cached mtime %.0f < "
+                "source file_mtime %.0f) — regenerating",
+                photo_id, cached_mtime, row["file_mtime"],
+            )
+            # ``generate_thumbnail`` short-circuits when the destination
+            # file already exists (an "already done" optimization), so a
+            # stale copy left in place would defeat the regen path. Unlink
+            # before falling through; the regen will write a fresh JPEG
+            # at the same path.
+            try:
+                os.remove(thumb_path)
+            except OSError:
+                log.debug(
+                    "Could not unlink stale thumbnail %s before regen",
+                    thumb_path, exc_info=True,
+                )
+
+        # Self-heal path: regenerate on miss (or stale) when the photo
+        # still exists.
         # Workspace-scoped lookup: a thumbnail URL only makes sense for a
         # photo the active workspace can actually see. Without this scope,
         # ``get_canonical_image_path`` would receive an empty folders dict

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9145,8 +9145,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "", 404
 
         db = _get_db()
-        if os.path.exists(thumb_path):
+        # Collapse the existence + freshness probe into a single
+        # ``getmtime`` so a concurrent ``Clear cache`` (or parallel
+        # regeneration) that unlinks the file between two separate
+        # syscalls can't surface as a 500 to the user. ``FileNotFoundError``
+        # here is the cache-miss signal and falls through to the regen
+        # path below; nothing else should be silently swallowed, so we
+        # bind the exception narrowly.
+        try:
             cached_mtime = os.path.getmtime(thumb_path)
+        except FileNotFoundError:
+            cached_mtime = None
+        if cached_mtime is not None:
             row = db.conn.execute(
                 "SELECT file_mtime FROM photos WHERE id=?", (photo_id,),
             ).fetchone()

--- a/vireo/tests/test_audit.py
+++ b/vireo/tests/test_audit.py
@@ -97,3 +97,74 @@ def test_remove_orphans(tmp_path):
 
     photo = db.get_photo(pid)
     assert photo is None
+
+
+def test_remove_orphans_endpoint_unlinks_cached_thumbnail(
+    tmp_path, monkeypatch,
+):
+    """The /api/audit/remove-orphans endpoint must remove cached
+    thumbnails for the photos it drops. Without this cleanup, the
+    next photo to inherit the same SQLite rowid (``photos.id`` is
+    INTEGER PRIMARY KEY without AUTOINCREMENT, so deleted IDs at the
+    high end are reused on the next insert) would inherit the orphaned
+    JPEG and the user would see the wrong photo on the encounter
+    grid.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    import models
+    from app import create_app
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(
+        models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"),
+    )
+    monkeypatch.setattr(
+        models, "CONFIG_PATH", str(tmp_path / "models.json"),
+    )
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir()
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder("/gone", name="gone")
+    pid = db.add_photo(
+        folder_id=fid, filename="missing.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    # Stage the cached thumbnail that will become orphaned by the
+    # remove-orphans call. This mirrors a real-world state where the
+    # source file vanished from disk but the cached JPEG persists.
+    thumb_file = thumb_dir / f"{pid}.jpg"
+    Image.new("RGB", (50, 50), (1, 2, 3)).save(str(thumb_file), "JPEG")
+    assert thumb_file.exists(), "precondition: cached thumb staged"
+
+    app = create_app(
+        db_path=db_path, thumb_cache_dir=str(thumb_dir),
+        api_token="test-token-123",
+    )
+    client = app.test_client()
+    resp = client.post(
+        "/api/audit/remove-orphans",
+        json={"photo_ids": [pid]},
+    )
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["removed"] == 1
+
+    # The DB row is gone …
+    assert db.get_photo(pid) is None
+    # … and so is the cached thumbnail. A future photo that inherits
+    # this ID will get a fresh thumbnail from its own source.
+    assert not thumb_file.exists(), (
+        "remove-orphans left a cached thumbnail behind; the next photo "
+        "to inherit this rowid will be served the orphaned JPEG"
+    )

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -507,6 +507,56 @@ def test_serve_thumbnail_regenerates_when_cached_predates_source(
     assert os.path.getmtime(thumb_file) >= photo_mtime
 
 
+def test_serve_thumbnail_handles_race_between_exists_and_getmtime(
+    tmp_path, monkeypatch,
+):
+    """The cache-hit path checks ``os.path.exists`` then calls
+    ``os.path.getmtime`` separately. If the cached file vanishes between
+    those two syscalls — concurrent ``Clear cache`` from Settings, a
+    parallel regeneration that unlinked the stale file, an external
+    cleanup process — ``getmtime`` raises ``FileNotFoundError``. The
+    route must catch that and treat the request as a cache miss, not
+    propagate to Flask's global handler as a 500.
+
+    Simulated by monkeypatching ``os.path.getmtime`` to raise unconditionally
+    once. The route must respond 200 (regenerated) — and never 500 —
+    proving the race is handled.
+    """
+    import app as app_module
+
+    app, _db, pid, thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+
+    # Stage a cached file so the ``os.path.exists`` branch is taken,
+    # but make ``getmtime`` raise as if the file disappeared between
+    # the two syscalls. Patching the symbol the route uses
+    # (``app_module.os.path.getmtime``) reaches inside the request
+    # thread without affecting test infrastructure.
+    thumb_file = os.path.join(thumb_dir, f"{pid}.jpg")
+    Image.new("RGB", (50, 50), (1, 2, 3)).save(thumb_file, "JPEG", quality=70)
+
+    real_getmtime = app_module.os.path.getmtime
+    raised = {"count": 0}
+
+    def racing_getmtime(path):
+        if path == thumb_file and raised["count"] == 0:
+            raised["count"] += 1
+            raise FileNotFoundError(2, "File not found", path)
+        return real_getmtime(path)
+
+    monkeypatch.setattr(app_module.os.path, "getmtime", racing_getmtime)
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 200, (
+        f"race between exists() and getmtime() leaked a {resp.status_code} "
+        f"to the user; the route should treat the missing file as a cache "
+        f"miss and self-heal"
+    )
+    assert resp.data[:2] == b"\xff\xd8", "response body is not a JPEG"
+    assert raised["count"] == 1, "test setup did not exercise the race"
+
+
 def test_serve_thumbnail_does_not_loop_on_future_dated_source(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -751,6 +751,107 @@ def test_serve_thumbnail_resolves_when_folder_status_is_missing(tmp_path, monkey
     assert os.path.exists(os.path.join(thumb_dir, f"{pid}.jpg"))
 
 
+def test_serve_thumbnail_does_not_unlink_cross_workspace_cache(
+    tmp_path, monkeypatch,
+):
+    """The stale-cache guard fires before any workspace check, so a
+    request for a photo outside the active workspace can still drive
+    the unlink-and-regen branch — destroying another workspace's
+    cached thumbnail as a side effect, even though the request
+    ultimately 404s. The fix is to validate workspace access before
+    mutating the cache: stale-detection is fine, but the on-disk
+    unlink must not happen until we know the active workspace owns
+    the photo. Otherwise a single ill-aimed grid scroll on
+    workspace B could wipe workspace A's thumbnails.
+    """
+    app, db, pid, thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+
+    # Stage a stale cached file for the photo so the staleness guard
+    # would normally fire (cached_mtime older than file_mtime).
+    thumb_file = os.path.join(thumb_dir, f"{pid}.jpg")
+    Image.new("RGB", (50, 50), (1, 2, 3)).save(thumb_file, "JPEG", quality=70)
+    photo_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    stale_mtime = photo_mtime - 86400
+    os.utime(thumb_file, (stale_mtime, stale_mtime))
+
+    # Switch to a workspace that doesn't have the photo's folder linked.
+    other_ws = db.create_workspace("Other")
+    db.update_workspace(other_ws, last_opened_at="2030-01-01T00:00:00Z")
+    db.set_active_workspace(other_ws)
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+    assert resp.status_code == 404
+    # The other workspace's cached thumbnail must survive the request.
+    assert os.path.exists(thumb_file), (
+        "cross-workspace request unlinked another workspace's cached "
+        "thumbnail; the staleness guard must not mutate cache files "
+        "for photos the active workspace cannot see"
+    )
+
+
+def test_serve_thumbnail_does_not_pin_stale_when_unlink_fails(
+    tmp_path, monkeypatch,
+):
+    """If ``os.remove`` fails on the stale file (Windows file lock,
+    permissions, antivirus quarantine), ``generate_thumbnail`` short-
+    circuits because its destination still exists, so the stale JPEG
+    is never re-encoded. Aligning the file's mtime to the source's
+    ``file_mtime`` afterward would mark the stale image as fresh
+    forever — pinning the wrong image until manual cache clear.
+
+    The route must detect this and either skip the mtime alignment
+    (so the next request retries) or refuse to call ``generate_thumbnail``
+    when the stale file is still on disk. Either way: a request that
+    cannot rewrite the file must NOT advance its mtime.
+    """
+    import app as app_module
+
+    app, db, pid, thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+
+    # Stage a stale cached file. Give it sentinel bytes so we can
+    # confirm the stale content is still on disk afterward.
+    thumb_file = os.path.join(thumb_dir, f"{pid}.jpg")
+    Image.new("RGB", (50, 50), (1, 2, 3)).save(thumb_file, "JPEG", quality=70)
+    sentinel_bytes = open(thumb_file, "rb").read()
+    photo_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    stale_mtime = photo_mtime - 86400
+    os.utime(thumb_file, (stale_mtime, stale_mtime))
+
+    # Make ``os.remove`` fail when called on this thumbnail — simulating
+    # a file lock or permission denial. Other unlink calls in the test
+    # process must keep working.
+    real_remove = app_module.os.remove
+
+    def failing_remove(path, *args, **kwargs):
+        if path == thumb_file:
+            raise PermissionError(13, "Permission denied", path)
+        return real_remove(path, *args, **kwargs)
+
+    monkeypatch.setattr(app_module.os, "remove", failing_remove)
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+    assert resp.status_code == 200
+
+    # The on-disk file must still be the stale sentinel — generate_thumbnail
+    # short-circuited because os.remove couldn't drop the file.
+    assert open(thumb_file, "rb").read() == sentinel_bytes
+    # And critically, its mtime must NOT have been advanced to the
+    # source's file_mtime — that would falsely mark it fresh and pin
+    # the wrong image indefinitely. Allow equality with the original
+    # stale_mtime; the route is permitted to leave it untouched.
+    assert os.path.getmtime(thumb_file) < photo_mtime, (
+        "stale thumbnail was pinned as fresh after a failed unlink; "
+        "next request will not retry the regen and the wrong image "
+        "stays cached forever"
+    )
+
+
 def test_serve_thumbnail_404s_for_photo_outside_active_workspace(tmp_path, monkeypatch):
     """The route must 404 when the photo exists in the DB but its folder
     isn't linked to the active workspace. Without workspace scoping,

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -459,6 +459,82 @@ def test_serve_thumbnail_404s_for_deleted_photo(tmp_path, monkeypatch):
     assert resp.status_code == 404
 
 
+def test_serve_thumbnail_regenerates_when_cached_predates_source(
+    tmp_path, monkeypatch,
+):
+    """Reused photo IDs leave behind cached thumbnails belonging to the
+    previous tenant of that ID. ``photos.id`` is INTEGER PRIMARY KEY
+    *without* AUTOINCREMENT, so SQLite reuses the highest freed rowids
+    on the next insert. Combined with delete paths that don't clean up
+    the on-disk cache (``audit.remove_orphans``, folder consolidation,
+    companion-pair dedup in the scanner), a thumbnail at ``<id>.jpg``
+    can persist after its original photo is gone, and a *different*
+    photo later inserted at the same ID gets the stale image served on
+    every grid scroll. The route must compare the cached thumbnail's
+    mtime against the photo's ``file_mtime`` and regenerate when the
+    cache predates the source — anchoring correctness in the data
+    rather than depending on every delete site to clean up.
+    """
+    app, db, pid, thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+
+    # Pre-populate a sentinel thumbnail (the "stale" tenant). Backdate it
+    # so its mtime is older than the photo's file_mtime — this is the
+    # condition the route must detect.
+    thumb_file = os.path.join(thumb_dir, f"{pid}.jpg")
+    Image.new("RGB", (50, 50), (1, 2, 3)).save(thumb_file, "JPEG", quality=70)
+    sentinel_size = os.path.getsize(thumb_file)
+    photo_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    stale_mtime = photo_mtime - 86400  # one day older than the source
+    os.utime(thumb_file, (stale_mtime, stale_mtime))
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 200
+    assert resp.data[:2] == b"\xff\xd8", "response body is not a JPEG"
+    # The stale sentinel was 50x50 at quality 70; a regenerated thumbnail
+    # of the 800x600 source at quality 85 produces a different file size.
+    # Comparing sizes is enough to prove the file was rewritten — we
+    # don't need to round-trip through PIL.
+    assert os.path.getsize(thumb_file) != sentinel_size, (
+        "stale thumbnail was served unchanged; the route did not "
+        "detect that the cached file predates the source"
+    )
+    # And the regenerated thumb's mtime is now >= file_mtime, so a
+    # subsequent request hits the fast path.
+    assert os.path.getmtime(thumb_file) >= photo_mtime
+
+
+def test_serve_thumbnail_serves_cached_when_thumb_newer_than_source(
+    tmp_path, monkeypatch,
+):
+    """The stale-cache guard must not regress the common case: a thumbnail
+    generated *after* its source file was last modified is fresh and
+    must be served without re-decoding. Otherwise every grid scroll
+    burns CPU on a thumbnail re-render."""
+    app, db, pid, thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+
+    thumb_file = os.path.join(thumb_dir, f"{pid}.jpg")
+    Image.new("RGB", (50, 50), (1, 2, 3)).save(thumb_file, "JPEG", quality=70)
+    sentinel_size = os.path.getsize(thumb_file)
+    photo_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    fresh_mtime = photo_mtime + 60  # generated after the source was written
+    os.utime(thumb_file, (fresh_mtime, fresh_mtime))
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 200
+    assert os.path.getsize(thumb_file) == sentinel_size, (
+        "fresh cached thumbnail was rewritten — the stale-cache guard "
+        "is firing on cache hits where it shouldn't"
+    )
+
+
 def test_serve_thumbnail_404s_for_non_numeric_filename(tmp_path, monkeypatch):
     """Garbage URLs (e.g. /thumbnails/foo.jpg) must 404 cleanly without
     raising — defends the route against arbitrary path probes."""

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -507,6 +507,53 @@ def test_serve_thumbnail_regenerates_when_cached_predates_source(
     assert os.path.getmtime(thumb_file) >= photo_mtime
 
 
+def test_serve_thumbnail_does_not_loop_on_future_dated_source(
+    tmp_path, monkeypatch,
+):
+    """``photos.file_mtime`` can legitimately be in the future — files
+    copied from a machine with clock skew, archives that preserve
+    future filesystem timestamps, NEFs whose embedded metadata reflects
+    a different timezone. A naive ``cached_mtime < file_mtime`` check
+    treats every request as stale because the regenerated thumbnail's
+    own mtime defaults to ``time.time()``, which is still less than the
+    stored future ``file_mtime``. The route must break the loop after
+    regeneration so a subsequent request hits the fast path instead of
+    re-decoding the source on every grid scroll.
+    """
+    import time as _time
+
+    app, db, pid, thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+    # Set the photo's file_mtime to one day in the future, simulating
+    # the clock-skew / preserved-future-timestamp case.
+    future_mtime = _time.time() + 86400
+    db.conn.execute(
+        "UPDATE photos SET file_mtime=? WHERE id=?", (future_mtime, pid),
+    )
+    db.conn.commit()
+
+    thumb_file = os.path.join(thumb_dir, f"{pid}.jpg")
+    assert not os.path.exists(thumb_file), "precondition: cache miss"
+
+    client = app.test_client()
+    # First request triggers regeneration (cache miss → self-heal path).
+    resp1 = client.get(f"/thumbnails/{pid}.jpg")
+    assert resp1.status_code == 200
+    assert os.path.exists(thumb_file)
+    after_first = os.path.getmtime(thumb_file)
+
+    # Second request must NOT regenerate. If the freshness check still
+    # fires for future-dated sources, the route would unlink the file
+    # and re-encode the source, bumping the mtime to a new ``now``.
+    resp2 = client.get(f"/thumbnails/{pid}.jpg")
+    assert resp2.status_code == 200
+    after_second = os.path.getmtime(thumb_file)
+    assert after_second == after_first, (
+        "thumbnail regenerated a second time despite being just-written; "
+        "future-dated photos.file_mtime causes an infinite regeneration "
+        "loop on every request"
+    )
+
+
 def test_serve_thumbnail_serves_cached_when_thumb_newer_than_source(
     tmp_path, monkeypatch,
 ):


### PR DESCRIPTION
## Summary

- Fixes the bug where the encounter grid shows the *previous* tenant's image for a photo whose ID was reused after delete (e.g., May2026 import inherited rowids 41014–41044 from a deleted Apr 28 batch, so 31 photos showed willet/etc. thumbnails while the lightbox correctly opened to the actual May 1 photo).
- `serve_thumbnail` now compares the cached file's mtime against `photos.file_mtime` and regenerates when the cache predates the source — anchoring correctness in the data, independent of whether every delete site cleans up.
- `/api/audit/remove-orphans` now routes through `db.delete_photos` + `_cleanup_cached_files_for_deleted_photos` (instead of the older `audit.remove_orphans`) so the cached thumbnails / previews / working copies don't leak when orphans are pruned. Also picks up the FK-cascading cleanup (detections, predictions, collection rules, iNat submissions) that the older path skipped.

## Why two layers

Defense in depth. `photos.id` is `INTEGER PRIMARY KEY` *without* `AUTOINCREMENT`, so SQLite reuses freed rowids — and there are still other delete paths that bypass the cache cleanup (folder consolidation in `Database.consolidate_folders`, companion-pair dedup in `scanner._merge_companion_pair`). The mtime guard makes stale cache hits structurally impossible regardless of how the row got deleted. The orphan-cleanup fix is hygiene to stop creating new leaks.

## Test plan

- [x] `vireo/tests/test_thumbnails.py` — added `test_serve_thumbnail_regenerates_when_cached_predates_source` (RED → GREEN) and `test_serve_thumbnail_serves_cached_when_thumb_newer_than_source` (regression guard).
- [x] `vireo/tests/test_audit.py` — added `test_remove_orphans_endpoint_unlinks_cached_thumbnail`.
- [x] Full project test suite passes (test_workspaces, test_db, test_app, test_photos_api, test_edits_api, test_jobs_api, test_darktable_api, test_config, test_audit, test_thumbnails, test_delete_api).

🤖 Generated with [Claude Code](https://claude.com/claude-code)