### PR TITLE
[codex] Show XMP sync banner in Browse

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3771,6 +3771,7 @@ async function lightboxNotWildlife() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'Landscape', type: 'genre' }),
     }, { toast: false });
+    if (typeof checkPendingSync === 'function') checkPendingSync();
     // Advance to next photo if more remain
     var idx = _lightboxPhotoList.findIndex(function(x) { return x.id === currentId; });
     if (idx >= 0 && _lightboxPhotoList.length > 1) {

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -41,7 +41,7 @@ async function checkPendingSync() {
     if (data.pending_count > 0) {
       document.getElementById('syncBannerText').textContent =
         data.pending_count + ' change' + (data.pending_count !== 1 ? 's' : '') +
-        ' pending \u2014 keywords have been added to the database but not written to XMP sidecar files yet.';
+        ' pending \u2014 metadata changes have been saved in Vireo but not written to XMP sidecar files yet.';
       banner.style.display = 'flex';
     } else {
       banner.style.display = 'none';

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -818,6 +818,8 @@ body {
 
 {% include '_navbar.html' %}
 
+{% include '_sync_panel.html' %}
+
 <div class="main-layout">
 
   <!-- Sidebar -->
@@ -1191,6 +1193,12 @@ var calendarData = null;
 var clipSearchActive = false;
 var searchFilterTimer = null;
 
+function refreshPendingSyncBanner() {
+  if (typeof checkPendingSync === 'function') {
+    checkPendingSync();
+  }
+}
+
 function hasActiveBrowseFilter() {
   var searchInput = document.getElementById('searchInput');
   var colorFilter = document.getElementById('colorFilter');
@@ -1351,6 +1359,7 @@ async function bootstrapBrowse() {
     renderGrid();
     updateFilterSummary();
     loadSummary();
+    refreshPendingSyncBanner();
 
     document.getElementById('loadingState').style.display = 'none';
     // Lazy-load collection photo counts to avoid N+1 on init
@@ -2605,6 +2614,7 @@ async function applySelectionKeyword(keywordId) {
   selectionKeywordKey = '';
   loadSelectionKeywordSuggestions(getActiveSelection());
   loadKeywords();
+  refreshPendingSyncBanner();
   showUndoToast();
 }
 
@@ -2621,6 +2631,7 @@ async function batchSetRating(rating) {
     if (p) p.rating = rating;
   });
   refreshGridCards(ids);
+  refreshPendingSyncBanner();
   showUndoToast();
 }
 
@@ -2686,6 +2697,7 @@ async function confirmBatchKeyword() {
   selectionKeywordKey = '';
   loadSelectionKeywordSuggestions(ids);
   loadKeywords();
+  refreshPendingSyncBanner();
   showUndoToast();
 }
 
@@ -2829,6 +2841,7 @@ async function undoLast() {
     var data = await safeFetch('/api/undo', { method: 'POST' });
     showToast('Undone: ' + data.undone + ' — Ctrl+Shift+Z to redo');
     resetAndLoad();
+    refreshPendingSyncBanner();
   } catch(e) {}
 }
 
@@ -2837,6 +2850,7 @@ async function redoLast() {
     var data = await safeFetch('/api/redo', { method: 'POST' });
     showToast('Redone: ' + data.redone);
     resetAndLoad();
+    refreshPendingSyncBanner();
   } catch(e) {}
 }
 
@@ -3193,6 +3207,7 @@ async function setRating(photoId, rating) {
     if (p) p.rating = rating;
     refreshGridCards([photoId]);
     loadDetail(photoId);
+    refreshPendingSyncBanner();
   } catch(e) {}
 }
 
@@ -3266,6 +3281,7 @@ async function addKeyword() {
     input.value = '';
     loadDetail(selectedPhotoId);
     loadKeywords();
+    refreshPendingSyncBanner();
   } catch(e) {}
 }
 
@@ -3275,6 +3291,7 @@ async function removeKeyword(photoId, keywordId) {
       method: 'DELETE',
     });
     loadDetail(photoId);
+    refreshPendingSyncBanner();
   } catch(e) {}
 }
 
@@ -3732,6 +3749,7 @@ async function setRatingFor(photoId, rating) {
   if (p) p.rating = rating;
   refreshGridCards([photoId]);
   if (selectedPhotoId === photoId) loadDetail(photoId);
+  refreshPendingSyncBanner();
 }
 
 async function setFlagFor(photoId, flag) {

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -15,11 +15,14 @@ def test_index_redirects_to_browse(app_and_db, monkeypatch):
 
 
 def test_browse_page(app_and_db):
-    """GET /browse returns 200."""
+    """GET /browse returns 200 and includes pending-XMP sync UI."""
     app, _ = app_and_db
     client = app.test_client()
     resp = client.get('/browse')
     assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'id="syncBanner"' in html
+    assert 'function refreshPendingSyncBanner()' in html
 
 
 def test_help_static_assets_served(app_and_db):


### PR DESCRIPTION
## Summary
- Include the shared pending-XMP sync panel on Browse and refresh it after keyword/rating edits, undo, redo, and the shared lightbox keyword action.
- Update the banner copy so it covers all metadata changes, not only keywords.
- Add a regression assertion that `/browse` renders the sync UI.

## Validation
- `pytest vireo/tests/test_app.py::test_browse_page vireo/tests/test_build_static.py::test_build_static_produces_files`
