### PR TITLE
[codex] Update misses selection actions

### DIFF
--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -1,8 +1,8 @@
 """E2E tests for multi-select on /misses.
 
-Covers ctrl-click toggle, shift-click range, shift+J/K keyboard extension,
-Esc-to-clear, and bulk P/X/U acting on the selection. Plain-click behavior
-(open lightbox) is preserved when no modifier is held.
+Covers plain-click selection, ctrl-click toggle, shift-click range, shift+J/K
+keyboard extension, Esc-to-clear, toolbar actions, and bulk P/X/U acting on the
+selection. Double-click opens the shared lightbox.
 """
 import time
 
@@ -75,10 +75,8 @@ def test_shift_click_selects_range_within_category(live_server, page):
         state="visible", timeout=3000,
     )
 
-    # Anchor on the first card via plain click — but plain click opens the
-    # lightbox, so use ctrl-click to set focus + add to selection without
-    # opening the overlay.
-    _ctrl_click(page, page.locator(f"[data-testid='miss-card-clipped-{pids[0]}']"))
+    # Anchor on the first card via plain click.
+    page.locator(f"[data-testid='miss-card-clipped-{pids[0]}']").click()
     page.locator(f"[data-testid='miss-card-clipped-{pids[3]}']").click(
         modifiers=["Shift"],
     )
@@ -347,9 +345,8 @@ def test_per_card_unflag_keeps_selection_when_other_category_still_renders(live_
     assert "selected" in oof_class
 
 
-def test_plain_click_still_opens_lightbox(live_server, page):
-    """Regression: plain (no-modifier) click on a miss card must still open
-    the shared lightbox — the multi-select model only kicks in with Ctrl/Shift."""
+def test_plain_click_selects_without_opening_lightbox(live_server, page):
+    """Plain click highlights/selects the card; it no longer opens lightbox."""
     url = live_server["url"]
     db = live_server["db"]
     pids = live_server["data"]["photos"]
@@ -361,7 +358,89 @@ def test_plain_click_still_opens_lightbox(live_server, page):
 
     card.click()
 
+    assert page.evaluate("selection.size") == 1
+    assert page.evaluate(f"selection.has({pids[0]})")
+    assert "selected" in (card.get_attribute("class") or "")
+    assert not page.evaluate(
+        "document.getElementById('lightboxOverlay').classList.contains('active')"
+    )
+
+
+def test_double_click_opens_lightbox(live_server, page):
+    """Double-click on a miss card opens the shared lightbox."""
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "oof")
+
+    page.goto(f"{url}/misses")
+    card = page.locator(f"[data-testid='miss-card-oof-{pids[0]}']")
+    card.wait_for(state="visible", timeout=3000)
+
+    card.dblclick()
+
     page.wait_for_function(
         "document.getElementById('lightboxOverlay').classList.contains('active')",
         timeout=3000,
     )
+
+
+def test_selection_bar_unmarks_selected_misses(live_server, page):
+    """The visible toolbar can clear the selected photos' miss flags."""
+    url = live_server["url"]
+    db = live_server["db"]
+    a, b = live_server["data"]["photos"][:2]
+    _seed_misses(db, [a, b], "no_subject")
+
+    page.goto(f"{url}/misses")
+    first = page.locator(f"[data-testid='miss-card-no_subject-{a}']")
+    second = page.locator(f"[data-testid='miss-card-no_subject-{b}']")
+    first.wait_for(state="visible", timeout=3000)
+    second.wait_for(state="visible", timeout=3000)
+
+    first.click()
+    _ctrl_click(page, second)
+    assert page.evaluate("selection.size") == 2
+
+    page.get_by_role("button", name="Unmark missed").click()
+
+    page.wait_for_function(
+        f"!document.querySelector('[data-testid=\"miss-card-no_subject-{a}\"]')"
+        f" && !document.querySelector('[data-testid=\"miss-card-no_subject-{b}\"]')",
+        timeout=3000,
+    )
+    rows = db.conn.execute(
+        "SELECT id, miss_no_subject FROM photos WHERE id IN (?, ?)",
+        (a, b),
+    ).fetchall()
+    assert {r["id"]: r["miss_no_subject"] for r in rows} == {a: 0, b: 0}
+
+
+def test_selection_bar_deletes_selected_misses_from_vireo(live_server, page):
+    """The visible toolbar can delete selected miss photos through the shared confirmation."""
+    url = live_server["url"]
+    db = live_server["db"]
+    a, b = live_server["data"]["photos"][:2]
+    _seed_misses(db, [a, b], "clipped")
+
+    page.goto(f"{url}/misses")
+    first = page.locator(f"[data-testid='miss-card-clipped-{a}']")
+    second = page.locator(f"[data-testid='miss-card-clipped-{b}']")
+    first.wait_for(state="visible", timeout=3000)
+    second.wait_for(state="visible", timeout=3000)
+
+    first.click()
+    _ctrl_click(page, second)
+    assert page.evaluate("selection.size") == 2
+
+    page.get_by_role("button", name="Delete selected").click()
+    page.locator("#deleteModal.open").wait_for(state="visible", timeout=3000)
+    page.locator("#deleteConfirmBtn").click()
+
+    page.wait_for_function(
+        f"!document.querySelector('[data-testid=\"miss-card-clipped-{a}\"]')"
+        f" && !document.querySelector('[data-testid=\"miss-card-clipped-{b}\"]')",
+        timeout=3000,
+    )
+    assert db.get_photo(a) is None
+    assert db.get_photo(b) is None

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7831,7 +7831,8 @@ class Database:
             params.append(since)
 
         rows = self.conn.execute(
-            f"SELECT p.id, p.folder_id, p.filename, p.timestamp, p.burst_id, "
+            f"SELECT p.id, p.folder_id, p.filename, p.companion_path, "
+            f"       p.timestamp, p.burst_id, "
             f"       p.subject_size, p.crop_complete, "
             f"       p.subject_tenengrad, p.bg_tenengrad, "
             f"       p.miss_no_subject, p.miss_clipped, p.miss_oof, "

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -29,6 +29,43 @@
     max-width: 800px;
   }
 
