### PR TITLE
Add zoom test to command palette

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -65,6 +65,7 @@ ALL_PAGES = [
     {"id": "dashboard",       "label": "Dashboard",       "href": "/dashboard"},
     {"id": "audit",           "label": "Audit",           "href": "/audit"},
     {"id": "compare",         "label": "Compare",         "href": "/compare"},
+    {"id": "zoom_test",       "label": "Zoom Test",       "href": "/zoom-test"},
     {"id": "settings",        "label": "Settings",        "href": "/settings"},
     {"id": "workspace",       "label": "Workspace",       "href": "/workspace"},
     {"id": "lightroom",       "label": "Lightroom",       "href": "/lightroom"},

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -63,7 +63,7 @@ ALL_NAV_IDS = frozenset({
     "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
     "misses", "highlights", "browse", "map", "variants",
     "dashboard", "audit", "compare",
-    "settings", "workspace", "lightroom", "shortcuts",
+    "zoom_test", "settings", "workspace", "lightroom", "shortcuts",
     "keywords", "duplicates", "logs",
 })
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1861,6 +1861,7 @@ window.NAV_ALL_PAGES = [
   {id: 'dashboard',       label: 'Dashboard',       href: '/dashboard'},
   {id: 'audit',           label: 'Audit',           href: '/audit'},
   {id: 'compare',         label: 'Compare',         href: '/compare'},
+  {id: 'zoom_test',       label: 'Zoom Test',       href: '/zoom-test'},
   {id: 'settings',        label: 'Settings',        href: '/settings'},
   {id: 'workspace',       label: 'Workspace',       href: '/workspace'},
   {id: 'lightroom',       label: 'Lightroom',       href: '/lightroom'},

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -10082,7 +10082,7 @@ def test_all_nav_ids_covers_every_page():
         "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
         "misses", "highlights", "browse", "map", "variants",
         "dashboard", "audit", "compare",
-        "settings", "workspace", "lightroom", "shortcuts",
+        "zoom_test", "settings", "workspace", "lightroom", "shortcuts",
         "keywords", "duplicates", "logs",
     }
     assert expected == ALL_NAV_IDS


### PR DESCRIPTION
Adds the Zoom Test page to the shared page registry used by Cmd-K and user navigation settings. Updates the navbar JavaScript fallback and nav ID coverage test so the registry stays consistent. Also records the Lightroom comparison findings in a lightbox zoom design note, with Natural Layout: Device 1:1 as the implementation target. Verified with focused app and DB tests.