### PR TITLE
[codex] Add species control for predictionless pipeline groups

### DIFF
--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -1,0 +1,92 @@
+import json
+import os
+
+from playwright.sync_api import expect
+
+
+def _write_predictionless_pipeline_cache(live_server, photo_ids):
+    db = live_server["db"]
+    rows = db.conn.execute(
+        "SELECT id, filename, timestamp FROM photos WHERE id IN (?, ?) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    ids = [p["id"] for p in photos]
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": ids,
+                "photo_count": len(ids),
+                "burst_count": 1,
+                "time_range": [photos[0]["timestamp"], photos[-1]["timestamp"]],
+                "species": [],
+                "species_predictions": [],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": [
+                    {
+                        "photo_ids": ids,
+                        "species_predictions": [],
+                        "species_override": None,
+                    }
+                ],
+            }
+        ],
+        "summary": {
+            "total_photos": len(ids),
+            "encounter_count": 1,
+            "burst_count": 1,
+            "keep_count": 0,
+            "review_count": len(ids),
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def test_predictionless_pipeline_encounter_can_add_species(live_server, page):
+    photo_ids = live_server["data"]["photos"][1:3]
+    _write_predictionless_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+
+    species_name = page.locator(".species-widget .species-name").first
+    expect(species_name).to_have_text("Add species")
+    species_name.click()
+
+    input_box = page.locator(".species-dropdown.open input").first
+    input_box.fill("Yellow-breasted Chat")
+    input_box.press("Enter")
+
+    expect(species_name).to_have_text("Yellow-breasted Chat")
+
+    db = live_server["db"]
+    rows = db.conn.execute(
+        """
+        SELECT p.id
+        FROM photos p
+        JOIN photo_keywords pk ON pk.photo_id = p.id
+        JOIN keywords k ON k.id = pk.keyword_id
+        WHERE p.id IN (?, ?) AND k.name = ? AND k.is_species = 1
+        """,
+        (*photo_ids, "Yellow-breasted Chat"),
+    ).fetchall()
+    assert {r["id"] for r in rows} == set(photo_ids)

--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -90,3 +90,10 @@ def test_predictionless_pipeline_encounter_can_add_species(live_server, page):
         (*photo_ids, "Yellow-breasted Chat"),
     ).fetchall()
     assert {r["id"] for r in rows} == set(photo_ids)
