### PR TITLE
Bursts: drop pHash from cut decision, keep time + DINOv2 only

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10686,8 +10686,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not isinstance(new_pipeline, dict):
             return json_error("pipeline must be an object")
         # (kind, min, max). kind="unit" → 0..1 float; "score" → 0..1 float;
-        # "seconds" → non-negative float; "phash" → 0..256 int (8x8 phash =
-        # 64 bits, 256 leaves headroom for future hash sizes).
+        # "seconds" → non-negative float.
         schema = {
             "w_time": ("unit", 0.0, 1.0),
             "w_subj": ("unit", 0.0, 1.0),
@@ -10706,7 +10705,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "merge_max_gap": ("seconds", 0.0, 86400.0),
             "merge_tau": ("seconds", 1.0, 86400.0),
             "burst_time_gap": ("seconds", 0.0, 86400.0),
-            "burst_phash_threshold": ("phash", 0, 256),
             "burst_embedding_threshold": ("score", 0.0, 1.0),
         }
         rejected = [k for k in new_pipeline if k not in schema]
@@ -10719,16 +10717,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # bool is an int subclass — reject explicitly so True/False
                 # don't silently succeed for numeric keys.
                 return json_error(f"{k} must be a number, got bool")
-            if kind == "phash":
-                if not isinstance(raw_v, int):
-                    return json_error(f"{k} must be an integer")
-                v = raw_v
-            else:
-                if not isinstance(raw_v, (int, float)):
-                    return json_error(f"{k} must be a number")
-                v = float(raw_v)
-                if v != v or v in (float("inf"), float("-inf")):
-                    return json_error(f"{k} must be finite")
+            if not isinstance(raw_v, (int, float)):
+                return json_error(f"{k} must be a number")
+            v = float(raw_v)
+            if v != v or v in (float("inf"), float("-inf")):
+                return json_error(f"{k} must be finite")
             if v < lo or v > hi:
                 return json_error(f"{k} out of range [{lo}, {hi}]")
             coerced[k] = v

--- a/vireo/bursts.py
+++ b/vireo/bursts.py
@@ -1,8 +1,8 @@
 """Burst clustering within encounters for the culling pipeline (Stage 3).
 
 Groups near-duplicates and small pose variants into tight bursts within each
-encounter. Uses sequential cuts on time gap, crop pHash hamming distance,
-and DINOv2 crop embedding cosine similarity.
+encounter. Cuts a new burst between adjacent photos when the time gap is
+large or the DINOv2 crop embedding cosine similarity drops.
 
 All thresholds are configurable with defaults from the pipeline design doc.
 """
@@ -16,7 +16,6 @@ log = logging.getLogger(__name__)
 # Default thresholds (from design doc, subject to calibration)
 DEFAULTS = {
     "burst_time_gap": 3.0,  # seconds — cut if delta_t exceeds this
-    "burst_phash_threshold": 12,  # hamming distance — cut if exceeds this
     "burst_embedding_threshold": 0.80,  # cosine similarity — cut if below this
 }
 
@@ -32,7 +31,7 @@ def _cosine_sim(a, b):
         # Stale DINOv2 embeddings from a previous variant can reach here on
         # datasets that straddle a variant switch. Treat as "no embedding
         # signal" — same as the None branch — so the burst-cut decision
