### PR TITLE
[codex] Fix missing photo sidecar cleanup

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -5866,8 +5866,15 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({photo_ids: ids, mode: 'vireo'}),
   });
+  // Best-effort: refreshing the Misses page is an auxiliary UI sync. A
+  // failure here must not reject the delete flow or block the caller's
+  // own loadMissingPhotos() refresh.
   if (typeof loadMisses === 'function') {
-    await loadMisses();
+    try {
+      await loadMisses();
+    } catch (err) {
+      console.error('Failed to refresh Misses after delete:', err);
+    }
   }
 }
 </script>

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -5826,8 +5826,12 @@ function _updateMissingPhotosBulkBtn() {
 }
 
 async function removeOneMissingPhoto(id) {
-  if (!confirm('Remove this photo from Vireo?\n\nCached thumbnail/preview/working copy (if any) will also be deleted. The XMP sidecar on disk will not be touched.')) return;
-  await _deleteMissingPhotoIds([id], false);
+  const deleteSidecars = document.getElementById('missingPhotosDeleteSidecars').checked;
+  const sidecarMsg = deleteSidecars
+    ? '\n\nLeftover XMP sidecars will also be deleted from disk.'
+    : '\n\nThe XMP sidecar on disk will not be touched.';
+  if (!confirm(`Remove this photo from Vireo?\n\nCached thumbnail/preview/working copy (if any) will also be deleted.${sidecarMsg}`)) return;
+  await _deleteMissingPhotoIds([id], deleteSidecars);
   loadMissingPhotos();
 }
 
@@ -5862,6 +5866,9 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({photo_ids: ids, mode: 'vireo'}),
   });
+  if (typeof loadMisses === 'function') {
+    await loadMisses();
+  }
 }
 </script>
 <script src="/static/vireo-utils.js"></script>


### PR DESCRIPTION
## Summary
Fixes the Missing Originals modal so the per-row Remove action honors the existing “Also delete leftover XMP sidecars” checkbox, matching the bulk remove flow. After deleting missing photo rows, the shared helper now refreshes the Misses page when it is open so stale miss cards disappear immediately.

## Validation
- `.venv/bin/python -m pytest vireo/tests/test_app.py -k "missing_delete_sidecars" -q`