+
+
+def test_species_name_arg_keeps_nullish_values_empty(live_server, page):
+    page.goto(f"{live_server['url']}/pipeline/review")
+
+    assert page.evaluate("speciesNameArg(null)") == "''"
+    assert page.evaluate("speciesNameArg(undefined)") == "''"

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -650,6 +650,12 @@ input[type="range"]::-moz-range-thumb {
 .species-name.confirmed {
   color: var(--accent);
 }
+.species-name.missing {
+  color: var(--accent);
+}
+.species-name.missing:hover {
+  color: var(--accent-hover);
+}
 .species-badge {
   font-size: 10px;
   padding: 1px 6px;
@@ -662,6 +668,10 @@ input[type="range"]::-moz-range-thumb {
 }
 .species-badge.confirmed {
   background: rgba(36, 229, 202, 0.2);
+  color: var(--accent);
+}
+.species-badge.missing {
+  background: rgba(36, 229, 202, 0.14);
   color: var(--accent);
 }
 .species-confirm-btn {
@@ -1337,6 +1347,17 @@ function encounterKey(enc) {
   return enc.photo_ids.slice().sort(function(a, b) { return a - b; }).join(',');
 }
 
+function escapeHtml(s) {
+  if (s == null) return '';
+  var d = document.createElement('div');
+  d.textContent = String(s);
+  return d.innerHTML;
+}
+
+function speciesNameArg(name) {
+  return "'" + escapeHtml(String(name).replace(/\\/g, '\\\\').replace(/'/g, "\\'")) + "'";
+}
+
 // GRM resolution slider — index into GRM_RES_STOPS. Persists across photos within a session.
 var GRM_RES_STOPS = [
   {size: 1920, label: '1920', kind: 'preview'},
@@ -1484,12 +1505,6 @@ function renderAlgorithmTrace() {
   }
   var photoMap = {};
   (pipelineResults.photos || []).forEach(function(p) { photoMap[p.id] = p; });
-  function escapeHtml(s) {
-    if (s == null) return '';
-    var d = document.createElement('div');
-    d.textContent = String(s);
-    return d.innerHTML;
-  }
   function shortName(fname) {
     if (!fname) return '';
     var dot = fname.lastIndexOf('.');
@@ -2480,35 +2495,38 @@ function renderSpeciesWidget(enc, encIdx, level, burstIdx, pos) {
   // level: 'encounter' or 'burst'
   // pos:   'top' (default) or 'bot' — disambiguates the duplicated bottom widget
   pos = pos || 'top';
-  var isConfirmed, displayName, predictions;
+  var isConfirmed, displayName, predictions, candidateSpecies;
   if (level === 'burst') {
     var burst = enc.bursts[burstIdx];
     var ovr = burst.species_override;
     if (ovr) {
       isConfirmed = !!ovr.confirmed;
-      displayName = ovr.species || (enc.species ? enc.species[0] : 'Unknown');
+      candidateSpecies = ovr.species || enc.confirmed_species || (enc.species ? enc.species[0] : null);
     } else {
       // No per-burst override: inherit from the encounter so confirming the
       // encounter visibly cascades to every burst.
       isConfirmed = !!enc.species_confirmed;
-      displayName = enc.confirmed_species || (enc.species ? enc.species[0] : 'Unknown');
+      candidateSpecies = enc.confirmed_species || (enc.species ? enc.species[0] : null);
     }
+    displayName = candidateSpecies || 'Add species';
     predictions = burst.species_predictions || [];
   } else {
     isConfirmed = enc.species_confirmed;
-    displayName = enc.confirmed_species || (enc.species ? enc.species[0] : 'Unknown');
+    candidateSpecies = enc.confirmed_species || (enc.species ? enc.species[0] : null);
+    displayName = candidateSpecies || 'Add species';
     predictions = enc.species_predictions || [];
   }
 
-  var cls = isConfirmed ? 'confirmed' : 'unconfirmed';
-  var badge = isConfirmed ? '&#10003;' : '?';
+  var hasCandidate = !!candidateSpecies;
+  var cls = isConfirmed ? 'confirmed' : (hasCandidate ? 'unconfirmed' : 'missing');
+  var badge = isConfirmed ? '&#10003;' : (hasCandidate ? '?' : '+');
   var widgetCls = level === 'burst' ? 'burst-species-widget' : 'species-widget';
 
   var idKey = (burstIdx != null ? burstIdx : 'enc') + '_' + pos;
   var html = '<span class="' + widgetCls + '" data-enc="' + encIdx + '" data-burst="' + (burstIdx != null ? burstIdx : '') + '">';
-  html += '<span class="species-name ' + cls + '" onclick="toggleSpeciesDropdown(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ',\'' + pos + '\')">' + escapeHtml(displayName) + '</span>';
+  html += '<span class="species-name ' + cls + '" title="' + (hasCandidate ? 'Change species' : 'Add species') + '" onclick="toggleSpeciesDropdown(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ',\'' + pos + '\')">' + escapeHtml(displayName) + '</span>';
   html += '<span class="species-badge ' + cls + '">' + badge + '</span>';
-  if (!isConfirmed) {
+  if (!isConfirmed && hasCandidate) {
     html += '<button class="species-confirm-btn" onclick="confirmSpecies(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ',null)" title="Confirm as ' + escapeHtml(displayName) + '">&#10003;</button>';
   }
 
@@ -2518,9 +2536,10 @@ function renderSpeciesWidget(enc, encIdx, level, burstIdx, pos) {
   html += '<div class="species-dropdown-search"><input type="text" placeholder="Search or type a new name..." oninput="searchSpecies(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ',\'' + pos + '\')" onkeydown="speciesInputKey(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ')"></div>';
 
   // "Use encounter label" option for burst level
-  if (level === 'burst' && enc.species) {
+  var encounterLabel = enc.confirmed_species || (enc.species ? enc.species[0] : null);
+  if (level === 'burst' && encounterLabel) {
     html += '<div class="species-dropdown-item" onclick="clearBurstOverride(event, ' + encIdx + ',' + burstIdx + ')">';
-    html += '<span class="sp-name" style="color:var(--text-dim);">Use encounter label (' + escapeHtml(enc.species[0] || '') + ')</span>';
+    html += '<span class="sp-name" style="color:var(--text-dim);">Use encounter label (' + escapeHtml(encounterLabel) + ')</span>';
     html += '</div>';
   }
 
@@ -2529,7 +2548,7 @@ function renderSpeciesWidget(enc, encIdx, level, burstIdx, pos) {
     var modelParts = (sp.models || []).map(function(m) {
       return escapeHtml(m.model) + ' ' + (m.confidence * 100).toFixed(0) + '%';
     });
-    html += '<div class="species-dropdown-item" onclick="confirmSpecies(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ',\'' + escapeHtml(sp.species).replace(/'/g, "\\'") + '\')">';
+    html += '<div class="species-dropdown-item" onclick="confirmSpecies(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ',' + speciesNameArg(sp.species) + ')">';
     html += '<span class="sp-name">' + escapeHtml(sp.species) + '</span>';
     html += '<span class="sp-models">' + modelParts.join(', ') + '</span>';
     html += '</div>';
@@ -2594,7 +2613,7 @@ function searchSpecies(event, encIdx, burstIdx, pos) {
         + '</div>';
     }
     results.forEach(function(name) {
-      html += '<div class="species-dropdown-item" onclick="confirmSpecies(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ',\'' + escapeHtml(name).replace(/'/g, "\\'") + '\')">';
+      html += '<div class="species-dropdown-item" onclick="confirmSpecies(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ',' + speciesNameArg(name) + ')">';
       html += '<span class="sp-name">' + escapeHtml(name) + '</span>';
       html += '<span class="sp-models" style="color:var(--text-dim);">search</span>';
       html += '</div>';

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1355,6 +1355,7 @@ function escapeHtml(s) {
 }
 
 function speciesNameArg(name) {
+  if (name == null) return "''";
   return "'" + escapeHtml(String(name).replace(/\\/g, '\\\\').replace(/'/g, "\\'")) + "'";
 }
 


### PR DESCRIPTION
## Summary

- Show a visible `Add species` control for Pipeline Review encounters and bursts that have no classifier species candidate.
- Reuse the existing species dropdown/search/manual-entry flow so users can type a species name and apply it through the existing confirmation endpoint.
- Add browser coverage for manually adding a species to a predictionless pipeline encounter.

## Why

Predictionless groups previously rendered as `Unknown`. The label was technically clickable, but it did not clearly communicate that users could add a species, and the adjacent confirm button could not apply anything because there was no candidate species. This made cases like `DSC_3844.NEF` in the May 2026 workspace hard to correct from Pipeline Review.

## Validation

- `pytest tests/e2e/test_pipeline_review_species.py -q`
- `pytest tests/e2e/test_page_loads.py tests/e2e/test_pipeline_review_species.py -q`
- `pytest vireo/tests/test_app.py -q -k "encounter_species or pipeline_review"`
- `git diff --check`