### PR TITLE
[codex] Improve keyword compare page

### DIFF
--- a/tests/e2e/test_compare_page.py
+++ b/tests/e2e/test_compare_page.py
@@ -1,0 +1,23 @@
+from playwright.sync_api import expect
+
+
+def test_compare_page_shows_keyword_workflow(live_server, page):
+    page.goto(f"{live_server['url']}/compare")
+
+    expect(page.locator("#summaryGrid")).to_be_visible()
+    expect(page.locator("#filterRow")).to_contain_text("Needs review")
+    expect(page.locator(".compare-table")).to_be_visible()
+    expect(page.locator("th", has_text="Photo")).to_be_visible()
+    expect(page.locator("th", has_text="Status")).to_be_visible()
+    expect(page.locator("th", has_text="Current keywords")).to_be_visible()
+    page.locator("#filterRow button", has_text="All").click()
+    expect(page.locator(".keyword-pill.species").first).to_contain_text("Red-tailed Hawk")
+
+
+def test_compare_page_filters_conflicts_without_crashing(live_server, page):
+    page.goto(f"{live_server['url']}/compare")
+
+    expect(page.locator("#summaryGrid")).to_be_visible()
+    page.locator("#filterRow button", has_text="Matches").click()
+
+    expect(page.locator("#filterRow .active")).to_contain_text("Matches")

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -83,6 +83,26 @@ def test_compare_prediction_to_keywords_conflict_with_shared_rank():
     assert result["shared_rank"] == "genus"
 
 
+def test_compare_prediction_to_keywords_conflict_outranks_refinement():
+    # Prediction refines "Sparrow" but conflicts with "Red-tailed Hawk".
+    # The most severe relationship (conflict) must win regardless of the
+    # order keywords are evaluated in, so the row stays in the review flow.
+    result = compare_prediction_to_keywords(
+        "White-crowned Sparrow",
+        ["Sparrow", "Red-tailed Hawk"],
+        FakeTaxonomy(),
+    )
+    assert result["category"] == "conflict"
+
+    # Same keywords, reversed order — result must be stable.
+    reversed_result = compare_prediction_to_keywords(
+        "White-crowned Sparrow",
+        ["Red-tailed Hawk", "Sparrow"],
+        FakeTaxonomy(),
+    )
+    assert reversed_result["category"] == "conflict"
+
+
 def test_compare_prediction_to_keywords_new_without_species_keyword():
     result = compare_prediction_to_keywords(
         "Red-tailed Hawk",

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -103,6 +103,36 @@ def test_compare_prediction_to_keywords_conflict_outranks_refinement():
     assert reversed_result["category"] == "conflict"
 
 
+def test_compare_prediction_to_keywords_match_does_not_hide_conflict():
+    # An exact match must not short-circuit the scan: a contradictory
+    # species keyword on the same photo still has to surface as a conflict
+    # so the row stays in the review flow.
+    result = compare_prediction_to_keywords(
+        "Red-tailed Hawk",
+        ["Red-tailed Hawk", "White-crowned Sparrow"],
+        FakeTaxonomy(),
+    )
+    assert result["category"] == "conflict"
+
+    # Order must not matter.
+    reversed_result = compare_prediction_to_keywords(
+        "Red-tailed Hawk",
+        ["White-crowned Sparrow", "Red-tailed Hawk"],
+        FakeTaxonomy(),
+    )
+    assert reversed_result["category"] == "conflict"
+
+
+def test_compare_prediction_to_keywords_pure_match():
+    # With only an agreeing keyword the result is still a match.
+    result = compare_prediction_to_keywords(
+        "Red-tailed Hawk",
+        ["Red-tailed Hawk"],
+        FakeTaxonomy(),
+    )
+    assert result["category"] == "match"
+
+
 def test_compare_prediction_to_keywords_new_without_species_keyword():
     result = compare_prediction_to_keywords(
         "Red-tailed Hawk",

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,93 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "vireo"))
+
+from compare import compare_prediction_to_keywords
+
+
+class FakeTaxonomy:
+    taxa = {
+        "sparrow": {
+            "scientific_name": "Passerellidae",
+            "lineage_names": ["Animalia", "Chordata", "Aves"],
+            "lineage_ranks": ["kingdom", "phylum", "class"],
+        },
+        "white-crowned sparrow": {
+            "scientific_name": "Zonotrichia leucophrys",
+            "lineage_names": ["Animalia", "Chordata", "Aves", "Passeriformes", "Passerellidae", "Zonotrichia"],
+            "lineage_ranks": ["kingdom", "phylum", "class", "order", "family", "genus"],
+        },
+        "golden-crowned sparrow": {
+            "scientific_name": "Zonotrichia atricapilla",
+            "lineage_names": ["Animalia", "Chordata", "Aves", "Passeriformes", "Passerellidae", "Zonotrichia"],
+            "lineage_ranks": ["kingdom", "phylum", "class", "order", "family", "genus"],
+        },
+        "red-tailed hawk": {
+            "scientific_name": "Buteo jamaicensis",
+            "lineage_names": ["Animalia", "Chordata", "Aves", "Accipitriformes", "Accipitridae", "Buteo"],
+            "lineage_ranks": ["kingdom", "phylum", "class", "order", "family", "genus"],
+        },
+    }
+
+    def lookup(self, name):
+        return self.taxa.get(name.lower())
+
+    def relationship(self, name_a, name_b):
+        a = self.lookup(name_a)
+        b = self.lookup(name_b)
+        if not a or not b:
+            return None
+        sci_a = a["scientific_name"].lower()
+        sci_b = b["scientific_name"].lower()
+        if sci_a == sci_b:
+            return "same"
+        if sci_a in [n.lower() for n in b["lineage_names"]]:
+            return "ancestor"
+        if sci_b in [n.lower() for n in a["lineage_names"]]:
+            return "descendant"
+        if a["lineage_names"][-1] == b["lineage_names"][-1]:
+            return "sibling"
+        return "unrelated"
+
+
+def test_compare_prediction_to_keywords_refinement():
+    result = compare_prediction_to_keywords(
+        "White-crowned Sparrow",
+        ["Sparrow"],
+        FakeTaxonomy(),
+    )
+
+    assert result["category"] == "refinement"
+    assert result["matched_keyword"] == "Sparrow"
+
+
+def test_compare_prediction_to_keywords_broader():
+    result = compare_prediction_to_keywords(
+        "Sparrow",
+        ["White-crowned Sparrow"],
+        FakeTaxonomy(),
+    )
+
+    assert result["category"] == "broader"
+
+
+def test_compare_prediction_to_keywords_conflict_with_shared_rank():
+    result = compare_prediction_to_keywords(
+        "Golden-crowned Sparrow",
+        ["White-crowned Sparrow"],
+        FakeTaxonomy(),
+    )
+
+    assert result["category"] == "conflict"
+    assert result["shared_rank"] == "genus"
+
+
+def test_compare_prediction_to_keywords_new_without_species_keyword():
+    result = compare_prediction_to_keywords(
+        "Red-tailed Hawk",
+        [],
+        FakeTaxonomy(),
+    )
+
+    assert result["category"] == "new"

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4276,6 +4276,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/api/predictions/compare")
     def api_predictions_compare():
+        from compare import compare_prediction_to_keywords
+        from taxonomy import load_local_taxonomy
+
         db = _get_db()
         collection_id = request.args.get("collection_id", None, type=int)
         if not collection_id:
@@ -4284,36 +4287,215 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         photos = db.get_collection_photos(collection_id, per_page=999999)
         photo_ids = [p["id"] for p in photos]
         if not photo_ids:
-            return jsonify({"models": [], "photos": []})
+            return jsonify({
+                "models": [],
+                "photos": [],
+                "summary": {
+                    "photos": 0,
+                    "models": 0,
+                    "matches": 0,
+                    "refinements": 0,
+                    "broader": 0,
+                    "conflicts": 0,
+                    "new": 0,
+                    "missing_predictions": 0,
+                    "needs_review": 0,
+                },
+                "taxonomy_available": False,
+            })
 
         preds = db.get_predictions(photo_ids=photo_ids)
+        keywords_by_photo = db.get_keywords_for_photos(photo_ids)
+        species_by_photo = db.get_species_keywords_for_photos(photo_ids)
+        taxonomy = load_local_taxonomy()
+
+        def summarize_photo(row):
+            return {
+                "photo_id": row["id"],
+                "filename": row["filename"],
+                "timestamp": row["timestamp"],
+                "rating": row["rating"],
+                "flag": row["flag"],
+                "width": row["width"],
+                "height": row["height"],
+                "keywords": keywords_by_photo.get(row["id"], []),
+                "species_keywords": species_by_photo.get(row["id"], []),
+                "predictions": {},
+                "row_category": "missing_prediction",
+                "row_label": "Missing prediction",
+            }
 
         # Collect distinct models and build per-photo lookup
         # With multi-detection, each photo may have multiple predictions per model
         models = set()
-        by_photo = {}
+        by_photo = {p["id"]: summarize_photo(p) for p in photos}
         for pr in preds:
             d = dict(pr)
+            if d.get("status") == "alternative":
+                continue
             pid = d["photo_id"]
             model = d["model"]
             models.add(model)
             if pid not in by_photo:
-                by_photo[pid] = {"photo_id": pid, "filename": d["filename"], "predictions": {}}
+                continue
             if model not in by_photo[pid]["predictions"]:
                 by_photo[pid]["predictions"][model] = []
