### PR TITLE
[codex] Add persistent lightbox overlay toggles

### DIFF
--- a/tests/e2e/test_lightbox_context_menu.py
+++ b/tests/e2e/test_lightbox_context_menu.py
@@ -223,6 +223,57 @@ def test_mask_toggle_off_clears_pending_onload(live_server, page):
     ), "mask overlay must stay hidden after a late load fires while toggled off"
 
 
+def test_mask_toggle_off_then_on_after_failed_load_stays_hidden(live_server, page):
+    """Toggling masks off then back on after a failed load must not surface
+    a broken-image overlay through the same-URL fast path.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.evaluate("localStorage.removeItem('vireo.lb.masksVisible');")
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.dblclick()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+
+    # Drive the overlay to a known failed-load state via a real 404 URL.
+    # _lbApplyMaskVisibility() assigns onerror which removes `show`.
+    page.evaluate(
+        """
+        _lbMasksVisible = true;
+        _lbMaskCurrentUrl = '/__definitely_missing__/mask.png';
+        _lbApplyMaskVisibility();
+        """
+    )
+    # Wait until the browser settles the request (onerror has fired).
+    page.wait_for_function(
+        "document.getElementById('lightboxMaskOverlay').complete"
+        " && document.getElementById('lightboxMaskOverlay').naturalWidth === 0",
+        timeout=3000,
+    )
+    assert not page.locator("#lightboxMaskOverlay").evaluate(
+        "el => el.classList.contains('show')"
+    ), "failed load should leave the overlay hidden"
+
+    # User toggles masks off, then back on. The src never changes, so the
+    # same-URL branch in _lbApplyMaskVisibility() runs. It must NOT add
+    # `show`, since the previous load failed and would render as a
+    # broken-image icon.
+    page.evaluate(
+        """
+        _lbMasksVisible = false;
+        _lbApplyMaskVisibility();
+        _lbMasksVisible = true;
+        _lbApplyMaskVisibility();
+        """
+    )
+    assert not page.locator("#lightboxMaskOverlay").evaluate(
+        "el => el.classList.contains('show')"
+    ), "same-URL re-show after a failed load must not reveal a broken overlay"
+
+
 def test_lightbox_close_menu_item_closes_overlay(live_server, page):
     """The 'Close Lightbox' menu item dismisses the overlay."""
     url = live_server["url"]

--- a/tests/e2e/test_lightbox_context_menu.py
+++ b/tests/e2e/test_lightbox_context_menu.py
@@ -162,6 +162,67 @@ def test_lightbox_right_click_does_not_toggle_zoom(live_server, page):
     assert before == after
 
 
+def test_mask_toggle_off_clears_pending_onload(live_server, page):
+    """Hiding masks while a mask image request is in flight must not let the
+    pending onload handler re-add `show` after the user toggled off.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.evaluate("localStorage.removeItem('vireo.lb.masksVisible');")
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.dblclick()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+
+    # Simulate the "request in flight" state: toggle on with a URL set,
+    # then call _lbApplyMaskVisibility() so it assigns img.onload.
+    page.evaluate(
+        """
+        _lbMasksVisible = true;
+        _lbMaskCurrentUrl = '/dummy-mask-url-for-test.png';
+        _lbApplyMaskVisibility();
+        """
+    )
+    assert page.evaluate(
+        "typeof document.getElementById('lightboxMaskOverlay').onload === 'function'"
+    ), "onload should be assigned while a mask request is in flight"
+
+    # User toggles masks off while the load is still pending.
+    page.evaluate(
+        """
+        _lbMasksVisible = false;
+        _lbApplyMaskVisibility();
+        """
+    )
+    assert page.evaluate(
+        "document.getElementById('lightboxMaskOverlay').onload === null"
+    ), "onload must be cleared when masks are toggled off mid-load"
+
+    # Even if a late load fires (simulated by invoking the stored handler
+    # captured before the toggle, or any direct .add('show') from a leftover
+    # callback), the overlay must remain hidden. Manually re-arm the handler
+    # the way the old code did and fire it — defense-in-depth: the handler
+    # itself also re-checks visibility before adding `show`.
+    page.evaluate(
+        """
+        const img = document.getElementById('lightboxMaskOverlay');
+        // Re-arm as the old buggy assignment used to.
+        img.onload = function() {
+          if (_lbMasksVisible && _lbMaskCurrentUrl) {
+            img.classList.add('show');
+          }
+        };
+        img.onload();
+        """
+    )
+    assert not page.locator("#lightboxMaskOverlay").evaluate(
+        "el => el.classList.contains('show')"
+    ), "mask overlay must stay hidden after a late load fires while toggled off"
+
+
 def test_lightbox_close_menu_item_closes_overlay(live_server, page):
     """The 'Close Lightbox' menu item dismisses the overlay."""
     url = live_server["url"]

