### PR TITLE
[codex] Harden batch delete endpoint

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -631,15 +631,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def _consume_delete_retry_tokens(tokens):
         if not isinstance(tokens, list) or not tokens:
             raise ValueError("retry_tokens required")
-        paths = []
         now = time.time()
+        # Validate every token before consuming any. Otherwise a request like
+        # [valid, invalid] would pop the valid entry, return 400, and leave
+        # the caller with no way to retry — and in the disk flow the DB row
+        # is already gone, so the file would be stranded.
+        seen = set()
+        validated = []
         for token in tokens:
             if not isinstance(token, str) or not token:
                 raise ValueError("retry_tokens must be a list of strings")
-            entry = app._delete_retry_tokens.pop(token, None)
+            if token in seen:
+                raise ValueError("delete retry token is invalid or expired")
+            seen.add(token)
+            entry = app._delete_retry_tokens.get(token)
             if not entry or entry.get("expires_at", 0) < now:
                 raise ValueError("delete retry token is invalid or expired")
-            paths.append(entry["path"])
+            validated.append((token, entry["path"]))
+        paths = []
+        for token, path in validated:
+            app._delete_retry_tokens.pop(token, None)
+            paths.append(path)
         return paths
 
     def _get_db():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -12,6 +12,7 @@ import math
 import os
 import queue
 import re
+import secrets
 import subprocess
 import sys
 import time
@@ -125,6 +126,7 @@ logging.getLogger("werkzeug").addFilter(_QuietRequestFilter())
 # SQLite versions. Sized below 999 to leave headroom for additional bound
 # parameters in joined statements.
 _SQL_PARAM_CHUNK = 900
+_DELETE_RETRY_TOKEN_TTL_SECONDS = 10 * 60
 
 
 def _chunked(seq, size=_SQL_PARAM_CHUNK):
@@ -615,6 +617,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def json_error(msg, status=400):
         """Return a JSON error response. Standard shape: {"error": "msg"}."""
         return jsonify({"error": msg}), status
+
+    app._delete_retry_tokens = {}
+
+    def _issue_delete_retry_token(path):
+        token = secrets.token_urlsafe(24)
+        app._delete_retry_tokens[token] = {
+            "path": path,
+            "expires_at": time.time() + _DELETE_RETRY_TOKEN_TTL_SECONDS,
+        }
+        return token
+
+    def _consume_delete_retry_tokens(tokens):
+        if not isinstance(tokens, list) or not tokens:
+            raise ValueError("retry_tokens required")
+        paths = []
+        now = time.time()
+        for token in tokens:
+            if not isinstance(token, str) or not token:
+                raise ValueError("retry_tokens must be a list of strings")
+            entry = app._delete_retry_tokens.pop(token, None)
+            if not entry or entry.get("expires_at", 0) < now:
+                raise ValueError("delete retry token is invalid or expired")
+            paths.append(entry["path"])
+        return paths
 
     def _get_db():
         """Get a Database instance. One connection per request via Flask g."""
@@ -2628,12 +2654,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         photo_ids = body.get("photo_ids", [])
         mode = body.get("mode", "vireo")
         include_companions = body.get("include_companions", False)
-        # For disk_permanent retry: accept paths directly since DB rows
-        # were already deleted in the initial disk-mode call.
-        paths = body.get("paths", [])
+        retry_tokens = body.get("retry_tokens", [])
 
-        if mode == "disk_permanent" and paths:
-            # Retry path: DB already cleaned up, just delete files
+        if mode == "disk_permanent" and retry_tokens:
+            try:
+                paths = _consume_delete_retry_tokens(retry_tokens)
+            except ValueError as e:
+                return json_error(str(e), 400)
             trashed = 0
             trash_failed = []
             for p in paths:
@@ -2649,13 +2676,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "ok": True, "deleted": 0, "trashed": trashed,
                 "trash_failed": trash_failed,
             })
+        if mode == "disk_permanent" and body.get("paths"):
+            return json_error("retry_tokens required for permanent delete retry", 400)
 
         if not photo_ids:
             return json_error("photo_ids required")
+        if (
+            not isinstance(photo_ids, list)
+            or any(isinstance(pid, bool) or not isinstance(pid, int) for pid in photo_ids)
+        ):
+            return json_error("photo_ids must be a list of integers")
         if mode not in ("vireo", "disk", "disk_permanent"):
             return json_error("mode must be 'vireo', 'disk', or 'disk_permanent'")
 
-        result = db.delete_photos(photo_ids, include_companions=include_companions)
+        try:
+            result = db.delete_photos(
+                photo_ids,
+                include_companions=include_companions,
+                verify_workspace=True,
+            )
+        except ValueError as e:
+            return json_error(str(e), 403)
 
         _cleanup_cached_files_for_deleted_photos(result["files"])
 
@@ -2687,7 +2728,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                 trashed += 1
                             except Exception:
                                 log.warning("Trash failed for %s", filepath, exc_info=True)
