### PR TITLE
[codex] Add rapid review 1:1 zoom

### DIFF
--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -9,7 +9,18 @@ _PNG_1X1 = (
 )
 
 
-def _mock_pipeline_rapid_review(page, *, results=None, state_ok=True, apply_photos=None, save_payloads=None):
+def _mock_pipeline_rapid_review(
+    page,
+    *,
+    results=None,
+    state_ok=True,
+    apply_photos=None,
+    save_payloads=None,
+    preview_body=None,
+    preview_content_type="image/png",
+    original_body=None,
+    original_content_type="image/png",
+):
     image_body = base64.b64decode(_PNG_1X1)
     if results is None:
         results = {
@@ -73,7 +84,11 @@ def _mock_pipeline_rapid_review(page, *, results=None, state_ok=True, apply_phot
     )
     page.route(
         "**/photos/*/preview?*",
-        lambda route: route.fulfill(body=image_body, content_type="image/png"),
+        lambda route: route.fulfill(body=preview_body or image_body, content_type=preview_content_type),
+    )
+    page.route(
+        "**/photos/*/original",
+        lambda route: route.fulfill(body=original_body or image_body, content_type=original_content_type),
     )
 
 
@@ -194,6 +209,43 @@ def test_rapid_review_preserves_burst_override_species_on_apply_next(live_server
 
     expect(page.locator("#filename")).to_have_text("d.jpg")
     expect(page.locator("#speciesInput")).to_have_value("Override bird")
+
+
+def test_rapid_review_click_main_image_opens_original_at_one_to_one(live_server, page):
+    original_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="3000" height="2000">'
+        '<rect width="3000" height="2000" fill="#101820"/>'
+        '<circle cx="2600" cy="1700" r="180" fill="#f2aa4c"/>'
+        "</svg>"
+    )
+    _mock_pipeline_rapid_review(
+        page,
+        preview_body=original_svg,
+        preview_content_type="image/svg+xml",
+        original_body=original_svg,
+        original_content_type="image/svg+xml",
+    )
+
+    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    img = page.locator("#currentPhoto")
+    stage = page.locator("#photoStage")
+
+    stage.click(position={"x": 12, "y": 12})
+
+    expect(stage).to_have_class(re.compile(r"\bzoomed\b"))
+    expect(img).to_have_attribute("src", re.compile(r"/photos/1/original$"))
+    page.wait_for_function(
+        """() => {
+          const img = document.getElementById('currentPhoto');
+          return img && img.naturalWidth === 3000 && img.style.width === '3000px';
+        }"""
+    )
+    assert stage.evaluate("el => el.scrollWidth") >= 3000
+
+    stage.click(position={"x": 12, "y": 12})
+
+    expect(stage).not_to_have_class(re.compile(r"\bzoomed\b"))
+    expect(img).to_have_attribute("src", re.compile(r"/photos/1/preview\?size=2560$"))
 
 
 def test_classic_pipeline_review_opens_requested_burst_from_url(live_server, page):

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -168,11 +168,30 @@
   position: relative;
   overflow: hidden;
 }
