### PR TITLE
Fix lightbox device-pixel 1:1 zoom

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -196,6 +196,12 @@ def test_browse_lightbox_defers_one_to_one_until_original_size_known(live_server
         "**/photos/*/full",
         lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
     )
+    held_original = {}
+
+    def hold_original(route):
+        held_original["route"] = route
+
+    page.route("**/photos/*/original", hold_original)
 
     url = live_server["url"]
     page.set_viewport_size({"width": 1000, "height": 800})
@@ -246,17 +252,31 @@ def test_browse_lightbox_defers_one_to_one_until_original_size_known(live_server
         }"""
     )
     assert upgraded is True
+    if "route" in held_original:
+        held_original.pop("route").abort()
 
 
 def test_browse_lightbox_does_not_retry_original_after_unavailable(live_server, page):
     """After /original fails, source selection should stay on preview/full tiers."""
-    svg = (
+    full_svg = (
         '<svg xmlns="http://www.w3.org/2000/svg" width="8000" height="4000" '
         'viewBox="0 0 8000 4000"><rect width="8000" height="4000" fill="#246"/></svg>'
     )
+    fallback_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="3840" height="1920" '
+        'viewBox="0 0 3840 1920"><rect width="3840" height="1920" fill="#642"/></svg>'
+    )
     page.route(
         "**/photos/*/full",
-        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+        lambda route: route.fulfill(body=full_svg, content_type="image/svg+xml"),
+    )
+    page.route(
+        "**/photos/*/original",
+        lambda route: route.abort(),
+    )
+    page.route(
+        "**/photos/*/preview?size=3840",
+        lambda route: route.fulfill(body=fallback_svg, content_type="image/svg+xml"),
     )
 
     url = live_server["url"]
@@ -292,6 +312,24 @@ def test_browse_lightbox_does_not_retry_original_after_unavailable(live_server, 
 
     assert choices["unknownDimsChoice"] == "full"
     assert choices["largeNeededChoice"] == "3840"
+
+    page.evaluate(
+        """() => {
+            window._lbOriginalUnavailable = false;
+            window._lbZoom = 100;
+            window._lbNativeZoom = 100;
+            window._lbFullLongEdge = 1000;
+            window._lbScheduleSourceSwap();
+        }"""
+    )
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return window._lbOriginalUnavailable &&
+                   window._lbCurrentSrcKey === '3840' &&
+                   img && img.complete && img.naturalWidth === 3840;
+        }"""
+    )
 
 
 def test_browse_e_f_g_keyboard_modes(live_server, page):

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -144,9 +144,17 @@ def test_browse_lightbox_one_to_one_uses_device_pixels_and_natural_layout(live_s
     page.wait_for_function(
         """() => {
             const img = document.getElementById('lightboxImg');
-            return img && img.complete && img.naturalWidth === 4000 && window._lbNativeZoom > 1;
+            return img && img.complete && img.naturalWidth === 4000;
         }"""
     )
+    page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbRecomputeNativeZoom();
+        }"""
+    )
+    page.wait_for_function("window._lbNativeZoom > 1")
 
     page.keyboard.press("z")
     metrics = page.evaluate(
@@ -173,6 +181,117 @@ def test_browse_lightbox_one_to_one_uses_device_pixels_and_natural_layout(live_s
     assert metrics["styleHeight"] == "2000px"
     assert abs(metrics["rectWidth"] - 2000) < 2
     assert abs(metrics["rectHeight"] - 1000) < 2
+
+
+def test_browse_lightbox_defers_one_to_one_until_original_size_known(live_server, page):
+    """A loaded preview/full tier must not masquerade as true 1:1."""
+    page.add_init_script(
+        "Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true });"
+    )
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="960" '
+        'viewBox="0 0 1920 960"><rect width="1920" height="960" fill="#274"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+    )
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 1920;
+        }"""
+    )
+
+    state = page.evaluate(
+        """() => {
+            window._lbPhotoW = null;
+            window._lbPhotoH = null;
+            window._lbOriginalUnavailable = false;
+            window._lbCurrentSrcKey = 'full';
+            window._lbZoom = 1;
+            window._lbRecomputeNativeZoom();
+            window.toggleLightboxZoom();
+            return {
+                nativeZoom: window._lbNativeZoom,
+                pending: window._lbPending1To1,
+                zoom: window._lbZoom,
+                sourceKey: window._lbPickSourceKey(),
+            };
+        }"""
+    )
+
+    assert state["nativeZoom"] is None
+    assert state["pending"] is True
+    assert state["zoom"] > 1
+    assert state["sourceKey"] == "original"
+
+    upgraded = page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbRecomputeNativeZoom();
+            window._lbApplyPendingOneToOneZoom();
+            return Math.abs(window._lbZoom - window._lbNativeZoom) < 0.01;
+        }"""
+    )
+    assert upgraded is True
+
+
+def test_browse_lightbox_does_not_retry_original_after_unavailable(live_server, page):
+    """After /original fails, source selection should stay on preview/full tiers."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="8000" height="4000" '
+        'viewBox="0 0 8000 4000"><rect width="8000" height="4000" fill="#246"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+    )
+
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 8000;
+        }"""
+    )
+    choices = page.evaluate(
+        """() => {
+            window._lbOriginalUnavailable = true;
+            window._lbZoom = 2;
+            window._lbNativeZoom = null;
+            const unknownDimsChoice = window._lbPickSourceKey();
+            window._lbPhotoW = 8000;
+            window._lbPhotoH = 4000;
+            window._lbFullLongEdge = 1000;
+            window._lbFitScale = 0.1;
+            window._lbNativeZoom = 100;
+            window._lbZoom = 100;
+            const largeNeededChoice = window._lbPickSourceKey();
+            return { unknownDimsChoice, largeNeededChoice };
+        }"""
+    )
+
+    assert choices["unknownDimsChoice"] == "full"
+    assert choices["largeNeededChoice"] == "3840"
 
 
 def test_browse_e_f_g_keyboard_modes(live_server, page):

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -1,4 +1,5 @@
 import base64
+import time
 
 from playwright.sync_api import expect
 
@@ -330,6 +331,73 @@ def test_browse_lightbox_does_not_retry_original_after_unavailable(live_server, 
                    img && img.complete && img.naturalWidth === 3840;
         }"""
     )