-                                trash_failed.append({"path": filepath})
+                                trash_failed.append({
+                                    "path": filepath,
+                                    "retry_token": _issue_delete_retry_token(filepath),
+                                })
                     else:  # disk_permanent
                         try:
                             os.remove(filepath)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4309,14 +4309,46 @@ class Database:
                 )
         self.conn.commit()
 
-    def delete_photos(self, photo_ids, include_companions=False):
+    def delete_photos(self, photo_ids, include_companions=False, verify_workspace=False):
         """Delete photos and all associated data.
 
         Returns dict with 'deleted' count and 'files' list of
         {photo_id, folder_path, filename, companion_path} for file cleanup.
+
+        Args:
+            verify_workspace: when True, raises ValueError if any existing
+                photo id is outside the active workspace. Missing ids are
+                still skipped for API compatibility.
         """
         if not photo_ids:
             return {"deleted": 0, "files": []}
+
+        if verify_workspace:
+            placeholders = ",".join("?" for _ in photo_ids)
+            existing = {
+                row["id"]
+                for row in self.conn.execute(
+                    f"SELECT id FROM photos WHERE id IN ({placeholders})",
+                    list(photo_ids),
+                ).fetchall()
+            }
+            visible = {
+                row["id"]
+                for row in self.conn.execute(
+                    f"""SELECT p.id FROM photos p
+                        JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                        WHERE wf.workspace_id = ? AND p.id IN ({placeholders})""",
+                    [self._ws_id()] + list(photo_ids),
+                ).fetchall()
+            }
+            hidden = existing - visible
+            if hidden:
+                raise ValueError(
+                    f"Photo {min(hidden)} does not belong to the active workspace"
+                )
+            photo_ids = [pid for pid in photo_ids if pid in visible]
+            if not photo_ids:
+                return {"deleted": 0, "files": []}
 
         # Resolve to actual existing photos
         placeholders = ",".join("?" for _ in photo_ids)

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3385,15 +3385,18 @@ async function confirmDelete() {
 
   if (data.trash_failed && data.trash_failed.length > 0) {
     var paths = data.trash_failed.map(function(f) { return f.path; });
+    var retryTokens = data.trash_failed
+      .map(function(f) { return f.retry_token; })
+      .filter(Boolean);
     if (confirm('Trash not available for ' + paths.length + ' file(s):\n' +
         paths.slice(0, 5).join('\n') +
         (paths.length > 5 ? '\n... and ' + (paths.length - 5) + ' more' : '') +
-        '\n\nPermanently delete instead?')) {
+        '\n\nPermanently delete instead?') && retryTokens.length) {
       try {
         await safeFetch('/api/batch/delete', {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({paths: paths, mode: 'disk_permanent'}),
+          body: JSON.stringify({retry_tokens: retryTokens, mode: 'disk_permanent'}),
         });
       } catch(e) { /* already removed from DB */ }
     }

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -1,6 +1,7 @@
 """Tests for photo deletion API and database cleanup."""
 import json
 import os
+import time
 
 from PIL import Image
 
@@ -318,31 +319,73 @@ def test_api_batch_delete_invalid_mode(app_and_db):
     assert resp.status_code == 400
 
 
-def test_api_batch_delete_disk_permanent_retry_with_paths(app_and_db, tmp_path):
-    """disk_permanent retry works with paths after DB rows are already gone."""
+def test_api_batch_delete_rejects_other_workspace_photo(app_and_db):
+    """Batch delete must not remove photos hidden from the active workspace."""
+    app, db = app_and_db
+    client = app.test_client()
+    default_ws = db._active_workspace_id
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+    other_fid = db.add_folder("/secret/photos", name="secret")
+    other_pid = db.add_photo(
+        other_fid,
+        "secret.jpg",
+        ".jpg",
+        file_size=100,
+        file_mtime=1.0,
+    )
+    db.set_active_workspace(default_ws)
+
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": [other_pid],
+        "mode": "vireo",
+    })
+
+    assert resp.status_code == 403
+    assert db.get_photo(other_pid) is not None
+
+
+def test_api_batch_delete_disk_permanent_retry_rejects_raw_paths(app_and_db, tmp_path):
+    """Permanent-delete retry must not accept client-supplied filesystem paths."""
     app, db = app_and_db
     client = app.test_client()
 
-    # Create files to delete
-    file1 = str(tmp_path / "photo1.jpg")
-    file2 = str(tmp_path / "photo2.jpg")
-    Image.new("RGB", (10, 10)).save(file1)
-    Image.new("RGB", (10, 10)).save(file2)
-    assert os.path.exists(file1)
-    assert os.path.exists(file2)
+    target = str(tmp_path / "not_from_vireo.jpg")
+    Image.new("RGB", (10, 10)).save(target)
 
