### PR TITLE
[codex] Fix pipeline planning and cancellation UX

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1409,8 +1409,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # reflects what /api/pipeline/regroup-live would actually consume —
         # mismatched-variant embeddings are dropped at load time, so counting
         # them here would lie about readiness.
+        dinov2_variant = pipeline_cfg.get("dinov2_variant")
+        sam2_variant = pipeline_cfg.get("sam2_variant")
+        proxy_longest_edge = pipeline_cfg.get("proxy_longest_edge")
         review_readiness = compute_review_readiness(
-            db, dinov2_variant=pipeline_cfg.get("dinov2_variant"),
+            db, dinov2_variant=dinov2_variant,
         )
         if results is not None:
             # Cache exists — even if features have changed underneath,
@@ -1445,12 +1448,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "total_photos": total_photos,
             "taxonomy_available": taxonomy_available,
             "pipeline_config": {
-                "sam2_variant": pipeline_cfg.get("sam2_variant", "sam2-small"),
-                "dinov2_variant": pipeline_cfg.get("dinov2_variant", "vit-b14"),
-                "proxy_longest_edge": pipeline_cfg.get("proxy_longest_edge", 1536),
+                "sam2_variant": sam2_variant,
+                "dinov2_variant": dinov2_variant,
+                "proxy_longest_edge": proxy_longest_edge,
                 "eye_detect_enabled": pipeline_cfg.get("eye_detect_enabled", True),
             },
             "mask_variant_coverage": db.mask_variant_coverage(),
+            "sam_variant_warning": db.sam_variant_rerun_warning(sam2_variant),
             "results": results,
             "review_readiness": review_readiness,
             "workspace_overrides": ws_overrides,
@@ -4650,23 +4654,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/pipeline/extract-readiness")
     def api_extract_readiness():
         """Report SAM2/DINOv2 download status for the Extract Features card."""
+        import config as cfg
         from dino_embed import DINOV2_VARIANTS, dinov2_status
         from masking import SAM2_VARIANTS, sam2_status
 
         db = _get_db()
         pipeline_cfg = db.get_effective_config(cfg.load()).get("pipeline", {})
-        sam2_variant = request.args.get("sam2_variant") or pipeline_cfg.get(
-            "sam2_variant", "sam2-small"
-        )
-        dinov2_variant = request.args.get("dinov2_variant") or pipeline_cfg.get(
-            "dinov2_variant", "vit-b14"
-        )
+        sam2_variant = request.args.get("sam2_variant") or pipeline_cfg.get("sam2_variant")
+        dinov2_variant = request.args.get("dinov2_variant") or pipeline_cfg.get("dinov2_variant")
 
         return jsonify({
             "sam2": sam2_status(sam2_variant),
             "sam2_known": sam2_variant in SAM2_VARIANTS,
             "dinov2": dinov2_status(dinov2_variant),
             "dinov2_known": dinov2_variant in DINOV2_VARIANTS,
+            "sam_variant_warning": db.sam_variant_rerun_warning(sam2_variant),
         })
 
     @app.route("/api/system/install-exiftool", methods=["POST"])
@@ -10216,9 +10218,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         effective_cfg = db.get_effective_config(cfg.load())
         pipeline_cfg = effective_cfg.get("pipeline", {})
