### PR TITLE
[codex] Load more browse photos during arrow navigation

### DIFF
--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -386,6 +386,31 @@ def test_arrow_navigation_loads_next_page_at_loaded_boundary(live_server, page):
     assert page.evaluate("selectedPhotoId === photos[2].id")
 
 
+def test_shift_arrow_navigation_preserves_range_selection_at_loaded_boundary(
+    live_server, page
+):
+    """Loading another page for keyboard navigation must preserve modifiers."""
+    url = live_server["url"]
+    page.route(
+        "**/api/config",
+        lambda route: route.fulfill(
+            json={"photos_per_page": 2, "keyboard_shortcuts": {}}
+        ),
+    )
+    page.goto(f"{url}/browse")
+
+    cards = page.locator(".grid-card")
+    cards.nth(1).wait_for(state="visible")
+    page.wait_for_function("photos.length === 2 && totalPhotos > photos.length")
+
+    cards.nth(1).click()
+    page.keyboard.press("Shift+ArrowRight")
+
+    page.wait_for_function("photos.length > 2 && selectedPhotos.has(photos[2].id)")
+    assert page.evaluate("selectedPhotos.has(photos[1].id)")
+    assert page.evaluate("selectedPhotoId === photos[1].id")
+
+
 def test_multiselect_offers_partial_keyword_fill(live_server, page):
     """Selecting mixed tagged/untagged photos offers one-click keyword fill."""
     url = live_server["url"]

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -362,6 +362,30 @@ def test_singleton_set_keyboard_shortcut_applies(live_server, page):
     )
 
 
+def test_arrow_navigation_loads_next_page_at_loaded_boundary(live_server, page):
+    """Keyboard navigation should continue past the currently loaded page."""
+    url = live_server["url"]
+    page.route(
+        "**/api/config",
+        lambda route: route.fulfill(
+            json={"photos_per_page": 2, "keyboard_shortcuts": {}}
+        ),
+    )
+    page.goto(f"{url}/browse")
+
+    cards = page.locator(".grid-card")
+    cards.nth(1).wait_for(state="visible")
+    page.wait_for_function("photos.length === 2 && totalPhotos > photos.length")
+
+    cards.nth(1).click()
+    assert page.evaluate("selectedIndex") == 1
+
+    page.keyboard.press("ArrowRight")
+
+    page.wait_for_function("photos.length > 2 && selectedIndex === 2", timeout=3000)
+    assert page.evaluate("selectedPhotoId === photos[2].id")
+
+
 def test_multiselect_offers_partial_keyword_fill(live_server, page):
     """Selecting mixed tagged/untagged photos offers one-click keyword fill."""
     url = live_server["url"]

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4419,11 +4419,11 @@ document.addEventListener('keydown', function(e) {
   // Arrow keys: navigate grid (not configurable)
   if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
     e.preventDefault();
-    moveBrowseSelection(1);
+    moveBrowseSelection(1, e);
     return;
   } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
     e.preventDefault();
-    moveBrowseSelection(-1);
+    moveBrowseSelection(-1, e);
     return;
   }
 
@@ -4487,14 +4487,19 @@ document.addEventListener('keydown', function(e) {
   }
 });
 
-async function moveBrowseSelection(delta) {
+async function moveBrowseSelection(delta, e) {
   var nextIndex = selectedIndex + delta;
   if (delta > 0 && nextIndex >= photos.length && !allLoaded) {
     await loadPhotos();
     nextIndex = selectedIndex + delta;
   }
   if (nextIndex < 0 || nextIndex >= photos.length || !photos[nextIndex]) return;
-  selectPhoto({ shiftKey: false, metaKey: false, ctrlKey: false }, photos[nextIndex].id, nextIndex);
+  var selectionEvent = {
+    shiftKey: !!(e && e.shiftKey),
+    metaKey: !!(e && e.metaKey),
+    ctrlKey: !!(e && e.ctrlKey),
+  };
+  selectPhoto(selectionEvent, photos[nextIndex].id, nextIndex);
   scrollToCard(selectedIndex);
 }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4419,16 +4419,12 @@ document.addEventListener('keydown', function(e) {
   // Arrow keys: navigate grid (not configurable)
   if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
     e.preventDefault();
-    if (selectedIndex < photos.length - 1) {
-      selectPhoto(e, photos[selectedIndex + 1].id, selectedIndex + 1);
-      scrollToCard(selectedIndex);
-    }
+    moveBrowseSelection(1);
+    return;
   } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
     e.preventDefault();
-    if (selectedIndex > 0) {
-      selectPhoto(e, photos[selectedIndex - 1].id, selectedIndex - 1);
-      scrollToCard(selectedIndex);
-    }
+    moveBrowseSelection(-1);
+    return;
   }
 
   // Must stay aligned with updateBatchBar(): any non-empty selectedPhotos is
@@ -4490,6 +4486,17 @@ document.addEventListener('keydown', function(e) {
     }
   }
 });
+
+async function moveBrowseSelection(delta) {
+  var nextIndex = selectedIndex + delta;
+  if (delta > 0 && nextIndex >= photos.length && !allLoaded) {
+    await loadPhotos();
+    nextIndex = selectedIndex + delta;
+  }
+  if (nextIndex < 0 || nextIndex >= photos.length || !photos[nextIndex]) return;
+  selectPhoto({ shiftKey: false, metaKey: false, ctrlKey: false }, photos[nextIndex].id, nextIndex);
+  scrollToCard(selectedIndex);
+}
 
 function scrollToCard(idx) {
   var cards = document.querySelectorAll('.grid-card');


### PR DESCRIPTION
## Summary
Browse keyboard navigation now asks the existing pagination path to load the next page when Right/Down reaches the last loaded photo. This fixes the limit where selection stopped at the end of the client-side `photos` array even when more photos existed. Added an e2e regression test that forces two-photo pages and verifies ArrowRight loads and selects the next page.

## Validation
- `pytest tests/e2e/test_browse_single_select.py -q`