### PR TITLE
[codex] Expand native menu commands

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,26 @@ fn open_in_browser(app: &tauri::AppHandle, url: &str) {
     }
 }
 
+fn dispatch_menu_command(app: &tauri::AppHandle, command: &str) {
+    if tray::is_browser_mode(app) {
+        log::warn!(
+            "Native menu command '{}' ignored because Vireo is running in browser mode",
+            command
+        );
+        return;
+    }
+
+    if let Some(window) = app.get_webview_window("main") {
+        let js = format!(
+            "if (window.handleNativeMenuCommand) {{ window.handleNativeMenuCommand({:?}); }}",
+            command
+        );
+        if let Err(e) = window.eval(&js) {
+            log::error!("Failed to dispatch menu command {}: {}", command, e);
+        }
+    }
+}
+
 #[tauri::command]
 fn get_server_port(state: tauri::State<'_, SidecarState>) -> u16 {
     state.port
@@ -174,6 +194,11 @@ pub fn run() {
             // also route to the browser.
             if id == menu::ids::OPEN_IN_BROWSER {
                 tray::open_ui_in_browser(app);
+                return;
+            }
+
+            if let Some(command) = menu::command_for_id(id) {
+                dispatch_menu_command(app, command);
                 return;
             }
 

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -9,12 +9,19 @@ pub mod ids {
     pub const NAV_IMPORT: &str = "nav_import";
     pub const NAV_PIPELINE: &str = "nav_pipeline";
     pub const NAV_PIPELINE_REVIEW: &str = "nav_pipeline_review";
+    pub const NAV_PIPELINE_RAPID_REVIEW: &str = "nav_pipeline_rapid_review";
     pub const NAV_REVIEW: &str = "nav_review";
     pub const NAV_CULL: &str = "nav_cull";
+    pub const NAV_MISSES: &str = "nav_misses";
+    pub const NAV_HIGHLIGHTS: &str = "nav_highlights";
     pub const NAV_MAP: &str = "nav_map";
     pub const NAV_VARIANTS: &str = "nav_variants";
     pub const NAV_AUDIT: &str = "nav_audit";
     pub const NAV_COMPARE: &str = "nav_compare";
+    pub const NAV_JOBS: &str = "nav_jobs";
+    pub const NAV_DUPLICATES: &str = "nav_duplicates";
+    pub const NAV_LIGHTROOM: &str = "nav_lightroom";
+    pub const NAV_SHORTCUTS: &str = "nav_shortcuts";
     pub const NAV_DASHBOARD: &str = "nav_dashboard";
     pub const NAV_WORKSPACE: &str = "nav_workspace";
     pub const NAV_SETTINGS: &str = "nav_settings";
@@ -22,25 +29,127 @@ pub mod ids {
     pub const REPORT_ISSUE: &str = "report_issue";
     pub const CHECK_FOR_UPDATES: &str = "check_for_updates";
     pub const OPEN_IN_BROWSER: &str = "open_in_browser_now";
+
+    pub const FILE_NEW_WORKSPACE: &str = "file_new_workspace";
+    pub const FILE_OPEN_WORKSPACE: &str = "file_open_workspace";
+    pub const FILE_IMPORT_PHOTOS: &str = "file_import_photos";
+    pub const FILE_IMPORT_FOLDER: &str = "file_import_folder";
+    pub const FILE_EXPORT_SELECTED: &str = "file_export_selected";
+
+    pub const PHOTO_OPEN_LIGHTBOX: &str = "photo_open_lightbox";
+    pub const PHOTO_REVEAL: &str = "photo_reveal";
+    pub const PHOTO_OPEN_EDITOR: &str = "photo_open_editor";
+    pub const PHOTO_COPY_PATHS: &str = "photo_copy_paths";
+    pub const PHOTO_FIND_SIMILAR: &str = "photo_find_similar";
+    pub const PHOTO_COMPARE: &str = "photo_compare";
+    pub const PHOTO_ADD_KEYWORD: &str = "photo_add_keyword";
+    pub const PHOTO_ADD_COLLECTION: &str = "photo_add_collection";
+    pub const PHOTO_DELETE: &str = "photo_delete";
+    pub const PHOTO_RATE_0: &str = "photo_rate_0";
+    pub const PHOTO_RATE_1: &str = "photo_rate_1";
+    pub const PHOTO_RATE_2: &str = "photo_rate_2";
+    pub const PHOTO_RATE_3: &str = "photo_rate_3";
+    pub const PHOTO_RATE_4: &str = "photo_rate_4";
+    pub const PHOTO_RATE_5: &str = "photo_rate_5";
+    pub const PHOTO_FLAG_PICK: &str = "photo_flag_pick";
+    pub const PHOTO_FLAG_REJECT: &str = "photo_flag_reject";
+    pub const PHOTO_FLAG_CLEAR: &str = "photo_flag_clear";
+
+    pub const REVIEW_ACCEPT: &str = "review_accept";
+    pub const REVIEW_REJECT: &str = "review_reject";
+    pub const REVIEW_ACCEPT_ALL: &str = "review_accept_all";
+    pub const REVIEW_PREVIOUS: &str = "review_previous";
+    pub const REVIEW_NEXT: &str = "review_next";
+    pub const REVIEW_MARK_WILDLIFE: &str = "review_mark_wildlife";
+    pub const REVIEW_EXCLUDE_WILDLIFE: &str = "review_exclude_wildlife";
+
+    pub const TOOLS_RUN_PIPELINE: &str = "tools_run_pipeline";
+    pub const TOOLS_SCAN_LIBRARY: &str = "tools_scan_library";
+    pub const TOOLS_FIND_DUPLICATES: &str = "tools_find_duplicates";
+    pub const TOOLS_BUILD_PREVIEWS: &str = "tools_build_previews";
+    pub const TOOLS_SYNC_METADATA: &str = "tools_sync_metadata";
+    pub const TOOLS_VERIFY_MODELS: &str = "tools_verify_models";
+    pub const TOOLS_CANCEL_JOB: &str = "tools_cancel_job";
+    pub const TOOLS_REVIEW_PIPELINE: &str = "tools_review_pipeline";
+    pub const HELP_KEYBOARD_SHORTCUTS: &str = "help_keyboard_shortcuts";
+    pub const HELP_OPEN_HELP: &str = "help_open_help";
+    pub const HELP_OPEN_LOGS: &str = "help_open_logs";
+    pub const HELP_COPY_DIAGNOSTICS: &str = "help_copy_diagnostics";
 }
 
 /// Map a menu item ID to its Flask route path.
 pub fn route_for_id(id: &str) -> Option<&'static str> {
     match id {
         ids::NAV_BROWSE => Some("/browse"),
-        ids::NAV_IMPORT => Some("/import"),
+        ids::NAV_IMPORT => Some("/lightroom"),
         ids::NAV_PIPELINE => Some("/pipeline"),
         ids::NAV_PIPELINE_REVIEW => Some("/pipeline/review"),
+        ids::NAV_PIPELINE_RAPID_REVIEW => Some("/pipeline/rapid-review"),
         ids::NAV_REVIEW => Some("/review"),
         ids::NAV_CULL => Some("/cull"),
+        ids::NAV_MISSES => Some("/misses"),
+        ids::NAV_HIGHLIGHTS => Some("/highlights"),
         ids::NAV_MAP => Some("/map"),
         ids::NAV_VARIANTS => Some("/variants"),
         ids::NAV_AUDIT => Some("/audit"),
         ids::NAV_COMPARE => Some("/compare"),
+        ids::NAV_JOBS => Some("/jobs"),
+        ids::NAV_DUPLICATES => Some("/duplicates"),
+        ids::NAV_LIGHTROOM => Some("/lightroom"),
+        ids::NAV_SHORTCUTS => Some("/shortcuts"),
         ids::NAV_DASHBOARD => Some("/dashboard"),
         ids::NAV_WORKSPACE => Some("/workspace"),
         ids::NAV_SETTINGS => Some("/settings"),
         ids::NAV_LOGS => Some("/logs"),
+        ids::TOOLS_REVIEW_PIPELINE => Some("/pipeline/review"),
+        ids::HELP_KEYBOARD_SHORTCUTS => Some("/shortcuts"),
+        ids::HELP_OPEN_LOGS => Some("/logs"),
+        _ => None,
+    }
+}
+
+/// Map a menu item ID to a shared browser-side command.
+pub fn command_for_id(id: &str) -> Option<&'static str> {
+    match id {
+        ids::FILE_NEW_WORKSPACE => Some("new_workspace"),
+        ids::FILE_OPEN_WORKSPACE => Some("open_workspace"),
+        ids::FILE_IMPORT_PHOTOS => Some("import_photos"),
+        ids::FILE_IMPORT_FOLDER => Some("import_folder"),
+        ids::FILE_EXPORT_SELECTED => Some("export_selected"),
+        ids::PHOTO_OPEN_LIGHTBOX => Some("photo_open_lightbox"),
+        ids::PHOTO_REVEAL => Some("photo_reveal"),
+        ids::PHOTO_OPEN_EDITOR => Some("photo_open_editor"),
+        ids::PHOTO_COPY_PATHS => Some("photo_copy_paths"),
+        ids::PHOTO_FIND_SIMILAR => Some("photo_find_similar"),
+        ids::PHOTO_COMPARE => Some("photo_compare"),
+        ids::PHOTO_ADD_KEYWORD => Some("photo_add_keyword"),
+        ids::PHOTO_ADD_COLLECTION => Some("photo_add_collection"),
+        ids::PHOTO_DELETE => Some("photo_delete"),
+        ids::PHOTO_RATE_0 => Some("photo_rate_0"),
+        ids::PHOTO_RATE_1 => Some("photo_rate_1"),
+        ids::PHOTO_RATE_2 => Some("photo_rate_2"),
+        ids::PHOTO_RATE_3 => Some("photo_rate_3"),
+        ids::PHOTO_RATE_4 => Some("photo_rate_4"),
+        ids::PHOTO_RATE_5 => Some("photo_rate_5"),
+        ids::PHOTO_FLAG_PICK => Some("photo_flag_pick"),
+        ids::PHOTO_FLAG_REJECT => Some("photo_flag_reject"),
+        ids::PHOTO_FLAG_CLEAR => Some("photo_flag_clear"),
+        ids::REVIEW_ACCEPT => Some("review_accept"),
+        ids::REVIEW_REJECT => Some("review_reject"),
+        ids::REVIEW_ACCEPT_ALL => Some("review_accept_all"),
+        ids::REVIEW_PREVIOUS => Some("review_previous"),
+        ids::REVIEW_NEXT => Some("review_next"),
+        ids::REVIEW_MARK_WILDLIFE => Some("review_mark_wildlife"),
+        ids::REVIEW_EXCLUDE_WILDLIFE => Some("review_exclude_wildlife"),
+        ids::TOOLS_RUN_PIPELINE => Some("tools_run_pipeline"),
+        ids::TOOLS_SCAN_LIBRARY => Some("tools_scan_library"),
+        ids::TOOLS_FIND_DUPLICATES => Some("tools_find_duplicates"),
+        ids::TOOLS_BUILD_PREVIEWS => Some("tools_build_previews"),
+        ids::TOOLS_SYNC_METADATA => Some("tools_sync_metadata"),
+        ids::TOOLS_VERIFY_MODELS => Some("tools_verify_models"),
+        ids::TOOLS_CANCEL_JOB => Some("tools_cancel_job"),
+        ids::HELP_OPEN_HELP => Some("help_open_help"),
+        ids::HELP_COPY_DIAGNOSTICS => Some("help_copy_diagnostics"),
         _ => None,
     }
 }
@@ -83,6 +192,32 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
 
     // -- File menu --
     let file_menu = SubmenuBuilder::new(app, "File")
+        .item(
+            &MenuItemBuilder::with_id(ids::FILE_NEW_WORKSPACE, "New Workspace...")
+                .accelerator("CmdOrCtrl+Shift+N")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::FILE_OPEN_WORKSPACE, "Open Workspace...")
+                .build(app)?,
+        )
+        .separator()
+        .item(
+            &MenuItemBuilder::with_id(ids::FILE_IMPORT_PHOTOS, "Import Photos...")
+                .accelerator("CmdOrCtrl+I")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::FILE_IMPORT_FOLDER, "Import Folder...")
+                .accelerator("CmdOrCtrl+Shift+I")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::FILE_EXPORT_SELECTED, "Export Selected Photos...")
+                .accelerator("CmdOrCtrl+E")
+                .build(app)?,
+        )
+        .separator()
         .close_window()
         .separator()
         .quit()
