### PR TITLE
[codex] Support recursive workspace folder roots

### DIFF
--- a/.github/actions/fire-routine/action.yml
+++ b/.github/actions/fire-routine/action.yml
@@ -47,6 +47,11 @@ runs:
         echo
 
         if [[ "${status}" -lt 200 || "${status}" -ge 300 ]]; then
+          error_type=$(jq -r '.error.type // empty' < "${response}")
+          if [[ "${status}" == "429" && "${error_type}" == "rate_limit_error" ]]; then
+            echo "::warning::Routine fire skipped because the routine provider returned a rate-limit/quota error."
+            exit 0
+          fi
           echo "::error::Routine fire failed with status ${status}"
           exit 1
         fi

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -76,12 +76,66 @@ def test_workspace_folders(db):
     assert folders[0]["id"] == folder_id
 
 
+def test_workspace_folder_roots_hide_recursive_descendants(db):
+    ws_id = db._active_workspace_id
+    root_id = db.add_folder("/photos/usa/2026", name="2026")
+    child_id = db.add_folder(
+        "/photos/usa/2026/2026-05-01",
+        name="2026-05-01",
+        parent_id=root_id,
+    )
+
+    folders = {f["id"] for f in db.get_workspace_folders(ws_id)}
+    roots = db.get_workspace_folder_roots(ws_id)
+
+    assert root_id in folders
+    assert child_id in folders
+    assert [f["id"] for f in roots] == [root_id]
+
+
+def test_workspace_root_materializes_existing_path_descendants(db):
+    ws_id = db._active_workspace_id
+    db.set_active_workspace(None)
+    root_id = db.add_folder("/photos/usa/2026", name="2026")
+    # Historical DBs can have path-descendant folders without parent_id.
+    child_id = db.add_folder("/photos/usa/2026/2026-05-01", name="2026-05-01")
+    db.add_photo(child_id, "bird.jpg", ".jpg", 1000, 1.0)
+    db.set_active_workspace(ws_id)
+
+    db.add_workspace_folder(ws_id, root_id)
+
+    folders = {f["id"] for f in db.get_workspace_folders(ws_id)}
+    roots = db.get_workspace_folder_roots(ws_id)
+    photos = db.get_photos()
+
+    assert root_id in folders
+    assert child_id in folders
+    assert [f["id"] for f in roots] == [root_id]
+    assert [p["filename"] for p in photos] == ["bird.jpg"]
+
+
 def test_remove_workspace_folder(db):
     ws_id = db.create_workspace("Test")
     folder_id = db.add_folder("/photos/kenya", name="kenya")
     db.add_workspace_folder(ws_id, folder_id)
     db.remove_workspace_folder(ws_id, folder_id)
     assert len(db.get_workspace_folders(ws_id)) == 0
+
+
+def test_remove_workspace_root_unlinks_descendants(db):
+    ws_id = db._active_workspace_id
+    root_id = db.add_folder("/photos/usa/2026", name="2026")
+    child_id = db.add_folder(
+        "/photos/usa/2026/2026-05-01",
+        name="2026-05-01",
+        parent_id=root_id,
+    )
+    db.add_photo(child_id, "bird.jpg", ".jpg", 1000, 1.0)
+
+    db.remove_workspace_folder(ws_id, root_id)
+
+    assert len(db.get_workspace_folders(ws_id)) == 0
+    assert db.get_photos() == []
 
 
 def test_set_active_workspace(db):

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -160,6 +160,25 @@ def test_workspace_root_materializes_windows_style_descendants(db):
     assert [p["filename"] for p in photos] == ["bird.jpg"]
 
 
+def test_workspace_root_materialization_is_case_sensitive(db):
+    ws_id = db._active_workspace_id
+    db.set_active_workspace(None)
+    root_id = db.add_folder("/photos/USA/2026", name="2026")
+    child_id = db.add_folder("/photos/USA/2026/2026-05-01", name="2026-05-01")
+    other_id = db.add_folder("/photos/usa/2026/2026-05-02", name="2026-05-02")
+    db.add_photo(child_id, "bird.jpg", ".jpg", 1000, 1.0)
+    db.add_photo(other_id, "wrong-case.jpg", ".jpg", 1000, 1.0)
+    db.set_active_workspace(ws_id)
+
+    db.add_workspace_folder(ws_id, root_id)
+
+    folders = {f["id"] for f in db.get_workspace_folders(ws_id)}
+    assert root_id in folders
+    assert child_id in folders
+    assert other_id not in folders
+    assert {p["filename"] for p in db.get_photos()} == {"bird.jpg"}
+
+
 def test_remove_workspace_folder(db):
     ws_id = db.create_workspace("Test")
     folder_id = db.add_folder("/photos/kenya", name="kenya")

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -179,6 +179,32 @@ def test_workspace_root_materialization_is_case_sensitive(db):
     assert {p["filename"] for p in db.get_photos()} == {"bird.jpg"}
 
 
+def test_workspace_large_recursive_root_operations_chunk_sql_params(db):
+    ws_id = db._active_workspace_id
+    db.set_active_workspace(None)
+    root_id = db.add_folder("/photos/big", name="big")
+    for idx in range(1005):
+        db.add_folder(f"/photos/big/day-{idx:04d}", name=f"day-{idx:04d}")
+    db.set_active_workspace(ws_id)
+
+    db.add_workspace_folder(ws_id, root_id)
+
+    assert len(db.get_workspace_folders(ws_id)) == 1006
+    assert [f["id"] for f in db.get_workspace_folder_roots(ws_id)] == [root_id]
+
+    target_ws_id = db.create_workspace("Target")
+    result = db.move_folders_to_workspace(ws_id, target_ws_id, [root_id])
+
+    assert result["folders_moved"] == 1
+    assert len(db.get_workspace_folders(ws_id)) == 0
+    assert len(db.get_workspace_folders(target_ws_id)) == 1006
+    assert [f["id"] for f in db.get_workspace_folder_roots(target_ws_id)] == [root_id]
+
+    db.remove_workspace_folder_tree(target_ws_id, root_id)
+
+    assert len(db.get_workspace_folders(target_ws_id)) == 0
+
+
 def test_remove_workspace_folder(db):
     ws_id = db.create_workspace("Test")
     folder_id = db.add_folder("/photos/kenya", name="kenya")

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -78,12 +78,16 @@ def test_workspace_folders(db):
 
 def test_workspace_folder_roots_hide_recursive_descendants(db):
     ws_id = db._active_workspace_id
+    db.set_active_workspace(None)
     root_id = db.add_folder("/photos/usa/2026", name="2026")
     child_id = db.add_folder(
         "/photos/usa/2026/2026-05-01",
         name="2026-05-01",
         parent_id=root_id,
     )
+    db.set_active_workspace(ws_id)
+
+    db.add_workspace_folder(ws_id, root_id)
 
     folders = {f["id"] for f in db.get_workspace_folders(ws_id)}
     roots = db.get_workspace_folder_roots(ws_id)
@@ -112,6 +116,25 @@ def test_workspace_root_materializes_existing_path_descendants(db):
     assert child_id in folders
     assert [f["id"] for f in roots] == [root_id]
     assert [p["filename"] for p in photos] == ["bird.jpg"]
