### PR TITLE
[codex] Add browse pick and reject filters

### DIFF
--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -21,3 +21,37 @@ def test_keyword_search_empty_state_and_clear(live_server, page):
     cards.first.wait_for(state="visible")
     expect(page.locator("#emptyState")).to_be_hidden()
     expect(page.locator("#welcomeState")).to_be_hidden()
+
+
+def test_flag_quick_filters_show_picks_and_rejects(live_server, page):
+    """Browse keeps always-visible quick filters for picked and rejected photos."""
+    url = live_server["url"]
+    db = live_server["db"]
+    photos = db.get_photos()
+    pick_id = photos[0]["id"]
+    reject_id = photos[1]["id"]
+    db.update_photo_flag(pick_id, "flagged")
+    db.update_photo_flag(reject_id, "rejected")
+
+    page.goto(f"{url}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    pick_btn = page.locator("#pickFilterBtn")
+    reject_btn = page.locator("#rejectFilterBtn")
+    expect(pick_btn).to_be_visible()
+    expect(reject_btn).to_be_visible()
+
+    pick_btn.click()
+    expect(pick_btn).to_have_class("flag-filter-btn active-pick")
+    expect(page.locator(".grid-card")).to_have_count(1)
+    assert page.locator(".grid-card").first.get_attribute("data-id") == str(pick_id)
+
+    reject_btn.click()
+    expect(pick_btn).to_have_class("flag-filter-btn")
+    expect(reject_btn).to_have_class("flag-filter-btn active-reject")
+    expect(page.locator(".grid-card")).to_have_count(1)
+    assert page.locator(".grid-card").first.get_attribute("data-id") == str(reject_id)
+
+    reject_btn.click()
+    expect(reject_btn).to_have_class("flag-filter-btn")
+    expect(page.locator(".grid-card")).to_have_count(5)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1339,6 +1339,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             p["detections"] = det_map.get(p["id"], [])
         return photo_dicts
 
+    def _request_flag_filter():
+        flag = request.args.get("flag", None)
+        if flag in (None, ""):
+            return None
+        if flag not in ("none", "flagged", "rejected"):
+            raise ValueError("flag must be 'none', 'flagged', or 'rejected'")
+        return flag
+
     @app.route("/api/browse/init")
     def api_browse_init():
         """Combined endpoint for browse page initial load — one request instead of five."""
@@ -1782,6 +1790,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         date_to = request.args.get("date_to", None)
         keyword = request.args.get("keyword", None)
         color_label = request.args.get("color_label", None)
+        try:
+            flag = _request_flag_filter()
+        except ValueError as e:
+            return json_error(str(e), 400)
 
         photos = db.get_photos(
             folder_id=folder_id,
@@ -1793,10 +1805,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             date_to=date_to,
             keyword=keyword,
             color_label=color_label,
+            flag=flag,
         )
 
         # Total count — use count_photos for unfiltered, otherwise use efficient COUNT query
-        if not any([folder_id, rating_min, date_from, date_to, keyword, color_label]):
+        if not any([folder_id, rating_min, date_from, date_to, keyword, color_label, flag]):
             total = db.count_photos()
         else:
             total = db.count_filtered_photos(
@@ -1806,6 +1819,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 date_to=date_to,
                 keyword=keyword,
                 color_label=color_label,
+                flag=flag,
             )
 
         photo_dicts = [dict(p) for p in photos]
@@ -1831,9 +1845,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         rating_min = request.args.get("rating_min", None, type=int)
         keyword = request.args.get("keyword", None)
         color_label = request.args.get("color_label", None)
+        try:
+            flag = _request_flag_filter()
+        except ValueError as e:
+            return json_error(str(e), 400)
         data = db.get_calendar_data(
             year=year, folder_id=folder_id, rating_min=rating_min, keyword=keyword,
-            color_label=color_label,
+            color_label=color_label, flag=flag,
         )
         return jsonify(data)
 
@@ -1847,6 +1865,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         keyword = request.args.get("keyword", None)
         collection_id = request.args.get("collection_id", None, type=int)
         color_label = request.args.get("color_label", None)
+        try:
+            flag = _request_flag_filter()
+        except ValueError as e:
+            return json_error(str(e), 400)
         return jsonify(
             db.get_browse_summary(
                 folder_id=folder_id,
@@ -1856,6 +1878,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 keyword=keyword,
                 collection_id=collection_id,
                 color_label=color_label,
+                flag=flag,
             )
         )
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3831,7 +3831,7 @@ class Database:
             "detected_count": detected_count,
         }
 
