### PR TITLE
[codex] Disable suggested burst review decisions

### DIFF
--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -575,22 +575,23 @@ def test_classic_pipeline_review_opens_requested_burst_from_url(live_server, pag
         "photos": [
             {"id": 1, "filename": "a.jpg", "label": "REVIEW", "quality_composite": 0.3, "subject_tenengrad": 10},
             {"id": 2, "filename": "b.jpg", "label": "REVIEW", "quality_composite": 0.6, "subject_tenengrad": 20},
+            {"id": 3, "filename": "c.jpg", "label": "REVIEW", "quality_composite": 0.9, "subject_tenengrad": 30},
         ],
         "encounters": [
             {
-                "photo_ids": [1, 2],
-                "photo_count": 2,
+                "photo_ids": [1, 2, 3],
+                "photo_count": 3,
                 "burst_count": 1,
                 "species": ["Test bird"],
-                "bursts": [{"photo_ids": [1, 2]}],
+                "bursts": [{"photo_ids": [1, 2, 3]}],
             }
         ],
         "summary": {
-            "total_photos": 2,
+            "total_photos": 3,
             "encounter_count": 1,
             "burst_count": 1,
             "keep_count": 0,
-            "review_count": 2,
+            "review_count": 3,
             "reject_count": 0,
         },
     }
@@ -600,7 +601,7 @@ def test_classic_pipeline_review_opens_requested_burst_from_url(live_server, pag
             json={
                 "results": results,
                 "workspace_overrides": {},
-                "review_readiness": {"state": "ready", "total_photos": 2},
+                "review_readiness": {"state": "ready", "total_photos": 3},
             }
         ),
     )
@@ -611,6 +612,7 @@ def test_classic_pipeline_review_opens_requested_burst_from_url(live_server, pag
                 "photos": {
                     "1": {"flag": "none", "has_species_keyword": False},
                     "2": {"flag": "none", "has_species_keyword": False},
+                    "3": {"flag": "none", "has_species_keyword": False},
                 },
                 "species_kid": None,
             }
