### PR TITLE
feat(review): add iNaturalist / Editor / darktable / Browse to burst menu

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4385,6 +4385,46 @@ window.buildOpenInEditorMenuItems = function(photoIds) {
   }
 })();
 
+/* ---------- Develop with darktable ----------
+ * Lifted out of browse.html so review.html (burst-review modal) and any
+ * other surface can dispatch a darktable develop job for an arbitrary list
+ * of photo IDs. Checks availability, confirms, posts the job, and streams
+ * progress via SSE.
+ */
+async function developPhotos(photoIds) {
+  if (!photoIds || !photoIds.length) return;
+  try {
+    var status = await safeFetch('/api/darktable/status', {}, { toast: false });
+    if (!status.available) {
+      showToast('darktable-cli not found. Configure it in Settings.');
+      return;
+    }
+  } catch(_) {
+    showToast('Could not check darktable availability.');
+    return;
+  }
+  if (!confirm('Develop ' + photoIds.length + ' photo(s) with darktable?')) return;
+  try {
+    var data = await safeFetch('/api/jobs/develop', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: photoIds}),
+    });
+    showToast('Developing ' + photoIds.length + ' photo(s)...');
+    safeEventSource('/api/jobs/' + data.job_id + '/stream', {
+      onProgress: function(prog) {
+        showToast('Developing: ' + prog.current + '/' + prog.total + ' — ' + (prog.current_file || ''));
+      },
+      onComplete: function(result) {
+        showToast('Development complete: ' + (result.developed || 0) + ' developed, ' + (result.errors || 0) + ' errors');
+      },
+      onError: function() {}
+    });
+  } catch(e) {
+    showToast(e.message || 'Error starting develop job');
+  }
+}
+
 /* ---------- Safe EventSource ---------- */
 function safeEventSource(url, callbacks) {
   callbacks = callbacks || {};

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3469,44 +3469,10 @@ function scrollToCard(idx) {
   if (cards[idx]) cards[idx].scrollIntoView({ block: 'nearest', behavior: 'smooth' });
 }
 
-async function developSelected() {
+function developSelected() {
   var ids = getActiveSelection();
   if (!ids.length) return;
-
-  // Check darktable availability first
-  try {
-    var status = await safeFetch('/api/darktable/status', {}, { toast: false });
-    if (!status.available) {
-      showToast('darktable-cli not found. Configure it in Settings.');
-      return;
-    }
-  } catch(e) {
-    showToast('Could not check darktable availability.');
-    return;
-  }
-
-  if (!confirm('Develop ' + ids.length + ' photo(s) with darktable?')) return;
-
-  try {
-    var data = await safeFetch('/api/jobs/develop', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({photo_ids: ids}),
-    });
-    showToast('Developing ' + ids.length + ' photo(s)...');
-    // Monitor job progress via SSE
-    safeEventSource('/api/jobs/' + data.job_id + '/stream', {
-      onProgress: function(prog) {
-        showToast('Developing: ' + prog.current + '/' + prog.total + ' — ' + (prog.current_file || ''));
-      },
-      onComplete: function(result) {
-        showToast('Development complete: ' + (result.developed || 0) + ' developed, ' + (result.errors || 0) + ' errors');
-      },
-      onError: function() {}
-    });
-  } catch(e) {
-    showToast(e.message || 'Error starting develop job');
-  }
+  developPhotos(ids);
 }
 
 function openInEditorBatch(event) {

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1392,8 +1392,27 @@ function buildBurstGroupContextMenu(photoId, filename) {
     { label: 'Reveal in Finder/Folder', onClick: function() { revealReviewPhoto(photoId); } },
     { label: 'Copy Path',               onClick: function() { copyReviewPhotoPath(photoId); } },
     { separator: true },
+    // Send-elsewhere actions: get the photo into another tool without losing
+    // burst-review state. "Show in Browse" opens in a new tab so the modal
+    // and current pick/reject decisions stay intact.
+    { label: 'Send to iNaturalist',
+      onClick: function() {
+        if (typeof window.submitToInat === 'function') window.submitToInat(photoId);
+      } },
+  ].concat(
+    typeof window.buildOpenInEditorMenuItems === 'function'
+      ? window.buildOpenInEditorMenuItems([photoId])
+      : []
+  ).concat([
+    { label: 'Develop in darktable',
+      onClick: function() {
+        if (typeof window.developPhotos === 'function') window.developPhotos([photoId]);
+      } },
+    { label: 'Show in Browse tab',
+      onClick: function() { window.open('/browse?photo_id=' + photoId, '_blank'); } },
+    { separator: true },
     { label: 'Remove from Group',       onClick: function() { grmRemoveFromGroup(); } },
-  ];
+  ]);
 }
 
 document.addEventListener('contextmenu', function(e) {


### PR DESCRIPTION
## Summary

Right-click on a card in the burst-review modal (the modal opened from \"Review burst group\" on the pipeline review page) now offers four send-elsewhere actions in addition to the existing triage actions:

- **Send to iNaturalist** — uses the existing single-photo \`submitToInat\` flow (prepare modal + submit)
- **Open in Editor** — single \"Open in Editor\" with 0–1 editors configured; one \"Open in <name>\" entry per editor with 2+ configured. Uses \`buildOpenInEditorMenuItems\` from #793.
- **Develop in darktable** — checks darktable availability, confirms, posts the develop job, streams progress via SSE
- **Show in Browse tab** — opens \`/browse?photo_id=<id>\` in a new tab so the burst-review modal and current pick/reject decisions stay intact

## Stacking

This PR is based on #793 (\`claude/multi-editor-config\`). Merge that one first; this one will rebase onto main automatically.

## Refactor

To use the darktable develop flow from review.html without duplicating the SSE plumbing, \`developSelected\` in browse.html is split into a thin wrapper calling a new generic \`developPhotos(ids)\` in \`_navbar.html\`. Behaviour for the existing Browse \"Develop\" button is unchanged.

## Test plan

- [x] Full required suite from CLAUDE.md (\`tests/test_workspaces test_db test_app test_photos_api test_edits_api test_jobs_api test_darktable_api test_config test_open_external\`): **940 passed, 1 skipped**.
- [x] Templates render via Flask test client (\`/settings\`, \`/browse\`, \`/review\` all 200).
- [ ] Manual: open a burst group on the pipeline review page, right-click a photo, verify all 4 new items appear and each fires its action.
- [ ] Manual: with 2+ editors configured, verify the menu shows \"Open in <name>\" entries instead of a single \"Open in Editor\".
- [ ] Manual: confirm the existing Browse \"Develop\" button still works (the \`developSelected\` refactor).
- [ ] Manual: confirm \"Show in Browse tab\" opens a new tab, scrolls to the photo, and leaves the burst-review modal intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)