### PR TITLE
[codex] Auto-filter browse search

### DIFF
--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -11,7 +11,6 @@ def test_keyword_search_empty_state_and_clear(live_server, page):
 
     search = page.locator("#searchInput")
     search.fill("definitely-no-such-photo")
-    search.press("Enter")
 
     expect(page.locator("#emptyState")).to_be_visible()
     expect(page.locator("#welcomeState")).to_be_hidden()

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -298,3 +298,23 @@ def test_filterByCollection_clears_multiselect_set(live_server, page):
     assert page.evaluate("selectedPhotos.size") == 0
     assert page.evaluate("selectedPhotoId") is None
     expect(bar).to_be_hidden()
+
+
+def test_filterByCollection_cancels_pending_search_debounce(live_server, page):
+    """A delayed search apply must not kick the user out of collection mode."""
+    db = live_server["db"]
+    rules = json.dumps([{"field": "extension", "op": "is", "value": ".jpg"}])
+    collection_id = db.add_collection("Debounce Collection", rules)
+
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    page.locator("#searchInput").fill("hum")
+    page.evaluate(f"filterByCollection({collection_id})")
+    page.wait_for_function(
+        f"activeCollectionId === {collection_id}", timeout=2000
+    )
+
+    page.wait_for_timeout(350)
+    assert page.evaluate("activeCollectionId") == collection_id

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -792,7 +792,7 @@ body {
 
     <!-- Filter Bar -->
     <div class="filter-bar">
-      <input type="text" id="searchInput" placeholder="Search keywords or filenames..." onkeydown="if(event.key==='Enter')applyFilters()" oninput="if(!this.value.trim())applyFilters()">
+      <input type="text" id="searchInput" placeholder="Search keywords or filenames..." onkeydown="if(event.key==='Enter')applySearchFilterNow()" oninput="scheduleSearchFilter()">
       <input type="text" id="clipSearchInput" placeholder="CLIP search: describe what you see..."
              style="flex:1;min-width:200px;"
              onkeydown="if(event.key==='Enter')runClipSearch()">
@@ -1125,6 +1125,7 @@ var calendarYear = new Date().getFullYear();
 var selectedDay = null;
 var calendarData = null;
 var clipSearchActive = false;
+var searchFilterTimer = null;
 
 function hasActiveBrowseFilter() {
   var searchInput = document.getElementById('searchInput');
@@ -2089,6 +2090,22 @@ function calendarChangeYear(delta) {
 function applyFilters() {
   if (timelineMode) loadCalendarData();
   resetAndLoad();
+}
+
+function scheduleSearchFilter() {
+  if (searchFilterTimer) clearTimeout(searchFilterTimer);
+  searchFilterTimer = setTimeout(function() {
+    searchFilterTimer = null;
+    applyFilters();
+  }, 250);
+}
+
+function applySearchFilterNow() {
+  if (searchFilterTimer) {
+    clearTimeout(searchFilterTimer);
+    searchFilterTimer = null;
+  }
+  applyFilters();
 }
 
 function setFilterRating(val) {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1462,6 +1462,7 @@ async function loadCollectionCounts() {
 }
 
 async function filterByCollection(id) {
+  cancelScheduledSearchFilter();
   activeFolderId = null;
   activeKeyword = null;
   activeCollectionId = id;
@@ -1838,6 +1839,7 @@ async function saveCollection() {
 
 /* ---------- Photo Loading ---------- */
 function resetAndLoad() {
+  cancelScheduledSearchFilter();
   photos = [];
   currentPage = 1;
   allLoaded = false;
@@ -2093,18 +2095,22 @@ function applyFilters() {
 }
 
 function scheduleSearchFilter() {
-  if (searchFilterTimer) clearTimeout(searchFilterTimer);
+  cancelScheduledSearchFilter();
   searchFilterTimer = setTimeout(function() {
     searchFilterTimer = null;
     applyFilters();
   }, 250);
 }
 
-function applySearchFilterNow() {
+function cancelScheduledSearchFilter() {
   if (searchFilterTimer) {
     clearTimeout(searchFilterTimer);
     searchFilterTimer = null;
   }
+}
+
+function applySearchFilterNow() {
+  cancelScheduledSearchFilter();
   applyFilters();
 }
 


### PR DESCRIPTION
This updates the Browse keyword search to apply automatically as the user types, using a short debounce to avoid reloading the grid on every keystroke. Enter still applies the search immediately by clearing any pending debounce. This fixes the prior behavior where non-empty searches only ran after pressing Enter, while clearing the field refreshed automatically. Validated with `pytest tests/e2e/test_browse_search_empty_state.py`.