### PR TITLE
[codex] Add keyword autocomplete

### DIFF
--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -192,6 +192,30 @@ def test_add_keyword_autocomplete_retries_after_fetch_failure(live_server, page)
     ).to_be_visible()
 
 
+def test_add_keyword_autocomplete_caches_empty_result(live_server, page):
+    """A successful empty keyword list should be treated as loaded."""
+    target_id = live_server["data"]["photos"][1]
+    calls = {"count": 0}
+
+    def route_keyword_all(route):
+        calls["count"] += 1
+        route.fulfill(status=200, content_type="application/json", body="[]")
+
+    page.route("**/api/keywords/all", route_keyword_all)
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(f'.grid-card[data-id="{target_id}"]').click()
+
+    keyword_input = page.locator("#addKeywordInput")
+    with page.expect_response(
+        lambda r: "/api/keywords/all" in r.url and r.status == 200
+    ):
+        keyword_input.click()
+
+    keyword_input.fill("AL")
+    page.wait_for_timeout(100)
+    assert calls["count"] == 1
+
+
 def test_cmd_click_toggles_focus_out_of_set_reconciles(live_server, page):
     """click A, cmd-click B, cmd-click A: the focus must not linger on A.
 

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -119,6 +119,36 @@ def test_clear_button_closes_detail_panel(live_server, page):
     )
 
 
+def test_add_keyword_input_suggests_existing_keyword(live_server, page):
+    """Typing in the add-keyword field should offer matching existing keywords."""
+    db = live_server["db"]
+    source_id = live_server["data"]["photos"][0]
+    target_id = live_server["data"]["photos"][1]
+    keyword_id = db.add_keyword("Alan's Hummingbird")
+    db.tag_photo(source_id, keyword_id)
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(f'.grid-card[data-id="{target_id}"]').click()
+
+    keyword_input = page.locator("#addKeywordInput")
+    keyword_input.fill("AL")
+
+    suggestion = page.locator(
+        "#addKeywordSuggestions .keyword-suggestion-option",
+        has_text="Alan's Hummingbird",
+    )
+    expect(suggestion).to_be_visible()
+
+    with page.expect_response(
+        lambda r: f"/api/photos/{target_id}/keywords" in r.url
+        and r.request.method == "POST"
+        and r.status == 200
+    ):
+        suggestion.click()
+
+    expect(page.locator("#detailKeywords")).to_contain_text("Alan's Hummingbird")
+
+
 def test_cmd_click_toggles_focus_out_of_set_reconciles(live_server, page):
     """click A, cmd-click B, cmd-click A: the focus must not linger on A.
 

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -149,6 +149,49 @@ def test_add_keyword_input_suggests_existing_keyword(live_server, page):
     expect(page.locator("#detailKeywords")).to_contain_text("Alan's Hummingbird")
 
 
