### PR TITLE
[codex] Add explicit Not Wildlife exclusion

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1948,6 +1948,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                        [{'photo_id': photo_id, 'old_value': old_flag, 'new_value': flag}])
         return jsonify({"ok": True})
 
+    @app.route("/api/photos/<int:photo_id>/wildlife_excluded", methods=["POST"])
+    def api_set_wildlife_excluded(photo_id):
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        excluded = body.get("excluded")
+        if not isinstance(excluded, bool):
+            return json_error("excluded must be a boolean")
+        old = db.get_photo(photo_id)
+        if not old:
+            return json_error("not found", 404)
+        old_value = "1" if old["wildlife_excluded"] else "0"
+        new_value = "1" if excluded else "0"
+        try:
+            db.update_photo_wildlife_excluded(photo_id, excluded)
+        except ValueError as e:
+            return json_error(str(e), 403)
+        db.record_edit(
+            "wildlife_excluded",
+            "Excluded from wildlife classification" if excluded else "Included in wildlife classification",
+            new_value,
+            [{"photo_id": photo_id, "old_value": old_value, "new_value": new_value}],
+        )
+        return jsonify({"ok": True, "wildlife_excluded": excluded})
+
     @app.route("/api/photos/<int:photo_id>/color_label", methods=["POST"])
     def api_set_color_label(photo_id):
         db = _get_db()

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1441,6 +1441,31 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         )
         photos = thread_db.get_collection_photos(params.collection_id, per_page=999999)
 
+        pre_count = len(photos)
+        kept_ids = set(thread_db.filter_out_wildlife_excluded(
+            [p["id"] for p in photos],
+        ))
+        photos = [p for p in photos if p["id"] in kept_ids]
+        skipped_wildlife = pre_count - len(photos)
+        if skipped_wildlife:
+            log.info(
+                "Skipping %d photo(s) marked not wildlife",
+                skipped_wildlife,
+            )
+            runner.push_event(
+                job["id"], "progress",
+                {
+                    "current": 0,
+                    "total": len(photos),
+                    "current_file": (
+                        f"Skipped {skipped_wildlife} photo(s) marked not wildlife"
+                    ),
+                    "rate": 0,
+                    "phase": "Step 1/5: Loading photos",
+                    "skipped_wildlife_excluded": skipped_wildlife,
+                },
+            )
+
         # Skip photos already tagged with a 'subject' keyword (per workspace
         # config). reclassify=True bypasses so users can verify existing tags.
         if not params.reclassify:

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1441,10 +1441,14 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         )
         photos = thread_db.get_collection_photos(params.collection_id, per_page=999999)
 
+        photo_ids = [p["id"] for p in photos]
         pre_count = len(photos)
-        kept_ids = set(thread_db.filter_out_wildlife_excluded(
-            [p["id"] for p in photos],
-        ))
+        kept_raw = getattr(
+            thread_db, "filter_out_wildlife_excluded", lambda ids: ids
+        )(photo_ids)
+        if not isinstance(kept_raw, (list, tuple, set)):
+            kept_raw = photo_ids
+        kept_ids = set(kept_raw)
         photos = [p for p in photos if p["id"] in kept_ids]
         skipped_wildlife = pre_count - len(photos)
         if skipped_wildlife:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -290,6 +290,7 @@ class Database:
                 miss_clipped             INTEGER,
                 miss_oof                 INTEGER,
                 miss_computed_at         TEXT,
+                wildlife_excluded        INTEGER NOT NULL DEFAULT 0,
                 UNIQUE(folder_id, filename)
             );
 
@@ -784,6 +785,13 @@ class Database:
             self.conn.execute(
                 "ALTER TABLE photos ADD COLUMN active_mask_variant TEXT"
             )
+        try:
+            self.conn.execute("SELECT wildlife_excluded FROM photos LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute(
+                "ALTER TABLE photos "
+                "ADD COLUMN wildlife_excluded INTEGER NOT NULL DEFAULT 0"
+            )
 
         # Backfill pre-existing photos with mask_path set on the photos
         # row but no row in photo_masks. They get migrated to
@@ -1107,6 +1115,24 @@ class Database:
             ).fetchall()
             for r in rows:
                 excluded.add(r["photo_id"])