+            comparison = compare_prediction_to_keywords(
+                d["species"],
+                species_by_photo.get(pid, []),
+                taxonomy,
+            )
             by_photo[pid]["predictions"][model].append({
+                "id": d["id"],
                 "species": d["species"],
                 "confidence": d["confidence"],
+                "status": d["status"],
+                "category": comparison["category"],
+                "category_label": comparison["label"],
+                "category_detail": comparison["detail"],
+                "matched_keyword": comparison["matched_keyword"],
+                "shared_rank": comparison["shared_rank"],
                 "box_x": d.get("box_x"),
                 "box_y": d.get("box_y"),
                 "box_w": d.get("box_w"),
                 "box_h": d.get("box_h"),
             })
 
+        priority = {
+            "conflict": 6,
+            "refinement": 5,
+            "broader": 4,
+            "new": 3,
+            "missing_prediction": 2,
+            "match": 1,
+        }
+        labels = {
+            "conflict": "Conflict",
+            "refinement": "Refinement",
+            "broader": "Broader",
+            "new": "No species keyword",
+            "missing_prediction": "Missing prediction",
+            "match": "Match",
+        }
+        summary = {
+            "photos": len(photos),
+            "models": 0,
+            "matches": 0,
+            "refinements": 0,
+            "broader": 0,
+            "conflicts": 0,
+            "new": 0,
+            "missing_predictions": 0,
+            "needs_review": 0,
+        }
+
+        for photo in by_photo.values():
+            row_category = "missing_prediction"
+            has_pending_prediction = False
+            for model_preds in photo["predictions"].values():
+                for pred in model_preds:
+                    if pred.get("status") == "pending":
+                        has_pending_prediction = True
+                    cat = pred["category"]
+                    if cat == "match":
+                        summary["matches"] += 1
+                    elif cat == "refinement":
+                        summary["refinements"] += 1
+                    elif cat == "broader":
+                        summary["broader"] += 1
+                    elif cat == "conflict":
+                        summary["conflicts"] += 1
+                    elif cat == "new":
+                        summary["new"] += 1
+                    if priority[cat] > priority[row_category]:
+                        row_category = cat
+            if not photo["predictions"]:
+                summary["missing_predictions"] += 1
+            photo["row_category"] = row_category
+            photo["row_label"] = labels[row_category]
+            photo["needs_review"] = (
+                row_category in {"conflict", "refinement", "broader", "new"}
+                and has_pending_prediction
+            )
+            if photo["needs_review"]:
+                summary["needs_review"] += 1
+
+        model_list = sorted(models)
+        summary["models"] = len(model_list)
+
         return jsonify({
-            "models": sorted(models),
+            "models": model_list,
             "photos": list(by_photo.values()),
+            "summary": summary,
+            "taxonomy_available": taxonomy is not None,
         })
+
+    @app.route("/api/predictions/<int:pred_id>/reviewed", methods=["POST"])
+    def api_mark_prediction_reviewed(pred_id):
+        db = _get_db()
+        pred = db.conn.execute(
+            """SELECT pr.id, pr.species, d.photo_id
+               FROM predictions pr
+               JOIN detections d ON d.id = pr.detection_id
+               WHERE pr.id = ?""",
+            (pred_id,),
+        ).fetchone()
+        if pred is None:
+            return json_error("prediction not found", 404)
+        db.update_prediction_status(pred_id, "reviewed")
+        db.record_edit(
+            "prediction_reviewed",
+            f'Marked prediction "{pred["species"]}" reviewed',
+            "reviewed",
+            [{"photo_id": pred["photo_id"], "old_value": "pending", "new_value": "reviewed"}],
+        )
+        return jsonify({"ok": True})
+
+    @app.route("/api/predictions/<int:pred_id>/replace-keywords", methods=["POST"])
+    def api_replace_species_keywords_with_prediction(pred_id):
+        db = _get_db()
+        pred = db.conn.execute(
+            """SELECT pr.id, pr.species, d.photo_id
+               FROM predictions pr
+               JOIN detections d ON d.id = pr.detection_id
+               WHERE pr.id = ?""",
+            (pred_id,),
+        ).fetchone()
+        if pred is None:
+            return json_error("prediction not found", 404)
+        old_species = [
+            row["name"] for row in db.conn.execute(
+                """SELECT k.name
+                   FROM photo_keywords pk
+                   JOIN keywords k ON k.id = pk.keyword_id
+                   WHERE pk.photo_id = ?
+                     AND (k.is_species = 1 OR k.type = 'taxonomy')""",
+                (pred["photo_id"],),
+            ).fetchall()
+        ]
+        db.conn.execute(
+            """DELETE FROM photo_keywords
+               WHERE photo_id = ?
+                 AND keyword_id IN (
+                   SELECT id FROM keywords
+                   WHERE is_species = 1 OR type = 'taxonomy'
+                 )""",
+            (pred["photo_id"],),
+        )
+        result = db.accept_prediction(pred_id)
+        if result is None:
+            return json_error("prediction not found", 404)
+        db.record_edit(
+            "prediction_replace_species",
+            f'Replaced species keyword with "{result["species"]}"',
+            result["species"],
+            [{
+                "photo_id": pred["photo_id"],
+                "old_value": ", ".join(old_species),
+                "new_value": result["species"],
+            }],
+        )
+        return jsonify({"ok": True})
 
     @app.route("/api/predictions/<int:pred_id>/accept", methods=["POST"])
     def api_accept_prediction(pred_id):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4437,14 +4437,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_mark_prediction_reviewed(pred_id):
         db = _get_db()
         pred = db.conn.execute(
-            """SELECT pr.id, pr.species, d.photo_id
+            """SELECT pr.id, pr.species, d.photo_id,
+                      COALESCE(pr_rev.status, 'pending') AS status
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
+               LEFT JOIN prediction_review pr_rev
+                 ON pr_rev.prediction_id = pr.id
+                AND pr_rev.workspace_id = ?
                WHERE pr.id = ?""",
-            (pred_id,),
+            (db._ws_id(), pred_id),
         ).fetchone()
         if pred is None:
             return json_error("prediction not found", 404)
+        # Only pending predictions may transition to reviewed. Without this
+        # guard a stale/double request or a direct API call against an
+        # already accepted/rejected prediction would silently overwrite the
+        # prior decision, corrupting review state and audit history.
+        if pred["status"] != "pending":
+            return json_error(
+                f'prediction already {pred["status"]}; cannot mark reviewed',
+                409,
+            )
         db.update_prediction_status(pred_id, "reviewed")
         db.record_edit(
             "prediction_reviewed",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4390,12 +4390,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         }
 
         for photo in by_photo.values():
-            row_category = "missing_prediction"
-            has_pending_prediction = False
+            highest_category = "missing_prediction"
+            pending_category = None
             for model_preds in photo["predictions"].values():
                 for pred in model_preds:
-                    if pred.get("status") == "pending":
-                        has_pending_prediction = True
                     cat = pred["category"]
                     if cat == "match":
                         summary["matches"] += 1
@@ -4407,16 +4405,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         summary["conflicts"] += 1
                     elif cat == "new":
                         summary["new"] += 1
-                    if priority[cat] > priority[row_category]:
-                        row_category = cat
+                    if priority[cat] > priority[highest_category]:
+                        highest_category = cat
+                    if pred.get("status") == "pending" and (
+                        pending_category is None
+                        or priority[cat] > priority[pending_category]
+                    ):
+                        pending_category = cat
             if not photo["predictions"]:
                 summary["missing_predictions"] += 1
+            row_category = pending_category or highest_category
             photo["row_category"] = row_category
             photo["row_label"] = labels[row_category]
-            photo["needs_review"] = (
-                row_category in {"conflict", "refinement", "broader", "new"}
-                and has_pending_prediction
-            )
+            photo["needs_review"] = row_category in {
+                "conflict", "refinement", "broader", "new",
+            } and pending_category is not None
             if photo["needs_review"]:
                 summary["needs_review"] += 1
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4454,71 +4454,31 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/predictions/<int:pred_id>/replace-keywords", methods=["POST"])
     def api_replace_species_keywords_with_prediction(pred_id):
         db = _get_db()
-        ws = db._ws_id()
-        pred = db.conn.execute(
-            """SELECT pr.id, pr.species, pr.classifier_model AS model,
-                      pr_rev.group_id, d.photo_id
-               FROM predictions pr
-               JOIN detections d ON d.id = pr.detection_id
-               LEFT JOIN prediction_review pr_rev
-                 ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
-               WHERE pr.id = ?""",
-            (ws, pred_id),
-        ).fetchone()
-        if pred is None:
-            return json_error("prediction not found", 404)
-        affected_photo_ids = [pred["photo_id"]]
-        if pred["group_id"]:
-            affected_photo_ids = [
-                row["photo_id"] for row in db.conn.execute(
-                    """SELECT DISTINCT d.photo_id
-                       FROM predictions pr
-                       JOIN prediction_review pr_rev
-                         ON pr_rev.prediction_id = pr.id
-                        AND pr_rev.workspace_id = ?
-                       JOIN detections d ON d.id = pr.detection_id
-                       JOIN photos ph ON ph.id = d.photo_id
-                       JOIN workspace_folders wf
-                         ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
-                       WHERE pr_rev.group_id = ? AND pr.classifier_model = ?""",
-                    (ws, ws, pred["group_id"], pred["model"]),
-                ).fetchall()
-            ]
-
-        placeholders = ",".join("?" for _ in affected_photo_ids)
-        old_species_by_photo = {pid: [] for pid in affected_photo_ids}
-        for row in db.conn.execute(
-            f"""SELECT pk.photo_id, k.name
-                FROM photo_keywords pk
-                JOIN keywords k ON k.id = pk.keyword_id
-                WHERE pk.photo_id IN ({placeholders})
-                  AND (k.is_species = 1 OR k.type = 'taxonomy')""",
-            affected_photo_ids,
-        ).fetchall():
-            old_species_by_photo.setdefault(row["photo_id"], []).append(row["name"])
-        db.conn.execute(
-            f"""DELETE FROM photo_keywords
-                WHERE photo_id IN ({placeholders})
-                  AND keyword_id IN (
-                    SELECT id FROM keywords
-                    WHERE is_species = 1 OR type = 'taxonomy'
-                  )""",
-            affected_photo_ids,
-        )
-        result = db.accept_prediction(pred_id)
+        # accept_prediction(replace_species=True) strips existing
+        # species/taxonomy keywords from *every* photo it tags (the whole
+        # group, not just this photo) inside one transaction, so grouped
+        # photos are replaced consistently.
+        result = db.accept_prediction(pred_id, replace_species=True)
         if result is None:
             return json_error("prediction not found", 404)
-        items = [{
-            "photo_id": pid,
-            "old_value": ", ".join(old_species_by_photo.get(pid, [])),
-            "new_value": result["species"],
-        } for pid in affected_photo_ids]
+        items = [
+            {
+                "photo_id": a["photo_id"],
+                "old_value": ", ".join(a.get("old_species", [])),
+                "new_value": result["species"],
+            }
+            for a in result["affected"]
+        ]
+        is_batch = len(items) > 1
+        desc = f'Replaced species keyword with "{result["species"]}"'
+        if is_batch:
+            desc += f" across {len(items)} photos"
         db.record_edit(
             "prediction_replace_species",
-            f'Replaced species keyword with "{result["species"]}"',
+            desc,
             result["species"],
             items,
-            is_batch=len(items) > 1,
+            is_batch=is_batch,
         )
         return jsonify({"ok": True})
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4454,46 +4454,71 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/predictions/<int:pred_id>/replace-keywords", methods=["POST"])
     def api_replace_species_keywords_with_prediction(pred_id):
         db = _get_db()
+        ws = db._ws_id()
         pred = db.conn.execute(
-            """SELECT pr.id, pr.species, d.photo_id
+            """SELECT pr.id, pr.species, pr.classifier_model AS model,
+                      pr_rev.group_id, d.photo_id
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
+               LEFT JOIN prediction_review pr_rev
+                 ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
                WHERE pr.id = ?""",
-            (pred_id,),
+            (ws, pred_id),
         ).fetchone()
         if pred is None:
             return json_error("prediction not found", 404)
