### PR TITLE
[codex] Clarify pipeline review summary units

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -44,8 +44,8 @@
 /* Summary bar */
 .summary-bar {
   display: flex;
-  gap: 20px;
-  align-items: center;
+  gap: 18px;
+  align-items: stretch;
   flex-wrap: wrap;
   margin-bottom: 20px;
   padding: 16px 20px;
@@ -53,9 +53,33 @@
   border-radius: 8px;
   border: 1px solid var(--border-primary);
 }
-.summary-stat { text-align: center; }
+.summary-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-right: 18px;
+  border-right: 1px solid var(--border-primary);
+}
+.summary-group:last-of-type { border-right: none; padding-right: 0; }
+.summary-group-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+}
+.summary-group-stats {
+  display: flex;
+  gap: 18px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+.summary-stat { min-width: 58px; text-align: left; }
+.summary-stat.wide { min-width: 150px; }
 .summary-stat .num { font-size: 28px; font-weight: 700; }
 .summary-stat .label { font-size: 11px; color: var(--text-dim); margin-top: 2px; }
+.summary-stat .detail { font-size: 11px; color: var(--text-muted); margin-top: 2px; white-space: nowrap; }
+.summary-stat .ratio { white-space: nowrap; }
 
 /* Empty state */
 .empty-state {
@@ -1192,41 +1216,58 @@ input[type="range"]::-moz-range-thumb {
 
     <!-- Summary bar (hidden until data loads) -->
     <div class="summary-bar" id="summaryBar" style="display:none">
-      <div class="summary-stat">
-        <div class="num" id="statTotalPhotos">0</div>
-        <div class="label">Photos</div>
+      <div class="summary-group" aria-label="Inventory counts">
+        <div class="summary-group-title">Inventory</div>
+        <div class="summary-group-stats">
+          <div class="summary-stat" title="Total photos included in this pipeline review result">
+            <div class="num" id="statTotalPhotos">0</div>
+            <div class="label">Photos</div>
+          </div>
+          <div class="summary-stat" title="Encounter groups built from nearby, similar photos">
+            <div class="num" id="statEncounterCount">0</div>
+            <div class="label">Encounters</div>
+          </div>
+          <div class="summary-stat" title="Burst groups inside encounters">
+            <div class="num" id="statBurstCount">0</div>
+            <div class="label">Bursts</div>
+          </div>
+        </div>
       </div>
-      <div class="summary-stat">
-        <div class="num" id="statEncounterCount">0</div>
-        <div class="label">Encounters</div>
+      <div class="summary-group" aria-label="Triage counts">
+        <div class="summary-group-title">Triage</div>
+        <div class="summary-group-stats">
+          <div class="summary-stat" title="Photos currently labeled KEEP by triage">
+            <div class="num" style="color:var(--accent);" id="statKeepCount">0</div>
+            <div class="label">Keep Photos</div>
+          </div>
+          <div class="summary-stat" title="Photos currently labeled REVIEW by triage">
+            <div class="num" style="color:var(--warning);" id="statReviewCount">0</div>
+            <div class="label">Review Photos</div>
+          </div>
+          <div class="summary-stat" title="Photos currently labeled REJECT by triage">
+            <div class="num" style="color:var(--danger);" id="statRejectCount">0</div>
+            <div class="label">Reject Photos</div>
+          </div>
+          <div class="summary-stat" id="statProtectedWrap" style="display:none" title="Protected photos that triage kept out of automatic rejection">
+            <div class="num" style="color:var(--warning);" id="statProtected">0</div>
+            <div class="label">Protected Photos</div>
+          </div>
+        </div>
       </div>
-      <div class="summary-stat">
-        <div class="num" id="statBurstCount">0</div>
-        <div class="label">Bursts</div>
-      </div>
-      <div class="summary-stat">
-        <div class="num" style="color:var(--accent);" id="statKeepCount">0</div>
-        <div class="label">Keep</div>
-      </div>
-      <div class="summary-stat">
-        <div class="num" style="color:var(--warning);" id="statReviewCount">0</div>
-        <div class="label">Review</div>
-      </div>
-      <div class="summary-stat">
-        <div class="num" style="color:var(--danger);" id="statRejectCount">0</div>
-        <div class="label">Reject</div>
-      </div>
-      <div class="summary-stat" id="statProtectedWrap" style="display:none">
-        <div class="num" style="color:var(--warning);" id="statProtected">0</div>
-        <div class="label">Protected</div>
-      </div>
-      <div class="summary-stat">
-        <div class="num" style="color:var(--success, #4caf50);" id="statConfirmedCount">0</div>
-        <div class="label">Confirmed</div>
-      </div>
-      <div class="summary-stat">
-        <div class="num" id="statUnconfirmedCount">0</div>
-        <div class="label">Unconfirmed</div>
+      <div class="summary-group" id="speciesReviewSummary" aria-label="Species review counts" title="Species confirmation is counted by review unit: bursts when an encounter has bursts, otherwise encounters.">
+        <div class="summary-group-title">Species Review</div>
+        <div class="summary-group-stats">
+          <div class="summary-stat wide">
+            <div class="num ratio" style="color:var(--success, #4caf50);" id="statConfirmedCount">0 / 0</div>
+            <div class="label" id="statConfirmedLabel">Review Units Confirmed</div>
+            <div class="detail" id="statConfirmedDetail">0 review units need confirmation</div>
+          </div>
+          <div class="summary-stat wide">
+            <div class="num" id="statUnconfirmedCount">0</div>
+            <div class="label" id="statUnconfirmedLabel">Need Confirmation</div>
+            <div class="detail" id="statUnconfirmedDetail">0 review units total</div>
+          </div>
+        </div>
       </div>
       <a id="missesReviewBtn" href="/misses" data-testid="pipeline-review-misses"
          style="display:none;margin-left:auto;padding:8px 14px;
@@ -2097,10 +2138,37 @@ function refreshLocalSummaryCounts() {
   return summary;
 }
 
+function getConfirmationUnitName(summary) {
+  var confirmed = Number(summary.confirmed_count || 0);
+  var unconfirmed = Number(summary.unconfirmed_count || 0);
+  var totalUnits = confirmed + unconfirmed;
+  var bursts = Number(summary.burst_count || 0);
+  var encounters = Number(summary.encounter_count || 0);
+  if (totalUnits > 0 && bursts === totalUnits) return totalUnits === 1 ? 'Burst' : 'Bursts';
+  if (totalUnits > 0 && encounters === totalUnits) return totalUnits === 1 ? 'Encounter' : 'Encounters';
+  return totalUnits === 1 ? 'Review Unit' : 'Review Units';
+}
+
+function confirmationUnitForCount(unitName, count) {
+  if (count !== 1) return unitName.toLowerCase();
+  if (unitName === 'Bursts') return 'burst';
+  if (unitName === 'Encounters') return 'encounter';
+  if (unitName === 'Review Units') return 'review unit';
+  return unitName.toLowerCase();
+}
+
+function formatConfirmationDetail(count, unitName, suffix) {
+  return count + ' ' + confirmationUnitForCount(unitName, count) + ' ' + suffix;
+}
+
 function updateSummaryBar(summary) {
   if (pipelineResults && (summary.confirmed_count == null || summary.unconfirmed_count == null)) {
     summary = refreshLocalSummaryCounts() || summary;
   }
+  var confirmed = Number(summary.confirmed_count || 0);
+  var unconfirmed = Number(summary.unconfirmed_count || 0);
+  var confirmationTotal = confirmed + unconfirmed;
+  var confirmationUnit = getConfirmationUnitName(summary);
   var el;
   el = document.getElementById('statTotalPhotos'); if (el) el.textContent = summary.total_photos;
   el = document.getElementById('statEncounterCount'); if (el) el.textContent = summary.encounter_count;
@@ -2108,8 +2176,16 @@ function updateSummaryBar(summary) {
   el = document.getElementById('statKeepCount'); if (el) el.textContent = summary.keep_count;
   el = document.getElementById('statReviewCount'); if (el) el.textContent = summary.review_count;
   el = document.getElementById('statRejectCount'); if (el) el.textContent = summary.reject_count;
-  el = document.getElementById('statConfirmedCount'); if (el) el.textContent = summary.confirmed_count || 0;
-  el = document.getElementById('statUnconfirmedCount'); if (el) el.textContent = summary.unconfirmed_count || 0;
+  el = document.getElementById('statConfirmedCount'); if (el) el.textContent = confirmed + ' / ' + confirmationTotal;
+  el = document.getElementById('statConfirmedLabel'); if (el) el.textContent = confirmationUnit + ' Confirmed';
+  el = document.getElementById('statConfirmedDetail'); if (el) el.textContent = formatConfirmationDetail(unconfirmed, confirmationUnit, 'need confirmation');
+  el = document.getElementById('statUnconfirmedCount'); if (el) el.textContent = unconfirmed;
+  el = document.getElementById('statUnconfirmedLabel'); if (el) el.textContent = 'Need Confirmation';
+  el = document.getElementById('statUnconfirmedDetail'); if (el) el.textContent = formatConfirmationDetail(confirmationTotal, confirmationUnit, 'total');
+  el = document.getElementById('speciesReviewSummary');
+  if (el) {
+    el.title = 'Species confirmation is counted by review unit: bursts when an encounter has bursts, otherwise encounters. Current basis: ' + confirmationUnit.toLowerCase() + '.';
+  }
   var protWrap = document.getElementById('statProtectedWrap');
   if (protWrap) {
     if (summary.rarity_protected) {

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -864,11 +864,18 @@ def test_species_search(app_and_db):
 
 
 def test_pipeline_review_page(app_and_db):
-    """GET /pipeline/review returns 200."""
+    """GET /pipeline/review returns 200 with explicit summary units."""
     app, _ = app_and_db
     client = app.test_client()
     resp = client.get('/pipeline/review')
     assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "Inventory" in html
+    assert "Triage" in html
+    assert "Species Review" in html
+    assert "Keep Photos" in html
+    assert "Review Units Confirmed" in html
+    assert "Species confirmation is counted by review unit" in html
 
 
 def test_classify_route_removed(app_and_db):


### PR DESCRIPTION
Restructures the Pipeline Review summary bar into Inventory, Triage, and Species Review groups so users can see which counts are photos versus review units. Species confirmation now renders as a confirmed/total ratio with adaptive units such as bursts or encounters, plus details for how many still need confirmation. This addresses the confusing case where confirmed and unconfirmed summed to bursts rather than photos. Validated with `python -m pytest vireo/tests/test_app.py::test_pipeline_review_page` and `git diff --check`.