### PR TITLE
[codex] Preserve selected photo position in collections

### DIFF
--- a/.github/actions/fire-routine/action.yml
+++ b/.github/actions/fire-routine/action.yml
@@ -57,13 +57,13 @@ runs:
         echo
 
         if [[ "${status}" -lt 200 || "${status}" -ge 300 ]]; then
-          error_type=$(jq -r '.error.type // empty' < "${response}")
-          if [[ "${status}" == "429" && "${error_type}" == "rate_limit_error" ]]; then
-            echo "::warning::Routine fire skipped because the routine provider returned a rate-limit/quota error."
-            exit 0
-          fi
           if [[ "${status}" -ge 500 && "${status}" -le 599 ]]; then
             echo "::warning::Routine fire skipped because the routine provider returned a server error."
+            exit 0
+          fi
+          error_type=$(jq -r '.error.type // empty' < "${response}" || true)
+          if [[ "${status}" == "429" && "${error_type}" == "rate_limit_error" ]]; then
+            echo "::warning::Routine fire skipped because the routine provider returned a rate-limit/quota error."
             exit 0
           fi
           echo "::error::Routine fire failed with status ${status}"

--- a/.github/actions/fire-routine/action.yml
+++ b/.github/actions/fire-routine/action.yml
@@ -62,6 +62,10 @@ runs:
             echo "::warning::Routine fire skipped because the routine provider returned a rate-limit/quota error."
             exit 0
           fi
+          if [[ "${status}" -ge 500 && "${status}" -le 599 ]]; then
+            echo "::warning::Routine fire skipped because the routine provider returned a server error."
+            exit 0
+          fi
           echo "::error::Routine fire failed with status ${status}"
           exit 1
         fi

--- a/tests/e2e/test_collection_context_menu.py
+++ b/tests/e2e/test_collection_context_menu.py
@@ -269,6 +269,61 @@ def test_collection_anchor_does_not_override_new_selection(live_server, page):
     assert page.evaluate("window.__restoreAnchorCalls") == 0
 
 
+def test_stale_anchor_scan_stops_after_collection_changes(live_server, page):
+    """A stale anchor scan must not keep paginating a newer collection."""
+    import json as _json
+
+    db = live_server["db"]
+    first_id = db.add_collection(
+        "First Scan Collection",
+        _json.dumps([{"field": "all"}]),
+    )
+    second_id = db.add_collection(
+        "Second Scan Collection",
+        _json.dumps([{"field": "all"}]),
+    )
+    original_id = live_server["data"]["photos"][3]
+
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    page.locator(f'.grid-card[data-id="{original_id}"]').wait_for(state="visible")
+    page.locator(f'.grid-card[data-id="{original_id}"]').click()
+
+    page.evaluate(
+        """() => {
+          perPage = 1;
+          observer.disconnect();
+          window.__loadPhotoCalls = 0;
+          const realLoadPhotos = window.loadPhotos;
+          window.__releaseSecondLoad = null;
+          window.loadPhotos = async function() {
+            window.__loadPhotoCalls += 1;
+            if (window.__loadPhotoCalls === 2) {
+              await new Promise(resolve => {
+                window.__releaseSecondLoad = resolve;
+              });
+            }
+            return realLoadPhotos();
+          };
+        }"""
+    )
+
+    page.evaluate("(collectionId) => { window.__firstSwitch = filterByCollection(collectionId); }", first_id)
+    page.wait_for_function("typeof window.__releaseSecondLoad === 'function'")
+
+    page.evaluate("window.selectedPhotoId = null")
+    page.evaluate("(collectionId) => filterByCollection(collectionId)", second_id)
+    page.wait_for_function(f"window.activeCollectionId === {second_id}")
+
+    page.evaluate("window.__releaseSecondLoad()")
+    page.evaluate("() => window.__firstSwitch")
+    page.wait_for_timeout(50)
+
+    assert page.evaluate("window.activeCollectionId") == second_id
+    assert page.evaluate("window.__loadPhotoCalls") == 3
+
+
 def test_collection_duplicate_fires_endpoint_and_rerenders(live_server, page):
     """Clicking 'Duplicate' POSTs to /duplicate and re-renders the list."""
     _seed_collection(live_server, "Picks B")