--- a/tests/e2e/test_lightbox_context_menu.py
+++ b/tests/e2e/test_lightbox_context_menu.py
@@ -71,6 +71,77 @@ def test_lightbox_right_click_opens_menu(live_server, page):
     assert menu.locator(".vireo-ctx-chip").count() > 5
 
 
+def test_lightbox_overlay_toggles_persist_and_context_restores(live_server, page):
+    """Lightbox overlay visibility toggles persist and stay recoverable."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.evaluate(
+        """
+        [
+          'vireo.lb.boxesVisible',
+          'vireo.lb.masksVisible',
+          'vireo.lb.eyeVisible',
+          'vireo.lb.infoVisible',
+          'vireo.lb.chromeVisible',
+        ].forEach(k => localStorage.removeItem(k));
+        """
+    )
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.dblclick()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+
+    page.locator("#lightboxToggleBoxes").click()
+    page.locator("#lightboxToggleMasks").click()
+    page.locator("#lightboxToggleEye").click()
+    page.locator("#lightboxToggleInfo").click()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('lb-hide-info')",
+        timeout=2000,
+    )
+
+    page.locator("#lightboxToggleChrome").click()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('lb-hide-chrome')",
+        timeout=2000,
+    )
+    assert page.evaluate("localStorage.getItem('vireo.lb.boxesVisible')") == "0"
+    assert page.evaluate("localStorage.getItem('vireo.lb.masksVisible')") == "0"
+    assert page.evaluate("localStorage.getItem('vireo.lb.eyeVisible')") == "0"
+    assert page.evaluate("localStorage.getItem('vireo.lb.infoVisible')") == "0"
+    assert page.evaluate("localStorage.getItem('vireo.lb.chromeVisible')") == "0"
+
+    _fire_contextmenu_on_lightbox(page)
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    menu.locator(".vireo-ctx-item", has_text="Lightbox controls: Off").click()
+    page.wait_for_function(
+        "!document.getElementById('lightboxOverlay').classList.contains('lb-hide-chrome')",
+        timeout=2000,
+    )
+    assert page.evaluate("localStorage.getItem('vireo.lb.chromeVisible')") == "1"
+
+    page.evaluate("closeLightbox()")
+    page.reload()
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.dblclick()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('lb-hide-info')",
+        timeout=2000,
+    )
+    assert page.locator("#lightboxToggleBoxes").inner_text() == "Show Boxes"
+    assert page.locator("#lightboxToggleMasks").inner_text() == "Show Masks"
+    assert page.locator("#lightboxToggleEye").inner_text() == "Show Eye"
+
+
 def test_lightbox_right_click_does_not_toggle_zoom(live_server, page):
     """Right-click must not trip the click-to-zoom / pan handlers.
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -475,6 +475,16 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   z-index: 10000;
 }
 .lightbox-close:hover { opacity: 1; }
