### PR TITLE
[codex] Fix pipeline inspector binary embeddings

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -12074,8 +12074,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("Photo not found", 404)
 
         result = dict(photo)
-        # Remove binary embedding and dead detection columns from response
+        # Remove binary embedding and dead detection columns from response.
+        # The inspector only needs display/debug fields; returning BLOBs makes
+        # jsonify fail once the extract stage has populated DINO embeddings.
         result.pop("embedding", None)
+        result.pop("dino_subject_embedding", None)
+        result.pop("dino_global_embedding", None)
         result.pop("detection_box", None)
         result.pop("detection_conf", None)
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1081,6 +1081,25 @@ def test_api_photo_pipeline_detections(app_and_db):
     assert "crop_box" in data
 
 
+def test_api_photo_pipeline_omits_binary_embeddings(app_and_db):
+    """Pipeline inspector payload must stay JSON-serializable after extract."""
+    app, db = app_and_db
+    pid = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    db.conn.execute(
+        "UPDATE photos SET dino_subject_embedding = ?, dino_global_embedding = ? "
+        "WHERE id = ?",
+        (b"\x00\x01subject", b"\x02\x03global", pid),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.get(f"/api/photos/{pid}/pipeline")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "dino_subject_embedding" not in data
+    assert "dino_global_embedding" not in data
+
+
 def test_api_photo_pipeline_predictions_honor_threshold_and_fingerprint(app_and_db):
     """The pipeline-debug endpoint's `predictions` list must apply the same
     detector_confidence floor and fingerprint scoping as `detections`,


### PR DESCRIPTION
Fixes the pipeline inspector failing with an internal server error after DINO extract has populated binary embedding columns. The photo pipeline API now omits the DINO subject/global embedding BLOBs from the JSON payload, matching the existing behavior for other non-display fields. Added a regression test that seeds binary embeddings and verifies the inspector endpoint stays JSON-serializable. Validation: `uv run --no-sync pytest vireo/tests/test_app.py -k 'api_photo_pipeline'`.