+
+
+def test_workspace_root_hides_materialized_descendant_when_parent_has_photos(db):
+    ws_id = db._active_workspace_id
+    db.set_active_workspace(None)
+    root_id = db.add_folder("/photos/usa/2026", name="2026")
+    child_id = db.add_folder(
+        "/photos/usa/2026/2026-05-01",
+        name="2026-05-01",
+        parent_id=root_id,
+    )
+    db.add_photo(root_id, "root.jpg", ".jpg", 1000, 1.0)
+    db.add_photo(child_id, "child.jpg", ".jpg", 1000, 1.0)
+    db.set_active_workspace(ws_id)
+
+    db.add_workspace_folder(ws_id, root_id)
+
+    assert [f["id"] for f in db.get_workspace_folder_roots(ws_id)] == [root_id]
+    assert {p["filename"] for p in db.get_photos()} == {"root.jpg", "child.jpg"}
 
 
 def test_workspace_root_materializes_windows_style_descendants(db):

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -205,6 +205,27 @@ def test_workspace_large_recursive_root_operations_chunk_sql_params(db):
     assert len(db.get_workspace_folders(target_ws_id)) == 0
 
 
+def test_materializing_workspace_descendants_invalidates_new_images_cache(db):
+    ws_id = db.create_workspace("USA 2026")
+    root_id = db.add_folder("/photos/usa/2026", name="2026")
+    child_id = db.add_folder("/photos/usa/2026/day-1", name="day-1")
+
+    db.conn.execute(
+        """INSERT INTO workspace_folders (workspace_id, folder_id, is_root)
+           VALUES (?, ?, 1)""",
+        (ws_id, root_id),
+    )
+    db.conn.commit()
+    db._new_images_cache.set(
+        db._db_path, ws_id, {"new_count": 0, "per_root": [], "sample": []}
+    )
+
+    folders = {f["id"] for f in db.get_workspace_folders(ws_id)}
+
+    assert child_id in folders
+    assert db._new_images_cache.get(db._db_path, ws_id) is None
+
+
 def test_remove_workspace_folder(db):
     ws_id = db.create_workspace("Test")
     folder_id = db.add_folder("/photos/kenya", name="kenya")
@@ -933,6 +954,24 @@ def test_move_folders_collections_stay_behind(db_with_workspace):
     assert len(db.get_collections()) == 1
     db.set_active_workspace(ws2)
     assert len(db.get_collections()) == 0
+
+
+def test_move_folders_blocks_descendant_when_source_root_remains(db):
+    ws1 = db.create_workspace("Source")
+    ws2 = db.create_workspace("Target")
+    root_id = db.add_folder("/photos/usa/2026", name="2026")
+    child_id = db.add_folder(
+        "/photos/usa/2026/day-1",
+        name="day-1",
+        parent_id=root_id,
+    )
+    db.add_workspace_folder(ws1, root_id)
+
+    with pytest.raises(ValueError, match="covered by another source workspace folder"):
+        db.move_folders_to_workspace(ws1, ws2, [child_id])
+
+    assert {f["id"] for f in db.get_workspace_folders(ws1)} == {root_id, child_id}
+    assert db.get_workspace_folders(ws2) == []
 
 
 def test_move_folders_validates_source_workspace(db):

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -114,6 +114,29 @@ def test_workspace_root_materializes_existing_path_descendants(db):
     assert [p["filename"] for p in photos] == ["bird.jpg"]
 
 
+def test_workspace_root_materializes_windows_style_descendants(db):
+    ws_id = db._active_workspace_id
+    db.set_active_workspace(None)
+    root_id = db.add_folder(r"C:\photos\usa\2026", name="2026")
+    child_id = db.add_folder(
+        r"C:\photos\usa\2026\2026-05-01",
+        name="2026-05-01",
+    )
+    db.add_photo(child_id, "bird.jpg", ".jpg", 1000, 1.0)
+    db.set_active_workspace(ws_id)
+
+    db.add_workspace_folder(ws_id, root_id)
+
+    folders = {f["id"] for f in db.get_workspace_folders(ws_id)}
+    roots = db.get_workspace_folder_roots(ws_id)
+    photos = db.get_photos()
+
+    assert root_id in folders
+    assert child_id in folders
+    assert [f["id"] for f in roots] == [root_id]
+    assert [p["filename"] for p in photos] == ["bird.jpg"]
+
+
 def test_remove_workspace_folder(db):
     ws_id = db.create_workspace("Test")
     folder_id = db.add_folder("/photos/kenya", name="kenya")
@@ -132,7 +155,7 @@ def test_remove_workspace_root_unlinks_descendants(db):
     )
     db.add_photo(child_id, "bird.jpg", ".jpg", 1000, 1.0)
 
-    db.remove_workspace_folder(ws_id, root_id)
+    db.remove_workspace_folder_tree(ws_id, root_id)
 
     assert len(db.get_workspace_folders(ws_id)) == 0
     assert db.get_photos() == []

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3378,7 +3378,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not ws:
             return json_error("No active workspace", 404)
         result = dict(ws)
-        result["folders"] = [dict(f) for f in db.get_workspace_folders(ws["id"])]
+        result["folders"] = [dict(f) for f in db.get_workspace_folder_roots(ws["id"])]
         return jsonify(result)
 
     @app.route("/api/workspaces", methods=["POST"])
@@ -3482,7 +3482,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/workspaces/<int:ws_id>/folders", methods=["GET"])
     def api_workspace_folders(ws_id):
         db = _get_db()
