### PR TITLE
[codex] Add shared keyword fill for browse selection

### DIFF
--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -331,6 +331,37 @@ def test_multiselect_offers_partial_keyword_fill(live_server, page):
     assert restored_with_keyword == original_with_keyword
 
 
+def test_multiselect_shrink_to_focused_photo_restores_detail(live_server, page):
+    """Leaving multi-select with a focused photo must restore the detail pane."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    page.locator(".grid-card").first.wait_for(state="visible")
+    first_filename = page.evaluate("photos[0].filename")
+
+    page.evaluate("""
+      selectedPhotoId = photos[0].id;
+      selectedIndex = 0;
+      selectedPhotos.clear();
+      selectedPhotos.add(photos[0].id);
+      selectedPhotos.add(photos[1].id);
+      updateBatchBar();
+    """)
+    expect(page.locator("#selectionPanel")).to_be_visible()
+
+    page.evaluate("""
+      selectedPhotos.delete(photos[1].id);
+      updateBatchBar();
+    """)
+
+    expect(page.locator("#selectionPanel")).to_be_hidden()
+    page.wait_for_function(
+        "document.getElementById('detailContent').classList.contains('visible')",
+        timeout=3000,
+    )
+    expect(page.locator("#detailFilename")).to_have_text(first_filename)
+
+
 def test_reject_shortcut_keeps_existing_thumbnail_nodes(live_server, page):
     """Rejecting one photo should not rebuild the whole grid.
 

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -285,6 +285,19 @@ def test_multiselect_offers_partial_keyword_fill(live_server, page):
     expect(row).to_be_visible()
     expect(row).to_contain_text("missing from 4")
 
