### PR TITLE
[codex] Add pipeline review confirmation counts

### DIFF
--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -450,6 +450,7 @@ def _clear_derived_scores(photos):
 
 def _make_summary(encounters, all_photos):
     """Build summary stats dict from triage results."""
+    confirmation_counts = _count_raw_confirmation_units(encounters)
     return {
         "total_photos": len(all_photos),
         "encounter_count": len(encounters),
@@ -460,7 +461,86 @@ def _make_summary(encounters, all_photos):
         "rarity_protected": sum(
             1 for p in all_photos if p.get("rarity_protected")
         ),
+        **confirmation_counts,
     }
+
+
+def _photos_uniformly_confirmed(photos):
+    species = [p.get("confirmed_species") for p in photos]
+    confirmed = {s for s in species if s}
+    return bool(photos) and len(confirmed) == 1 and all(species)
+
+
+def _count_raw_confirmation_units(encounters):
+    """Count confirmed/unconfirmed review units in raw encounter structures.
+
+    The review page hides confirmed items at the burst level when bursts are
+    present, otherwise at the encounter level. Mirror that unit here so the
+    summary bar matches the user's review workload.
+    """
+    confirmed = 0
+    unconfirmed = 0
+    for enc in encounters:
+        bursts = enc.get("bursts") or []
+        if bursts:
+            for burst in bursts:
+                if _photos_uniformly_confirmed(burst):
+                    confirmed += 1
+                else:
+                    unconfirmed += 1
+        elif _photos_uniformly_confirmed(enc.get("photos", [])):
+            confirmed += 1
+        else:
+            unconfirmed += 1
+    return {
+        "confirmed_count": confirmed,
+        "unconfirmed_count": unconfirmed,
+    }
+
+
+def _serialized_burst_confirmed(enc, burst):
+    ovr = burst.get("species_override") if isinstance(burst, dict) else None
+    if ovr:
+        return bool(ovr.get("confirmed"))
+    return bool(enc.get("species_confirmed"))
+
+
+def _count_serialized_confirmation_units(encounters):
+    """Count confirmed/unconfirmed review units in cached JSON results."""
+    confirmed = 0
+    unconfirmed = 0
+    for enc in encounters:
+        bursts = enc.get("bursts") or []
+        if bursts:
+            for burst in bursts:
+                if _serialized_burst_confirmed(enc, burst):
+                    confirmed += 1
+                else:
+                    unconfirmed += 1
+        elif enc.get("species_confirmed"):
+            confirmed += 1
+        else:
+            unconfirmed += 1
+    return {
+        "confirmed_count": confirmed,
+        "unconfirmed_count": unconfirmed,
+    }
+
+
+def refresh_serialized_summary(results):
+    """Recompute cached summary counts in place and return the summary."""
+    photos = results.get("photos", []) or []
+    encounters = results.get("encounters", []) or []
+    summary = results.setdefault("summary", {})
+    summary["total_photos"] = len(photos)
+    summary["encounter_count"] = len(encounters)
+    summary["burst_count"] = sum(e.get("burst_count", 0) for e in encounters)
+    summary["keep_count"] = sum(1 for p in photos if p.get("label") == "KEEP")
+    summary["review_count"] = sum(1 for p in photos if p.get("label") == "REVIEW")
+    summary["reject_count"] = sum(1 for p in photos if p.get("label") == "REJECT")
+    summary["rarity_protected"] = sum(1 for p in photos if p.get("rarity_protected"))
+    summary.update(_count_serialized_confirmation_units(encounters))
+    return summary
 
 
 def reflow(encounters, config=None):
@@ -707,7 +787,9 @@ def load_results(cache_dir, workspace_id):
     if not os.path.exists(path):
         return None
     with open(path) as f:
-        return json.load(f)
+        data = json.load(f)
+    refresh_serialized_summary(data)
+    return data
 
 
 def prune_missing_photos(cache_dir, workspace_id, db):