-        folders = db.get_workspace_folders(ws_id)
+        folders = db.get_workspace_folder_roots(ws_id)
         return jsonify([dict(f) for f in folders])
 
     @app.route("/api/workspaces/<int:ws_id>/folders", methods=["POST"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3498,7 +3498,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/workspaces/<int:ws_id>/folders/<int:folder_id>", methods=["DELETE"])
     def api_remove_workspace_folder(ws_id, folder_id):
         db = _get_db()
-        db.remove_workspace_folder(ws_id, folder_id)
+        db.remove_workspace_folder_tree(ws_id, folder_id)
         return jsonify({"ok": True})
 
     @app.route("/api/workspaces/<int:ws_id>/move-folders", methods=["POST"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3391,8 +3391,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         try:
             ws_id = db.create_workspace(name, config_overrides=body.get("config_overrides"))
             # Link selected folders if provided
-            for folder_id in body.get("folder_ids", []):
+            folder_ids = body.get("folder_ids", [])
+            for folder_id in folder_ids:
                 db.add_workspace_folder(ws_id, folder_id)
+            db.mark_workspace_folder_roots(ws_id, folder_ids)
             ws = db.get_workspace(ws_id)
             return jsonify(dict(ws))
         except Exception as e:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -32,17 +32,8 @@ def _nfc(name: str) -> str:
     return unicodedata.normalize("NFC", name)
 
 
-def _escape_like(value: str) -> str:
-    """Escape a literal string for a SQLite LIKE pattern using backslash."""
-    return (
-        value.replace("\\", "\\\\")
-        .replace("%", "\\%")
-        .replace("_", "\\_")
-    )
-
-
 def _path_for_subtree_match(value: str) -> str:
-    """Normalize a stored path for platform-neutral subtree LIKE matching."""
+    """Normalize a stored path for platform-neutral subtree prefix matching."""
     return value.replace("\\", "/").rstrip("/")
 
 # Canonical set of keyword type values stored in keywords.type.
@@ -717,18 +708,11 @@ class Database:
                      JOIN folders child ON child.id = child_wf.folder_id
                      WHERE root_wf.workspace_id = child_wf.workspace_id
                        AND root_wf.folder_id != child_wf.folder_id
-                       AND REPLACE(child.path, '\\', '/') LIKE (
-                         REPLACE(
-                           REPLACE(
-                             REPLACE(
-                               RTRIM(REPLACE(root.path, '\\', '/'), '/'),
-                               '\\', '\\\\'
-                             ),
-                             '%', '\\%'
-                           ),
-                           '_', '\\_'
-                         ) || '/%'
-                       ) ESCAPE '\\'
+                       AND substr(
+                         REPLACE(child.path, '\\', '/'),
+                         1,
+                         length(RTRIM(REPLACE(root.path, '\\', '/'), '/') || '/')
+                       ) = RTRIM(REPLACE(root.path, '\\', '/'), '/') || '/'
                    )"""
             )
         # Migration: working-copy failure markers. Backfill (and the inline
@@ -1246,12 +1230,12 @@ class Database:
         if row is None or not row["path"]:
             return [folder_id]
         root_path = _path_for_subtree_match(row["path"])
-        like = _escape_like(root_path) + "/%"
+        prefix = root_path + "/"
         rows = self.conn.execute(
             """SELECT id FROM folders
                WHERE id = ?
-                  OR REPLACE(path, '\\', '/') LIKE ? ESCAPE '\\'""",
-            (folder_id, like),
+                  OR substr(REPLACE(path, '\\', '/'), 1, ?) = ?""",
+            (folder_id, len(prefix), prefix),
         ).fetchall()
         ids = {folder_id}
         ids.update(r["id"] for r in rows)
@@ -1311,18 +1295,11 @@ class Database:
                JOIN folders root ON root.id = wf.folder_id
                JOIN folders child
                  ON child.path = root.path
-                 OR REPLACE(child.path, '\\', '/') LIKE (
-                    REPLACE(
-                      REPLACE(
-                        REPLACE(
-                          RTRIM(REPLACE(root.path, '\\', '/'), '/'),
-                          '\\', '\\\\'
-                        ),
-                        '%', '\\%'
-                      ),
-                      '_', '\\_'
-                    ) || '/%'
-                 ) ESCAPE '\\'
+                 OR substr(
+                      REPLACE(child.path, '\\', '/'),
+                      1,
+                      length(RTRIM(REPLACE(root.path, '\\', '/'), '/') || '/')
+                    ) = RTRIM(REPLACE(root.path, '\\', '/'), '/') || '/'
                LEFT JOIN workspace_folders existing
                  ON existing.workspace_id = wf.workspace_id
                 AND existing.folder_id = child.id

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1241,7 +1241,7 @@ class Database:
         ids.update(r["id"] for r in rows)
         return list(ids)
 
-    def add_workspace_folder(self, workspace_id, folder_id):
+    def add_workspace_folder(self, workspace_id, folder_id, *, is_root=True):
         """Link a folder and its known descendants to a workspace."""
         folder_ids = self._folder_subtree_ids_by_path(folder_id)
         self.conn.executemany(
@@ -1249,13 +1249,14 @@ class Database:
                (workspace_id, folder_id, is_root) VALUES (?, ?, 0)""",
             [(workspace_id, fid) for fid in folder_ids],
         )
-        placeholders = ",".join("?" for _ in folder_ids)
-        self.conn.execute(
-            f"""UPDATE workspace_folders
-                SET is_root = CASE WHEN folder_id = ? THEN 1 ELSE 0 END
-                WHERE workspace_id = ? AND folder_id IN ({placeholders})""",
-            [folder_id, workspace_id] + folder_ids,
-        )
+        if is_root:
+            placeholders = ",".join("?" for _ in folder_ids)
+            self.conn.execute(
+                f"""UPDATE workspace_folders
+                    SET is_root = CASE WHEN folder_id = ? THEN 1 ELSE 0 END
+                    WHERE workspace_id = ? AND folder_id IN ({placeholders})""",
+                [folder_id, workspace_id] + folder_ids,
+            )
         self.conn.commit()
         # The folder's untracked files now count toward this workspace's
         # new-images backlog. Drop any stale cached payload so the next read
@@ -1612,8 +1613,12 @@ class Database:
 
     # -- Folders --
 
-    def add_folder(self, path, name=None, parent_id=None):
+    def add_folder(self, path, name=None, parent_id=None, *, workspace_root=True):
         """Insert a folder. Automatically links it to the active workspace.
+
+        ``workspace_root`` controls whether that automatic link is a
+        user-facing workspace root. Scanner-discovered descendants pass
+        ``False`` so recursive roots do not expand over time.
 
         Returns the folder id.
         """
@@ -1631,7 +1636,11 @@ class Database:
             folder_id = row["id"]
         # Auto-link to active workspace
         if self._active_workspace_id is not None:
-            self.add_workspace_folder(self._active_workspace_id, folder_id)
+            self.add_workspace_folder(
+                self._active_workspace_id,
+                folder_id,
+                is_root=workspace_root,
+            )
         return folder_id
 
     def get_folder_tree(self):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1327,6 +1327,7 @@ class Database:
             [(workspace_id, r["id"]) for r in rows],
         )
         self.conn.commit()
+        self._new_images_cache.invalidate_workspaces(self._db_path, [workspace_id])
 
     def mark_workspace_folder_roots(self, workspace_id, folder_ids):
         """Mark specific linked folders as user-facing roots."""
@@ -1430,6 +1431,27 @@ class Database:
 
         if not folder_ids:
             return {"folders_moved": 0, "pending_changes_moved": 0}
+
+        selected_folder_ids = set(folder_ids)
+        source_folder_paths = {
+            folder["id"]: _path_for_subtree_match(folder["path"])
+            for folder in source_folders
+            if folder["path"]
+        }
+        remaining_source_paths = [
+            path
+            for fid, path in source_folder_paths.items()
+            if fid not in selected_folder_ids
+        ]
+        for fid in selected_folder_ids:
+            selected_path = source_folder_paths.get(fid)
+            if selected_path and any(
+                selected_path.startswith(path + "/") for path in remaining_source_paths
+            ):
+                raise ValueError(
+                    "Cannot move a folder that is covered by another source "
+                    "workspace folder; move the covering folder or remove it first"
+                )
 
         moved_folder_ids = []
         seen_folder_ids = set()
@@ -2011,12 +2033,26 @@ class Database:
             (target_folder_id, source_folder_id),
         )
 
-        # Transfer workspace visibility from source to target
-        self.conn.execute(
-            "INSERT OR IGNORE INTO workspace_folders (workspace_id, folder_id) "
-            "SELECT workspace_id, ? FROM workspace_folders WHERE folder_id = ?",
-            (target_folder_id, source_folder_id),
-        )
+        # Transfer workspace visibility from source to target while preserving
+        # whether the source link was a user-facing root or a materialized
+        # descendant.
+        workspace_links = self.conn.execute(
+            "SELECT workspace_id, is_root FROM workspace_folders WHERE folder_id = ?",
+            (source_folder_id,),
+        ).fetchall()
+        for link in workspace_links:
+            self.conn.execute(
+                """INSERT OR IGNORE INTO workspace_folders
+                   (workspace_id, folder_id, is_root) VALUES (?, ?, ?)""",
+                (link["workspace_id"], target_folder_id, link["is_root"]),
+            )
+            if link["is_root"]:
+                self.conn.execute(
+                    """UPDATE workspace_folders
+                       SET is_root = 1
+                       WHERE workspace_id = ? AND folder_id = ?""",
+                    (link["workspace_id"], target_folder_id),
+                )
 
         # Remove source folder
         self.conn.execute(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -40,6 +40,11 @@ def _escape_like(value: str) -> str:
         .replace("_", "\\_")
     )
 
+
+def _path_for_subtree_match(value: str) -> str:
+    """Normalize a stored path for platform-neutral subtree LIKE matching."""
+    return value.replace("\\", "/").rstrip("/")
+
 # Canonical set of keyword type values stored in keywords.type.
 # - taxonomy: a species/genus/etc. (linked to taxa via taxon_id)
 # - individual: a named person, pet, or otherwise tracked individual
@@ -1206,12 +1211,13 @@ class Database:
         ).fetchone()
         if row is None or not row["path"]:
             return [folder_id]
-        root_path = row["path"].rstrip(os.sep)
-        like = _escape_like(root_path) + os.sep + "%"
+        root_path = _path_for_subtree_match(row["path"])
+        like = _escape_like(root_path) + "/%"
         rows = self.conn.execute(
             """SELECT id FROM folders
-               WHERE path = ? OR path LIKE ? ESCAPE '\\'""",
-            (root_path, like),
+               WHERE id = ?
+                  OR REPLACE(path, '\\', '/') LIKE ? ESCAPE '\\'""",
+            (folder_id, like),
         ).fetchall()
         ids = {folder_id}
         ids.update(r["id"] for r in rows)
@@ -1231,7 +1237,18 @@ class Database:
         self._new_images_cache.invalidate_workspaces(self._db_path, [workspace_id])
 
     def remove_workspace_folder(self, workspace_id, folder_id):
-        """Unlink a folder and its descendants from a workspace."""
+        """Unlink a single folder from a workspace."""
+        self.conn.execute(
+            "DELETE FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+            (workspace_id, folder_id),
+        )
+        self.conn.commit()
+        # The folder no longer contributes to this workspace's new-images
+        # backlog. Drop the cached payload so the banner reflects the change.
+        self._new_images_cache.invalidate_workspaces(self._db_path, [workspace_id])
+
+    def remove_workspace_folder_tree(self, workspace_id, folder_id):
+        """Unlink a folder and its path descendants from a workspace."""
         folder_ids = self._folder_subtree_ids_by_path(folder_id)
         placeholders = ",".join("?" for _ in folder_ids)
         self.conn.execute(
@@ -1252,16 +1269,24 @@ class Database:
                JOIN folders root ON root.id = wf.folder_id
                JOIN folders child
                  ON child.path = root.path
-                 OR child.path LIKE (
-                    REPLACE(REPLACE(REPLACE(root.path, '\\', '\\\\'), '%', '\\%'), '_', '\\_')
-                    || ? || '%'
+                 OR REPLACE(child.path, '\\', '/') LIKE (
+                    REPLACE(
+                      REPLACE(
+                        REPLACE(
+                          RTRIM(REPLACE(root.path, '\\', '/'), '/'),
+                          '\\', '\\\\'
+                        ),
+                        '%', '\\%'
+                      ),
+                      '_', '\\_'
+                    ) || '/%'
                  ) ESCAPE '\\'
                LEFT JOIN workspace_folders existing
                  ON existing.workspace_id = wf.workspace_id
                 AND existing.folder_id = child.id
                WHERE wf.workspace_id = ?
                  AND existing.folder_id IS NULL""",
-            (os.sep, workspace_id),
+            (workspace_id,),
         ).fetchall()
         if not rows:
             return
@@ -1300,13 +1325,22 @@ class Database:
                    JOIN folders ancestor ON ancestor.id = awf.folder_id
                    WHERE awf.workspace_id = wf.workspace_id
                      AND ancestor.id != f.id
-                     AND f.path LIKE (
-                       REPLACE(REPLACE(REPLACE(ancestor.path, '\\', '\\\\'), '%', '\\%'), '_', '\\_')
-                       || ? || '%'
+                     AND ancestor.photo_count = 0
+                     AND REPLACE(f.path, '\\', '/') LIKE (
+                       REPLACE(
+                         REPLACE(
+                           REPLACE(
+                             RTRIM(REPLACE(ancestor.path, '\\', '/'), '/'),
+                             '\\', '\\\\'
+                           ),
+                           '%', '\\%'
+                         ),
+                         '_', '\\_'
+                       ) || '/%'
                      ) ESCAPE '\\'
                  )
                ORDER BY f.path""",
-            (workspace_id, os.sep),
+            (workspace_id,),
         ).fetchall()
 
     def get_workspace_extensions(self):
@@ -1371,7 +1405,15 @@ class Database:
         if not folder_ids:
             return {"folders_moved": 0, "pending_changes_moved": 0}
 
-        placeholders = ",".join("?" for _ in folder_ids)
+        moved_folder_ids = []
+        seen_folder_ids = set()
+        for fid in folder_ids:
+            for subtree_id in self._folder_subtree_ids_by_path(fid):
+                if subtree_id in source_folder_ids and subtree_id not in seen_folder_ids:
+                    seen_folder_ids.add(subtree_id)
+                    moved_folder_ids.append(subtree_id)
+
+        placeholders = ",".join("?" for _ in moved_folder_ids)
 
         try:
             # Move pending_changes
@@ -1379,7 +1421,7 @@ class Database:
                 f"""UPDATE pending_changes SET workspace_id = ?
                     WHERE workspace_id = ?
                     AND photo_id IN (SELECT id FROM photos WHERE folder_id IN ({placeholders}))""",
-                [target_ws_id, source_ws_id] + list(folder_ids),
+                [target_ws_id, source_ws_id] + moved_folder_ids,
             )
             pending_changes_moved = cur.rowcount
 
@@ -1408,7 +1450,7 @@ class Database:
                       AND d.photo_id IN (
                           SELECT id FROM photos WHERE folder_id IN ({placeholders})
                       )""",
-                [target_ws_id, source_ws_id] + list(folder_ids),
+                [target_ws_id, source_ws_id] + moved_folder_ids,
             )
             self.conn.execute(
                 f"""DELETE FROM prediction_review
@@ -1423,15 +1465,15 @@ class Database:
                                 SELECT id FROM photos WHERE folder_id IN ({placeholders})
                             )
                       )""",
-                [source_ws_id, source_ws_id] + list(folder_ids),
+                [source_ws_id, source_ws_id] + moved_folder_ids,
             )
 
             # Move workspace_folders: remove from source, add to target
             self.conn.execute(
                 f"DELETE FROM workspace_folders WHERE workspace_id = ? AND folder_id IN ({placeholders})",
-                [source_ws_id] + list(folder_ids),
+                [source_ws_id] + moved_folder_ids,
             )
-            for fid in folder_ids:
+            for fid in moved_folder_ids:
                 self.conn.execute(
                     "INSERT OR IGNORE INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
                     (target_ws_id, fid),

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -31,6 +31,15 @@ def _nfc(name: str) -> str:
     """
     return unicodedata.normalize("NFC", name)
 
