### PR TITLE
Pipeline review: persist Apply & Close to photo flags

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11162,7 +11162,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     if pid in photos_with_species:
                         continue
                     db.tag_photo(pid, species_kid)
-                    db.queue_change(pid, "keyword_add", species)
+                    # Use the shared helper so a pending `keyword_remove` for
+                    # the same species cancels out instead of co-existing with
+                    # a new `keyword_add`. sync_to_xmp applies removals after
+                    # adds, so a leftover remove would strip the keyword from
+                    # XMP even though the DB still has the tag.
+                    _queue_keyword_add(pid, species)
                     kw_added_pids.append(pid)
         except ValueError as e:
             return json_error(str(e), 403)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11056,8 +11056,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         species_kid = None
         if species:
+            # Read-only mirror of the species-aware lookup in db.add_keyword(
+            # species, is_species=True): match top-level taxonomy/general rows
+            # case-insensitively, prefer taxonomy. Excludes homonym rows of
+            # other deliberate types (individual, location, genre) so a person
+            # tag named like a species doesn't get reported as the species
+            # keyword for has_species_keyword / Apply-label purposes.
             row = db.conn.execute(
-                "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE LIMIT 1",
+                "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
+                "AND parent_id IS NULL AND type IN ('taxonomy', 'general') "
+                "ORDER BY (type = 'taxonomy') DESC, id ASC LIMIT 1",
                 (species,),
             ).fetchone()
             if row:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11073,6 +11073,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         photos = {}
         for pid in photo_ids:
+            # Same workspace guard the apply endpoint uses, so a malicious
+            # or buggy client can't read flag/keyword state for photos that
+            # don't belong to the active workspace.
+            if not db._photo_in_workspace(pid):
+                continue
             row = db.get_photo(pid)
             if not row:
                 continue

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11037,6 +11037,151 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         save_results_raw(body, cache_dir, db._active_workspace_id)
         return jsonify({"ok": True})
 
