### PR TITLE
[codex] Speed up iNat21 classification batching

### DIFF
--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -970,8 +970,9 @@ def _classify_photos(
                 })
 
                 if len(batch) >= _BATCH_SIZE:
+                    pre_len = len(raw_results)
                     failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=top_k)
-                    _record_batch_classifier_runs(db, batch, model_name, fp, raw_results)
+                    _record_batch_classifier_runs(db, batch, model_name, fp, raw_results, pre_len)
                     batch = []
         else:
             # No detections — use (or create) a full-image synthetic detection
@@ -1065,34 +1066,42 @@ def _classify_photos(
             })
 
             if len(batch) >= _BATCH_SIZE:
+                pre_len = len(raw_results)
                 failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=top_k)
-                _record_batch_classifier_runs(db, batch, model_name, fp, raw_results)
+                _record_batch_classifier_runs(db, batch, model_name, fp, raw_results, pre_len)
                 batch = []
 
     # Flush remaining images
     if batch:
+        pre_len = len(raw_results)
         failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=top_k)
-        _record_batch_classifier_runs(db, batch, model_name, fp, raw_results)
+        _record_batch_classifier_runs(db, batch, model_name, fp, raw_results, pre_len)
 
     return raw_results, failed, skipped_existing
 
 
-def _record_batch_classifier_runs(db, batch, model_name, labels_fingerprint, raw_results):
+def _record_batch_classifier_runs(
+    db, batch, model_name, labels_fingerprint, raw_results, raw_results_start=0,
+):
     """Record classifier_runs rows for every detection in ``batch``.
 
-    ``batch`` is the list of entries that were just passed to _flush_batch;
-    ``raw_results`` may already contain entries from prior batches, so we scope
-    the prediction_count lookup to entries that reference this batch's
-    detection_ids.  Called after _flush_batch has committed predictions so the
-    run row is only written for detections that actually produced output.
+    ``batch`` is the list of entries that were just passed to _flush_batch.
+    ``raw_results_start`` is ``len(raw_results)`` captured *before* that
+    _flush_batch call, so only the rows this flush appended
+    (``raw_results[raw_results_start:]``) are tallied. Earlier rows belong to
+    prior batches; re-scanning the whole growing list on every flush would
+    make the bookkeeping O(n^2) across a large collection. Called after
+    _flush_batch has committed predictions so the run row is only written for
+    detections that actually produced output.
     """
     if not batch:
         return
-    # Tally how many raw_results entries reference each detection_id. Entries
-    # without a detection_id (unusual, but possible on synthesized rows) are
-    # ignored. For a per-detection batch this is typically 0 or 1.
+    # Tally how many of this flush's raw_results entries reference each
+    # detection_id. Entries without a detection_id (unusual, but possible on
+    # synthesized rows) are ignored. For a per-detection batch this is
+    # typically 0 or 1.
     counts: dict = {}
-    for r in raw_results:
+    for r in raw_results[raw_results_start:]:
         did = r.get("detection_id")
         if did is not None:
             counts[did] = counts.get(did, 0) + 1

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2039,6 +2039,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
                     _record_batch_classifier_runs(
                         thread_db, pending, model_name, spec_fp, raw_results,
+                        pre_len,
                     )
 
                     new_count = len(raw_results) - pre_len

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1814,8 +1814,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         try:
             import config as cfg
             from classify_job import (
+                _BATCH_SIZE,
                 _flush_batch,
                 _prepare_image,
+                _record_batch_classifier_runs,
                 _store_grouped_predictions,
             )
 
@@ -1995,6 +1997,55 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 processed_in_spec = 0
                 start_time = time.time()
                 batch_size = 32  # classification batch granularity
+                inference_batch_size = _BATCH_SIZE
+                inference_batch: list = []
+                has_flushed_in_spec = False
+
+                def _close_pending_inference(inference_batch=inference_batch):
+                    for entry in inference_batch:
+                        with contextlib.suppress(Exception):
+                            entry["img"].close()
+                    inference_batch.clear()
+
+                def _flush_pending_inference(
+                    inference_batch=inference_batch,
+                    raw_results=raw_results,
+                    clf=clf,
+                    model_type=model_type,
+                    model_name=model_name,
+                    spec_fp=spec_fp,
+                ):
+                    nonlocal failed, has_flushed_in_spec
+                    if not inference_batch:
+                        return
+
+                    pending = list(inference_batch)
+                    inference_batch.clear()
+                    has_flushed_in_spec = True
+                    pre_len = len(raw_results)
+                    n_batch_failed = _flush_batch(
+                        pending, clf, model_type, model_name,
+                        thread_db, raw_results,
+                    )
+                    failed += n_batch_failed
+
+                    successful_det_ids = {
+                        r.get("detection_id") for r in raw_results[pre_len:]
+                    }
+                    if n_batch_failed:
+                        for entry in pending:
+                            if entry.get("detection_id") not in successful_det_ids:
+                                failed_photo_ids.add(entry["photo"]["id"])
+
+                    _record_batch_classifier_runs(
+                        thread_db, pending, model_name, spec_fp, raw_results,
+                    )
+
+                    new_count = len(raw_results) - pre_len
+                    if new_count > 0:
+                        stages["classify"]["count"] = (
+                            stages["classify"].get("count", 0) + new_count
+                        )
 
                 for batch_start in range(0, total, batch_size):
                     if _should_abort(abort):