+
+def _escape_like(value: str) -> str:
+    """Escape a literal string for a SQLite LIKE pattern using backslash."""
+    return (
+        value.replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_")
+    )
+
 # Canonical set of keyword type values stored in keywords.type.
 # - taxonomy: a species/genus/etc. (linked to taxa via taxon_id)
 # - individual: a named person, pet, or otherwise tracked individual
@@ -1185,11 +1194,35 @@ class Database:
         # data until TTL expiry.
         self._new_images_cache.invalidate_workspaces(self._db_path, [workspace_id])
 
+    def _folder_subtree_ids_by_path(self, folder_id):
+        """Return folder_id plus known descendants, using paths as fallback.
+
+        Older databases can contain child folders whose ``parent_id`` is NULL
+        even though their paths clearly live below a parent. Path-prefix
+        matching keeps recursive workspace roots working for those rows too.
+        """
+        row = self.conn.execute(
+            "SELECT path FROM folders WHERE id = ?", (folder_id,)
+        ).fetchone()
+        if row is None or not row["path"]:
+            return [folder_id]
+        root_path = row["path"].rstrip(os.sep)
+        like = _escape_like(root_path) + os.sep + "%"
+        rows = self.conn.execute(
+            """SELECT id FROM folders
+               WHERE path = ? OR path LIKE ? ESCAPE '\\'""",
+            (root_path, like),
+        ).fetchall()
+        ids = {folder_id}
+        ids.update(r["id"] for r in rows)
+        return list(ids)
+
     def add_workspace_folder(self, workspace_id, folder_id):
