### PR TITLE
[codex] Refresh browse sidebar counts after delete

### DIFF
--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -428,6 +428,36 @@ def test_filterByCollection_clears_multiselect_set(live_server, page):
     expect(bar).to_be_hidden()
 
 
+def test_delete_refreshes_smart_collection_count(live_server, page):
+    """Deleting a photo from Browse refreshes smart collection counts."""
+    db = live_server["db"]
+    needs = next(c for c in db.get_collections() if c["name"] == "Needs Identification")
+    collection_id = needs["id"]
+    delete_id = live_server["data"]["photos"][1]
+    before = db.count_collection_photos(collection_id)
+    assert delete_id in db.collection_photo_ids(collection_id)
+
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    count = page.locator(
+        f"#collectionList .tree-item[data-collection-id='{collection_id}'] .count"
+    )
+    expect(count).to_have_text(str(before))
+
+    page.locator(f".grid-card[data-id='{delete_id}']").click()
+    expect(page.locator("#batchBar")).to_be_visible()
+    page.locator("#batchBar button[title='Delete selected photos']").click()
+    page.locator("#deleteModal.open").wait_for(state="visible", timeout=3000)
+    page.locator("#deleteConfirmBtn").click()
+
+    page.wait_for_function(
+        f"!document.querySelector('.grid-card[data-id=\"{delete_id}\"]')",
+        timeout=3000,
+    )
+    expect(count).to_have_text(str(before - 1), timeout=3000)
+
+
 def test_filterByCollection_cancels_pending_search_debounce(live_server, page):
     """A delayed search apply must not kick the user out of collection mode."""
     db = live_server["db"]

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3843,6 +3843,9 @@ function lightboxDelete() {
       selectedPhotos.delete(currentId);
       if (selectedPhotoId === currentId) selectedPhotoId = null;
       renderGrid();
+      if (typeof refreshBrowseSidebarCounts === 'function') {
+        refreshBrowseSidebarCounts();
+      }
     }
   });
 }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1610,6 +1610,12 @@ async function loadCollectionCounts() {
   } catch(e) {}
 }
 
+function refreshBrowseSidebarCounts() {
+  loadFolders();
+  loadKeywords();
+  loadCollectionCounts();
+}
+
 async function filterByCollection(id) {
   cancelScheduledSearchFilter();
   activeFolderId = null;
@@ -2795,6 +2801,7 @@ function batchDelete() {
     renderGrid();
     updateFilterSummary();
     loadSummary();
+    refreshBrowseSidebarCounts();
     // Update total count display
     var countEl = document.getElementById('photoCount');
     if (countEl) {


### PR DESCRIPTION
## Summary
Refresh the Browse sidebar facets after photos are deleted so smart collection counts, folder counts, and keyword counts no longer stay stale in the UI. The backend was already recalculating collection counts correctly; the delete callbacks refreshed the grid and summary but did not reload the sidebar counts. This also updates lightbox deletion to use the same sidebar refresh when Browse state is present.

## Validation
- `pytest tests/e2e/test_browse_single_select.py::test_delete_refreshes_smart_collection_count -q`
- `pytest vireo/tests/test_delete_api.py::test_delete_photos_cleans_collection_rules -q`
- `pytest vireo/tests/test_collections_api.py -q`