### PR TITLE
tauri: flip running app to browser mode without restart

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -169,25 +169,18 @@ pub fn run() {
 
             // "Open in Browser" — flip from the WKWebView to the user's
             // default browser at runtime. Does not persist; it's a one-shot
-            // flip for this session.
+            // flip for this session. Routes through tray::open_ui_in_browser
+            // so the runtime mode flag flips and later menu/tray actions
+            // also route to the browser.
             if id == menu::ids::OPEN_IN_BROWSER {
-                let port = app.state::<SidecarState>().port;
-                let url = format!("http://127.0.0.1:{}", port);
-                open_in_browser(app, &url);
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.hide();
-                }
+                tray::open_ui_in_browser(app);
                 return;
             }
 
             // Navigation items — evaluate JS in the main webview, or in
             // browser mode open the route in the user's default browser.
             if let Some(route) = menu::route_for_id(id) {
-                let browser_mode = app
-                    .try_state::<tray::TrayMode>()
-                    .map(|m| m.browser_mode)
-                    .unwrap_or(false);
-                if browser_mode {
+                if tray::is_browser_mode(app) {
                     let port = app.state::<SidecarState>().port;
                     let url = format!("http://127.0.0.1:{}{}", port, route);
                     open_in_browser(app, &url);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -167,6 +167,19 @@ pub fn run() {
                 return;
             }
 
+            // "Open in Browser" — flip from the WKWebView to the user's
+            // default browser at runtime. Does not persist; it's a one-shot
+            // flip for this session.
+            if id == menu::ids::OPEN_IN_BROWSER {
+                let port = app.state::<SidecarState>().port;
+                let url = format!("http://127.0.0.1:{}", port);
+                open_in_browser(app, &url);
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.hide();
+                }
+                return;
+            }
+
             // Navigation items — evaluate JS in the main webview, or in
             // browser mode open the route in the user's default browser.
             if let Some(route) = menu::route_for_id(id) {

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -21,6 +21,7 @@ pub mod ids {
     pub const NAV_LOGS: &str = "nav_logs";
     pub const REPORT_ISSUE: &str = "report_issue";
     pub const CHECK_FOR_UPDATES: &str = "check_for_updates";
+    pub const OPEN_IN_BROWSER: &str = "open_in_browser_now";
 }
 
 /// Map a menu item ID to its Flask route path.
@@ -178,6 +179,12 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
                 .build(app)?,
         );
     }
+
+    view_builder = view_builder.separator().item(
+        &MenuItemBuilder::with_id(ids::OPEN_IN_BROWSER, "Open in Browser")
+            .accelerator("CmdOrCtrl+Shift+B")
+            .build(app)?,
+    );
 
     let view_menu = view_builder.build()?;
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -178,20 +178,27 @@ fn hide_main_window(app: &AppHandle) {
 /// "flip to browser" for the rest of the session — most browsers focus an
 /// existing tab on the same origin rather than opening a duplicate.
 pub fn open_ui_in_browser(app: &AppHandle) {
-    let (port, was_window_mode) = match app.try_state::<TrayMode>() {
-        Some(mode) => (
-            mode.port,
-            !mode.browser_mode.swap(true, Ordering::Relaxed),
-        ),
+    let port = match app.try_state::<TrayMode>() {
+        Some(mode) => mode.port,
         None => {
             log::error!("TrayMode not initialised; cannot open browser");
             return;
         }
     };
     let url = format!("http://127.0.0.1:{}", port);
+    // Try the browser launch first. If it fails (no default browser,
+    // opener plugin permission denied, etc.) we leave the window-mode
+    // UI alone — flipping the flag and hiding the window before
+    // confirming a successful launch would lock the user out of the
+    // in-app UI on the failure path.
     if let Err(e) = app.opener().open_url(&url, None::<&str>) {
         log::error!("Failed to open browser at {}: {}", url, e);
+        return;
     }
+    let was_window_mode = match app.try_state::<TrayMode>() {
+        Some(mode) => !mode.browser_mode.swap(true, Ordering::Relaxed),
+        None => false,
+    };
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.hide();
     }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tauri::{
     AppHandle, Manager,
@@ -26,13 +26,19 @@ pub struct TrayPollState {
     pub stop: Arc<AtomicBool>,
 }
 
-/// Whether the app launched in browser mode. Stored in Tauri state so the
-/// menu-event handler (which only gets an `AppHandle`) can branch correctly
-/// without re-reading the config file.
+/// Whether the app is currently running in browser mode. Stored in Tauri
+/// state so the menu-event handler (which only gets an `AppHandle`) can
+/// branch correctly without re-reading the config file.
+///
+/// Mutable because the user can flip from window mode to browser mode at
+/// runtime via View → Open in Browser; we don't currently flip the other way.
 pub struct TrayMode {
-    pub browser_mode: bool,
+    pub browser_mode: AtomicBool,
     /// Sidecar port — used to construct the URL we hand to the browser.
     pub port: u16,
+    /// Latest job-status text shown in the tray menu, kept here so we can
+    /// rebuild the menu on a runtime mode flip without losing the label.
+    pub job_status: Mutex<String>,
 }
 
 /// Menu item IDs
@@ -48,9 +54,14 @@ const QUIT: &str = "quit";
 /// "Open in browser" item, since the WKWebView window is intentionally
 /// hidden in that mode and showing it would be confusing.
 pub fn create_tray(app: &AppHandle, port: u16, browser_mode: bool) -> tauri::Result<()> {
-    app.manage(TrayMode { browser_mode, port });
+    let initial_status = "No active jobs";
+    app.manage(TrayMode {
+        browser_mode: AtomicBool::new(browser_mode),
+        port,
+        job_status: Mutex::new(initial_status.to_string()),
+    });
 
-    let menu = build_menu(app, "No active jobs", browser_mode)?;
+    let menu = build_menu(app, initial_status, browser_mode)?;
 
     TrayIconBuilder::with_id("main-tray")
         .icon(app.default_window_icon().unwrap().clone())
@@ -157,18 +168,21 @@ fn hide_main_window(app: &AppHandle) {
     }
 }
 
-/// Open (or re-open) the UI in the user's default browser, and hide the
-/// app window if it's currently shown.
+/// Open (or re-open) the UI in the user's default browser, hide the app
+/// window if shown, and flip the runtime `browser_mode` flag on so all
+/// later menu navigation and tray clicks route to the browser too.
 ///
 /// In browser mode this is what the tray's left-click and "Open in browser"
-/// menu item do (the window is already hidden, so the hide call is a no-op).
-/// In window mode it doubles as a runtime "flip to browser" — the user gets
-/// the UI in their browser and the WKWebView window goes away so they aren't
-/// looking at two copies. Most browsers focus an existing tab on the same
-/// origin rather than opening a duplicate.
-fn open_ui_in_browser(app: &AppHandle) {
-    let port = match app.try_state::<TrayMode>() {
-        Some(mode) => mode.port,
+/// menu item do (the window is already hidden and the flag already true,
+/// so this is idempotent). In window mode it acts as a one-shot runtime
+/// "flip to browser" for the rest of the session — most browsers focus an
+/// existing tab on the same origin rather than opening a duplicate.
+pub fn open_ui_in_browser(app: &AppHandle) {
+    let (port, was_window_mode) = match app.try_state::<TrayMode>() {
+        Some(mode) => (
+            mode.port,
+            !mode.browser_mode.swap(true, Ordering::Relaxed),
+        ),
         None => {
             log::error!("TrayMode not initialised; cannot open browser");
             return;
@@ -181,20 +195,32 @@ fn open_ui_in_browser(app: &AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.hide();
     }
+    // First time we flip from window → browser, rebuild the tray menu so
+    // the Show/Hide Window items are replaced by the browser-mode layout.
+    if was_window_mode {
+        let status = app
+            .try_state::<TrayMode>()
+            .and_then(|m| m.job_status.lock().ok().map(|s| s.clone()))
+            .unwrap_or_else(|| "No active jobs".to_string());
+        update_tray_menu(app, &status);
+    }
 }
 
 /// Activate the UI: show the main window, or open the browser, depending
-/// on which launch mode we're in.
+/// on which mode we're currently in.
 fn activate_ui(app: &AppHandle) {
-    let browser_mode = app
-        .try_state::<TrayMode>()
-        .map(|m| m.browser_mode)
-        .unwrap_or(false);
-    if browser_mode {
+    if is_browser_mode(app) {
         open_ui_in_browser(app);
     } else {
         show_main_window(app);
     }
+}
+
+/// Read the current runtime mode.
+pub fn is_browser_mode(app: &AppHandle) -> bool {
+    app.try_state::<TrayMode>()
+        .map(|m| m.browser_mode.load(Ordering::Relaxed))
+        .unwrap_or(false)
 }
 
 /// Query the Flask backend for running jobs.
@@ -223,10 +249,12 @@ fn fetch_running_job_count(port: u16) -> usize {
 
 /// Rebuild the tray menu with updated job status text.
 fn update_tray_menu(app: &AppHandle, job_status: &str) {
-    let browser_mode = app
-        .try_state::<TrayMode>()
-        .map(|m| m.browser_mode)
-        .unwrap_or(false);
+    let browser_mode = is_browser_mode(app);
+    if let Some(mode) = app.try_state::<TrayMode>() {
+        if let Ok(mut s) = mode.job_status.lock() {
+            *s = job_status.to_string();
+        }
+    }
     if let Some(tray) = app.tray_by_id("main-tray") {
         match build_menu(app, job_status, browser_mode) {
             Ok(menu) => {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -109,7 +109,14 @@ pub fn build_menu(
     } else {
         let show = MenuItem::with_id(app, SHOW_WINDOW, "Show Window", true, None::<&str>)?;
         let hide = MenuItem::with_id(app, HIDE_WINDOW, "Hide Window", true, None::<&str>)?;
-        Menu::with_items(app, &[&show, &hide, &sep1, &jobs, &sep2, &quit])
+        let open = MenuItem::with_id(
+            app,
+            OPEN_IN_BROWSER,
+            "Open in Browser",
+            true,
+            None::<&str>,
+        )?;
+        Menu::with_items(app, &[&show, &hide, &open, &sep1, &jobs, &sep2, &quit])
     }
 }
 
@@ -150,12 +157,15 @@ fn hide_main_window(app: &AppHandle) {
     }
 }
 
-/// Open (or re-open) the UI in the user's default browser.
+/// Open (or re-open) the UI in the user's default browser, and hide the
+/// app window if it's currently shown.
 ///
 /// In browser mode this is what the tray's left-click and "Open in browser"
-/// menu item do. Most browsers will focus an existing tab pointed at the
-/// same origin rather than opening a duplicate; if not, the user gets a
-/// fresh tab — either way they end up looking at the UI.
+/// menu item do (the window is already hidden, so the hide call is a no-op).
+/// In window mode it doubles as a runtime "flip to browser" — the user gets
+/// the UI in their browser and the WKWebView window goes away so they aren't
+/// looking at two copies. Most browsers focus an existing tab on the same
+/// origin rather than opening a duplicate.
 fn open_ui_in_browser(app: &AppHandle) {
     let port = match app.try_state::<TrayMode>() {
         Some(mode) => mode.port,
@@ -167,6 +177,9 @@ fn open_ui_in_browser(app: &AppHandle) {
     let url = format!("http://127.0.0.1:{}", port);
     if let Err(e) = app.opener().open_url(&url, None::<&str>) {
         log::error!("Failed to open browser at {}: {}", url, e);
+    }
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.hide();
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds **View → Open in Browser** (Cmd+Shift+B) and a tray-menu **Open in Browser** entry that work in window mode.
- Both open the live sidecar URL in the default browser and hide the WKWebView window — no restart, no port hunting.
- Reads the active port from `SidecarState`, so it works regardless of which ephemeral port the sidecar bound to. One-shot for the session; the persistent **Settings → Open in default browser on launch** preference is unchanged.

## Test plan
- [x] `cargo check` clean
- [x] Python suite (run with `--timeout=30`): 912 passed, 1 skipped
- [ ] Manually verify View → Open in Browser opens the correct port and hides the window
- [ ] Manually verify tray "Open in Browser" does the same in window mode
- [ ] Confirm Cmd+Shift+B accelerator fires