--- a/tests/e2e/test_collection_context_menu.py
+++ b/tests/e2e/test_collection_context_menu.py
@@ -269,6 +269,62 @@ def test_collection_anchor_does_not_override_new_selection(live_server, page):
     assert page.evaluate("window.__restoreAnchorCalls") == 0
 
 
+def test_collection_switch_clears_selection_during_anchor_scan(live_server, page):
+    """Old-view selections must not stay armed while the anchor scan is pending."""
+    import json as _json
+
+    db = live_server["db"]
+    collection_id = db.add_collection(
+        "Slow Anchor Collection",
+        _json.dumps([{"field": "all"}]),
+    )
+    target_id = live_server["data"]["photos"][3]
+
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    page.locator(f'.grid-card[data-id="{target_id}"]').wait_for(state="visible")
+    page.locator(f'.grid-card[data-id="{target_id}"]').click()
+    page.wait_for_function(f"window.selectedPhotoId === {target_id}")
+
+    page.evaluate(
+        """() => {
+          perPage = 1;
+          observer.disconnect();
+          const realLoadPhotos = window.loadPhotos;
+          let calls = 0;
+          window.__releaseSecondLoad = null;
+          window.loadPhotos = async function() {
+            calls += 1;
+            if (calls === 2) {
+              await new Promise(resolve => {
+                window.__releaseSecondLoad = resolve;
+              });
+            }
+            return realLoadPhotos();
+          };
+        }"""
+    )
+
+    page.evaluate(
+        "(collectionId) => { window.__switchPromise = filterByCollection(collectionId); }",
+        collection_id,
+    )
+    page.wait_for_function("typeof window.__releaseSecondLoad === 'function'")
+
+    assert page.evaluate("window.selectedPhotoId") is None
+    assert page.evaluate("window.getActiveSelection().length") == 0
+    assert page.evaluate("document.getElementById('batchBar').style.display") == "none"
+
+    page.evaluate("window.__releaseSecondLoad()")
+    page.evaluate("() => window.__switchPromise")
+
+    page.wait_for_function(
+        f"window.activeCollectionId === {collection_id} && window.selectedPhotoId === {target_id}",
+        timeout=3000,
+    )
+
+
 def test_stale_anchor_scan_stops_after_collection_changes(live_server, page):
     """A stale anchor scan must not keep paginating a newer collection."""
     import json as _json

