### PR TITLE
[codex] Expand smart collection rules

### DIFF
--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -336,3 +336,26 @@ def test_drag_reorder_persists_via_reorder_endpoint(live_server, page):
         const t = window._navTabs.getTabs();
         return t.indexOf('browse') > t.indexOf('review');
     }""", timeout=3000)
+
+
+def test_mouse_drag_reorder_commits_when_released_in_tab_strip(live_server, page):
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1366, "height": 800})
+    page.goto(f"{url}/browse")
+    page.wait_for_selector(".nav-tab[data-nav-id='browse']")
+    page.wait_for_selector(".nav-tab[data-nav-id='review']")
+
+    browse = page.locator(".nav-tab[data-nav-id='browse']").bounding_box()
+    review = page.locator(".nav-tab[data-nav-id='review']").bounding_box()
+    assert browse is not None
+    assert review is not None
+
+    page.mouse.move(browse["x"] + browse["width"] / 2, browse["y"] + browse["height"] / 2)
+    page.mouse.down()
+    page.mouse.move(review["x"] + review["width"] + 12, review["y"] + review["height"] / 2, steps=12)
+    page.mouse.up()
+
+    page.wait_for_function("""() => {
+        const t = window._navTabs.getTabs();
+        return t.indexOf('browse') > t.indexOf('review');
+    }""", timeout=3000)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3603,19 +3603,43 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         if _has_all_rule(rules):
             return json_error("Cannot add photos to this collection", 400)
-        def _find_photo_ids_rule(node):
+        def _find_photo_ids_rule(node, group_modes=()):
             if isinstance(node, list):
                 for child in node:
-                    found = _find_photo_ids_rule(child)
+                    found = _find_photo_ids_rule(child, group_modes)
                     if found is not None:
                         return found
             elif isinstance(node, dict):
                 if node.get("field") == "photo_ids":
-                    return node
-                return _find_photo_ids_rule(node.get("rules"))
+                    return node, group_modes
+                if "rules" in node:
+                    mode = node.get("mode", "all")
+                    return _find_photo_ids_rule(
+                        node.get("rules"), group_modes + (mode,)
+                    )
             return None
 
-        ids_rule = _find_photo_ids_rule(rules)
+        def _has_non_all_group(node):
+            if isinstance(node, list):
+                return any(_has_non_all_group(child) for child in node)
+            if not isinstance(node, dict):
+                return False
+            if "rules" in node and node.get("field") is None:
+                if node.get("mode", "all") != "all":
+                    return True
+                return _has_non_all_group(node.get("rules"))
+            return False
+
+        found_ids_rule = _find_photo_ids_rule(rules)
+        if found_ids_rule is not None:
+            ids_rule, group_modes = found_ids_rule
+            if any(mode != "all" for mode in group_modes):
+                return json_error("Cannot add photos to this collection", 400)
+        else:
+            ids_rule = None
+            if _has_non_all_group(rules):
+                return json_error("Cannot add photos to this collection", 400)
+
         if ids_rule is None:
             ids_rule = {"field": "photo_ids", "value": []}
             if isinstance(rules, list):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3480,6 +3480,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         rules = body.get("rules", [])
         if not name:
             return json_error("name required")
+        try:
+            db.count_photos_for_rules(rules)
+        except ValueError as e:
+            return json_error(str(e), 400)
         cid = db.add_collection(name, json.dumps(rules))
         return jsonify({"ok": True, "id": cid})
 
@@ -3529,16 +3533,40 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/api/collections/<int:collection_id>", methods=["PUT"])
     def api_update_collection(collection_id):
-        """Rename a collection. Body: {"name": "..."}."""
+        """Update a collection. Body: {"name": "...", "rules": [...|group]}."""
         db = _get_db()
         body = request.get_json(silent=True) or {}
-        name = (body.get("name") or "").strip()
-        if not name:
-            return json_error("name required")
-        try:
-            db.rename_collection(collection_id, name)
-        except ValueError:
+        row = db.conn.execute(
+            "SELECT id, name, rules FROM collections WHERE id = ? AND workspace_id = ?",
+            (collection_id, db._ws_id()),
+        ).fetchone()
+        if not row:
             return json_error("collection not found", 404)
+
+        updates = []
+        params = []
+        if "name" in body:
+            name = (body.get("name") or "").strip()
+            if not name:
+                return json_error("name required")
+            updates.append("name = ?")
+            params.append(name)
+        if "rules" in body:
+            rules = body.get("rules")
+            try:
+                db.count_photos_for_rules(rules)
+            except ValueError as e:
+                return json_error(str(e), 400)
+            updates.append("rules = ?")
+            params.append(json.dumps(rules))
+        if updates:
+            params.extend([collection_id, db._ws_id()])
+            db.conn.execute(
+                f"UPDATE collections SET {', '.join(updates)} "
+                "WHERE id = ? AND workspace_id = ?",
+                params,
+            )
+            db.conn.commit()
         return jsonify({"ok": True})
 
     @app.route("/api/collections/<int:collection_id>/add-photos", methods=["POST"])
@@ -3560,17 +3588,38 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Refuse to mutate smart/system collections like "All Photos" — adding
         # a photo_ids rule would AND-combine with the sentinel and silently
         # convert the dynamic default into a static subset.
-        if any(r.get("field") == "all" for r in rules):
+        def _has_all_rule(node):
+            if isinstance(node, list):
+                return any(_has_all_rule(child) for child in node)
+            if not isinstance(node, dict):
+                return False
+            if node.get("field") == "all":
+                return True
+            return _has_all_rule(node.get("rules"))
+
+        if _has_all_rule(rules):
             return json_error("Cannot add photos to this collection", 400)
-        # Find or create a photo_ids rule
-        ids_rule = None
-        for r in rules:
-            if r.get("field") == "photo_ids":
-                ids_rule = r
-                break
+        def _find_photo_ids_rule(node):
+            if isinstance(node, list):
+                for child in node:
+                    found = _find_photo_ids_rule(child)
+                    if found is not None:
+                        return found
+            elif isinstance(node, dict):
+                if node.get("field") == "photo_ids":
+                    return node
+                return _find_photo_ids_rule(node.get("rules"))
+            return None
+
+        ids_rule = _find_photo_ids_rule(rules)
         if ids_rule is None:
             ids_rule = {"field": "photo_ids", "value": []}
-            rules.append(ids_rule)
+            if isinstance(rules, list):
+                rules.append(ids_rule)
+            elif isinstance(rules, dict) and isinstance(rules.get("rules"), list):
+                rules["rules"].append(ids_rule)
+            else:
+                rules = [ids_rule]
 
         # Merge new IDs
         existing = set(ids_rule["value"])

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4693,15 +4693,27 @@ class Database:
                 (self._ws_id(),),
             ).fetchall()
             deleted_set = set(all_ids)
+            def _remove_deleted_photo_ids(node):
+                if isinstance(node, list):
+                    changed_any = False
+                    for child in node:
+                        changed_any = _remove_deleted_photo_ids(child) or changed_any
+                    return changed_any
+                if not isinstance(node, dict):
+                    return False
+                changed_any = _remove_deleted_photo_ids(node.get("rules"))
+                if node.get("field") == "photo_ids" and "value" in node:
+                    values = node.get("value")
+                    if not isinstance(values, list):
+                        return changed_any
+                    original_len = len(values)
+                    node["value"] = [v for v in values if v not in deleted_set]
+                    return changed_any or len(node["value"]) != original_len
+                return changed_any
+
             for coll in collections:
                 rules = _json.loads(coll["rules"])
-                changed = False
-                for rule in rules:
-                    if rule.get("field") == "photo_ids" and "value" in rule:
-                        original_len = len(rule["value"])
-                        rule["value"] = [v for v in rule["value"] if v not in deleted_set]
-                        if len(rule["value"]) != original_len:
-                            changed = True
+                changed = _remove_deleted_photo_ids(rules)
                 if changed:
                     self.conn.execute(
                         "UPDATE collections SET rules = ? WHERE id = ?",
@@ -8652,43 +8664,109 @@ class Database:
         return self._build_query_from_rules(rules)
 
     def _build_query_from_rules(self, rules):
-        """Build SQL clauses from a rules list (not yet persisted).
+        """Build SQL clauses from a smart-collection rule tree.
 
         Returns (folder_join, join_clause, where, params). Raises ValueError on
         malformed input — callers that accept rules from untrusted sources
         (e.g. the live-preview API) should catch and surface a 400.
+
+        Backward compatibility: the original collection format was a flat list
+        of rule objects, implicitly combined with AND. Newer collections may use
+        a grouped tree:
+
+            {"mode": "all"|"any"|"none", "rules": [rule_or_group, ...]}
         """