+.photo-stage.zoomed {
+  align-items: flex-start;
+  justify-content: flex-start;
+  overflow: auto;
+  cursor: grab;
+}
+.photo-stage.zoomed.dragging {
+  cursor: grabbing;
+}
 .photo-stage img {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
   display: block;
+  cursor: zoom-in;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+.photo-stage.zoomed img {
+  flex: 0 0 auto;
+  max-width: none;
+  max-height: none;
+  object-fit: none;
+  cursor: grab;
 }
 .stage-empty {
   color: var(--text-muted);
@@ -432,8 +451,8 @@
     </div>
 
     <section class="review-surface" id="reviewSurface">
-      <div class="photo-stage" id="photoStage">
-        <img id="currentPhoto" alt="">
+      <div class="photo-stage" id="photoStage" onclick="toggleRapidZoom(event)">
+        <img id="currentPhoto" alt="" draggable="false" onload="rapidImageLoaded()">
         <div class="status-pill review" id="statusPill">Review</div>
         <div class="stage-empty" id="stageEmpty" style="display:none;">No active photo</div>
       </div>
@@ -511,6 +530,11 @@ var rapid = {
   seeded: false,
   applying: false,
   loadError: false,
+  zoomed: false,
+  zoomPhotoId: null,
+  zoomAnchor: null,
+  zoomDrag: null,
+  suppressZoomClick: false,
   // Bumped on each openSession; used to drop stale /group/state responses
   // when the user switches bursts before the previous fetch resolves.
   openToken: 0,
@@ -524,6 +548,10 @@ function escapeHtml(s) {
 
 function photoPreviewUrl(id) {
   return '/photos/' + id + '/preview?size=2560';
+}
+
+function photoOriginalUrl(id) {
+  return '/photos/' + id + '/original';
 }
 
 function thumbUrl(id) {
@@ -618,6 +646,7 @@ async function openSession(index) {
   rapid.initialFlags = {};
   rapid.history = [];
   rapid.currentIndex = rapid.items.length ? 0 : -1;
+  resetRapidZoom();
   rapid.seeded = false;
   rapid.loadError = false;
   // Bump the token so any in-flight /group/state fetch from a previous
@@ -672,6 +701,121 @@ function currentPhoto() {
   return rapid.items[rapid.currentIndex];
 }
 
+function resetRapidZoom() {
+  rapid.zoomed = false;
+  rapid.zoomPhotoId = null;
+  rapid.zoomAnchor = null;
+  rapid.zoomDrag = null;
+  rapid.suppressZoomClick = false;
+  var stage = document.getElementById('photoStage');
+  var img = document.getElementById('currentPhoto');
+  if (stage) {
+    stage.classList.remove('zoomed', 'dragging');
+    stage.scrollLeft = 0;
+    stage.scrollTop = 0;
+  }
+  if (img) {
+    img.style.width = '';
+    img.style.height = '';
+  }
+}
+
+function applyRapidZoomLayout() {
+  var p = currentPhoto();
+  var stage = document.getElementById('photoStage');
+  var img = document.getElementById('currentPhoto');
+  var shouldZoom = !!(p && rapid.zoomed && rapid.zoomPhotoId === p.id);
+  stage.classList.toggle('zoomed', shouldZoom);
+  if (!shouldZoom) {
+    img.style.width = '';
+    img.style.height = '';
+    stage.scrollLeft = 0;
+    stage.scrollTop = 0;
+    return;
+  }
+  if (img.complete && img.naturalWidth && img.naturalHeight) {
+    img.style.width = img.naturalWidth + 'px';
+    img.style.height = img.naturalHeight + 'px';
+    if (rapid.zoomAnchor) {
+      var anchor = rapid.zoomAnchor;
+      rapid.zoomAnchor = null;
+      requestAnimationFrame(function() {
+        stage.scrollLeft = Math.max(0, anchor.x * img.offsetWidth - stage.clientWidth / 2);
+        stage.scrollTop = Math.max(0, anchor.y * img.offsetHeight - stage.clientHeight / 2);
+      });
+    }
+  }
+}
+
+function rapidImageLoaded() {
+  applyRapidZoomLayout();
+}
+
+function toggleRapidZoom(e) {
+  if (e) e.stopPropagation();
+  if (rapid.suppressZoomClick) {
+    rapid.suppressZoomClick = false;
+    return;
+  }
+  var p = currentPhoto();
+  if (!p) return;
+  if (rapid.zoomed && rapid.zoomPhotoId === p.id) {
+    resetRapidZoom();
+    renderCurrent();
+    return;
+  }
+  var img = document.getElementById('currentPhoto');
+  var rect = img.getBoundingClientRect();
+  rapid.zoomed = true;
+  rapid.zoomPhotoId = p.id;
+  rapid.zoomAnchor = {
+    x: rect.width ? Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)) : 0.5,
+    y: rect.height ? Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height)) : 0.5,
+  };
+  renderCurrent();
+}
+
+function rapidZoomPointerDown(e) {
+  var p = currentPhoto();
+  if (!p || !rapid.zoomed || rapid.zoomPhotoId !== p.id || e.button !== 0) return;
+  var stage = document.getElementById('photoStage');
+  rapid.zoomDrag = {
+    pointerId: e.pointerId,
+    startX: e.clientX,
+    startY: e.clientY,
+    scrollLeft: stage.scrollLeft,
+    scrollTop: stage.scrollTop,
+    moved: false,
+  };
+  stage.classList.add('dragging');
+  e.currentTarget.setPointerCapture(e.pointerId);
+}
+
+function rapidZoomPointerMove(e) {
+  if (!rapid.zoomDrag) return;
+  var stage = document.getElementById('photoStage');
+  var dx = e.clientX - rapid.zoomDrag.startX;
+  var dy = e.clientY - rapid.zoomDrag.startY;
+  if (!rapid.zoomDrag.moved && (Math.abs(dx) > 3 || Math.abs(dy) > 3)) {
+    rapid.zoomDrag.moved = true;
+  }
+  if (rapid.zoomDrag.moved) {
+    stage.scrollLeft = rapid.zoomDrag.scrollLeft - dx;
+    stage.scrollTop = rapid.zoomDrag.scrollTop - dy;
+  }
+}
+
+function rapidZoomPointerUp(e) {
+  if (!rapid.zoomDrag) return;
+  var moved = rapid.zoomDrag.moved;
+  rapid.zoomDrag = null;
+  document.getElementById('photoStage').classList.remove('dragging');
+  if (moved) rapid.suppressZoomClick = true;
+  try {
+    e.currentTarget.releasePointerCapture(e.pointerId);
+  } catch (_) {}
+}
+
 function zoneFor(id) {
   if (rapid.picks.has(id)) return 'pick';
   if (rapid.rejects.has(id)) return 'reject';
@@ -705,6 +849,7 @@ function decideCurrent(zone) {
   rapid.reviewed.add(id);
   rapid.touched.add(id);
   advanceToNext();
+  resetRapidZoom();
   renderAll();
 }
 
@@ -753,6 +898,7 @@ function undoLast() {
   if (entry.prevTouched) rapid.touched.add(entry.id);
   else rapid.touched.delete(entry.id);
   rapid.currentIndex = entry.prevIndex;
+  resetRapidZoom();
   renderAll();
 }
 
@@ -760,6 +906,7 @@ function selectPhoto(id) {
   var idx = rapid.items.findIndex(function(p) { return p.id === id; });
   if (idx >= 0) {
     rapid.currentIndex = idx;
+    resetRapidZoom();
     renderAll();
   }
 }
@@ -786,6 +933,7 @@ function renderCurrent() {
   var empty = document.getElementById('stageEmpty');
   var pill = document.getElementById('statusPill');
   if (!p) {
+    resetRapidZoom();
     img.removeAttribute('src');
     img.style.display = 'none';
     empty.style.display = '';
@@ -799,7 +947,11 @@ function renderCurrent() {
     return;
   }
   img.style.display = '';
-  img.src = photoPreviewUrl(p.id);
+  var shouldZoom = rapid.zoomed && rapid.zoomPhotoId === p.id;
+  var src = shouldZoom ? photoOriginalUrl(p.id) : photoPreviewUrl(p.id);
+  img.title = shouldZoom ? 'Click to fit image' : 'Click for 1:1 zoom';
+  if (img.getAttribute('src') !== src) img.src = src;
+  applyRapidZoomLayout();
   empty.style.display = 'none';
   var zone = zoneFor(p.id);
   pill.style.display = '';
@@ -1003,6 +1155,10 @@ document.addEventListener('keydown', function(e) {
 });
 
 initRapidReview();
+document.getElementById('photoStage').addEventListener('pointerdown', rapidZoomPointerDown);
+document.getElementById('photoStage').addEventListener('pointermove', rapidZoomPointerMove);
+document.getElementById('photoStage').addEventListener('pointerup', rapidZoomPointerUp);
+document.getElementById('photoStage').addEventListener('pointercancel', rapidZoomPointerUp);
 </script>
 </body>
 </html>


### PR DESCRIPTION
Adds click-to-zoom support to rapid review so the main image swaps from the 2560px preview to the original image and lays it out at natural 1:1 pixel size. The zoom centers around the clicked point, supports drag panning, and resets when changing photos, sessions, or decisions. This fixes the inability to inspect arbitrary image regions closely from rapid review.

Validated with `pytest tests/e2e/test_pipeline_rapid_review.py`, the focused 1:1 test, `python -m ruff check tests/e2e/test_pipeline_rapid_review.py`, and `git diff --check`.