### PR TITLE
[codex] Support multi-drag in burst review

### DIFF
--- a/tests/e2e/test_burst_group_context_menu.py
+++ b/tests/e2e/test_burst_group_context_menu.py
@@ -192,6 +192,65 @@ def test_burst_move_to_picks_updates_state(live_server, page):
     assert in_picks is True
 
 
+def test_burst_multi_selected_cards_drag_together(live_server, page):
+    """Ctrl/Cmd-style multi-selection should pan selected burst cards together."""
+    n = _seed_burst_group(live_server["db"])
+    if n < 2:
+        pytest.skip("need at least 2 burst cards")
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    cards = page.locator("#grmOverlay .grm-card[data-photo-id]")
+    assert cards.count() >= 2
+    first_pid = cards.nth(0).get_attribute("data-photo-id")
+    second_pid = cards.nth(1).get_attribute("data-photo-id")
+    assert first_pid and second_pid
+
+    # Start from an empty selection so this exercises normal click + additive
+    # Ctrl-click rather than depending on the modal's auto-selected AI best.
+    page.evaluate(
+        """() => {
+          grmState.selected = null;
+          grmState.selectedIds.clear();
+          grmState.selectionAnchor = null;
+          renderGroupModal();
+        }"""
+    )
+
+    first = page.locator(f'#grmOverlay .grm-card[data-photo-id="{first_pid}"]')
+    second = page.locator(f'#grmOverlay .grm-card[data-photo-id="{second_pid}"]')
+    first.click()
+    second.click(modifiers=["Control"])
+
+    selected = page.evaluate("Array.from(grmState.selectedIds).map(String).sort()")
+    assert selected == sorted([first_pid, second_pid])
+
+    bbox = first.bounding_box()
+    assert bbox is not None
+    x = bbox["x"] + bbox["width"] / 2
+    y = bbox["y"] + bbox["height"] / 2
+    page.mouse.move(x, y)
+    page.mouse.down()
+    page.mouse.move(x + 30, y + 12)
+    page.mouse.up()
+
+    offsets = page.evaluate(
+        """([a, b]) => ({
+          a: _grmOffsets[a],
+          b: _grmOffsets[b],
+        })""",
+        [first_pid, second_pid],
+    )
+    assert offsets["a"] and offsets["b"]
+    assert abs(offsets["a"]["tx"] - offsets["b"]["tx"]) < 0.01
+    assert abs(offsets["a"]["ty"] - offsets["b"]["ty"]) < 0.01
+    assert abs(offsets["a"]["tx"]) > 0
+    assert abs(offsets["a"]["ty"]) > 0
+
+
 def test_review_card_menu_has_no_burst_items(live_server, page):
     """The ordinary review-card menu must not expose burst-only actions.
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3072,6 +3072,8 @@ var grmState = {
   rejects: new Set(),
   removed: new Set(),
   selected: null,     // photo id
+  selectedIds: new Set(),
+  selectionAnchor: null,
   sessionId: 0        // bumped on each openGroupReview; used to drop stale fetches
 };
 
@@ -3131,6 +3133,8 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
     rejects: new Set(),
     removed: new Set(),
     selected: null,
+    selectedIds: new Set(),
+    selectionAnchor: null,
     // Filled in by the /group/state fetch below. Keys: photo_id → {flag,
     // has_species_keyword}. This is the live DB snapshot the modal opened
     // with, used to (a) render "from DB" markers and (b) compute the
@@ -3274,7 +3278,7 @@ function renderGroupModal() {
   var items = grmState.items.filter(function(p) { return !grmState.removed.has(p.id); });
 
   function renderCard(p) {
-    var isSelected = p.id === grmState.selected;
+    var isSelected = grmState.selectedIds && grmState.selectedIds.has(p.id);
     var cls = 'grm-card' + (isSelected ? ' selected' : '');
     var qScore = p.quality_composite != null ? Math.round(p.quality_composite * 100) : '-';
     var sharp = p.subject_tenengrad != null ? Math.round(p.subject_tenengrad) : '-';
@@ -3474,8 +3478,61 @@ function grmApplyTitle(diff) {
     : 'Apply will make no database changes, then close this burst.';
 }
 
-function grmSelect(photoId) {
-  grmState.selected = (grmState.selected === photoId) ? null : photoId;
+function _grmVisibleItems() {
+  return grmState.items.filter(function(p) { return !grmState.removed.has(p.id); });
+}
+
+function _grmEnsureSelectedIds() {
+  if (!grmState.selectedIds) grmState.selectedIds = new Set();
+  return grmState.selectedIds;
+}
+
+function _grmSelectRange(anchorId, photoId) {
+  var selectedIds = _grmEnsureSelectedIds();
+  var items = _grmVisibleItems();
+  var a = items.findIndex(function(p) { return p.id === anchorId; });
+  var b = items.findIndex(function(p) { return p.id === photoId; });
+  if (a < 0 || b < 0) {
+    selectedIds.add(photoId);
+    return;
+  }
+  var start = Math.min(a, b);
+  var end = Math.max(a, b);
+  for (var i = start; i <= end; i++) {
+    selectedIds.add(items[i].id);
+  }
+}
+
+function grmSelect(photoId, mode) {
+  var selectedIds = _grmEnsureSelectedIds();
+  if (mode === 'toggle') {
+    if (selectedIds.has(photoId)) {
+      selectedIds.delete(photoId);
+      if (grmState.selected === photoId) {
+        var remaining = Array.from(selectedIds);
+        grmState.selected = remaining.length ? remaining[remaining.length - 1] : null;
+      }
+    } else {
+      selectedIds.add(photoId);
+      grmState.selected = photoId;
+      grmState.selectionAnchor = photoId;
+    }
+  } else if (mode === 'range') {
+    if (!grmState.selectionAnchor) grmState.selectionAnchor = grmState.selected || photoId;
+    _grmSelectRange(grmState.selectionAnchor, photoId);
+    grmState.selected = photoId;
+  } else {
+    if (grmState.selected === photoId && selectedIds.size === 1 && selectedIds.has(photoId)) {
+      selectedIds.clear();
+      grmState.selected = null;
+      grmState.selectionAnchor = null;
+    } else {
+      selectedIds.clear();
+      selectedIds.add(photoId);
+      grmState.selected = photoId;
+      grmState.selectionAnchor = photoId;
+    }
+  }
   renderGroupModal();
 
   // Update loupe preview
@@ -3846,14 +3903,27 @@ function grmCardMouseDown(e) {
   if (e.button !== 0) return;
   var card = e.currentTarget;
   var photoId = card.dataset.photoId;
-  var cur = _grmOffsets[photoId] || { tx: 0, ty: 0 };
+  var selectedIds = _grmEnsureSelectedIds();
+  var numericPhotoId = parseInt(photoId, 10);
+  var targetIds = selectedIds.has(numericPhotoId) || selectedIds.has(photoId)
+    ? Array.from(selectedIds)
+    : [photoId];
+  var targets = targetIds.map(function(pid) {
+    var targetCard = document.querySelector('#grmOverlay .grm-card[data-photo-id="' + pid + '"]');
+    if (!targetCard) return null;
+    var cur = _grmOffsets[pid] || { tx: 0, ty: 0 };
+    return { card: targetCard, photoId: String(pid), origTx: cur.tx, origTy: cur.ty };
+  }).filter(Boolean);
+  if (!targets.length) {
+    var cur = _grmOffsets[photoId] || { tx: 0, ty: 0 };
+    targets = [{ card: card, photoId: String(photoId), origTx: cur.tx, origTy: cur.ty }];
+  }
   _grmDragging = {
     card: card,
     photoId: photoId,
+    targets: targets,
     startX: e.clientX,
     startY: e.clientY,
-    origTx: cur.tx,
-    origTy: cur.ty,
     moved: false,
   };
   document.addEventListener('mousemove', grmCardMouseMove);
@@ -3874,32 +3944,34 @@ function grmCardMouseMove(e) {
   var dy = e.clientY - _grmDragging.startY;
   if (!_grmDragging.moved && (Math.abs(dx) > 3 || Math.abs(dy) > 3)) {
     _grmDragging.moved = true;
-    _grmDragging.card.classList.add('dragging');
+    _grmDragging.targets.forEach(function(target) { target.card.classList.add('dragging'); });
   }
   if (!_grmDragging.moved) return;
-  // Use the actual displayed scale so dx/dy in screen pixels translate to
-  // pre-scale offset units that, when re-scaled, follow the cursor 1:1.
-  // Must mirror _grmComputeCardTransform's hover/non-hover branch: after a
-  // zoom-in followed by mouseleave (grmLoupeReset clears _grmLastHoverX) the
-  // card is displayed at cover-fit while _grmZoomMultiplier stays at its
-  // hovered value, so the denominator must match what's actually on screen
-  // or pans would jump when hover resumes.
-  var coverFit = grmCardCoverFit(_grmDragging.card);
-  var hovering = _grmLastHoverX != null;
-  var scale = hovering ? Math.max(coverFit, _grmZoomMultiplier) : coverFit;
-  var z = scale > 0.01 ? scale : 1;
-  var newTx = _grmDragging.origTx + dx / z;
-  var newTy = _grmDragging.origTy + dy / z;
-  _grmOffsets[_grmDragging.photoId] = { tx: newTx, ty: newTy };
-  _grmApplyCardTransform(_grmDragging.card);
-  _grmUpdateIndicator(_grmDragging.card);
+  // Use each card's actual displayed scale so the same screen drag produces
+  // the same visible pan on every selected photo, even across mixed sizes.
+  _grmDragging.targets.forEach(function(target) {
+    // Must mirror _grmComputeCardTransform's hover/non-hover branch: after a
+    // zoom-in followed by mouseleave (grmLoupeReset clears _grmLastHoverX) the
+    // card is displayed at cover-fit while _grmZoomMultiplier stays at its
+    // hovered value, so the denominator must match what's actually on screen
+    // or pans would jump when hover resumes.
+    var coverFit = grmCardCoverFit(target.card);
+    var hovering = _grmLastHoverX != null;
+    var scale = hovering ? Math.max(coverFit, _grmZoomMultiplier) : coverFit;
+    var z = scale > 0.01 ? scale : 1;
+    var newTx = target.origTx + dx / z;
+    var newTy = target.origTy + dy / z;
+    _grmOffsets[target.photoId] = { tx: newTx, ty: newTy };
+    _grmApplyCardTransform(target.card);
+    _grmUpdateIndicator(target.card);
+  });
 }
 
 function grmCardMouseUp(e) {
   if (!_grmDragging) return;
   var moved = _grmDragging.moved;
   var card = _grmDragging.card;
-  card.classList.remove('dragging');
+  _grmDragging.targets.forEach(function(target) { target.card.classList.remove('dragging'); });
   document.removeEventListener('mousemove', grmCardMouseMove);
   document.removeEventListener('mouseup', grmCardMouseUp);
   _grmDragging = null;
@@ -3918,7 +3990,8 @@ function grmCardClick(e, photoId) {
     _grmSuppressNextClick = false;
     return;
   }
-  grmSelect(photoId);
+  var mode = e && (e.metaKey || e.ctrlKey) ? 'toggle' : (e && e.shiftKey ? 'range' : 'single');
+  grmSelect(photoId, mode);
 }
 
 function grmCardDblClick(e) {
@@ -4017,6 +4090,8 @@ function grmRemoveFromGroup() {
   grmState.picks.delete(grmState.selected);
   grmState.rejects.delete(grmState.selected);
   grmState.selected = null;
+  if (grmState.selectedIds) grmState.selectedIds.clear();
+  grmState.selectionAnchor = null;
   renderGroupModal();
   document.getElementById('grmLoupeDetail').innerHTML = '';
 }

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1376,10 +1376,10 @@ document.addEventListener('contextmenu', function(e) {
  * names, different closest() matches.
  *
  * Critical: grmMovePick / grmMoveReject / grmMoveCandidate / grmRemoveFromGroup
- * all operate on grmState.selected. On right-click we MUST force-set
- * grmState.selected to the clicked card's photo_id before opening the menu.
- * We assign directly (not via grmSelect, which toggles) so a right-click on
- * a non-selected card doesn't deselect it.
+ * all operate on grmState.selected. On right-click we force the clicked card
+ * to be the primary selection before opening the menu. If the clicked card is
+ * already part of a multi-selection, preserve that set so drag alignment state
+ * is not lost.
  */
 function buildBurstGroupContextMenu(photoId, filename) {
   var rateChip = function(n) {
@@ -1448,10 +1448,12 @@ document.addEventListener('contextmenu', function(e) {
   var item = grmState.items.find(function(it) { return it.photo_id === photoId; });
   var filename = item ? item.filename : '';
   // Force-select the right-clicked card so move/remove actions target it.
-  // Assign directly rather than calling grmSelect() — that helper toggles
-  // selection, which would deselect when right-clicking the already-selected
-  // card.
   grmState.selected = photoId;
+  if (!grmState.selectedIds) grmState.selectedIds = new Set();
+  if (!grmState.selectedIds.has(photoId)) {
+    grmState.selectedIds = new Set([photoId]);
+  }
+  grmState.selectionAnchor = photoId;
   renderGroupModal();
   if (typeof openContextMenu !== 'function') return;
   openContextMenu(e, buildBurstGroupContextMenu(photoId, filename));
@@ -1465,10 +1467,10 @@ function updateThumbSize(val) {
 }
 
 /* ==================== Group Review Modal ==================== */
-var grmState = { groupId: null, model: null, items: [], picks: new Set(), rejects: new Set(), removed: new Set(), selected: null, upgraded: false };
+var grmState = { groupId: null, model: null, items: [], picks: new Set(), rejects: new Set(), removed: new Set(), selected: null, selectedIds: new Set(), selectionAnchor: null, upgraded: false };
 
 function openGroupReview(groupId, model) {
-  grmState = { groupId: groupId, model: model, items: [], picks: new Set(), rejects: new Set(), removed: new Set(), selected: null, upgraded: false };
+  grmState = { groupId: groupId, model: model, items: [], picks: new Set(), rejects: new Set(), removed: new Set(), selected: null, selectedIds: new Set(), selectionAnchor: null, upgraded: false };
   _grmLoupeLocked = false;
   // Reset zoom state so a high zoom from a prior burst doesn't leak in. With
   // the natural-size layout, _grmZoomLevel is now a multiplier above
@@ -1539,7 +1541,7 @@ function renderGroupModal() {
 
   function renderCard(it) {
     var isBest = it.photo_id === bestId;
-    var isSelected = it.photo_id === grmState.selected;
+    var isSelected = grmState.selectedIds && grmState.selectedIds.has(it.photo_id);
     var cls = 'grm-card' + (isSelected ? ' selected' : '') + (isBest ? ' ai-best' : '');
     var qScore = it.quality_score != null ? Math.round(it.quality_score * 100) : '-';
     var sharp = it.subject_sharpness != null ? Math.round(it.subject_sharpness) : (it.sharpness != null ? Math.round(it.sharpness) : '-');
@@ -1616,8 +1618,61 @@ function renderGroupModal() {
   grmRefreshResetAllVisibility();
 }
 
-function grmSelect(photoId) {
-  grmState.selected = (grmState.selected === photoId) ? null : photoId;
+function _grmVisibleItems() {
+  return grmState.items.filter(function(it) { return !grmState.removed.has(it.id); });
+}
+
+function _grmEnsureSelectedIds() {
+  if (!grmState.selectedIds) grmState.selectedIds = new Set();
+  return grmState.selectedIds;
+}
+
+function _grmSelectRange(anchorId, photoId) {
+  var selectedIds = _grmEnsureSelectedIds();
+  var items = _grmVisibleItems();
+  var a = items.findIndex(function(it) { return it.photo_id === anchorId; });
+  var b = items.findIndex(function(it) { return it.photo_id === photoId; });
+  if (a < 0 || b < 0) {
+    selectedIds.add(photoId);
+    return;
+  }
+  var start = Math.min(a, b);
+  var end = Math.max(a, b);
+  for (var i = start; i <= end; i++) {
+    selectedIds.add(items[i].photo_id);
+  }
+}
+
+function grmSelect(photoId, mode) {
+  var selectedIds = _grmEnsureSelectedIds();
+  if (mode === 'toggle') {
+    if (selectedIds.has(photoId)) {
+      selectedIds.delete(photoId);
+      if (grmState.selected === photoId) {
+        var remaining = Array.from(selectedIds);
+        grmState.selected = remaining.length ? remaining[remaining.length - 1] : null;
+      }
+    } else {
+      selectedIds.add(photoId);
+      grmState.selected = photoId;
+      grmState.selectionAnchor = photoId;
+    }
+  } else if (mode === 'range') {
+    if (!grmState.selectionAnchor) grmState.selectionAnchor = grmState.selected || photoId;
+    _grmSelectRange(grmState.selectionAnchor, photoId);
+    grmState.selected = photoId;
+  } else {
+    if (grmState.selected === photoId && selectedIds.size === 1 && selectedIds.has(photoId)) {
+      selectedIds.clear();
+      grmState.selected = null;
+      grmState.selectionAnchor = null;
+    } else {
+      selectedIds.clear();
+      selectedIds.add(photoId);
+      grmState.selected = photoId;
+      grmState.selectionAnchor = photoId;
+    }
+  }
   renderGroupModal();
 
   // Update loupe preview
@@ -1975,14 +2030,26 @@ function grmCardMouseDown(e) {
   if (e.button !== 0) return;
   var card = e.currentTarget;
   var photoId = card.dataset.photoId;
-  var cur = _grmOffsets[photoId] || { tx: 0, ty: 0 };
+  var selectedIds = _grmEnsureSelectedIds();
+  var targetIds = selectedIds.has(parseInt(photoId, 10)) || selectedIds.has(photoId)
+    ? Array.from(selectedIds)
+    : [photoId];
+  var targets = targetIds.map(function(pid) {
+    var targetCard = document.querySelector('.grm-card[data-photo-id="' + pid + '"]');
+    if (!targetCard) return null;
+    var cur = _grmOffsets[pid] || { tx: 0, ty: 0 };
+    return { card: targetCard, photoId: String(pid), origTx: cur.tx, origTy: cur.ty };
+  }).filter(Boolean);
+  if (!targets.length) {
+    var cur = _grmOffsets[photoId] || { tx: 0, ty: 0 };
+    targets = [{ card: card, photoId: String(photoId), origTx: cur.tx, origTy: cur.ty }];
+  }
   _grmDragging = {
     card: card,
     photoId: photoId,
+    targets: targets,
     startX: e.clientX,
     startY: e.clientY,
-    origTx: cur.tx,
-    origTy: cur.ty,
     moved: false,
   };
   document.addEventListener('mousemove', grmCardMouseMove);
@@ -2003,27 +2070,30 @@ function grmCardMouseMove(e) {
   var dy = e.clientY - _grmDragging.startY;
   if (!_grmDragging.moved && (Math.abs(dx) > 3 || Math.abs(dy) > 3)) {
     _grmDragging.moved = true;
-    _grmDragging.card.classList.add('dragging');
+    _grmDragging.targets.forEach(function(target) { target.card.classList.add('dragging'); });
   }
   if (!_grmDragging.moved) return;
-  // Convert screen-pixel drag delta to image-coordinate (pre-scale CSS)
-  // pixels by dividing by the displayed scale of the dragged card.
-  var coverFit = _grmCardCoverFit(_grmDragging.card);
-  var hovering = _grmLoupeHovering || _grmLoupeLocked;
-  var s = hovering ? Math.max(coverFit, coverFit * _grmZoomLevel) : coverFit;
-  var z = s > 0.001 ? s : 1;
-  var newTx = _grmDragging.origTx + dx / z;
-  var newTy = _grmDragging.origTy + dy / z;
-  _grmOffsets[_grmDragging.photoId] = { tx: newTx, ty: newTy };
-  _grmApplyCardTransform(_grmDragging.card);
-  _grmUpdateIndicator(_grmDragging.card);
+  // Convert screen-pixel drag delta to each image's pre-scale coordinate
+  // space. That keeps the visible pan delta identical across selected cards
+  // even when their displayed scales differ.
+  _grmDragging.targets.forEach(function(target) {
+    var coverFit = _grmCardCoverFit(target.card);
+    var hovering = _grmLoupeHovering || _grmLoupeLocked;
+    var s = hovering ? Math.max(coverFit, coverFit * _grmZoomLevel) : coverFit;
+    var z = s > 0.001 ? s : 1;
+    var newTx = target.origTx + dx / z;
+    var newTy = target.origTy + dy / z;
+    _grmOffsets[target.photoId] = { tx: newTx, ty: newTy };
+    _grmApplyCardTransform(target.card);
+    _grmUpdateIndicator(target.card);
+  });
 }
 
 function grmCardMouseUp(e) {
   if (!_grmDragging) return;
   var moved = _grmDragging.moved;
   var card = _grmDragging.card;
-  card.classList.remove('dragging');
+  _grmDragging.targets.forEach(function(target) { target.card.classList.remove('dragging'); });
   document.removeEventListener('mousemove', grmCardMouseMove);
   document.removeEventListener('mouseup', grmCardMouseUp);
   _grmDragging = null;
@@ -2042,7 +2112,8 @@ function grmCardClick(e, photoId) {
     _grmSuppressNextClick = false;
     return;
   }
-  grmSelect(photoId);
+  var mode = e && (e.metaKey || e.ctrlKey) ? 'toggle' : (e && e.shiftKey ? 'range' : 'single');
+  grmSelect(photoId, mode);
 }
 
 function grmCardDblClick(e) {
@@ -2147,6 +2218,8 @@ function grmRemoveFromGroup() {
   grmState.picks.delete(grmState.selected);
   grmState.rejects.delete(grmState.selected);
   grmState.selected = null;
+  if (grmState.selectedIds) grmState.selectedIds.clear();
+  grmState.selectionAnchor = null;
   renderGroupModal();
 }
 
@@ -2210,13 +2283,13 @@ document.addEventListener('keydown', function(e) {
     // Select previous card
     var items = grmState.items.filter(function(it) { return !grmState.removed.has(it.id); });
     var idx = items.findIndex(function(it) { return it.photo_id === grmState.selected; });
-    if (idx > 0) { grmState.selected = items[idx - 1].photo_id; renderGroupModal(); }
+    if (idx > 0) { grmSelect(items[idx - 1].photo_id, 'single'); }
     e.preventDefault(); return;
   }
   if (e.key === 'ArrowRight') {
     var items = grmState.items.filter(function(it) { return !grmState.removed.has(it.id); });
     var idx = items.findIndex(function(it) { return it.photo_id === grmState.selected; });
-    if (idx < items.length - 1) { grmState.selected = items[idx + 1].photo_id; renderGroupModal(); }
+    if (idx < items.length - 1) { grmSelect(items[idx + 1].photo_id, 'single'); }
     e.preventDefault(); return;
   }
   if (e.key === 'Delete' || e.key === 'Backspace') { grmRemoveFromGroup(); e.preventDefault(); return; }


### PR DESCRIPTION
Adds multi-selection state to burst group review cards while keeping the primary selection for loupe and pick/reject actions. Ctrl/Cmd-click toggles cards into the selection set, Shift-click selects ranges, and dragging a selected card now pans every selected card by the same visible delta. The same behavior is wired into the pipeline review burst modal for consistency. Validated with focused burst group e2e tests, including a new regression for multi-selected drag offsets.