-        sam2_variant = pipeline_cfg.get("sam2_variant", "sam2-small")
-        dinov2_variant = pipeline_cfg.get("dinov2_variant", "vit-b14")
-        proxy_longest_edge = pipeline_cfg.get("proxy_longest_edge", 1536)
+        sam2_variant = pipeline_cfg.get("sam2_variant")
+        dinov2_variant = pipeline_cfg.get("dinov2_variant")
+        proxy_longest_edge = pipeline_cfg.get("proxy_longest_edge")
         # Workspace-effective detector_confidence floor. Both the
         # collection branch (via get_detections) and the workspace SQL
         # below filter on this so we don't run SAM/DINO on noisy

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -81,6 +81,9 @@ DEFAULTS = {
         "reject_clip_high": 0.30,
         "reject_composite": 0.40,
         # Miss detection
+        "sam2_variant": "sam2-small",
+        "dinov2_variant": "vit-b14",
+        "proxy_longest_edge": 1536,
         "miss_enabled": True,
         "miss_det_confidence": 0.25,
         "miss_det_confidence_burst": 0.15,

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -393,6 +393,37 @@ SCHEMA = {
         "label": "Reject: composite",
         "desc": "Combined reject threshold.",
     },
+    "pipeline.sam2_variant": {
+        "type": "enum",
+        "enum": ["sam2-tiny", "sam2-small", "sam2-base-plus", "sam2-large"],
+        "enum_labels": {
+            "sam2-tiny": "SAM2 Tiny",
+            "sam2-small": "SAM2 Small",
+            "sam2-base-plus": "SAM2 Base+",
+            "sam2-large": "SAM2 Large",
+        },
+        "category": "Pipeline", "scope": "both",
+        "label": "SAM2 variant",
+        "desc": "SAM2 model variant used for pipeline mask extraction.",
+    },
+    "pipeline.dinov2_variant": {
+        "type": "enum",
+        "enum": ["vit-s14", "vit-b14", "vit-l14"],
+        "enum_labels": {
+            "vit-s14": "DINOv2 ViT-S/14",
+            "vit-b14": "DINOv2 ViT-B/14",
+            "vit-l14": "DINOv2 ViT-L/14",
+        },
+        "category": "Pipeline", "scope": "both",
+        "label": "DINOv2 variant",
+        "desc": "DINOv2 model variant used for pipeline feature embeddings.",
+    },
+    "pipeline.proxy_longest_edge": {
+        "type": "int", "min": 1024, "max": 2048,
+        "category": "Pipeline", "scope": "both",
+        "label": "Proxy longest edge",
+        "desc": "Maximum proxy image dimension used for masking and embeddings.",
+    },
     "pipeline.miss_enabled": {
         "type": "bool",
         "category": "Pipeline", "scope": "both",

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -5309,7 +5309,10 @@ class Database:
                     ON d.photo_id = p.id
                    AND d.detector_model != 'full-image'
                    AND d.detector_confidence >= ?
-                 WHERE pm.variant != 'unknown'{scope_sql}
+                 WHERE pm.variant != 'unknown'
+                   AND pm.path IS NOT NULL
+                   AND pm.path != ''
+                   AND p.mask_path IS NOT NULL{scope_sql}
                  GROUP BY pm.variant""",
             (ws, min_conf, *scope_params),
         ).fetchall()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3730,13 +3730,13 @@ class Database:
         Counting those would inflate ``detail.stale`` and keep the
         stage flagged Outdated/Will run forever in mixed workspaces.
 
-        The ``photos.mask_path IS NOT NULL`` gate keeps this count
-        disjoint from ``count_photos_pending_masks``'s ``pending``
-        (``mask_path IS NULL``). Photos with ``mask_path IS NULL`` are
-        already pending — they will be re-extracted regardless of
-        whether their ``photo_masks`` row's prompt matches — so
-        counting them here would double-count when a planner combines
-        ``pending + stale`` as total work.
+        The active-mask and variant-path gates keep this count disjoint from
+        ``count_photos_pending_masks``'s ``pending``. Photos with no active
+        mask, no selected-variant row, or an incomplete selected-variant path
+        are already pending — they will be re-extracted regardless of whether
+        their ``photo_masks`` row's prompt matches — so counting them here
+        would double-count when a planner combines ``pending + stale`` as
+        total work.
         """
         import config as cfg
         ws = self._ws_id()
@@ -3753,6 +3753,8 @@ class Database:
                   ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
                WHERE pm.variant = ?
                  AND p.mask_path IS NOT NULL
+                 AND pm.path IS NOT NULL
+                 AND pm.path != ''
                  AND EXISTS (
                     SELECT 1 FROM detections d0
                      WHERE d0.photo_id = pm.photo_id

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3573,15 +3573,9 @@ class Database:
                       COUNT(DISTINCT p.id) AS eligible,
                       COUNT(DISTINCT CASE
                         WHEN p.mask_path IS NULL
-                          OR (pm.photo_id IS NOT NULL AND pm.path IS NULL)
-                          OR (
-                            pm.photo_id IS NULL
-                            AND EXISTS (
-                              SELECT 1 FROM photo_masks pm_any
-                               WHERE pm_any.photo_id = p.id
-                                 AND pm_any.variant != 'unknown'
-                            )
-                          )
+                          OR pm.photo_id IS NULL
+                          OR pm.path IS NULL
+                          OR pm.path = ''
                         THEN p.id END) AS pending
                     FROM photos p
                     JOIN workspace_folders wf

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3149,6 +3149,46 @@ class Database:
             "total_dets": row["total_dets"] or 0,
         }
 
+    def count_primary_detections_in_scope(self, photo_ids=None, min_conf=None):
+        """Count photos whose primary real detection is pipeline-classifiable.
+
+        The streaming pipeline classifies at most one detection per photo: the
+        highest-confidence non-full-image detection above the active threshold.
+        This mirrors that gate for the Pipeline page plan so secondary boxes
+        do not inflate pending classify work.
+        """
+        ws = self._ws_id()
+        if min_conf is None:
+            import config as cfg
+            min_conf = self.get_effective_config(cfg.load()).get(
+                "detector_confidence", 0.2,
+            )
+        scope_sql, scope_params = self._scope_clause(photo_ids)
+        row = self.conn.execute(
+            f"""WITH ranked AS (
+                    SELECT d.id, d.photo_id,
+                           ROW_NUMBER() OVER (
+                             PARTITION BY d.photo_id
+                             ORDER BY d.detector_confidence DESC, d.id ASC
+                           ) AS rn
+                      FROM detections d
+                      JOIN photos p ON p.id = d.photo_id
+                      JOIN workspace_folders wf
+                        ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                     WHERE d.detector_model != 'full-image'
+                       AND d.detector_confidence >= ?{scope_sql}
+                )
+                SELECT COUNT(*) AS primary_dets,
+                       COUNT(DISTINCT photo_id) AS photos_with_dets
+                  FROM ranked
+                 WHERE rn = 1""",
+            (ws, min_conf, *scope_params),
+        ).fetchone()
+        return {
+            "photos_with_dets": row["photos_with_dets"] or 0,
+            "total_dets": row["primary_dets"] or 0,
+        }
+
     def count_classify_pending_pairs(
         self, classifier_model, labels_fingerprint,
         photo_ids=None, min_conf=None,
@@ -3181,6 +3221,48 @@ class Database:
                   AND d.detector_confidence >= ?
                   AND cr.detection_id IS NULL{scope_sql}""",
             (ws, classifier_model, labels_fingerprint, min_conf, *scope_params),
+        ).fetchone()
+        return row["pending"] or 0
+
+    def count_primary_classify_pending_pairs(
+        self, classifier_model, labels_fingerprint,
+        photo_ids=None, min_conf=None,
+    ):
+        """Count primary detections lacking a classifier run for (model, fp).
+
+        Mirrors pipeline_job.classify_stage, which picks one primary detection
+        per photo rather than classifying every detection row.
+        """
+        ws = self._ws_id()
+        if min_conf is None:
+            import config as cfg
+            min_conf = self.get_effective_config(cfg.load()).get(
+                "detector_confidence", 0.2,
+            )
+        scope_sql, scope_params = self._scope_clause(photo_ids)
+        row = self.conn.execute(
+            f"""WITH ranked AS (
+                    SELECT d.id, d.photo_id,
+                           ROW_NUMBER() OVER (
+                             PARTITION BY d.photo_id
+                             ORDER BY d.detector_confidence DESC, d.id ASC
+                           ) AS rn
+                      FROM detections d
+                      JOIN photos p ON p.id = d.photo_id
+                      JOIN workspace_folders wf
+                        ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                     WHERE d.detector_model != 'full-image'
+                       AND d.detector_confidence >= ?{scope_sql}
+                )
+                SELECT COUNT(*) AS pending
+                  FROM ranked d
+                  LEFT JOIN classifier_runs cr
+                    ON cr.detection_id = d.id
+                   AND cr.classifier_model = ?
+                   AND cr.labels_fingerprint = ?
+                 WHERE d.rn = 1
+                   AND cr.detection_id IS NULL""",
+            (ws, min_conf, *scope_params, classifier_model, labels_fingerprint),
         ).fetchone()
         return row["pending"] or 0
 
@@ -3227,6 +3309,52 @@ class Database:
                  ){scope_sql}""",
             (ws, min_conf, classifier_model, labels_fingerprint,
              classifier_model, labels_fingerprint, *scope_params),
+        ).fetchone()
+        return row["n"] or 0
+
+    def count_primary_classify_stale(
+        self, classifier_model, labels_fingerprint,
+        photo_ids=None, min_conf=None,
+    ):
+        """Count stale classifier runs on primary detections only."""
+        ws = self._ws_id()
+        if min_conf is None:
+            import config as cfg
+            min_conf = self.get_effective_config(cfg.load()).get(
+                "detector_confidence", 0.2,
+            )
+        scope_sql, scope_params = self._scope_clause(photo_ids)
+        row = self.conn.execute(
+            f"""WITH ranked AS (
+                    SELECT d.id, d.photo_id,
+                           ROW_NUMBER() OVER (
+                             PARTITION BY d.photo_id
+                             ORDER BY d.detector_confidence DESC, d.id ASC
+                           ) AS rn
+                      FROM detections d
+                      JOIN photos p ON p.id = d.photo_id
+                      JOIN workspace_folders wf
+                        ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                     WHERE d.detector_model != 'full-image'
+                       AND d.detector_confidence >= ?{scope_sql}
+                )
+                SELECT COUNT(*) AS n
+                  FROM ranked d
+                 WHERE d.rn = 1
+                   AND EXISTS (
+                      SELECT 1 FROM classifier_runs cr_stale
+                       WHERE cr_stale.detection_id = d.id
+                         AND cr_stale.classifier_model = ?
+                         AND cr_stale.labels_fingerprint != ?
+                   )
+                   AND NOT EXISTS (
+                      SELECT 1 FROM classifier_runs cr_cur
+                       WHERE cr_cur.detection_id = d.id
+                         AND cr_cur.classifier_model = ?
+                         AND cr_cur.labels_fingerprint = ?
+                   )""",
+            (ws, min_conf, *scope_params, classifier_model, labels_fingerprint,
+             classifier_model, labels_fingerprint),
         ).fetchone()
         return row["n"] or 0
 
@@ -3418,15 +3546,19 @@ class Database:
             out[key] = (float(med), n)
         return out
 
-    def count_photos_pending_masks(self, photo_ids=None, min_conf=None):
+    def count_photos_pending_masks(self, photo_ids=None, min_conf=None,
+                                   sam2_variant=None):
         """Return (pending, eligible) for the extract-masks stage.
 
         eligible = photos in scope with at least one real detection above the
             workspace's effective detector_confidence
-        pending  = eligible photos whose mask_path IS NULL
+        pending  = eligible photos whose mask_path IS NULL, or when
+            ``sam2_variant`` is supplied, whose ``photo_masks`` row for that
+            variant is missing/incomplete
 
-        Mirrors extract_masks_stage's per-photo gate (which keys solely on
-        mask_path being unset for photos with non-full-image detections).
+        The variant-aware mode mirrors extract_masks_stage's current per-photo
+        cache check: masks made by another SAM variant do not make the selected
+        variant complete.
         """
         ws = self._ws_id()
         if min_conf is None:
@@ -3435,21 +3567,50 @@ class Database:
                 "detector_confidence", 0.2,
             )
         scope_sql, scope_params = self._scope_clause(photo_ids)
-        row = self.conn.execute(
-            f"""SELECT
-                  COUNT(DISTINCT p.id) AS eligible,
-                  COUNT(DISTINCT CASE WHEN p.mask_path IS NULL THEN p.id END)
-                    AS pending
-                FROM photos p
-                JOIN workspace_folders wf
-                  ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
-                JOIN detections d
-                  ON d.photo_id = p.id
-                 AND d.detector_model != 'full-image'
-                 AND d.detector_confidence >= ?
-                WHERE 1=1{scope_sql}""",
-            (ws, min_conf, *scope_params),
-        ).fetchone()
+        if sam2_variant:
+            row = self.conn.execute(
+                f"""SELECT
+                      COUNT(DISTINCT p.id) AS eligible,
+                      COUNT(DISTINCT CASE
+                        WHEN p.mask_path IS NULL
+                          OR (pm.photo_id IS NOT NULL AND pm.path IS NULL)
+                          OR (
+                            pm.photo_id IS NULL
+                            AND EXISTS (
+                              SELECT 1 FROM photo_masks pm_any
+                               WHERE pm_any.photo_id = p.id
+                                 AND pm_any.variant != 'unknown'
+                            )
+                          )
+                        THEN p.id END) AS pending
+                    FROM photos p
+                    JOIN workspace_folders wf
+                      ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                    JOIN detections d
+                      ON d.photo_id = p.id
+                     AND d.detector_model != 'full-image'
+                     AND d.detector_confidence >= ?
+                    LEFT JOIN photo_masks pm
+                      ON pm.photo_id = p.id AND pm.variant = ?
+                    WHERE 1=1{scope_sql}""",
+                (ws, min_conf, sam2_variant, *scope_params),
+            ).fetchone()
+        else:
+            row = self.conn.execute(
+                f"""SELECT
+                      COUNT(DISTINCT p.id) AS eligible,
+                      COUNT(DISTINCT CASE WHEN p.mask_path IS NULL THEN p.id END)
+                        AS pending
+                    FROM photos p
+                    JOIN workspace_folders wf
+                      ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                    JOIN detections d
+                      ON d.photo_id = p.id
+                     AND d.detector_model != 'full-image'
+                     AND d.detector_confidence >= ?
+                    WHERE 1=1{scope_sql}""",
+                (ws, min_conf, *scope_params),
+            ).fetchone()
         return {
             "eligible": row["eligible"] or 0,
             "pending": row["pending"] or 0,
@@ -5095,6 +5256,98 @@ class Database:
              "active_count": r["active_count"] or 0}
             for r in rows
         ]
