### PR TITLE
[codex] Fix pipeline review readiness coverage

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -5002,11 +5002,9 @@ class Database:
           * has at least one non-synthetic detection (excludes full-image
             rows that exist only to anchor predictions)
           * has at least one prediction on that detection
-          * EITHER has not been processed (eye_tenengrad IS NULL) OR was
-            processed with a stale fingerprint (eye_kp_fingerprint differs
-            from EYE_KP_FINGERPRINT_VERSION). The stale path lets a
-            keypoint-model bump re-run on already-processed photos, since
-            (eye_x, eye_y, eye_conf, eye_tenengrad) are model-specific.
+          * has not been attempted with the current keypoint model fingerprint
+            yet. The stage stamps eye_kp_fingerprint even when no trustworthy
+            eye is found, so no-eye photos do not rerun forever.
           * (optional) photo.id is in ``photo_ids`` when provided — lets the
             caller scope the stage to a collection so a pipeline run doesn't
             touch unrelated photos elsewhere in the workspace
@@ -5057,8 +5055,7 @@ class Database:
                 AND d.detector_confidence >= ?
                JOIN predictions pr ON pr.detection_id = d.id
                WHERE p.mask_path IS NOT NULL
-                 AND (p.eye_tenengrad IS NULL
-                      OR p.eye_kp_fingerprint IS NULL
+                 AND (p.eye_kp_fingerprint IS NULL
                       OR p.eye_kp_fingerprint != ?){extra_where}
                  AND pr.labels_fingerprint = (
                     SELECT pr2.labels_fingerprint FROM predictions pr2

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -1232,6 +1232,14 @@ def _process_photo_for_eye(db, row, folders, *, C, T, k_window):
     from quality import compute_eye_tenengrad
 
     def mark_attempted_without_eye():
+        # Stamp the current eye-keypoint fingerprint only after the model
+        # has actually run and produced no trustworthy eye. Pre-model gates
+        # (Gate 1: classifier confidence, taxonomy routing, missing weights,
+        # missing image, etc.) depend on runtime settings or external state
+        # the user can change, so stamping there would permanently filter
+        # the photo out of future runs even after the user lowers the gate
+        # or adds the missing model — a functional regression. Those photos
+        # remain on the to-do list and are cheaply re-skipped on each run.
         db.update_photo_pipeline_features(
             row["id"],
             eye_x=None,
@@ -1243,11 +1251,9 @@ def _process_photo_for_eye(db, row, folders, *, C, T, k_window):
 
     # Gate 1: classifier confidence + species in scope.
     if (row.get("species_conf") or 0.0) < C:
-        mark_attempted_without_eye()
         return
     model_name = _resolve_keypoint_model(db, row)
     if model_name is None:
-        mark_attempted_without_eye()
         return
 
     # Gate 2: weights present on disk. The pipeline job auto-downloads both

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -846,23 +846,70 @@ def load_results_raw(cache_dir, workspace_id):
         return json.load(f)
 
 
-def _count_usable_embeddings(db, expected_variant):
+def _count_stage_targets(db):
+    """Return detection-aware target counts for review readiness.
+
+    Masks, DINO embeddings, and species predictions are only expected for
+    photos with a real detector box above the workspace threshold. Photos where
+    the detector found no qualifying subject can still appear in review as
+    subject-absent rejects, but rerunning mask/embedding/species stages will not
+    fill those rows.
+    """
+    import config as cfg
+
+    ws = db._ws_id()
+    min_conf = db.get_effective_config(cfg.load()).get(
+        "detector_confidence", 0.2
+    )
+    row = db.conn.execute(
+        """SELECT COUNT(DISTINCT p.id) AS n
+           FROM photos p
+           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+           JOIN folders f ON f.id = p.folder_id
+                         AND f.status IN ('ok', 'partial')
+           JOIN detections d ON d.photo_id = p.id
+                            AND d.detector_model != 'full-image'
+                            AND d.detector_confidence >= ?
+           WHERE wf.workspace_id = ?""",
+        (min_conf, ws),
+    ).fetchone()
+    detected = row["n"] or 0
+
+    return {"detected": detected}
+
+
+def _count_usable_embeddings(db, expected_variant, detected_only=False):
     """Count workspace photos whose stored DINO embedding is usable under
     ``expected_variant`` — i.e. the same rule ``load_photo_features`` applies
     via :func:`_embedding_usable`. Without ``expected_variant`` we accept any
     non-null embedding (back-compat for callers that don't know the variant).
     """
     ws = db._ws_id()
+    join_detection = ""
+    params_prefix = []
+    if detected_only:
+        import config as cfg
+        min_conf = db.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
+        join_detection = (
+            "JOIN detections d ON d.photo_id = p.id "
+            "AND d.detector_model != 'full-image' "
+            "AND d.detector_confidence >= ?"
+        )
+        params_prefix.append(min_conf)
+
     if expected_variant is None:
         row = db.conn.execute(
-            """SELECT COUNT(*) AS n
+            f"""SELECT COUNT(DISTINCT p.id) AS n
                FROM photos p
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                JOIN folders f ON f.id = p.folder_id
                              AND f.status IN ('ok', 'partial')
+               {join_detection}
                WHERE wf.workspace_id = ?
                  AND p.dino_subject_embedding IS NOT NULL""",
-            (ws,),
+            (*params_prefix, ws),
         ).fetchone()
         return row["n"] or 0
 
@@ -872,30 +919,64 @@ def _count_usable_embeddings(db, expected_variant):
     except Exception:
         # Unknown variant — only the exact-match branch can pass.
         row = db.conn.execute(
-            """SELECT COUNT(*) AS n
+            f"""SELECT COUNT(DISTINCT p.id) AS n
                FROM photos p
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                JOIN folders f ON f.id = p.folder_id
                              AND f.status IN ('ok', 'partial')
+               {join_detection}
                WHERE wf.workspace_id = ?
                  AND p.dino_subject_embedding IS NOT NULL
                  AND p.dino_embedding_variant = ?""",
-            (ws, expected_variant),
+            (*params_prefix, ws, expected_variant),
         ).fetchone()
         return row["n"] or 0
 
     row = db.conn.execute(
-        """SELECT COUNT(*) AS n
+        f"""SELECT COUNT(DISTINCT p.id) AS n
            FROM photos p
            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
            JOIN folders f ON f.id = p.folder_id
                          AND f.status IN ('ok', 'partial')
+           {join_detection}
            WHERE wf.workspace_id = ?
              AND p.dino_subject_embedding IS NOT NULL
              AND (p.dino_embedding_variant = ?
                   OR (p.dino_embedding_variant IS NULL
                       AND length(p.dino_subject_embedding) = ?))""",
-        (ws, expected_variant, expected_bytes),
+        (*params_prefix, ws, expected_variant, expected_bytes),
+    ).fetchone()
+    return row["n"] or 0
+
+
+def _count_eye_keypoint_attempts(db):
+    """Count photos already evaluated by the current eye-keypoint model.
+
+    Legacy successful rows may have ``eye_x`` but no fingerprint, so count
+    those as attempted for review-readiness back-compat. New runs stamp the
+    fingerprint even when no trusted eye is found.
+    """
+    import config as cfg
+
+    ws = db._ws_id()
+    min_conf = db.get_effective_config(cfg.load()).get(
+        "detector_confidence", 0.2
+    )
+    row = db.conn.execute(
+        """SELECT COUNT(DISTINCT p.id) AS n
+           FROM photos p
+           JOIN workspace_folders wf
+             ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+           JOIN folders f ON f.id = p.folder_id
+                         AND f.status IN ('ok', 'partial')
+           JOIN detections d
+             ON d.photo_id = p.id
+            AND d.detector_model != 'full-image'
+            AND d.detector_confidence >= ?
+           JOIN predictions pr ON pr.detection_id = d.id
+           WHERE p.mask_path IS NOT NULL
+             AND (p.eye_kp_fingerprint = ? OR p.eye_x IS NOT NULL)""",
+        (ws, min_conf, EYE_KP_FINGERPRINT_VERSION),
     ).fetchone()
     return row["n"] or 0
 
@@ -937,15 +1018,34 @@ def compute_review_readiness(db, mask_threshold=0.25, dinov2_variant=None):
     """
     cov = db.get_coverage_stats()
     total = cov["total"]
-    usable_embeddings = _count_usable_embeddings(db, dinov2_variant)
+    targets = _count_stage_targets(db) if total else {
+        "detected": 0,
+    }
+    detected_target = targets["detected"]
+    # Once real detector output exists, masks/embeddings/species are expected
+    # only for detector-backed subject photos. Before detection has produced
+    # any eligible subject rows, fall back to total so first-run or legacy
+    # partially-masked workspaces still surface incomplete feature coverage.
+    feature_target = detected_target or total
+    embedding_detected_only = detected_target > 0
+    usable_embeddings = _count_usable_embeddings(
+        db, dinov2_variant, detected_only=embedding_detected_only,
+    )
+    eye_target = db.count_eye_keypoint_eligible() if total else 0
+    eye_attempts = _count_eye_keypoint_attempts(db) if eye_target else 0
     out = {
         "state": "empty",
         "total_photos": total,
         "with_masks": cov["mask"],
+        "mask_target_photos": feature_target,
         "with_sharpness": cov["subject_sharpness"],
         "with_embeddings": usable_embeddings,
+        "embedding_target_photos": feature_target,
         "with_eye_keypoints": cov["eye"],
+        "with_eye_keypoint_attempts": eye_attempts,
+        "eye_keypoint_target_photos": eye_target,
         "with_predictions": cov["classified"],
+        "prediction_target_photos": feature_target,
         "missing_required": [],
         "enhancing_missing": [],
     }
@@ -956,7 +1056,8 @@ def compute_review_readiness(db, mask_threshold=0.25, dinov2_variant=None):
     # Use ceiling so the gate honors the documented minimum fraction — e.g.
     # 1 mask out of 5 (20%) must classify as insufficient against a 25%
     # threshold, not slip through because int() floored 1.25 down to 1.
-    if cov["mask"] < max(1, math.ceil(total * mask_threshold)):
+    required_masks = max(1, math.ceil(feature_target * mask_threshold))
+    if cov["mask"] < required_masks:
         out["state"] = "insufficient"
         out["missing_required"].append("masks")
         # Still surface enhancing_missing so the diagnostic is complete
@@ -964,13 +1065,13 @@ def compute_review_readiness(db, mask_threshold=0.25, dinov2_variant=None):
         out["state"] = "computable"
 
     # Enhancing: per-stage gaps that would improve quality if filled
-    if cov["mask"] < total and "masks" not in out["missing_required"]:
+    if cov["mask"] < feature_target and "masks" not in out["missing_required"]:
         out["enhancing_missing"].append("masks_partial")
-    if usable_embeddings < total:
+    if usable_embeddings < feature_target:
         out["enhancing_missing"].append("embeddings")
-    if cov["eye"] < total:
+    if eye_attempts < eye_target:
         out["enhancing_missing"].append("eye_keypoints")
-    if cov["classified"] < total:
+    if cov["classified"] < feature_target:
         out["enhancing_missing"].append("species_predictions")
 
     return out
@@ -1130,11 +1231,23 @@ def _process_photo_for_eye(db, row, folders, *, C, T, k_window):
     from image_loader import load_image
     from quality import compute_eye_tenengrad
 
+    def mark_attempted_without_eye():
+        db.update_photo_pipeline_features(
+            row["id"],
+            eye_x=None,
+            eye_y=None,
+            eye_conf=None,
+            eye_tenengrad=None,
+            eye_kp_fingerprint=EYE_KP_FINGERPRINT_VERSION,
+        )
+
     # Gate 1: classifier confidence + species in scope.
     if (row.get("species_conf") or 0.0) < C:
+        mark_attempted_without_eye()
         return
     model_name = _resolve_keypoint_model(db, row)
     if model_name is None:
+        mark_attempted_without_eye()
         return
 
     # Gate 2: weights present on disk. The pipeline job auto-downloads both
@@ -1198,6 +1311,7 @@ def _process_photo_for_eye(db, row, folders, *, C, T, k_window):
         eye_candidates.append(k_point)
 
     if not eye_candidates:
+        mark_attempted_without_eye()
         return
 
     # Pick the eye with the highest windowed tenengrad — "best" eye wins.

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2305,10 +2305,15 @@ function renderEmptyState(readiness) {
   // Per-stage rows
   var rows = [
     ['Photos', readiness.total_photos, readiness.total_photos],
-    ['Masks', readiness.with_masks, readiness.total_photos],
-    ['Embeddings', readiness.with_embeddings, readiness.total_photos],
-    ['Eye keypoints', readiness.with_eye_keypoints, readiness.total_photos],
-    ['Species predictions', readiness.with_predictions, readiness.total_photos],
+    ['Masks', readiness.with_masks, readiness.mask_target_photos || readiness.total_photos],
+    ['Embeddings', readiness.with_embeddings, readiness.embedding_target_photos || readiness.total_photos],
+    ['Eye keypoints', readiness.with_eye_keypoint_attempts != null
+      ? readiness.with_eye_keypoint_attempts
+      : readiness.with_eye_keypoints,
+      readiness.eye_keypoint_target_photos != null
+        ? readiness.eye_keypoint_target_photos
+        : readiness.total_photos],
+    ['Species predictions', readiness.with_predictions, readiness.prediction_target_photos || readiness.total_photos],
   ];
   stages.innerHTML = rows.map(function(r) {
     var name = r[0], n = r[1], total = r[2];

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -971,6 +971,99 @@ def test_compute_review_readiness_variant_aware_embeddings(tmp_path):
     assert out_explicit_mismatch["with_embeddings"] == 0
 
 
+def test_compute_review_readiness_ignores_no_subject_photos_for_enhancers(tmp_path):
+    """No-subject photos should not make the review page claim masks,
+    embeddings, or species predictions are incomplete.
+
+    The detector can legitimately evaluate a workspace photo and find no
+    above-threshold subject. Those photos are reviewable as subject-absent
+    rejects, but rerunning SAM/DINO/species stages will not produce subject
+    features for them.
+    """
+    from db import Database
+    from dino_embed import embedding_to_blob
+    from pipeline import compute_review_readiness
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+    pids = [
+        db.add_photo(
+            fid, f"photo{i}.jpg", ".jpg", 1000, 1.0,
+            timestamp=datetime(2026, 3, 20, 10, 0, i).isoformat(),
+            width=4000, height=3000,
+        )
+        for i in range(4)
+    ]
+    emb = np.ones(768, dtype=np.float32)
+    emb = emb / np.linalg.norm(emb)
+
+    for pid in pids[:2]:
+        det_ids = db.write_detection_batch(pid, "megadetector-v6", [
+            {"box": {"x": 0.2, "y": 0.2, "w": 0.4, "h": 0.4}, "confidence": 0.9},
+        ])
+        db.add_prediction(det_ids[0], "robin", 0.9, "bioclip", category="match")
+        db.update_photo_pipeline_features(pid, mask_path=f"/masks/{pid}.png")
+        db.update_photo_embeddings(
+            pid,
+            dino_subject_embedding=embedding_to_blob(emb),
+            dino_global_embedding=embedding_to_blob(emb),
+        )
+
+    for pid in pids[2:]:
+        db.write_detection_batch(pid, "megadetector-v6", [])
+
+    out = compute_review_readiness(db)
+    assert out["state"] == "computable"
+    assert out["total_photos"] == 4
+    assert out["mask_target_photos"] == 2
+    assert out["embedding_target_photos"] == 2
+    assert out["prediction_target_photos"] == 2
+    assert "masks_partial" not in out["enhancing_missing"]
+    assert "embeddings" not in out["enhancing_missing"]
+    assert "species_predictions" not in out["enhancing_missing"]
+
+
+def test_compute_review_readiness_eye_attempts_clear_eye_gap(tmp_path):
+    """A current eye-keypoint attempt should satisfy readiness even when
+    no trustworthy eye point was written."""
+    from db import Database
+    from dino_embed import embedding_to_blob
+    from pipeline import EYE_KP_FINGERPRINT_VERSION, compute_review_readiness
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+    pid = db.add_photo(
+        fid, "photo.jpg", ".jpg", 1000, 1.0,
+        timestamp=datetime(2026, 3, 20, 10, 0, 0).isoformat(),
+        width=4000, height=3000,
+    )
+    det_ids = db.write_detection_batch(pid, "megadetector-v6", [
+        {"box": {"x": 0.2, "y": 0.2, "w": 0.4, "h": 0.4}, "confidence": 0.9},
+    ])
+    db.add_prediction(det_ids[0], "robin", 0.9, "bioclip", category="match")
+    emb = np.ones(768, dtype=np.float32)
+    emb = emb / np.linalg.norm(emb)
+    db.update_photo_pipeline_features(
+        pid,
+        mask_path=f"/masks/{pid}.png",
+        eye_x=None,
+        eye_y=None,
+        eye_conf=None,
+        eye_tenengrad=None,
+        eye_kp_fingerprint=EYE_KP_FINGERPRINT_VERSION,
+    )
+    db.update_photo_embeddings(
+        pid,
+        dino_subject_embedding=embedding_to_blob(emb),
+        dino_global_embedding=embedding_to_blob(emb),
+    )
+
+    out = compute_review_readiness(db)
+    assert out["with_eye_keypoint_attempts"] == 1
+    assert out["eye_keypoint_target_photos"] == 1
+    assert "eye_keypoints" not in out["enhancing_missing"]
+
+
 def test_save_results_preserves_miss_computed_at_across_reflow(tmp_path):
     """save_results must preserve an existing miss_computed_at marker
     when the caller's results dict doesn't carry one. reflow and

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -1990,6 +1990,129 @@ def test_eye_stage_gate1_low_classifier_conf_no_write(tmp_path, monkeypatch):
     assert _read_eye_fields(db, pid) == (None, None, None, None)
 
 
+def test_eye_stage_gate1_failure_does_not_stamp_fingerprint(tmp_path, monkeypatch):
+    """Gate 1 (classifier conf) short-circuits cheaply but must NOT stamp
+    eye_kp_fingerprint: the gate is driven by the user-configurable
+    `eye_classifier_conf_gate`, so stamping would permanently filter the
+    photo out of `list_photos_for_eye_keypoint_stage` even after the user
+    lowers the gate. The photo must remain eligible on a subsequent run
+    with a more permissive threshold.
+    """
+    import keypoints as kp
+    from pipeline import detect_eye_keypoints_stage
+
+    db, pid, models_dir = _setup_eligible_mammal_with_files(
+        tmp_path, classifier_conf=0.3,
+    )
+    monkeypatch.setattr(kp, "MODELS_DIR", models_dir)
+
+    # First pass: high gate skips the photo at Gate 1.
+    monkeypatch.setattr(
+        kp, "detect_keypoints",
+        lambda *a, **kw: (_ for _ in ()).throw(
+            AssertionError("Gate 1 should short-circuit before model runs")
+        ),
+    )
+    detect_eye_keypoints_stage(
+        db, config={"eye_detect_enabled": True, "eye_classifier_conf_gate": 0.5},
+    )
+
+    # Fingerprint must still be NULL — the photo wasn't actually evaluated.
+    fp_row = db.conn.execute(
+        "SELECT eye_kp_fingerprint FROM photos WHERE id=?", (pid,),
+    ).fetchone()
+    assert fp_row[0] is None, (
+        "Gate 1 (low classifier confidence) must not stamp eye_kp_fingerprint; "
+        "stamping locks the photo out of future runs even after the user "
+        "lowers eye_classifier_conf_gate."
+    )
+
+    # Photo must still surface as a candidate for the next stage run.
+    rows = db.list_photos_for_eye_keypoint_stage()
+    assert any(r["id"] == pid for r in rows)
+
+    # Second pass: lower the gate. Now the model runs and writes eye fields.
+    good = [
+        {"name": "left_eye", "x": 300.0, "y": 300.0, "conf": 0.88},
+        {"name": "right_eye", "x": 350.0, "y": 300.0, "conf": 0.85},
+    ]
+    monkeypatch.setattr(kp, "detect_keypoints", lambda *a, **kw: good)
+    detect_eye_keypoints_stage(
+        db, config={"eye_detect_enabled": True, "eye_classifier_conf_gate": 0.1},
+    )
+    eye_x, eye_y, eye_conf, _ = _read_eye_fields(db, pid)
+    assert eye_x is not None and eye_y is not None and eye_conf is not None
+
+
+def test_eye_stage_unrouted_taxonomy_does_not_stamp_fingerprint(tmp_path, monkeypatch):
+    """When `_resolve_keypoint_model` returns None for a photo (e.g. the
+    species' taxonomy class isn't in the routing map yet), the stage must
+    not stamp eye_kp_fingerprint. The routing depends on
+    `_EYE_KEYPOINT_MODEL_FOR_CLASS` and taxonomy data which can be extended
+    later; stamping would prevent the photo from re-running after such
+    an extension.
+    """
+    import keypoints as kp
+    from pipeline import detect_eye_keypoints_stage
+
+    db, pid, models_dir = _setup_eligible_mammal_with_files(
+        tmp_path, taxonomy_class="Actinopterygii",  # ray-finned fish
+    )
+    monkeypatch.setattr(kp, "MODELS_DIR", models_dir)
+
+    def _boom(*a, **kw):
+        raise AssertionError(
+            "detect_keypoints should not run for unrouted taxonomy"
+        )
+
+    monkeypatch.setattr(kp, "detect_keypoints", _boom)
+    detect_eye_keypoints_stage(db, config={"eye_detect_enabled": True})
+
+    fp_row = db.conn.execute(
+        "SELECT eye_kp_fingerprint FROM photos WHERE id=?", (pid,),
+    ).fetchone()
+    assert fp_row[0] is None, (
+        "Unrouted-taxonomy short-circuit must not stamp eye_kp_fingerprint; "
+        "the routing map / taxonomy data can be extended later and the "
+        "photo must remain eligible to re-run then."
+    )
+    rows = db.list_photos_for_eye_keypoint_stage()
+    assert any(r["id"] == pid for r in rows)
+
+
+def test_eye_stage_gate3_failure_stamps_fingerprint(tmp_path, monkeypatch):
+    """Inverse case: when the model actually runs and finds no
+    trustworthy eye (Gate 3/4 fail), eye_kp_fingerprint must be stamped so
+    `list_photos_for_eye_keypoint_stage` does not keep returning the photo
+    on every subsequent run. This is the original motivation for the
+    no-eye attempt marker — it should not be weakened by the fix to the
+    pre-model gates.
+    """
+    import keypoints as kp
+    from pipeline import EYE_KP_FINGERPRINT_VERSION, detect_eye_keypoints_stage
+
+    db, pid, models_dir = _setup_eligible_mammal_with_files(tmp_path)
+    monkeypatch.setattr(kp, "MODELS_DIR", models_dir)
+
+    # All eye points below the detection-conf gate → Gate 3 fails.
+    low = [
+        {"name": "left_eye", "x": 300.0, "y": 300.0, "conf": 0.2},
+        {"name": "right_eye", "x": 350.0, "y": 300.0, "conf": 0.15},
+    ]
+    monkeypatch.setattr(kp, "detect_keypoints", lambda *a, **kw: low)
+    detect_eye_keypoints_stage(
+        db, config={"eye_detect_enabled": True, "eye_detection_conf_gate": 0.5},
+    )
+
+    fp_row = db.conn.execute(
+        "SELECT eye_kp_fingerprint FROM photos WHERE id=?", (pid,),
+    ).fetchone()
+    assert fp_row[0] == EYE_KP_FINGERPRINT_VERSION
+    # And the photo is no longer eligible on the next selection pass.
+    rows = db.list_photos_for_eye_keypoint_stage()
+    assert not any(r["id"] == pid for r in rows)
+
+
 def test_eye_stage_gate1_out_of_scope_species_no_write(tmp_path, monkeypatch):
     """Gate 1: species class not in {Aves, Mammalia} → no write."""
     import keypoints as kp


### PR DESCRIPTION
## Summary

Fixes the pipeline review degraded-results banner so it measures feature completeness against photos that are actually eligible for each stage.

## Root Cause

The review readiness check compared masks, DINO embeddings, species predictions, and eye keypoints against every photo in the workspace. Photos where MegaDetector found no above-threshold subject cannot receive subject masks, subject embeddings, or detector-backed species predictions, so complete runs could still be reported as incomplete.

Eye keypoints had a related issue: no trustworthy eye point left no durable "attempted" marker, so already-evaluated no-eye photos could keep asking the user to rerun the stage.

## Changes

- Make review readiness use a detector-aware target count for masks, embeddings, and species predictions.
- Add target-count fields for the pipeline review readiness UI.
- Count current eye-keypoint attempts separately from successful eye-coordinate writes.
- Stamp the current eye-keypoint fingerprint when a photo is evaluated but no trusted eye is written.
- Add regression tests for no-subject photos and no-eye attempts.

## Validation

- `pytest -q vireo/tests/test_pipeline.py::test_compute_review_readiness_empty_workspace vireo/tests/test_pipeline.py::test_compute_review_readiness_no_masks vireo/tests/test_pipeline.py::test_compute_review_readiness_masks_present_no_eye vireo/tests/test_pipeline.py::test_compute_review_readiness_full_features vireo/tests/test_pipeline.py::test_compute_review_readiness_at_mask_threshold_boundary vireo/tests/test_pipeline.py::test_compute_review_readiness_below_threshold_uses_ceiling vireo/tests/test_pipeline.py::test_compute_review_readiness_variant_aware_embeddings vireo/tests/test_pipeline.py::test_compute_review_readiness_ignores_no_subject_photos_for_enhancers vireo/tests/test_pipeline.py::test_compute_review_readiness_eye_attempts_clear_eye_gap`
- `pytest -q vireo/tests/test_pipeline_api.py::test_pipeline_page_init_includes_review_readiness vireo/tests/test_pipeline_api.py::test_pipeline_page_init_review_readiness_state_ready_when_cache_exists vireo/tests/test_pipeline_api.py::test_pipeline_page_init_state_ready_folds_blocking_gaps_into_enhancing vireo/tests/test_pipeline_plan.py -k eye_keypoint vireo/tests/test_pipeline_job.py -k eye_keypoint vireo/tests/test_db.py::test_list_photos_for_eye_keypoint_stage_prefers_routable_prediction vireo/tests/test_db.py::test_list_photos_for_eye_keypoint_stage_keeps_confidence_order_when_routable vireo/tests/test_db.py::test_list_photos_for_eye_keypoint_stage_filters_to_active_fingerprint vireo/tests/test_db.py::test_list_photos_for_eye_keypoint_stage_scopes_to_photo_ids`