-    def get_calendar_data(self, year, folder_id=None, rating_min=None, keyword=None, color_label=None):
+    def get_calendar_data(self, year, folder_id=None, rating_min=None, keyword=None, color_label=None, flag=None):
         """Return daily photo counts for a given year, scoped to active workspace."""
         ws = self._ws_id()
         conditions = ["wf.workspace_id = ?", "p.timestamp IS NOT NULL",
@@ -3850,6 +3850,9 @@ class Database:
         if rating_min is not None:
             conditions.append("p.rating >= ?")
             where_params.append(rating_min)
+        if flag is not None:
+            conditions.append("COALESCE(p.flag, 'none') = ?")
+            where_params.append(flag)
         if keyword is not None:
             join_clause += """
                 LEFT JOIN photo_keywords pk ON pk.photo_id = p.id
@@ -3906,6 +3909,7 @@ class Database:
         date_to=None,
         keyword=None,
         color_label=None,
+        flag=None,
     ):
         """Return paginated, filtered photo list scoped to active workspace."""
         conditions = ["wf.workspace_id = ?"]
@@ -3926,6 +3930,9 @@ class Database:
         if date_to is not None:
             conditions.append("p.timestamp <= ?")
             where_params.append(_inclusive_date_to(date_to))
+        if flag is not None:
+            conditions.append("COALESCE(p.flag, 'none') = ?")
+            where_params.append(flag)
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
@@ -3985,6 +3992,7 @@ class Database:
         date_to=None,
         keyword=None,
         color_label=None,
+        flag=None,
     ):
         """Return count of photos matching the given filters, scoped to active workspace."""
         conditions = ["wf.workspace_id = ?"]
@@ -4005,6 +4013,9 @@ class Database:
         if date_to is not None:
             conditions.append("p.timestamp <= ?")
             where_params.append(_inclusive_date_to(date_to))
+        if flag is not None:
+            conditions.append("COALESCE(p.flag, 'none') = ?")
+            where_params.append(flag)
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
@@ -4045,6 +4056,7 @@ class Database:
         keyword=None,
         collection_id=None,
         color_label=None,
+        flag=None,
     ):
         """Return summary stats for the browse panel, scoped to active workspace and filters."""
         ws = self._ws_id()
@@ -4067,6 +4079,9 @@ class Database:
         if date_to is not None:
             conditions.append("p.timestamp <= ?")
             where_params.append(_inclusive_date_to(date_to))
+        if flag is not None:
+            conditions.append("COALESCE(p.flag, 'none') = ?")
+            where_params.append(flag)
 
         # When browsing a collection, restrict photos to those matching the
         # collection's rules by using a subquery from _build_collection_query.

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -125,6 +125,32 @@ body {
   outline: none;
 }
 .filter-bar label { font-size: 12px; color: var(--text-dim); }
+.flag-filter {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.flag-filter-btn {
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  border: 1px solid var(--border-secondary);
+  border-radius: 4px;
+  padding: 5px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.flag-filter-btn:hover { border-color: var(--accent); }
+.flag-filter-btn.active-pick {
+  background: color-mix(in srgb, var(--accent) 18%, var(--bg-tertiary));
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.flag-filter-btn.active-reject {
+  background: color-mix(in srgb, var(--danger) 18%, var(--bg-tertiary));
+  border-color: var(--danger);
+  color: var(--danger);
+}
 
 /* Rating filter */
 .rating-filter { display: flex; align-items: center; gap: 2px; }
@@ -867,6 +893,10 @@ body {
         <span class="rating-star" data-val="4" onclick="setFilterRating(4)">&#9733;</span>
         <span class="rating-star" data-val="5" onclick="setFilterRating(5)">&#9733;</span>
       </div>
+      <div class="flag-filter" aria-label="Flag filters">
+        <button id="pickFilterBtn" class="flag-filter-btn" type="button" onclick="setFlagFilter('flagged')" title="Show only picks">P Picks</button>
+        <button id="rejectFilterBtn" class="flag-filter-btn" type="button" onclick="setFlagFilter('rejected')" title="Show only rejects">X Rejects</button>
+      </div>
       <select id="colorFilter" onchange="applyFilters()" title="Filter by color label" style="font-size:12px;">
         <option value="">Color: Any</option>
         <option value="red">Red</option>
@@ -1181,6 +1211,7 @@ var colorLabels = {};    // {photo_id: color_string}
 var colorLabelGen = 0;   // bumped on local edits; guards against stale fetch responses
 var loadEpoch = 0;       // bumped on any grid reset; guards against stale loadPhotos responses
 var filterRating = 0;
+var flagFilter = '';
 var activeFolderId = null;
 var activeKeyword = null;
 var activeCollectionId = null;
@@ -1202,6 +1233,7 @@ function hasActiveBrowseFilter() {
     activeCollectionId ||
     clipSearchActive ||
     filterRating > 0 ||
+    flagFilter ||
     (searchInput && searchInput.value.trim()) ||
     (colorFilter && colorFilter.value) ||
     (dateFrom && dateFrom.value) ||
@@ -1963,6 +1995,7 @@ async function loadPhotos() {
 
     if (activeFolderId) params.set('folder_id', activeFolderId);
     if (filterRating > 0) params.set('rating_min', filterRating);
+    if (flagFilter) params.set('flag', flagFilter);
 
     var colorFilter = document.getElementById('colorFilter').value;
     if (colorFilter) params.set('color_label', colorFilter);
@@ -2029,6 +2062,7 @@ async function loadCalendarData() {
   params.set('year', calendarYear);
   if (activeFolderId) params.set('folder_id', activeFolderId);
   if (filterRating > 0) params.set('rating_min', filterRating);
+  if (flagFilter) params.set('flag', flagFilter);
   var colorFilter = document.getElementById('colorFilter').value;
   if (colorFilter) params.set('color_label', colorFilter);
   var search = document.getElementById('searchInput').value.trim();
@@ -2207,6 +2241,20 @@ function setFilterRating(val) {
     el.classList.toggle('active', parseInt(el.dataset.val) <= filterRating);
   });
   resetAndLoad();
+}
+
+function setFlagFilter(flag) {
+  flagFilter = flagFilter === flag ? '' : flag;
+  updateFlagFilterButtons();
+  if (timelineMode) loadCalendarData();
+  resetAndLoad();
+}
+
+function updateFlagFilterButtons() {
+  var pick = document.getElementById('pickFilterBtn');
+  var reject = document.getElementById('rejectFilterBtn');
+  if (pick) pick.classList.toggle('active-pick', flagFilter === 'flagged');
+  if (reject) reject.classList.toggle('active-reject', flagFilter === 'rejected');
 }
 
 function updateFilterSummary() {
@@ -3122,6 +3170,7 @@ async function loadSummary() {
   var params = new URLSearchParams();
   if (activeFolderId) params.set('folder_id', activeFolderId);
   if (filterRating > 0) params.set('rating_min', filterRating);
+  if (flagFilter) params.set('flag', flagFilter);
   var colorFilter = document.getElementById('colorFilter').value;
   if (colorFilter) params.set('color_label', colorFilter);
   var dateFrom = document.getElementById('dateFrom').value;

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -321,6 +321,34 @@ def test_get_photos_filter_by_rating(tmp_path):
     assert results[0]['filename'] == 'b.jpg'
 
 
+def test_get_photos_filter_by_flag(tmp_path):
+    """get_photos and count_filtered_photos can filter picks and rejects."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    picked = db.add_photo(folder_id=fid, filename='pick.jpg', extension='.jpg',
+                          file_size=100, file_mtime=1.0,
+                          timestamp='2024-01-01T10:00:00')
+    rejected = db.add_photo(folder_id=fid, filename='reject.jpg', extension='.jpg',
+                            file_size=100, file_mtime=2.0,
+                            timestamp='2024-01-02T10:00:00')
+    db.add_photo(folder_id=fid, filename='plain.jpg', extension='.jpg',
+                 file_size=100, file_mtime=3.0,
+                 timestamp='2024-01-03T10:00:00')
+    db.update_photo_flag(picked, 'flagged')
+    db.update_photo_flag(rejected, 'rejected')
+
+    picks = db.get_photos(flag='flagged')
+    rejects = db.get_photos(flag='rejected')
+
+    assert [p['filename'] for p in picks] == ['pick.jpg']
+    assert [p['filename'] for p in rejects] == ['reject.jpg']
+    assert db.count_filtered_photos(flag='flagged') == 1
+    assert db.count_filtered_photos(flag='rejected') == 1
+    assert db.get_browse_summary(flag='flagged')['filtered_total'] == 1
+    assert db.get_calendar_data(2024, flag='rejected')['days'] == {'2024-01-02': 1}
+
+
 def test_get_photos_filter_by_date_range(tmp_path):
     """get_photos can filter by date range."""
     from db import Database

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -149,6 +149,33 @@ def test_api_photos_filter_keyword(app_and_db):
     assert data['photos'][0]['filename'] == 'bird1.jpg'
 
 
