### PR TITLE
Fix keyword-undo test flakiness from $HOME leak in workspaces client fixture

### DIFF
--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -349,12 +349,32 @@ def test_job_history_filtered_by_workspace(db_with_workspace):
 
 
 @pytest.fixture
-def client(tmp_path):
-    """Flask test client with a fresh DB."""
+def client(tmp_path, monkeypatch):
+    """Flask test client with a fresh DB.
+
+    Isolates $HOME and config paths to tmp_path so create_app's
+    ``_mark_species_and_maybe_backfill`` doesn't read the developer's real
+    ``~/.vireo/taxonomy.json``. Without this, the lazy
+    ``from taxonomy import ...`` inside that helper freezes
+    ``taxonomy.TAXONOMY_JSON_PATH`` to the real path on first import; later
+    tests in ``vireo/tests/`` then load the real 554MB taxonomy via the
+    cached module, retype "Cardinal" as a species, and trigger the
+    auto-Wildlife backfill — breaking ``test_remove_keyword_from_photo`` and
+    ``test_undo_keyword_remove_clears_pending_change`` with a phantom
+    Wildlife tag.
+    """
     import os
     import sys
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "vireo"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    import models
     from app import create_app
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
     app = create_app(str(tmp_path / "test.db"))
     app.config["TESTING"] = True
     with app.test_client() as c:


### PR DESCRIPTION
## Summary

- Fixes `vireo/tests/test_edits_api.py::test_remove_keyword_from_photo` and `test_undo_keyword_remove_clears_pending_change` failing in full-suite order on main.
- Roots out a `\$HOME` leak in `tests/test_workspaces.py::client` that polluted `taxonomy.TAXONOMY_JSON_PATH` for the whole pytest session.
- Side effect: pre-PR suite drops from ~40 minutes to ~27 seconds (client-fixture tests no longer load the 554MB real taxonomy).

## Root cause

`tests/test_workspaces.py::client` called `create_app()` without monkeypatching `\$HOME`. On first invocation in a session, `_mark_species_and_maybe_backfill` runs synchronously inside `create_app` and does a lazy `from taxonomy import ...`. With the real `\$HOME`, `taxonomy.TAXONOMY_JSON_PATH = os.path.expanduser("~/.vireo/taxonomy.json")` froze to the developer's real 554MB taxonomy file at module-import time.

Later tests in `vireo/tests/` (which *do* monkeypatch `\$HOME` in their `app_and_db` fixture) still found `taxonomy` already in `sys.modules` with the real path frozen in. `load_local_taxonomy()` loaded the production taxonomy, `mark_species_keywords` retyped the fixture keyword "Cardinal" as `type='taxonomy', is_species=1`, and `backfill_wildlife_genre()` then auto-tagged the test photo with Wildlife — producing the `{'Cardinal', 'Wildlife'} != {'Cardinal'}` failure.

In isolation the bug doesn't reproduce because `app_and_db` is the first fixture to import `taxonomy`, by which point HOME has been monkeypatched to `tmp_path`.

## Fix

Mirror the existing `vireo/tests/conftest.py::app_and_db` pattern in `tests/test_workspaces.py::client` — monkeypatch `\$HOME`, `cfg.CONFIG_PATH`, `models.DEFAULT_MODELS_DIR`, and `models.CONFIG_PATH` to `tmp_path` before calling `create_app`. The first lazy taxonomy import then freezes `TAXONOMY_JSON_PATH` to a per-test tmp path that doesn't exist, so `load_local_taxonomy()` returns None for every test in the session — no species marking, no auto-Wildlife.

## Test plan

- [x] Failing repro pair: `tests/test_workspaces.py::test_api_get_workspaces vireo/tests/test_edits_api.py::test_remove_keyword_from_photo vireo/tests/test_edits_api.py::test_undo_keyword_remove_clears_pending_change` — passes
- [x] Failing pair full files: `tests/test_workspaces.py vireo/tests/test_edits_api.py` — 109 passed, 2.5s
- [x] `tests/test_workspaces.py` alone — 68 passed, 0.77s
- [x] Pre-PR suite: `tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` — 921 passed, 1 skipped, 27s

🤖 Generated with [Claude Code](https://claude.com/claude-code)