### PR TITLE
misses: don't flag no_subject when classifier is confident

### DIFF
--- a/vireo/config.py
+++ b/vireo/config.py
@@ -85,6 +85,12 @@ DEFAULTS = {
         "miss_bbox_area_min": 0.005,
         "miss_bbox_area_min_singleton": 0.002,
         "miss_oof_ratio": 0.5,
+        # If any stored classifier prediction on a photo's detections has
+        # confidence >= this, the photo cannot be flagged no_subject — the
+        # classifier saw something even when the detector's confidence was
+        # below the workspace `detector_confidence` cutoff. Set to 1.01 to
+        # disable the override.
+        "miss_classifier_override_conf": 0.8,
         # Eye-focus detection
         "eye_detect_enabled": True,
         "eye_classifier_conf_gate": 0.50,

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -417,6 +417,16 @@ SCHEMA = {
         "label": "Miss: out-of-focus ratio",
         "desc": "Out-of-focus area ratio threshold.",
     },
+    "pipeline.miss_classifier_override_conf": {
+        "type": "float", "min": 0.0, "max": 1.01, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Miss: classifier-override confidence",
+        "desc": (
+            "If any stored classifier prediction on a photo's detections "
+            "is at least this confident, the photo cannot be flagged "
+            "no_subject. Set to 1.01 to disable."
+        ),
+    },
     "pipeline.eye_detect_enabled": {
         "type": "bool",
         "category": "Pipeline", "scope": "both",

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -158,12 +158,23 @@ def compute_misses_for_workspace(
     min_conf = db.get_effective_config(cfg.load()).get(
         "detector_confidence", 0.2
     )
+    # max_prediction_conf is the highest classifier confidence across all
+    # detections of the photo, ignoring the workspace detector_confidence
+    # cutoff. A classifier prediction at or above
+    # `miss_classifier_override_conf` overrides the no_subject flag — the
+    # canonical case is a hummingbird where megadetector returned a
+    # below-threshold box but BioCLIP identified the species with high
+    # confidence on that same box.
     rows = db.conn.execute(
         "SELECT p.id, p.burst_id, "
         "       (SELECT MAX(d.detector_confidence) FROM detections d "
         "        WHERE d.photo_id = p.id "
         "          AND d.detector_confidence >= ?) "
         "         AS detection_conf, "
+        "       (SELECT MAX(pr.confidence) FROM predictions pr "
+        "        JOIN detections d2 ON d2.id = pr.detection_id "
+        "        WHERE d2.photo_id = p.id) "
+        "         AS max_prediction_conf, "
         "       p.subject_size, p.crop_complete, "
         "       p.subject_tenengrad, p.bg_tenengrad "
         "FROM photos p "
@@ -171,6 +182,9 @@ def compute_misses_for_workspace(
         "WHERE wf.workspace_id = ?",
         (min_conf, ws_id),
     ).fetchall()
+    override_conf = _miss_threshold(
+        pipeline_config, "miss_classifier_override_conf"
+    )
 
     target_ids = None
     if collection_id is not None:
@@ -197,6 +211,14 @@ def compute_misses_for_workspace(
         now = datetime.now(UTC).isoformat(timespec="microseconds")
     updates = []
 
+    def _apply_classifier_override(row, flags):
+        if not flags["no_subject"]:
+            return flags
+        max_pred = row.get("max_prediction_conf")
+        if max_pred is not None and max_pred >= override_conf:
+            return {**flags, "no_subject": False}
+        return flags
+
     for burst_rows in by_burst.values():
         for row in burst_rows:
             if target_ids is not None and row["id"] not in target_ids:
@@ -205,6 +227,7 @@ def compute_misses_for_workspace(
                 continue
             siblings = [s for s in burst_rows if s["id"] != row["id"]]
             flags = classify_miss(row, siblings, pipeline_config)
+            flags = _apply_classifier_override(row, flags)
             updates.append((
                 int(flags["no_subject"]),
                 int(flags["clipped"]),
@@ -219,6 +242,7 @@ def compute_misses_for_workspace(
         if row["id"] in excluded:
             continue
         flags = classify_miss(row, siblings=[], config=pipeline_config)
+        flags = _apply_classifier_override(row, flags)
         updates.append((
             int(flags["no_subject"]),
             int(flags["clipped"]),

--- a/vireo/tests/test_misses.py
+++ b/vireo/tests/test_misses.py
@@ -480,3 +480,123 @@ def test_compute_misses_uses_injected_now_timestamp(tmp_path):
         "SELECT miss_computed_at FROM photos WHERE id=?", (pid,),
     ).fetchone())
     assert row["miss_computed_at"] == fixed_ts
+
+
+def _photo_with_weak_detection(db, name, file_mtime, det_conf=0.143):
+    """Helper: photo with one below-cutoff detection and no quality features.
+
+    Mirrors the canonical hummingbird case — megadetector returned a
+    sub-threshold box, no later pipeline stage measured quality features.
+    Without a classifier prediction this photo is flagged ``no_subject``.
+    Returns ``(photo_id, detection_id)``.
+    """
+    folder_id = db.add_folder(f"/tmp/{name}", name=name)
+    pid = db.add_photo(
+        folder_id, f"{name}.jpg", extension=".jpg", file_size=100,
+        file_mtime=file_mtime, timestamp=f"2026-04-22T10:00:0{file_mtime}",
+    )
+    det_ids = db.save_detections(
+        pid,
+        [{"box": {"x": 0.19, "y": 0.22, "w": 0.33, "h": 0.23},
+          "confidence": det_conf, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    db.conn.commit()
+    return pid, det_ids[0]
+
+
+def test_high_classifier_confidence_overrides_no_subject(tmp_path):
+    """Canonical hummingbird case: detector below workspace cutoff, but a
+    classifier prediction at 0.996 on the same box. The photo must not be
+    flagged ``no_subject``."""
+    import config as cfg
+    from db import Database
+    from misses import compute_misses_for_workspace
+
+    db = Database(str(tmp_path / "m.db"))
+    pid, det_id = _photo_with_weak_detection(db, "hummer", 1)
+    db.add_prediction(
+        det_id, species="Allen's Hummingbird", confidence=0.996,
+        model="BioCLIP-2.5",
+    )
+    db.conn.commit()
+
+    n = compute_misses_for_workspace(db, cfg.DEFAULTS["pipeline"])
+    assert n == 1
+
+    row = dict(db.conn.execute(
+        "SELECT miss_no_subject, miss_clipped, miss_oof FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone())
+    assert row["miss_no_subject"] == 0
+    assert row["miss_clipped"] == 0
+    assert row["miss_oof"] == 0
+
+
+def test_low_classifier_confidence_does_not_override_no_subject(tmp_path):
+    """Classifier prediction below ``miss_classifier_override_conf`` (0.8 by
+    default) must not rescue the photo — the detector signal still wins."""
+    import config as cfg
+    from db import Database
+    from misses import compute_misses_for_workspace
+
+    db = Database(str(tmp_path / "m.db"))
+    pid, det_id = _photo_with_weak_detection(db, "weak", 1)
+    db.add_prediction(
+        det_id, species="Maybe-A-Bird", confidence=0.40,
+        model="BioCLIP-2.5",
+    )
+    db.conn.commit()
+
+    compute_misses_for_workspace(db, cfg.DEFAULTS["pipeline"])
+
+    row = dict(db.conn.execute(
+        "SELECT miss_no_subject FROM photos WHERE id=?", (pid,),
+    ).fetchone())
+    assert row["miss_no_subject"] == 1
+
+
+def test_no_classifier_prediction_does_not_override_no_subject(tmp_path):
+    """Without any stored prediction the override can't fire — the existing
+    detector-only behaviour must hold."""
+    import config as cfg
+    from db import Database
+    from misses import compute_misses_for_workspace
+
+    db = Database(str(tmp_path / "m.db"))
+    pid, _det_id = _photo_with_weak_detection(db, "noclass", 1)
+
+    compute_misses_for_workspace(db, cfg.DEFAULTS["pipeline"])
+
+    row = dict(db.conn.execute(
+        "SELECT miss_no_subject FROM photos WHERE id=?", (pid,),
+    ).fetchone())
+    assert row["miss_no_subject"] == 1
+
+
+def test_classifier_override_threshold_is_configurable(tmp_path):
+    """Lowering ``miss_classifier_override_conf`` rescues photos that the
+    default 0.8 would not. Confirms the threshold is honoured rather than
+    hard-coded."""
+    import config as cfg
+    from db import Database
+    from misses import compute_misses_for_workspace
+
+    db = Database(str(tmp_path / "m.db"))
+    pid, det_id = _photo_with_weak_detection(db, "tunable", 1)
+    db.add_prediction(
+        det_id, species="Probably-A-Bird", confidence=0.50,
+        model="BioCLIP-2.5",
+    )
+    db.conn.commit()
+
+    pipeline_config = {
+        **cfg.DEFAULTS["pipeline"],
+        "miss_classifier_override_conf": 0.40,
+    }
+    compute_misses_for_workspace(db, pipeline_config)
+
+    row = dict(db.conn.execute(
+        "SELECT miss_no_subject FROM photos WHERE id=?", (pid,),
+    ).fetchone())
+    assert row["miss_no_subject"] == 0


### PR DESCRIPTION
## Summary

- If any stored classifier prediction on a photo's detections has confidence ≥ `miss_classifier_override_conf` (default 0.8), the photo can no longer be flagged `no_subject`.
- Adds `pipeline.miss_classifier_override_conf` to `config.DEFAULTS` and the settings schema.
- 4 new tests in `vireo/tests/test_misses.py`.

## Motivation

Investigating `DSC_3656.NEF` (photo 41273 in the May2026 workspace) — a clearly visible hummingbird flagged on the misses page as `no_subject`. Megadetector's best box was 0.143 (below the workspace `detector_confidence` cutoff of 0.2), but BioCLIP-2.5 had already run on that exact box and called it **Allen's Hummingbird (Selasphorus sasin) at 99.64%**. The old miss classifier ignored classifier evidence and trusted only detector confidence, so the photo was hidden as a "no subject" miss despite a 99.6% species identification on it.

## Behaviour change

The override only applies to `no_subject`. `clipped` and `oof` need bbox geometry + tenengrad measurements that aren't computed when the detector misses — they can't be evaluated retroactively, and a species identification doesn't tell us whether the bird is clipped or OOF.

The new `max_prediction_conf` subquery deliberately does **not** filter by the workspace `detector_confidence` cutoff: a classifier prediction on a sub-cutoff detection is exactly the signal we want to honour.

## Backfill

I'll run `compute_misses_for_workspace` once per workspace against `~/.vireo/vireo.db` after merge so existing `no_subject` photos with stored ≥0.8 predictions get rescued — no app-side migration, no permanent UI surface.

## Test plan

- [x] `python -m pytest vireo/tests/test_misses.py -v` — 20 passed (4 new)
- [x] Full CLAUDE.md suite: `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_misses.py vireo/tests/test_pipeline_job.py` — 1076 passed, 1 skipped
- [ ] Post-merge: run one-time backfill and confirm DSC_3656.NEF disappears from /misses

🤖 Generated with [Claude Code](https://claude.com/claude-code)