### PR TITLE
[codex] Fix Rapid Review shortcuts

### DIFF
--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -144,7 +144,7 @@ def test_page_scope_shadows_global_for_same_key(live_server, page):
 
 
 def test_navbar_nav_shortcuts_registered_globally(live_server, page):
-    """Each NAV_ROUTES entry is registered as a global Keymap shortcut after config load."""
+    """Navigation entries with default keys are registered globally after config load."""
     url = live_server["url"]
     page.goto(f"{url}/browse", timeout=15000)
     page.wait_for_load_state("networkidle")
@@ -156,11 +156,12 @@ def test_navbar_nav_shortcuts_registered_globally(live_server, page):
             .map(s => s.name)
     """)
     expected = {
-        'pipeline', 'lightroom', 'pipeline_review', 'review', 'cull',
+        'lightroom', 'pipeline_review', 'review', 'cull',
         'browse', 'map', 'variants', 'dashboard', 'audit', 'compare',
         'workspace', 'shortcuts', 'settings', 'keywords'
     }
     assert expected.issubset(set(names))
+    assert 'pipeline' not in names
 
 
 def test_pressing_b_navigates_to_browse(live_server, page):

--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -20,26 +20,28 @@ def _mock_pipeline_rapid_review(
     preview_content_type="image/png",
     original_body=None,
     original_content_type="image/png",
+    shortcut_config=None,
 ):
     image_body = base64.b64decode(_PNG_1X1)
-    shortcut_config = {
-        "keyboard_shortcuts": {
-            # Keep the old collision in this fixture so Rapid Review proves
-            # page shortcuts win even when an existing config still has P for
-            # Pipeline.
-            "navigation": {"pipeline": "p"},
-            "pipeline_rapid_review": {
-                "pick": "p",
-                "reject": "x",
-                "next": "arrowright",
-                "back": "arrowleft",
-                "clear": "u",
-                "apply": "enter",
-                "exit": "escape",
-                "zoom": "z",
-            },
+    if shortcut_config is None:
+        shortcut_config = {
+            "keyboard_shortcuts": {
+                # Keep the old collision in this fixture so Rapid Review proves
+                # page shortcuts win even when an existing config still has P for
+                # Pipeline.
+                "navigation": {"pipeline": "p"},
+                "pipeline_rapid_review": {
+                    "pick": "p",
+                    "reject": "x",
+                    "next": "arrowright",
+                    "back": "arrowleft",
+                    "clear": "u",
+                    "apply": "enter",
+                    "exit": "escape",
+                    "zoom": "z",
+                },
+            }
         }
-    }
     if results is None:
         results = {
             "photos": [
@@ -118,7 +120,7 @@ def test_rapid_review_decision_keys_advance_through_queue(live_server, page):
 
     expect(page.locator("#filename")).to_have_text("a.jpg")
 
-    page.keyboard.press("ArrowDown")
+    page.keyboard.press("x")
     expect(page.locator("#filename")).to_have_text("b.jpg")
     expect(page.locator("#rejectCount")).to_have_text("1")
 
@@ -148,6 +150,50 @@ def test_rapid_review_pick_key_wins_over_pipeline_nav_shortcut(live_server, page
     assert page.url.endswith("/pipeline/rapid-review")
 
 
+def test_rapid_review_honors_remapped_decision_shortcuts(live_server, page):
+    _mock_pipeline_rapid_review(
+        page,
+        shortcut_config={
+            "keyboard_shortcuts": {
+                "navigation": {"pipeline": "p"},
+                "pipeline_rapid_review": {
+                    "pick": "k",
+                    "reject": "j",
+                    "next": "n",
+                    "back": "h",
+                    "clear": "u",
+                    "apply": "enter",
+                    "exit": "escape",
+                    "zoom": "z",
+                },
+            }
+        },
+    )
+
+    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    page.wait_for_function(
+        """() => window._vireoShortcuts
+          && window._vireoShortcuts.pipeline_rapid_review
+          && window._vireoShortcuts.pipeline_rapid_review.reject === 'j'"""
+    )
+
+    page.keyboard.press("ArrowDown")
+    expect(page.locator("#filename")).to_have_text("a.jpg")
+    expect(page.locator("#rejectCount")).to_have_text("0")
+
+    page.keyboard.press("j")
+    expect(page.locator("#filename")).to_have_text("b.jpg")
+    expect(page.locator("#rejectCount")).to_have_text("1")
+
+    page.keyboard.press("n")
+    expect(page.locator("#filename")).to_have_text("c.jpg")
+    expect(page.locator("#metricReviewed")).to_have_text("2/3")
+
+    page.keyboard.press("h")
+    expect(page.locator("#filename")).to_have_text("b.jpg")
+    expect(page.locator("#metricReviewed")).to_have_text("1/3")
+
+
 def test_rapid_review_keeps_apply_disabled_when_state_load_fails(live_server, page):
     _mock_pipeline_rapid_review(page, state_ok=False)
 
@@ -157,7 +203,7 @@ def test_rapid_review_keeps_apply_disabled_when_state_load_fails(live_server, pa
     expect(page.locator("#applyBtn")).to_be_disabled()
     expect(page.locator("#burstSubtitle")).to_contain_text("Failed to load burst state")
 
-    page.keyboard.press("ArrowDown")
+    page.keyboard.press("x")
     expect(page.locator("#filename")).to_have_text("a.jpg")
     expect(page.locator("#rejectCount")).to_have_text("0")
 
@@ -382,7 +428,7 @@ def test_rapid_review_apply_next_skips_bursts_outside_active_queue(live_server, 
     page.goto(f"{live_server['url']}/pipeline/rapid-review")
     expect(page.locator("#filename")).to_have_text("first.jpg")
     page.locator("#speciesInput").fill("Test bird")
-    page.keyboard.press("ArrowUp")
+    page.keyboard.press("p")
 
     with page.expect_response("**/api/pipeline/save-cache"):
         page.locator("#applyNextBtn").click()
@@ -419,7 +465,7 @@ def test_rapid_review_rebases_active_session_after_apply_rebuild(live_server, pa
     expect(page.locator("#applyBtn")).to_be_enabled()
     expect(page.locator("#filename")).to_have_text("first.jpg")
     page.locator("#speciesInput").fill("Test bird")
-    page.keyboard.press("ArrowUp")
+    page.keyboard.press("p")
 
     page.evaluate(
         """async () => {
@@ -456,7 +502,7 @@ def test_rapid_review_filter_change_prompts_with_staged_decisions(live_server, p
 
     page.goto(f"{live_server['url']}/pipeline/rapid-review")
     expect(page.locator("#applyBtn")).to_be_enabled()
-    page.keyboard.press("ArrowDown")
+    page.keyboard.press("x")
     page.locator("#queueFilter").select_option("all")
 
     expect(page.locator("#queuePrompt")).to_be_visible()

--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -22,6 +22,24 @@ def _mock_pipeline_rapid_review(
     original_content_type="image/png",
 ):
     image_body = base64.b64decode(_PNG_1X1)
+    shortcut_config = {
+        "keyboard_shortcuts": {
+            # Keep the old collision in this fixture so Rapid Review proves
+            # page shortcuts win even when an existing config still has P for
+            # Pipeline.
+            "navigation": {"pipeline": "p"},
+            "pipeline_rapid_review": {
+                "pick": "p",
+                "reject": "x",
+                "next": "arrowright",
+                "back": "arrowleft",
+                "clear": "u",
+                "apply": "enter",
+                "exit": "escape",
+                "zoom": "z",
+            },
+        }
+    }
     if results is None:
         results = {
             "photos": [
@@ -41,6 +59,7 @@ def _mock_pipeline_rapid_review(
             "summary": {"keep_count": 0, "review_count": 3, "reject_count": 0},
         }
 
+    page.route("**/api/config", lambda route: route.fulfill(json=shortcut_config))
     page.route("**/api/pipeline/results", lambda route: route.fulfill(json=results))
     if state_ok:
         page.route(
@@ -110,6 +129,23 @@ def test_rapid_review_decision_keys_advance_through_queue(live_server, page):
     page.keyboard.press("ArrowLeft")
     expect(page.locator("#filename")).to_have_text("b.jpg")
     expect(page.locator("#metricReviewed")).to_have_text("1/3")
+
+
+def test_rapid_review_pick_key_wins_over_pipeline_nav_shortcut(live_server, page):
+    _mock_pipeline_rapid_review(page)
+
+    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    page.wait_for_function(
+        """() => window.Keymap
+          && window.Keymap.getScope() === 'pipeline_rapid_review'
+          && window.Keymap.shortcutsForScope('global').some(s => s.name === 'pipeline' && s.key === 'p')"""
+    )
+
+    page.keyboard.press("p")
+
+    expect(page.locator("#filename")).to_have_text("b.jpg")
+    expect(page.locator("#pickCount")).to_have_text("1")
+    assert page.url.endswith("/pipeline/rapid-review")
 
 
 def test_rapid_review_keeps_apply_disabled_when_state_load_fails(live_server, page):
@@ -243,6 +279,16 @@ def test_rapid_review_click_main_image_opens_original_at_one_to_one(live_server,
     assert stage.evaluate("el => el.scrollWidth") >= 3000
 
     stage.click(position={"x": 12, "y": 12})
+
+    expect(stage).not_to_have_class(re.compile(r"\bzoomed\b"))
+    expect(img).to_have_attribute("src", re.compile(r"/photos/1/preview\?size=2560$"))
+
+    page.keyboard.press("z")
+
+    expect(stage).to_have_class(re.compile(r"\bzoomed\b"))
+    expect(img).to_have_attribute("src", re.compile(r"/photos/1/original$"))
+
+    page.keyboard.press("z")
 
     expect(stage).not_to_have_class(re.compile(r"\bzoomed\b"))
     expect(img).to_have_attribute("src", re.compile(r"/photos/1/preview\?size=2560$"))

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -129,7 +129,7 @@ DEFAULTS = {
     "keyboard_shortcuts": {
         "navigation": {
             "import": "i",
-            "pipeline": "p",
+            "pipeline": "",
             "pipeline_review": "e",
             "review": "r",
             "cull": "c",
@@ -147,6 +147,16 @@ DEFAULTS = {
         "review": {
             "accept": "a",
             "skip": "s",
+        },
+        "pipeline_rapid_review": {
+            "pick": "p",
+            "reject": "x",
+            "next": "arrowright",
+            "back": "arrowleft",
+            "clear": "u",
+            "apply": "enter",
+            "exit": "escape",
+            "zoom": "z",
         },
         "browse": {
             "rate_0": "0",
@@ -178,6 +188,17 @@ def _deep_merge(base, override):
     return result
 
 
+def _migrate_shortcuts(config):
+    shortcuts = config.get("keyboard_shortcuts")
+    if not isinstance(shortcuts, dict):
+        return
+    navigation = shortcuts.get("navigation")
+    if not isinstance(navigation, dict):
+        return
+    if navigation.get("pipeline") == "p":
+        navigation["pipeline"] = DEFAULTS["keyboard_shortcuts"]["navigation"]["pipeline"]
+
+
 def load():
     """Load config, returning defaults for any missing keys."""
     config = copy.deepcopy(DEFAULTS)
@@ -187,6 +208,7 @@ def load():
                 config = _deep_merge(config, json.load(f))
         except Exception:
             log.warning("Failed to read config, using defaults")
+    _migrate_shortcuts(config)
     return config
 
 

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -188,17 +188,6 @@ def _deep_merge(base, override):
     return result
 
 
-def _migrate_shortcuts(config):
-    shortcuts = config.get("keyboard_shortcuts")
-    if not isinstance(shortcuts, dict):
-        return
-    navigation = shortcuts.get("navigation")
-    if not isinstance(navigation, dict):
-        return
-    if navigation.get("pipeline") == "p":
-        navigation["pipeline"] = DEFAULTS["keyboard_shortcuts"]["navigation"]["pipeline"]
-
-
 def load():
     """Load config, returning defaults for any missing keys."""
     config = copy.deepcopy(DEFAULTS)
@@ -208,7 +197,6 @@ def load():
                 config = _deep_merge(config, json.load(f))
         except Exception:
             log.warning("Failed to read config, using defaults")
-    _migrate_shortcuts(config)
     return config
 
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2204,7 +2204,7 @@ window.NAV_ALL_PAGES = [
   };
 
   var NAV_DEFAULTS = {
-    pipeline: 'i', lightroom: 'l', pipeline_review: 'e', review: 'r',
+    pipeline: '', lightroom: 'l', pipeline_review: 'e', review: 'r',
     cull: 'c', browse: 'b', map: 'm', variants: 'v',
     dashboard: 'd', audit: 'a', compare: 'o', workspace: 'w',
     shortcuts: '/', settings: ',', keywords: 'k'
@@ -2355,6 +2355,7 @@ window.NAV_ALL_PAGES = [
   var _pageCtx = null;
   if (_path === '/browse') _pageCtx = 'browse';
   else if (_path === '/review') _pageCtx = 'review';
+  else if (_path.startsWith('/pipeline/rapid-review')) _pageCtx = 'pipeline_rapid_review';
   if (_pageCtx && window.Keymap && window.Keymap.setScope) {
     window.Keymap.setScope(_pageCtx);
   }
@@ -2399,6 +2400,12 @@ window.NAV_ALL_PAGES = [
       _title: 'Review',
       accept: 'Accept prediction', skip: 'Skip / reject',
     },
+    pipeline_rapid_review: {
+      _title: 'Rapid Review',
+      pick: 'Pick', reject: 'Reject', next: 'Next / review',
+      back: 'Back / undo', clear: 'Clear to review',
+      apply: 'Apply', exit: 'Exit', zoom: 'Toggle zoom',
+    },
     browse: {
       _title: 'Browse',
       rate_0: 'Clear rating', rate_1: 'Rate 1', rate_2: 'Rate 2',
@@ -2411,12 +2418,16 @@ window.NAV_ALL_PAGES = [
 
   var SC_DEFAULTS = {
     navigation: {
-      import: 'i', pipeline: 'p', pipeline_review: 'e', review: 'r',
+      import: 'i', pipeline: '', pipeline_review: 'e', review: 'r',
       cull: 'c', browse: 'b', map: 'm', variants: 'v',
       dashboard: 'd', audit: 'a', compare: 'o', workspace: 'w',
       shortcuts: '/', settings: ',', keywords: 'k',
     },
     review: { accept: 'a', skip: 's' },
+    pipeline_rapid_review: {
+      pick: 'p', reject: 'x', next: 'arrowright', back: 'arrowleft',
+      clear: 'u', apply: 'enter', exit: 'escape', zoom: 'z',
+    },
     browse: {
       rate_0: '0', rate_1: '1', rate_2: '2', rate_3: '3',
       rate_4: '4', rate_5: '5',
@@ -3894,8 +3905,9 @@ function matchesShortcut(e, shortcutStr) {
 }
 
 function formatShortcut(str) {
-  if (!str) return '';
+  if (!str) return 'Unassigned';
   return str.split('+').map(function(p) {
+    if (p === ' ') return 'Space';
     return p.charAt(0).toUpperCase() + p.slice(1);
   }).join('+');
 }

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -1684,16 +1684,16 @@ document.addEventListener('keydown', function(e) {
     return;
   }
   if (e.target && e.target.tagName === 'INPUT') return;
-  if (e.key === 'ArrowDown' || rapidShortcutMatches(e, 'reject')) {
+  if (rapidShortcutMatches(e, 'reject')) {
     e.preventDefault();
     decideCurrent('reject');
-  } else if (e.key === 'ArrowUp' || rapidShortcutMatches(e, 'pick')) {
+  } else if (rapidShortcutMatches(e, 'pick')) {
     e.preventDefault();
     decideCurrent('pick');
-  } else if (e.key === 'ArrowRight' || e.key === ' ' || rapidShortcutMatches(e, 'next')) {
+  } else if (rapidShortcutMatches(e, 'next')) {
     e.preventDefault();
     decideCurrent('review');
-  } else if (e.key === 'ArrowLeft' || rapidShortcutMatches(e, 'back')) {
+  } else if (rapidShortcutMatches(e, 'back')) {
     e.preventDefault();
     undoLast();
   } else if (rapidShortcutMatches(e, 'clear')) {

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -540,6 +540,80 @@ var rapid = {
   openToken: 0,
 };
 
+var RAPID_SCOPE = 'pipeline_rapid_review';
+var RAPID_SC_DEFAULTS = {
+  pick: 'p',
+  reject: 'x',
+  next: 'arrowright',
+  back: 'arrowleft',
+  clear: 'u',
+  apply: 'enter',
+  exit: 'escape',
+  zoom: 'z',
+};
+var rapidShortcuts = Object.assign({}, RAPID_SC_DEFAULTS);
+var rapidShortcutsRegistered = false;
+
+if (window.Keymap && window.Keymap.setScope) {
+  window.Keymap.setScope(RAPID_SCOPE);
+}
+
+function rapidShortcutMatches(e, action) {
+  var shortcut = rapidShortcuts[action];
+  if (!shortcut) return false;
+  if (window.Keymap && window.Keymap.matchesShortcut) {
+    return window.Keymap.matchesShortcut(e, shortcut);
+  }
+  if (typeof matchesShortcut === 'function') return matchesShortcut(e, shortcut);
+  return false;
+}
+
+function handleRapidShortcutAction(action) {
+  if (action === 'pick') decideCurrent('pick');
+  else if (action === 'reject') decideCurrent('reject');
+  else if (action === 'next') decideCurrent('review');
+  else if (action === 'back') undoLast();
+  else if (action === 'clear') clearCurrent();
+  else if (action === 'apply') applyCurrent(false);
+  else if (action === 'exit') window.location.href = '/pipeline/review';
+  else if (action === 'zoom') toggleRapidZoom();
+  return true;
+}
+
+function registerRapidShortcuts() {
+  if (rapidShortcutsRegistered || !window.Keymap || !window.Keymap.register) return;
+  Object.keys(RAPID_SC_DEFAULTS).forEach(function(action) {
+    var key = rapidShortcuts[action];
+    if (!key) return;
+    window.Keymap.register(RAPID_SCOPE, {
+      key: key,
+      name: action,
+      description: action,
+      category: 'Rapid Review',
+      action: function() { return handleRapidShortcutAction(action); },
+    });
+  });
+  rapidShortcutsRegistered = true;
+}
+
+async function loadRapidShortcuts() {
+  try {
+    var cfg = await safeFetch('/api/config', {}, { toast: false });
+    var saved = (cfg.keyboard_shortcuts || {})[RAPID_SCOPE] || {};
+    rapidShortcuts = Object.assign({}, RAPID_SC_DEFAULTS, saved);
+    window._vireoShortcuts = window._vireoShortcuts || {};
+    if (cfg.keyboard_shortcuts) {
+      Object.keys(cfg.keyboard_shortcuts).forEach(function(ctx) {
+        if (!window._vireoShortcuts[ctx]) window._vireoShortcuts[ctx] = cfg.keyboard_shortcuts[ctx];
+      });
+    }
+    window._vireoShortcuts[RAPID_SCOPE] = rapidShortcuts;
+  } catch (e) {
+    rapidShortcuts = Object.assign({}, RAPID_SC_DEFAULTS);
+  }
+  registerRapidShortcuts();
+}
+
 function escapeHtml(s) {
   return String(s == null ? '' : s).replace(/[&<>"']/g, function(c) {
     return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];
@@ -766,11 +840,17 @@ function toggleRapidZoom(e) {
   }
   var img = document.getElementById('currentPhoto');
   var rect = img.getBoundingClientRect();
+  var anchorX = 0.5;
+  var anchorY = 0.5;
+  if (e && typeof e.clientX === 'number' && typeof e.clientY === 'number') {
+    anchorX = rect.width ? Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)) : 0.5;
+    anchorY = rect.height ? Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height)) : 0.5;
+  }
   rapid.zoomed = true;
   rapid.zoomPhotoId = p.id;
   rapid.zoomAnchor = {
-    x: rect.width ? Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)) : 0.5,
-    y: rect.height ? Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height)) : 0.5,
+    x: anchorX,
+    y: anchorY,
   };
   renderCurrent();
 }
@@ -1129,31 +1209,36 @@ function openClassic() {
 }
 
 document.addEventListener('keydown', function(e) {
+  if (e.defaultPrevented) return;
   if (e.target && e.target.tagName === 'INPUT') return;
-  if (e.key === 'ArrowDown' || e.key === 'x' || e.key === 'X') {
+  if (e.key === 'ArrowDown' || rapidShortcutMatches(e, 'reject')) {
     e.preventDefault();
     decideCurrent('reject');
-  } else if (e.key === 'ArrowUp' || e.key === 'p' || e.key === 'P') {
+  } else if (e.key === 'ArrowUp' || rapidShortcutMatches(e, 'pick')) {
     e.preventDefault();
     decideCurrent('pick');
-  } else if (e.key === 'ArrowRight' || e.key === ' ') {
+  } else if (e.key === 'ArrowRight' || e.key === ' ' || rapidShortcutMatches(e, 'next')) {
     e.preventDefault();
     decideCurrent('review');
-  } else if (e.key === 'ArrowLeft') {
+  } else if (e.key === 'ArrowLeft' || rapidShortcutMatches(e, 'back')) {
     e.preventDefault();
     undoLast();
-  } else if (e.key === 'u' || e.key === 'U') {
+  } else if (rapidShortcutMatches(e, 'clear')) {
     e.preventDefault();
     clearCurrent();
-  } else if (e.key === 'Enter') {
+  } else if (rapidShortcutMatches(e, 'apply')) {
     e.preventDefault();
     applyCurrent(false);
-  } else if (e.key === 'Escape') {
+  } else if (rapidShortcutMatches(e, 'exit')) {
     e.preventDefault();
     window.location.href = '/pipeline/review';
+  } else if (rapidShortcutMatches(e, 'zoom')) {
+    e.preventDefault();
+    toggleRapidZoom();
   }
 });
 
+loadRapidShortcuts();
 initRapidReview();
 document.getElementById('photoStage').addEventListener('pointerdown', rapidZoomPointerDown);
 document.getElementById('photoStage').addEventListener('pointermove', rapidZoomPointerMove);

--- a/vireo/templates/shortcuts.html
+++ b/vireo/templates/shortcuts.html
@@ -89,6 +89,17 @@ var SHORTCUT_LABELS = {
     accept: 'Accept prediction',
     skip: 'Skip / reject prediction',
   },
+  pipeline_rapid_review: {
+    _title: 'Rapid Review',
+    pick: 'Pick photo',
+    reject: 'Reject photo',
+    next: 'Next / leave for review',
+    back: 'Back / undo',
+    clear: 'Clear to review',
+    apply: 'Apply staged changes',
+    exit: 'Exit to classic review',
+    zoom: 'Toggle zoom',
+  },
   browse: {
     _title: 'Browse',
     rate_0: 'Rate 0 (clear)',
@@ -114,12 +125,16 @@ var SHORTCUT_LABELS = {
 
 var SHORTCUT_DEFAULTS = {
   navigation: {
-    import: 'i', pipeline: 'p', pipeline_review: 'e', review: 'r',
+    import: 'i', pipeline: '', pipeline_review: 'e', review: 'r',
     cull: 'c', browse: 'b', map: 'm', variants: 'v',
     dashboard: 'd', audit: 'a', compare: 'o', workspace: 'w',
     shortcuts: '/', settings: ',', keywords: 'k',
   },
   review: { accept: 'a', skip: 's' },
+  pipeline_rapid_review: {
+    pick: 'p', reject: 'x', next: 'arrowright', back: 'arrowleft',
+    clear: 'u', apply: 'enter', exit: 'escape', zoom: 'z',
+  },
   browse: {
     rate_0: '0', rate_1: '1', rate_2: '2', rate_3: '3',
     rate_4: '4', rate_5: '5',

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -178,8 +178,8 @@ def test_deep_merge_preserves_pipeline(tmp_path):
     assert loaded["photos_per_page"] == 50
 
 
-def test_load_migrates_legacy_pipeline_p_shortcut(tmp_path):
-    """Existing configs with the former Pipeline=P default stop claiming P."""
+def test_load_preserves_user_pipeline_p_shortcut(tmp_path):
+    """A saved Pipeline=P binding is treated as user config, not rewritten."""
     import json
 
     import config as cfg
@@ -190,7 +190,7 @@ def test_load_migrates_legacy_pipeline_p_shortcut(tmp_path):
 
     loaded = cfg.load()
 
-    assert loaded["keyboard_shortcuts"]["navigation"]["pipeline"] == ""
+    assert loaded["keyboard_shortcuts"]["navigation"]["pipeline"] == "p"
     assert loaded["keyboard_shortcuts"]["pipeline_rapid_review"]["pick"] == "p"
 
 

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -97,6 +97,17 @@ def test_ingest_recent_destinations_default():
     assert DEFAULTS["ingest"]["recent_destinations"] == []
 
 
+def test_keyboard_shortcut_defaults_include_rapid_review():
+    """Rapid Review owns P/X/Z locally instead of relying on global nav."""
+    from config import DEFAULTS
+
+    shortcuts = DEFAULTS["keyboard_shortcuts"]
+    assert shortcuts["navigation"]["pipeline"] == ""
+    assert shortcuts["pipeline_rapid_review"]["pick"] == "p"
+    assert shortcuts["pipeline_rapid_review"]["reject"] == "x"
+    assert shortcuts["pipeline_rapid_review"]["zoom"] == "z"
+
+
 def test_working_copy_defaults(tmp_path, monkeypatch):
     """Config includes working copy defaults."""
     import config as cfg
@@ -165,6 +176,22 @@ def test_deep_merge_preserves_pipeline(tmp_path):
     assert loaded["pipeline"]["burst_time_gap"] == 3.0
     # Top-level defaults preserved
     assert loaded["photos_per_page"] == 50
+
+
+def test_load_migrates_legacy_pipeline_p_shortcut(tmp_path):
+    """Existing configs with the former Pipeline=P default stop claiming P."""
+    import json
+
+    import config as cfg
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    with open(cfg.CONFIG_PATH, "w") as f:
+        json.dump({"keyboard_shortcuts": {"navigation": {"pipeline": "p"}}}, f)
+
+    loaded = cfg.load()
+
+    assert loaded["keyboard_shortcuts"]["navigation"]["pipeline"] == ""
+    assert loaded["keyboard_shortcuts"]["pipeline_rapid_review"]["pick"] == "p"
 
 
 def test_conftest_autouse_fixture_restores_cfg_path(tmp_path):


### PR DESCRIPTION
Rapid Review now owns its page-scoped shortcuts, so P picks a photo instead of triggering global Pipeline navigation. The default Pipeline navigation shortcut is unassigned, while explicit saved Pipeline=P user bindings are preserved. Rapid Review shortcuts are editable in the shortcuts UI, and Z toggles the 1:1 zoom from the recent zoom work. Validated with the focused config, keymap, and Rapid Review e2e tests plus ruff and diff whitespace checks.