### PR TITLE
[codex] Add settings page text search

### DIFF
--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -35,3 +35,15 @@ def test_settings_cmd_f_opens_page_text_search(live_server, page):
     expect(page.locator(".settings-find-mark").first).to_be_visible()
     expect(page.locator(".settings-find-mark.active")).to_have_count(1)
     expect(page.locator("#settingsFindStatus")).to_contain_text("of")
+
+
+def test_settings_text_search_ignores_hidden_update_section(live_server, page):
+    """Settings find should not count permanently hidden page text."""
+    url = live_server["url"]
+    page.goto(f"{url}/settings", timeout=5000)
+
+    page.keyboard.press("Control+F")
+    page.locator("#settingsFindInput").fill("Check for Updates")
+
+    expect(page.locator(".settings-find-mark")).to_have_count(0)
+    expect(page.locator("#settingsFindStatus")).to_have_text("0 results")

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -17,3 +17,21 @@ def test_settings_system_info_renders(live_server, page):
     # Compute device should be populated
     device_name = page.locator("#deviceName")
     expect(device_name).not_to_have_text("-", timeout=api_timeout)
+
+
+def test_settings_cmd_f_opens_page_text_search(live_server, page):
+    """Settings captures find shortcut and highlights page text matches."""
+    url = live_server["url"]
+    page.goto(f"{url}/settings", timeout=5000)
+
+    page.keyboard.press("Control+F")
+
+    find_panel = page.locator("#settingsFindPanel")
+    find_input = page.locator("#settingsFindInput")
+    expect(find_panel).to_be_visible()
+    expect(find_input).to_be_focused()
+
+    find_input.fill("api")
+    expect(page.locator(".settings-find-mark").first).to_be_visible()
+    expect(page.locator(".settings-find-mark.active")).to_have_count(1)
+    expect(page.locator("#settingsFindStatus")).to_contain_text("of")

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -48,11 +48,73 @@
   }
   .scope-tab:hover { color: var(--text-primary); }
   .scope-tab.active { color: var(--text-primary); border-bottom-color: var(--accent); font-weight: 500; }