+def test_api_photos_filter_flag(app_and_db):
+    """GET /api/photos?flag= filters to picks or rejects."""
+    app, db = app_and_db
+    db.conn.execute("UPDATE photos SET flag='flagged' WHERE filename='bird1.jpg'")
+    db.conn.execute("UPDATE photos SET flag='rejected' WHERE filename='bird2.jpg'")
+    db.conn.commit()
+
+    client = app.test_client()
+    picks = client.get('/api/photos?flag=flagged').get_json()
+    rejects = client.get('/api/photos?flag=rejected').get_json()
+
+    assert picks['total'] == 1
+    assert [p['filename'] for p in picks['photos']] == ['bird1.jpg']
+    assert rejects['total'] == 1
+    assert [p['filename'] for p in rejects['photos']] == ['bird2.jpg']
+
+
+def test_api_photos_rejects_unknown_flag_filter(app_and_db):
+    """GET /api/photos?flag= validates the flag filter value."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    resp = client.get('/api/photos?flag=bogus')
+
+    assert resp.status_code == 400
+
+
 def test_api_photo_detail(app_and_db):
     """GET /api/photos/<id> returns photo with keywords."""
     app, db = app_and_db


### PR DESCRIPTION
Adds always-visible P Picks and X Rejects quick filters to the Browse toolbar so users can jump straight to flagged picks or rejected photos.
Threads a validated flag filter through photo listing, counts, browse summary, and calendar data so pagination and related views stay consistent.
Adds DB/API and Playwright coverage for the new filter behavior.
Validation: `pytest vireo/tests/test_db.py::test_get_photos_filter_by_flag vireo/tests/test_photos_api.py::test_api_photos_filter_flag vireo/tests/test_photos_api.py::test_api_photos_rejects_unknown_flag_filter` and `pytest tests/e2e/test_browse_search_empty_state.py`.