### PR TITLE
Pipeline page: show whether each model uses a label list

### DIFF
--- a/vireo/models.py
+++ b/vireo/models.py
@@ -43,6 +43,8 @@ KNOWN_MODELS = [
         "size_mb": 400,
         "architecture": "ViT-B/16",
         "parameters": "150M",
+        "supports_label_lists": True,
+        "label_list_tag": "uses label list",
     },
     {
         "id": "bioclip-2",
@@ -65,6 +67,8 @@ KNOWN_MODELS = [
         "size_mb": 1500,
         "architecture": "ViT-L/14",
         "parameters": "428M",
+        "supports_label_lists": True,
+        "label_list_tag": "uses label list",
     },
     {
         "id": "bioclip-2.5-vith14",
@@ -85,6 +89,8 @@ KNOWN_MODELS = [
         "size_mb": 3900,
         "architecture": "ViT-H/14",
         "parameters": "986M",
+        "supports_label_lists": True,
+        "label_list_tag": "uses label list",
     },
     {
         "id": "timm-inat21-eva02-l",
@@ -106,6 +112,8 @@ KNOWN_MODELS = [
         "size_mb": 1200,
         "architecture": "EVA-02 Large",
         "parameters": "304M",
+        "supports_label_lists": False,
+        "label_list_tag": "fixed 10K species",
     },
 ]
 
@@ -246,6 +254,8 @@ def get_models():
                     "weights_path": path,
                     "downloaded": downloaded,
                     "state": "ok" if downloaded else "missing",
+                    "supports_label_lists": True,
+                    "label_list_tag": "uses label list",
                 }
             )
 

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -938,6 +938,7 @@ body { padding-bottom: 36px; }
         <div class="setting-item">
           <div class="setting-label">Labels</div>
           <div id="labelsPicker" style="font-size:12px;max-height:100px;overflow-y:auto;"></div>
+          <div id="labelsPickerNote" style="font-size:11px;color:var(--text-faint);margin-top:4px;display:none;"></div>
         </div>
       </div>
       <div class="readiness-panel" id="readinessPanel" style="display:none;"></div>
@@ -1250,6 +1251,7 @@ function applyClassifyQueryParams() {
       cb.checked = wantLabels.has(cb.value) || wantLabels.has(base);
     });
   }
+  if (typeof updateLabelsPickerState === 'function') updateLabelsPickerState();
 }
 
 document.addEventListener('DOMContentLoaded', initPipelinePage);
@@ -2984,16 +2986,60 @@ async function loadModels() {
         cb.className = 'model-checkbox';
         cb.value = m.id;
         cb.dataset.name = m.name;
+        cb.dataset.supportsLists = m.supports_label_lists ? '1' : '0';
         cb.style.cssText = 'accent-color:var(--accent);margin-right:4px;';
-        cb.onchange = function() { updateReadiness(); schedulePlanRefresh(); };
+        cb.onchange = function() { updateReadiness(); updateLabelsPickerState(); schedulePlanRefresh(); };
         if (m.id === data.active_id) cb.checked = true;
         label.appendChild(cb);
         label.appendChild(document.createTextNode(m.name + ' (' + m.model_str + ')'));
+        if (m.label_list_tag) {
+          var pill = document.createElement('span');
+          pill.textContent = m.label_list_tag;
+          pill.style.cssText = 'margin-left:6px;padding:1px 6px;border-radius:8px;font-size:10px;color:var(--text-faint);background:var(--surface-2,rgba(255,255,255,0.06));';
+          label.appendChild(pill);
+        }
         div.appendChild(label);
       });
     }
     updateReadiness();
+    updateLabelsPickerState();
   } catch(e) {}
