### PR TITLE
[codex] Refresh smart collection counts

### DIFF
--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -393,6 +393,29 @@ def test_reject_shortcut_keeps_existing_thumbnail_nodes(live_server, page):
     )
 
 
+def test_reject_shortcut_refreshes_rejected_collection_count(live_server, page):
+    """Flagging a photo as rejected should refresh matching smart-collection counts."""
+    db = live_server["db"]
+    rules = json.dumps([{"field": "flag", "op": "is", "value": "rejected"}])
+    collection_id = db.add_collection("Rejected", rules)
+
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    count = page.locator(
+        f'.tree-item[data-collection-id="{collection_id}"] .count'
+    )
+    expect(count).to_have_text("0")
+
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click()
+
+    page.keyboard.press("x")
+
+    expect(count).to_have_text("1")
+
+
 def test_filterByCollection_clears_multiselect_set(live_server, page):
     """Switching to a collection must drop a surviving multi-select set.
 

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -416,6 +416,44 @@ def test_reject_shortcut_refreshes_rejected_collection_count(live_server, page):
     expect(count).to_have_text("1")
 
 
+def test_collection_count_refresh_ignores_stale_response(live_server, page):
+    """Older collection-count responses must not overwrite newer badge counts."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+    page.wait_for_load_state("networkidle")
+
+    final_count = page.evaluate(
+        """async () => {
+          renderCollectionList([{id: 999001, name: 'Rejected', photo_count: 0}]);
+          collectionCountLoadGen = 0;
+          var originalSafeFetch = safeFetch;
+          var resolvers = [];
+          safeFetch = function(url, opts, options) {
+            if (url === '/api/collections') {
+              return new Promise(function(resolve) { resolvers.push(resolve); });
+            }
+            return originalSafeFetch(url, opts, options);
+          };
+          try {
+            var first = loadCollectionCounts();
+            var second = loadCollectionCounts();
+            resolvers[1]([{id: 999001, photo_count: 2}]);
+            await second;
+            resolvers[0]([{id: 999001, photo_count: 1}]);
+            await first;
+            return document.querySelector(
+              '.tree-item[data-collection-id="999001"] .count'
+            ).textContent;
+          } finally {
+            safeFetch = originalSafeFetch;
+          }
+        }"""
+    )
+
+    assert final_count == "2"
+
+
 def test_filterByCollection_clears_multiselect_set(live_server, page):
     """Switching to a collection must drop a surviving multi-select set.
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1215,6 +1215,7 @@ var selectedDay = null;
 var calendarData = null;
 var clipSearchActive = false;
 var searchFilterTimer = null;
+var collectionCountRefreshTimer = null;
 
 function hasActiveBrowseFilter() {
   var searchInput = document.getElementById('searchInput');
@@ -1567,6 +1568,14 @@ async function loadCollectionCounts() {
       }
     });
   } catch(e) {}
+}
+
+function scheduleCollectionCountsRefresh() {
+  if (collectionCountRefreshTimer) clearTimeout(collectionCountRefreshTimer);
+  collectionCountRefreshTimer = setTimeout(function() {
+    collectionCountRefreshTimer = null;
+    loadCollectionCounts();
+  }, 150);
 }
 
 async function filterByCollection(id) {
@@ -2648,6 +2657,7 @@ async function batchSetRating(rating) {
     if (p) p.rating = rating;
   });
   refreshGridCards(ids);
+  scheduleCollectionCountsRefresh();
   showUndoToast();
 }
 
@@ -2667,6 +2677,7 @@ async function batchSetFlag(flag) {
   if (selectedPhotoId != null && ids.indexOf(selectedPhotoId) !== -1) {
     updateDetailFlagButtons(flag);
   }
+  scheduleCollectionCountsRefresh();
   showUndoToast();
 }
 
@@ -2685,6 +2696,7 @@ async function batchSetColorLabel(color) {
     else delete colorLabels[id];
   });
   refreshGridCards(ids);
+  scheduleCollectionCountsRefresh();
   showUndoToast();
 }
 
@@ -2713,6 +2725,7 @@ async function confirmBatchKeyword() {
   selectionKeywordKey = '';
   loadSelectionKeywordSuggestions(ids);
   loadKeywords();
+  scheduleCollectionCountsRefresh();
   showUndoToast();
 }
 
@@ -2856,6 +2869,7 @@ async function undoLast() {
     var data = await safeFetch('/api/undo', { method: 'POST' });
     showToast('Undone: ' + data.undone + ' — Ctrl+Shift+Z to redo');
     resetAndLoad();
+    scheduleCollectionCountsRefresh();
   } catch(e) {}
 }
 
@@ -2864,6 +2878,7 @@ async function redoLast() {
     var data = await safeFetch('/api/redo', { method: 'POST' });
     showToast('Redone: ' + data.redone);
     resetAndLoad();
+    scheduleCollectionCountsRefresh();
   } catch(e) {}
 }
 
@@ -3222,6 +3237,7 @@ async function setRating(photoId, rating) {
     var p = photos.find(function(x) { return x.id === photoId; });
     if (p) p.rating = rating;
     refreshGridCards([photoId]);
+    scheduleCollectionCountsRefresh();
     loadDetail(photoId);
   } catch(e) {}
 }
@@ -3239,6 +3255,7 @@ async function setFlag(flag) {
     if (p) p.flag = flag;
     refreshGridCards([photoId]);
     if (selectedPhotoId === photoId) updateDetailFlagButtons(flag);
+    scheduleCollectionCountsRefresh();
   } catch(e) {}
 }
 
@@ -3307,6 +3324,7 @@ async function setColorLabel(color) {
   }
   if (selectedPhotoId === photoId) updateDetailColors();
   refreshGridCards([photoId]);
+  scheduleCollectionCountsRefresh();
 }
 
 function updateDetailColors() {
@@ -3330,6 +3348,7 @@ async function addKeyword() {
     input.value = '';
     loadDetail(selectedPhotoId);
     loadKeywords();
+    scheduleCollectionCountsRefresh();
   } catch(e) {}
 }
 
@@ -3339,6 +3358,8 @@ async function removeKeyword(photoId, keywordId) {
       method: 'DELETE',
     });
     loadDetail(photoId);
+    loadKeywords();
+    scheduleCollectionCountsRefresh();
   } catch(e) {}
 }
 
@@ -3795,6 +3816,7 @@ async function setRatingFor(photoId, rating) {
   var p = photos.find(function(x) { return x.id === photoId; });
   if (p) p.rating = rating;
   refreshGridCards([photoId]);
+  scheduleCollectionCountsRefresh();
   if (selectedPhotoId === photoId) loadDetail(photoId);
 }
 
@@ -3809,6 +3831,7 @@ async function setFlagFor(photoId, flag) {
   if (p) p.flag = flag;
   refreshGridCards([photoId]);
   if (selectedPhotoId === photoId) updateDetailFlagButtons(flag);
+  scheduleCollectionCountsRefresh();
   return true;
 }
 
@@ -3824,6 +3847,7 @@ async function setColorLabelFor(photoId, color) {
   else delete colorLabels[photoId];
   refreshGridCards([photoId]);
   if (selectedPhotoId === photoId) updateDetailColors();
+  scheduleCollectionCountsRefresh();
 }
 
 function revealPhoto(photoId) {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1249,6 +1249,7 @@ var calendarData = null;
 var clipSearchActive = false;
 var searchFilterTimer = null;
 var collectionCountRefreshTimer = null;
+var collectionCountLoadGen = 0;
 
 function refreshPendingSyncBanner() {
   if (typeof checkPendingSync === 'function') {
@@ -1589,8 +1590,10 @@ async function loadCollections() {
 }
 
 async function loadCollectionCounts() {
+  var gen = ++collectionCountLoadGen;
   try {
     var data = await safeFetch('/api/collections', {}, { toast: false });
+    if (gen !== collectionCountLoadGen) return;
     if (!data) return;
     var items = document.querySelectorAll('#collectionList .tree-item');
     var countsById = {};


### PR DESCRIPTION
Fixes stale Browse sidebar counts for smart collections after photo edits, including the Rejected collection showing 0 after photos were marked rejected. The root cause was that edit flows updated local photo/card state but never refreshed collection count badges, while opening a collection fetched fresh data from the backend. This adds a debounced collection-count refresh after flag, rating, color label, keyword, undo, and redo changes. Validation: pytest tests/e2e/test_browse_single_select.py -q; pytest vireo/tests/test_collections_api.py vireo/tests/test_db.py::test_collection_untagged_rule vireo/tests/test_db.py::test_all_photos_collection_returns_all_photos -q.