### PR TITLE
[codex] Fix navbar tab drag reorder

### DIFF
--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -336,3 +336,26 @@ def test_drag_reorder_persists_via_reorder_endpoint(live_server, page):
         const t = window._navTabs.getTabs();
         return t.indexOf('browse') > t.indexOf('review');
     }""", timeout=3000)
+
+
+def test_mouse_drag_reorder_commits_when_released_in_tab_strip(live_server, page):
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1366, "height": 800})
+    page.goto(f"{url}/browse")
+    page.wait_for_selector(".nav-tab[data-nav-id='browse']")
+    page.wait_for_selector(".nav-tab[data-nav-id='review']")
+
+    browse = page.locator(".nav-tab[data-nav-id='browse']").bounding_box()
+    review = page.locator(".nav-tab[data-nav-id='review']").bounding_box()
+    assert browse is not None
+    assert review is not None
+
+    page.mouse.move(browse["x"] + browse["width"] / 2, browse["y"] + browse["height"] / 2)
+    page.mouse.down()
+    page.mouse.move(review["x"] + review["width"] + 12, review["y"] + review["height"] / 2, steps=12)
+    page.mouse.up()
+
+    page.wait_for_function("""() => {
+        const t = window._navTabs.getTabs();
+        return t.indexOf('browse') > t.indexOf('review');
+    }""", timeout=3000)

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2167,7 +2167,8 @@ window.NAV_ALL_PAGES = [
 (function() {
   function strip() { return document.getElementById('navTabStrip'); }
   function tabAnchors() {
-    return Array.from(strip().querySelectorAll('.nav-tab:not(.is-ephemeral)'));
+    const s = strip();
+    return s ? Array.from(s.querySelectorAll('.nav-tab:not(.is-ephemeral)')) : [];
   }
 
   let draggedEl = null;
@@ -2181,6 +2182,39 @@ window.NAV_ALL_PAGES = [
   function removeIndicator() {
     if (indicator && indicator.parentNode) indicator.parentNode.removeChild(indicator);
     indicator = null;
+  }
+  function visibleDropAnchors() {
+    return tabAnchors().filter(a => a !== draggedEl && a.style.display !== 'none');
+  }
+  function dropReference(clientX) {
+    const anchors = visibleDropAnchors();
+    if (!anchors.length) return null;
+    for (const anchor of anchors) {
+      const rect = anchor.getBoundingClientRect();
+      if (clientX < rect.left + rect.width / 2) return anchor;
+    }
+    return anchors[anchors.length - 1].nextSibling;
+  }
+  function showDropIndicator(clientX) {
+    const s = strip();
+    if (!s) return;
+    removeIndicator();
+    indicator = createIndicator();
+    s.insertBefore(indicator, dropReference(clientX));
+  }
+  function persistCurrentOrder() {
+    const newOrder = tabAnchors().map(a => a.dataset.navId);
+    if (window._navTabs) window._navTabs.setTabs(newOrder);
+  }
+  function commitDrop(e) {
+    if (!draggedEl) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const s = strip();
+    if (!s) return;
+    removeIndicator();
+    s.insertBefore(draggedEl, dropReference(e.clientX));
+    persistCurrentOrder();
   }
 
   function bindDragHandlers() {
@@ -2204,23 +2238,10 @@ window.NAV_ALL_PAGES = [
         if (!draggedEl || draggedEl === this) return;
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
-        removeIndicator();
-        const rect = this.getBoundingClientRect();
-        const midX = rect.left + rect.width / 2;
-        indicator = createIndicator();
-        if (e.clientX < midX) strip().insertBefore(indicator, this);
-        else strip().insertBefore(indicator, this.nextSibling);
+        showDropIndicator(e.clientX);
       });
       link.addEventListener('drop', function(e) {
-        if (!draggedEl || draggedEl === this) return;
-        e.preventDefault();
-        const rect = this.getBoundingClientRect();
-        const midX = rect.left + rect.width / 2;
-        if (e.clientX < midX) strip().insertBefore(draggedEl, this);
-        else strip().insertBefore(draggedEl, this.nextSibling);
-        removeIndicator();
-        const newOrder = tabAnchors().map(a => a.dataset.navId);
-        if (window._navTabs) window._navTabs.setTabs(newOrder);
+        commitDrop(e);
       });
     });
   }
@@ -2237,6 +2258,13 @@ window.NAV_ALL_PAGES = [
     s.addEventListener('dragleave', function(e) {
       if (!s.contains(e.relatedTarget)) removeIndicator();
     });
+    s.addEventListener('dragover', function(e) {
+      if (!draggedEl) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      showDropIndicator(e.clientX);
+    });
+    s.addEventListener('drop', commitDrop);
     bindDragHandlers();
     const mo = new MutationObserver(() => bindDragHandlers());
     mo.observe(s, {childList: true});


### PR DESCRIPTION
Fixes navbar tab drag reorder so releasing over the tab strip commits the new order instead of snapping back. The root cause was that persistence only ran when the drop landed on another tab anchor, so drops in strip gaps were ignored. The change centralizes drop placement, accepts drop events on the full tab strip, and persists the reordered pinned tabs. Adds a mouse-level e2e regression for dragging Browse past Review. Validated with `python -m pytest tests/e2e/test_navigation.py -q`.