-    # Retry with paths (no photo_ids needed)
     resp = client.post("/api/batch/delete", json={
         "mode": "disk_permanent",
-        "paths": [file1, file2],
+        "paths": [target],
+    })
+
+    assert resp.status_code == 400
+    assert os.path.exists(target)
+
+
+def test_api_batch_delete_disk_permanent_retry_with_token(app_and_db, tmp_path):
+    """disk_permanent retry only works with a server-issued retry token."""
+    app, db = app_and_db
+    client = app.test_client()
+
+    target = str(tmp_path / "photo1.jpg")
+    Image.new("RGB", (10, 10)).save(target)
+    token = "test-retry-token"
+    app._delete_retry_tokens[token] = {
+        "path": target,
+        "expires_at": time.time() + 60,
+    }
+
+    resp = client.post("/api/batch/delete", json={
+        "mode": "disk_permanent",
+        "retry_tokens": [token],
     })
 
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["ok"] is True
-    assert data["trashed"] == 2
-    assert not os.path.exists(file1)
-    assert not os.path.exists(file2)
+    assert data["trashed"] == 1
+    assert not os.path.exists(target)
+    assert token not in app._delete_retry_tokens
 
 
 def test_api_batch_delete_disk_deletes_companion_file(app_and_db, tmp_path):

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -362,6 +362,61 @@ def test_api_batch_delete_disk_permanent_retry_rejects_raw_paths(app_and_db, tmp
     assert os.path.exists(target)
 
 
+def test_api_batch_delete_retry_tokens_atomic_on_invalid(app_and_db, tmp_path):
+    """If any retry token in a batch is invalid, no valid token is consumed."""
+    app, db = app_and_db
+    client = app.test_client()
+
+    target = str(tmp_path / "photo1.jpg")
+    Image.new("RGB", (10, 10)).save(target)
+    valid_token = "valid-retry-token"
+    app._delete_retry_tokens[valid_token] = {
+        "path": target,
+        "expires_at": time.time() + 60,
+    }
+
+    resp = client.post("/api/batch/delete", json={
+        "mode": "disk_permanent",
+        "retry_tokens": [valid_token, "bogus-token"],
+    })
+
+    assert resp.status_code == 400
+    # The valid token must still be usable, and the file must still exist.
+    assert valid_token in app._delete_retry_tokens
+    assert os.path.exists(target)
+
+    resp = client.post("/api/batch/delete", json={
+        "mode": "disk_permanent",
+        "retry_tokens": [valid_token],
+    })
+    assert resp.status_code == 200
+    assert not os.path.exists(target)
+    assert valid_token not in app._delete_retry_tokens
+
+
+def test_api_batch_delete_retry_tokens_reject_duplicates(app_and_db, tmp_path):
+    """A duplicated retry token in one request must be rejected without consuming it."""
+    app, db = app_and_db
+    client = app.test_client()
+
+    target = str(tmp_path / "photo1.jpg")
+    Image.new("RGB", (10, 10)).save(target)
+    token = "dup-retry-token"
+    app._delete_retry_tokens[token] = {
+        "path": target,
+        "expires_at": time.time() + 60,
+    }
+
+    resp = client.post("/api/batch/delete", json={
+        "mode": "disk_permanent",
+        "retry_tokens": [token, token],
+    })
+
+    assert resp.status_code == 400
+    assert token in app._delete_retry_tokens
+    assert os.path.exists(target)
+
+
 def test_api_batch_delete_disk_permanent_retry_with_token(app_and_db, tmp_path):
     """disk_permanent retry only works with a server-issued retry token."""
     app, db = app_and_db


### PR DESCRIPTION
## Problem

`/api/batch/delete` had two high-risk paths:

- It accepted `disk_permanent` retry requests with raw filesystem `paths`, then called `os.remove` on each path. A caller could ask the app process to delete files that were never resolved from Vireo's database.
- It passed client-supplied `photo_ids` directly into `db.delete_photos`, whose lookup is intentionally global for internal callers. That let the route delete photos outside the active workspace.

## Fix Plan

1. Keep direct permanent deletion by `photo_ids`, but only after the route verifies the IDs belong to the active workspace.
2. Replace raw retry paths with short-lived server-issued retry tokens. Failed Trash attempts now return `{path, retry_token}`; the UI sends `retry_tokens` back if the user confirms permanent deletion.
3. Preserve `Database.delete_photos` compatibility for internal callers by adding an opt-in `verify_workspace` parameter that the API route uses.
4. Cover the dangerous cases with focused regression tests.

## Changes

- Added one-time in-memory delete retry tokens with a 10-minute TTL.
- Rejected raw `paths` on permanent-delete retry requests.
- Validated batch delete photo IDs as integers and active-workspace members before deleting.
- Updated the shared delete modal to send retry tokens instead of raw paths.
- Added tests for cross-workspace delete rejection, raw-path rejection, and token-based retry.

## Validation

- `python -m ruff check vireo/app.py vireo/db.py vireo/tests/test_delete_api.py`
- `python -m pytest vireo/tests/test_delete_api.py -q`
- `python -m pytest tests/test_workspaces.py vireo/tests/test_app.py -q`