+}
+
+// Grey out the labels picker when no selected model uses label lists,
+// or show a "BioCLIP-only" note when selection is mixed.
+function updateLabelsPickerState() {
+  var picker = document.getElementById('labelsPicker');
+  var note = document.getElementById('labelsPickerNote');
+  if (!picker || !note) return;
+  var selected = Array.from(document.querySelectorAll('.model-checkbox:checked'));
+  if (selected.length === 0) {
+    picker.style.opacity = '';
+    picker.style.pointerEvents = '';
+    note.style.display = 'none';
+    return;
+  }
+  var supporting = selected.filter(function(cb) { return cb.dataset.supportsLists === '1'; });
+  var nonSupporting = selected.filter(function(cb) { return cb.dataset.supportsLists !== '1'; });
+  if (supporting.length === 0) {
+    // Only fixed-class-set models selected — list selection does nothing.
+    picker.style.opacity = '0.4';
+    picker.style.pointerEvents = 'none';
+    var names = nonSupporting.map(function(cb) { return cb.dataset.name; }).join(', ');
+    note.textContent = names + ' uses a fixed class set — label lists do not apply.';
+    note.style.display = '';
+  } else if (nonSupporting.length > 0) {
+    // Mixed: list applies only to the supporting models.
+    picker.style.opacity = '';
+    picker.style.pointerEvents = '';
+    var ignoringNames = nonSupporting.map(function(cb) { return cb.dataset.name; }).join(', ');
+    note.textContent = 'Note: ' + ignoringNames + ' ignores label lists (fixed class set).';
+    note.style.display = '';
+  } else {
+    picker.style.opacity = '';
+    picker.style.pointerEvents = '';
+    note.style.display = 'none';
+  }
 }
 
 async function loadLabels() {

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -96,6 +96,54 @@ def test_known_model_ids_unique():
     assert len(ids) == len(set(ids))
 
 
+def test_known_models_declare_label_list_support():
+    """Every KNOWN_MODELS entry must declare supports_label_lists (a hard
+    capability flag) and label_list_tag (a short human-readable note shown
+    next to the model name on the pipeline page).
+
+    BioCLIP variants are zero-shot and accept a custom label list at
+    inference time; timm classifiers (iNat21 EVA-02) have a fixed softmax
+    head and ignore label lists entirely. The pipeline UI uses these
+    fields to grey out the labels picker when no selected model uses it
+    and to render an honest capability tag next to each model name.
+    """
+    from models import KNOWN_MODELS
+
+    by_id = {m["id"]: m for m in KNOWN_MODELS}
+    for m in KNOWN_MODELS:
+        assert "supports_label_lists" in m, (
+            f"{m['id']} missing supports_label_lists"
+        )
+        assert isinstance(m["supports_label_lists"], bool)
+        assert "label_list_tag" in m, f"{m['id']} missing label_list_tag"
+        assert isinstance(m["label_list_tag"], str) and m["label_list_tag"]
+
+    # BioCLIP family supports label lists.
+    for mid in ("bioclip-vit-b-16", "bioclip-2", "bioclip-2.5-vith14"):
+        assert by_id[mid]["supports_label_lists"] is True, (
+            f"{mid} must support label lists (it's zero-shot CLIP)"
+        )
+
+    # iNat21 has a fixed 10K-class head; lists do not apply.
+    assert by_id["timm-inat21-eva02-l"]["supports_label_lists"] is False
+
+
+def test_get_models_propagates_label_list_capability(tmp_path, monkeypatch):
+    """get_models() must propagate supports_label_lists and label_list_tag
+    to every returned entry so the /api/models endpoint can expose them
+    to the pipeline page UI."""
+    import models
+
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
+
+    by_id = {m["id"]: m for m in models.get_models()}
+    assert by_id["bioclip-vit-b-16"]["supports_label_lists"] is True
+    assert by_id["timm-inat21-eva02-l"]["supports_label_lists"] is False
+    assert by_id["timm-inat21-eva02-l"]["label_list_tag"]
+    assert by_id["bioclip-vit-b-16"]["label_list_tag"]
+
+
 # ---------------------------------------------------------------------------
 # get_models
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- iNat21 silently ignored the labels picker because its softmax head is fixed at 10K classes; BioCLIP actually uses the list. The UI made them look identical.
- Add a `supports_label_lists` capability flag (and short tag string) per model in `vireo/models.py`, exposed via `/api/models`.
- On the pipeline page: render a small pill next to each model name (`uses label list` / `fixed 10K species`), and grey out the labels picker with an explanatory note when no selected model uses lists. Mixed selections (BioCLIP + iNat21) show a note that the list only applies to BioCLIP.
- No DB changes — predictions already encode this asymmetry: iNat21 predictions are tagged `labels_fingerprint="legacy"` regardless of what was "selected", so there's no per-iNat21→list association to clean up.

## Why this and not auto-filtering iNat21 to the selected list
The fix could have made iNat21 post-filter its 10K predictions to the selected list, but that's a different feature than what BioCLIP does (zero-shot embedding against the list) and would surprise users who expect "use list X" to mean the same thing for both models. Decided with @jss367 to keep the two model families distinct and surface the capability honestly instead.

## Test plan
- [x] `vireo/tests/test_models.py` — added two tests asserting `supports_label_lists` + `label_list_tag` are present on every `KNOWN_MODELS` entry and propagate through `get_models()`. Failed before the change, pass after.
- [x] Focused suite (test_models, test_pipeline_plan, test_classify_job, test_settings_api): 254 passed.
- [x] Drove the pipeline page in Playwright with both models stubbed-as-downloaded:
  - iNat21 only → labels picker dimmed (opacity 0.4) + note "iNat21 (EVA-02 Large) uses a fixed class set — label lists do not apply."
  - iNat21 + BioCLIP → picker normal + note "Note: iNat21 (EVA-02 Large) ignores label lists (fixed class set)."
  - BioCLIP only → picker normal, note hidden.
  - Pills render inline next to each model name.