### PR TITLE
[codex] Clarify pipeline preview size setting

### DIFF
--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -238,6 +238,10 @@ body { padding-bottom: 36px; }
   font-size: 11px; color: var(--text-faint, #5A8890);
   text-transform: uppercase; margin-bottom: 6px;
 }
+.setting-hint {
+  font-size: 12px; color: var(--text-secondary, #8BB8C0);
+  margin-top: 6px;
+}
 .setting-select {
   background: var(--bg-input, #14374E);
   color: var(--text-primary, #E0F0F0);
@@ -893,7 +897,7 @@ body { padding-bottom: 36px; }
       </p>
       <div class="setting-row">
         <div class="setting-item">
-          <div class="setting-label">Preview quality</div>
+          <div class="setting-label">Preview size</div>
           <select class="setting-select" id="cfgPreviewSize"
                   onchange="schedulePlanRefresh()">
             <option value="1280">1280px</option>
@@ -902,6 +906,7 @@ body { padding-bottom: 36px; }
             <option value="3840">3840px</option>
             <option value="0">Full resolution</option>
           </select>
+          <div class="setting-hint">Largest edge for cached previews.</div>
         </div>
       </div>
       <div class="progress-wrap" id="progressPreviews" style="display:none;">
@@ -2404,7 +2409,7 @@ async function startPipeline() {
     }
   }
 
-  // Preview quality
+  // Preview size
   body.preview_max_size = parseInt(document.getElementById('cfgPreviewSize').value);
 
   // Optional stages


### PR DESCRIPTION
## Summary

- Rename the pipeline dropdown from “Preview quality” to “Preview size”.
- Add a short hint explaining that the value controls the largest edge for cached previews.
- Align the nearby JavaScript comment with the `preview_max_size` behavior.

## Why

The pipeline dropdown submits `preview_max_size` and offers pixel-size choices, including full resolution. Calling it “Preview quality” made it sound like JPEG compression quality, which is controlled separately in Settings by `preview_quality`.

## Validation

- Confirmed the pipeline template now uses “Preview size”.
- Confirmed Settings still has the true JPEG “Preview quality” label.
- No automated test suite run; this is a copy-only UI change.