### PR TITLE
fix(review): restore 1:1 default zoom when hovering burst-loupe cards

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3092,17 +3092,13 @@ function grmCardCoverFit(card) {
   return Math.max(GRM_CARD_W / W, GRM_CARD_H / H);
 }
 
-// Effective max for `_grmZoomMultiplier`. Multiplier=1 = cover-fit (today's
-// default visual). To reach 1:1 source-to-CSS we need multiplier ~ 1/coverFit
-// (e.g. ~30 for a 5400px-wide image). To reach 1:1 source-to-DEVICE pixels
-// (true pixel-peep on a Retina display), multiplier ~ DPR/coverFit.
+// Effective max for `_grmZoomMultiplier`. Since the <img> is laid out at
+// natural source size, the multiplier IS the source-to-CSS pixel ratio:
+// multiplier=1 → 1:1 source-to-CSS, multiplier=DPR → 1:1 source-to-DEVICE
+// (true pixel-peep on a Retina display). Allow a little headroom past that.
 function grmMaxZoomMultiplier() {
   var dpr = window.devicePixelRatio || 1;
-  var card = document.querySelector('#grmOverlay .grm-card');
-  if (!card) return 30 * dpr;
-  var coverFit = grmCardCoverFit(card);
-  if (!coverFit) return 30 * dpr;
-  return Math.max(3, dpr / coverFit);
+  return Math.max(3, dpr * 2);
 }
 
 // Compute the transform for one card. Returns the CSS transform string and