+
+
+def test_browse_lightbox_ignores_stale_original_failure_after_nav(live_server, page):
+    """A late /original error from the previous photo must not poison the next photo."""
+    full_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="8000" height="4000" '
+        'viewBox="0 0 8000 4000"><rect width="8000" height="4000" fill="#246"/></svg>'
+    )
+    held_original = {}
+
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=full_svg, content_type="image/svg+xml"),
+    )
+
+    def hold_original(route):
+        if "route" not in held_original:
+            held_original["route"] = route
+        else:
+            route.abort()
+
+    page.route("**/photos/*/original", hold_original)
+
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 8000;
+        }"""
+    )
+
+    with page.expect_request("**/photos/*/original"):
+        page.evaluate(
+            """() => {
+                window._lbPhotoW = 8000;
+                window._lbPhotoH = 4000;
+                window._lbFullLongEdge = 1000;
+                window._lbOriginalUnavailable = false;
+                window._lbZoom = 100;
+                window._lbNativeZoom = 100;
+                window._lbCurrentSrcKey = 'full';
+                window._lbScheduleSourceSwap();
+            }"""
+        )
+    deadline = time.time() + 2
+    while "route" not in held_original and time.time() < deadline:
+        page.wait_for_timeout(25)
+    assert "route" in held_original
+
+    page.evaluate(
+        """() => {
+            const next = window._lightboxPhotoList[1];
+            window.openLightbox(next.id, next.filename, window._lightboxPhotoList);
+        }"""
+    )
+    page.wait_for_function("window._lightboxCurrentId === window._lightboxPhotoList[1].id")
+    held_original.pop("route").abort()
+    page.wait_for_timeout(100)
+
+    assert page.evaluate("window._lbOriginalUnavailable") is False
 
 
 def test_browse_e_f_g_keyboard_modes(live_server, page):

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -113,6 +113,68 @@ def test_browse_lightbox_one_to_one_nav_falls_back_when_original_fails(live_serv
     assert "/full" in page.locator("#lightboxImg").get_attribute("src")
 
 
+def test_browse_lightbox_one_to_one_uses_device_pixels_and_natural_layout(live_server, page):
+    """1:1 uses natural image coordinates and maps source pixels to device pixels."""
+    page.add_init_script(
+        "Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true });"
+    )
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#3a7"/>'
+        '<path d="M0 0L4000 2000M4000 0L0 2000" stroke="#fff" stroke-width="12"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+    )
+    page.route(
+        "**/photos/*/original",
+        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+    )
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 4000 && window._lbNativeZoom > 1;
+        }"""
+    )
+
+    page.keyboard.press("z")
+    metrics = page.evaluate(
+        """() => {
+            const t = document.getElementById('lightboxTransform');
+            const rect = t.getBoundingClientRect();
+            return {
+                dpr: window.devicePixelRatio,
+                zoom: window._lbZoom,
+                nativeZoom: window._lbNativeZoom,
+                fitScale: window._lbFitScale,
+                styleWidth: t.style.width,
+                styleHeight: t.style.height,
+                rectWidth: rect.width,
+                rectHeight: rect.height,
+            };
+        }"""
+    )
+
+    expected_native_zoom = (1 / metrics["dpr"]) / metrics["fitScale"]
+    assert abs(metrics["nativeZoom"] - expected_native_zoom) < 0.01
+    assert abs(metrics["zoom"] - metrics["nativeZoom"]) < 0.01
+    assert metrics["styleWidth"] == "4000px"
+    assert metrics["styleHeight"] == "2000px"
+    assert abs(metrics["rectWidth"] - 2000) < 2
+    assert abs(metrics["rectHeight"] - 1000) < 2
+
+
 def test_browse_e_f_g_keyboard_modes(live_server, page):
     """Browse grid shortcuts open the image, request fullscreen, and return to grid."""
     url = live_server["url"]

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4375,6 +4375,7 @@ function _lbRecomputeNativeZoom() {
   var dpr = window.devicePixelRatio || 1;
   // Guard: very small images (nativeZoom < 1) clamp to 1.0 so fit == 1:1
   _lbNativeZoom = Math.max(1.0, (1 / dpr) / _lbFitScale);
+  _lbApplyTransform();
 }
 
 function _lbSetZoom(newZoom, anchorClientX, anchorClientY) {
@@ -4554,6 +4555,7 @@ function _lbScheduleSourceSwap() {
         _lbOriginalUnavailable = true;
         _lbRecomputeNativeZoom();
         _lbApplyTransform();
+        _lbScheduleSourceSwap();
       }
       // Keep current source on failure
     };

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4360,6 +4360,13 @@ function _lbRecomputeNativeZoom() {
     _lbNativeZoom = null;
     return;
   }