-        if not isinstance(rules, list):
-            raise ValueError("rules must be a list")
-        # Only photo_ids and timestamp/between consume list values; every other
-        # field binds `value` as a single SQL parameter, so a list there raises
-        # sqlite3.ProgrammingError ("type 'list' is not supported"). Without
-        # this distinction the preview route would surface those as 500s on
-        # inputs like {"field":"rating","value":[4]}.
-        for r in rules:
-            if not isinstance(r, dict) or "field" not in r:
-                raise ValueError("each rule must be an object with a 'field'")
-            field = r.get("field")
-            op = r.get("op")
-            val = r.get("value")
-            list_allowed = field == "photo_ids" or (field == "timestamp" and op == "between")
-            if isinstance(val, list):
+        if isinstance(rules, list):
+            root = {"mode": "all", "rules": rules}
+        elif isinstance(rules, dict) and "rules" in rules:
+            root = rules
+        else:
+            raise ValueError("rules must be a list or group object")
+
+        def _is_scalar(value):
+            return value is None or isinstance(value, (str, int, float, bool))
+
+        def _validate_node(node):
+            if not isinstance(node, dict):
+                raise ValueError("each rule must be an object")
+            if "rules" in node and "field" not in node:
+                mode = node.get("mode", "all")
+                if mode not in ("all", "any", "none"):
+                    raise ValueError("rule group mode must be all, any, or none")
+                children = node.get("rules")
+                if not isinstance(children, list):
+                    raise ValueError("rule group rules must be a list")
+                for child in children:
+                    _validate_node(child)
+                return
+            if "field" not in node:
+                raise ValueError("each rule must have a 'field'")
+            field = node.get("field")
+            op = node.get("op")
+            value = node.get("value")
+            list_allowed = (
+                field == "photo_ids"
+                or (field == "timestamp" and op == "between")
+            )
+            if isinstance(value, list):
                 if not list_allowed:
                     raise ValueError(f"rule field {field!r} does not accept a list value")
-                for item in val:
-                    if item is not None and not isinstance(item, (str, int, float, bool)):
+                for item in value:
+                    if not _is_scalar(item):
                         raise ValueError("rule list values must be scalars")
-                continue
-            if val is None or isinstance(val, (str, int, float, bool)):
-                continue
-            raise ValueError("rule value must be a scalar")
+                return
+            if not _is_scalar(value):
+                raise ValueError("rule value must be a scalar")
 
-        conditions = []
-        params = []
-        need_keyword_join = False
-        need_prediction_join = False
+        def _truthy(value):
+            return value is True or value == 1 or value == "1" or value == "true"
 
-        for rule in rules:
+        def _falsey(value):
+            return value is False or value == 0 or value == "0" or value == "false"
+
+        def _numeric_condition(column, op, value, allow_null=False):
+            if op == ">=":
+                return f"{column} >= ?", [value]
+            if op == "<=":
+                return f"{column} <= ?", [value]
+            if op in ("equals", "is"):
+                return f"{column} = ?", [value]
+            if op == "is not":
+                prefix = f"{column} IS NULL OR " if allow_null else ""
+                return f"({prefix}{column} != ?)", [value]
+            return "0", []
+
+        def _keyword_exists(predicate, predicate_params):
+            return (
+                "EXISTS (SELECT 1 FROM photo_keywords pk "
+                "JOIN keywords k ON k.id = pk.keyword_id "
+                f"WHERE pk.photo_id = p.id AND {predicate})",
+                list(predicate_params),
+            )
+
+        def _keyword_not_exists(predicate, predicate_params):
+            return (
+                "NOT EXISTS (SELECT 1 FROM photo_keywords pk "
+                "JOIN keywords k ON k.id = pk.keyword_id "
+                f"WHERE pk.photo_id = p.id AND {predicate})",
+                list(predicate_params),
+            )
+
+        def _prediction_exists(predicate, predicate_params, review_join=False):
+            review = (
+                " LEFT JOIN prediction_review prv "
+                "ON prv.prediction_id = pred.id AND prv.workspace_id = ?"
+                if review_join else ""
+            )
+            params = ([self._ws_id()] if review_join else []) + list(predicate_params)
+            return (
+                "EXISTS (SELECT 1 FROM detections det "
+                "JOIN predictions pred ON pred.detection_id = det.id"
+                f"{review} WHERE det.photo_id = p.id AND {predicate})",
+                params,
+            )
+
+        def _build_leaf(rule):
             field = rule["field"]
             op = rule.get("op", "")
             value = rule.get("value")
@@ -8696,172 +8774,84 @@ class Database:
             if field == "all":
                 # Sentinel for defaults like "All Photos" — adds no condition,
                 # so the workspace-folder join alone determines matches.
-                continue
-            elif field == "photo_ids":
-                # Static collection — explicit list of photo IDs
+                return None, []
+            if field == "photo_ids":
                 ids = value if isinstance(value, list) else []
-                if ids:
-                    placeholders = ",".join("?" for _ in ids)
-                    conditions.append(f"p.id IN ({placeholders})")
-                    params.extend(ids)
-                else:
-                    conditions.append("0")  # empty collection
-            elif field == "rating":
-                if op == ">=":
-                    conditions.append("p.rating >= ?")
-                    params.append(value)
-                elif op == "<=":
-                    conditions.append("p.rating <= ?")
-                    params.append(value)
-                elif op in ("equals", "is"):
-                    conditions.append("p.rating = ?")
-                    params.append(value)
-                elif op == "is not":
-                    conditions.append("p.rating != ?")
-                    params.append(value)
-            elif field == "keyword":
+                if not ids:
+                    return "0", []
+                placeholders = ",".join("?" for _ in ids)
+                return f"p.id IN ({placeholders})", list(ids)
+            if field in ("rating", "quality_score", "sharpness",
+                         "subject_sharpness", "noise_estimate",
+                         "crop_complete"):
+                column = "p.subject_tenengrad" if field == "subject_sharpness" else f"p.{field}"
+                return _numeric_condition(column, op, value, allow_null=True)
+            if field == "keyword":
                 if op == "contains":
-                    need_keyword_join = True
-                    conditions.append("k.name LIKE ?")
-                    params.append(f"%{value}%")
-                elif op == "not_contains":
-                    conditions.append(
-                        """NOT EXISTS (
-                        SELECT 1 FROM photo_keywords pk4
-                        JOIN keywords k4 ON k4.id = pk4.keyword_id
-                        WHERE pk4.photo_id = p.id AND k4.name LIKE ?)"""
-                    )
-                    params.append(f"%{value}%")
-                elif op in ("equals", "is"):
-                    need_keyword_join = True
-                    conditions.append("k.name = ?")
-                    params.append(value)
-                elif op == "is not":
-                    conditions.append(
-                        """NOT EXISTS (
-                        SELECT 1 FROM photo_keywords pk4
-                        JOIN keywords k4 ON k4.id = pk4.keyword_id
-                        WHERE pk4.photo_id = p.id AND k4.name = ?)"""
-                    )
-                    params.append(value)
-            elif field == "folder":
+                    return _keyword_exists("k.name LIKE ?", [f"%{value}%"])
+                if op == "not_contains":
+                    return _keyword_not_exists("k.name LIKE ?", [f"%{value}%"])
+                if op in ("equals", "is"):
+                    return _keyword_exists("k.name = ?", [value])
+                if op == "is not":
+                    return _keyword_not_exists("k.name = ?", [value])
+            if field == "folder":
                 if op == "under":
-                    conditions.append("f.path LIKE ?")
-                    params.append(f"{value}%")
-                elif op == "not_under":
-                    conditions.append("(f.path IS NULL OR f.path NOT LIKE ?)")
-                    params.append(f"{value}%")
-            elif field == "flag":
+                    return "f.path LIKE ?", [f"{value}%"]
+                if op == "not_under":
+                    return "(f.path IS NULL OR f.path NOT LIKE ?)", [f"{value}%"]
+            if field == "flag":
                 if op in ("equals", "is"):
-                    conditions.append("p.flag = ?")
-                    params.append(value)
-                elif op == "is not":
-                    conditions.append("p.flag != ?")
-                    params.append(value)
-            elif field == "color_label":
+                    return "p.flag = ?", [value]
+                if op == "is not":
+                    return "p.flag != ?", [value]
+            if field == "color_label":
+                exists = (
+                    "EXISTS (SELECT 1 FROM photo_color_labels pcl "
+                    "WHERE pcl.photo_id = p.id AND pcl.workspace_id = ? "
+                    "AND pcl.color = ?)"
+                )
+                params = [self._ws_id(), value]
                 if op in ("equals", "is"):