-        old_species = [
-            row["name"] for row in db.conn.execute(
-                """SELECT k.name
-                   FROM photo_keywords pk
-                   JOIN keywords k ON k.id = pk.keyword_id
-                   WHERE pk.photo_id = ?
-                     AND (k.is_species = 1 OR k.type = 'taxonomy')""",
-                (pred["photo_id"],),
-            ).fetchall()
-        ]
+        affected_photo_ids = [pred["photo_id"]]
+        if pred["group_id"]:
+            affected_photo_ids = [
+                row["photo_id"] for row in db.conn.execute(
+                    """SELECT DISTINCT d.photo_id
+                       FROM predictions pr
+                       JOIN prediction_review pr_rev
+                         ON pr_rev.prediction_id = pr.id
+                        AND pr_rev.workspace_id = ?
+                       JOIN detections d ON d.id = pr.detection_id
+                       JOIN photos ph ON ph.id = d.photo_id
+                       JOIN workspace_folders wf
+                         ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
+                       WHERE pr_rev.group_id = ? AND pr.classifier_model = ?""",
+                    (ws, ws, pred["group_id"], pred["model"]),
+                ).fetchall()
+            ]
+
+        placeholders = ",".join("?" for _ in affected_photo_ids)
+        old_species_by_photo = {pid: [] for pid in affected_photo_ids}
+        for row in db.conn.execute(
+            f"""SELECT pk.photo_id, k.name
+                FROM photo_keywords pk
+                JOIN keywords k ON k.id = pk.keyword_id
+                WHERE pk.photo_id IN ({placeholders})
+                  AND (k.is_species = 1 OR k.type = 'taxonomy')""",
+            affected_photo_ids,
+        ).fetchall():
+            old_species_by_photo.setdefault(row["photo_id"], []).append(row["name"])
         db.conn.execute(
-            """DELETE FROM photo_keywords
-               WHERE photo_id = ?
-                 AND keyword_id IN (
-                   SELECT id FROM keywords
-                   WHERE is_species = 1 OR type = 'taxonomy'
-                 )""",
-            (pred["photo_id"],),
+            f"""DELETE FROM photo_keywords
+                WHERE photo_id IN ({placeholders})
+                  AND keyword_id IN (
+                    SELECT id FROM keywords
+                    WHERE is_species = 1 OR type = 'taxonomy'
+                  )""",
+            affected_photo_ids,
         )
         result = db.accept_prediction(pred_id)
         if result is None:
             return json_error("prediction not found", 404)
+        items = [{
+            "photo_id": pid,
+            "old_value": ", ".join(old_species_by_photo.get(pid, [])),
+            "new_value": result["species"],
+        } for pid in affected_photo_ids]
         db.record_edit(
             "prediction_replace_species",
             f'Replaced species keyword with "{result["species"]}"',
             result["species"],
-            [{
-                "photo_id": pred["photo_id"],
-                "old_value": ", ".join(old_species),
-                "new_value": result["species"],
-            }],
+            items,
+            is_batch=len(items) > 1,
         )
         return jsonify({"ok": True})
 

--- a/vireo/compare.py
+++ b/vireo/compare.py
@@ -171,8 +171,6 @@ def compare_prediction_to_keywords(prediction, existing_species, taxonomy):
 
         if best is None or _CATEGORY_PRIORITY[result["category"]] > _CATEGORY_PRIORITY[best["category"]]:
             best = result
