### PR TITLE
[codex] Avoid browse thumbnail reload on flag edits

### DIFF
--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -265,6 +265,37 @@ def test_singleton_set_keyboard_shortcut_applies(live_server, page):
     )
 
 
+def test_reject_shortcut_keeps_existing_thumbnail_nodes(live_server, page):
+    """Rejecting one photo should not rebuild the whole grid.
+
+    Regression: setFlag() called renderGrid(), replacing every thumbnail
+    <img> node and causing the visible grid to briefly blank/reload.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click()
+    pid = int(first.get_attribute("data-id"))
+
+    page.evaluate(
+        """() => {
+          window.__firstThumbNode = document.querySelector('.grid-card img');
+        }"""
+    )
+
+    page.keyboard.press("x")
+    page.wait_for_function(
+        f"(photos.find(function(p){{return p.id==={pid};}}) || {{}}).flag === 'rejected'",
+        timeout=3000,
+    )
+
+    assert page.evaluate(
+        "() => window.__firstThumbNode === document.querySelector('.grid-card img')"
+    )
+
+
 def test_filterByCollection_clears_multiselect_set(live_server, page):
     """Switching to a collection must drop a surviving multi-select set.
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1242,6 +1242,25 @@ function renderCardField(field, p) {
   }
 }
 
+function renderCardInfo(p) {
+  var infoHtml = '';
+  cardFields.forEach(function(field) {
+    infoHtml += renderCardField(field, p);
+  });
+  return infoHtml;
+}
+
+function refreshGridCards(photoIds) {
+  photoIds.forEach(function(id) {
+    var p = photos.find(function(x) { return x.id === id; });
+    if (!p) return;
+    var card = document.querySelector('.grid-card[data-id="' + id + '"]');
+    if (!card) return;
+    var info = card.querySelector('.grid-card-info');
+    if (info) info.innerHTML = renderCardInfo(p);
+  });
+}
+
 /* ---------- Bootstrap ---------- */
 bootstrapBrowse();
 
@@ -2290,12 +2309,6 @@ function renderGrid() {
       speciesBadgeHtml += '</div>';
     }
 
-    // Build info area from configured card fields
-    var infoHtml = '';
-    cardFields.forEach(function(field) {
-      infoHtml += renderCardField(field, p);
-    });
-
     html += '<div class="grid-card' + selectedClass + '" data-id="' + p.id + '" data-idx="' + idx + '" data-filename="' + escapeAttr(p.filename) + '" onclick="selectPhoto(event,' + p.id + ',' + idx + ')">' +
       '<div class="grid-card-img-wrap">' +
         '<img src="/thumbnails/' + p.id + '.jpg" loading="lazy" alt="' + escapeAttr(p.filename) + '">' +
@@ -2305,7 +2318,7 @@ function renderGrid() {
         speciesBadgeHtml +
       '</div>' +
       '<div class="grid-card-info">' +
-        infoHtml +
+        renderCardInfo(p) +
       '</div>' +
     '</div>';
   });
@@ -2423,7 +2436,7 @@ async function batchSetRating(rating) {
     var p = photos.find(function(x) { return x.id === id; });
     if (p) p.rating = rating;
   });
-  renderGrid();
+  refreshGridCards(ids);
   showUndoToast();
 }
 
@@ -2439,7 +2452,10 @@ async function batchSetFlag(flag) {
     var p = photos.find(function(x) { return x.id === id; });
     if (p) p.flag = flag;
   });
-  renderGrid();
+  refreshGridCards(ids);
+  if (selectedPhotoId != null && ids.indexOf(selectedPhotoId) !== -1) {
+    updateDetailFlagButtons(flag);
+  }
   showUndoToast();
 }
 
@@ -2457,7 +2473,7 @@ async function batchSetColorLabel(color) {
     if (color) colorLabels[id] = color;
     else delete colorLabels[id];
   });
-  renderGrid();
+  refreshGridCards(ids);
   showUndoToast();
 }
 
