### PR TITLE
[codex] Improve burst review overflow

### DIFF
--- a/tests/e2e/test_burst_group_natural_size.py
+++ b/tests/e2e/test_burst_group_natural_size.py
@@ -173,3 +173,39 @@ def test_burst_card_box_is_180x120(live_server, page, tmp_path):
     assert bbox is not None
     assert abs(bbox["width"] - 180) < 1, f"box width {bbox['width']} != 180"
     assert abs(bbox["height"] - 120) < 1, f"box height {bbox['height']} != 120"
+
+
+def test_burst_modal_thumb_slider_resizes_wrapped_grid(live_server, page, tmp_path):
+    """The burst modal should expose the same kind of thumbnail-size control as
+    other review grids, and the strips should wrap instead of requiring
+    horizontal scrolling for large bursts.
+    """
+    db = live_server["db"]
+    n = _seed_burst_with_real_photos(db, tmp_path)
+    if n < 1:
+        pytest.skip("could not seed burst group")
+    _ensure_photo_files_on_disk(db, tmp_path)
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    assert page.locator("#grmThumbSizeSlider").is_visible()
+    flex_wrap = page.locator("#grmCandidates").evaluate(
+        "el => getComputedStyle(el).flexWrap"
+    )
+    assert flex_wrap == "wrap"
+
+    page.locator("#grmThumbSizeSlider").evaluate(
+        """el => {
+          el.value = 220;
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+        }"""
+    )
+
+    box = page.locator(".grm-card .grm-card-img-box").first
+    bbox = box.bounding_box()
+    assert bbox is not None
+    assert abs(bbox["width"] - 220) < 1, f"box width {bbox['width']} != 220"
+    assert abs(bbox["height"] - 147) < 1, f"box height {bbox['height']} != 147"

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -872,6 +872,8 @@ input[type="range"]::-moz-range-thumb {
   background: rgba(0,0,0,0.8);
   z-index: 500;
   flex-direction: column;
+  --grm-card-w: 180px;
+  --grm-card-h: 120px;
 }
 .grm-overlay.open { display: flex; }
 
@@ -895,13 +897,14 @@ input[type="range"]::-moz-range-thumb {
   padding: 10px 20px;
   min-height: 80px;
   border-bottom: 1px solid var(--border-primary);
+  flex-shrink: 0;
 }
 .grm-zone-label {
   font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em;
   margin-bottom: 6px; font-weight: 600;
 }
 .grm-picks .grm-zone-label { color: var(--accent); }
-.grm-candidates { flex: 1; overflow-x: auto; overflow-y: hidden; }
+.grm-candidates { flex: 0 0 auto; overflow: visible; }
 .grm-candidates .grm-zone-label { color: var(--text-dim); }
 .grm-rejects .grm-zone-label { color: var(--danger); }
 