@@ -812,16 +894,7 @@ def prune_results(cache_dir, workspace_id, deleted_ids):
         pruned_encounters.append(enc)
     data["encounters"] = pruned_encounters
 
-    photos = data["photos"]
-    summary = data.get("summary") or {}
-    summary["total_photos"] = len(photos)
-    summary["encounter_count"] = len(pruned_encounters)
-    summary["burst_count"] = sum(e.get("burst_count", 0) for e in pruned_encounters)
-    summary["keep_count"] = sum(1 for p in photos if p.get("label") == "KEEP")
-    summary["review_count"] = sum(1 for p in photos if p.get("label") == "REVIEW")
-    summary["reject_count"] = sum(1 for p in photos if p.get("label") == "REJECT")
-    summary["rarity_protected"] = sum(1 for p in photos if p.get("rarity_protected"))
-    data["summary"] = summary
+    refresh_serialized_summary(data)
 
     with open(path, "w") as f:
         json.dump(data, f)
@@ -1098,6 +1171,7 @@ def rebuild_species_predictions(results, photo_ids):
 
 def save_results_raw(results, cache_dir, workspace_id):
     """Save an already-serialized results dict back to the JSON cache."""
+    refresh_serialized_summary(results)
     path = os.path.join(cache_dir, f"pipeline_results_ws{workspace_id}.json")
     with open(path, "w") as f:
         json.dump(results, f)

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -44,8 +44,9 @@
 /* Summary bar */
 .summary-bar {
   display: flex;
-  gap: 24px;
+  gap: 20px;
   align-items: center;
+  flex-wrap: wrap;
   margin-bottom: 20px;
   padding: 16px 20px;
   background: var(--bg-secondary);
@@ -1209,6 +1210,14 @@ input[type="range"]::-moz-range-thumb {
         <div class="num" style="color:var(--warning);" id="statProtected">0</div>
         <div class="label">Protected</div>
       </div>
+      <div class="summary-stat">
+        <div class="num" style="color:var(--success, #4caf50);" id="statConfirmedCount">0</div>
+        <div class="label">Confirmed</div>
+      </div>
+      <div class="summary-stat">
+        <div class="num" id="statUnconfirmedCount">0</div>
+        <div class="label">Unconfirmed</div>
+      </div>
       <a id="missesReviewBtn" href="/misses" data-testid="pipeline-review-misses"
          style="display:none;margin-left:auto;padding:8px 14px;
                 background:var(--danger);color:#fff;border-radius:6px;
@@ -2026,7 +2035,55 @@ function doRegroupLive() {
   });
 }
 
