### PR TITLE
[codex] Restore selected photo detail panel

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -264,7 +264,7 @@ body {
 .summary-folder-row { display: flex; justify-content: space-between; align-items: center; padding: 3px 0; font-size: 12px; }
 .summary-folder-name { color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; margin-right: 8px; }
 .summary-folder-count { color: var(--text-muted); font-size: 11px; flex-shrink: 0; }
-.selection-panel { display: block; }
+.selection-panel { display: block; margin-bottom: 16px; }
 .selection-panel.hidden { display: none; }
 .selection-heading {
   font-size: 18px;
@@ -2564,8 +2564,8 @@ function updateSelectionPanel(ids) {
 
   var detail = document.getElementById('detailContent');
   var summary = document.getElementById('summaryPanel');
-  if (detail) detail.classList.remove('visible');
   if (summary) summary.classList.add('hidden');
+  if (detail) detail.classList.toggle('visible', selectedPhotoId != null);
   panel.classList.remove('hidden');
   document.getElementById('selectionCount').textContent = ids.length + ' photos selected';
   loadSelectionKeywordSuggestions(ids);

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2526,6 +2526,10 @@ function getActiveSelection() {
   return [];
 }
 
+function detailMatchesSelectedPhoto() {
+  return selectedPhotoId != null && window._detailPhotoId === selectedPhotoId;
+}
+
 function updateBatchBar() {
   var bar = document.getElementById('batchBar');
   if (!bar) return;
@@ -2565,7 +2569,7 @@ function updateSelectionPanel(ids) {
   var detail = document.getElementById('detailContent');
   var summary = document.getElementById('summaryPanel');
   if (summary) summary.classList.add('hidden');
-  if (detail) detail.classList.toggle('visible', selectedPhotoId != null);
+  if (detail) detail.classList.toggle('visible', detailMatchesSelectedPhoto());
   panel.classList.remove('hidden');
   document.getElementById('selectionCount').textContent = ids.length + ' photos selected';
   loadSelectionKeywordSuggestions(ids);
@@ -2878,12 +2882,14 @@ async function showUndoToast() {
 
 async function loadDetail(id) {
   document.getElementById('summaryPanel').classList.add('hidden');
-  document.getElementById('detailContent').classList.add('visible');
+  var detail = document.getElementById('detailContent');
+  if (detail) detail.classList.toggle('visible', window._detailPhotoId === id);
 
   try {
     var photo = await safeFetch('/api/photos/' + id, {}, { toast: false });
-    if (selectedPhotoId === id && getActiveSelection().length === 1) {
+    if (selectedPhotoId === id) {
       renderDetail(photo);
+      if (detail) detail.classList.add('visible');
     }
   } catch(e) {}
 }


### PR DESCRIPTION
## Summary
Keep the focused photo detail panel visible during multi-select when a focused photo exists, so location, keyword entry, metadata, and editor actions remain available.
The missing-keyword quick-add panel still appears for multi-selection and now sits above the normal detail controls with spacing.

## Validation
Ran `git diff --check`.