@@ -2126,46 +2177,31 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             failed += 1
                             failed_photo_ids.add(photo["id"])
                             continue
-                        img_batch = [{
+                        inference_batch.append({
                             "photo": photo,
                             "detection_id": primary_det["id"],
                             "folder_path": folder_path,
                             "image_path": image_path,
                             "img": img,
-                        }]
-                        pre_len = len(raw_results)
-                        n_batch_failed = _flush_batch(
-                            img_batch, clf, model_type, model_name,
-                            thread_db, raw_results,
-                        )
-                        if n_batch_failed:
-                            failed_photo_ids.add(photo["id"])
-                        failed += n_batch_failed
-
-                        # Record the classifier_runs row so the next pass over
-                        # the same (detection, model, fingerprint) short-
-                        # circuits. prediction_count reflects how many rows
-                        # _flush_batch added to raw_results for this detection.
-                        #
-                        # Only persist when the batch produced at least one
-                        # prediction. A count of 0 means the classifier
-                        # failed (transient load error, decode error, etc.);
-                        # caching that would strand the detection without
-                        # predictions until the user forces --reclassify.
-                        new_count = len(raw_results) - pre_len
-                        if new_count > 0:
-                            thread_db.record_classifier_run(
-                                primary_det["id"], model_name, spec_fp,
-                                prediction_count=new_count,
-                            )
-                            stages["classify"]["count"] = (
-                                stages["classify"].get("count", 0) + 1
-                            )
+                        })
+                        # Flush the first real inference immediately. That
+                        # preserves the existing cancel checkpoint after model
+                        # warm-up, then later images batch normally for GPU
+                        # throughput.
+                        if (
+                            not has_flushed_in_spec
+                            or len(inference_batch) >= inference_batch_size
+                        ):
+                            _flush_pending_inference()
 
                     # Batch boundary: surface the per-photo accumulated
                     # count + cached to the UI. Replaces the old per-batch
                     # pre-advance which lied about progress when batches
                     # contained cache hits.
+                    if _should_abort(abort):
+                        _close_pending_inference()
+                    else:
+                        _flush_pending_inference()
                     stages["classify"]["total"] = total * len(resolved_specs_local)
                     elapsed = max(time.time() - start_time, 0.01)
                     _emit_progress(
@@ -2185,6 +2221,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             "total": total,
                         },
                     )
+
+                if _should_abort(abort):
+                    _close_pending_inference()
+                else:
+                    _flush_pending_inference()
 
                 # Skip the grouping/storage finalization on cancel — it can
                 # take a minute on large collections and the user has already

--- a/vireo/tests/test_timm_classifier.py
+++ b/vireo/tests/test_timm_classifier.py
@@ -79,7 +79,7 @@ def _make_fake_session(num_classes=3):
         logits = np.array([[5.0, 2.0, 0.5]] * batch_size, dtype=np.float32)
         return [logits]
 
-    session.run = fake_run
+    session.run = MagicMock(side_effect=fake_run)
     return session
 
 
@@ -257,6 +257,21 @@ def test_classify_batch(tmp_path):
     # Each image should produce results for all 3 classes
     assert len(results[0]) == 3
     assert len(results[1]) == 3
+
+
+def test_classify_batch_runs_single_onnx_batch(tmp_path):
+    """classify_batch() sends the whole image batch through ONNX at once."""
+    clf = _make_fake_classifier(tmp_path)
+
+    img1 = Image.new("RGB", (336, 336), color="red")
+    img2 = Image.new("RGB", (336, 336), color="blue")
+
+    clf.classify_batch([img1, img2], threshold=0.0)
+
+    assert clf._session.run.call_count == 1
+    _output_names, input_dict = clf._session.run.call_args.args
+    input_arr = input_dict[clf._input_name]
+    assert input_arr.shape[0] == 2
 
 
 def test_classify_with_pil_image(tmp_path):

--- a/vireo/timm_classifier.py
+++ b/vireo/timm_classifier.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 
+import numpy as np
 import onnx_runtime
 
 log = logging.getLogger(__name__)
@@ -208,11 +209,18 @@ class TimmClassifier:
         Returns:
             list of prediction lists (one per image)
         """
+        if not images:
+            return []
+
+        input_arr = np.concatenate(
+            [self._preprocess(img) for img in images],
+            axis=0,
+        )
+        output = self._session.run(None, {self._input_name: input_arr})
+        logits = output[0]
+        probs_batch = onnx_runtime.softmax(logits, axis=-1)
+
         results = []
-        for img in images:
-            input_arr = self._preprocess(img)
-            output = self._session.run(None, {self._input_name: input_arr})
-            logits = output[0]
-            probs = onnx_runtime.softmax(logits, axis=-1).flatten()
+        for probs in probs_batch:
             results.append(self._build_results(probs, threshold))
         return results


### PR DESCRIPTION
Batches iNat21 ONNX inference so `TimmClassifier.classify_batch()` sends multiple images through a single runtime call instead of one call per image. Updates the streaming pipeline classify stage to accumulate inference batches while preserving the first-inference cancel checkpoint and proper classifier-run bookkeeping. Adds test coverage proving timm batch inference uses one ONNX call. Validated with targeted classifier, classify-job, pipeline-job, ONNX runtime, ruff, and diff checks.