### PR TITLE
[codex] Cache already-labeled classification matches

### DIFF
--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -30,7 +30,7 @@ except ImportError:
     load_image = None
     load_working_image = None
 
-from db import Database, commit_with_retry
+from db import AUTO_MATCH_REVIEW_MARKER, Database, commit_with_retry
 from models import get_active_model, get_models
 
 try:
@@ -1148,8 +1148,10 @@ def _store_match_prediction(
         model=model_name,
         category="match",
         status="accepted",
+        individual=AUTO_MATCH_REVIEW_MARKER,
         taxonomy=tax_hierarchy,
         labels_fingerprint=labels_fingerprint,
+        preserve_manual_review=True,
     )
     if store_alternatives:
         for alt in item.get("alternatives", []):
@@ -1165,6 +1167,7 @@ def _store_match_prediction(
                 status="alternative",
                 taxonomy=alt_tax,
                 labels_fingerprint=labels_fingerprint,
+                preserve_manual_review=True,
             )
     # add_prediction is INSERT-OR-IGNORE: a row cached as non-match on an
     # earlier pass keeps its stale category here. Re-stamp it 'match' so the

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1151,6 +1151,14 @@ def _store_match_prediction(db, item, model_name, labels_fingerprint, tax=None):
             taxonomy=alt_tax,
             labels_fingerprint=labels_fingerprint,
         )
