### PR TITLE
[codex] Smooth 1:1 lightbox navigation

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -1,4 +1,11 @@
+import base64
+
 from playwright.sync_api import expect
+
+_PNG_1X1 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+    "/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
 
 
 def test_browse_lightbox_arrows_navigate(live_server, page):
@@ -71,6 +78,39 @@ def test_browse_lightbox_arrows_preserve_one_to_one_zoom(live_server, page):
     )
     assert restored
     assert page.evaluate("window._lbZoom") > 1.001
+
+
+def test_browse_lightbox_one_to_one_nav_falls_back_when_original_fails(live_server, page):
+    """1:1 arrow navigation falls back to /full when the original is unavailable."""
+    image_body = base64.b64decode(_PNG_1X1)
+    page.route("**/photos/*/original", lambda route: route.fulfill(status=503, body="missing"))
+    page.route("**/photos/*/full", lambda route: route.fulfill(body=image_body, content_type="image/png"))
+
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.evaluate(
+        """() => {
+            window._lbNativeZoom = 2;
+            window._lbZoom = 2;
+            window._lbPending1To1 = false;
+        }"""
+    )
+
+    page.locator("[title='Next (→)']").click()
+    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return window._lbCurrentSrcKey === 'full' && img && img.complete && img.naturalWidth > 0;
+        }"""
+    )
+    assert "/full" in page.locator("#lightboxImg").get_attribute("src")
 
 
 def test_browse_e_f_g_keyboard_modes(live_server, page):

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -58,7 +58,9 @@ def test_browse_lightbox_arrows_preserve_one_to_one_zoom(live_server, page):
 
     page.locator("[title='Next (→)']").click()
     expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
-    assert page.evaluate("window._lbPending1To1 || window._lbZoom > 1.001") is True
+    assert page.evaluate("window._lbZoom > 1.001") is True
+    assert page.evaluate("window._lbPending1To1") is True
+    assert page.evaluate("window._lbCurrentSrcKey") == "original"
 
     restored = page.evaluate(
         """() => {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3427,8 +3427,9 @@ function openLightbox(photoId, filename, photoList, options) {
     })
     .catch(function() {});
 