+  if (!_lbPhotoW && !_lbPhotoH && !_lbOriginalUnavailable && _lbCurrentSrcKey !== 'original') {
+    // A preview/full tier can load before the metadata request returns. Do not
+    // treat that tier's decoded size as true 1:1; keep z/click in pending mode
+    // so the later original dimensions can upgrade the zoom accurately.
+    _lbNativeZoom = null;
+    return;
+  }
   var metrics = _lbUpdateLayoutMetrics();
   if (!metrics || !_lbFitScale) {
     _lbNativeZoom = null;
@@ -4471,7 +4478,7 @@ function _lbPickSourceKey() {
   // initial image load completes).
   var dims = _lbLayoutDims();
   if (!dims || !_lbNativeZoom) {
-    return _lbZoom > 1.001 ? 'original' : 'full';
+    return (_lbZoom > 1.001 && !_lbOriginalUnavailable) ? 'original' : 'full';
   }
   var longEdge = Math.max(dims.w, dims.h);
   var displayedLong = longEdge * _lbFitScale * _lbZoom;
@@ -4485,7 +4492,7 @@ function _lbPickSourceKey() {
   if (needed <= fullLongEdge) return 'full';
   if (needed <= 2560) return '2560';
   if (needed <= 3840) return '3840';
-  return 'original';
+  return _lbOriginalUnavailable ? '3840' : 'original';
 }
 
 function _lbSrcUrl(photoId, key) {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4512,6 +4512,7 @@ function _lbScheduleSourceSwap() {
     if (_lbDesiredSrcKey !== desired) return;          // newer request won
     if (_lbDesiredSrcKey === _lbCurrentSrcKey) return; // already there
     var photoId = _lightboxCurrentId;
+    var swapOpenSeq = _lbOpenSeq;
     var key = _lbDesiredSrcKey;
     var url = _lbSrcUrl(photoId, key);
 
@@ -4519,6 +4520,7 @@ function _lbScheduleSourceSwap() {
     preloader.onload = function() {
       // Ignore stale: different photo, or desired key changed to something else
       if (_lightboxCurrentId !== photoId) return;
+      if (_lbOpenSeq !== swapOpenSeq) return;
       if (_lbDesiredSrcKey !== key) return;
       var img = document.getElementById('lightboxImg');
       if (!img) return;
@@ -4529,6 +4531,7 @@ function _lbScheduleSourceSwap() {
       img.addEventListener('load', function onSwapLoad() {
         img.removeEventListener('load', onSwapLoad);
         if (_lightboxCurrentId !== photoId) return;
+        if (_lbOpenSeq !== swapOpenSeq) return;
         // A newer swap may have preempted us before this load fired — in that
         // case img.naturalWidth belongs to a DIFFERENT source than our closure's
         // `key`, so bail rather than record wrong dims or recalibrate stale state.
@@ -4549,6 +4552,8 @@ function _lbScheduleSourceSwap() {
       _lbCurrentSrcKey = key;
     };
     preloader.onerror = function() {
+      if (_lightboxCurrentId !== photoId) return;
+      if (_lbOpenSeq !== swapOpenSeq) return;
       if (key === 'original') {
         _lbOriginalUnavailable = true;
         _lbRecomputeNativeZoom();

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -423,9 +423,6 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   height: 92vh;
   overflow: hidden;
   position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 .lightbox-img-wrap.zoomed {
   cursor: grab;
@@ -435,15 +432,19 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 }
 .lightbox-transform {
   /* Shared container for img + detection overlay; gets transform applied */
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
   transform-origin: 0 0;
   will-change: transform;
 }
-.lightbox-overlay img {
-  max-width: 95vw;
-  max-height: 92vh;
+#lightboxImg {
+  position: static;
   display: block;
-  object-fit: contain;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
   border-radius: 4px;
   cursor: zoom-in;
   user-select: none;
@@ -2914,12 +2915,14 @@ var _lbZoom = 1.0;          // current zoom (1.0 = fit)
 var _lbPanX = 0;            // pan translation in CSS pixels
 var _lbPanY = 0;
 var _lbNativeZoom = null;   // zoom value corresponding to 1:1 for current photo
+var _lbFitScale = 1.0;      // natural image scale at zoom=1.0
 var _lbPhotoW = null;       // original photo width (px)
 var _lbPhotoH = null;       // original photo height (px)
 var _lbCurrentSrcKey = null; // 'full' | '2560' | '3840' | 'original'
 var _lbFullLongEdge = null;  // actual long edge of /full for current photo (may be < 1920 if preview_max_size is configured low)
 var _lbSessionFullLongEdge = null;  // last learned /full size across photos; better fallback than hardcoded 1920 for custom preview_max_size
 var _lbPending1To1 = false;  // true when z/click was pressed with unknown nativeZoom; upgrade to true 1:1 once learned
+var _lbOriginalUnavailable = false;  // true after /original fails; fall back to current decoded source dimensions
 var _lbCurrentWildlifeExcluded = false;
 var _lbFlagEditSeq = 0;      // increments for local flag writes so stale metadata fetches cannot overwrite the chip
 var _lbOpenSeq = 0;          // increments for every lightbox open so old metadata fetches cannot reapply after reopen
@@ -3439,6 +3442,7 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbCurrentSrcKey = preserveOneToOne ? 'original' : 'full';
   _lbFullLongEdge = null;
   _lbPending1To1 = preserveOneToOne;
+  _lbOriginalUnavailable = false;
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;
   _lbApplyTransform();  // Clear stale pan while preserving 1:1 scale when requested.
@@ -3486,6 +3490,7 @@ function openLightbox(photoId, filename, photoList, options) {
       img.onerror = null;
       return;
     }
+    _lbOriginalUnavailable = true;
     _lbCurrentSrcKey = 'full';
     _lbDesiredSrcKey = null;
     img.onload = handleInitialImageLoad;
@@ -4280,7 +4285,13 @@ function formatShortcut(str) {
 function _lbApplyTransform() {
   var t = document.getElementById('lightboxTransform');
   if (!t) return;
-  t.style.transform = 'translate(' + _lbPanX + 'px, ' + _lbPanY + 'px) scale(' + _lbZoom + ')';
+  var metrics = _lbUpdateLayoutMetrics();
+  if (!metrics) return;
+  var renderedW = metrics.w * metrics.scale;
+  var renderedH = metrics.h * metrics.scale;
+  var tx = (metrics.wrapW - renderedW) / 2 + _lbPanX;
+  var ty = (metrics.wrapH - renderedH) / 2 + _lbPanY;
+  t.style.transform = 'translate(' + tx + 'px, ' + ty + 'px) scale(' + metrics.scale + ')';
   var badge = document.getElementById('lightboxZoomBadge');
   if (!badge) return;
   if (_lbZoom <= 1.001) {
@@ -4294,30 +4305,69 @@ function _lbApplyTransform() {
   }
 }
 
-function _lbRecomputeNativeZoom() {
-  // Compute zoom value that corresponds to 1:1 (one screen pixel == one image pixel).
-  // We need the displayed size of the image at zoom=1.0 (fit) to compare against native.
+function _lbOrientedPhotoDims(img) {
+  if (!_lbPhotoW || !_lbPhotoH) return null;
+  var w = _lbPhotoW;
+  var h = _lbPhotoH;
+  if (img && img.naturalWidth && img.naturalHeight) {
+    var storedAspect = w / h;
+    var imgAspect = img.naturalWidth / img.naturalHeight;
+    if (Math.abs(storedAspect - imgAspect) > Math.abs((1 / storedAspect) - imgAspect)) {
+      w = _lbPhotoH;
+      h = _lbPhotoW;
+    }
+  }
+  return { w: w, h: h };
+}
+
+function _lbLayoutDims() {
   var img = document.getElementById('lightboxImg');
-  if (!img || !img.complete || !_lbPhotoW || !_lbPhotoH || !img.naturalWidth || !img.naturalHeight) {
+  if (!img) return null;
+  // While /original is available, keep the transform layer in original photo
+  // coordinates even if the currently displayed tier is /full. That matches the
+  // sharp zoom-test path and avoids recalibrating pan/zoom when the source swaps.
+  var originalDims = !_lbOriginalUnavailable ? _lbOrientedPhotoDims(img) : null;
+  if (originalDims) return originalDims;
+  if (img.naturalWidth && img.naturalHeight) {
+    return { w: img.naturalWidth, h: img.naturalHeight };
+  }
+  return null;
+}
+
+function _lbUpdateLayoutMetrics() {
+  var wrap = document.getElementById('lightboxWrap');
+  var t = document.getElementById('lightboxTransform');
+  if (!wrap || !t) return null;
+  var dims = _lbLayoutDims();
+  if (!dims || !dims.w || !dims.h) return null;
+  var wrapW = wrap.clientWidth;
+  var wrapH = wrap.clientHeight;
+  if (!wrapW || !wrapH) return null;
+  _lbFitScale = Math.min(1.0, wrapW / dims.w, wrapH / dims.h);
+  if (!_lbFitScale || _lbFitScale <= 0) _lbFitScale = 1.0;
+  t.style.width = dims.w + 'px';
+  t.style.height = dims.h + 'px';
+  var scale = _lbFitScale * _lbZoom;
+  return { w: dims.w, h: dims.h, wrapW: wrapW, wrapH: wrapH, scale: scale };
+}
+
+function _lbRecomputeNativeZoom() {
+  // Compute zoom value that corresponds to 1:1: one decoded source pixel per
+  // physical display pixel. On Retina/HiDPI displays this is intentionally
+  // smaller than CSS 1:1 by devicePixelRatio.
+  var img = document.getElementById('lightboxImg');
+  if (!img || !img.complete || !img.naturalWidth || !img.naturalHeight) {
     _lbNativeZoom = null;
     return;
   }
-  var fitDisplayedW = img.clientWidth || img.naturalWidth;
-  if (fitDisplayedW <= 0) {
+  var metrics = _lbUpdateLayoutMetrics();
+  if (!metrics || !_lbFitScale) {
     _lbNativeZoom = null;
     return;
   }
-  // Stored dims from /api/photos are pre-EXIF-orientation (scanner reads raw EXIF
-  // width/height). The loaded image applies orientation. If the aspect ratios disagree,
-  // the stored dims are rotated 90°; swap to match the displayed image.
-  var photoW = _lbPhotoW;
-  var storedAspect = _lbPhotoW / _lbPhotoH;
-  var imgAspect = img.naturalWidth / img.naturalHeight;
-  if (Math.abs(storedAspect - imgAspect) > Math.abs((1 / storedAspect) - imgAspect)) {
-    photoW = _lbPhotoH;
-  }
+  var dpr = window.devicePixelRatio || 1;
   // Guard: very small images (nativeZoom < 1) clamp to 1.0 so fit == 1:1
-  _lbNativeZoom = Math.max(1.0, photoW / fitDisplayedW);
+  _lbNativeZoom = Math.max(1.0, (1 / dpr) / _lbFitScale);
 }
 
 function _lbSetZoom(newZoom, anchorClientX, anchorClientY) {
@@ -4332,12 +4382,20 @@ function _lbSetZoom(newZoom, anchorClientX, anchorClientY) {
   var t = document.getElementById('lightboxTransform');
   if (!wrap || !t) return;
 
-  // The transform container is flex-centered in the wrap, so wrap-local
-  // coordinates are NOT image-local. Use the transform element's own
-  // getBoundingClientRect() — it already bakes in the current translate+scale.
-  // Cursor at clientX has image-local coord (clientX - rect.left) / zoom.
+  var metrics = _lbUpdateLayoutMetrics();
+  if (!metrics) {
+    _lbZoom = newZoom;
+    if (_lbZoom <= 1.001) {
+      _lbPanX = 0;
+      _lbPanY = 0;
+    }
+    wrap.classList.toggle('zoomed', _lbZoom > 1.001);
+    _lbApplyTransform();
+    _lbScheduleSourceSwap();
+    return;
+  }
+  // Cursor at clientX has image-local coord (clientX - rect.left) / scale.
   // Anchor invariant: that image coord must still land under the cursor after zoom.
-  //   newPanX = _lbPanX + (clientX - rect.left) - imgX * newZoom
   var rect = t.getBoundingClientRect();
   var anchorX, anchorY;
   if (anchorClientX != null && anchorClientY != null) {
@@ -4349,10 +4407,15 @@ function _lbSetZoom(newZoom, anchorClientX, anchorClientY) {
     anchorX = wrapRect.left + wrapRect.width / 2;
     anchorY = wrapRect.top + wrapRect.height / 2;
   }
-  var imgX = (anchorX - rect.left) / _lbZoom;
-  var imgY = (anchorY - rect.top) / _lbZoom;
-  _lbPanX = _lbPanX + (anchorX - rect.left) - imgX * newZoom;
-  _lbPanY = _lbPanY + (anchorY - rect.top) - imgY * newZoom;
+  var currentScale = metrics.scale;
+  var imgX = (anchorX - rect.left) / currentScale;
+  var imgY = (anchorY - rect.top) / currentScale;
+  var newScale = _lbFitScale * newZoom;
+  var newBaseX = anchorX - imgX * newScale;
+  var newBaseY = anchorY - imgY * newScale;
+  var wrapRectForBase = wrap.getBoundingClientRect();
+  _lbPanX = newBaseX - (wrapRectForBase.left + (wrapRectForBase.width - metrics.w * newScale) / 2);
+  _lbPanY = newBaseY - (wrapRectForBase.top + (wrapRectForBase.height - metrics.h * newScale) / 2);
   _lbZoom = newZoom;
 
   if (_lbZoom <= 1.001) {
@@ -4367,43 +4430,30 @@ function _lbSetZoom(newZoom, anchorClientX, anchorClientY) {
 }
 
 function _lbClampPan() {
-  var wrap = document.getElementById('lightboxWrap');
-  var t = document.getElementById('lightboxTransform');
-  if (!wrap || !t) return;
-  var img = document.getElementById('lightboxImg');
-  if (!img) return;
-  var wrapW = wrap.clientWidth;
-  var wrapH = wrap.clientHeight;
-  // Pre-transform size of the transform container equals img.clientWidth/Height,
-  // because #lightboxDetections is absolutely positioned.
-  var baseW = img.clientWidth;
-  var baseH = img.clientHeight;
-  if (!baseW || !baseH) return;
+  var metrics = _lbUpdateLayoutMetrics();
+  if (!metrics) return;
   // Effective rendered size after scale
-  var scaledW = baseW * _lbZoom;
-  var scaledH = baseH * _lbZoom;
-  // The transform element's pre-transform top-left is determined by flex centering.
-  // Flex-centered top-left = ((wrapW - baseW) / 2, (wrapH - baseH) / 2)
-  var baseLeft = (wrapW - baseW) / 2;
-  var baseTop = (wrapH - baseH) / 2;
-  // After applying transform, the rendered top-left is baseLeft + _lbPanX,
-  // and the rendered bottom-right is baseLeft + _lbPanX + scaledW.
+  var scaledW = metrics.w * metrics.scale;
+  var scaledH = metrics.h * metrics.scale;
+  var baseLeft = (metrics.wrapW - scaledW) / 2;
+  var baseTop = (metrics.wrapH - scaledH) / 2;
+  // After applying transform, rendered top-left is base + pan.
   // Clamp so at least minVisible px of image stays inside the wrap, per axis.
   var minVisible = 80;
   // X: rendered right >= minVisible; rendered left <= wrapW - minVisible
   //   panX >= minVisible - baseLeft - scaledW
   //   panX <= wrapW - minVisible - baseLeft
   var minPanX = minVisible - baseLeft - scaledW;
-  var maxPanX = wrapW - minVisible - baseLeft;
-  if (scaledW <= wrapW) {
+  var maxPanX = metrics.wrapW - minVisible - baseLeft;
+  if (scaledW <= metrics.wrapW) {
     // Image fits horizontally; center it
     _lbPanX = 0;
   } else {
     _lbPanX = Math.max(minPanX, Math.min(maxPanX, _lbPanX));
   }
   var minPanY = minVisible - baseTop - scaledH;
-  var maxPanY = wrapH - minVisible - baseTop;
-  if (scaledH <= wrapH) {
+  var maxPanY = metrics.wrapH - minVisible - baseTop;
+  if (scaledH <= metrics.wrapH) {
     _lbPanY = 0;
   } else {
     _lbPanY = Math.max(minPanY, Math.min(maxPanY, _lbPanY));
@@ -4419,15 +4469,12 @@ function _lbPickSourceKey() {
   // a proper displayed-long-edge (photo dims missing, or nativeZoom not yet
   // established — the latter happens briefly when API dims arrive before the
   // initial image load completes).
-  if (!_lbPhotoW || !_lbPhotoH || !_lbNativeZoom) {
+  var dims = _lbLayoutDims();
+  if (!dims || !_lbNativeZoom) {
     return _lbZoom > 1.001 ? 'original' : 'full';
   }
-  var longEdge = Math.max(_lbPhotoW, _lbPhotoH);
-  // Displayed long edge in CSS pixels at current zoom.
-  // At zoom == _lbNativeZoom, displayed long edge == longEdge.
-  var displayedLong = (_lbNativeZoom && _lbNativeZoom > 0)
-    ? longEdge * (_lbZoom / _lbNativeZoom)
-    : 0;
+  var longEdge = Math.max(dims.w, dims.h);
+  var displayedLong = longEdge * _lbFitScale * _lbZoom;
   // DPR consideration: high-DPI screens need more pixels for a crisp display.
   var dpr = window.devicePixelRatio || 1;
   var needed = displayedLong * dpr;
@@ -4496,6 +4543,11 @@ function _lbScheduleSourceSwap() {
       _lbCurrentSrcKey = key;
     };
     preloader.onerror = function() {
+      if (key === 'original') {
+        _lbOriginalUnavailable = true;
+        _lbRecomputeNativeZoom();
+        _lbApplyTransform();
+      }
       // Keep current source on failure
     };
     preloader.src = url;

--- a/vireo/tests/test_tabs_api.py
+++ b/vireo/tests/test_tabs_api.py
@@ -109,6 +109,7 @@ def test_reorder_tabs_rejects_non_string_entries(app_and_db):
 
 
 def test_get_tabs_endpoint_new_shape(app_and_db):
+    from app import ALL_PAGES
     from db import DEFAULT_TABS
     app, db = app_and_db
     client = app.test_client()
@@ -119,8 +120,9 @@ def test_get_tabs_endpoint_new_shape(app_and_db):
     assert "all_pages" in body
     # all_pages must include every nav id, in a stable order, with label and href
     ids = [p["id"] for p in body["all_pages"]]
+    expected_ids = [p["id"] for p in ALL_PAGES]
     assert "duplicates" in ids
     assert "browse" in ids
-    assert len(ids) == 21
+    assert ids == expected_ids
     sample = next(p for p in body["all_pages"] if p["id"] == "duplicates")
     assert sample == {"id": "duplicates", "label": "Duplicates", "href": "/duplicates"}


### PR DESCRIPTION
Updates the shared lightbox to render from natural image coordinates and compute 1:1 as one source pixel per device pixel. This matches the winning Zoom Test strategy, fixes the HiDPI 200% apparent zoom issue, and avoids the current fit-layer resampling path. Adds a Playwright regression that forces a 2x display and verifies the natural 4000px layer renders as 2000 CSS px at 1:1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added E2E coverage for lightbox 1:1/device-pixel scaling, deferring 1:1 until original size is known, and avoiding retries when original tier is unavailable. Updated a unit test to derive expected navigation pages from app configuration.

* **Refactor**
  * Reworked lightbox transform/zoom/pan logic to use explicit layout metrics for consistent geometry and source selection.

* **Bug Fixes**
  * Improved zoom/pan consistency across source swaps and ensured reliable fallback when original sources fail.

* **Style**
  * Updated lightbox layout/CSS for more reliable transform rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->