@@ -910,12 +913,13 @@ input[type="range"]::-moz-range-thumb {
   gap: 10px;
   padding: 4px 0;
   min-height: 60px;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
+  align-items: flex-start;
 }
 
 .grm-card {
   flex-shrink: 0;
-  width: 180px;
+  width: var(--grm-card-w);
   background: var(--bg-tertiary);
   border-radius: 6px;
   overflow: hidden;
@@ -956,13 +960,13 @@ input[type="range"]::-moz-range-thumb {
 .grm-reset-offsets-btn.visible { display: inline-block; }
 .grm-reset-offsets-btn:hover { color: var(--text-primary); }
 /* Card image is laid out at its natural source-pixel size and then scaled
- * down via CSS transform into the 180x120 viewport. Laying out at natural
+ * down via CSS transform into the thumbnail viewport. Laying out at natural
  * size forces the browser to rasterize the layer at full source resolution,
  * so detail survives the transform — instead of being bilinearly upsampled
  * from a tiny pre-scale bitmap (the WKWebView burst-loupe quality bug). */
 .grm-card-img-box {
-  width: 180px;
-  height: 120px;
+  width: var(--grm-card-w);
+  height: var(--grm-card-h);
   position: relative;
   overflow: hidden;
 }
@@ -994,6 +998,21 @@ input[type="range"]::-moz-range-thumb {
 .grm-footer .grm-hint { font-size: 11px; color: var(--text-ghost); flex: 1; }
 .grm-res-control { display: flex; align-items: center; gap: 8px; }
 .grm-res-control input[type="range"] { width: 100px; }
+.grm-thumb-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.grm-thumb-control input[type="range"] {
+  width: 110px;
+  accent-color: var(--accent);
+}
+.grm-thumb-control label,
+.grm-thumb-control span {
+  font-size: 12px;
+  color: var(--text-muted);
+}
 
 /* Loupe mode — split layout with preview on right */
 .grm-body {
@@ -1407,6 +1426,11 @@ input[type="range"]::-moz-range-thumb {
     <label style="font-size:12px;color:var(--text-muted);">Species:</label>
     <input type="text" id="grmSpecies" oninput="grmOnSpeciesInput()" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:13px;width:200px;">
     <button onclick="grmRemoveFromGroup()" style="background:var(--bg-tertiary);color:var(--text-muted);border:none;border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;">Remove from group</button>
+    <div class="grm-thumb-control" title="Thumbnail size">
+      <label for="grmThumbSizeSlider">Thumbs</label>
+      <input type="range" id="grmThumbSizeSlider" min="100" max="320" step="20" value="180" oninput="grmSetThumbSize(this.value)">
+      <span id="grmThumbSizeVal">180px</span>
+    </div>
     <div class="grm-res-control" title="Image resolution — higher = slower but better for pixel-peeping">
       <label style="font-size:12px;color:var(--text-muted);">Res:</label>
       <input type="range" id="grmResSlider" min="0" max="3" step="1" value="3" oninput="grmSetResolution(this.value)">
@@ -3131,6 +3155,7 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   grmRefreshResetAllVisibility();
 
   document.getElementById('grmOverlay').classList.add('open');
+  grmSetThumbSize(GRM_CARD_W, false);
 
   // Disable Apply while we wait for /group/state — clicking it before
   // seed completes would send empty picks/rejects, which the server treats
@@ -3569,10 +3594,11 @@ function buildPipelineMetadataHtml(photo) {
  * Mouse wheel is a fine-tune multiplier on top.
  */
 
-// Card thumbnails are 180px wide × 120px tall (3:2). Used to compute the
-// cover-fit ratio when deriving a 1:1 scale.
+// Card thumbnails default to 180px wide × 120px tall (3:2). Used to compute
+// the cover-fit ratio when deriving a 1:1 scale.
 var GRM_CARD_W = 180;
 var GRM_CARD_H = 120;
+var GRM_THUMB_STORAGE_KEY = 'vireo.burstReviewThumbSize';
 
 var _grmZoomMultiplier = 1;   // wheel fine-tune on top of the 1:1 base scale
 var _grmLoupeLocked = false;
@@ -3585,10 +3611,42 @@ var _grmOffsets = {};
 var _grmDragging = null;
 var _grmSuppressNextClick = false;
 
+function _grmInitialThumbSize() {
+  try {
+    var stored = parseInt(window.localStorage.getItem(GRM_THUMB_STORAGE_KEY), 10);
+    if (stored) return Math.max(100, Math.min(320, stored));
+  } catch(e) {}
+  return 180;
+}
+
+function grmSetThumbSize(value, persist) {
+  var size = parseInt(value, 10);
+  if (!size) size = 180;
+  size = Math.max(100, Math.min(320, size));
+  GRM_CARD_W = size;
+  GRM_CARD_H = Math.round(size * 2 / 3);
+  var overlay = document.getElementById('grmOverlay');
+  if (overlay) {
+    overlay.style.setProperty('--grm-card-w', GRM_CARD_W + 'px');
+    overlay.style.setProperty('--grm-card-h', GRM_CARD_H + 'px');
+  }
+  var slider = document.getElementById('grmThumbSizeSlider');
+  if (slider) slider.value = GRM_CARD_W;
+  var label = document.getElementById('grmThumbSizeVal');
+  if (label) label.textContent = GRM_CARD_W + 'px';
+  if (persist !== false) {
+    try { window.localStorage.setItem(GRM_THUMB_STORAGE_KEY, String(GRM_CARD_W)); } catch(e) {}
+  }
+  grmApplyCardTransforms();
+}
+
+GRM_CARD_W = _grmInitialThumbSize();
+GRM_CARD_H = Math.round(GRM_CARD_W * 2 / 3);
+
 // Compute the served image's natural dimensions for the current resolution
 // slider stop. The browser will lay the <img> out at exactly these CSS
 // pixels, so the transform-scale layer is rasterized at full source size
-// instead of upscaled from a 180x120 tile (the WKWebView quality bug).
+// instead of upscaled from a tiny tile (the WKWebView quality bug).
 //
 // Returns expected dims; on image load `grmCardImgLoaded` reconciles against
 // the actual `naturalWidth/Height` (which can differ for NEFs that fall back
@@ -3611,7 +3669,7 @@ function grmNaturalDims(photo) {
 }
 
 // Cover-fit scale for one card: the smallest scale at which the image still
-// covers the 180x120 viewport. Matches the prior "no-zoom" visible state.
+// covers the current thumbnail viewport. Matches the prior "no-zoom" visible state.
 function grmCardCoverFit(card) {
   var W = parseFloat(card.dataset.natW) || GRM_CARD_W;
   var H = parseFloat(card.dataset.natH) || GRM_CARD_H;
@@ -3631,8 +3689,8 @@ function grmMaxZoomMultiplier() {
 // currently-visible burst cards. The hover formula floors per-card at each
 // card's own coverFit, so once the multiplier reaches the minimum coverFit
 // every card is already at cover-fit and further wheel-down would be a
-// dead no-op. A high-resolution photo can have coverFit ~0.03 (5400px wide
-// in a 180px viewport), well below the legacy 0.33 floor.
+// dead no-op. A high-resolution photo can have a very small coverFit,
+// well below the legacy 0.33 floor.
 function grmMinZoomMultiplier() {
   var cards = document.querySelectorAll('#grmOverlay .grm-card');
   var minCover = Infinity;
@@ -3778,7 +3836,7 @@ function grmLoupeReset() {
   _grmLastHoverY = null;
   // Re-apply transforms in their default (non-hovered, cover-fit, centred)
   // state. We can't just clear `style.transform` because the natural-size
-  // <img> needs a scale-down transform at all times to fit the 180x120 box.
+  // <img> needs a scale-down transform at all times to fit the thumbnail box.
   grmApplyCardTransforms();
 }
 

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -354,6 +354,8 @@
     background: rgba(0,0,0,0.8);
     z-index: 500;
     flex-direction: column;
+    --grm-card-w: 180px;
+    --grm-card-h: 120px;
   }
   .grm-overlay.open { display: flex; }
 
@@ -377,13 +379,14 @@
     padding: 10px 20px;
     min-height: 80px;
     border-bottom: 1px solid var(--border-primary, #14374E);
+    flex-shrink: 0;
   }
   .grm-zone-label {
     font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em;
     margin-bottom: 6px; font-weight: 600;
   }
   .grm-picks .grm-zone-label { color: var(--accent, #24E5CA); }
-  .grm-candidates { flex: 1; overflow-x: auto; overflow-y: hidden; }
+  .grm-candidates { flex: 0 0 auto; overflow: visible; }
   .grm-candidates .grm-zone-label { color: var(--text-dim, #888); }
   .grm-rejects .grm-zone-label { color: var(--danger, #e74c3c); }
 
@@ -392,12 +395,13 @@
     gap: 10px;
     padding: 4px 0;
     min-height: 60px;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
+    align-items: flex-start;
   }
 
   .grm-card {
     flex-shrink: 0;
-    width: 180px;
+    width: var(--grm-card-w);
     background: var(--bg-tertiary, #14374E);
     border-radius: 6px;
     overflow: hidden;
@@ -439,13 +443,13 @@
   .grm-reset-offsets-btn.visible { display: inline-block; }
   .grm-reset-offsets-btn:hover { color: var(--text-primary, #E0F0F0); }
   /* Card image is laid out at its natural source-pixel size and then scaled
-   * down via CSS transform into the 180x120 viewport. Laying out at natural
+   * down via CSS transform into the thumbnail viewport. Laying out at natural
    * size forces the browser to rasterize the layer at full source resolution,
    * so detail survives the transform — instead of being bilinearly upsampled
    * from a tiny pre-scale bitmap (the WKWebView burst-loupe quality bug). */
   .grm-card-img-box {
-    width: 180px;
-    height: 120px;
+    width: var(--grm-card-w);
+    height: var(--grm-card-h);
     position: relative;
     overflow: hidden;
   }
@@ -476,6 +480,21 @@
     flex-shrink: 0;
   }
   .grm-footer .grm-hint { font-size: 11px; color: var(--text-ghost, #555); flex: 1; }
+  .grm-thumb-control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+  .grm-thumb-control input[type="range"] {
+    width: 110px;
+    accent-color: var(--accent, #24E5CA);
+  }
+  .grm-thumb-control label,
+  .grm-thumb-control span {
+    font-size: 12px;
+    color: var(--text-muted, #888);
+  }
 
   /* Loupe mode — split layout with preview on right */
   .grm-body {
@@ -1464,6 +1483,7 @@ function openGroupReview(groupId, model) {
   _grmPendingSnap = false;
   grmRefreshResetAllVisibility();
   document.getElementById('grmOverlay').classList.add('open');
+  grmSetThumbSize(GRM_CARD_W, false);
   loadGroupData(groupId);
 }
 
@@ -1644,9 +1664,9 @@ function renderLoupePreds(item) {
 // Multiplier above each card's cover-fit scale. 1 = cover-fit (no zoom);
 // values past 1 zoom in towards CSS 1:1 and beyond to device 1:1 on Retina.
 var _grmZoomLevel = 1;
-// Card thumbnails are 180px wide x 120px tall (3:2). The image inside is
-// laid out at the served photo's natural pixel dimensions; transform-scale
-// shrinks it to fit the viewport.
+// Card thumbnails default to 180px wide x 120px tall (3:2). The image inside
+// is laid out at the served photo's natural pixel dimensions; transform-scale
+// shrinks it to fit the current viewport.
 var GRM_CARD_W = 180;
 var GRM_CARD_H = 120;
 var _grmLoupeLocked = false;
@@ -1672,6 +1692,39 @@ var _grmLoupeHovering = false;
 // reconciles dims so the 1:1 zoom is computed against the axes the browser
 // actually paints.
 var _grmPendingSnap = false;
+var GRM_THUMB_STORAGE_KEY = 'vireo.burstReviewThumbSize';
+
+function _grmInitialThumbSize() {
+  try {
+    var stored = parseInt(window.localStorage.getItem(GRM_THUMB_STORAGE_KEY), 10);
+    if (stored) return Math.max(100, Math.min(320, stored));
+  } catch(e) {}
+  return 180;
+}
+
+function grmSetThumbSize(value, persist) {
+  var size = parseInt(value, 10);
+  if (!size) size = 180;
+  size = Math.max(100, Math.min(320, size));
+  GRM_CARD_W = size;
+  GRM_CARD_H = Math.round(size * 2 / 3);
+  var overlay = document.getElementById('grmOverlay');
+  if (overlay) {
+    overlay.style.setProperty('--grm-card-w', GRM_CARD_W + 'px');
+    overlay.style.setProperty('--grm-card-h', GRM_CARD_H + 'px');
+  }
+  var slider = document.getElementById('grmThumbSizeSlider');
+  if (slider) slider.value = GRM_CARD_W;
+  var label = document.getElementById('grmThumbSizeVal');
+  if (label) label.textContent = GRM_CARD_W + 'px';
+  if (persist !== false) {
+    try { window.localStorage.setItem(GRM_THUMB_STORAGE_KEY, String(GRM_CARD_W)); } catch(e) {}
+  }
+  _grmApplyAllCardTransforms(_grmLoupeLastX, _grmLoupeLastY);
+}
+
+GRM_CARD_W = _grmInitialThumbSize();
+GRM_CARD_H = Math.round(GRM_CARD_W * 2 / 3);
 
 // Natural-size dims for one card. When the strip is still on the 400px
 // thumbnail, we use a 400px-fit; once upgraded to /original we use the
@@ -1913,7 +1966,7 @@ function grmLoupeReset() {
   if (_grmDragging) return;
   // Re-apply transforms in their default (cover-fit, centred) state. We
   // can't just clear `style.transform` because the natural-size <img> needs
-  // a scale-down transform at all times to fit the 180x120 viewport.
+  // a scale-down transform at all times to fit the thumbnail viewport.
   _grmLoupeHovering = false;
   _grmApplyAllCardTransforms(_grmLoupeLastX, _grmLoupeLastY);
 }
@@ -2210,6 +2263,11 @@ document.addEventListener('keydown', function(e) {
     <label style="font-size:12px;color:var(--text-muted,#888);">Consensus species:</label>
     <input type="text" id="grmSpecies" oninput="grmUpdateApplyLabel()" style="background:var(--bg-input,#14374E);color:var(--text-primary,#E0F0F0);border:1px solid var(--border-secondary,#1A4560);border-radius:4px;padding:6px 10px;font-size:13px;width:200px;">
     <button onclick="grmRemoveFromGroup()" style="background:var(--bg-tertiary,#14374E);color:var(--text-muted,#888);border:none;border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;">Remove from group</button>
+    <div class="grm-thumb-control" title="Thumbnail size">
+      <label for="grmThumbSizeSlider">Thumbs</label>
+      <input type="range" id="grmThumbSizeSlider" min="100" max="320" step="20" value="180" oninput="grmSetThumbSize(this.value)">
+      <span id="grmThumbSizeVal">180px</span>
+    </div>
     <span class="grm-hint">↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; 1 = 1:1 zoom &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
     <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;">Apply & Close</button>
   </div>


### PR DESCRIPTION
Updates Review Burst Group strips to wrap into a grid when many photos are present, avoiding horizontal-only overflow. Adds a thumbnail size slider to both review modals and preserves the natural-size image transform math used for loupe sharpness comparison. The thumbnail preference is shared across the review and pipeline review burst modals. Adds e2e coverage for the slider resizing behavior and wrapped candidate grid.

Validation: `pytest tests/e2e/test_burst_group_natural_size.py`.