+function countConfirmationUnits(results) {
+  var counts = {confirmed: 0, unconfirmed: 0};
+  if (!results || !Array.isArray(results.encounters)) return counts;
+  results.encounters.forEach(function(enc) {
+    var bursts = enc.bursts || [];
+    if (bursts.length > 0) {
+      bursts.forEach(function(burst) {
+        if (isBurstConfirmed(enc, burst)) counts.confirmed++;
+        else counts.unconfirmed++;
+      });
+    } else if (enc.species_confirmed) {
+      counts.confirmed++;
+    } else {
+      counts.unconfirmed++;
+    }
+  });
+  return counts;
+}
+
+function refreshLocalSummaryCounts() {
+  if (!pipelineResults) return null;
+  var summary = pipelineResults.summary || {};
+  var photos = pipelineResults.photos || [];
+  summary.total_photos = photos.length;
+  summary.encounter_count = (pipelineResults.encounters || []).length;
+  summary.burst_count = (pipelineResults.encounters || []).reduce(function(total, enc) {
+    return total + (enc.burst_count || ((enc.bursts || []).length));
+  }, 0);
+  summary.keep_count = 0;
+  summary.review_count = 0;
+  summary.reject_count = 0;
+  summary.rarity_protected = 0;
+  photos.forEach(function(p) {
+    if (p.label === 'KEEP') summary.keep_count++;
+    else if (p.label === 'REVIEW') summary.review_count++;
+    else if (p.label === 'REJECT') summary.reject_count++;
+    if (p.rarity_protected) summary.rarity_protected++;
+  });
+  var confirmCounts = countConfirmationUnits(pipelineResults);
+  summary.confirmed_count = confirmCounts.confirmed;
+  summary.unconfirmed_count = confirmCounts.unconfirmed;
+  pipelineResults.summary = summary;
+  return summary;
+}
+
 function updateSummaryBar(summary) {
+  if (pipelineResults && (summary.confirmed_count == null || summary.unconfirmed_count == null)) {
+    summary = refreshLocalSummaryCounts() || summary;
+  }
   var el;
   el = document.getElementById('statTotalPhotos'); if (el) el.textContent = summary.total_photos;
   el = document.getElementById('statEncounterCount'); if (el) el.textContent = summary.encounter_count;
@@ -2034,6 +2091,8 @@ function updateSummaryBar(summary) {
   el = document.getElementById('statKeepCount'); if (el) el.textContent = summary.keep_count;
   el = document.getElementById('statReviewCount'); if (el) el.textContent = summary.review_count;
   el = document.getElementById('statRejectCount'); if (el) el.textContent = summary.reject_count;
+  el = document.getElementById('statConfirmedCount'); if (el) el.textContent = summary.confirmed_count || 0;
+  el = document.getElementById('statUnconfirmedCount'); if (el) el.textContent = summary.unconfirmed_count || 0;
   var protWrap = document.getElementById('statProtectedWrap');
   if (protWrap) {
     if (summary.rarity_protected) {
@@ -2680,9 +2739,11 @@ async function confirmSpecies(event, encIdx, burstIdx, speciesName) {
     }
   } else if (burstIdx != null && enc.bursts && enc.bursts[burstIdx]) {
     enc.bursts[burstIdx].species_override = { species: speciesName, confirmed: true };
+    updateSummaryBar(refreshLocalSummaryCounts());
   } else {
     enc.species_confirmed = true;
     enc.confirmed_species = speciesName;
+    updateSummaryBar(refreshLocalSummaryCounts());
   }
   renderResults();
   checkPendingSync();
@@ -2701,6 +2762,7 @@ async function clearBurstOverride(event, encIdx, burstIdx) {
     body: JSON.stringify(pipelineResults),
   });
   renderResults();
+  updateSummaryBar(refreshLocalSummaryCounts());
 }
 
 // -- Detach & Undo --
@@ -3851,17 +3913,7 @@ async function grmApply() {
   // Clear the species input for next use
   document.getElementById('grmSpecies').value = '';
   renderResults();
-  // Recalculate summary counts from photo labels
-  var summary = pipelineResults.summary;
-  summary.keep_count = 0;
-  summary.review_count = 0;
-  summary.reject_count = 0;
-  pipelineResults.photos.forEach(function(p) {
-    if (p.label === 'KEEP') summary.keep_count++;
-    else if (p.label === 'REVIEW') summary.review_count++;
-    else if (p.label === 'REJECT') summary.reject_count++;
-  });
-  updateSummaryBar(summary);
+  updateSummaryBar(refreshLocalSummaryCounts());
 }
 
 initPipelineReviewPage();

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -463,6 +463,9 @@ def test_encounter_species_updates_pipeline_cache(app_and_db):
     resp = client.post("/api/encounters/species",
                        json={"species": "Blue Jay", "photo_ids": photo_ids})
     assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["summary"]["confirmed_count"] == 1
+    assert body["summary"]["unconfirmed_count"] == 0
 
     # Read cache back and check
     with open(path) as f:
@@ -470,6 +473,8 @@ def test_encounter_species_updates_pipeline_cache(app_and_db):
     enc = updated["encounters"][0]
     assert enc["species_confirmed"] is True
     assert enc["confirmed_species"] == "Blue Jay"
+    assert updated["summary"]["confirmed_count"] == 1
+    assert updated["summary"]["unconfirmed_count"] == 0
 
 
 def _seed_encounter_cache(app, db, photo_ids, *, confirmed_species=None, bursts=None):

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -490,7 +490,7 @@ def _sample_cache():
                 "time_range": ["2026-03-20T10:00:00", "2026-03-20T10:00:04"],
                 "photo_ids": [1, 2, 3],
                 "bursts": [
-                    {"photo_ids": [1, 2], "species_predictions": [], "species_override": None},
+                    {"photo_ids": [1, 2], "species_predictions": [], "species_override": {"species": "American Robin", "confirmed": True}},
                     {"photo_ids": [3], "species_predictions": [], "species_override": None},
                 ],
             },
