### PR TITLE
Highlights: keep noise-detection photos out of species tags & quality scores

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10307,6 +10307,40 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if missing:
             return json_error(f"Unknown photo_ids: {missing}")
 
+        # Drop photos whose only detections are below the workspace's
+        # detector_confidence threshold — those are MegaDetector noise boxes,
+        # not real subjects, and tagging them with a species lets them slip
+        # into highlights / by-species views with the wrong label. Photos
+        # with NO detection rows at all stay eligible: this endpoint also
+        # serves manual species assertions on photos that were never run
+        # through the pipeline. See the "Mountain chickadee" highlights bug.
+        import config as cfg
+        effective_cfg = db.get_effective_config(cfg.load())
+        det_conf_threshold = effective_cfg.get("detector_confidence", 0.2)
+        det_rows = db.conn.execute(
+            f"""SELECT photo_id,
+                       MAX(detector_confidence) AS max_conf,
+                       COUNT(*) AS n
+                FROM detections WHERE photo_id IN ({placeholders})
+                GROUP BY photo_id""",
+            photo_ids,
+        ).fetchall()
+        skipped_photo_ids = [
+            r["photo_id"] for r in det_rows
+            if r["n"] > 0 and (r["max_conf"] or 0) < det_conf_threshold
+        ]
+        if skipped_photo_ids:
+            skipped_set = set(skipped_photo_ids)
+            photo_ids = [pid for pid in photo_ids if pid not in skipped_set]
+            if not photo_ids:
+                return jsonify({
+                    "ok": True,
+                    "species": species,
+                    "photo_count": 0,
+                    "skipped_photo_ids": skipped_photo_ids,
+                    "previous_species": None,
+                })
+
         # Look up the previous species (if any) from the pipeline cache before
         # mutating. We reuse the same cached dict to write the update below.
         from pipeline import load_results_raw, save_results_raw
@@ -10471,6 +10505,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "keyword_id": kid,
             "photo_count": len(photo_ids),
             "previous_species": replaced,
+            "skipped_photo_ids": skipped_photo_ids,
         }
         if cached:
             response["encounters"] = cached.get("encounters", [])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10329,24 +10329,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             r["photo_id"] for r in det_rows
             if r["n"] > 0 and (r["max_conf"] or 0) < det_conf_threshold
         ]
+        # Load the pipeline cache before the all-skipped early return: the
+        # client's confirmSpecies fallback (templates/pipeline_review.html
+        # ~L2620) treats a successful response without ``encounters`` as a
+        # local-confirmation and sets ``species_confirmed=true`` itself.
+        # Returning the unchanged cache here keeps the encounter's confirmed
+        # state consistent with what actually happened on the server (i.e.,
+        # nothing).
+        from pipeline import load_results_raw, save_results_raw
+
+        cache_dir = os.path.dirname(db_path)
+        cached = load_results_raw(cache_dir, db._active_workspace_id)
         if skipped_photo_ids:
             skipped_set = set(skipped_photo_ids)
             photo_ids = [pid for pid in photo_ids if pid not in skipped_set]
             if not photo_ids:
-                return jsonify({
+                resp_body = {
                     "ok": True,
                     "species": species,
                     "photo_count": 0,
                     "skipped_photo_ids": skipped_photo_ids,
                     "previous_species": None,
-                })
-
-        # Look up the previous species (if any) from the pipeline cache before
-        # mutating. We reuse the same cached dict to write the update below.
-        from pipeline import load_results_raw, save_results_raw
-
-        cache_dir = os.path.dirname(db_path)
-        cached = load_results_raw(cache_dir, db._active_workspace_id)
+                }
+                if cached:
+                    resp_body["encounters"] = cached.get("encounters", [])
+                    resp_body["summary"] = cached.get("summary", {})
+                return jsonify(resp_body)
         previous_species = None
         target_enc = None
         target_enc_idx = None

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -445,6 +445,14 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
             if detections:
                 # Use highest-confidence detection as primary for quality scoring
                 primary = get_primary_detection(detections)