+    @app.route("/api/pipeline/group/state", methods=["POST"])
+    def api_pipeline_group_state():
+        """Return current DB state for a set of photos in a pipeline burst.
+
+        Used by the burst-review modal on open so it can seed picks/rejects
+        from the live `photos.flag` value (rather than the stale cached value
+        in pipelineResults) and show whether each photo already has the
+        consensus species keyword applied.
+
+        Body: {photo_ids: [int], species: str}
+        Returns: {photos: {pid: {flag, has_species_keyword}}, species_kid: int|None}
+        """
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        photo_ids = list(body.get("photo_ids", []) or [])
+        species = (body.get("species") or "").strip()
+
+        species_kid = None
+        if species:
+            row = db.conn.execute(
+                "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE LIMIT 1",
+                (species,),
+            ).fetchone()
+            if row:
+                species_kid = row["id"]
+
+        photos = {}
+        for pid in photo_ids:
+            row = db.get_photo(pid)
+            if not row:
+                continue
+            has_kw = False
+            if species_kid is not None:
+                has_kw = any(k["id"] == species_kid for k in db.get_photo_keywords(pid))
+            photos[pid] = {
+                "flag": row["flag"] or "none",
+                "has_species_keyword": has_kw,
+            }
+        return jsonify({"photos": photos, "species_kid": species_kid})
+
+    @app.route("/api/pipeline/group/apply", methods=["POST"])
+    def api_pipeline_group_apply():
+        """Apply pick/reject decisions and species to a pipeline burst group.
+
+        Diff-based: only writes flag changes for photos whose flag actually
+        changes, only adds the species keyword when it isn't already on the
+        photo, and clears flags on photos moved to candidates that were
+        previously flagged/rejected. Returns per-photo new flag/keyword state
+        so the client can update its rendered cards without reloading.
+        """
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        picks = list(body.get("picks", []) or [])
+        rejects = list(body.get("rejects", []) or [])
+        candidates = list(body.get("candidates", []) or [])
+        species = (body.get("species") or "").strip()
+
+        # The same photo can't be in two zones. Reject conflicting input.
+        seen = set()
+        for pid in picks + rejects + candidates:
+            if pid in seen:
+                return json_error(f"Photo {pid} appears in more than one zone", 400)
+            seen.add(pid)
+
+        # All photos must be in the active workspace.
+        for pid in picks + rejects + candidates:
+            if not db._photo_in_workspace(pid):
+                return json_error(f"Photo {pid} is not in the active workspace", 403)
+
+        # Capture current state for diffing + edit history.
+        old_flags = {}
+        for pid in picks + rejects + candidates:
+            row = db.get_photo(pid)
+            if row:
+                old_flags[pid] = row["flag"] or "none"
+
+        species_kid = None
+        photos_with_species = set()
+        if species:
+            species_kid = db.add_keyword(species, is_species=True)
+            for pid in picks:
+                kws = db.get_photo_keywords(pid)
+                if any(k["id"] == species_kid for k in kws):
+                    photos_with_species.add(pid)
+
+        try:
+            # Apply target flags. We rely on update_photo_flag's own write
+            # being a no-op at the SQL level when the value matches, but we
+            # still skip when unchanged so we don't record useless history.
+            flag_items = []
+            for pid in picks:
+                old = old_flags.get(pid, "none")
+                if old != "flagged":
+                    db.update_photo_flag(pid, "flagged")
+                    flag_items.append({"photo_id": pid, "old_value": old, "new_value": "flagged"})
+            for pid in rejects:
+                old = old_flags.get(pid, "none")
+                if old != "rejected":
+                    db.update_photo_flag(pid, "rejected")
+                    flag_items.append({"photo_id": pid, "old_value": old, "new_value": "rejected"})
+            for pid in candidates:
+                old = old_flags.get(pid, "none")
+                if old in ("flagged", "rejected"):
+                    db.update_photo_flag(pid, "none")
+                    flag_items.append({"photo_id": pid, "old_value": old, "new_value": "none"})
+
+            kw_added_pids = []
+            if species and species_kid is not None:
+                for pid in picks:
+                    if pid in photos_with_species:
+                        continue
+                    db.tag_photo(pid, species_kid)
+                    db.queue_change(pid, "keyword_add", species)
+                    kw_added_pids.append(pid)
+        except ValueError as e:
+            return json_error(str(e), 403)
+
+        if flag_items:
+            desc = (
+                f"Pipeline burst group: flagged {len(picks)}, rejected {len(rejects)}, "
+                f"cleared {sum(1 for it in flag_items if it['new_value'] == 'none')}"
+            )
+            db.record_edit("flag", desc, "pipeline_group_apply", flag_items,
+                           is_batch=len(flag_items) > 1)
+
+        if kw_added_pids and species_kid is not None:
+            kw_items = [{"photo_id": pid, "old_value": "", "new_value": str(species_kid)}
+                        for pid in kw_added_pids]
+            db.record_edit("keyword_add",
+                           f'Added "{species}" to {len(kw_added_pids)} photos (pipeline burst group)',
+                           str(species_kid), kw_items, is_batch=len(kw_added_pids) > 1)
+
+        # Return new per-photo state so the client can update without a reload.
+        result_photos = {}
+        for pid in picks + rejects + candidates:
+            row = db.get_photo(pid)
+            if not row:
+                continue
+            kws = db.get_photo_keywords(pid)
+            result_photos[pid] = {
+                "flag": row["flag"] or "none",
+                "has_species_keyword": species_kid is not None and any(k["id"] == species_kid for k in kws),
+            }
+        return jsonify({"ok": True, "photos": result_photos})
+
     @app.route("/api/pipeline/config", methods=["GET", "POST"])
     def api_pipeline_config():
         """Get or update pipeline model configuration.

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2762,7 +2762,8 @@ var grmState = {
   picks: new Set(),
   rejects: new Set(),
   removed: new Set(),
-  selected: null      // photo id
+  selected: null,     // photo id
+  sessionId: 0        // bumped on each openGroupReview; used to drop stale fetches
 };
 
 function findBurstForPhoto(photoId) {
@@ -2792,6 +2793,9 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
 
   var items = photoIds.map(function(pid) { return photoMap[pid]; }).filter(Boolean);
 
+  // Bump the session id so any in-flight /group/state fetch from a previous
+  // openGroupReview call lands as stale and gets ignored when it resolves.
+  var sessionId = (grmState.sessionId || 0) + 1;
   grmState = {
     encIdx: encIdx,
     burstIdx: burstIdx,
@@ -2804,7 +2808,8 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
     // has_species_keyword}. This is the live DB snapshot the modal opened
     // with, used to (a) render "from DB" markers and (b) compute the
     // change-only Apply button label.
-    dbState: {}
+    dbState: {},
+    sessionId: sessionId
   };
   _grmLoupeLocked = false;
   _grmZoomMultiplier = 1;
@@ -2837,8 +2842,12 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ photo_ids: items.map(function(p) { return p.id; }), species: initialSpecies }),
   }, { toast: false }).then(function(data) {
+    // Drop the response if a newer openGroupReview has fired since: seeding
+    // burst A's DB state into burst B's modal would mis-flag photos on Apply.
+    if (grmState.sessionId !== sessionId) return;
     grmSeedFromDbState(data && data.photos ? data.photos : {}, items, selectPhotoId);
   }).catch(function() {
+    if (grmState.sessionId !== sessionId) return;
     // Network/error fallback: seed from heuristic only.
     grmSeedFromDbState({}, items, selectPhotoId);
   });

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2809,7 +2809,12 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
     // with, used to (a) render "from DB" markers and (b) compute the
     // change-only Apply button label.
     dbState: {},
-    sessionId: sessionId
+    sessionId: sessionId,
+    // False until /group/state resolves and grmSeedFromDbState runs. Apply &
+    // Close is gated on this so a click during the seed window can't ship
+    // an empty picks/rejects payload (which would clear pre-existing flags
+    // by treating every photo as a candidate).
+    seeded: false
   };
   _grmLoupeLocked = false;
   _grmZoomMultiplier = 1;
@@ -2821,6 +2826,17 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   grmRefreshResetAllVisibility();
 
   document.getElementById('grmOverlay').classList.add('open');
+
+  // Disable Apply while we wait for /group/state — clicking it before
+  // seed completes would send empty picks/rejects, which the server treats
+  // as "all candidates" and silently clears prior flags.
+  var applyBtn = document.getElementById('grmApplyBtn');
+  if (applyBtn) {
+    applyBtn.disabled = true;
+    applyBtn.style.opacity = '0.5';
+    applyBtn.style.cursor = 'wait';
+    applyBtn.textContent = 'Loading…';
+  }
 
   // Reset the species input to this encounter's value so a stale value from a
   // previously-reviewed group doesn't leak in when the prior modal was closed
@@ -2902,6 +2918,16 @@ function grmSeedFromDbState(dbPhotos, items, selectPhotoId) {
     });
     initSelect = firstPick || (items[0] && items[0].id);
   }
+  // Mark the modal seeded *before* re-rendering so grmUpdateApplyLabel
+  // (called from renderGroupModal) re-enables the button.
+  grmState.seeded = true;
+  var applyBtn = document.getElementById('grmApplyBtn');
+  if (applyBtn) {
+    applyBtn.disabled = false;
+    applyBtn.style.opacity = '';
+    applyBtn.style.cursor = '';
+  }
+
   if (initSelect) {
     grmSelect(initSelect);
   } else {
@@ -3582,6 +3608,13 @@ document.addEventListener('contextmenu', function(e) {
 /* --- Apply & Close --- */
 
 async function grmApply() {
+  // Belt-and-suspenders: the button is disabled until seed completes, but
+  // a stuck-open modal whose /group/state never resolved (offline, server
+  // error after retry) must not let Apply clear flags.
+  if (!grmState.seeded) {
+    console.warn('grmApply called before /group/state seed completed; ignoring.');
+    return;
+  }
   var species = document.getElementById('grmSpecies').value.trim();
 
   var picksArr = Array.from(grmState.picks);

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2864,9 +2864,36 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
     grmSeedFromDbState(data && data.photos ? data.photos : {}, items, selectPhotoId);
   }).catch(function() {
     if (grmState.sessionId !== sessionId) return;
-    // Network/error fallback: seed from heuristic only.
-    grmSeedFromDbState({}, items, selectPhotoId);
+    // /group/state failed (network, 5xx, etc). Do NOT seed from an empty
+    // snapshot — that would treat every previously flagged/rejected photo
+    // as an unflagged candidate, and a click on Apply would clear those
+    // flags. Keep the modal in the "Loading…" state with Apply disabled so
+    // the user can either retry by reopening the burst or close out via ×.
+    grmShowSeedError(items, selectPhotoId);
   });
+}
+
+// /group/state failed. Render the cards with no flag state so the user can
+// still inspect photos, but leave Apply disabled and surface what's wrong
+// in the button label. We deliberately do NOT set grmState.seeded = true
+// here — grmApply early-returns until it is, so a stray click can't clear
+// flags from a degraded snapshot.
+function grmShowSeedError(items, selectPhotoId) {
+  grmState.dbState = {};
+  var initSelect = selectPhotoId || (items[0] && items[0].id);
+  if (initSelect) {
+    grmSelect(initSelect);
+  } else {
+    renderGroupModal();
+  }
+  var btn = document.getElementById('grmApplyBtn');
+  if (btn) {
+    btn.disabled = true;
+    btn.style.opacity = '0.5';
+    btn.style.cursor = 'not-allowed';
+    btn.textContent = 'Could not load — reopen to retry';
+    btn.title = 'Loading photo flag state failed; close and reopen this burst to try again.';
+  }
 }
 
 // Seed picks/rejects on modal open. Photos already flagged/rejected in the
@@ -3079,6 +3106,11 @@ function grmRefreshSpeciesKeywordState() {
 function grmUpdateApplyLabel() {
   var btn = document.getElementById('grmApplyBtn');
   if (!btn) return;
+  // While the modal is unseeded (loading or seed failed), the button owns
+  // its own label/disabled state set by openGroupReview / grmShowSeedError.
+  // Don't compute a diff against an empty/unknown dbState — it would
+  // misreport pending writes and clobber the error/loading message.
+  if (!grmState || !grmState.seeded) return;
   var diff = grmComputeDiff();
   var parts = [];
   if (diff.flagNew > 0) parts.push('Flag ' + diff.flagNew);

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1299,7 +1299,7 @@ input[type="range"]::-moz-range-thumb {
   </div>
   <div class="grm-footer">
     <label style="font-size:12px;color:var(--text-muted);">Species:</label>
-    <input type="text" id="grmSpecies" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:13px;width:200px;">
+    <input type="text" id="grmSpecies" oninput="grmUpdateApplyLabel()" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:13px;width:200px;">
     <button onclick="grmRemoveFromGroup()" style="background:var(--bg-tertiary);color:var(--text-muted);border:none;border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;">Remove from group</button>
     <div class="grm-res-control" title="Image resolution — higher = slower but better for pixel-peeping">
       <label style="font-size:12px;color:var(--text-muted);">Res:</label>
@@ -1307,7 +1307,7 @@ input[type="range"]::-moz-range-thumb {
       <span id="grmResLabel" style="font-size:11px;color:var(--text-dim);min-width:140px;">1920 · preview</span>
     </div>
     <span class="grm-hint">↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
-    <button onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);">Apply & Close</button>
+    <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);">Apply & Close</button>
   </div>
 </div>
 
@@ -2799,7 +2799,12 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
     picks: new Set(),
     rejects: new Set(),
     removed: new Set(),
-    selected: null
+    selected: null,
+    // Filled in by the /group/state fetch below. Keys: photo_id → {flag,
+    // has_species_keyword}. This is the live DB snapshot the modal opened
+    // with, used to (a) render "from DB" markers and (b) compute the
+    // change-only Apply button label.
+    dbState: {}
   };
   _grmLoupeLocked = false;
   _grmZoomMultiplier = 1;
@@ -2810,43 +2815,90 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   _grmSuppressNextClick = false;
   grmRefreshResetAllVisibility();
 
-  // Auto-pick the AI best (highest quality_composite)
-  var best = null;
-  items.forEach(function(p) {
-    if (!best || (p.quality_composite || 0) > (best.quality_composite || 0)) best = p;
-  });
-  if (best) grmState.picks.add(best.id);
-
-  // Auto-reject the lowest quality
-  if (items.length > 2) {
-    var sorted = items.slice().sort(function(a, b) { return (a.quality_composite || 0) - (b.quality_composite || 0); });
-    var worstThird = Math.max(1, Math.floor(sorted.length / 3));
-    for (var i = 0; i < worstThird; i++) {
-      if (!grmState.picks.has(sorted[i].id)) {
-        grmState.rejects.add(sorted[i].id);
-      }
-    }
-  }
-
   document.getElementById('grmOverlay').classList.add('open');
 
   // Reset the species input to this encounter's value so a stale value from a
   // previously-reviewed group doesn't leak in when the prior modal was closed
   // via × or Escape (only Apply & Close clears it).
-  document.getElementById('grmSpecies').value = enc.confirmed_species || (enc.species ? enc.species[0] : '') || '';
+  var initialSpecies = enc.confirmed_species || (enc.species ? enc.species[0] : '') || '';
+  document.getElementById('grmSpecies').value = initialSpecies;
 
   // Sync slider DOM with persisted resolution choice
   var slider = document.getElementById('grmResSlider');
   if (slider) slider.value = grmResolutionIdx;
   grmUpdateResLabel();
 
-  // Auto-select the requested photo (or the best)
-  var initSelect = selectPhotoId || (best ? best.id : null);
+  // Render an empty modal first so it appears responsive while we fetch DB
+  // state. The seed pass below populates picks/rejects and re-renders.
+  renderGroupModal();
+
+  safeFetch('/api/pipeline/group/state', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ photo_ids: items.map(function(p) { return p.id; }), species: initialSpecies }),
+  }, { toast: false }).then(function(data) {
+    grmSeedFromDbState(data && data.photos ? data.photos : {}, items, selectPhotoId);
+  }).catch(function() {
+    // Network/error fallback: seed from heuristic only.
+    grmSeedFromDbState({}, items, selectPhotoId);
+  });
+}
+
+// Seed picks/rejects on modal open. Photos already flagged/rejected in the
+// DB land in those zones; the quality-score heuristic only fills in zones
+// for photos with no flag set, so re-opening a burst respects prior choices.
+function grmSeedFromDbState(dbPhotos, items, selectPhotoId) {
+  grmState.dbState = dbPhotos || {};
+
+  var unflagged = [];
+  items.forEach(function(p) {
+    var st = grmState.dbState[p.id];
+    var flag = st ? st.flag : null;
+    if (flag === 'flagged') {
+      grmState.picks.add(p.id);
+    } else if (flag === 'rejected') {
+      grmState.rejects.add(p.id);
+    } else {
+      unflagged.push(p);
+    }
+  });
+
+  // Heuristic fallback for photos with no DB flag: auto-pick the highest
+  // quality and auto-reject the worst third (only if no DB picks yet — we
+  // don't want to override the user's prior pick by piling on more).
+  if (grmState.picks.size === 0 && unflagged.length > 0) {
+    var best = unflagged[0];
+    unflagged.forEach(function(p) {
+      if ((p.quality_composite || 0) > (best.quality_composite || 0)) best = p;
+    });
+    grmState.picks.add(best.id);
+  }
+  if (grmState.rejects.size === 0 && items.length > 2) {
+    var sorted = unflagged.slice().sort(function(a, b) {
+      return (a.quality_composite || 0) - (b.quality_composite || 0);
+    });
+    var worstThird = Math.max(1, Math.floor(items.length / 3));
+    for (var i = 0; i < worstThird && i < sorted.length; i++) {
+      if (!grmState.picks.has(sorted[i].id)) {
+        grmState.rejects.add(sorted[i].id);
+      }
+    }
+  }
+
+  var initSelect = selectPhotoId;
+  if (!initSelect) {
+    var firstPick = null;
+    items.forEach(function(p) {
+      if (firstPick == null && grmState.picks.has(p.id)) firstPick = p.id;
+    });
+    initSelect = firstPick || (items[0] && items[0].id);
+  }
   if (initSelect) {
     grmSelect(initSelect);
   } else {
     renderGroupModal();
   }
+  grmUpdateApplyLabel();
 }
 
 function closeGroupReview() {
@@ -2873,9 +2925,21 @@ function renderGroupModal() {
     var qScore = p.quality_composite != null ? Math.round(p.quality_composite * 100) : '-';
     var sharp = p.subject_tenengrad != null ? Math.round(p.subject_tenengrad) : '-';
 
+    // Read flag/keyword state from the live DB snapshot the modal opened
+    // with, not the (potentially stale) cached p.flag — so a photo flagged
+    // earlier in this session shows the "already in DB" marker even if the
+    // pipeline cache hasn't been refreshed.
+    var dbSt = (grmState.dbState && grmState.dbState[p.id]) || {};
+    var dbFlag = dbSt.flag || 'none';
+    var hasKw = !!dbSt.has_species_keyword;
+
     var flagHtml = '';
-    if (p.flag === 'flagged') flagHtml = '<span class="photo-flag-badge flag-flagged" style="bottom:auto;top:4px;left:4px;">P</span>';
-    else if (p.flag === 'rejected') flagHtml = '<span class="photo-flag-badge flag-rejected" style="bottom:auto;top:4px;left:4px;">X</span>';
+    if (dbFlag === 'flagged') flagHtml = '<span class="photo-flag-badge flag-flagged" title="Already flagged in library" style="bottom:auto;top:4px;left:4px;">P</span>';
+    else if (dbFlag === 'rejected') flagHtml = '<span class="photo-flag-badge flag-rejected" title="Already rejected in library" style="bottom:auto;top:4px;left:4px;">X</span>';
+
+    var kwHtml = hasKw
+      ? '<span class="grm-card-kw-badge" title="Species keyword already applied" style="position:absolute;top:4px;right:4px;background:var(--accent);color:var(--accent-text);font-size:10px;font-weight:600;padding:2px 6px;border-radius:3px;letter-spacing:0.04em;">TAG</span>'
+      : '';
 
     var nat = grmNaturalDims(p);
     var imgStyle = 'width:' + nat.w + 'px;height:' + nat.h + 'px;';
@@ -2888,6 +2952,7 @@ function renderGroupModal() {
         '<img src="' + grmPhotoUrl(p.id) + '" style="' + imgStyle + '"' +
           ' onload="grmCardImgLoaded(this)" loading="lazy" draggable="false">' +
         flagHtml +
+        kwHtml +
       '</div>' +
       '<div class="grm-card-info">' +
         '<div class="grm-card-species">' + escapeHtml(p.filename || '') + '</div>' +
@@ -2921,6 +2986,52 @@ function renderGroupModal() {
   });
   grmApplyCardTransforms();
   grmRefreshResetAllVisibility();
+  grmUpdateApplyLabel();
+}
+
+// Update the Apply button label to reflect the *new* DB writes that will
+// happen — not the totals in each zone — so the user can see at a glance
+// what they're committing to. A photo already flagged in the DB and still
+// in the picks zone is a no-op and isn't counted.
+function grmUpdateApplyLabel() {
+  var btn = document.getElementById('grmApplyBtn');
+  if (!btn) return;
+  var diff = grmComputeDiff();
+  var parts = [];
+  if (diff.flagNew > 0) parts.push('Flag ' + diff.flagNew);
+  if (diff.rejectNew > 0) parts.push('Reject ' + diff.rejectNew);
+  if (diff.clearNew > 0) parts.push('Clear ' + diff.clearNew);
+  if (diff.tagNew > 0) parts.push('Tag ' + diff.tagNew + (diff.species ? ' as ' + diff.species : ''));
+  btn.textContent = parts.length ? parts.join(' · ') + ' & Close' : 'Apply & Close';
+}
+
+// Diff the current modal zones against the DB snapshot we opened with.
+// Returns counts of new flag/reject/clear writes plus tag adds that the
+// apply call will perform.
+function grmComputeDiff() {
+  var speciesEl = document.getElementById('grmSpecies');
+  var species = speciesEl ? (speciesEl.value || '').trim() : '';
+  var diff = { flagNew: 0, rejectNew: 0, clearNew: 0, tagNew: 0, species: species };
+  if (!grmState || !grmState.items) return diff;
+
+  grmState.items.forEach(function(p) {
+    if (grmState.removed && grmState.removed.has(p.id)) return;
+    var st = (grmState.dbState && grmState.dbState[p.id]) || {};
+    var oldFlag = st.flag || 'none';
+    var hasKw = !!st.has_species_keyword;
+    var newFlag;
+    if (grmState.picks.has(p.id)) newFlag = 'flagged';
+    else if (grmState.rejects.has(p.id)) newFlag = 'rejected';
+    else newFlag = 'none';
+
+    if (newFlag !== oldFlag) {
+      if (newFlag === 'flagged') diff.flagNew++;
+      else if (newFlag === 'rejected') diff.rejectNew++;
+      else diff.clearNew++;
+    }
+    if (species && newFlag === 'flagged' && !hasKw) diff.tagNew++;
+  });
+  return diff;
 }
 
 function grmSelect(photoId) {
@@ -3461,8 +3572,36 @@ document.addEventListener('contextmenu', function(e) {
 
 /* --- Apply & Close --- */
 
-function grmApply() {
+async function grmApply() {
   var species = document.getElementById('grmSpecies').value.trim();
+
+  var picksArr = Array.from(grmState.picks);
+  var rejectsArr = Array.from(grmState.rejects);
+  var candidatesArr = grmState.items
+    .filter(function(p) {
+      return !grmState.picks.has(p.id) && !grmState.rejects.has(p.id) && !grmState.removed.has(p.id);
+    })
+    .map(function(p) { return p.id; });
+
+  // Persist to the database first. If this fails we abort so the local
+  // pipeline cache and the DB can't drift apart — the prior fire-and-forget
+  // save-cache + no-DB-write was the bug behind this whole change.
+  var applyResp;
+  try {
+    applyResp = await safeFetch('/api/pipeline/group/apply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        picks: picksArr,
+        rejects: rejectsArr,
+        candidates: candidatesArr,
+        species: species,
+      }),
+    });
+  } catch (e) {
+    console.error('Pipeline group apply failed:', e);
+    return;
+  }
 
   // Update local pipelineResults with pick/reject/candidate decisions
   var photoMap = {};
@@ -3485,6 +3624,17 @@ function grmApply() {
       if (p) p.label = 'REVIEW';
     }
   });
+
+  // Sync the in-memory pipeline cache's per-photo `flag` with what the
+  // server just wrote, so the badges in the main grid (which read p.flag)
+  // refresh without a full reload.
+  if (applyResp && applyResp.photos) {
+    Object.keys(applyResp.photos).forEach(function(pidStr) {
+      var pid = parseInt(pidStr, 10);
+      var p = photoMap[pid];
+      if (p) p.flag = applyResp.photos[pidStr].flag;
+    });
+  }
 
   // Detach removed photos from the burst into new single-photo bursts
   if (grmState.removed.size > 0) {
@@ -3513,7 +3663,7 @@ function grmApply() {
     }
   }
 
-  // Save to cache
+  // Save the updated pipeline cache (label + flag changes + detached bursts).
   safeFetch('/api/pipeline/save-cache', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1299,7 +1299,7 @@ input[type="range"]::-moz-range-thumb {
   </div>
   <div class="grm-footer">
     <label style="font-size:12px;color:var(--text-muted);">Species:</label>
-    <input type="text" id="grmSpecies" oninput="grmUpdateApplyLabel()" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:13px;width:200px;">
+    <input type="text" id="grmSpecies" oninput="grmOnSpeciesInput()" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:13px;width:200px;">
     <button onclick="grmRemoveFromGroup()" style="background:var(--bg-tertiary);color:var(--text-muted);border:none;border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;">Remove from group</button>
     <div class="grm-res-control" title="Image resolution — higher = slower but better for pixel-peeping">
       <label style="font-size:12px;color:var(--text-muted);">Res:</label>
@@ -3022,6 +3022,54 @@ function renderGroupModal() {
   grmApplyCardTransforms();
   grmRefreshResetAllVisibility();
   grmUpdateApplyLabel();
+}
+
+// Debounce species-keyword refetches so we don't hit /group/state on every
+// keystroke. The Apply label still updates synchronously; only the keyword
+// portion of dbState is async.
+var _grmSpeciesRefetchTimer = null;
+var _grmSpeciesRefetchToken = 0;
+
+// Called from the species <input>'s oninput. Refresh the Apply label
+// immediately (the diff uses the typed value), and schedule a debounced
+// refetch of has_species_keyword so the TAG markers + Tag-N preview reflect
+// the *currently typed* species, not the one the modal opened with.
+function grmOnSpeciesInput() {
+  grmUpdateApplyLabel();
+  if (_grmSpeciesRefetchTimer) clearTimeout(_grmSpeciesRefetchTimer);
+  _grmSpeciesRefetchTimer = setTimeout(grmRefreshSpeciesKeywordState, 250);
+}
+
+function grmRefreshSpeciesKeywordState() {
+  if (!grmState || !grmState.items || grmState.items.length === 0) return;
+  var speciesEl = document.getElementById('grmSpecies');
+  var species = speciesEl ? (speciesEl.value || '').trim() : '';
+  var sessionId = grmState.sessionId;
+  var token = ++_grmSpeciesRefetchToken;
+  var photoIds = grmState.items.map(function(p) { return p.id; });
+
+  safeFetch('/api/pipeline/group/state', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ photo_ids: photoIds, species: species }),
+  }, { toast: false }).then(function(data) {
+    // Drop the response if the modal moved on (different burst opened, or
+    // the user kept typing and a newer fetch is in flight).
+    if (grmState.sessionId !== sessionId) return;
+    if (token !== _grmSpeciesRefetchToken) return;
+    var fresh = (data && data.photos) || {};
+    // Only update the keyword field — the flag field is owned by the user's
+    // in-modal moves at this point and would be wrong to overwrite from DB.
+    Object.keys(fresh).forEach(function(pidStr) {
+      var pid = parseInt(pidStr, 10);
+      if (!grmState.dbState[pid]) grmState.dbState[pid] = { flag: 'none' };
+      grmState.dbState[pid].has_species_keyword = !!fresh[pidStr].has_species_keyword;
+    });
+    renderGroupModal();
+  }).catch(function() {
+    // Network/server error: leave previous keyword markers in place. The
+    // Apply label is still correct as a worst-case overestimate of tags.
+  });
 }
 
 // Update the Apply button label to reflect the *new* DB writes that will

--- a/vireo/tests/test_pipeline_group_apply.py
+++ b/vireo/tests/test_pipeline_group_apply.py
@@ -227,3 +227,29 @@ def test_state_endpoint_handles_unknown_species(app_and_db):
     assert data['species_kid'] is None
     for pid in pids:
         assert data['photos'][str(pid)]['has_species_keyword'] is False
+
+
+def test_state_endpoint_ignores_homonym_non_species_keyword(app_and_db):
+    """A non-species keyword (e.g. an 'individual' tag) sharing the species name
+    must NOT be reported as the species keyword. Otherwise has_species_keyword
+    and the Apply-label preview would lie about what apply will write."""
+    app, db = app_and_db
+    pids = _photo_ids(db)
+    pid = pids[0]
+
+    # Pre-existing 'individual' tag named like the species we're about to type.
+    individual_kid = db.add_keyword('Robin', kw_type='individual')
+    db.tag_photo(pid, individual_kid)
+
+    client = app.test_client()
+    resp = client.post('/api/pipeline/group/state', json={
+        'photo_ids': [pid],
+        'species': 'Robin',
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    # The individual tag is not the species keyword. Either no species kid is
+    # reported, or it's a different id from the individual.
+    assert data['species_kid'] != individual_kid
+    assert data['photos'][str(pid)]['has_species_keyword'] is False

--- a/vireo/tests/test_pipeline_group_apply.py
+++ b/vireo/tests/test_pipeline_group_apply.py
@@ -229,6 +229,28 @@ def test_state_endpoint_handles_unknown_species(app_and_db):
         assert data['photos'][str(pid)]['has_species_keyword'] is False
 
 
+def test_state_endpoint_scopes_to_active_workspace(app_and_db):
+    """The state endpoint must not leak flag/keyword status for photos that
+    don't belong to the active workspace, matching the apply endpoint guard."""
+    app, db = app_and_db
+    photos_in_default = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()
+    pid = photos_in_default['id']
+
+    other_ws = db.create_workspace('Other')
+    db.update_workspace(other_ws, last_opened_at='2099-01-01T00:00:00')
+
+    client = app.test_client()
+    resp = client.post('/api/pipeline/group/state', json={
+        'photo_ids': [pid],
+        'species': 'Coyote',
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Photo from a different workspace must not appear in the response.
+    assert str(pid) not in data['photos']
+    assert pid not in data['photos']
+
+
 def test_state_endpoint_ignores_homonym_non_species_keyword(app_and_db):
     """A non-species keyword (e.g. an 'individual' tag) sharing the species name
     must NOT be reported as the species keyword. Otherwise has_species_keyword

--- a/vireo/tests/test_pipeline_group_apply.py
+++ b/vireo/tests/test_pipeline_group_apply.py
@@ -1,0 +1,229 @@
+"""Tests for /api/pipeline/group/state and /api/pipeline/group/apply.
+
+These endpoints back the burst-review modal on the pipeline review page.
+Apply must be diff-based (only writes when state actually changes), must
+clear flags on photos moved to candidates, and must add the consensus
+species keyword on picks while skipping photos that already have it.
+"""
+
+
+def _photo_ids(db):
+    return [p['id'] for p in db.get_photos()]
+
+
+def test_apply_flags_picks_rejects_and_adds_keyword(app_and_db):
+    app, db = app_and_db
+    pids = _photo_ids(db)
+    pick_id, reject_id = pids[0], pids[1]
+    client = app.test_client()
+
+    resp = client.post('/api/pipeline/group/apply', json={
+        'picks': [pick_id],
+        'rejects': [reject_id],
+        'candidates': [],
+        'species': 'Coyote',
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['ok'] is True
+
+    assert db.get_photo(pick_id)['flag'] == 'flagged'
+    assert db.get_photo(reject_id)['flag'] == 'rejected'
+
+    pick_kws = {k['name'] for k in db.get_photo_keywords(pick_id)}
+    assert 'Coyote' in pick_kws
+
+    # Reject should NOT get the species keyword.
+    reject_kws = {k['name'] for k in db.get_photo_keywords(reject_id)}
+    assert 'Coyote' not in reject_kws
+
+    # Returned per-photo state matches what we just wrote.
+    photos = data['photos']
+    assert photos[str(pick_id)]['flag'] == 'flagged'
+    assert photos[str(pick_id)]['has_species_keyword'] is True
+    assert photos[str(reject_id)]['flag'] == 'rejected'
+
+
+def test_apply_clears_flag_when_photo_moved_to_candidates(app_and_db):
+    """If a photo was rejected previously and the user moves it back to
+    candidates, Apply & Close must clear the flag in the DB."""
+    app, db = app_and_db
+    pids = _photo_ids(db)
+    pid = pids[0]
+    db.update_photo_flag(pid, 'rejected')
+    client = app.test_client()
+
+    resp = client.post('/api/pipeline/group/apply', json={
+        'picks': [],
+        'rejects': [],
+        'candidates': [pid],
+        'species': '',
+    })
+    assert resp.status_code == 200
+    assert db.get_photo(pid)['flag'] == 'none'
+
+
+def test_apply_is_idempotent_when_state_unchanged(app_and_db):
+    """Applying the same state twice doesn't double-record edit history."""
+    app, db = app_and_db
+    pids = _photo_ids(db)
+    pid = pids[0]
+    db.update_photo_flag(pid, 'flagged')
+    client = app.test_client()
+
+    # Snapshot edit history count.
+    before = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM edit_history WHERE workspace_id = ?",
+        (db._active_workspace_id,),
+    ).fetchone()['n']
+
+    resp = client.post('/api/pipeline/group/apply', json={
+        'picks': [pid],
+        'rejects': [],
+        'candidates': [],
+        'species': '',
+    })
+    assert resp.status_code == 200
+
+    after = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM edit_history WHERE workspace_id = ?",
+        (db._active_workspace_id,),
+    ).fetchone()['n']
+    assert after == before  # no flag transition → no history row
+
+
+def test_apply_skips_keyword_when_already_applied(app_and_db):
+    """If the photo already has the species keyword, Apply must not add a
+    duplicate or queue a redundant XMP sync change."""
+    app, db = app_and_db
+    pids = _photo_ids(db)
+    pid = pids[0]
+    kid = db.add_keyword('Coyote', is_species=True)
+    db.tag_photo(pid, kid)
+    client = app.test_client()
+
+    resp = client.post('/api/pipeline/group/apply', json={
+        'picks': [pid],
+        'rejects': [],
+        'candidates': [],
+        'species': 'Coyote',
+    })
+    assert resp.status_code == 200
+
+    # Exactly one association — no duplicate.
+    n = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
+        (pid, kid),
+    ).fetchone()['n']
+    assert n == 1
+
+    # No pending sync change for an already-applied keyword.
+    pending = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM pending_changes "
+        "WHERE photo_id = ? AND change_type = 'keyword_add' AND value = ? AND workspace_id = ?",
+        (pid, 'Coyote', db._active_workspace_id),
+    ).fetchone()['n']
+    assert pending == 0
+
+
+def test_apply_records_edit_history_for_undo(app_and_db):
+    """Flag and keyword changes must be recorded in edit_history so undo
+    works the same way it does on the regular review page."""
+    app, db = app_and_db
+    pids = _photo_ids(db)
+    pid = pids[0]
+    client = app.test_client()
+
+    resp = client.post('/api/pipeline/group/apply', json={
+        'picks': [pid],
+        'rejects': [],
+        'candidates': [],
+        'species': 'Coyote',
+    })
+    assert resp.status_code == 200
+
+    rows = db.conn.execute(
+        "SELECT action_type FROM edit_history WHERE workspace_id = ? ORDER BY id",
+        (db._active_workspace_id,),
+    ).fetchall()
+    actions = [r['action_type'] for r in rows]
+    assert 'flag' in actions
+    assert 'keyword_add' in actions
+
+
+def test_apply_rejects_conflicting_zones(app_and_db):
+    app, db = app_and_db
+    pids = _photo_ids(db)
+    pid = pids[0]
+    client = app.test_client()
+
+    resp = client.post('/api/pipeline/group/apply', json={
+        'picks': [pid],
+        'rejects': [pid],
+        'candidates': [],
+    })
+    assert resp.status_code == 400
+
+
+def test_apply_rejects_photo_outside_workspace(app_and_db):
+    """Photo belonging to a folder not in the active workspace is rejected
+    with 403, matching the existing predictions/group/apply endpoint."""
+    app, db = app_and_db
+    photos_in_default = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()
+    pid = photos_in_default['id']
+
+    # Create a second workspace with no folders and bump its last_opened_at
+    # so the request-scoped Database picks it as the active workspace.
+    other_ws = db.create_workspace('Other')
+    db.update_workspace(other_ws, last_opened_at='2099-01-01T00:00:00')
+
+    client = app.test_client()
+    resp = client.post('/api/pipeline/group/apply', json={
+        'picks': [pid],
+        'rejects': [],
+        'candidates': [],
+    })
+    assert resp.status_code == 403
+
+
+def test_state_endpoint_returns_current_flags_and_keyword_status(app_and_db):
+    app, db = app_and_db
+    pids = _photo_ids(db)
+    flagged_id, rejected_id, neutral_id = pids[0], pids[1], pids[2]
+    db.update_photo_flag(flagged_id, 'flagged')
+    db.update_photo_flag(rejected_id, 'rejected')
+    kid = db.add_keyword('Coyote', is_species=True)
+    db.tag_photo(flagged_id, kid)
+    client = app.test_client()
+
+    resp = client.post('/api/pipeline/group/state', json={
+        'photo_ids': [flagged_id, rejected_id, neutral_id],
+        'species': 'Coyote',
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    photos = data['photos']
+    assert photos[str(flagged_id)]['flag'] == 'flagged'
+    assert photos[str(flagged_id)]['has_species_keyword'] is True
+    assert photos[str(rejected_id)]['flag'] == 'rejected'
+    assert photos[str(rejected_id)]['has_species_keyword'] is False
+    assert photos[str(neutral_id)]['flag'] == 'none'
+    assert photos[str(neutral_id)]['has_species_keyword'] is False
+    assert data['species_kid'] == kid
+
+
+def test_state_endpoint_handles_unknown_species(app_and_db):
+    """When the typed species doesn't exist as a keyword yet, has_species_keyword
+    is always False (the keyword gets created on apply, not on state lookup)."""
+    app, db = app_and_db
+    pids = _photo_ids(db)
+    client = app.test_client()
+    resp = client.post('/api/pipeline/group/state', json={
+        'photo_ids': pids,
+        'species': 'NeverSeenBefore',
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['species_kid'] is None
+    for pid in pids:
+        assert data['photos'][str(pid)]['has_species_keyword'] is False

--- a/vireo/tests/test_pipeline_group_apply.py
+++ b/vireo/tests/test_pipeline_group_apply.py
@@ -126,6 +126,38 @@ def test_apply_skips_keyword_when_already_applied(app_and_db):
     assert pending == 0
 
 
+def test_apply_cancels_pending_keyword_remove(app_and_db):
+    """If a `keyword_remove` for the same species is already pending sync,
+    a pick that adds that species must cancel the remove rather than queue a
+    contradictory `keyword_add` alongside it. sync_to_xmp applies removes
+    after adds, so a leftover remove would strip the tag from XMP even
+    though the DB has it."""
+    app, db = app_and_db
+    pids = _photo_ids(db)
+    pid = pids[0]
+    # Pre-existing pending remove for "Coyote".
+    db.queue_change(pid, 'keyword_remove', 'Coyote')
+    client = app.test_client()
+
+    resp = client.post('/api/pipeline/group/apply', json={
+        'picks': [pid],
+        'rejects': [],
+        'candidates': [],
+        'species': 'Coyote',
+    })
+    assert resp.status_code == 200
+
+    pending = db.conn.execute(
+        "SELECT change_type FROM pending_changes "
+        "WHERE photo_id = ? AND value = 'Coyote' AND workspace_id = ?",
+        (pid, db._active_workspace_id),
+    ).fetchall()
+    types = {row['change_type'] for row in pending}
+    # The remove must be cancelled and no add queued in its place.
+    assert 'keyword_remove' not in types
+    assert 'keyword_add' not in types
+
+
 def test_apply_records_edit_history_for_undo(app_and_db):
     """Flag and keyword changes must be recorded in edit_history so undo
     works the same way it does on the regular review page."""


### PR DESCRIPTION
## Summary

The burst-review modal on the pipeline review page only updated the in-memory pipeline cache — picks/rejects never reached \`photos.flag\`, so a photo "rejected" in pipeline review still showed up as unflagged in Browse, Cull, and XMP sync. Exact black-box gap CORE_PHILOSOPHY warns against.

- New \`POST /api/pipeline/group/apply\` endpoint persists picks → \`flag='flagged'\`, rejects → \`flag='rejected'\`, candidates that were previously flagged → \`flag='none'\`. Adds the consensus species keyword on picks (skipped when already tagged), queues an XMP sync change, and records every change in \`edit_history\` so undo works.
- New \`POST /api/pipeline/group/state\` endpoint returns current per-photo flag + species-keyword status. The modal calls this on open so it can:
  - seed picks/rejects from the live \`photos.flag\` (not the stale pipeline cache)
  - show per-card markers for "already flagged/rejected in DB" and "already has the species keyword"
- The Apply button label now reflects the *new* writes (e.g. "Flag 2 · Reject 1 · Tag 3 as Coyote & Close") so the user sees what's about to happen.
- 9 new tests in \`vireo/tests/test_pipeline_group_apply.py\` cover all flag transitions, idempotence, keyword dedupe, edit-history recording, and validation. Full project suite (930+ tests) still passes.

## Test plan

- [x] \`python -m pytest vireo/tests/test_pipeline_group_apply.py -v\` — 9 new tests pass
- [x] Full project suite per CLAUDE.md — 930 passed, 1 skipped
- [x] \`vireo/tests/test_predictions_api.py\` + \`test_pipeline.py\` + \`test_pipeline_job.py\` — 216 passed
- [ ] **Manual** — open a burst on the pipeline review page, drag a photo to REJECT, click Apply & Close, navigate to Browse and confirm the X badge shows on that photo
- [ ] **Manual** — re-open the same burst, confirm the rejected photo lands in REJECTS automatically with the "X" pre-existing-flag marker
- [ ] **Manual** — type a consensus species, click Apply & Close on a pick, confirm the keyword shows up in Browse and the next time the burst is opened the pick has the "TAG" marker
- [ ] **Manual** — drag a previously rejected photo back to candidates, click Apply & Close, confirm Browse no longer shows it as rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)