### PR TITLE
Jobs badge: count all running jobs, not just current workspace

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4764,10 +4764,10 @@ function formatDuration(seconds) {
     var thisWs = allRunning.filter(function(j) { return j.workspace_id === _activeWsId; });
     var otherWs = allRunning.filter(function(j) { return j.workspace_id !== _activeWsId; });
 
-    // Badge counts only current workspace
-    document.getElementById('jobsBadge').textContent = thisWs.length;
+    // Badges count all running jobs across workspaces
+    document.getElementById('jobsBadge').textContent = allRunning.length;
     var navBadge = document.getElementById('navJobBadge');
-    if (navBadge) navBadge.textContent = thisWs.length > 0 ? ' (' + thisWs.length + ')' : '';
+    if (navBadge) navBadge.textContent = allRunning.length > 0 ? ' (' + allRunning.length + ')' : '';
 
     if (allRunning.length === 0) {
       var lastDone = activeJobs.filter(function(j) { return j.status !== 'running'; })[0];
@@ -4826,7 +4826,7 @@ function formatDuration(seconds) {
 
   function updateSummary() {
     var summary = document.getElementById('jobSummary');
-    var running = activeJobs.filter(function(j) { return j.status === 'running' && j.workspace_id === _activeWsId; });
+    var running = activeJobs.filter(function(j) { return j.status === 'running'; });
 
     if (running.length === 0) {
       summary.textContent = 'No active jobs';
@@ -4862,7 +4862,7 @@ function formatDuration(seconds) {
   }
 
   function updateActivityDot() {
-    var running = activeJobs.filter(function(j) { return j.status === 'running' && j.workspace_id === _activeWsId; });
+    var running = activeJobs.filter(function(j) { return j.status === 'running'; });
     var dot = document.getElementById('navActivityDot');
     if (dot) dot.classList.toggle('active', running.length > 0);
   }


### PR DESCRIPTION
## Summary
- The "Jobs (N)" nav badge, bottom-panel tab badge, jobs summary line, and nav activity dot were all filtered to the active workspace.
- With two jobs running across workspaces, the navbar said "Jobs (1)" while the bottom panel listed both — inconsistent and confusing.
- Switched all four to count every running job, regardless of workspace.

## Test plan
- [ ] Start two jobs in different workspaces; navbar badge shows "(2)" and bottom-panel Jobs tab badge shows "2".
- [ ] Switch workspaces while both run; counts stay at 2.
- [ ] Summary line above the jobs pane shows progress for the running job even when it's in a different workspace.
- [ ] Nav activity dot pulses while any job runs.
- [ ] All jobs complete: badges disappear, summary returns to "No active jobs".

🤖 Generated with [Claude Code](https://claude.com/claude-code)