### PR TITLE
[codex] Fix rapid review tab pinning

### DIFF
--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -240,6 +240,26 @@ def test_ephemeral_tab_pin_button_persists_tab(live_server, page):
     )
 
 
+def test_rapid_review_ephemeral_tab_pin_button_persists_tab(live_server, page):
+    """Rapid Review can be pinned from its ephemeral tab."""
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline/rapid-review")
+    page.wait_for_selector(
+        ".nav-tab[data-nav-id='pipeline_rapid_review'].is-ephemeral",
+        timeout=3000,
+    )
+    page.click("[data-testid='nav-tab-pin-pipeline_rapid_review']")
+    page.wait_for_selector(
+        ".nav-tab[data-nav-id='pipeline_rapid_review']:not(.is-ephemeral)",
+        timeout=3000,
+    )
+    page.reload()
+    page.wait_for_selector(
+        ".nav-tab[data-nav-id='pipeline_rapid_review']:not(.is-ephemeral)",
+        timeout=3000,
+    )
+
+
 def test_close_ephemeral_navigates_to_rightmost_visible_pinned_tab(live_server, page):
     """When pinned tabs overflow, closing the ephemeral tab must navigate to
     the rightmost *visible* pinned tab — not the last pinned id, which may be

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1091,6 +1091,14 @@ def test_pin_tab_rejects_unknown_id(db):
         db.pin_tab("not_a_real_page")
 
 
+def test_all_registered_pages_are_valid_tab_ids():
+    from app import ALL_PAGES
+    from db import ALL_NAV_IDS
+
+    registered_ids = {page["id"] for page in ALL_PAGES}
+    assert registered_ids <= ALL_NAV_IDS
+
+
 def test_unpin_tab_removes(db):
     ws_id = db.create_workspace("Fresh")
     db.set_active_workspace(ws_id)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -58,7 +58,7 @@ KEYWORD_TYPES = frozenset({"taxonomy", "individual", "location", "genre", "gener
 SUBJECT_TYPES_DEFAULT = frozenset({"taxonomy", "individual", "genre"})
 
 ALL_NAV_IDS = frozenset({
-    "pipeline", "jobs", "pipeline_review", "review", "cull",
+    "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
     "misses", "highlights", "browse", "map", "variants",
     "dashboard", "audit", "compare",
     "settings", "workspace", "lightroom", "shortcuts",

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -9913,7 +9913,7 @@ def test_count_classifier_runs_excludes_full_image_and_below_threshold(tmp_path)
 def test_all_nav_ids_covers_every_page():
     from db import ALL_NAV_IDS
     expected = {
-        "pipeline", "jobs", "pipeline_review", "review", "cull",
+        "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
         "misses", "highlights", "browse", "map", "variants",
         "dashboard", "audit", "compare",
         "settings", "workspace", "lightroom", "shortcuts",


### PR DESCRIPTION
Rapid Review is now included in the backend tab allowlist, so clicking the ephemeral tab pin persists `pipeline_rapid_review` instead of returning 400. The root cause was drift between the frontend/page registry and `ALL_NAV_IDS` in `vireo/db.py`. Added a workspace-level registry/allowlist drift check and a focused E2E test that pins Rapid Review and verifies it survives reload.

Validation: `pytest tests/test_workspaces.py -q`; `pytest tests/e2e/test_navigation.py::test_rapid_review_ephemeral_tab_pin_button_persists_tab tests/e2e/test_navigation.py::test_ephemeral_tab_pin_button_persists_tab -q`.