+
+    def sam_variant_rerun_warning(
+        self,
+        sam2_variant,
+        photo_ids=None,
+        min_conf=None,
+        selected_max_ratio=0.25,
+        alternate_min_ratio=0.80,
+    ):
+        """Warn when selected SAM coverage is poor but another variant is high.
+
+        The target set matches the extract-masks stage's existing-photo
+        eligibility: active-workspace photos in scope with at least one real
+        detection above the workspace detector-confidence floor. This keeps a
+        workspace-level SAM configuration from looking empty just because a
+        different variant already produced masks for those same target photos.
+        """
+        if not sam2_variant or sam2_variant == "unknown":
+            return None
+        if min_conf is None:
+            import config as cfg
+            min_conf = self.get_effective_config(cfg.load()).get(
+                "detector_confidence", 0.2,
+            )
+
+        ws = self._ws_id()
+        scope_sql, scope_params = self._scope_clause(photo_ids)
+        target_row = self.conn.execute(
+            f"""SELECT COUNT(DISTINCT p.id) AS n
+                  FROM photos p
+                  JOIN workspace_folders wf
+                    ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                  JOIN detections d
+                    ON d.photo_id = p.id
+                   AND d.detector_model != 'full-image'
+                   AND d.detector_confidence >= ?
+                 WHERE 1=1{scope_sql}""",
+            (ws, min_conf, *scope_params),
+        ).fetchone()
+        target_count = target_row["n"] or 0
+        if target_count == 0:
+            return None
+
+        coverage_rows = self.conn.execute(
+            f"""SELECT pm.variant, COUNT(DISTINCT pm.photo_id) AS count
+                  FROM photo_masks pm
+                  JOIN photos p ON p.id = pm.photo_id
+                  JOIN workspace_folders wf
+                    ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                  JOIN detections d
+                    ON d.photo_id = p.id
+                   AND d.detector_model != 'full-image'
+                   AND d.detector_confidence >= ?
+                 WHERE pm.variant != 'unknown'{scope_sql}
+                 GROUP BY pm.variant""",
+            (ws, min_conf, *scope_params),
+        ).fetchall()
+        counts = {r["variant"]: r["count"] or 0 for r in coverage_rows}
+        selected_count = counts.get(sam2_variant, 0)
+        selected_ratio = selected_count / target_count
+        if selected_ratio > selected_max_ratio:
+            return None
+
+        alternates = [
+            (variant, count, count / target_count)
+            for variant, count in counts.items()
+            if variant != sam2_variant
+        ]
+        if not alternates:
+            return None
+        alt_variant, alt_count, alt_ratio = max(
+            alternates, key=lambda item: (item[2], item[1], item[0])
+        )
+        if alt_ratio < alternate_min_ratio:
+            return None
+
+        return {
+            "code": "sam_variant_rerun",
+            "selected_variant": sam2_variant,
+            "selected_count": selected_count,
+            "selected_ratio": selected_ratio,
+            "alternate_variant": alt_variant,
+            "alternate_count": alt_count,
+            "alternate_ratio": alt_ratio,
+            "target_count": target_count,
+            "message": (
+                f"{sam2_variant} has masks for {selected_count} of "
+                f"{target_count} target photos, while {alt_variant} already "
+                f"has masks for {alt_count}. Starting will rerun SAM for the "
+                f"selected variant."
+            ),
+        }
 
     def mask_variants_summary(self):
         """Per-variant summary: count, total bytes (best-effort, sums

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -566,6 +566,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     runner, job["id"], stages, "scan", message,
                 )
 
+            def cancel_check():
+                return _should_abort(abort) or runner.is_cancelled(job["id"])
+
             # Accumulator so multi-folder scans (repair loop, scan-in-place
             # with sources=[...]) don't rewind the overall progress at each
             # folder boundary. scan() reports (current, total) local to the
@@ -675,14 +678,30 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             restrict_files=set(file_paths),
                             vireo_dir=effective_vireo_dir,
                             thumb_cache_dir=effective_thumb_cache_dir,
+                            cancel_check=cancel_check,
                         )
                     except (OSError, RuntimeError) as e:
+                        if str(e) == "scan cancelled" and (
+                            _should_abort(abort) or runner.is_cancelled(job["id"])
+                        ):
+                            abort.set()
+                            stages["scan"]["status"] = "skipped"
+                            runner.update_step(
+                                job["id"], "scan",
+                                status="completed",
+                                summary="Cancelled",
+                            )
+                            break
                         log.warning(
                             "Repair scan failed for %s: %s", folder_path, e,
                         )
                         unreachable += 1
                     finally:
                         advance_scan_acc()
+
+                if _should_abort(abort) or runner.is_cancelled(job["id"]):
+                    scan_to_thumb.put(_SENTINEL)
+                    return
 
                 summary = f"{total_broken} photos repaired"
                 if unreachable:
@@ -848,6 +867,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     vireo_dir=effective_vireo_dir,
                     thumb_cache_dir=effective_thumb_cache_dir,
                     permission_error_callback=_on_denied,
+                    cancel_check=cancel_check,
                 )
             else:
                 # Scan-in-place: scan each source folder independently.
@@ -884,18 +904,34 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             vireo_dir=effective_vireo_dir,
                             thumb_cache_dir=effective_thumb_cache_dir,
                             permission_error_callback=_on_denied,
+                            cancel_check=cancel_check,
                         )
                     finally:
                         advance_scan_acc()
-            stages["scan"]["status"] = "completed"
-            runner.update_step(job["id"], "scan", status="completed",
-                               summary=f"{stages['scan']['count']} photos")
+            if _should_abort(abort) or runner.is_cancelled(job["id"]):
+                stages["scan"]["status"] = "skipped"
+                runner.update_step(
+                    job["id"], "scan", status="completed", summary="Cancelled",
+                )
+            else:
+                stages["scan"]["status"] = "completed"
+                runner.update_step(job["id"], "scan", status="completed",
+                                   summary=f"{stages['scan']['count']} photos")
         except Exception as e:
-            errors.append(f"[scan] Fatal: {e}")
-            log.exception("Pipeline scan stage failed")
-            abort.set()
-            stages["scan"]["status"] = "failed"
-            runner.update_step(job["id"], "scan", status="failed", error=str(e))
+            if str(e) == "scan cancelled" and (
+                _should_abort(abort) or runner.is_cancelled(job["id"])
+            ):
+                abort.set()
+                stages["scan"]["status"] = "skipped"
+                runner.update_step(
+                    job["id"], "scan", status="completed", summary="Cancelled",
+                )
+            else:
+                errors.append(f"[scan] Fatal: {e}")
+                log.exception("Pipeline scan stage failed")
+                abort.set()
+                stages["scan"]["status"] = "failed"
+                runner.update_step(job["id"], "scan", status="failed", error=str(e))
         finally:
             # Invalidate the new-images cache for every root fed to do_scan,
             # on both success and exception paths. scanner.scan commits photo
@@ -926,7 +962,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         # Wait for scanner to complete (don't check abort -- we want the
         # collection regardless so the user can see scanned photos)
         while True:
-            if stages["scan"]["status"] in ("completed", "failed"):
+            if stages["scan"]["status"] in ("completed", "failed", "skipped"):
                 break
             time.sleep(0.1)
 
@@ -2454,9 +2490,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
             effective_cfg = thread_db.get_effective_config(cfg.load())
             pipeline_cfg = effective_cfg.get("pipeline", {})
-            sam2_variant = pipeline_cfg.get("sam2_variant", "sam2-small")
-            dinov2_variant = pipeline_cfg.get("dinov2_variant", "vit-b14")
-            proxy_longest_edge = pipeline_cfg.get("proxy_longest_edge", 1536)
+            sam2_variant = pipeline_cfg.get("sam2_variant")
+            dinov2_variant = pipeline_cfg.get("dinov2_variant")
+            proxy_longest_edge = pipeline_cfg.get("proxy_longest_edge")
 
             masks_dir = os.path.join(os.path.dirname(db_path), "masks")
             os.makedirs(masks_dir, exist_ok=True)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -700,6 +700,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         advance_scan_acc()
 
                 if _should_abort(abort) or runner.is_cancelled(job["id"]):
+                    stages["scan"]["status"] = "skipped"
+                    runner.update_step(
+                        job["id"], "scan",
+                        status="completed",
+                        summary="Cancelled",
+                    )
                     scan_to_thumb.put(_SENTINEL)
                     return
 

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -409,12 +409,10 @@ def _extract_plan(db, params, photo_ids, pipeline_cfg, new_count=0):
     # Roll them into ``pending`` so the UI's pill text ("N to redo") and
     # progress bar (`(eligible - pending) / eligible`) reflect the actual
     # work — otherwise stale-only states render as "0 to redo" + 100% bar.
-    # The two sets are disjoint by construction: pending requires
-    # ``mask_path IS NULL`` while ``count_extract_stale`` requires
-    # ``mask_path IS NOT NULL``. Without that gate, a photo in an
-    # interrupted state (photo_masks row inserted but mask_path not
-    # yet updated) would land in both buckets and inflate work past
-    # eligible.
+    # The two sets are disjoint by construction: pending includes missing or
+    # incomplete selected-variant rows, while ``count_extract_stale`` requires
+    # a complete active row. Without those gates, interrupted rows would land
+    # in both buckets and inflate work past eligible.
     work = pending + stale
     if new_count > 0:
         # Up-to-N new imports will need masks once classify produces

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -103,7 +103,7 @@ def _resolve_labels_for_models(models, labels_files, db):
     job would write. Returns: model_id -> {fingerprint, n, blocked?}.
     """
     from labels import get_active_labels, get_saved_labels, load_merged_labels
-    from labels_fingerprint import LEGACY_SENTINEL, TOL_SENTINEL, compute_fingerprint
+    from labels_fingerprint import TOL_SENTINEL, compute_fingerprint
 
     saved_by_file = {s["labels_file"]: s for s in get_saved_labels()}
 
@@ -136,7 +136,10 @@ def _resolve_labels_for_models(models, labels_files, db):
     out = {}
     for m in models:
         if m["model_type"] == "timm":
-            out[m["id"]] = {"fingerprint": LEGACY_SENTINEL, "n": 0}
+            # timm models have an intrinsic, fixed class head. The runtime
+            # computes the same sentinel by calling compute_fingerprint(None),
+            # and the inventory page keys intrinsic timm coverage this way too.
+            out[m["id"]] = {"fingerprint": TOL_SENTINEL, "n": 0}
         elif not labels:
             if m["model_str"] in tol_supported:
                 out[m["id"]] = {"fingerprint": TOL_SENTINEL, "n": 0}
@@ -174,7 +177,7 @@ def _classify_plan(db, params, photo_ids, new_count=0):
 
     label_resolution = _resolve_labels_for_models(models, params.labels_files, db)
 