-        if result["category"] == "match":
-            return result
 
     return best or {
         "category": "conflict",

--- a/vireo/compare.py
+++ b/vireo/compare.py
@@ -115,6 +115,19 @@ def compare_prediction_to_keywords(prediction, existing_species, taxonomy):
 
     pred_taxon = taxonomy.lookup(prediction)
     if pred_taxon is None:
+        # Taxonomy is loaded but doesn't know this prediction (custom,
+        # legacy, or not-yet-indexed taxon). An exact text match against an
+        # existing species keyword is still an obvious agreement — treat it
+        # as a match instead of flagging a needless conflict.
+        for kw in existing_species:
+            if kw.lower() == prediction.lower():
+                return {
+                    "category": "match",
+                    "label": "Match",
+                    "detail": "Prediction text matches an existing species keyword.",
+                    "matched_keyword": kw,
+                    "shared_rank": None,
+                }
         return {
             "category": "conflict",
             "label": "Unknown prediction",

--- a/vireo/compare.py
+++ b/vireo/compare.py
@@ -4,6 +4,14 @@ import logging
 
 log = logging.getLogger(__name__)
 
+_CATEGORY_PRIORITY = {
+    "conflict": 50,
+    "refinement": 40,
+    "broader": 30,
+    "new": 20,
+    "match": 10,
+}
+
 
 def categorize(prediction, existing_keywords, taxonomy):
     """Categorize a prediction relative to existing keywords using taxonomy.
@@ -50,3 +58,126 @@ def categorize(prediction, existing_keywords, taxonomy):
 
     # No existing taxon matched/contained the prediction
     return "disagreement"
+
+
+def _taxon_rank_map(taxon):
+    if not taxon:
+        return {}
+    ranks = taxon.get("lineage_ranks") or []
+    names = taxon.get("lineage_names") or []
+    return {rank: name for rank, name in zip(ranks, names, strict=False)}
+
+
+def _shared_rank(pred_taxon, keyword_taxon):
+    pred = _taxon_rank_map(pred_taxon)
+    kw = _taxon_rank_map(keyword_taxon)
+    for rank in ("genus", "family", "order", "class", "phylum", "kingdom"):
+        if pred.get(rank) and pred.get(rank) == kw.get(rank):
+            return rank
+    return None
+
+
+def compare_prediction_to_keywords(prediction, existing_species, taxonomy):
+    """Return a UI-oriented comparison between one prediction and species keywords.
+
+    The legacy ``categorize`` result is intentionally coarse because it is
+    stored on prediction rows. The Compare page needs a sharper explanation:
+    match/refinement/broader/new/conflict plus the keyword and taxonomic rank
+    that made that decision.
+    """
+    existing_species = [kw for kw in existing_species if kw]
+    if not existing_species:
+        return {
+            "category": "new",
+            "label": "New species keyword",
+            "detail": "No species keyword is currently attached to this photo.",
+            "matched_keyword": None,
+            "shared_rank": None,
+        }
+
+    if taxonomy is None:
+        for kw in existing_species:
+            if kw.lower() == prediction.lower():
+                return {
+                    "category": "match",
+                    "label": "Match",
+                    "detail": "Prediction text matches an existing species keyword.",
+                    "matched_keyword": kw,
+                    "shared_rank": None,
+                }
+        return {
+            "category": "conflict",
+            "label": "Conflict",
+            "detail": "Taxonomy data is unavailable, so only exact keyword matches can be confirmed.",
+            "matched_keyword": existing_species[0],
+            "shared_rank": None,
+        }
+
+    pred_taxon = taxonomy.lookup(prediction)
+    if pred_taxon is None:
+        return {
+            "category": "conflict",
+            "label": "Unknown prediction",
+            "detail": "The predicted species was not found in the local taxonomy.",
+            "matched_keyword": existing_species[0],
+            "shared_rank": None,
+        }
+
+    best = None
+    for kw in existing_species:
+        keyword_taxon = taxonomy.lookup(kw)
+        rel = taxonomy.relationship(kw, prediction)
+        shared = _shared_rank(pred_taxon, keyword_taxon)
+        if rel == "same":
+            result = {
+                "category": "match",
+                "label": "Match",
+                "detail": "Prediction agrees with the existing species keyword.",
+                "matched_keyword": kw,
+                "shared_rank": shared,
+            }
+        elif rel == "ancestor":
+            result = {
+                "category": "refinement",
+                "label": "Refinement",
+                "detail": "Prediction is more specific than the existing species keyword.",
+                "matched_keyword": kw,
+                "shared_rank": shared,
+            }
+        elif rel == "descendant":
+            result = {
+                "category": "broader",
+                "label": "Broader",
+                "detail": "Prediction is broader than the existing species keyword.",
+                "matched_keyword": kw,
+                "shared_rank": shared,
+            }
+        else:
+            if rel == "sibling":
+                detail = "Prediction and keyword share the same immediate parent."
+            elif shared:
+                detail = f"Prediction and keyword share the same {shared}."
+            elif rel is None:
+                detail = "At least one keyword was not found in the local taxonomy."
+            else:
+                detail = "Prediction and species keyword are taxonomically distant."
+            result = {
+                "category": "conflict",
+                "label": "Conflict",
+                "detail": detail,
+                "matched_keyword": kw,
+                "shared_rank": shared,
+            }
+
+        if best is None or _CATEGORY_PRIORITY[result["category"]] < _CATEGORY_PRIORITY[best["category"]]:
+            best = result
+        if result["category"] == "match":
+            return result
+
+    return best or {
+        "category": "conflict",
+        "label": "Conflict",
+        "detail": "Prediction and species keyword could not be matched.",
+        "matched_keyword": existing_species[0],
+        "shared_rank": None,
+    }

--- a/vireo/compare.py
+++ b/vireo/compare.py
@@ -169,7 +169,7 @@ def compare_prediction_to_keywords(prediction, existing_species, taxonomy):
                 "shared_rank": shared,
             }
 
-        if best is None or _CATEGORY_PRIORITY[result["category"]] < _CATEGORY_PRIORITY[best["category"]]:
+        if best is None or _CATEGORY_PRIORITY[result["category"]] > _CATEGORY_PRIORITY[best["category"]]:
             best = result
         if result["category"] == "match":
             return result

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -6602,16 +6602,23 @@ class Database:
         """Return species (taxonomy) keyword names for a batch of photos.
 
         Returns a dict mapping photo_id -> list of species name strings.
+
+        Treats a keyword as species when ``is_species = 1`` *or*
+        ``type = 'taxonomy'`` so that upgraded/legacy data whose species tags
+        are taxonomy-typed but not yet marked ``is_species`` is still
+        recognized. This mirrors the species definition used by
+        ``accept_prediction`` so the Compare page does not misclassify
+        already-tagged photos as ``new``.
         """
         if not photo_ids:
             return {}
         placeholders = ",".join("?" for _ in photo_ids)
         rows = self.conn.execute(
-            f"""SELECT pk.photo_id, k.name
+            f"""SELECT DISTINCT pk.photo_id, k.name
                 FROM photo_keywords pk
                 JOIN keywords k ON k.id = pk.keyword_id
                 WHERE pk.photo_id IN ({placeholders})
-                  AND k.is_species = 1
+                  AND (k.is_species = 1 OR k.type = 'taxonomy')
                 ORDER BY k.name""",
             list(photo_ids),
         ).fetchall()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7588,11 +7588,18 @@ class Database:
         ).fetchone()
         return bool(row["is_species"]) if row else False
 
-    def accept_prediction(self, prediction_id):
+    def accept_prediction(self, prediction_id, replace_species=False):
         """Accept a prediction: mark as accepted and add species keyword.
 
         If the prediction belongs to a group, derives the consensus species
         from the individual votes and applies that to all photos.
+
+        When ``replace_species`` is True, every photo that receives the new
+        keyword first has its existing species/taxonomy keywords removed, so
+        grouped photos are replaced consistently rather than accumulating both
+        the old and new species tags. Each entry in the returned ``affected``
+        list carries the ``old_species`` names that were stripped from that
+        photo (empty when ``replace_species`` is False).
 
         All database changes are performed atomically in a single transaction.
         On failure, all changes are rolled back.
@@ -7660,7 +7667,39 @@ class Database:
                     pass
 
             kid = self.add_keyword(species, is_species=True, _commit=False)
-            affected = []  # list of {"photo_id": int, "prediction_id": int}
+            # list of {"photo_id", "prediction_id", "old_species"}
+            affected = []
+
+            def _accept_for_photo(photo_id, this_pred_id):
+                self.update_prediction_status(this_pred_id, "accepted", _commit=False)
+                old_species = []
+                if replace_species:
+                    old_species = [
+                        row["name"] for row in self.conn.execute(
+                            """SELECT k.name
+                               FROM photo_keywords pk
+                               JOIN keywords k ON k.id = pk.keyword_id
+                               WHERE pk.photo_id = ?
+                                 AND (k.is_species = 1 OR k.type = 'taxonomy')""",
+                            (photo_id,),
+                        ).fetchall()
+                    ]
+                    self.conn.execute(
+                        """DELETE FROM photo_keywords
+                           WHERE photo_id = ?
+                             AND keyword_id IN (
+                               SELECT id FROM keywords
+                               WHERE is_species = 1 OR type = 'taxonomy'
+                             )""",
+                        (photo_id,),
+                    )
+                self.tag_photo(photo_id, kid, _commit=False)
+                self.queue_change(photo_id, "keyword_add", species, _commit=False)
+                affected.append({
+                    "photo_id": photo_id,
+                    "prediction_id": this_pred_id,
+                    "old_species": old_species,
+                })
 
             # If grouped, accept all predictions in the group (in this workspace).
             if pred["group_id"]:
@@ -7677,15 +7716,9 @@ class Database:
                     (ws, ws, pred["group_id"], pred["model"]),
                 ).fetchall()
                 for gp in group_preds:
-                    self.update_prediction_status(gp["id"], "accepted", _commit=False)
-                    self.tag_photo(gp["photo_id"], kid, _commit=False)
-                    self.queue_change(gp["photo_id"], "keyword_add", species, _commit=False)
-                    affected.append({"photo_id": gp["photo_id"], "prediction_id": gp["id"]})
+                    _accept_for_photo(gp["photo_id"], gp["id"])
             else:
-                self.update_prediction_status(prediction_id, "accepted", _commit=False)
-                self.tag_photo(pred["photo_id"], kid, _commit=False)
-                self.queue_change(pred["photo_id"], "keyword_add", species, _commit=False)
-                affected.append({"photo_id": pred["photo_id"], "prediction_id": prediction_id})
+                _accept_for_photo(pred["photo_id"], prediction_id)
 
             self.conn.commit()
             return {"species": species, "keyword_id": kid, "affected": affected}

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -8513,6 +8513,11 @@ class Database:
         # would silently advance the undo cursor without reverting state.
         # Adding undo support is a follow-up if it becomes important.
         'location_set', 'location_clear', 'location_link',
+        # Compare-page review actions are auditable but not undoable in v1
+        # for the same reason: _apply_undo/_apply_redo have no handlers, so
+        # leaving them undoable would mark the entry undone without
+        # restoring the prediction status or the replaced species keywords.
+        'prediction_reviewed', 'prediction_replace_species',
     )
 
     def undo_last_edit(self):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7693,6 +7693,24 @@ class Database:
                              )""",
                         (photo_id,),
                     )
