### PR TITLE
[codex] Warn on CPU-only ML jobs

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -644,7 +644,38 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             g.db = Database(db_path)
         return g.db
 
-    _GPU_RUNTIME_PROVIDERS = ("CoreMLExecutionProvider", "CUDAExecutionProvider")
+    _ACCELERATED_RUNTIME_PROVIDERS = {
+        "ACLExecutionProvider",
+        "ArmNNExecutionProvider",
+        "CANNExecutionProvider",
+        "CoreMLExecutionProvider",
+        "CUDAExecutionProvider",
+        "DmlExecutionProvider",
+        "MIGraphXExecutionProvider",
+        "NNAPIExecutionProvider",
+        "OpenVINOExecutionProvider",
+        "QNNExecutionProvider",
+        "ROCMExecutionProvider",
+        "TensorrtExecutionProvider",
+        "VitisAIExecutionProvider",
+        "WebGPUExecutionProvider",
+    }
+    _PROVIDER_DEVICE_INFO = {
+        "ACLExecutionProvider": ("ACL", "Arm Compute Library acceleration"),
+        "ArmNNExecutionProvider": ("ArmNN", "Arm NN acceleration"),
+        "CANNExecutionProvider": ("CANN", "Huawei CANN acceleration"),
+        "CoreMLExecutionProvider": ("CoreML", "Apple CoreML acceleration"),
+        "CUDAExecutionProvider": ("CUDA", "NVIDIA CUDA acceleration"),
+        "DmlExecutionProvider": ("DirectML", "Microsoft DirectML acceleration"),
+        "MIGraphXExecutionProvider": ("MIGraphX", "AMD MIGraphX acceleration"),
+        "NNAPIExecutionProvider": ("NNAPI", "Android NNAPI acceleration"),
+        "OpenVINOExecutionProvider": ("OpenVINO", "Intel OpenVINO acceleration"),
+        "QNNExecutionProvider": ("QNN", "Qualcomm QNN acceleration"),
+        "ROCMExecutionProvider": ("ROCm", "AMD ROCm acceleration"),
+        "TensorrtExecutionProvider": ("TensorRT", "NVIDIA TensorRT acceleration"),
+        "VitisAIExecutionProvider": ("Vitis AI", "AMD/Xilinx Vitis AI acceleration"),
+        "WebGPUExecutionProvider": ("WebGPU", "WebGPU acceleration"),
+    }
     _CPU_WARNING_MIN_WORK_ITEMS = 25
 
     def _runtime_execution_info():
@@ -657,6 +688,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "device_detail": "No GPU acceleration",
             "onnxruntime_version": None,
             "onnxruntime_providers": [],
+            "accelerated_provider_available": False,
             "gpu_provider_available": False,
             "cpu_only": True,
         }
@@ -666,17 +698,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             info["onnxruntime_version"] = ort.__version__
             available = list(ort.get_available_providers())
             info["onnxruntime_providers"] = available
-            info["gpu_provider_available"] = any(
-                p in available for p in _GPU_RUNTIME_PROVIDERS
-            )
-            info["cpu_only"] = not info["gpu_provider_available"]
+            accelerated = [
+                p for p in available if p in _ACCELERATED_RUNTIME_PROVIDERS
+            ]
+            info["accelerated_provider_available"] = bool(accelerated)
+            # Back-compat for callers that already key off this field.
+            info["gpu_provider_available"] = bool(accelerated)
+            info["cpu_only"] = not bool(accelerated)
 
-            if "CoreMLExecutionProvider" in available:
-                info["device"] = "CoreML"
-                info["device_detail"] = "Apple CoreML acceleration"
-            elif "CUDAExecutionProvider" in available:
-                info["device"] = "CUDA"
-                info["device_detail"] = "NVIDIA CUDA acceleration"
+            if accelerated:
+                device, detail = _PROVIDER_DEVICE_INFO.get(
+                    accelerated[0],
+                    (accelerated[0].replace("ExecutionProvider", ""), "Hardware acceleration"),
+                )
+                info["device"] = device
+                info["device_detail"] = detail
             else:
                 info["device"] = "CPU"
                 info["device_detail"] = "GPU not available - using CPU"
@@ -691,7 +727,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return None
 
         info = _runtime_execution_info()