+        return [pid for pid in photo_ids_list if pid not in excluded]
+
+    def filter_out_wildlife_excluded(self, photo_ids):
+        """Return photo ids not explicitly excluded from wildlife classification."""
+        if not photo_ids:
+            return []
+        photo_ids_list = list(photo_ids)
+        excluded = set()
+        chunk_size = self._FILTER_SUBJECT_CHUNK
+        for chunk in _chunks(photo_ids_list, chunk_size):
+            placeholders = ",".join("?" * len(chunk))
+            rows = self.conn.execute(
+                f"""SELECT id FROM photos
+                    WHERE wildlife_excluded = 1
+                      AND id IN ({placeholders})""",
+                chunk,
+            ).fetchall()
+            excluded.update(r["id"] for r in rows)
         return [pid for pid in photo_ids_list if pid not in excluded]
 
     def get_workspace_active_labels(self):
@@ -2713,7 +2739,8 @@ class Database:
     PHOTO_COLS = """id, folder_id, filename, extension, file_size, file_mtime, xmp_mtime,
                     timestamp, width, height, rating, flag, thumb_path, sharpness,
                     subject_sharpness, subject_size, quality_score,
-                    latitude, longitude, companion_path, working_copy_path"""
+                    latitude, longitude, companion_path, working_copy_path,
+                    wildlife_excluded"""
 
     # Columns for single-photo detail queries (includes exif_data JSON +
     # eye-focus fields consumed by the review lightbox's crosshair overlay)
@@ -4448,6 +4475,16 @@ class Database:
         if verify_workspace:
             self._verify_photo_in_workspace(photo_id)
         self.conn.execute("UPDATE photos SET flag = ? WHERE id = ?", (flag, photo_id))
+        self.conn.commit()
+
+    def update_photo_wildlife_excluded(self, photo_id, excluded, verify_workspace=True):
+        """Set whether a photo is excluded from wildlife detection/classification."""
+        if verify_workspace:
+            self._verify_photo_in_workspace(photo_id)
+        self.conn.execute(
+            "UPDATE photos SET wildlife_excluded = ? WHERE id = ?",
+            (1 if excluded else 0, photo_id),
+        )
         self.conn.commit()
 
     def batch_update_photo_flag(self, photo_ids, flag, verify_workspace=True):
@@ -8222,6 +8259,10 @@ class Database:
                     self.queue_change(pid, 'rating', old_val)
             elif entry['action_type'] == 'flag':
                 self.update_photo_flag(pid, old_val, verify_workspace=False)
+            elif entry['action_type'] == 'wildlife_excluded':
+                self.update_photo_wildlife_excluded(
+                    pid, old_val == "1", verify_workspace=False
+                )
             elif entry['action_type'] == 'color_label':
                 if old_val:
                     self.set_color_label(pid, old_val)
@@ -8341,6 +8382,10 @@ class Database:
                     self.queue_change(pid, 'rating', new_val)
             elif entry['action_type'] == 'flag':
                 self.update_photo_flag(pid, entry['new_value'], verify_workspace=False)
+            elif entry['action_type'] == 'wildlife_excluded':
+                self.update_photo_wildlife_excluded(
+                    pid, new_val == "1", verify_workspace=False
+                )
             elif entry['action_type'] == 'color_label':
                 if new_val:
                     self.set_color_label(pid, new_val)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1490,10 +1490,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 candidate_photos = _filter_excluded(
                     thread_db.get_collection_photos(collection_id, per_page=999999)
                 )
-                candidate_ids = thread_db.filter_out_wildlife_excluded(
-                    [p["id"] for p in candidate_photos]
-                )
-                if not candidate_ids:
+                photo_ids = [p["id"] for p in candidate_photos]
+                candidate_ids = thread_db.filter_out_wildlife_excluded(photo_ids)
+                if candidate_photos and not candidate_ids:
                     stages["model_loader"]["status"] = "skipped"
                     runner.update_step(
                         job["id"], "model_loader", status="completed",
@@ -1646,9 +1645,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             photos = _filter_excluded(
                 thread_db.get_collection_photos(collection_id, per_page=999999)
             )
-            kept_ids = set(thread_db.filter_out_wildlife_excluded(
-                [p["id"] for p in photos]
-            ))
+            photo_ids = [p["id"] for p in photos]
+            kept_ids = set(thread_db.filter_out_wildlife_excluded(photo_ids))
             skipped_wildlife = len(photos) - len(kept_ids)
             if skipped_wildlife:
                 log.info(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1486,6 +1486,23 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             thread_db = Database(db_path)
             thread_db.set_active_workspace(workspace_id)
 
+            if collection_id:
+                candidate_photos = _filter_excluded(
+                    thread_db.get_collection_photos(collection_id, per_page=999999)
+                )
+                candidate_ids = thread_db.filter_out_wildlife_excluded(
+                    [p["id"] for p in candidate_photos]
+                )
+                if not candidate_ids:
+                    stages["model_loader"]["status"] = "skipped"
+                    runner.update_step(
+                        job["id"], "model_loader", status="completed",
+                        summary="Skipped (all photos marked not wildlife)",
+                    )
+                    _update_stages(runner, job["id"], stages)
+                    models_ready.set()
+                    return
+
             # Specs were pre-resolved at job start so step_defs could carry
             # the model's display name on each `classify:<id>` row. If that
             # resolution raised, surface the same error here — model_loader
@@ -1629,6 +1646,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             photos = _filter_excluded(
                 thread_db.get_collection_photos(collection_id, per_page=999999)
             )
+            kept_ids = set(thread_db.filter_out_wildlife_excluded(
+                [p["id"] for p in photos]
+            ))
+            skipped_wildlife = len(photos) - len(kept_ids)
+            if skipped_wildlife:
+                log.info(
+                    "Skipping %d photo(s) marked not wildlife",
+                    skipped_wildlife,
+                )
+            photos = [p for p in photos if p["id"] in kept_ids]
             folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
             total = len(photos)
             detect_state["photos"] = photos

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2741,7 +2741,7 @@ async function createWorkspace() {
       <span>Mask:</span>
       <select id="lightboxMaskSelect" onchange="event.stopPropagation(); _lbOnMaskVariantChange();"></select>
     </span>
-    <button id="lightboxNotWildlife" onclick="event.stopPropagation(); lightboxNotWildlife();" style="background:rgba(0,0,0,0.6);color:var(--warn);border:1px solid var(--warn);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;" title="Mark as Landscape — drops out of Needs Identification and stops the classifier">
+    <button id="lightboxNotWildlife" onclick="event.stopPropagation(); lightboxToggleWildlifeExcluded();" style="background:rgba(0,0,0,0.6);color:var(--warn);border:1px solid var(--warn);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;" title="Exclude from wildlife detection and classification">
       Not Wildlife
     </button>
     <button id="lightboxInat" onclick="" style="background:rgba(0,0,0,0.6);color:#74ac00;border:1px solid #74ac00;border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;">
@@ -2817,6 +2817,7 @@ var _lbCurrentSrcKey = null; // 'full' | '2560' | '3840' | 'original'
 var _lbFullLongEdge = null;  // actual long edge of /full for current photo (may be < 1920 if preview_max_size is configured low)
 var _lbSessionFullLongEdge = null;  // last learned /full size across photos; better fallback than hardcoded 1920 for custom preview_max_size
 var _lbPending1To1 = false;  // true when z/click was pressed with unknown nativeZoom; upgrade to true 1:1 once learned
+var _lbCurrentWildlifeExcluded = false;
 
 function _lbStoredBool(key, fallback) {
   try {
@@ -3046,6 +3047,15 @@ function _lbApplyMaskToggleButton() {
   if (btn) btn.textContent = _lbMasksVisible ? 'Hide Masks' : 'Show Masks';
 }
 
+function _lbApplyWildlifeExcludedButton() {
+  var btn = document.getElementById('lightboxNotWildlife');
+  if (!btn) return;
+  btn.textContent = _lbCurrentWildlifeExcluded ? 'Include Wildlife' : 'Not Wildlife';
+  btn.title = _lbCurrentWildlifeExcluded
+    ? 'Include this photo in wildlife detection and classification'
+    : 'Exclude from wildlife detection and classification';
+}
+
 function toggleLightboxMasks() {
   _lbMasksVisible = !_lbMasksVisible;
   _lbPersistBool('vireo.lb.masksVisible', _lbMasksVisible);
@@ -3131,6 +3141,8 @@ function openLightbox(photoId, filename, photoList) {
 
   _lightboxCurrentId = photoId;
   if (photoList) _lightboxPhotoList = photoList;
+  var currentFromList = _lightboxPhotoList.find(function(x) { return x.id === photoId; });
+  _lbCurrentWildlifeExcluded = !!(currentFromList && currentFromList.wildlife_excluded);
 
   var overlay = document.getElementById('lightboxOverlay');
   var img = document.getElementById('lightboxImg');
@@ -3172,6 +3184,8 @@ function openLightbox(photoId, filename, photoList) {
       if (!data || _lightboxCurrentId !== photoId) return;
       _lbPhotoW = data.width || null;
       _lbPhotoH = data.height || null;
+      _lbCurrentWildlifeExcluded = !!data.wildlife_excluded;
+      _lbApplyWildlifeExcludedButton();
       _lbRecomputeNativeZoom();
       _lbRenderEyeCrosshair(data);
     })
@@ -3209,6 +3223,7 @@ function openLightbox(photoId, filename, photoList) {
   _lbApplyChromeVisibility();
   _lbApplyEyeVisibility();
   _lbApplyMaskToggleButton();
+  _lbApplyWildlifeExcludedButton();
 
   // Fetch and render detection bounding boxes
   _lbLoadDetections(photoId);
@@ -3448,6 +3463,7 @@ function buildLightboxContextMenu(pid) {
   items.push(toggleItem('Eye marker', _lbEyeVisible, toggleLightboxEye));
   items.push(toggleItem('Filename and counter', _lbInfoVisible, toggleLightboxInfo));
   items.push(toggleItem('Lightbox controls', _lbChromeVisible, toggleLightboxChrome));
+  items.push(toggleItem('Wildlife classification', !_lbCurrentWildlifeExcluded, lightboxToggleWildlifeExcluded));
   items.push({ separator: true });
 
   if (has('findSimilar')) {
@@ -3561,24 +3577,30 @@ async function confirmDelete() {
   if (savedCallback) savedCallback(data);
 }
 
-async function lightboxNotWildlife() {
+async function lightboxToggleWildlifeExcluded() {
   if (!_lightboxCurrentId) return;
   var currentId = _lightboxCurrentId;
+  var excluded = !_lbCurrentWildlifeExcluded;
   try {
-    await safeFetch('/api/photos/' + currentId + '/keywords', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: 'Landscape', type: 'genre' }),
-    }, { toast: false });
-    // Advance to next photo if more remain
-    var idx = _lightboxPhotoList.findIndex(function(x) { return x.id === currentId; });
-    if (idx >= 0 && _lightboxPhotoList.length > 1) {
-      var nextIdx = (idx + 1) % _lightboxPhotoList.length;
-      var next = _lightboxPhotoList[nextIdx];
-      openLightbox(next.id, next.filename, _lightboxPhotoList);
+    if (typeof window.setWildlifeExcludedFor === 'function') {
+      await window.setWildlifeExcludedFor(currentId, excluded);
+    } else {
+      await safeFetch('/api/photos/' + currentId + '/wildlife_excluded', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ excluded: excluded }),
+      }, { toast: false });
+    }
+    _lbCurrentWildlifeExcluded = excluded;
+    _lbApplyWildlifeExcludedButton();
+    if (window.toast) {
+      window.toast(
+        excluded ? 'Excluded from wildlife classification' : 'Included in wildlife classification',
+        'success'
+      );
     }
   } catch (e) {
-    if (window.toast) window.toast('Tag failed: ' + (e && e.message ? e.message : 'unknown'), 'error');
+    if (window.toast) window.toast('Update failed: ' + (e && e.message ? e.message : 'unknown'), 'error');
   }
 }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -322,6 +322,19 @@ body {
 .detail-flag-btn:hover { border-color: var(--accent); }
 .detail-flag-btn.active-flag { background: var(--accent); color: var(--bg-primary); border-color: var(--accent); }
 .detail-flag-btn.active-reject { background: var(--danger); color: var(--text-primary); border-color: var(--danger); }
+.detail-wildlife-btn {
+  padding: 5px 12px;
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+}
+.detail-wildlife-btn.active {
+  border-color: var(--warn);
+  color: var(--warn);
+}
 .detail-colors { display: flex; gap: 6px; margin-bottom: 8px; }
 .detail-color-btn {
   width: 24px; height: 24px; border-radius: 50%; border: 2px solid transparent;
@@ -744,6 +757,13 @@ body {
   font-size: 9px; padding: 1px 5px; border-radius: 3px;
   pointer-events: none; z-index: 2;
 }
+.no-wildlife-badge {
+  position: absolute; top: 4px; left: 4px;
+  background: rgba(0,0,0,0.72); color: var(--warn);
+  border: 1px solid color-mix(in srgb, var(--warn) 70%, transparent);
+  font-size: 9px; padding: 1px 5px; border-radius: 3px;
+  pointer-events: none; z-index: 2;
+}
 .species-badges {
   position: absolute; bottom: 4px; left: 4px; right: 4px;
   display: flex; flex-wrap: wrap; gap: 2px;
@@ -988,6 +1008,11 @@ body {
           <button class="detail-flag-btn" onclick="setFlag('flagged')">Flag (P)</button>
           <button class="detail-flag-btn" onclick="setFlag('rejected')">Reject (X)</button>
         </div>
+      </div>
+
+      <div class="detail-section">
+        <div class="detail-section-title">Wildlife Classification</div>
+        <button class="detail-wildlife-btn" id="detailWildlifeExcluded" onclick="toggleDetailWildlifeExcluded()">Not Wildlife</button>
       </div>
 
       <div class="detail-section">
@@ -2274,6 +2299,7 @@ function renderGrid() {
       clipBadge = '<span class="clip-score-badge">' + Math.round(p._similarity * 100) + '%</span>';
     }
     var inatBadge = inatSubmitted[String(p.id)] ? '<span class="inat-badge">iNat</span>' : '';
+    var wildlifeBadge = p.wildlife_excluded ? '<span class="no-wildlife-badge">No Wildlife</span>' : '';
 
     // Species badges on image overlay (only when NOT in cardFields — if in cardFields, rendered below)
     var speciesBadgeHtml = '';
@@ -2302,6 +2328,7 @@ function renderGrid() {
         clipBadge +
         boxHtml +
         inatBadge +
+        wildlifeBadge +
         speciesBadgeHtml +
       '</div>' +
       '<div class="grid-card-info">' +
@@ -2680,6 +2707,9 @@ function renderDetail(photo) {
   // Color labels
   updateDetailColors();
 
+  // Wildlife classification exclusion
+  updateDetailWildlifeExcluded(photo);
+
   // Keywords
   var kwTypeIcons = {general:'●', taxonomy:'🌿', individual:'👤', location:'📍', genre:'🎭'};
   var kwTypeLabels = {general:'General', taxonomy:'Taxonomy', individual:'Individual', location:'Location', genre:'Genre'};
@@ -2999,6 +3029,40 @@ async function setFlag(flag) {
     if (p) p.flag = flag;
     renderGrid();
     loadDetail(selectedPhotoId);
+  } catch(e) {}
+}
+
+function updateDetailWildlifeExcluded(photo) {
+  var btn = document.getElementById('detailWildlifeExcluded');
+  if (!btn) return;
+  var excluded = !!(photo && photo.wildlife_excluded);
+  btn.classList.toggle('active', excluded);
+  btn.textContent = excluded ? 'Include Wildlife Classification' : 'Not Wildlife';
+  btn.title = excluded
+    ? 'Include this photo in wildlife detection and classification'
+    : 'Exclude this photo from wildlife detection and classification';
+}
+
+async function setWildlifeExcludedFor(photoId, excluded) {
+  await safeFetch('/api/photos/' + photoId + '/wildlife_excluded', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ excluded: excluded }),
+  }, { toast: false });
+  var p = photos.find(function(x) { return x.id === photoId; });
+  if (p) p.wildlife_excluded = excluded ? 1 : 0;
+  renderGrid();
+  if (selectedPhotoId === photoId) loadDetail(photoId);
+  showUndoToast();
+}
+window.setWildlifeExcludedFor = setWildlifeExcludedFor;
+
+async function toggleDetailWildlifeExcluded() {
+  if (!selectedPhotoId) return;
+  var p = photos.find(function(x) { return x.id === selectedPhotoId; });
+  var current = p ? !!p.wildlife_excluded : false;
+  try {
+    await setWildlifeExcludedFor(selectedPhotoId, !current);
   } catch(e) {}
 }
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2761,6 +2761,32 @@ def test_add_keyword_route_handles_non_string_type(app_and_db):
     # Anything other than a crash is acceptable here; the point is no 500.
 
 
+def test_wildlife_excluded_route_does_not_add_landscape_keyword(app_and_db):
+    """Not Wildlife is workflow state, not a hidden Landscape keyword."""
+    app, db = app_and_db
+    folder_id = db.add_folder("/tmp/p")
+    db.add_workspace_folder(db._active_workspace_id, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "p.jpg", extension=".jpg", file_size=1, file_mtime=1.0,
+    )
+    client = app.test_client()
+
+    resp = client.post(
+        f"/api/photos/{photo_id}/wildlife_excluded",
+        json={"excluded": True},
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["wildlife_excluded"] is True
+    row = db.conn.execute(
+        "SELECT wildlife_excluded FROM photos WHERE id = ?", (photo_id,)
+    ).fetchone()
+    assert row["wildlife_excluded"] == 1
+    keywords = [dict(k) for k in db.get_photo_keywords(photo_id)]
+    assert all(k["name"] != "Landscape" for k in keywords)
+
+
 def test_batch_keyword_route_handles_non_string_type(app_and_db):
     """Same regression for the batch endpoint."""
     app, db = app_and_db

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -2602,6 +2602,29 @@ def test_classify_job_reclassify_true_bypasses_subject_skip(tmp_path):
     )
 
 
+def test_classify_job_always_skips_wildlife_excluded_photos(tmp_path):
+    """Explicit Not Wildlife state skips classification even on reclassify."""
+    from db import Database
+
+    db_path, ws, col_id, p1, p2 = _setup_two_photo_classify_workspace(tmp_path)
+    db = Database(db_path)
+    db.set_active_workspace(ws)
+    db.update_photo_wildlife_excluded(p2, True)
+    db.conn.close()
+
+    seen, events, _ = _run_classify_capturing_photos(
+        db_path, ws, col_id, reclassify=True,
+    )
+
+    assert seen == [p1]
+    progress_events = [
+        d for (_jid, kind, d) in events
+        if kind == "progress" and d.get("skipped_wildlife_excluded")
+    ]
+    assert progress_events
+    assert progress_events[0]["skipped_wildlife_excluded"] == 1
+
+
 def test_classify_job_short_circuits_when_all_photos_skipped(tmp_path):
     """Regression: when the subject-skip filter empties the photo set, the
     job must short-circuit before model load. Loading a model is expensive

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7562,6 +7562,24 @@ def test_filter_out_subject_tagged_excludes_tagged_photos(tmp_path):
     assert kept == [p2]
 
 
+def test_filter_out_wildlife_excluded_drops_marked_photos(tmp_path):
+    """Explicit Not Wildlife state is independent of keyword subject tagging."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.create_workspace("ws")
+    db.set_active_workspace(ws)
+    fid = db.add_folder('/photos', name='photos')
+    db.add_workspace_folder(ws, fid)
+    p1 = db.add_photo(folder_id=fid, filename='p1.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='p2.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+
+    db.update_photo_wildlife_excluded(p1, True)
+
+    assert db.filter_out_wildlife_excluded([p1, p2]) == [p2]
+
+
 def test_filter_out_subject_tagged_empty_set_returns_all(tmp_path):
     """An empty subject_types set means no type counts as 'identifying',
     so every input photo is kept."""


### PR DESCRIPTION
Adds an explicit per-photo `wildlife_excluded` state so the Not Wildlife action no longer silently adds the `Landscape` keyword. The lightbox and Browse detail panel now toggle this state, show a visible No Wildlife badge, and support undo/redo through edit history. Classifier and pipeline runs skip photos marked Not Wildlife, including avoiding model loading when a collection has no wildlife-classification candidates. Validated with targeted DB/API/classifier tests, nearby regression tests, Python compile checks, and `git diff --check`.