-        # falls back to time + phash instead of raising.
+        # falls back to the time gap instead of raising.
         global _warned_dim_mismatch
         if not _warned_dim_mismatch:
             log.warning(
@@ -47,22 +46,6 @@ def _cosine_sim(a, b):
     if norm_a == 0 or norm_b == 0:
         return 1.0
     return max(0.0, float(np.dot(a, b) / (norm_a * norm_b)))
-
-
-def _hamming_distance(phash_a, phash_b):
-    """Hamming distance between two hex-encoded pHash strings.
-
-    Returns:
-        int — number of differing bits, or -1 if either is None
-    """
-    if phash_a is None or phash_b is None:
-        return -1  # no hash → don't cut on this criterion
-    try:
-        int_a = int(phash_a, 16)
-        int_b = int(phash_b, 16)
-        return bin(int_a ^ int_b).count("1")
-    except (ValueError, TypeError):
-        return -1
 
 
 def _parse_timestamp(ts):
@@ -90,15 +73,13 @@ def detect_bursts(photos, config=None):
     """Detect burst boundaries within an encounter.
 
     Walk through photos in timestamp order. Cut a new burst between
-    adjacent photos (i, i+1) if ANY of these fire:
+    adjacent photos (i, i+1) if either of these fire:
       - delta_t > burst_time_gap
-      - Hamming(phash_crop_i, phash_crop_j) > burst_phash_threshold
       - cosine(dino_subject_i, dino_subject_j) < burst_embedding_threshold
 
     Args:
         photos: list of photo dicts (already within one encounter), each with:
             - timestamp: datetime or ISO string
-            - phash_crop: hex string or None
             - dino_subject_embedding: numpy array or None
         config: optional dict overriding DEFAULTS
 
@@ -126,12 +107,6 @@ def detect_bursts(photos, config=None):
         ts_b = _parse_timestamp(pb.get("timestamp"))
         dt = _time_delta_seconds(ts_a, ts_b)
         if dt > cfg["burst_time_gap"]:
-            cuts.add(i)
-            continue
-
-        # Crop pHash hamming distance
-        hamming = _hamming_distance(pa.get("phash_crop"), pb.get("phash_crop"))
-        if hamming >= 0 and hamming > cfg["burst_phash_threshold"]:
             cuts.add(i)
             continue
 

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -86,7 +86,6 @@ DEFAULTS = {
         "eye_window_k": 0.08,
         "reject_eye_focus": 0.35,
         "burst_time_gap": 3.0,
-        "burst_phash_threshold": 12,
         "burst_embedding_threshold": 0.80,
         "burst_lambda": 0.85,
         "burst_max_keep": 3,

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -448,12 +448,6 @@ SCHEMA = {
         "label": "Burst: time gap (s)",
         "desc": "Maximum time gap between frames in a burst.",
     },
-    "pipeline.burst_phash_threshold": {
-        "type": "int", "min": 0, "max": 64,
-        "category": "Pipeline", "scope": "both",
-        "label": "Burst: pHash threshold",
-        "desc": "pHash distance threshold for burst grouping.",
-    },
     "pipeline.burst_embedding_threshold": {
         "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
         "category": "Pipeline", "scope": "both",

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1139,11 +1139,6 @@ input[type="range"]::-moz-range-thumb {
           <span class="slider-val" id="valBurstTime">3</span>
         </div>
         <div class="slider-row">
-          <span class="slider-label" title="Max perceptual hash distance — lower means more visually similar">pHash dist</span>
-          <input type="range" min="1" max="32" value="12" step="1" id="slBurstPhash" oninput="onGroupingChange(this)">
-          <span class="slider-val" id="valBurstPhash">12</span>
-        </div>
-        <div class="slider-row">
           <span class="slider-label" title="Max embedding distance — higher tolerates more visually different shots">Emb. distance</span>
           <input type="range" min="0" max="100" value="20" step="1" id="slBurstEmb" oninput="onGroupingChange(this)">
           <span class="slider-val" id="valBurstEmb">0.20</span>
@@ -1832,7 +1827,7 @@ var GROUPING_DEFAULTS = {
   // Merge
   merge_score: 62, merge_max_gap: 60, merge_tau: 20,
   // Bursts
-  burst_time_gap: 3, burst_phash_threshold: 12, burst_embedding_threshold: 20,
+  burst_time_gap: 3, burst_embedding_threshold: 20,
 };
 
 /* Load slider defaults from server config (overrides hard-coded values above) */
@@ -1861,7 +1856,6 @@ var GROUPING_DEFAULTS = {
     GROUPING_DEFAULTS.merge_max_gap = p.merge_max_gap != null ? p.merge_max_gap : 60;
     GROUPING_DEFAULTS.merge_tau = p.merge_tau != null ? p.merge_tau : 20;
     GROUPING_DEFAULTS.burst_time_gap = p.burst_time_gap != null ? p.burst_time_gap : 3;
-    GROUPING_DEFAULTS.burst_phash_threshold = p.burst_phash_threshold != null ? p.burst_phash_threshold : 12;
     // Stored as cosine similarity; UI shows distance = 1 - similarity.
     GROUPING_DEFAULTS.burst_embedding_threshold = Math.round((1 - (p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.80)) * 100);
     applyScoringDefaults();
@@ -1880,10 +1874,10 @@ function updateSliderDisplay(slider) {
   var id = slider.id;
   var valEl = document.getElementById('val' + id.substring(2));
   if (!valEl) return;
-  // Integer sliders (raw values, not /100): keep counts, raw seconds, phash distance
+  // Integer sliders (raw values, not /100): keep counts, raw seconds
   var INT_SLIDERS = [
     'slBurstKeep','slEncKeep',
-    'slBurstTime','slBurstPhash',
+    'slBurstTime',
     'slTauEnc','slHardCutTime',
     'slMergeMaxGap','slMergeTau',
   ];
@@ -1924,7 +1918,6 @@ function getGroupingConfig() {
     merge_max_gap: num('slMergeMaxGap'),
     merge_tau: num('slMergeTau'),
     burst_time_gap: num('slBurstTime'),
-    burst_phash_threshold: Math.round(num('slBurstPhash')),
     // UI shows distance; bursts.py expects cosine similarity = 1 - distance.
     burst_embedding_threshold: 1 - pct('slBurstEmb'),
   };
@@ -2047,7 +2040,6 @@ function applyGroupingDefaults() {
   setVal('slMergeTau', GROUPING_DEFAULTS.merge_tau);
   // Bursts
   setVal('slBurstTime', GROUPING_DEFAULTS.burst_time_gap);
-  setVal('slBurstPhash', GROUPING_DEFAULTS.burst_phash_threshold);
   setVal('slBurstEmb', GROUPING_DEFAULTS.burst_embedding_threshold);
   document.querySelectorAll('.sidebar-section input[type="range"]').forEach(function(sl) {
     updateSliderDisplay(sl);

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -652,15 +652,6 @@
         </div>
       </div>
       <div class="setting-row">
-        <div class="setting-label">pHash threshold</div>
-        <div style="display:flex;align-items:center;gap:8px;">
-          <input type="range" id="cfgBurstPhash" min="1" max="32" value="12"
-                 style="width:120px;accent-color:var(--accent);"
-                 oninput="document.getElementById('cfgBurstPhashVal').textContent = this.value; saveConfig()">
-          <span style="font-size:13px;color:var(--text-primary);min-width:24px;" id="cfgBurstPhashVal">12</span>
-        </div>
-      </div>
-      <div class="setting-row">
         <div class="setting-label">Embedding distance</div>
         <div style="display:flex;align-items:center;gap:8px;">
           <input type="range" id="cfgBurstEmb" min="1" max="50" value="20"
@@ -1308,9 +1299,6 @@ async function loadConfig() {
     var btg = p.burst_time_gap != null ? p.burst_time_gap : 3;
     document.getElementById('cfgBurstTimeGap').value = btg;
     document.getElementById('cfgBurstTimeGapVal').textContent = btg + 's';
-    var bph = p.burst_phash_threshold != null ? p.burst_phash_threshold : 12;
-    document.getElementById('cfgBurstPhash').value = bph;
-    document.getElementById('cfgBurstPhashVal').textContent = bph;
     // Stored as cosine similarity; UI shows distance = 1 - similarity.
     var bemb = Math.round((1 - (p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.80)) * 100);
     document.getElementById('cfgBurstEmb').value = bemb;
@@ -1465,7 +1453,6 @@ function saveConfig() {
             eye_window_k: parseInt(document.getElementById('cfgEyeWindowK').value, 10) / 100,
             reject_eye_focus: parseInt(document.getElementById('cfgRejectEyeFocus').value, 10) / 100,
             burst_time_gap: parseInt(document.getElementById('cfgBurstTimeGap').value, 10) || 3,
-            burst_phash_threshold: parseInt(document.getElementById('cfgBurstPhash').value, 10) || 12,
             burst_embedding_threshold: 1 - parseInt(document.getElementById('cfgBurstEmb').value, 10) / 100,
             burst_lambda: parseInt(document.getElementById('cfgBurstLambda').value, 10) / 100,
             burst_max_keep: parseInt(document.getElementById('cfgBurstMaxKeep').value, 10) || 3,
@@ -1497,7 +1484,7 @@ function resetPipelineDefaults() {
     cfgRejectComposite: [40, '%'],
     cfgEyeClassifierConfGate: [50, '%'], cfgEyeDetectionConfGate: [50, '%'],
     cfgRejectEyeFocus: [35, '%'],
-    cfgBurstTimeGap: [3, 's'], cfgBurstPhash: [12, ''], cfgBurstEmb: [20, '%'],
+    cfgBurstTimeGap: [3, 's'], cfgBurstEmb: [20, '%'],
     cfgBurstLambda: [85, '%'], cfgEncLambda: [70, '%'],
     cfgHardCutScore: [42, '%'], cfgSoftCutScore: [52, '%'], cfgMergeScore: [62, '%'],
   };

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4223,10 +4223,10 @@ def test_save_grouping_defaults_rejects_bad_values(tmp_path, monkeypatch):
         json={"pipeline": {"merge_tau": 0.0}},
     )
     assert resp.status_code == 400
-    # phash threshold must be int, not float.
+    # Unknown keys (e.g. removed thresholds) must be rejected.
     resp = client.post(
         "/api/pipeline/save-grouping-defaults",
-        json={"pipeline": {"burst_phash_threshold": 12.5}},
+        json={"pipeline": {"burst_phash_threshold": 12}},
     )
     assert resp.status_code == 400
 
@@ -4250,8 +4250,6 @@ def test_save_grouping_defaults_rejects_bad_values(tmp_path, monkeypatch):
         import math as _math
         assert isinstance(pipe["tau_enc"], (int, float))
         assert _math.isfinite(pipe["tau_enc"])
-    if "burst_phash_threshold" in pipe:
-        assert isinstance(pipe["burst_phash_threshold"], int)
 
 
 def test_collection_preview_returns_match_count(app_and_db):

--- a/vireo/tests/test_bursts.py
+++ b/vireo/tests/test_bursts.py
@@ -2,7 +2,7 @@
 """Tests for burst clustering within encounters (Stage 3).
 
 Uses synthetic photo dicts to verify burst boundary detection based on
-time gaps, pHash hamming distance, and embedding cosine similarity.
+time gaps and embedding cosine similarity.
 """
 import os
 import sys
@@ -13,14 +13,13 @@ import numpy as np
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
-def _make_photo(ts_offset_s=0, subj_emb=None, phash_crop=None, photo_id=None):
+def _make_photo(ts_offset_s=0, subj_emb=None, photo_id=None):
     """Helper to build a photo dict for burst testing."""
     base = datetime(2026, 3, 20, 10, 0, 0)
     return {
         "id": photo_id or ts_offset_s,
         "timestamp": (base + timedelta(seconds=ts_offset_s)).isoformat(),
         "dino_subject_embedding": subj_emb,
-        "phash_crop": phash_crop,
     }
 
 
@@ -59,55 +58,6 @@ def test_burst_no_cut_within_time():
     assert len(bursts[0]) == 4
 
 
-# -- Burst detection: pHash hamming --
-
-
-def test_burst_cut_on_phash():
-    """High pHash hamming distance should trigger a burst cut."""
-    from bursts import detect_bursts
-
-    # Create two hashes that differ by many bits
-    hash_a = "0000000000000000"  # all zeros
-    hash_b = "ffffffffffffffff"  # all ones → hamming = 64
-
-    photos = [
-        _make_photo(0.0, phash_crop=hash_a),
-        _make_photo(0.5, phash_crop=hash_a),
-        _make_photo(1.0, phash_crop=hash_b),  # very different pHash
-        _make_photo(1.5, phash_crop=hash_b),
-    ]
-    bursts = detect_bursts(photos)
-    assert len(bursts) == 2
-
-
-def test_burst_no_cut_similar_phash():
-    """Similar pHash (low hamming) should not trigger a cut."""
-    from bursts import detect_bursts
-
-    # Hashes that differ by only 1 bit
-    hash_a = "0000000000000000"
-    hash_b = "0000000000000001"  # hamming = 1
-
-    photos = [
-        _make_photo(0.0, phash_crop=hash_a),
-        _make_photo(0.5, phash_crop=hash_b),
-    ]
-    bursts = detect_bursts(photos)
-    assert len(bursts) == 1
-
-
-def test_burst_no_cut_missing_phash():
-    """Missing pHash should not trigger a cut on that criterion."""
-    from bursts import detect_bursts
-
-    photos = [
-        _make_photo(0.0, phash_crop=None),
-        _make_photo(0.5, phash_crop=None),
-    ]
-    bursts = detect_bursts(photos)
-    assert len(bursts) == 1
-
-
 # -- Burst detection: embedding cosine --
 
 
@@ -144,7 +94,7 @@ def test_burst_no_cut_similar_embedding():
 def test_burst_mismatched_embedding_dims_does_not_crash():
     """Adjacent photos with stale-variant embeddings at different dims must
     not raise 'shapes not aligned' — treat as 'no embedding signal' so the
-    cut decision falls back to time + phash."""
+    cut decision falls back to the time gap."""
     from bursts import detect_bursts
 
     emb_768 = np.ones(768, dtype=np.float32)
@@ -209,25 +159,6 @@ def test_burst_custom_time_gap():
     assert len(detect_bursts(photos, config={"burst_time_gap": 1.5})) == 3
 
 
-def test_burst_custom_phash_threshold():
-    """Custom pHash threshold changes sensitivity."""
-    from bursts import detect_bursts
-
-    # Create hashes with moderate hamming distance (~16 bits different)
-    hash_a = "00000000000000ff"  # 8 bits set
-    hash_b = "000000000000ff00"  # 8 different bits set → hamming ≈ 16
-
-    photos = [
-        _make_photo(0.0, phash_crop=hash_a),
-        _make_photo(0.5, phash_crop=hash_b),
-    ]
-    # Default threshold 12 → cut (16 > 12)
-    assert len(detect_bursts(photos)) == 2
-
-    # Raise threshold to 20 → no cut (16 < 20)
-    assert len(detect_bursts(photos, config={"burst_phash_threshold": 20})) == 1
-
-
 def test_burst_custom_embedding_threshold():
     """Custom embedding threshold changes sensitivity."""
     from bursts import detect_bursts
@@ -259,21 +190,14 @@ def test_burst_custom_embedding_threshold():
 
 
 def test_burst_any_criterion_triggers_cut():
-    """A cut fires if ANY single criterion exceeds its threshold."""
+    """A cut fires if either time or embedding criterion fires."""
     from bursts import detect_bursts
 
     emb = np.ones(768, dtype=np.float32)
-    hash_same = "0000000000000000"
-
-    # Time is fine (1s), pHash is fine (same), but we'll trick embedding
-    # by using orthogonal vectors
-    emb_diff = np.zeros(768, dtype=np.float32)
-    emb_diff[0] = 1.0  # somewhat different from all-ones
-
     photos = [
-        _make_photo(0.0, subj_emb=emb, phash_crop=hash_same),
+        _make_photo(0.0, subj_emb=emb),
         # Only time triggers: 5s > 3s
-        _make_photo(5.0, subj_emb=emb, phash_crop=hash_same),
+        _make_photo(5.0, subj_emb=emb),
     ]
     bursts = detect_bursts(photos)
     assert len(bursts) == 2  # time alone is enough


### PR DESCRIPTION
## Summary

Burst detection currently cuts a new burst when *any* of three signals fire: time gap, crop pHash hamming distance, or DINOv2 subject embedding cosine similarity. Analysis on the Apr 2026 workspace (4377 adjacent pairs across 79 encounters) shows pHash is the lone vetoer in **45%** of all cuts (501/1114), splitting otherwise-tight bursts where DINOv2 says "same subject" (cos 0.81–0.96) and the time gap is sub-second. Worst case: a 20fps Western bluebird sequence where every consecutive frame trips the threshold because of small framing drift.

This PR removes pHash from the burst-cut decision. DINOv2 + time gap remain.

### Why this is safe
- The 458 cuts where pHash and DINOv2 currently agree still happen via DINOv2 alone (by definition both fired).
- The 32 DINOv2-only cuts (real subject changes pHash missed) still happen.
- The 67 time-only cuts (long gaps) still happen.
- pHash's unique contribution (501 cuts) was almost entirely false positives on tight crops.

### What's still using `phash_crop`
- `vireo/selection.py` — MMR diversity penalty when picking keepers (soft continuous score, weight 0.40). Noise here is harmless.
- `vireo/highlights.py` — best-photo selection.
- UI display in pipeline_review.html.

So `phash_crop` keeps being computed in the masking job — only the burst-cut consumer is removed.

## Changes
- `vireo/bursts.py`: drop `_hamming_distance`, `burst_phash_threshold` from DEFAULTS, and the pHash cut block in `detect_bursts()`.
- `vireo/config.py`, `vireo/config_schema.py`: drop `burst_phash_threshold`.
- `vireo/app.py`: drop the key from the live-regroup validation schema.
- `vireo/templates/settings.html`, `vireo/templates/pipeline_review.html`: remove the pHash slider and its load/save plumbing.
- Tests updated.

Existing workspaces' `last_group_fingerprint` will mismatch (since `bursts.DEFAULTS` changed) and they'll be re-grouped on the next pipeline run, which is the right behavior.

## Test plan
- [x] `python -m pytest vireo/tests/test_bursts.py` (12 passed)
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_config.py` (526 passed, 1 skipped)
- [x] `python -m pytest vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py` (393 passed)
- [x] `python -m pytest vireo/tests/test_pipeline.py vireo/tests/test_pipeline_plan.py vireo/tests/test_selection.py` (110 passed)
- [ ] Re-run pipeline on Apr 2026 workspace and confirm Steller's jay sequence (DSC_1090, DSC_1092) and Western bluebird sequence are now in single bursts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)