-        if info["gpu_provider_available"]:
+        if info["accelerated_provider_available"]:
             return None
 
         providers = info["onnxruntime_providers"]
@@ -726,25 +762,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         return warning
 
-    def _runtime_warning_is_dismissed(warning):
-        if not warning:
-            return False
-        return warning.get("id") in getattr(app, "_runtime_warning_dismissals", set())
-
-    def _filter_dismissed_runtime_warning(job):
-        warning = job.get("runtime_warning")
-        if _runtime_warning_is_dismissed(warning):
-            job = dict(job)
-            job["runtime_warning"] = None
-        return job
-
     def _count_lines(path):
         if not path:
             return None
         try:
             with open(path) as f:
                 return sum(1 for line in f if line.strip())
-        except OSError:
+        except (OSError, UnicodeError):
             return None
 
     def _runtime_warning_work_units(description, count_fn):
@@ -994,7 +1018,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     app._job_runner = JobRunner(db=init_db)
     app._log_broadcaster = LogBroadcaster(buffer_size=500)
-    app._runtime_warning_dismissals = set()
     app._log_broadcaster.install()
 
     # Self-healing background backfill of missing working copies. RAW (and
@@ -5671,7 +5694,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             workspace_id=active_ws,
             runtime_warning=_build_cpu_runtime_warning(
                 "precompute-embeddings",
-                work_units=_count_lines(labels_file),
+                work_units=_runtime_warning_work_units(
+                    "precompute labels file",
+                    lambda: _count_lines(labels_file),
+                ),
                 reason="large_embedding_precompute_cpu_only",
             ),
         )
@@ -9057,14 +9083,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_jobs_list():
         runner = app._job_runner
         db = _get_db()