+                    # The DB rows are gone, but sync_to_xmp only strips a
+                    # keyword from the sidecar when a matching keyword_remove
+                    # pending change exists. Queue one per removed species so a
+                    # "replace" actually clears the stale tags downstream. A
+                    # still-pending add for the same keyword cancels out
+                    # instead of stacking (mirrors _queue_keyword_remove).
+                    new_species_lower = species.lower()
+                    for old_name in old_species:
+                        if old_name.lower() == new_species_lower:
+                            continue
+                        cancelled = self.remove_pending_changes(
+                            photo_id, "keyword_add", old_name, _commit=False,
+                        )
+                        if cancelled == 0:
+                            self.queue_change(
+                                photo_id, "keyword_remove", old_name,
+                                _commit=False,
+                            )
                 self.tag_photo(photo_id, kid, _commit=False)
                 self.queue_change(photo_id, "keyword_add", species, _commit=False)
                 affected.append({

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -6579,6 +6579,25 @@ class Database:
             (photo_id,),
         ).fetchall()
 
+    def get_keywords_for_photos(self, photo_ids):
+        """Return keywords for a batch of photos keyed by photo id."""
+        if not photo_ids:
+            return {}
+        placeholders = ",".join("?" for _ in photo_ids)
+        rows = self.conn.execute(
+            f"""SELECT pk.photo_id, k.id, k.name, k.parent_id, k.type,
+                       k.is_species
+                FROM photo_keywords pk
+                JOIN keywords k ON k.id = pk.keyword_id
+                WHERE pk.photo_id IN ({placeholders})
+                ORDER BY k.type, k.name""",
+            list(photo_ids),
+        ).fetchall()
+        result = {}
+        for r in rows:
+            result.setdefault(r["photo_id"], []).append(dict(r))
+        return result
+
     def get_species_keywords_for_photos(self, photo_ids):
         """Return species (taxonomy) keyword names for a batch of photos.
 

--- a/vireo/templates/compare.html
+++ b/vireo/templates/compare.html
@@ -564,9 +564,15 @@ function renderPhotoCell(photo) {
     encodeURIComponent(photo.photo_id) + '">Open photo</a></div></div></div>';
 }
 
+function isSpeciesKeyword(k) {
+  // Mirror the backend species definition (get_species_keywords_for_photos):
+  // upgraded/legacy taxonomy tags can be type='taxonomy' with is_species=0.
+  return !!k.is_species || k.type === 'taxonomy';
+}
+
 function renderKeywordCell(photo) {
-  var species = (photo.keywords || []).filter(function(k) { return !!k.is_species; });
-  var other = (photo.keywords || []).filter(function(k) { return !k.is_species; });
+  var species = (photo.keywords || []).filter(isSpeciesKeyword);
+  var other = (photo.keywords || []).filter(function(k) { return !isSpeciesKeyword(k); });
   var html = '';
   if (species.length) {
     html += '<div class="keyword-group">' + species.map(function(k) {

--- a/vireo/templates/compare.html
+++ b/vireo/templates/compare.html
@@ -6,69 +6,254 @@
 <link rel="icon" type="image/png" href="/favicon.ico">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
 <link rel="stylesheet" href="/static/vireo-base.css">
-<title>Vireo - Compare Models</title>
+<title>Vireo - Compare Keywords</title>
 <style>
 body { padding-bottom: 36px; }
-.content { max-width: 1200px; }
+.content { max-width: 1440px; }
 
-.compare-bar {
+.compare-toolbar {
   background: var(--bg-secondary);
   border: 1px solid var(--border-primary);
   border-radius: 8px;
   padding: 12px 16px;
-  margin-bottom: 16px;
-  display: flex;
-  align-items: center;
+  margin-bottom: 14px;
+  display: grid;
+  grid-template-columns: minmax(180px, 1.2fr) repeat(2, minmax(160px, 0.9fr)) minmax(180px, 1fr);
   gap: 12px;
+  align-items: end;
 }
-.compare-bar label { font-size: 13px; color: var(--text-secondary); }
-.compare-bar select {
-  background: var(--bg-input); color: var(--text-primary);
-  border: 1px solid var(--border-primary); border-radius: 4px;
-  padding: 4px 8px; font-size: 13px;
+.control label {
+  display: block;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 5px;
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+.control select,
+.control input {
+  width: 100%;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  padding: 7px 9px;
+  font-size: 13px;
 }
 
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(110px, 1fr));
+  gap: 8px;
+  margin-bottom: 14px;
+}
+.summary-item {
+  border: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  padding: 10px 12px;
+  min-width: 0;
+}
+.summary-value {
+  display: block;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.summary-label {
+  display: block;
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.filter-row,
+.batch-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+.filter-btn,
+.batch-btn,
+.inline-btn {
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  padding: 6px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.filter-btn.active {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.batch-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.inline-btn {
+  padding: 4px 7px;
+  font-size: 11px;
+  text-decoration: none;
+}
+.inline-btn.primary {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 60%, var(--border-primary));
+}
+.inline-btn.danger {
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 50%, var(--border-primary));
+}
+.inline-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+.batch-count {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-right: 4px;
+}
+
+.taxonomy-note {
+  display: none;
+  margin-bottom: 12px;
+  color: var(--warning);
+  font-size: 12px;
+}
+.taxonomy-note.visible { display: block; }
+
+.compare-empty {
+  text-align: center;
+  padding: 48px 16px;
+  color: var(--text-muted);
+}
+.table-wrap {
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  overflow: auto;
+  background: var(--bg-primary);
+}
 .compare-table {
   width: 100%;
   border-collapse: collapse;
   font-size: 13px;
 }
 .compare-table th {
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-  padding: 8px 12px;
-  text-align: left;
-  border-bottom: 1px solid var(--border-primary);
   position: sticky;
   top: 0;
   z-index: 1;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  padding: 8px 10px;
+  text-align: left;
+  border-bottom: 1px solid var(--border-primary);
+  white-space: nowrap;
 }
 .compare-table td {
-  padding: 6px 12px;
+  padding: 8px 10px;
   border-bottom: 1px solid var(--border-subtle);
-  vertical-align: middle;
+  vertical-align: top;
 }
-.compare-table tr:hover { background: var(--bg-tertiary); }
-.compare-table tr.disagree { background: color-mix(in srgb, var(--warning) 8%, transparent); }
-.compare-table tr.disagree:hover { background: color-mix(in srgb, var(--warning) 14%, transparent); }
+.compare-table tr:hover { background: var(--bg-secondary); }
+.select-col { width: 30px; }
+.photo-col { min-width: 220px; }
+.keyword-col { min-width: 220px; }
+.model-col { min-width: 250px; }
 
-.thumb-cell {
+.photo-cell {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 9px;
+  min-width: 0;
 }
-.thumb-cell img {
-  width: 40px; height: 40px;
+.photo-cell img {
+  width: 44px;
+  height: 44px;
   object-fit: cover;
   border-radius: 4px;
+  flex: 0 0 auto;
 }
-.conf { color: var(--text-muted); font-size: 11px; }
+.photo-name {
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.photo-meta {
+  color: var(--text-muted);
+  font-size: 11px;
+  margin-top: 3px;
+}
+
+.keyword-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-bottom: 5px;
+}
+.keyword-pill,
+.status-pill,
+.category-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 4px;
+  border: 1px solid var(--border-primary);
+  padding: 2px 6px;
+  font-size: 11px;
+  line-height: 1.4;
+}
+.keyword-pill.species {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border-primary));
+}
+.keyword-pill.general { color: var(--text-muted); }
 .empty-cell { color: var(--text-ghost); }
 
-.compare-empty {
-  text-align: center;
-  padding: 48px 16px;
+.category-pill.match { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 45%, var(--border-primary)); }
+.category-pill.refinement { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 45%, var(--border-primary)); }
+.category-pill.broader { color: var(--info); border-color: color-mix(in srgb, var(--info) 45%, var(--border-primary)); }
+.category-pill.conflict { color: var(--warning); border-color: color-mix(in srgb, var(--warning) 55%, var(--border-primary)); }
+.category-pill.new { color: var(--text-primary); }
+.category-pill.missing_prediction { color: var(--text-muted); }
+
+.pred {
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.pred:last-child { border-bottom: none; }
+.pred-main {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+.pred-species { color: var(--text-primary); font-weight: 600; }
+.pred-confidence { color: var(--text-muted); font-size: 11px; }
+.pred-detail {
+  margin-top: 4px;
   color: var(--text-muted);
+  font-size: 11px;
+}
+.pred-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 7px;
+}
+.status-pill {
+  color: var(--text-muted);
+  text-transform: capitalize;
+}
+.status-pill.accepted { color: var(--accent); }
+.status-pill.rejected { color: var(--danger); }
+.status-pill.reviewed { color: var(--accent); }
+
+@media (max-width: 900px) {
+  .compare-toolbar { grid-template-columns: 1fr; }
+  .summary-grid { grid-template-columns: repeat(2, minmax(120px, 1fr)); }
 }
 </style>
 </head>
@@ -77,24 +262,99 @@ body { padding-bottom: 36px; }
 {% include '_navbar.html' %}
 
 <div class="content">
-  <div class="compare-bar">
-    <label>Collection:</label>
-    <select id="collectionPicker" onchange="loadComparison()">
-      <option value="">Select collection...</option>
-    </select>
-    <span id="compareStatus" style="font-size:12px;color:var(--text-muted);"></span>
+  <div class="compare-toolbar">
+    <div class="control">
+      <label for="collectionPicker">Collection</label>
+      <select id="collectionPicker" onchange="loadComparison()">
+        <option value="">Select collection...</option>
+      </select>
+    </div>
+    <div class="control">
+      <label for="modelA">Model A</label>
+      <select id="modelA" onchange="renderCompare()">
+        <option value="all">All models</option>
+      </select>
+    </div>
+    <div class="control">
+      <label for="modelB">Model B</label>
+      <select id="modelB" onchange="renderCompare()">
+        <option value="">No second model</option>
+      </select>
+    </div>
+    <div class="control">
+      <label for="compareSearch">Search</label>
+      <input id="compareSearch" type="search" placeholder="Filename, keyword, species" oninput="renderCompare()">
+    </div>
+  </div>
+
+  <div id="summaryGrid" class="summary-grid" style="display:none;"></div>
+  <div id="taxonomyNote" class="taxonomy-note">Taxonomy data is unavailable. Compare can confirm exact keyword matches, but broader/refinement/conflict labels are limited.</div>
+  <div id="filterRow" class="filter-row" style="display:none;"></div>
+  <div id="batchRow" class="batch-row" style="display:none;">
+    <span id="batchCount" class="batch-count">0 selected</span>
+    <button class="batch-btn" id="batchAccept" onclick="batchAction('accept')">Add prediction keyword</button>
+    <button class="batch-btn" id="batchReplace" onclick="batchAction('replace')">Replace species keyword</button>
+    <button class="batch-btn" id="batchReject" onclick="batchAction('reject')">Reject prediction</button>
+    <button class="batch-btn" id="batchReviewed" onclick="batchAction('reviewed')">Mark reviewed</button>
   </div>
 
   <div id="compareContent">
-    <div class="compare-empty">Select a collection to compare model predictions.</div>
+    <div class="compare-empty">Select a collection to compare keywords and predictions.</div>
   </div>
 </div>
 
 <script>
+var compareData = null;
+var activeFilter = 'needs_review';
+var selectedRows = new Set();
+var loadingSeq = 0;
+
+var FILTERS = [
+  { id: 'needs_review', label: 'Needs review' },
+  { id: 'conflict', label: 'Conflicts' },
+  { id: 'refinement', label: 'Refinements' },
+  { id: 'broader', label: 'Broader' },
+  { id: 'new', label: 'No species keyword' },
+  { id: 'missing_prediction', label: 'Missing predictions' },
+  { id: 'match', label: 'Matches' },
+  { id: 'reviewed', label: 'Reviewed' },
+  { id: 'all', label: 'All' },
+];
+
+var CATEGORY_ORDER = {
+  conflict: 6,
+  refinement: 5,
+  broader: 4,
+  new: 3,
+  missing_prediction: 2,
+  match: 1,
+};
+
+function escapeHtml(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function escapeAttr(value) {
+  return escapeHtml(value).replace(/`/g, '&#096;');
+}
+
+async function jsonFetch(url, options) {
+  var resp = await fetch(url, options || {});
+  var data = await resp.json().catch(function() { return {}; });
+  if (!resp.ok || data.error) {
+    throw new Error(data.error || ('Request failed: ' + resp.status));
+  }
+  return data;
+}
+
 async function loadCollections() {
   try {
-    var resp = await fetch('/api/collections');
-    var data = await resp.json();
+    var data = await jsonFetch('/api/collections');
     var sel = document.getElementById('collectionPicker');
     data.forEach(function(c) {
       var opt = document.createElement('option');
@@ -102,85 +362,338 @@ async function loadCollections() {
       opt.textContent = c.name;
       sel.appendChild(opt);
     });
-  } catch(e) { console.error('loadCollections error:', e); }
+    var all = data.find(function(c) { return c.name === 'All Photos'; });
+    if (all) {
+      sel.value = all.id;
+      loadComparison();
+    }
+  } catch(e) {
+    document.getElementById('compareContent').innerHTML =
+      '<div class="compare-empty">Could not load collections.</div>';
+  }
 }
 
 async function loadComparison() {
   var collId = document.getElementById('collectionPicker').value;
   var content = document.getElementById('compareContent');
-  var status = document.getElementById('compareStatus');
+  selectedRows.clear();
+  updateBatchControls();
 
   if (!collId) {
-    content.innerHTML = '<div class="compare-empty">Select a collection to compare model predictions.</div>';
+    compareData = null;
+    document.getElementById('summaryGrid').style.display = 'none';
+    document.getElementById('filterRow').style.display = 'none';
+    document.getElementById('batchRow').style.display = 'none';
+    content.innerHTML = '<div class="compare-empty">Select a collection to compare keywords and predictions.</div>';
     return;
   }
 
-  status.textContent = 'Loading...';
+  var seq = ++loadingSeq;
+  content.innerHTML = '<div class="compare-empty">Loading keyword comparison...</div>';
   try {
-    var resp = await fetch('/api/predictions/compare?collection_id=' + collId);
-    var data = await resp.json();
-    status.textContent = '';
-
-    if (data.models.length === 0) {
-      content.innerHTML = '<div class="compare-empty">No predictions found for this collection. Run classification first.</div>';
-      return;
-    }
-
-    if (data.models.length < 2) {
-      content.innerHTML = '<div class="compare-empty">Only one model has predictions. Run classification with at least two models to compare.</div>';
-      return;
-    }
-
-    renderTable(data);
+    var data = await jsonFetch('/api/predictions/compare?collection_id=' + encodeURIComponent(collId));
+    if (seq !== loadingSeq) return;
+    compareData = data;
+    populateModelSelects(data.models || []);
+    activeFilter = data.summary && data.summary.needs_review > 0 ? 'needs_review' : 'all';
+    renderCompare();
   } catch(e) {
-    status.textContent = 'Error loading data';
-    console.error('loadComparison error:', e);
+    if (seq !== loadingSeq) return;
+    content.innerHTML = '<div class="compare-empty">Error loading comparison: ' + escapeHtml(e.message) + '</div>';
   }
 }
 
-function renderTable(data) {
+function populateModelSelects(models) {
+  var a = document.getElementById('modelA');
+  var b = document.getElementById('modelB');
+  var oldA = a.value || 'all';
+  var oldB = b.value || '';
+  a.innerHTML = '<option value="all">All models</option>';
+  b.innerHTML = '<option value="">No second model</option>';
+  models.forEach(function(m) {
+    a.innerHTML += '<option value="' + escapeAttr(m) + '">' + escapeHtml(m) + '</option>';
+    b.innerHTML += '<option value="' + escapeAttr(m) + '">' + escapeHtml(m) + '</option>';
+  });
+  a.value = models.indexOf(oldA) >= 0 ? oldA : 'all';
+  b.value = models.indexOf(oldB) >= 0 ? oldB : '';
+}
+
+function visibleModels() {
+  if (!compareData) return [];
+  var a = document.getElementById('modelA').value;
+  var b = document.getElementById('modelB').value;
+  if (a === 'all') return compareData.models || [];
+  var models = [a];
+  if (b && b !== a) models.push(b);
+  return models;
+}
+
+function renderCompare() {
+  if (!compareData) return;
+  renderSummary();
+  renderFilters();
+  renderTaxonomyNote();
+  var rows = filteredRows();
+  selectedRows.forEach(function(id) {
+    if (!rows.some(function(p) { return p.photo_id === id; })) selectedRows.delete(id);
+  });
+  renderTable(rows);
+  updateBatchControls();
+}
+
+function renderSummary() {
+  var s = compareData.summary || {};
+  var items = [
+    ['photos', 'Photos'],
+    ['models', 'Models'],
+    ['needs_review', 'Needs review'],
+    ['conflicts', 'Conflicts'],
+    ['refinements', 'Refinements'],
+    ['broader', 'Broader'],
+    ['new', 'No species keyword'],
+    ['missing_predictions', 'Missing predictions'],
+  ];
+  document.getElementById('summaryGrid').style.display = '';
+  document.getElementById('summaryGrid').innerHTML = items.map(function(item) {
+    return '<div class="summary-item"><span class="summary-value">' +
+      escapeHtml(s[item[0]] || 0) + '</span><span class="summary-label">' +
+      escapeHtml(item[1]) + '</span></div>';
+  }).join('');
+}
+
+function renderTaxonomyNote() {
+  document.getElementById('taxonomyNote').classList.toggle(
+    'visible',
+    compareData && compareData.taxonomy_available === false
+  );
+}
+
+function filterCount(filter) {
+  return (compareData.photos || []).filter(function(photo) {
+    return photoMatchesFilter(photo, filter.id);
+  }).length;
+}
+
+function renderFilters() {
+  var row = document.getElementById('filterRow');
+  row.style.display = '';
+  row.innerHTML = FILTERS.map(function(f) {
+    var cls = f.id === activeFilter ? 'filter-btn active' : 'filter-btn';
+    return '<button class="' + cls + '" onclick="setFilter(\'' + f.id + '\')">' +
+      escapeHtml(f.label) + ' <span>' + filterCount(f) + '</span></button>';
+  }).join('');
+}
+
+function setFilter(filter) {
+  activeFilter = filter;
+  renderCompare();
+}
+
+function hasReviewedPrediction(photo) {
+  return Object.keys(photo.predictions || {}).some(function(model) {
+    return (photo.predictions[model] || []).some(function(p) {
+      return p.status && p.status !== 'pending';
+    });
+  });
+}
+
+function photoMatchesFilter(photo, filter) {
+  if (filter === 'all') return true;
+  if (filter === 'needs_review') return !!photo.needs_review;
+  if (filter === 'reviewed') return hasReviewedPrediction(photo);
+  return photo.row_category === filter;
+}
+
+function searchableText(photo) {
+  var parts = [photo.filename, photo.row_label];
+  (photo.keywords || []).forEach(function(k) { parts.push(k.name, k.type); });
+  Object.keys(photo.predictions || {}).forEach(function(model) {
+    parts.push(model);
+    (photo.predictions[model] || []).forEach(function(p) {
+      parts.push(p.species, p.category_label, p.matched_keyword, p.status);
+    });
+  });
+  return parts.join(' ').toLowerCase();
+}
+
+function filteredRows() {
+  var q = document.getElementById('compareSearch').value.trim().toLowerCase();
+  return (compareData.photos || []).filter(function(photo) {
+    if (!photoMatchesFilter(photo, activeFilter)) return false;
+    if (q && searchableText(photo).indexOf(q) < 0) return false;
+    return true;
+  });
+}
+
+function renderTable(rows) {
   var content = document.getElementById('compareContent');
-  var html = '<table class="compare-table"><thead><tr>';
-  html += '<th>Photo</th>';
-  data.models.forEach(function(m) {
-    html += '<th>' + escapeHtml(m) + '</th>';
+  var models = visibleModels();
+  if (!compareData.photos.length) {
+    content.innerHTML = '<div class="compare-empty">This collection has no photos.</div>';
+    return;
+  }
+  if (!rows.length) {
+    content.innerHTML = '<div class="compare-empty">No photos match the current filter.</div>';
+    return;
+  }
+
+  var html = '<div class="table-wrap"><table class="compare-table"><thead><tr>' +
+    '<th class="select-col"><input type="checkbox" onchange="toggleAllRows(this.checked)"></th>' +
+    '<th class="photo-col">Photo</th>' +
+    '<th>Status</th>' +
+    '<th class="keyword-col">Current keywords</th>';
+  models.forEach(function(m) {
+    html += '<th class="model-col">' + escapeHtml(m) + '</th>';
   });
   html += '</tr></thead><tbody>';
 
-  data.photos.forEach(function(photo) {
-    // Determine if models disagree — collect top species per model
-    var topSpecies = new Set();
-    data.models.forEach(function(m) {
-      var preds = photo.predictions[m];
-      if (preds && preds.length > 0) topSpecies.add(preds[0].species);
+  rows.forEach(function(photo) {
+    html += '<tr data-photo-id="' + photo.photo_id + '">' +
+      '<td><input type="checkbox" ' + (selectedRows.has(photo.photo_id) ? 'checked' : '') +
+      ' onchange="toggleRow(' + photo.photo_id + ', this.checked)"></td>' +
+      '<td>' + renderPhotoCell(photo) + '</td>' +
+      '<td><span class="category-pill ' + escapeAttr(photo.row_category) + '">' +
+      escapeHtml(photo.row_label) + '</span></td>' +
+      '<td>' + renderKeywordCell(photo) + '</td>';
+    models.forEach(function(m) {
+      html += '<td>' + renderPredictionCell(photo, m) + '</td>';
     });
-    var disagree = topSpecies.size > 1;
-
-    html += '<tr class="' + (disagree ? 'disagree' : '') + '">';
-    html += '<td><div class="thumb-cell">';
-    html += '<img src="/thumbnails/' + photo.photo_id + '.jpg" loading="lazy" alt="">';
-    html += '<span>' + escapeHtml(photo.filename) + '</span>';
-    html += '</div></td>';
-
-    data.models.forEach(function(m) {
-      var preds = photo.predictions[m];
-      if (preds && preds.length > 0) {
-        var parts = [];
-        preds.forEach(function(pred) {
-          parts.push(escapeHtml(pred.species) +
-            ' <span class="conf">' + Math.round(pred.confidence * 100) + '%</span>');
-        });
-        html += '<td>' + parts.join('<br>') + '</td>';
-      } else {
-        html += '<td class="empty-cell">&mdash;</td>';
-      }
-    });
-
     html += '</tr>';
   });
-
-  html += '</tbody></table>';
+  html += '</tbody></table></div>';
   content.innerHTML = html;
+}
+
+function renderPhotoCell(photo) {
+  var meta = [];
+  if (photo.timestamp) meta.push(photo.timestamp.replace('T', ' ').substring(0, 16));
+  if (photo.rating) meta.push(photo.rating + ' star' + (photo.rating === 1 ? '' : 's'));
+  if (photo.flag && photo.flag !== 'none') meta.push(photo.flag);
+  return '<div class="photo-cell">' +
+    '<img src="/thumbnails/' + photo.photo_id + '.jpg" loading="lazy" alt="">' +
+    '<div><div class="photo-name">' + escapeHtml(photo.filename) + '</div>' +
+    '<div class="photo-meta">' + escapeHtml(meta.join(' · ')) + '</div>' +
+    '<div class="pred-actions"><a class="inline-btn" href="/browse?photo_id=' +
+    encodeURIComponent(photo.photo_id) + '">Open photo</a></div></div></div>';
+}
+
+function renderKeywordCell(photo) {
+  var species = (photo.keywords || []).filter(function(k) { return !!k.is_species; });
+  var other = (photo.keywords || []).filter(function(k) { return !k.is_species; });
+  var html = '';
+  if (species.length) {
+    html += '<div class="keyword-group">' + species.map(function(k) {
+      return '<span class="keyword-pill species" title="Species keyword">' +
+        escapeHtml(k.name) + '</span>';
+    }).join('') + '</div>';
+  } else {
+    html += '<div class="empty-cell">No species keyword</div>';
+  }
+  if (other.length) {
+    html += '<div class="keyword-group">' + other.map(function(k) {
+      return '<span class="keyword-pill general" title="' + escapeAttr(k.type || 'keyword') + '">' +
+        escapeHtml(k.name) + '</span>';
+    }).join('') + '</div>';
+  }
+  return html;
+}
+
+function renderPredictionCell(photo, model) {
+  var preds = (photo.predictions || {})[model] || [];
+  if (!preds.length) return '<span class="empty-cell">No prediction</span>';
+  return preds.map(function(pred) {
+    var status = pred.status || 'pending';
+    var disabled = status !== 'pending' ? ' disabled' : '';
+    var detail = pred.category_detail || '';
+    if (pred.matched_keyword) detail += ' Keyword: ' + pred.matched_keyword + '.';
+    if (pred.shared_rank) detail += ' Shared ' + pred.shared_rank + '.';
+    return '<div class="pred">' +
+      '<div class="pred-main"><span class="pred-species">' + escapeHtml(pred.species) + '</span>' +
+      '<span class="pred-confidence">' + Math.round((pred.confidence || 0) * 100) + '%</span>' +
+      '<span class="category-pill ' + escapeAttr(pred.category) + '">' + escapeHtml(pred.category_label) + '</span>' +
+      '<span class="status-pill ' + escapeAttr(status) + '">' + escapeHtml(status) + '</span></div>' +
+      '<div class="pred-detail">' + escapeHtml(detail) + '</div>' +
+      '<div class="pred-actions">' +
+      '<button class="inline-btn primary" onclick="predictionAction(' + pred.id + ', \'accept\')"' + disabled + '>Add keyword</button>' +
+      '<button class="inline-btn primary" onclick="predictionAction(' + pred.id + ', \'replace\')"' + disabled + '>Replace keyword</button>' +
+      '<button class="inline-btn danger" onclick="predictionAction(' + pred.id + ', \'reject\')"' + disabled + '>Reject</button>' +
+      '<button class="inline-btn" onclick="predictionAction(' + pred.id + ', \'reviewed\')"' + disabled + '>Reviewed</button>' +
+      '</div></div>';
+  }).join('');
+}
+
+function toggleRow(photoId, checked) {
+  if (checked) selectedRows.add(photoId);
+  else selectedRows.delete(photoId);
+  updateBatchControls();
+}
+
+function toggleAllRows(checked) {
+  filteredRows().forEach(function(photo) {
+    if (checked) selectedRows.add(photo.photo_id);
+    else selectedRows.delete(photo.photo_id);
+  });
+  renderCompare();
+}
+
+function updateBatchControls() {
+  var row = document.getElementById('batchRow');
+  if (!compareData) {
+    row.style.display = 'none';
+    return;
+  }
+  row.style.display = '';
+  document.getElementById('batchCount').textContent = selectedRows.size + ' selected';
+  ['batchAccept', 'batchReplace', 'batchReject', 'batchReviewed'].forEach(function(id) {
+    document.getElementById(id).disabled = selectedRows.size === 0;
+  });
+}
+
+function bestPrediction(photo) {
+  var models = visibleModels();
+  var best = null;
+  models.forEach(function(model) {
+    ((photo.predictions || {})[model] || []).forEach(function(pred) {
+      if (pred.status && pred.status !== 'pending') return;
+      if (!best) {
+        best = pred;
+        return;
+      }
+      var predScore = CATEGORY_ORDER[pred.category] || 0;
+      var bestScore = CATEGORY_ORDER[best.category] || 0;
+      if (predScore > bestScore || (predScore === bestScore && pred.confidence > best.confidence)) {
+        best = pred;
+      }
+    });
+  });
+  return best;
+}
+
+async function predictionAction(predId, action) {
+  var url = '/api/predictions/' + predId + '/' + endpointForAction(action);
+  await jsonFetch(url, { method: 'POST' });
+  await loadComparison();
+}
+
+function endpointForAction(action) {
+  if (action === 'accept') return 'accept';
+  if (action === 'replace') return 'replace-keywords';
+  if (action === 'reject') return 'reject';
+  return 'reviewed';
+}
+
+async function batchAction(action) {
+  var ids = Array.from(selectedRows);
+  var photos = (compareData.photos || []).filter(function(photo) {
+    return ids.indexOf(photo.photo_id) >= 0;
+  });
+  for (var i = 0; i < photos.length; i++) {
+    var pred = bestPrediction(photos[i]);
+    if (!pred) continue;
+    await jsonFetch('/api/predictions/' + pred.id + '/' + endpointForAction(action), { method: 'POST' });
+  }
+  selectedRows.clear();
+  await loadComparison();
 }
 
 loadCollections();

--- a/vireo/templates/compare.html
+++ b/vireo/templates/compare.html
@@ -479,7 +479,7 @@ function setFilter(filter) {
 function hasReviewedPrediction(photo) {
   return Object.keys(photo.predictions || {}).some(function(model) {
     return (photo.predictions[model] || []).some(function(p) {
-      return p.status && p.status !== 'pending';
+      return p.status === 'reviewed';
     });
   });
 }

--- a/vireo/templates/compare.html
+++ b/vireo/templates/compare.html
@@ -330,19 +330,6 @@ var CATEGORY_ORDER = {
   match: 1,
 };
 
-function escapeHtml(value) {
-  return String(value == null ? '' : value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}
-
-function escapeAttr(value) {
-  return escapeHtml(value).replace(/`/g, '&#096;');
-}
-
 async function jsonFetch(url, options) {
   var resp = await fetch(url, options || {});
   var data = await resp.json().catch(function() { return {}; });

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 
@@ -1017,6 +1018,35 @@ def test_compare_predictions_api(app_and_db):
         assert len(model_preds) >= 1
         assert "species" in model_preds[0]
         assert "confidence" in model_preds[0]
+
+
+def test_compare_ignores_resolved_predictions_for_needs_review(app_and_db):
+    """A resolved conflict plus a pending match should not stay in review."""
+    app, db = app_and_db
+    photo_id = db.conn.execute(
+        "SELECT id FROM photos ORDER BY id LIMIT 1"
+    ).fetchone()["id"]
+    species_id = db.add_keyword("Cardinal", is_species=True)
+    db.tag_photo(photo_id, species_id)
+    rules = json.dumps([{"field": "photo_ids", "value": [photo_id]}])
+    cid = db.add_collection("Single Photo", rules)
+
+    det_ids = db.save_detections(photo_id, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.3}, "confidence": 0.9, "category": "animal"},
+        {"box": {"x": 0.2, "y": 0.2, "w": 0.4, "h": 0.4}, "confidence": 0.85, "category": "animal"},
+    ], detector_model="MDV6")
+    db.add_prediction(
+        det_ids[0], "Blue Jay", 0.95, "model-a", status="accepted",
+    )
+    db.add_prediction(det_ids[1], "Cardinal", 0.92, "model-b")
+
+    resp = app.test_client().get(f"/api/predictions/compare?collection_id={cid}")
+
+    assert resp.status_code == 200
+    row = resp.get_json()["photos"][0]
+    assert row["row_category"] == "match"
+    assert row["needs_review"] is False
+    assert resp.get_json()["summary"]["needs_review"] == 0
 
 
 def test_replace_prediction_keywords_updates_grouped_photos(app_and_db):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1019,6 +1019,47 @@ def test_compare_predictions_api(app_and_db):
         assert "confidence" in model_preds[0]
 
 
+def test_replace_prediction_keywords_updates_grouped_photos(app_and_db):
+    """Replacing a grouped prediction removes old species keywords from the group."""
+    app, db = app_and_db
+    photos = db.conn.execute("SELECT id FROM photos ORDER BY id LIMIT 2").fetchall()
+    photo_ids = [p["id"] for p in photos]
+
+    old_one = db.add_keyword("Old Species One", is_species=True)
+    old_two = db.add_keyword("Old Species Two", is_species=True)
+    db.tag_photo(photo_ids[0], old_one)
+    db.tag_photo(photo_ids[1], old_two)
+
+    first_det = db.save_detections(photo_ids[0], [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.3}, "confidence": 0.9, "category": "animal"},
+    ], detector_model="MDV6")[0]
+    second_det = db.save_detections(photo_ids[1], [
+        {"box": {"x": 0.2, "y": 0.2, "w": 0.4, "h": 0.4}, "confidence": 0.85, "category": "animal"},
+    ], detector_model="MDV6")[0]
+    db.add_prediction(
+        first_det, "New Species", 0.95, "model-a", group_id="group-1",
+    )
+    db.add_prediction(
+        second_det, "New Species", 0.92, "model-a", group_id="group-1",
+    )
+    pred = db.conn.execute(
+        """SELECT id FROM predictions
+           WHERE detection_id = ? AND classifier_model = ?""",
+        (first_det, "model-a"),
+    ).fetchone()
+
+    resp = app.test_client().post(
+        f"/api/predictions/{pred['id']}/replace-keywords"
+    )
+
+    assert resp.status_code == 200
+    for pid in photo_ids:
+        names = {k["name"] for k in db.get_photo_keywords(pid)}
+        assert "New Species" in names
+        assert "Old Species One" not in names
+        assert "Old Species Two" not in names
+
+
 def test_api_predictions_include_bounding_box(app_and_db):
     """GET /api/predictions should return bounding box data from detections."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1089,6 +1089,25 @@ def test_replace_prediction_keywords_updates_grouped_photos(app_and_db):
         assert "Old Species One" not in names
         assert "Old Species Two" not in names
 
+    # The DB rows are gone, but sync_to_xmp only strips a sidecar keyword
+    # when a matching keyword_remove pending change exists. Without one the
+    # old species would silently linger in the XMP files.
+    changes = db.get_pending_changes()
+    removed = {
+        (c["photo_id"], c["value"])
+        for c in changes
+        if c["change_type"] == "keyword_remove"
+    }
+    assert (photo_ids[0], "Old Species One") in removed
+    assert (photo_ids[1], "Old Species Two") in removed
+    for pid in photo_ids:
+        assert any(
+            c["photo_id"] == pid
+            and c["change_type"] == "keyword_add"
+            and c["value"] == "New Species"
+            for c in changes
+        )
+
 
 def test_api_predictions_include_bounding_box(app_and_db):
     """GET /api/predictions should return bounding box data from detections."""

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -9523,6 +9523,29 @@ def test_update_keyword_rename_general_to_matching_taxon_visible_to_species_quer
     assert db.get_species_keywords_for_photos([pid]) == {pid: ["Lesser Scaup"]}
 
 
+def test_get_species_keywords_includes_taxonomy_typed_without_is_species(tmp_path):
+    """Legacy/upgraded data may carry species tags typed 'taxonomy' but with
+    is_species=0. get_species_keywords_for_photos must still surface them so
+    the Compare page does not misclassify already-tagged photos as 'new'
+    (mirrors the is_species OR type='taxonomy' definition accept_prediction
+    uses)."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+
+    fid = db.add_folder('/photos', name='photos')
+    pid = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    kid = db.add_keyword("Lesser Scaup")
+    db.tag_photo(pid, kid)
+    db.conn.execute(
+        "UPDATE keywords SET is_species = 0, type = 'taxonomy' WHERE id = ?",
+        (kid,),
+    )
+    db.conn.commit()
+
+    assert db.get_species_keywords_for_photos([pid]) == {pid: ["Lesser Scaup"]}
+
+
 def test_update_keyword_rename_general_no_match_stays_general(tmp_path):
     """Renaming a 'general' keyword to a name with no taxon match leaves
     it as 'general' with NULL taxon_id."""

--- a/vireo/tests/test_predictions_api.py
+++ b/vireo/tests/test_predictions_api.py
@@ -114,6 +114,71 @@ def test_reject_prediction(app_and_db):
     assert 'Northern Cardinal' not in kw_names
 
 
+def test_mark_prediction_reviewed(app_and_db):
+    """POST reviewed marks a pending prediction as reviewed."""
+    app, db = app_and_db
+    photos = _seed_predictions(db)
+    client = app.test_client()
+
+    det = _make_detection(db, photos[2]['id'])
+    db.add_prediction(detection_id=det, species='Blue Jay', confidence=0.90,
+                      model='test-model', category='new', group_id=None)
+    pred = db.conn.execute(
+        "SELECT id FROM predictions WHERE species = 'Blue Jay'"
+    ).fetchone()
+
+    resp = client.post(f'/api/predictions/{pred["id"]}/reviewed')
+    assert resp.status_code == 200
+    assert resp.get_json()['ok'] is True
+    assert db.get_review_status(pred['id'], db._active_workspace_id) == 'reviewed'
+
+
+def test_mark_prediction_reviewed_rejects_non_pending(app_and_db):
+    """Only pending predictions may transition to reviewed.
+
+    A stale/double request or direct API call against an already
+    accepted/rejected prediction must not silently overwrite the prior
+    decision; the endpoint returns 409 and the status is preserved.
+    """
+    app, db = app_and_db
+    photos = _seed_predictions(db)
+    client = app.test_client()
+
+    det_acc = _make_detection(db, photos[2]['id'])
+    db.add_prediction(detection_id=det_acc, species='Blue Jay', confidence=0.90,
+                      model='test-model', category='new', group_id=None)
+    accepted = db.conn.execute(
+        "SELECT id FROM predictions WHERE species = 'Blue Jay'"
+    ).fetchone()
+    db.update_prediction_status(accepted['id'], 'accepted')
+
+    resp = client.post(f'/api/predictions/{accepted["id"]}/reviewed')
+    assert resp.status_code == 409
+    assert db.get_review_status(
+        accepted['id'], db._active_workspace_id) == 'accepted'
+
+    rejected = db.conn.execute(
+        "SELECT id FROM predictions WHERE species = 'Northern Cardinal'"
+    ).fetchone()
+    db.update_prediction_status(rejected['id'], 'rejected')
+
+    resp = client.post(f'/api/predictions/{rejected["id"]}/reviewed')
+    assert resp.status_code == 409
+    assert db.get_review_status(
+        rejected['id'], db._active_workspace_id) == 'rejected'
+
+
+def test_mark_prediction_reviewed_missing_id_returns_404(app_and_db):
+    """Stale prediction IDs should 404, not 500 or a silent write."""
+    app, db = app_and_db
+    _seed_predictions(db)
+    client = app.test_client()
+
+    resp = client.post('/api/predictions/999999/reviewed')
+    assert resp.status_code == 404
+    assert db.get_review_status(999999, db._active_workspace_id) == 'pending'
+
+
 def test_reject_prediction_missing_id_returns_404(app_and_db):
     """Stale prediction IDs should 404, not 500.
 


### PR DESCRIPTION
Upgrades the Compare page into a keyword audit workflow with current keyword visibility, summary counts, filters, model focus controls, search, inline actions, batch actions, and open-photo links. The compare API now returns keyword-aware prediction categories and supports marking predictions reviewed or replacing species keywords from a prediction. Added tests for taxonomic category logic and the Compare page workflow. Validation: `python -m pytest tests/test_compare.py tests/e2e/test_compare_page.py -q`, `python -m pytest tests/e2e/test_page_loads.py tests/e2e/test_compare_page.py -q`, `python -m py_compile vireo/app.py vireo/db.py vireo/compare.py`, and `git diff --check`.