### PR TITLE
pipeline review: show cut thresholds in trace panel

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -430,6 +430,10 @@ input[type="range"]::-moz-range-thumb {
 .algo-trace .trace-empty {
   font-size: 11px; color: var(--text-dim); font-style: italic; padding: 4px;
 }
+.algo-trace .trace-thresholds {
+  font-size: 10px; color: var(--text-dim);
+  padding: 2px 4px 6px; border-bottom: 1px solid var(--border-primary);
+}
 .encounter-card.focused {
   /* Inset shadow instead of widening border-left from 1px → 3px:
      keeps the 1px border on all sides so the content position and
@@ -1458,6 +1462,16 @@ function renderAlgorithmTrace() {
     label.textContent = 'Encounter ' + (_focusedEncounterIdx + 1) + ' — ' + enc.trace.length + ' adjacent pair' + (enc.trace.length > 1 ? 's' : '');
   }
   var html = '';
+  var thr = enc.trace[0] && enc.trace[0].thresholds;
+  if (thr) {
+    var thrParts = [];
+    if (typeof thr.hard_cut_score === 'number') thrParts.push('hard_cut_score=' + thr.hard_cut_score.toFixed(2));
+    if (typeof thr.soft_cut_score === 'number') thrParts.push('soft_cut_score=' + thr.soft_cut_score.toFixed(2));
+    if (typeof thr.hard_cut_time === 'number') thrParts.push('hard_cut_time=' + thr.hard_cut_time + 's');
+    if (thrParts.length) {
+      html += '<div class="trace-thresholds">cut if: ' + thrParts.join(' · ') + '</div>';
+    }
+  }
   enc.trace.forEach(function(t, i) {
     var rowCls = 'trace-row';
     if (t.decision && t.decision.indexOf('cut_') === 0) rowCls += ' cut';


### PR DESCRIPTION
## Summary

The algorithm-trace panel on the pipeline-review page shows each adjacent-pair's score (e.g. `S=0.876`) and the resulting decision (`kept` / `cut_time` / `cut_score` / `cut_soft` / `merged_back`) but never displayed the thresholds those decisions were compared against. Reading a row required leaving the page and grepping `vireo/encounters.py` to find the cut values.

This adds a one-line caption at the top of each focused encounter's trace:

```
cut if: hard_cut_score=0.42 · soft_cut_score=0.52 · hard_cut_time=180s
```

The thresholds are pulled from `enc.trace[0].thresholds` — already on the trace payload (see `cut_microsegments` at `vireo/encounters.py:322-326`), so no backend change. Reflects the actual config used for the run, not the defaults.

Rendered once per encounter (DRY — the values are constant across pairs in a single run).

## Test plan

- [x] `python -m pytest vireo/tests/test_encounters.py -q` — 42 passed (data shape unchanged)
- [x] Headless Playwright smoke test on a fresh-HOME instance: load `/pipeline/review`, inject a stub encounter with two trace rows (`kept` + `cut_time`), assert the caption div appears before the first row and that all three threshold values are present in the rendered text
- [x] Visual check via screenshot — caption sits above the rows in dim text matching the existing `.trace-components` style; row colors (neutral kept / pink cut) unchanged