### PR TITLE
Add pipeline review pick/reject hotkeys

### DIFF
--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -623,3 +623,70 @@ def test_classic_pipeline_review_opens_requested_burst_from_url(live_server, pag
 
     expect(page.locator("#grmOverlay")).to_have_class(re.compile(r"\bopen\b"))
     expect(page.locator("#grmOverlay .grm-card[data-photo-id]")).to_have_count(2)
+
+    page.keyboard.press("x")
+    expect(page.locator("#grmCount")).to_have_text("0 picks, 1 rejects, 1 unsorted")
+
+    page.keyboard.press("p")
+    expect(page.locator("#grmCount")).to_have_text("1 picks, 0 rejects, 1 unsorted")
+
+
+def test_classic_pipeline_review_inspector_pick_reject_hotkeys(live_server, page):
+    image_body = base64.b64decode(_PNG_1X1)
+    results = {
+        "photos": [
+            {"id": 1, "filename": "solo.jpg", "label": "REVIEW", "quality_composite": 0.5, "subject_tenengrad": 10},
+        ],
+        "encounters": [
+            {
+                "photo_ids": [1],
+                "photo_count": 1,
+                "burst_count": 1,
+                "species": ["Test bird"],
+                "bursts": [{"photo_ids": [1]}],
+            }
+        ],
+        "summary": {
+            "total_photos": 1,
+            "encounter_count": 1,
+            "burst_count": 1,
+            "keep_count": 0,
+            "review_count": 1,
+            "reject_count": 0,
+        },
+    }
+    flag_payloads = []
+
+    def flag_route(route):
+        flag_payloads.append(route.request.post_data_json)
+        route.fulfill(json={"ok": True})
+
+    page.route(
+        "**/api/pipeline/page-init",
+        lambda route: route.fulfill(
+            json={
+                "results": results,
+                "workspace_overrides": {},
+                "review_readiness": {"state": "ready", "total_photos": 1},
+            }
+        ),
+    )
+    page.route("**/api/photos/1/flag", flag_route)
+    page.route("**/thumbnails/*.jpg", lambda route: route.fulfill(body=image_body, content_type="image/png"))
+    page.route("**/masks/*.png", lambda route: route.fulfill(status=404))
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    page.locator(".photo-card img").click()
+    expect(page.locator("#inspectOverlay")).to_have_class(re.compile(r"\bopen\b"))
+
+    with page.expect_response("**/api/photos/1/flag"):
+        page.keyboard.press("x")
+    expect(page.locator("#inspectPanel")).to_contain_text("Rejected (X)")
+    expect(page.locator(".photo-card .flag-rejected")).to_be_visible()
+    assert flag_payloads[-1] == {"flag": "rejected"}
+
+    with page.expect_response("**/api/photos/1/flag"):
+        page.keyboard.press("p")
+    expect(page.locator("#inspectPanel")).to_contain_text("Flagged (P)")
+    expect(page.locator(".photo-card .flag-flagged")).to_be_visible()
+    assert flag_payloads[-1] == {"flag": "flagged"}

--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -696,3 +696,75 @@ def test_classic_pipeline_review_inspector_pick_reject_hotkeys(live_server, page
     expect(page.locator("#inspectPanel")).to_contain_text("Flagged (P)")
     expect(page.locator(".photo-card .flag-flagged")).to_be_visible()
     assert flag_payloads[-1] == {"flag": "flagged"}
+
+
+def test_classic_pipeline_review_group_shortcuts_do_not_flag_stale_inspector_photo(live_server, page):
+    image_body = base64.b64decode(_PNG_1X1)
+    results = {
+        "photos": [
+            {"id": 1, "filename": "solo.jpg", "label": "REVIEW", "quality_composite": 0.5, "subject_tenengrad": 10},
+            {"id": 2, "filename": "burst-a.jpg", "label": "REVIEW", "quality_composite": 0.3, "subject_tenengrad": 10},
+            {"id": 3, "filename": "burst-b.jpg", "label": "REVIEW", "quality_composite": 0.6, "subject_tenengrad": 20},
+        ],
+        "encounters": [
+            {
+                "photo_ids": [1, 2, 3],
+                "photo_count": 3,
+                "burst_count": 2,
+                "species": ["Test bird"],
+                "bursts": [{"photo_ids": [1]}, {"photo_ids": [2, 3]}],
+            }
+        ],
+        "summary": {
+            "total_photos": 3,
+            "encounter_count": 1,
+            "burst_count": 2,
+            "keep_count": 0,
+            "review_count": 3,
+            "reject_count": 0,
+        },
+    }
+    stale_flag_payloads = []
+
+    def stale_flag_route(route):
+        stale_flag_payloads.append(route.request.post_data_json)
+        route.fulfill(json={"ok": True})
+
+    page.route(
+        "**/api/pipeline/page-init",
+        lambda route: route.fulfill(
+            json={
+                "results": results,
+                "workspace_overrides": {},
+                "review_readiness": {"state": "ready", "total_photos": 3},
+            }
+        ),
+    )
+    page.route(
+        "**/api/pipeline/group/state",
+        lambda route: route.fulfill(
+            json={
+                "photos": {
+                    "2": {"flag": "none", "has_species_keyword": False},
+                    "3": {"flag": "none", "has_species_keyword": False},
+                },
+                "species_kid": None,
+            }
+        ),
+    )
+    page.route("**/api/photos/1/flag", stale_flag_route)
+    page.route("**/thumbnails/*.jpg", lambda route: route.fulfill(body=image_body, content_type="image/png"))
+    page.route("**/masks/*.png", lambda route: route.fulfill(status=404))
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    page.locator(".photo-card[data-photo-id='1'] img").click()
+    expect(page.locator("#inspectOverlay")).to_have_class(re.compile(r"\bopen\b"))
+
+    page.locator("#inspectPanel .context-filmstrip img").nth(1).click()
+    expect(page.locator("#inspectOverlay")).not_to_have_class(re.compile(r"\bopen\b"))
+    expect(page.locator("#grmOverlay")).to_have_class(re.compile(r"\bopen\b"))
+
+    page.keyboard.press("x")
+    expect(page.locator("#grmCount")).to_have_text("0 picks, 1 rejects, 1 unsorted")
+    page.wait_for_timeout(200)
+    assert stale_flag_payloads == []

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1326,7 +1326,7 @@ input[type="range"]::-moz-range-thumb {
       <input type="range" id="grmResSlider" min="0" max="3" step="1" value="3" oninput="grmSetResolution(this.value)">
       <span id="grmResLabel" style="font-size:11px;color:var(--text-dim);min-width:140px;">1920 · preview</span>
     </div>
-    <span class="grm-hint">↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
+    <span class="grm-hint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
     <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);">Apply & Close</button>
   </div>
 </div>
@@ -2201,6 +2201,35 @@ function findEncounterForPhoto(photoId) {
   return null;
 }
 
+var inspectPhotoId = null;
+
+function pipelineReviewBareKey(e, key) {
+  return !e.ctrlKey && !e.metaKey && !e.altKey && e.key && e.key.toLowerCase() === key;
+}
+
+function setPipelineReviewFlag(photoId, flag) {
+  if (flag !== 'flagged' && flag !== 'rejected' && flag !== 'none') return Promise.resolve();
+  photoId = parseInt(photoId, 10);
+  if (!photoId) return Promise.resolve();
+
+  return safeFetch('/api/photos/' + photoId + '/flag', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ flag: flag }),
+  }).then(function() {
+    var photo = findPhotoInResults(photoId);
+    if (photo) photo.flag = flag;
+    renderResults();
+    if (inspectPhotoId === photoId && document.getElementById('inspectOverlay').classList.contains('open')) {
+      openInspect(photoId);
+    }
+    var msg = flag === 'flagged' ? 'Marked as pick' : (flag === 'rejected' ? 'Marked as reject' : 'Flag cleared');
+    showToast(msg, 'success');
+  });
+}
+
+window.setFlagFor = setPipelineReviewFlag;
+
 function openInspect(photoId) {
   var photo = findPhotoInResults(photoId);
   if (!photo) return;
@@ -2215,6 +2244,7 @@ function openInspect(photoId) {
   var enc = findEncounterForPhoto(photoId);
   var panel = document.getElementById('inspectPanel');
   var overlay = document.getElementById('inspectOverlay');
+  inspectPhotoId = photoId;
 
   var label = (photo.label || '').toLowerCase();
   var q = photo.quality_composite || 0;
@@ -2337,10 +2367,17 @@ function openInspect(photoId) {
 function closeInspect() {
   document.getElementById('inspectOverlay').classList.remove('open');
   document.removeEventListener('keydown', inspectKeyHandler);
+  inspectPhotoId = null;
 }
 
 function inspectKeyHandler(e) {
-  if (e.key === 'Escape') closeInspect();
+  if (e.key === 'Escape') { closeInspect(); return; }
+  if (pipelineReviewBareKey(e, 'p') || pipelineReviewBareKey(e, 'x')) {
+    var flag = pipelineReviewBareKey(e, 'p') ? 'flagged' : 'rejected';
+    setPipelineReviewFlag(inspectPhotoId, flag);
+    e.preventDefault();
+    e.stopPropagation();
+  }
 }
 
 function toggleMask() {
@@ -3823,6 +3860,8 @@ document.addEventListener('keydown', function(e) {
   }
   if (e.key === 'Delete' || e.key === 'Backspace') { grmRemoveFromGroup(); e.preventDefault(); return; }
   if (e.key === ' ') { grmMoveCandidate(); e.preventDefault(); return; }
+  if (pipelineReviewBareKey(e, 'p')) { grmMovePick(); e.preventDefault(); return; }
+  if (pipelineReviewBareKey(e, 'x')) { grmMoveReject(); e.preventDefault(); return; }
 });
 
 /* --- Right-click → open in Browse view ---

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2311,6 +2311,7 @@ function openInspect(photoId) {
   // Route multi-photo bursts to the GRM
   var burstInfo = findBurstForPhoto(photoId);
   if (burstInfo && burstInfo.photoIds.length >= 2) {
+    closeInspect();
     openGroupReview(burstInfo.encIdx, burstInfo.burstIdx, photoId);
     return;
   }


### PR DESCRIPTION
Adds keyboard shortcuts on the pipeline review page so X marks photos as rejected and P marks them as picks. Single-photo inspector shortcuts persist immediately via the photo flag API and refresh the inspector/grid badges. Burst review shortcuts move the selected photo between pick and reject zones before Apply & Close persists the group decision. Validated with focused Playwright coverage and the static template build test.