### PR TITLE
feat(editors): support multiple external editors with picker

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4829,11 +4829,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not file_paths:
             return json_error("No photos found", 404)
 
-        editor = cfg.get("external_editor")
-        if editor and not isinstance(editor, str):
-            return json_error(
-                "external_editor config must be a string path", 500
-            )
+        editors = cfg.get_editors()
+        editor_index = body.get("editor_index")
+        if editor_index is None:
+            # No index = use the first configured editor (or fall through to
+            # the OS default if no editors are configured at all).
+            editor = editors[0]["path"] if editors else ""
+        else:
+            if not isinstance(editor_index, int) or isinstance(editor_index, bool):
+                return json_error("editor_index must be an integer")
+            if not editors:
+                return json_error(
+                    "No external editors configured. Add one in Settings.", 400
+                )
+            if editor_index < 0 or editor_index >= len(editors):
+                return json_error(
+                    f"editor_index {editor_index} out of range "
+                    f"(have {len(editors)} editor(s))", 400
+                )
+            editor = editors[editor_index]["path"]
         editor_path = os.path.expanduser(editor) if editor else ""
 
         # On macOS, an .app bundle is a directory — execing it raises EACCES.

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -28,7 +28,13 @@ DEFAULTS = {
     "scan_workers": 0,
     "setup_complete": False,
     "darktable_bin": "",
+    # Legacy single-editor field. Kept for one-cycle migration: if
+    # `external_editors` is empty and this is set, get_editors() synthesizes
+    # a one-element list from it. Hidden from the schema-rendered settings.
     "external_editor": "",
+    # List of {"name": str, "path": str} dicts. Source of truth for the
+    # multi-editor "Open in Editor" picker.
+    "external_editors": [],
     "report_url": "https://script.google.com/macros/s/AKfycbwqjy8KaB0X04b9R614PWkikRmEsbarXXdarl0S0QC6thT9Uoyn8F74Gku-5z9h-TTf/exec",
     "darktable_style": "",
     "darktable_output_format": "jpg",
@@ -202,3 +208,33 @@ def set(key, value):
         config = load()
         config[key] = value
         save(config)
+
+
+def get_editors():
+    """Return the configured external editors as a list of {name, path} dicts.
+
+    Source of truth is ``external_editors``. If that's empty and the legacy
+    ``external_editor`` string is set, a one-element list is synthesized
+    (no on-disk migration — the file is left alone). Malformed entries
+    (missing path, non-string fields) are filtered out so callers can trust
+    the shape.
+    """
+    config = load()
+    raw = config.get("external_editors") or []
+    editors = []
+    if isinstance(raw, list):
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            path = entry.get("path")
+            if not isinstance(path, str) or not path.strip():
+                continue
+            name = entry.get("name")
+            if not isinstance(name, str) or not name.strip():
+                name = os.path.basename(path.rstrip("/")) or "Editor"
+            editors.append({"name": name.strip(), "path": path.strip()})
+    if not editors:
+        legacy = config.get("external_editor")
+        if isinstance(legacy, str) and legacy.strip():
+            editors.append({"name": "Editor", "path": legacy.strip()})
+    return editors

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -12,7 +12,18 @@ import math
 #   - setup_complete: internal state flag (not a user-facing setting)
 #   - ingest.recent_destinations: auto-populated MRU list, not a knob
 #   - keyboard_shortcuts.*: managed by a dedicated curated UI section
-EXCLUDED = ("setup_complete", "ingest.recent_destinations", "keyboard_shortcuts")
+EXCLUDED = (
+    "setup_complete",
+    "ingest.recent_destinations",
+    "keyboard_shortcuts",
+    # Legacy single-editor field; superseded by `external_editors`. Hidden
+    # from the schema-rendered settings UI but still read by config.get_editors
+    # for one-cycle migration of users who set the old string.
+    "external_editor",
+    # List of {name, path} dicts — has custom settings UI rather than a
+    # generic widget, so it lives outside SCHEMA.
+    "external_editors",
+)
 
 
 CATEGORIES = (
@@ -238,12 +249,6 @@ SCHEMA = {
         "category": "Paths", "scope": "global",
         "label": "darktable-cli path",
         "desc": "Absolute path to the darktable-cli binary.",
-    },
-    "external_editor": {
-        "type": "path",
-        "category": "Paths", "scope": "global",
-        "label": "External editor",
-        "desc": "Absolute path to an external image editor (used by 'Open in editor').",
     },
     "darktable_style": {
         "type": "string",

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4385,6 +4385,46 @@ window.buildOpenInEditorMenuItems = function(photoIds) {
   }
 })();
 
+/* ---------- Develop with darktable ----------
+ * Lifted out of browse.html so review.html (burst-review modal) and any
+ * other surface can dispatch a darktable develop job for an arbitrary list
+ * of photo IDs. Checks availability, confirms, posts the job, and streams
+ * progress via SSE.
+ */
+async function developPhotos(photoIds) {
+  if (!photoIds || !photoIds.length) return;
+  try {
+    var status = await safeFetch('/api/darktable/status', {}, { toast: false });
+    if (!status.available) {
+      showToast('darktable-cli not found. Configure it in Settings.');
+      return;
+    }
+  } catch(_) {
+    showToast('Could not check darktable availability.');
+    return;
+  }
+  if (!confirm('Develop ' + photoIds.length + ' photo(s) with darktable?')) return;
+  try {
+    var data = await safeFetch('/api/jobs/develop', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: photoIds}),
+    });
+    showToast('Developing ' + photoIds.length + ' photo(s)...');
+    safeEventSource('/api/jobs/' + data.job_id + '/stream', {
+      onProgress: function(prog) {
+        showToast('Developing: ' + prog.current + '/' + prog.total + ' — ' + (prog.current_file || ''));
+      },
+      onComplete: function(result) {
+        showToast('Development complete: ' + (result.developed || 0) + ' developed, ' + (result.errors || 0) + ' errors');
+      },
+      onError: function() {}
+    });
+  } catch(e) {
+    showToast(e.message || 'Error starting develop job');
+  }
+}
+
 /* ---------- Safe EventSource ---------- */
 function safeEventSource(url, callbacks) {
   callbacks = callbacks || {};

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3059,9 +3059,9 @@ function openLightbox(photoId, filename, photoList) {
   inatBtn.onclick = function() { submitToInat(photoId); };
   var editorBtn = document.getElementById('lightboxOpenEditor');
   if (editorBtn) {
-    if (typeof openInEditor === 'function') {
+    if (typeof openInEditorWithPicker === 'function') {
       editorBtn.style.display = '';
-      editorBtn.onclick = function() { openInEditor([photoId]); };
+      editorBtn.onclick = function(e) { openInEditorWithPicker([photoId], e); };
     } else {
       editorBtn.style.display = 'none';
     }
@@ -3301,8 +3301,7 @@ function buildLightboxContextMenu(pid) {
       onClick: function() { window.findSimilar(pid); } });
   }
   if (has('openInEditor')) {
-    items.push({ label: 'Open in Editor',
-      onClick: function() { window.openInEditor([pid]); } });
+    items = items.concat(window.buildOpenInEditorMenuItems([pid]));
   }
   if (has('revealPhoto')) {
     items.push({ label: 'Reveal in Finder/Folder',
@@ -4257,20 +4256,134 @@ async function safeFetch(url, opts, options) {
   return JSON.parse(text);
 }
 
-/* ---------- Open in External Editor ---------- */
-async function openInEditor(photoIds) {
+/* ---------- Open in External Editor ----------
+ * Three entry points for opening photos in an external editor:
+ *   - openInEditor(ids, editorIndex)         — direct call, posts to backend
+ *   - openInEditorWithPicker(ids, event)     — for buttons: shows a picker
+ *                                              menu when 2+ editors exist,
+ *                                              otherwise opens directly.
+ *   - getExternalEditorsSync()               — for context-menu builders that
+ *                                              need to inline editor entries
+ *                                              synchronously; reads the cache.
+ *
+ * Editors are cached on first read of /api/config; settings.html invalidates
+ * via window.invalidateEditorsCache() after saving so the next click picks
+ * up changes.
+ */
+var _externalEditorsCache = null;
+var _externalEditorsLoading = null;
+
+async function getExternalEditors() {
+  if (_externalEditorsCache !== null) return _externalEditorsCache;
+  if (_externalEditorsLoading) return _externalEditorsLoading;
+  _externalEditorsLoading = (async function() {
+    var arr = [];
+    try {
+      var cfg = await safeFetch('/api/config', {}, { toast: false });
+      arr = Array.isArray(cfg.external_editors) ? cfg.external_editors : [];
+      if (arr.length === 0 && (cfg.external_editor || '').trim()) {
+        arr = [{ name: 'Editor', path: cfg.external_editor.trim() }];
+      }
+    } catch(_) {
+      arr = [];
+    }
+    _externalEditorsCache = arr
+      .map(function(e) {
+        var name = (e && e.name) || '';
+        var path = (e && e.path) || '';
+        if (!name && path) {
+          var parts = path.replace(/\/+$/, '').split('/');
+          name = parts[parts.length - 1] || 'Editor';
+        }
+        return { name: name, path: path };
+      })
+      .filter(function(e) { return e.path; });
+    _externalEditorsLoading = null;
+    return _externalEditorsCache;
+  })();
+  return _externalEditorsLoading;
+}
+
+// Synchronous accessor for context-menu builders. Returns the cached list,
+// or an empty array if the cache hasn't been warmed yet. Pages that build
+// menus call getExternalEditors() at init so this is normally populated by
+// the time the user opens a menu.
+window.getExternalEditorsSync = function() {
+  return _externalEditorsCache || [];
+};
+
+window.invalidateEditorsCache = function() {
+  _externalEditorsCache = null;
+  _externalEditorsLoading = null;
+};
+
+async function openInEditor(photoIds, editorIndex) {
   if (!photoIds || !photoIds.length) return;
+  var body = { photo_ids: photoIds };
+  if (typeof editorIndex === 'number') body.editor_index = editorIndex;
   try {
     var data = await safeFetch('/api/photos/open-external', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({photo_ids: photoIds}),
+      body: JSON.stringify(body),
     });
     showToast('Opened ' + data.opened + ' photo(s) in editor', 'success');
   } catch(e) {
     showToast(e.message || 'Failed to open in editor');
   }
 }
+
+async function openInEditorWithPicker(photoIds, event) {
+  if (!photoIds || !photoIds.length) return;
+  var editors = await getExternalEditors();
+  if (editors.length <= 1) {
+    // 0 editors → backend uses OS default. 1 editor → that one is the default.
+    return openInEditor(photoIds);
+  }
+  var items = editors.map(function(ed, idx) {
+    return {
+      label: 'Open in ' + ed.name,
+      onClick: function() { openInEditor(photoIds, idx); },
+    };
+  });
+  if (event && typeof window.openContextMenu === 'function') {
+    window.openContextMenu(event, items);
+  } else {
+    // No anchor event — fall back to the first editor rather than swallowing.
+    openInEditor(photoIds, 0);
+  }
+}
+
+// Build the "Open in Editor" entries for a context menu. With 0 or 1 editors
+// configured, this is a single "Open in Editor" item (backend picks default).
+// With 2+, it returns one "Open in <name>" item per editor so the user picks
+// inline without a nested submenu.
+window.buildOpenInEditorMenuItems = function(photoIds) {
+  var editors = window.getExternalEditorsSync();
+  if (editors.length > 1) {
+    return editors.map(function(ed, idx) {
+      return {
+        label: 'Open in ' + ed.name,
+        onClick: function() { window.openInEditor(photoIds, idx); },
+      };
+    });
+  }
+  return [{
+    label: 'Open in Editor',
+    onClick: function() { window.openInEditor(photoIds); },
+  }];
+};
+
+// Warm the cache so context-menu builders can render editor entries
+// synchronously the first time the user opens a menu.
+(function() {
+  var run = function() { getExternalEditors().catch(function() {}); };
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', run, { once: true });
+  } else {
+    run();
+  }
+})();
 
 /* ---------- Safe EventSource ---------- */
 function safeEventSource(url, callbacks) {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4287,17 +4287,28 @@ async function getExternalEditors() {
     } catch(_) {
       arr = [];
     }
-    _externalEditorsCache = arr
-      .map(function(e) {
-        var name = (e && e.name) || '';
-        var path = (e && e.path) || '';
-        if (!name && path) {
-          var parts = path.replace(/\/+$/, '').split('/');
-          name = parts[parts.length - 1] || 'Editor';
-        }
-        return { name: name, path: path };
-      })
-      .filter(function(e) { return e.path; });
+    // Mirror cfg.get_editors() shape-filtering on the server: hand-edited
+    // config.json (or any client posting to /api/config, which doesn't
+    // shape-validate this key) can yield {"path": 123} or similar. Without
+    // the typeof guard, path.replace() would throw TypeError inside this
+    // async IIFE, leaving _externalEditorsLoading as a rejected promise
+    // that every later "Open in Editor" click resolves against.
+    _externalEditorsCache = [];
+    arr.forEach(function(e) {
+      if (!e || typeof e !== 'object') return;
+      var path = e.path;
+      if (typeof path !== 'string') return;
+      path = path.trim();
+      if (!path) return;
+      var name = e.name;
+      if (typeof name !== 'string' || !name.trim()) {
+        var parts = path.replace(/\/+$/, '').split('/');
+        name = parts[parts.length - 1] || 'Editor';
+      } else {
+        name = name.trim();
+      }
+      _externalEditorsCache.push({ name: name, path: path });
+    });
     _externalEditorsLoading = null;
     return _externalEditorsCache;
   })();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -877,7 +877,7 @@ body {
       <button onclick="batchAddKeyword()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">+ Keyword</button>
       <button onclick="addToCollection()" style="background:var(--bg-tertiary);color:var(--info);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">+ Collection</button>
       <button id="developBtn" onclick="developSelected()" title="Develop selected RAW photos with darktable" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Develop</button>
-      <button onclick="openInEditorBatch()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Open in Editor</button>
+      <button onclick="openInEditorBatch(event)" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Open in Editor</button>
       <button onclick="batchSubmitInat()" style="background:var(--bg-tertiary);color:#74ac00;border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">iNaturalist</button>
       <button onclick="openExportModal()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Export</button>
       <button onclick="batchDelete()" style="background:var(--danger);color:white;border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;" title="Delete selected photos">Delete</button>
@@ -1044,7 +1044,7 @@ body {
         <button onclick="openPipeline(window._detailPhotoId)" style="flex:1;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--border-secondary);border-radius:4px;padding:8px;font-size:12px;cursor:pointer;">
           Inspect Pipeline
         </button>
-        <button onclick="openInEditor([window._detailPhotoId])" style="flex:1;background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border-secondary);border-radius:4px;padding:8px;font-size:12px;cursor:pointer;">
+        <button onclick="openInEditorWithPicker([window._detailPhotoId], event)" style="flex:1;background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border-secondary);border-radius:4px;padding:8px;font-size:12px;cursor:pointer;">
           Open in Editor
         </button>
       </div>
@@ -3509,13 +3509,13 @@ async function developSelected() {
   }
 }
 
-function openInEditorBatch() {
+function openInEditorBatch(event) {
   var ids = getActiveSelection();
   if (!ids.length) return;
   if (ids.length > 20) {
     if (!confirm('Open ' + ids.length + ' photos in editor?')) return;
   }
-  openInEditor(ids);
+  openInEditorWithPicker(ids, event);
 }
 
 /* ---------- Right-click context menu on grid cards ---------- */
@@ -3657,8 +3657,7 @@ function buildPhotoContextMenu(photoIds) {
     { separator: true },
     { label: 'Find Similar', disabled: !one, disabledHint: hint,
       onClick: function() { if (typeof findSimilar === 'function') findSimilar(photoIds[0]); } },
-    { label: 'Open in Editor',
-      onClick: function() { if (typeof openInEditor === 'function') openInEditor(photoIds); } },
+  ].concat(buildOpenInEditorMenuItems(photoIds)).concat([
     { label: 'Reveal in Finder/Folder', disabled: !one, disabledHint: hint,
       onClick: function() { revealPhoto(photoIds[0]); } },
     { label: 'Copy Path',

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3469,44 +3469,10 @@ function scrollToCard(idx) {
   if (cards[idx]) cards[idx].scrollIntoView({ block: 'nearest', behavior: 'smooth' });
 }
 
-async function developSelected() {
+function developSelected() {
   var ids = getActiveSelection();
   if (!ids.length) return;
-
-  // Check darktable availability first
-  try {
-    var status = await safeFetch('/api/darktable/status', {}, { toast: false });
-    if (!status.available) {
-      showToast('darktable-cli not found. Configure it in Settings.');
-      return;
-    }
-  } catch(e) {
-    showToast('Could not check darktable availability.');
-    return;
-  }
-
-  if (!confirm('Develop ' + ids.length + ' photo(s) with darktable?')) return;
-
-  try {
-    var data = await safeFetch('/api/jobs/develop', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({photo_ids: ids}),
-    });
-    showToast('Developing ' + ids.length + ' photo(s)...');
-    // Monitor job progress via SSE
-    safeEventSource('/api/jobs/' + data.job_id + '/stream', {
-      onProgress: function(prog) {
-        showToast('Developing: ' + prog.current + '/' + prog.total + ' — ' + (prog.current_file || ''));
-      },
-      onComplete: function(result) {
-        showToast('Development complete: ' + (result.developed || 0) + ' developed, ' + (result.errors || 0) + ' errors');
-      },
-      onError: function() {}
-    });
-  } catch(e) {
-    showToast(e.message || 'Error starting develop job');
-  }
+  developPhotos(ids);
 }
 
 function openInEditorBatch(event) {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3667,7 +3667,7 @@ function buildPhotoContextMenu(photoIds) {
     { label: 'Add to Collection\u2026', onClick: function() { addToCollection(); } },
     { separator: true },
     { label: 'Delete', onClick: function() { batchDelete(); } },
-  ];
+  ]);
 }
 
 // Document-level delegation: grids re-render on sort/filter/scroll, so

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1392,8 +1392,27 @@ function buildBurstGroupContextMenu(photoId, filename) {
     { label: 'Reveal in Finder/Folder', onClick: function() { revealReviewPhoto(photoId); } },
     { label: 'Copy Path',               onClick: function() { copyReviewPhotoPath(photoId); } },
     { separator: true },
+    // Send-elsewhere actions: get the photo into another tool without losing
+    // burst-review state. "Show in Browse" opens in a new tab so the modal
+    // and current pick/reject decisions stay intact.
+    { label: 'Send to iNaturalist',
+      onClick: function() {
+        if (typeof window.submitToInat === 'function') window.submitToInat(photoId);
+      } },
+  ].concat(
+    typeof window.buildOpenInEditorMenuItems === 'function'
+      ? window.buildOpenInEditorMenuItems([photoId])
+      : []
+  ).concat([
+    { label: 'Develop in darktable',
+      onClick: function() {
+        if (typeof window.developPhotos === 'function') window.developPhotos([photoId]);
+      } },
+    { label: 'Show in Browse tab',
+      onClick: function() { window.open('/browse?photo_id=' + photoId, '_blank'); } },
+    { separator: true },
     { label: 'Remove from Group',       onClick: function() { grmRemoveFromGroup(); } },
-  ];
+  ]);
 }
 
 document.addEventListener('contextmenu', function(e) {

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1476,6 +1476,13 @@ function saveConfig() {
           inat_token: document.getElementById('cfgInatToken').value.trim(),
           google_maps_api_key: document.getElementById('cfgGoogleMapsApiKey').value.trim(),
           external_editors: collectExternalEditors(),
+          // Always clear the legacy single-editor field when we save the new
+          // list. Otherwise a user who once had `external_editor` set and now
+          // removes every editor from the list can't get back to OS-default
+          // behavior — `cfg.get_editors()` falls back to the legacy field
+          // whenever the new list is empty, so the old value keeps haunting
+          // them. Saving from the new UI is the migration completion step.
+          external_editor: '',
           darktable_bin: document.getElementById('cfgDarktableBin').value.trim(),
           darktable_style: document.getElementById('cfgDarktableStyle').value.trim(),
           darktable_output_format: document.getElementById('cfgDarktableFormat').value,

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -833,21 +833,14 @@
     </div>
   </div>
 
-  <!-- External Editor -->
+  <!-- External Editors -->
   <div class="section">
-    <div class="section-title">External Editor</div>
+    <div class="section-title">External Editors</div>
     <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
-      Application used when clicking "Open in Editor" in the browse tab. Leave empty to use your OS default.
+      Applications used when clicking "Open in Editor" in the browse tab, lightbox, or burst review. Add as many as you like (e.g. Lightroom, Affinity, Photoshop) — when more than one is configured you'll get a picker. With none configured, photos open in the OS default app.
     </p>
-    <div class="setting-row">
-      <div class="setting-label">
-        Editor path
-        <small>Full path to the editor executable or .app bundle (e.g. /usr/bin/darktable, /Applications/RawTherapee.app, /Applications/Adobe Lightroom Classic/Adobe Lightroom Classic.app). Leave empty to open with your OS default application.</small>
-      </div>
-      <input type="text" id="cfgExternalEditor" placeholder="OS default"
-             style="width:280px;background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:12px;font-family:monospace;"
-             onchange="saveConfig()">
-    </div>
+    <div id="cfgExternalEditorsList" style="display:flex;flex-direction:column;gap:6px;margin-bottom:8px;"></div>
+    <button type="button" onclick="addExternalEditor()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;">+ Add editor</button>
   </div>
 
   <!-- darktable Development -->
@@ -1183,6 +1176,90 @@ function saveWsConfig() {
 }
 
 var _saveTimer = null;
+
+// ---------- External Editors list ----------
+// Source-of-truth for the editor list in settings UI. Populated by
+// loadConfig() and read back on save via collectExternalEditors().
+var _editorsState = [];
+
+function renderExternalEditors() {
+  var container = document.getElementById('cfgExternalEditorsList');
+  if (!container) return;
+  container.innerHTML = '';
+  if (_editorsState.length === 0) {
+    var empty = document.createElement('div');
+    empty.style.cssText = 'color:var(--text-dim);font-size:12px;font-style:italic;';
+    empty.textContent = 'No editors configured. Photos will open in your OS default app.';
+    container.appendChild(empty);
+    return;
+  }
+  _editorsState.forEach(function(ed, i) {
+    var row = document.createElement('div');
+    row.style.cssText = 'display:flex;align-items:center;gap:6px;';
+    var inputCss = 'background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:12px;';
+
+    var nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.placeholder = 'Display name (e.g. Lightroom)';
+    nameInput.value = ed.name || '';
+    nameInput.style.cssText = inputCss + 'width:160px;';
+    nameInput.addEventListener('input', function() {
+      _editorsState[i].name = nameInput.value;
+      saveConfig();
+    });
+
+    var pathInput = document.createElement('input');
+    pathInput.type = 'text';
+    pathInput.placeholder = '/Applications/Adobe Lightroom Classic/Adobe Lightroom Classic.app';
+    pathInput.value = ed.path || '';
+    pathInput.style.cssText = inputCss + 'flex:1;min-width:240px;font-family:monospace;';
+    pathInput.addEventListener('input', function() {
+      _editorsState[i].path = pathInput.value;
+      saveConfig();
+    });
+
+    var removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = '×';
+    removeBtn.title = 'Remove';
+    removeBtn.style.cssText = 'background:var(--bg-tertiary);color:var(--text-dim);border:1px solid var(--border-secondary);border-radius:4px;width:28px;height:28px;font-size:16px;cursor:pointer;line-height:1;';
+    removeBtn.addEventListener('click', function() {
+      _editorsState.splice(i, 1);
+      renderExternalEditors();
+      saveConfig();
+    });
+
+    row.appendChild(nameInput);
+    row.appendChild(pathInput);
+    row.appendChild(removeBtn);
+    container.appendChild(row);
+  });
+}
+
+function addExternalEditor() {
+  _editorsState.push({ name: '', path: '' });
+  renderExternalEditors();
+  // Defer save until the user has typed something. Empty entries get filtered
+  // out by collectExternalEditors() anyway, but a save here would just be
+  // a no-op write that triggers extra disk churn.
+}
+
+function collectExternalEditors() {
+  // Drop entries with empty paths; default the display name to the basename
+  // of the path when the user didn't fill one in. Mirrors what the backend
+  // does in cfg.get_editors() so what's shown matches what's used.
+  return _editorsState
+    .map(function(e) { return { name: (e.name || '').trim(), path: (e.path || '').trim() }; })
+    .filter(function(e) { return e.path.length > 0; })
+    .map(function(e) {
+      if (!e.name) {
+        var parts = e.path.replace(/\/+$/, '').split('/');
+        e.name = parts[parts.length - 1] || 'Editor';
+      }
+      return e;
+    });
+}
+
 async function loadConfig() {
   try {
     var cfg = await safeFetch('/api/config', {}, { toast: false });
@@ -1199,8 +1276,16 @@ async function loadConfig() {
     document.getElementById('cfgGoogleMapsApiKey').value = cfg.google_maps_api_key || '';
     document.getElementById('cfgKeywordCase').value = cfg.keyword_case || 'auto';
     document.getElementById('cfgMaxEditHistory').value = cfg.max_edit_history != null ? cfg.max_edit_history : 1000;
-    // Load darktable settings
-    document.getElementById('cfgExternalEditor').value = cfg.external_editor || '';
+    // Load editor list. Synthesize from the legacy single string if the user
+    // hasn't migrated yet — saving from the new UI completes the migration.
+    var editors = Array.isArray(cfg.external_editors) ? cfg.external_editors.slice() : [];
+    if (editors.length === 0 && (cfg.external_editor || '').trim()) {
+      editors = [{ name: 'Editor', path: cfg.external_editor.trim() }];
+    }
+    _editorsState = editors.map(function(e) {
+      return { name: (e && e.name) || '', path: (e && e.path) || '' };
+    });
+    renderExternalEditors();
     document.getElementById('cfgDarktableBin').value = cfg.darktable_bin || '';
     document.getElementById('cfgDarktableStyle').value = cfg.darktable_style || '';
     document.getElementById('cfgDarktableFormat').value = cfg.darktable_output_format || 'jpg';
@@ -1390,7 +1475,7 @@ function saveConfig() {
           hf_token: hfToken,
           inat_token: document.getElementById('cfgInatToken').value.trim(),
           google_maps_api_key: document.getElementById('cfgGoogleMapsApiKey').value.trim(),
-          external_editor: document.getElementById('cfgExternalEditor').value.trim(),
+          external_editors: collectExternalEditors(),
           darktable_bin: document.getElementById('cfgDarktableBin').value.trim(),
           darktable_style: document.getElementById('cfgDarktableStyle').value.trim(),
           darktable_output_format: document.getElementById('cfgDarktableFormat').value,
@@ -1472,6 +1557,11 @@ function saveConfig() {
         }),
       });
       if (typeof loadPreviewCacheStatus === 'function') loadPreviewCacheStatus();
+      // Drop the cached editor list so the next "Open in Editor" click
+      // sees changes to the editors list without a page reload.
+      if (typeof window.invalidateEditorsCache === 'function') {
+        window.invalidateEditorsCache();
+      }
     } catch(e) {}
   }, 500);
 }

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1248,8 +1248,13 @@ function collectExternalEditors() {
   // Drop entries with empty paths; default the display name to the basename
   // of the path when the user didn't fill one in. Mirrors what the backend
   // does in cfg.get_editors() so what's shown matches what's used.
+  // Defense-in-depth: loadConfig() already coerces _editorsState entries to
+  // strings, but if any later code path stored a non-string (or a future edit
+  // skips that load step), calling .trim() directly here would TypeError and
+  // block every settings autosave until the malformed entry is repaired.
+  var asStr = function(v) { return typeof v === 'string' ? v.trim() : ''; };
   return _editorsState
-    .map(function(e) { return { name: (e.name || '').trim(), path: (e.path || '').trim() }; })
+    .map(function(e) { return { name: asStr(e && e.name), path: asStr(e && e.path) }; })
     .filter(function(e) { return e.path.length > 0; })
     .map(function(e) {
       if (!e.name) {
@@ -1278,13 +1283,21 @@ async function loadConfig() {
     document.getElementById('cfgMaxEditHistory').value = cfg.max_edit_history != null ? cfg.max_edit_history : 1000;
     // Load editor list. Synthesize from the legacy single string if the user
     // hasn't migrated yet — saving from the new UI completes the migration.
-    var editors = Array.isArray(cfg.external_editors) ? cfg.external_editors.slice() : [];
-    if (editors.length === 0 && (cfg.external_editor || '').trim()) {
-      editors = [{ name: 'Editor', path: cfg.external_editor.trim() }];
-    }
-    _editorsState = editors.map(function(e) {
-      return { name: (e && e.name) || '', path: (e && e.path) || '' };
+    // Defend against malformed entries (non-string path/name from hand-edited
+    // config.json or any non-validating /api/config writer) so we don't crash
+    // the settings page on load.
+    var rawList = Array.isArray(cfg.external_editors) ? cfg.external_editors : [];
+    _editorsState = [];
+    rawList.forEach(function(e) {
+      if (!e || typeof e !== 'object') return;
+      var path = typeof e.path === 'string' ? e.path : '';
+      var name = typeof e.name === 'string' ? e.name : '';
+      _editorsState.push({ name: name, path: path });
     });
+    if (_editorsState.length === 0 && typeof cfg.external_editor === 'string'
+        && cfg.external_editor.trim()) {
+      _editorsState = [{ name: 'Editor', path: cfg.external_editor.trim() }];
+    }
     renderExternalEditors();
     document.getElementById('cfgDarktableBin').value = cfg.darktable_bin || '';
     document.getElementById('cfgDarktableStyle').value = cfg.darktable_style || '';

--- a/vireo/tests/test_open_external.py
+++ b/vireo/tests/test_open_external.py
@@ -252,12 +252,12 @@ def test_open_external_directory_with_multiple_app_bundles_errors(app_and_db, mo
     assert launched == []
 
 
-def test_open_external_rejects_non_string_editor(app_and_db, monkeypatch):
-    """Non-string external_editor values return a structured 500, not an uncaught TypeError.
+def test_open_external_filters_malformed_legacy_editor(app_and_db, monkeypatch):
+    """Non-string legacy `external_editor` is filtered out, not an error.
 
     /api/config doesn't type-validate writes, so the persisted value can be any
-    JSON type. The endpoint must guard expanduser() to keep returning the
-    documented JSON error envelope.
+    JSON type. cfg.get_editors() rejects non-string entries, so the endpoint
+    falls back cleanly to the OS default opener instead of erroring.
     """
     app, _ = app_and_db
     client = app.test_client()
@@ -265,15 +265,133 @@ def test_open_external_rejects_non_string_editor(app_and_db, monkeypatch):
     import config as cfg
     cfg.set("external_editor", 12345)
 
-    _patch_launchers(monkeypatch)
+    monkeypatch.setattr(sys, 'platform', 'darwin')
+    launched = _patch_launchers(monkeypatch)
 
     resp = client.post('/api/photos/open-external',
                        data=json.dumps({"photo_ids": [1]}),
                        content_type='application/json')
-    assert resp.status_code == 500
-    body = resp.get_json()
-    assert "error" in body
-    assert "string" in body["error"].lower()
+    assert resp.status_code == 200
+    # Falls through to plain `open <files>` (no -a flag, no editor binary).
+    assert launched[0][0] == 'run'
+    assert launched[0][1][0] == 'open'
+    assert '-a' not in launched[0][1]
+
+
+def test_open_external_uses_first_editor_from_list(app_and_db, monkeypatch):
+    """external_editors list takes precedence over legacy external_editor."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    client.post('/api/config',
+                data=json.dumps({
+                    "external_editor": "/usr/bin/legacy",
+                    "external_editors": [
+                        {"name": "Lightroom", "path": "/usr/bin/lr"},
+                        {"name": "Affinity", "path": "/usr/bin/affinity"},
+                    ],
+                }),
+                content_type='application/json')
+
+    launched = _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [1]}),
+                       content_type='application/json')
+    assert resp.status_code == 200
+    # First editor wins when no editor_index is passed; legacy field is ignored.
+    assert launched[0][1][0] == '/usr/bin/lr'
+
+
+def test_open_external_editor_index_picks_specific_editor(app_and_db, monkeypatch):
+    """editor_index in the request body picks that editor from the list."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    client.post('/api/config',
+                data=json.dumps({
+                    "external_editors": [
+                        {"name": "First", "path": "/usr/bin/first"},
+                        {"name": "Second", "path": "/usr/bin/second"},
+                        {"name": "Third", "path": "/usr/bin/third"},
+                    ],
+                }),
+                content_type='application/json')
+
+    launched = _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [1], "editor_index": 2}),
+                       content_type='application/json')
+    assert resp.status_code == 200
+    assert launched[0][1][0] == '/usr/bin/third'
+
+
+def test_open_external_editor_index_out_of_range(app_and_db):
+    """editor_index >= len(editors) returns 400 with a useful message."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    client.post('/api/config',
+                data=json.dumps({
+                    "external_editors": [{"name": "Only", "path": "/usr/bin/only"}],
+                }),
+                content_type='application/json')
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [1], "editor_index": 5}),
+                       content_type='application/json')
+    assert resp.status_code == 400
+    assert "out of range" in resp.get_json()["error"]
+
+
+def test_open_external_editor_index_with_no_editors(app_and_db):
+    """editor_index passed with no editors configured returns 400, not OS default."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [1], "editor_index": 0}),
+                       content_type='application/json')
+    assert resp.status_code == 400
+    assert "No external editors configured" in resp.get_json()["error"]
+
+
+def test_open_external_legacy_editor_synthesizes_when_list_empty(app_and_db, monkeypatch):
+    """Empty external_editors + legacy external_editor still works (back-compat)."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    client.post('/api/config',
+                data=json.dumps({"external_editor": "/usr/bin/legacy"}),
+                content_type='application/json')
+
+    launched = _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [1]}),
+                       content_type='application/json')
+    assert resp.status_code == 200
+    assert launched[0][1][0] == '/usr/bin/legacy'
+
+
+def test_get_editors_filters_malformed_entries(app_and_db):
+    """cfg.get_editors() drops dicts missing a path or with non-string fields."""
+    import config as cfg
+    cfg.set("external_editors", [
+        {"name": "Good", "path": "/usr/bin/good"},
+        {"name": "NoPath"},
+        {"path": ""},
+        "not even a dict",
+        {"name": "", "path": "/Applications/Foo.app"},
+    ])
+    editors = cfg.get_editors()
+    assert [e["path"] for e in editors] == [
+        "/usr/bin/good", "/Applications/Foo.app",
+    ]
+    # Empty name falls back to the basename of the path.
+    assert editors[0]["name"] == "Good"
+    assert editors[1]["name"] == "Foo.app"
 
 
 def test_open_external_expands_user_in_editor_path(app_and_db, monkeypatch, tmp_path):

