### PR TITLE
[codex] Clarify DNG converter setup error

### DIFF
--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -192,7 +192,10 @@ def convert_to_dng(dng_converter_bin, input_path, output_dir):
         return {
             "success": False,
             "output_path": "",
-            "error": "Adobe DNG Converter not found or not configured",
+            "error": (
+                "Adobe DNG Converter not found or not configured. "
+                "You will need to download it from Adobe."
+            ),
         }
 
     os.makedirs(output_dir, exist_ok=True)

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -387,3 +387,4 @@ def test_develop_photo_reports_missing_dng_converter_for_nikon_he(tmp_path, monk
     assert result["success"] is False
     assert "Nikon High Efficiency NEF" in result["error"]
     assert "DNG conversion failed" in result["error"]
+    assert "download it from Adobe" in result["error"]


### PR DESCRIPTION
Updates the missing Adobe DNG Converter error so users are told they need to download it from Adobe. This applies to Nikon High Efficiency NEF conversion failures where Vireo cannot find a configured converter. Adds a focused test assertion for the new guidance. Validation: `python -m pytest vireo/tests/test_develop.py` passed.