+  .misses-selection-bar {
+    display: none;
+    align-items: center;
+    gap: 8px;
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    margin: 0 0 12px;
+    padding: 8px 10px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.18);
+  }
+  .misses-selection-bar.active { display: flex; }
+  .misses-selection-count {
+    font-size: 12px;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+    margin-right: auto;
+  }
+  .misses-selection-btn {
+    border: 1px solid var(--border-secondary);
+    border-radius: 4px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    padding: 5px 10px;
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .misses-selection-btn:hover { border-color: var(--accent); }
+  .misses-selection-btn.danger {
+    background: var(--danger);
+    border-color: var(--danger);
+    color: #fff;
+  }
+
   .misses-section {
     margin-bottom: 28px;
     border: 1px solid var(--border-primary);
@@ -262,8 +299,22 @@
   <p class="misses-intro">
     Frames flagged as misses by the pipeline. Bulk-reject a category to set
     <code>flag=rejected</code> on every photo in it; photos aren't deleted.
-    Click a thumbnail to open at fit-to-screen; click the photo to toggle 1:1 zoom.
+    Click a thumbnail to select it; Shift-click selects a range. Double-click
+    opens the image at fit-to-screen; click the photo to toggle 1:1 zoom.
   </p>
+
+  <div class="misses-selection-bar" id="missesSelectionBar">
+    <span class="misses-selection-count" id="missesSelectionCount">0 selected</span>
+    <button class="misses-selection-btn" type="button" onclick="bulkUnflagSelection()">
+      Unmark missed
+    </button>
+    <button class="misses-selection-btn danger" type="button" onclick="deleteSelectedMisses()">
+      Delete selected
+    </button>
+    <button class="misses-selection-btn" type="button" onclick="clearSelection()">
+      Clear
+    </button>
+  </div>
 
   <div id="scopeBanner" style="display:none;padding:8px 12px;margin-bottom:12px;
        background:var(--bg-tertiary);border:1px solid var(--border-primary);
@@ -385,6 +436,8 @@ function render() {
       '</div>';
     focusedCategory = null;
     focusedIndex = -1;
+    selection.clear();
+    updateSelectionBar();
     return;
   }
 
@@ -399,9 +452,10 @@ function render() {
       '<kbd>Shift+J/K</kbd> extend selection &middot; ' +
       '<kbd>U</kbd>/<kbd>P</kbd>/<kbd>X</kbd> unflag/flag/reject (focused or selection) &middot; ' +
       '<kbd>Esc</kbd> clear selection &middot; ' +
-      'Ctrl/Shift-click to multi-select; click to open lightbox' +
+      'Click to select; Shift-click range; double-click to open lightbox' +
     '</div>';
   root.innerHTML = html;
+  updateSelectionBar();
 }
 
 function renderSection(cat, photos) {
@@ -475,7 +529,8 @@ function renderCard(cat, p, idx) {
       'data-filename="' + escapeAttr(p.filename || '') + '" ' +
       'data-testid="miss-card-' + cat + '-' + p.id + '" ' +
       'aria-label="' + ariaLabel + '" ' +
-      'onclick="onCardClick(\'' + cat + '\', ' + idx + ', ' + p.id + ', event)">' +
+      'onclick="onCardClick(\'' + cat + '\', ' + idx + ', ' + p.id + ', event)" ' +
+      'ondblclick="onCardDoubleClick(\'' + cat + '\', ' + idx + ', event)">' +
       '<div class="miss-card-img-wrap">' +
         '<img src="/thumbnails/' + p.id + '.jpg" loading="lazy" alt="' + escapeAttr(p.filename || '') + '">' +
         bboxHtml +
@@ -674,10 +729,9 @@ async function unflagMiss(cat, photoId, e) {
 }
 
 /* ---------- Selection ----------
- * Plain click preserves the legacy "click to open lightbox" behavior — adding
- * a focus side-effect is safe because openMiss already calls setFocused. The
- * selection model is purely additive: only ctrl/shift-click engage it, so a
- * user who never reaches for a modifier sees no behavior change.
+ * Plain click selects exactly one photo. Ctrl/Cmd-click toggles additional
+ * photos, and Shift-click selects a range from the focused anchor. Double-click
+ * opens the shared lightbox.
  *
  * Range selection (shift-click, shift+J/K) stays within a single category
  * because the misses page renders a separate grid per category and the user's
@@ -690,6 +744,7 @@ function clearSelection() {
   document.querySelectorAll('.miss-card.selected').forEach(function(el) {
     el.classList.remove('selected');
   });
+  updateSelectionBar();
 }
 
 function setSelected(photoId, on) {
@@ -701,6 +756,16 @@ function setSelected(photoId, on) {
   // visually out of sync with the selection set.
   var els = document.querySelectorAll('.miss-card[data-photo-id="' + photoId + '"]');
   els.forEach(function(el) { el.classList.toggle('selected', on); });
+  updateSelectionBar();
+}
+
+function updateSelectionBar() {
+  var bar = document.getElementById('missesSelectionBar');
+  var countEl = document.getElementById('missesSelectionCount');
+  if (!bar || !countEl) return;
+  var n = selection.size;
+  bar.classList.toggle('active', n > 0);
+  countEl.textContent = n + ' selected';
 }
 
 function selectRangeWithinCategory(cat, fromIdx, toIdx) {
@@ -732,11 +797,76 @@ function onCardClick(cat, idx, photoId, e) {
     setFocused(cat, idx);
     return;
   }
-  // Plain click: clear any prior selection, then fall through to the legacy
-  // open-lightbox path. openMiss() calls setFocused() so the anchor moves with
-  // the click.
+  // Plain click selects exactly this card and moves the shift-click anchor.
+  if (e) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
   clearSelection();
+  setSelected(photoId, true);
+  setFocused(cat, idx);
+}
+
+function onCardDoubleClick(cat, idx, e) {
+  if (e && e.target && e.target.closest('button')) return;
+  if (e) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
   openMiss(cat, idx, e);
+}
+
+function removePhotosFromMissesData(ids) {
+  var deleted = new Set(ids);
+  CATEGORY_ORDER.forEach(function(cat) {
+    missesData[cat] = (missesData[cat] || []).filter(function(p) {
+      return !deleted.has(p.id);
+    });
+  });
+  pruneSelectionToVisible();
+}
+
+function getSelectedPhotoRows() {
+  var rowsById = {};
+  CATEGORY_ORDER.forEach(function(cat) {
+    (missesData[cat] || []).forEach(function(p) {
+      if (selection.has(p.id) && !rowsById[p.id]) rowsById[p.id] = p;
+    });
+  });
+  return Object.keys(rowsById).map(function(id) { return rowsById[id]; });
+}
+
+async function deleteSelectedMisses() {
+  if (selection.size === 0) return;
+  var rows = getSelectedPhotoRows();
+  var ids = rows.map(function(p) { return p.id; });
+  var companionCount = rows.filter(function(p) { return !!p.companion_path; }).length;
+
+  var afterDelete = function(data) {
+    clearSelection();
+    removePhotosFromMissesData(ids);
+    render();
+    loadMisses();
+  };
+
+  if (typeof showDeleteDialog === 'function') {
+    showDeleteDialog(ids, companionCount, afterDelete);
+    return;
+  }
+
+  if (!confirm('Delete ' + ids.length + ' selected photo' + (ids.length === 1 ? '' : 's') + '?')) return;
+  try {
+    var r = await fetch('/api/batch/delete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ photo_ids: ids, mode: 'vireo' }),
+    });
+    if (!r.ok) throw new Error('http ' + r.status);
+    var data = await r.json();
+    afterDelete(data);
+  } catch (err) {
+    if (typeof showToast === 'function') showToast('Delete failed', 'error');
+  }
 }
 
 /* ---------- Focus tracking + keyboard shortcuts ---------- */


### PR DESCRIPTION
Changes the misses page so single-click selects photos, Shift-click selects ranges, and double-click opens the shared lightbox. Adds a sticky selection bar for unmarking selected photos as missed or deleting them through the existing delete confirmation flow. Includes companion-path data in miss rows so delete confirmation can account for companion files. Validated with `python -m pytest tests/e2e/test_misses_multi_select.py tests/e2e/test_misses_flag_hotkeys.py -q` (`19 passed`).