+  .settings-find-panel {
+    position: fixed;
+    top: 14px;
+    right: 18px;
+    z-index: 10000;
+    display: none;
+    align-items: center;
+    gap: 6px;
+    padding: 8px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-secondary);
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  }
+  .settings-find-panel.open { display: flex; }
+  .settings-find-panel input {
+    width: 220px;
+    background: var(--bg-input);
+    color: var(--text-primary);
+    border: 1px solid var(--border-secondary);
+    border-radius: 4px;
+    padding: 5px 8px;
+    font-size: 13px;
+    outline: none;
+  }
+  .settings-find-panel input:focus { border-color: var(--accent); }
+  .settings-find-panel button {
+    width: 28px;
+    height: 28px;
+    border-radius: 4px;
+    border: 1px solid var(--border-secondary);
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .settings-find-panel button:hover { color: var(--text-primary); border-color: var(--accent); }
+  .settings-find-status {
+    min-width: 62px;
+    font-size: 12px;
+    color: var(--text-dim);
+    text-align: center;
+    white-space: nowrap;
+  }
+  .settings-find-mark {
+    background: color-mix(in srgb, var(--accent) 35%, transparent);
+    color: var(--text-primary);
+    border-radius: 2px;
+    padding: 0 1px;
+  }
+  .settings-find-mark.active {
+    background: var(--accent);
+    color: var(--accent-text);
+  }
 </style>
 </head>
 <body>
 
 {% include '_navbar.html' %}
+
+<div class="settings-find-panel" id="settingsFindPanel" role="search" aria-label="Find in settings">
+  <input type="search" id="settingsFindInput" placeholder="Find in settings" autocomplete="off" aria-label="Find in settings">
+  <span class="settings-find-status" id="settingsFindStatus">0 results</span>
+  <button type="button" onclick="moveSettingsFind(-1)" title="Previous match" aria-label="Previous match">^</button>
+  <button type="button" onclick="moveSettingsFind(1)" title="Next match" aria-label="Next match">v</button>
+  <button type="button" onclick="closeSettingsFind()" title="Close find" aria-label="Close find">x</button>
+</div>
 
 <div class="content">
 
@@ -1091,6 +1153,220 @@ loadThemePicker();
 loadPreviewCacheStatus();
 loadDetectionCacheStats();
 loadAllSettings();
+
+var SETTINGS_FIND_STATE = {
+  marks: [],
+  activeIndex: -1,
+  observer: null,
+  refreshTimer: null,
+};
+
+setupSettingsFind();
+
+function setupSettingsFind() {
+  var input = document.getElementById('settingsFindInput');
+  if (!input) return;
+  input.addEventListener('input', function() {
+    refreshSettingsFind(this.value, 0);
+  });
+  input.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      moveSettingsFind(e.shiftKey ? -1 : 1);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      closeSettingsFind();
+    }
+  });
+  document.addEventListener('keydown', function(e) {
+    var key = (e.key || '').toLowerCase();
+    if ((e.metaKey || e.ctrlKey) && !e.altKey && key === 'f') {
+      e.preventDefault();
+      openSettingsFind();
+    } else if (key === 'escape' && isSettingsFindOpen()) {
+      e.preventDefault();
+      closeSettingsFind();
+    }
+  }, true);
+}
+
+function isSettingsFindOpen() {
+  var panel = document.getElementById('settingsFindPanel');
+  return !!panel && panel.classList.contains('open');
+}
+
+function openSettingsFind() {
+  var panel = document.getElementById('settingsFindPanel');
+  var input = document.getElementById('settingsFindInput');
+  if (!panel || !input) return;
+  panel.classList.add('open');
+  input.focus();
+  input.select();
+  refreshSettingsFind(input.value, SETTINGS_FIND_STATE.activeIndex >= 0 ? SETTINGS_FIND_STATE.activeIndex : 0);
+}
+
+function closeSettingsFind() {
+  var panel = document.getElementById('settingsFindPanel');
+  var input = document.getElementById('settingsFindInput');
+  if (panel) panel.classList.remove('open');
+  if (input) input.value = '';
+  disconnectSettingsFindObserver();
+  clearTimeout(SETTINGS_FIND_STATE.refreshTimer);
+  SETTINGS_FIND_STATE.refreshTimer = null;
+  clearSettingsFindMarks();
+  updateSettingsFindStatus();
+}
+
+function getSettingsFindRoot() {
+  return document.querySelector('.content');
+}
+
+function disconnectSettingsFindObserver() {
+  if (SETTINGS_FIND_STATE.observer) {
+    SETTINGS_FIND_STATE.observer.disconnect();
+    SETTINGS_FIND_STATE.observer = null;
+  }
+}
+
+function connectSettingsFindObserver() {
+  var root = getSettingsFindRoot();
+  var input = document.getElementById('settingsFindInput');
+  if (!root || !input || !input.value.trim()) return;
+  SETTINGS_FIND_STATE.observer = new MutationObserver(function() {
+    clearTimeout(SETTINGS_FIND_STATE.refreshTimer);
+    SETTINGS_FIND_STATE.refreshTimer = setTimeout(function() {
+      refreshSettingsFind(input.value, SETTINGS_FIND_STATE.activeIndex);
+    }, 100);
+  });
+  SETTINGS_FIND_STATE.observer.observe(root, { childList: true, subtree: true, characterData: true });
+}
+
+function clearSettingsFindMarks() {
+  disconnectSettingsFindObserver();
+  document.querySelectorAll('mark.settings-find-mark').forEach(function(mark) {
+    var parent = mark.parentNode;
+    if (!parent) return;
+    parent.replaceChild(document.createTextNode(mark.textContent), mark);
+    parent.normalize();
+  });
+  SETTINGS_FIND_STATE.marks = [];
+  SETTINGS_FIND_STATE.activeIndex = -1;
+}
+
+function shouldSkipSettingsFindTextNode(node) {
+  if (!node.nodeValue || !node.nodeValue.trim()) return true;
+  var el = node.parentElement;
+  if (!el) return true;
+  if (el.closest('.settings-find-panel')) return true;
+  return !!el.closest('script, style, noscript, textarea, input, select, option, mark.settings-find-mark');
+}
+
+function refreshSettingsFind(query, preferredIndex) {
+  var root = getSettingsFindRoot();
+  if (!root) return;
+  disconnectSettingsFindObserver();
+  clearSettingsFindMarks();
+  var q = (query || '').trim();
+  if (!q) {
+    updateSettingsFindStatus();
+    return;
+  }
+
+  var qLower = q.toLowerCase();
+  var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode: function(node) {
+      if (shouldSkipSettingsFindTextNode(node)) return NodeFilter.FILTER_REJECT;
+      return node.nodeValue.toLowerCase().indexOf(qLower) !== -1
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_REJECT;
+    }
+  });
+  var nodes = [];
+  var current;
+  while ((current = walker.nextNode())) nodes.push(current);
+
+  nodes.forEach(function(node) {
+    var text = node.nodeValue;
+    var lower = text.toLowerCase();
+    var frag = document.createDocumentFragment();
+    var pos = 0;
+    var idx = lower.indexOf(qLower, pos);
+    while (idx !== -1) {
+      if (idx > pos) frag.appendChild(document.createTextNode(text.slice(pos, idx)));
+      var mark = document.createElement('mark');
+      mark.className = 'settings-find-mark';
+      mark.textContent = text.slice(idx, idx + q.length);
+      frag.appendChild(mark);
+      SETTINGS_FIND_STATE.marks.push(mark);
+      pos = idx + q.length;
+      idx = lower.indexOf(qLower, pos);
+    }
+    if (pos < text.length) frag.appendChild(document.createTextNode(text.slice(pos)));
+    node.parentNode.replaceChild(frag, node);
+  });
+
+  if (SETTINGS_FIND_STATE.marks.length) {
+    setSettingsFindActive(Math.max(0, Math.min(preferredIndex || 0, SETTINGS_FIND_STATE.marks.length - 1)));
+  } else {
+    SETTINGS_FIND_STATE.activeIndex = -1;
+    updateSettingsFindStatus();
+  }
+  connectSettingsFindObserver();
+}
+
+function setSettingsFindActive(index) {
+  var marks = SETTINGS_FIND_STATE.marks;
+  marks.forEach(function(mark) { mark.classList.remove('active'); });
+  if (!marks.length) {
+    SETTINGS_FIND_STATE.activeIndex = -1;
+    updateSettingsFindStatus();
+    return;
+  }
+  SETTINGS_FIND_STATE.activeIndex = ((index % marks.length) + marks.length) % marks.length;
+  var active = marks[SETTINGS_FIND_STATE.activeIndex];
+  active.classList.add('active');
+  revealSettingsFindMatch(active);
+  updateSettingsFindStatus();
+}
+
+function revealSettingsFindMatch(mark) {
+  var body = mark.closest('.collapsible-body');
+  while (body) {
+    body.classList.add('open');
+    var header = body.previousElementSibling;
+    if (header && header.classList.contains('collapsible-header')) header.classList.add('open');
+    body = body.parentElement ? body.parentElement.closest('.collapsible-body') : null;
+  }
+  var advanced = mark.closest('#advancedContent');
+  if (advanced) {
+    advanced.style.display = '';
+    var advancedTitle = advanced.previousElementSibling;
+    var icon = advancedTitle ? advancedTitle.querySelector('span') : null;
+    if (icon) icon.textContent = '\u25BC';
+  }
+  mark.scrollIntoView({ block: 'center', inline: 'nearest' });
+}
+
+function moveSettingsFind(delta) {
+  var input = document.getElementById('settingsFindInput');
+  if (!isSettingsFindOpen()) openSettingsFind();
+  if (!SETTINGS_FIND_STATE.marks.length && input && input.value.trim()) {
+    refreshSettingsFind(input.value, 0);
+  }
+  if (!SETTINGS_FIND_STATE.marks.length) return;
+  setSettingsFindActive(SETTINGS_FIND_STATE.activeIndex + delta);
+}
+
+function updateSettingsFindStatus() {
+  var status = document.getElementById('settingsFindStatus');
+  if (!status) return;
+  var total = SETTINGS_FIND_STATE.marks.length;
+  if (!total) {
+    status.textContent = '0 results';
+  } else {
+    status.textContent = (SETTINGS_FIND_STATE.activeIndex + 1) + ' of ' + total;
+  }
+}
 
 function toggleSection(header) {
   header.classList.toggle('open');

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1258,7 +1258,25 @@ function shouldSkipSettingsFindTextNode(node) {
   var el = node.parentElement;
   if (!el) return true;
   if (el.closest('.settings-find-panel')) return true;
-  return !!el.closest('script, style, noscript, textarea, input, select, option, mark.settings-find-mark');
+  if (el.closest('script, style, noscript, textarea, input, select, option, mark.settings-find-mark')) return true;
+  return isSettingsFindTextHidden(el);
+}
+
+function isSettingsFindTextHidden(el) {
+  var root = getSettingsFindRoot();
+  var current = el;
+  while (current && current !== root) {
+    if (
+      !current.classList.contains('collapsible-body') &&
+      current.id !== 'advancedContent'
+    ) {
+      var style = window.getComputedStyle(current);
+      if (style.display === 'none' || style.visibility === 'hidden') return true;
+    }
+    if (current.hasAttribute('hidden') || current.getAttribute('aria-hidden') === 'true') return true;
+    current = current.parentElement;
+  }
+  return false;
 }
 
 function refreshSettingsFind(query, preferredIndex) {


### PR DESCRIPTION
Adds a settings-page find panel opened by Cmd+F or Ctrl+F, with match highlighting, count display, and next/previous navigation. It searches visible page text and expands matching collapsed settings sections so results are reachable. This fixes the settings page relying on browser find behavior that is not reliable inside the app shell. Validated with pytest tests/e2e/test_settings.py.