+                if primary and primary["confidence"] < det_conf_threshold:
+                    # Top detection is below the workspace's detector_confidence
+                    # threshold — it's noise, not a real subject. Skip scoring
+                    # and clear any stale quality fields from a prior run so
+                    # noise photos don't float to the top of highlights with a
+                    # giant ``subject_size`` from a whole-frame noise box.
+                    db.update_photo_quality(photo["id"])
+                    primary = None
                 if primary:
                     det_box = primary["box"]
                     subject_size = det_box["w"] * det_box["h"]

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -287,6 +287,81 @@ def test_encounter_species_rejects_invalid_photo_ids(app_and_db):
     assert not any(c["value"] == "Robin" for c in pending)
 
 
+def test_encounter_species_skips_sub_threshold_photos(app_and_db):
+    """POST /api/encounters/species must skip photos whose only detections
+    are below the workspace's detector_confidence threshold.
+
+    Regression for the "Mountain chickadee" highlights bug: when an
+    encounter is bulk-confirmed, photos with only noise-level detections
+    (e.g. confidence ~0.02 from MegaDetector emitting a whole-frame box on
+    a frame with no real subject) were tagged with the species too. Those
+    bad tags then made the photos eligible for highlights and they floated
+    to the top by quality_score because the noise box happened to span the
+    whole frame.
+
+    Photos with NO detections at all stay eligible (this endpoint is also
+    used to label photos that were never run through the pipeline — the
+    user is asserting the species manually).
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    photos = db.conn.execute("SELECT id FROM photos ORDER BY id").fetchall()
+    p_real, p_noise, p_undetected = photos[0]["id"], photos[1]["id"], photos[2]["id"]
+
+    db.save_detections(
+        p_real,
+        [{"box": {"x": 0.3, "y": 0.3, "w": 0.4, "h": 0.4},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    db.save_detections(
+        p_noise,
+        [{"box": {"x": 0.01, "y": 0.01, "w": 0.98, "h": 0.98},
+          "confidence": 0.02, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    # p_undetected has no detection rows at all.
+
+    resp = client.post(
+        "/api/encounters/species",
+        json={"species": "Mountain Chickadee",
+              "photo_ids": [p_real, p_noise, p_undetected]},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    real_tags = {k["name"] for k in db.get_photo_keywords(p_real)}
+    noise_tags = {k["name"] for k in db.get_photo_keywords(p_noise)}
+    undetected_tags = {k["name"] for k in db.get_photo_keywords(p_undetected)}
+
+    assert "Mountain Chickadee" in real_tags, (
+        "photo with high-confidence detection must still be tagged"
+    )
+    assert "Mountain Chickadee" not in noise_tags, (
+        "photo whose only detection is below threshold must NOT be tagged — "
+        "those are noise photos and the tag is what makes them appear in "
+        "highlights with the wrong species"
+    )
+    assert "Mountain Chickadee" in undetected_tags, (
+        "photo with no detections at all is a manual-tagging case (user "
+        "asserting species on a photo never run through the pipeline) — "
+        "this must continue to work"
+    )
+
+    # Response should reflect what actually happened so the UI can warn
+    # about skipped photos (otherwise the user thinks all 48 were tagged
+    # but really only 47 were).
+    assert data["photo_count"] == 2, (
+        f"photo_count should reflect actually-tagged photos (2), got {data['photo_count']}"
+    )
+    skipped = data.get("skipped_photo_ids") or []
+    assert p_noise in skipped, (
+        f"skipped_photo_ids should list the noise photo so the UI can warn; "
+        f"got {skipped!r}"
+    )
+
+
 def test_encounter_species_updates_pipeline_cache(app_and_db):
     """POST /api/encounters/species updates species_confirmed in pipeline cache."""
     import json as _json

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -362,6 +362,70 @@ def test_encounter_species_skips_sub_threshold_photos(app_and_db):
     )
 
 
+def test_encounter_species_all_skipped_returns_cached_encounters(app_and_db):
+    """When every submitted photo is sub-threshold, the response must still
+    include ``encounters`` from the cached pipeline results. Without that,
+    the client's confirmSpecies fallback (templates/pipeline_review.html)
+    interprets the successful response as a local-confirmation and sets
+    ``species_confirmed=true`` on the encounter — even though the server
+    did nothing.
+    """
+    import json as _json
+    app, db = app_and_db
+    client = app.test_client()
+
+    photos = db.conn.execute("SELECT id FROM photos ORDER BY id").fetchall()
+    p_noise = photos[0]["id"]
+
+    db.save_detections(
+        p_noise,
+        [{"box": {"x": 0.01, "y": 0.01, "w": 0.98, "h": 0.98},
+          "confidence": 0.02, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+
+    cache_dir = os.path.dirname(app.config["DB_PATH"])
+    ws_id = db._active_workspace_id
+    sentinel_summary = {"total_photos": 999}
+    sentinel_encounters = [
+        {
+            "species": ["Sparrow", 0.8],
+            "confirmed_species": None,
+            "species_confirmed": False,
+            "photo_count": 1,
+            "photo_ids": [p_noise],
+            "bursts": [],
+            "species_predictions": [],
+        },
+    ]
+    os.makedirs(cache_dir, exist_ok=True)
+    with open(os.path.join(cache_dir, f"pipeline_results_ws{ws_id}.json"), "w") as fh:
+        _json.dump(
+            {"encounters": sentinel_encounters, "summary": sentinel_summary},
+            fh,
+        )
+
+    resp = client.post(
+        "/api/encounters/species",
+        json={"species": "Mountain Chickadee", "photo_ids": [p_noise]},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["photo_count"] == 0
+    assert data["skipped_photo_ids"] == [p_noise]
+    # The cached encounters/summary must be echoed so the client doesn't
+    # locally mark the encounter confirmed.
+    assert "encounters" in data, (
+        "all-skipped response must include encounters so the client doesn't "
+        "fall through to the local-confirm branch"
+    )
+    assert data["encounters"][0]["species_confirmed"] is False, (
+        "encounter must remain unconfirmed in the response — nothing was "
+        "actually tagged"
+    )
+    assert data["summary"] == sentinel_summary
+
+
 def test_encounter_species_updates_pipeline_cache(app_and_db):
     """POST /api/encounters/species updates species_confirmed in pipeline cache."""
     import json as _json

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -623,6 +623,136 @@ def test_detect_batch_does_not_cache_failed_detector_runs(tmp_path, monkeypatch)
     assert call_count["n"] == 2, "failed photos must be retried on next pass"
 
 
+def test_detect_batch_skips_quality_score_when_primary_below_threshold(
+    tmp_path, monkeypatch
+):
+    """Photos whose only detection is below the workspace's
+    detector_confidence threshold must NOT get a quality_score (or any
+    subject_size / subject_sharpness from the noise box) — those values
+    drive the highlights ranking, and a noise box that happens to span the
+    frame would otherwise produce a sky-high ``subject_size`` and float
+    these no-real-subject photos to the top of highlights.
+
+    Regression for the "Mountain chickadee" highlights bug: photos with
+    detector_confidence ~0.02 still received quality_score ~0.86 because
+    the noise box covered ~98% of the frame.
+    """
+    from unittest.mock import patch
+
+    from classify_job import _detect_batch
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "noise.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    # Pre-populate stale quality fields to confirm the fix also clears
+    # rotten state from prior runs (self-healing — see CLAUDE.md memory
+    # "App self-heals broken state").
+    db.update_photo_quality(
+        photo_id,
+        subject_sharpness=2900.0,
+        subject_size=0.98,
+        quality_score=0.86,
+        sharpness=2900.0,
+    )
+
+    img = Image.new("RGB", (100, 100), color="gray")
+    img.save(str(tmp_path / "noise.jpg"))
+
+    # Sub-threshold "noise" detection covering nearly the whole frame —
+    # exactly what MegaDetector emits when there's no real subject.
+    fake_detections = [
+        {"box": {"x": 0.01, "y": 0.01, "w": 0.98, "h": 0.98},
+         "confidence": 0.027, "category": "animal"},
+    ]
+
+    photos = [{"id": photo_id, "folder_id": folder_id, "filename": "noise.jpg"}]
+    folders = {folder_id: str(tmp_path)}
+
+    with patch("classify_job.detect_animals", return_value=fake_detections), \
+         patch("classify_job.get_primary_detection", return_value=fake_detections[0]), \
+         patch("classify_job.compute_sharpness", return_value=2900.0):
+        _detect_batch(
+            photos=photos, folders=folders, runner=None, job={"id": 0},
+            reclassify=True, db=db,
+            det_conf_threshold=0.2,
+            already_detected_ids=set(),
+        )
+
+    row = db.conn.execute(
+        "SELECT quality_score, subject_size, subject_sharpness FROM photos WHERE id = ?",
+        (photo_id,),
+    ).fetchone()
+    assert row["quality_score"] is None, (
+        "sub-threshold detection must not produce a quality_score; "
+        f"got {row['quality_score']!r}"
+    )
+    assert row["subject_size"] is None, (
+        "sub-threshold detection must not produce subject_size; "
+        f"got {row['subject_size']!r}"
+    )
+    assert row["subject_sharpness"] is None, (
+        "sub-threshold detection must not produce subject_sharpness; "
+        f"got {row['subject_sharpness']!r}"
+    )
+
+
+def test_detect_batch_scores_normally_when_primary_at_threshold(
+    tmp_path, monkeypatch
+):
+    """Counterpart to the sub-threshold test: a detection at or above the
+    threshold still produces a quality_score so we don't break the happy
+    path."""
+    from unittest.mock import patch
+
+    from classify_job import _detect_batch
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "bird.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+
+    img = Image.new("RGB", (100, 100), color="gray")
+    img.save(str(tmp_path / "bird.jpg"))
+
+    fake_detections = [
+        {"box": {"x": 0.3, "y": 0.3, "w": 0.4, "h": 0.4},
+         "confidence": 0.85, "category": "animal"},
+    ]
+
+    photos = [{"id": photo_id, "folder_id": folder_id, "filename": "bird.jpg"}]
+    folders = {folder_id: str(tmp_path)}
+
+    with patch("classify_job.detect_animals", return_value=fake_detections), \
+         patch("classify_job.get_primary_detection", return_value=fake_detections[0]), \
+         patch("classify_job.compute_sharpness", return_value=1500.0):
+        _detect_batch(
+            photos=photos, folders=folders, runner=None, job={"id": 0},
+            reclassify=True, db=db,
+            det_conf_threshold=0.2,
+            already_detected_ids=set(),
+        )
+
+    row = db.conn.execute(
+        "SELECT quality_score, subject_size FROM photos WHERE id = ?",
+        (photo_id,),
+    ).fetchone()
+    assert row["quality_score"] is not None and row["quality_score"] > 0
+    assert row["subject_size"] is not None
+
+
 def test_classify_photos_reclassifies_when_gate_has_no_cached_rows(tmp_path):
     """If classifier_runs has a (model, fp) key but get_predictions_for_detection
     returns nothing (e.g. a prior pass stored `category == 'match'` which


### PR DESCRIPTION
## The bug

In Apr2026 workspace, the top photos by quality score in highlights were tagged \"Mountain chickadee\" but contained no chickadee. Investigation showed:

- The photos had only sub-threshold MegaDetector noise boxes (confidence ~0.02, well below the workspace's 0.2 threshold).
- Those noise boxes happened to span ~98% of the frame, so \`subject_size\` was huge → \`quality_score\` was ~0.86.
- The wrong species tag came from a bulk encounter Confirm Species action: when an encounter contained mostly real chickadees plus a few noise photos that got swept in, confirming the encounter tagged all of them.

## The fixes

### `vireo/classify_job.py`
\`_detect_batch\` now checks if the primary detection's confidence is below the workspace-effective \`detector_confidence\` threshold. If it is, no quality scoring runs, and any stale quality fields from a prior run are cleared (self-healing per the project's \"app self-heals broken state\" convention).

### `vireo/app.py` — `/api/encounters/species`
Before tagging, drops photo_ids whose only detection rows are sub-threshold. Photos with no detection rows at all stay eligible (this endpoint also serves manual species assertions on photos that never went through the pipeline). The response now includes \`skipped_photo_ids\` so future UI can surface the count.

## Tests

New:
- \`test_detect_batch_skips_quality_score_when_primary_below_threshold\` — sub-threshold detection produces no quality_score and clears stale fields.
- \`test_detect_batch_scores_normally_when_primary_at_threshold\` — happy path still works.
- \`test_encounter_species_skips_sub_threshold_photos\` — noise photo not tagged; high-conf photo tagged; no-detection photo still tagged (manual case).

Verified:
- \`vireo/tests/test_classify_job.py\` — 50 passed
- \`vireo/tests/test_app.py\` — 175 passed
- \`vireo/tests/test_db.py\` + \`test_edits_api.py\` + \`test_pipeline.py\` — 542 passed, 1 skipped

## Not in this PR

Existing rows with bad species tags / stale quality_score from before this fix need a one-time cleanup pass. A dry-run query against the dev DB shows the scope is meaningful (1600+ wrong species tags + 4000+ stale quality scores across 14 workspaces), so this warrants a separate explicit decision rather than being bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)