-                    conditions.append(
-                        """EXISTS (
-                        SELECT 1 FROM photo_color_labels pcl
-                        WHERE pcl.photo_id = p.id AND pcl.workspace_id = ? AND pcl.color = ?)"""
-                    )
-                    params.append(self._ws_id())
-                    params.append(value)
-                elif op == "is not":
-                    conditions.append(
-                        """NOT EXISTS (
-                        SELECT 1 FROM photo_color_labels pcl
-                        WHERE pcl.photo_id = p.id AND pcl.workspace_id = ? AND pcl.color = ?)"""
-                    )
-                    params.append(self._ws_id())
-                    params.append(value)
-            elif field == "has_species":
-                if op == "equals" and value is False or value == 0:
-                    conditions.append(
-                        """NOT EXISTS (
-                        SELECT 1 FROM photo_keywords pk3
-                        JOIN keywords k3 ON k3.id = pk3.keyword_id
-                        WHERE pk3.photo_id = p.id AND k3.is_species = 1)"""
-                    )
-                elif op == "equals" and value is True or value == 1:
-                    conditions.append(
-                        """EXISTS (
-                        SELECT 1 FROM photo_keywords pk3
-                        JOIN keywords k3 ON k3.id = pk3.keyword_id
-                        WHERE pk3.photo_id = p.id AND k3.is_species = 1)"""
-                    )
-            elif field == "has_subject":
-                # Match the has_species pattern, but resolve "subject" via
-                # the workspace's configured subject_types (a set of keyword
-                # types). Sorted for deterministic SQL parameter order.
-                #
-                # When 'taxonomy' is among the subject types, also count
-                # legacy species rows (is_species=1 with a non-taxonomy
-                # type). Upgraded databases retain those rows until the
-                # background mark_species_keywords pass retypes them; the
-                # type-only predicate would otherwise place already-
-                # identified photos into 'Needs Identification'.
+                    return exists, params
+                if op == "is not":
+                    return f"NOT {exists}", params
+            if field == "has_species":
+                if op == "equals" and _falsey(value):
+                    return _keyword_not_exists("k.is_species = 1", [])
+                if op == "equals" and _truthy(value):
+                    return _keyword_exists("k.is_species = 1", [])
+            if field == "has_subject":
                 subject_types = sorted(self.get_subject_types())
                 if not subject_types:
-                    if op == "equals" and (value is True or value == 1):
-                        conditions.append("0")  # nothing matches
-                    # value==0 with empty subject_types is a no-op (every
-                    # photo is "not identified" by the empty set)
-                    continue
-                type_placeholders = ",".join("?" * len(subject_types))
-                type_clause = f"k5.type IN ({type_placeholders})"
+                    if op == "equals" and _truthy(value):
+                        return "0", []
+                    return None, []
+                placeholders = ",".join("?" * len(subject_types))
+                type_clause = f"k.type IN ({placeholders})"
                 if "taxonomy" in subject_types:
-                    type_clause = f"({type_clause} OR k5.is_species = 1)"
-                if op == "equals" and (value is False or value == 0):
-                    conditions.append(
-                        f"""NOT EXISTS (
-                        SELECT 1 FROM photo_keywords pk5
-                        JOIN keywords k5 ON k5.id = pk5.keyword_id
-                        WHERE pk5.photo_id = p.id AND {type_clause})"""
-                    )
-                    params.extend(subject_types)
-                elif op == "equals" and (value is True or value == 1):
-                    conditions.append(
-                        f"""EXISTS (
-                        SELECT 1 FROM photo_keywords pk5
-                        JOIN keywords k5 ON k5.id = pk5.keyword_id
-                        WHERE pk5.photo_id = p.id AND {type_clause})"""
-                    )
-                    params.extend(subject_types)
-            elif field == "keyword_count":
-                if op == "equals":
-                    conditions.append(
-                        """(SELECT COUNT(*) FROM photo_keywords pk2
-                                         WHERE pk2.photo_id = p.id) = ?"""
-                    )
-                    params.append(value)
-                elif op == ">=":
-                    conditions.append(
-                        """(SELECT COUNT(*) FROM photo_keywords pk2
-                                         WHERE pk2.photo_id = p.id) >= ?"""
-                    )
-                    params.append(value)
-            elif field == "timestamp":
+                    type_clause = f"({type_clause} OR k.is_species = 1)"
+                if op == "equals" and _falsey(value):
+                    return _keyword_not_exists(type_clause, subject_types)
+                if op == "equals" and _truthy(value):
+                    return _keyword_exists(type_clause, subject_types)
+            if field == "keyword_count":
+                expr = "(SELECT COUNT(*) FROM photo_keywords pk2 WHERE pk2.photo_id = p.id)"
+                return _numeric_condition(expr, op, value)
+            if field == "timestamp":
                 if op == "between" and isinstance(value, list) and len(value) == 2:
-                    conditions.append("p.timestamp >= ? AND p.timestamp <= ?")
-                    params.append(value[0])
-                    params.append(_inclusive_date_to(value[1]))
-                elif op == "recent_days":
-                    conditions.append("p.timestamp >= datetime('now', ?)")
-                    params.append(f"-{value} days")
-            elif field == "extension":
-                # Match case-insensitively: get_workspace_extensions() returns
-                # lowercased options, but photos imported by older scans may
-                # have stored mixed-case extensions (.JPG vs .jpg). SQLite's
-                # default = / != is case-sensitive, so without LOWER() a
-                # rule saved as ".jpg" would silently miss .JPG rows.
+                    return "p.timestamp >= ? AND p.timestamp <= ?", [
+                        value[0],
+                        _inclusive_date_to(value[1]),
+                    ]
+                if op == "recent_days":
+                    return "p.timestamp >= datetime('now', ?)", [f"-{value} days"]
+            if field == "extension":
                 if op in ("equals", "is"):
