### PR TITLE
Land Codex P2 fix on PR #806 (proxy push workaround)

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3006,9 +3006,16 @@ function _lbApplyMaskVisibility() {
   };
   if (img.getAttribute('src') !== _lbMaskCurrentUrl) {
     img.src = _lbMaskCurrentUrl;
-  } else {
+  } else if (img.naturalWidth > 0) {
+    // Same URL and we know it loaded successfully — safe to re-show
+    // without re-fetching.
     img.classList.add('show');
   }
+  // If src matches but naturalWidth is 0, the previous load either failed
+  // (onerror already hid the overlay; re-adding `show` would surface a
+  // broken-image icon) or is still in flight (the onload assigned above
+  // will add `show` when the request resolves). Either way, don't add
+  // `show` here.
 }
 
 function _lbApplyMaskUrl(url) {


### PR DESCRIPTION
Ephemeral helper PR to land the navbar.html fix on #806. Direct push to `browse-image-no-overlays` is blocked by the local-proxy ACL on this routine; pushing to the designated `claude/sweet-feynman-rNdrS` branch and merging it forward is the workaround.

Carries one commit:

- fix: don't re-show mask overlay on same-URL re-toggle after failed load (addresses Codex P2 review on #806)

Will be rebase-merged immediately and the branch deleted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Czc4zWecZQuDAnFEbNVHyb)_