### PR TITLE
[codex] Always convert HE NEFs for darktable editor

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5200,7 +5200,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "darktable" in " ".join(parts).lower()
 
         file_paths = [path for _photo, path in photo_paths]
-        if _is_darktable_editor() and cfg.get("darktable_auto_convert_dng"):
+        if _is_darktable_editor():
             from develop import convert_to_dng, is_nikon_high_efficiency_nef
 
             vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
@@ -5232,12 +5232,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         os.path.isfile(candidate)
                         and os.path.getmtime(candidate) >= source_mtime
                     ):
+                        log.info(
+                            "Using cached DNG for darktable external editor: %s",
+                            candidate,
+                        )
                         fresh_cached = candidate
                         break
                 if fresh_cached:
                     converted_paths.append(fresh_cached)
                     continue
 
+                log.info(
+                    "Converting Nikon HE NEF for darktable external editor: %s",
+                    input_path,
+                )
                 conversion = convert_to_dng(
                     cfg.get("dng_converter_bin") or "",
                     input_path,

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -39,7 +39,7 @@ DEFAULTS = {
     "darktable_style": "",
     "darktable_output_format": "jpg",
     "darktable_output_dir": "",
-    "darktable_auto_convert_dng": False,
+    "darktable_auto_convert_dng": True,
     "dng_converter_bin": "",
     # When true, the Tauri desktop wrapper opens this UI in the user's
     # default web browser on launch instead of creating its WKWebView

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -22,6 +22,7 @@ def test_darktable_default_values():
     assert DEFAULTS["darktable_style"] == ""
     assert DEFAULTS["darktable_output_format"] == "jpg"
     assert DEFAULTS["darktable_output_dir"] == ""
+    assert DEFAULTS["darktable_auto_convert_dng"] is True
 
 
 def test_max_edit_history_default():

--- a/vireo/tests/test_open_external.py
+++ b/vireo/tests/test_open_external.py
@@ -208,7 +208,6 @@ def test_open_external_converts_nikon_he_nef_for_darktable(
                     "external_editors": [
                         {"name": "darktable", "path": str(bundle)},
                     ],
-                    "darktable_auto_convert_dng": True,
                     "dng_converter_bin": "/fake/dng-converter",
                 }),
                 content_type='application/json')


### PR DESCRIPTION
## Summary
This follow-up makes the darktable external-editor path convert Nikon High Efficiency NEFs whenever needed, instead of depending on the RAW Development auto-convert checkbox. It also changes the default config so missing configs inherit `darktable_auto_convert_dng: true` for the darktable-cli Develop path, while explicit existing `false` values remain user-controlled. The endpoint now logs when it creates or reuses a cached DNG for darktable.

## Validation
- `python -m pytest vireo/tests/test_config.py vireo/tests/test_open_external.py vireo/tests/test_darktable_api.py vireo/tests/test_develop.py -q`