### PR TITLE
[codex] Make pipeline review sidebar collapsible

### DIFF
--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 
 from playwright.sync_api import expect
 
@@ -97,3 +98,38 @@ def test_species_name_arg_keeps_nullish_values_empty(live_server, page):
 
     assert page.evaluate("speciesNameArg(null)") == "''"
     assert page.evaluate("speciesNameArg(undefined)") == "''"
+
+
+def test_pipeline_review_sidebar_collapses_and_persists(live_server, page):
+    photo_ids = live_server["data"]["photos"][1:3]
+    _write_predictionless_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+
+    layout = page.locator("#pipelineLayout")
+    sidebar = page.locator("#pipelineSidebar")
+    content = page.locator("#pipelineSidebarContent")
+    toggle = page.locator("[data-testid='pipeline-sidebar-toggle']")
+
+    expect(content).to_be_visible()
+    expanded_width = sidebar.bounding_box()["width"]
+
+    toggle.click()
+
+    expect(layout).to_have_class(re.compile(r"\bsidebar-collapsed\b"))
+    expect(content).to_be_hidden()
+    expect(toggle).to_have_attribute("aria-expanded", "false")
+    page.wait_for_timeout(250)
+    collapsed_width = sidebar.bounding_box()["width"]
+    assert collapsed_width < expanded_width
+    assert collapsed_width <= 60
+
+    page.reload()
+    expect(layout).to_have_class(re.compile(r"\bsidebar-collapsed\b"))
+    expect(content).to_be_hidden()
+    expect(toggle).to_have_attribute("aria-expanded", "false")
+
+    toggle.click()
+    expect(layout).not_to_have_class(re.compile(r"\bsidebar-collapsed\b"))
+    expect(content).to_be_visible()
+    expect(toggle).to_have_attribute("aria-expanded", "true")

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -14,6 +14,18 @@
   height: calc(100vh - 48px - var(--bottom-offset, 28px));
   overflow: hidden;
 }
+.pipeline-layout.sidebar-collapsed .pipeline-sidebar {
+  width: 44px;
+  padding: 10px 6px;
+  overflow: hidden;
+}
+.pipeline-layout.sidebar-collapsed .sidebar-content {
+  display: none;
+}
+.pipeline-layout.sidebar-collapsed .pipeline-sidebar-toggle {
+  margin-left: 0;
+  margin-right: 0;
+}
 
 /* -- Sidebar -- */
 .pipeline-sidebar {
@@ -23,6 +35,29 @@
   border-right: 1px solid var(--border-primary);
   padding: 20px 16px;
   overflow-y: auto;
+  transition: width 0.18s ease, padding 0.18s ease;
+}
+.pipeline-sidebar-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  width: 32px;
+  height: 32px;
+  margin: 0 0 14px auto;
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+.pipeline-sidebar-toggle:hover {
+  border-color: var(--text-muted);
+  color: var(--text-primary);
 }
 .sidebar-section { margin-bottom: 24px; position: relative; }
 .sidebar-title {
@@ -37,6 +72,7 @@
 /* -- Main area -- */
 .pipeline-main {
   flex: 1;
+  min-width: 0;
   padding: 20px 24px;
   overflow-y: auto;
 }
@@ -1014,9 +1050,19 @@ input[type="range"]::-moz-range-thumb {
 <body>
 {% include '_navbar.html' %}
 
-<div class="pipeline-layout">
+<div class="pipeline-layout" id="pipelineLayout">
   <!-- Sidebar -->
-  <div class="pipeline-sidebar">
+  <div class="pipeline-sidebar" id="pipelineSidebar">
+    <button type="button"
+            class="pipeline-sidebar-toggle"
+            id="pipelineSidebarToggle"
+            data-testid="pipeline-sidebar-toggle"
+            onclick="togglePipelineSidebar()"
+            aria-controls="pipelineSidebarContent"
+            aria-label="Collapse sidebar"
+            aria-expanded="true"
+            title="Collapse sidebar">&#8249;</button>
+    <div class="sidebar-content" id="pipelineSidebarContent">
     <div class="sidebar-section" id="sidebarScoring" style="display:none">
       <div class="sidebar-title">Scoring Thresholds</div>
       <div class="reflow-indicator" id="reflowIndicator">Recomputing...</div>
@@ -1178,6 +1224,7 @@ input[type="range"]::-moz-range-thumb {
 
     <div class="sidebar-section">
       <a href="/pipeline" class="back-link">&larr; Back to Pipeline</a>
+    </div>
     </div>
   </div>
 
@@ -1351,6 +1398,36 @@ var reviewReadiness = null;
 // instead of letting it migrate to a sibling encounter that happens to
 // share the original first photo_id.
 var collapsedEncounters = new Set();
+var PIPELINE_SIDEBAR_STORAGE_KEY = 'vireo.pipelineReview.sidebarCollapsed';
+
+function setPipelineSidebarCollapsed(collapsed, persist) {
+  var layout = document.getElementById('pipelineLayout');
+  var toggle = document.getElementById('pipelineSidebarToggle');
+  if (!layout || !toggle) return;
+  layout.classList.toggle('sidebar-collapsed', !!collapsed);
+  toggle.textContent = collapsed ? '\u203a' : '\u2039';
+  toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+  toggle.setAttribute('aria-label', collapsed ? 'Expand sidebar' : 'Collapse sidebar');
+  toggle.title = collapsed ? 'Expand sidebar' : 'Collapse sidebar';
+  if (persist !== false) {
+    try {
+      window.localStorage.setItem(PIPELINE_SIDEBAR_STORAGE_KEY, collapsed ? '1' : '0');
+    } catch (e) {}
+  }
+}
+
+function togglePipelineSidebar() {
+  var layout = document.getElementById('pipelineLayout');
+  setPipelineSidebarCollapsed(!(layout && layout.classList.contains('sidebar-collapsed')));
+}
+
+function initPipelineSidebarState() {
+  var collapsed = false;
+  try {
+    collapsed = window.localStorage.getItem(PIPELINE_SIDEBAR_STORAGE_KEY) === '1';
+  } catch (e) {}
+  setPipelineSidebarCollapsed(collapsed, false);
+}
 
 function encounterKey(enc) {
   if (!enc || !enc.photo_ids || !enc.photo_ids.length) return null;
@@ -2474,6 +2551,7 @@ function computeReviewNow() {
 }
 
 function initPipelineReviewPage() {
+  initPipelineSidebarState();
   safeFetch('/api/pipeline/page-init', {}, { toast: false })
   .then(function(data) {
     // Capture overrides regardless of state so computeReviewNow() can apply


### PR DESCRIPTION
Adds a sticky collapse/expand control to the Pipeline Review sidebar so the tuning sliders can be hidden and the review area can use the space. The collapsed state is persisted in localStorage and reflected through ARIA attributes. Includes an e2e regression test covering collapse, reload persistence, and re-expansion.

Validation: `pytest tests/e2e/test_pipeline_review_species.py`