-        """Link a folder to a workspace."""
-        self.conn.execute(
+        """Link a folder and its known descendants to a workspace."""
+        folder_ids = self._folder_subtree_ids_by_path(folder_id)
+        self.conn.executemany(
             "INSERT OR IGNORE INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
-            (workspace_id, folder_id),
+            [(workspace_id, fid) for fid in folder_ids],
         )
         self.conn.commit()
         # The folder's untracked files now count toward this workspace's
@@ -1198,24 +1231,82 @@ class Database:
         self._new_images_cache.invalidate_workspaces(self._db_path, [workspace_id])
 
     def remove_workspace_folder(self, workspace_id, folder_id):
-        """Unlink a folder from a workspace."""
+        """Unlink a folder and its descendants from a workspace."""
+        folder_ids = self._folder_subtree_ids_by_path(folder_id)
+        placeholders = ",".join("?" for _ in folder_ids)
         self.conn.execute(
-            "DELETE FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
-            (workspace_id, folder_id),
+            f"""DELETE FROM workspace_folders
+                WHERE workspace_id = ? AND folder_id IN ({placeholders})""",
+            [workspace_id] + folder_ids,
         )
         self.conn.commit()
         # The folder no longer contributes to this workspace's new-images
         # backlog. Drop the cached payload so the banner reflects the change.
         self._new_images_cache.invalidate_workspaces(self._db_path, [workspace_id])
 
+    def _materialize_workspace_descendants(self, workspace_id):
+        """Ensure linked folders include all known path descendants."""
+        rows = self.conn.execute(
+            """SELECT DISTINCT child.id
+               FROM workspace_folders wf
+               JOIN folders root ON root.id = wf.folder_id
+               JOIN folders child
+                 ON child.path = root.path
+                 OR child.path LIKE (
+                    REPLACE(REPLACE(REPLACE(root.path, '\\', '\\\\'), '%', '\\%'), '_', '\\_')
+                    || ? || '%'
+                 ) ESCAPE '\\'
+               LEFT JOIN workspace_folders existing
+                 ON existing.workspace_id = wf.workspace_id
+                AND existing.folder_id = child.id
+               WHERE wf.workspace_id = ?
+                 AND existing.folder_id IS NULL""",
+            (os.sep, workspace_id),
+        ).fetchall()
+        if not rows:
+            return
+        self.conn.executemany(
+            "INSERT OR IGNORE INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+            [(workspace_id, r["id"]) for r in rows],
+        )
+        self.conn.commit()
+
     def get_workspace_folders(self, workspace_id):
-        """Return all folders linked to a workspace."""
+        """Return all explicit folder links for a workspace.
+
+        Parent folders are recursive roots: if a linked folder has known
+        descendants in ``folders``, keep those descendants linked internally so
+        existing workspace-scoped photo queries continue to work.
+        """
+        self._materialize_workspace_descendants(workspace_id)
         return self.conn.execute(
             """SELECT f.* FROM folders f
                JOIN workspace_folders wf ON wf.folder_id = f.id
                WHERE wf.workspace_id = ?
                ORDER BY f.path""",
             (workspace_id,),
+        ).fetchall()
+
+    def get_workspace_folder_roots(self, workspace_id):
+        """Return user-facing workspace roots, hiding covered descendants."""
+        self._materialize_workspace_descendants(workspace_id)
+        return self.conn.execute(
+            """SELECT f.* FROM folders f
+               JOIN workspace_folders wf ON wf.folder_id = f.id
+               WHERE wf.workspace_id = ?
+                 AND NOT EXISTS (
+                   SELECT 1
+                   FROM workspace_folders awf
+                   JOIN folders ancestor ON ancestor.id = awf.folder_id
+                   WHERE awf.workspace_id = wf.workspace_id
+                     AND ancestor.id != f.id
+                     AND f.path LIKE (
+                       REPLACE(REPLACE(REPLACE(ancestor.path, '\\', '\\\\'), '%', '\\%'), '_', '\\_')
+                       || ? || '%'
+                     ) ESCAPE '\\'
+                 )
+               ORDER BY f.path""",
+            (workspace_id, os.sep),
         ).fetchall()
 
     def get_workspace_extensions(self):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -344,6 +344,7 @@ class Database:
             CREATE TABLE IF NOT EXISTS workspace_folders (
                 workspace_id    INTEGER REFERENCES workspaces(id) ON DELETE CASCADE,
                 folder_id       INTEGER REFERENCES folders(id),
+                is_root         INTEGER NOT NULL DEFAULT 1,
                 PRIMARY KEY (workspace_id, folder_id)
             );
 
@@ -697,6 +698,39 @@ class Database:
             self.conn.execute("SELECT pinned_at FROM workspaces LIMIT 0")
         except sqlite3.OperationalError:
             self.conn.execute("ALTER TABLE workspaces ADD COLUMN pinned_at TEXT")
+        # Migration: distinguish user-facing workspace roots from internal
+        # descendant links materialized for recursive roots.
+        try:
+            self.conn.execute("SELECT is_root FROM workspace_folders LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute(
+                "ALTER TABLE workspace_folders "
+                "ADD COLUMN is_root INTEGER NOT NULL DEFAULT 1"
+            )
+            self.conn.execute(
+                """UPDATE workspace_folders AS child_wf
+                   SET is_root = 0
+                   WHERE EXISTS (
+                     SELECT 1
+                     FROM workspace_folders AS root_wf
+                     JOIN folders root ON root.id = root_wf.folder_id
+                     JOIN folders child ON child.id = child_wf.folder_id
+                     WHERE root_wf.workspace_id = child_wf.workspace_id
+                       AND root_wf.folder_id != child_wf.folder_id
+                       AND REPLACE(child.path, '\\', '/') LIKE (
+                         REPLACE(
+                           REPLACE(
+                             REPLACE(
+                               RTRIM(REPLACE(root.path, '\\', '/'), '/'),
+                               '\\', '\\\\'
+                             ),
+                             '%', '\\%'
+                           ),
+                           '_', '\\_'
+                         ) || '/%'
+                       ) ESCAPE '\\'
+                   )"""
+            )
         # Migration: working-copy failure markers. Backfill (and the inline
         # scan extraction) record a failure here when extract_working_copy
         # returns False, gated by file_mtime so a user-replaced file retries
@@ -1227,8 +1261,16 @@ class Database:
         """Link a folder and its known descendants to a workspace."""
         folder_ids = self._folder_subtree_ids_by_path(folder_id)
         self.conn.executemany(
-            "INSERT OR IGNORE INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+            """INSERT OR IGNORE INTO workspace_folders
+               (workspace_id, folder_id, is_root) VALUES (?, ?, 0)""",
             [(workspace_id, fid) for fid in folder_ids],
+        )
+        placeholders = ",".join("?" for _ in folder_ids)
+        self.conn.execute(
+            f"""UPDATE workspace_folders
+                SET is_root = CASE WHEN folder_id = ? THEN 1 ELSE 0 END
+                WHERE workspace_id = ? AND folder_id IN ({placeholders})""",
+            [folder_id, workspace_id] + folder_ids,
         )
         self.conn.commit()
         # The folder's untracked files now count toward this workspace's
@@ -1291,8 +1333,22 @@ class Database:
         if not rows:
             return
         self.conn.executemany(
-            "INSERT OR IGNORE INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+            """INSERT OR IGNORE INTO workspace_folders
+               (workspace_id, folder_id, is_root) VALUES (?, ?, 0)""",
             [(workspace_id, r["id"]) for r in rows],
+        )
+        self.conn.commit()
+
+    def mark_workspace_folder_roots(self, workspace_id, folder_ids):
+        """Mark specific linked folders as user-facing roots."""
+        if not folder_ids:
+            return
+        placeholders = ",".join("?" for _ in folder_ids)
+        self.conn.execute(
+            f"""UPDATE workspace_folders
+                SET is_root = 1
+                WHERE workspace_id = ? AND folder_id IN ({placeholders})""",
+            [workspace_id] + list(folder_ids),
         )
         self.conn.commit()
 
@@ -1318,27 +1374,7 @@ class Database:
         return self.conn.execute(
             """SELECT f.* FROM folders f
                JOIN workspace_folders wf ON wf.folder_id = f.id
-               WHERE wf.workspace_id = ?
-                 AND NOT EXISTS (
-                   SELECT 1
-                   FROM workspace_folders awf
-                   JOIN folders ancestor ON ancestor.id = awf.folder_id
-                   WHERE awf.workspace_id = wf.workspace_id
-                     AND ancestor.id != f.id
-                     AND ancestor.photo_count = 0
-                     AND REPLACE(f.path, '\\', '/') LIKE (
-                       REPLACE(
-                         REPLACE(
-                           REPLACE(
-                             RTRIM(REPLACE(ancestor.path, '\\', '/'), '/'),
-                             '\\', '\\\\'
-                           ),
-                           '%', '\\%'
-                         ),
-                         '_', '\\_'
-                       ) || '/%'
-                     ) ESCAPE '\\'
-                 )
+               WHERE wf.workspace_id = ? AND wf.is_root = 1
                ORDER BY f.path""",
             (workspace_id,),
         ).fetchall()
@@ -1473,11 +1509,19 @@ class Database:
                 f"DELETE FROM workspace_folders WHERE workspace_id = ? AND folder_id IN ({placeholders})",
                 [source_ws_id] + moved_folder_ids,
             )
-            for fid in moved_folder_ids:
-                self.conn.execute(
-                    "INSERT OR IGNORE INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
-                    (target_ws_id, fid),
-                )
+            self.conn.executemany(
+                """INSERT OR IGNORE INTO workspace_folders
+                   (workspace_id, folder_id, is_root) VALUES (?, ?, 0)""",
+                [(target_ws_id, fid) for fid in moved_folder_ids],
+            )
+            selected_placeholders = ",".join("?" for _ in folder_ids)
+            self.conn.execute(
+                f"""UPDATE workspace_folders
+                    SET is_root = 1
+                    WHERE workspace_id = ?
+                      AND folder_id IN ({selected_placeholders})""",
+                [target_ws_id] + list(folder_ids),
+            )
 
             self.conn.commit()
         except Exception:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -15,6 +15,8 @@ log = logging.getLogger(__name__)
 
 _UNSET = object()  # sentinel for "not provided" vs explicit None
 
+_SQLITE_PARAM_CHUNK_SIZE = 800
+
 
 def _nfc(name: str) -> str:
     """NFC-normalize a filename for byte-exact comparison against scandir output.
@@ -35,6 +37,13 @@ def _nfc(name: str) -> str:
 def _path_for_subtree_match(value: str) -> str:
     """Normalize a stored path for platform-neutral subtree prefix matching."""
     return value.replace("\\", "/").rstrip("/")
+
+
+def _chunks(values, size=_SQLITE_PARAM_CHUNK_SIZE):
+    values = list(values)
+    for idx in range(0, len(values), size):
+        yield values[idx:idx + size]
+
 
 # Canonical set of keyword type values stored in keywords.type.
 # - taxonomy: a species/genus/etc. (linked to taxa via taxon_id)
@@ -1250,13 +1259,14 @@ class Database:
             [(workspace_id, fid) for fid in folder_ids],
         )
         if is_root:
-            placeholders = ",".join("?" for _ in folder_ids)
-            self.conn.execute(
-                f"""UPDATE workspace_folders
-                    SET is_root = CASE WHEN folder_id = ? THEN 1 ELSE 0 END
-                    WHERE workspace_id = ? AND folder_id IN ({placeholders})""",
-                [folder_id, workspace_id] + folder_ids,
-            )
+            for chunk in _chunks(folder_ids):
+                placeholders = ",".join("?" for _ in chunk)
+                self.conn.execute(
+                    f"""UPDATE workspace_folders
+                        SET is_root = CASE WHEN folder_id = ? THEN 1 ELSE 0 END
+                        WHERE workspace_id = ? AND folder_id IN ({placeholders})""",
+                    [folder_id, workspace_id] + chunk,
+                )
         self.conn.commit()
         # The folder's untracked files now count toward this workspace's
         # new-images backlog. Drop any stale cached payload so the next read
@@ -1277,12 +1287,13 @@ class Database:
     def remove_workspace_folder_tree(self, workspace_id, folder_id):
         """Unlink a folder and its path descendants from a workspace."""
         folder_ids = self._folder_subtree_ids_by_path(folder_id)
-        placeholders = ",".join("?" for _ in folder_ids)
-        self.conn.execute(
-            f"""DELETE FROM workspace_folders
-                WHERE workspace_id = ? AND folder_id IN ({placeholders})""",
-            [workspace_id] + folder_ids,
-        )
+        for chunk in _chunks(folder_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            self.conn.execute(
+                f"""DELETE FROM workspace_folders
+                    WHERE workspace_id = ? AND folder_id IN ({placeholders})""",
+                [workspace_id] + chunk,
+            )
         self.conn.commit()
         # The folder no longer contributes to this workspace's new-images
         # backlog. Drop the cached payload so the banner reflects the change.
@@ -1321,13 +1332,14 @@ class Database:
         """Mark specific linked folders as user-facing roots."""
         if not folder_ids:
             return
-        placeholders = ",".join("?" for _ in folder_ids)
-        self.conn.execute(
-            f"""UPDATE workspace_folders
-                SET is_root = 1
-                WHERE workspace_id = ? AND folder_id IN ({placeholders})""",
-            [workspace_id] + list(folder_ids),
-        )
+        for chunk in _chunks(folder_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            self.conn.execute(
+                f"""UPDATE workspace_folders
+                    SET is_root = 1
+                    WHERE workspace_id = ? AND folder_id IN ({placeholders})""",
+                [workspace_id] + chunk,
+            )
         self.conn.commit()
 
     def get_workspace_folders(self, workspace_id):
@@ -1427,17 +1439,18 @@ class Database:
                     seen_folder_ids.add(subtree_id)
                     moved_folder_ids.append(subtree_id)
 
-        placeholders = ",".join("?" for _ in moved_folder_ids)
-
         try:
             # Move pending_changes
-            cur = self.conn.execute(
-                f"""UPDATE pending_changes SET workspace_id = ?
-                    WHERE workspace_id = ?
-                    AND photo_id IN (SELECT id FROM photos WHERE folder_id IN ({placeholders}))""",
-                [target_ws_id, source_ws_id] + moved_folder_ids,
-            )
-            pending_changes_moved = cur.rowcount
+            pending_changes_moved = 0
+            for chunk in _chunks(moved_folder_ids):
+                placeholders = ",".join("?" for _ in chunk)
+                cur = self.conn.execute(
+                    f"""UPDATE pending_changes SET workspace_id = ?
+                        WHERE workspace_id = ?
+                        AND photo_id IN (SELECT id FROM photos WHERE folder_id IN ({placeholders}))""",
+                    [target_ws_id, source_ws_id] + chunk,
+                )
+                pending_changes_moved += cur.rowcount
 
             # Move prediction_review rows for predictions whose photo is in
             # the moved folders. Without this the accepted/rejected/group
@@ -1449,57 +1462,63 @@ class Database:
             # source. That way if the target already has a review row for
             # the same (prediction_id), we keep the target's value rather
             # than overwriting it.
-            self.conn.execute(
-                f"""INSERT OR IGNORE INTO prediction_review
-                      (prediction_id, workspace_id, status, reviewed_at,
-                       individual, group_id, vote_count, total_votes)
-                    SELECT pr_rev.prediction_id, ?, pr_rev.status,
-                           pr_rev.reviewed_at, pr_rev.individual,
-                           pr_rev.group_id, pr_rev.vote_count,
-                           pr_rev.total_votes
-                    FROM prediction_review pr_rev
-                    JOIN predictions p ON p.id = pr_rev.prediction_id
-                    JOIN detections d ON d.id = p.detection_id
-                    WHERE pr_rev.workspace_id = ?
-                      AND d.photo_id IN (
-                          SELECT id FROM photos WHERE folder_id IN ({placeholders})
-                      )""",
-                [target_ws_id, source_ws_id] + moved_folder_ids,
-            )
-            self.conn.execute(
-                f"""DELETE FROM prediction_review
-                    WHERE workspace_id = ?
-                      AND prediction_id IN (
-                          SELECT pr_rev.prediction_id
-                          FROM prediction_review pr_rev
-                          JOIN predictions p ON p.id = pr_rev.prediction_id
-                          JOIN detections d ON d.id = p.detection_id
-                          WHERE pr_rev.workspace_id = ?
-                            AND d.photo_id IN (
-                                SELECT id FROM photos WHERE folder_id IN ({placeholders})
-                            )
-                      )""",
-                [source_ws_id, source_ws_id] + moved_folder_ids,
-            )
+            for chunk in _chunks(moved_folder_ids):
+                placeholders = ",".join("?" for _ in chunk)
+                self.conn.execute(
+                    f"""INSERT OR IGNORE INTO prediction_review
+                          (prediction_id, workspace_id, status, reviewed_at,
+                           individual, group_id, vote_count, total_votes)
+                        SELECT pr_rev.prediction_id, ?, pr_rev.status,
+                               pr_rev.reviewed_at, pr_rev.individual,
+                               pr_rev.group_id, pr_rev.vote_count,
+                               pr_rev.total_votes
+                        FROM prediction_review pr_rev
+                        JOIN predictions p ON p.id = pr_rev.prediction_id
+                        JOIN detections d ON d.id = p.detection_id
+                        WHERE pr_rev.workspace_id = ?
+                          AND d.photo_id IN (
+                              SELECT id FROM photos WHERE folder_id IN ({placeholders})
+                          )""",
+                    [target_ws_id, source_ws_id] + chunk,
+                )
+                self.conn.execute(
+                    f"""DELETE FROM prediction_review
+                        WHERE workspace_id = ?
+                          AND prediction_id IN (
+                              SELECT pr_rev.prediction_id
+                              FROM prediction_review pr_rev
+                              JOIN predictions p ON p.id = pr_rev.prediction_id
+                              JOIN detections d ON d.id = p.detection_id
+                              WHERE pr_rev.workspace_id = ?
+                                AND d.photo_id IN (
+                                    SELECT id FROM photos WHERE folder_id IN ({placeholders})
+                                )
+                          )""",
+                    [source_ws_id, source_ws_id] + chunk,
+                )
 
             # Move workspace_folders: remove from source, add to target
-            self.conn.execute(
-                f"DELETE FROM workspace_folders WHERE workspace_id = ? AND folder_id IN ({placeholders})",
-                [source_ws_id] + moved_folder_ids,
-            )
+            for chunk in _chunks(moved_folder_ids):
+                placeholders = ",".join("?" for _ in chunk)
+                self.conn.execute(
+                    f"""DELETE FROM workspace_folders
+                        WHERE workspace_id = ? AND folder_id IN ({placeholders})""",
+                    [source_ws_id] + chunk,
+                )
             self.conn.executemany(
                 """INSERT OR IGNORE INTO workspace_folders
                    (workspace_id, folder_id, is_root) VALUES (?, ?, 0)""",
                 [(target_ws_id, fid) for fid in moved_folder_ids],
             )
-            selected_placeholders = ",".join("?" for _ in folder_ids)
-            self.conn.execute(
-                f"""UPDATE workspace_folders
-                    SET is_root = 1
-                    WHERE workspace_id = ?
-                      AND folder_id IN ({selected_placeholders})""",
-                [target_ws_id] + list(folder_ids),
-            )
+            for chunk in _chunks(folder_ids):
+                selected_placeholders = ",".join("?" for _ in chunk)
+                self.conn.execute(
+                    f"""UPDATE workspace_folders
+                        SET is_root = 1
+                        WHERE workspace_id = ?
+                          AND folder_id IN ({selected_placeholders})""",
+                    [target_ws_id] + chunk,
+                )
 
             self.conn.commit()
         except Exception:

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -977,6 +977,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             path=folder_str,
             name=folder_path.name,
             parent_id=parent_id,
+            workspace_root=False,
         )
         folder_cache[folder_str] = folder_id
         return folder_id

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -977,7 +977,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             path=folder_str,
             name=folder_path.name,
             parent_id=parent_id,
-            workspace_root=False,
+            workspace_root=(folder_path == root_path),
         )
         folder_cache[folder_str] = folder_id
         return folder_id

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -5386,6 +5386,42 @@ def test_relocate_folder_merge_preserves_workspace_links(tmp_path):
     assert ws2 in ws_ids, "target folder should retain its original workspace"
 
 
+def test_relocate_folder_merge_preserves_non_root_workspace_link(tmp_path):
+    """_merge_into_existing must not promote materialized descendants to roots."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws1 = db.ensure_default_workspace()
+    db.set_active_workspace(ws1)
+
+    existing_path = str(tmp_path / "existing")
+    os.makedirs(existing_path)
+
+    fid_missing = db.add_folder("/old/path", name="missing")
+    fid_existing = db.conn.execute(
+        "INSERT INTO folders (path, name) VALUES (?, ?)", (existing_path, "existing")
+    ).lastrowid
+    db.conn.execute(
+        """UPDATE workspace_folders
+           SET is_root = 0
+           WHERE workspace_id = ? AND folder_id = ?""",
+        (ws1, fid_missing),
+    )
+    db.conn.commit()
+
+    db.conn.execute("UPDATE folders SET status = 'missing' WHERE id = ?", (fid_missing,))
+    db.conn.commit()
+
+    db.relocate_folder(fid_missing, existing_path)
+
+    row = db.conn.execute(
+        """SELECT is_root FROM workspace_folders
+           WHERE workspace_id = ? AND folder_id = ?""",
+        (ws1, fid_existing),
+    ).fetchone()
+    assert row is not None
+    assert row["is_root"] == 0
+
+
 def test_relocate_folder_cascade_skips_duplicate(tmp_path):
     """relocate_folder skips cascading a child if its target path is already tracked."""
     from db import Database

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -2253,6 +2253,31 @@ def test_scan_links_restrict_dirs_when_all_files_skipped(tmp_path):
     )
 
 
+def test_scan_does_not_promote_discovered_descendants_to_workspace_roots(tmp_path):
+    """Scanner-created child links should stay hidden behind the chosen root."""
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "USA2026")
+    _create_test_images(root, {
+        "day1": ["bird.jpg"],
+    })
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db._active_workspace_id
+    db.set_active_workspace(None)
+    root_id = db.add_folder(root, name="USA2026")
+    db.add_workspace_folder(ws_id, root_id)
+    db.set_active_workspace(ws_id)
+
+    scan(root, db)
+
+    linked_paths = {f["path"] for f in db.get_workspace_folders(ws_id)}
+    root_paths = [f["path"] for f in db.get_workspace_folder_roots(ws_id)]
+    assert os.path.join(root, "day1") in linked_paths
+    assert root_paths == [root]
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions required")
 def test_scan_surfaces_permission_denied_subdirs(tmp_path):
     """A subdir the kernel won't let us enter must surface as a denied path,

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -2278,6 +2278,27 @@ def test_scan_does_not_promote_discovered_descendants_to_workspace_roots(tmp_pat
     assert root_paths == [root]
 
 
+def test_scan_promotes_top_level_target_to_workspace_root(tmp_path):
+    """A normal scan should make its selected root visible in workspace APIs."""
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {
+        "day1": ["bird.jpg"],
+    })
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db._active_workspace_id
+
+    scan(root, db)
+
+    linked_paths = {f["path"] for f in db.get_workspace_folders(ws_id)}
+    root_paths = [f["path"] for f in db.get_workspace_folder_roots(ws_id)]
+    assert os.path.join(root, "day1") in linked_paths
+    assert root_paths == [root]
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions required")
 def test_scan_surfaces_permission_denied_subdirs(tmp_path):
     """A subdir the kernel won't let us enter must surface as a denied path,

--- a/vireo/tests/test_workspaces_api.py
+++ b/vireo/tests/test_workspaces_api.py
@@ -73,13 +73,13 @@ def test_create_workspace_with_folders(app_and_db):
     assert resp.status_code == 200
     ws_id = resp.get_json()["id"]
 
-    # Verify folders are linked internally while the API exposes roots.
+    # Verify explicitly selected folders are linked and remain visible roots.
     folder_resp = client.get(f"/api/workspaces/{ws_id}/folders")
     assert folder_resp.status_code == 200
     linked = folder_resp.get_json()
-    assert len(db.get_workspace_folders(ws_id)) == len(folder_ids)
-    assert len(linked) == 1
-    assert linked[0]["id"] == folder_ids[0]
+    assert len(linked) == len(folder_ids)
+    linked_ids = {f["id"] for f in linked}
+    assert linked_ids == set(folder_ids)
 
 
 def test_update_workspace(app_and_db):

--- a/vireo/tests/test_workspaces_api.py
+++ b/vireo/tests/test_workspaces_api.py
@@ -73,13 +73,13 @@ def test_create_workspace_with_folders(app_and_db):
     assert resp.status_code == 200
     ws_id = resp.get_json()["id"]
 
-    # Verify folders are linked
+    # Verify folders are linked internally while the API exposes roots.
     folder_resp = client.get(f"/api/workspaces/{ws_id}/folders")
     assert folder_resp.status_code == 200
     linked = folder_resp.get_json()
-    assert len(linked) == len(folder_ids)
-    linked_ids = {f["id"] for f in linked}
-    assert linked_ids == set(folder_ids)
+    assert len(db.get_workspace_folders(ws_id)) == len(folder_ids)
+    assert len(linked) == 1
+    assert linked[0]["id"] == folder_ids[0]
 
 
 def test_update_workspace(app_and_db):


### PR DESCRIPTION
## Summary

This makes workspace folders behave like recursive roots while preserving the existing explicit folder-link model internally.

- Linking a workspace folder now also links known descendant folders so existing workspace-scoped photo queries keep working.
- Removing a workspace folder removes that folder and its descendants from the workspace.
- Workspace-facing APIs now return root folders only, so a library like `USA/2026` can appear as one folder instead of a long list of dated subfolders.
- Added regression coverage for recursive roots, historical descendant folders with missing `parent_id`, and root removal.

## Why

The `USA2026` workspace currently needs many dated subfolders linked directly because photos live in those child folders. This PR lets the user manage the parent folder as the visible workspace root without losing descendant photos from Vireo views.

New files still need to be discovered by a scan, but once descendant folders are known, the workspace can show the parent root instead of every child.

## Validation

- `python -m pytest tests/test_workspaces.py vireo/tests/test_scanner.py::test_scan_links_root_when_all_files_skipped vireo/tests/test_scanner.py::test_scan_links_restrict_dirs_when_all_files_skipped -q`
- `python -m pytest vireo/tests/test_db.py -k "folder_tree or workspace_extensions or get_photos_scoped or count_photos" -q`