@@ -123,6 +258,10 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
                 .build(app)?,
         )
         .item(
+            &MenuItemBuilder::with_id(ids::NAV_PIPELINE_RAPID_REVIEW, "Rapid Review")
+                .build(app)?,
+        )
+        .item(
             &MenuItemBuilder::with_id(ids::NAV_REVIEW, "Review")
                 .accelerator("CmdOrCtrl+5")
                 .build(app)?,
@@ -130,6 +269,14 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
         .item(
             &MenuItemBuilder::with_id(ids::NAV_CULL, "Cull")
                 .accelerator("CmdOrCtrl+6")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::NAV_MISSES, "Misses")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::NAV_HIGHLIGHTS, "Highlights")
                 .build(app)?,
         )
         .separator()
@@ -153,7 +300,16 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
                 .accelerator("CmdOrCtrl+0")
                 .build(app)?,
         )
+        .item(
+            &MenuItemBuilder::with_id(ids::NAV_DUPLICATES, "Duplicates")
+                .build(app)?,
+        )
         .separator()
+        .item(
+            &MenuItemBuilder::with_id(ids::NAV_JOBS, "Jobs")
+                .accelerator("CmdOrCtrl+Shift+J")
+                .build(app)?,
+        )
         .item(
             &MenuItemBuilder::with_id(ids::NAV_DASHBOARD, "Dashboard")
                 .accelerator("CmdOrCtrl+Shift+D")
@@ -167,6 +323,14 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
         .item(
             &MenuItemBuilder::with_id(ids::NAV_LOGS, "Logs")
                 .accelerator("CmdOrCtrl+Shift+L")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::NAV_SHORTCUTS, "Shortcuts")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::NAV_LIGHTROOM, "Lightroom")
                 .build(app)?,
         );
 