@@ -622,4 +624,8 @@ def test_classic_pipeline_review_opens_requested_burst_from_url(live_server, pag
     page.goto(f"{live_server['url']}/pipeline/review?enc=0&burst=0")
 
     expect(page.locator("#grmOverlay")).to_have_class(re.compile(r"\bopen\b"))
-    expect(page.locator("#grmOverlay .grm-card[data-photo-id]")).to_have_count(2)
+    expect(page.locator("#grmOverlay .grm-card[data-photo-id]")).to_have_count(3)
+    expect(page.locator("#grmPicks .grm-card[data-photo-id]")).to_have_count(0)
+    expect(page.locator("#grmRejects .grm-card[data-photo-id]")).to_have_count(0)
+    expect(page.locator("#grmCandidates .grm-card[data-photo-id]")).to_have_count(3)
+    expect(page.locator("#grmCount")).to_have_text("0 picks, 0 rejects, 3 unsorted")

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -866,7 +866,6 @@ input[type="range"]::-moz-range-thumb {
 }
 .grm-card:hover { border-color: var(--text-ghost); }
 .grm-card.selected { border-color: var(--accent); }
-.grm-card.ai-best { border-color: var(--warning); }
 .grm-card.dragging { cursor: grabbing; }
 .grm-card.dragging img { pointer-events: none; }
 .grm-card.has-offset::after {
@@ -923,7 +922,6 @@ input[type="range"]::-moz-range-thumb {
 .grm-card-species { color: var(--text-primary); font-weight: 600; }
 .grm-card-scores { color: var(--text-dim); }
 .grm-card-scores .score-val { color: var(--text-secondary); }
-.grm-card-ai { color: var(--warning); font-size: 10px; font-weight: 600; }
 
 .grm-footer {
   padding: 12px 20px;
@@ -3033,13 +3031,11 @@ function grmShowSeedError(items, selectPhotoId) {
   }
 }
 
-// Seed picks/rejects on modal open. Photos already flagged/rejected in the
-// DB land in those zones; the quality-score heuristic only fills in zones
-// for photos with no flag set, so re-opening a burst respects prior choices.
+// Seed picks/rejects on modal open only from live DB state. Unflagged photos
+// stay as candidates until the user explicitly moves them.
 function grmSeedFromDbState(dbPhotos, items, selectPhotoId) {
   grmState.dbState = dbPhotos || {};
 
-  var unflagged = [];
   items.forEach(function(p) {
     var st = grmState.dbState[p.id];
     var flag = st ? st.flag : null;
@@ -3047,40 +3043,16 @@ function grmSeedFromDbState(dbPhotos, items, selectPhotoId) {
       grmState.picks.add(p.id);
     } else if (flag === 'rejected') {
       grmState.rejects.add(p.id);
-    } else {
-      unflagged.push(p);
     }
   });
 
-  // Heuristic fallback for photos with no DB flag: auto-pick the highest
-  // quality and auto-reject the worst third (only if no DB picks yet — we
-  // don't want to override the user's prior pick by piling on more).
-  if (grmState.picks.size === 0 && unflagged.length > 0) {
-    var best = unflagged[0];
-    unflagged.forEach(function(p) {
-      if ((p.quality_composite || 0) > (best.quality_composite || 0)) best = p;
-    });
-    grmState.picks.add(best.id);
-  }
-  if (grmState.rejects.size === 0 && items.length > 2) {
-    var sorted = unflagged.slice().sort(function(a, b) {
-      return (a.quality_composite || 0) - (b.quality_composite || 0);
-    });
-    var worstThird = Math.max(1, Math.floor(items.length / 3));
-    for (var i = 0; i < worstThird && i < sorted.length; i++) {
-      if (!grmState.picks.has(sorted[i].id)) {
-        grmState.rejects.add(sorted[i].id);
-      }
-    }
-  }
-
   var initSelect = selectPhotoId;
   if (!initSelect) {
-    var firstPick = null;
+    var firstSelected = null;
     items.forEach(function(p) {
-      if (firstPick == null && grmState.picks.has(p.id)) firstPick = p.id;
+      if (firstSelected == null && (grmState.picks.has(p.id) || grmState.rejects.has(p.id))) firstSelected = p.id;
     });
-    initSelect = firstPick || (items[0] && items[0].id);
+    initSelect = firstSelected || (items[0] && items[0].id);
   }
   // Mark the modal seeded *before* re-rendering so grmUpdateApplyLabel
   // (called from renderGroupModal) re-enables the button.
@@ -3110,17 +3082,9 @@ function closeGroupReview() {
 function renderGroupModal() {
   var items = grmState.items.filter(function(p) { return !grmState.removed.has(p.id); });
 
-  // Find AI best
-  var bestId = null;
-  var bestScore = -1;
-  items.forEach(function(p) {
-    if ((p.quality_composite || 0) > bestScore) { bestScore = p.quality_composite || 0; bestId = p.id; }
-  });
-
   function renderCard(p) {
-    var isBest = p.id === bestId;
     var isSelected = p.id === grmState.selected;
-    var cls = 'grm-card' + (isSelected ? ' selected' : '') + (isBest ? ' ai-best' : '');
+    var cls = 'grm-card' + (isSelected ? ' selected' : '');
     var qScore = p.quality_composite != null ? Math.round(p.quality_composite * 100) : '-';
     var sharp = p.subject_tenengrad != null ? Math.round(p.subject_tenengrad) : '-';
 
@@ -3156,7 +3120,6 @@ function renderGroupModal() {
       '<div class="grm-card-info">' +
         '<div class="grm-card-species">' + escapeHtml(p.filename || '') + '</div>' +
         '<div class="grm-card-scores">Q: <span class="score-val">' + qScore + '</span> S: <span class="score-val">' + sharp + '</span></div>' +
-        (isBest ? '<div class="grm-card-ai">AI BEST</div>' : '') +
       '</div>' +
     '</div>';
   }


### PR DESCRIPTION
## Summary
Disables client-side suggested picks/rejects in the pipeline review burst modal so unflagged photos remain candidates until the user explicitly moves them. Existing saved library flags still seed Picks and Rejects, and the AI BEST visual marker was removed because it implied a suggested pick.

## Validation
- `pytest tests/e2e/test_pipeline_rapid_review.py::test_classic_pipeline_review_opens_requested_burst_from_url`
- `pytest tests/e2e/test_burst_group_context_menu.py`
- `git diff --check`