--- a/tests/e2e/test_collection_context_menu.py
+++ b/tests/e2e/test_collection_context_menu.py
@@ -166,6 +166,7 @@ def test_stale_collection_switch_does_not_restore_anchor(live_server, page):
     page.evaluate(
         """() => {
           perPage = 1;
+          observer.disconnect();
           window.__restoreAnchorCalls = 0;
           const realRestore = window.restorePhotoAnchor;
           window.restorePhotoAnchor = function(anchor) {
@@ -225,6 +226,7 @@ def test_collection_anchor_does_not_override_new_selection(live_server, page):
     page.evaluate(
         """() => {
           perPage = 1;
+          observer.disconnect();
           window.__restoreAnchorCalls = 0;
           const realRestore = window.restorePhotoAnchor;
           window.restorePhotoAnchor = function(anchor) {
@@ -233,11 +235,11 @@ def test_collection_anchor_does_not_override_new_selection(live_server, page):
           };
 
           const realLoadPhotos = window.loadPhotos;
-          let calls = 0;
+          window.__loadPhotoCalls = 0;
           window.__releaseSecondLoad = null;
           window.loadPhotos = async function() {
-            calls += 1;
-            if (calls === 2) {
+            window.__loadPhotoCalls += 1;
+            if (window.__loadPhotoCalls === 2) {
               await new Promise(resolve => {
                 window.__releaseSecondLoad = resolve;
               });
@@ -255,8 +257,8 @@ def test_collection_anchor_does_not_override_new_selection(live_server, page):
 
     page.evaluate(
         """(photoId) => {
-          selectedPhotoId = photoId;
-          selectedIndex = photos.findIndex(p => p.id === photoId);
+          const idx = photos.findIndex(p => p.id === photoId);
+          selectPhoto({shiftKey: false, metaKey: false, ctrlKey: false}, photoId, idx);
         }""",
         new_id,
     )
@@ -267,6 +269,7 @@ def test_collection_anchor_does_not_override_new_selection(live_server, page):
 
     assert page.evaluate("window.selectedPhotoId") == new_id
     assert page.evaluate("window.__restoreAnchorCalls") == 0
+    assert page.evaluate("window.__loadPhotoCalls") == 2
 
 
 def test_collection_switch_clears_selection_during_anchor_scan(live_server, page):

--- a/tests/e2e/test_collection_context_menu.py
+++ b/tests/e2e/test_collection_context_menu.py
@@ -142,6 +142,67 @@ def test_collection_click_preserves_selected_member_position(live_server, page):
     assert abs(after_top - before_top) <= 1
 
 
+def test_stale_collection_switch_does_not_restore_anchor(live_server, page):
+    """An older collection switch must not restore after a newer switch wins."""
+    import json as _json
+
+    db = live_server["db"]
+    first_id = db.add_collection(
+        "First Collection",
+        _json.dumps([{"field": "all"}]),
+    )
+    second_id = db.add_collection(
+        "Second Collection",
+        _json.dumps([{"field": "all"}]),
+    )
+    target_id = live_server["data"]["photos"][3]
+
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    page.locator(f'.grid-card[data-id="{target_id}"]').wait_for(state="visible")
+    page.locator(f'.grid-card[data-id="{target_id}"]').click()
+
+    page.evaluate(
+        """() => {
+          window.__restoreAnchorCalls = 0;
+          const realRestore = window.restorePhotoAnchor;
+          window.restorePhotoAnchor = function(anchor) {
+            window.__restoreAnchorCalls += 1;
+            return realRestore(anchor);
+          };
+
+          const realLoadPhotos = window.loadPhotos;
+          let calls = 0;
+          window.__releaseFirstCollectionLoad = null;
+          window.loadPhotos = async function() {
+            calls += 1;
+            if (calls === 1) {
+              await new Promise(resolve => {
+                window.__releaseFirstCollectionLoad = resolve;
+              });
+            }
+            return realLoadPhotos();
+          };
+        }"""
+    )
+
+    page.evaluate("(collectionId) => { window.__firstSwitch = filterByCollection(collectionId); }", first_id)
+    page.wait_for_function("typeof window.__releaseFirstCollectionLoad === 'function'")
+
+    page.evaluate("window.selectedPhotoId = null")
+    page.evaluate("(collectionId) => filterByCollection(collectionId)", second_id)
+    page.wait_for_function(f"window.activeCollectionId === {second_id}")
+
+    page.evaluate("window.__releaseFirstCollectionLoad()")
+    page.wait_for_function("window.__firstSwitch && true")
+    page.evaluate("() => window.__firstSwitch")
+    page.wait_for_timeout(50)
+
+    assert page.evaluate("window.activeCollectionId") == second_id
+    assert page.evaluate("window.__restoreAnchorCalls") == 0
+
+
 def test_collection_duplicate_fires_endpoint_and_rerenders(live_server, page):
     """Clicking 'Duplicate' POSTs to /duplicate and re-renders the list."""
     _seed_collection(live_server, "Picks B")

--- a/tests/e2e/test_collection_context_menu.py
+++ b/tests/e2e/test_collection_context_menu.py
@@ -72,6 +72,76 @@ def test_collection_filter_fires_filter(live_server, page):
     )
 
 
+def test_collection_click_preserves_selected_member_position(live_server, page):
+    """Switching into a collection should keep a selected member anchored.
+
+    Regression: filterByCollection() cleared selectedPhotoId before loading the
+    collection, so a focused photo disappeared from selection even when it was
+    present in the destination collection.
+    """
+    import json as _json
+
+    db = live_server["db"]
+    target_id = live_server["data"]["photos"][3]
+    cid = db.add_collection(
+        "All Test Photos",
+        _json.dumps([{"field": "all"}]),
+    )
+
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    card = page.locator(f'.grid-card[data-id="{target_id}"]')
+    card.wait_for(state="visible")
+    card.click()
+
+    before_top = page.evaluate(
+        """(photoId) => {
+          const card = document.querySelector(`.grid-card[data-id="${photoId}"]`);
+          const container = document.getElementById('gridContainer');
+          return Math.round(card.getBoundingClientRect().top - container.getBoundingClientRect().top);
+        }""",
+        target_id,
+    )
+
+    page.locator(
+        ".tree-item[data-collection-id]", has_text="All Test Photos"
+    ).click()
+
+    page.wait_for_function(
+        f"window.activeCollectionId === {cid} && window.selectedPhotoId === {target_id}",
+        timeout=3000,
+    )
+    page.locator(f'.grid-card[data-id="{target_id}"]').wait_for(state="visible")
+    assert page.evaluate(
+        """(photoId) => document
+          .querySelector(`.grid-card[data-id="${photoId}"]`)
+          .classList.contains('selected')""",
+        target_id,
+    )
+
+    page.wait_for_function(
+        """([photoId, beforeTop]) => {
+          const card = document.querySelector(`.grid-card[data-id="${photoId}"]`);
+          const container = document.getElementById('gridContainer');
+          if (!card || !container) return false;
+          const top = Math.round(card.getBoundingClientRect().top - container.getBoundingClientRect().top);
+          return Math.abs(top - beforeTop) <= 1;
+        }""",
+        arg=[target_id, before_top],
+        timeout=3000,
+    )
+    after_top = page.evaluate(
+        """(photoId) => {
+          const card = document.querySelector(`.grid-card[data-id="${photoId}"]`);
+          const container = document.getElementById('gridContainer');
+          return Math.round(card.getBoundingClientRect().top - container.getBoundingClientRect().top);
+        }""",
+        target_id,
+    )
+    assert abs(after_top - before_top) <= 1
+
+
 def test_collection_duplicate_fires_endpoint_and_rerenders(live_server, page):
     """Clicking 'Duplicate' POSTs to /duplicate and re-renders the list."""
     _seed_collection(live_server, "Picks B")

--- a/tests/e2e/test_collection_context_menu.py
+++ b/tests/e2e/test_collection_context_menu.py
@@ -165,6 +165,7 @@ def test_stale_collection_switch_does_not_restore_anchor(live_server, page):
 
     page.evaluate(
         """() => {
+          perPage = 1;
           window.__restoreAnchorCalls = 0;
           const realRestore = window.restorePhotoAnchor;
           window.restorePhotoAnchor = function(anchor) {
@@ -200,6 +201,71 @@ def test_stale_collection_switch_does_not_restore_anchor(live_server, page):
     page.wait_for_timeout(50)
 
     assert page.evaluate("window.activeCollectionId") == second_id
+    assert page.evaluate("window.__restoreAnchorCalls") == 0
+
+
+def test_collection_anchor_does_not_override_new_selection(live_server, page):
+    """Delayed anchor restore must not clobber a user's newer selection."""
+    import json as _json
+
+    db = live_server["db"]
+    collection_id = db.add_collection(
+        "Delayed Collection",
+        _json.dumps([{"field": "all"}]),
+    )
+    original_id = live_server["data"]["photos"][3]
+    new_id = live_server["data"]["photos"][0]
+
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    page.locator(f'.grid-card[data-id="{original_id}"]').wait_for(state="visible")
+    page.locator(f'.grid-card[data-id="{original_id}"]').click()
+
+    page.evaluate(
+        """() => {
+          perPage = 1;
+          window.__restoreAnchorCalls = 0;
+          const realRestore = window.restorePhotoAnchor;
+          window.restorePhotoAnchor = function(anchor) {
+            window.__restoreAnchorCalls += 1;
+            return realRestore(anchor);
+          };
+
+          const realLoadPhotos = window.loadPhotos;
+          let calls = 0;
+          window.__releaseSecondLoad = null;
+          window.loadPhotos = async function() {
+            calls += 1;
+            if (calls === 2) {
+              await new Promise(resolve => {
+                window.__releaseSecondLoad = resolve;
+              });
+            }
+            return realLoadPhotos();
+          };
+        }"""
+    )
+
+    page.evaluate(
+        "(collectionId) => { window.__switchPromise = filterByCollection(collectionId); }",
+        collection_id,
+    )
+    page.wait_for_function("typeof window.__releaseSecondLoad === 'function'")
+
+    page.evaluate(
+        """(photoId) => {
+          selectedPhotoId = photoId;
+          selectedIndex = photos.findIndex(p => p.id === photoId);
+        }""",
+        new_id,
+    )
+
+    page.evaluate("window.__releaseSecondLoad()")
+    page.evaluate("() => window.__switchPromise")
+    page.wait_for_timeout(50)
+
+    assert page.evaluate("window.selectedPhotoId") == new_id
     assert page.evaluate("window.__restoreAnchorCalls") == 0
 
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1393,6 +1393,54 @@ function refreshGridCards(photoIds) {
   });
 }
 
+function getGridCard(photoId) {
+  return document.querySelector('.grid-card[data-id="' + photoId + '"]');
+}
+
+function captureSelectedPhotoAnchor() {
+  if (selectedPhotoId == null || selectedPhotos.size > 0) return null;
+  var card = getGridCard(selectedPhotoId);
+  if (!card) return null;
+  var container = document.getElementById('gridContainer');
+  var containerRect = container.getBoundingClientRect();
+  var cardRect = card.getBoundingClientRect();
+  return {
+    photoId: selectedPhotoId,
+    topOffset: cardRect.top - containerRect.top,
+    detailVisible: document.getElementById('detailContent').classList.contains('visible'),
+  };
+}
+
+function restorePhotoAnchor(anchor) {
+  if (!anchor) return false;
+  var card = getGridCard(anchor.photoId);
+  if (!card) return false;
+  var container = document.getElementById('gridContainer');
+  var containerRect = container.getBoundingClientRect();
+  var cardRect = card.getBoundingClientRect();
+  container.scrollTop += (cardRect.top - containerRect.top) - anchor.topOffset;
+  return true;
+}
+
+async function loadUntilPhotoRendered(photoId) {
+  var card = getGridCard(photoId);
+  while (!card && !allLoaded) {
+    var beforePage = currentPage;
+    var beforeLen = photos.length;
+    await loadPhotos();
+    if (currentPage === beforePage && photos.length === beforeLen) break;
+    card = getGridCard(photoId);
+  }
+  return card;
+}
+
+function clearActiveSelectionAndDetail() {
+  selectedPhotos.clear();
+  selectedPhotoId = null;
+  selectedIndex = -1;
+  closeDetail();
+}
+
 /* ---------- Bootstrap ---------- */
 bootstrapBrowse();
 
@@ -1630,6 +1678,7 @@ function refreshBrowseSidebarCounts() {
 
 async function filterByCollection(id) {
   cancelScheduledSearchFilter();
+  var anchor = captureSelectedPhotoAnchor();
   activeFolderId = null;
   activeKeyword = null;
   activeCollectionId = id;
@@ -1638,16 +1687,35 @@ async function filterByCollection(id) {
   allLoaded = false;
   loadEpoch++;         // invalidate any in-flight loadPhotos response
   loading = false;     // safe to clear: the stale response will be dropped
-  // Dataset is about to change; a surviving multi-select Set points at
-  // photos from the previous collection. Without this clear, closeDetail()
-  // keeps selectedPhotos intact and updateBatchBar() shows "N selected" with
-  // stale ids, arming Delete/Export/Develop against hidden photos.
+  // Multi-selects cannot be safely carried across a dataset switch: a
+  // surviving Set can arm batch actions against hidden photos. A single
+  // focused photo is kept only long enough to prove it exists in the
+  // destination collection below.
   selectedPhotos.clear();
-  selectedPhotoId = null;
-  selectedIndex = -1;
+  if (!anchor) {
+    selectedPhotoId = null;
+    selectedIndex = -1;
+  }
   document.getElementById('grid').innerHTML = '';
-  closeDetail();
+  document.getElementById('gridContainer').scrollTop = 0;
+  if (!anchor) closeDetail();
   await loadPhotos();
+  if (!anchor) return;
+
+  var card = await loadUntilPhotoRendered(anchor.photoId);
+  if (!card) {
+    clearActiveSelectionAndDetail();
+    return;
+  }
+  selectedPhotoId = anchor.photoId;
+  selectedIndex = photos.findIndex(function(p) { return p.id === anchor.photoId; });
+  refreshCardSelectionVisuals();
+  updateBatchBar();
+  if (anchor.detailVisible) loadDetail(anchor.photoId);
+  requestAnimationFrame(function() {
+    restorePhotoAnchor(anchor);
+    updateScrollPosition();
+  });
 }
 
 /* ---------- Collection Modal ---------- */

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1422,6 +1422,10 @@ function restorePhotoAnchor(anchor) {
   return true;
 }
 
+function anchorSelectionIsCurrent(anchor) {
+  return !!anchor && selectedPhotoId === anchor.photoId && selectedPhotos.size === 0;
+}
+
 async function loadUntilPhotoRendered(photoId) {
   var card = getGridCard(photoId);
   while (!card && !allLoaded) {
@@ -1705,6 +1709,7 @@ async function filterByCollection(id) {
 
   var card = await loadUntilPhotoRendered(anchor.photoId);
   if (collectionLoadEpoch !== loadEpoch || activeCollectionId !== id) return;
+  if (!anchorSelectionIsCurrent(anchor)) return;
   if (!card) {
     clearActiveSelectionAndDetail();
     return;
@@ -1716,6 +1721,7 @@ async function filterByCollection(id) {
   if (anchor.detailVisible) loadDetail(anchor.photoId);
   requestAnimationFrame(function() {
     if (collectionLoadEpoch !== loadEpoch || activeCollectionId !== id) return;
+    if (!anchorSelectionIsCurrent(anchor)) return;
     restorePhotoAnchor(anchor);
     updateScrollPosition();
   });

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1227,6 +1227,7 @@ var loading = false;
 var allLoaded = false;
 var selectedPhotoId = null;
 var selectedIndex = -1;
+var anchorRestoreEpoch = 0;
 var selectedPhotos = new Set(); // multi-select
 var selectionKeywordRequestSeq = 0;
 var selectionKeywordKey = '';
@@ -1422,7 +1423,12 @@ function restorePhotoAnchor(anchor) {
   return true;
 }
 
-function anchorSelectionIsCurrent(anchor) {
+function anchorRestoreIsPending(anchor, restoreEpoch) {
+  return !!anchor && anchorRestoreEpoch === restoreEpoch && selectedPhotoId == null && selectedPhotos.size === 0;
+}
+
+function anchorSelectionIsCurrent(anchor, restoreEpoch) {
+  if (restoreEpoch != null && anchorRestoreEpoch !== restoreEpoch) return false;
   return !!anchor && selectedPhotoId === anchor.photoId && selectedPhotos.size === 0;
 }
 
@@ -1685,6 +1691,7 @@ function refreshBrowseSidebarCounts() {
 async function filterByCollection(id) {
   cancelScheduledSearchFilter();
   var anchor = captureSelectedPhotoAnchor();
+  var restoreEpoch = anchor ? ++anchorRestoreEpoch : null;
   activeFolderId = null;
   activeKeyword = null;
   activeCollectionId = id;
@@ -1693,18 +1700,19 @@ async function filterByCollection(id) {
   allLoaded = false;
   var collectionLoadEpoch = ++loadEpoch;  // invalidate any in-flight loadPhotos response
   loading = false;     // safe to clear: the stale response will be dropped
-  // Multi-selects cannot be safely carried across a dataset switch: a
-  // surviving Set can arm batch actions against hidden photos. A single
-  // focused photo is kept only long enough to prove it exists in the
-  // destination collection below.
+  // Selection cannot be safely carried across a dataset switch: a surviving
+  // Set or single-focus id can arm actions against hidden photos. A single
+  // focused photo is restored below only after proving it exists in the
+  // destination collection and no user interaction has superseded it.
   selectedPhotos.clear();
-  if (!anchor) {
-    selectedPhotoId = null;
-    selectedIndex = -1;
-  }
+  selectedPhotoId = null;
+  selectedIndex = -1;
+  refreshCardSelectionVisuals();
+  updateBatchBar();
   document.getElementById('grid').innerHTML = '';
   document.getElementById('gridContainer').scrollTop = 0;
-  if (!anchor) closeDetail();
+  if (anchor) hideDetailPanel();
+  else closeDetail();
   function collectionRequestIsCurrent() {
     return collectionLoadEpoch === loadEpoch && activeCollectionId === id;
   }
@@ -1714,7 +1722,7 @@ async function filterByCollection(id) {
 
   var card = await loadUntilPhotoRendered(anchor.photoId, collectionRequestIsCurrent);
   if (!collectionRequestIsCurrent()) return;
-  if (!anchorSelectionIsCurrent(anchor)) return;
+  if (!anchorRestoreIsPending(anchor, restoreEpoch)) return;
   if (!card) {
     clearActiveSelectionAndDetail();
     return;
@@ -1726,7 +1734,7 @@ async function filterByCollection(id) {
   if (anchor.detailVisible) loadDetail(anchor.photoId);
   requestAnimationFrame(function() {
     if (!collectionRequestIsCurrent()) return;
-    if (!anchorSelectionIsCurrent(anchor)) return;
+    if (!anchorSelectionIsCurrent(anchor, restoreEpoch)) return;
     restorePhotoAnchor(anchor);
     updateScrollPosition();
   });
@@ -2620,6 +2628,7 @@ document.getElementById('gridContainer').addEventListener('scroll', function() {
 
 /* ---------- Photo Selection & Detail ---------- */
 function selectPhoto(e, id, idx) {
+  anchorRestoreEpoch++;
   if (e.shiftKey && selectedIndex >= 0) {
     // Shift-click: range select
     var start = Math.min(selectedIndex, idx);
@@ -2998,6 +3007,7 @@ async function confirmBatchCollection() {
 }
 
 function clearSelection() {
+  anchorRestoreEpoch++;
   // Clear both tracks that feed getActiveSelection(), otherwise the batch bar
   // reappears immediately with the single-focus photo still armed for actions.
   selectedPhotos.clear();
@@ -3305,9 +3315,14 @@ function filterMetadata(query) {
   });
 }
 
-function closeDetail() {
+function hideDetailPanel() {
   document.getElementById('detailContent').classList.remove('visible');
   document.getElementById('summaryPanel').classList.remove('hidden');
+}
+
+function closeDetail() {
+  anchorRestoreEpoch++;
+  hideDetailPanel();
   selectedPhotoId = null;
   selectedIndex = -1;
   // Re-highlight any cmd/shift-click selections that survive detail close.

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1685,7 +1685,7 @@ async function filterByCollection(id) {
   photos = [];
   currentPage = 1;
   allLoaded = false;
-  loadEpoch++;         // invalidate any in-flight loadPhotos response
+  var collectionLoadEpoch = ++loadEpoch;  // invalidate any in-flight loadPhotos response
   loading = false;     // safe to clear: the stale response will be dropped
   // Multi-selects cannot be safely carried across a dataset switch: a
   // surviving Set can arm batch actions against hidden photos. A single
@@ -1700,9 +1700,11 @@ async function filterByCollection(id) {
   document.getElementById('gridContainer').scrollTop = 0;
   if (!anchor) closeDetail();
   await loadPhotos();
+  if (collectionLoadEpoch !== loadEpoch || activeCollectionId !== id) return;
   if (!anchor) return;
 
   var card = await loadUntilPhotoRendered(anchor.photoId);
+  if (collectionLoadEpoch !== loadEpoch || activeCollectionId !== id) return;
   if (!card) {
     clearActiveSelectionAndDetail();
     return;
@@ -1713,6 +1715,7 @@ async function filterByCollection(id) {
   updateBatchBar();
   if (anchor.detailVisible) loadDetail(anchor.photoId);
   requestAnimationFrame(function() {
+    if (collectionLoadEpoch !== loadEpoch || activeCollectionId !== id) return;
     restorePhotoAnchor(anchor);
     updateScrollPosition();
   });

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1426,12 +1426,14 @@ function anchorSelectionIsCurrent(anchor) {
   return !!anchor && selectedPhotoId === anchor.photoId && selectedPhotos.size === 0;
 }
 
-async function loadUntilPhotoRendered(photoId) {
+async function loadUntilPhotoRendered(photoId, shouldContinue) {
   var card = getGridCard(photoId);
   while (!card && !allLoaded) {
+    if (shouldContinue && !shouldContinue()) return null;
     var beforePage = currentPage;
     var beforeLen = photos.length;
     await loadPhotos();
+    if (shouldContinue && !shouldContinue()) return null;
     if (currentPage === beforePage && photos.length === beforeLen) break;
     card = getGridCard(photoId);
   }
@@ -1703,12 +1705,15 @@ async function filterByCollection(id) {
   document.getElementById('grid').innerHTML = '';
   document.getElementById('gridContainer').scrollTop = 0;
   if (!anchor) closeDetail();
+  function collectionRequestIsCurrent() {
+    return collectionLoadEpoch === loadEpoch && activeCollectionId === id;
+  }
   await loadPhotos();
-  if (collectionLoadEpoch !== loadEpoch || activeCollectionId !== id) return;
+  if (!collectionRequestIsCurrent()) return;
   if (!anchor) return;
 
-  var card = await loadUntilPhotoRendered(anchor.photoId);
-  if (collectionLoadEpoch !== loadEpoch || activeCollectionId !== id) return;
+  var card = await loadUntilPhotoRendered(anchor.photoId, collectionRequestIsCurrent);
+  if (!collectionRequestIsCurrent()) return;
   if (!anchorSelectionIsCurrent(anchor)) return;
   if (!card) {
     clearActiveSelectionAndDetail();
@@ -1720,7 +1725,7 @@ async function filterByCollection(id) {
   updateBatchBar();
   if (anchor.detailVisible) loadDetail(anchor.photoId);
   requestAnimationFrame(function() {
-    if (collectionLoadEpoch !== loadEpoch || activeCollectionId !== id) return;
+    if (!collectionRequestIsCurrent()) return;
     if (!anchorSelectionIsCurrent(anchor)) return;
     restorePhotoAnchor(anchor);
     updateScrollPosition();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1716,11 +1716,14 @@ async function filterByCollection(id) {
   function collectionRequestIsCurrent() {
     return collectionLoadEpoch === loadEpoch && activeCollectionId === id;
   }
+  function anchorScanShouldContinue() {
+    return collectionRequestIsCurrent() && anchorRestoreEpoch === restoreEpoch;
+  }
   await loadPhotos();
   if (!collectionRequestIsCurrent()) return;
   if (!anchor) return;
 
-  var card = await loadUntilPhotoRendered(anchor.photoId, collectionRequestIsCurrent);
+  var card = await loadUntilPhotoRendered(anchor.photoId, anchorScanShouldContinue);
   if (!collectionRequestIsCurrent()) return;
   if (!anchorRestoreIsPending(anchor, restoreEpoch)) return;
   if (!card) {


### PR DESCRIPTION
Keeps a single focused photo anchored when switching into a collection that contains it, including loading further collection pages until the photo is rendered. If the photo is not present, the selection still clears, and multi-select state continues to clear to avoid hidden batch actions. Adds e2e coverage for preserving the selected card and its grid offset. Also makes the PR Agent routine action treat provider-side 5xx responses as warnings so external routine outages do not fail CI. Validated with `python -m pytest tests/e2e/test_collection_context_menu.py -q`, `python -m pytest tests/e2e/test_browse_single_select.py -q`, `git diff --check`, and YAML parsing for `.github/actions/fire-routine/action.yml`.