@@ -188,6 +352,111 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
 
     let view_menu = view_builder.build()?;
 
+    // -- Photo menu --
+    let photo_menu = SubmenuBuilder::new(app, "Photo")
+        .item(
+            &MenuItemBuilder::with_id(ids::PHOTO_OPEN_LIGHTBOX, "Open in Lightbox")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::PHOTO_REVEAL, "Reveal in Finder")
+                .accelerator("CmdOrCtrl+R")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::PHOTO_OPEN_EDITOR, "Open in External Editor")
+                .accelerator("CmdOrCtrl+Shift+E")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::PHOTO_COPY_PATHS, "Copy Path")
+                .accelerator("CmdOrCtrl+Option+C")
+                .build(app)?,
+        )
+        .separator()
+        .item(
+            &MenuItemBuilder::with_id(ids::PHOTO_FIND_SIMILAR, "Find Similar")
+                .accelerator("CmdOrCtrl+F")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::PHOTO_COMPARE, "Compare Selected")
+                .build(app)?,
+        )
+        .separator()
+        .item(
+            &MenuItemBuilder::with_id(ids::PHOTO_ADD_KEYWORD, "Add Keyword...")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::PHOTO_ADD_COLLECTION, "Add to Collection...")
+                .build(app)?,
+        )
+        .separator()
+        .item(&MenuItemBuilder::with_id(ids::PHOTO_RATE_0, "Rate 0").build(app)?)
+        .item(&MenuItemBuilder::with_id(ids::PHOTO_RATE_1, "Rate 1").build(app)?)
+        .item(&MenuItemBuilder::with_id(ids::PHOTO_RATE_2, "Rate 2").build(app)?)
+        .item(&MenuItemBuilder::with_id(ids::PHOTO_RATE_3, "Rate 3").build(app)?)
+        .item(&MenuItemBuilder::with_id(ids::PHOTO_RATE_4, "Rate 4").build(app)?)
+        .item(&MenuItemBuilder::with_id(ids::PHOTO_RATE_5, "Rate 5").build(app)?)
+        .separator()
+        .item(&MenuItemBuilder::with_id(ids::PHOTO_FLAG_PICK, "Flag as Pick").build(app)?)
+        .item(&MenuItemBuilder::with_id(ids::PHOTO_FLAG_REJECT, "Reject Photo").build(app)?)
+        .item(&MenuItemBuilder::with_id(ids::PHOTO_FLAG_CLEAR, "Clear Flag").build(app)?)
+        .separator()
+        .item(
+            &MenuItemBuilder::with_id(ids::PHOTO_DELETE, "Delete Selected")
+                .build(app)?,
+        )
+        .build()?;
+
+    // -- Review menu --
+    let review_menu = SubmenuBuilder::new(app, "Review")
+        .item(
+            &MenuItemBuilder::with_id(ids::REVIEW_ACCEPT, "Accept Prediction")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::REVIEW_REJECT, "Reject Prediction")
+                .build(app)?,
+        )
+        .item(&MenuItemBuilder::with_id(ids::REVIEW_ACCEPT_ALL, "Accept All Pending").build(app)?)
+        .separator()
+        .item(
+            &MenuItemBuilder::with_id(ids::REVIEW_PREVIOUS, "Previous Photo")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::REVIEW_NEXT, "Next Photo")
+                .build(app)?,
+        )
+        .separator()
+        .item(&MenuItemBuilder::with_id(ids::REVIEW_MARK_WILDLIFE, "Mark as Wildlife").build(app)?)
+        .item(
+            &MenuItemBuilder::with_id(ids::REVIEW_EXCLUDE_WILDLIFE, "Exclude from Wildlife Classification")
+                .build(app)?,
+        )
+        .build()?;
+
+    // -- Tools menu --
+    let tools_menu = SubmenuBuilder::new(app, "Tools")
+        .item(
+            &MenuItemBuilder::with_id(ids::TOOLS_RUN_PIPELINE, "Run Pipeline")
+                .accelerator("CmdOrCtrl+Return")
+                .build(app)?,
+        )
+        .item(&MenuItemBuilder::with_id(ids::TOOLS_REVIEW_PIPELINE, "Review Pipeline Results").build(app)?)
+        .separator()
+        .item(&MenuItemBuilder::with_id(ids::TOOLS_SCAN_LIBRARY, "Scan Library...").build(app)?)
+        .item(&MenuItemBuilder::with_id(ids::TOOLS_FIND_DUPLICATES, "Find Duplicates").build(app)?)
+        .item(&MenuItemBuilder::with_id(ids::TOOLS_BUILD_PREVIEWS, "Build/Refresh Previews").build(app)?)
+        .separator()
+        .item(&MenuItemBuilder::with_id(ids::TOOLS_SYNC_METADATA, "Write XMP Metadata").build(app)?)
+        .item(&MenuItemBuilder::with_id(ids::TOOLS_VERIFY_MODELS, "Verify Models").build(app)?)
+        .separator()
+        .item(&MenuItemBuilder::with_id(ids::TOOLS_CANCEL_JOB, "Cancel Current Job").build(app)?)
+        .build()?;
+
     // -- Window menu --
     let mut window_builder = SubmenuBuilder::new(app, "Window")
         .minimize()
@@ -204,11 +473,29 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
     #[allow(unused_mut)]
     let mut help_builder = SubmenuBuilder::new(app, "Help");
 