-        active = [
-            _filter_dismissed_runtime_warning(_strip_heavy_for_list(j))
-            for j in runner.list_jobs()
-        ]
-        history = [
-            _filter_dismissed_runtime_warning(_strip_heavy_for_list(j))
-            for j in runner.get_history(db, limit=10)
-        ]
+        active = [_strip_heavy_for_list(j) for j in runner.list_jobs()]
+        history = [_strip_heavy_for_list(j) for j in runner.get_history(db, limit=10)]
         ws_rows = db.get_workspaces()
         ws_names = {w["id"]: w["name"] for w in ws_rows}
         return jsonify({
@@ -9080,8 +9100,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         warning_id = body.get("id")
         if not warning_id:
             return json_error("id required")
-        app._runtime_warning_dismissals.add(str(warning_id))
-        log.info("Dismissed runtime warning: %s", warning_id)
+        log.info("Client dismissed runtime warning: %s", warning_id)
         return jsonify({"ok": True, "id": str(warning_id)})
 
     @app.route("/api/jobs/<job_id>")
@@ -9089,7 +9108,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         job = app._job_runner.get(job_id)
         if not job:
             return json_error("job not found", 404)
-        return jsonify(_filter_dismissed_runtime_warning(job))
+        return jsonify(job)
 
     @app.route("/api/jobs/<job_id>/cancel", methods=["POST"])
     def api_job_cancel(job_id):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -644,6 +644,109 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             g.db = Database(db_path)
         return g.db
 
+    _GPU_RUNTIME_PROVIDERS = ("CoreMLExecutionProvider", "CUDAExecutionProvider")
+    _CPU_WARNING_MIN_WORK_ITEMS = 25
+
+    def _runtime_execution_info():
+        """Return ONNX Runtime provider/device information for UI diagnostics."""
+        import platform
+
+        info = {
+            "platform": platform.platform(),
+            "device": "CPU",
+            "device_detail": "No GPU acceleration",
+            "onnxruntime_version": None,
+            "onnxruntime_providers": [],
+            "gpu_provider_available": False,
+            "cpu_only": True,
+        }
+        try:
+            import onnxruntime as ort
+
+            info["onnxruntime_version"] = ort.__version__
+            available = list(ort.get_available_providers())
+            info["onnxruntime_providers"] = available
+            info["gpu_provider_available"] = any(
+                p in available for p in _GPU_RUNTIME_PROVIDERS
+            )
+            info["cpu_only"] = not info["gpu_provider_available"]
+
+            if "CoreMLExecutionProvider" in available:
+                info["device"] = "CoreML"
+                info["device_detail"] = "Apple CoreML acceleration"
+            elif "CUDAExecutionProvider" in available:
+                info["device"] = "CUDA"
+                info["device_detail"] = "NVIDIA CUDA acceleration"
+            else:
+                info["device"] = "CPU"
+                info["device_detail"] = "GPU not available - using CPU"
+        except ImportError:
+            info["device_detail"] = "onnxruntime not installed"
+
+        return info
+
+    def _build_cpu_runtime_warning(job_type, *, work_units=None, reason=None):
+        """Build a dismissible CPU-only warning for expensive ML jobs."""
+        if work_units is None or work_units < _CPU_WARNING_MIN_WORK_ITEMS:
+            return None
+
+        info = _runtime_execution_info()
+        if info["gpu_provider_available"]:
+            return None
+
+        providers = info["onnxruntime_providers"]
+        provider_text = ", ".join(providers) if providers else "none detected"
+        label = job_type.replace("-", " ").replace("_", " ").title()
+        warning = {
+            "id": "cpu-only-ml",
+            "kind": "cpu-only-ml",
+            "title": "Using CPU only",
+            "message": f"This {label} job may be much slower than expected.",
+            "detail": f"Available ONNX Runtime providers: {provider_text}",
+            "next_action": (
+                "Install the CUDA/CoreML runtime, check accelerator "
+                "availability, or continue on CPU."
+            ),
+            "device": info["device"],
+            "device_detail": info["device_detail"],
+            "onnxruntime_version": info["onnxruntime_version"],
+            "onnxruntime_providers": providers,
+            "work_units": work_units,
+            "reason": reason or "large_ml_job_cpu_only",
+        }
+        log.warning(
+            "CPU-only runtime warning for %s job (%s work item%s): "
+            "providers=%s device=%s reason=%s",
+            job_type,
+            work_units,
+            "" if work_units == 1 else "s",
+            provider_text,
+            info["device"],
+            warning["reason"],
+        )
+        return warning
+
+    def _runtime_warning_is_dismissed(warning):
+        if not warning:
+            return False
+        return warning.get("id") in getattr(app, "_runtime_warning_dismissals", set())
+
+    def _filter_dismissed_runtime_warning(job):
+        warning = job.get("runtime_warning")
+        if _runtime_warning_is_dismissed(warning):
+            job = dict(job)
+            job["runtime_warning"] = None
+        return job
+
+    def _count_lines(path):
+        if not path:
+            return None
+        try:
+            with open(path) as f:
+                return sum(1 for line in f if line.strip())
+        except OSError:
+            return None
+
     @app.teardown_appcontext
     def _close_db(exc):
         db = g.pop("db", None)
@@ -883,6 +986,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     app._job_runner = JobRunner(db=init_db)
     app._log_broadcaster = LogBroadcaster(buffer_size=500)
+    app._runtime_warning_dismissals = set()
     app._log_broadcaster.install()
 
     # Self-healing background backfill of missing working copies. RAW (and
@@ -5557,6 +5661,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "labels_file": labels_file,
             },
             workspace_id=active_ws,
+            runtime_warning=_build_cpu_runtime_warning(
+                "precompute-embeddings",
+                work_units=_count_lines(labels_file),
+                reason="large_embedding_precompute_cpu_only",
+            ),
         )
         return jsonify({"job_id": job_id})
 
@@ -6850,33 +6959,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/system/info")
     def api_system_info():
         """Return system information: ONNX Runtime, hardware."""
-        import platform
-
-        info = {
-            "platform": platform.platform(),
-            "device": "CPU",
-            "device_detail": "No GPU acceleration",
-            "onnxruntime_version": None,
-            "onnxruntime_providers": [],
-        }
-        try:
-            import onnxruntime as ort
-
-            info["onnxruntime_version"] = ort.__version__
-            available = ort.get_available_providers()
-            info["onnxruntime_providers"] = available
-
-            if "CoreMLExecutionProvider" in available:
-                info["device"] = "CoreML"
-                info["device_detail"] = "Apple CoreML acceleration"
-            elif "CUDAExecutionProvider" in available:
-                info["device"] = "CUDA"
-                info["device_detail"] = "NVIDIA CUDA acceleration"
-            else:
-                info["device"] = "CPU"
-                info["device_detail"] = "GPU not available — using CPU"
-        except ImportError:
-            info["device_detail"] = "onnxruntime not installed"
+        info = _runtime_execution_info()
 
         # "installed" requires both module AND weights — module-only
         # lets classify silently fall back to full-image classification.