--- a/vireo/tests/test_open_external.py
+++ b/vireo/tests/test_open_external.py
@@ -375,6 +375,44 @@ def test_open_external_legacy_editor_synthesizes_when_list_empty(app_and_db, mon
     assert launched[0][1][0] == '/usr/bin/legacy'
 
 
+def test_clearing_editor_list_does_not_resurrect_legacy_field(app_and_db, monkeypatch):
+    """Saving an empty external_editors list must let the user reach OS default.
+
+    Without this, a user who had `external_editor` set in the old single-string
+    config, and then removes every editor from the new list in Settings, would
+    keep getting the legacy value back via cfg.get_editors() — the new list is
+    empty, so it synthesizes from the legacy field. The settings UI guards
+    against this by clearing `external_editor` whenever it saves the new list.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+
+    # Pre-existing legacy value (simulates a config that pre-dates this PR).
+    import config as cfg
+    cfg.set("external_editor", "/usr/bin/legacy")
+
+    # The settings UI's saveConfig posts both keys together — empty list and
+    # empty legacy field — to complete the migration.
+    client.post('/api/config',
+                data=json.dumps({
+                    "external_editors": [],
+                    "external_editor": "",
+                }),
+                content_type='application/json')
+
+    monkeypatch.setattr(sys, 'platform', 'darwin')
+    launched = _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [1]}),
+                       content_type='application/json')
+    assert resp.status_code == 200
+    # Should be the OS default opener (`open <file>`), not the legacy editor.
+    assert launched[0][1][0] == 'open'
+    assert '-a' not in launched[0][1]
+    assert '/usr/bin/legacy' not in launched[0][1]
+
+
 def test_get_editors_filters_malformed_entries(app_and_db):
     """cfg.get_editors() drops dicts missing a path or with non-string fields."""
     import config as cfg

--- a/vireo/tests/test_open_external.py
+++ b/vireo/tests/test_open_external.py
@@ -414,22 +414,34 @@ def test_clearing_editor_list_does_not_resurrect_legacy_field(app_and_db, monkey
 
 
 def test_get_editors_filters_malformed_entries(app_and_db):
-    """cfg.get_editors() drops dicts missing a path or with non-string fields."""
+    """cfg.get_editors() drops dicts missing a path or with non-string fields.
+
+    The same filtering shape is mirrored in _navbar.html's getExternalEditors()
+    so a hand-edited config.json (or any /api/config writer that doesn't
+    validate the list shape) can't trip path.replace() and leave the JS
+    cache as a permanently-rejected promise.
+    """
     import config as cfg
     cfg.set("external_editors", [
         {"name": "Good", "path": "/usr/bin/good"},
         {"name": "NoPath"},
         {"path": ""},
         "not even a dict",
+        {"name": "NumPath", "path": 12345},      # non-string path → drop
+        {"name": 999, "path": "/usr/bin/numname"},  # non-string name → use basename
         {"name": "", "path": "/Applications/Foo.app"},
     ])
     editors = cfg.get_editors()
     assert [e["path"] for e in editors] == [
-        "/usr/bin/good", "/Applications/Foo.app",
+        "/usr/bin/good",
+        "/usr/bin/numname",
+        "/Applications/Foo.app",
     ]
-    # Empty name falls back to the basename of the path.
     assert editors[0]["name"] == "Good"
-    assert editors[1]["name"] == "Foo.app"
+    # Non-string name falls back to the basename of the path.
+    assert editors[1]["name"] == "numname"
+    # Empty name falls back to the basename of the path.
+    assert editors[2]["name"] == "Foo.app"
 
 
 def test_open_external_expands_user_in_editor_path(app_and_db, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- Replaces the single \`external_editor\` config string with \`external_editors\`: a list of \`{name, path}\` dicts. The user can configure as many editors as they want (Lightroom, Affinity, Photoshop, darktable launched standalone, etc.) and gets a picker when 2+ are configured.
- All existing \"Open in Editor\" surfaces (browse batch button, browse detail panel, browse context menu, lightbox button, lightbox context menu) wire up to the new picker. With 0 or 1 editor configured, the UX is unchanged.
- One-cycle backwards compatibility: legacy \`external_editor\` string is honored at read time via \`cfg.get_editors()\` until the user saves anything in the new settings UI.

## Backend

- \`cfg.get_editors()\` returns the editors list, synthesizing a single entry from the legacy field when the list is empty. Malformed entries (missing path, non-string fields) are filtered.
- \`POST /api/photos/open-external\` accepts an optional \`editor_index\` body field. Out-of-range and \"no editors configured\" cases return a 400 with a descriptive error.
- \`external_editor\` removed from \`config_schema.SCHEMA\` (kept in \`DEFAULTS\` for migration). Both keys added to \`EXCLUDED\` since \`external_editors\` has a custom settings UI.

## Frontend

- New helpers in \`_navbar.html\`: \`getExternalEditors()\` (async + cached), \`getExternalEditorsSync()\` (sync read for context-menu builders), \`openInEditorWithPicker(ids, event)\` (direct vs. picker decision), \`buildOpenInEditorMenuItems(ids)\` (shared by browse + lightbox context menus).
- Cache warms on DOMContentLoaded; settings.html invalidates after save so the next click sees changes.

## Settings

- \"External Editor\" section becomes \"External Editors\": per-row name + path inputs, remove button, \"+ Add editor\" at the bottom.

## Test plan

- [x] Full required suite from CLAUDE.md: \`tests/test_workspaces test_db test_app test_photos_api test_edits_api test_jobs_api test_darktable_api test_config test_open_external test_config_schema\` — **978 passed, 1 skipped**.
- [x] New tests cover: list takes precedence over legacy field, \`editor_index\` selection, out-of-range, no-editors-with-index, legacy-field synthesis, malformed-entry filtering.
- [x] Templates render via Flask test client (\`/settings\`, \`/browse\`, \`/review\` all 200).
- [ ] Manual: add two editors in Settings, right-click a photo in Browse — expect \"Open in <name>\" entries instead of a single \"Open in Editor\".
- [ ] Manual: same for lightbox context menu and the lightbox \"Open in Editor\" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)