-    det_counts = db.count_real_detections_in_scope(photo_ids)
+    det_counts = db.count_primary_detections_in_scope(photo_ids)
     total_dets = det_counts["total_dets"]
     photos_with_dets = det_counts["photos_with_dets"]
 
@@ -190,7 +193,7 @@ def _classify_plan(db, params, photo_ids, new_count=0):
             if info.get("blocked"):
                 continue
             fp = info["fingerprint"]
-            stale_total += db.count_classify_stale(
+            stale_total += db.count_primary_classify_stale(
                 classifier_model=m["name"],
                 labels_fingerprint=fp,
                 photo_ids=photo_ids,
@@ -236,7 +239,7 @@ def _classify_plan(db, params, photo_ids, new_count=0):
         if params.reclassify:
             pending = total_dets
         else:
-            pending = db.count_classify_pending_pairs(
+            pending = db.count_primary_classify_pending_pairs(
                 classifier_model=m["name"],
                 labels_fingerprint=fp,
                 photo_ids=photo_ids,
@@ -353,11 +356,14 @@ def _extract_plan(db, params, photo_ids, pipeline_cfg, new_count=0):
             "state": "will-skip",
             "summary": "Disabled — stage will be skipped",
         }
-    counts = db.count_photos_pending_masks(photo_ids)
+    sam2_variant = pipeline_cfg.get("sam2_variant")
+    counts = db.count_photos_pending_masks(
+        photo_ids, sam2_variant=sam2_variant,
+    )
     eligible = counts["eligible"]
     pending = counts["pending"]
-    sam2_variant = pipeline_cfg.get("sam2_variant", "sam2-small")
     stale = db.count_extract_stale(sam2_variant, photo_ids)
+    sam_warning = db.sam_variant_rerun_warning(sam2_variant, photo_ids)
     if eligible == 0:
         # Without imports: classify hasn't run yet, no photos eligible —
         # the pill renders "Will run" with no count, which is honest.
@@ -430,6 +436,8 @@ def _extract_plan(db, params, photo_ids, pipeline_cfg, new_count=0):
         "stale": stale,
         "fingerprint_outdated": stale > 0,
     }
+    if sam_warning:
+        detail["sam_variant_warning"] = sam_warning
     if new_count > 0:
         detail["new_photos"] = new_count
     return {

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -9,7 +9,7 @@ import multiprocessing
 import os
 import sys
 from collections import defaultdict, deque
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, TimeoutError
 from datetime import datetime
 from pathlib import Path
 
@@ -1152,12 +1152,21 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     def _iter_features():
         if workers > 1:
             mp_ctx = multiprocessing.get_context(_SCAN_MP_METHOD)
-            with ProcessPoolExecutor(max_workers=workers, mp_context=mp_ctx) as pool:
+            pool = ProcessPoolExecutor(max_workers=workers, mp_context=mp_ctx)
+            try:
                 # Bounded in-flight window instead of pool.map(): on Python
                 # 3.11 Executor.map eagerly submits every input, so on a
                 # 200k-file scan we would hold 200k queued futures in RAM.
                 # A few submissions per worker is enough to keep them fed
                 # while the main thread drains results in order.
+                def _feature_result(fut):
+                    while True:
+                        _check_cancelled()
+                        try:
+                            return fut.result(timeout=0.2)
+                        except TimeoutError:
+                            continue
+
                 max_in_flight = workers * 4
                 pending = deque()
                 inputs = zip(files_to_process, paths_to_extract, strict=True)
@@ -1167,11 +1176,16 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     if len(pending) >= max_in_flight:
                         done_path, done_fut = pending.popleft()
                         _check_cancelled()
-                        yield done_path, done_fut.result()
+                        yield done_path, _feature_result(done_fut)
                 while pending:
                     done_path, done_fut = pending.popleft()
                     _check_cancelled()
-                    yield done_path, done_fut.result()
+                    yield done_path, _feature_result(done_fut)
+            except BaseException:
+                pool.shutdown(wait=False, cancel_futures=True)
+                raise
+            else:
+                pool.shutdown(wait=True)
         else:
             for image_path, path_str in zip(files_to_process, paths_to_extract, strict=True):
                 _check_cancelled()

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -773,7 +773,7 @@ def backfill_working_copies(db, vireo_dir, progress_callback=None,
     }
 
 
-def scan(root, db, progress_callback=None, incremental=False, extract_full_metadata=True, photo_callback=None, skip_paths=None, status_callback=None, recursive=True, restrict_dirs=None, restrict_files=None, vireo_dir=None, thumb_cache_dir=None, permission_error_callback=None):
+def scan(root, db, progress_callback=None, incremental=False, extract_full_metadata=True, photo_callback=None, skip_paths=None, status_callback=None, recursive=True, restrict_dirs=None, restrict_files=None, vireo_dir=None, thumb_cache_dir=None, permission_error_callback=None, cancel_check=None):
     """Walk a folder tree, discover photos, read metadata, populate database.
 
     Args:
@@ -812,14 +812,22 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             continues; accessible siblings are still discovered. Without
             this hook, a denied subdir would silently produce zero hits
             — a "Found 0 images" black box from the user's perspective.
+        cancel_check: optional callable returning truthy when the caller
+            wants scanning to stop promptly. When set, scan raises
+            RuntimeError("scan cancelled") at cancellation checkpoints.
     """
     root_path = Path(root)
     if not root_path.is_dir():
         log.warning("Root path does not exist or is not a directory: %s", root)
         return
 
+    def _check_cancelled():
+        if cancel_check is not None and cancel_check():
+            raise RuntimeError("scan cancelled")
+
     # Discover all image files (incremental enumeration for progress reporting)
     log.info("Discovering files in %s ...", root)
+    _check_cancelled()
     if status_callback:
         status_callback("Discovering files...")
     image_files = []
@@ -864,6 +872,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         # root is still used as the folder hierarchy root for _ensure_folder.
         restrict_files_set = set(restrict_files) if restrict_files is not None else None
         for d in restrict_dirs:
+            _check_cancelled()
             dp = Path(d)
             if dp.is_dir():
                 # iterdir() raises PermissionError when the kernel refuses
@@ -882,6 +891,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     _on_walk_error(e)
                     continue
                 for f in entries:
+                    _check_cancelled()
                     if (f.is_file()
                             and f.suffix.lower() in SUPPORTED_EXTENSIONS
                             and not f.name.startswith(".")
@@ -895,8 +905,11 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             for dirpath, _dirnames, filenames in os.walk(
                 str(root_path), onerror=_on_walk_error,
             ):
+                _check_cancelled()
                 for name in filenames:
                     checked += 1
+                    if checked % 100 == 0:
+                        _check_cancelled()
                     if checked % 500 == 0 and status_callback:
                         status_callback(
                             f"Discovering files... ({len(image_files)} found)"
@@ -924,6 +937,8 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 _on_walk_error(e)
                 entries = []
             for checked, f in enumerate(entries, 1):
+                if checked % 100 == 0:
+                    _check_cancelled()
                 if checked % 500 == 0 and status_callback:
                     status_callback(
                         f"Discovering files... ({len(image_files)} found)"
@@ -934,6 +949,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                         and (skip_paths is None or str(f) not in skip_paths)):
                     image_files.append(f)
     image_files.sort()
+    _check_cancelled()
 
     total = len(image_files)
     log.info("Found %d images in %s", total, root)
@@ -1044,6 +1060,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     _ensure_folder(dp)
 
         for image_path in image_files:
+            _check_cancelled()
             stat = image_path.stat()
             file_mtime = stat.st_mtime
             xmp_path = image_path.with_suffix(".xmp")
@@ -1117,7 +1134,9 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     paths_to_extract = [str(ip) for ip in files_to_process]
     if paths_to_extract and status_callback:
         status_callback(f"Extracting metadata ({len(paths_to_extract)} files)...")
+    _check_cancelled()
     metadata_map = extract_metadata(paths_to_extract) if paths_to_extract else {}
+    _check_cancelled()
 
     # Compute phash + file_hash in parallel across all files that need
     # processing. These are the two per-file operations that actually read
@@ -1143,19 +1162,24 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 pending = deque()
                 inputs = zip(files_to_process, paths_to_extract, strict=True)
                 for image_path, path_str in inputs:
+                    _check_cancelled()
                     pending.append((image_path, pool.submit(_compute_file_features, path_str)))
                     if len(pending) >= max_in_flight:
                         done_path, done_fut = pending.popleft()
+                        _check_cancelled()
                         yield done_path, done_fut.result()
                 while pending:
                     done_path, done_fut = pending.popleft()
+                    _check_cancelled()
                     yield done_path, done_fut.result()
         else:
             for image_path, path_str in zip(files_to_process, paths_to_extract, strict=True):
+                _check_cancelled()
                 yield image_path, _compute_file_features(path_str)
 
     try:
         for image_path, (phash, file_hash) in _iter_features():
+            _check_cancelled()
             folder_id = _ensure_folder(image_path.parent)
             touched_folder_ids.add(folder_id)
 
@@ -1387,6 +1411,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 progress_callback=None,
                 status_callback=status_callback,
                 scope=wc_scope,
+                cancel_check=cancel_check,
             )
 
         # Batched untracked-preview sweep. One os.listdir(previews/) for

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2926,6 +2926,7 @@ function _waitForPipelineTerminal(jobId, resolve) {
     actionStatus.textContent = 'Connection lost while cancelling. Checking job status...';
   }
   var attempts = 0;
+  var statusFailures = 0;
   var terminalStatuses = {completed: true, failed: true, cancelled: true};
   var timer = setInterval(function() {
     attempts += 1;
@@ -2935,6 +2936,7 @@ function _waitForPipelineTerminal(jobId, resolve) {
         return resp.json();
       })
       .then(function(job) {
+        statusFailures = 0;
         if (!terminalStatuses[job.status]) {
           if (attempts === 120 && actionStatus) {
             actionStatus.textContent = 'Still cancelling. Waiting for pipeline job to stop...';
@@ -2951,11 +2953,10 @@ function _waitForPipelineTerminal(jobId, resolve) {
         resolve();
       })
       .catch(function() {
-        if (attempts < 10) return;
-        clearInterval(timer);
-        _pipelineResolve = null;
-        document.getElementById('statusSource').textContent = 'Connection lost';
-        resolve();
+        statusFailures += 1;
+        if (statusFailures === 10 && actionStatus) {
+          actionStatus.textContent = 'Still cancelling. Job status is temporarily unavailable...';
+        }
       });
   }, 1000);
 }

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1100,6 +1100,7 @@ body { padding-bottom: 36px; }
       Start Pipeline
     </button>
   </div>
+  <div id="pipelineActionStatus" class="status-msg" style="margin-top:8px;"></div>
   <div id="modelWarningBanner" style="display:none;background:var(--warning,#f0c040);color:#000;padding:8px 14px;border-radius:6px;margin:8px 0;font-size:13px;">
     <span id="modelWarningText"></span>
     <button onclick="this.parentElement.style.display='none'" style="float:right;background:none;border:none;cursor:pointer;font-size:16px;line-height:1;padding:0 4px;">&times;</button>
@@ -1172,6 +1173,9 @@ function initPipelinePage() {
       if (typeof updateExtractReadiness === 'function') updateExtractReadiness();
       if (typeof renderSam2Coverage === 'function') {
         renderSam2Coverage(data.mask_variant_coverage || []);
+      }
+      if (typeof updateSamVariantWarning === 'function') {
+        updateSamVariantWarning(data.sam_variant_warning || null);
       }
 
       // Populate recent destinations
@@ -2207,7 +2211,21 @@ function getIngestFileTypes() {
 
 function updateStartButton() {
   var btn = document.getElementById('btnStartPipeline');
-  if (_pipelineRunning) { btn.disabled = true; return; }
+  var actionStatus = document.getElementById('pipelineActionStatus');
+  if (_pipelineRunning) {
+    if (actionStatus) {
+      actionStatus.textContent = _pipelineCancelling
+        ? 'Cancelling the running pipeline. Start will be available after the job stops.'
+        : 'A pipeline is running. Stop it or wait for it to finish before starting another.';
+      actionStatus.className = 'status-msg';
+    }
+    btn.disabled = !!_pipelineCancelling;
+    return;
+  }
+  if (actionStatus) {
+    actionStatus.textContent = '';
+    actionStatus.className = 'status-msg';
+  }
 
   if (_sourceMode === 'import') {
     var hasFolders = _sourceFolders.length > 0;
@@ -2308,13 +2326,17 @@ function onStageToggle(stage) {
 // -- Pipeline orchestration --
 var _pipelineRunning = false;
 var _pipelineAbort = false;
+var _pipelineCancelling = false;
 var _pipelineEventSource = null;
 var _pipelineResolve = null;
+var _currentPipelineJobId = null;
 
 async function startPipeline() {
   if (_pipelineRunning) return;
   _pipelineRunning = true;
   _pipelineAbort = false;
+  _pipelineCancelling = false;
+  _currentPipelineJobId = null;
   document.getElementById('modelWarningBanner').style.display = 'none';
 
   // Create new workspace if requested
@@ -2324,6 +2346,7 @@ async function startPipeline() {
       document.getElementById('destWsError').textContent = 'Name is required';
       document.getElementById('destWsError').style.display = '';
       _pipelineRunning = false;
+      _pipelineCancelling = false;
       return;
     }
     try {
@@ -2346,6 +2369,7 @@ async function startPipeline() {
       document.getElementById('destWsError').textContent = e.message || 'Failed to create workspace';
       document.getElementById('destWsError').style.display = '';
       _pipelineRunning = false;
+      _pipelineCancelling = false;
       return;
     }
   }
@@ -2467,10 +2491,16 @@ async function startPipeline() {
       document.getElementById('statusSource').textContent = (data && data.error) || 'Failed to start pipeline';
       return;
     }
+    _currentPipelineJobId = data.job_id;
+    if (_pipelineCancelling) {
+      _pipelineCancelling = false;
+      stopPipeline();
+    }
 
     // Show model warning banner if returned
     if (data.model_warning) {
       var banner = document.getElementById('modelWarningBanner');
+      banner.dataset.kind = 'model';
       document.getElementById('modelWarningText').textContent = data.model_warning;
       banner.style.display = '';
     }
@@ -2482,16 +2512,21 @@ async function startPipeline() {
       _pipelineResolve = resolve;
       _pipelineEventSource = safeEventSource('/api/jobs/' + data.job_id + '/stream', {
         onProgress: function(p) {
-          if (_pipelineAbort) return;
           _updatePipelineStageUI(p);
         },
         onComplete: function(result) {
           _pipelineResolve = null;
+          _pipelineEventSource = null;
           window.dispatchEvent(new CustomEvent('vireo-job-done', {detail: {job_id: data.job_id}}));
           _onPipelineComplete(result);
           resolve();
         },
         onError: function() {
+          _pipelineEventSource = null;
+          if (_pipelineCancelling) {
+            _waitForPipelineTerminal(data.job_id, resolve);
+            return;
+          }
           _pipelineResolve = null;
           document.getElementById('statusSource').textContent = 'Connection lost';
           resolve();
@@ -2502,6 +2537,9 @@ async function startPipeline() {
     document.getElementById('statusSource').textContent = 'Error: ' + e.message;
   } finally {
     _pipelineRunning = false;
+    _pipelineCancelling = false;
+    _pipelineAbort = false;
+    _currentPipelineJobId = null;
     btn.textContent = 'Start Pipeline';
     btn.onclick = startPipeline;
     updateStartButton();
@@ -2730,6 +2768,23 @@ function _updatePipelineStageUI(p) {
 }
 
 function _onPipelineComplete(result) {
+  if (result.status === 'cancelled') {
+    var actionStatus = document.getElementById('pipelineActionStatus');
+    if (actionStatus) {
+      actionStatus.textContent = 'Pipeline cancelled.';
+      actionStatus.className = 'status-msg';
+    }
+    ['Source', 'Scan', 'Previews', 'Classify', 'Extract', 'EyeKeypoints', 'Group'].forEach(function(cardSuffix) {
+      if (_runningStages[cardSuffix]) {
+        delete _runningStages[cardSuffix];
+        _stageOutcomes[cardSuffix] = 'will-skip';
+        _setPill(cardSuffix, 'will-skip', 'Cancelled');
+      }
+    });
+    refreshPipelineUI();
+    return;
+  }
+
   var succeeded = (result.status === 'completed');
   var r = result.result || {};
   var stageResults = r.stages || {};
@@ -2865,20 +2920,79 @@ function _onPipelineComplete(result) {
   }
 }
 
-function stopPipeline() {
+function _waitForPipelineTerminal(jobId, resolve) {
+  var actionStatus = document.getElementById('pipelineActionStatus');
+  if (actionStatus) {
+    actionStatus.textContent = 'Connection lost while cancelling. Checking job status...';
+  }
+  var attempts = 0;
+  var timer = setInterval(function() {
+    attempts += 1;
+    fetch('/api/jobs/' + encodeURIComponent(jobId))
+      .then(function(resp) {
+        if (!resp.ok) throw new Error('job status unavailable');
+        return resp.json();
+      })
+      .then(function(job) {
+        if (job.status === 'running' && attempts < 120) return;
+        clearInterval(timer);
+        _pipelineResolve = null;
+        _onPipelineComplete({
+          status: job.status,
+          result: job.result,
+          errors: job.errors || [],
+        });
+        resolve();
+      })
+      .catch(function() {
+        if (attempts < 10) return;
+        clearInterval(timer);
+        _pipelineResolve = null;
+        document.getElementById('statusSource').textContent = 'Connection lost';
+        resolve();
+      });
+  }, 1000);
+}
+
+async function stopPipeline() {
+  if (_pipelineCancelling) return;
   _pipelineAbort = true;
-  if (_pipelineEventSource) {
-    _pipelineEventSource.close();
-    _pipelineEventSource = null;
-  }
-  // Resolve the pending stream promise so the finally block runs
-  if (_pipelineResolve) {
-    _pipelineResolve();
-    _pipelineResolve = null;
-  }
+  _pipelineCancelling = true;
   var btn = document.getElementById('btnStartPipeline');
   btn.disabled = true;
-  btn.textContent = 'Stopping...';
+  btn.textContent = 'Cancelling...';
+  var actionStatus = document.getElementById('pipelineActionStatus');
+  if (actionStatus) {
+    actionStatus.textContent = 'Sending cancellation request...';
+    actionStatus.className = 'status-msg';
+  }
+  if (!_currentPipelineJobId) {
+    if (actionStatus) actionStatus.textContent = 'Waiting for pipeline job id before cancelling...';
+    return;
+  }
+  try {
+    var resp = await fetch('/api/jobs/' + encodeURIComponent(_currentPipelineJobId) + '/cancel', {
+      method: 'POST',
+    });
+    if (!resp.ok) {
+      var data = {};
+      try { data = await resp.json(); } catch(e) {}
+      throw new Error((data && data.error) || 'Unable to cancel pipeline');
+    }
+    btn.textContent = 'Stopping...';
+    if (actionStatus) {
+      actionStatus.textContent = 'Cancellation requested. Waiting for the running stage to stop...';
+    }
+  } catch(e) {
+    _pipelineAbort = false;
+    _pipelineCancelling = false;
+    btn.disabled = false;
+    btn.textContent = 'Stop Pipeline';
+    if (actionStatus) {
+      actionStatus.textContent = e.message || 'Unable to cancel pipeline';
+      actionStatus.className = 'status-msg error';
+    }
+  }
 }
 
 async function runImportStep() {
@@ -3259,11 +3373,35 @@ async function runClassifyStep(collectionId) {
 
 // -- Card 3: Extract Features --
 
-var _savedModelConfig = {
-  sam2_variant: 'sam2-small',
-  dinov2_variant: 'vit-b14',
-  proxy_longest_edge: 1536,
-};
+function _currentModelConfigFromDom() {
+  var samEl = document.getElementById('cfgSam2');
+  var dinoEl = document.getElementById('cfgDinov2');
+  var proxyEl = document.getElementById('cfgProxy');
+  return {
+    sam2_variant: samEl ? samEl.value : '',
+    dinov2_variant: dinoEl ? dinoEl.value : '',
+    proxy_longest_edge: proxyEl ? parseInt(proxyEl.value, 10) : 0,
+  };
+}
+
+var _savedModelConfig = _currentModelConfigFromDom();
+var _samVariantWarning = null;
+
+function updateSamVariantWarning(warning) {
+  _samVariantWarning = warning || null;
+  var banner = document.getElementById('modelWarningBanner');
+  var text = document.getElementById('modelWarningText');
+  if (!banner || !text) return;
+  if (_samVariantWarning && _samVariantWarning.message) {
+    banner.dataset.kind = 'sam-variant';
+    text.textContent = _samVariantWarning.message;
+    banner.style.display = '';
+  } else if (banner.dataset.kind === 'sam-variant') {
+    text.textContent = '';
+    banner.style.display = 'none';
+    delete banner.dataset.kind;
+  }
+}
 
 function onModelConfigChange() {
   var proxyEl = document.getElementById('cfgProxy');
@@ -3288,6 +3426,7 @@ function onModelConfigChange() {
   }).catch(function() {});
 
   updateExtractReadiness();
+  schedulePlanRefresh();
 }
 
 async function updateExtractReadiness() {
@@ -3306,6 +3445,14 @@ async function updateExtractReadiness() {
     panel.appendChild(renderModelReadiness('SAM2', r.sam2, r.sam2_known));
     panel.appendChild(document.createElement('br'));
     panel.appendChild(renderModelReadiness('DINOv2', r.dinov2, r.dinov2_known));
+    if (r.sam_variant_warning && r.sam_variant_warning.message) {
+      panel.appendChild(document.createElement('br'));
+      var warn = document.createElement('div');
+      warn.style.cssText = 'margin-top:6px;color:var(--warning,#f0c040);';
+      warn.textContent = r.sam_variant_warning.message;
+      panel.appendChild(warn);
+    }
+    updateSamVariantWarning(r.sam_variant_warning || null);
     panel.style.display = '';
   } catch(e) {
     panel.style.display = 'none';
@@ -3892,9 +4039,14 @@ async function refreshPipelinePlan() {
     // back to stale state right after the user changed a setting.
     if (seq !== _planFetchSeq) return;
     _pipelinePlan = data;
+    var extract = data && data.stages ? data.stages.Extract : null;
+    var warning = extract && extract.detail
+      ? extract.detail.sam_variant_warning : null;
+    updateSamVariantWarning(warning || null);
   } catch(e) {
     if (seq !== _planFetchSeq) return;
     _pipelinePlan = null;
+    updateSamVariantWarning(null);
   }
   refreshPipelineUI();
 }

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2926,6 +2926,7 @@ function _waitForPipelineTerminal(jobId, resolve) {
     actionStatus.textContent = 'Connection lost while cancelling. Checking job status...';
   }
   var attempts = 0;
+  var terminalStatuses = {completed: true, failed: true, cancelled: true};
   var timer = setInterval(function() {
     attempts += 1;
     fetch('/api/jobs/' + encodeURIComponent(jobId))
@@ -2934,7 +2935,12 @@ function _waitForPipelineTerminal(jobId, resolve) {
         return resp.json();
       })
       .then(function(job) {
-        if (job.status === 'running' && attempts < 120) return;
+        if (!terminalStatuses[job.status]) {
+          if (attempts === 120 && actionStatus) {
+            actionStatus.textContent = 'Still cancelling. Waiting for pipeline job to stop...';
+          }
+          return;
+        }
         clearInterval(timer);
         _pipelineResolve = null;
         _onPipelineComplete({

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2927,6 +2927,7 @@ function _waitForPipelineTerminal(jobId, resolve) {
   }
   var attempts = 0;
   var statusFailures = 0;
+  var maxStatusFailures = 300;
   var terminalStatuses = {completed: true, failed: true, cancelled: true};
   var timer = setInterval(function() {
     attempts += 1;
@@ -2956,6 +2957,16 @@ function _waitForPipelineTerminal(jobId, resolve) {
         statusFailures += 1;
         if (statusFailures === 10 && actionStatus) {
           actionStatus.textContent = 'Still cancelling. Job status is temporarily unavailable...';
+        }
+        if (statusFailures >= maxStatusFailures) {
+          clearInterval(timer);
+          _pipelineResolve = null;
+          _onPipelineComplete({
+            status: 'cancelled',
+            result: {cancelled: true},
+            errors: ['Cancellation status stayed unavailable after repeated retries.'],
+          });
+          resolve();
         }
       });
   }, 1000);

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -79,6 +79,9 @@ def test_pipeline_defaults_exist():
     assert p["reject_composite"] == 0.40
     assert p["hard_cut_score"] == 0.42
     assert p["merge_score"] == 0.62
+    assert p["sam2_variant"] == "sam2-small"
+    assert p["dinov2_variant"] == "vit-b14"
+    assert p["proxy_longest_edge"] == 1536
 
 
 def test_ingest_defaults_present():

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -705,6 +705,33 @@ def _seed_workspace_with_masks(db_path):
     return p1, p2
 
 
+def _seed_workspace_with_large_only_masks(db_path):
+    from db import Database
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.add_folder("/photos/large-only", name="large-only")
+    db.add_workspace_folder(ws_id, fid)
+    photo_ids = []
+    for name in ("a.jpg", "b.jpg"):
+        pid = db.add_photo(folder_id=fid, filename=name, extension=".jpg",
+                           file_size=1, file_mtime=1.0)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="megadetector-v6",
+        )
+        db.upsert_photo_mask(
+            pid, "sam2-large", f"/m/{pid}.large.png",
+            detector_model="megadetector-v6",
+            prompt_x=0.1, prompt_y=0.1, prompt_w=0.5, prompt_h=0.5,
+        )
+        db.set_active_mask_variant(pid, "sam2-large")
+        photo_ids.append(pid)
+    db.close()
+    return photo_ids
+
+
 def test_pipeline_page_init_includes_mask_variant_coverage(setup):
     """page-init exposes mask_variant_coverage so the SAM2 dropdown card
     can render per-variant counts and an active-variant selector."""
@@ -721,6 +748,33 @@ def test_pipeline_page_init_includes_mask_variant_coverage(setup):
         assert cov["sam2-small"]["active_count"] == 2
         assert cov["sam2-large"]["count"] == 1
         assert cov["sam2-large"]["active_count"] == 0
+
+
+def test_pipeline_page_init_warns_when_selected_sam_has_poor_coverage(setup):
+    app, db_path = setup
+    _seed_workspace_with_large_only_masks(db_path)
+
+    with app.test_client() as c:
+        resp = c.get("/api/pipeline/page-init")
+        assert resp.status_code == 200
+        warning = resp.get_json()["sam_variant_warning"]
+        assert warning["selected_variant"] == "sam2-small"
+        assert warning["alternate_variant"] == "sam2-large"
+        assert warning["target_count"] == 2
+        assert "Starting will rerun SAM" in warning["message"]
+
+
+def test_extract_readiness_includes_sam_variant_coverage_warning(setup, tmp_path, monkeypatch):
+    app, db_path = setup
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _seed_workspace_with_large_only_masks(db_path)
+
+    with app.test_client() as c:
+        resp = c.get("/api/pipeline/extract-readiness?sam2_variant=sam2-small")
+        assert resp.status_code == 200
+        warning = resp.get_json()["sam_variant_warning"]
+        assert warning["selected_variant"] == "sam2-small"
+        assert warning["alternate_count"] == 2
 
 
 def test_pipeline_page_init_includes_review_readiness(setup):

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -600,6 +600,40 @@ def test_count_extract_stale_excludes_photos_with_null_mask_path(tmp_path):
     assert db.count_extract_stale("sam2-small") == 0
 
 
+def test_count_extract_stale_excludes_incomplete_variant_paths(tmp_path):
+    """Incomplete selected-variant rows are pending, not stale.
+
+    A migrated/interrupted row can have ``photos.mask_path`` set but no
+    selected-variant row, or an empty ``photo_masks.path`` for the configured
+    variant. The planner counts those as pending, so stale must not count
+    them again.
+    """
+    db, folder_id = _make_db(tmp_path)
+    pid_missing, _ = _add_photo_with_detection(db, folder_id, "missing-row.jpg")
+    pid_empty, _ = _add_photo_with_detection(db, folder_id, "empty-path.jpg")
+    db.conn.execute(
+        "UPDATE photos SET mask_path='/m/missing-row.png' WHERE id=?",
+        (pid_missing,),
+    )
+    db.conn.execute(
+        "UPDATE photos SET mask_path='/m/empty-path.png' WHERE id=?",
+        (pid_empty,),
+    )
+    db.conn.execute(
+        "INSERT INTO photo_masks(photo_id, variant, path, created_at, "
+        "detector_model, prompt_x, prompt_y, prompt_w, prompt_h) "
+        "VALUES (?, 'sam2-small', '', 0, 'megadetector-v6', "
+        "0.9, 0.9, 0.05, 0.05)",
+        (pid_empty,),
+    )
+    db.conn.commit()
+
+    counts = db.count_photos_pending_masks(sam2_variant="sam2-small")
+    assert counts["eligible"] == 2
+    assert counts["pending"] == 2
+    assert db.count_extract_stale("sam2-small") == 0
+
+
 def test_count_extract_stale_ignores_photos_without_primary_detection(tmp_path):
     """Photos with only ``full-image`` detections aren't eligible for
     extract — a stale ``photo_masks`` row left over from a prior detector

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -320,6 +320,38 @@ def test_extract_plan_warns_when_other_sam_variant_has_coverage(tmp_path):
     assert warning["target_count"] == 2
 
 
+def test_extract_plan_variant_warning_ignores_incomplete_masks(tmp_path):
+    from pipeline_plan import PipelinePlanParams, compute_plan
+
+    db, folder_id = _make_db(tmp_path)
+    p1, _ = _add_photo_with_detection(db, folder_id, "interrupted.jpg")
+    p2, _ = _add_photo_with_detection(db, folder_id, "missing_path.jpg")
+    # p1 simulates an interrupted run: the variant row exists, but
+    # photos.mask_path was never activated.
+    db.conn.execute(
+        "INSERT INTO photo_masks(photo_id, variant, path, created_at, "
+        "detector_model, prompt_x, prompt_y, prompt_w, prompt_h) "
+        "VALUES (?, 'sam2-large', '/m/interrupted.png', 0, "
+        "'megadetector-v6', 0.1, 0.1, 0.5, 0.5)",
+        (p1,),
+    )
+    # p2 has an active-looking photo row, but the per-variant row has no
+    # file path, so it should not count as alternate variant coverage.
+    db.conn.execute("UPDATE photos SET mask_path='/m/missing.png' WHERE id=?", (p2,))
+    db.conn.execute(
+        "INSERT INTO photo_masks(photo_id, variant, path, created_at, "
+        "detector_model, prompt_x, prompt_y, prompt_w, prompt_h) "
+        "VALUES (?, 'sam2-large', '', 0, "
+        "'megadetector-v6', 0.1, 0.1, 0.5, 0.5)",
+        (p2,),
+    )
+    db.conn.commit()
+
+    plan = compute_plan(db, PipelinePlanParams(), str(tmp_path / "test.db"))
+
+    assert plan["stages"]["Extract"]["detail"].get("sam_variant_warning") is None
+
+
 def test_count_photos_pending_masks_ignores_photos_without_real_detections(tmp_path):
     """A photo with only a synthetic full-image anchor should not be
     counted as eligible for mask extraction — the actual stage skips it.

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -233,6 +233,37 @@ def test_count_classify_stale_counts_old_only_runs(tmp_path):
     assert db.count_classify_stale("BioCLIP-2", TOL_SENTINEL) == 1
 
 
+def test_primary_classify_counts_ignore_secondary_detections(tmp_path):
+    """Pipeline classify uses one primary detection per photo.
+
+    Secondary boxes may exist in the detector cache, but they are not work the
+    streaming pipeline will classify, so primary-scoped plan helpers must not
+    count them as pending or stale.
+    """
+    db, folder_id = _make_db(tmp_path)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="multi.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    det_ids = db.save_detections(
+        photo_id,
+        [
+            {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+             "confidence": 0.95, "category": "animal"},
+            {"box": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2},
+             "confidence": 0.85, "category": "animal"},
+        ],
+        detector_model="megadetector-v6",
+    )
+    db.record_classifier_run(det_ids[0], "BioCLIP-2", "fp1", prediction_count=1)
+    db.record_classifier_run(det_ids[1], "BioCLIP-2", "fp_old", prediction_count=1)
+
+    assert db.count_real_detections_in_scope()["total_dets"] == 2
+    assert db.count_primary_detections_in_scope()["total_dets"] == 1
+    assert db.count_primary_classify_pending_pairs("BioCLIP-2", "fp1") == 0
+    assert db.count_primary_classify_stale("BioCLIP-2", "fp1") == 0
+
+
 def test_count_photos_pending_masks(tmp_path):
     db, folder_id = _make_db(tmp_path)
     pid_unmasked, _ = _add_photo_with_detection(db, folder_id, "no_mask.jpg")
@@ -245,6 +276,48 @@ def test_count_photos_pending_masks(tmp_path):
 
     counts = db.count_photos_pending_masks()
     assert counts == {"eligible": 2, "pending": 1}
+
+
+def test_count_photos_pending_masks_is_variant_aware(tmp_path):
+    db, folder_id = _make_db(tmp_path)
+    p1, _ = _add_photo_with_detection(db, folder_id, "a.jpg")
+    p2, _ = _add_photo_with_detection(db, folder_id, "b.jpg")
+    for pid in (p1, p2):
+        db.upsert_photo_mask(
+            pid, "sam2-large", f"/m/{pid}.large.png",
+            detector_model="megadetector-v6",
+            prompt_x=0.1, prompt_y=0.1, prompt_w=0.5, prompt_h=0.5,
+        )
+        db.set_active_mask_variant(pid, "sam2-large")
+
+    assert db.count_photos_pending_masks() == {"eligible": 2, "pending": 0}
+    assert db.count_photos_pending_masks(
+        sam2_variant="sam2-small",
+    ) == {"eligible": 2, "pending": 2}
+
+
+def test_extract_plan_warns_when_other_sam_variant_has_coverage(tmp_path):
+    from pipeline_plan import PipelinePlanParams, compute_plan
+
+    db, folder_id = _make_db(tmp_path)
+    p1, _ = _add_photo_with_detection(db, folder_id, "a.jpg")
+    p2, _ = _add_photo_with_detection(db, folder_id, "b.jpg")
+    for pid in (p1, p2):
+        db.upsert_photo_mask(
+            pid, "sam2-large", f"/m/{pid}.large.png",
+            detector_model="megadetector-v6",
+            prompt_x=0.1, prompt_y=0.1, prompt_w=0.5, prompt_h=0.5,
+        )
+        db.set_active_mask_variant(pid, "sam2-large")
+
+    plan = compute_plan(db, PipelinePlanParams(), str(tmp_path / "test.db"))
+    extract = plan["stages"]["Extract"]
+    assert extract["state"] == "will-run"
+    assert extract["detail"]["pending"] == 2
+    warning = extract["detail"]["sam_variant_warning"]
+    assert warning["selected_variant"] == "sam2-small"
+    assert warning["alternate_variant"] == "sam2-large"
+    assert warning["target_count"] == 2
 
 
 def test_count_photos_pending_masks_ignores_photos_without_real_detections(tmp_path):
@@ -551,6 +624,85 @@ def test_classify_plan_done_prior_when_all_pairs_recorded(tmp_path, monkeypatch)
     classify = plan["stages"]["Classify"]
     assert classify["state"] == "done-prior"
     assert "Already classified" in classify["summary"]
+
+
+def test_classify_plan_timm_intrinsic_uses_runtime_fingerprint(
+    tmp_path, monkeypatch,
+):
+    """timm/iNat21 has a fixed class head and runtime records it as `tol`.
+
+    The planner must use the same fingerprint or cached iNat21 rows render as
+    stale/outdated even though the next pipeline run will skip them.
+    """
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+
+    db, folder_id = _make_db(tmp_path)
+    _, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+
+    import labels as labels_mod
+    import models as models_mod
+
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "inat", "name": "iNat21 (EVA-02 Large)",
+         "model_str": "hf-hub:timm/eva02_large_patch14_clip_336.merged2b_ft_inat21",
+         "model_type": "timm", "downloaded": True},
+    ])
+    # Label files do not apply to timm models; keep the environment out of it.
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+    db.record_classifier_run(
+        did, "iNat21 (EVA-02 Large)", TOL_SENTINEL, prediction_count=1,
+    )
+
+    plan = compute_plan(
+        db, _params(model_ids=["inat"]), str(tmp_path / "test.db"),
+    )
+    classify = plan["stages"]["Classify"]
+    assert classify["state"] == "done-prior"
+    assert classify["detail"]["pending"] == 0
+    assert classify["detail"]["stale"] == 0
+    assert classify["detail"]["fingerprint_outdated"] is False
+
+
+def test_classify_plan_counts_primary_detections_only(tmp_path, monkeypatch):
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+
+    db, folder_id = _make_db(tmp_path)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="multi.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    det_ids = db.save_detections(
+        photo_id,
+        [
+            {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+             "confidence": 0.95, "category": "animal"},
+            {"box": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2},
+             "confidence": 0.85, "category": "animal"},
+        ],
+        detector_model="megadetector-v6",
+    )
+
+    import labels as labels_mod
+    import models as models_mod
+
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+    db.record_classifier_run(det_ids[0], "BioCLIP-2", TOL_SENTINEL, 1)
+
+    plan = compute_plan(db, _params(model_ids=["m1"]), str(tmp_path / "test.db"))
+    classify = plan["stages"]["Classify"]
+    assert classify["state"] == "done-prior"
+    assert classify["detail"]["eligible"] == 1
+    assert classify["detail"]["pending"] == 0
+    assert classify["detail"]["stale"] == 0
 
 
 def test_classify_plan_will_run_when_new_model_added(tmp_path, monkeypatch):

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -36,6 +36,15 @@ def _add_photo_with_detection(db, folder_id, filename, conf=0.9,
     return photo_id, det_ids[0]
 
 
+def _mark_sam_done(db, photo_id, path, variant="sam2-small"):
+    db.upsert_photo_mask(
+        photo_id, variant, path,
+        detector_model="megadetector-v6",
+        prompt_x=0.1, prompt_y=0.1, prompt_w=0.5, prompt_h=0.5,
+    )
+    db.set_active_mask_variant(photo_id, variant)
+
+
 # -------- db helpers --------
 
 def test_photos_by_paths_returns_known_and_omits_unknown(tmp_path):
@@ -294,6 +303,53 @@ def test_count_photos_pending_masks_is_variant_aware(tmp_path):
     assert db.count_photos_pending_masks(
         sam2_variant="sam2-small",
     ) == {"eligible": 2, "pending": 2}
+
+
+def test_count_photos_pending_masks_selected_variant_requires_cache_row(tmp_path):
+    db, folder_id = _make_db(tmp_path)
+    p_done, _ = _add_photo_with_detection(db, folder_id, "done.jpg")
+    p_legacy, _ = _add_photo_with_detection(db, folder_id, "legacy.jpg")
+
+    db.upsert_photo_mask(
+        p_done, "sam2-small", "/m/done.small.png",
+        detector_model="megadetector-v6",
+        prompt_x=0.1, prompt_y=0.1, prompt_w=0.5, prompt_h=0.5,
+    )
+    db.set_active_mask_variant(p_done, "sam2-small")
+    db.conn.execute(
+        "UPDATE photos SET mask_path='/m/legacy.png' WHERE id=?",
+        (p_legacy,),
+    )
+    db.conn.execute(
+        "INSERT INTO photo_masks(photo_id, variant, path, created_at, "
+        "detector_model, prompt_x, prompt_y, prompt_w, prompt_h) "
+        "VALUES (?, 'unknown', '/m/legacy.png', 0, "
+        "'unknown', -1, -1, -1, -1)",
+        (p_legacy,),
+    )
+    db.conn.commit()
+
+    assert db.count_photos_pending_masks(
+        sam2_variant="sam2-small",
+    ) == {"eligible": 2, "pending": 1}
+
+
+def test_count_photos_pending_masks_treats_empty_variant_path_as_pending(tmp_path):
+    db, folder_id = _make_db(tmp_path)
+    pid, _ = _add_photo_with_detection(db, folder_id, "empty.jpg")
+    db.conn.execute("UPDATE photos SET mask_path='/m/empty.png' WHERE id=?", (pid,))
+    db.conn.execute(
+        "INSERT INTO photo_masks(photo_id, variant, path, created_at, "
+        "detector_model, prompt_x, prompt_y, prompt_w, prompt_h) "
+        "VALUES (?, 'sam2-small', '', 0, "
+        "'megadetector-v6', 0.1, 0.1, 0.5, 0.5)",
+        (pid,),
+    )
+    db.conn.commit()
+
+    assert db.count_photos_pending_masks(
+        sam2_variant="sam2-small",
+    ) == {"eligible": 1, "pending": 1}
 
 
 def test_extract_plan_warns_when_other_sam_variant_has_coverage(tmp_path):
@@ -1358,8 +1414,12 @@ def test_extract_plan_done_prior_when_all_masks_present(tmp_path):
     from pipeline_plan import compute_plan
     db, folder_id = _make_db(tmp_path)
     pid, _ = _add_photo_with_detection(db, folder_id, "a.jpg")
-    db.conn.execute("UPDATE photos SET mask_path='/m/a.png' WHERE id=?", (pid,))
-    db.conn.commit()
+    db.upsert_photo_mask(
+        pid, "sam2-small", "/m/a.png",
+        detector_model="megadetector-v6",
+        prompt_x=0.1, prompt_y=0.1, prompt_w=0.5, prompt_h=0.5,
+    )
+    db.set_active_mask_variant(pid, "sam2-small")
     plan = compute_plan(db, _params(), str(tmp_path / "test.db"))
     extract = plan["stages"]["Extract"]
     assert extract["state"] == "done-prior"
@@ -1370,9 +1430,12 @@ def test_extract_plan_will_run_when_some_photos_missing_masks(tmp_path):
     from pipeline_plan import compute_plan
     db, folder_id = _make_db(tmp_path)
     pid_done, _ = _add_photo_with_detection(db, folder_id, "done.jpg")
-    db.conn.execute(
-        "UPDATE photos SET mask_path='/m/done.png' WHERE id=?", (pid_done,),
+    db.upsert_photo_mask(
+        pid_done, "sam2-small", "/m/done.png",
+        detector_model="megadetector-v6",
+        prompt_x=0.1, prompt_y=0.1, prompt_w=0.5, prompt_h=0.5,
     )
+    db.set_active_mask_variant(pid_done, "sam2-small")
     _add_photo_with_detection(db, folder_id, "todo.jpg")
     db.conn.commit()
 
@@ -1725,8 +1788,7 @@ def test_regroup_plan_done_prior_when_cache_exists_and_no_upstream_work(tmp_path
     db, folder_id = _make_db(tmp_path)
     # Make Classify and Extract done-prior so upstream_will_run is False.
     pid, did = _add_photo_with_detection(db, folder_id, "a.jpg")
-    db.conn.execute("UPDATE photos SET mask_path='/m/a.png' WHERE id=?", (pid,))
-    db.conn.commit()
+    _mark_sam_done(db, pid, "/m/a.png")
     from labels_fingerprint import TOL_SENTINEL
     db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=1)
 
@@ -1796,8 +1858,7 @@ def test_regroup_plan_will_run_when_workspace_fingerprint_outdated(tmp_path, mon
     db, folder_id = _make_db(tmp_path)
 
     pid, did = _add_photo_with_detection(db, folder_id, "a.jpg")
-    db.conn.execute("UPDATE photos SET mask_path='/m/a.png' WHERE id=?", (pid,))
-    db.conn.commit()
+    _mark_sam_done(db, pid, "/m/a.png")
     from labels_fingerprint import TOL_SENTINEL
     db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=1)
 
@@ -2079,8 +2140,7 @@ def test_import_plan_does_not_leak_active_workspace_state(tmp_path):
     # Fully-classified detection + masked photo in the active workspace.
     pid, did = _add_photo_with_detection(db, folder_id, "old.jpg")
     db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=1)
-    db.conn.execute("UPDATE photos SET mask_path='/m/old.png' WHERE id=?", (pid,))
-    db.conn.commit()
+    _mark_sam_done(db, pid, "/m/old.png")
 
     # Without source_paths → plan is whole-workspace (the old buggy
     # behaviour), so Extract reports done-prior.
@@ -2408,8 +2468,7 @@ def test_compute_plan_distinguishes_none_from_empty_source_paths(tmp_path, monke
     _stub_models(monkeypatch)
     pid, did = _add_photo_with_detection(db, folder_id, "old.jpg")
     db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=1)
-    db.conn.execute("UPDATE photos SET mask_path='/m/old.png' WHERE id=?", (pid,))
-    db.conn.commit()
+    _mark_sam_done(db, pid, "/m/old.png")
 
     # source_paths=None → whole-workspace fallback (Extract sees the
     # masked photo and reports "done-prior").

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -73,6 +73,51 @@ def test_scan_discovers_photos(tmp_path):
     assert filenames == {'img1.jpg', 'img2.jpg', 'img3.jpg'}
 
 
+def test_scan_cancel_check_aborts_before_discovery(tmp_path):
+    """scan() honors cancel_check before doing scan work."""
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['img1.jpg']})
+    db = Database(str(tmp_path / "test.db"))
+
+    with pytest.raises(RuntimeError, match="scan cancelled"):
+        scan(root, db, cancel_check=lambda: True)
+
+    assert db.get_photos(per_page=100) == []
+
+
+def test_scan_cancel_check_aborts_before_metadata_extraction(tmp_path, monkeypatch):
+    """A cancel requested after discovery stops before expensive metadata work."""
+    import scanner
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['img1.jpg', 'img2.jpg']})
+    db = Database(str(tmp_path / "test.db"))
+    cancelled = {"value": False}
+
+    def progress_cb(current, total):
+        if current == 0 and total == 2:
+            cancelled["value"] = True
+
+    def fail_extract_metadata(_paths):
+        raise AssertionError("extract_metadata should not run after cancellation")
+
+    monkeypatch.setattr(scanner, "extract_metadata", fail_extract_metadata)
+
+    with pytest.raises(RuntimeError, match="scan cancelled"):
+        scanner.scan(
+            root,
+            db,
+            progress_callback=progress_cb,
+            cancel_check=lambda: cancelled["value"],
+        )
+
+    assert db.get_photos(per_page=100) == []
+
+
 def test_scan_non_recursive_only_finds_root_photos(tmp_path):
     """scan(recursive=False) only finds photos in the root folder, not subfolders."""
     from db import Database


### PR DESCRIPTION
## Summary
- centralize pipeline defaults for SAM/DINO/proxy settings and surface SAM variant mismatch warnings in planning
- make Stop Pipeline call backend cancellation, wait for terminal status, and explain disabled Start Pipeline states
- add scanner cancellation checks so discovery, metadata, hashing, extraction, and working-copy handling can stop promptly
- fix classify planning for timm/iNat21 by using the `tol` runtime fingerprint and counting only primary detections

## Tests
- `pytest -q vireo/tests/test_config.py vireo/tests/test_pipeline_api.py vireo/tests/test_pipeline_plan.py vireo/tests/test_scanner.py vireo/tests/test_pipeline_job.py::test_pipeline_cancel_via_runner_skips_remaining_stages vireo/tests/test_pipeline_job.py::test_pipeline_cancellation_takes_precedence_over_failure`
- `git diff --check -- . ':!.context'`