@@ -3112,11 +3108,13 @@ function _grmComputeCardTransform(card) {
   var H = parseFloat(card.dataset.natH) || GRM_CARD_H;
   var coverFit = Math.max(GRM_CARD_W / W, GRM_CARD_H / H);
   var hovering = _grmLastHoverX != null;
-  // Scale: cover-fit when not hovering; cover-fit * multiplier when hovering.
-  // Floor at coverFit so a fractional multiplier never reveals card background.
+  // The <img> is laid out at natural source-pixel size, so transform `scale`
+  // IS the source-to-CSS pixel ratio. Cover-fit when not hovering; multiplier
+  // (1 = true 1:1) when hovering, floored at coverFit so a sub-1 multiplier
+  // never reveals card background.
   var s = coverFit;
   if (hovering) {
-    s = Math.max(coverFit, coverFit * _grmZoomMultiplier);
+    s = Math.max(coverFit, _grmZoomMultiplier);
   }
   // Hover-anchor: cursor at fractional position f of the loupe maps to the
   // same fractional position in the source image. Place pixel (f*W, f*H) of
@@ -3281,12 +3279,12 @@ function grmCardMouseMove(e) {
   // pre-scale offset units that, when re-scaled, follow the cursor 1:1.
   // Must mirror _grmComputeCardTransform's hover/non-hover branch: after a
   // zoom-in followed by mouseleave (grmLoupeReset clears _grmLastHoverX) the
-  // card is displayed at cover-fit while _grmZoomMultiplier stays >1, so a
-  // naive `coverFit * multiplier` denominator would shrink drag motion by
-  // that factor and pans would jump when hover resumes.
+  // card is displayed at cover-fit while _grmZoomMultiplier stays at its
+  // hovered value, so the denominator must match what's actually on screen
+  // or pans would jump when hover resumes.
   var coverFit = grmCardCoverFit(_grmDragging.card);
   var hovering = _grmLastHoverX != null;
-  var scale = hovering ? Math.max(coverFit, coverFit * _grmZoomMultiplier) : coverFit;
+  var scale = hovering ? Math.max(coverFit, _grmZoomMultiplier) : coverFit;
   var z = scale > 0.01 ? scale : 1;
   var newTx = _grmDragging.origTx + dx / z;
   var newTy = _grmDragging.origTy + dy / z;

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3101,6 +3101,22 @@ function grmMaxZoomMultiplier() {
   return Math.max(3, dpr * 2);
 }
 
+// Effective floor for `_grmZoomMultiplier`: the smallest coverFit across all
+// currently-visible burst cards. The hover formula floors per-card at each
+// card's own coverFit, so once the multiplier reaches the minimum coverFit
+// every card is already at cover-fit and further wheel-down would be a
+// dead no-op. A high-resolution photo can have coverFit ~0.03 (5400px wide
+// in a 180px viewport), well below the legacy 0.33 floor.
+function grmMinZoomMultiplier() {
+  var cards = document.querySelectorAll('#grmOverlay .grm-card');
+  var minCover = Infinity;
+  for (var i = 0; i < cards.length; i++) {
+    var cf = grmCardCoverFit(cards[i]);
+    if (cf > 0 && cf < minCover) minCover = cf;
+  }
+  return isFinite(minCover) ? minCover : 0.33;
+}
+
 // Compute the transform for one card. Returns the CSS transform string and
 // flags whether the user is in the zoomed (hover) state.
 function _grmComputeCardTransform(card) {
@@ -3215,14 +3231,16 @@ function grmLoupeMove(e) {
 
 function grmLoupeZoom(e) {
   e.preventDefault();
-  // Multiplier=1 = cover-fit (no zoom). Allow scaling up well past 1.0 to
-  // reach 1:1 source-to-CSS pixels and beyond to 1:1 source-to-DEVICE pixels
-  // on Retina (DPR) displays — the actual pixel-peep target.
+  // Multiplier is the source-to-CSS pixel ratio: 1 = true 1:1, DPR = 1:1
+  // source-to-DEVICE on Retina (the pixel-peep target). Floor at the
+  // smallest visible coverFit so wheel-down can always return every card
+  // to cover-fit even for high-resolution photos.
   var max = grmMaxZoomMultiplier();
+  var min = grmMinZoomMultiplier();
   if (e.deltaY < 0) {
     _grmZoomMultiplier = Math.min(max, _grmZoomMultiplier * 1.25);
   } else {
-    _grmZoomMultiplier = Math.max(0.33, _grmZoomMultiplier / 1.25);
+    _grmZoomMultiplier = Math.max(min, _grmZoomMultiplier / 1.25);
   }
   grmApplyCardTransforms();
 }


### PR DESCRIPTION
## Summary

In commit bd849e5 (\"fix(review): lay out burst-strip imgs at natural size for true 1:1 zoom\") the burst Group Review Modal's zoom math was rewritten for the new natural-size `<img>` layout, but the meaning of `_grmZoomMultiplier` was inverted in the rewrite.

- The variable's comment still says \"wheel fine-tune on top of the 1:1 base scale.\"
- The actual hover formula became `s = Math.max(coverFit, coverFit * _grmZoomMultiplier)`, so the default `_grmZoomMultiplier = 1` produced **cover-fit (no zoom)** instead of 1:1.
- Result: clicking/hovering the loupe stopped zooming the left strip cards entirely. Wheel zoom still worked but had to climb ~30x to actually reach 1:1 on a typical 5400px-wide photo.

This restores the documented behaviour by treating the multiplier as the source-to-CSS pixel ratio it claims to be:

- `s = Math.max(coverFit, _grmZoomMultiplier)` — multiplier=1 is true 1:1, multiplier≥`dpr` is 1:1 source-to-DEVICE on Retina.
- `grmMaxZoomMultiplier()` simplified to `max(3, dpr * 2)` — no longer compensates for `coverFit`.
- Drag-pan denominator updated to mirror the same hover math.
- Stale comments updated.

## Test plan

- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` → 921 passed, 1 skipped
- [ ] Open Pipeline Review, expand a burst group, hover the loupe → all strip cards zoom to 1:1 (default)
- [ ] Click the loupe → zoom locks (crosshair turns orange); click again → unlocks
- [ ] Wheel up/down on the loupe → cards zoom past 1:1 up to ~`2*DPR`, and back down to cover-fit
- [ ] Drag a strip thumbnail to pan → motion follows cursor 1:1 at any zoom level
- [ ] Mouseleave → cards return to cover-fit

🤖 Generated with [Claude Code](https://claude.com/claude-code)