### PR TITLE
[codex] Raise default burst embedding distance

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1209,6 +1209,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     # -- Page routes --
 
+    @app.route("/config-defaults.js")
+    def config_defaults_js():
+        """Expose backend defaults to browser code without template literals."""
+        return Response(
+            "window.VIREO_CONFIG_DEFAULTS = "
+            + json.dumps(cfg.DEFAULTS, separators=(",", ":"))
+            + ";\n",
+            mimetype="application/javascript",
+        )
+
     @app.route("/")
     def index():
         from models import get_active_model

--- a/vireo/bursts.py
+++ b/vireo/bursts.py
@@ -10,13 +10,16 @@ All thresholds are configurable with defaults from the pipeline design doc.
 import logging
 
 import numpy as np
+from config import DEFAULTS as CONFIG_DEFAULTS
 
 log = logging.getLogger(__name__)
 
-# Default thresholds (from design doc, subject to calibration)
+# Default thresholds mirror the application config source of truth.
 DEFAULTS = {
-    "burst_time_gap": 3.0,  # seconds — cut if delta_t exceeds this
-    "burst_embedding_threshold": 0.40,  # cosine similarity — cut if below this
+    "burst_time_gap": CONFIG_DEFAULTS["pipeline"]["burst_time_gap"],
+    "burst_embedding_threshold": CONFIG_DEFAULTS["pipeline"][
+        "burst_embedding_threshold"
+    ],
 }
 
 

--- a/vireo/bursts.py
+++ b/vireo/bursts.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 # Default thresholds (from design doc, subject to calibration)
 DEFAULTS = {
     "burst_time_gap": 3.0,  # seconds — cut if delta_t exceeds this
-    "burst_embedding_threshold": 0.80,  # cosine similarity — cut if below this
+    "burst_embedding_threshold": 0.40,  # cosine similarity — cut if below this
 }
 
 

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -100,7 +100,7 @@ DEFAULTS = {
         "eye_window_k": 0.08,
         "reject_eye_focus": 0.35,
         "burst_time_gap": 3.0,
-        "burst_embedding_threshold": 0.80,
+        "burst_embedding_threshold": 0.40,
         "burst_lambda": 0.85,
         "burst_max_keep": 3,
         "encounter_lambda": 0.70,

--- a/vireo/static/vireo-utils.js
+++ b/vireo/static/vireo-utils.js
@@ -16,3 +16,75 @@ function escapeAttr(str) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 }
+
+var VireoPipelineConfig = (function() {
+  function asNumber(value, key) {
+    var n = Number(value);
+    if (!Number.isFinite(n)) {
+      throw new Error('Missing numeric pipeline config: ' + key);
+    }
+    return n;
+  }
+
+  function percent(value, key) {
+    return Math.round(asNumber(value, key) * 100);
+  }
+
+  function pipelineFromConfig(config) {
+    if (!config || typeof config.pipeline !== 'object' || config.pipeline === null) {
+      throw new Error('Missing pipeline config');
+    }
+    return config.pipeline;
+  }
+
+  function embeddingThresholdToDistancePercent(threshold) {
+    return Math.round((1 - asNumber(threshold, 'burst_embedding_threshold')) * 100);
+  }
+
+  function embeddingDistancePercentToThreshold(distancePercent) {
+    return 1 - asNumber(distancePercent, 'burst_embedding_distance') / 100;
+  }
+
+  function buildSliderDefaults(config) {
+    var p = pipelineFromConfig(config);
+    return {
+      scoring: {
+        reject_crop_complete: percent(p.reject_crop_complete, 'reject_crop_complete'),
+        reject_focus: percent(p.reject_focus, 'reject_focus'),
+        reject_clip_high: percent(p.reject_clip_high, 'reject_clip_high'),
+        reject_composite: percent(p.reject_composite, 'reject_composite'),
+        burst_lambda: percent(p.burst_lambda, 'burst_lambda'),
+        burst_max_keep: asNumber(p.burst_max_keep, 'burst_max_keep'),
+        encounter_lambda: percent(p.encounter_lambda, 'encounter_lambda'),
+        encounter_max_keep: asNumber(p.encounter_max_keep, 'encounter_max_keep'),
+      },
+      grouping: {
+        w_time: percent(p.w_time, 'w_time'),
+        w_subj: percent(p.w_subj, 'w_subj'),
+        w_global: percent(p.w_global, 'w_global'),
+        w_species: percent(p.w_species, 'w_species'),
+        w_meta: percent(p.w_meta, 'w_meta'),
+        tau_enc: asNumber(p.tau_enc, 'tau_enc'),
+        hard_cut_time: asNumber(p.hard_cut_time, 'hard_cut_time'),
+        hard_cut_score: percent(p.hard_cut_score, 'hard_cut_score'),
+        soft_cut_score: percent(p.soft_cut_score, 'soft_cut_score'),
+        merge_score: percent(p.merge_score, 'merge_score'),
+        merge_max_gap: asNumber(p.merge_max_gap, 'merge_max_gap'),
+        merge_tau: asNumber(p.merge_tau, 'merge_tau'),
+        burst_time_gap: asNumber(p.burst_time_gap, 'burst_time_gap'),
+        burst_embedding_distance: embeddingThresholdToDistancePercent(
+          p.burst_embedding_threshold
+        ),
+      },
+    };
+  }
+
+  return {
+    asNumber: asNumber,
+    percent: percent,
+    pipelineFromConfig: pipelineFromConfig,
+    embeddingThresholdToDistancePercent: embeddingThresholdToDistancePercent,
+    embeddingDistancePercentToThreshold: embeddingDistancePercentToThreshold,
+    buildSliderDefaults: buildSliderDefaults,
+  };
+})();