+def test_add_keyword_autocomplete_retries_after_fetch_failure(live_server, page):
+    """A transient keyword suggestion fetch failure must not poison the cache."""
+    db = live_server["db"]
+    source_id = live_server["data"]["photos"][0]
+    target_id = live_server["data"]["photos"][1]
+    keyword_id = db.add_keyword("Alan's Hummingbird")
+    db.tag_photo(source_id, keyword_id)
+    calls = {"count": 0}
+
+    def route_keyword_all(route):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            route.fulfill(
+                status=503,
+                content_type="application/json",
+                body='{"error":"temporary"}',
+            )
+            return
+        route.continue_()
+
+    page.route("**/api/keywords/all", route_keyword_all)
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(f'.grid-card[data-id="{target_id}"]').click()
+
+    keyword_input = page.locator("#addKeywordInput")
+    with page.expect_response(
+        lambda r: "/api/keywords/all" in r.url and r.status == 503
+    ):
+        keyword_input.click()
+
+    with page.expect_response(
+        lambda r: "/api/keywords/all" in r.url and r.status == 200
+    ):
+        keyword_input.fill("AL")
+
+    expect(
+        page.locator(
+            "#addKeywordSuggestions .keyword-suggestion-option",
+            has_text="Alan's Hummingbird",
+        )
+    ).to_be_visible()
+
+
 def test_cmd_click_toggles_focus_out_of_set_reconciles(live_server, page):
     """click A, cmd-click B, cmd-click A: the focus must not linger on A.
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2249,23 +2249,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_add_keyword(photo_id):
         db = _get_db()
         body = request.get_json(silent=True) or {}
-        name = body.get("name", "").strip()
-        if not name:
-            return json_error("name required")
-        # Validate kw_type at the boundary (isinstance guard against
-        # non-hashable JSON; membership against the canonical enum).
-        # Pass it through to add_keyword so its type-reconciliation logic
-        # runs — a post-update SQL `UPDATE keywords SET type = ?` would
-        # silently rewrite an existing user-typed row (e.g. someone's
-        # 'individual' Charlie) and bypass the taxonomy/general upgrade
-        # rules in add_keyword.
-        kw_type_raw = body.get("type")
-        kw_type = (
-            kw_type_raw
-            if isinstance(kw_type_raw, str) and kw_type_raw in KEYWORD_TYPES
-            else None
-        )
-        kid = db.add_keyword(name, kw_type=kw_type)
+        keyword_id = body.get("keyword_id")
+        name = body.get("name", "")
+        name = name.strip() if isinstance(name, str) else ""
+        if keyword_id is not None:
+            if isinstance(keyword_id, bool) or not isinstance(keyword_id, int):
+                return json_error("keyword_id must be an integer")
+            keyword_row = db.conn.execute(
+                "SELECT id, name FROM keywords WHERE id = ?", (keyword_id,)
+            ).fetchone()
+            if keyword_row is None:
+                return json_error("keyword not found", 404)
+            kid = keyword_row["id"]
+            name = keyword_row["name"]
+        else:
+            if not name:
+                return json_error("name required")
+            # Validate kw_type at the boundary (isinstance guard against
+            # non-hashable JSON; membership against the canonical enum).
+            # Pass it through to add_keyword so its type-reconciliation logic
+            # runs — a post-update SQL `UPDATE keywords SET type = ?` would
+            # silently rewrite an existing user-typed row (e.g. someone's
+            # 'individual' Charlie) and bypass the taxonomy/general upgrade
+            # rules in add_keyword.
+            kw_type_raw = body.get("type")
+            kw_type = (
+                kw_type_raw
+                if isinstance(kw_type_raw, str) and kw_type_raw in KEYWORD_TYPES
+                else None
+            )
+            kid = db.add_keyword(name, kw_type=kw_type)
         db.tag_photo(photo_id, kid)
         _queue_keyword_add(photo_id, name)
         db.record_edit('keyword_add', f'Added keyword "{name}"', str(kid),

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -494,6 +494,52 @@ body {
   outline: none;
 }
 .add-kw-input:focus { border-color: var(--accent); }
+.keyword-autocomplete {
+  position: relative;
+  width: 100%;
+}
+.keyword-suggestion-list {
+  display: none;
+  position: absolute;
+  z-index: 1001;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  max-height: 220px;
+  overflow-y: auto;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-secondary);
+  border-radius: 4px;
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--bg-primary) 55%, transparent);
+  padding: 4px 0;
+}
+.keyword-suggestion-list.open { display: block; }
+.keyword-suggestion-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 9px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+.keyword-suggestion-option:hover,
+.keyword-suggestion-option.active {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+.keyword-suggestion-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.keyword-suggestion-meta {
+  flex-shrink: 0;
+  color: var(--text-dim);
+  font-size: 11px;
+}
 .location-section .filled-place {
   font-weight: 600;
   color: var(--text-primary);
@@ -1132,7 +1178,10 @@ body {
       <div class="detail-section">
         <div class="detail-section-title">Keywords</div>
         <div id="detailKeywords"></div>
-        <input class="add-kw-input" id="addKeywordInput" placeholder="Add keyword..." onkeydown="if(event.key==='Enter')addKeyword()">
+        <div class="keyword-autocomplete">
+          <input class="add-kw-input" id="addKeywordInput" placeholder="Add keyword..." autocomplete="off">
+          <div class="keyword-suggestion-list" id="addKeywordSuggestions" role="listbox"></div>
+        </div>
       </div>
 
       <div class="detail-section">
@@ -1190,7 +1239,10 @@ body {
 <div class="modal-overlay" id="batchKeywordModal">
   <div class="modal">
     <h3 id="batchKeywordTitle">Add Keyword</h3>
-    <input class="modal-input" id="batchKeywordInput" placeholder="Keyword name" onkeydown="if(event.key==='Enter')confirmBatchKeyword()">
+    <div class="keyword-autocomplete">
+      <input class="modal-input" id="batchKeywordInput" placeholder="Keyword name" autocomplete="off">
+      <div class="keyword-suggestion-list" id="batchKeywordSuggestions" role="listbox"></div>
+    </div>
     <div class="modal-actions">
       <button class="modal-btn modal-btn-primary" onclick="confirmBatchKeyword()">Add</button>
       <button class="modal-btn modal-btn-cancel" onclick="hideBatchKeywordModal()">Cancel</button>
@@ -1248,11 +1300,188 @@ var selectedDay = null;
 var calendarData = null;
 var clipSearchActive = false;
 var searchFilterTimer = null;
+var keywordAutocompleteCache = null;
+var keywordAutocompletePromise = null;
+var keywordAutocompleteStates = {};
 
 function refreshPendingSyncBanner() {
   if (typeof checkPendingSync === 'function') {
     checkPendingSync();
   }
+}
+
+function invalidateKeywordAutocompleteCache() {
+  keywordAutocompleteCache = null;
+  keywordAutocompletePromise = null;
+}
+
+async function loadKeywordAutocompleteOptions(force) {
+  if (!force && keywordAutocompleteCache) return keywordAutocompleteCache;
+  if (!force && keywordAutocompletePromise) return keywordAutocompletePromise;
+  keywordAutocompletePromise = safeFetch('/api/keywords/all', {}, { toast: false })
+    .then(function(rows) {
+      keywordAutocompleteCache = (rows || [])
+        .filter(function(k) { return k && k.name; })
+        .map(function(k) {
+          return {
+            id: k.id,
+            name: k.name,
+            type: k.type || 'general',
+            photo_count: k.photo_count || 0,
+            search: String(k.name || '').toLowerCase(),
+          };
+        })
+        .sort(function(a, b) {
+          return a.search.localeCompare(b.search) || a.id - b.id;
+        });
+      return keywordAutocompleteCache;
+    })
+    .catch(function() {
+      keywordAutocompleteCache = [];
+      return keywordAutocompleteCache;
+    })
+    .finally(function() {
+      keywordAutocompletePromise = null;
+    });
+  return keywordAutocompletePromise;
+}
+
+function getKeywordAutocompleteState(inputId) {
+  if (!keywordAutocompleteStates[inputId]) {
+    keywordAutocompleteStates[inputId] = {
+      matches: [],
+      activeIndex: -1,
+      selectedKeyword: null,
+      dropdownId: '',
+      submitFn: null,
+    };
+  }
+  return keywordAutocompleteStates[inputId];
+}
+
+function keywordMatchScore(search, query) {
+  if (search === query) return 0;
+  if (search.indexOf(query) === 0) return 1;
+  if (search.split(/[\s\-_/]+/).some(function(part) { return part.indexOf(query) === 0; })) return 2;
+  var idx = search.indexOf(query);
+  return idx === -1 ? 99 : 3 + idx / 1000;
+}
+
+function hideKeywordSuggestions(inputId) {
+  var state = getKeywordAutocompleteState(inputId);
+  var dropdown = document.getElementById(state.dropdownId);
+  if (dropdown) {
+    dropdown.classList.remove('open');
+    dropdown.innerHTML = '';
+  }
+  state.matches = [];
+  state.activeIndex = -1;
+}
+
+function renderKeywordSuggestions(inputId) {
+  var input = document.getElementById(inputId);
+  var state = getKeywordAutocompleteState(inputId);
+  var dropdown = document.getElementById(state.dropdownId);
+  if (!input || !dropdown) return;
+  var query = input.value.trim().toLowerCase();
+  state.selectedKeyword = null;
+  if (!query || !keywordAutocompleteCache || !keywordAutocompleteCache.length) {
+    hideKeywordSuggestions(inputId);
+    return;
+  }
+
+  state.matches = keywordAutocompleteCache
+    .map(function(k) {
+      return { keyword: k, score: keywordMatchScore(k.search, query) };
+    })
+    .filter(function(item) { return item.score < 99; })
+    .sort(function(a, b) {
+      return a.score - b.score || a.keyword.search.localeCompare(b.keyword.search) || a.keyword.id - b.keyword.id;
+    })
+    .slice(0, 8)
+    .map(function(item) { return item.keyword; });
+
+  if (!state.matches.length) {
+    hideKeywordSuggestions(inputId);
+    return;
+  }
+  if (state.activeIndex < 0 || state.activeIndex >= state.matches.length) state.activeIndex = 0;
+
+  dropdown.innerHTML = state.matches.map(function(k, idx) {
+    var active = idx === state.activeIndex ? ' active' : '';
+    var count = k.photo_count === 1 ? '1 photo' : k.photo_count + ' photos';
+    return '<div class="keyword-suggestion-option' + active + '" role="option" data-index="' + idx + '">' +
+      '<span class="keyword-suggestion-name">' + escapeHtml(k.name) + '</span>' +
+      '<span class="keyword-suggestion-meta">' + escapeHtml(count) + '</span>' +
+      '</div>';
+  }).join('');
+  dropdown.classList.add('open');
+}
+
+function chooseKeywordSuggestion(inputId, index) {
+  var input = document.getElementById(inputId);
+  var state = getKeywordAutocompleteState(inputId);
+  var keyword = state.matches[index];
+  if (!input || !keyword) return;
+  input.value = keyword.name;
+  state.selectedKeyword = keyword;
+  hideKeywordSuggestions(inputId);
+  if (typeof state.submitFn === 'function') {
+    state.submitFn(keyword);
+  }
+}
+
+function bindKeywordAutocomplete(inputId, dropdownId, submitFn) {
+  var input = document.getElementById(inputId);
+  var dropdown = document.getElementById(dropdownId);
+  if (!input || !dropdown) return;
+  var state = getKeywordAutocompleteState(inputId);
+  state.dropdownId = dropdownId;
+  state.submitFn = submitFn;
+
+  input.addEventListener('focus', function() {
+    loadKeywordAutocompleteOptions().then(function() { renderKeywordSuggestions(inputId); });
+  });
+  input.addEventListener('input', function() {
+    var s = getKeywordAutocompleteState(inputId);
+    s.activeIndex = 0;
+    s.selectedKeyword = null;
+    loadKeywordAutocompleteOptions().then(function() { renderKeywordSuggestions(inputId); });
+  });
+  input.addEventListener('keydown', function(e) {
+    var s = getKeywordAutocompleteState(inputId);
+    var isOpen = dropdown.classList.contains('open') && s.matches.length > 0;
+    if (isOpen && e.key === 'ArrowDown') {
+      e.preventDefault();
+      s.activeIndex = (s.activeIndex + 1) % s.matches.length;
+      renderKeywordSuggestions(inputId);
+      return;
+    }
+    if (isOpen && e.key === 'ArrowUp') {
+      e.preventDefault();
+      s.activeIndex = (s.activeIndex - 1 + s.matches.length) % s.matches.length;
+      renderKeywordSuggestions(inputId);
+      return;
+    }
+    if (e.key === 'Escape') {
+      hideKeywordSuggestions(inputId);
+      return;
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (isOpen && s.activeIndex >= 0) chooseKeywordSuggestion(inputId, s.activeIndex);
+      else if (typeof submitFn === 'function') submitFn(null);
+    }
+  });
+  input.addEventListener('blur', function() {
+    setTimeout(function() { hideKeywordSuggestions(inputId); }, 120);
+  });
+  dropdown.addEventListener('mousedown', function(e) {
+    var option = e.target.closest('.keyword-suggestion-option');
+    if (!option) return;
+    e.preventDefault();
+    chooseKeywordSuggestion(inputId, parseInt(option.dataset.index, 10));
+  });
 }
 
 function hasActiveBrowseFilter() {
@@ -2750,25 +2979,37 @@ async function batchSetColorLabel(color) {
 function batchAddKeyword() {
   document.getElementById('batchKeywordTitle').textContent = 'Add keyword to ' + getActiveSelection().length + ' photos';
   document.getElementById('batchKeywordInput').value = '';
+  getKeywordAutocompleteState('batchKeywordInput').selectedKeyword = null;
+  hideKeywordSuggestions('batchKeywordInput');
   document.getElementById('batchKeywordModal').classList.add('open');
   setTimeout(function() { document.getElementById('batchKeywordInput').focus(); }, 50);
 }
 
 function hideBatchKeywordModal() {
   document.getElementById('batchKeywordModal').classList.remove('open');
+  hideKeywordSuggestions('batchKeywordInput');
 }
 
 async function confirmBatchKeyword() {
-  var name = document.getElementById('batchKeywordInput').value.trim();
+  var input = document.getElementById('batchKeywordInput');
+  var name = input.value.trim();
   if (!name) return;
   hideBatchKeywordModal();
   var ids = getActiveSelection();
+  var state = getKeywordAutocompleteState('batchKeywordInput');
+  var selectedKeyword = state.selectedKeyword && state.selectedKeyword.name === name
+    ? state.selectedKeyword
+    : null;
+  var payload = selectedKeyword && selectedKeyword.id
+    ? {photo_ids: ids, keyword_id: selectedKeyword.id}
+    : {photo_ids: ids, name: name};
   try {
     await safeFetch('/api/batch/keyword', {
       method: 'POST', headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({photo_ids: ids, name: name}),
+      body: JSON.stringify(payload),
     });
   } catch(e) { return; }
+  if (!selectedKeyword) invalidateKeywordAutocompleteCache();
   selectionKeywordKey = '';
   loadSelectionKeywordSuggestions(ids);
   loadKeywords();
@@ -3380,18 +3621,30 @@ function updateDetailColors() {
   });
 }
 
-async function addKeyword() {
+async function addKeyword(keyword) {
   if (!selectedPhotoId) return;
   var input = document.getElementById('addKeywordInput');
   var name = input.value.trim();
   if (!name) return;
+  var state = getKeywordAutocompleteState('addKeywordInput');
+  var selectedKeyword = keyword || (
+    state.selectedKeyword && state.selectedKeyword.name === name
+      ? state.selectedKeyword
+      : null
+  );
+  var payload = selectedKeyword && selectedKeyword.id
+    ? { keyword_id: selectedKeyword.id }
+    : { name: name };
   try {
     await safeFetch('/api/photos/' + selectedPhotoId + '/keywords', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: name }),
+      body: JSON.stringify(payload),
     });
     input.value = '';
+    state.selectedKeyword = null;
+    hideKeywordSuggestions('addKeywordInput');
+    if (!selectedKeyword) invalidateKeywordAutocompleteCache();
     loadDetail(selectedPhotoId);
     loadKeywords();
     refreshPendingSyncBanner();
@@ -3696,9 +3949,14 @@ function _onLocationInputKeydown(e) {
 // to re-bind on every photo load.
 document.addEventListener('DOMContentLoaded', function() {
   var input = document.getElementById('locationInput');
-  if (!input) return;
-  input.addEventListener('focus', _onLocationInputFocus);
-  input.addEventListener('keydown', _onLocationInputKeydown);
+  if (input) {
+    input.addEventListener('focus', _onLocationInputFocus);
+    input.addEventListener('keydown', _onLocationInputKeydown);
+  }
+  bindKeywordAutocomplete('addKeywordInput', 'addKeywordSuggestions', addKeyword);
+  bindKeywordAutocomplete('batchKeywordInput', 'batchKeywordSuggestions', function() {
+    confirmBatchKeyword();
+  });
 });
 
 /* ---------- Keyword Type Dropdown ---------- */

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1339,8 +1339,7 @@ async function loadKeywordAutocompleteOptions(force) {
       return keywordAutocompleteCache;
     })
     .catch(function() {
-      keywordAutocompleteCache = [];
-      return keywordAutocompleteCache;
+      return [];
     })
     .finally(function() {
       keywordAutocompletePromise = null;

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1318,7 +1318,7 @@ function invalidateKeywordAutocompleteCache() {
 }
 
 async function loadKeywordAutocompleteOptions(force) {
-  if (!force && keywordAutocompleteCache) return keywordAutocompleteCache;
+  if (!force && keywordAutocompleteCache !== null) return keywordAutocompleteCache;
   if (!force && keywordAutocompletePromise) return keywordAutocompletePromise;
   keywordAutocompletePromise = safeFetch('/api/keywords/all', {}, { toast: false })
     .then(function(rows) {

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -25,6 +25,27 @@ def test_browse_page(app_and_db):
     assert 'function refreshPendingSyncBanner()' in html
 
 
+def test_api_add_keyword_accepts_existing_keyword_id(app_and_db):
+    """POST /api/photos/<id>/keywords can attach an existing keyword by id."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo = db.conn.execute(
+        "SELECT id FROM photos WHERE filename = 'bird3.jpg'"
+    ).fetchone()
+    keyword = db.conn.execute(
+        "SELECT id, name FROM keywords WHERE name = 'Cardinal'"
+    ).fetchone()
+
+    resp = client.post(
+        f"/api/photos/{photo['id']}/keywords",
+        json={"keyword_id": keyword["id"]},
+    )
+
+    assert resp.status_code == 200
+    names = {k["name"] for k in db.get_photo_keywords(photo["id"])}
+    assert "Cardinal" in names
+
+
 def test_help_static_assets_served(app_and_db):
     """The help modal's JS, JSON, and vendored Fuse library must be served.
 


### PR DESCRIPTION
Adds workspace-scoped autocomplete to the single-photo and batch add-keyword inputs, so typing a prefix like AL offers existing keywords such as Alan's Hummingbird. The root cause was that those fields were plain text even though the app already exposes workspace keyword data through /api/keywords/all. The single-photo keyword API now accepts keyword_id, matching the existing batch path and avoiding name-only duplicate handling when a suggestion is selected. Validated with targeted backend and Playwright tests plus git diff --check.