### PR TITLE
[codex] Sync flags to XMP

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2112,6 +2112,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             db.update_photo_flag(photo_id, flag)
         except ValueError as e:
             return json_error(str(e), 403)
+        db.queue_flag_change_if_enabled(photo_id, flag)
         db.record_edit('flag', f'Set flag to {flag}', flag,
                        [{'photo_id': photo_id, 'old_value': old_flag, 'new_value': flag}])
         return jsonify({"ok": True})
@@ -2878,6 +2879,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             db.batch_update_photo_flag(valid_ids, flag)
         except ValueError as e:
             return json_error(str(e), 403)
+        for pid in valid_ids:
+            db.queue_flag_change_if_enabled(pid, flag, _commit=False)
+        db.conn.commit()
         items = [{'photo_id': pid, 'old_value': old_values[pid], 'new_value': flag} for pid in old_values]
         db.record_edit('flag', f'Set flag to {flag} on {len(photo_ids)} photos',
                        flag, items, is_batch=True)
@@ -4445,6 +4449,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if pid in old_flags:
                 flag_items.append({'photo_id': pid, 'old_value': old_flags[pid], 'new_value': 'rejected'})
         if flag_items:
+            for item in flag_items:
+                db.queue_flag_change_if_enabled(
+                    item["photo_id"], item["new_value"], _commit=False
+                )
+            db.conn.commit()
             desc = f'Group prediction: flagged {len(picks)}, rejected {len(rejects)}'
             db.record_edit('flag', desc, 'group_apply', flag_items, is_batch=True)
 
@@ -4520,6 +4529,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                  "new_value": "rejected"}
                 for a in affected
             ]
