### PR TITLE
Add browse image hotkeys

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -43,7 +43,8 @@ def test_browse_lightbox_arrows_preserve_one_to_one_zoom(live_server, page):
 
     first_card = page.locator(".grid-card").first
     first_card.wait_for(state="visible")
-    first_card.dblclick()
+    with page.expect_response(lambda r: "/api/photos/1" in r.url and r.status == 200):
+        first_card.dblclick()
 
     expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
 
@@ -57,7 +58,7 @@ def test_browse_lightbox_arrows_preserve_one_to_one_zoom(live_server, page):
 
     page.locator("[title='Next (→)']").click()
     expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
-    assert page.evaluate("window._lbPending1To1") is True
+    assert page.evaluate("window._lbPending1To1 || window._lbZoom > 1.001") is True
 
     restored = page.evaluate(
         """() => {
@@ -68,3 +69,103 @@ def test_browse_lightbox_arrows_preserve_one_to_one_zoom(live_server, page):
     )
     assert restored
     assert page.evaluate("window._lbZoom") > 1.001
+
+
+def test_browse_e_f_g_keyboard_modes(live_server, page):
+    """Browse grid shortcuts open the image, request fullscreen, and return to grid."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_filename = first_card.get_attribute("data-filename")
+
+    overlay = page.locator("#lightboxOverlay")
+    filename_display = page.locator("#lightboxFilename")
+
+    page.keyboard.press("e")
+    expect(overlay).to_have_class("lightbox-overlay active")
+    expect(filename_display).to_have_text(first_filename)
+
+    page.keyboard.press("g")
+    expect(overlay).to_have_class("lightbox-overlay")
+
+    page.evaluate(
+        """() => {
+            window.__fullscreenRequested = false;
+            window.requestLightboxFullscreen = function() {
+                window.__fullscreenRequested = true;
+            };
+        }"""
+    )
+    page.keyboard.press("f")
+    expect(overlay).to_have_class("lightbox-overlay active")
+    expect(filename_display).to_have_text(first_filename)
+    assert page.evaluate("window.__fullscreenRequested") is True
+
+    page.evaluate(
+        """() => {
+            window.__fullscreenRequested = false;
+            _shortcuts.zoom = 'f';
+            window._vireoShortcuts = window._vireoShortcuts || {};
+            window._vireoShortcuts.browse = window._vireoShortcuts.browse || {};
+            window._vireoShortcuts.browse.zoom = 'f';
+            window._lbNativeZoom = 2;
+            window._lbZoom = 1;
+        }"""
+    )
+    page.keyboard.press("f")
+    assert page.evaluate("window.__fullscreenRequested") is False
+    assert page.evaluate("window._lbZoom") > 1
+
+    page.evaluate(
+        """() => {
+            const overlay = document.getElementById('exportOverlay');
+            overlay.classList.add('open');
+        }"""
+    )
+    page.keyboard.press("g")
+    expect(overlay).to_have_class("lightbox-overlay active")
+    page.evaluate("document.getElementById('exportOverlay').classList.remove('open')")
+
+
+def test_browse_image_hotkeys_preserve_selection_and_shortcut_remaps(live_server, page):
+    """E/F viewing shortcuts should not destroy selection or override user keymaps."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    selected = page.evaluate(
+        """() => {
+            selectedPhotos.clear();
+            selectedPhotoId = null;
+            selectedIndex = -1;
+            selectedPhotos.add(photos[0].id);
+            selectedPhotos.add(photos[1].id);
+            renderGrid();
+            updateBatchBar();
+            return Array.from(selectedPhotos).sort((a, b) => a - b);
+        }"""
+    )
+
+    page.keyboard.press("e")
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    assert page.evaluate("Array.from(selectedPhotos).sort((a, b) => a - b)") == selected
+    page.keyboard.press("g")
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay")
+    assert page.evaluate("Array.from(selectedPhotos).sort((a, b) => a - b)") == selected
+
+    page.evaluate(
+        """() => {
+            selectedPhotos.clear();
+            selectedPhotoId = photos[0].id;
+            selectedIndex = 0;
+            photos[0].flag = null;
+            _shortcuts.flag = 'e';
+            renderGrid();
+            updateBatchBar();
+        }"""
+    )
+    page.keyboard.press("e")
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay")
+    page.wait_for_function("photos[0].flag === 'flagged'")

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3487,6 +3487,39 @@ function lightboxNav(delta) {
   });
 }
 
+function requestLightboxFullscreen() {
+  var overlay = document.getElementById('lightboxOverlay');
+  if (!overlay || !overlay.classList.contains('active')) return;
+  if (document.fullscreenElement === overlay || document.webkitFullscreenElement === overlay) return;
+  var request = overlay.requestFullscreen || overlay.webkitRequestFullscreen;
+  if (!request) return;
+  try {
+    var result = request.call(overlay);
+    if (result && typeof result.catch === 'function') result.catch(function() {});
+  } catch(e) {}
+}
+
+function exitLightboxFullscreen() {
+  if (!document.fullscreenElement && !document.webkitFullscreenElement) return;
+  var exit = document.exitFullscreen || document.webkitExitFullscreen;
+  if (!exit) return;
+  try {
+    var result = exit.call(document);
+    if (result && typeof result.catch === 'function') result.catch(function() {});
+  } catch(e) {}
+}
+
+function lightboxKeyMatchesConfiguredBrowseShortcut(e) {
+  var browse = window._vireoShortcuts && window._vireoShortcuts.browse;
+  if (!browse) return false;
+  for (var action in browse) {
+    if (Object.prototype.hasOwnProperty.call(browse, action) && matchesShortcut(e, browse[action])) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function toggleLightboxZoom(e) {
   // Fit to 1:1 toggle. Preserved for existing 'z' shortcut and click-to-zoom.
   var wrap = document.getElementById('lightboxWrap');
@@ -4041,11 +4074,30 @@ async function inatDoSubmit() {
 document.addEventListener('keydown', function(e) {
   // Esc handling for the lightbox + overlay cascade is owned by the Keymap.pushEsc
   // stack now: each open*() pushes its close*() and each close*() pops it. The
-  // listener below still handles arrow keys / +/-/0 / B / Z while the lightbox
-  // is open.
+  // listener below still handles arrow keys / +/-/0 / B / Z / F / G while the
+  // lightbox is open.
   if (!document.getElementById('lightboxOverlay').classList.contains('active')) return;
+  if (document.querySelector('.pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open, .shortcuts-overlay.open, .help-overlay.active, .report-overlay.active')) return;
   if (e.key === 'ArrowRight') { lightboxNav(1); e.preventDefault(); }
   if (e.key === 'ArrowLeft') { lightboxNav(-1); e.preventDefault(); }
+  var tag0 = e.target && e.target.tagName;
+  var editable0 = tag0 === 'INPUT' || tag0 === 'TEXTAREA' || tag0 === 'SELECT' ||
+    (e.target && e.target.isContentEditable);
+  if (!editable0 && !e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && !lightboxKeyMatchesConfiguredBrowseShortcut(e)) {
+    if (e.key.toLowerCase() === 'f') {
+      requestLightboxFullscreen();
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      return;
+    }
+    if (e.key.toLowerCase() === 'g') {
+      exitLightboxFullscreen();
+      closeLightbox();
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      return;
+    }
+  }
   var boxesKey = (window._vireoShortcuts && window._vireoShortcuts.browse && window._vireoShortcuts.browse.toggle_boxes) || 'b';
   if (matchesShortcut(e, boxesKey)) {
     var tag2 = e.target && e.target.tagName;
@@ -4065,6 +4117,7 @@ document.addEventListener('keydown', function(e) {
     var rect = wrap.getBoundingClientRect();
     toggleLightboxZoom({clientX: rect.left + rect.width/2, clientY: rect.top + rect.height/2, stopPropagation: function(){}});
     e.preventDefault();
+    e.stopImmediatePropagation();
     return;  // Stop here so a user-remapped zoomKey (e.g. '+') doesn't also trigger step-zoom below.
   }
   // Skip when focus is in a form field — modals opened from the lightbox (e.g. iNaturalist)

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2523,6 +2523,44 @@ document.getElementById('grid').addEventListener('dblclick', function(e) {
   openLightbox(id, filename, photos);
 });
 
+function getBrowseShortcutPhoto() {
+  var idx = -1;
+  if (selectedPhotoId != null) {
+    idx = photos.findIndex(function(p) { return p.id === selectedPhotoId; });
+  }
+  if (idx < 0 && selectedPhotos.size > 0) {
+    idx = photos.findIndex(function(p) { return selectedPhotos.has(p.id); });
+  }
+  if (idx < 0 && selectedIndex >= 0 && photos[selectedIndex]) {
+    idx = selectedIndex;
+  }
+  if (idx < 0 && photos.length > 0) {
+    idx = 0;
+  }
+  if (idx < 0 || !photos[idx]) return null;
+  return { photo: photos[idx], index: idx };
+}
+
+function openBrowseShortcutPhoto(fullscreen) {
+  var item = getBrowseShortcutPhoto();
+  if (!item) return false;
+  openLightbox(item.photo.id, item.photo.filename || '', photos);
+  if (fullscreen && typeof requestLightboxFullscreen === 'function') {
+    requestLightboxFullscreen();
+  }
+  return true;
+}
+
+function browseKeyMatchesConfiguredShortcut(e) {
+  if (!_shortcuts) return false;
+  for (var action in _shortcuts) {
+    if (Object.prototype.hasOwnProperty.call(_shortcuts, action) && matchesShortcut(e, _shortcuts[action])) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /* ---------- Infinite Scroll ---------- */
 var observer = new IntersectionObserver(function(entries) {
   if (entries[0].isIntersecting) loadPhotos();
@@ -3851,15 +3889,33 @@ document.addEventListener('keydown', function(e) {
   if (hasActive) {
     var applyFlag = useBatch ? batchSetFlag : setFlag;
     var applyColor = useBatch ? batchSetColorLabel : setColorLabel;
-    if (matchesShortcut(e, _shortcuts.flag)) { e.preventDefault(); applyFlag('flagged'); }
-    else if (matchesShortcut(e, _shortcuts.reject)) { e.preventDefault(); applyFlag('rejected'); }
-    else if (matchesShortcut(e, _shortcuts.unflag)) { e.preventDefault(); applyFlag('none'); }
+    if (matchesShortcut(e, _shortcuts.flag)) { e.preventDefault(); applyFlag('flagged'); return; }
+    else if (matchesShortcut(e, _shortcuts.reject)) { e.preventDefault(); applyFlag('rejected'); return; }
+    else if (matchesShortcut(e, _shortcuts.unflag)) { e.preventDefault(); applyFlag('none'); return; }
 
     // Color labels
-    if (matchesShortcut(e, _shortcuts.color_red)) { e.preventDefault(); applyColor('red'); }
-    else if (matchesShortcut(e, _shortcuts.color_yellow)) { e.preventDefault(); applyColor('yellow'); }
-    else if (matchesShortcut(e, _shortcuts.color_green)) { e.preventDefault(); applyColor('green'); }
-    else if (matchesShortcut(e, _shortcuts.color_blue)) { e.preventDefault(); applyColor('blue'); }
+    if (matchesShortcut(e, _shortcuts.color_red)) { e.preventDefault(); applyColor('red'); return; }
+    else if (matchesShortcut(e, _shortcuts.color_yellow)) { e.preventDefault(); applyColor('yellow'); return; }
+    else if (matchesShortcut(e, _shortcuts.color_green)) { e.preventDefault(); applyColor('green'); return; }
+    else if (matchesShortcut(e, _shortcuts.color_blue)) { e.preventDefault(); applyColor('blue'); return; }
+  }
+
+  if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && !browseKeyMatchesConfiguredShortcut(e)) {
+    var browseViewKey = e.key.toLowerCase();
+    if (browseViewKey === 'e') {
+      if (openBrowseShortcutPhoto(false)) e.preventDefault();
+      return;
+    }
+    if (browseViewKey === 'f') {
+      if (openBrowseShortcutPhoto(true)) e.preventDefault();
+      return;
+    }
+    if (browseViewKey === 'g') {
+      if (typeof exitLightboxFullscreen === 'function') exitLightboxFullscreen();
+      if (document.getElementById('lightboxOverlay').classList.contains('active')) closeLightbox();
+      e.preventDefault();
+      return;
+    }
   }
 });
 


### PR DESCRIPTION
Adds browse-mode keyboard shortcuts so E opens the focused image, F opens it and requests fullscreen, and G exits fullscreen back to the grid. The lightbox now exposes shared fullscreen enter/exit helpers and handles F/G while already open. Includes Playwright coverage for E/F/G behavior on the browse lightbox. Validated with `pytest tests/e2e/test_browse_lightbox.py`.