### PR TITLE
batch delete: chunk photo_ids to stay under SQLite param cap

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2657,12 +2657,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Chunked because delete_photos issues several IN-clause queries; a
         # 1000+ id request would hit SQLite's bound-parameter cap on legacy
-        # builds.
+        # builds. We pass ``commit=False`` so all chunks share one outer
+        # transaction — without that, an error on a later chunk would 500
+        # the request after earlier chunks already committed, leaving DB
+        # rows gone and cached files / disk trashing not yet cleaned up
+        # for them.
         result = {"deleted": 0, "files": []}
-        for chunk in _chunked(photo_ids):
-            chunk_result = db.delete_photos(chunk, include_companions=include_companions)
-            result["deleted"] += chunk_result["deleted"]
-            result["files"].extend(chunk_result["files"])
+        try:
+            for chunk in _chunked(photo_ids):
+                chunk_result = db.delete_photos(
+                    chunk,
+                    include_companions=include_companions,
+                    commit=False,
+                )
+                result["deleted"] += chunk_result["deleted"]
+                result["files"].extend(chunk_result["files"])
+            db.conn.commit()
+        except Exception:
+            db.conn.rollback()
+            raise
 
         _cleanup_cached_files_for_deleted_photos(result["files"])
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2655,7 +2655,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if mode not in ("vireo", "disk", "disk_permanent"):
             return json_error("mode must be 'vireo', 'disk', or 'disk_permanent'")
 
-        result = db.delete_photos(photo_ids, include_companions=include_companions)
+        # Chunked because delete_photos issues several IN-clause queries; a
+        # 1000+ id request would hit SQLite's bound-parameter cap on legacy
+        # builds.
+        result = {"deleted": 0, "files": []}
+        for chunk in _chunked(photo_ids):
+            chunk_result = db.delete_photos(chunk, include_companions=include_companions)
+            result["deleted"] += chunk_result["deleted"]
+            result["files"].extend(chunk_result["files"])
 
         _cleanup_cached_files_for_deleted_photos(result["files"])
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2661,8 +2661,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # transaction — without that, an error on a later chunk would 500
         # the request after earlier chunks already committed, leaving DB
         # rows gone and cached files / disk trashing not yet cleaned up
-        # for them.
-        result = {"deleted": 0, "files": []}
+        # for them. ``commit=False`` also defers the pipeline-cache prune
+        # (a non-transactional file write) to the caller so a rolled-back
+        # later chunk doesn't leave the cache permanently stripped of rows
+        # the DB just restored.
+        result = {"deleted": 0, "ids": [], "files": []}
         try:
             for chunk in _chunked(photo_ids):
                 chunk_result = db.delete_photos(
@@ -2671,12 +2674,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     commit=False,
                 )
                 result["deleted"] += chunk_result["deleted"]
+                result["ids"].extend(chunk_result["ids"])
                 result["files"].extend(chunk_result["files"])
             db.conn.commit()
         except Exception:
             db.conn.rollback()
             raise
 
+        # Run the deferred non-DB side effects only after the outer
+        # transaction committed successfully.
+        db.prune_pipeline_cache_for_ids(result["ids"])
         _cleanup_cached_files_for_deleted_photos(result["files"])
 
         trashed = 0

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4309,20 +4309,43 @@ class Database:
                 )
         self.conn.commit()
 
+    def prune_pipeline_cache_for_ids(self, ids):
+        """Remove ``ids`` from the workspace's pipeline review cache file.
+
+        Split out from ``delete_photos`` so chunked callers can defer it to
+        after their outer transaction commits — pruning the on-disk cache
+        is not transactional, so running it per-chunk would leave the cache
+        permanently stripped of rows that a later rollback restores.
+        """
+        if not ids or self._db_path == ":memory:" or not self._active_workspace_id:
+            return
+        try:
+            from pipeline import prune_results
+            prune_results(
+                os.path.dirname(self._db_path),
+                self._active_workspace_id,
+                ids,
+            )
+        except Exception:
+            log.exception("Failed to prune pipeline cache after delete")
+
     def delete_photos(self, photo_ids, include_companions=False, commit=True):
         """Delete photos and all associated data.
 
-        Returns dict with 'deleted' count and 'files' list of
+        Returns dict with 'deleted' count, 'ids' list of deleted photo IDs
+        (post-companion-resolution), and 'files' list of
         {photo_id, folder_path, filename, companion_path} for file cleanup.
 
         When ``commit`` is ``False``, this call participates in an outer
         transaction managed by the caller: no ``commit()``/``rollback()`` is
-        issued here, so the caller can chain several ``delete_photos`` calls
-        atomically (used by the batch-delete route to chunk under SQLite's
-        bound-parameter cap without losing all-or-nothing semantics).
+        issued here, **and** the non-DB pipeline-cache prune is skipped so
+        a later failed chunk can roll the DB back without leaving a
+        permanently-mutated cache file on disk. The caller is responsible
+        for invoking ``prune_pipeline_cache_for_ids`` with the union of
+        returned ``ids`` after the outer commit succeeds.
         """
         if not photo_ids:
-            return {"deleted": 0, "files": []}
+            return {"deleted": 0, "ids": [], "files": []}
 
         # Resolve to actual existing photos
         placeholders = ",".join("?" for _ in photo_ids)
@@ -4334,7 +4357,7 @@ class Database:
         ).fetchall()
 
         if not rows:
-            return {"deleted": 0, "files": []}
+            return {"deleted": 0, "ids": [], "files": []}
 
         # Resolve companions
         if include_companions:
@@ -4437,18 +4460,14 @@ class Database:
                 self.invalidate_new_images_cache_for_folders(affected_folder_ids)
 
         # Prune the pipeline review cache so deleted photos don't render as
-        # blank cards on the pipeline review page.
-        if all_ids and self._db_path != ":memory:" and self._active_workspace_id:
-            try:
-                from pipeline import prune_results
-                prune_results(
-                    os.path.dirname(self._db_path),
-                    self._active_workspace_id,
-                    all_ids,
-                )
-            except Exception:
-                log.exception("Failed to prune pipeline cache after delete")
-        return {"deleted": len(all_ids), "files": files}
+        # blank cards on the pipeline review page. Skipped when ``commit`` is
+        # False so chunked callers can defer this non-transactional side
+        # effect until after their outer commit — otherwise a rolled-back
+        # later chunk would leave the on-disk cache permanently stripped of
+        # rows the DB just restored.
+        if commit:
+            self.prune_pipeline_cache_for_ids(all_ids)
+        return {"deleted": len(all_ids), "ids": all_ids, "files": files}
 
     # ------------------------------------------------------------------
     # preview_cache LRU

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4309,11 +4309,17 @@ class Database:
                 )
         self.conn.commit()
 
-    def delete_photos(self, photo_ids, include_companions=False):
+    def delete_photos(self, photo_ids, include_companions=False, commit=True):
         """Delete photos and all associated data.
 
         Returns dict with 'deleted' count and 'files' list of
         {photo_id, folder_path, filename, companion_path} for file cleanup.
+
+        When ``commit`` is ``False``, this call participates in an outer
+        transaction managed by the caller: no ``commit()``/``rollback()`` is
+        issued here, so the caller can chain several ``delete_photos`` calls
+        atomically (used by the batch-delete route to chunk under SQLite's
+        bound-parameter cap without losing all-or-nothing semantics).
         """
         if not photo_ids:
             return {"deleted": 0, "files": []}
@@ -4417,9 +4423,11 @@ class Database:
                     (count, fid),
                 )
 
-            self.conn.commit()
+            if commit:
+                self.conn.commit()
         except Exception:
-            self.conn.rollback()
+            if commit:
+                self.conn.rollback()
             raise
         finally:
             # Always invalidate — even on rollback we may have partially dirtied

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -318,6 +318,54 @@ def test_api_batch_delete_invalid_mode(app_and_db):
     assert resp.status_code == 400
 
 