-  img.onload = function() {
+  function handleInitialImageLoad() {
     img.onload = null;
+    img.onerror = null;
     // Only record the /full tier size if the currently loaded source is still /full.
     // A quick user zoom can trigger a debounced swap to a higher tier before /full
     // finishes loading, which would otherwise make us record the swapped source's
@@ -3444,7 +3445,22 @@ function openLightbox(photoId, filename, photoList, options) {
     _lbRecomputeNativeZoom();
     _lbApplyPendingOneToOneZoom();
     _lbApplyTransform();
-  };
+  }
+  function handleInitialImageError() {
+    if (_lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
+    if (_lbCurrentSrcKey !== 'original') {
+      img.onload = null;
+      img.onerror = null;
+      return;
+    }
+    _lbCurrentSrcKey = 'full';
+    _lbDesiredSrcKey = null;
+    img.onload = handleInitialImageLoad;
+    img.onerror = handleInitialImageError;
+    img.src = _lbSrcUrl(photoId, 'full');
+  }
+  img.onload = handleInitialImageLoad;
+  img.onerror = handleInitialImageError;
   img.src = _lbSrcUrl(photoId, _lbCurrentSrcKey);
   label.textContent = filename || '';
   inspectBtn.onclick = function() { closeLightbox(); openPipeline(photoId); };

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3364,6 +3364,10 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbOpenSeq += 1;
   var openSeq = _lbOpenSeq;
   options = options || {};
+  var preserveOneToOne = !!options.preserveOneToOne;
+  var transitionZoom = preserveOneToOne
+    ? Math.max(1.0, _lbZoom || _lbNativeZoom || 1.0)
+    : 1.0;
 
   _lightboxCurrentId = photoId;
   if (photoList) _lightboxPhotoList = photoList;
@@ -3378,8 +3382,10 @@ function openLightbox(photoId, filename, photoList, options) {
   var similarBtn = document.getElementById('lightboxSimilar');
   var inatBtn = document.getElementById('lightboxInat');
   var wrap = document.getElementById('lightboxWrap');
-  // Reset zoom when loading a new image
-  wrap.classList.remove('zoomed');
+  // Reset pan for the new photo, but keep a 1:1 transform during arrow
+  // navigation so the outgoing image does not visibly snap back to fit before
+  // the replacement finishes loading.
+  wrap.classList.toggle('zoomed', transitionZoom > 1.001);
   wrap.scrollTop = 0;
   wrap.scrollLeft = 0;
   document.getElementById('lightboxZoomBadge').style.display = 'none';
@@ -3391,18 +3397,18 @@ function openLightbox(photoId, filename, photoList, options) {
   if (eyeContainer) { eyeContainer.innerHTML = ''; eyeContainer.style.display = 'none'; }
 
   // Reset continuous zoom state for new photo
-  _lbZoom = 1.0;
+  _lbZoom = transitionZoom;
   _lbPanX = 0;
   _lbPanY = 0;
   _lbNativeZoom = null;
   _lbPhotoW = null;
   _lbPhotoH = null;
-  _lbCurrentSrcKey = 'full';
+  _lbCurrentSrcKey = preserveOneToOne ? 'original' : 'full';
   _lbFullLongEdge = null;
-  _lbPending1To1 = !!options.preserveOneToOne;
+  _lbPending1To1 = preserveOneToOne;
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;
-  _lbApplyTransform();  // Clear any lingering translate/scale from prior photo before the new one renders.
+  _lbApplyTransform();  // Clear stale pan while preserving 1:1 scale when requested.
 
   // Fetch original dimensions (async, non-blocking for image display)
   var flagFetchSeq = _lbFlagEditSeq;
@@ -3421,7 +3427,6 @@ function openLightbox(photoId, filename, photoList, options) {
     })
     .catch(function() {});
 
-  img.src = '/photos/' + photoId + '/full';
   img.onload = function() {
     img.onload = null;
     // Only record the /full tier size if the currently loaded source is still /full.
@@ -3432,10 +3437,15 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbFullLongEdge = Math.max(img.naturalWidth, img.naturalHeight);
       _lbSessionFullLongEdge = _lbFullLongEdge;
     }
+    if (_lightboxCurrentId === photoId && _lbCurrentSrcKey === 'original' && !_lbPhotoW && img.naturalWidth) {
+      _lbPhotoW = img.naturalWidth;
+      _lbPhotoH = img.naturalHeight;
+    }
     _lbRecomputeNativeZoom();
     _lbApplyPendingOneToOneZoom();
     _lbApplyTransform();
   };
+  img.src = _lbSrcUrl(photoId, _lbCurrentSrcKey);
   label.textContent = filename || '';
   inspectBtn.onclick = function() { closeLightbox(); openPipeline(photoId); };
   similarBtn.onclick = function() { closeLightbox(); findSimilar(photoId); };
@@ -4237,7 +4247,7 @@ function _lbRecomputeNativeZoom() {
   // Compute zoom value that corresponds to 1:1 (one screen pixel == one image pixel).
   // We need the displayed size of the image at zoom=1.0 (fit) to compare against native.
   var img = document.getElementById('lightboxImg');
-  if (!img || !_lbPhotoW || !_lbPhotoH || !img.naturalWidth || !img.naturalHeight) {
+  if (!img || !img.complete || !_lbPhotoW || !_lbPhotoH || !img.naturalWidth || !img.naturalHeight) {
     _lbNativeZoom = null;
     return;
   }


### PR DESCRIPTION
This fixes the browse lightbox arrow transition while viewing at 1:1 by preserving the zoom transform during navigation instead of snapping the outgoing image back to fit. When preserving 1:1, the lightbox now starts the next image from the original source and resolves pending native zoom only after a loaded current image is available. The browse lightbox regression test now asserts that arrow navigation keeps zoom active immediately and requests the original source. Validated with the browse lightbox E2E tests plus the shared lightbox context menu and flag hotkey E2E tests.