@@ -523,6 +523,8 @@ def _sample_cache():
             "review_count": 1,
             "reject_count": 2,
             "rarity_protected": 1,
+            "confirmed_count": 1,
+            "unconfirmed_count": 2,
         },
     }
 
@@ -580,6 +582,8 @@ def test_prune_results_recomputes_counts(tmp_path):
     assert summary["review_count"] == 1
     assert summary["reject_count"] == 0
     assert summary["rarity_protected"] == 1
+    assert summary["confirmed_count"] == 1
+    assert summary["unconfirmed_count"] == 2
 
 
 def test_prune_results_no_overlap_returns_false(tmp_path):

--- a/vireo/tests/test_reflow.py
+++ b/vireo/tests/test_reflow.py
@@ -158,12 +158,15 @@ def test_make_summary(tmp_path):
     from pipeline import _make_summary
 
     photos = [
-        {"label": "KEEP", "rarity_protected": False},
-        {"label": "KEEP", "rarity_protected": False},
-        {"label": "REVIEW", "rarity_protected": True},
+        {"label": "KEEP", "rarity_protected": False, "confirmed_species": "Blue Jay"},
+        {"label": "KEEP", "rarity_protected": False, "confirmed_species": "Blue Jay"},
+        {"label": "REVIEW", "rarity_protected": True, "confirmed_species": None},
         {"label": "REJECT"},
     ]
-    encounters = [{"burst_count": 2}, {"burst_count": 1}]
+    encounters = [
+        {"burst_count": 2, "photos": photos[:3], "bursts": [photos[:2], photos[2:3]]},
+        {"burst_count": 1, "photos": photos[3:], "bursts": [photos[3:]]},
+    ]
 
     s = _make_summary(encounters, photos)
     assert s["total_photos"] == 4
@@ -173,3 +176,5 @@ def test_make_summary(tmp_path):
     assert s["rarity_protected"] == 1
     assert s["burst_count"] == 3
     assert s["encounter_count"] == 2
+    assert s["confirmed_count"] == 1
+    assert s["unconfirmed_count"] == 2


### PR DESCRIPTION
## Summary

Adds confirmed and unconfirmed counts to the Pipeline Review summary bar. The counts follow the same review unit semantics as the existing Hide confirmed behavior: burst-level when an encounter has bursts, otherwise encounter-level.

The summary data is recomputed for raw pipeline results, cached serialized results, cache pruning, cache saves, and local UI updates after confirmation-related actions so the top bar stays current.

## Validation

- `pytest vireo/tests/test_reflow.py::test_make_summary vireo/tests/test_pipeline.py::test_prune_results_recomputes_counts vireo/tests/test_app.py::test_encounter_species_updates_pipeline_cache`
- `pytest vireo/tests/test_pipeline.py::test_save_load_results_roundtrip vireo/tests/test_pipeline.py::test_load_results_missing vireo/tests/test_app.py::test_encounter_species_all_skipped_returns_cached_encounters vireo/tests/test_app.py::test_burst_override_change_untags_previous`
- `python -m py_compile vireo/pipeline.py`
- `git diff --check`