### PR TITLE
lint: fix unsorted imports in test_photos_api.py

### DIFF
--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1717,12 +1717,11 @@ def test_storage_delete_files_chunks_large_thumb_id_list(
     """
     import os
 
-    from PIL import Image
-
     import config as cfg
     import models
     from app import create_app
     from db import Database
+    from PIL import Image
 
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))


### PR DESCRIPTION
## Summary

The lint job (`ruff check vireo/ tests/`) has been failing on every PR since #795 landed because a local import block inside `test_storage_delete_files_chunks_large_thumb_id_list` is unsorted.

## What changed

- Ran `ruff check --fix vireo/tests/test_photos_api.py` to reorder the local imports inside the test body.
- No production code touched, no test logic changed.

## Test plan

- [x] `ruff check vireo/ tests/` → `All checks passed!`
- [x] `pytest vireo/tests/test_photos_api.py::test_storage_delete_files_chunks_large_thumb_id_list` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)