### PR TITLE
[codex] Add DNG fallback for Nikon darktable export

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4844,14 +4844,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/darktable/status")
     def api_darktable_status():
         import config as cfg
-        from develop import find_darktable
+        from develop import find_darktable, find_dng_converter
 
         configured = cfg.get("darktable_bin")
         binary = find_darktable(configured)
+        dng_configured = cfg.get("dng_converter_bin")
+        dng_binary = find_dng_converter(dng_configured)
         return jsonify({
             "available": binary is not None,
             "bin": binary or "",
             "configured_bin": configured,
+            "dng_available": dng_binary is not None,
+            "dng_bin": dng_binary or "",
+            "configured_dng_bin": dng_configured,
+            "auto_convert_dng": cfg.get("darktable_auto_convert_dng"),
             "style": cfg.get("darktable_style"),
             "output_format": cfg.get("darktable_output_format"),
             "output_dir": cfg.get("darktable_output_dir"),
@@ -9706,6 +9712,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         style = body.get("style") or cfg.get("darktable_style") or ""
         output_format = body.get("output_format") or cfg.get("darktable_output_format") or "jpg"
         output_dir = body.get("output_dir") or cfg.get("darktable_output_dir") or ""
+        auto_convert_dng = body.get("auto_convert_dng")
+        if auto_convert_dng is None:
+            auto_convert_dng = cfg.get("darktable_auto_convert_dng")
+        dng_converter_bin = body.get("dng_converter_bin") or cfg.get("dng_converter_bin") or ""
         width = body.get("width")
 
         runner = app._job_runner
@@ -9750,12 +9760,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     out_dir = os.path.join(folder_path, "developed")
                 out_path = output_path_for_photo(photo["filename"], out_dir, output_format)
 
+                try:
+                    photo_metadata = json.loads(photo["exif_data"]) if photo["exif_data"] else None
+                except (TypeError, json.JSONDecodeError):
+                    photo_metadata = None
+
                 result = develop_photo(
                     darktable_bin=binary,
                     input_path=input_path,
                     output_path=out_path,
                     style=style if style else None,
                     width=width,
+                    auto_convert_dng=bool(auto_convert_dng),
+                    dng_converter_bin=dng_converter_bin,
+                    metadata=photo_metadata,
                 )
 
                 if result["success"]:

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -39,6 +39,8 @@ DEFAULTS = {
     "darktable_style": "",
     "darktable_output_format": "jpg",
     "darktable_output_dir": "",
+    "darktable_auto_convert_dng": False,
+    "dng_converter_bin": "",
     # When true, the Tauri desktop wrapper opens this UI in the user's
     # default web browser on launch instead of creating its WKWebView
     # window. The Flask sidecar and tray icon still run as usual.

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -270,6 +270,18 @@ SCHEMA = {
         "label": "Darktable output directory",
         "desc": 'Where developed photos are saved. Empty = create a "developed" subfolder next to originals.',
     },
+    "darktable_auto_convert_dng": {
+        "type": "bool",
+        "category": "Paths", "scope": "global",
+        "label": "Auto-convert unsupported Nikon NEFs to DNG",
+        "desc": "Before darktable development, convert Nikon High Efficiency NEF files to DNG when needed.",
+    },
+    "dng_converter_bin": {
+        "type": "path",
+        "category": "Paths", "scope": "global",
+        "label": "Adobe DNG Converter path",
+        "desc": "Optional path to Adobe DNG Converter. Leave empty to auto-detect the app.",
+    },
 
     # --- Integrations -----------------------------------------------------
     "inat_token": {

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -1,13 +1,16 @@
 """Wrapper for darktable-cli to develop RAW photos."""
 
+import contextlib
 import logging
 import os
 import shutil
 import subprocess
+import tempfile
 
 log = logging.getLogger(__name__)
 
 _DIAG_MAX_CHARS = 500
+_NIKON_HE_COMPRESSION_VALUES = {13, 14}
 
 
 def _format_subprocess_diag(stdout, stderr):
@@ -55,6 +58,34 @@ def find_darktable(configured_path):
     return None
 
 
+def find_dng_converter(configured_path):
+    """Find Adobe DNG Converter or another compatible DNG converter binary."""
+    if configured_path and os.path.isfile(configured_path):
+        return os.path.realpath(configured_path)
+
+    candidates = [
+        shutil.which("Adobe DNG Converter"),
+        shutil.which("Adobe DNG Converter.exe"),
+        "/Applications/Adobe DNG Converter.app/Contents/MacOS/Adobe DNG Converter",
+    ]
+
+    program_files = os.environ.get("PROGRAMFILES")
+    if program_files:
+        candidates.append(
+            os.path.join(
+                program_files,
+                "Adobe",
+                "Adobe DNG Converter",
+                "Adobe DNG Converter.exe",
+            )
+        )
+
+    for candidate in candidates:
+        if candidate and os.path.isfile(candidate):
+            return os.path.realpath(candidate)
+    return None
+
+
 def build_command(darktable_bin, input_path, output_path, style=None, width=None):
     """Build the darktable-cli command list.
 
@@ -91,7 +122,116 @@ def output_path_for_photo(filename, output_dir, output_format):
     return os.path.join(output_dir, f"{stem}.{output_format}")
 
 
-def develop_photo(darktable_bin, input_path, output_path, style=None, width=None):
+def _nested_get(metadata, group, tag):
+    if not isinstance(metadata, dict):
+        return None
+    group_data = metadata.get(group)
+    if isinstance(group_data, dict) and tag in group_data:
+        return group_data.get(tag)
+    return None
+
+
+def _parse_nef_compression(value):
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    text = str(value).strip().lower()
+    if text.isdigit():
+        return int(text)
+    if "high efficiency" in text:
+        return 14 if "*" in text or "star" in text else 13
+    return None
+
+
+def _metadata_nef_compression(metadata):
+    for group in ("Nikon", "MakerNotes", "EXIF", "File"):
+        value = _nested_get(metadata, group, "NEFCompression")
+        parsed = _parse_nef_compression(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _read_nef_compression_with_exiftool(input_path):
+    try:
+        from metadata import extract_metadata
+    except Exception:
+        return None
+
+    extracted = extract_metadata([input_path], restricted_tags=["-NEFCompression"])
+    return _metadata_nef_compression(extracted.get(input_path))
+
+
+def is_nikon_high_efficiency_nef(input_path, metadata=None):
+    """Return True when a NEF uses Nikon's darktable-unsupported HE/HE* mode."""
+    if os.path.splitext(input_path)[1].lower() != ".nef":
+        return False
+
+    compression = _metadata_nef_compression(metadata)
+    if compression is None:
+        compression = _read_nef_compression_with_exiftool(input_path)
+    return compression in _NIKON_HE_COMPRESSION_VALUES
+
+
+def convert_to_dng(dng_converter_bin, input_path, output_dir):
+    """Convert a RAW file to DNG, returning a result dict like develop_photo."""
+    binary = find_dng_converter(dng_converter_bin)
+    if not binary:
+        return {
+            "success": False,
+            "output_path": "",
+            "error": "Adobe DNG Converter not found or not configured",
+        }
+
+    os.makedirs(output_dir, exist_ok=True)
+    stem = os.path.splitext(os.path.basename(input_path))[0]
+    output_path = os.path.join(output_dir, f"{stem}.dng")
+    if os.path.exists(output_path):
+        with contextlib.suppress(OSError):
+            os.unlink(output_path)
+
+    cmd = [binary, "-dng1.4", "-d", output_dir, input_path]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+        if result.returncode != 0:
+            diag = _format_subprocess_diag(result.stdout, result.stderr)
+            return {
+                "success": False,
+                "output_path": output_path,
+                "error": f"DNG converter exited with code {result.returncode}: {diag}",
+            }
+        if not os.path.isfile(output_path):
+            alt_output_path = os.path.join(output_dir, f"{stem}.DNG")
+            if os.path.isfile(alt_output_path):
+                output_path = alt_output_path
+        if not os.path.isfile(output_path):
+            diag = _format_subprocess_diag(result.stdout, result.stderr)
+            suffix = f": {diag}" if diag else ""
+            return {
+                "success": False,
+                "output_path": output_path,
+                "error": f"DNG converter did not create {os.path.basename(output_path)}{suffix}",
+            }
+        return {"success": True, "output_path": output_path, "error": None}
+    except subprocess.TimeoutExpired:
+        return {"success": False, "output_path": output_path, "error": "DNG converter timed out after 180 seconds"}
+    except FileNotFoundError:
+        return {"success": False, "output_path": output_path, "error": f"DNG converter binary not found at {binary}"}
+
+
+def develop_photo(
+    darktable_bin,
+    input_path,
+    output_path,
+    style=None,
+    width=None,
+    auto_convert_dng=False,
+    dng_converter_bin="",
+    metadata=None,
+):
     """Develop a single photo using darktable-cli.
 
     Args:
@@ -112,7 +252,25 @@ def develop_photo(darktable_bin, input_path, output_path, style=None, width=None
         return {"success": False, "output_path": output_path, "error": f"Input file not found: {input_path}"}
 
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    cmd = build_command(binary, input_path, output_path, style=style, width=width)
+    darktable_input = input_path
+    tmp_dir = None
+
+    if auto_convert_dng and is_nikon_high_efficiency_nef(input_path, metadata=metadata):
+        tmp_dir = tempfile.TemporaryDirectory(prefix="vireo-dng-")
+        conversion = convert_to_dng(dng_converter_bin, input_path, tmp_dir.name)
+        if not conversion["success"]:
+            tmp_dir.cleanup()
+            return {
+                "success": False,
+                "output_path": output_path,
+                "error": (
+                    "Nikon High Efficiency NEF detected, but DNG conversion failed: "
+                    f"{conversion['error']}"
+                ),
+            }
+        darktable_input = conversion["output_path"]
+
+    cmd = build_command(binary, darktable_input, output_path, style=style, width=width)
 
     try:
         log.info("Developing %s -> %s", os.path.basename(input_path), output_path)
@@ -132,3 +290,6 @@ def develop_photo(darktable_bin, input_path, output_path, style=None, width=None
         return {"success": False, "output_path": output_path, "error": "darktable-cli timed out after 120 seconds"}
     except FileNotFoundError:
         return {"success": False, "output_path": output_path, "error": f"darktable-cli binary not found at {binary}"}
+    finally:
+        if tmp_dir is not None:
+            tmp_dir.cleanup()

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -69,8 +69,17 @@ def find_dng_converter(configured_path):
         "/Applications/Adobe DNG Converter.app/Contents/MacOS/Adobe DNG Converter",
     ]
 
-    program_files = os.environ.get("PROGRAMFILES")
-    if program_files:
+    # Adobe DNG Converter on Windows has shipped under a few layouts: the
+    # current installer drops the binary directly in
+    # "Program Files\Adobe DNG Converter", while older 32-bit builds nest it
+    # one level deeper under "Program Files (x86)\Adobe\Adobe DNG Converter".
+    for env_var in ("PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMW6432"):
+        program_files = os.environ.get(env_var)
+        if not program_files:
+            continue
+        candidates.append(
+            os.path.join(program_files, "Adobe DNG Converter", "Adobe DNG Converter.exe")
+        )
         candidates.append(
             os.path.join(
                 program_files,

--- a/vireo/static/help.json
+++ b/vireo/static/help.json
@@ -110,8 +110,8 @@
   {
     "question": "How do I use Vireo with Darktable?",
     "category": "Settings",
-    "keywords": ["darktable", "editor", "external", "develop", "raw", "processing"],
-    "answer": "Configure the Darktable binary path in Settings. You can then send photos to Darktable for editing, apply styles, and export processed versions."
+    "keywords": ["darktable", "editor", "external", "develop", "raw", "processing", "dng", "nikon"],
+    "answer": "Configure the Darktable binary path in Settings. You can then send photos to Darktable for editing, apply styles, and export processed versions. If you shoot Nikon High Efficiency NEFs, enable auto-convert to DNG and configure Adobe DNG Converter if Vireo cannot auto-detect it."
   },
   {
     "question": "Is Vireo free?",

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -897,6 +897,27 @@
         <button onclick="browseForOutputDir()" class="btn btn-secondary tauri-only" style="display:none;white-space:nowrap;">Browse&hellip;</button>
       </div>
     </div>
+    <div class="setting-row">
+      <div class="setting-label">
+        Auto convert to DNG if necessary
+        <small>For Nikon High Efficiency NEFs that darktable cannot decode, convert through Adobe DNG Converter first.</small>
+      </div>
+      <input type="checkbox" id="cfgDarktableAutoConvertDng"
+             onchange="saveConfig(); loadDarktableStatus();"
+             style="accent-color:var(--accent);">
+    </div>
+    <div class="setting-row">
+      <div class="setting-label">
+        Adobe DNG Converter path
+        <small>Leave empty to auto-detect the macOS app bundle or PATH. Required only when DNG conversion is enabled.</small>
+      </div>
+      <div style="display:flex;align-items:center;gap:6px;">
+        <input type="text" id="cfgDngConverterBin" placeholder="auto-detect"
+               style="width:280px;background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:12px;font-family:monospace;"
+               onchange="saveConfig(); loadDarktableStatus();">
+        <button onclick="browseForDngConverter()" class="btn btn-secondary tauri-only" style="display:none;white-space:nowrap;">Browse&hellip;</button>
+      </div>
+    </div>
   </div>
 
   <!-- System Info -->
@@ -1303,6 +1324,8 @@ async function loadConfig() {
     document.getElementById('cfgDarktableStyle').value = cfg.darktable_style || '';
     document.getElementById('cfgDarktableFormat').value = cfg.darktable_output_format || 'jpg';
     document.getElementById('cfgDarktableOutputDir').value = cfg.darktable_output_dir || '';
+    document.getElementById('cfgDarktableAutoConvertDng').checked = cfg.darktable_auto_convert_dng === true;
+    document.getElementById('cfgDngConverterBin').value = cfg.dng_converter_bin || '';
     loadDarktableStatus();
     // Load display settings
     document.getElementById('cfgPhotosPerPage').value = cfg.photos_per_page != null ? cfg.photos_per_page : 50;
@@ -1500,6 +1523,8 @@ function saveConfig() {
           darktable_style: document.getElementById('cfgDarktableStyle').value.trim(),
           darktable_output_format: document.getElementById('cfgDarktableFormat').value,
           darktable_output_dir: document.getElementById('cfgDarktableOutputDir').value.trim(),
+          darktable_auto_convert_dng: document.getElementById('cfgDarktableAutoConvertDng').checked,
+          dng_converter_bin: document.getElementById('cfgDngConverterBin').value.trim(),
           photos_per_page: parseInt(document.getElementById('cfgPhotosPerPage').value, 10) || 50,
           thumbnail_size: parseInt(document.getElementById('cfgThumbSize').value, 10) || 400,
           thumbnail_quality: parseInt(document.getElementById('cfgThumbQuality').value, 10) || 85,
@@ -1671,6 +1696,15 @@ async function loadDarktableStatus() {
     } else {
       el.innerHTML = '<span style="color:var(--danger);font-size:13px;">&#10007; darktable-cli not found</span>' +
         '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">Install darktable or set the path below</span>';
+    }
+    if (data.auto_convert_dng) {
+      if (data.dng_available) {
+        el.innerHTML += '<div style="color:var(--accent);font-size:13px;margin-top:4px;">&#10003; Adobe DNG Converter found' +
+          '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">' + escapeHtml(data.dng_bin) + '</span></div>';
+      } else {
+        el.innerHTML += '<div style="color:var(--danger);font-size:13px;margin-top:4px;">&#10007; Adobe DNG Converter not found' +
+          '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">Install it or set the path below</span></div>';
+      }
     }
   } catch(e) {}
 }
@@ -2620,6 +2654,15 @@ async function browseForDarktable() {
   if (path) {
     document.getElementById('cfgDarktableBin').value = path;
     saveConfig();
+  }
+}
+
+async function browseForDngConverter() {
+  var path = await pickFile({ title: 'Select Adobe DNG Converter binary' });
+  if (path) {
+    document.getElementById('cfgDngConverterBin').value = path;
+    saveConfig();
+    loadDarktableStatus();
   }
 }
 

--- a/vireo/tests/test_darktable_api.py
+++ b/vireo/tests/test_darktable_api.py
@@ -35,6 +35,8 @@ def test_api_config_saves_darktable_settings(app_and_db):
                            "darktable_style": "Wildlife",
                            "darktable_output_format": "tiff",
                            "darktable_output_dir": "/output",
+                           "darktable_auto_convert_dng": True,
+                           "dng_converter_bin": "/Applications/Adobe DNG Converter.app/Contents/MacOS/Adobe DNG Converter",
                        }),
                        content_type='application/json')
     assert resp.status_code == 200
@@ -45,6 +47,8 @@ def test_api_config_saves_darktable_settings(app_and_db):
     assert cfg["darktable_style"] == "Wildlife"
     assert cfg["darktable_output_format"] == "tiff"
     assert cfg["darktable_output_dir"] == "/output"
+    assert cfg["darktable_auto_convert_dng"] is True
+    assert cfg["dng_converter_bin"] == "/Applications/Adobe DNG Converter.app/Contents/MacOS/Adobe DNG Converter"
 
 
 def _poll_job(client, job_id, timeout_iters=50):

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -22,6 +22,16 @@ def test_find_darktable_returns_configured_path(tmp_path):
     assert find_darktable(str(fake_bin)) == str(fake_bin)
 
 
+def test_find_dng_converter_returns_configured_path(tmp_path):
+    """find_dng_converter returns the configured converter binary if it exists."""
+    from develop import find_dng_converter
+
+    fake_bin = tmp_path / "Adobe DNG Converter"
+    fake_bin.touch()
+    fake_bin.chmod(0o755)
+    assert find_dng_converter(str(fake_bin)) == str(fake_bin)
+
+
 def test_find_darktable_returns_none_for_bad_configured_path(monkeypatch):
     """find_darktable returns None when configured path doesn't exist and PATH has nothing."""
     from develop import find_darktable
@@ -149,6 +159,27 @@ def test_find_darktable_resolves_symlink(tmp_path):
         assert develop.find_darktable("") == str(real)
 
 
+def test_is_nikon_high_efficiency_nef_from_metadata(tmp_path):
+    """ExifTool NEFCompression values 13/14 are Nikon HE/HE*."""
+    import develop
+
+    raw = tmp_path / "bird.NEF"
+    raw.touch()
+
+    assert develop.is_nikon_high_efficiency_nef(
+        str(raw), metadata={"Nikon": {"NEFCompression": 13}}
+    )
+    assert develop.is_nikon_high_efficiency_nef(
+        str(raw), metadata={"Nikon": {"NEFCompression": "High Efficiency*"}}
+    )
+    assert not develop.is_nikon_high_efficiency_nef(
+        str(raw), metadata={"Nikon": {"NEFCompression": 3}}
+    )
+    assert not develop.is_nikon_high_efficiency_nef(
+        str(tmp_path / "bird.CR3"), metadata={"Nikon": {"NEFCompression": 13}}
+    )
+
+
 def _fake_completed(returncode, stdout="", stderr=""):
     import subprocess
     return subprocess.CompletedProcess(args=[], returncode=returncode,
@@ -244,3 +275,79 @@ def test_develop_photo_truncates_verbose_failure(tmp_path, monkeypatch):
     # error message darktable prints near the end) must survive.
     assert "TAIL_MARKER" in result["error"]
     assert len(result["error"]) < 800
+
+
+def test_develop_photo_converts_nikon_he_nef_before_darktable(tmp_path, monkeypatch):
+    """When enabled, Nikon HE NEFs are converted to DNG before darktable-cli."""
+    import subprocess
+
+    import develop
+
+    raw = tmp_path / "bird.NEF"
+    raw.touch()
+    darktable_bin = tmp_path / "darktable-cli"
+    darktable_bin.touch()
+    darktable_bin.chmod(0o755)
+    dng_bin = tmp_path / "Adobe DNG Converter"
+    dng_bin.touch()
+    dng_bin.chmod(0o755)
+    out = tmp_path / "out" / "bird.jpg"
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[0] == str(dng_bin):
+            dng_dir = cmd[cmd.index("-d") + 1]
+            dng_path = os.path.join(dng_dir, "bird.dng")
+            with open(dng_path, "w") as f:
+                f.write("dng")
+            return _fake_completed(0)
+        assert cmd[0] == str(darktable_bin)
+        assert cmd[1].endswith("bird.dng")
+        os.makedirs(os.path.dirname(cmd[2]), exist_ok=True)
+        with open(cmd[2], "w") as f:
+            f.write("jpg")
+        return _fake_completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = develop.develop_photo(
+        str(darktable_bin),
+        str(raw),
+        str(out),
+        auto_convert_dng=True,
+        dng_converter_bin=str(dng_bin),
+        metadata={"Nikon": {"NEFCompression": 14}},
+    )
+
+    assert result["success"] is True
+    assert len(calls) == 2
+    assert calls[0][0] == str(dng_bin)
+    assert calls[1][0] == str(darktable_bin)
+
+
+def test_develop_photo_reports_missing_dng_converter_for_nikon_he(tmp_path, monkeypatch):
+    """HE files fail early with a useful DNG converter message when enabled."""
+    import develop
+
+    raw = tmp_path / "bird.NEF"
+    raw.touch()
+    darktable_bin = tmp_path / "darktable-cli"
+    darktable_bin.touch()
+    darktable_bin.chmod(0o755)
+    out = tmp_path / "out" / "bird.jpg"
+
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+
+    result = develop.develop_photo(
+        str(darktable_bin),
+        str(raw),
+        str(out),
+        auto_convert_dng=True,
+        dng_converter_bin=str(tmp_path / "missing-dng-converter"),
+        metadata={"Nikon": {"NEFCompression": 13}},
+    )
+
+    assert result["success"] is False
+    assert "Nikon High Efficiency NEF" in result["error"]
+    assert "DNG conversion failed" in result["error"]

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -32,6 +32,42 @@ def test_find_dng_converter_returns_configured_path(tmp_path):
     assert find_dng_converter(str(fake_bin)) == str(fake_bin)
 
 
+def test_find_dng_converter_finds_windows_default_install(tmp_path, monkeypatch):
+    """Default Windows install (Program Files\\Adobe DNG Converter\\...) is detected."""
+    from develop import find_dng_converter
+
+    program_files = tmp_path / "Program Files"
+    converter_dir = program_files / "Adobe DNG Converter"
+    converter_dir.mkdir(parents=True)
+    fake_bin = converter_dir / "Adobe DNG Converter.exe"
+    fake_bin.touch()
+
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.delenv("PROGRAMFILES(X86)", raising=False)
+    monkeypatch.delenv("PROGRAMW6432", raising=False)
+    monkeypatch.setenv("PROGRAMFILES", str(program_files))
+
+    assert find_dng_converter("") == str(fake_bin)
+
+
+def test_find_dng_converter_finds_windows_x86_nested_install(tmp_path, monkeypatch):
+    """Older 32-bit installs (Program Files (x86)\\Adobe\\Adobe DNG Converter) are detected."""
+    from develop import find_dng_converter
+
+    program_files_x86 = tmp_path / "Program Files (x86)"
+    converter_dir = program_files_x86 / "Adobe" / "Adobe DNG Converter"
+    converter_dir.mkdir(parents=True)
+    fake_bin = converter_dir / "Adobe DNG Converter.exe"
+    fake_bin.touch()
+
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.delenv("PROGRAMFILES", raising=False)
+    monkeypatch.delenv("PROGRAMW6432", raising=False)
+    monkeypatch.setenv("PROGRAMFILES(X86)", str(program_files_x86))
+
+    assert find_dng_converter("") == str(fake_bin)
+
+
 def test_find_darktable_returns_none_for_bad_configured_path(monkeypatch):
     """find_darktable returns None when configured path doesn't exist and PATH has nothing."""
     from develop import find_darktable


### PR DESCRIPTION
Adds optional DNG conversion before darktable development for Nikon High Efficiency NEFs, detected via NEFCompression metadata values 13/14.
The settings UI now includes an auto-convert checkbox and optional Adobe DNG Converter path, with status reporting for converter availability.
This keeps normal RAW files on the existing darktable path while routing unsupported Nikon HE/HE* files through a temporary DNG.
Validated with focused develop/darktable/config-schema tests plus broader app/config/job coverage.