--- a/vireo/static/vireo-utils.js
+++ b/vireo/static/vireo-utils.js
@@ -18,6 +18,19 @@ function escapeAttr(str) {
 }
 
 var VireoPipelineConfig = (function() {
+  function defaultPipeline() {
+    var defaults = window.VIREO_CONFIG_DEFAULTS;
+    if (!defaults || typeof defaults.pipeline !== 'object' || defaults.pipeline === null) {
+      throw new Error('Missing rendered pipeline defaults');
+    }
+    return defaults.pipeline;
+  }
+
+  function pipelineValue(pipeline, key) {
+    if (pipeline && pipeline[key] != null) return pipeline[key];
+    return defaultPipeline()[key];
+  }
+
   function asNumber(value, key) {
     var n = Number(value);
     if (!Number.isFinite(n)) {
@@ -31,8 +44,9 @@ var VireoPipelineConfig = (function() {
   }
 
   function pipelineFromConfig(config) {
-    if (!config || typeof config.pipeline !== 'object' || config.pipeline === null) {
-      throw new Error('Missing pipeline config');
+    if (!config) return defaultPipeline();
+    if (typeof config.pipeline !== 'object' || config.pipeline === null) {
+      return defaultPipeline();
     }
     return config.pipeline;
   }
@@ -49,37 +63,61 @@ var VireoPipelineConfig = (function() {
     var p = pipelineFromConfig(config);
     return {
       scoring: {
-        reject_crop_complete: percent(p.reject_crop_complete, 'reject_crop_complete'),
-        reject_focus: percent(p.reject_focus, 'reject_focus'),
-        reject_clip_high: percent(p.reject_clip_high, 'reject_clip_high'),
-        reject_composite: percent(p.reject_composite, 'reject_composite'),
-        burst_lambda: percent(p.burst_lambda, 'burst_lambda'),
-        burst_max_keep: asNumber(p.burst_max_keep, 'burst_max_keep'),
-        encounter_lambda: percent(p.encounter_lambda, 'encounter_lambda'),
-        encounter_max_keep: asNumber(p.encounter_max_keep, 'encounter_max_keep'),
+        reject_crop_complete: percent(
+          pipelineValue(p, 'reject_crop_complete'), 'reject_crop_complete'
+        ),
+        reject_focus: percent(pipelineValue(p, 'reject_focus'), 'reject_focus'),
+        reject_clip_high: percent(
+          pipelineValue(p, 'reject_clip_high'), 'reject_clip_high'
+        ),
+        reject_composite: percent(
+          pipelineValue(p, 'reject_composite'), 'reject_composite'
+        ),
+        burst_lambda: percent(pipelineValue(p, 'burst_lambda'), 'burst_lambda'),
+        burst_max_keep: asNumber(
+          pipelineValue(p, 'burst_max_keep'), 'burst_max_keep'
+        ),
+        encounter_lambda: percent(
+          pipelineValue(p, 'encounter_lambda'), 'encounter_lambda'
+        ),
+        encounter_max_keep: asNumber(
+          pipelineValue(p, 'encounter_max_keep'), 'encounter_max_keep'
+        ),
       },
       grouping: {
-        w_time: percent(p.w_time, 'w_time'),
-        w_subj: percent(p.w_subj, 'w_subj'),
-        w_global: percent(p.w_global, 'w_global'),
-        w_species: percent(p.w_species, 'w_species'),
-        w_meta: percent(p.w_meta, 'w_meta'),
-        tau_enc: asNumber(p.tau_enc, 'tau_enc'),
-        hard_cut_time: asNumber(p.hard_cut_time, 'hard_cut_time'),
-        hard_cut_score: percent(p.hard_cut_score, 'hard_cut_score'),
-        soft_cut_score: percent(p.soft_cut_score, 'soft_cut_score'),
-        merge_score: percent(p.merge_score, 'merge_score'),
-        merge_max_gap: asNumber(p.merge_max_gap, 'merge_max_gap'),
-        merge_tau: asNumber(p.merge_tau, 'merge_tau'),
-        burst_time_gap: asNumber(p.burst_time_gap, 'burst_time_gap'),
+        w_time: percent(pipelineValue(p, 'w_time'), 'w_time'),
+        w_subj: percent(pipelineValue(p, 'w_subj'), 'w_subj'),
+        w_global: percent(pipelineValue(p, 'w_global'), 'w_global'),
+        w_species: percent(pipelineValue(p, 'w_species'), 'w_species'),
+        w_meta: percent(pipelineValue(p, 'w_meta'), 'w_meta'),
+        tau_enc: asNumber(pipelineValue(p, 'tau_enc'), 'tau_enc'),
+        hard_cut_time: asNumber(
+          pipelineValue(p, 'hard_cut_time'), 'hard_cut_time'
+        ),
+        hard_cut_score: percent(
+          pipelineValue(p, 'hard_cut_score'), 'hard_cut_score'
+        ),
+        soft_cut_score: percent(
+          pipelineValue(p, 'soft_cut_score'), 'soft_cut_score'
+        ),
+        merge_score: percent(pipelineValue(p, 'merge_score'), 'merge_score'),
+        merge_max_gap: asNumber(
+          pipelineValue(p, 'merge_max_gap'), 'merge_max_gap'
+        ),
+        merge_tau: asNumber(pipelineValue(p, 'merge_tau'), 'merge_tau'),
+        burst_time_gap: asNumber(
+          pipelineValue(p, 'burst_time_gap'), 'burst_time_gap'
+        ),
         burst_embedding_distance: embeddingThresholdToDistancePercent(
-          p.burst_embedding_threshold
+          pipelineValue(p, 'burst_embedding_threshold')
         ),
       },
     };
   }
 
   return {
+    defaultPipeline: defaultPipeline,
+    pipelineValue: pipelineValue,
     asNumber: asNumber,
     percent: percent,
     pipelineFromConfig: pipelineFromConfig,

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1,4 +1,5 @@
 <link rel="stylesheet" href="/static/vireo-theme.css">
+<script src="/config-defaults.js"></script>
 <style>
 /* ---------- Global Overrides ---------- */
 body { background: var(--bg-primary) !important; color: var(--text-primary) !important; }

--- a/vireo/templates/cull.html
+++ b/vireo/templates/cull.html
@@ -444,7 +444,9 @@ async function loadPipelineSliderDefaults() {
     GROUPING_DEFAULTS = defaults.grouping;
   } catch(e) {
     console.warn('Could not load pipeline config:', e);
-    return;
+    var defaults = VireoPipelineConfig.buildSliderDefaults();
+    SCORING_DEFAULTS = defaults.scoring;
+    GROUPING_DEFAULTS = defaults.grouping;
   }
   applyScoringDefaults();
   applyGroupingDefaults();

--- a/vireo/templates/cull.html
+++ b/vireo/templates/cull.html
@@ -372,8 +372,8 @@ body { padding-bottom: 36px; }
       </div>
       <div class="slider-row">
         <span class="slider-label" title="Max embedding distance - higher tolerates more visually different shots">Emb. distance</span>
-        <input type="range" min="0" max="100" value="20" step="1" id="slBurstEmb" oninput="onGroupingChange(this)">
-        <span class="slider-val" id="valBurstEmb">0.20</span>
+        <input type="range" min="0" max="100" value="60" step="1" id="slBurstEmb" oninput="onGroupingChange(this)">
+        <span class="slider-val" id="valBurstEmb">0.60</span>
       </div>
     </div>
 
@@ -408,7 +408,7 @@ var GROUPING_DEFAULTS = {
   w_time: 35, w_subj: 35, w_global: 15, w_species: 10, w_meta: 5,
   tau_enc: 40, hard_cut_time: 180, hard_cut_score: 42, soft_cut_score: 52,
   merge_score: 62, merge_max_gap: 60, merge_tau: 20,
-  burst_time_gap: 3, burst_embedding_threshold: 20,
+  burst_time_gap: 3, burst_embedding_threshold: 60,
 };
 
 (async function() {
@@ -469,7 +469,7 @@ async function loadPipelineSliderDefaults() {
     GROUPING_DEFAULTS.merge_max_gap = p.merge_max_gap != null ? p.merge_max_gap : 60;
     GROUPING_DEFAULTS.merge_tau = p.merge_tau != null ? p.merge_tau : 20;
     GROUPING_DEFAULTS.burst_time_gap = p.burst_time_gap != null ? p.burst_time_gap : 3;
-    GROUPING_DEFAULTS.burst_embedding_threshold = Math.round((1 - (p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.80)) * 100);
+    GROUPING_DEFAULTS.burst_embedding_threshold = Math.round((1 - (p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.40)) * 100);
   } catch(e) {}
   applyScoringDefaults();
   applyGroupingDefaults();

--- a/vireo/templates/cull.html
+++ b/vireo/templates/cull.html
@@ -372,8 +372,8 @@ body { padding-bottom: 36px; }
       </div>
       <div class="slider-row">
         <span class="slider-label" title="Max embedding distance - higher tolerates more visually different shots">Emb. distance</span>
-        <input type="range" min="0" max="100" value="60" step="1" id="slBurstEmb" oninput="onGroupingChange(this)">
-        <span class="slider-val" id="valBurstEmb">0.60</span>
+        <input type="range" min="0" max="100" step="1" id="slBurstEmb" oninput="onGroupingChange(this)">
+        <span class="slider-val" id="valBurstEmb"></span>
       </div>
     </div>
 
@@ -400,16 +400,8 @@ var expandedSpecies = {};
 var _reflowTimer = null;
 var _regroupTimer = null;
 
-var SCORING_DEFAULTS = {
-  reject_crop_complete: 60, reject_focus: 35, reject_clip_high: 30, reject_composite: 40,
-  burst_lambda: 85, burst_max_keep: 3, encounter_lambda: 70, encounter_max_keep: 5,
-};
-var GROUPING_DEFAULTS = {
-  w_time: 35, w_subj: 35, w_global: 15, w_species: 10, w_meta: 5,
-  tau_enc: 40, hard_cut_time: 180, hard_cut_score: 42, soft_cut_score: 52,
-  merge_score: 62, merge_max_gap: 60, merge_tau: 20,
-  burst_time_gap: 3, burst_embedding_threshold: 60,
-};
+var SCORING_DEFAULTS = {};
+var GROUPING_DEFAULTS = {};
 
 (async function() {
   await loadPipelineSliderDefaults();
@@ -447,30 +439,13 @@ async function onCullCollectionChange() {
 async function loadPipelineSliderDefaults() {
   try {
     var cfg = await safeFetch('/api/config', {}, { toast: false });
-    var p = cfg.pipeline || {};
-    SCORING_DEFAULTS.reject_crop_complete = Math.round((p.reject_crop_complete != null ? p.reject_crop_complete : 0.60) * 100);
-    SCORING_DEFAULTS.reject_focus = Math.round((p.reject_focus != null ? p.reject_focus : 0.35) * 100);
-    SCORING_DEFAULTS.reject_clip_high = Math.round((p.reject_clip_high != null ? p.reject_clip_high : 0.30) * 100);
-    SCORING_DEFAULTS.reject_composite = Math.round((p.reject_composite != null ? p.reject_composite : 0.40) * 100);
-    SCORING_DEFAULTS.burst_lambda = Math.round((p.burst_lambda != null ? p.burst_lambda : 0.85) * 100);
-    SCORING_DEFAULTS.burst_max_keep = p.burst_max_keep != null ? p.burst_max_keep : 3;
-    SCORING_DEFAULTS.encounter_lambda = Math.round((p.encounter_lambda != null ? p.encounter_lambda : 0.70) * 100);
-    SCORING_DEFAULTS.encounter_max_keep = p.encounter_max_keep != null ? p.encounter_max_keep : 5;
-    GROUPING_DEFAULTS.w_time = Math.round((p.w_time != null ? p.w_time : 0.35) * 100);
-    GROUPING_DEFAULTS.w_subj = Math.round((p.w_subj != null ? p.w_subj : 0.35) * 100);
-    GROUPING_DEFAULTS.w_global = Math.round((p.w_global != null ? p.w_global : 0.15) * 100);
-    GROUPING_DEFAULTS.w_species = Math.round((p.w_species != null ? p.w_species : 0.10) * 100);
-    GROUPING_DEFAULTS.w_meta = Math.round((p.w_meta != null ? p.w_meta : 0.05) * 100);
-    GROUPING_DEFAULTS.tau_enc = p.tau_enc != null ? p.tau_enc : 40;
-    GROUPING_DEFAULTS.hard_cut_time = p.hard_cut_time != null ? p.hard_cut_time : 180;
-    GROUPING_DEFAULTS.hard_cut_score = Math.round((p.hard_cut_score != null ? p.hard_cut_score : 0.42) * 100);
-    GROUPING_DEFAULTS.soft_cut_score = Math.round((p.soft_cut_score != null ? p.soft_cut_score : 0.52) * 100);
-    GROUPING_DEFAULTS.merge_score = Math.round((p.merge_score != null ? p.merge_score : 0.62) * 100);
-    GROUPING_DEFAULTS.merge_max_gap = p.merge_max_gap != null ? p.merge_max_gap : 60;
-    GROUPING_DEFAULTS.merge_tau = p.merge_tau != null ? p.merge_tau : 20;
-    GROUPING_DEFAULTS.burst_time_gap = p.burst_time_gap != null ? p.burst_time_gap : 3;
-    GROUPING_DEFAULTS.burst_embedding_threshold = Math.round((1 - (p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.40)) * 100);
-  } catch(e) {}
+    var defaults = VireoPipelineConfig.buildSliderDefaults(cfg);
+    SCORING_DEFAULTS = defaults.scoring;
+    GROUPING_DEFAULTS = defaults.grouping;
+  } catch(e) {
+    console.warn('Could not load pipeline config:', e);
+    return;
+  }
   applyScoringDefaults();
   applyGroupingDefaults();
 }
@@ -525,7 +500,9 @@ function getGroupingConfig() {
     merge_max_gap: num('slMergeMaxGap'),
     merge_tau: num('slMergeTau'),
     burst_time_gap: num('slBurstTime'),
-    burst_embedding_threshold: 1 - pct('slBurstEmb'),
+    burst_embedding_threshold: VireoPipelineConfig.embeddingDistancePercentToThreshold(
+      sliderVal('slBurstEmb')
+    ),
   };
 }
 
@@ -556,7 +533,7 @@ function applyGroupingDefaults() {
   setVal('slMergeMaxGap', GROUPING_DEFAULTS.merge_max_gap);
   setVal('slMergeTau', GROUPING_DEFAULTS.merge_tau);
   setVal('slBurstTime', GROUPING_DEFAULTS.burst_time_gap);
-  setVal('slBurstEmb', GROUPING_DEFAULTS.burst_embedding_threshold);
+  setVal('slBurstEmb', GROUPING_DEFAULTS.burst_embedding_distance);
   document.querySelectorAll('#cullSettings input[type="range"]').forEach(updateSliderDisplay);
 }
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1229,8 +1229,8 @@ input[type="range"]::-moz-range-thumb {
         </div>
         <div class="slider-row">
           <span class="slider-label" title="Max embedding distance — higher tolerates more visually different shots">Emb. distance</span>
-          <input type="range" min="0" max="100" value="20" step="1" id="slBurstEmb" oninput="onGroupingChange(this)">
-          <span class="slider-val" id="valBurstEmb">0.20</span>
+          <input type="range" min="0" max="100" value="60" step="1" id="slBurstEmb" oninput="onGroupingChange(this)">
+          <span class="slider-val" id="valBurstEmb">0.60</span>
         </div>
       </div>
 
@@ -2013,7 +2013,7 @@ var GROUPING_DEFAULTS = {
   // Merge
   merge_score: 62, merge_max_gap: 60, merge_tau: 20,
   // Bursts
-  burst_time_gap: 3, burst_embedding_threshold: 20,
+  burst_time_gap: 3, burst_embedding_threshold: 60,
 };
 
 /* Load slider defaults from server config (overrides hard-coded values above) */
@@ -2043,7 +2043,7 @@ var GROUPING_DEFAULTS = {
     GROUPING_DEFAULTS.merge_tau = p.merge_tau != null ? p.merge_tau : 20;
     GROUPING_DEFAULTS.burst_time_gap = p.burst_time_gap != null ? p.burst_time_gap : 3;
     // Stored as cosine similarity; UI shows distance = 1 - similarity.
-    GROUPING_DEFAULTS.burst_embedding_threshold = Math.round((1 - (p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.80)) * 100);
+    GROUPING_DEFAULTS.burst_embedding_threshold = Math.round((1 - (p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.40)) * 100);
     applyScoringDefaults();
     applyGroupingDefaults();
   } catch(e) {

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2011,12 +2011,14 @@ var GROUPING_DEFAULTS = {};
     var defaults = VireoPipelineConfig.buildSliderDefaults(cfg);
     SCORING_DEFAULTS = defaults.scoring;
     GROUPING_DEFAULTS = defaults.grouping;
-    applyScoringDefaults();
-    applyGroupingDefaults();
   } catch(e) {
     console.warn('Could not load pipeline config:', e);
-    return;
+    var defaults = VireoPipelineConfig.buildSliderDefaults();
+    SCORING_DEFAULTS = defaults.scoring;
+    GROUPING_DEFAULTS = defaults.grouping;
   }
+  applyScoringDefaults();
+  applyGroupingDefaults();
 })();
 
 function sliderVal(id) {

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1229,8 +1229,8 @@ input[type="range"]::-moz-range-thumb {
         </div>
         <div class="slider-row">
           <span class="slider-label" title="Max embedding distance — higher tolerates more visually different shots">Emb. distance</span>
-          <input type="range" min="0" max="100" value="60" step="1" id="slBurstEmb" oninput="onGroupingChange(this)">
-          <span class="slider-val" id="valBurstEmb">0.60</span>
+          <input type="range" min="0" max="100" step="1" id="slBurstEmb" oninput="onGroupingChange(this)">
+          <span class="slider-val" id="valBurstEmb"></span>
         </div>
       </div>
 
@@ -2001,53 +2001,21 @@ function setMinConfidence(val) {
 var _reflowTimer = null;
 var _regroupTimer = null;
 
-var SCORING_DEFAULTS = {
-  reject_crop_complete: 60, reject_focus: 35, reject_clip_high: 30, reject_composite: 40,
-  burst_lambda: 85, burst_max_keep: 3, encounter_lambda: 70, encounter_max_keep: 5,
-};
-var GROUPING_DEFAULTS = {
-  // Weights (stored as 0-100 for slider; converted to 0..1 fraction in getGroupingConfig)
-  w_time: 35, w_subj: 35, w_global: 15, w_species: 10, w_meta: 5,
-  // Cut thresholds
-  tau_enc: 40, hard_cut_time: 180, hard_cut_score: 42, soft_cut_score: 52,
-  // Merge
-  merge_score: 62, merge_max_gap: 60, merge_tau: 20,
-  // Bursts
-  burst_time_gap: 3, burst_embedding_threshold: 60,
-};
+var SCORING_DEFAULTS = {};
+var GROUPING_DEFAULTS = {};
 
-/* Load slider defaults from server config (overrides hard-coded values above) */
+/* Load slider defaults from the backend config source of truth. */
 (async function() {
   try {
     var cfg = await safeFetch('/api/config');
-    var p = cfg.pipeline || {};
-    SCORING_DEFAULTS.reject_crop_complete = Math.round((p.reject_crop_complete != null ? p.reject_crop_complete : 0.60) * 100);
-    SCORING_DEFAULTS.reject_focus = Math.round((p.reject_focus != null ? p.reject_focus : 0.35) * 100);
-    SCORING_DEFAULTS.reject_clip_high = Math.round((p.reject_clip_high != null ? p.reject_clip_high : 0.30) * 100);
-    SCORING_DEFAULTS.reject_composite = Math.round((p.reject_composite != null ? p.reject_composite : 0.40) * 100);
-    SCORING_DEFAULTS.burst_lambda = Math.round((p.burst_lambda != null ? p.burst_lambda : 0.85) * 100);
-    SCORING_DEFAULTS.burst_max_keep = p.burst_max_keep != null ? p.burst_max_keep : 3;
-    SCORING_DEFAULTS.encounter_lambda = Math.round((p.encounter_lambda != null ? p.encounter_lambda : 0.70) * 100);
-    SCORING_DEFAULTS.encounter_max_keep = p.encounter_max_keep != null ? p.encounter_max_keep : 5;
-    GROUPING_DEFAULTS.w_time = Math.round((p.w_time != null ? p.w_time : 0.35) * 100);
-    GROUPING_DEFAULTS.w_subj = Math.round((p.w_subj != null ? p.w_subj : 0.35) * 100);
-    GROUPING_DEFAULTS.w_global = Math.round((p.w_global != null ? p.w_global : 0.15) * 100);
-    GROUPING_DEFAULTS.w_species = Math.round((p.w_species != null ? p.w_species : 0.10) * 100);
-    GROUPING_DEFAULTS.w_meta = Math.round((p.w_meta != null ? p.w_meta : 0.05) * 100);
-    GROUPING_DEFAULTS.tau_enc = p.tau_enc != null ? p.tau_enc : 40;
-    GROUPING_DEFAULTS.hard_cut_time = p.hard_cut_time != null ? p.hard_cut_time : 180;
-    GROUPING_DEFAULTS.hard_cut_score = Math.round((p.hard_cut_score != null ? p.hard_cut_score : 0.42) * 100);
-    GROUPING_DEFAULTS.soft_cut_score = Math.round((p.soft_cut_score != null ? p.soft_cut_score : 0.52) * 100);
-    GROUPING_DEFAULTS.merge_score = Math.round((p.merge_score != null ? p.merge_score : 0.62) * 100);
-    GROUPING_DEFAULTS.merge_max_gap = p.merge_max_gap != null ? p.merge_max_gap : 60;
-    GROUPING_DEFAULTS.merge_tau = p.merge_tau != null ? p.merge_tau : 20;
-    GROUPING_DEFAULTS.burst_time_gap = p.burst_time_gap != null ? p.burst_time_gap : 3;
-    // Stored as cosine similarity; UI shows distance = 1 - similarity.
-    GROUPING_DEFAULTS.burst_embedding_threshold = Math.round((1 - (p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.40)) * 100);
+    var defaults = VireoPipelineConfig.buildSliderDefaults(cfg);
+    SCORING_DEFAULTS = defaults.scoring;
+    GROUPING_DEFAULTS = defaults.grouping;
     applyScoringDefaults();
     applyGroupingDefaults();
   } catch(e) {
-    console.warn('Could not load pipeline config, using built-in defaults:', e);
+    console.warn('Could not load pipeline config:', e);
+    return;
   }
 })();
 
@@ -2104,8 +2072,9 @@ function getGroupingConfig() {
     merge_max_gap: num('slMergeMaxGap'),
     merge_tau: num('slMergeTau'),
     burst_time_gap: num('slBurstTime'),
-    // UI shows distance; bursts.py expects cosine similarity = 1 - distance.
-    burst_embedding_threshold: 1 - pct('slBurstEmb'),
+    burst_embedding_threshold: VireoPipelineConfig.embeddingDistancePercentToThreshold(
+      sliderVal('slBurstEmb')
+    ),
   };
 }
 
@@ -2311,7 +2280,7 @@ function applyGroupingDefaults() {
   setVal('slMergeTau', GROUPING_DEFAULTS.merge_tau);
   // Bursts
   setVal('slBurstTime', GROUPING_DEFAULTS.burst_time_gap);
-  setVal('slBurstEmb', GROUPING_DEFAULTS.burst_embedding_threshold);
+  setVal('slBurstEmb', GROUPING_DEFAULTS.burst_embedding_distance);
   document.querySelectorAll('.sidebar-section input[type="range"]').forEach(function(sl) {
     updateSliderDisplay(sl);
   });

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1911,46 +1911,71 @@ function saveConfig() {
 }
 
 function resetPipelineDefaults() {
-  var defs = {
-    cfgWFocus: [45, '%'], cfgWExposure: [20, '%'], cfgWComposition: [15, '%'],
-    cfgWArea: [10, '%'], cfgWNoise: [10, '%'],
-    cfgRejectCrop: [60, '%'], cfgRejectFocus: [35, '%'], cfgRejectClip: [30, '%'],
-    cfgRejectComposite: [40, '%'],
-    cfgEyeClassifierConfGate: [50, '%'], cfgEyeDetectionConfGate: [50, '%'],
-    cfgRejectEyeFocus: [35, '%'],
-    cfgBurstTimeGap: [3, 's'], cfgBurstEmb: [20, '%'],
-    cfgBurstLambda: [85, '%'], cfgEncLambda: [70, '%'],
-    cfgHardCutScore: [42, '%'], cfgSoftCutScore: [52, '%'], cfgMergeScore: [62, '%'],
-  };
-  for (var id in defs) {
-    var val = defs[id][0], suffix = defs[id][1];
+  var p = VireoPipelineConfig.defaultPipeline();
+  function setPercent(id, key) {
+    setValue(id, VireoPipelineConfig.percent(p[key], key), '%');
+  }
+  function setValue(id, val, suffix) {
     document.getElementById(id).value = val;
     var span = document.getElementById(id + 'Val');
     if (span) span.textContent = val + suffix;
   }
-  // cfgEyeWindowK shows its display value as a ratio, not a percent — reset
-  // separately so the visible label stays consistent with how loadConfig
-  // renders it.
-  document.getElementById('cfgEyeWindowK').value = 8;
-  document.getElementById('cfgEyeWindowKVal').textContent = '0.08';
-  document.getElementById('cfgEyeDetectEnabled').checked = true;
-  // Miss-detection defaults (non-percent display values).
-  document.getElementById('cfgMissEnabled').checked = true;
-  document.getElementById('cfgMissDetConf').value = 25;
-  document.getElementById('cfgMissDetConfVal').textContent = '25%';
-  document.getElementById('cfgMissBboxMin').value = 5;
-  document.getElementById('cfgMissBboxMinVal').textContent = '0.005';
-  document.getElementById('cfgMissOofRatio').value = 50;
-  document.getElementById('cfgMissOofRatioVal').textContent = '0.50';
-  document.getElementById('cfgBurstMaxKeep').value = 3;
-  document.getElementById('cfgEncMaxKeep').value = 5;
-  document.getElementById('cfgWTime').value = 35;
-  document.getElementById('cfgWSubj').value = 35;
-  document.getElementById('cfgWGlobal').value = 15;
-  document.getElementById('cfgWSpecies').value = 10;
-  document.getElementById('cfgWMeta').value = 5;
-  document.getElementById('cfgHardCutTime').value = 180;
-  document.getElementById('cfgMergeMaxGap').value = 60;
+  setPercent('cfgWFocus', 'w_focus');
+  setPercent('cfgWExposure', 'w_exposure');
+  setPercent('cfgWComposition', 'w_composition');
+  setPercent('cfgWArea', 'w_area');
+  setPercent('cfgWNoise', 'w_noise');
+  setPercent('cfgRejectCrop', 'reject_crop_complete');
+  setPercent('cfgRejectFocus', 'reject_focus');
+  setPercent('cfgRejectClip', 'reject_clip_high');
+  setPercent('cfgRejectComposite', 'reject_composite');
+  setPercent('cfgEyeClassifierConfGate', 'eye_classifier_conf_gate');
+  setPercent('cfgEyeDetectionConfGate', 'eye_detection_conf_gate');
+  setPercent('cfgRejectEyeFocus', 'reject_eye_focus');
+  setValue('cfgBurstTimeGap', p.burst_time_gap, 's');
+  setValue(
+    'cfgBurstEmb',
+    VireoPipelineConfig.embeddingThresholdToDistancePercent(
+      p.burst_embedding_threshold
+    ),
+    '%'
+  );
+  setPercent('cfgBurstLambda', 'burst_lambda');
+  setPercent('cfgEncLambda', 'encounter_lambda');
+  setPercent('cfgHardCutScore', 'hard_cut_score');
+  setPercent('cfgSoftCutScore', 'soft_cut_score');
+  setPercent('cfgMergeScore', 'merge_score');
+  var eyeWindow = VireoPipelineConfig.percent(p.eye_window_k, 'eye_window_k');
+  document.getElementById('cfgEyeWindowK').value = eyeWindow;
+  document.getElementById('cfgEyeWindowKVal').textContent =
+    (eyeWindow / 100).toFixed(2);
+  document.getElementById('cfgEyeDetectEnabled').checked = p.eye_detect_enabled !== false;
+  document.getElementById('cfgMissEnabled').checked = p.miss_enabled !== false;
+  setPercent('cfgMissDetConf', 'miss_det_confidence');
+  var bboxMin = Math.round(
+    VireoPipelineConfig.asNumber(p.miss_bbox_area_min, 'miss_bbox_area_min') * 1000
+  );
+  document.getElementById('cfgMissBboxMin').value = bboxMin;
+  document.getElementById('cfgMissBboxMinVal').textContent =
+    (bboxMin / 1000).toFixed(3);
+  var missOofRatio = VireoPipelineConfig.percent(p.miss_oof_ratio, 'miss_oof_ratio');
+  document.getElementById('cfgMissOofRatio').value = missOofRatio;
+  document.getElementById('cfgMissOofRatioVal').textContent =
+    (missOofRatio / 100).toFixed(2);
+  document.getElementById('cfgBurstMaxKeep').value = p.burst_max_keep;
+  document.getElementById('cfgEncMaxKeep').value = p.encounter_max_keep;
+  document.getElementById('cfgWTime').value =
+    VireoPipelineConfig.percent(p.w_time, 'w_time');
+  document.getElementById('cfgWSubj').value =
+    VireoPipelineConfig.percent(p.w_subj, 'w_subj');
+  document.getElementById('cfgWGlobal').value =
+    VireoPipelineConfig.percent(p.w_global, 'w_global');
+  document.getElementById('cfgWSpecies').value =
+    VireoPipelineConfig.percent(p.w_species, 'w_species');
+  document.getElementById('cfgWMeta').value =
+    VireoPipelineConfig.percent(p.w_meta, 'w_meta');
+  document.getElementById('cfgHardCutTime').value = p.hard_cut_time;
+  document.getElementById('cfgMergeMaxGap').value = p.merge_max_gap;
   saveConfig();
 }
 

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -716,10 +716,10 @@
       <div class="setting-row">
         <div class="setting-label">Embedding distance</div>
         <div style="display:flex;align-items:center;gap:8px;">
-          <input type="range" id="cfgBurstEmb" min="1" max="50" value="20"
+          <input type="range" id="cfgBurstEmb" min="1" max="100" value="60"
                  style="width:120px;accent-color:var(--accent);"
                  oninput="document.getElementById('cfgBurstEmbVal').textContent = this.value + '%'; saveConfig()">
-          <span style="font-size:13px;color:var(--text-primary);min-width:36px;" id="cfgBurstEmbVal">20%</span>
+          <span style="font-size:13px;color:var(--text-primary);min-width:36px;" id="cfgBurstEmbVal">60%</span>
         </div>
       </div>
 
@@ -1715,7 +1715,7 @@ async function loadConfig() {
     document.getElementById('cfgBurstTimeGap').value = btg;
     document.getElementById('cfgBurstTimeGapVal').textContent = btg + 's';
     // Stored as cosine similarity; UI shows distance = 1 - similarity.
-    var bemb = Math.round((1 - (p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.80)) * 100);
+    var bemb = Math.round((1 - (p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.40)) * 100);
     document.getElementById('cfgBurstEmb').value = bemb;
     document.getElementById('cfgBurstEmbVal').textContent = bemb + '%';
     var bl = Math.round((p.burst_lambda != null ? p.burst_lambda : 0.85) * 100);

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -716,10 +716,10 @@
       <div class="setting-row">
         <div class="setting-label">Embedding distance</div>
         <div style="display:flex;align-items:center;gap:8px;">
-          <input type="range" id="cfgBurstEmb" min="1" max="100" value="60"
+          <input type="range" id="cfgBurstEmb" min="1" max="100"
                  style="width:120px;accent-color:var(--accent);"
                  oninput="document.getElementById('cfgBurstEmbVal').textContent = this.value + '%'; saveConfig()">
-          <span style="font-size:13px;color:var(--text-primary);min-width:36px;" id="cfgBurstEmbVal">60%</span>
+          <span style="font-size:13px;color:var(--text-primary);min-width:36px;" id="cfgBurstEmbVal"></span>
         </div>
       </div>
 
@@ -1655,94 +1655,97 @@ async function loadConfig() {
     document.getElementById('cfgCullPhash').value = cph;
     document.getElementById('cfgCullPhashVal').textContent = cph;
     // Load pipeline settings
-    var p = cfg.pipeline || {};
-    var wf = Math.round((p.w_focus != null ? p.w_focus : 0.45) * 100);
+    var p = VireoPipelineConfig.pipelineFromConfig(cfg);
+    var wf = VireoPipelineConfig.percent(p.w_focus, 'w_focus');
     document.getElementById('cfgWFocus').value = wf;
     document.getElementById('cfgWFocusVal').textContent = wf + '%';
-    var we = Math.round((p.w_exposure != null ? p.w_exposure : 0.20) * 100);
+    var we = VireoPipelineConfig.percent(p.w_exposure, 'w_exposure');
     document.getElementById('cfgWExposure').value = we;
     document.getElementById('cfgWExposureVal').textContent = we + '%';
-    var wc = Math.round((p.w_composition != null ? p.w_composition : 0.15) * 100);
+    var wc = VireoPipelineConfig.percent(p.w_composition, 'w_composition');
     document.getElementById('cfgWComposition').value = wc;
     document.getElementById('cfgWCompositionVal').textContent = wc + '%';
-    var wa = Math.round((p.w_area != null ? p.w_area : 0.10) * 100);
+    var wa = VireoPipelineConfig.percent(p.w_area, 'w_area');
     document.getElementById('cfgWArea').value = wa;
     document.getElementById('cfgWAreaVal').textContent = wa + '%';
-    var wn = Math.round((p.w_noise != null ? p.w_noise : 0.10) * 100);
+    var wn = VireoPipelineConfig.percent(p.w_noise, 'w_noise');
     document.getElementById('cfgWNoise').value = wn;
     document.getElementById('cfgWNoiseVal').textContent = wn + '%';
-    var rc = Math.round((p.reject_crop_complete != null ? p.reject_crop_complete : 0.60) * 100);
+    var rc = VireoPipelineConfig.percent(p.reject_crop_complete, 'reject_crop_complete');
     document.getElementById('cfgRejectCrop').value = rc;
     document.getElementById('cfgRejectCropVal').textContent = rc + '%';
-    var rf = Math.round((p.reject_focus != null ? p.reject_focus : 0.35) * 100);
+    var rf = VireoPipelineConfig.percent(p.reject_focus, 'reject_focus');
     document.getElementById('cfgRejectFocus').value = rf;
     document.getElementById('cfgRejectFocusVal').textContent = rf + '%';
-    var rcl = Math.round((p.reject_clip_high != null ? p.reject_clip_high : 0.30) * 100);
+    var rcl = VireoPipelineConfig.percent(p.reject_clip_high, 'reject_clip_high');
     document.getElementById('cfgRejectClip').value = rcl;
     document.getElementById('cfgRejectClipVal').textContent = rcl + '%';
-    var rco = Math.round((p.reject_composite != null ? p.reject_composite : 0.40) * 100);
+    var rco = VireoPipelineConfig.percent(p.reject_composite, 'reject_composite');
     document.getElementById('cfgRejectComposite').value = rco;
     document.getElementById('cfgRejectCompositeVal').textContent = rco + '%';
 
     // Miss detection tunables
     document.getElementById('cfgMissEnabled').checked = p.miss_enabled !== false;
-    var mdc = Math.round((p.miss_det_confidence != null ? p.miss_det_confidence : 0.25) * 100);
+    var mdc = VireoPipelineConfig.percent(p.miss_det_confidence, 'miss_det_confidence');
     document.getElementById('cfgMissDetConf').value = mdc;
     document.getElementById('cfgMissDetConfVal').textContent = mdc + '%';
-    var mbm = Math.round((p.miss_bbox_area_min != null ? p.miss_bbox_area_min : 0.005) * 1000);
+    var mbm = Math.round(VireoPipelineConfig.asNumber(p.miss_bbox_area_min, 'miss_bbox_area_min') * 1000);
     document.getElementById('cfgMissBboxMin').value = mbm;
     document.getElementById('cfgMissBboxMinVal').textContent = (mbm / 1000).toFixed(3);
-    var mor = Math.round((p.miss_oof_ratio != null ? p.miss_oof_ratio : 0.50) * 100);
+    var mor = VireoPipelineConfig.percent(p.miss_oof_ratio, 'miss_oof_ratio');
     document.getElementById('cfgMissOofRatio').value = mor;
     document.getElementById('cfgMissOofRatioVal').textContent = (mor / 100).toFixed(2);
 
     // Eye-focus detection tunables
     document.getElementById('cfgEyeDetectEnabled').checked =
       p.eye_detect_enabled !== false;  // default true
-    var ecg = Math.round((p.eye_classifier_conf_gate != null ? p.eye_classifier_conf_gate : 0.50) * 100);
+    var ecg = VireoPipelineConfig.percent(p.eye_classifier_conf_gate, 'eye_classifier_conf_gate');
     document.getElementById('cfgEyeClassifierConfGate').value = ecg;
     document.getElementById('cfgEyeClassifierConfGateVal').textContent = ecg + '%';
-    var edg = Math.round((p.eye_detection_conf_gate != null ? p.eye_detection_conf_gate : 0.50) * 100);
+    var edg = VireoPipelineConfig.percent(p.eye_detection_conf_gate, 'eye_detection_conf_gate');
     document.getElementById('cfgEyeDetectionConfGate').value = edg;
     document.getElementById('cfgEyeDetectionConfGateVal').textContent = edg + '%';
-    var ewk = Math.round((p.eye_window_k != null ? p.eye_window_k : 0.08) * 100);
+    var ewk = VireoPipelineConfig.percent(p.eye_window_k, 'eye_window_k');
     document.getElementById('cfgEyeWindowK').value = ewk;
     document.getElementById('cfgEyeWindowKVal').textContent = (ewk / 100).toFixed(2);
-    var rejectEye = Math.round((p.reject_eye_focus != null ? p.reject_eye_focus : 0.35) * 100);
+    var rejectEye = VireoPipelineConfig.percent(p.reject_eye_focus, 'reject_eye_focus');
     document.getElementById('cfgRejectEyeFocus').value = rejectEye;
     document.getElementById('cfgRejectEyeFocusVal').textContent = rejectEye + '%';
-    var btg = p.burst_time_gap != null ? p.burst_time_gap : 3;
+    var btg = VireoPipelineConfig.asNumber(p.burst_time_gap, 'burst_time_gap');
     document.getElementById('cfgBurstTimeGap').value = btg;
     document.getElementById('cfgBurstTimeGapVal').textContent = btg + 's';
-    // Stored as cosine similarity; UI shows distance = 1 - similarity.
-    var bemb = Math.round((1 - (p.burst_embedding_threshold != null ? p.burst_embedding_threshold : 0.40)) * 100);
+    var bemb = VireoPipelineConfig.embeddingThresholdToDistancePercent(
+      p.burst_embedding_threshold
+    );
     document.getElementById('cfgBurstEmb').value = bemb;
     document.getElementById('cfgBurstEmbVal').textContent = bemb + '%';
-    var bl = Math.round((p.burst_lambda != null ? p.burst_lambda : 0.85) * 100);
+    var bl = VireoPipelineConfig.percent(p.burst_lambda, 'burst_lambda');
     document.getElementById('cfgBurstLambda').value = bl;
     document.getElementById('cfgBurstLambdaVal').textContent = bl + '%';
-    document.getElementById('cfgBurstMaxKeep').value = p.burst_max_keep != null ? p.burst_max_keep : 3;
-    var el = Math.round((p.encounter_lambda != null ? p.encounter_lambda : 0.70) * 100);
+    document.getElementById('cfgBurstMaxKeep').value = VireoPipelineConfig.asNumber(p.burst_max_keep, 'burst_max_keep');
+    var el = VireoPipelineConfig.percent(p.encounter_lambda, 'encounter_lambda');
     document.getElementById('cfgEncLambda').value = el;
     document.getElementById('cfgEncLambdaVal').textContent = el + '%';
-    document.getElementById('cfgEncMaxKeep').value = p.encounter_max_keep != null ? p.encounter_max_keep : 5;
-    document.getElementById('cfgWTime').value = Math.round((p.w_time != null ? p.w_time : 0.35) * 100);
-    document.getElementById('cfgWSubj').value = Math.round((p.w_subj != null ? p.w_subj : 0.35) * 100);
-    document.getElementById('cfgWGlobal').value = Math.round((p.w_global != null ? p.w_global : 0.15) * 100);
-    document.getElementById('cfgWSpecies').value = Math.round((p.w_species != null ? p.w_species : 0.10) * 100);
-    document.getElementById('cfgWMeta').value = Math.round((p.w_meta != null ? p.w_meta : 0.05) * 100);
-    document.getElementById('cfgHardCutTime').value = p.hard_cut_time != null ? p.hard_cut_time : 180;
-    var hcs = Math.round((p.hard_cut_score != null ? p.hard_cut_score : 0.42) * 100);
+    document.getElementById('cfgEncMaxKeep').value = VireoPipelineConfig.asNumber(p.encounter_max_keep, 'encounter_max_keep');
+    document.getElementById('cfgWTime').value = VireoPipelineConfig.percent(p.w_time, 'w_time');
+    document.getElementById('cfgWSubj').value = VireoPipelineConfig.percent(p.w_subj, 'w_subj');
+    document.getElementById('cfgWGlobal').value = VireoPipelineConfig.percent(p.w_global, 'w_global');
+    document.getElementById('cfgWSpecies').value = VireoPipelineConfig.percent(p.w_species, 'w_species');
+    document.getElementById('cfgWMeta').value = VireoPipelineConfig.percent(p.w_meta, 'w_meta');
+    document.getElementById('cfgHardCutTime').value = VireoPipelineConfig.asNumber(p.hard_cut_time, 'hard_cut_time');
+    var hcs = VireoPipelineConfig.percent(p.hard_cut_score, 'hard_cut_score');
     document.getElementById('cfgHardCutScore').value = hcs;
     document.getElementById('cfgHardCutScoreVal').textContent = hcs + '%';
-    var scs = Math.round((p.soft_cut_score != null ? p.soft_cut_score : 0.52) * 100);
+    var scs = VireoPipelineConfig.percent(p.soft_cut_score, 'soft_cut_score');
     document.getElementById('cfgSoftCutScore').value = scs;
     document.getElementById('cfgSoftCutScoreVal').textContent = scs + '%';
-    var ms = Math.round((p.merge_score != null ? p.merge_score : 0.62) * 100);
+    var ms = VireoPipelineConfig.percent(p.merge_score, 'merge_score');
     document.getElementById('cfgMergeScore').value = ms;
     document.getElementById('cfgMergeScoreVal').textContent = ms + '%';
-    document.getElementById('cfgMergeMaxGap').value = p.merge_max_gap != null ? p.merge_max_gap : 60;
-  } catch(e) {}
+    document.getElementById('cfgMergeMaxGap').value = VireoPipelineConfig.asNumber(p.merge_max_gap, 'merge_max_gap');
+  } catch(e) {
+    console.warn('Could not load settings config:', e);
+  }
 }
 
 var CARD_FIELD_OPTIONS = [
@@ -1877,7 +1880,9 @@ function saveConfig() {
             eye_window_k: parseInt(document.getElementById('cfgEyeWindowK').value, 10) / 100,
             reject_eye_focus: parseInt(document.getElementById('cfgRejectEyeFocus').value, 10) / 100,
             burst_time_gap: parseInt(document.getElementById('cfgBurstTimeGap').value, 10) || 3,
-            burst_embedding_threshold: 1 - parseInt(document.getElementById('cfgBurstEmb').value, 10) / 100,
+            burst_embedding_threshold: VireoPipelineConfig.embeddingDistancePercentToThreshold(
+              parseInt(document.getElementById('cfgBurstEmb').value, 10)
+            ),
             burst_lambda: parseInt(document.getElementById('cfgBurstLambda').value, 10) / 100,
             burst_max_keep: parseInt(document.getElementById('cfgBurstMaxKeep').value, 10) || 3,
             encounter_lambda: parseInt(document.getElementById('cfgEncLambda').value, 10) / 100,

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1745,6 +1745,10 @@ async function loadConfig() {
     document.getElementById('cfgMergeMaxGap').value = VireoPipelineConfig.asNumber(p.merge_max_gap, 'merge_max_gap');
   } catch(e) {
     console.warn('Could not load settings config:', e);
+    var fallbackDistance = VireoPipelineConfig.buildSliderDefaults()
+      .grouping.burst_embedding_distance;
+    document.getElementById('cfgBurstEmb').value = fallbackDistance;
+    document.getElementById('cfgBurstEmbVal').textContent = fallbackDistance + '%';
   }
 }
 

--- a/vireo/tests/test_bursts.py
+++ b/vireo/tests/test_bursts.py
@@ -140,6 +140,19 @@ def test_burst_empty():
     assert detect_bursts([]) == []
 
 
+def test_burst_defaults_mirror_config():
+    """Burst helper defaults come from the application config defaults."""
+    from bursts import DEFAULTS as BURST_DEFAULTS
+    from config import DEFAULTS as CONFIG_DEFAULTS
+
+    assert BURST_DEFAULTS["burst_time_gap"] == CONFIG_DEFAULTS["pipeline"][
+        "burst_time_gap"
+    ]
+    assert BURST_DEFAULTS["burst_embedding_threshold"] == CONFIG_DEFAULTS[
+        "pipeline"
+    ]["burst_embedding_threshold"]
+
+
 # -- Configurable thresholds --
 
 

--- a/vireo/tests/test_bursts.py
+++ b/vireo/tests/test_bursts.py
@@ -178,8 +178,9 @@ def test_burst_custom_embedding_threshold():
         _make_photo(0.5, subj_emb=similar),
     ]
 
-    # Default 0.80 → likely cut if cosine < 0.80
+    # Default 0.40 → likely keep moderate flying-bird pose changes together.
     result_default = detect_bursts(photos)
+    assert len(result_default) == 1
 
     # Very low threshold → no cut
     result_low = detect_bursts(photos, config={"burst_embedding_threshold": 0.3})

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -74,6 +74,7 @@ def test_pipeline_defaults_exist():
     p = DEFAULTS["pipeline"]
     assert p["w_focus"] == 0.45
     assert p["burst_time_gap"] == 3.0
+    assert p["burst_embedding_threshold"] == 0.40
     assert p["burst_lambda"] == 0.85
     assert p["encounter_lambda"] == 0.70
     assert p["reject_composite"] == 0.40


### PR DESCRIPTION
Raises the default burst embedding distance from 0.20 to 0.60, stored as a lower cosine similarity cutoff of 0.40. Centralizes pipeline slider default mapping in shared browser code and makes the standalone burst helper mirror `config.DEFAULTS`, so Pipeline Review, Cull, Settings, and burst detection no longer carry separate copies of the same default. The shared helper owns the similarity-threshold to embedding-distance conversion, reducing drift risk when these controls change again. Validated with `node --check vireo/static/vireo-utils.js` and `python -m pytest vireo/tests/test_bursts.py vireo/tests/test_config.py vireo/tests/test_config_schema.py vireo/tests/test_settings_api.py -q`.