### PR TITLE
Remove eye compare review experiment

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1279,10 +1279,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def pipeline_review_page():
         return render_template("pipeline_review.html")
 
-    @app.route("/pipeline/eye-review")
-    def pipeline_eye_review_page():
-        return render_template("pipeline_review.html")
-
     @app.route("/pipeline/rapid-review")
     def pipeline_rapid_review_page():
         return render_template("pipeline_rapid_review.html")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1274,10 +1274,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def pipeline_review_page():
         return render_template("pipeline_review.html")
 
-    @app.route("/pipeline/eye-review")
-    def pipeline_eye_review_page():
-        return render_template("pipeline_review.html")
-
     @app.route("/pipeline/rapid-review")
     def pipeline_rapid_review_page():
         return render_template("pipeline_rapid_review.html")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -54,7 +54,6 @@ ALL_PAGES = [
     {"id": "pipeline",        "label": "Pipeline",        "href": "/pipeline"},
     {"id": "jobs",            "label": "Jobs",            "href": "/jobs"},
     {"id": "pipeline_review", "label": "Pipeline Review", "href": "/pipeline/review"},
-    {"id": "pipeline_eye_review", "label": "Eye Compare", "href": "/pipeline/eye-review"},
     {"id": "pipeline_rapid_review", "label": "Rapid Review", "href": "/pipeline/rapid-review"},
     {"id": "review",          "label": "Review",          "href": "/review"},
     {"id": "cull",            "label": "Cull",            "href": "/cull"},
@@ -1273,11 +1272,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/pipeline/review")
     def pipeline_review_page():
-        return render_template("pipeline_review.html", pipeline_eye_review=False)
+        return render_template("pipeline_review.html")
 
     @app.route("/pipeline/eye-review")
     def pipeline_eye_review_page():
-        return render_template("pipeline_review.html", pipeline_eye_review=True)
+        return render_template("pipeline_review.html")
 
     @app.route("/pipeline/rapid-review")
     def pipeline_rapid_review_page():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -54,6 +54,7 @@ ALL_PAGES = [
     {"id": "pipeline",        "label": "Pipeline",        "href": "/pipeline"},
     {"id": "jobs",            "label": "Jobs",            "href": "/jobs"},
     {"id": "pipeline_review", "label": "Pipeline Review", "href": "/pipeline/review"},
+    {"id": "pipeline_eye_review", "label": "Eye Compare", "href": "/pipeline/eye-review"},
     {"id": "pipeline_rapid_review", "label": "Rapid Review", "href": "/pipeline/rapid-review"},
     {"id": "review",          "label": "Review",          "href": "/review"},
     {"id": "cull",            "label": "Cull",            "href": "/cull"},
@@ -1272,7 +1273,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/pipeline/review")
     def pipeline_review_page():
-        return render_template("pipeline_review.html")
+        return render_template("pipeline_review.html", pipeline_eye_review=False)
+
+    @app.route("/pipeline/eye-review")
+    def pipeline_eye_review_page():
+        return render_template("pipeline_review.html", pipeline_eye_review=True)
 
     @app.route("/pipeline/rapid-review")
     def pipeline_rapid_review_page():

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -60,7 +60,7 @@ KEYWORD_TYPES = frozenset({"taxonomy", "individual", "location", "genre", "gener
 SUBJECT_TYPES_DEFAULT = frozenset({"taxonomy", "individual", "genre"})
 
 ALL_NAV_IDS = frozenset({
-    "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
+    "pipeline", "jobs", "pipeline_review", "pipeline_eye_review", "pipeline_rapid_review", "review", "cull",
     "misses", "highlights", "browse", "map", "variants",
     "dashboard", "audit", "compare",
     "settings", "workspace", "lightroom", "shortcuts",

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -60,7 +60,7 @@ KEYWORD_TYPES = frozenset({"taxonomy", "individual", "location", "genre", "gener
 SUBJECT_TYPES_DEFAULT = frozenset({"taxonomy", "individual", "genre"})
 
 ALL_NAV_IDS = frozenset({
-    "pipeline", "jobs", "pipeline_review", "pipeline_eye_review", "pipeline_rapid_review", "review", "cull",
+    "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
     "misses", "highlights", "browse", "map", "variants",
     "dashboard", "audit", "compare",
     "settings", "workspace", "lightroom", "shortcuts",

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1495,7 +1495,6 @@ document.addEventListener('keydown', function(e) {
     const cur = (function() {
       const p = window.location.pathname;
       if (p.startsWith('/pipeline/rapid-review')) return 'pipeline_rapid_review';
-      if (p.startsWith('/pipeline/eye-review')) return 'pipeline_review';
       if (p.startsWith('/pipeline/review')) return 'pipeline_review';
       if (p === '/' || p.startsWith('/browse')) return 'browse';
       return (p.split('/')[1] || '').replace(/-/g, '_');
@@ -1895,7 +1894,6 @@ window.NAV_ALL_PAGES = [
   function currentNavId() {
     const p = window.location.pathname;
     if (p.startsWith('/pipeline/rapid-review')) return 'pipeline_rapid_review';
-    if (p.startsWith('/pipeline/eye-review')) return 'pipeline_review';
     if (p.startsWith('/pipeline/review')) return 'pipeline_review';
     if (p === '/' || p.startsWith('/browse')) return 'browse';
     const seg = (p.split('/')[1] || '').replace(/-/g, '_');
@@ -6346,7 +6344,6 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
   function currentNavId() {
     const p = window.location.pathname;
     if (p.startsWith('/pipeline/rapid-review')) return 'pipeline_rapid_review';
-    if (p.startsWith('/pipeline/eye-review')) return 'pipeline_review';
     if (p.startsWith('/pipeline/review')) return 'pipeline_review';
     if (p === '/' || p.startsWith('/browse')) return 'browse';
     return (p.split('/')[1] || '').replace(/-/g, '_');

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1495,7 +1495,7 @@ document.addEventListener('keydown', function(e) {
     const cur = (function() {
       const p = window.location.pathname;
       if (p.startsWith('/pipeline/rapid-review')) return 'pipeline_rapid_review';
-      if (p.startsWith('/pipeline/eye-review')) return 'pipeline_eye_review';
+      if (p.startsWith('/pipeline/eye-review')) return 'pipeline_review';
       if (p.startsWith('/pipeline/review')) return 'pipeline_review';
       if (p === '/' || p.startsWith('/browse')) return 'browse';
       return (p.split('/')[1] || '').replace(/-/g, '_');
@@ -1895,7 +1895,7 @@ window.NAV_ALL_PAGES = [
   function currentNavId() {
     const p = window.location.pathname;
     if (p.startsWith('/pipeline/rapid-review')) return 'pipeline_rapid_review';
-    if (p.startsWith('/pipeline/eye-review')) return 'pipeline_eye_review';
+    if (p.startsWith('/pipeline/eye-review')) return 'pipeline_review';
     if (p.startsWith('/pipeline/review')) return 'pipeline_review';
     if (p === '/' || p.startsWith('/browse')) return 'browse';
     const seg = (p.split('/')[1] || '').replace(/-/g, '_');
@@ -6346,7 +6346,7 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
   function currentNavId() {
     const p = window.location.pathname;
     if (p.startsWith('/pipeline/rapid-review')) return 'pipeline_rapid_review';
-    if (p.startsWith('/pipeline/eye-review')) return 'pipeline_eye_review';
+    if (p.startsWith('/pipeline/eye-review')) return 'pipeline_review';
     if (p.startsWith('/pipeline/review')) return 'pipeline_review';
     if (p === '/' || p.startsWith('/browse')) return 'browse';
     return (p.split('/')[1] || '').replace(/-/g, '_');

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1850,7 +1850,6 @@ window.NAV_ALL_PAGES = [
   {id: 'pipeline',        label: 'Pipeline',        href: '/pipeline'},
   {id: 'jobs',            label: 'Jobs',            href: '/jobs'},
   {id: 'pipeline_review', label: 'Pipeline Review', href: '/pipeline/review'},
-  {id: 'pipeline_eye_review', label: 'Eye Compare', href: '/pipeline/eye-review'},
   {id: 'pipeline_rapid_review', label: 'Rapid Review', href: '/pipeline/rapid-review'},
   {id: 'review',          label: 'Review',          href: '/review'},
   {id: 'cull',            label: 'Cull',            href: '/cull'},

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1495,6 +1495,7 @@ document.addEventListener('keydown', function(e) {
     const cur = (function() {
       const p = window.location.pathname;
       if (p.startsWith('/pipeline/rapid-review')) return 'pipeline_rapid_review';
+      if (p.startsWith('/pipeline/eye-review')) return 'pipeline_eye_review';
       if (p.startsWith('/pipeline/review')) return 'pipeline_review';
       if (p === '/' || p.startsWith('/browse')) return 'browse';
       return (p.split('/')[1] || '').replace(/-/g, '_');
@@ -6346,6 +6347,7 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
   function currentNavId() {
     const p = window.location.pathname;
     if (p.startsWith('/pipeline/rapid-review')) return 'pipeline_rapid_review';
+    if (p.startsWith('/pipeline/eye-review')) return 'pipeline_eye_review';
     if (p.startsWith('/pipeline/review')) return 'pipeline_review';
     if (p === '/' || p.startsWith('/browse')) return 'browse';
     return (p.split('/')[1] || '').replace(/-/g, '_');

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1495,7 +1495,6 @@ document.addEventListener('keydown', function(e) {
     const cur = (function() {
       const p = window.location.pathname;
       if (p.startsWith('/pipeline/rapid-review')) return 'pipeline_rapid_review';
-      if (p.startsWith('/pipeline/eye-review')) return 'pipeline_review';
       if (p.startsWith('/pipeline/review')) return 'pipeline_review';
       if (p === '/' || p.startsWith('/browse')) return 'browse';
       return (p.split('/')[1] || '').replace(/-/g, '_');
@@ -1896,7 +1895,6 @@ window.NAV_ALL_PAGES = [
   function currentNavId() {
     const p = window.location.pathname;
     if (p.startsWith('/pipeline/rapid-review')) return 'pipeline_rapid_review';
-    if (p.startsWith('/pipeline/eye-review')) return 'pipeline_review';
     if (p.startsWith('/pipeline/review')) return 'pipeline_review';
     if (p === '/' || p.startsWith('/browse')) return 'browse';
     const seg = (p.split('/')[1] || '').replace(/-/g, '_');
@@ -6738,7 +6736,6 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
   function currentNavId() {
     const p = window.location.pathname;
     if (p.startsWith('/pipeline/rapid-review')) return 'pipeline_rapid_review';
-    if (p.startsWith('/pipeline/eye-review')) return 'pipeline_review';
     if (p.startsWith('/pipeline/review')) return 'pipeline_review';
     if (p === '/' || p.startsWith('/browse')) return 'browse';
     return (p.split('/')[1] || '').replace(/-/g, '_');

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1849,6 +1849,7 @@ window.NAV_ALL_PAGES = [
   {id: 'pipeline',        label: 'Pipeline',        href: '/pipeline'},
   {id: 'jobs',            label: 'Jobs',            href: '/jobs'},
   {id: 'pipeline_review', label: 'Pipeline Review', href: '/pipeline/review'},
+  {id: 'pipeline_eye_review', label: 'Eye Compare', href: '/pipeline/eye-review'},
   {id: 'pipeline_rapid_review', label: 'Rapid Review', href: '/pipeline/rapid-review'},
   {id: 'review',          label: 'Review',          href: '/review'},
   {id: 'cull',            label: 'Cull',            href: '/cull'},
@@ -1894,6 +1895,7 @@ window.NAV_ALL_PAGES = [
   function currentNavId() {
     const p = window.location.pathname;
     if (p.startsWith('/pipeline/rapid-review')) return 'pipeline_rapid_review';
+    if (p.startsWith('/pipeline/eye-review')) return 'pipeline_eye_review';
     if (p.startsWith('/pipeline/review')) return 'pipeline_review';
     if (p === '/' || p.startsWith('/browse')) return 'browse';
     const seg = (p.split('/')[1] || '').replace(/-/g, '_');

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1453,7 +1453,7 @@ input[type="range"]::-moz-range-thumb {
     </div>
     <div class="grm-loupe" id="grmLoupe">
       <div class="grm-loupe-img" id="grmLoupeImg" onmousedown="grmLoupePointerDown(event)" onmousemove="grmLoupeMove(event)" onmouseup="grmLoupePointerUp(event)" onmouseleave="grmLoupeReset()" onclick="grmLoupeToggleLock(event)" onwheel="grmLoupeZoom(event)">
-        <img id="grmLoupePhoto" src="" alt="">
+        <img id="grmLoupePhoto" alt="">
         <div class="grm-loupe-crosshair-h" id="grmCrosshairH"></div>
         <div class="grm-loupe-crosshair-v" id="grmCrosshairV"></div>
       </div>
@@ -3806,7 +3806,7 @@ function grmSelect(photoId, mode) {
     }
     grmUpdateResLabel();
   } else {
-    loupeImg.src = '';
+    loupeImg.removeAttribute('src');
     loupeInfo.textContent = PIPELINE_EYE_COMPARE
       ? 'Select a reference photo. Click the large photo to place the eye target.'
       : 'Select a photo to preview. Hover to compare sharpness across all frames.';

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -167,26 +167,6 @@
   padding: 0 4px;
 }
 
-.eye-review-banner {
-  margin: 12px 20px 0;
-  padding: 8px 12px;
-  border: 1px solid var(--accent);
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-  color: var(--text-primary);
-  border-radius: 6px;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-.eye-review-banner a {
-  margin-left: auto;
-  color: var(--accent);
-  text-decoration: none;
-  font-weight: 600;
-}
-.eye-review-banner a:hover { text-decoration: underline; }
-
 /* Filter bar */
 .filter-bar {
   display: flex;
@@ -907,16 +887,8 @@ input[type="range"]::-moz-range-thumb {
   flex-shrink: 0;
 }
 .grm-header h3 { font-size: 15px; color: var(--text-primary); }
-.grm-mode-switch {
-  margin-left: auto;
-  color: var(--accent);
-  text-decoration: none;
-  font-size: 12px;
-  font-weight: 600;
-}
-.grm-mode-switch:hover { text-decoration: underline; }
 .grm-close {
-  margin-left: 0;
+  margin-left: auto;
   background: none; border: none; color: var(--text-muted);
   font-size: 20px; cursor: pointer;
 }
@@ -1305,10 +1277,6 @@ input[type="range"]::-moz-range-thumb {
       <a href="/pipeline" class="degraded-banner-link">Open Pipeline</a>
       <button class="degraded-banner-close" onclick="dismissDegradedBanner()" aria-label="Dismiss">&times;</button>
     </div>
-    <div class="eye-review-banner" id="eyeReviewBanner" style="display:none;">
-      Eye Compare experiment: click the large photo to place the eye target, then drag left frames to align each crop.
-      <a href="/pipeline/review">Classic review</a>
-    </div>
 
     <!-- Summary bar (hidden until data loads) -->
     <div class="summary-bar" id="summaryBar" style="display:none">
@@ -1376,7 +1344,6 @@ input[type="range"]::-moz-range-thumb {
     <!-- Filter bar (hidden until data loads) -->
     <div class="filter-bar" id="filterBar" style="display:none">
       <a class="filter-btn" href="/pipeline/rapid-review" style="text-decoration:none;">Rapid Review</a>
-      <a class="filter-btn" id="eyeModeFilterLink" href="/pipeline/eye-review" style="text-decoration:none;">Eye Compare</a>
       <button class="filter-btn active" data-filter="all" onclick="setFilter('all')">All<span class="count" id="countAll"></span></button>
       <button class="filter-btn" data-filter="KEEP" onclick="setFilter('KEEP')">Keep<span class="count" id="countKeep"></span></button>
       <button class="filter-btn" data-filter="REVIEW" onclick="setFilter('REVIEW')">Review<span class="count" id="countReview"></span></button>
@@ -1427,7 +1394,6 @@ input[type="range"]::-moz-range-thumb {
   <div class="grm-header">
     <h3 id="grmTitle">Review Burst Group</h3>
     <span id="grmCount" style="font-size:12px;color:var(--text-dim);"></span>
-    <a id="grmModeSwitch" class="grm-mode-switch" href="/pipeline/eye-review">Try Eye Compare</a>
     <button class="grm-close" onclick="closeGroupReview()">&times;</button>
   </div>
   <div class="grm-body">
@@ -1446,8 +1412,8 @@ input[type="range"]::-moz-range-thumb {
       </div>
     </div>
     <div class="grm-loupe" id="grmLoupe">
-      <div class="grm-loupe-img" id="grmLoupeImg" onmousedown="grmLoupePointerDown(event)" onmousemove="grmLoupeMove(event)" onmouseup="grmLoupePointerUp(event)" onmouseleave="grmLoupeReset()" onclick="grmLoupeToggleLock(event)" onwheel="grmLoupeZoom(event)">
-        <img id="grmLoupePhoto" alt="">
+      <div class="grm-loupe-img" id="grmLoupeImg" onmousemove="grmLoupeMove(event)" onmouseleave="grmLoupeReset()" onclick="grmLoupeToggleLock(event)" onwheel="grmLoupeZoom(event)">
+        <img id="grmLoupePhoto" src="" alt="">
         <div class="grm-loupe-crosshair-h" id="grmCrosshairH"></div>
         <div class="grm-loupe-crosshair-v" id="grmCrosshairV"></div>
       </div>
@@ -1470,13 +1436,12 @@ input[type="range"]::-moz-range-thumb {
       <input type="range" id="grmResSlider" min="0" max="3" step="1" value="3" oninput="grmSetResolution(this.value)">
       <span id="grmResLabel" style="font-size:11px;color:var(--text-dim);min-width:140px;">1920 · preview</span>
     </div>
-    <span class="grm-hint" id="grmHint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
+    <span class="grm-hint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
     <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);" title="Apply pick/reject flag changes and species keywords, then close this burst.">Apply flags/species & Close</button>
   </div>
 </div>
 
 <script>
-var PIPELINE_EYE_COMPARE = window.location.pathname.indexOf('/pipeline/eye-review') === 0;
 var pipelineResults = null;
 var activeFilter = 'all';
 var minConfidence = 40;
@@ -2710,57 +2675,12 @@ function computeReviewNow() {
 }
 
 function initPipelineReviewPage() {
-  applyPipelineReviewModeChrome();
   initPipelineSidebarState();
   if (isBrowseBurstReviewRequest()) {
     openBrowseBurstReviewFromStorage();
     return;
   }
   loadPipelinePageInit();
-}
-
-function applyPipelineReviewModeChrome() {
-  var preserveBrowseBurst = isBrowseBurstReviewRequest();
-  var classicPath = '/pipeline/review' + (preserveBrowseBurst ? '?browse_burst=1' : '');
-  var eyeComparePath = '/pipeline/eye-review' + (preserveBrowseBurst ? '?browse_burst=1' : '');
-  var banner = document.getElementById('eyeReviewBanner');
-  var filterLink = document.getElementById('eyeModeFilterLink');
-  var modeSwitch = document.getElementById('grmModeSwitch');
-
-  if (!PIPELINE_EYE_COMPARE) {
-    if (filterLink) {
-      filterLink.href = eyeComparePath;
-    }
-    if (modeSwitch) {
-      modeSwitch.href = eyeComparePath;
-    }
-    return;
-  }
-
-  document.title = 'Vireo - Eye Compare';
-  if (banner) {
-    banner.style.display = 'flex';
-    var bannerLink = banner.querySelector('a');
-    if (bannerLink) {
-      bannerLink.href = classicPath;
-    }
-  }
-  if (filterLink) {
-    filterLink.href = classicPath;
-    filterLink.textContent = 'Classic Review';
-  }
-  if (modeSwitch) {
-    modeSwitch.href = classicPath;
-    modeSwitch.textContent = 'Classic Review';
-  }
-  var loupeInfo = document.getElementById('grmLoupeInfo');
-  if (loupeInfo) {
-    loupeInfo.textContent = 'Select a reference photo. Click the large photo to place the eye target.';
-  }
-  var hint = document.getElementById('grmHint');
-  if (hint) {
-    hint.textContent = 'P = pick   X = reject   ↑↓ move zone   ←→ navigate   Space = unsort   Del = remove   Click/drag preview to set eye target   Drag a thumbnail to align it; double-click to reset';
-  }
 }
 
 function loadPipelinePageInit() {
@@ -3310,10 +3230,7 @@ function openBrowseBurstReviewFromStorage() {
     // path must remain recoverable — both via the in-page Reopen button and
     // via a plain reload. clearBrowseBurstHandoff() runs only once the user
     // applies (workflow complete) or we fall back to normal review.
-    var params = new URLSearchParams(window.location.search || '');
-    var requestedPhotoId = params.has('photo') ? parseInt(params.get('photo'), 10) : null;
-    var initialPhotoId = loadedIds.indexOf(requestedPhotoId) !== -1 ? requestedPhotoId : loadedIds[0];
-    openGroupReview(0, 0, initialPhotoId);
+    openGroupReview(0, 0, loadedIds[0]);
   }).catch(function() {
     fallbackToNormalPipelineReview('Could not open burst review — showing the latest pipeline review instead.');
   });
@@ -3413,23 +3330,16 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   };
   _grmLoupeLocked = false;
   _grmZoomMultiplier = 1;
-  _grmLastHoverX = PIPELINE_EYE_COMPARE ? 50 : null;
-  _grmLastHoverY = PIPELINE_EYE_COMPARE ? 50 : null;
+  _grmLastHoverX = null;
+  _grmLastHoverY = null;
   _grmOffsets = {};
   _grmDragging = null;
-  _grmLoupeTargetDragging = false;
   _grmSuppressNextClick = false;
   grmRefreshResetAllVisibility();
 
   document.getElementById('grmOverlay').classList.add('open');
   var title = document.getElementById('grmTitle');
-  if (title) {
-    if (source === 'browse-selection') {
-      title.textContent = PIPELINE_EYE_COMPARE ? 'Eye Compare Selected Photos' : 'Review Selected Photos';
-    } else {
-      title.textContent = PIPELINE_EYE_COMPARE ? 'Eye Compare Burst Group' : 'Review Burst Group';
-    }
-  }
+  if (title) title.textContent = source === 'browse-selection' ? 'Review Selected Photos' : 'Review Burst Group';
   var removeBtn = document.getElementById('grmRemoveBtn');
   if (removeBtn) {
     removeBtn.textContent = source === 'browse-selection' ? 'Remove from review' : 'Remove from group';
@@ -3438,7 +3348,6 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
       : 'Detach this photo from the burst group on apply';
   }
   grmSetThumbSize(GRM_CARD_W, false);
-  grmUpdateModeSwitchLink();
 
   // Disable Apply while we wait for /group/state — clicking it before
   // seed completes would send empty picks/rejects, which the server treats
@@ -3456,7 +3365,6 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   // Sync slider DOM with persisted resolution choice
   var slider = document.getElementById('grmResSlider');
   if (slider) slider.value = grmResolutionIdx;
-  if (PIPELINE_EYE_COMPARE) grmPositionCrosshair(50, 50);
   grmUpdateResLabel();
 
   // Render an empty modal first so it appears responsive while we fetch DB
@@ -3551,23 +3459,7 @@ function closeGroupReview() {
   document.getElementById('grmOverlay').classList.remove('open');
   _grmOffsets = {};
   _grmDragging = null;
-  _grmLoupeTargetDragging = false;
   grmRefreshResetAllVisibility();
-}
-
-function grmUpdateModeSwitchLink() {
-  var link = document.getElementById('grmModeSwitch');
-  if (!link || !grmState) return;
-  var path = PIPELINE_EYE_COMPARE ? '/pipeline/review' : '/pipeline/eye-review';
-  var params = new URLSearchParams();
-  if (grmState.source === 'browse-selection' || isBrowseBurstReviewRequest()) {
-    params.set('browse_burst', '1');
-  }
-  if (Number.isInteger(grmState.encIdx)) params.set('enc', String(grmState.encIdx));
-  if (Number.isInteger(grmState.burstIdx)) params.set('burst', String(grmState.burstIdx));
-  if (grmState.selected) params.set('photo', String(grmState.selected));
-  var qs = params.toString();
-  link.href = path + (qs ? '?' + qs : '');
 }
 
 function renderGroupModal() {
@@ -3818,7 +3710,7 @@ function grmSelect(photoId, mode) {
     _grmSelectRange(grmState.selectionAnchor, photoId);
     grmState.selected = photoId;
   } else {
-    if (!PIPELINE_EYE_COMPARE && grmState.selected === photoId && selectedIds.size === 1 && selectedIds.has(photoId)) {
+    if (grmState.selected === photoId && selectedIds.size === 1 && selectedIds.has(photoId)) {
       selectedIds.clear();
       grmState.selected = null;
       grmState.selectionAnchor = null;
@@ -3829,7 +3721,6 @@ function grmSelect(photoId, mode) {
       grmState.selectionAnchor = photoId;
     }
   }
-  grmUpdateModeSwitchLink();
   renderGroupModal();
 
   // Update loupe preview
@@ -3842,19 +3733,15 @@ function grmSelect(photoId, mode) {
     var photo = grmState.items.find(function(p) { return p.id === grmState.selected; });
     if (photo) {
       var sharp = photo.subject_tenengrad != null ? Math.round(photo.subject_tenengrad) : '?';
-      loupeInfo.textContent = PIPELINE_EYE_COMPARE
-        ? (photo.filename || '') + ' - sharpness: ' + sharp + ' - click/drag to set eye target'
-        : (photo.filename || '') + ' - sharpness: ' + sharp + ' - move cursor to compare';
+      loupeInfo.textContent = (photo.filename || '') + ' — sharpness: ' + sharp + ' — move cursor to compare';
 
       // Render pipeline metadata in detail panel
       detailEl.innerHTML = buildPipelineMetadataHtml(photo);
     }
     grmUpdateResLabel();
   } else {
-    loupeImg.removeAttribute('src');
-    loupeInfo.textContent = PIPELINE_EYE_COMPARE
-      ? 'Select a reference photo. Click the large photo to place the eye target.'
-      : 'Select a photo to preview. Hover to compare sharpness across all frames.';
+    loupeImg.src = '';
+    loupeInfo.textContent = 'Select a photo to preview. Hover to compare sharpness across all frames.';
     detailEl.innerHTML = '';
     grmLoupeReset();
   }
@@ -3985,7 +3872,6 @@ var _grmLastHoverY = null;
 var _grmOffsets = {};
 var _grmDragging = null;
 var _grmSuppressNextClick = false;
-var _grmLoupeTargetDragging = false;
 
 function _grmInitialThumbSize() {
   try {
@@ -4160,45 +4046,7 @@ function grmCardImgLoaded(img) {
   }
 }
 
-function grmPositionCrosshair(x, y) {
-  var ch = document.getElementById('grmCrosshairH');
-  var cv = document.getElementById('grmCrosshairV');
-  if (ch) ch.style.top = y + '%';
-  if (cv) cv.style.left = x + '%';
-}
-
-function grmSetEyeTargetFromEvent(e) {
-  var rect = e.currentTarget.getBoundingClientRect();
-  var x = ((e.clientX - rect.left) / rect.width) * 100;
-  var y = ((e.clientY - rect.top) / rect.height) * 100;
-  x = Math.max(0, Math.min(100, x));
-  y = Math.max(0, Math.min(100, y));
-  _grmLastHoverX = x;
-  _grmLastHoverY = y;
-  grmPositionCrosshair(x, y);
-  grmApplyCardTransforms();
-}
-
-function grmLoupePointerDown(e) {
-  if (!PIPELINE_EYE_COMPARE) return;
-  if (e.button !== 0) return;
-  _grmLoupeTargetDragging = true;
-  grmSetEyeTargetFromEvent(e);
-  e.preventDefault();
-}
-
-function grmLoupePointerUp(e) {
-  if (!PIPELINE_EYE_COMPARE) return;
-  if (_grmLoupeTargetDragging) grmSetEyeTargetFromEvent(e);
-  _grmLoupeTargetDragging = false;
-}
-
 function grmLoupeToggleLock(e) {
-  if (PIPELINE_EYE_COMPARE) {
-    grmSetEyeTargetFromEvent(e);
-    _grmLoupeTargetDragging = false;
-    return;
-  }
   _grmLoupeLocked = !_grmLoupeLocked;
   var ch = document.getElementById('grmCrosshairH');
   var cv = document.getElementById('grmCrosshairV');
@@ -4213,11 +4061,6 @@ function grmLoupeToggleLock(e) {
 }
 
 function grmLoupeMove(e) {
-  if (PIPELINE_EYE_COMPARE) {
-    if (!_grmLoupeTargetDragging) return;
-    grmSetEyeTargetFromEvent(e);
-    return;
-  }
   if (_grmLoupeLocked) return;
 
   var rect = e.currentTarget.getBoundingClientRect();
@@ -4226,7 +4069,8 @@ function grmLoupeMove(e) {
   _grmLastHoverX = x;
   _grmLastHoverY = y;
 
-  grmPositionCrosshair(x, y);
+  document.getElementById('grmCrosshairH').style.top = y + '%';
+  document.getElementById('grmCrosshairV').style.left = x + '%';
 
   grmApplyCardTransforms();
 }
@@ -4248,10 +4092,6 @@ function grmLoupeZoom(e) {
 }
 
 function grmLoupeReset() {
-  if (PIPELINE_EYE_COMPARE) {
-    _grmLoupeTargetDragging = false;
-    return;
-  }
   if (_grmLoupeLocked) return;
   if (_grmDragging) return;
   _grmLastHoverX = null;

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -6,7 +6,7 @@
 <link rel="icon" type="image/png" href="/favicon.ico">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
 <link rel="stylesheet" href="/static/vireo-base.css">
-<title>Vireo - {% if pipeline_eye_review|default(false) %}Eye Compare{% else %}Pipeline Review{% endif %}</title>
+<title>Vireo - Pipeline Review</title>
 <style>
 /* Layout: sidebar + main */
 .pipeline-layout {
@@ -1305,12 +1305,10 @@ input[type="range"]::-moz-range-thumb {
       <a href="/pipeline" class="degraded-banner-link">Open Pipeline</a>
       <button class="degraded-banner-close" onclick="dismissDegradedBanner()" aria-label="Dismiss">&times;</button>
     </div>
-    {% if pipeline_eye_review|default(false) %}
-    <div class="eye-review-banner">
+    <div class="eye-review-banner" id="eyeReviewBanner" style="display:none;">
       Eye Compare experiment: click the large photo to place the eye target, then drag left frames to align each crop.
       <a href="/pipeline/review">Classic review</a>
     </div>
-    {% endif %}
 
     <!-- Summary bar (hidden until data loads) -->
     <div class="summary-bar" id="summaryBar" style="display:none">
@@ -1378,11 +1376,7 @@ input[type="range"]::-moz-range-thumb {
     <!-- Filter bar (hidden until data loads) -->
     <div class="filter-bar" id="filterBar" style="display:none">
       <a class="filter-btn" href="/pipeline/rapid-review" style="text-decoration:none;">Rapid Review</a>
-      {% if pipeline_eye_review|default(false) %}
-      <a class="filter-btn" href="/pipeline/review" style="text-decoration:none;">Classic Review</a>
-      {% else %}
-      <a class="filter-btn" href="/pipeline/eye-review" style="text-decoration:none;">Eye Compare</a>
-      {% endif %}
+      <a class="filter-btn" id="eyeModeFilterLink" href="/pipeline/eye-review" style="text-decoration:none;">Eye Compare</a>
       <button class="filter-btn active" data-filter="all" onclick="setFilter('all')">All<span class="count" id="countAll"></span></button>
       <button class="filter-btn" data-filter="KEEP" onclick="setFilter('KEEP')">Keep<span class="count" id="countKeep"></span></button>
       <button class="filter-btn" data-filter="REVIEW" onclick="setFilter('REVIEW')">Review<span class="count" id="countReview"></span></button>
@@ -1431,9 +1425,9 @@ input[type="range"]::-moz-range-thumb {
 <!-- Group Review Modal -->
 <div class="grm-overlay" id="grmOverlay">
   <div class="grm-header">
-    <h3 id="grmTitle">{% if pipeline_eye_review|default(false) %}Eye Compare Burst Group{% else %}Review Burst Group{% endif %}</h3>
+    <h3 id="grmTitle">Review Burst Group</h3>
     <span id="grmCount" style="font-size:12px;color:var(--text-dim);"></span>
-    <a id="grmModeSwitch" class="grm-mode-switch" href="{% if pipeline_eye_review|default(false) %}/pipeline/review{% else %}/pipeline/eye-review{% endif %}">{% if pipeline_eye_review|default(false) %}Classic Review{% else %}Try Eye Compare{% endif %}</a>
+    <a id="grmModeSwitch" class="grm-mode-switch" href="/pipeline/eye-review">Try Eye Compare</a>
     <button class="grm-close" onclick="closeGroupReview()">&times;</button>
   </div>
   <div class="grm-body">
@@ -1457,7 +1451,7 @@ input[type="range"]::-moz-range-thumb {
         <div class="grm-loupe-crosshair-h" id="grmCrosshairH"></div>
         <div class="grm-loupe-crosshair-v" id="grmCrosshairV"></div>
       </div>
-      <div class="grm-loupe-info" id="grmLoupeInfo">{% if pipeline_eye_review|default(false) %}Select a reference photo. Click the large photo to place the eye target.{% else %}Select a photo to preview. Hover to compare sharpness across all frames.{% endif %}</div>
+      <div class="grm-loupe-info" id="grmLoupeInfo">Select a photo to preview. Hover to compare sharpness across all frames.</div>
       <button type="button" class="grm-reset-offsets-btn" id="grmResetAllOffsets" onclick="grmResetAllOffsets()">Reset pan offsets</button>
       <div class="grm-loupe-detail" id="grmLoupeDetail"></div>
     </div>
@@ -1476,13 +1470,13 @@ input[type="range"]::-moz-range-thumb {
       <input type="range" id="grmResSlider" min="0" max="3" step="1" value="3" oninput="grmSetResolution(this.value)">
       <span id="grmResLabel" style="font-size:11px;color:var(--text-dim);min-width:140px;">1920 · preview</span>
     </div>
-    <span class="grm-hint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; {% if pipeline_eye_review|default(false) %}Click/drag preview to set eye target &nbsp; Drag a thumbnail to align it; double-click to reset{% else %}Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset{% endif %}</span>
+    <span class="grm-hint" id="grmHint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
     <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);" title="Apply pick/reject flag changes and species keywords, then close this burst.">Apply flags/species & Close</button>
   </div>
 </div>
 
 <script>
-var PIPELINE_EYE_COMPARE = {{ (pipeline_eye_review|default(false))|tojson }};
+var PIPELINE_EYE_COMPARE = window.location.pathname.indexOf('/pipeline/eye-review') === 0;
 var pipelineResults = null;
 var activeFilter = 'all';
 var minConfidence = 40;
@@ -2716,12 +2710,38 @@ function computeReviewNow() {
 }
 
 function initPipelineReviewPage() {
+  applyPipelineReviewModeChrome();
   initPipelineSidebarState();
   if (isBrowseBurstReviewRequest()) {
     openBrowseBurstReviewFromStorage();
     return;
   }
   loadPipelinePageInit();
+}
+
+function applyPipelineReviewModeChrome() {
+  if (!PIPELINE_EYE_COMPARE) return;
+  document.title = 'Vireo - Eye Compare';
+  var banner = document.getElementById('eyeReviewBanner');
+  if (banner) banner.style.display = 'flex';
+  var filterLink = document.getElementById('eyeModeFilterLink');
+  if (filterLink) {
+    filterLink.href = '/pipeline/review';
+    filterLink.textContent = 'Classic Review';
+  }
+  var modeSwitch = document.getElementById('grmModeSwitch');
+  if (modeSwitch) {
+    modeSwitch.href = '/pipeline/review';
+    modeSwitch.textContent = 'Classic Review';
+  }
+  var loupeInfo = document.getElementById('grmLoupeInfo');
+  if (loupeInfo) {
+    loupeInfo.textContent = 'Select a reference photo. Click the large photo to place the eye target.';
+  }
+  var hint = document.getElementById('grmHint');
+  if (hint) {
+    hint.textContent = 'P = pick   X = reject   ↑↓ move zone   ←→ navigate   Space = unsort   Del = remove   Click/drag preview to set eye target   Drag a thumbnail to align it; double-click to reset';
+  }
 }
 
 function loadPipelinePageInit() {

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -6,7 +6,7 @@
 <link rel="icon" type="image/png" href="/favicon.ico">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
 <link rel="stylesheet" href="/static/vireo-base.css">
-<title>Vireo - Pipeline Review</title>
+<title>Vireo - {% if pipeline_eye_review|default(false) %}Eye Compare{% else %}Pipeline Review{% endif %}</title>
 <style>
 /* Layout: sidebar + main */
 .pipeline-layout {
@@ -166,6 +166,26 @@
   cursor: pointer;
   padding: 0 4px;
 }
+
+.eye-review-banner {
+  margin: 12px 20px 0;
+  padding: 8px 12px;
+  border: 1px solid var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--text-primary);
+  border-radius: 6px;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.eye-review-banner a {
+  margin-left: auto;
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+.eye-review-banner a:hover { text-decoration: underline; }
 
 /* Filter bar */
 .filter-bar {
@@ -885,8 +905,16 @@ input[type="range"]::-moz-range-thumb {
   flex-shrink: 0;
 }
 .grm-header h3 { font-size: 15px; color: var(--text-primary); }
-.grm-close {
+.grm-mode-switch {
   margin-left: auto;
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: 600;
+}
+.grm-mode-switch:hover { text-decoration: underline; }
+.grm-close {
+  margin-left: 0;
   background: none; border: none; color: var(--text-muted);
   font-size: 20px; cursor: pointer;
 }
@@ -1258,6 +1286,12 @@ input[type="range"]::-moz-range-thumb {
       <a href="/pipeline" class="degraded-banner-link">Open Pipeline</a>
       <button class="degraded-banner-close" onclick="dismissDegradedBanner()" aria-label="Dismiss">&times;</button>
     </div>
+    {% if pipeline_eye_review|default(false) %}
+    <div class="eye-review-banner">
+      Eye Compare experiment: click the large photo to place the eye target, then drag left frames to align each crop.
+      <a href="/pipeline/review">Classic review</a>
+    </div>
+    {% endif %}
 
     <!-- Summary bar (hidden until data loads) -->
     <div class="summary-bar" id="summaryBar" style="display:none">
@@ -1325,6 +1359,11 @@ input[type="range"]::-moz-range-thumb {
     <!-- Filter bar (hidden until data loads) -->
     <div class="filter-bar" id="filterBar" style="display:none">
       <a class="filter-btn" href="/pipeline/rapid-review" style="text-decoration:none;">Rapid Review</a>
+      {% if pipeline_eye_review|default(false) %}
+      <a class="filter-btn" href="/pipeline/review" style="text-decoration:none;">Classic Review</a>
+      {% else %}
+      <a class="filter-btn" href="/pipeline/eye-review" style="text-decoration:none;">Eye Compare</a>
+      {% endif %}
       <button class="filter-btn active" data-filter="all" onclick="setFilter('all')">All<span class="count" id="countAll"></span></button>
       <button class="filter-btn" data-filter="KEEP" onclick="setFilter('KEEP')">Keep<span class="count" id="countKeep"></span></button>
       <button class="filter-btn" data-filter="REVIEW" onclick="setFilter('REVIEW')">Review<span class="count" id="countReview"></span></button>
@@ -1373,8 +1412,9 @@ input[type="range"]::-moz-range-thumb {
 <!-- Group Review Modal -->
 <div class="grm-overlay" id="grmOverlay">
   <div class="grm-header">
-    <h3>Review Burst Group</h3>
+    <h3>{% if pipeline_eye_review|default(false) %}Eye Compare Burst Group{% else %}Review Burst Group{% endif %}</h3>
     <span id="grmCount" style="font-size:12px;color:var(--text-dim);"></span>
+    <a id="grmModeSwitch" class="grm-mode-switch" href="{% if pipeline_eye_review|default(false) %}/pipeline/review{% else %}/pipeline/eye-review{% endif %}">{% if pipeline_eye_review|default(false) %}Classic Review{% else %}Try Eye Compare{% endif %}</a>
     <button class="grm-close" onclick="closeGroupReview()">&times;</button>
   </div>
   <div class="grm-body">
@@ -1393,12 +1433,12 @@ input[type="range"]::-moz-range-thumb {
       </div>
     </div>
     <div class="grm-loupe" id="grmLoupe">
-      <div class="grm-loupe-img" id="grmLoupeImg" onmousemove="grmLoupeMove(event)" onmouseleave="grmLoupeReset()" onclick="grmLoupeToggleLock(event)" onwheel="grmLoupeZoom(event)">
+      <div class="grm-loupe-img" id="grmLoupeImg" onmousedown="grmLoupePointerDown(event)" onmousemove="grmLoupeMove(event)" onmouseup="grmLoupePointerUp(event)" onmouseleave="grmLoupeReset()" onclick="grmLoupeToggleLock(event)" onwheel="grmLoupeZoom(event)">
         <img id="grmLoupePhoto" src="" alt="">
         <div class="grm-loupe-crosshair-h" id="grmCrosshairH"></div>
         <div class="grm-loupe-crosshair-v" id="grmCrosshairV"></div>
       </div>
-      <div class="grm-loupe-info" id="grmLoupeInfo">Select a photo to preview. Hover to compare sharpness across all frames.</div>
+      <div class="grm-loupe-info" id="grmLoupeInfo">{% if pipeline_eye_review|default(false) %}Select a reference photo. Click the large photo to place the eye target.{% else %}Select a photo to preview. Hover to compare sharpness across all frames.{% endif %}</div>
       <button type="button" class="grm-reset-offsets-btn" id="grmResetAllOffsets" onclick="grmResetAllOffsets()">Reset pan offsets</button>
       <div class="grm-loupe-detail" id="grmLoupeDetail"></div>
     </div>
@@ -1412,12 +1452,13 @@ input[type="range"]::-moz-range-thumb {
       <input type="range" id="grmResSlider" min="0" max="3" step="1" value="3" oninput="grmSetResolution(this.value)">
       <span id="grmResLabel" style="font-size:11px;color:var(--text-dim);min-width:140px;">1920 · preview</span>
     </div>
-    <span class="grm-hint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
+    <span class="grm-hint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; {% if pipeline_eye_review|default(false) %}Click/drag preview to set eye target &nbsp; Drag a thumbnail to align it; double-click to reset{% else %}Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset{% endif %}</span>
     <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);" title="Apply pick/reject flag changes and species keywords, then close this burst.">Apply flags/species & Close</button>
   </div>
 </div>
 
 <script>
+var PIPELINE_EYE_COMPARE = {{ (pipeline_eye_review|default(false))|tojson }};
 var pipelineResults = null;
 var activeFilter = 'all';
 var minConfidence = 40;
@@ -3123,14 +3164,16 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   };
   _grmLoupeLocked = false;
   _grmZoomMultiplier = 1;
-  _grmLastHoverX = null;
-  _grmLastHoverY = null;
+  _grmLastHoverX = PIPELINE_EYE_COMPARE ? 50 : null;
+  _grmLastHoverY = PIPELINE_EYE_COMPARE ? 50 : null;
   _grmOffsets = {};
   _grmDragging = null;
+  _grmLoupeTargetDragging = false;
   _grmSuppressNextClick = false;
   grmRefreshResetAllVisibility();
 
   document.getElementById('grmOverlay').classList.add('open');
+  grmUpdateModeSwitchLink();
 
   // Disable Apply while we wait for /group/state — clicking it before
   // seed completes would send empty picks/rejects, which the server treats
@@ -3148,6 +3191,7 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   // Sync slider DOM with persisted resolution choice
   var slider = document.getElementById('grmResSlider');
   if (slider) slider.value = grmResolutionIdx;
+  if (PIPELINE_EYE_COMPARE) grmPositionCrosshair(50, 50);
   grmUpdateResLabel();
 
   // Render an empty modal first so it appears responsive while we fetch DB
@@ -3242,7 +3286,20 @@ function closeGroupReview() {
   document.getElementById('grmOverlay').classList.remove('open');
   _grmOffsets = {};
   _grmDragging = null;
+  _grmLoupeTargetDragging = false;
   grmRefreshResetAllVisibility();
+}
+
+function grmUpdateModeSwitchLink() {
+  var link = document.getElementById('grmModeSwitch');
+  if (!link || !grmState) return;
+  var path = PIPELINE_EYE_COMPARE ? '/pipeline/review' : '/pipeline/eye-review';
+  var params = new URLSearchParams();
+  if (Number.isInteger(grmState.encIdx)) params.set('enc', String(grmState.encIdx));
+  if (Number.isInteger(grmState.burstIdx)) params.set('burst', String(grmState.burstIdx));
+  if (grmState.selected) params.set('photo', String(grmState.selected));
+  var qs = params.toString();
+  link.href = path + (qs ? '?' + qs : '');
 }
 
 function renderGroupModal() {
@@ -3450,7 +3507,10 @@ function grmApplyTitle(diff) {
 }
 
 function grmSelect(photoId) {
-  grmState.selected = (grmState.selected === photoId) ? null : photoId;
+  grmState.selected = PIPELINE_EYE_COMPARE
+    ? photoId
+    : ((grmState.selected === photoId) ? null : photoId);
+  grmUpdateModeSwitchLink();
   renderGroupModal();
 
   // Update loupe preview
@@ -3463,7 +3523,9 @@ function grmSelect(photoId) {
     var photo = grmState.items.find(function(p) { return p.id === grmState.selected; });
     if (photo) {
       var sharp = photo.subject_tenengrad != null ? Math.round(photo.subject_tenengrad) : '?';
-      loupeInfo.textContent = (photo.filename || '') + ' — sharpness: ' + sharp + ' — move cursor to compare';
+      loupeInfo.textContent = PIPELINE_EYE_COMPARE
+        ? (photo.filename || '') + ' - sharpness: ' + sharp + ' - click/drag to set eye target'
+        : (photo.filename || '') + ' - sharpness: ' + sharp + ' - move cursor to compare';
 
       // Render pipeline metadata in detail panel
       detailEl.innerHTML = buildPipelineMetadataHtml(photo);
@@ -3471,7 +3533,9 @@ function grmSelect(photoId) {
     grmUpdateResLabel();
   } else {
     loupeImg.src = '';
-    loupeInfo.textContent = 'Select a photo to preview. Hover to compare sharpness across all frames.';
+    loupeInfo.textContent = PIPELINE_EYE_COMPARE
+      ? 'Select a reference photo. Click the large photo to place the eye target.'
+      : 'Select a photo to preview. Hover to compare sharpness across all frames.';
     detailEl.innerHTML = '';
     grmLoupeReset();
   }
@@ -3584,6 +3648,7 @@ var _grmLastHoverY = null;
 var _grmOffsets = {};
 var _grmDragging = null;
 var _grmSuppressNextClick = false;
+var _grmLoupeTargetDragging = false;
 
 // Compute the served image's natural dimensions for the current resolution
 // slider stop. The browser will lay the <img> out at exactly these CSS
@@ -3726,7 +3791,45 @@ function grmCardImgLoaded(img) {
   }
 }
 
+function grmPositionCrosshair(x, y) {
+  var ch = document.getElementById('grmCrosshairH');
+  var cv = document.getElementById('grmCrosshairV');
+  if (ch) ch.style.top = y + '%';
+  if (cv) cv.style.left = x + '%';
+}
+
+function grmSetEyeTargetFromEvent(e) {
+  var rect = e.currentTarget.getBoundingClientRect();
+  var x = ((e.clientX - rect.left) / rect.width) * 100;
+  var y = ((e.clientY - rect.top) / rect.height) * 100;
+  x = Math.max(0, Math.min(100, x));
+  y = Math.max(0, Math.min(100, y));
+  _grmLastHoverX = x;
+  _grmLastHoverY = y;
+  grmPositionCrosshair(x, y);
+  grmApplyCardTransforms();
+}
+
+function grmLoupePointerDown(e) {
+  if (!PIPELINE_EYE_COMPARE) return;
+  if (e.button !== 0) return;
+  _grmLoupeTargetDragging = true;
+  grmSetEyeTargetFromEvent(e);
+  e.preventDefault();
+}
+
+function grmLoupePointerUp(e) {
+  if (!PIPELINE_EYE_COMPARE) return;
+  if (_grmLoupeTargetDragging) grmSetEyeTargetFromEvent(e);
+  _grmLoupeTargetDragging = false;
+}
+
 function grmLoupeToggleLock(e) {
+  if (PIPELINE_EYE_COMPARE) {
+    grmSetEyeTargetFromEvent(e);
+    _grmLoupeTargetDragging = false;
+    return;
+  }
   _grmLoupeLocked = !_grmLoupeLocked;
   var ch = document.getElementById('grmCrosshairH');
   var cv = document.getElementById('grmCrosshairV');
@@ -3741,6 +3844,11 @@ function grmLoupeToggleLock(e) {
 }
 
 function grmLoupeMove(e) {
+  if (PIPELINE_EYE_COMPARE) {
+    if (!_grmLoupeTargetDragging) return;
+    grmSetEyeTargetFromEvent(e);
+    return;
+  }
   if (_grmLoupeLocked) return;
 
   var rect = e.currentTarget.getBoundingClientRect();
@@ -3749,8 +3857,7 @@ function grmLoupeMove(e) {
   _grmLastHoverX = x;
   _grmLastHoverY = y;
 
-  document.getElementById('grmCrosshairH').style.top = y + '%';
-  document.getElementById('grmCrosshairV').style.left = x + '%';
+  grmPositionCrosshair(x, y);
 
   grmApplyCardTransforms();
 }
@@ -3772,6 +3879,10 @@ function grmLoupeZoom(e) {
 }
 
 function grmLoupeReset() {
+  if (PIPELINE_EYE_COMPARE) {
+    _grmLoupeTargetDragging = false;
+    return;
+  }
   if (_grmLoupeLocked) return;
   if (_grmDragging) return;
   _grmLastHoverX = null;

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1413,7 +1413,7 @@ input[type="range"]::-moz-range-thumb {
     </div>
     <div class="grm-loupe" id="grmLoupe">
       <div class="grm-loupe-img" id="grmLoupeImg" onmousemove="grmLoupeMove(event)" onmouseleave="grmLoupeReset()" onclick="grmLoupeToggleLock(event)" onwheel="grmLoupeZoom(event)">
-        <img id="grmLoupePhoto" src="" alt="">
+        <img id="grmLoupePhoto" alt="">
         <div class="grm-loupe-crosshair-h" id="grmCrosshairH"></div>
         <div class="grm-loupe-crosshair-v" id="grmCrosshairV"></div>
       </div>
@@ -3740,7 +3740,7 @@ function grmSelect(photoId, mode) {
     }
     grmUpdateResLabel();
   } else {
-    loupeImg.src = '';
+    loupeImg.removeAttribute('src');
     loupeInfo.textContent = 'Select a photo to preview. Hover to compare sharpness across all frames.';
     detailEl.innerHTML = '';
     grmLoupeReset();

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2720,18 +2720,37 @@ function initPipelineReviewPage() {
 }
 
 function applyPipelineReviewModeChrome() {
-  if (!PIPELINE_EYE_COMPARE) return;
-  document.title = 'Vireo - Eye Compare';
+  var preserveBrowseBurst = isBrowseBurstReviewRequest();
+  var classicPath = '/pipeline/review' + (preserveBrowseBurst ? '?browse_burst=1' : '');
+  var eyeComparePath = '/pipeline/eye-review' + (preserveBrowseBurst ? '?browse_burst=1' : '');
   var banner = document.getElementById('eyeReviewBanner');
-  if (banner) banner.style.display = 'flex';
   var filterLink = document.getElementById('eyeModeFilterLink');
+  var modeSwitch = document.getElementById('grmModeSwitch');
+
+  if (!PIPELINE_EYE_COMPARE) {
+    if (filterLink) {
+      filterLink.href = eyeComparePath;
+    }
+    if (modeSwitch) {
+      modeSwitch.href = eyeComparePath;
+    }
+    return;
+  }
+
+  document.title = 'Vireo - Eye Compare';
+  if (banner) {
+    banner.style.display = 'flex';
+    var bannerLink = banner.querySelector('a');
+    if (bannerLink) {
+      bannerLink.href = classicPath;
+    }
+  }
   if (filterLink) {
-    filterLink.href = '/pipeline/review';
+    filterLink.href = classicPath;
     filterLink.textContent = 'Classic Review';
   }
-  var modeSwitch = document.getElementById('grmModeSwitch');
   if (modeSwitch) {
-    modeSwitch.href = '/pipeline/review';
+    modeSwitch.href = classicPath;
     modeSwitch.textContent = 'Classic Review';
   }
   var loupeInfo = document.getElementById('grmLoupeInfo');
@@ -3291,7 +3310,10 @@ function openBrowseBurstReviewFromStorage() {
     // path must remain recoverable — both via the in-page Reopen button and
     // via a plain reload. clearBrowseBurstHandoff() runs only once the user
     // applies (workflow complete) or we fall back to normal review.
-    openGroupReview(0, 0, loadedIds[0]);
+    var params = new URLSearchParams(window.location.search || '');
+    var requestedPhotoId = params.has('photo') ? parseInt(params.get('photo'), 10) : null;
+    var initialPhotoId = loadedIds.indexOf(requestedPhotoId) !== -1 ? requestedPhotoId : loadedIds[0];
+    openGroupReview(0, 0, initialPhotoId);
   }).catch(function() {
     fallbackToNormalPipelineReview('Could not open burst review — showing the latest pipeline review instead.');
   });
@@ -3538,6 +3560,9 @@ function grmUpdateModeSwitchLink() {
   if (!link || !grmState) return;
   var path = PIPELINE_EYE_COMPARE ? '/pipeline/review' : '/pipeline/eye-review';
   var params = new URLSearchParams();
+  if (grmState.source === 'browse-selection' || isBrowseBurstReviewRequest()) {
+    params.set('browse_burst', '1');
+  }
   if (Number.isInteger(grmState.encIdx)) params.set('enc', String(grmState.encIdx));
   if (Number.isInteger(grmState.burstIdx)) params.set('burst', String(grmState.burstIdx));
   if (grmState.selected) params.set('photo', String(grmState.selected));

--- a/vireo/tests/test_tabs_api.py
+++ b/vireo/tests/test_tabs_api.py
@@ -122,7 +122,7 @@ def test_get_tabs_endpoint_new_shape(app_and_db):
     ids = [p["id"] for p in body["all_pages"]]
     assert "duplicates" in ids
     assert "browse" in ids
-    expected_ids = {p["id"] for p in ALL_PAGES}
-    assert set(ids) == expected_ids
+    expected_ids = [p["id"] for p in ALL_PAGES]
+    assert ids == expected_ids
     sample = next(p for p in body["all_pages"] if p["id"] == "duplicates")
     assert sample == {"id": "duplicates", "label": "Duplicates", "href": "/duplicates"}

--- a/vireo/tests/test_tabs_api.py
+++ b/vireo/tests/test_tabs_api.py
@@ -109,6 +109,7 @@ def test_reorder_tabs_rejects_non_string_entries(app_and_db):
 
 
 def test_get_tabs_endpoint_new_shape(app_and_db):
+    from app import ALL_PAGES
     from db import DEFAULT_TABS
     app, db = app_and_db
     client = app.test_client()
@@ -121,6 +122,6 @@ def test_get_tabs_endpoint_new_shape(app_and_db):
     ids = [p["id"] for p in body["all_pages"]]
     assert "duplicates" in ids
     assert "browse" in ids
-    assert len(ids) == 21
+    assert len(ids) == len(ALL_PAGES)
     sample = next(p for p in body["all_pages"] if p["id"] == "duplicates")
     assert sample == {"id": "duplicates", "label": "Duplicates", "href": "/duplicates"}

--- a/vireo/tests/test_tabs_api.py
+++ b/vireo/tests/test_tabs_api.py
@@ -122,6 +122,7 @@ def test_get_tabs_endpoint_new_shape(app_and_db):
     ids = [p["id"] for p in body["all_pages"]]
     assert "duplicates" in ids
     assert "browse" in ids
-    assert len(ids) == len(ALL_PAGES)
+    expected_ids = {p["id"] for p in ALL_PAGES}
+    assert set(ids) == expected_ids
     sample = next(p for p in body["all_pages"] if p["id"] == "duplicates")
     assert sample == {"id": "duplicates", "label": "Duplicates", "href": "/duplicates"}


### PR DESCRIPTION
## Summary
- remove the /pipeline/eye-review route and navbar mapping
- remove Eye Compare banner, mode switch links, and mode-specific modal behavior
- keep the existing Classic Review burst workflow as the only review page
- make the tabs endpoint test assert against app.ALL_PAGES instead of a stale hard-coded page count

## Tests
- pytest vireo/tests/test_app.py::test_templates_jinja_free_except_includes vireo/tests/test_tabs_api.py::test_get_tabs_endpoint_new_shape vireo/tests/test_db.py::test_all_nav_ids_covers_every_page -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Removed the Eye Compare feature and its UI/controls from the pipeline review experience; related mode switch and banner removed.
  * Simplified group-review modal and loupe behavior; burst review now opens consistently on the first photo.
  * Navigation/tab detection updated to highlight the rapid-review route instead of the removed eye-review route.
* **Tests**
  * Tests updated to derive expected pages from the shared page list rather than hardcoded values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->