### PR TITLE
Preserve 1:1 lightbox zoom when navigating

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -34,3 +34,37 @@ def test_browse_lightbox_arrows_navigate(live_server, page):
     page.locator("[title='Previous (←)']").click()
     expect(filename_display).to_have_text(first_filename)
     expect(counter).to_contain_text("1 /")
+
+
+def test_browse_lightbox_arrows_preserve_one_to_one_zoom(live_server, page):
+    """Navigating from a 1:1 lightbox view keeps the next photo at 1:1."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+
+    page.evaluate(
+        """() => {
+            window._lbNativeZoom = 2;
+            window._lbZoom = 2;
+            window._lbPending1To1 = false;
+        }"""
+    )
+
+    page.locator("[title='Next (→)']").click()
+    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    assert page.evaluate("window._lbPending1To1") is True
+
+    restored = page.evaluate(
+        """() => {
+            window._lbNativeZoom = 2.5;
+            window._lbApplyPendingOneToOneZoom();
+            return Math.abs(window._lbZoom - window._lbNativeZoom) <= Math.max(0.01, window._lbNativeZoom * 0.01);
+        }"""
+    )
+    assert restored
+    assert page.evaluate("window._lbZoom") > 1.001

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2892,6 +2892,19 @@ var _lbFlagEditSeq = 0;      // increments for local flag writes so stale metada
 var _lbOpenSeq = 0;          // increments for every lightbox open so old metadata fetches cannot reapply after reopen
 var _lbFlagPendingWrites = 0;
 
+function _lbIsOneToOneZoom() {
+  if (_lbPending1To1) return true;
+  if (!_lbNativeZoom || _lbNativeZoom <= 1.001) return false;
+  var tolerance = Math.max(0.01, _lbNativeZoom * 0.01);
+  return Math.abs(_lbZoom - _lbNativeZoom) <= tolerance;
+}
+
+function _lbApplyPendingOneToOneZoom() {
+  if (!_lbPending1To1 || !_lbNativeZoom) return;
+  _lbPending1To1 = false;
+  _lbSetZoom(_lbNativeZoom, null, null);
+}
+
 function _lbNormalizeFlag(flag) {
   if (flag === 'flagged' || flag === 'rejected' || flag === 'none') return flag;
   if (flag == null || flag === '') return 'none';
@@ -3342,13 +3355,14 @@ function _lbLoadMaskVariants(photoId) {
     .catch(function() { /* network error → leave control hidden */ });
 }
 
-function openLightbox(photoId, filename, photoList) {
+function openLightbox(photoId, filename, photoList, options) {
   var alreadyOpen = !!window._lbEscToken;
   if (alreadyOpen) Keymap.popEsc(window._lbEscToken);
   window._lbEscToken = Keymap.pushEsc(function() { closeLightbox(); });
   if (!alreadyOpen) Keymap.lockBodyScroll();
   _lbOpenSeq += 1;
   var openSeq = _lbOpenSeq;
+  options = options || {};
 
   _lightboxCurrentId = photoId;
   if (photoList) _lightboxPhotoList = photoList;
@@ -3384,7 +3398,7 @@ function openLightbox(photoId, filename, photoList) {
   _lbPhotoH = null;
   _lbCurrentSrcKey = 'full';
   _lbFullLongEdge = null;
-  _lbPending1To1 = false;
+  _lbPending1To1 = !!options.preserveOneToOne;
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;
   _lbApplyTransform();  // Clear any lingering translate/scale from prior photo before the new one renders.
@@ -3401,6 +3415,7 @@ function openLightbox(photoId, filename, photoList) {
       _lbApplyWildlifeExcludedButton();
       _lbRecordFetchedFlag(photoId, data.flag, flagFetchSeq);
       _lbRecomputeNativeZoom();
+      _lbApplyPendingOneToOneZoom();
       _lbRenderEyeCrosshair(data);
     })
     .catch(function() {});
@@ -3417,6 +3432,7 @@ function openLightbox(photoId, filename, photoList) {
       _lbSessionFullLongEdge = _lbFullLongEdge;
     }
     _lbRecomputeNativeZoom();
+    _lbApplyPendingOneToOneZoom();
     _lbApplyTransform();
   };
   label.textContent = filename || '';
@@ -3466,7 +3482,9 @@ function lightboxNav(delta) {
   var newIdx = idx + delta;
   if (newIdx < 0 || newIdx >= _lightboxPhotoList.length) return;
   var next = _lightboxPhotoList[newIdx];
-  openLightbox(next.id, next.filename, _lightboxPhotoList);
+  openLightbox(next.id, next.filename, _lightboxPhotoList, {
+    preserveOneToOne: _lbIsOneToOneZoom()
+  });
 }
 
 function toggleLightboxZoom(e) {


### PR DESCRIPTION
Preserves one-to-one lightbox zoom when moving to the next or previous photo from browse mode.

The previous navigation path always reset zoom state in `openLightbox`, so a user who clicked left or right from a 1:1 view landed back at fit-to-screen. This carries the 1:1 intent across navigation and reapplies it once the next photo dimensions are known, with regression coverage for browse lightbox arrows.

Validated with `python -m pytest tests/e2e/test_browse_lightbox.py -q` and `python -m pytest tests/e2e/test_lightbox_context_menu.py tests/e2e/test_lightbox_flag_hotkeys.py -q`.