+    original_with_keyword = page.evaluate("""
+      async () => {
+        const ids = photos.map(p => p.id);
+        const details = await Promise.all(
+          ids.map(id => fetch('/api/photos/' + id).then(r => r.json()))
+        );
+        return details
+          .filter(p => (p.keywords || []).some(k => k.name === 'Red-tailed Hawk'))
+          .map(p => p.id)
+          .sort((a, b) => a - b);
+      }
+    """)
+
     row.locator("button", has_text="Add to 4").click()
 
     page.wait_for_function("""
@@ -301,6 +314,21 @@ def test_multiselect_offers_partial_keyword_fill(live_server, page):
     expect(
         page.locator(".selection-keyword-row", has_text="Red-tailed Hawk")
     ).to_have_count(0)
+
+    page.evaluate("async () => (await fetch('/api/undo', {method: 'POST'})).ok")
+    restored_with_keyword = page.evaluate("""
+      async () => {
+        const ids = photos.map(p => p.id);
+        const details = await Promise.all(
+          ids.map(id => fetch('/api/photos/' + id).then(r => r.json()))
+        );
+        return details
+          .filter(p => (p.keywords || []).some(k => k.name === 'Red-tailed Hawk'))
+          .map(p => p.id)
+          .sort((a, b) => a - b);
+      }
+    """)
+    assert restored_with_keyword == original_with_keyword
 
 
 def test_filterByCollection_clears_multiselect_set(live_server, page):

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -265,6 +265,44 @@ def test_singleton_set_keyboard_shortcut_applies(live_server, page):
     )
 
 
+def test_multiselect_offers_partial_keyword_fill(live_server, page):
+    """Selecting mixed tagged/untagged photos offers one-click keyword fill."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    cards = page.locator(".grid-card")
+    cards.first.wait_for(state="visible")
+    assert cards.count() >= 5
+
+    page.evaluate("""
+      photos.forEach(function(p) { selectedPhotos.add(p.id); });
+      renderGrid();
+      updateBatchBar();
+    """)
+
+    expect(page.locator("#selectionPanel")).to_be_visible()
+    row = page.locator(".selection-keyword-row", has_text="Red-tailed Hawk")
+    expect(row).to_be_visible()
+    expect(row).to_contain_text("missing from 4")
+
+    row.locator("button", has_text="Add to 4").click()
+
+    page.wait_for_function("""
+      async () => {
+        const ids = photos.map(p => p.id);
+        const details = await Promise.all(
+          ids.map(id => fetch('/api/photos/' + id).then(r => r.json()))
+        );
+        return details.every(p =>
+          (p.keywords || []).some(k => k.name === 'Red-tailed Hawk')
+        );
+      }
+    """, timeout=3000)
+    expect(
+        page.locator(".selection-keyword-row", has_text="Red-tailed Hawk")
+    ).to_have_count(0)
+
+
 def test_filterByCollection_clears_multiselect_set(live_server, page):
     """Switching to a collection must drop a surviving multi-select set.
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2107,6 +2107,75 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                        [{'photo_id': photo_id, 'old_value': str(keyword_id), 'new_value': ''}])
         return jsonify({"ok": True})
 
+    @app.route("/api/selection/keyword-suggestions", methods=["POST"])
+    def api_selection_keyword_suggestions():
+        """Return selected keywords that are present on some, but not all photos."""
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        raw_ids = body.get("photo_ids", [])
+        if not isinstance(raw_ids, list) or not raw_ids:
+            return json_error("photo_ids required")
+
+        photo_ids = []
+        seen = set()
+        for raw in raw_ids:
+            if isinstance(raw, bool) or not isinstance(raw, int):
+                return json_error("photo_ids must be integers")
+            if raw not in seen:
+                photo_ids.append(raw)
+                seen.add(raw)
+        if not photo_ids:
+            return json_error("photo_ids required")
+        if len(photo_ids) > 1000:
+            return json_error("too many photo_ids", 400)
+
+        for pid in photo_ids:
+            if not db._photo_in_workspace(pid):
+                return json_error(
+                    f"Photo {pid} does not belong to the active workspace", 403
+                )
+
+        placeholders = ",".join("?" for _ in photo_ids)
+        rows = db.conn.execute(
+            f"""SELECT pk.photo_id, k.id, k.name, k.type
+                FROM photo_keywords pk
+                JOIN keywords k ON k.id = pk.keyword_id
+                WHERE pk.photo_id IN ({placeholders})
+                ORDER BY LOWER(k.name), k.id""",
+            photo_ids,
+        ).fetchall()
+
+        selected_count = len(photo_ids)
+        by_keyword = {}
+        for row in rows:
+            entry = by_keyword.setdefault(
+                row["id"],
+                {
+                    "id": row["id"],
+                    "name": row["name"],
+                    "type": row["type"],
+                    "photo_ids": set(),
+                },
+            )
+            entry["photo_ids"].add(row["photo_id"])
+
+        suggestions = []
+        for entry in by_keyword.values():
+            count = len(entry["photo_ids"])
+            missing_count = selected_count - count
+            if 0 < count < selected_count:
+                suggestions.append({
+                    "id": entry["id"],
+                    "name": entry["name"],
+                    "type": entry["type"],
+                    "count": count,
+                    "missing_count": missing_count,
+                })
+        suggestions.sort(
+            key=lambda item: (-item["count"], item["name"].lower(), item["id"])
+        )
+        return jsonify({"selected_count": selected_count, "suggestions": suggestions})
+
     @app.route("/api/keywords/<int:keyword_id>", methods=["PUT"])
     def api_update_keyword(keyword_id):
         db = _get_db()
@@ -2625,19 +2694,34 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         body = request.get_json(silent=True) or {}
         photo_ids = body.get("photo_ids", [])
-        name = body.get("name", "").strip()
-        if not photo_ids or not name:
-            return json_error("photo_ids and name required")
-        # Route kw_type through add_keyword so its type-reconciliation logic
-        # runs (preserves existing user-typed rows; only upgrades 'general').
-        # See api_add_keyword for the rationale.
-        kw_type_raw = body.get("type")
-        kw_type = (
-            kw_type_raw
-            if isinstance(kw_type_raw, str) and kw_type_raw in KEYWORD_TYPES
-            else None
-        )
-        kid = db.add_keyword(name, kw_type=kw_type)
+        keyword_id = body.get("keyword_id")
+        name = body.get("name", "")
+        name = name.strip() if isinstance(name, str) else ""
+        if not photo_ids:
+            return json_error("photo_ids required")
+        if keyword_id is not None:
+            if isinstance(keyword_id, bool) or not isinstance(keyword_id, int):
+                return json_error("keyword_id must be an integer")
+            keyword_row = db.conn.execute(
+                "SELECT id, name FROM keywords WHERE id = ?", (keyword_id,)
+            ).fetchone()
+            if keyword_row is None:
+                return json_error("keyword not found", 404)
+            kid = keyword_row["id"]
+            name = keyword_row["name"]
+        else:
+            if not name:
+                return json_error("photo_ids and name required")
+            # Route kw_type through add_keyword so its type-reconciliation logic
+            # runs (preserves existing user-typed rows; only upgrades 'general').
+            # See api_add_keyword for the rationale.
+            kw_type_raw = body.get("type")
+            kw_type = (
+                kw_type_raw
+                if isinstance(kw_type_raw, str) and kw_type_raw in KEYWORD_TYPES
+                else None
+            )
+            kid = db.add_keyword(name, kw_type=kw_type)
         for pid in photo_ids:
             db.tag_photo(pid, kid)
             _queue_keyword_add(pid, name)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2164,12 +2164,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             count = len(entry["photo_ids"])
             missing_count = selected_count - count
             if 0 < count < selected_count:
+                missing_photo_ids = [
+                    pid for pid in photo_ids if pid not in entry["photo_ids"]
+                ]
                 suggestions.append({
                     "id": entry["id"],
                     "name": entry["name"],
                     "type": entry["type"],
                     "count": count,
                     "missing_count": missing_count,
+                    "missing_photo_ids": missing_photo_ids,
                 })
         suggestions.sort(
             key=lambda item: (-item["count"], item["name"].lower(), item["id"])
@@ -2722,13 +2726,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 else None
             )
             kid = db.add_keyword(name, kw_type=kw_type)
-        for pid in photo_ids:
+
+        placeholders = ",".join("?" for _ in photo_ids)
+        existing_rows = db.conn.execute(
+            f"""SELECT photo_id FROM photo_keywords
+                WHERE keyword_id = ? AND photo_id IN ({placeholders})""",
+            [kid] + list(photo_ids),
+        ).fetchall()
+        already_tagged = {row["photo_id"] for row in existing_rows}
+        added_ids = [pid for pid in photo_ids if pid not in already_tagged]
+
+        for pid in added_ids:
             db.tag_photo(pid, kid)
             _queue_keyword_add(pid, name)
-        items = [{'photo_id': pid, 'old_value': '', 'new_value': str(kid)} for pid in photo_ids]
-        db.record_edit('keyword_add', f'Added "{name}" to {len(photo_ids)} photos',
-                       str(kid), items, is_batch=True)
-        return jsonify({"ok": True, "updated": len(photo_ids)})
+        items = [{'photo_id': pid, 'old_value': '', 'new_value': str(kid)} for pid in added_ids]
+        if items:
+            db.record_edit('keyword_add', f'Added "{name}" to {len(added_ids)} photos',
+                           str(kid), items, is_batch=True)
+        return jsonify({"ok": True, "updated": len(added_ids)})
 
     @app.route("/api/batch/delete", methods=["POST"])
     def api_batch_delete():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2135,15 +2135,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     f"Photo {pid} does not belong to the active workspace", 403
                 )
 
-        placeholders = ",".join("?" for _ in photo_ids)
-        rows = db.conn.execute(
-            f"""SELECT pk.photo_id, k.id, k.name, k.type
-                FROM photo_keywords pk
-                JOIN keywords k ON k.id = pk.keyword_id
-                WHERE pk.photo_id IN ({placeholders})
-                ORDER BY LOWER(k.name), k.id""",
-            photo_ids,
-        ).fetchall()
+        rows = []
+        batch_size = 800
+        for i in range(0, len(photo_ids), batch_size):
+            chunk = photo_ids[i:i + batch_size]
+            placeholders = ",".join("?" for _ in chunk)
+            rows.extend(db.conn.execute(
+                f"""SELECT pk.photo_id, k.id, k.name, k.type
+                    FROM photo_keywords pk
+                    JOIN keywords k ON k.id = pk.keyword_id
+                    WHERE pk.photo_id IN ({placeholders})
+                    ORDER BY LOWER(k.name), k.id""",
+                chunk,
+            ).fetchall())
 
         selected_count = len(photo_ids)
         by_keyword = {}

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2727,13 +2727,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             kid = db.add_keyword(name, kw_type=kw_type)
 
-        placeholders = ",".join("?" for _ in photo_ids)
-        existing_rows = db.conn.execute(
-            f"""SELECT photo_id FROM photo_keywords
-                WHERE keyword_id = ? AND photo_id IN ({placeholders})""",
-            [kid] + list(photo_ids),
-        ).fetchall()
-        already_tagged = {row["photo_id"] for row in existing_rows}
+        already_tagged = set()
+        batch_size = 800
+        for i in range(0, len(photo_ids), batch_size):
+            chunk = list(photo_ids[i:i + batch_size])
+            placeholders = ",".join("?" for _ in chunk)
+            existing_rows = db.conn.execute(
+                f"""SELECT photo_id FROM photo_keywords
+                    WHERE keyword_id = ? AND photo_id IN ({placeholders})""",
+                [kid] + chunk,
+            ).fetchall()
+            already_tagged.update(row["photo_id"] for row in existing_rows)
         added_ids = [pid for pid in photo_ids if pid not in already_tagged]
 
         for pid in added_ids:

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -264,6 +264,58 @@ body {
 .summary-folder-row { display: flex; justify-content: space-between; align-items: center; padding: 3px 0; font-size: 12px; }
 .summary-folder-name { color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; margin-right: 8px; }
 .summary-folder-count { color: var(--text-muted); font-size: 11px; flex-shrink: 0; }
+.selection-panel { display: block; }
+.selection-panel.hidden { display: none; }
+.selection-heading {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+.selection-keyword-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.selection-keyword-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+}
+.selection-keyword-name {
+  min-width: 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.selection-keyword-meta {
+  margin-top: 2px;
+  color: var(--text-dim);
+  font-size: 11px;
+}
+.selection-keyword-add {
+  flex-shrink: 0;
+  background: var(--accent);
+  color: var(--accent-text);
+  border: none;
+  border-radius: 4px;
+  padding: 5px 8px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.selection-keyword-add:hover { filter: brightness(1.05); }
+.selection-empty {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
 .detail-close {
   float: right;
   background: none;
@@ -970,6 +1022,15 @@ body {
       </div>
     </div>
 
+    <!-- Multi-select Detail -->
+    <div class="selection-panel hidden" id="selectionPanel">
+      <div class="selection-heading" id="selectionCount">0 photos selected</div>
+      <div class="detail-section">
+        <div class="detail-section-title">Fill Missing Keywords</div>
+        <div class="selection-keyword-list" id="selectionKeywordSuggestions"></div>
+      </div>
+    </div>
+
     <!-- Photo Detail (shown when a photo is selected) -->
     <div class="detail-content" id="detailContent">
       <button class="detail-close" onclick="closeDetail()">&times;</button>
@@ -1110,6 +1171,8 @@ var allLoaded = false;
 var selectedPhotoId = null;
 var selectedIndex = -1;
 var selectedPhotos = new Set(); // multi-select
+var selectionKeywordRequestSeq = 0;
+var selectionKeywordKey = '';
 var showDetectionBoxes = false;
 var cardFields = ["filename", "rating", "flag", "color_label", "sharpness"]; // default, overridden by config
 var inatSubmitted = {};  // {photo_id: true}
@@ -2409,6 +2472,97 @@ function updateBatchBar() {
   } else {
     bar.style.display = 'none';
   }
+  updateSelectionPanel(ids);
+}
+
+function updateSelectionPanel(ids) {
+  var panel = document.getElementById('selectionPanel');
+  if (!panel) return;
+  if (ids.length <= 1) {
+    var wasVisible = !panel.classList.contains('hidden');
+    panel.classList.add('hidden');
+    selectionKeywordKey = '';
+    selectionKeywordRequestSeq++;
+    var list = document.getElementById('selectionKeywordSuggestions');
+    if (list) list.innerHTML = '';
+    if (wasVisible && !selectedPhotoId) {
+      var detail = document.getElementById('detailContent');
+      var summary = document.getElementById('summaryPanel');
+      if (detail) detail.classList.remove('visible');
+      if (summary) summary.classList.remove('hidden');
+      loadSummary();
+    }
+    return;
+  }
+
+  var detail = document.getElementById('detailContent');
+  var summary = document.getElementById('summaryPanel');
+  if (detail) detail.classList.remove('visible');
+  if (summary) summary.classList.add('hidden');
+  panel.classList.remove('hidden');
+  document.getElementById('selectionCount').textContent = ids.length + ' photos selected';
+  loadSelectionKeywordSuggestions(ids);
+}
+
+async function loadSelectionKeywordSuggestions(ids) {
+  var key = ids.slice().sort(function(a, b) { return a - b; }).join(',');
+  if (key === selectionKeywordKey) return;
+  selectionKeywordKey = key;
+  var seq = ++selectionKeywordRequestSeq;
+  var list = document.getElementById('selectionKeywordSuggestions');
+  if (list) list.innerHTML = '<div class="selection-empty">Checking selected keywords...</div>';
+
+  try {
+    var data = await safeFetch('/api/selection/keyword-suggestions', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: ids}),
+    }, { toast: false });
+    if (seq !== selectionKeywordRequestSeq) return;
+    renderSelectionKeywordSuggestions(data.suggestions || []);
+  } catch(e) {
+    if (seq === selectionKeywordRequestSeq && list) {
+      list.innerHTML = '<div class="selection-empty">Could not load keyword suggestions.</div>';
+    }
+  }
+}
+
+function renderSelectionKeywordSuggestions(suggestions) {
+  var list = document.getElementById('selectionKeywordSuggestions');
+  if (!list) return;
+  if (!suggestions.length) {
+    list.innerHTML = '<div class="selection-empty">No partial keywords in this selection.</div>';
+    return;
+  }
+
+  var html = '';
+  suggestions.slice(0, 8).forEach(function(k) {
+    var missing = k.missing_count || 0;
+    html += '<div class="selection-keyword-row">' +
+      '<div style="min-width:0;">' +
+        '<div class="selection-keyword-name">' + escapeHtml(k.name) + '</div>' +
+        '<div class="selection-keyword-meta">On ' + k.count + ', missing from ' + missing + '</div>' +
+      '</div>' +
+      '<button class="selection-keyword-add" onclick="applySelectionKeyword(' + k.id + ')" title="Add this keyword to the selected photos missing it">Add to ' + missing + '</button>' +
+    '</div>';
+  });
+  list.innerHTML = html;
+}
+
+async function applySelectionKeyword(keywordId) {
+  var ids = getActiveSelection();
+  if (ids.length <= 1) return;
+  try {
+    await safeFetch('/api/batch/keyword', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: ids, keyword_id: keywordId}),
+    });
+  } catch(e) { return; }
+  selectionKeywordKey = '';
+  loadSelectionKeywordSuggestions(ids);
+  loadKeywords();
+  showUndoToast();
 }
 
 async function batchSetRating(rating) {
@@ -2483,6 +2637,9 @@ async function confirmBatchKeyword() {
       body: JSON.stringify({photo_ids: ids, name: name}),
     });
   } catch(e) { return; }
+  selectionKeywordKey = '';
+  loadSelectionKeywordSuggestions(ids);
+  loadKeywords();
   showUndoToast();
 }
 
@@ -2652,7 +2809,9 @@ async function loadDetail(id) {
 
   try {
     var photo = await safeFetch('/api/photos/' + id, {}, { toast: false });
-    renderDetail(photo);
+    if (selectedPhotoId === id && getActiveSelection().length === 1) {
+      renderDetail(photo);
+    }
   } catch(e) {}
 }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1173,6 +1173,7 @@ var selectedIndex = -1;
 var selectedPhotos = new Set(); // multi-select
 var selectionKeywordRequestSeq = 0;
 var selectionKeywordKey = '';
+var selectionKeywordMissingById = {};
 var showDetectionBoxes = false;
 var cardFields = ["filename", "rating", "flag", "color_label", "sharpness"]; // default, overridden by config
 var inatSubmitted = {};  // {photo_id: true}
@@ -2482,6 +2483,7 @@ function updateSelectionPanel(ids) {
     var wasVisible = !panel.classList.contains('hidden');
     panel.classList.add('hidden');
     selectionKeywordKey = '';
+    selectionKeywordMissingById = {};
     selectionKeywordRequestSeq++;
     var list = document.getElementById('selectionKeywordSuggestions');
     if (list) list.innerHTML = '';
@@ -2531,13 +2533,16 @@ function renderSelectionKeywordSuggestions(suggestions) {
   var list = document.getElementById('selectionKeywordSuggestions');
   if (!list) return;
   if (!suggestions.length) {
+    selectionKeywordMissingById = {};
     list.innerHTML = '<div class="selection-empty">No partial keywords in this selection.</div>';
     return;
   }
 
   var html = '';
+  selectionKeywordMissingById = {};
   suggestions.slice(0, 8).forEach(function(k) {
     var missing = k.missing_count || 0;
+    selectionKeywordMissingById[String(k.id)] = k.missing_photo_ids || [];
     html += '<div class="selection-keyword-row">' +
       '<div style="min-width:0;">' +
         '<div class="selection-keyword-name">' + escapeHtml(k.name) + '</div>' +
@@ -2550,8 +2555,8 @@ function renderSelectionKeywordSuggestions(suggestions) {
 }
 
 async function applySelectionKeyword(keywordId) {
-  var ids = getActiveSelection();
-  if (ids.length <= 1) return;
+  var ids = selectionKeywordMissingById[String(keywordId)] || [];
+  if (!ids.length) return;
   try {
     await safeFetch('/api/batch/keyword', {
       method: 'POST',
@@ -2560,7 +2565,7 @@ async function applySelectionKeyword(keywordId) {
     });
   } catch(e) { return; }
   selectionKeywordKey = '';
-  loadSelectionKeywordSuggestions(ids);
+  loadSelectionKeywordSuggestions(getActiveSelection());
   loadKeywords();
   showUndoToast();
 }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2500,7 +2500,9 @@ function updateSelectionPanel(ids) {
     selectionKeywordRequestSeq++;
     var list = document.getElementById('selectionKeywordSuggestions');
     if (list) list.innerHTML = '';
-    if (wasVisible && !selectedPhotoId) {
+    if (wasVisible && selectedPhotoId) {
+      loadDetail(selectedPhotoId);
+    } else if (wasVisible) {
       var detail = document.getElementById('detailContent');
       var summary = document.getElementById('summaryPanel');
       if (detail) detail.classList.remove('visible');

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2847,6 +2847,32 @@ def test_batch_keyword_route_accepts_existing_keyword_id(app_and_db):
     assert [row["photo_id"] for row in tagged_after_undo] == [ids[0]]
 
 
+def test_batch_keyword_route_chunks_large_existing_keyword_lookup(app_and_db):
+    """Large batch keyword adds must not exceed SQLite's variable limit."""
+    app, db = app_and_db
+    folder_id = db.get_folder_tree()[0]["id"]
+    ids = [
+        db.add_photo(
+            folder_id,
+            f"large-batch-{idx}.jpg",
+            extension=".jpg",
+            file_size=1,
+            file_mtime=1.0,
+        )
+        for idx in range(1005)
+    ]
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/batch/keyword",
+        json={"photo_ids": ids, "name": "Large Batch"},
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["updated"] == len(ids)
+
+
 def test_create_app_runs_wildlife_backfill_synchronously_on_first_boot(tmp_path, monkeypatch):
     """Regression: on first boot after upgrade (wildlife_backfill_done
     marker unset), create_app must complete the species-marking +

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2781,6 +2781,60 @@ def test_batch_keyword_route_handles_non_string_type(app_and_db):
     )
 
 
+def test_selection_keyword_suggestions_return_partial_keywords(app_and_db):
+    """Multi-select suggestions should offer keywords present on only some photos."""
+    app, db = app_and_db
+    ids = [
+        row["id"]
+        for row in db.conn.execute(
+            "SELECT id FROM photos ORDER BY filename"
+        ).fetchall()
+    ]
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/selection/keyword-suggestions",
+        json={"photo_ids": ids},
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    by_name = {item["name"]: item for item in data["suggestions"]}
+    assert by_name["Cardinal"]["count"] == 1
+    assert by_name["Cardinal"]["missing_count"] == 2
+    assert by_name["Sparrow"]["count"] == 1
+    assert by_name["Sparrow"]["missing_count"] == 2
+
+
+def test_batch_keyword_route_accepts_existing_keyword_id(app_and_db):
+    """The fill-missing-keywords button applies the exact selected keyword row."""
+    app, db = app_and_db
+    rows = db.conn.execute(
+        "SELECT id, filename FROM photos ORDER BY filename"
+    ).fetchall()
+    ids = [row["id"] for row in rows]
+    cardinal_id = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = 'Cardinal'"
+    ).fetchone()["id"]
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/batch/keyword",
+        json={"photo_ids": ids, "keyword_id": cardinal_id},
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 200
+    tagged = db.conn.execute(
+        """SELECT photo_id FROM photo_keywords
+           WHERE keyword_id = ?
+           ORDER BY photo_id""",
+        (cardinal_id,),
+    ).fetchall()
+    assert [row["photo_id"] for row in tagged] == sorted(ids)
+
+
 def test_create_app_runs_wildlife_backfill_synchronously_on_first_boot(tmp_path, monkeypatch):
     """Regression: on first boot after upgrade (wildlife_backfill_done
     marker unset), create_app must complete the species-marking +

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2808,6 +2808,37 @@ def test_selection_keyword_suggestions_return_partial_keywords(app_and_db):
     assert by_name["Sparrow"]["missing_count"] == 2
 
 
+def test_selection_keyword_suggestions_chunks_large_selection(app_and_db):
+    """Large selection suggestions must not exceed SQLite's variable limit."""
+    app, db = app_and_db
+    folder_id = db.get_folder_tree()[0]["id"]
+    ids = [
+        db.add_photo(
+            folder_id,
+            f"large-suggestion-{idx}.jpg",
+            extension=".jpg",
+            file_size=1,
+            file_mtime=1.0,
+        )
+        for idx in range(1000)
+    ]
+    keyword_id = db.add_keyword("Large Suggestion")
+    db.tag_photo(ids[0], keyword_id)
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/selection/keyword-suggestions",
+        json={"photo_ids": ids},
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 200
+    by_name = {item["name"]: item for item in resp.get_json()["suggestions"]}
+    assert by_name["Large Suggestion"]["count"] == 1
+    assert by_name["Large Suggestion"]["missing_count"] == 999
+    assert len(by_name["Large Suggestion"]["missing_photo_ids"]) == 999
+
+
 def test_batch_keyword_route_accepts_existing_keyword_id(app_and_db):
     """The fill-missing-keywords button preserves pre-existing links on undo."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2803,12 +2803,13 @@ def test_selection_keyword_suggestions_return_partial_keywords(app_and_db):
     by_name = {item["name"]: item for item in data["suggestions"]}
     assert by_name["Cardinal"]["count"] == 1
     assert by_name["Cardinal"]["missing_count"] == 2
+    assert sorted(by_name["Cardinal"]["missing_photo_ids"]) == sorted(ids[1:])
     assert by_name["Sparrow"]["count"] == 1
     assert by_name["Sparrow"]["missing_count"] == 2
 
 
 def test_batch_keyword_route_accepts_existing_keyword_id(app_and_db):
-    """The fill-missing-keywords button applies the exact selected keyword row."""
+    """The fill-missing-keywords button preserves pre-existing links on undo."""
     app, db = app_and_db
     rows = db.conn.execute(
         "SELECT id, filename FROM photos ORDER BY filename"
@@ -2826,6 +2827,7 @@ def test_batch_keyword_route_accepts_existing_keyword_id(app_and_db):
     )
 
     assert resp.status_code == 200
+    assert resp.get_json()["updated"] == 2
     tagged = db.conn.execute(
         """SELECT photo_id FROM photo_keywords
            WHERE keyword_id = ?
@@ -2833,6 +2835,16 @@ def test_batch_keyword_route_accepts_existing_keyword_id(app_and_db):
         (cardinal_id,),
     ).fetchall()
     assert [row["photo_id"] for row in tagged] == sorted(ids)
+
+    undo_resp = client.post("/api/undo")
+    assert undo_resp.status_code == 200
+    tagged_after_undo = db.conn.execute(
+        """SELECT photo_id FROM photo_keywords
+           WHERE keyword_id = ?
+           ORDER BY photo_id""",
+        (cardinal_id,),
+    ).fetchall()
+    assert [row["photo_id"] for row in tagged_after_undo] == [ids[0]]
 
 
 def test_create_app_runs_wildlife_backfill_synchronously_on_first_boot(tmp_path, monkeypatch):


### PR DESCRIPTION
Adds a multi-select panel in Browse that suggests keywords present on some selected photos and offers one-click fill for the missing selected photos. Adds a selection keyword suggestion API and extends batch keyword writes to apply an existing keyword id, preserving the exact keyword row. Includes Flask and Playwright coverage for partial keyword suggestions and the fill action. Validated with targeted app tests, the browse single-select E2E suite, `compileall`, and `git diff --check`.