+.lightbox-overlay.lb-hide-chrome .lightbox-close,
+.lightbox-overlay.lb-hide-chrome .lightbox-nav,
+.lightbox-overlay.lb-hide-chrome .lightbox-actions {
+  display: none !important;
+}
+.lightbox-overlay.lb-hide-info .lightbox-filename,
+.lightbox-overlay.lb-hide-info #lightboxCounter,
+.lightbox-overlay.lb-hide-info .lightbox-zoom-badge {
+  display: none !important;
+}
 .lb-detection-box {
   position: absolute;
   border: 2px solid;
@@ -2684,8 +2694,8 @@ async function createWorkspace() {
 <!-- Lightbox -->
 <div class="lightbox-overlay" id="lightboxOverlay" onclick="closeLightbox(event)">
   <span class="lightbox-close" onclick="closeLightbox(event)">&times;</span>
-  <div onclick="event.stopPropagation(); lightboxNav(-1);" style="position:absolute;left:12px;top:50%;transform:translateY(-50%);font-size:36px;color:rgba(255,255,255,0.5);cursor:pointer;padding:16px;user-select:none;z-index:10001;" title="Previous (←)">&#9664;</div>
-  <div onclick="event.stopPropagation(); lightboxNav(1);" style="position:absolute;right:12px;top:50%;transform:translateY(-50%);font-size:36px;color:rgba(255,255,255,0.5);cursor:pointer;padding:16px;user-select:none;z-index:10001;" title="Next (→)">&#9654;</div>
+  <div id="lightboxPrev" class="lightbox-nav" onclick="event.stopPropagation(); lightboxNav(-1);" style="position:absolute;left:12px;top:50%;transform:translateY(-50%);font-size:36px;color:rgba(255,255,255,0.5);cursor:pointer;padding:16px;user-select:none;z-index:10001;" title="Previous (←)">&#9664;</div>
+  <div id="lightboxNext" class="lightbox-nav" onclick="event.stopPropagation(); lightboxNav(1);" style="position:absolute;right:12px;top:50%;transform:translateY(-50%);font-size:36px;color:rgba(255,255,255,0.5);cursor:pointer;padding:16px;user-select:none;z-index:10001;" title="Next (→)">&#9654;</div>
   <div class="lightbox-img-wrap" id="lightboxWrap" onclick="event.stopPropagation(); if (Math.abs(_lbZoom - 1.0) < 0.001 && !window._lightboxZoomHandled) toggleLightboxZoom(event); window._lightboxZoomHandled = false;">
     <span class="lightbox-zoom-badge" id="lightboxZoomBadge" style="display:none;">1:1</span>
     <div class="lightbox-transform" id="lightboxTransform">
@@ -2697,9 +2707,21 @@ async function createWorkspace() {
   </div>
   <div class="lightbox-filename" id="lightboxFilename"></div>
   <div id="lightboxCounter" style="display:none;position:absolute;top:16px;left:50%;transform:translateX(-50%);color:rgba(255,255,255,0.6);font-size:13px;background:rgba(0,0,0,0.5);padding:3px 10px;border-radius:4px;"></div>
-  <div style="position:absolute;bottom:16px;right:24px;display:flex;gap:8px;">
+  <div id="lightboxActions" class="lightbox-actions" style="position:absolute;bottom:16px;right:24px;display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end;max-width:calc(100vw - 48px);">
     <button id="lightboxToggleBoxes" onclick="event.stopPropagation(); toggleLightboxBoxes();" style="background:rgba(0,0,0,0.6);color:var(--text-secondary);border:1px solid var(--text-faint);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;" title="Toggle detection boxes (b)">
       Hide Boxes
+    </button>
+    <button id="lightboxToggleMasks" onclick="event.stopPropagation(); toggleLightboxMasks();" style="background:rgba(0,0,0,0.6);color:var(--text-secondary);border:1px solid var(--text-faint);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;" title="Toggle mask overlay">
+      Hide Masks
+    </button>
+    <button id="lightboxToggleEye" onclick="event.stopPropagation(); toggleLightboxEye();" style="background:rgba(0,0,0,0.6);color:var(--text-secondary);border:1px solid var(--text-faint);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;" title="Toggle eye marker">
+      Hide Eye
+    </button>
+    <button id="lightboxToggleInfo" onclick="event.stopPropagation(); toggleLightboxInfo();" style="background:rgba(0,0,0,0.6);color:var(--text-secondary);border:1px solid var(--text-faint);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;" title="Toggle filename, counter, and zoom badge">
+      Hide Info
+    </button>
+    <button id="lightboxToggleChrome" onclick="event.stopPropagation(); toggleLightboxChrome();" style="background:rgba(0,0,0,0.6);color:var(--text-secondary);border:1px solid var(--text-faint);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;" title="Toggle lightbox controls">
+      Hide UI
     </button>
     <span class="lb-mask-controls" id="lightboxMaskControls" onclick="event.stopPropagation();" title="SAM mask overlay">
       <span>Mask:</span>
@@ -2781,9 +2803,25 @@ var _lbCurrentSrcKey = null; // 'full' | '2560' | '3840' | 'original'
 var _lbFullLongEdge = null;  // actual long edge of /full for current photo (may be < 1920 if preview_max_size is configured low)
 var _lbSessionFullLongEdge = null;  // last learned /full size across photos; better fallback than hardcoded 1920 for custom preview_max_size
 var _lbPending1To1 = false;  // true when z/click was pressed with unknown nativeZoom; upgrade to true 1:1 once learned
-var _lbBoxesVisible = (function() {
-  try { return localStorage.getItem('vireo.lb.boxesVisible') !== '0'; } catch (e) { return true; }
-})();
+
+function _lbStoredBool(key, fallback) {
+  try {
+    var value = localStorage.getItem(key);
+    if (value === '0') return false;
+    if (value === '1') return true;
+  } catch (e) {}
+  return fallback;
+}
+
+function _lbPersistBool(key, value) {
+  try { localStorage.setItem(key, value ? '1' : '0'); } catch (e) {}
+}
+
+var _lbBoxesVisible = _lbStoredBool('vireo.lb.boxesVisible', true);
+var _lbMasksVisible = _lbStoredBool('vireo.lb.masksVisible', true);
+var _lbEyeVisible = _lbStoredBool('vireo.lb.eyeVisible', true);
+var _lbInfoVisible = _lbStoredBool('vireo.lb.infoVisible', true);
+var _lbChromeVisible = _lbStoredBool('vireo.lb.chromeVisible', true);
 
 function _lbApplyBoxesVisibility() {
   var container = document.getElementById('lightboxDetections');
@@ -2794,8 +2832,50 @@ function _lbApplyBoxesVisibility() {
 
 function toggleLightboxBoxes() {
   _lbBoxesVisible = !_lbBoxesVisible;
-  try { localStorage.setItem('vireo.lb.boxesVisible', _lbBoxesVisible ? '1' : '0'); } catch (e) {}
+  _lbPersistBool('vireo.lb.boxesVisible', _lbBoxesVisible);
   _lbApplyBoxesVisibility();
+}
+
+function _lbApplyInfoVisibility() {
+  var overlay = document.getElementById('lightboxOverlay');
+  if (overlay) overlay.classList.toggle('lb-hide-info', !_lbInfoVisible);
+  var btn = document.getElementById('lightboxToggleInfo');
+  if (btn) btn.textContent = _lbInfoVisible ? 'Hide Info' : 'Show Info';
+}
+
+function toggleLightboxInfo() {
+  _lbInfoVisible = !_lbInfoVisible;
+  _lbPersistBool('vireo.lb.infoVisible', _lbInfoVisible);
+  _lbApplyInfoVisibility();
+}
+
+function _lbApplyChromeVisibility() {
+  var overlay = document.getElementById('lightboxOverlay');
+  if (overlay) overlay.classList.toggle('lb-hide-chrome', !_lbChromeVisible);
+  var btn = document.getElementById('lightboxToggleChrome');
+  if (btn) btn.textContent = _lbChromeVisible ? 'Hide UI' : 'Show UI';
+}
+
+function toggleLightboxChrome() {
+  _lbChromeVisible = !_lbChromeVisible;
+  _lbPersistBool('vireo.lb.chromeVisible', _lbChromeVisible);
+  _lbApplyChromeVisibility();
+}
+
+function _lbApplyEyeVisibility() {
+  var container = document.getElementById('lightboxEye');
+  if (container) {
+    container.style.display =
+      (_lbEyeVisible && container.childElementCount > 0) ? 'block' : 'none';
+  }
+  var btn = document.getElementById('lightboxToggleEye');
+  if (btn) btn.textContent = _lbEyeVisible ? 'Hide Eye' : 'Show Eye';
+}
+
+function toggleLightboxEye() {
+  _lbEyeVisible = !_lbEyeVisible;
+  _lbPersistBool('vireo.lb.eyeVisible', _lbEyeVisible);
+  _lbApplyEyeVisibility();
 }
 
 /* Species color palette for lightbox bounding boxes */
@@ -2840,7 +2920,7 @@ function _lbRenderEyeCrosshair(photo) {
     marker.appendChild(label);
   }
   container.appendChild(marker);
-  container.style.display = 'block';
+  _lbApplyEyeVisibility();
 }
 
 function _lbLoadDetections(photoId) {
@@ -2884,6 +2964,7 @@ function _lbLoadDetections(photoId) {
  */
 var _lbMaskActiveVariant = null;     // name of the photo's currently-active variant
 var _lbMaskAvailable = [];           // [{variant, url, created_at}, ...]
+var _lbMaskCurrentUrl = null;
 
 function _lbResetMaskOverlay() {
   var img = document.getElementById('lightboxMaskOverlay');
@@ -2894,16 +2975,14 @@ function _lbResetMaskOverlay() {
   if (sel) sel.innerHTML = '';
   _lbMaskActiveVariant = null;
   _lbMaskAvailable = [];
+  _lbMaskCurrentUrl = null;
 }
 
-function _lbApplyMaskUrl(url) {
-  // Set the overlay's src and reveal it. If url is empty/null, hide
-  // the overlay (e.g. the photo has no mask for the chosen variant).
+function _lbApplyMaskVisibility() {
   var img = document.getElementById('lightboxMaskOverlay');
   if (!img) return;
-  if (!url) {
+  if (!_lbMasksVisible || !_lbMaskCurrentUrl) {
     img.classList.remove('show');
-    img.removeAttribute('src');
     return;
   }
   // onerror guards against the file being deleted out from under us
@@ -2912,7 +2991,32 @@ function _lbApplyMaskUrl(url) {
   // broken-image icon over the photo.
   img.onerror = function() { img.classList.remove('show'); };
   img.onload = function() { img.classList.add('show'); };
-  img.src = url;
+  if (img.getAttribute('src') !== _lbMaskCurrentUrl) {
+    img.src = _lbMaskCurrentUrl;
+  } else {
+    img.classList.add('show');
+  }
+}
+
+function _lbApplyMaskUrl(url) {
+  // Set the selected overlay URL. Visibility is controlled separately so
+  // users can keep their mask preference across photos and sessions.
+  var img = document.getElementById('lightboxMaskOverlay');
+  _lbMaskCurrentUrl = url || null;
+  if (!url && img) img.removeAttribute('src');
+  _lbApplyMaskVisibility();
+}
+
+function _lbApplyMaskToggleButton() {
+  var btn = document.getElementById('lightboxToggleMasks');
+  if (btn) btn.textContent = _lbMasksVisible ? 'Hide Masks' : 'Show Masks';
+}
+
+function toggleLightboxMasks() {
+  _lbMasksVisible = !_lbMasksVisible;
+  _lbPersistBool('vireo.lb.masksVisible', _lbMasksVisible);
+  _lbApplyMaskToggleButton();
+  _lbApplyMaskVisibility();
 }
 
 function _lbOnMaskVariantChange() {
@@ -3067,6 +3171,10 @@ function openLightbox(photoId, filename, photoList) {
     }
   }
   overlay.classList.add('active');
+  _lbApplyInfoVisibility();
+  _lbApplyChromeVisibility();
+  _lbApplyEyeVisibility();
+  _lbApplyMaskToggleButton();
 
   // Fetch and render detection bounding boxes
   _lbLoadDetections(photoId);
@@ -3276,6 +3384,12 @@ function buildLightboxContextMenu(pid) {
       },
     };
   };
+  var toggleItem = function(label, visible, onClick) {
+    return {
+      label: label + ': ' + (visible ? 'On' : 'Off'),
+      onClick: onClick,
+    };
+  };
 
   var items = [
     { chips: [0, 1, 2, 3, 4, 5].map(rateChip) },
@@ -3294,6 +3408,12 @@ function buildLightboxContextMenu(pid) {
     flagChip('rejected', '\u2715', 'Reject'),
     flagChip('none', '\u25CB', 'Unflag'),
   ] });
+  items.push({ separator: true });
+  items.push(toggleItem('Detection boxes', _lbBoxesVisible, toggleLightboxBoxes));
+  items.push(toggleItem('Mask overlay', _lbMasksVisible, toggleLightboxMasks));
+  items.push(toggleItem('Eye marker', _lbEyeVisible, toggleLightboxEye));
+  items.push(toggleItem('Filename and counter', _lbInfoVisible, toggleLightboxInfo));
+  items.push(toggleItem('Lightbox controls', _lbChromeVisible, toggleLightboxChrome));
   items.push({ separator: true });
 
   if (has('findSimilar')) {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2983,6 +2983,13 @@ function _lbApplyMaskVisibility() {
   if (!img) return;
   if (!_lbMasksVisible || !_lbMaskCurrentUrl) {
     img.classList.remove('show');
+    // A previous call may have assigned onload to re-add `show` once
+    // the mask image finished loading. If the user toggles masks off
+    // while that request is still in flight, the pending callback
+    // would override the hide as soon as it fires. Clear both handlers
+    // so an in-flight load can't resurrect the overlay.
+    img.onload = null;
+    img.onerror = null;
     return;
   }
   // onerror guards against the file being deleted out from under us
@@ -2990,7 +2997,13 @@ function _lbApplyMaskVisibility() {
   // exists but the file is gone → silently hide instead of leaving a
   // broken-image icon over the photo.
   img.onerror = function() { img.classList.remove('show'); };
-  img.onload = function() { img.classList.add('show'); };
+  img.onload = function() {
+    // Re-check the toggle: the user may have hidden masks between
+    // src assignment and the load resolving.
+    if (_lbMasksVisible && _lbMaskCurrentUrl) {
+      img.classList.add('show');
+    }
+  };
   if (img.getAttribute('src') !== _lbMaskCurrentUrl) {
     img.src = _lbMaskCurrentUrl;
   } else {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3006,9 +3006,16 @@ function _lbApplyMaskVisibility() {
   };
   if (img.getAttribute('src') !== _lbMaskCurrentUrl) {
     img.src = _lbMaskCurrentUrl;
-  } else {
+  } else if (img.naturalWidth > 0) {
+    // Same URL and we know it loaded successfully — safe to re-show
+    // without re-fetching.
     img.classList.add('show');
   }
+  // If src matches but naturalWidth is 0, the previous load either failed
+  // (onerror already hid the overlay; re-adding `show` would surface a
+  // broken-image icon) or is still in flight (the onload assigned above
+  // will add `show` when the request resolves). Either way, don't add
+  // `show` here.
 }
 
 function _lbApplyMaskUrl(url) {


### PR DESCRIPTION
## Summary

Adds persisted lightbox overlay controls so users can turn off visual/UI overlays once and keep that preference across Browse sessions.

## Changes

- Added lightbox toggles for detection boxes, mask overlay, eye marker, filename/counter/zoom info, and lightbox controls.
- Stores each toggle in `localStorage` and reapplies it when a lightbox opens.
- Adds the same toggles to the lightbox right-click menu, so controls can be restored even after hiding the visible UI.
- Adds E2E coverage for persistence across reload and context-menu recovery.

## Validation

- `pytest tests/e2e/test_browse_lightbox.py tests/e2e/test_lightbox_context_menu.py` passed (`7 passed`).
- `git diff --check` passed.

Note: pytest printed a background-thread shutdown traceback after the passing summary, but exited successfully.