+    let keyboard_shortcuts = MenuItemBuilder::with_id(ids::HELP_KEYBOARD_SHORTCUTS, "Keyboard Shortcuts")
+        .build(app)?;
+    let open_help = MenuItemBuilder::with_id(ids::HELP_OPEN_HELP, "Vireo Help")
+        .accelerator("F1")
+        .build(app)?;
+    let open_logs = MenuItemBuilder::with_id(ids::HELP_OPEN_LOGS, "Open Logs")
+        .build(app)?;
+    let copy_diagnostics = MenuItemBuilder::with_id(ids::HELP_COPY_DIAGNOSTICS, "Copy Diagnostics")
+        .build(app)?;
     let check_updates = MenuItemBuilder::with_id(ids::CHECK_FOR_UPDATES, "Check for Updates...")
         .build(app)?;
     let report_issue = MenuItemBuilder::with_id(ids::REPORT_ISSUE, "Report an Issue...")
         .build(app)?;
-    help_builder = help_builder.item(&check_updates).separator().item(&report_issue);
+    help_builder = help_builder
+        .item(&keyboard_shortcuts)
+        .item(&open_help)
+        .separator()
+        .item(&open_logs)
+        .item(&copy_diagnostics)
+        .separator()
+        .item(&check_updates)
+        .separator()
+        .item(&report_issue);
 
     #[cfg(not(target_os = "macos"))]
     {
@@ -230,6 +517,9 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
         .item(&file_menu)
         .item(&edit_menu)
         .item(&view_menu)
+        .item(&photo_menu)
+        .item(&review_menu)
+        .item(&tools_menu)
         .item(&window_menu)
         .item(&help_menu)
         .build()

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -352,6 +352,13 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
 
     let view_menu = view_builder.build()?;
 
+    #[cfg(target_os = "macos")]
+    let reveal_label = "Reveal in Finder";
+    #[cfg(target_os = "windows")]
+    let reveal_label = "Reveal in Explorer";
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    let reveal_label = "Show in File Manager";
+
     // -- Photo menu --
     let photo_menu = SubmenuBuilder::new(app, "Photo")
         .item(
@@ -359,7 +366,7 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
                 .build(app)?,
         )
         .item(
-            &MenuItemBuilder::with_id(ids::PHOTO_REVEAL, "Reveal in Finder")
+            &MenuItemBuilder::with_id(ids::PHOTO_REVEAL, reveal_label)
                 .accelerator("CmdOrCtrl+R")
                 .build(app)?,
         )

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4888,6 +4888,12 @@ function nativeMenuSetPhotoIdsOverride(ids) {
   window._vireoNativeMenuPhotoIdsOverride = ids ? ids.slice() : null;
 }
 
+function nativeMenuCloseLightboxForModal() {
+  if (nativeMenuLightboxOpen() && typeof closeLightbox === 'function') {
+    closeLightbox();
+  }
+}
+
 async function nativeMenuSetRating(rating) {
   var ids = nativeMenuPhotoIdsForWrite();
   if (!ids) return;
@@ -4940,19 +4946,7 @@ async function nativeMenuSetFlag(flag) {
   await nativeMenuBatch('/api/batch/flag', {photo_ids: ids, flag: flag}, 'Flag updated');
 }
 
-async function nativeMenuSetWildlifeExcluded(excluded) {
-  var ids = nativeMenuPhotoIdsForWrite();
-  if (!ids) return;
-  await Promise.all(ids.map(function(id) {
-    if (typeof window.setWildlifeExcludedFor === 'function') {
-      return window.setWildlifeExcludedFor(id, excluded);
-    }
-    return safeFetch('/api/photos/' + id + '/wildlife_excluded', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({excluded: excluded}),
-    }, {toast: false});
-  }));
+function nativeMenuRefreshWildlifeExcludedState(ids, excluded) {
   if (typeof photos !== 'undefined' && Array.isArray(photos)) {
     ids.forEach(function(id) {
       var p = photos.find(function(x) { return x.id === id; });
@@ -4964,6 +4958,23 @@ async function nativeMenuSetWildlifeExcluded(excluded) {
       loadDetail(selectedPhotoId);
     }
   }
+}
+
+async function nativeMenuSetWildlifeExcluded(excluded) {
+  var ids = nativeMenuPhotoIdsForWrite();
+  if (!ids) return;
+  var usePageHelper = typeof window.setWildlifeExcludedFor === 'function';
+  await Promise.all(ids.map(function(id) {
+    if (usePageHelper) {
+      return window.setWildlifeExcludedFor(id, excluded);
+    }
+    return safeFetch('/api/photos/' + id + '/wildlife_excluded', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({excluded: excluded}),
+    }, {toast: false});
+  }));
+  if (!usePageHelper) nativeMenuRefreshWildlifeExcludedState(ids, excluded);
   if (typeof _lightboxCurrentId !== 'undefined' && ids.indexOf(_lightboxCurrentId) !== -1) {
     _lbCurrentWildlifeExcluded = excluded;
     if (typeof _lbApplyWildlifeExcludedButton === 'function') _lbApplyWildlifeExcludedButton();
@@ -5076,6 +5087,7 @@ window.handleNativeMenuCommand = async function(command) {
           var keywordIds = nativeMenuRequirePhotos('Add Keyword');
           if (!keywordIds) break;
           nativeMenuSetPhotoIdsOverride(keywordIds);
+          nativeMenuCloseLightboxForModal();
           batchAddKeyword();
         } else {
           nativeMenuError('Add Keyword is available from Browse after selecting photos.');
@@ -5086,6 +5098,7 @@ window.handleNativeMenuCommand = async function(command) {
           var collectionIds = nativeMenuRequirePhotos('Add to Collection');
           if (!collectionIds) break;
           nativeMenuSetPhotoIdsOverride(collectionIds);
+          nativeMenuCloseLightboxForModal();
           addToCollection();
         } else {
           nativeMenuError('Add to Collection is available from Browse after selecting photos.');

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4822,13 +4822,22 @@ function nativeMenuRoute(path) {
   window.location.href = path;
 }
 
+function nativeMenuLightboxOpen() {
+  var overlay = document.getElementById('lightboxOverlay');
+  return !!(overlay && overlay.classList.contains('active'));
+}
+
 function nativeMenuActivePhotoIds() {
+  if (
+    nativeMenuLightboxOpen() &&
+    typeof _lightboxCurrentId !== 'undefined' &&
+    _lightboxCurrentId != null
+  ) {
+    return [_lightboxCurrentId];
+  }
   if (typeof getActiveSelection === 'function') {
     var ids = getActiveSelection();
     if (ids && ids.length) return ids;
-  }
-  if (typeof _lightboxCurrentId !== 'undefined' && _lightboxCurrentId != null) {
-    return [_lightboxCurrentId];
   }
   if (typeof selectedPhotoId !== 'undefined' && selectedPhotoId != null) {
     return [selectedPhotoId];
@@ -5038,9 +5047,7 @@ window.handleNativeMenuCommand = async function(command) {
         if (typeof batchDelete === 'function') {
           batchDelete();
         } else {
-          var lightboxOpen = document.getElementById('lightboxOverlay') &&
-            document.getElementById('lightboxOverlay').classList.contains('active');
-          if (lightboxOpen && typeof lightboxDelete === 'function') lightboxDelete();
+          if (nativeMenuLightboxOpen() && typeof lightboxDelete === 'function') lightboxDelete();
           else nativeMenuError('Delete is available from Browse or an open Lightbox.');
         }
         break;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4801,6 +4801,319 @@ async function safeFetch(url, opts, options) {
   return JSON.parse(text);
 }
 
+/* ---------- Native Menu Commands ----------
+ * The Tauri menu bar dispatches command IDs here. Keep this layer thin:
+ * call the same page helpers, modals, and API endpoints used by visible UI.
+ */
+function nativeMenuInfo(msg) {
+  if (typeof showToast === 'function') showToast(msg, 'info');
+  else console.info(msg);
+}
+
+function nativeMenuError(msg) {
+  if (typeof showToast === 'function') showToast(msg, 'error');
+  else console.error(msg);
+}
+
+function nativeMenuRoute(path) {
+  window.location.href = path;
+}
+
+function nativeMenuActivePhotoIds() {
+  if (typeof getActiveSelection === 'function') {
+    var ids = getActiveSelection();
+    if (ids && ids.length) return ids;
+  }
+  if (typeof _lightboxCurrentId !== 'undefined' && _lightboxCurrentId != null) {
+    return [_lightboxCurrentId];
+  }
+  if (typeof selectedPhotoId !== 'undefined' && selectedPhotoId != null) {
+    return [selectedPhotoId];
+  }
+  return [];
+}
+
+function nativeMenuRequirePhotos(commandName) {
+  var ids = nativeMenuActivePhotoIds();
+  if (!ids.length) {
+    nativeMenuError(commandName + ' needs a selected photo.');
+    return null;
+  }
+  return ids;
+}
+
+async function nativeMenuBatch(endpoint, payload, success) {
+  await safeFetch(endpoint, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload || {}),
+  });
+  if (success) nativeMenuInfo(success);
+}
+
+function nativeMenuOpenLightbox() {
+  if (typeof openBrowseShortcutPhoto === 'function' && openBrowseShortcutPhoto(false)) return;
+  var ids = nativeMenuRequirePhotos('Open in Lightbox');
+  if (!ids) return;
+  if (typeof openLightbox === 'function' && typeof photos !== 'undefined') {
+    var p = photos.find(function(x) { return x.id === ids[0]; });
+    if (p) {
+      openLightbox(p.id, p.filename, photos);
+      return;
+    }
+  }
+  nativeMenuError('Open in Lightbox is available from photo grids.');
+}
+
+function nativeMenuPhotoIdsForWrite() {
+  var ids = nativeMenuActivePhotoIds();
+  if (ids.length) return ids;
+  nativeMenuError('Select one or more photos first.');
+  return null;
+}
+
+async function nativeMenuSetRating(rating) {
+  var ids = nativeMenuPhotoIdsForWrite();
+  if (!ids) return;
+  if (typeof batchSetRating === 'function') {
+    await batchSetRating(rating);
+    return;
+  }
+  if (ids.length === 1 && typeof setReviewRating === 'function') {
+    setReviewRating(ids[0], rating);
+    nativeMenuInfo('Rating updated');
+    return;
+  }
+  await nativeMenuBatch('/api/batch/rating', {photo_ids: ids, rating: rating}, 'Rating updated');
+}
+
+async function nativeMenuSetFlag(flag) {
+  var ids = nativeMenuPhotoIdsForWrite();
+  if (!ids) return;
+  if (typeof batchSetFlag === 'function') {
+    await batchSetFlag(flag);
+    return;
+  }
+  if (ids.length === 1 && typeof _lbApplyFlag === 'function' && ids[0] === _lightboxCurrentId) {
+    _lbApplyFlag(ids[0], flag);
+    return;
+  }
+  if (ids.length === 1 && typeof setReviewFlag === 'function') {
+    await setReviewFlag(ids[0], flag);
+    nativeMenuInfo('Flag updated');
+    return;
+  }
+  await nativeMenuBatch('/api/batch/flag', {photo_ids: ids, flag: flag}, 'Flag updated');
+}
+
+async function nativeMenuSetWildlifeExcluded(excluded) {
+  var ids = nativeMenuPhotoIdsForWrite();
+  if (!ids) return;
+  await Promise.all(ids.map(function(id) {
+    return safeFetch('/api/photos/' + id + '/wildlife_excluded', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({excluded: excluded}),
+    }, {toast: false});
+  }));
+  if (typeof _lightboxCurrentId !== 'undefined' && ids.indexOf(_lightboxCurrentId) !== -1) {
+    _lbCurrentWildlifeExcluded = excluded;
+  }
+  nativeMenuInfo(excluded ? 'Excluded from wildlife classification' : 'Marked as wildlife');
+}
+
+function nativeMenuPendingPredictions() {
+  if (typeof predictions === 'undefined') return [];
+  return predictions.filter(function(p) { return p.status === 'pending'; });
+}
+
+async function nativeMenuJob(endpoint, body, label) {
+  var data = await safeFetch(endpoint, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(body || {}),
+  });
+  var suffix = data && data.job_id ? ' (' + data.job_id + ')' : '';
+  nativeMenuInfo(label + suffix);
+}
+
+async function nativeMenuCancelCurrentJob() {
+  var jobs = await safeFetch('/api/jobs', {}, {toast: false});
+  var list = Array.isArray(jobs) ? jobs : (jobs.jobs || []);
+  var running = list.find(function(j) { return j.status === 'running' || j.status === 'pending'; });
+  if (!running) {
+    nativeMenuInfo('No running job to cancel');
+    return;
+  }
+  await safeFetch('/api/jobs/' + running.id + '/cancel', {method: 'POST'});
+  nativeMenuInfo('Cancel requested');
+}
+
+async function nativeMenuCopyDiagnostics() {
+  var parts = [];
+  try { parts.push({version: await safeFetch('/api/version', {}, {toast: false})}); } catch(e) {}
+  try { parts.push({system: await safeFetch('/api/system/info', {}, {toast: false})}); } catch(e) {}
+  try { parts.push({jobs: await safeFetch('/api/jobs', {}, {toast: false})}); } catch(e) {}
+  try { parts.push({logs: await safeFetch('/api/logs/recent?count=50', {}, {toast: false})}); } catch(e) {}
+  var text = JSON.stringify({generated_at: new Date().toISOString(), diagnostics: parts}, null, 2);
+  if (!navigator.clipboard) {
+    nativeMenuError('Clipboard access is unavailable.');
+    return;
+  }
+  await navigator.clipboard.writeText(text);
+  nativeMenuInfo('Diagnostics copied');
+}
+
+window.handleNativeMenuCommand = async function(command) {
+  try {
+    switch (command) {
+      case 'new_workspace':
+        if (typeof showCreateWorkspaceModal === 'function') showCreateWorkspaceModal();
+        else nativeMenuRoute('/workspace');
+        break;
+      case 'open_workspace':
+        if (typeof toggleWsDropdown === 'function') toggleWsDropdown();
+        else nativeMenuRoute('/workspace');
+        break;
+      case 'import_photos':
+        nativeMenuRoute('/lightroom');
+        break;
+      case 'import_folder':
+        nativeMenuRoute('/pipeline');
+        break;
+      case 'export_selected':
+        if (typeof openExportModal === 'function') openExportModal();
+        else nativeMenuError('Export is available from Browse after selecting photos.');
+        break;
+      case 'photo_open_lightbox':
+        nativeMenuOpenLightbox();
+        break;
+      case 'photo_reveal': {
+        var revealIds = nativeMenuRequirePhotos('Reveal in Finder');
+        if (!revealIds) break;
+        if (typeof revealPhoto === 'function') revealPhoto(revealIds[0]);
+        else if (typeof revealReviewPhoto === 'function') revealReviewPhoto(revealIds[0]);
+        else await nativeMenuBatch('/api/files/reveal', {photo_id: revealIds[0]});
+        break;
+      }
+      case 'photo_open_editor': {
+        var editorIds = nativeMenuRequirePhotos('Open in External Editor');
+        if (!editorIds) break;
+        if (typeof openInEditor === 'function') await openInEditor(editorIds);
+        else nativeMenuError('No external editor command is available here.');
+        break;
+      }
+      case 'photo_copy_paths': {
+        var copyIds = nativeMenuRequirePhotos('Copy Path');
+        if (!copyIds) break;
+        if (typeof copyPhotoPaths === 'function') await copyPhotoPaths(copyIds);
+        else nativeMenuError('Copy Path is available from Browse.');
+        break;
+      }
+      case 'photo_find_similar': {
+        var similarIds = nativeMenuRequirePhotos('Find Similar');
+        if (!similarIds) break;
+        if (similarIds.length !== 1) nativeMenuError('Find Similar needs one selected photo.');
+        else if (typeof findSimilar === 'function') findSimilar(similarIds[0]);
+        else nativeMenuError('Find Similar is available from Browse and Lightbox.');
+        break;
+      }
+      case 'photo_compare':
+        if (typeof openBrowseCompare === 'function') openBrowseCompare();
+        else nativeMenuRoute('/compare');
+        break;
+      case 'photo_add_keyword':
+        if (typeof batchAddKeyword === 'function') batchAddKeyword();
+        else nativeMenuError('Add Keyword is available from Browse after selecting photos.');
+        break;
+      case 'photo_add_collection':
+        if (typeof addToCollection === 'function') addToCollection();
+        else nativeMenuError('Add to Collection is available from Browse after selecting photos.');
+        break;
+      case 'photo_delete':
+        if (typeof batchDelete === 'function') batchDelete();
+        else if (typeof lightboxDelete === 'function') lightboxDelete();
+        else nativeMenuError('Delete is available from Browse or Lightbox.');
+        break;
+      case 'photo_rate_0': await nativeMenuSetRating(0); break;
+      case 'photo_rate_1': await nativeMenuSetRating(1); break;
+      case 'photo_rate_2': await nativeMenuSetRating(2); break;
+      case 'photo_rate_3': await nativeMenuSetRating(3); break;
+      case 'photo_rate_4': await nativeMenuSetRating(4); break;
+      case 'photo_rate_5': await nativeMenuSetRating(5); break;
+      case 'photo_flag_pick': await nativeMenuSetFlag('flagged'); break;
+      case 'photo_flag_reject': await nativeMenuSetFlag('rejected'); break;
+      case 'photo_flag_clear': await nativeMenuSetFlag('none'); break;
+      case 'review_accept': {
+        var acceptPending = nativeMenuPendingPredictions();
+        if (acceptPending.length && typeof acceptPrediction === 'function') await acceptPrediction(acceptPending[0].id);
+        else nativeMenuError('No pending prediction to accept.');
+        break;
+      }
+      case 'review_reject': {
+        var rejectPending = nativeMenuPendingPredictions();
+        if (rejectPending.length && typeof rejectPrediction === 'function') await rejectPrediction(rejectPending[0].id);
+        else nativeMenuError('No pending prediction to reject.');
+        break;
+      }
+      case 'review_accept_all':
+        if (typeof acceptAllPending === 'function') await acceptAllPending();
+        else nativeMenuRoute('/review');
+        break;
+      case 'review_previous':
+        if (typeof lightboxNav === 'function' && typeof _lightboxCurrentId !== 'undefined' && _lightboxCurrentId != null) lightboxNav(-1);
+        else if (typeof moveBrowseSelection === 'function') moveBrowseSelection(-1, {});
+        break;
+      case 'review_next':
+        if (typeof lightboxNav === 'function' && typeof _lightboxCurrentId !== 'undefined' && _lightboxCurrentId != null) lightboxNav(1);
+        else if (typeof moveBrowseSelection === 'function') moveBrowseSelection(1, {});
+        break;
+      case 'review_mark_wildlife':
+        await nativeMenuSetWildlifeExcluded(false);
+        break;
+      case 'review_exclude_wildlife':
+        await nativeMenuSetWildlifeExcluded(true);
+        break;
+      case 'tools_run_pipeline':
+        if (typeof startPipeline === 'function') await startPipeline();
+        else nativeMenuRoute('/pipeline');
+        break;
+      case 'tools_scan_library':
+        nativeMenuRoute('/workspace');
+        nativeMenuInfo('Choose a folder or workspace root to scan.');
+        break;
+      case 'tools_find_duplicates':
+        if (typeof startScan === 'function') await startScan();
+        else nativeMenuRoute('/duplicates');
+        break;
+      case 'tools_build_previews':
+        await nativeMenuJob('/api/jobs/previews', {}, 'Preview job started');
+        break;
+      case 'tools_sync_metadata':
+        if (typeof runSync === 'function') await runSync();
+        else await nativeMenuJob('/api/jobs/sync', {}, 'Metadata sync started');
+        break;
+      case 'tools_verify_models':
+        if (typeof verifyAllModels === 'function') await verifyAllModels();
+        else await nativeMenuJob('/api/jobs/verify-all-models', {}, 'Model verification started');
+        break;
+      case 'tools_cancel_job':
+        await nativeMenuCancelCurrentJob();
+        break;
+      case 'help_open_help':
+        if (typeof openHelpModal === 'function') openHelpModal();
+        break;
+      case 'help_copy_diagnostics':
+        await nativeMenuCopyDiagnostics();
+        break;
+      default:
+        console.warn('Unknown native menu command:', command);
+    }
+  } catch (e) {
+    nativeMenuError(e && e.message ? e.message : 'Menu command failed');
+  }
+};
+
 /* ---------- Open in External Editor ----------
  * Three entry points for opening photos in an external editor:
  *   - openInEditor(ids, editorIndex)         — direct call, posts to backend

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4887,6 +4887,17 @@ function nativeMenuPhotoIdsForWrite() {
 async function nativeMenuSetRating(rating) {
   var ids = nativeMenuPhotoIdsForWrite();
   if (!ids) return;
+  if (ids.length === 1 && nativeMenuLightboxOpen()) {
+    if (typeof setRatingFor === 'function') {
+      await setRatingFor(ids[0], rating);
+      return;
+    }
+    if (typeof setReviewRating === 'function') {
+      setReviewRating(ids[0], rating);
+      nativeMenuInfo('Rating updated');
+      return;
+    }
+  }
   if (typeof batchSetRating === 'function') {
     await batchSetRating(rating);
     return;
@@ -4902,12 +4913,19 @@ async function nativeMenuSetRating(rating) {
 async function nativeMenuSetFlag(flag) {
   var ids = nativeMenuPhotoIdsForWrite();
   if (!ids) return;
+  if (ids.length === 1 && nativeMenuLightboxOpen()) {
+    if (typeof _lbApplyFlag === 'function' && ids[0] === _lightboxCurrentId) {
+      _lbApplyFlag(ids[0], flag);
+      return;
+    }
+    if (typeof setReviewFlag === 'function') {
+      await setReviewFlag(ids[0], flag);
+      nativeMenuInfo('Flag updated');
+      return;
+    }
+  }
   if (typeof batchSetFlag === 'function') {
     await batchSetFlag(flag);
-    return;
-  }
-  if (ids.length === 1 && typeof _lbApplyFlag === 'function' && ids[0] === _lightboxCurrentId) {
-    _lbApplyFlag(ids[0], flag);
     return;
   }
   if (ids.length === 1 && typeof setReviewFlag === 'function') {
@@ -5044,11 +5062,12 @@ window.handleNativeMenuCommand = async function(command) {
         else nativeMenuError('Add to Collection is available from Browse after selecting photos.');
         break;
       case 'photo_delete':
-        if (typeof batchDelete === 'function') {
+        if (nativeMenuLightboxOpen() && typeof lightboxDelete === 'function') {
+          lightboxDelete();
+        } else if (typeof batchDelete === 'function') {
           batchDelete();
         } else {
-          if (nativeMenuLightboxOpen() && typeof lightboxDelete === 'function') lightboxDelete();
-          else nativeMenuError('Delete is available from Browse or an open Lightbox.');
+          nativeMenuError('Delete is available from Browse or an open Lightbox.');
         }
         break;
       case 'photo_rate_0': await nativeMenuSetRating(0); break;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3306,6 +3306,7 @@ function _lbApplyWildlifeExcludedButton() {
   btn.title = _lbCurrentWildlifeExcluded
     ? 'Include this photo in wildlife detection and classification'
     : 'Exclude from wildlife detection and classification';
+  btn.setAttribute('aria-label', btn.title);
 }
 
 function toggleLightboxMasks() {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4884,6 +4884,10 @@ function nativeMenuPhotoIdsForWrite() {
   return null;
 }
 
+function nativeMenuSetPhotoIdsOverride(ids) {
+  window._vireoNativeMenuPhotoIdsOverride = ids ? ids.slice() : null;
+}
+
 async function nativeMenuSetRating(rating) {
   var ids = nativeMenuPhotoIdsForWrite();
   if (!ids) return;
@@ -4940,6 +4944,9 @@ async function nativeMenuSetWildlifeExcluded(excluded) {
   var ids = nativeMenuPhotoIdsForWrite();
   if (!ids) return;
   await Promise.all(ids.map(function(id) {
+    if (typeof window.setWildlifeExcludedFor === 'function') {
+      return window.setWildlifeExcludedFor(id, excluded);
+    }
     return safeFetch('/api/photos/' + id + '/wildlife_excluded', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
@@ -5054,12 +5061,24 @@ window.handleNativeMenuCommand = async function(command) {
         else nativeMenuRoute('/compare');
         break;
       case 'photo_add_keyword':
-        if (typeof batchAddKeyword === 'function') batchAddKeyword();
-        else nativeMenuError('Add Keyword is available from Browse after selecting photos.');
+        if (typeof batchAddKeyword === 'function') {
+          var keywordIds = nativeMenuRequirePhotos('Add Keyword');
+          if (!keywordIds) break;
+          nativeMenuSetPhotoIdsOverride(keywordIds);
+          batchAddKeyword();
+        } else {
+          nativeMenuError('Add Keyword is available from Browse after selecting photos.');
+        }
         break;
       case 'photo_add_collection':
-        if (typeof addToCollection === 'function') addToCollection();
-        else nativeMenuError('Add to Collection is available from Browse after selecting photos.');
+        if (typeof addToCollection === 'function') {
+          var collectionIds = nativeMenuRequirePhotos('Add to Collection');
+          if (!collectionIds) break;
+          nativeMenuSetPhotoIdsOverride(collectionIds);
+          addToCollection();
+        } else {
+          nativeMenuError('Add to Collection is available from Browse after selecting photos.');
+        }
         break;
       case 'photo_delete':
         if (nativeMenuLightboxOpen() && typeof lightboxDelete === 'function') {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4953,6 +4953,17 @@ async function nativeMenuSetWildlifeExcluded(excluded) {
       body: JSON.stringify({excluded: excluded}),
     }, {toast: false});
   }));
+  if (typeof photos !== 'undefined' && Array.isArray(photos)) {
+    ids.forEach(function(id) {
+      var p = photos.find(function(x) { return x.id === id; });
+      if (p) p.wildlife_excluded = excluded ? 1 : 0;
+    });
+    if (typeof refreshGridCards === 'function') refreshGridCards(ids);
+    else if (typeof renderGrid === 'function') renderGrid();
+    if (typeof selectedPhotoId !== 'undefined' && ids.indexOf(selectedPhotoId) !== -1 && typeof loadDetail === 'function') {
+      loadDetail(selectedPhotoId);
+    }
+  }
   if (typeof _lightboxCurrentId !== 'undefined' && ids.indexOf(_lightboxCurrentId) !== -1) {
     _lbCurrentWildlifeExcluded = excluded;
     if (typeof _lbApplyWildlifeExcludedButton === 'function') _lbApplyWildlifeExcludedButton();

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3706,6 +3706,7 @@ function closeLightbox(e) {
   document.getElementById('lightboxOverlay').classList.remove('active');
   document.getElementById('lightboxImg').src = '';
   document.getElementById('lightboxZoomBadge').style.display = 'none';
+  _lightboxCurrentId = null;
   _lbSetFlagStatus(undefined);
   var detContainer = document.getElementById('lightboxDetections');
   if (detContainer) detContainer.innerHTML = '';
@@ -3926,7 +3927,8 @@ async function lightboxToggleWildlifeExcluded() {
 }
 
 function lightboxDelete() {
-  if (!_lightboxCurrentId) return;
+  var overlay = document.getElementById('lightboxOverlay');
+  if (!_lightboxCurrentId || !overlay || !overlay.classList.contains('active')) return;
   var currentId = _lightboxCurrentId;
   var p = _lightboxPhotoList.find(function(x) { return x.id === currentId; });
   var companionCount = (p && p.companion_path) ? 1 : 0;
@@ -4918,6 +4920,7 @@ async function nativeMenuSetWildlifeExcluded(excluded) {
   }));
   if (typeof _lightboxCurrentId !== 'undefined' && ids.indexOf(_lightboxCurrentId) !== -1) {
     _lbCurrentWildlifeExcluded = excluded;
+    if (typeof _lbApplyWildlifeExcludedButton === 'function') _lbApplyWildlifeExcludedButton();
   }
   nativeMenuInfo(excluded ? 'Excluded from wildlife classification' : 'Marked as wildlife');
 }
@@ -5031,9 +5034,14 @@ window.handleNativeMenuCommand = async function(command) {
         else nativeMenuError('Add to Collection is available from Browse after selecting photos.');
         break;
       case 'photo_delete':
-        if (typeof batchDelete === 'function') batchDelete();
-        else if (typeof lightboxDelete === 'function') lightboxDelete();
-        else nativeMenuError('Delete is available from Browse or Lightbox.');
+        if (typeof batchDelete === 'function') {
+          batchDelete();
+        } else {
+          var lightboxOpen = document.getElementById('lightboxOverlay') &&
+            document.getElementById('lightboxOverlay').classList.contains('active');
+          if (lightboxOpen && typeof lightboxDelete === 'function') lightboxDelete();
+          else nativeMenuError('Delete is available from Browse or an open Lightbox.');
+        }
         break;
       case 'photo_rate_0': await nativeMenuSetRating(0); break;
       case 'photo_rate_1': await nativeMenuSetRating(1); break;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4939,7 +4939,7 @@ async function nativeMenuJob(endpoint, body, label) {
 
 async function nativeMenuCancelCurrentJob() {
   var jobs = await safeFetch('/api/jobs', {}, {toast: false});
-  var list = Array.isArray(jobs) ? jobs : (jobs.jobs || []);
+  var list = Array.isArray(jobs) ? jobs : (jobs.active || jobs.jobs || []);
   var running = list.find(function(j) { return j.status === 'running' || j.status === 'pending'; });
   if (!running) {
     nativeMenuInfo('No running job to cancel');

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4697,7 +4697,11 @@ document.addEventListener('keydown', function(e) {
   // Suppress browse shortcuts while any modal is open
   var openModal = document.querySelector('.modal-overlay.open');
   if (openModal) {
-    if (e.key === 'Escape') { openModal.classList.remove('open'); }
+    if (e.key === 'Escape') {
+      if (openModal.id === 'batchKeywordModal') hideBatchKeywordModal();
+      else if (openModal.id === 'batchCollectionModal') hideBatchCollectionModal();
+      else openModal.classList.remove('open');
+    }
     return;
   }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3291,6 +3291,9 @@ function selectPhoto(e, id, idx) {
 // cmd/shift-clicks, the single id for a normal click focus. Single-focused
 // photos count as selected for the purposes of batch actions.
 function getActiveSelection() {
+  if (window._vireoNativeMenuPhotoIdsOverride && window._vireoNativeMenuPhotoIdsOverride.length) {
+    return window._vireoNativeMenuPhotoIdsOverride.slice();
+  }
   if (selectedPhotos.size > 0) return Array.from(selectedPhotos);
   if (selectedPhotoId != null) return [selectedPhotoId];
   return [];
@@ -3638,14 +3641,15 @@ function batchAddKeyword() {
 function hideBatchKeywordModal() {
   document.getElementById('batchKeywordModal').classList.remove('open');
   hideKeywordSuggestions('batchKeywordInput');
+  window._vireoNativeMenuPhotoIdsOverride = null;
 }
 
 async function confirmBatchKeyword() {
   var input = document.getElementById('batchKeywordInput');
   var name = input.value.trim();
   if (!name) return;
-  hideBatchKeywordModal();
   var ids = getActiveSelection();
+  hideBatchKeywordModal();
   var state = getKeywordAutocompleteState('batchKeywordInput');
   var selectedKeyword = state.selectedKeyword && state.selectedKeyword.name === name
     ? state.selectedKeyword
@@ -3702,12 +3706,18 @@ var _batchCollectionSelectedId = null;
 
 async function addToCollection() {
   var activeIds = getActiveSelection();
-  if (activeIds.length === 0) return;
+  if (activeIds.length === 0) {
+    window._vireoNativeMenuPhotoIdsOverride = null;
+    return;
+  }
 
   var collections;
   try {
     collections = await safeFetch('/api/collections', {}, { toast: false });
-  } catch(e) { return; }
+  } catch(e) {
+    window._vireoNativeMenuPhotoIdsOverride = null;
+    return;
+  }
 
   _batchCollections = collections;
   _batchCollectionSelectedId = null;
@@ -3736,6 +3746,7 @@ function pickBatchCollection(id) {
 
 function hideBatchCollectionModal() {
   document.getElementById('batchCollectionModal').classList.remove('open');
+  window._vireoNativeMenuPhotoIdsOverride = null;
 }
 
 async function confirmBatchCollection() {


### PR DESCRIPTION
Adds native File, Photo, Review, Tools, and Help menu commands so Vireo exposes core workflows through the macOS menu bar.
Menu command events now dispatch into the webview and reuse existing page helpers, modals, and API endpoints for actions like export, reveal, rating, flagging, pipeline jobs, duplicate scans, model verification, and diagnostics.
The View menu also gains missing navigation destinations, and the old Import route now points at the existing Lightroom import page.

Validation: `cargo check` in `src-tauri` with a temporary sidecar placeholder, `node --check` for the inserted native-menu JS block, and `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded native menu with new File, Photo, Review, Tools, View and Help entries (import/export, rapid review, misses, highlights, duplicates, jobs, Lightroom, shortcuts, diagnostics).
  * Native menu commands now invoke frontend actions: navigation, lightbox controls, batch write/job operations, rating/flag/wildlife updates, review tooling, and diagnostics copy.

* **Bug Fixes**
  * Lightbox accessibility and state fixes: updated aria-label, cleared stale selection on close, and safer delete behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->