+def test_api_batch_delete_chunks_large_photo_id_lists(app_and_db, monkeypatch):
+    """Route must chunk photo_ids before calling delete_photos so SQLite's
+    bound-parameter cap (~999 on legacy builds) can't trip on bulk deletes."""
+    import app as appmod
+    from db import Database
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    fid = db.add_folder('/photos/bulk', name='bulk')
+    bulk_ids = [
+        db.add_photo(
+            folder_id=fid,
+            filename=f"bulk{i}.jpg",
+            extension='.jpg',
+            file_size=10,
+            file_mtime=float(i),
+        )
+        for i in range(5)
+    ]
+
+    def small_chunked(seq, size=2):
+        for i in range(0, len(seq), size):
+            yield seq[i:i + size]
+    monkeypatch.setattr(appmod, "_chunked", small_chunked)
+
+    chunks_seen = []
+    real_delete = Database.delete_photos
+
+    def spy(self, photo_ids, **kwargs):
+        chunks_seen.append(list(photo_ids))
+        return real_delete(self, photo_ids, **kwargs)
+
+    monkeypatch.setattr(Database, "delete_photos", spy)
+
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": bulk_ids,
+        "mode": "vireo",
+    })
+
+    assert resp.status_code == 200
+    assert resp.get_json()["deleted"] == len(bulk_ids)
+    assert len(chunks_seen) >= 3, f"expected chunked calls, got {chunks_seen}"
+    assert all(len(c) <= 2 for c in chunks_seen)
+    for pid in bulk_ids:
+        assert db.get_photo(pid) is None
+
+
 def test_api_batch_delete_disk_permanent_retry_with_paths(app_and_db, tmp_path):
     """disk_permanent retry works with paths after DB rows are already gone."""
     app, db = app_and_db

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -419,6 +419,176 @@ def test_api_batch_delete_chunked_loop_is_atomic_on_failure(app_and_db, monkeypa
         assert db.get_photo(pid) is not None, f"photo {pid} was deleted despite rollback"
 
 
+def test_api_batch_delete_chunked_failure_preserves_pipeline_cache(
+    app_and_db, monkeypatch
+):
+    """When a later chunk fails and the route rolls the DB back, the
+    pipeline review cache must NOT have already been pruned for the
+    earlier chunks' photos — those rows still exist, so pruning them
+    would orphan their pipeline entries with no way to restore them
+    (the cache file is non-transactional)."""
+    import app as appmod
+    from db import Database
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    fid = db.add_folder('/photos/pcache', name='pcache')
+    bulk_ids = [
+        db.add_photo(
+            folder_id=fid,
+            filename=f"pcache{i}.jpg",
+            extension='.jpg',
+            file_size=10,
+            file_mtime=float(i),
+        )
+        for i in range(5)
+    ]
+
+    # Seed a pipeline review cache that references every photo.
+    cache_dir = os.path.dirname(db._db_path)
+    cache_path = os.path.join(
+        cache_dir, f"pipeline_results_ws{db._active_workspace_id}.json"
+    )
+    cache = {
+        "encounters": [{
+            "species": None,
+            "photo_count": len(bulk_ids),
+            "burst_count": 1,
+            "photo_ids": list(bulk_ids),
+            "bursts": [{
+                "photo_ids": list(bulk_ids),
+                "species_predictions": [],
+                "species_override": None,
+            }],
+        }],
+        "photos": [{"id": pid, "label": "KEEP"} for pid in bulk_ids],
+        "summary": {
+            "total_photos": len(bulk_ids),
+            "encounter_count": 1,
+            "burst_count": 1,
+            "keep_count": len(bulk_ids),
+            "review_count": 0,
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    with open(cache_path, "w") as f:
+        json.dump(cache, f)
+
+    def small_chunked(seq, size=2):
+        for i in range(0, len(seq), size):
+            yield seq[i:i + size]
+    monkeypatch.setattr(appmod, "_chunked", small_chunked)
+
+    real_delete = Database.delete_photos
+    calls = {"n": 0}
+
+    def flaky(self, photo_ids, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("simulated SQLite error mid-loop")
+        return real_delete(self, photo_ids, **kwargs)
+
+    monkeypatch.setattr(Database, "delete_photos", flaky)
+
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": bulk_ids,
+        "mode": "vireo",
+    })
+
+    assert resp.status_code >= 500
+
+    # The on-disk pipeline cache must still reference every original
+    # photo — none were actually deleted (the DB rolled back), so the
+    # cache must not have been pre-pruned for the first chunk.
+    with open(cache_path) as f:
+        cache_after = json.load(f)
+    assert [p["id"] for p in cache_after["photos"]] == list(bulk_ids)
+    assert cache_after["encounters"][0]["photo_ids"] == list(bulk_ids)
+    assert cache_after["encounters"][0]["bursts"][0]["photo_ids"] == list(bulk_ids)
+    assert cache_after["summary"]["total_photos"] == len(bulk_ids)
+
+
+def test_api_batch_delete_chunked_success_prunes_pipeline_cache(
+    app_and_db, monkeypatch
+):
+    """On the happy path (all chunks commit), the pipeline cache must
+    still be pruned of the deleted photos exactly once after the outer
+    commit — i.e., deferring the prune doesn't drop it on the floor."""
+    import app as appmod
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    fid = db.add_folder('/photos/pchunk', name='pchunk')
+    bulk_ids = [
+        db.add_photo(
+            folder_id=fid,
+            filename=f"pchunk{i}.jpg",
+            extension='.jpg',
+            file_size=10,
+            file_mtime=float(i),
+        )
+        for i in range(5)
+    ]
+    survivor = db.add_photo(
+        folder_id=fid,
+        filename="survivor.jpg",
+        extension='.jpg',
+        file_size=10,
+        file_mtime=99.0,
+    )
+
+    cache_dir = os.path.dirname(db._db_path)
+    cache_path = os.path.join(
+        cache_dir, f"pipeline_results_ws{db._active_workspace_id}.json"
+    )
+    all_in_cache = list(bulk_ids) + [survivor]
+    cache = {
+        "encounters": [{
+            "species": None,
+            "photo_count": len(all_in_cache),
+            "burst_count": 1,
+            "photo_ids": list(all_in_cache),
+            "bursts": [{
+                "photo_ids": list(all_in_cache),
+                "species_predictions": [],
+                "species_override": None,
+            }],
+        }],
+        "photos": [{"id": pid, "label": "KEEP"} for pid in all_in_cache],
+        "summary": {
+            "total_photos": len(all_in_cache),
+            "encounter_count": 1,
+            "burst_count": 1,
+            "keep_count": len(all_in_cache),
+            "review_count": 0,
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    with open(cache_path, "w") as f:
+        json.dump(cache, f)
+
+    def small_chunked(seq, size=2):
+        for i in range(0, len(seq), size):
+            yield seq[i:i + size]
+    monkeypatch.setattr(appmod, "_chunked", small_chunked)
+
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": bulk_ids,
+        "mode": "vireo",
+    })
+    assert resp.status_code == 200
+
+    with open(cache_path) as f:
+        cache_after = json.load(f)
+    assert [p["id"] for p in cache_after["photos"]] == [survivor]
+    assert cache_after["encounters"][0]["photo_ids"] == [survivor]
+    assert cache_after["summary"]["total_photos"] == 1
+
+
 def test_api_batch_delete_disk_permanent_retry_with_paths(app_and_db, tmp_path):
     """disk_permanent retry works with paths after DB rows are already gone."""
     app, db = app_and_db

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -366,6 +366,59 @@ def test_api_batch_delete_chunks_large_photo_id_lists(app_and_db, monkeypatch):
         assert db.get_photo(pid) is None
 
 
+def test_api_batch_delete_chunked_loop_is_atomic_on_failure(app_and_db, monkeypatch):
+    """A failure in a later chunk must roll back earlier chunks so DB rows
+    and cached files don't drift apart. Without a shared transaction the
+    earlier chunks' commits would survive, leaving the route 500ing after
+    deleting only part of the selection."""
+    import app as appmod
+    from db import Database
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    fid = db.add_folder('/photos/atomic', name='atomic')
+    bulk_ids = [
+        db.add_photo(
+            folder_id=fid,
+            filename=f"atomic{i}.jpg",
+            extension='.jpg',
+            file_size=10,
+            file_mtime=float(i),
+        )
+        for i in range(5)
+    ]
+
+    def small_chunked(seq, size=2):
+        for i in range(0, len(seq), size):
+            yield seq[i:i + size]
+    monkeypatch.setattr(appmod, "_chunked", small_chunked)
+
+    real_delete = Database.delete_photos
+    calls = {"n": 0}
+
+    def flaky(self, photo_ids, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("simulated SQLite error mid-loop")
+        return real_delete(self, photo_ids, **kwargs)
+
+    monkeypatch.setattr(Database, "delete_photos", flaky)
+
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": bulk_ids,
+        "mode": "vireo",
+    })
+
+    # Route should fail visibly rather than silently dropping rows.
+    assert resp.status_code >= 500
+    # No DB rows should be missing — the first chunk's DML must roll back
+    # along with the failed chunk's, restoring the all-or-nothing semantics
+    # the single-call path had.
+    for pid in bulk_ids:
+        assert db.get_photo(pid) is not None, f"photo {pid} was deleted despite rollback"
+
+
 def test_api_batch_delete_disk_permanent_retry_with_paths(app_and_db, tmp_path):
     """disk_permanent retry works with paths after DB rows are already gone."""
     app, db = app_and_db


### PR DESCRIPTION
## Summary
- `/api/batch/delete` passes the request `photo_ids` straight to `db.delete_photos`, whose internal `IN (...)` queries can trip SQLite's ~999 bound-parameter cap on a 1000+ id request.
- The disk-cleanup path at `app.py:7930` already chunks via `_chunked(...)` for exactly this reason; this PR applies the same pattern to the batch-delete route.

## Why now
Came out of a review of #798. That PR addresses two theoretical concerns; this is the one nearby reliability bug that could actually bite during normal use (bulk-deleting a folder of >998 photos). Latent — may not have been triggered on modern SQLite builds where the param cap is higher — but worth closing.

## Test plan
- [x] New test patches `_chunked` to a tiny chunk size and asserts the route makes multiple chunked calls and deletes all rows.
- [x] Verified RED before fix: test fails on `origin/main` with `expected chunked calls, got [[...]]`.
- [x] `python -m pytest vireo/tests/test_delete_api.py -q` — 25 passed.
- [x] Project smoke set (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py`) — 924 passed, 1 skipped.