### PR TITLE
Fix concurrency hazards across pipelines

### DIFF
--- a/vireo/labels.py
+++ b/vireo/labels.py
@@ -1,10 +1,12 @@
 """Fetch regional species labels from iNaturalist for classification."""
 
+import contextlib
 import json
 import logging
 import os
 import re
 import ssl
+import tempfile
 import urllib.parse
 import urllib.request
 
@@ -234,9 +236,8 @@ def save_labels(name, place_id, place_name, taxon_groups, species,
     meta_path = os.path.join(LABELS_DIR, f"{slug}.json")
 
     # Write labels file (one per line)
-    with open(labels_path, "w") as f:
-        for sp in sorted(set(species)):
-            f.write(sp + "\n")
+    species_text = "".join(sp + "\n" for sp in sorted(set(species)))
+    _atomic_write_text(labels_path, species_text)
 
     # Write metadata
     filter_info = OBSERVATION_FILTERS.get(
@@ -252,10 +253,31 @@ def save_labels(name, place_id, place_name, taxon_groups, species,
         "species_count": len(set(species)),
         "labels_file": labels_path,
     }
-    with open(meta_path, "w") as f:
-        json.dump(meta, f, indent=2)
+    _atomic_write_text(meta_path, json.dumps(meta, indent=2))
 
     return labels_path
+
+
+def _atomic_write_text(path, text):
+    """Write text to ``path`` via a sibling temp file + os.replace().
+
+    Two concurrent label-fetch jobs targeting the same slug can otherwise
+    interleave bytes inside a half-written .txt or .json. Atomic rename
+    guarantees that any reader sees either the old contents or the full new
+    contents, never a partial mix.
+    """
+    directory = os.path.dirname(path) or "."
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f".{os.path.basename(path)}.", suffix=".tmp", dir=directory
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        os.replace(tmp_path, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
 
 
 def delete_labels(labels_file):

--- a/vireo/masking.py
+++ b/vireo/masking.py
@@ -44,6 +44,7 @@ _decoder_session = None
 _sam2_variant_loaded = None
 
 _sam2_download_lock = threading.Lock()
+_sam2_session_lock = threading.Lock()
 
 
 def _sam2_model_dir(variant):
@@ -181,45 +182,51 @@ def _get_sam2_sessions(variant="sam2-small"):
     """
     global _encoder_session, _decoder_session, _sam2_variant_loaded
 
-    if (
-        _encoder_session is not None
-        and _decoder_session is not None
-        and _sam2_variant_loaded == variant
-    ):
-        return _encoder_session, _decoder_session
+    # Serialize variant swaps and first-load races. Two concurrent jobs (e.g.
+    # one classify, one mask) calling this with different variants would
+    # otherwise race on the global session assignment, leaving the trio in an
+    # inconsistent state where _sam2_variant_loaded says one thing but the
+    # sessions belong to another variant.
+    with _sam2_session_lock:
+        if (
+            _encoder_session is not None
+            and _decoder_session is not None
+            and _sam2_variant_loaded == variant
+        ):
+            return _encoder_session, _decoder_session
 
-    if variant not in SAM2_VARIANTS:
-        raise ValueError(
-            f"Unknown SAM2 variant: {variant}. "
-            f"Choose from: {list(SAM2_VARIANTS.keys())}"
+        if variant not in SAM2_VARIANTS:
+            raise ValueError(
+                f"Unknown SAM2 variant: {variant}. "
+                f"Choose from: {list(SAM2_VARIANTS.keys())}"
+            )
+
+        model_dir = os.path.join(
+            os.path.expanduser("~"), ".vireo", "models", variant
         )
+        encoder_path = os.path.join(model_dir, "image_encoder.onnx")
+        decoder_path = os.path.join(model_dir, "mask_decoder.onnx")
 
-    model_dir = os.path.join(
-        os.path.expanduser("~"), ".vireo", "models", variant
-    )
-    encoder_path = os.path.join(model_dir, "image_encoder.onnx")
-    decoder_path = os.path.join(model_dir, "mask_decoder.onnx")
+        if not os.path.isfile(encoder_path):
+            raise FileNotFoundError(
+                f"SAM2 image encoder not found at {encoder_path}. "
+                f"Download it first via the models page."
+            )
+        if not os.path.isfile(decoder_path):
+            raise FileNotFoundError(
+                f"SAM2 mask decoder not found at {decoder_path}. "
+                f"Download it first via the models page."
+            )
 
-    if not os.path.isfile(encoder_path):
-        raise FileNotFoundError(
-            f"SAM2 image encoder not found at {encoder_path}. "
-            f"Download it first via the models page."
-        )
-    if not os.path.isfile(decoder_path):
-        raise FileNotFoundError(
-            f"SAM2 mask decoder not found at {decoder_path}. "
-            f"Download it first via the models page."
-        )
+        log.info("Loading SAM2 ONNX (%s)...", variant)
+        enc_sess = onnx_runtime.create_session(encoder_path)
+        dec_sess = onnx_runtime.create_session(decoder_path)
 
-    log.info("Loading SAM2 ONNX (%s)...", variant)
-    enc_sess = onnx_runtime.create_session(encoder_path)
-    dec_sess = onnx_runtime.create_session(decoder_path)
-
-    _encoder_session = enc_sess
-    _decoder_session = dec_sess
-    _sam2_variant_loaded = variant
-    log.info("SAM2 ONNX loaded (%s)", variant)
-    return enc_sess, dec_sess
+        _encoder_session = enc_sess
+        _decoder_session = dec_sess
+        _sam2_variant_loaded = variant
+        log.info("SAM2 ONNX loaded (%s)", variant)
+        return enc_sess, dec_sess
 
 
 def generate_mask(image, detection_box, variant="sam2-small"):

--- a/vireo/model_verify.py
+++ b/vireo/model_verify.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import ssl
+import threading
 import time
 import urllib.request
 from dataclasses import dataclass, field
@@ -122,6 +123,38 @@ _verified_this_process: set[str] = set()
 # call retries the network check.
 _verify_error_cache: dict[str, float] = {}
 _VERIFY_ERROR_TTL = 300  # 5 minutes
+
+# Guards reads/writes of the two caches above so concurrent jobs (e.g. two
+# pipelines both verifying their model list at startup) don't observe
+# torn / inconsistent state across compound check-then-modify sequences.
+_cache_lock = threading.Lock()
+
+
+def _is_verified(model_id: str) -> bool:
+    with _cache_lock:
+        return model_id in _verified_this_process
+
+
+def _recent_error_age(model_id: str) -> float | None:
+    with _cache_lock:
+        ts = _verify_error_cache.get(model_id)
+    return None if ts is None else (time.monotonic() - ts)
+
+
+def _mark_verified(model_id: str) -> None:
+    with _cache_lock:
+        _verified_this_process.add(model_id)
+        _verify_error_cache.pop(model_id, None)
+
+
+def _mark_unverified(model_id: str) -> None:
+    with _cache_lock:
+        _verified_this_process.discard(model_id)
+
+
+def _record_error(model_id: str) -> None:
+    with _cache_lock:
+        _verify_error_cache[model_id] = time.monotonic()
 
 
 def sha256_file(path: str) -> str:
@@ -289,13 +322,13 @@ def verify_if_needed(model_id: str, model_dir: str, hf_subdir: str) -> None:
     error), records the failure time in _verify_error_cache and returns
     without writing .verify_failed so the pipeline continues fail-open.
     """
-    if model_id in _verified_this_process:
+    if _is_verified(model_id):
         return
 
     # Fail-open for recent hash-fetch failures so repeated pipeline starts
     # don't each stall for the full _FETCH_TIMEOUT on every model.
-    error_ts = _verify_error_cache.get(model_id)
-    if error_ts is not None and (time.monotonic() - error_ts) < _VERIFY_ERROR_TTL:
+    age = _recent_error_age(model_id)
+    if age is not None and age < _VERIFY_ERROR_TTL:
         return
 
     pinned = _has_pinned_revision(model_dir)
@@ -308,7 +341,7 @@ def verify_if_needed(model_id: str, model_dir: str, hf_subdir: str) -> None:
     try:
         result = verify_model(model_dir, hf_subdir)
     except VerifyError as e:
-        _verify_error_cache[model_id] = time.monotonic()
+        _record_error(model_id)
         write_verify_skipped(model_dir, str(e))
         return
 
@@ -319,8 +352,7 @@ def verify_if_needed(model_id: str, model_dir: str, hf_subdir: str) -> None:
         except OSError:
             pass
         raise ModelCorruptError(model_id, result)
-    _verified_this_process.add(model_id)
-    _verify_error_cache.pop(model_id, None)
+    _mark_verified(model_id)
     sentinel = os.path.join(model_dir, VERIFY_FAILED_SENTINEL)
     if os.path.isfile(sentinel):
         with contextlib.suppress(OSError):
@@ -339,21 +371,20 @@ def _verify_unpinned(model_id: str, model_dir: str, hf_subdir: str) -> None:
     try:
         latest_rev = fetch_latest_revision(ONNX_REPO)
     except VerifyError as e:
-        _verify_error_cache[model_id] = time.monotonic()
+        _record_error(model_id)
         write_verify_skipped(model_dir, str(e))
         return
 
     try:
         result = verify_model(model_dir, hf_subdir, revision=latest_rev)
     except VerifyError as e:
-        _verify_error_cache[model_id] = time.monotonic()
+        _record_error(model_id)
         write_verify_skipped(model_dir, str(e))
         return
 
     if result.ok:
         write_pinned_revision(model_dir, latest_rev)
-        _verified_this_process.add(model_id)
-        _verify_error_cache.pop(model_id, None)
+        _mark_verified(model_id)
         sentinel = os.path.join(model_dir, VERIFY_FAILED_SENTINEL)
         if os.path.isfile(sentinel):
             with contextlib.suppress(OSError):
@@ -367,7 +398,7 @@ def _verify_unpinned(model_id: str, model_dir: str, hf_subdir: str) -> None:
             model_id, result.mismatches, result.missing,
         )
         # Cache as checked so we don't re-warn on every pipeline start.
-        _verified_this_process.add(model_id)
+        _mark_verified(model_id)
         # Clear any stale .verify_skipped: the hash fetch succeeded this
         # time, so the old "couldn't reach HF" reason no longer reflects
         # reality. Without this, a previously-unverified model keeps
@@ -380,8 +411,9 @@ def clear_verified_cache(model_id: str) -> None:
     """Drop a model from the per-process verification cache so that the
     next call to verify_if_needed will re-hash. Called by download_model
     after a successful re-download."""
-    _verified_this_process.discard(model_id)
-    _verify_error_cache.pop(model_id, None)
+    with _cache_lock:
+        _verified_this_process.discard(model_id)
+        _verify_error_cache.pop(model_id, None)
 
 
 def verify_all_models(progress_callback=None) -> dict[str, VerifyResult]:
@@ -447,7 +479,7 @@ def verify_all_models(progress_callback=None) -> dict[str, VerifyResult]:
             results[model_id] = result
             if result.ok:
                 write_pinned_revision(weights_path, latest_rev)
-                _verified_this_process.add(model_id)
+                _mark_verified(model_id)
                 clear_verify_skipped(weights_path)
             else:
                 # Mismatch is ambiguous for unpinned installs — don't
@@ -458,7 +490,7 @@ def verify_all_models(progress_callback=None) -> dict[str, VerifyResult]:
                 # previously-unverified model stays stuck with an
                 # outdated network-error badge and makes Retry look
                 # ineffective even though verification actually ran.
-                _verified_this_process.discard(model_id)
+                _mark_unverified(model_id)
                 clear_verify_skipped(weights_path)
             continue
 
@@ -481,8 +513,8 @@ def verify_all_models(progress_callback=None) -> dict[str, VerifyResult]:
                     )
             except OSError:
                 pass
-            _verified_this_process.discard(model_id)
+            _mark_unverified(model_id)
         else:
-            _verified_this_process.add(model_id)
+            _mark_verified(model_id)
             clear_verify_skipped(weights_path)
     return results

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -661,17 +661,12 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
     if status_callback:
         status_callback(f"Extracting {total} working copies...")
 
-    # Commit in small batches so a long backfill streams progress out
-    # incrementally instead of holding a single transaction across 10k+ rows.
-    BATCH = 25
-    pending = 0
-
-    def _flush():
-        nonlocal pending
-        if pending:
-            commit_with_retry(db.conn)
-            pending = 0
-
+    # Commit per row so the writer lock is released between iterations.
+    # Otherwise the first UPDATE in a batch auto-opens a transaction and
+    # subsequent slow extract_working_copy() calls (RAW decode → JPEG
+    # encode, multi-second per file on a slow disk) hold the writer lock
+    # for the whole batch, starving any concurrent writer (e.g. a parallel
+    # pipeline's add_photo INSERT past the 30s busy_timeout).
     for i, row in enumerate(rows, 1):
         if cancel_check is not None and cancel_check():
             log.info("Working-copy extraction cancelled after %d/%d rows", i - 1, total)
@@ -687,7 +682,10 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
             if os.path.isfile(companion):
                 source = companion
 
-        if extract_working_copy(source, wc_abs, max_size=wc_max_size, quality=wc_quality):
+        # extract_working_copy is slow (RAW decode + JPEG encode); run it
+        # before any DB write so no transaction is open while it runs.
+        ok = extract_working_copy(source, wc_abs, max_size=wc_max_size, quality=wc_quality)
+        if ok:
             db.conn.execute(
                 "UPDATE photos SET working_copy_path=?,"
                 " working_copy_failed_at=NULL,"
@@ -714,14 +712,10 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
                 " WHERE id=?",
                 (row["file_mtime"], row["id"]),
             )
-        pending += 1
+        commit_with_retry(db.conn)
 
-        if pending >= BATCH:
-            _flush()
         if progress_callback is not None:
             progress_callback(i, total)
-
-    _flush()
 
 
 def backfill_working_copies(db, vireo_dir, progress_callback=None,

--- a/vireo/text_encoder.py
+++ b/vireo/text_encoder.py
@@ -6,6 +6,7 @@ Uses ONNX Runtime for inference with text encoder models stored in
 
 import logging
 import os
+import threading
 
 import numpy as np
 import onnx_runtime
@@ -14,6 +15,10 @@ log = logging.getLogger(__name__)
 
 # Cache: model_dir -> (text_session, text_input_name, tokenizer)
 _session_cache = {}
+# Serializes lookup + (slow) load + cache write so two concurrent jobs don't
+# both run the expensive ONNX session creation for the same model and race on
+# the dict assignment.
+_session_cache_lock = threading.Lock()
 
 # Map model_str identifiers to local model directory names
 _MODEL_DIR_MAP = {
@@ -61,7 +66,11 @@ def _get_text_session(model_str, pretrained_str=None):
             )
         model_dir = os.path.join(_MODELS_ROOT, dir_name)
 
-    if model_dir not in _session_cache:
+    with _session_cache_lock:
+        cached = _session_cache.get(model_dir)
+        if cached is not None:
+            return cached
+
         log.info("Loading CLIP text encoder for %s...", model_str)
         from tokenizers import Tokenizer
 
@@ -82,10 +91,10 @@ def _get_text_session(model_str, pretrained_str=None):
         input_name = session.get_inputs()[0].name
         tokenizer = Tokenizer.from_file(tokenizer_path)
 
-        _session_cache[model_dir] = (session, input_name, tokenizer)
+        entry = (session, input_name, tokenizer)
+        _session_cache[model_dir] = entry
         log.info("CLIP text encoder loaded")
-
-    return _session_cache[model_dir]
+        return entry
 
 
 def encode_text(query, model_str, pretrained_str=None):

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -1,7 +1,9 @@
 """Generate and manage local thumbnail cache for the photo browser."""
 
+import contextlib
 import logging
 import os
+import tempfile
 
 from image_loader import get_canonical_image_path, load_image
 
@@ -35,7 +37,21 @@ def generate_thumbnail(photo_id, source_path, cache_dir, size=THUMB_SIZE, qualit
         return None
 
     os.makedirs(cache_dir, exist_ok=True)
-    img.save(thumb_path, "JPEG", quality=quality)
+    # Atomic write: two concurrent jobs (or two iterations of the same job
+    # racing on a freshly added photo) can both see the missing thumb and
+    # call img.save() on the same path, producing a half-written or
+    # interleaved JPEG. Write to a sibling temp file then os.replace().
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f".{photo_id}.", suffix=".jpg.tmp", dir=cache_dir
+    )
+    os.close(fd)
+    try:
+        img.save(tmp_path, "JPEG", quality=quality)
+        os.replace(tmp_path, thumb_path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
     return thumb_path
 
 
@@ -99,6 +115,11 @@ def generate_all(db, cache_dir, progress_callback=None, config=None, vireo_dir=N
         else:
             folder_path = folders.get(photo["folder_id"], "")
             source_path = os.path.join(folder_path, photo["filename"])
+        # generate_thumbnail decodes the source image (slow for RAW). Run
+        # it before any UPDATE so no transaction is open while it runs;
+        # then commit per photo to release the writer lock between
+        # iterations and avoid blocking concurrent jobs (a parallel scan's
+        # add_photo INSERT) past the 30s busy_timeout.
         if generate_thumbnail(photo["id"], source_path, cache_dir, size=thumb_size, quality=thumb_quality) is not None:
             generated += 1
             # Record on-disk presence in the photos table so the dashboard's
@@ -109,13 +130,13 @@ def generate_all(db, cache_dir, progress_callback=None, config=None, vireo_dir=N
                 "UPDATE photos SET thumb_path=? WHERE id=?",
                 (f"{photo['id']}.jpg", photo["id"]),
             )
+            db.conn.commit()
         else:
             failed += 1
 
         if progress_callback:
             progress_callback(i + 1, total)
 
-    db.conn.commit()
     if failed:
         log.warning("Thumbnail generation: %d of %d failed", failed, total)
     result = {"generated": generated, "skipped": skipped, "failed": failed}


### PR DESCRIPTION
## Summary

Audit + fixes for the case where multiple pipelines run concurrently. Found six spots where shared resources weren't synchronized — three causing data corruption, three causing wasted work or contention.

### Data-corruption bugs
- **SAM2 sessions** (`masking.py`) — global `_encoder_session` / `_decoder_session` / `_sam2_variant_loaded` mutated without a lock. Two jobs loading different variants race and leave the trio inconsistent. Added `_sam2_session_lock`.
- **Thumbnail writes** (`thumbnails.py`) — check-then-write on `~/.vireo/thumbnails/{id}.jpg`. Two jobs racing produce corrupted JPEGs. Switched to tempfile + `os.replace()`.
- **Label file writes** (`labels.py`) — `save_labels()` wrote `.txt` and `.json` non-atomically. Concurrent fetches could interleave bytes. Added `_atomic_write_text` helper.

### Race / contention fixes
- **Text encoder cache** (`text_encoder.py`) — `_session_cache` dict mutated without a lock; concurrent jobs duplicate the expensive ONNX `create_session` call. Wrapped in `_session_cache_lock` (double-checked).
- **Model verification cache** (`model_verify.py`) — `_verified_this_process` / `_verify_error_cache` accessed across compound check-then-modify with no sync. Added `_cache_lock` and small helpers (`_is_verified`, `_mark_verified`, `_record_error`, etc.); routed all call sites through them.
- **Writer-lock starvation** (`scanner.py`, `thumbnails.py`) — BATCH commits in working-copy extraction and thumbnail generation left the writer lock held through subsequent slow image I/O (RAW decode → JPEG), causing concurrent writers' `INSERT`s to time out past the 30s `busy_timeout`. Switched both loops to per-row commit, matching the pattern already documented in `culling.py:180-186`.

## Test plan
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_model_verify.py vireo/tests/test_scanner.py vireo/tests/test_scanner_working_copy.py -q` → 1054 passed, 1 skipped, 2 failed
- [x] The 2 failures (`test_remove_keyword_from_photo`, `test_undo_keyword_remove_clears_pending_change`) are pre-existing failures on `main` (documented), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)