@@ -8892,7 +8975,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         import config as cfg
         from classify_job import ClassifyParams, run_classify_job
 
-        user_cfg = _get_db().get_effective_config(cfg.load())
+        db = _get_db()
+        user_cfg = db.get_effective_config(cfg.load())
         body = request.get_json(silent=True) or {}
         collection_id = body.get("collection_id")
 
@@ -8915,8 +8999,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
 
         runner = app._job_runner
-        active_ws = _get_db()._active_workspace_id
+        active_ws = db._active_workspace_id
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        work_units = db.count_collection_photos(collection_id)
+        runtime_warning = _build_cpu_runtime_warning(
+            "classify",
+            work_units=work_units,
+            reason="large_classification_job_cpu_only",
+        )
 
         def work(job):
             return run_classify_job(job, runner, db_path, active_ws, params, vireo_dir=vireo_dir)
@@ -8929,6 +9019,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "model_name": params.model_name,
             },
             workspace_id=active_ws,
+            runtime_warning=runtime_warning,
         )
         return jsonify({"job_id": job_id})
 
@@ -8955,8 +9046,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_jobs_list():
         runner = app._job_runner
         db = _get_db()
-        active = [_strip_heavy_for_list(j) for j in runner.list_jobs()]
-        history = [_strip_heavy_for_list(j) for j in runner.get_history(db, limit=10)]
+        active = [
+            _filter_dismissed_runtime_warning(_strip_heavy_for_list(j))
+            for j in runner.list_jobs()
+        ]
+        history = [
+            _filter_dismissed_runtime_warning(_strip_heavy_for_list(j))
+            for j in runner.get_history(db, limit=10)
+        ]
         ws_rows = db.get_workspaces()
         ws_names = {w["id"]: w["name"] for w in ws_rows}
         return jsonify({
@@ -8966,12 +9063,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "workspace_names": ws_names,
         })
 
+    @app.route("/api/jobs/runtime-warning/dismiss", methods=["POST"])
+    def api_job_runtime_warning_dismiss():
+        body = request.get_json(silent=True) or {}
+        warning_id = body.get("id")
+        if not warning_id:
+            return json_error("id required")
+        app._runtime_warning_dismissals.add(str(warning_id))
+        log.info("Dismissed runtime warning: %s", warning_id)
+        return jsonify({"ok": True, "id": str(warning_id)})
+
     @app.route("/api/jobs/<job_id>")
     def api_job_status(job_id):
         job = app._job_runner.get(job_id)
         if not job:
             return json_error("job not found", 404)
-        return jsonify(job)
+        return jsonify(_filter_dismissed_runtime_warning(job))
 
     @app.route("/api/jobs/<job_id>/cancel", methods=["POST"])
     def api_job_cancel(job_id):
@@ -9847,7 +9954,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         import config as cfg
 
-        effective_cfg = _get_db().get_effective_config(cfg.load())
+        db = _get_db()
+        effective_cfg = db.get_effective_config(cfg.load())
         pipeline_cfg = effective_cfg.get("pipeline", {})
         sam2_variant = pipeline_cfg.get("sam2_variant", "sam2-small")
         dinov2_variant = pipeline_cfg.get("dinov2_variant", "vit-b14")
@@ -9859,7 +9967,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         min_detector_conf = effective_cfg.get("detector_confidence", 0.2)
 
         runner = app._job_runner
-        active_ws = _get_db()._active_workspace_id
+        active_ws = db._active_workspace_id
+        work_units = (
+            db.count_collection_photos(collection_id)
+            if collection_id
+            else db.count_photos()
+        )
+        runtime_warning = _build_cpu_runtime_warning(
+            "extract-masks",
+            work_units=work_units,
+            reason="large_segmentation_job_cpu_only",
+        )
 
         def work(job):
             import numpy as np
@@ -10151,6 +10269,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "proxy_longest_edge": proxy_longest_edge,
             },
             workspace_id=active_ws,
+            runtime_warning=runtime_warning,
         )
         return jsonify({"job_id": job_id})
 
@@ -10245,6 +10364,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         from pipeline_job import PipelineParams, run_pipeline_job
 
         body = request.get_json(silent=True) or {}