@@ -2670,12 +2686,7 @@ function renderDetail(photo) {
   document.getElementById('detailRating').innerHTML = ratingHtml;
 
   // Flags
-  document.querySelectorAll('.detail-flag-btn').forEach(function(btn) {
-    btn.className = 'detail-flag-btn';
-  });
-  var flagBtns = document.querySelectorAll('.detail-flag-btn');
-  if (photo.flag === 'flagged') flagBtns[1].classList.add('active-flag');
-  else if (photo.flag === 'rejected') flagBtns[2].classList.add('active-reject');
+  updateDetailFlagButtons(photo.flag);
 
   // Color labels
   updateDetailColors();
@@ -2785,6 +2796,15 @@ function renderDetail(photo) {
   var searchInput = document.getElementById('metadataSearch');
   if (searchInput) searchInput.value = '';
   renderMetadataGroups(photo.metadata);
+}
+
+function updateDetailFlagButtons(flag) {
+  document.querySelectorAll('.detail-flag-btn').forEach(function(btn) {
+    btn.className = 'detail-flag-btn';
+  });
+  var flagBtns = document.querySelectorAll('.detail-flag-btn');
+  if (flag === 'flagged') flagBtns[1].classList.add('active-flag');
+  else if (flag === 'rejected') flagBtns[2].classList.add('active-reject');
 }
 
 function renderMetadataGroups(metadata) {
@@ -2982,23 +3002,24 @@ async function setRating(photoId, rating) {
     // Update local state
     var p = photos.find(function(x) { return x.id === photoId; });
     if (p) p.rating = rating;
-    renderGrid();
+    refreshGridCards([photoId]);
     loadDetail(photoId);
   } catch(e) {}
 }
 
 async function setFlag(flag) {
   if (!selectedPhotoId) return;
+  var photoId = selectedPhotoId;
   try {
-    await safeFetch('/api/photos/' + selectedPhotoId + '/flag', {
+    await safeFetch('/api/photos/' + photoId + '/flag', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ flag: flag }),
     });
-    var p = photos.find(function(x) { return x.id === selectedPhotoId; });
+    var p = photos.find(function(x) { return x.id === photoId; });
     if (p) p.flag = flag;
-    renderGrid();
-    loadDetail(selectedPhotoId);
+    refreshGridCards([photoId]);
+    if (selectedPhotoId === photoId) updateDetailFlagButtons(flag);
   } catch(e) {}
 }
 
@@ -3018,20 +3039,21 @@ async function fetchColorLabels(photoIds) {
 async function setColorLabel(color) {
   if (!selectedPhotoId) return;
   colorLabelGen++;
-  var current = colorLabels[selectedPhotoId] || null;
+  var photoId = selectedPhotoId;
+  var current = colorLabels[photoId] || null;
   var newColor = (current === color) ? null : color;
-  await safeFetch('/api/photos/' + selectedPhotoId + '/color_label', {
+  await safeFetch('/api/photos/' + photoId + '/color_label', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({color: newColor}),
   });
   if (newColor) {
-    colorLabels[selectedPhotoId] = newColor;
+    colorLabels[photoId] = newColor;
   } else {
-    delete colorLabels[selectedPhotoId];
+    delete colorLabels[photoId];
   }
-  updateDetailColors();
-  renderGrid();
+  if (selectedPhotoId === photoId) updateDetailColors();
+  refreshGridCards([photoId]);
 }
 
 function updateDetailColors() {
@@ -3519,7 +3541,7 @@ async function setRatingFor(photoId, rating) {
   } catch(e) { return; }
   var p = photos.find(function(x) { return x.id === photoId; });
   if (p) p.rating = rating;
-  renderGrid();
+  refreshGridCards([photoId]);
   if (selectedPhotoId === photoId) loadDetail(photoId);
 }
 
@@ -3532,8 +3554,8 @@ async function setFlagFor(photoId, flag) {
   } catch(e) { return; }
   var p = photos.find(function(x) { return x.id === photoId; });
   if (p) p.flag = flag;
-  renderGrid();
-  if (selectedPhotoId === photoId) loadDetail(photoId);
+  refreshGridCards([photoId]);
+  if (selectedPhotoId === photoId) updateDetailFlagButtons(flag);
 }
 
 async function setColorLabelFor(photoId, color) {
@@ -3546,7 +3568,7 @@ async function setColorLabelFor(photoId, color) {
   } catch(e) { return; }
   if (color) colorLabels[photoId] = color;
   else delete colorLabels[photoId];
-  renderGrid();
+  refreshGridCards([photoId]);
   if (selectedPhotoId === photoId) updateDetailColors();
 }
 


### PR DESCRIPTION
## Summary
This changes Browse flag, rating, and color edits to refresh only affected card metadata instead of rebuilding the whole grid. The root cause was `renderGrid()` replacing every thumbnail `<img>` node after a single reject action, which caused visible thumbnails to blank and reload. The detail flag controls now update in place for flag-only changes, and a regression test verifies the reject shortcut preserves the existing thumbnail node.

## Validation
- `python -m pytest tests/e2e/test_browse_single_select.py -q`
- `git diff --check origin/main...`