+            for item in items:
+                db.queue_flag_change_if_enabled(
+                    item["photo_id"], item["new_value"], _commit=False
+                )
+            db.conn.commit()
             db.record_edit(
                 "flag",
                 f"Rejected {len(items)} miss photos (category={category})",
@@ -11749,6 +11763,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(str(e), 403)
 
         if flag_items:
+            for item in flag_items:
+                db.queue_flag_change_if_enabled(
+                    item["photo_id"], item["new_value"], _commit=False
+                )
+            db.conn.commit()
             desc = (
                 f"Pipeline burst group: flagged {len(picks)}, rejected {len(rejects)}, "
                 f"cleared {sum(1 for it in flag_items if it['new_value'] == 'none')}"
@@ -11948,6 +11967,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if pid in old_flags:
                 flag_items.append({'photo_id': pid, 'old_value': old_flags[pid], 'new_value': 'rejected'})
         if flag_items:
+            for item in flag_items:
+                db.queue_flag_change_if_enabled(
+                    item["photo_id"], item["new_value"], _commit=False
+                )
+            db.conn.commit()
             db.record_edit('flag',
                            f'Culling: flagged {len(keepers)}, rejected {len(rejects)}',
                            'culling_apply', flag_items, is_batch=True)

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -20,6 +20,7 @@ DEFAULTS = {
     "similarity_threshold": 0.85,
     "preview_max_size": 1920,
     "keyword_case": "auto",
+    "sync_flags_to_xmp": True,
     "max_edit_history": 1000,
     "inat_token": "",
     "hf_token": "",

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -30,6 +30,7 @@ CATEGORIES = (
     "Detection",
     "Pipeline",
     "Culling",
+    "Metadata",
     "Display",
     "Working copy",
     "Preview",
@@ -115,6 +116,12 @@ SCHEMA = {
         "category": "Behavior", "scope": "global",
         "label": "Keyword case",
         "desc": "Capitalization convention for species keywords.",
+    },
+    "sync_flags_to_xmp": {
+        "type": "bool",
+        "category": "Metadata", "scope": "both",
+        "label": "Sync pick/reject flags to XMP",
+        "desc": "Write Vireo pick/reject flags to XMP sidecars using Lightroom-compatible pick metadata.",
     },
     "scan_workers": {
         "type": "int", "min": 0, "max": 64,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -8157,6 +8157,7 @@ class Database:
 
     def queue_flag_change_if_enabled(self, photo_id, flag, workspace_id=None, _commit=True):
         """Queue a flag write when the active config opts into XMP flag sync."""
+        ws_id = workspace_id if workspace_id is not None else self._ws_id()
         try:
             import config as cfg
 
@@ -8166,11 +8167,12 @@ class Database:
         except Exception:
             log.warning("Failed to read sync_flags_to_xmp config", exc_info=True)
             enabled = False
+        self.remove_pending_changes(photo_id, "flag", workspace_id=ws_id, _commit=False)
         if not enabled:
+            if _commit:
+                self.conn.commit()
             return None
 
-        ws_id = workspace_id if workspace_id is not None else self._ws_id()
-        self.remove_pending_changes(photo_id, "flag", workspace_id=ws_id, _commit=False)
         token = self.queue_change(
             photo_id, "flag", flag, workspace_id=ws_id, _commit=False
         )
@@ -8421,8 +8423,8 @@ class Database:
                     self.remove_pending_changes(pid, 'rating', old_val)
                     self.queue_change(pid, 'rating', new_val)
             elif entry['action_type'] == 'flag':
-                self.update_photo_flag(pid, entry['new_value'], verify_workspace=False)
-                self.queue_flag_change_if_enabled(pid, entry['new_value'])
+                self.update_photo_flag(pid, new_val, verify_workspace=False)
+                self.queue_flag_change_if_enabled(pid, new_val)
             elif entry['action_type'] == 'wildlife_excluded':
                 self.update_photo_wildlife_excluded(
                     pid, new_val == "1", verify_workspace=False

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -8155,6 +8155,29 @@ class Database:
         )
         self.conn.commit()
 
+    def queue_flag_change_if_enabled(self, photo_id, flag, workspace_id=None, _commit=True):
+        """Queue a flag write when the active config opts into XMP flag sync."""
+        try:
+            import config as cfg
+
+            enabled = bool(
+                self.get_effective_config(cfg.load()).get("sync_flags_to_xmp", False)
+            )
+        except Exception:
+            log.warning("Failed to read sync_flags_to_xmp config", exc_info=True)
+            enabled = False
+        if not enabled:
+            return None
+
+        ws_id = workspace_id if workspace_id is not None else self._ws_id()
+        self.remove_pending_changes(photo_id, "flag", workspace_id=ws_id, _commit=False)
+        token = self.queue_change(
+            photo_id, "flag", flag, workspace_id=ws_id, _commit=False
+        )
+        if _commit:
+            self.conn.commit()
+        return token
+
     # -- Edit History --
 
     def record_edit(self, action_type, description, new_value, items, is_batch=False, _commit=True):
@@ -8275,6 +8298,7 @@ class Database:
                     self.queue_change(pid, 'rating', old_val)
             elif entry['action_type'] == 'flag':
                 self.update_photo_flag(pid, old_val, verify_workspace=False)
+                self.queue_flag_change_if_enabled(pid, old_val)
             elif entry['action_type'] == 'wildlife_excluded':
                 self.update_photo_wildlife_excluded(
                     pid, old_val == "1", verify_workspace=False
@@ -8398,6 +8422,7 @@ class Database:
                     self.queue_change(pid, 'rating', new_val)
             elif entry['action_type'] == 'flag':
                 self.update_photo_flag(pid, entry['new_value'], verify_workspace=False)
+                self.queue_flag_change_if_enabled(pid, entry['new_value'])
             elif entry['action_type'] == 'wildlife_excluded':
                 self.update_photo_wildlife_excluded(
                     pid, new_val == "1", verify_workspace=False

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -8158,6 +8158,13 @@ class Database:
     def queue_flag_change_if_enabled(self, photo_id, flag, workspace_id=None, _commit=True):
         """Queue a flag write when the active config opts into XMP flag sync."""
         ws_id = workspace_id if workspace_id is not None else self._ws_id()
+        flag = flag or "none"
+        self.remove_pending_changes(photo_id, "flag", workspace_id=ws_id, _commit=False)
+        if flag not in {"none", "flagged", "rejected"}:
+            log.warning("Not queueing invalid XMP flag value for photo %s: %r", photo_id, flag)
+            if _commit:
+                self.conn.commit()
+            return None
         try:
             import config as cfg
 
@@ -8167,7 +8174,6 @@ class Database:
         except Exception:
             log.warning("Failed to read sync_flags_to_xmp config", exc_info=True)
             enabled = False
-        self.remove_pending_changes(photo_id, "flag", workspace_id=ws_id, _commit=False)
         if not enabled:
             if _commit:
                 self.conn.commit()

--- a/vireo/sync.py
+++ b/vireo/sync.py
@@ -4,7 +4,7 @@ import logging
 import os
 from collections import defaultdict
 
-from xmp import read_keywords, remove_keywords, write_rating, write_sidecar
+from xmp import read_keywords, remove_keywords, write_pick_flag, write_rating, write_sidecar
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +18,17 @@ def _get_xmp_path_for_photo(db, photo_id):
     folder_path = folders.get(photo["folder_id"], "")
     base = os.path.splitext(photo["filename"])[0]
     return os.path.join(folder_path, base + ".xmp")
+
+
+def _sync_flags_to_xmp_enabled(db):
+    """Return whether the active workspace should write flags to XMP."""
+    try:
+        import config as cfg
+
+        return bool(db.get_effective_config(cfg.load()).get("sync_flags_to_xmp", False))
+    except Exception:
+        log.warning("Failed to read sync_flags_to_xmp config", exc_info=True)
+        return False
 
 
 def sync_to_xmp(db, progress_callback=None):
@@ -39,6 +50,7 @@ def sync_to_xmp(db, progress_callback=None):
     for c in changes:
         by_photo[c["photo_id"]].append(c)
 
+    sync_flags = _sync_flags_to_xmp_enabled(db)
     synced = 0
     failed = 0
     failures = []
@@ -66,6 +78,7 @@ def sync_to_xmp(db, progress_callback=None):
             keywords_to_add = set()
             keywords_to_remove = set()
             new_rating = None
+            new_flag = None
             supported_ids = []
             unsupported_changes = []
 
@@ -80,7 +93,11 @@ def sync_to_xmp(db, progress_callback=None):
                     new_rating = int(c["value"])
                     supported_ids.append(c["id"])
                 elif c["change_type"] == "flag":
-                    unsupported_changes.append(c)
+                    if sync_flags:
+                        new_flag = c["value"]
+                        supported_ids.append(c["id"])
+                    else:
+                        unsupported_changes.append(c)
 
             # Write keywords
             if keywords_to_add:
@@ -91,6 +108,12 @@ def sync_to_xmp(db, progress_callback=None):
             # Handle keyword removals: remove matching li elements from bags
             if keywords_to_remove:
                 remove_keywords(xmp_path, keywords_to_remove)
+
+            # Write flag before rating: write_pick_flag creates a sidecar if
+            # needed, while write_rating intentionally only updates existing
+            # sidecars.
+            if new_flag is not None:
+                write_pick_flag(xmp_path, new_flag)
 
             # Write rating
             if new_rating is not None:

--- a/vireo/sync.py
+++ b/vireo/sync.py
@@ -94,7 +94,7 @@ def sync_to_xmp(db, progress_callback=None):
                     supported_ids.append(c["id"])
                 elif c["change_type"] == "flag":
                     if sync_flags:
-                        new_flag = c["value"]
+                        new_flag = c["value"] or "none"
                         supported_ids.append(c["id"])
                     else:
                         unsupported_changes.append(c)

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -148,6 +148,37 @@ def test_set_flag(app_and_db):
     )
 
 
+def test_set_flag_clears_pending_xmp_when_sync_disabled(app_and_db):
+    """Changing a flag with flag sync disabled clears stale queued flag writes."""
+    import config as cfg
+
+    app, db = app_and_db
+    client = app.test_client()
+    photos = db.get_photos()
+    pid = photos[0]['id']
+
+    resp = client.post(f'/api/photos/{pid}/flag', json={'flag': 'flagged'})
+    assert resp.status_code == 200
+    assert any(
+        c['photo_id'] == pid
+        and c['change_type'] == 'flag'
+        and c['value'] == 'flagged'
+        for c in db.get_pending_changes()
+    )
+
+    config = cfg.load()
+    config['sync_flags_to_xmp'] = False
+    cfg.save(config)
+
+    resp = client.post(f'/api/photos/{pid}/flag', json={'flag': 'rejected'})
+    assert resp.status_code == 200
+    assert db.get_photo(pid)['flag'] == 'rejected'
+    assert not any(
+        c['photo_id'] == pid and c['change_type'] == 'flag'
+        for c in db.get_pending_changes()
+    )
+
+
 def test_add_keyword_to_photo(app_and_db):
     """POST /api/photos/<id>/keywords adds keyword and queues pending change."""
     app, db = app_and_db
@@ -730,6 +761,38 @@ def test_undo_batch_flag_restores_all_photos(app_and_db):
 
     for pid in pids:
         assert (db.get_photo(pid)['flag'] or 'none') == originals[pid]
+
+
+def test_redo_batch_flag_restores_per_photo_flag_values(app_and_db):
+    """Redoing a batch flag action uses per-item values, not the action summary."""
+    app, db = app_and_db
+    client = app.test_client()
+    photos = db.get_photos()
+    pids = [p['id'] for p in photos[:3]]
+
+    resp = client.post('/api/culling/apply',
+                       json={'keepers': [pids[0]], 'rejects': [pids[1], pids[2]]})
+    assert resp.status_code == 200
+
+    resp = client.post('/api/undo')
+    assert resp.status_code == 200
+    resp = client.post('/api/redo')
+    assert resp.status_code == 200
+
+    assert db.get_photo(pids[0])['flag'] == 'flagged'
+    assert db.get_photo(pids[1])['flag'] == 'rejected'
+    assert db.get_photo(pids[2])['flag'] == 'rejected'
+
+    queued = {
+        c['photo_id']: c['value']
+        for c in db.get_pending_changes()
+        if c['change_type'] == 'flag' and c['photo_id'] in pids
+    }
+    assert queued == {
+        pids[0]: 'flagged',
+        pids[1]: 'rejected',
+        pids[2]: 'rejected',
+    }
 
 
 def test_undo_batch_keyword_add_removes_from_all_photos(app_and_db):

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -126,7 +126,7 @@ def test_undo_old_rating_action_does_not_clear_new_pending_change_reusing_id(app
 
 
 def test_set_flag(app_and_db):
-    """POST /api/photos/<id>/flag updates the local flag without queuing XMP sync."""
+    """POST /api/photos/<id>/flag updates the flag and queues XMP sync by default."""
     app, db = app_and_db
     client = app.test_client()
     photos = db.get_photos()
@@ -140,7 +140,12 @@ def test_set_flag(app_and_db):
     assert photo['flag'] == 'flagged'
 
     changes = db.get_pending_changes()
-    assert not any(c['photo_id'] == pid and c['change_type'] == 'flag' for c in changes)
+    assert any(
+        c['photo_id'] == pid
+        and c['change_type'] == 'flag'
+        and c['value'] == 'flagged'
+        for c in changes
+    )
 
 
 def test_add_keyword_to_photo(app_and_db):

--- a/vireo/tests/test_misses_api.py
+++ b/vireo/tests/test_misses_api.py
@@ -201,6 +201,12 @@ def test_api_bulk_reject_undo_restores_original_null_flag(client, db_with_misses
     assert after is None, (
         "undo must restore NULL, not an empty string — saw: %r" % after
     )
+    assert any(
+        c["photo_id"] == pid
+        and c["change_type"] == "flag"
+        and c["value"] == "none"
+        for c in db.get_pending_changes()
+    )
 
 
 def test_api_bulk_reject_no_matches_skips_edit_history(client, db_with_misses):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -176,6 +176,27 @@ def test_api_photos_rejects_unknown_flag_filter(app_and_db):
     assert resp.status_code == 400
 
 
+def test_api_set_flag_queues_xmp_when_enabled(app_and_db):
+    """POST /api/photos/<id>/flag queues a flag sync when configured."""
+    import config as cfg
+
+    app, db = app_and_db
+    config = cfg.load()
+    config["sync_flags_to_xmp"] = True
+    cfg.save(config)
+
+    target = [p for p in db.get_photos() if p["filename"] == "bird1.jpg"][0]
+
+    client = app.test_client()
+    resp = client.post(f'/api/photos/{target["id"]}/flag', json={"flag": "flagged"})
+
+    assert resp.status_code == 200
+    changes = db.get_pending_changes()
+    assert len(changes) == 1
+    assert changes[0]["change_type"] == "flag"
+    assert changes[0]["value"] == "flagged"
+
+
 def test_api_photo_detail(app_and_db):
     """GET /api/photos/<id> returns photo with keywords."""
     app, db = app_and_db

--- a/vireo/tests/test_sync.py
+++ b/vireo/tests/test_sync.py
@@ -150,12 +150,18 @@ def test_sync_from_xmp_preserves_keyword_when_only_case_differs(tmp_path):
     assert {k['name'] for k in keywords} == {'Sparrow'}
 
 
-def test_sync_to_xmp_reports_unsupported_flag_changes(tmp_path):
-    """Legacy flag pending changes remain queued and are reported as unsupported."""
+def test_sync_to_xmp_reports_unsupported_flag_changes_when_disabled(tmp_path, monkeypatch):
+    """Flag pending changes remain queued when XMP flag sync is disabled."""
     from xml.etree import ElementTree as ET
 
+    import config as cfg
     from db import Database
     from sync import sync_to_xmp
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    config = cfg.load()
+    config["sync_flags_to_xmp"] = False
+    cfg.save(config)
 
     db = Database(str(tmp_path / "test.db"))
     ws_id = db.ensure_default_workspace()
@@ -173,3 +179,37 @@ def test_sync_to_xmp_reports_unsupported_flag_changes(tmp_path):
     assert result['failures'][0]['error'] == 'unsupported change type: flag'
     assert before == after
     assert len(db.get_pending_changes()) == 1
+
+
+def test_sync_to_xmp_writes_flag_when_enabled(tmp_path, monkeypatch):
+    """sync_to_xmp writes xmpDM:pick when flag sync is enabled."""
+    from xml.etree import ElementTree as ET
+
+    import config as cfg
+    from db import Database
+    from sync import sync_to_xmp
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    config = cfg.load()
+    config["sync_flags_to_xmp"] = True
+    cfg.save(config)
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    pid, xmp_path = _setup_photo_with_xmp(tmp_path, db)
+
+    db.queue_change(pid, 'flag', 'rejected')
+
+    result = sync_to_xmp(db)
+
+    assert result['synced'] == 1
+    assert result['failed'] == 0
+    assert len(db.get_pending_changes()) == 0
+
+    tree = ET.parse(xmp_path)
+    desc = tree.getroot().find(
+        './/{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Description'
+    )
+    pick = desc.get('{http://ns.adobe.com/xmp/1.0/DynamicMedia/}pick')
+    assert pick == '-1'

--- a/vireo/tests/test_sync.py
+++ b/vireo/tests/test_sync.py
@@ -213,3 +213,37 @@ def test_sync_to_xmp_writes_flag_when_enabled(tmp_path, monkeypatch):
     )
     pick = desc.get('{http://ns.adobe.com/xmp/1.0/DynamicMedia/}pick')
     assert pick == '-1'
+
+
+def test_sync_to_xmp_treats_legacy_null_flag_as_none(tmp_path, monkeypatch):
+    """Legacy queued NULL flag values should clear XMP pick state."""
+    from xml.etree import ElementTree as ET
+
+    import config as cfg
+    from db import Database
+    from sync import sync_to_xmp
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    config = cfg.load()
+    config["sync_flags_to_xmp"] = True
+    cfg.save(config)
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    pid, xmp_path = _setup_photo_with_xmp(tmp_path, db)
+
+    db.queue_change(pid, 'flag', None)
+
+    result = sync_to_xmp(db)
+
+    assert result['synced'] == 1
+    assert result['failed'] == 0
+    assert len(db.get_pending_changes()) == 0
+
+    tree = ET.parse(xmp_path)
+    desc = tree.getroot().find(
+        './/{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Description'
+    )
+    pick = desc.get('{http://ns.adobe.com/xmp/1.0/DynamicMedia/}pick')
+    assert pick == '0'

--- a/vireo/tests/test_xmp.py
+++ b/vireo/tests/test_xmp.py
@@ -10,6 +10,7 @@ from xmp import (
     read_hierarchical_keywords,
     read_keywords,
     remove_keywords,
+    write_pick_flag,
     write_rating,
     write_sidecar,
 )
@@ -128,6 +129,24 @@ def test_write_rating_no_file(missing_xmp):
     # Should be a no-op, not raise
     write_rating(missing_xmp, 3)
     assert not os.path.exists(missing_xmp)
+
+
+# ── write_pick_flag ─────────────────────────────────────────────────────
+
+def test_write_pick_flag_existing_sidecar(sample_xmp):
+    write_pick_flag(sample_xmp, "flagged")
+
+    with open(sample_xmp) as f:
+        content = f.read()
+    assert 'xmpDM:pick="1"' in content
+
+
+def test_write_pick_flag_rejected_creates_sidecar(missing_xmp):
+    write_pick_flag(missing_xmp, "rejected")
+
+    with open(missing_xmp) as f:
+        content = f.read()
+    assert 'xmpDM:pick="-1"' in content
 
 
 # ── remove_keywords ─────────────────────────────────────────────────────

--- a/vireo/xmp.py
+++ b/vireo/xmp.py
@@ -16,6 +16,7 @@ NS_RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 NS_DC = "http://purl.org/dc/elements/1.1/"
 NS_LR = "http://ns.adobe.com/lightroom/1.0/"
 NS_XMP = "http://ns.adobe.com/xap/1.0/"
+NS_XMPDM = "http://ns.adobe.com/xmp/1.0/DynamicMedia/"
 
 # Register namespaces so ET preserves prefixes on output
 ET.register_namespace("x", NS_X)
@@ -23,6 +24,7 @@ ET.register_namespace("rdf", NS_RDF)
 ET.register_namespace("dc", NS_DC)
 ET.register_namespace("lr", NS_LR)
 ET.register_namespace("xmp", NS_XMP)
+ET.register_namespace("xmpDM", NS_XMPDM)
 ET.register_namespace("crs", "http://ns.adobe.com/camera-raw-settings/1.0/")
 ET.register_namespace("photoshop", "http://ns.adobe.com/photoshop/1.0/")
 ET.register_namespace("exif", "http://ns.adobe.com/exif/1.0/")
@@ -66,6 +68,34 @@ def _parse_xmp(xmp_path):
         return None
 
     return tree.getroot(), tree
+
+
+def _load_or_create_xmp(xmp_path):
+    """Load an XMP tree, or create a minimal sidecar tree."""
+    path = Path(xmp_path)
+
+    if path.exists():
+        try:
+            tree = ET.parse(path)
+            return tree.getroot(), tree
+        except ET.ParseError:
+            log.warning("Corrupt XMP file %s — creating new sidecar", path)
+
+    root = ET.Element(f"{{{NS_X}}}xmpmeta")
+    tree = ET.ElementTree(root)
+    return root, tree
+
+
+def _get_or_create_description(root):
+    """Find or create the first rdf:Description in an XMP tree."""
+    rdf = root.find(f"{{{NS_RDF}}}RDF")
+    if rdf is None:
+        rdf = ET.SubElement(root, f"{{{NS_RDF}}}RDF")
+
+    desc = rdf.find(f"{{{NS_RDF}}}Description")
+    if desc is None:
+        desc = ET.SubElement(rdf, f"{{{NS_RDF}}}Description")
+    return desc
 
 
 # ── Public API ──────────────────────────────────────────────────────────
@@ -183,6 +213,28 @@ def write_rating(xmp_path, rating):
         desc.set(f"{{{NS_XMP}}}Rating", str(rating))
         ET.indent(tree, space="  ")
         tree.write(xmp_path, xml_declaration=True, encoding="unicode")
+
+
+def write_pick_flag(xmp_path, flag):
+    """Write Lightroom-compatible pick/reject flag metadata.
+
+    Vireo stores flags as ``flagged`` / ``none`` / ``rejected``. Lightroom
+    Classic 13.2+ persists the equivalent pick state in ``xmpDM:pick`` using
+    values ``1`` / ``0`` / ``-1``.
+    """
+    values = {
+        "flagged": "1",
+        "none": "0",
+        "rejected": "-1",
+    }
+    if flag not in values:
+        raise ValueError("flag must be 'none', 'flagged', or 'rejected'")
+
+    root, tree = _load_or_create_xmp(xmp_path)
+    desc = _get_or_create_description(root)
+    desc.set(f"{{{NS_XMPDM}}}pick", values[flag])
+    ET.indent(tree, space="  ")
+    tree.write(xmp_path, xml_declaration=True, encoding="unicode")
 
 
 def remove_keywords(xmp_path, keywords_to_remove):


### PR DESCRIPTION
## Summary
Adds an opt-out Metadata setting to sync Vireo pick/reject flags to XMP by default. Flag changes now queue pending sync work across browse, batch, culling, miss review, group apply, undo, and redo flows. The XMP writer emits Lightroom-compatible `xmpDM:pick` values so picks, rejects, and cleared flags can travel with sidecars.

## Validation
Ran `pytest vireo/tests/test_xmp.py vireo/tests/test_sync.py vireo/tests/test_config_schema.py vireo/tests/test_photos_api.py` with 181 passing tests.