### PR TITLE
[codex] Show lightbox flag feedback

### DIFF
--- a/tests/e2e/test_lightbox_flag_hotkeys.py
+++ b/tests/e2e/test_lightbox_flag_hotkeys.py
@@ -53,6 +53,190 @@ def test_lightbox_x_rejects_photo(live_server, page):
 
     flag = _wait_for_flag(db, pid, "rejected")
     assert flag == "rejected", f"expected 'rejected', got {flag!r}"
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')"
+        " && document.getElementById('lightboxFlagStatus').textContent.trim() === 'Rejected'"
+        " && document.getElementById('lightboxFlagStatus').classList.contains('rejected')",
+        timeout=3000,
+    )
+
+
+def test_lightbox_x_not_overwritten_by_slow_initial_metadata(live_server, page):
+    """A slow /api/photos/<id> response from lightbox open must not clobber
+    the immediate flag feedback from a hotkey pressed while it is in flight."""
+    url = live_server["url"]
+    db = live_server["db"]
+    page.goto(f"{url}/browse")
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    pid = int(first.get_attribute("data-id"))
+
+    held = {}
+
+    def hold_initial_photo_fetch(route):
+        held["response"] = route.fetch()
+        held["route"] = route
+
+    page.route(f"**/api/photos/{pid}", hold_initial_photo_fetch)
+
+    first.dblclick()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+    page.wait_for_function(
+        "typeof _lightboxCurrentId !== 'undefined' && _lightboxCurrentId !== null",
+        timeout=3000,
+    )
+    deadline = time.time() + 3
+    while "route" not in held and time.time() < deadline:
+        time.sleep(0.05)
+    assert "route" in held, "expected lightbox metadata fetch to be held"
+
+    page.keyboard.press("x")
+    flag = _wait_for_flag(db, pid, "rejected")
+    assert flag == "rejected", f"expected 'rejected', got {flag!r}"
+    page.wait_for_function(
+        "document.getElementById('lightboxFlagStatus').textContent.trim() === 'Rejected'",
+        timeout=3000,
+    )
+
+    held["route"].fulfill(response=held["response"])
+    page.wait_for_timeout(100)
+    assert page.locator("#lightboxFlagStatus").inner_text().strip() == "Rejected"
+
+
+def test_lightbox_reopen_ignores_stale_metadata_from_previous_open(live_server, page):
+    """A delayed metadata response from an earlier open of the same photo
+    should not apply after the lightbox is closed and reopened."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    pid = int(first.get_attribute("data-id"))
+    base_photo = {
+        "id": pid,
+        "filename": first.get_attribute("data-filename") or "photo.jpg",
+        "width": 100,
+        "height": 100,
+        "flag": "none",
+        "metadata": None,
+        "keywords": [],
+        "location": None,
+        "xmp_exists": False,
+        "xmp_keywords": [],
+        "path": "",
+    }
+
+    held = {}
+    count = {"value": 0}
+
+    def hold_first_photo_fetch(route):
+        count["value"] += 1
+        if count["value"] == 1:
+            data = dict(base_photo)
+            data["flag"] = "rejected"
+            held["json"] = data
+            held["route"] = route
+            return
+        route.fulfill(json=base_photo)
+
+    page.route(f"**/api/photos/{pid}", hold_first_photo_fetch)
+
+    page.evaluate(
+        "pid => { const p = photos.find(x => x.id === pid);"
+        " openLightbox(pid, p ? p.filename : '', photos); }",
+        pid,
+    )
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+    deadline = time.time() + 3
+    while "route" not in held and time.time() < deadline:
+        time.sleep(0.05)
+    assert "route" in held, "expected first lightbox metadata fetch to be held"
+
+    page.evaluate("closeLightbox()")
+    page.evaluate(
+        "pid => { const p = photos.find(x => x.id === pid);"
+        " openLightbox(pid, p ? p.filename : '', photos); }",
+        pid,
+    )
+    page.wait_for_function(
+        "document.getElementById('lightboxFlagStatus').textContent.trim() === 'No flag'",
+        timeout=3000,
+    )
+
+    held["route"].fulfill(json=held["json"])
+    page.wait_for_timeout(100)
+    assert page.locator("#lightboxFlagStatus").inner_text().strip() == "No flag"
+
+
+def test_lightbox_x_reverts_feedback_when_flag_write_fails(live_server, page):
+    """A failed flag write should not leave a false rejected confirmation."""
+    url = live_server["url"]
+    db = live_server["db"]
+    _open_lightbox_on_browse(page, url)
+    pid = _current_lightbox_id(page)
+
+    page.route(
+        "**/api/batch/flag",
+        lambda route: route.fulfill(
+            status=500,
+            content_type="application/json",
+            body='{"error":"forced failure"}',
+        ),
+    )
+
+    page.keyboard.press("x")
+
+    page.wait_for_function(
+        "document.getElementById('lightboxFlagStatus').textContent.trim() === 'No flag'",
+        timeout=3000,
+    )
+    assert db.get_photo(pid)["flag"] in (None, "none")
+
+
+def test_lightbox_newer_failed_write_falls_back_to_older_success(live_server, page):
+    """If a newer flag write fails while an older write later succeeds, the
+    lightbox should settle on the older confirmed flag rather than stale state."""
+    url = live_server["url"]
+    _open_lightbox_on_browse(page, url)
+
+    held = {}
+    count = {"value": 0}
+
+    def handle_flag_write(route):
+        count["value"] += 1
+        if count["value"] == 1:
+            held["route"] = route
+            return
+        route.fulfill(
+            status=500,
+            content_type="application/json",
+            body='{"error":"forced failure"}',
+        )
+
+    page.route("**/api/batch/flag", handle_flag_write)
+
+    page.keyboard.press("x")
+    deadline = time.time() + 3
+    while "route" not in held and time.time() < deadline:
+        time.sleep(0.05)
+    assert "route" in held, "expected first flag write to be held"
+
+    page.keyboard.press("p")
+    page.wait_for_function(
+        "document.getElementById('lightboxFlagStatus').textContent.trim() === 'No flag'",
+        timeout=3000,
+    )
+
+    held["route"].fulfill(status=200, content_type="application/json", body="{}")
+    page.wait_for_function(
+        "document.getElementById('lightboxFlagStatus').textContent.trim() === 'Rejected'",
+        timeout=3000,
+    )
 
 
 def test_lightbox_p_flags_photo(live_server, page):
@@ -66,6 +250,11 @@ def test_lightbox_p_flags_photo(live_server, page):
 
     flag = _wait_for_flag(db, pid, "flagged")
     assert flag == "flagged", f"expected 'flagged', got {flag!r}"
+    page.wait_for_function(
+        "document.getElementById('lightboxFlagStatus').textContent.trim() === 'Flagged'"
+        " && document.getElementById('lightboxFlagStatus').classList.contains('flagged')",
+        timeout=3000,
+    )
 
 
 def test_lightbox_u_unflags_photo(live_server, page):
@@ -83,6 +272,11 @@ def test_lightbox_u_unflags_photo(live_server, page):
 
     flag = _wait_for_flag(db, pid, "none")
     assert flag == "none", f"expected 'none', got {flag!r}"
+    page.wait_for_function(
+        "document.getElementById('lightboxFlagStatus').textContent.trim() === 'No flag'"
+        " && document.getElementById('lightboxFlagStatus').classList.contains('visible')",
+        timeout=3000,
+    )
 
 
 def test_lightbox_honors_modifier_rebind(live_server, page):

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -464,6 +464,37 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   pointer-events: none;
   z-index: 1;
 }
+.lightbox-flag-status {
+  position: absolute;
+  bottom: 48px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: none;
+  align-items: center;
+  gap: 6px;
+  background: rgba(0,0,0,0.7);
+  border: 1px solid var(--text-faint);
+  color: var(--text-secondary);
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  pointer-events: none;
+  z-index: 10001;
+}
+.lightbox-flag-status.visible { display: inline-flex; }
+.lightbox-flag-status.flagged {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.lightbox-flag-status.rejected {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+.lightbox-flag-status.pending {
+  border-color: var(--text-faint);
+  color: var(--text-secondary);
+}
 .lightbox-close {
   position: absolute;
   top: 16px;
@@ -2720,6 +2751,7 @@ async function createWorkspace() {
     </div>
   </div>
   <div class="lightbox-filename" id="lightboxFilename"></div>
+  <div class="lightbox-flag-status" id="lightboxFlagStatus" aria-live="polite"></div>
   <div id="lightboxCounter" style="display:none;position:absolute;top:16px;left:50%;transform:translateX(-50%);color:rgba(255,255,255,0.6);font-size:13px;background:rgba(0,0,0,0.5);padding:3px 10px;border-radius:4px;"></div>
   <div id="lightboxActions" class="lightbox-actions" style="position:absolute;bottom:16px;right:24px;display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end;max-width:calc(100vw - 48px);">
     <button id="lightboxToggleBoxes" onclick="event.stopPropagation(); toggleLightboxBoxes();" style="background:rgba(0,0,0,0.6);color:var(--text-secondary);border:1px solid var(--text-faint);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;" title="Toggle detection boxes (b)">
@@ -2817,6 +2849,126 @@ var _lbCurrentSrcKey = null; // 'full' | '2560' | '3840' | 'original'
 var _lbFullLongEdge = null;  // actual long edge of /full for current photo (may be < 1920 if preview_max_size is configured low)
 var _lbSessionFullLongEdge = null;  // last learned /full size across photos; better fallback than hardcoded 1920 for custom preview_max_size
 var _lbPending1To1 = false;  // true when z/click was pressed with unknown nativeZoom; upgrade to true 1:1 once learned
+var _lbFlagEditSeq = 0;      // increments for local flag writes so stale metadata fetches cannot overwrite the chip
+var _lbOpenSeq = 0;          // increments for every lightbox open so old metadata fetches cannot reapply after reopen
+var _lbFlagPendingWrites = 0;
+
+function _lbNormalizeFlag(flag) {
+  if (flag === 'flagged' || flag === 'rejected' || flag === 'none') return flag;
+  if (flag == null || flag === '') return 'none';
+  return null;
+}
+
+function _lbSetFlagStatus(flag) {
+  var el = document.getElementById('lightboxFlagStatus');
+  if (!el) return;
+  if (typeof flag === 'undefined') {
+    el.className = 'lightbox-flag-status';
+    el.textContent = '';
+    return;
+  }
+  var normalized = _lbNormalizeFlag(flag);
+  el.className = 'lightbox-flag-status';
+  if (!normalized) {
+    el.textContent = '';
+    return;
+  }
+  if (normalized === 'flagged') {
+    el.textContent = 'Flagged';
+    el.classList.add('visible', 'flagged');
+  } else if (normalized === 'rejected') {
+    el.textContent = 'Rejected';
+    el.classList.add('visible', 'rejected');
+  } else {
+    el.textContent = 'No flag';
+    el.classList.add('visible');
+  }
+}
+
+function _lbPendingFlagLabel(flag) {
+  if (flag === 'flagged') return 'Flagging...';
+  if (flag === 'rejected') return 'Rejecting...';
+  if (flag === 'none') return 'Clearing flag...';
+  return 'Saving...';
+}
+
+function _lbSetPendingFlagStatus(flag) {
+  var el = document.getElementById('lightboxFlagStatus');
+  if (!el) return;
+  el.className = 'lightbox-flag-status visible pending';
+  el.textContent = _lbPendingFlagLabel(flag);
+}
+
+function _lbFlagFromPhotoList(photoId) {
+  var p = _lightboxPhotoList.find(function(x) { return x.id === photoId; });
+  if (!p || !Object.prototype.hasOwnProperty.call(p, 'flag')) return undefined;
+  return p.flag;
+}
+
+function _lbRecordFlag(photoId, flag) {
+  var normalized = _lbNormalizeFlag(flag);
+  if (!normalized) return;
+  var p = _lightboxPhotoList.find(function(x) { return x.id === photoId; });
+  if (p) p.flag = normalized;
+  if (_lightboxCurrentId === photoId) _lbSetFlagStatus(normalized);
+}
+
+function _lbCacheFlag(photoId, flag) {
+  var normalized = _lbNormalizeFlag(flag);
+  if (!normalized) return;
+  var p = _lightboxPhotoList.find(function(x) { return x.id === photoId; });
+  if (p) p.flag = normalized;
+}
+
+function _lbRecordFetchedFlag(photoId, flag, flagFetchSeq) {
+  if (_lbFlagEditSeq !== flagFetchSeq) return;
+  _lbRecordFlag(photoId, flag);
+}
+
+function _lbApplyFlag(photoId, flag) {
+  var normalized = _lbNormalizeFlag(flag);
+  if (!normalized || photoId == null) return false;
+  var seq = _lbFlagEditSeq + 1;
+  _lbFlagEditSeq = seq;
+  _lbFlagPendingWrites += 1;
+  _lbSetPendingFlagStatus(normalized);
+  var write;
+
+  if (typeof window.setFlagFor === 'function') {
+    write = window.setFlagFor(photoId, normalized);
+  } else if (typeof window.setReviewFlag === 'function') {
+    write = window.setReviewFlag(photoId, normalized);
+  } else if (typeof window.safeFetch === 'function') {
+    write = window.safeFetch('/api/photos/' + photoId + '/flag', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({flag: normalized}),
+    }, { toast: false }).then(function() { return true; }).catch(function() { return false; });
+  } else {
+    _lbSetFlagStatus(_lbFlagFromPhotoList(photoId));
+    return false;
+  }
+
+  Promise.resolve(write).then(function(ok) {
+    _lbFlagPendingWrites = Math.max(0, _lbFlagPendingWrites - 1);
+    if (_lightboxCurrentId !== photoId) return;
+    if (ok === false) {
+      if (_lbFlagEditSeq === seq) _lbSetFlagStatus(_lbFlagFromPhotoList(photoId));
+      return;
+    }
+    if (_lbFlagEditSeq === seq || _lbFlagPendingWrites === 0) {
+      _lbRecordFlag(photoId, normalized);
+    } else {
+      _lbCacheFlag(photoId, normalized);
+    }
+  }).catch(function() {
+    _lbFlagPendingWrites = Math.max(0, _lbFlagPendingWrites - 1);
+    if (_lbFlagEditSeq === seq && _lightboxCurrentId === photoId) {
+      _lbSetFlagStatus(_lbFlagFromPhotoList(photoId));
+    }
+  });
+
+  return true;
+}
 
 function _lbStoredBool(key, fallback) {
   try {
@@ -3147,9 +3299,12 @@ function openLightbox(photoId, filename, photoList) {
   if (alreadyOpen) Keymap.popEsc(window._lbEscToken);
   window._lbEscToken = Keymap.pushEsc(function() { closeLightbox(); });
   if (!alreadyOpen) Keymap.lockBodyScroll();
+  _lbOpenSeq += 1;
+  var openSeq = _lbOpenSeq;
 
   _lightboxCurrentId = photoId;
   if (photoList) _lightboxPhotoList = photoList;
+  _lbSetFlagStatus(_lbFlagFromPhotoList(photoId));
 
   var overlay = document.getElementById('lightboxOverlay');
   var img = document.getElementById('lightboxImg');
@@ -3185,12 +3340,14 @@ function openLightbox(photoId, filename, photoList) {
   _lbApplyTransform();  // Clear any lingering translate/scale from prior photo before the new one renders.
 
   // Fetch original dimensions (async, non-blocking for image display)
+  var flagFetchSeq = _lbFlagEditSeq;
   fetch('/api/photos/' + photoId)
     .then(function(r) { return r.ok ? r.json() : null; })
     .then(function(data) {
-      if (!data || _lightboxCurrentId !== photoId) return;
+      if (!data || _lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
       _lbPhotoW = data.width || null;
       _lbPhotoH = data.height || null;
+      _lbRecordFetchedFlag(photoId, data.flag, flagFetchSeq);
       _lbRecomputeNativeZoom();
       _lbRenderEyeCrosshair(data);
     })
@@ -3389,6 +3546,7 @@ function closeLightbox(e) {
   document.getElementById('lightboxOverlay').classList.remove('active');
   document.getElementById('lightboxImg').src = '';
   document.getElementById('lightboxZoomBadge').style.display = 'none';
+  _lbSetFlagStatus(undefined);
   var detContainer = document.getElementById('lightboxDetections');
   if (detContainer) detContainer.innerHTML = '';
   // Drop the mask overlay too — otherwise reopening on a photo with
@@ -3404,10 +3562,10 @@ function closeLightbox(e) {
  * `openInEditor`, `revealPhoto`, `copyPhotoPaths`) are defined on pages that
  * carry a photo grid (browse.html). On /review, there is no selection model
  * but per-photo `setReviewRating` / `setReviewFlag` helpers exist and the
- * rating/flag chips fall through to them. Color labels are not part of the
+ * rating/flag chips fall through to them. Pages without a page-local flag
+ * helper use the shared photo flag endpoint. Color labels are not part of the
  * review workflow, so the color row is omitted when `setColorLabelFor` is
- * absent. Any still-missing helper becomes a silent no-op so clicking can
- * never throw.
+ * absent.
  */
 function buildLightboxContextMenu(pid) {
   var has = function(name) { return typeof window[name] === 'function'; };
@@ -3432,8 +3590,7 @@ function buildLightboxContextMenu(pid) {
     return {
       label: icon, title: title,
       onClick: function() {
-        if (has('setFlagFor')) window.setFlagFor(pid, f);
-        else if (has('setReviewFlag')) window.setReviewFlag(pid, f);
+        _lbApplyFlag(pid, f);
       },
     };
   };
@@ -3852,14 +4009,7 @@ document.addEventListener('keydown', function(e) {
     else if (matchesShortcut(e, unflagKey)) lbFlag = 'none';
     if (lbFlag !== null && _lightboxCurrentId != null) {
       var pid = _lightboxCurrentId;
-      if (typeof window.setFlagFor === 'function') window.setFlagFor(pid, lbFlag);
-      else if (typeof window.setReviewFlag === 'function') window.setReviewFlag(pid, lbFlag);
-      else {
-        safeFetch('/api/photos/' + pid + '/flag', {
-          method: 'POST', headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({flag: lbFlag}),
-        }, { toast: false }).catch(function(){});
-      }
+      _lbApplyFlag(pid, lbFlag);
       e.preventDefault();
       e.stopImmediatePropagation();
       return;

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3574,11 +3574,12 @@ async function setFlagFor(photoId, flag) {
       method: 'POST', headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({photo_ids: [photoId], flag: flag}),
     });
-  } catch(e) { return; }
+  } catch(e) { return false; }
   var p = photos.find(function(x) { return x.id === photoId; });
   if (p) p.flag = flag;
   refreshGridCards([photoId]);
   if (selectedPhotoId === photoId) updateDetailFlagButtons(flag);
+  return true;
 }
 
 async function setColorLabelFor(photoId, color) {

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1240,11 +1240,11 @@ function setReviewRating(photoId, rating) {
 }
 
 function setReviewFlag(photoId, flag) {
-  safeFetch('/api/batch/flag', {
+  return safeFetch('/api/batch/flag', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ photo_ids: [photoId], flag: flag }),
-  }, { toast: false }).catch(function() {});
+  }, { toast: false }).then(function() { return true; }).catch(function() { return false; });
 }
 
 function revealReviewPhoto(photoId) {


### PR DESCRIPTION
Adds an in-lightbox flag status chip so pick/reject/unflag shortcuts show immediate feedback without leaving the current image or zoom state. The chip initializes from the current photo flag on open/navigation and updates from hotkeys plus lightbox context-menu actions. This fixes the ambiguity where pressing x rejected the photo but gave no visible confirmation in the lightbox. Validated with pytest tests/e2e/test_lightbox_flag_hotkeys.py.