+        db = _get_db()
         source = body.get("source")
         sources = body.get("sources")
         collection_id = body.get("collection_id")
@@ -10267,7 +10387,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # time instead of a 200 followed by an asynchronous job failure.
         if (
             source_snapshot_id is not None
-            and _get_db().get_new_images_snapshot(source_snapshot_id) is None
+            and db.get_new_images_snapshot(source_snapshot_id) is None
         ):
             return json_error(
                 f"source_snapshot_id {source_snapshot_id} not found",
@@ -10378,7 +10498,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 log.warning("Failed to save recent destination to config")
 
         runner = app._job_runner
-        active_ws = _get_db()._active_workspace_id
+        active_ws = db._active_workspace_id
+        work_units = None
+        if collection_id:
+            work_units = db.count_collection_photos(collection_id)
+        elif source_snapshot_id is not None:
+            snap = db.get_new_images_snapshot(source_snapshot_id)
+            work_units = snap["file_count"] if snap else None
+
+        runtime_warning = None
+        if not (params.skip_classify and params.skip_extract_masks):
+            runtime_warning = _build_cpu_runtime_warning(
+                "pipeline",
+                work_units=work_units,
+                reason="large_pipeline_ml_job_cpu_only",
+            )
 
         def work(job):
             return run_pipeline_job(
@@ -10397,6 +10531,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "skip_regroup": params.skip_regroup,
             },
             workspace_id=active_ws,
+            runtime_warning=runtime_warning,
         )
         result = {"job_id": job_id}
         if model_warning:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -747,6 +747,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         except OSError:
             return None
 
+    def _runtime_warning_work_units(description, count_fn):
+        """Best-effort sizing for warnings; never block job submission."""
+        try:
+            return count_fn()
+        except Exception:
+            log.debug("Could not size %s for runtime warning", description, exc_info=True)
+            return None
+
     @app.teardown_appcontext
     def _close_db(exc):
         db = g.pop("db", None)
