### PR TITLE
Clarify review apply actions

### DIFF
--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -21,6 +21,7 @@ def _mock_pipeline_rapid_review(
     original_body=None,
     original_content_type="image/png",
     shortcut_config=None,
+    state_photos=None,
 ):
     image_body = base64.b64decode(_PNG_1X1)
     if shortcut_config is None:
@@ -64,15 +65,17 @@ def _mock_pipeline_rapid_review(
     page.route("**/api/config", lambda route: route.fulfill(json=shortcut_config))
     page.route("**/api/pipeline/results", lambda route: route.fulfill(json=results))
     if state_ok:
+        if state_photos is None:
+            state_photos = {
+                "1": {"flag": "none", "has_species_keyword": False},
+                "2": {"flag": "none", "has_species_keyword": False},
+                "3": {"flag": "none", "has_species_keyword": False},
+            }
         page.route(
             "**/api/pipeline/group/state",
             lambda route: route.fulfill(
                 json={
-                    "photos": {
-                        "1": {"flag": "none", "has_species_keyword": False},
-                        "2": {"flag": "none", "has_species_keyword": False},
-                        "3": {"flag": "none", "has_species_keyword": False},
-                    },
+                    "photos": state_photos,
                     "species_kid": None,
                 }
             ),
@@ -206,6 +209,58 @@ def test_rapid_review_keeps_apply_disabled_when_state_load_fails(live_server, pa
     page.keyboard.press("x")
     expect(page.locator("#filename")).to_have_text("a.jpg")
     expect(page.locator("#rejectCount")).to_have_text("0")
+
+
+def test_rapid_review_apply_button_summarizes_pending_writes(live_server, page):
+    _mock_pipeline_rapid_review(page)
+
+    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+
+    expect(page.locator("#applyBtn")).to_have_text("Apply: no DB changes")
+
+    page.keyboard.press("p")
+    expect(page.locator("#applyBtn")).to_have_text("Apply: Flag 1 · Tag 1")
+
+    page.keyboard.press("x")
+    expect(page.locator("#applyBtn")).to_have_text("Apply: Flag 1 · Reject 1 · Tag 1")
+    expect(page.locator("#applyBtn")).to_have_attribute(
+        "title",
+        'Apply will flag 1 photo as a pick, reject 1 photo, add species keyword "Test bird" to 1 pick.',
+    )
+
+
+def test_rapid_review_species_edit_recounts_existing_keyword_state(live_server, page):
+    results = {
+        "photos": [
+            {"id": 1, "filename": "a.jpg", "label": "KEEP", "flag": "flagged"},
+        ],
+        "encounters": [
+            {
+                "photo_ids": [1],
+                "photo_count": 1,
+                "burst_count": 1,
+                "species": ["Test bird"],
+                "bursts": [{"photo_ids": [1]}],
+            }
+        ],
+        "summary": {"keep_count": 1, "review_count": 0, "reject_count": 0},
+    }
+    _mock_pipeline_rapid_review(
+        page,
+        results=results,
+        state_photos={"1": {"flag": "flagged", "has_species_keyword": True}},
+    )
+
+    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    expect(page.locator("#applyBtn")).to_have_text("Apply: no DB changes")
+
+    page.locator("#speciesInput").fill("New bird")
+
+    expect(page.locator("#applyBtn")).to_have_text("Apply: Set species · Tag 1")
+    expect(page.locator("#applyBtn")).to_have_attribute(
+        "title",
+        'Apply will set confirmed species to "New bird", add species keyword "New bird" to 1 pick.',
+    )
 
 
 def test_rapid_review_rewrites_all_burst_labels_before_saving_cache(live_server, page):
@@ -635,6 +690,11 @@ def test_classic_pipeline_review_opens_requested_burst_from_url(live_server, pag
 
     page.keyboard.press("p")
     expect(page.locator("#grmCount")).to_have_text("1 picks, 0 rejects, 2 unsorted")
+    expect(page.locator("#grmApplyBtn")).to_have_text("Flag 1 · Tag 1 as Test bird & Close")
+    expect(page.locator("#grmApplyBtn")).to_have_attribute(
+        "title",
+        'Apply will flag 1 photo as a pick, add species keyword "Test bird" to 1 pick, then close this burst.',
+    )
 
 
 def test_classic_pipeline_review_inspector_pick_reject_hotkeys(live_server, page):

--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -229,7 +229,7 @@ def test_rapid_review_apply_button_summarizes_pending_writes(live_server, page):
     )
 
 
-def test_rapid_review_species_edit_recounts_existing_keyword_state(live_server, page):
+def test_rapid_review_species_edit_refreshes_existing_keyword_state(live_server, page):
     results = {
         "photos": [
             {"id": 1, "filename": "a.jpg", "label": "KEEP", "flag": "flagged"},
@@ -256,10 +256,10 @@ def test_rapid_review_species_edit_recounts_existing_keyword_state(live_server, 
 
     page.locator("#speciesInput").fill("New bird")
 
-    expect(page.locator("#applyBtn")).to_have_text("Apply: Set species · Tag 1")
+    expect(page.locator("#applyBtn")).to_have_text("Apply: Set species")
     expect(page.locator("#applyBtn")).to_have_attribute(
         "title",
-        'Apply will set confirmed species to "New bird", add species keyword "New bird" to 1 pick.',
+        'Apply will set confirmed species to "New bird".',
     )
 
 

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -165,6 +165,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 18px;
   padding: 12px 18px;
 }
@@ -186,6 +187,8 @@
 .top-actions {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 8px;
   flex-shrink: 0;
 }
@@ -571,8 +574,8 @@
       <div class="top-actions">
         <button class="rapid-btn" id="undoBtn" onclick="undoLast()" title="Undo last decision">Undo</button>
         <button class="rapid-btn" onclick="openClassic()" title="Open this burst in classic pipeline review">Classic</button>
-        <button class="rapid-btn primary" id="applyBtn" onclick="applyCurrent(false)" title="Apply staged changes">Apply</button>
-        <button class="rapid-btn primary" id="applyNextBtn" onclick="applyCurrent(true)" title="Apply staged changes and open the next burst">Apply Next</button>
+        <button class="rapid-btn primary" id="applyBtn" onclick="applyCurrent(false)" title="Apply pick/reject flag changes and species keywords">Apply flags/species</button>
+        <button class="rapid-btn primary" id="applyNextBtn" onclick="applyCurrent(true)" title="Apply pick/reject flag changes and species keywords, then open the next burst">Apply flags/species & Next</button>
       </div>
     </div>
 
@@ -646,7 +649,7 @@
     <div class="queue-prompt-actions">
       <button class="rapid-btn" type="button" data-queue-choice="stay">Stay</button>
       <button class="rapid-btn" type="button" data-queue-choice="discard">Discard</button>
-      <button class="rapid-btn primary" type="button" data-queue-choice="apply">Apply</button>
+      <button class="rapid-btn primary" type="button" data-queue-choice="apply">Apply flags/species</button>
     </div>
   </div>
 </div>
@@ -664,6 +667,9 @@ var rapid = {
   reviewed: new Set(),
   touched: new Set(),
   initialFlags: {},
+  initialSpeciesKeywords: {},
+  keywordStateSpecies: '',
+  initialSpecies: '',
   history: [],
   currentIndex: -1,
   seeded: false,
@@ -1010,6 +1016,12 @@ function renderQueueControls() {
 
 function promptStagedQueueChange() {
   var prompt = document.getElementById('queuePrompt');
+  var applyBtn = prompt.querySelector('[data-queue-choice="apply"]');
+  if (applyBtn) {
+    var diff = rapidComputeApplyDiff();
+    applyBtn.textContent = rapidApplyButtonText('Apply', diff);
+    applyBtn.title = rapidApplyTitle(diff, false);
+  }
   prompt.hidden = false;
   return new Promise(function(resolve) {
     rapid.queuePromptResolve = resolve;
@@ -1100,6 +1112,9 @@ function showEmptyQueue() {
   rapid.reviewed = new Set();
   rapid.touched = new Set();
   rapid.initialFlags = {};
+  rapid.initialSpeciesKeywords = {};
+  rapid.keywordStateSpecies = '';
+  rapid.initialSpecies = '';
   rapid.history = [];
   rapid.currentIndex = -1;
   rapid.seeded = false;
@@ -1146,6 +1161,9 @@ async function openSession(index) {
   rapid.reviewed = new Set();
   rapid.touched = new Set();
   rapid.initialFlags = {};
+  rapid.initialSpeciesKeywords = {};
+  rapid.keywordStateSpecies = session.species || '';
+  rapid.initialSpecies = session.species || '';
   rapid.history = [];
   rapid.currentIndex = rapid.items.length ? 0 : -1;
   resetRapidZoom();
@@ -1173,6 +1191,7 @@ async function openSession(index) {
       var st = photos[p.id] || {};
       var flag = st.flag || p.flag || 'none';
       rapid.initialFlags[p.id] = flag;
+      rapid.initialSpeciesKeywords[p.id] = !!st.has_species_keyword;
       if (flag === 'flagged') rapid.picks.add(p.id);
       else if (flag === 'rejected') rapid.rejects.add(p.id);
     });
@@ -1535,14 +1554,85 @@ function candidateIdsForApply() {
   }).map(function(p) { return p.id; });
 }
 
+function rapidPlural(n, one, many) {
+  return n === 1 ? one : (many || one + 's');
+}
+
+function rapidComputeApplyDiff() {
+  var speciesEl = document.getElementById('speciesInput');
+  var species = speciesEl ? (speciesEl.value || '').trim() : '';
+  var diff = {
+    flagNew: 0,
+    rejectNew: 0,
+    clearNew: 0,
+    tagNew: 0,
+    speciesChanged: !!(species && species !== (rapid.initialSpecies || '')),
+    species: species,
+  };
+  if (!rapid.items) return diff;
+
+  rapid.items.forEach(function(p) {
+    var oldFlag = rapid.initialFlags[p.id] || 'none';
+    var newFlag = rapid.picks.has(p.id) ? 'flagged' : rapid.rejects.has(p.id) ? 'rejected' : 'none';
+    if (newFlag !== oldFlag) {
+      if (newFlag === 'flagged') diff.flagNew++;
+      else if (newFlag === 'rejected') diff.rejectNew++;
+      else diff.clearNew++;
+    }
+    var hasSpeciesKeyword = species &&
+      rapid.keywordStateSpecies === species &&
+      !!rapid.initialSpeciesKeywords[p.id];
+    if (species && newFlag === 'flagged' && !hasSpeciesKeyword) diff.tagNew++;
+  });
+  return diff;
+}
+
+function rapidApplyLabelParts(diff) {
+  var parts = [];
+  if (diff.flagNew > 0) parts.push('Flag ' + diff.flagNew);
+  if (diff.rejectNew > 0) parts.push('Reject ' + diff.rejectNew);
+  if (diff.clearNew > 0) parts.push('Clear ' + diff.clearNew);
+  if (diff.speciesChanged) parts.push('Set species');
+  if (diff.tagNew > 0) parts.push('Tag ' + diff.tagNew);
+  return parts;
+}
+
+function rapidApplyTitle(diff, openNext) {
+  var actions = [];
+  if (diff.flagNew > 0) actions.push('flag ' + diff.flagNew + ' ' + rapidPlural(diff.flagNew, 'photo') + ' as ' + rapidPlural(diff.flagNew, 'a pick', 'picks'));
+  if (diff.rejectNew > 0) actions.push('reject ' + diff.rejectNew + ' ' + rapidPlural(diff.rejectNew, 'photo'));
+  if (diff.clearNew > 0) actions.push('clear flags on ' + diff.clearNew + ' ' + rapidPlural(diff.clearNew, 'photo'));
+  if (diff.speciesChanged) actions.push('set confirmed species to "' + diff.species + '"');
+  if (diff.tagNew > 0) {
+    actions.push('add species keyword "' + diff.species + '" to ' + diff.tagNew + ' ' + rapidPlural(diff.tagNew, 'pick'));
+  }
+  var text = actions.length ? ('Apply will ' + actions.join(', ') + '.') : 'Apply will make no database changes for this burst.';
+  if (openNext) text += ' Then open the next burst.';
+  return text;
+}
+
+function rapidApplyButtonText(prefix, diff) {
+  var parts = rapidApplyLabelParts(diff);
+  return parts.length ? (prefix + ': ' + parts.join(' · ')) : (prefix + ': no DB changes');
+}
+
 function renderApplyState() {
   var disabled = !rapid.seeded || rapid.applying || rapid.sessionIndex < 0;
   document.getElementById('undoBtn').disabled = disabled || rapid.history.length === 0;
   document.querySelectorAll('.decision-btn').forEach(function(btn) {
     btn.disabled = disabled || !currentPhoto();
   });
-  document.getElementById('applyBtn').disabled = disabled;
-  document.getElementById('applyNextBtn').disabled = disabled || rapid.sessionIndex >= rapid.sessions.length - 1;
+  var applyBtn = document.getElementById('applyBtn');
+  var applyNextBtn = document.getElementById('applyNextBtn');
+  var diff = rapidComputeApplyDiff();
+  applyBtn.disabled = disabled;
+  applyNextBtn.disabled = disabled || rapid.sessionIndex >= rapid.sessions.length - 1;
+  applyBtn.textContent = rapid.applying ? 'Applying...' : rapidApplyButtonText('Apply', diff);
+  applyNextBtn.textContent = rapid.applying ? 'Applying...' : rapidApplyButtonText('Apply & Next', diff);
+  applyBtn.title = rapidApplyTitle(diff, false);
+  applyNextBtn.title = rapidApplyTitle(diff, true);
+  applyBtn.setAttribute('aria-label', applyBtn.title);
+  applyNextBtn.setAttribute('aria-label', applyNextBtn.title);
 }
 
 function updateSummaryFromPhotos() {

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -607,7 +607,7 @@
         </div>
         <div class="species-field">
           <label for="speciesInput">Species keyword for picks</label>
-          <input id="speciesInput" type="text" oninput="renderApplyState()">
+          <input id="speciesInput" type="text" oninput="rapidOnSpeciesInput()">
         </div>
         <div class="decision-grid">
           <button class="decision-btn pick" onclick="decideCurrent('pick')" title="Pick and advance">Pick</button>
@@ -712,6 +712,8 @@ var RAPID_SC_DEFAULTS = {
 };
 var rapidShortcuts = Object.assign({}, RAPID_SC_DEFAULTS);
 var rapidShortcutsRegistered = false;
+var _rapidSpeciesRefetchTimer = null;
+var _rapidSpeciesRefetchToken = 0;
 
 if (window.Keymap && window.Keymap.setScope) {
   window.Keymap.setScope(RAPID_SCOPE);
@@ -1552,6 +1554,41 @@ function candidateIdsForApply() {
     return zoneFor(p.id) === 'review' &&
       (rapid.touched.has(p.id) || initial === 'flagged' || initial === 'rejected');
   }).map(function(p) { return p.id; });
+}
+
+function rapidOnSpeciesInput() {
+  renderApplyState();
+  if (_rapidSpeciesRefetchTimer) clearTimeout(_rapidSpeciesRefetchTimer);
+  _rapidSpeciesRefetchTimer = setTimeout(rapidRefreshSpeciesKeywordState, 250);
+}
+
+function rapidRefreshSpeciesKeywordState() {
+  if (!rapid.items || !rapid.items.length || rapid.sessionIndex < 0) return;
+  var speciesEl = document.getElementById('speciesInput');
+  var species = speciesEl ? (speciesEl.value || '').trim() : '';
+  var token = ++_rapidSpeciesRefetchToken;
+  var openToken = rapid.openToken;
+  var sessionIndex = rapid.sessionIndex;
+  var photoIds = rapid.items.map(function(p) { return p.id; });
+
+  safeFetch('/api/pipeline/group/state', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({ photo_ids: photoIds, species: species }),
+  }, { toast: false }).then(function(data) {
+    if (token !== _rapidSpeciesRefetchToken) return;
+    if (rapid.openToken !== openToken || rapid.sessionIndex !== sessionIndex) return;
+    var fresh = (data && data.photos) || {};
+    photoIds.forEach(function(pid) {
+      var row = fresh[pid] || fresh[String(pid)] || {};
+      rapid.initialSpeciesKeywords[pid] = !!row.has_species_keyword;
+    });
+    rapid.keywordStateSpecies = species;
+    renderApplyState();
+  }).catch(function() {
+    // Keep the previous keyword snapshot. If the typed species differs from
+    // that snapshot, the Apply label remains a conservative tag overestimate.
+  });
 }
 
 function rapidPlural(n, one, many) {

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1413,7 +1413,7 @@ input[type="range"]::-moz-range-thumb {
       <span id="grmResLabel" style="font-size:11px;color:var(--text-dim);min-width:140px;">1920 · preview</span>
     </div>
     <span class="grm-hint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
-    <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);">Apply & Close</button>
+    <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);" title="Apply pick/reject flag changes and species keywords, then close this burst.">Apply flags/species & Close</button>
   </div>
 </div>
 
@@ -3120,6 +3120,11 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
 
   var items = photoIds.map(function(pid) { return photoMap[pid]; }).filter(Boolean);
 
+  // Reset the species input to this encounter's value so a stale value from a
+  // previously-reviewed group doesn't leak in when the prior modal was closed
+  // via × or Escape (only Apply & Close clears it).
+  var initialSpecies = enc.confirmed_species || (enc.species ? enc.species[0] : '') || '';
+
   // Bump the session id so any in-flight /group/state fetch from a previous
   // openGroupReview call lands as stale and gets ignored when it resolves.
   var sessionId = (grmState.sessionId || 0) + 1;
@@ -3136,6 +3141,8 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
     // with, used to (a) render "from DB" markers and (b) compute the
     // change-only Apply button label.
     dbState: {},
+    keywordStateSpecies: initialSpecies,
+    initialSpecies: initialSpecies,
     sessionId: sessionId,
     // False until /group/state resolves and grmSeedFromDbState runs. Apply &
     // Close is gated on this so a click during the seed window can't ship
@@ -3165,10 +3172,6 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
     applyBtn.textContent = 'Loading…';
   }
 
-  // Reset the species input to this encounter's value so a stale value from a
-  // previously-reviewed group doesn't leak in when the prior modal was closed
-  // via × or Escape (only Apply & Close clears it).
-  var initialSpecies = enc.confirmed_species || (enc.species ? enc.species[0] : '') || '';
   document.getElementById('grmSpecies').value = initialSpecies;
 
   // Sync slider DOM with persisted resolution choice
@@ -3384,6 +3387,7 @@ function grmRefreshSpeciesKeywordState() {
       if (!grmState.dbState[pid]) grmState.dbState[pid] = { flag: 'none' };
       grmState.dbState[pid].has_species_keyword = !!fresh[pidStr].has_species_keyword;
     });
+    grmState.keywordStateSpecies = species;
     renderGroupModal();
   }).catch(function() {
     // Network/server error: leave previous keyword markers in place. The
@@ -3408,8 +3412,11 @@ function grmUpdateApplyLabel() {
   if (diff.flagNew > 0) parts.push('Flag ' + diff.flagNew);
   if (diff.rejectNew > 0) parts.push('Reject ' + diff.rejectNew);
   if (diff.clearNew > 0) parts.push('Clear ' + diff.clearNew);
+  if (diff.speciesChanged) parts.push('Set species');
   if (diff.tagNew > 0) parts.push('Tag ' + diff.tagNew + (diff.species ? ' as ' + diff.species : ''));
-  btn.textContent = parts.length ? parts.join(' · ') + ' & Close' : 'Apply & Close';
+  if (diff.detachNew > 0) parts.push('Detach ' + diff.detachNew);
+  btn.textContent = parts.length ? parts.join(' · ') + ' & Close' : 'No DB changes & Close';
+  btn.title = grmApplyTitle(diff);
 }
 
 // Diff the current modal zones against the DB snapshot we opened with.
@@ -3418,14 +3425,27 @@ function grmUpdateApplyLabel() {
 function grmComputeDiff() {
   var speciesEl = document.getElementById('grmSpecies');
   var species = speciesEl ? (speciesEl.value || '').trim() : '';
-  var diff = { flagNew: 0, rejectNew: 0, clearNew: 0, tagNew: 0, species: species };
+  var diff = {
+    flagNew: 0,
+    rejectNew: 0,
+    clearNew: 0,
+    tagNew: 0,
+    detachNew: 0,
+    speciesChanged: !!(species && grmState && species !== (grmState.initialSpecies || '')),
+    species: species
+  };
   if (!grmState || !grmState.items) return diff;
 
   grmState.items.forEach(function(p) {
-    if (grmState.removed && grmState.removed.has(p.id)) return;
+    if (grmState.removed && grmState.removed.has(p.id)) {
+      diff.detachNew++;
+      return;
+    }
     var st = (grmState.dbState && grmState.dbState[p.id]) || {};
     var oldFlag = st.flag || 'none';
-    var hasKw = !!st.has_species_keyword;
+    var hasKw = species &&
+      grmState.keywordStateSpecies === species &&
+      !!st.has_species_keyword;
     var newFlag;
     if (grmState.picks.has(p.id)) newFlag = 'flagged';
     else if (grmState.rejects.has(p.id)) newFlag = 'rejected';
@@ -3439,6 +3459,23 @@ function grmComputeDiff() {
     if (species && newFlag === 'flagged' && !hasKw) diff.tagNew++;
   });
   return diff;
+}
+
+function grmPlural(n, one, many) {
+  return n === 1 ? one : (many || one + 's');
+}
+
+function grmApplyTitle(diff) {
+  var actions = [];
+  if (diff.flagNew > 0) actions.push('flag ' + diff.flagNew + ' ' + grmPlural(diff.flagNew, 'photo') + ' as ' + grmPlural(diff.flagNew, 'a pick', 'picks'));
+  if (diff.rejectNew > 0) actions.push('reject ' + diff.rejectNew + ' ' + grmPlural(diff.rejectNew, 'photo'));
+  if (diff.clearNew > 0) actions.push('clear flags on ' + diff.clearNew + ' ' + grmPlural(diff.clearNew, 'photo'));
+  if (diff.speciesChanged) actions.push('set confirmed species to "' + diff.species + '"');
+  if (diff.tagNew > 0) actions.push('add species keyword "' + diff.species + '" to ' + diff.tagNew + ' ' + grmPlural(diff.tagNew, 'pick'));
+  if (diff.detachNew > 0) actions.push('detach ' + diff.detachNew + ' ' + grmPlural(diff.detachNew, 'photo') + ' from this burst');
+  return actions.length
+    ? 'Apply will ' + actions.join(', ') + ', then close this burst.'
+    : 'Apply will make no database changes, then close this burst.';
 }
 
 function grmSelect(photoId) {


### PR DESCRIPTION
Clarifies the Apply controls in classic pipeline review and rapid review so they summarize pending flag, reject, clear, species, keyword, and detach writes before the user commits them.
Rapid Review now tracks initial flag/keyword state for the active species and updates Apply / Apply & Next labels, titles, and queue-prompt wording from the computed DB diff.
Classic pipeline review now uses the same explicit diff-style label and tooltip, including no-op and detach cases.
Validated with `python -m pytest tests/e2e/test_pipeline_rapid_review.py -q`, `python -m pytest tests/e2e/test_pipeline_review_species.py -q`, and `git diff --check`.