-                    conditions.append("LOWER(p.extension) = LOWER(?)")
-                    params.append(value)
-                elif op == "is not":
-                    conditions.append("LOWER(p.extension) != LOWER(?)")
-                    params.append(value)
-            elif field in (
+                    return "LOWER(p.extension) = LOWER(?)", [value]
+                if op == "is not":
+                    return "LOWER(p.extension) != LOWER(?)", [value]
+            if field in (
                 "taxonomy_kingdom",
                 "taxonomy_phylum",
                 "taxonomy_class",
@@ -8869,29 +8859,108 @@ class Database:
                 "taxonomy_family",
                 "taxonomy_genus",
             ):
-                need_prediction_join = True
                 col = f"pred.{field}"
                 if op in ("equals", "is"):
-                    conditions.append(f"{col} = ?")
-                    params.append(value)
-                elif op == "is not":
-                    conditions.append(f"({col} IS NULL OR {col} != ?)")
-                    params.append(value)
-                elif op == "contains":
-                    conditions.append(f"{col} LIKE ?")
-                    params.append(f"%{value}%")
+                    return _prediction_exists(f"{col} = ?", [value])
+                if op == "is not":
+                    return (
+                        "NOT " + _prediction_exists(f"{col} = ?", [value])[0],
+                        [value],
+                    )
+                if op == "contains":
+                    return _prediction_exists(f"{col} LIKE ?", [f"%{value}%"])
+            if field == "prediction_confidence":
+                cond, cond_params = _numeric_condition("pred.confidence", op, value)
+                return _prediction_exists(cond, cond_params)
+            if field == "classifier_model":
+                if op in ("equals", "is"):
+                    return _prediction_exists("pred.classifier_model = ?", [value])
+                if op == "is not":
+                    return (
+                        "NOT " + _prediction_exists("pred.classifier_model = ?", [value])[0],
+                        [value],
+                    )
+                if op == "contains":
+                    return _prediction_exists("pred.classifier_model LIKE ?", [f"%{value}%"])
+            if field == "prediction_status":
+                if op in ("equals", "is"):
+                    return _prediction_exists(
+                        "COALESCE(prv.status, 'pending') = ?",
+                        [value],
+                        review_join=True,
+                    )
+                if op == "is not":
+                    exists, params = _prediction_exists(
+                        "COALESCE(prv.status, 'pending') = ?",
+                        [value],
+                        review_join=True,
+                    )
+                    return "NOT " + exists, params
+            if field == "needs_review":
+                exists, params = _prediction_exists(
+                    "COALESCE(prv.status, 'pending') = 'pending'",
+                    [],
+                    review_join=True,
+                )
+                return (exists if _truthy(value) else "NOT " + exists), params
+            if field == "has_mask":
+                has = "p.mask_path IS NOT NULL"
+                return (has if _truthy(value) else f"NOT ({has})"), []
+            if field == "active_mask_variant":
+                if op in ("equals", "is"):
+                    return "p.active_mask_variant = ?", [value]
+                if op == "is not":
+                    return "(p.active_mask_variant IS NULL OR p.active_mask_variant != ?)", [value]
+                if op == "contains":
+                    return "p.active_mask_variant LIKE ?", [f"%{value}%"]
+            if field == "has_gps":
+                has = "p.latitude IS NOT NULL AND p.longitude IS NOT NULL"
+                return (has if _truthy(value) else f"NOT ({has})"), []
+            if field == "location_keyword_missing":
+                gps = "p.latitude IS NOT NULL AND p.longitude IS NOT NULL"
+                no_loc = (
+                    "NOT EXISTS (SELECT 1 FROM photo_keywords pk "
+                    "JOIN keywords k ON k.id = pk.keyword_id "
+                    "WHERE pk.photo_id = p.id AND k.type = 'location')"
+                )
+                cond = f"({gps}) AND ({no_loc})"
+                return (cond if _truthy(value) else f"NOT ({cond})"), []
+            if field == "inat_submitted":
+                has = "EXISTS (SELECT 1 FROM inat_submissions ins WHERE ins.photo_id = p.id)"
+                return (has if _truthy(value) else f"NOT {has}"), []
+            if field == "is_duplicate":
+                has = (
+                    "p.file_hash IS NOT NULL AND EXISTS ("
+                    "SELECT 1 FROM photos p2 "
+                    "JOIN workspace_folders wf2 ON wf2.folder_id = p2.folder_id "
+                    "AND wf2.workspace_id = ? "
+                    "WHERE p2.id != p.id AND p2.file_hash = p.file_hash "
+                    "AND p2.flag != 'rejected')"
+                )
+                return (has if _truthy(value) else f"NOT ({has})"), [self._ws_id()]
+            raise ValueError(f"unsupported collection rule field/op: {field}/{op}")
 
-        join_clause = ""
-        if need_keyword_join:
-            join_clause += " JOIN photo_keywords pk ON pk.photo_id = p.id"
-            join_clause += " JOIN keywords k ON k.id = pk.keyword_id"
-        if need_prediction_join:
-            # Detections are global (no workspace_id); workspace scoping is
-            # enforced by the folder_join on workspace_folders below.
-            join_clause += (
-                " JOIN detections det ON det.photo_id = p.id"
-                " JOIN predictions pred ON pred.detection_id = det.id"
-            )
+        def _build_node(node):
+            if "rules" in node and "field" not in node:
+                mode = node.get("mode", "all")
+                child_sql = []
+                params = []
+                for child in node.get("rules", []):
+                    sql, child_params = _build_node(child)
+                    if sql:
+                        child_sql.append(f"({sql})")
+                        params.extend(child_params)
+                if not child_sql:
+                    return ("0", []) if mode == "any" else (None, [])
+                if mode == "all":
+                    return " AND ".join(child_sql), params
+                if mode == "any":
+                    return " OR ".join(child_sql), params
+                return "NOT (" + " OR ".join(child_sql) + ")", params
+            return _build_leaf(node)
+
+        _validate_node(root)
+        condition, params = _build_node(root)
 
         # Always join folders for folder-under rules, scoped to workspace
         folder_join = " JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')"
@@ -8900,11 +8969,9 @@ class Database:
         # folder_join comes before join_clause in the query, so its param goes first
         params.insert(0, self._ws_id())
 
-        where = ""
-        if conditions:
-            where = "WHERE " + " AND ".join(conditions)
+        where = f"WHERE {condition}" if condition else ""
 
-        return folder_join, join_clause, where, params
+        return folder_join, "", where, params
 
     def get_collection_photos(self, collection_id, page=1, per_page=50):
         """Build SQL from collection rules and return matching photos."""

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2167,7 +2167,8 @@ window.NAV_ALL_PAGES = [
 (function() {
   function strip() { return document.getElementById('navTabStrip'); }
   function tabAnchors() {
-    return Array.from(strip().querySelectorAll('.nav-tab:not(.is-ephemeral)'));
+    const s = strip();
+    return s ? Array.from(s.querySelectorAll('.nav-tab:not(.is-ephemeral)')) : [];
   }
 
   let draggedEl = null;
@@ -2181,6 +2182,39 @@ window.NAV_ALL_PAGES = [
   function removeIndicator() {
     if (indicator && indicator.parentNode) indicator.parentNode.removeChild(indicator);
     indicator = null;
+  }
+  function visibleDropAnchors() {
+    return tabAnchors().filter(a => a !== draggedEl && a.style.display !== 'none');
+  }
+  function dropReference(clientX) {
+    const anchors = visibleDropAnchors();
+    if (!anchors.length) return null;
+    for (const anchor of anchors) {
+      const rect = anchor.getBoundingClientRect();
+      if (clientX < rect.left + rect.width / 2) return anchor;
+    }
+    return anchors[anchors.length - 1].nextSibling;
+  }
+  function showDropIndicator(clientX) {
+    const s = strip();
+    if (!s) return;
+    removeIndicator();
+    indicator = createIndicator();
+    s.insertBefore(indicator, dropReference(clientX));
+  }
+  function persistCurrentOrder() {
+    const newOrder = tabAnchors().map(a => a.dataset.navId);
+    if (window._navTabs) window._navTabs.setTabs(newOrder);
+  }
+  function commitDrop(e) {
+    if (!draggedEl) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const s = strip();
+    if (!s) return;
+    removeIndicator();
+    s.insertBefore(draggedEl, dropReference(e.clientX));
+    persistCurrentOrder();
   }
 
   function bindDragHandlers() {
@@ -2204,23 +2238,10 @@ window.NAV_ALL_PAGES = [
         if (!draggedEl || draggedEl === this) return;
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
-        removeIndicator();
-        const rect = this.getBoundingClientRect();
-        const midX = rect.left + rect.width / 2;
-        indicator = createIndicator();
-        if (e.clientX < midX) strip().insertBefore(indicator, this);
-        else strip().insertBefore(indicator, this.nextSibling);
+        showDropIndicator(e.clientX);
       });
       link.addEventListener('drop', function(e) {
-        if (!draggedEl || draggedEl === this) return;
-        e.preventDefault();
-        const rect = this.getBoundingClientRect();
-        const midX = rect.left + rect.width / 2;
-        if (e.clientX < midX) strip().insertBefore(draggedEl, this);
-        else strip().insertBefore(draggedEl, this.nextSibling);
-        removeIndicator();
-        const newOrder = tabAnchors().map(a => a.dataset.navId);
-        if (window._navTabs) window._navTabs.setTabs(newOrder);
+        commitDrop(e);
       });
     });
   }
@@ -2237,6 +2258,13 @@ window.NAV_ALL_PAGES = [
     s.addEventListener('dragleave', function(e) {
       if (!s.contains(e.relatedTarget)) removeIndicator();
     });
+    s.addEventListener('dragover', function(e) {
+      if (!draggedEl) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      showDropIndicator(e.clientX);
+    });
+    s.addEventListener('drop', commitDrop);
     bindDragHandlers();
     const mo = new MutationObserver(() => bindDragHandlers());
     mo.observe(s, {childList: true});

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1343,13 +1343,14 @@ body {
 <!-- Collection Modal -->
 <div class="modal-overlay" id="collectionModal">
   <div class="modal">
-    <h3>New Smart Collection</h3>
+    <h3 id="collectionModalTitle">New Smart Collection</h3>
     <input class="modal-input" id="collectionName" placeholder="Collection name">
     <div id="ruleRows"></div>
     <button onclick="addRuleRow()" style="background:var(--bg-tertiary);color:var(--info);border:none;border-radius:4px;padding:4px 10px;font-size:11px;cursor:pointer;margin-bottom:8px;">+ Add Rule</button>
+    <button onclick="addRuleGroup()" style="background:var(--bg-tertiary);color:var(--info);border:none;border-radius:4px;padding:4px 10px;font-size:11px;cursor:pointer;margin-bottom:8px;">+ Add Group</button>
     <div class="modal-preview" id="rulePreview"></div>
     <div class="modal-actions">
-      <button class="modal-btn modal-btn-primary" onclick="saveCollection()">Save</button>
+      <button class="modal-btn modal-btn-primary" id="collectionSaveBtn" onclick="saveCollection()">Save</button>
       <button class="modal-btn modal-btn-cancel" onclick="hideCollectionModal()">Cancel</button>
     </div>
   </div>
@@ -1457,6 +1458,7 @@ var keywordAutocompletePromise = null;
 var keywordAutocompleteStates = {};
 var collectionCountRefreshTimer = null;
 var collectionCountLoadGen = 0;
+var collectionsById = {};
 var browseCompareIds = [];
 var browseCompareOffset = 0;
 var browseCompareSeq = 0;
@@ -1814,8 +1816,10 @@ async function bootstrapBrowse() {
 }
 
 function renderCollectionList(collections) {
+  collectionsById = {};
   var html = '';
   collections.forEach(function(c) {
+    collectionsById[c.id] = c;
     var count = c.photo_count != null ? c.photo_count : '';
     html += '<div class="tree-item" data-collection-id="' + c.id + '" onclick="filterByCollection(' + c.id + ')">' +
       '<span>' + escapeHtml(c.name) + '</span>' +
@@ -2035,7 +2039,8 @@ async function filterByCollection(id) {
 }
 
 /* ---------- Collection Modal ---------- */
-var collectionRules = [];
+var collectionEditorRoot = {mode: 'all', rules: []};
+var collectionEditingId = null;
 // Cached dropdown sources for the rule editor. Filled on first modal open
 // and reused across rule rows so toggling field=Extension or field=Folder
 // doesn't refetch on every render. Re-fetched each time the modal opens
@@ -2047,6 +2052,7 @@ var collectionFolders = [];
    The UI only shows ops the backend handles; non-matching combos used to
    silently produce zero matches. */
 var FIELD_OPS = {
+  all:         ['equals'],
   keyword:     ['is', 'is not', 'contains', 'not_contains'],
   rating:      ['is', 'is not', '>=', '<='],
   flag:        ['is', 'is not'],
@@ -2054,8 +2060,49 @@ var FIELD_OPS = {
   extension:   ['is', 'is not'],
   folder:      ['under', 'not_under'],
   timestamp:   ['between', 'recent_days'],
+  quality_score: ['is', 'is not', '>=', '<='],
+  sharpness: ['is', 'is not', '>=', '<='],
+  subject_sharpness: ['is', 'is not', '>=', '<='],
+  noise_estimate: ['is', 'is not', '>=', '<='],
+  crop_complete: ['is', 'is not', '>=', '<='],
+  has_mask: ['equals'],
+  active_mask_variant: ['is', 'is not', 'contains'],
+  has_gps: ['equals'],
+  location_keyword_missing: ['equals'],
+  inat_submitted: ['equals'],
+  is_duplicate: ['equals'],
+  prediction_confidence: ['is', 'is not', '>=', '<='],
+  classifier_model: ['is', 'is not', 'contains'],
+  prediction_status: ['is', 'is not'],
+  needs_review: ['equals'],
+};
+var FIELD_LABELS = {
+  all: 'All Photos',
+  keyword: 'Keyword',
+  rating: 'Rating',
+  flag: 'Flag',
+  color_label: 'Color Label',
+  extension: 'Extension',
+  folder: 'Folder',
+  timestamp: 'Date',
+  quality_score: 'Quality Score',
+  sharpness: 'Sharpness',
+  subject_sharpness: 'Subject Sharpness',
+  noise_estimate: 'Noise',
+  crop_complete: 'Crop Complete',
+  has_mask: 'Has Mask',
+  active_mask_variant: 'Mask Variant',
+  has_gps: 'Has GPS',
+  location_keyword_missing: 'GPS Without Location Keyword',
+  inat_submitted: 'iNaturalist Submitted',
+  is_duplicate: 'Duplicate',
+  prediction_confidence: 'Prediction Confidence',
+  classifier_model: 'Classifier Model',
+  prediction_status: 'Prediction Status',
+  needs_review: 'Needs Review',
 };
 var OP_LABELS = {
+  'equals':       'is',
   'is':           'is',
   'is not':       'is not',
   'contains':     'contains',
@@ -2069,37 +2116,54 @@ var OP_LABELS = {
 };
 
 function defaultValueForRule(field, op) {
+  if (field === 'all') return 1;
   if (field === 'color_label') return 'red';
   if (field === 'flag') return 'flagged';
   if (field === 'rating') return 0;
+  if (['quality_score', 'sharpness', 'subject_sharpness', 'noise_estimate',
+       'crop_complete', 'prediction_confidence'].indexOf(field) !== -1) return 0;
   if (field === 'extension') return collectionExtensions[0] || '';
   if (field === 'folder') return (collectionFolders[0] && collectionFolders[0].path) || '';
   if (field === 'timestamp') {
     if (op === 'between') return ['', ''];
     if (op === 'recent_days') return 7;
   }
+  if (field === 'active_mask_variant') return 'sam2-large';
+  if (field === 'prediction_status') return 'pending';
+  if (['has_mask', 'has_gps', 'location_keyword_missing', 'inat_submitted',
+       'is_duplicate', 'needs_review'].indexOf(field) !== -1) return 1;
   return '';
 }
 
-async function showCollectionModal() {
-  // Cancel any pending/in-flight preview from a previous session before
-  // resetting state — otherwise a stale response can land on the DOM and
-  // briefly show the previous rule set's count in the freshly opened modal.
-  resetPreviewState();
-  collectionRules = [];
-  document.getElementById('rulePreview').textContent = '';
-  document.getElementById('collectionName').value = '';
-  // Clear the rule-row DOM before awaiting the dropdown fetches. Without
-  // this, a slow/failed fetch leaves the previous session's <select>s
-  // visible and interactive while collectionRules is already empty, so
-  // changing one fires updateRule(idx, ...) against an undefined row and
-  // throws.
-  renderRules();
-  document.getElementById('collectionModal').classList.add('open');
-  // Fetch the dropdown sources before adding the first rule row so the
-  // initial render already has data — otherwise the user sees an empty
-  // <select> until they click off and back on. safeFetch already parses
-  // JSON for us (see _navbar.html), so the resolved values are arrays.
+function normalizeCollectionRules(rawRules) {
+  var parsed = rawRules;
+  if (typeof parsed === 'string') {
+    try { parsed = JSON.parse(parsed); } catch (e) { parsed = []; }
+  }
+  if (Array.isArray(parsed)) return {mode: 'all', rules: parsed};
+  if (parsed && typeof parsed === 'object' && Array.isArray(parsed.rules)) {
+    return {
+      mode: (['all', 'any', 'none'].indexOf(parsed.mode) !== -1) ? parsed.mode : 'all',
+      rules: parsed.rules,
+    };
+  }
+  return {mode: 'all', rules: []};
+}
+
+function walkRuleTree(node, fn) {
+  if (!node) return;
+  if (Array.isArray(node)) {
+    node.forEach(function(child) { walkRuleTree(child, fn); });
+    return;
+  }
+  if (node.rules && !node.field) {
+    node.rules.forEach(function(child) { walkRuleTree(child, fn); });
+  } else {
+    fn(node);
+  }
+}
+
+async function loadCollectionEditorSources() {
   try {
     var [exts, folders] = await Promise.all([
       safeFetch('/api/photos/extensions'),
@@ -2111,11 +2175,34 @@ async function showCollectionModal() {
     collectionExtensions = [];
     collectionFolders = [];
   }
+}
+
+async function showCollectionModal(collection) {
+  // Cancel any pending/in-flight preview from a previous session before
+  // resetting state — otherwise a stale response can land on the DOM and
+  // briefly show the previous rule set's count in the freshly opened modal.
+  resetPreviewState();
+  collectionEditingId = collection && collection.id ? collection.id : null;
+  collectionEditorRoot = normalizeCollectionRules(collection ? collection.rules : []);
+  document.getElementById('collectionModalTitle').textContent =
+    collectionEditingId ? 'Edit Smart Collection' : 'New Smart Collection';
+  document.getElementById('collectionSaveBtn').textContent =
+    collectionEditingId ? 'Update' : 'Save';
+  document.getElementById('rulePreview').textContent = '';
+  document.getElementById('collectionName').value = collection ? (collection.name || '') : '';
+  // Clear the rule-row DOM before awaiting the dropdown fetches. Without
+  // this, a slow/failed fetch leaves the previous session's <select>s
+  // visible and interactive while editor state is already reset, so
+  // changing one fires updateRule(idx, ...) against an undefined row and
+  // throws.
+  renderRules();
+  document.getElementById('collectionModal').classList.add('open');
+  await loadCollectionEditorSources();
   // Backfill any extension/folder rules added during the await: they got
   // value '' from defaultValueForRule because the source lists were empty.
   // After fetch, the <select> visually picks the first option but state
   // still holds '', so save/preview would run with an empty filter.
-  collectionRules.forEach(function(r) {
+  walkRuleTree(collectionEditorRoot, function(r) {
     if (r.field === 'extension' && !r.value) {
       r.value = collectionExtensions[0] || '';
     } else if (r.field === 'folder' && !r.value) {
@@ -2127,7 +2214,7 @@ async function showCollectionModal() {
   // clicks "+ Add Rule" while the fetch is in flight gets a phantom
   // keyword/contains/"" row tacked on when fetches resolve, silently
   // changing the saved collection's semantics.
-  if (collectionRules.length === 0 &&
+  if (collectionEditorRoot.rules.length === 0 &&
       document.getElementById('collectionModal').classList.contains('open')) {
     addRuleRow();
   } else {
@@ -2139,24 +2226,59 @@ async function showCollectionModal() {
 
 function hideCollectionModal() {
   resetPreviewState();
+  collectionEditingId = null;
   document.getElementById('collectionModal').classList.remove('open');
 }
 
-function addRuleRow() {
-  var idx = collectionRules.length;
-  collectionRules.push({field: 'keyword', op: 'contains', value: ''});
+function getRuleContainer(path) {
+  if (!path) return collectionEditorRoot;
+  var parts = path.split('.').filter(Boolean).map(function(p) { return parseInt(p, 10); });
+  var node = collectionEditorRoot;
+  parts.forEach(function(idx) { node = node.rules[idx]; });
+  return node;
+}
+
+function getRuleParent(path) {
+  var parts = path.split('.').filter(Boolean);
+  var idx = parseInt(parts.pop(), 10);
+  var parent = parts.length ? getRuleContainer(parts.join('.')) : collectionEditorRoot;
+  return {parent: parent, index: idx};
+}
+
+function addRuleRow(groupPath) {
+  var group = getRuleContainer(groupPath || '');
+  if (!group.rules) group.rules = [];
+  group.rules.push({field: 'keyword', op: 'contains', value: ''});
   renderRules();
 }
 
-function removeRule(idx) {
-  collectionRules.splice(idx, 1);
+function addRuleGroup(groupPath) {
+  var group = getRuleContainer(groupPath || '');
+  if (!group.rules) group.rules = [];
+  group.rules.push({mode: 'all', rules: [
+    {field: 'keyword', op: 'contains', value: ''}
+  ]});
   renderRules();
 }
 
-function updateRule(idx, key, val) {
-  var r = collectionRules[idx];
+function removeRule(path) {
+  var ref = getRuleParent(path);
+  ref.parent.rules.splice(ref.index, 1);
+  renderRules();
+}
+
+function updateRule(path, key, val) {
+  var r = getRuleContainer(path);
+  if (!r) return;
+  if (key === 'mode') {
+    r.mode = val;
+    renderRules();
+    return;
+  }
   if (key === 'field') {
     r.field = val;
+    delete r.rules;
+    delete r.mode;
     var ops = FIELD_OPS[val] || [];
     // If current op isn't valid for the new field, default to the field's
     // first listed op. Otherwise keep the user's selection.
@@ -2216,25 +2338,7 @@ async function updatePreviewNow() {
   _previewTimer = null;
   var el = document.getElementById('rulePreview');
   if (!el) return;
-  // An empty rules list is a valid save state — it matches every photo in
-  // the workspace — so we still query the API rather than blanking the
-  // preview text. Otherwise removing all rule rows would hide the count
-  // for what is actually a "match all photos" save.
-  // Coerce numeric fields the same way saveCollection() does, so the
-  // preview matches what would be saved.
-  var rules = collectionRules.map(function(r) {
-    var val = r.value;
-    if (r.field === 'rating') {
-      val = parseInt(val, 10) || 0;
-    } else if (r.field === 'timestamp' && r.op === 'recent_days') {
-      val = parseInt(val, 10) || 0;
-    } else if (r.field === 'timestamp' && r.op === 'between') {
-      var from = Array.isArray(val) ? (val[0] || '') : '';
-      var to   = Array.isArray(val) ? (val[1] || '') : '';
-      val = [from, to];
-    }
-    return {field: r.field, op: r.op, value: val};
-  });
+  var rules = serializeCollectionRules();
   var seq = ++_previewSeq;
   try {
     var data = await safeFetch('/api/collections/preview', {
@@ -2254,8 +2358,20 @@ async function updatePreviewNow() {
 }
 
 function renderRuleValueInput(r, i) {
+  var p = escapeAttr(i);
+  if (r.field === 'all') {
+    return '<span style="flex:1;color:var(--text-ghost);font-size:12px;">Matches every photo in this workspace</span>';
+  }
+  if (['has_mask', 'has_gps', 'location_keyword_missing', 'inat_submitted',
+       'is_duplicate', 'needs_review'].indexOf(r.field) !== -1) {
+    var boolVal = (r.value === true || r.value === 1 || r.value === '1' || r.value === 'true') ? '1' : '0';
+    return '<select onchange="updateRule(\'' + p + '\',\'value\',this.value)" style="flex:1;">' +
+        '<option value="1"' + (boolVal==='1'?' selected':'') + '>Yes</option>' +
+        '<option value="0"' + (boolVal==='0'?' selected':'') + '>No</option>' +
+      '</select>';
+  }
   if (r.field === 'color_label') {
-    return '<select onchange="updateRule(' + i + ',\'value\',this.value)" style="flex:1;">' +
+    return '<select onchange="updateRule(\'' + p + '\',\'value\',this.value)" style="flex:1;">' +
         '<option value="red"' + (r.value==='red'?' selected':'') + '>Red</option>' +
         '<option value="yellow"' + (r.value==='yellow'?' selected':'') + '>Yellow</option>' +
         '<option value="green"' + (r.value==='green'?' selected':'') + '>Green</option>' +
@@ -2264,10 +2380,17 @@ function renderRuleValueInput(r, i) {
       '</select>';
   }
   if (r.field === 'flag') {
-    return '<select onchange="updateRule(' + i + ',\'value\',this.value)" style="flex:1;">' +
+    return '<select onchange="updateRule(\'' + p + '\',\'value\',this.value)" style="flex:1;">' +
         '<option value="flagged"' + (r.value==='flagged'?' selected':'') + '>Pick</option>' +
         '<option value="rejected"' + (r.value==='rejected'?' selected':'') + '>Reject</option>' +
         '<option value="none"' + (r.value==='none'?' selected':'') + '>No flag</option>' +
+      '</select>';
+  }
+  if (r.field === 'prediction_status') {
+    return '<select onchange="updateRule(\'' + p + '\',\'value\',this.value)" style="flex:1;">' +
+        '<option value="pending"' + (r.value==='pending'?' selected':'') + '>Pending</option>' +
+        '<option value="accepted"' + (r.value==='accepted'?' selected':'') + '>Accepted</option>' +
+        '<option value="rejected"' + (r.value==='rejected'?' selected':'') + '>Rejected</option>' +
       '</select>';
   }
   if (r.field === 'extension') {
@@ -2276,7 +2399,7 @@ function renderRuleValueInput(r, i) {
     // (legacy rule, freshly switched field), include it as a sticky
     // option so the user can see+keep it instead of having it silently
     // snap to the first known extension on next render.
-    return '<select onchange="updateRule(' + i + ',\'value\',this.value)" style="flex:1;">' +
+    return '<select onchange="updateRule(\'' + p + '\',\'value\',this.value)" style="flex:1;">' +
         (collectionExtensions.length === 0
           ? '<option value="">(no extensions yet — scan a folder)</option>'
           : '') +
@@ -2297,7 +2420,7 @@ function renderRuleValueInput(r, i) {
     var stickyFolder = (r.value && paths.indexOf(r.value) === -1)
       ? '<option value="' + escapeAttr(String(r.value)) + '" selected>' + escapeHtml(String(r.value)) + '</option>'
       : '';
-    return '<select onchange="updateRule(' + i + ',\'value\',this.value)" style="flex:1;">' +
+    return '<select onchange="updateRule(\'' + p + '\',\'value\',this.value)" style="flex:1;">' +
         (collectionFolders.length === 0
           ? '<option value="">(no folders in this workspace)</option>'
           : '') +
@@ -2312,79 +2435,134 @@ function renderRuleValueInput(r, i) {
       var from = Array.isArray(r.value) ? (r.value[0] || '') : '';
       var to   = Array.isArray(r.value) ? (r.value[1] || '') : '';
       return '<div style="flex:1;display:flex;gap:6px;align-items:center;">' +
-          '<input type="date" value="' + escapeAttr(from) + '" onchange="updateRule(' + i + ',\'value_from\',this.value)" style="flex:1;">' +
+          '<input type="date" value="' + escapeAttr(from) + '" onchange="updateRule(\'' + p + '\',\'value_from\',this.value)" style="flex:1;">' +
           '<span style="color:var(--text-ghost);font-size:11px;">and</span>' +
-          '<input type="date" value="' + escapeAttr(to) + '" onchange="updateRule(' + i + ',\'value_to\',this.value)" style="flex:1;">' +
+          '<input type="date" value="' + escapeAttr(to) + '" onchange="updateRule(\'' + p + '\',\'value_to\',this.value)" style="flex:1;">' +
         '</div>';
     }
     if (r.op === 'recent_days') {
       var n = (typeof r.value === 'number' || (typeof r.value === 'string' && r.value !== '')) ? r.value : 7;
       return '<div style="flex:1;display:flex;gap:6px;align-items:center;">' +
-          '<input type="number" min="1" value="' + escapeAttr(String(n)) + '" onchange="updateRule(' + i + ',\'value\',this.value)" style="width:80px;">' +
+          '<input type="number" min="1" value="' + escapeAttr(String(n)) + '" onchange="updateRule(\'' + p + '\',\'value\',this.value)" style="width:80px;">' +
           '<span style="color:var(--text-ghost);font-size:11px;">days</span>' +
         '</div>';
     }
   }
-  return '<input type="text" value="' + escapeAttr(String(r.value == null ? '' : r.value)) + '" onchange="updateRule(' + i + ',\'value\',this.value)" placeholder="value" style="flex:1;">';
+  var numeric = ['rating', 'quality_score', 'sharpness', 'subject_sharpness',
+    'noise_estimate', 'crop_complete', 'prediction_confidence'].indexOf(r.field) !== -1;
+  return '<input type="' + (numeric ? 'number' : 'text') + '" value="' +
+    escapeAttr(String(r.value == null ? '' : r.value)) +
+    '" onchange="updateRule(\'' + p + '\',\'value\',this.value)" placeholder="value" style="flex:1;">';
+}
+
+function renderFieldOptions(selected) {
+  return Object.keys(FIELD_LABELS).map(function(field) {
+    return '<option value="' + escapeAttr(field) + '"' + (selected === field ? ' selected' : '') + '>' +
+      escapeHtml(FIELD_LABELS[field]) + '</option>';
+  }).join('');
+}
+
+function renderRuleNode(node, path, depth) {
+  var p = escapeAttr(path);
+  var indent = Math.min(depth, 4) * 12;
+  if (node.rules && !node.field) {
+    var groupHtml = '<div style="margin-left:' + indent + 'px;margin-bottom:8px;padding:8px;border:1px solid var(--border-subtle);border-radius:4px;">' +
+      '<div class="rule-row" style="margin-bottom:6px;">' +
+      '<span style="font-size:12px;color:var(--text-dim);">Match</span>' +
+      '<select onchange="updateRule(\'' + p + '\',\'mode\',this.value)">' +
+        '<option value="all"' + (node.mode==='all'?' selected':'') + '>all</option>' +
+        '<option value="any"' + (node.mode==='any'?' selected':'') + '>any</option>' +
+        '<option value="none"' + (node.mode==='none'?' selected':'') + '>none</option>' +
+      '</select>' +
+      '<span style="font-size:12px;color:var(--text-dim);flex:1;">of these rules</span>';
+    if (path) {
+      groupHtml += '<span class="remove-rule" onclick="removeRule(\'' + p + '\')">&times;</span>';
+    }
+    groupHtml += '</div>';
+    (node.rules || []).forEach(function(child, idx) {
+      groupHtml += renderRuleNode(child, path ? path + '.' + idx : String(idx), depth + 1);
+    });
+    groupHtml += '<button onclick="addRuleRow(\'' + p + '\')" style="background:var(--bg-tertiary);color:var(--info);border:none;border-radius:4px;padding:3px 8px;font-size:11px;cursor:pointer;margin-right:4px;">+ Rule</button>' +
+      '<button onclick="addRuleGroup(\'' + p + '\')" style="background:var(--bg-tertiary);color:var(--info);border:none;border-radius:4px;padding:3px 8px;font-size:11px;cursor:pointer;">+ Group</button>' +
+      '</div>';
+    return groupHtml;
+  }
+  var ops = FIELD_OPS[node.field] || [];
+  var opOptions = ops.map(function(op) {
+    var label = OP_LABELS[op] || op;
+    return '<option value="' + escapeAttr(op) + '"' + (node.op===op?' selected':'') + '>' + escapeHtml(label) + '</option>';
+  }).join('');
+  return '<div class="rule-row" style="margin-left:' + indent + 'px;">' +
+    '<select onchange="updateRule(\'' + p + '\',\'field\',this.value)">' +
+      renderFieldOptions(node.field) +
+    '</select>' +
+    '<select onchange="updateRule(\'' + p + '\',\'op\',this.value)">' +
+      opOptions +
+    '</select>' +
+    renderRuleValueInput(node, path) +
+    '<span class="remove-rule" onclick="removeRule(\'' + p + '\')">&times;</span>' +
+  '</div>';
 }
 
 function renderRules() {
-  var html = '';
-  collectionRules.forEach(function(r, i) {
-    var ops = FIELD_OPS[r.field] || [];
-    var opOptions = ops.map(function(op) {
-      var label = OP_LABELS[op] || op;
-      return '<option value="' + escapeAttr(op) + '"' + (r.op===op?' selected':'') + '>' + escapeHtml(label) + '</option>';
-    }).join('');
-    html += '<div class="rule-row">' +
-      '<select onchange="updateRule(' + i + ',\'field\',this.value)">' +
-        '<option value="keyword"' + (r.field==='keyword'?' selected':'') + '>Keyword</option>' +
-        '<option value="rating"' + (r.field==='rating'?' selected':'') + '>Rating</option>' +
-        '<option value="flag"' + (r.field==='flag'?' selected':'') + '>Flag</option>' +
-        '<option value="color_label"' + (r.field==='color_label'?' selected':'') + '>Color Label</option>' +
-        '<option value="extension"' + (r.field==='extension'?' selected':'') + '>Extension</option>' +
-        '<option value="folder"' + (r.field==='folder'?' selected':'') + '>Folder</option>' +
-        '<option value="timestamp"' + (r.field==='timestamp'?' selected':'') + '>Date</option>' +
-      '</select>' +
-      '<select onchange="updateRule(' + i + ',\'op\',this.value)">' +
-        opOptions +
-      '</select>' +
-      renderRuleValueInput(r, i) +
-      '<span class="remove-rule" onclick="removeRule(' + i + ')">&times;</span>' +
-    '</div>';
-  });
-  document.getElementById('ruleRows').innerHTML = html;
+  document.getElementById('ruleRows').innerHTML = renderRuleNode(collectionEditorRoot, '', 0);
   schedulePreviewUpdate();
+}
+
+function coerceRuleForSave(node) {
+  if (node.rules && !node.field) {
+    return {
+      mode: (['all', 'any', 'none'].indexOf(node.mode) !== -1) ? node.mode : 'all',
+      rules: (node.rules || []).map(coerceRuleForSave),
+    };
+  }
+  var val = node.value;
+  if (['rating', 'quality_score', 'sharpness', 'subject_sharpness',
+       'noise_estimate', 'crop_complete', 'prediction_confidence'].indexOf(node.field) !== -1) {
+    val = parseFloat(val);
+    if (isNaN(val)) val = 0;
+  } else if (['has_mask', 'has_gps', 'location_keyword_missing', 'inat_submitted',
+              'is_duplicate', 'needs_review', 'all'].indexOf(node.field) !== -1) {
+    val = (val === true || val === 1 || val === '1' || val === 'true') ? 1 : 0;
+  } else if (node.field === 'timestamp' && node.op === 'recent_days') {
+    val = parseInt(val, 10) || 0;
+  } else if (node.field === 'timestamp' && node.op === 'between') {
+      var from = Array.isArray(val) ? (val[0] || '') : '';
+      var to   = Array.isArray(val) ? (val[1] || '') : '';
+      val = [from, to];
+  }
+  return {field: node.field, op: node.op, value: val};
+}
+
+function serializeCollectionRules() {
+  return coerceRuleForSave(collectionEditorRoot);
+}
+
+async function editCollection(cid) {
+  var collection = collectionsById[cid];
+  if (!collection) {
+    var list = await safeFetch('/api/collections', {}, {toast: false});
+    renderCollectionList(list || []);
+    collection = collectionsById[cid];
+  }
+  if (collection) showCollectionModal(collection);
 }
 
 async function saveCollection() {
   var name = document.getElementById('collectionName').value.trim();
   if (!name) return;
-
-  // Convert string values to numbers / lists where the backend expects them.
-  // See vireo/db.py::_build_collection_query for the per-field/op shapes.
-  var rules = collectionRules.map(function(r) {
-    var val = r.value;
-    if (r.field === 'rating') {
-      val = parseInt(val, 10) || 0;
-    } else if (r.field === 'timestamp' && r.op === 'recent_days') {
-      val = parseInt(val, 10) || 0;
-    } else if (r.field === 'timestamp' && r.op === 'between') {
-      var from = Array.isArray(val) ? (val[0] || '') : '';
-      var to   = Array.isArray(val) ? (val[1] || '') : '';
-      val = [from, to];
-    }
-    return {field: r.field, op: r.op, value: val};
-  });
+  var rules = serializeCollectionRules();
 
   try {
-    await safeFetch('/api/collections', {
-      method: 'POST',
+    var url = collectionEditingId ? '/api/collections/' + collectionEditingId : '/api/collections';
+    await safeFetch(url, {
+      method: collectionEditingId ? 'PUT' : 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({name: name, rules: rules}),
     });
     hideCollectionModal();
     loadCollections();
+    loadCollectionCounts();
   } catch(e) {}
 }
 
@@ -4818,6 +4996,8 @@ document.addEventListener('contextmenu', function(e) {
     { label: 'Filter by this Collection',
       onClick: function() { filterByCollection(cid); } },
     { separator: true },
+    { label: 'Edit Rules',
+      onClick: function() { editCollection(cid); } },
     { label: 'Rename',
       onClick: function() { renameCollection(cid, name); } },
     { label: 'Duplicate',

--- a/vireo/tests/test_collections_api.py
+++ b/vireo/tests/test_collections_api.py
@@ -104,6 +104,39 @@ def test_create_collection_with_rules(app_and_db):
     assert stored_rules == rules
 
 
+def test_update_collection_can_replace_rules(app_and_db):
+    """PUT /api/collections/<id> updates rules as well as the name."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/collections",
+        json={"name": "Draft", "rules": [{"field": "rating", "op": ">=", "value": 5}]},
+    )
+    assert resp.status_code == 200
+    cid = resp.get_json()["id"]
+
+    grouped = {
+        "mode": "any",
+        "rules": [
+            {"field": "rating", "op": ">=", "value": 3},
+            {"field": "flag", "op": "equals", "value": "flagged"},
+        ],
+    }
+    resp = client.put(
+        f"/api/collections/{cid}",
+        json={"name": "Useful", "rules": grouped},
+    )
+    assert resp.status_code == 200
+
+    row = db.conn.execute(
+        "SELECT name, rules FROM collections WHERE id = ?", (cid,)
+    ).fetchone()
+    assert row["name"] == "Useful"
+    assert json.loads(row["rules"]) == grouped
+
+
 def test_collection_photos_with_rating_rule(app_and_db):
     """Collection with rating >= 3 rule returns photos with rating >= 3."""
     app, db = app_and_db

--- a/vireo/tests/test_collections_api.py
+++ b/vireo/tests/test_collections_api.py
@@ -260,6 +260,35 @@ def test_cannot_add_photos_to_all_photos_default(app_and_db):
     assert json.loads(row["rules"]) == [{"field": "all"}]
 
 
+def test_cannot_add_photos_to_none_grouped_collection(app_and_db):
+    """Adding photos to a "none" group would exclude the selected IDs."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    rules = {
+        "mode": "none",
+        "rules": [{"field": "flag", "op": "is", "value": "rejected"}],
+    }
+    resp = client.post(
+        "/api/collections",
+        json={"name": "Not rejected", "rules": rules},
+    )
+    cid = resp.get_json()["id"]
+
+    pid = db.get_photos()[0]["id"]
+    resp = client.post(
+        f"/api/collections/{cid}/add-photos",
+        json={"photo_ids": [pid]},
+    )
+    assert resp.status_code == 400
+
+    row = db.conn.execute(
+        "SELECT rules FROM collections WHERE id = ?", (cid,)
+    ).fetchone()
+    assert json.loads(row["rules"]) == rules
+
+
 def test_collection_add_photos_empty_list(app_and_db):
     """POST /api/collections/<id>/add-photos with empty photo_ids returns 400."""
     app, db = app_and_db

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6441,6 +6441,103 @@ def test_collection_color_label_not_equals_rule(tmp_path):
     assert 'c.jpg' in filenames
 
 
+def test_collection_group_any_and_none_rules(tmp_path):
+    """Smart collections support grouped OR and NONE logic."""
+    import json
+
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='five.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='pick.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+    p3 = db.add_photo(folder_id=fid, filename='other.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET rating = 5 WHERE id = ?", (p1,))
+    db.conn.execute("UPDATE photos SET flag = 'flagged' WHERE id = ?", (p2,))
+    db.conn.commit()
+
+    any_rules = {
+        "mode": "any",
+        "rules": [
+            {"field": "rating", "op": ">=", "value": 5},
+            {"field": "flag", "op": "equals", "value": "flagged"},
+        ],
+    }
+    cid = db.add_collection("Five or Pick", json.dumps(any_rules))
+    assert [p["filename"] for p in db.get_collection_photos(cid, per_page=10)] == [
+        "five.jpg",
+        "pick.jpg",
+    ]
+
+    none_rules = {
+        "mode": "none",
+        "rules": [
+            {"field": "rating", "op": ">=", "value": 5},
+            {"field": "flag", "op": "equals", "value": "flagged"},
+        ],
+    }
+    cid = db.add_collection("Neither", json.dumps(none_rules))
+    assert [p["filename"] for p in db.get_collection_photos(cid, per_page=10)] == [
+        "other.jpg",
+    ]
+
+
+def test_collection_vireo_native_fields(tmp_path):
+    """Smart collections can target Vireo AI/quality workflow fields."""
+    import json
+
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='match.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='miss.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+
+    db.conn.execute(
+        "UPDATE photos SET quality_score = 0.91, mask_path = ?, "
+        "active_mask_variant = 'sam2-large', latitude = 1.0, longitude = 2.0 "
+        "WHERE id = ?",
+        (str(tmp_path / "mask.png"), p1),
+    )
+    db.conn.execute(
+        "UPDATE photos SET quality_score = 0.20, latitude = 3.0, longitude = 4.0 "
+        "WHERE id = ?",
+        (p2,),
+    )
+    loc_kw = db.add_keyword("Yosemite", kw_type="location")
+    db.tag_photo(p2, loc_kw)
+    db.conn.execute(
+        "INSERT INTO inat_submissions (photo_id, observation_id, observation_url) "
+        "VALUES (?, 123, 'https://example.test/obs/123')",
+        (p1,),
+    )
+    det_id = db.save_detections(
+        p1,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.95, "category": "animal"}],
+        "megadetector-v6",
+    )[0]
+    db.add_prediction(det_id, "Red Fox", 0.93, "bioclip", status="accepted")
+
+    rules = {
+        "mode": "all",
+        "rules": [
+            {"field": "quality_score", "op": ">=", "value": 0.9},
+            {"field": "has_mask", "op": "equals", "value": 1},
+            {"field": "active_mask_variant", "op": "equals", "value": "sam2-large"},
+            {"field": "has_gps", "op": "equals", "value": 1},
+            {"field": "location_keyword_missing", "op": "equals", "value": 1},
+            {"field": "inat_submitted", "op": "equals", "value": 1},
+            {"field": "prediction_confidence", "op": ">=", "value": 0.9},
+            {"field": "classifier_model", "op": "equals", "value": "bioclip"},
+            {"field": "prediction_status", "op": "equals", "value": "accepted"},
+        ],
+    }
+    cid = db.add_collection("Vireo Native", json.dumps(rules))
+    photos = db.get_collection_photos(cid, per_page=10)
+    assert [p["filename"] for p in photos] == ["match.jpg"]
+
+
 def test_undo_color_label(tmp_path):
     """Undo reverts a color label change."""
     from db import Database


### PR DESCRIPTION
Adds editable smart collection rules in Browse, including nested all/any/none groups and rule validation on create/update. Expands the backend rule engine with Vireo-native predicates for quality, masks, GPS/location gaps, iNaturalist, duplicates, and prediction state. Keeps existing flat rule arrays compatible while cleaning nested static photo-id rules when photos are deleted. Validated with py_compile, JS syntax checks, focused collection/API tests, collection context-menu E2E, and page-load E2E.