@@ -9001,7 +9009,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         runner = app._job_runner
         active_ws = db._active_workspace_id
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
-        work_units = db.count_collection_photos(collection_id)
+        work_units = _runtime_warning_work_units(
+            "classify collection",
+            lambda: db.count_collection_photos(collection_id),
+        )
         runtime_warning = _build_cpu_runtime_warning(
             "classify",
             work_units=work_units,
@@ -9968,10 +9979,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         runner = app._job_runner
         active_ws = db._active_workspace_id
-        work_units = (
-            db.count_collection_photos(collection_id)
+        work_units = _runtime_warning_work_units(
+            "extract-masks collection" if collection_id else "extract-masks workspace",
+            lambda: db.count_collection_photos(collection_id)
             if collection_id
-            else db.count_photos()
+            else db.count_photos(),
         )
         runtime_warning = _build_cpu_runtime_warning(
             "extract-masks",
@@ -10501,10 +10513,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         active_ws = db._active_workspace_id
         work_units = None
         if collection_id:
-            work_units = db.count_collection_photos(collection_id)
+            work_units = _runtime_warning_work_units(
+                "pipeline collection",
+                lambda: db.count_collection_photos(collection_id),
+            )
         elif source_snapshot_id is not None:
-            snap = db.get_new_images_snapshot(source_snapshot_id)
-            work_units = snap["file_count"] if snap else None
+            work_units = _runtime_warning_work_units(
+                "pipeline new-images snapshot",
+                lambda: (db.get_new_images_snapshot(source_snapshot_id) or {}).get(
+                    "file_count"
+                ),
+            )
 
         runtime_warning = None
         if not (params.skip_classify and params.skip_extract_masks):

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -71,7 +71,7 @@ class JobRunner:
             db.conn.execute("ALTER TABLE job_history ADD COLUMN summary TEXT DEFAULT ''")
 
     def start(self, job_type, work_fn, config=None, workspace_id=None,
-              ephemeral=False):
+              ephemeral=False, runtime_warning=None):
         """Start a background job.
 
         Args:
@@ -86,6 +86,8 @@ class JobRunner:
                        (e.g. the new-images filesystem walk) — it is fine to
                        lose the record on process restart and we don't want
                        it to clutter the history list.
+            runtime_warning: optional user-facing warning metadata to expose
+                       while the job is running.
 
         Returns:
             job_id string
@@ -106,6 +108,7 @@ class JobRunner:
             "workspace_id": workspace_id,
             "steps": [],
             "ephemeral": ephemeral,
+            "runtime_warning": runtime_warning,
         }
 
         with self._lock:

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1163,6 +1163,26 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 /* When the missing-folders banner is visible above, new-images stacks
    naturally in document flow — both are non-fixed block-level elements. */
 
+.runtime-warning-banner {
+  background: color-mix(in srgb, var(--warning, #ffb020) 18%, var(--bg-secondary));
+  color: var(--text-primary, #E6F1F5);
+  padding: 8px 16px;
+  font-size: 13px;
+  display: none;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid var(--warning, #ffb020);
+}
+.runtime-warning-banner strong { color: var(--warning, #ffb020); }
+.runtime-warning-banner .runtime-warning-text {
+  flex: 1;
+  min-width: 0;
+  line-height: 1.4;
+}
+.runtime-warning-banner .banner-dismiss {
+  color: var(--text-secondary, #9fb3bd);
+}
+
 .dup-cleanup-banner {
   background: var(--bg-tertiary, #153D55);
   color: var(--text-primary, #E6F1F5);
@@ -1385,6 +1405,11 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
     <span class="activity-dot" id="navActivityDot"></span>
   </span>
 </nav>
+
+<div class="runtime-warning-banner" id="runtimeWarningBanner" data-testid="runtime-warning-banner">
+  <div class="runtime-warning-text" id="runtimeWarningText"></div>
+  <button class="banner-dismiss" type="button" onclick="dismissRuntimeWarning()" title="Dismiss">&times;</button>
+</div>
 
 <!-- Command palette (cmd+K) -->
 <div class="cmd-palette-overlay" id="commandPalette" hidden onclick="if(event.target===this)closeCommandPalette()">
@@ -4689,6 +4714,52 @@ function formatDuration(seconds) {
   var _jobPollTimer = null;
   var _navJobPollTimer = null;
 
+  function runtimeWarningDismissKey(id) {
+    return 'vireo_runtime_warning_dismissed_' + String(id || '');
+  }
+
+  function findRuntimeWarning() {
+    for (var i = 0; i < activeJobs.length; i++) {
+      var j = activeJobs[i];
+      if (j.status === 'running' && j.runtime_warning) return j.runtime_warning;
+    }
+    return null;
+  }
+
+  function updateRuntimeWarningBanner() {
+    var banner = document.getElementById('runtimeWarningBanner');
+    var text = document.getElementById('runtimeWarningText');
+    if (!banner || !text) return;
+
+    var warning = findRuntimeWarning();
+    if (!warning || localStorage.getItem(runtimeWarningDismissKey(warning.id)) === '1') {
+      banner.style.display = 'none';
+      banner.dataset.warningId = '';
+      return;
+    }
+
+    banner.dataset.warningId = warning.id || '';
+    text.innerHTML =
+      '<strong>' + bpEscape(warning.title || 'Using CPU only') + '.</strong> ' +
+      bpEscape(warning.message || 'This job may be much slower than expected.') +
+      ' ' + bpEscape(warning.detail || '') +
+      ' ' + bpEscape(warning.next_action || '');
+    banner.style.display = 'flex';
+  }
+
+  window.dismissRuntimeWarning = function() {
+    var banner = document.getElementById('runtimeWarningBanner');
+    if (!banner) return;
+    var id = banner.dataset.warningId || 'cpu-only-ml';
+    localStorage.setItem(runtimeWarningDismissKey(id), '1');
+    banner.style.display = 'none';
+    fetch('/api/jobs/runtime-warning/dismiss', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({id: id})
+    }).catch(function() {});
+  };
+
   // Theme system
   var THEMES = [
     {id: 'vireo-dark', name: 'Vireo Dark', icon: '\u2600'},
@@ -5073,6 +5144,7 @@ function formatDuration(seconds) {
       updateSummary();
       updateActivityDot();
       updateDockProgress();
+      updateRuntimeWarningBanner();
     }
   });
 
@@ -5086,6 +5158,7 @@ function formatDuration(seconds) {
         updateSummary();
         updateActivityDot();
         updateDockProgress();
+        updateRuntimeWarningBanner();
       })
       .catch(function() {});
   }

--- a/vireo/tests/test_job_submission_api.py
+++ b/vireo/tests/test_job_submission_api.py
@@ -104,6 +104,23 @@ def test_large_classify_job_skips_warning_when_gpu_provider_present(
     assert job["runtime_warning"] is None
 
 
+def test_large_classify_job_skips_warning_when_directml_provider_present(
+    app_and_db, monkeypatch,
+):
+    """Non-CUDA/CoreML accelerated ONNX providers also suppress warnings."""
+    _stub_classify_job(monkeypatch)
+    _set_onnx_providers(monkeypatch, ["DmlExecutionProvider", "CPUExecutionProvider"])
+    app, db = app_and_db
+    cid = _collection_with_photo_count(db, 30)
+
+    client = app.test_client()
+    resp = client.post("/api/jobs/classify", json={"collection_id": cid})
+    assert resp.status_code == 200
+
+    job = _job_from_response(client, resp.get_json()["job_id"])
+    assert job["runtime_warning"] is None
+
+
 def test_small_classify_job_does_not_show_cpu_only_warning(
     app_and_db, monkeypatch,
 ):
@@ -122,7 +139,7 @@ def test_small_classify_job_does_not_show_cpu_only_warning(
 
 
 def test_cpu_only_runtime_warning_can_be_dismissed(app_and_db, monkeypatch):
-    """Dismissing a runtime warning hides it from subsequent job polling."""
+    """Dismissing a warning is client-local and does not suppress API data."""
     _stub_classify_job(monkeypatch, sleep=0.4)
     _set_onnx_providers(monkeypatch, ["CPUExecutionProvider"])
     app, db = app_and_db
@@ -143,7 +160,25 @@ def test_cpu_only_runtime_warning_can_be_dismissed(app_and_db, monkeypatch):
     assert dismiss.status_code == 200
 
     job = _job_from_response(client, job_id)
-    assert job["runtime_warning"] is None
+    assert job["runtime_warning"]["id"] == "cpu-only-ml"
+
+
+def test_precompute_embedding_warning_sizing_ignores_decode_errors(
+    app_and_db, monkeypatch, tmp_path,
+):
+    """A non-UTF-8 labels file must not make job submission fail."""
+    _set_onnx_providers(monkeypatch, ["CPUExecutionProvider"])
+    labels_file = tmp_path / "labels.txt"
+    labels_file.write_bytes(b"\xff\xfe\x00")
+
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/jobs/precompute-embeddings",
+        json={"model_id": "missing-model", "labels_file": str(labels_file)},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["job_id"].startswith("precompute-embeddings-")
 
 
 def test_job_cull_returns_job_id(app_and_db):

--- a/vireo/tests/test_job_submission_api.py
+++ b/vireo/tests/test_job_submission_api.py
@@ -1,10 +1,59 @@
 """Tests for job submission and history API routes."""
 
+import json
 import os
+import sys
 import time
+from types import SimpleNamespace
 
 from PIL import Image
 from wait import wait_for_job_via_client
+
+
+def _stub_classify_job(monkeypatch, sleep=0.2):
+    import classify_job
+
+    def fake_run_classify_job(*args, **kwargs):
+        time.sleep(sleep)
+        return {"ok": True}
+
+    monkeypatch.setattr(classify_job, "run_classify_job", fake_run_classify_job)
+
+
+def _set_onnx_providers(monkeypatch, providers):
+    fake_ort = SimpleNamespace(
+        __version__="1.test",
+        get_available_providers=lambda: list(providers),
+    )
+    monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
+
+
+def _collection_with_photo_count(db, count):
+    fid = db.get_folder_tree()[0]["id"]
+    photo_ids = [
+        r["id"]
+        for r in db.conn.execute("SELECT id FROM photos ORDER BY id").fetchall()
+    ]
+    while len(photo_ids) < count:
+        idx = len(photo_ids)
+        photo_ids.append(
+            db.add_photo(
+                folder_id=fid,
+                filename=f"runtime-warning-{idx}.jpg",
+                extension=".jpg",
+                file_size=1000 + idx,
+                file_mtime=float(idx),
+            )
+        )
+    return db.add_collection(
+        f"runtime-warning-{count}",
+        json.dumps([{"field": "photo_ids", "value": photo_ids[:count]}]),
+    )
+
+
+def _job_from_response(client, job_id):
+    data = client.get("/api/jobs").get_json()
+    return next(j for j in data["active"] if j["id"] == job_id)
 
 
 def test_job_thumbnails_returns_job_id(app_and_db):
@@ -16,6 +65,85 @@ def test_job_thumbnails_returns_job_id(app_and_db):
     data = resp.get_json()
     assert "job_id" in data
     assert data["job_id"].startswith("thumbnails-")
+
+
+def test_large_classify_job_gets_cpu_only_runtime_warning(
+    app_and_db, monkeypatch,
+):
+    """Large ML jobs expose a CPU-only warning with provider details."""
+    _stub_classify_job(monkeypatch)
+    _set_onnx_providers(monkeypatch, ["CPUExecutionProvider"])
+    app, db = app_and_db
+    cid = _collection_with_photo_count(db, 30)
+
+    client = app.test_client()
+    resp = client.post("/api/jobs/classify", json={"collection_id": cid})
+    assert resp.status_code == 200
+
+    job = _job_from_response(client, resp.get_json()["job_id"])
+    warning = job["runtime_warning"]
+    assert warning["title"] == "Using CPU only"
+    assert warning["onnxruntime_providers"] == ["CPUExecutionProvider"]
+    assert "Available ONNX Runtime providers: CPUExecutionProvider" in warning["detail"]
+
+
+def test_large_classify_job_skips_warning_when_gpu_provider_present(
+    app_and_db, monkeypatch,
+):
+    """A GPU-capable ONNX Runtime provider suppresses the CPU-only warning."""
+    _stub_classify_job(monkeypatch)
+    _set_onnx_providers(monkeypatch, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+    app, db = app_and_db
+    cid = _collection_with_photo_count(db, 30)
+
+    client = app.test_client()
+    resp = client.post("/api/jobs/classify", json={"collection_id": cid})
+    assert resp.status_code == 200
+
+    job = _job_from_response(client, resp.get_json()["job_id"])
+    assert job["runtime_warning"] is None
+
+
+def test_small_classify_job_does_not_show_cpu_only_warning(
+    app_and_db, monkeypatch,
+):
+    """Small jobs keep CPU-only execution quiet to avoid warning noise."""
+    _stub_classify_job(monkeypatch)
+    _set_onnx_providers(monkeypatch, ["CPUExecutionProvider"])
+    app, db = app_and_db
+    cid = _collection_with_photo_count(db, 3)
+
+    client = app.test_client()
+    resp = client.post("/api/jobs/classify", json={"collection_id": cid})
+    assert resp.status_code == 200
+
+    job = _job_from_response(client, resp.get_json()["job_id"])
+    assert job["runtime_warning"] is None
+
+
+def test_cpu_only_runtime_warning_can_be_dismissed(app_and_db, monkeypatch):
+    """Dismissing a runtime warning hides it from subsequent job polling."""
+    _stub_classify_job(monkeypatch, sleep=0.4)
+    _set_onnx_providers(monkeypatch, ["CPUExecutionProvider"])
+    app, db = app_and_db
+    cid = _collection_with_photo_count(db, 30)
+
+    client = app.test_client()
+    resp = client.post("/api/jobs/classify", json={"collection_id": cid})
+    assert resp.status_code == 200
+    job_id = resp.get_json()["job_id"]
+
+    warning = _job_from_response(client, job_id)["runtime_warning"]
+    assert warning["id"] == "cpu-only-ml"
+
+    dismiss = client.post(
+        "/api/jobs/runtime-warning/dismiss",
+        json={"id": warning["id"]},
+    )
+    assert dismiss.status_code == 200
+
+    job = _job_from_response(client, job_id)
+    assert job["runtime_warning"] is None
 
 
 def test_job_cull_returns_job_id(app_and_db):


### PR DESCRIPTION
Adds CPU-only runtime warning metadata for large ML jobs and exposes provider/device details through job polling and system info.

Shows a dismissible global banner when classification, pipeline, mask extraction, or embedding precompute work is likely expensive on CPU-only ONNX Runtime.

Covers CPU-only, GPU-provider-present, small-job suppression, and dismissal behavior with focused tests.

Validation: pytest focused job/app/jobs suites, ruff check, and py_compile.