### PR TITLE
[codex] Fix lightbox mask hiding

### DIFF
--- a/tests/e2e/test_lightbox_context_menu.py
+++ b/tests/e2e/test_lightbox_context_menu.py
@@ -274,6 +274,51 @@ def test_mask_toggle_off_then_on_after_failed_load_stays_hidden(live_server, pag
     ), "same-URL re-show after a failed load must not reveal a broken overlay"
 
 
+def test_mask_toggle_off_detaches_loaded_overlay_image(live_server, page):
+    """The Hide Masks button should fully detach a loaded overlay image.
+
+    CSS display normally hides `.show`, but keeping the mask src attached can
+    leave stale composited pixels visible in embedded WebViews. Removing src
+    makes the hidden state unambiguous.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.evaluate("localStorage.removeItem('vireo.lb.masksVisible');")
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.dblclick()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+
+    page.evaluate(
+        """
+        _lbMasksVisible = true;
+        _lbMaskCurrentUrl =
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+        _lbApplyMaskVisibility();
+        """
+    )
+    page.wait_for_function(
+        "document.getElementById('lightboxMaskOverlay').naturalWidth > 0",
+        timeout=3000,
+    )
+    assert page.locator("#lightboxMaskOverlay").evaluate(
+        "el => el.classList.contains('show')"
+    ), "loaded mask overlay should be visible before hiding"
+
+    page.locator("#lightboxToggleMasks").click()
+    assert page.evaluate("localStorage.getItem('vireo.lb.masksVisible')") == "0"
+    assert page.locator("#lightboxToggleMasks").inner_text() == "Show Masks"
+    assert not page.locator("#lightboxMaskOverlay").evaluate(
+        "el => el.classList.contains('show')"
+    ), "hide must remove the visible overlay class"
+    assert page.locator("#lightboxMaskOverlay").evaluate(
+        "el => !el.hasAttribute('src')"
+    ), "hide must detach the loaded mask src"
+
+
 def test_lightbox_close_menu_item_closes_overlay(live_server, page):
     """The 'Close Lightbox' menu item dismisses the overlay."""
     url = live_server["url"]

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2979,10 +2979,17 @@ function _lbLoadDetections(photoId) {
 var _lbMaskActiveVariant = null;     // name of the photo's currently-active variant
 var _lbMaskAvailable = [];           // [{variant, url, created_at}, ...]
 var _lbMaskCurrentUrl = null;
+var _lbMaskLoadSeq = 0;
 
 function _lbResetMaskOverlay() {
   var img = document.getElementById('lightboxMaskOverlay');
-  if (img) { img.classList.remove('show'); img.removeAttribute('src'); }
+  _lbMaskLoadSeq++;
+  if (img) {
+    img.classList.remove('show');
+    img.onload = null;
+    img.onerror = null;
+    img.removeAttribute('src');
+  }
   var ctrls = document.getElementById('lightboxMaskControls');
   if (ctrls) ctrls.classList.remove('has-variants');
   var sel = document.getElementById('lightboxMaskSelect');
@@ -3002,24 +3009,36 @@ function _lbApplyMaskVisibility() {
     // while that request is still in flight, the pending callback
     // would override the hide as soon as it fires. Clear both handlers
     // so an in-flight load can't resurrect the overlay.
+    _lbMaskLoadSeq++;
     img.onload = null;
     img.onerror = null;
+    // Detach the decoded mask image while hidden. The class normally
+    // controls display, but removing src avoids stale blended pixels in
+    // WebView/compositor edge cases and forces a clean reload on show.
+    img.removeAttribute('src');
     return;
   }
+  var expectedUrl = _lbMaskCurrentUrl;
+  var seq = ++_lbMaskLoadSeq;
   // onerror guards against the file being deleted out from under us
   // between the /api/photos/<id>/masks call and the GET. The DB row
   // exists but the file is gone → silently hide instead of leaving a
   // broken-image icon over the photo.
-  img.onerror = function() { img.classList.remove('show'); };
+  img.onerror = function() {
+    if (seq === _lbMaskLoadSeq && _lbMaskCurrentUrl === expectedUrl) {
+      img.classList.remove('show');
+    }
+  };
   img.onload = function() {
     // Re-check the toggle: the user may have hidden masks between
     // src assignment and the load resolving.
-    if (_lbMasksVisible && _lbMaskCurrentUrl) {
+    if (seq === _lbMaskLoadSeq && _lbMasksVisible && _lbMaskCurrentUrl === expectedUrl) {
       img.classList.add('show');
     }
   };
-  if (img.getAttribute('src') !== _lbMaskCurrentUrl) {
-    img.src = _lbMaskCurrentUrl;
+  if (img.getAttribute('src') !== expectedUrl) {
+    img.classList.remove('show');
+    img.src = expectedUrl;
   } else if (img.naturalWidth > 0) {
     // Same URL and we know it loaded successfully — safe to re-show
     // without re-fetching.


### PR DESCRIPTION
Fixes the Browse lightbox mask toggle so hiding masks clears the visible class, detaches the loaded mask image, and ignores stale load callbacks. The root cause was that the overlay image source and async handlers could remain attached after Hide Masks, which could leave stale composited mask pixels visible in WebView. Adds e2e coverage that opens Browse, loads a mask overlay, clicks Hide Masks, and verifies the overlay is fully detached. Validated with `pytest tests/e2e/test_lightbox_context_menu.py` and `pytest tests/e2e/test_browse_lightbox.py tests/e2e/test_lightbox_context_menu.py`.