+    # add_prediction is INSERT-OR-IGNORE: a row cached as non-match on an
+    # earlier pass keeps its stale category here. Re-stamp it 'match' so the
+    # downgrade in reconcile_match_review_state still fires if this detection
+    # later stops being a match.
+    db.reconcile_match_review_state(
+        item["detection_id"], model_name, labels_fingerprint,
+        item["prediction"], "match",
+    )
 
 
 def _store_grouped_predictions(
@@ -1218,6 +1226,14 @@ def _store_grouped_predictions(
                 taxonomy=tax_hierarchy,
                 labels_fingerprint=labels_fingerprint,
             )
+            # If this detection was a cached 'match', its auto-accepted
+            # review row would otherwise survive the now non-match reuse
+            # (add_prediction's default pending never overwrites it) and
+            # keep it out of the queue. Downgrade it back to pending.
+            db.reconcile_match_review_state(
+                item["detection_id"], model_name, labels_fingerprint,
+                item["prediction"], category,
+            )
             # Store alternative predictions
             for alt in item.get("alternatives", []):
                 alt_tax = alt.get("taxonomy") or (
@@ -1271,6 +1287,16 @@ def _store_grouped_predictions(
             cons_hierarchy = rep_tax or (
                 tax.get_hierarchy(cons["prediction"]) if tax else {}
             )
+
+            # Drop any stale auto-accept from a prior 'match' pass first, so
+            # the update_prediction_group_info upsert below re-inserts a
+            # fresh pending row (its ON CONFLICT keeps the existing status)
+            # and the burst re-enters review.
+            for item in group:
+                db.reconcile_match_review_state(
+                    item["detection_id"], model_name, labels_fingerprint,
+                    item["prediction"], category,
+                )
 
             for item in group:
                 if item.get("_existing"):

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1115,6 +1115,44 @@ def _record_batch_classifier_runs(db, batch, model_name, labels_fingerprint, raw
         )
 
 
+def _store_match_prediction(db, item, model_name, labels_fingerprint, tax=None):
+    """Persist an already-labeled classifier result as a reusable cache row.
+
+    A taxonomy ``match`` means the photo's XMP already carries this species, so
+    it should not re-enter the pending review queue.  The raw classifier output
+    still needs a prediction row, though; otherwise the next non-reclassify run
+    sees a classifier_runs key with no cached prediction to surface and pays for
+    inference again.
+    """
+    tax_hierarchy = item.get("taxonomy") or (
+        tax.get_hierarchy(item["prediction"]) if tax else {}
+    )
+    db.add_prediction(
+        detection_id=item["detection_id"],
+        species=item["prediction"],
+        confidence=round(item["confidence"], 4),
+        model=model_name,
+        category="match",
+        status="accepted",
+        taxonomy=tax_hierarchy,
+        labels_fingerprint=labels_fingerprint,
+    )
+    for alt in item.get("alternatives", []):
+        alt_tax = alt.get("taxonomy") or (
+            tax.get_hierarchy(alt["species"]) if tax else {}
+        )
+        db.add_prediction(
+            detection_id=item["detection_id"],
+            species=alt["species"],
+            confidence=round(alt["confidence"], 4),
+            model=model_name,
+            category="match",
+            status="alternative",
+            taxonomy=alt_tax,
+            labels_fingerprint=labels_fingerprint,
+        )
+
+
 def _store_grouped_predictions(
     raw_results, job_id, model_name, grouping_window, similarity_threshold, tax, db,
     labels_fingerprint="legacy",
@@ -1162,6 +1200,9 @@ def _store_grouped_predictions(
                 category = categorize(item["prediction"], existing, tax)
 
             if category == "match":
+                _store_match_prediction(
+                    db, item, model_name, labels_fingerprint, tax,
+                )
                 skipped_match += 1
                 continue
 
@@ -1218,6 +1259,10 @@ def _store_grouped_predictions(
                 category = categorize(cons["prediction"], existing, tax)
 
             if category == "match":
+                for item in group:
+                    _store_match_prediction(
+                        db, item, model_name, labels_fingerprint, tax,
+                    )
                 skipped_match += len(group)
                 continue
 

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1302,11 +1302,14 @@ def _store_grouped_predictions(
             # Drop any stale auto-accept from a prior 'match' pass first, so
             # the update_prediction_group_info upsert below re-inserts a
             # fresh pending row (its ON CONFLICT keeps the existing status)
-            # and the burst re-enters review.
+            # and the burst re-enters review. A prior match pass cached every
+            # detection under the consensus species, so reconcile that same
+            # species (not each frame's own prediction) or the downgrade
+            # misses a dissenting frame's cached row and it stays hidden.
             for item in group:
                 db.reconcile_match_review_state(
                     item["detection_id"], model_name, labels_fingerprint,
-                    item["prediction"], category,
+                    cons["prediction"], category,
                 )
 
             for item in group:

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1118,6 +1118,7 @@ def _record_batch_classifier_runs(db, batch, model_name, labels_fingerprint, raw
 def _store_match_prediction(
     db, item, model_name, labels_fingerprint, tax=None,
     species=None, confidence=None, taxonomy=None,
+    store_alternatives=True,
 ):
     """Persist an already-labeled classifier result as a reusable cache row.
 
@@ -1126,6 +1127,14 @@ def _store_match_prediction(
     still needs a prediction row, though; otherwise the next non-reclassify run
     sees a classifier_runs key with no cached prediction to surface and pays for
     inference again.
+
+    ``store_alternatives`` must be False when ``species``/``confidence`` are a
+    consensus override (burst groups): the per-frame ``item["alternatives"]``
+    are runner-ups for that frame's own top-1, not for the consensus species,
+    and an alternative's confidence can exceed the consensus average. Since
+    ``get_predictions_for_detection`` orders ``confidence DESC``, caching them
+    would let a per-frame alternative outrank the consensus primary and become
+    the cached top-1 on later non-reclassify runs.
     """
     species = species or item["prediction"]
     confidence = item["confidence"] if confidence is None else confidence
@@ -1142,20 +1151,21 @@ def _store_match_prediction(
         taxonomy=tax_hierarchy,
         labels_fingerprint=labels_fingerprint,
     )
-    for alt in item.get("alternatives", []):
-        alt_tax = alt.get("taxonomy") or (
-            tax.get_hierarchy(alt["species"]) if tax else {}
-        )
-        db.add_prediction(
-            detection_id=item["detection_id"],
-            species=alt["species"],
-            confidence=round(alt["confidence"], 4),
-            model=model_name,
-            category="match",
-            status="alternative",
-            taxonomy=alt_tax,
-            labels_fingerprint=labels_fingerprint,
-        )
+    if store_alternatives:
+        for alt in item.get("alternatives", []):
+            alt_tax = alt.get("taxonomy") or (
+                tax.get_hierarchy(alt["species"]) if tax else {}
+            )
+            db.add_prediction(
+                detection_id=item["detection_id"],
+                species=alt["species"],
+                confidence=round(alt["confidence"], 4),
+                model=model_name,
+                category="match",
+                status="alternative",
+                taxonomy=alt_tax,
+                labels_fingerprint=labels_fingerprint,
+            )
     # add_prediction is INSERT-OR-IGNORE: a row cached as non-match on an
     # earlier pass keeps its stale category here. Re-stamp it 'match' so the
     # downgrade in reconcile_match_review_state still fires if this detection
@@ -1289,6 +1299,7 @@ def _store_grouped_predictions(
                         species=cons["prediction"],
                         confidence=cons["confidence"],
                         taxonomy=cons_hierarchy,
+                        store_alternatives=False,
                     )
                 skipped_match += len(group)
                 continue

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1115,7 +1115,10 @@ def _record_batch_classifier_runs(db, batch, model_name, labels_fingerprint, raw
         )
 
 
-def _store_match_prediction(db, item, model_name, labels_fingerprint, tax=None):
+def _store_match_prediction(
+    db, item, model_name, labels_fingerprint, tax=None,
+    species=None, confidence=None, taxonomy=None,
+):
     """Persist an already-labeled classifier result as a reusable cache row.
 
     A taxonomy ``match`` means the photo's XMP already carries this species, so
@@ -1124,13 +1127,15 @@ def _store_match_prediction(db, item, model_name, labels_fingerprint, tax=None):
     sees a classifier_runs key with no cached prediction to surface and pays for
     inference again.
     """
-    tax_hierarchy = item.get("taxonomy") or (
-        tax.get_hierarchy(item["prediction"]) if tax else {}
+    species = species or item["prediction"]
+    confidence = item["confidence"] if confidence is None else confidence
+    tax_hierarchy = taxonomy or item.get("taxonomy") or (
+        tax.get_hierarchy(species) if tax else {}
     )
     db.add_prediction(
         detection_id=item["detection_id"],
-        species=item["prediction"],
-        confidence=round(item["confidence"], 4),
+        species=species,
+        confidence=round(confidence, 4),
         model=model_name,
         category="match",
         status="accepted",
@@ -1157,7 +1162,7 @@ def _store_match_prediction(db, item, model_name, labels_fingerprint, tax=None):
     # later stops being a match.
     db.reconcile_match_review_state(
         item["detection_id"], model_name, labels_fingerprint,
-        item["prediction"], "match",
+        species, "match",
     )
 
 
@@ -1275,9 +1280,15 @@ def _store_grouped_predictions(
                 category = categorize(cons["prediction"], existing, tax)
 
             if category == "match":
+                cons_hierarchy = (
+                    tax.get_hierarchy(cons["prediction"]) if tax else {}
+                )
                 for item in group:
                     _store_match_prediction(
                         db, item, model_name, labels_fingerprint, tax,
+                        species=cons["prediction"],
+                        confidence=cons["confidence"],
+                        taxonomy=cons_hierarchy,
                     )
                 skipped_match += len(group)
                 continue

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -6631,6 +6631,56 @@ class Database:
             )
         self.conn.commit()
 
+    def reconcile_match_review_state(
+        self,
+        detection_id,
+        classifier_model,
+        labels_fingerprint,
+        species,
+        category,
+    ):
+        """Re-sync a cached prediction's category and auto-review on reuse.
+
+        Taxonomy ``match`` predictions are auto-accepted and intentionally
+        hidden from the pending review queue (``_store_match_prediction``
+        writes ``status='accepted'``).  That review row is durable, so when a
+        detection stops being a match — e.g. the photo's XMP keywords were
+        edited — a later non-reclassify run reuses the cached prediction but
+        the stale ``accepted`` row would keep it out of the queue until a
+        full reclassify/clear is forced.  Matches are never user-reviewable
+        (they never appear in the queue), so the only ``accepted`` row on a
+        ``category='match'`` prediction is auto-written and safe to drop here
+        so the prediction re-enters pending review.
+
+        The persisted ``category`` is always refreshed to the current value:
+        ``add_prediction`` is INSERT-OR-IGNORE so it never updates it on
+        reuse, and a stale ``match`` marker would defeat the downgrade above
+        on the next flip (and mislead the ``/api/predictions``
+        disagreement/refinement enrichment).
+        """
+        ws = self._ws_id()
+        row = self.conn.execute(
+            """SELECT id, category FROM predictions
+               WHERE detection_id = ? AND classifier_model = ?
+                 AND labels_fingerprint = ? AND species IS ?""",
+            (detection_id, classifier_model, labels_fingerprint, species),
+        ).fetchone()
+        if row is None:
+            return
+        pred_id = row["id"]
+        if row["category"] == "match" and category != "match":
+            self.conn.execute(
+                "DELETE FROM prediction_review "
+                "WHERE prediction_id = ? AND workspace_id = ?",
+                (pred_id, ws),
+            )
+        if row["category"] != category:
+            self.conn.execute(
+                "UPDATE predictions SET category = ? WHERE id = ?",
+                (category, pred_id),
+            )
+        commit_with_retry(self.conn)
+
     def clear_predictions(self, model=None, collection_photo_ids=None,
                           labels_fingerprint=None, clear_run_keys=True):
         """Clear predictions, optionally filtered by model, photo set, and fingerprint.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -15,6 +15,8 @@ log = logging.getLogger(__name__)
 
 _UNSET = object()  # sentinel for "not provided" vs explicit None
 
+AUTO_MATCH_REVIEW_MARKER = "__vireo_auto_match__"
+
 _SQLITE_PARAM_CHUNK_SIZE = 800
 
 
@@ -6537,6 +6539,7 @@ class Database:
         individual=None,
         taxonomy=None,
         labels_fingerprint="legacy",
+        preserve_manual_review=False,
     ):
         """Store a classification prediction for a detection.
 
@@ -6556,6 +6559,9 @@ class Database:
                       family, genus, scientific_name from taxonomy lookup
             labels_fingerprint: fingerprint of the label set used to classify
                 (defaults to 'legacy' for backwards-compatible inserts).
+            preserve_manual_review: when True, do not overwrite an existing
+                accepted/rejected review row unless it was auto-created for an
+                XMP taxonomy match.
         """
         if detection_id is None:
             raise ValueError(
@@ -6614,6 +6620,19 @@ class Database:
         )
         if pred_id is not None and has_review_state:
             ws_id = self._ws_id()
+            if preserve_manual_review:
+                review = self.conn.execute(
+                    """SELECT status, individual FROM prediction_review
+                       WHERE prediction_id = ? AND workspace_id = ?""",
+                    (pred_id, ws_id),
+                ).fetchone()
+                if (
+                    review is not None
+                    and review["status"] in {"accepted", "rejected"}
+                    and review["individual"] != AUTO_MATCH_REVIEW_MARKER
+                ):
+                    self.conn.commit()
+                    return
             self.conn.execute(
                 """INSERT INTO prediction_review
                      (prediction_id, workspace_id, status, reviewed_at,
@@ -6643,14 +6662,13 @@ class Database:
 
         Taxonomy ``match`` predictions are auto-accepted and intentionally
         hidden from the pending review queue (``_store_match_prediction``
-        writes ``status='accepted'``).  That review row is durable, so when a
-        detection stops being a match — e.g. the photo's XMP keywords were
-        edited — a later non-reclassify run reuses the cached prediction but
-        the stale ``accepted`` row would keep it out of the queue until a
-        full reclassify/clear is forced.  Matches are never user-reviewable
-        (they never appear in the queue), so the only ``accepted`` row on a
-        ``category='match'`` prediction is auto-written and safe to drop here
-        so the prediction re-enters pending review.
+        writes ``status='accepted'`` with ``AUTO_MATCH_REVIEW_MARKER``).  That
+        review row is durable, so when a detection stops being a match — e.g.
+        the photo's XMP keywords were edited — a later non-reclassify run
+        reuses the cached prediction but the stale auto-accepted row would keep
+        it out of the queue until a full reclassify/clear is forced.  Only the
+        marked auto-review row is safe to drop here; explicit user decisions
+        from before a temporary XMP match must remain intact.
 
         The persisted ``category`` is always refreshed to the current value:
         ``add_prediction`` is INSERT-OR-IGNORE so it never updates it on
@@ -6671,8 +6689,9 @@ class Database:
         if row["category"] == "match" and category != "match":
             self.conn.execute(
                 "DELETE FROM prediction_review "
-                "WHERE prediction_id = ? AND workspace_id = ?",
-                (pred_id, ws),
+                "WHERE prediction_id = ? AND workspace_id = ? "
+                "AND status = 'accepted' AND individual = ?",
+                (pred_id, ws, AUTO_MATCH_REVIEW_MARKER),
             )
         if row["category"] != category:
             self.conn.execute(

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1131,7 +1131,7 @@ def test_store_grouped_predictions_persists_match_for_cache(tmp_path, monkeypatc
 
 
 def test_store_grouped_predictions_persists_group_match_for_cache(tmp_path, monkeypatch):
-    """Burst groups that are already labeled also need per-detection cache rows."""
+    """Already-labeled burst groups cache consensus species per detection."""
     from datetime import datetime
 
     import classify_job
@@ -1179,8 +1179,8 @@ def test_store_grouped_predictions_persists_group_match_for_cache(tmp_path, monk
             },
             "folder_path": str(tmp_path),
             "detection_id": det_id,
-            "prediction": "Robin",
-            "confidence": 0.9 - (idx * 0.01),
+            "prediction": "Robin" if idx == 0 else "Sparrow",
+            "confidence": 0.9 if idx == 0 else 0.5,
             "alternatives": [],
             "taxonomy": {},
             "timestamp": datetime(2024, 1, 1, 12, 0, idx),
@@ -1202,11 +1202,11 @@ def test_store_grouped_predictions_persists_group_match_for_cache(tmp_path, monk
     assert result["predictions_stored"] == 0
     assert result["already_labeled"] == 2
     rows = db.conn.execute(
-        "SELECT detection_id, category FROM predictions ORDER BY detection_id"
+        "SELECT detection_id, species, category FROM predictions ORDER BY detection_id"
     ).fetchall()
-    assert [(r["detection_id"], r["category"]) for r in rows] == [
-        (det_ids[0], "match"),
-        (det_ids[1], "match"),
+    assert [(r["detection_id"], r["species"], r["category"]) for r in rows] == [
+        (det_ids[0], "Robin", "match"),
+        (det_ids[1], "Robin", "match"),
     ]
 
 

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1382,6 +1382,73 @@ def test_match_then_unmatch_reenters_pending_on_reuse(tmp_path, monkeypatch):
     assert rows["Sparrow"]["status"] == "alternative"   # still nested
 
 
+@pytest.mark.parametrize("manual_status", ["accepted", "rejected"])
+def test_match_flip_preserves_manual_review_on_reuse(
+    tmp_path, monkeypatch, manual_status
+):
+    """A temporary XMP match must not erase an explicit user decision."""
+    import classify_job
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path))
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_id = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="MDV6",
+    )[0]
+
+    class Tax:
+        def get_hierarchy(self, _species):
+            return {}
+
+    def run(category):
+        monkeypatch.setattr("compare.categorize", lambda *_a, **_k: category)
+        return classify_job._store_grouped_predictions(
+            raw_results=[{
+                "photo": {
+                    "id": photo_id, "filename": "a.jpg",
+                    "folder_id": folder_id, "timestamp": None, "burst_id": None,
+                },
+                "folder_path": str(tmp_path),
+                "detection_id": det_id,
+                "prediction": "Robin",
+                "confidence": 0.88,
+                "alternatives": [],
+                "taxonomy": {},
+                "timestamp": None,
+                "_existing": True,
+            }],
+            job_id="job-abc",
+            model_name="bioclip-2",
+            grouping_window=0,
+            similarity_threshold=0.99,
+            tax=Tax(),
+            db=db,
+            labels_fingerprint="fp-active",
+        )
+
+    run("disagreement")
+    pred_id = db.get_predictions(photo_ids=[photo_id])[0]["id"]
+    db.update_prediction_status(pred_id, manual_status)
+
+    run("match")
+    matched = db.get_predictions(photo_ids=[photo_id])[0]
+    assert matched["category"] == "match"
+    assert matched["status"] == manual_status
+
+    run("disagreement")
+    downgraded = db.get_predictions(photo_ids=[photo_id])[0]
+    assert downgraded["category"] == "disagreement"
+    assert downgraded["status"] == manual_status
+
+
 def test_group_match_then_unmatch_reenters_pending_on_reuse(tmp_path, monkeypatch):
     """Burst groups cached as 'match' must also re-enter review when the
     photos stop matching and the cached predictions are reused.

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1210,6 +1210,107 @@ def test_store_grouped_predictions_persists_group_match_for_cache(tmp_path, monk
     ]
 
 
+def test_group_match_drops_per_frame_alternatives(tmp_path, monkeypatch):
+    """Burst match caches only the consensus species — per-frame alternatives
+    are dropped so a high-confidence dissenting runner-up can't outrank the
+    consensus primary via get_predictions_for_detection's confidence ordering.
+    """
+    from datetime import datetime
+
+    import classify_job
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path))
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_ids = [
+        db.add_photo(
+            folder_id, f"{idx}.jpg", extension=".jpg",
+            file_size=100, file_mtime=1.0,
+        )
+        for idx in range(2)
+    ]
+    det_ids = [
+        db.save_detections(
+            pid,
+            [{
+                "box": {"x": 0, "y": 0, "w": 1, "h": 1},
+                "confidence": 0.9,
+                "category": "animal",
+            }],
+            detector_model="MDV6",
+        )[0]
+        for pid in photo_ids
+    ]
+
+    monkeypatch.setattr("compare.categorize", lambda *_a, **_k: "match")
+
+    class Tax:
+        def get_hierarchy(self, _species):
+            return {}
+
+    # Both frames agree on "Robin" at 0.6, so consensus is Robin@~0.6.
+    # Frame 0 carries a dissenting "Hawk" alternative at 0.95 — higher than
+    # the consensus confidence. The old code cached it as an 'alternative'
+    # row that won the confidence-DESC ordering and became the cached top-1.
+    raw_results = [
+        {
+            "photo": {
+                "id": pid,
+                "filename": f"{idx}.jpg",
+                "folder_id": folder_id,
+                "timestamp": None,
+                "burst_id": None,
+            },
+            "folder_path": str(tmp_path),
+            "detection_id": det_id,
+            "prediction": "Robin",
+            "confidence": 0.6,
+            "alternatives": (
+                [{"species": "Hawk", "confidence": 0.95}] if idx == 0 else []
+            ),
+            "taxonomy": {},
+            "timestamp": datetime(2024, 1, 1, 12, 0, idx),
+        }
+        for idx, (pid, det_id) in enumerate(
+            zip(photo_ids, det_ids, strict=True)
+        )
+    ]
+
+    result = classify_job._store_grouped_predictions(
+        raw_results=raw_results,
+        job_id="job-abc",
+        model_name="bioclip-2",
+        grouping_window=10,
+        similarity_threshold=0.99,
+        tax=Tax(),
+        db=db,
+        labels_fingerprint="fp-active",
+    )
+
+    assert result["already_labeled"] == 2
+    # No "Hawk" alternative row was persisted for either detection.
+    rows = db.conn.execute(
+        "SELECT detection_id, species, category, status "
+        "FROM predictions "
+        "LEFT JOIN prediction_review "
+        "  ON prediction_review.prediction_id = predictions.id "
+        "ORDER BY detection_id"
+    ).fetchall()
+    assert [
+        (r["detection_id"], r["species"], r["category"], r["status"])
+        for r in rows
+    ] == [
+        (det_ids[0], "Robin", "match", "accepted"),
+        (det_ids[1], "Robin", "match", "accepted"),
+    ]
+    # The cached top-1 (confidence-DESC) is the consensus species, not Hawk.
+    top = db.get_predictions_for_detection(det_ids[0], min_classifier_conf=0)
+    assert top[0]["species"] == "Robin"
+
+
 def test_match_then_unmatch_reenters_pending_on_reuse(tmp_path, monkeypatch):
     """A detection cached as a 'match' is auto-accepted and hidden from the
     review queue.  If the photo's XMP later stops matching, a non-reclassify

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1063,6 +1063,153 @@ def test_store_grouped_predictions_writes_active_fingerprint(tmp_path):
     assert hits == {photo_id}
 
 
+def test_store_grouped_predictions_persists_match_for_cache(tmp_path, monkeypatch):
+    """Already-labeled matches should not be pending review, but they still
+    need prediction rows so the next run can reuse the classifier output.
+    """
+    import classify_job
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path))
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_id = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="MDV6",
+    )[0]
+
+    monkeypatch.setattr("compare.categorize", lambda *_args, **_kwargs: "match")
+
+    class Tax:
+        def get_hierarchy(self, _species):
+            return {}
+
+    result = classify_job._store_grouped_predictions(
+        raw_results=[{
+            "photo": {
+                "id": photo_id, "filename": "a.jpg",
+                "folder_id": folder_id, "timestamp": None, "burst_id": None,
+            },
+            "folder_path": str(tmp_path),
+            "detection_id": det_id,
+            "prediction": "Robin",
+            "confidence": 0.88,
+            "alternatives": [{"species": "Sparrow", "confidence": 0.12}],
+            "taxonomy": {},
+            "timestamp": None,
+        }],
+        job_id="job-abc",
+        model_name="bioclip-2",
+        grouping_window=0,
+        similarity_threshold=0.99,
+        tax=Tax(),
+        db=db,
+        labels_fingerprint="fp-active",
+    )
+
+    assert result["predictions_stored"] == 0
+    assert result["already_labeled"] == 1
+
+    cached = db.get_predictions_for_detection(
+        det_id,
+        classifier_model="bioclip-2",
+        labels_fingerprint="fp-active",
+        min_classifier_conf=0,
+    )
+    assert [row["species"] for row in cached] == ["Robin", "Sparrow"]
+    assert cached[0]["category"] == "match"
+
+    reviewed = db.get_predictions(photo_ids=[photo_id])
+    statuses = {row["species"]: row["status"] for row in reviewed}
+    assert statuses == {"Robin": "accepted", "Sparrow": "alternative"}
+
+
+def test_store_grouped_predictions_persists_group_match_for_cache(tmp_path, monkeypatch):
+    """Burst groups that are already labeled also need per-detection cache rows."""
+    from datetime import datetime
+
+    import classify_job
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path))
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_ids = [
+        db.add_photo(
+            folder_id, f"{idx}.jpg", extension=".jpg",
+            file_size=100, file_mtime=1.0,
+        )
+        for idx in range(2)
+    ]
+    det_ids = [
+        db.save_detections(
+            pid,
+            [{
+                "box": {"x": 0, "y": 0, "w": 1, "h": 1},
+                "confidence": 0.9,
+                "category": "animal",
+            }],
+            detector_model="MDV6",
+        )[0]
+        for pid in photo_ids
+    ]
+
+    monkeypatch.setattr("compare.categorize", lambda *_args, **_kwargs: "match")
+
+    class Tax:
+        def get_hierarchy(self, _species):
+            return {}
+
+    raw_results = [
+        {
+            "photo": {
+                "id": pid,
+                "filename": f"{idx}.jpg",
+                "folder_id": folder_id,
+                "timestamp": None,
+                "burst_id": None,
+            },
+            "folder_path": str(tmp_path),
+            "detection_id": det_id,
+            "prediction": "Robin",
+            "confidence": 0.9 - (idx * 0.01),
+            "alternatives": [],
+            "taxonomy": {},
+            "timestamp": datetime(2024, 1, 1, 12, 0, idx),
+        }
+        for idx, (pid, det_id) in enumerate(zip(photo_ids, det_ids, strict=True))
+    ]
+
+    result = classify_job._store_grouped_predictions(
+        raw_results=raw_results,
+        job_id="job-abc",
+        model_name="bioclip-2",
+        grouping_window=10,
+        similarity_threshold=0.99,
+        tax=Tax(),
+        db=db,
+        labels_fingerprint="fp-active",
+    )
+
+    assert result["predictions_stored"] == 0
+    assert result["already_labeled"] == 2
+    rows = db.conn.execute(
+        "SELECT detection_id, category FROM predictions ORDER BY detection_id"
+    ).fetchall()
+    assert [(r["detection_id"], r["category"]) for r in rows] == [
+        (det_ids[0], "match"),
+        (det_ids[1], "match"),
+    ]
+
+
 def test_classifier_skipped_when_run_already_recorded(tmp_path, monkeypatch):
     """If (detection, classifier_model, fingerprint) already ran, don't invoke again."""
     from db import Database

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1210,6 +1210,158 @@ def test_store_grouped_predictions_persists_group_match_for_cache(tmp_path, monk
     ]
 
 
+def test_match_then_unmatch_reenters_pending_on_reuse(tmp_path, monkeypatch):
+    """A detection cached as a 'match' is auto-accepted and hidden from the
+    review queue.  If the photo's XMP later stops matching, a non-reclassify
+    run reuses the cached prediction; the stale 'accepted' review row must be
+    downgraded so the prediction re-enters the pending queue.
+    """
+    import classify_job
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path))
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_id = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="MDV6",
+    )[0]
+
+    class Tax:
+        def get_hierarchy(self, _species):
+            return {}
+
+    def run(category, alternatives, extra):
+        monkeypatch.setattr("compare.categorize", lambda *_a, **_k: category)
+        return classify_job._store_grouped_predictions(
+            raw_results=[{
+                "photo": {
+                    "id": photo_id, "filename": "a.jpg",
+                    "folder_id": folder_id, "timestamp": None, "burst_id": None,
+                },
+                "folder_path": str(tmp_path),
+                "detection_id": det_id,
+                "prediction": "Robin",
+                "confidence": 0.88,
+                "alternatives": alternatives,
+                "taxonomy": {},
+                "timestamp": None,
+                **extra,
+            }],
+            job_id="job-abc",
+            model_name="bioclip-2",
+            grouping_window=0,
+            similarity_threshold=0.99,
+            tax=Tax(),
+            db=db,
+            labels_fingerprint="fp-active",
+        )
+
+    # Run 1: photo already labeled -> match -> auto-accepted, out of queue.
+    run("match", [{"species": "Sparrow", "confidence": 0.12}], {})
+    statuses = {
+        r["species"]: r["status"]
+        for r in db.get_predictions(photo_ids=[photo_id])
+    }
+    assert statuses == {"Robin": "accepted", "Sparrow": "alternative"}
+
+    # Run 2: XMP keyword removed -> no longer a match. The classify gate
+    # surfaces the cached prediction (_existing) and skips inference.
+    run("disagreement", [], {"_existing": True})
+
+    rows = {r["species"]: r for r in db.get_predictions(photo_ids=[photo_id])}
+    assert rows["Robin"]["status"] == "pending"        # back in the queue
+    assert rows["Robin"]["category"] == "disagreement"  # stale marker cleared
+    assert rows["Sparrow"]["status"] == "alternative"   # still nested
+
+
+def test_group_match_then_unmatch_reenters_pending_on_reuse(tmp_path, monkeypatch):
+    """Burst groups cached as 'match' must also re-enter review when the
+    photos stop matching and the cached predictions are reused.
+    """
+    from datetime import datetime
+
+    import classify_job
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path))
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_ids = [
+        db.add_photo(
+            folder_id, f"{i}.jpg", extension=".jpg",
+            file_size=100, file_mtime=1.0,
+        )
+        for i in range(2)
+    ]
+    det_ids = [
+        db.save_detections(
+            pid,
+            [{
+                "box": {"x": 0, "y": 0, "w": 1, "h": 1},
+                "confidence": 0.9,
+                "category": "animal",
+            }],
+            detector_model="MDV6",
+        )[0]
+        for pid in photo_ids
+    ]
+
+    class Tax:
+        def get_hierarchy(self, _species):
+            return {}
+
+    def run(category, extra):
+        monkeypatch.setattr("compare.categorize", lambda *_a, **_k: category)
+        raw = [
+            {
+                "photo": {
+                    "id": pid, "filename": f"{i}.jpg",
+                    "folder_id": folder_id, "timestamp": None,
+                    "burst_id": None,
+                },
+                "folder_path": str(tmp_path),
+                "detection_id": did,
+                "prediction": "Robin",
+                "confidence": 0.9 - (i * 0.01),
+                "alternatives": [],
+                "taxonomy": {},
+                "timestamp": datetime(2024, 1, 1, 12, 0, i),
+                **extra,
+            }
+            for i, (pid, did) in enumerate(
+                zip(photo_ids, det_ids, strict=True)
+            )
+        ]
+        return classify_job._store_grouped_predictions(
+            raw_results=raw, job_id="job-abc", model_name="bioclip-2",
+            grouping_window=10, similarity_threshold=0.99, tax=Tax(),
+            db=db, labels_fingerprint="fp-active",
+        )
+
+    run("match", {})
+    accepted = db.get_predictions(photo_ids=photo_ids, status="accepted")
+    assert {r["detection_id"] for r in accepted} == set(det_ids)
+
+    run("disagreement", {"_existing": True})
+
+    pending = db.get_predictions(photo_ids=photo_ids, status="pending")
+    by_det = {r["detection_id"]: r for r in pending}
+    assert set(by_det) == set(det_ids)
+    for r in by_det.values():
+        assert r["status"] == "pending"
+        assert r["group_id"]  # burst grouping metadata reapplied
+        assert r["category"] == "disagreement"
+
+
 def test_classifier_skipped_when_run_already_recorded(tmp_path, monkeypatch):
     """If (detection, classifier_model, fingerprint) already ran, don't invoke again."""
     from db import Database

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1362,6 +1362,98 @@ def test_group_match_then_unmatch_reenters_pending_on_reuse(tmp_path, monkeypatc
         assert r["category"] == "disagreement"
 
 
+def test_mixed_group_match_then_unmatch_reenters_pending_for_dissenters(
+    tmp_path, monkeypatch
+):
+    """A mixed burst is cached as 'match' under the consensus species for
+    every detection. When it later stops matching and the cached rows are
+    reused, the downgrade must reconcile by the consensus species so the
+    dissenting frame's detection also re-enters the pending queue rather
+    than staying durably hidden as an auto-accepted match.
+    """
+    from datetime import datetime
+
+    import classify_job
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path))
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_ids = [
+        db.add_photo(
+            folder_id, f"{i}.jpg", extension=".jpg",
+            file_size=100, file_mtime=1.0,
+        )
+        for i in range(2)
+    ]
+    det_ids = [
+        db.save_detections(
+            pid,
+            [{
+                "box": {"x": 0, "y": 0, "w": 1, "h": 1},
+                "confidence": 0.9,
+                "category": "animal",
+            }],
+            detector_model="MDV6",
+        )[0]
+        for pid in photo_ids
+    ]
+
+    class Tax:
+        def get_hierarchy(self, _species):
+            return {}
+
+    # Frame 0 predicts Robin, frame 1 dissents with Sparrow -> consensus Robin.
+    species_by_frame = ["Robin", "Sparrow"]
+
+    def run(category, extra):
+        monkeypatch.setattr("compare.categorize", lambda *_a, **_k: category)
+        raw = [
+            {
+                "photo": {
+                    "id": pid, "filename": f"{i}.jpg",
+                    "folder_id": folder_id, "timestamp": None,
+                    "burst_id": None,
+                },
+                "folder_path": str(tmp_path),
+                "detection_id": did,
+                "prediction": species_by_frame[i],
+                "confidence": 0.9 if i == 0 else 0.5,
+                "alternatives": [],
+                "taxonomy": {},
+                "timestamp": datetime(2024, 1, 1, 12, 0, i),
+                **extra,
+            }
+            for i, (pid, did) in enumerate(
+                zip(photo_ids, det_ids, strict=True)
+            )
+        ]
+        return classify_job._store_grouped_predictions(
+            raw_results=raw, job_id="job-abc", model_name="bioclip-2",
+            grouping_window=10, similarity_threshold=0.99, tax=Tax(),
+            db=db, labels_fingerprint="fp-active",
+        )
+
+    run("match", {})
+    accepted = db.get_predictions(photo_ids=photo_ids, status="accepted")
+    assert {r["detection_id"] for r in accepted} == set(det_ids)
+    assert {r["species"] for r in accepted} == {"Robin"}
+
+    run("disagreement", {"_existing": True})
+
+    pending = db.get_predictions(photo_ids=photo_ids, status="pending")
+    by_det = {r["detection_id"]: r for r in pending}
+    # Both detections, including the dissenting Sparrow frame, re-enter
+    # review; none stay hidden as a stale auto-accepted match.
+    assert set(by_det) == set(det_ids)
+    for r in by_det.values():
+        assert r["status"] == "pending"
+        assert r["category"] == "disagreement"
+    assert not db.get_predictions(photo_ids=photo_ids, status="accepted")
+
+
 def test_classifier_skipped_when_run_already_recorded(tmp_path, monkeypatch):
     """If (detection, classifier_model, fingerprint) already ran, don't invoke again."""
     from db import Database


### PR DESCRIPTION
## Summary
- Persist taxonomy-match classifier outputs as accepted cache rows so future non-reclassify runs can reuse them.
- Store alternatives for those matches as alternative rows, keeping them out of the pending review queue.
- Add regression tests for single-photo and burst-group already-labeled matches.

## Validation
- `python -m pytest vireo/tests/test_classify_job.py vireo/tests/test_predictions_api.py vireo/tests/test_db.py::test_alternative_predictions_filtered_from_pending vireo/tests/test_db.py::test_get_predictions_for_detection_filters vireo/tests/test_db.py::test_review_status_absence_is_pending -q`
- `python -m ruff check vireo/classify_job.py vireo/tests/test_classify_job.py`
- `git diff --check`