### PR TITLE
[codex] Add burst review box sharpness controls

### DIFF
--- a/tests/e2e/test_burst_group_context_menu.py
+++ b/tests/e2e/test_burst_group_context_menu.py
@@ -90,6 +90,7 @@ def test_burst_card_right_click_opens_menu(live_server, page):
         "Move to Rejects",
         "Move to Candidates",
         "Open in Lightbox",
+        "Open in Browse Mode",
         "Reveal in",
         "Copy Path",
         "Remove from Group",

--- a/tests/e2e/test_burst_group_natural_size.py
+++ b/tests/e2e/test_burst_group_natural_size.py
@@ -209,3 +209,53 @@ def test_burst_modal_thumb_slider_resizes_wrapped_grid(live_server, page, tmp_pa
     assert bbox is not None
     assert abs(bbox["width"] - 220) < 1, f"box width {bbox['width']} != 220"
     assert abs(bbox["height"] - 147) < 1, f"box height {bbox['height']} != 147"
+
+
+def test_burst_modal_resolution_and_right_zoom_controls(live_server, page, tmp_path):
+    db = live_server["db"]
+    n = _seed_burst_with_real_photos(db, tmp_path)
+    if n < 1:
+        pytest.skip("could not seed burst group")
+    _ensure_photo_files_on_disk(db, tmp_path)
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    expect(page.locator("#grmResSlider")).to_be_visible()
+    expect(page.locator("#grmLoupeZoomSlider")).to_be_visible()
+
+    page.locator("#grmResSlider").evaluate(
+        """el => {
+          el.value = 3;
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+        }"""
+    )
+    expect(page.locator("#grmResLabel")).to_contain_text("original")
+
+    page.locator("#grmLoupeZoomSlider").evaluate(
+        """el => {
+          el.value = 200;
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+        }"""
+    )
+    transform = page.locator("#grmLoupePhoto").evaluate("el => el.style.transform")
+    assert "scale(2" in transform
+
+
+def test_burst_modal_scores_visible_box_sharpness(live_server, page, tmp_path):
+    db = live_server["db"]
+    n = _seed_burst_with_real_photos(db, tmp_path)
+    if n < 1:
+        pytest.skip("could not seed burst group")
+    _ensure_photo_files_on_disk(db, tmp_path)
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    expect(page.locator("#grmBoxSharpnessBtn")).to_be_visible()
+    page.locator("#grmBoxSharpnessBtn").click()
+    expect(page.locator(".grm-card-scores", has_text="Box:")).to_have_count(n)

--- a/tests/e2e/test_burst_group_natural_size.py
+++ b/tests/e2e/test_burst_group_natural_size.py
@@ -11,6 +11,7 @@ rather than visual pixel quality, since the latter is hard to test
 deterministically across browser engines.
 """
 import os
+import re
 
 import pytest
 from PIL import Image
@@ -212,6 +213,7 @@ def test_burst_modal_thumb_slider_resizes_wrapped_grid(live_server, page, tmp_pa
 
 
 def test_burst_modal_resolution_and_right_zoom_controls(live_server, page, tmp_path):
+    """The burst modal exposes image resolution and right-side loupe zoom controls."""
     db = live_server["db"]
     n = _seed_burst_with_real_photos(db, tmp_path)
     if n < 1:
@@ -241,7 +243,9 @@ def test_burst_modal_resolution_and_right_zoom_controls(live_server, page, tmp_p
         }"""
     )
     transform = page.locator("#grmLoupePhoto").evaluate("el => el.style.transform")
-    assert "scale(2" in transform
+    match = re.search(r"scale\(([-0-9.]+)\)", transform)
+    assert match, f"scale transform missing from {transform!r}"
+    assert abs(float(match.group(1)) - 2.0) < 0.01
 
 
 def test_burst_modal_scores_visible_box_sharpness(live_server, page, tmp_path):
@@ -288,6 +292,7 @@ def test_burst_modal_scores_visible_box_sharpness(live_server, page, tmp_path):
 
 
 def test_region_sharpness_endpoint_accepts_large_batches(live_server, page, tmp_path):
+    """The region sharpness API accepts expected batch sizes and rejects bad payloads."""
     db = live_server["db"]
     n = _seed_burst_with_real_photos(db, tmp_path)
     if n < 1:
@@ -316,3 +321,15 @@ def test_region_sharpness_endpoint_accepts_large_batches(live_server, page, tmp_
     assert response.status == 200
     body = response.json()
     assert len(body["results"]) == 101
+
+    non_object_response = page.request.post(
+        f"{url}/api/photos/sharpness/regions",
+        data=[],
+    )
+    assert non_object_response.status == 400
+
+    oversized_response = page.request.post(
+        f"{url}/api/photos/sharpness/regions",
+        data={"regions": regions * 2},
+    )
+    assert oversized_response.status == 400

--- a/tests/e2e/test_burst_group_natural_size.py
+++ b/tests/e2e/test_burst_group_natural_size.py
@@ -245,6 +245,7 @@ def test_burst_modal_resolution_and_right_zoom_controls(live_server, page, tmp_p
 
 
 def test_burst_modal_scores_visible_box_sharpness(live_server, page, tmp_path):
+    """Box sharpness scoring should render results without changing selection."""
     db = live_server["db"]
     n = _seed_burst_with_real_photos(db, tmp_path)
     if n < 1:
@@ -276,6 +277,9 @@ def test_burst_modal_scores_visible_box_sharpness(live_server, page, tmp_path):
 
     expect(page.locator("#grmBoxSharpnessBtn")).to_be_visible()
     page.locator("#grmBoxSharpnessBtn").click()
+    page.locator(".grm-card-scores", has_text="Box:").first.wait_for(
+        state="visible", timeout=5000
+    )
     expect(page.locator(".grm-card-scores", has_text="Box:")).to_have_count(n)
 
     if cards.count() >= 2:

--- a/tests/e2e/test_burst_group_natural_size.py
+++ b/tests/e2e/test_burst_group_natural_size.py
@@ -256,6 +256,59 @@ def test_burst_modal_scores_visible_box_sharpness(live_server, page, tmp_path):
     page.wait_for_load_state("networkidle")
     _open_burst_modal(page)
 
+    cards = page.locator("#grmOverlay .grm-card[data-photo-id]")
+    if cards.count() >= 2:
+        first_pid = cards.nth(0).get_attribute("data-photo-id")
+        second_pid = cards.nth(1).get_attribute("data-photo-id")
+        page.evaluate(
+            """([first, second]) => {
+              const a = parseInt(first, 10);
+              const b = parseInt(second, 10);
+              grmState.selected = b;
+              grmState.selectedIds = new Set([a, b]);
+              grmState.selectionAnchor = a;
+              renderGroupModal();
+            }""",
+            [first_pid, second_pid],
+        )
+        before = page.evaluate("Array.from(grmState.selectedIds).map(String).sort()")
+        assert before == sorted([first_pid, second_pid])
+
     expect(page.locator("#grmBoxSharpnessBtn")).to_be_visible()
     page.locator("#grmBoxSharpnessBtn").click()
     expect(page.locator(".grm-card-scores", has_text="Box:")).to_have_count(n)
+
+    if cards.count() >= 2:
+        after = page.evaluate("Array.from(grmState.selectedIds).map(String).sort()")
+        assert after == before
+
+
+def test_region_sharpness_endpoint_accepts_large_batches(live_server, page, tmp_path):
+    db = live_server["db"]
+    n = _seed_burst_with_real_photos(db, tmp_path)
+    if n < 1:
+        pytest.skip("could not seed burst group")
+    _ensure_photo_files_on_disk(db, tmp_path)
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    pid = int(page.locator("#grmOverlay .grm-card[data-photo-id]").first.get_attribute("data-photo-id"))
+    regions = [{
+        "photo_id": pid,
+        "x": 0,
+        "y": 0,
+        "w": 120,
+        "h": 80,
+        "source_w": 600,
+        "source_h": 400,
+    } for _ in range(101)]
+    response = page.request.post(
+        f"{url}/api/photos/sharpness/regions",
+        data={"regions": regions},
+    )
+    assert response.status == 200
+    body = response.json()
+    assert len(body["results"]) == 101

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4710,10 +4710,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         for raw in regions:
             if not isinstance(raw, dict):
+                results.append({
+                    "photo_id": None,
+                    "sharpness": None,
+                    "error": "region must be an object",
+                })
+                continue
+            raw_photo_id = raw.get("photo_id")
+            if isinstance(raw_photo_id, bool):
+                results.append({
+                    "photo_id": None,
+                    "sharpness": None,
+                    "error": "invalid photo_id",
+                })
                 continue
             try:
-                photo_id = int(raw.get("photo_id"))
+                photo_id = int(raw_photo_id)
             except (TypeError, ValueError):
+                results.append({
+                    "photo_id": None,
+                    "sharpness": None,
+                    "error": "invalid photo_id",
+                })
                 continue
             photo = db.get_photo(photo_id, verify_workspace=True)
             if not photo:
@@ -4735,27 +4753,47 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 continue
 
             def _float(name, default, region=raw):
+                raw_value = region.get(name, default)
                 try:
-                    return float(region.get(name, default))
+                    value = float(raw_value)
                 except (TypeError, ValueError):
-                    return default
+                    raise ValueError(f"invalid {name}") from None
+                if not math.isfinite(value):
+                    raise ValueError(f"invalid {name}")
+                return value
 
-            source_w = _float("source_w", photo["width"] or img.width)
-            source_h = _float("source_h", photo["height"] or img.height)
+            try:
+                source_w = _float("source_w", photo["width"] or img.width)
+                source_h = _float("source_h", photo["height"] or img.height)
+                x = _float("x", 0)
+                y = _float("y", 0)
+                w = _float("w", source_w)
+                h = _float("h", source_h)
+            except ValueError as exc:
+                results.append({
+                    "photo_id": photo_id,
+                    "sharpness": None,
+                    "error": str(exc),
+                })
+                continue
+
             if source_w <= 0 or source_h <= 0:
                 source_w, source_h = img.width, img.height
 
-            x = _float("x", 0)
-            y = _float("y", 0)
-            w = _float("w", source_w)
-            h = _float("h", source_h)
-
             scale_x = img.width / source_w
             scale_y = img.height / source_h
-            ix = max(0, min(img.width - 1, int(round(x * scale_x))))
-            iy = max(0, min(img.height - 1, int(round(y * scale_y))))
-            iw = max(1, int(round(w * scale_x)))
-            ih = max(1, int(round(h * scale_y)))
+            try:
+                ix = max(0, min(img.width - 1, int(round(x * scale_x))))
+                iy = max(0, min(img.height - 1, int(round(y * scale_y))))
+                iw = max(1, int(round(w * scale_x)))
+                ih = max(1, int(round(h * scale_y)))
+            except OverflowError:
+                results.append({
+                    "photo_id": photo_id,
+                    "sharpness": None,
+                    "error": "invalid region bounds",
+                })
+                continue
             if ix + iw > img.width:
                 iw = img.width - ix
             if iy + ih > img.height:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4701,8 +4701,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         regions = body.get("regions")
         if not isinstance(regions, list):
             return json_error("regions must be a list")
-        if len(regions) > 100:
-            return json_error("too many regions", 413)
 
         from image_loader import load_working_image
         from sharpness import _score_from_pil

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4687,6 +4687,94 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         preds = db.get_group_predictions(group_id)
         return jsonify([dict(p) for p in preds])
 
+    @app.route("/api/photos/sharpness/regions", methods=["POST"])
+    def api_photo_region_sharpness():
+        """Score sharpness for explicit per-photo image regions.
+
+        The burst-review UI sends the visible crop inside each comparison
+        thumbnail, expressed in the coordinate space of the image currently
+        laid out in the browser. We map that crop onto the 1024px working
+        image used by the existing sharpness scorer.
+        """
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        regions = body.get("regions")
+        if not isinstance(regions, list):
+            return json_error("regions must be a list")
+        if len(regions) > 100:
+            return json_error("too many regions", 413)
+
+        from image_loader import load_working_image
+        from sharpness import _score_from_pil
+
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        results = []
+
+        for raw in regions:
+            if not isinstance(raw, dict):
+                continue
+            try:
+                photo_id = int(raw.get("photo_id"))
+            except (TypeError, ValueError):
+                continue
+            photo = db.get_photo(photo_id, verify_workspace=True)
+            if not photo:
+                results.append({"photo_id": photo_id, "sharpness": None, "error": "not found"})
+                continue
+
+            folder = db.conn.execute(
+                "SELECT id, path FROM folders WHERE id = ?", (photo["folder_id"],)
+            ).fetchone()
+            if not folder:
+                results.append({"photo_id": photo_id, "sharpness": None, "error": "folder not found"})
+                continue
+
+            photo_dict = dict(photo)
+            folders = {folder["id"]: folder["path"]}
+            img = load_working_image(photo_dict, vireo_dir, max_size=1024, folders=folders)
+            if img is None:
+                results.append({"photo_id": photo_id, "sharpness": None, "error": "could not load image"})
+                continue
+
+            def _float(name, default, region=raw):
+                try:
+                    return float(region.get(name, default))
+                except (TypeError, ValueError):
+                    return default
+
+            source_w = _float("source_w", photo["width"] or img.width)
+            source_h = _float("source_h", photo["height"] or img.height)
+            if source_w <= 0 or source_h <= 0:
+                source_w, source_h = img.width, img.height
+
+            x = _float("x", 0)
+            y = _float("y", 0)
+            w = _float("w", source_w)
+            h = _float("h", source_h)
+
+            scale_x = img.width / source_w
+            scale_y = img.height / source_h
+            ix = max(0, min(img.width - 1, int(round(x * scale_x))))
+            iy = max(0, min(img.height - 1, int(round(y * scale_y))))
+            iw = max(1, int(round(w * scale_x)))
+            ih = max(1, int(round(h * scale_y)))
+            if ix + iw > img.width:
+                iw = img.width - ix
+            if iy + ih > img.height:
+                ih = img.height - iy
+
+            if iw < 2 or ih < 2:
+                score = None
+            else:
+                score = _score_from_pil(img, (ix, iy, iw, ih))
+            results.append({
+                "photo_id": photo_id,
+                "sharpness": score,
+                "region": {"x": ix, "y": iy, "w": iw, "h": ih},
+            })
+
+        return jsonify({"results": results})
+
     @app.route("/api/predictions/group/apply", methods=["POST"])
     def api_prediction_group_apply():
         """Apply pick/reject decisions and species to a burst group."""

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4698,9 +4698,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """
         db = _get_db()
         body = request.get_json(silent=True) or {}
+        if not isinstance(body, dict):
+            return json_error("request body must be a JSON object", 400)
         regions = body.get("regions")
         if not isinstance(regions, list):
             return json_error("regions must be a list")
+        max_regions = 200
+        if len(regions) > max_regions:
+            return json_error(f"too many regions (max {max_regions})", 400)
 
         from image_loader import load_working_image
         from sharpness import _score_from_pil

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -996,8 +996,23 @@ input[type="range"]::-moz-range-thumb {
   flex-shrink: 0;
 }
 .grm-footer .grm-hint { font-size: 11px; color: var(--text-ghost); flex: 1; }
-.grm-res-control { display: flex; align-items: center; gap: 8px; }
-.grm-res-control input[type="range"] { width: 100px; }
+.grm-res-control,
+.grm-loupe-zoom-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.grm-res-control input[type="range"],
+.grm-loupe-zoom-control input[type="range"] {
+  width: 100px;
+  accent-color: var(--accent);
+}
+.grm-loupe-zoom-control label,
+.grm-loupe-zoom-control span {
+  font-size: 12px;
+  color: var(--text-muted);
+}
 .grm-thumb-control {
   display: flex;
   align-items: center;
@@ -1049,6 +1064,7 @@ input[type="range"]::-moz-range-thumb {
   height: 100%;
   object-fit: contain;
   display: block;
+  transform-origin: 50% 50%;
 }
 .grm-loupe-info {
   padding: 8px 12px;
@@ -1056,6 +1072,22 @@ input[type="range"]::-moz-range-thumb {
   color: var(--text-dim);
   border-top: 1px solid var(--border-primary);
   text-align: center;
+}
+.grm-region-sharpness-btn {
+  margin: 6px 12px 0;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  border: none;
+  border-radius: 4px;
+  padding: 4px 10px;
+  font-size: 11px;
+  cursor: pointer;
+  align-self: center;
+}
+.grm-region-sharpness-btn:hover { color: var(--text-primary); }
+.grm-region-sharpness-btn:disabled {
+  opacity: 0.55;
+  cursor: wait;
 }
 .grm-loupe-crosshair-h {
   position: absolute;
@@ -1419,6 +1451,7 @@ input[type="range"]::-moz-range-thumb {
       </div>
       <div class="grm-loupe-info" id="grmLoupeInfo">Select a photo to preview. Hover to compare sharpness across all frames.</div>
       <button type="button" class="grm-reset-offsets-btn" id="grmResetAllOffsets" onclick="grmResetAllOffsets()">Reset pan offsets</button>
+      <button type="button" class="grm-region-sharpness-btn" id="grmBoxSharpnessBtn" onclick="grmCalculateBoxSharpness()">Score box sharpness</button>
       <div class="grm-loupe-detail" id="grmLoupeDetail"></div>
     </div>
   </div>
@@ -1436,7 +1469,12 @@ input[type="range"]::-moz-range-thumb {
       <input type="range" id="grmResSlider" min="0" max="3" step="1" value="3" oninput="grmSetResolution(this.value)">
       <span id="grmResLabel" style="font-size:11px;color:var(--text-dim);min-width:140px;">1920 · preview</span>
     </div>
-    <span class="grm-hint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
+    <div class="grm-loupe-zoom-control" title="Right preview zoom">
+      <label for="grmLoupeZoomSlider">Right:</label>
+      <input type="range" id="grmLoupeZoomSlider" min="100" max="500" step="25" value="100" oninput="grmSetLoupeZoom(this.value)">
+      <span id="grmLoupeZoomVal">1×</span>
+    </div>
+    <span class="grm-hint" id="grmHint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
     <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);" title="Apply pick/reject flag changes and species keywords, then close this burst.">Apply flags/species & Close</button>
   </div>
 </div>
@@ -1576,11 +1614,35 @@ function grmSetResolution(idx) {
   });
   if (grmState && grmState.selected) {
     var loupe = document.getElementById('grmLoupePhoto');
-    if (loupe) loupe.src = grmPhotoUrl(grmState.selected);
+    if (loupe) {
+      loupe.src = grmPhotoUrl(grmState.selected);
+      grmApplyLoupeZoom();
+    }
   }
   // Re-apply card transforms so cover-fit snaps to the new natural size.
   grmApplyCardTransforms();
   grmUpdateResLabel();
+}
+
+function grmSetLoupeZoom(value) {
+  var pct = parseInt(value, 10);
+  if (!pct) pct = 100;
+  pct = Math.max(100, Math.min(500, pct));
+  _grmLoupeZoomLevel = pct / 100;
+  var slider = document.getElementById('grmLoupeZoomSlider');
+  if (slider) slider.value = pct;
+  var label = document.getElementById('grmLoupeZoomVal');
+  if (label) label.textContent = _grmLoupeZoomLevel.toFixed(_grmLoupeZoomLevel >= 2 ? 1 : 2).replace(/\.0$/, '') + '×';
+  grmApplyLoupeZoom();
+}
+
+function grmApplyLoupeZoom() {
+  var img = document.getElementById('grmLoupePhoto');
+  if (!img) return;
+  var x = _grmLastHoverX == null ? 50 : _grmLastHoverX;
+  var y = _grmLastHoverY == null ? 50 : _grmLastHoverY;
+  img.style.transformOrigin = x + '% ' + y + '%';
+  img.style.transform = 'scale(' + _grmLoupeZoomLevel + ')';
 }
 
 function setSpeciesFilter(val) {
@@ -3330,6 +3392,7 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   };
   _grmLoupeLocked = false;
   _grmZoomMultiplier = 1;
+  _grmLoupeZoomLevel = 1;
   _grmLastHoverX = null;
   _grmLastHoverY = null;
   _grmOffsets = {};
@@ -3365,6 +3428,7 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   // Sync slider DOM with persisted resolution choice
   var slider = document.getElementById('grmResSlider');
   if (slider) slider.value = grmResolutionIdx;
+  grmSetLoupeZoom(100);
   grmUpdateResLabel();
 
   // Render an empty modal first so it appears responsive while we fetch DB
@@ -3470,6 +3534,7 @@ function renderGroupModal() {
     var cls = 'grm-card' + (isSelected ? ' selected' : '');
     var qScore = p.quality_composite != null ? Math.round(p.quality_composite * 100) : '-';
     var sharp = p.subject_tenengrad != null ? Math.round(p.subject_tenengrad) : '-';
+    var boxSharp = p.box_sharpness != null ? Math.round(p.box_sharpness) : null;
 
     // Read flag/keyword state from the live DB snapshot the modal opened
     // with, not the (potentially stale) cached p.flag — so a photo flagged
@@ -3489,6 +3554,8 @@ function renderGroupModal() {
 
     var nat = grmNaturalDims(p);
     var imgStyle = 'width:' + nat.w + 'px;height:' + nat.h + 'px;';
+    var scoresHtml = 'Q: <span class="score-val">' + qScore + '</span> S: <span class="score-val">' + sharp + '</span>';
+    if (boxSharp != null) scoresHtml += ' Box: <span class="score-val">' + boxSharp + '</span>';
     return '<div class="' + cls + '" data-photo-id="' + p.id + '"' +
         ' data-nat-w="' + nat.w + '" data-nat-h="' + nat.h + '"' +
         ' onmousedown="grmCardMouseDown(event)"' +
@@ -3502,7 +3569,7 @@ function renderGroupModal() {
       '</div>' +
       '<div class="grm-card-info">' +
         '<div class="grm-card-species">' + escapeHtml(p.filename || '') + '</div>' +
-        '<div class="grm-card-scores">Q: <span class="score-val">' + qScore + '</span> S: <span class="score-val">' + sharp + '</span></div>' +
+        '<div class="grm-card-scores">' + scoresHtml + '</div>' +
       '</div>' +
     '</div>';
   }
@@ -3709,6 +3776,11 @@ function grmSelect(photoId, mode) {
     if (!grmState.selectionAnchor) grmState.selectionAnchor = grmState.selected || photoId;
     _grmSelectRange(grmState.selectionAnchor, photoId);
     grmState.selected = photoId;
+  } else if (mode === 'force') {
+    selectedIds.clear();
+    selectedIds.add(photoId);
+    grmState.selected = photoId;
+    grmState.selectionAnchor = photoId;
   } else {
     if (grmState.selected === photoId && selectedIds.size === 1 && selectedIds.has(photoId)) {
       selectedIds.clear();
@@ -3730,10 +3802,12 @@ function grmSelect(photoId, mode) {
 
   if (grmState.selected) {
     loupeImg.src = grmPhotoUrl(grmState.selected);
+    grmApplyLoupeZoom();
     var photo = grmState.items.find(function(p) { return p.id === grmState.selected; });
     if (photo) {
       var sharp = photo.subject_tenengrad != null ? Math.round(photo.subject_tenengrad) : '?';
-      loupeInfo.textContent = (photo.filename || '') + ' — sharpness: ' + sharp + ' — move cursor to compare';
+      var boxSharp = photo.box_sharpness != null ? ' - box sharpness: ' + Math.round(photo.box_sharpness) : '';
+      loupeInfo.textContent = (photo.filename || '') + ' - sharpness: ' + sharp + boxSharp + ' - move cursor to compare';
 
       // Render pipeline metadata in detail panel
       detailEl.innerHTML = buildPipelineMetadataHtml(photo);
@@ -3863,6 +3937,7 @@ var GRM_CARD_H = 120;
 var GRM_THUMB_STORAGE_KEY = 'vireo.burstReviewThumbSize';
 
 var _grmZoomMultiplier = 1;   // wheel fine-tune on top of the 1:1 base scale
+var _grmLoupeZoomLevel = 1;
 var _grmLoupeLocked = false;
 var _grmLastHoverX = null;    // last cursor x% on the loupe (null = no hover yet)
 var _grmLastHoverY = null;
@@ -3993,6 +4068,10 @@ function _grmComputeCardTransform(card) {
   return {
     transform: 'translate(' + tx + 'px, ' + ty + 'px) scale(' + s + ')',
     scale: s,
+    tx: tx,
+    ty: ty,
+    w: W,
+    h: H,
     zoomed: hovering,
   };
 }
@@ -4046,6 +4125,13 @@ function grmCardImgLoaded(img) {
   }
 }
 
+function grmPositionCrosshair(x, y) {
+  var ch = document.getElementById('grmCrosshairH');
+  var cv = document.getElementById('grmCrosshairV');
+  if (ch) ch.style.top = y + '%';
+  if (cv) cv.style.left = x + '%';
+}
+
 function grmLoupeToggleLock(e) {
   _grmLoupeLocked = !_grmLoupeLocked;
   var ch = document.getElementById('grmCrosshairH');
@@ -4069,8 +4155,8 @@ function grmLoupeMove(e) {
   _grmLastHoverX = x;
   _grmLastHoverY = y;
 
-  document.getElementById('grmCrosshairH').style.top = y + '%';
-  document.getElementById('grmCrosshairV').style.left = x + '%';
+  grmPositionCrosshair(x, y);
+  grmApplyLoupeZoom();
 
   grmApplyCardTransforms();
 }
@@ -4088,6 +4174,7 @@ function grmLoupeZoom(e) {
   } else {
     _grmZoomMultiplier = Math.max(min, _grmZoomMultiplier / 1.25);
   }
+  grmApplyLoupeZoom();
   grmApplyCardTransforms();
 }
 
@@ -4219,6 +4306,58 @@ function grmResetAllOffsets() {
   grmRefreshResetAllVisibility();
 }
 
+function grmVisibleRegionForCard(card) {
+  var t = _grmComputeCardTransform(card);
+  var scale = t.scale || 1;
+  var W = t.w || (parseFloat(card.dataset.natW) || GRM_CARD_W);
+  var H = t.h || (parseFloat(card.dataset.natH) || GRM_CARD_H);
+  var x = Math.max(0, -t.tx / scale);
+  var y = Math.max(0, -t.ty / scale);
+  var w = Math.min(W - x, GRM_CARD_W / scale);
+  var h = Math.min(H - y, GRM_CARD_H / scale);
+  return {
+    photo_id: parseInt(card.dataset.photoId, 10),
+    x: x,
+    y: y,
+    w: Math.max(1, w),
+    h: Math.max(1, h),
+    source_w: W,
+    source_h: H,
+  };
+}
+
+async function grmCalculateBoxSharpness() {
+  var cards = Array.from(document.querySelectorAll('#grmOverlay .grm-card[data-photo-id]'));
+  if (!cards.length) return;
+  var btn = document.getElementById('grmBoxSharpnessBtn');
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = 'Scoring...';
+  }
+  try {
+    var data = await safeFetch('/api/photos/sharpness/regions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ regions: cards.map(grmVisibleRegionForCard) }),
+    }, { toast: false });
+    var byPhoto = {};
+    (data.results || []).forEach(function(r) { byPhoto[r.photo_id] = r; });
+    grmState.items.forEach(function(photo) {
+      var r = byPhoto[photo.id];
+      if (r && r.sharpness != null) photo.box_sharpness = r.sharpness;
+    });
+    renderGroupModal();
+    if (grmState.selected) grmSelect(grmState.selected, 'force');
+  } catch(e) {
+    console.error('Box sharpness failed:', e);
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = 'Score box sharpness';
+    }
+  }
+}
+
 function _grmUpdateIndicator(card) {
   var off = _grmOffsets[card.dataset.photoId];
   if (off && (off.tx !== 0 || off.ty !== 0)) {
@@ -4328,17 +4467,30 @@ document.addEventListener('keydown', function(e) {
   if (pipelineReviewBareKey(e, 'x')) { grmMoveReject(); e.preventDefault(); return; }
 });
 
-/* --- Right-click → open in Browse view ---
+function buildPipelinePhotoContextMenu(photoId) {
+  return [
+    {
+      label: 'Open in Browse Mode',
+      onClick: function() { window.open('/browse?photo_id=' + photoId, '_blank', 'noopener'); },
+    },
+  ];
+}
+
+/* --- Right-click menu ---
  * Catches contextmenu on photo cards (main grid) and grm-cards (group review
- * modal). Opens /browse?photo_id=<id> in a new tab so the user keeps their
- * pipeline-review state intact. */
+ * modal). Browse opens in a new tab so the user keeps their pipeline-review
+ * state intact. */
 document.addEventListener('contextmenu', function(e) {
   var card = e.target.closest('.photo-card[data-photo-id], .grm-card[data-photo-id]');
   if (!card) return;
   var pid = parseInt(card.dataset.photoId, 10);
   if (!pid) return;
   e.preventDefault();
-  window.open('/browse?photo_id=' + pid, '_blank', 'noopener');
+  if (typeof openContextMenu === 'function') {
+    openContextMenu(e, buildPipelinePhotoContextMenu(pid));
+  } else {
+    window.open('/browse?photo_id=' + pid, '_blank', 'noopener');
+  }
 });
 
 /* --- Apply & Close --- */

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3829,17 +3829,13 @@ function grmRefreshSelectedLoupe() {
     if (photo) {
       var sharp = photo.subject_tenengrad != null ? Math.round(photo.subject_tenengrad) : '?';
       var boxSharp = photo.box_sharpness != null ? ' - box sharpness: ' + Math.round(photo.box_sharpness) : '';
-      loupeInfo.textContent = PIPELINE_EYE_COMPARE
-        ? (photo.filename || '') + ' - sharpness: ' + sharp + boxSharp + ' - click/drag to set eye target'
-        : (photo.filename || '') + ' - sharpness: ' + sharp + boxSharp + ' - move cursor to compare';
+      loupeInfo.textContent = (photo.filename || '') + ' - sharpness: ' + sharp + boxSharp + ' - move cursor to compare';
       detailEl.innerHTML = buildPipelineMetadataHtml(photo);
     }
     grmUpdateResLabel();
   } else {
     loupeImg.removeAttribute('src');
-    loupeInfo.textContent = PIPELINE_EYE_COMPARE
-      ? 'Select a reference photo. Click the large photo to place the eye target.'
-      : 'Select a photo to preview. Hover to compare sharpness across all frames.';
+    loupeInfo.textContent = 'Select a photo to preview. Hover to compare sharpness across all frames.';
     detailEl.innerHTML = '';
     grmLoupeReset();
   }
@@ -4335,10 +4331,16 @@ function grmVisibleRegionForCard(card) {
   var scale = t.scale || 1;
   var W = t.w || (parseFloat(card.dataset.natW) || GRM_CARD_W);
   var H = t.h || (parseFloat(card.dataset.natH) || GRM_CARD_H);
-  var x = Math.max(0, -t.tx / scale);
-  var y = Math.max(0, -t.ty / scale);
-  var w = Math.min(W - x, GRM_CARD_W / scale);
-  var h = Math.min(H - y, GRM_CARD_H / scale);
+  var left = -t.tx / scale;
+  var top = -t.ty / scale;
+  var right = left + (GRM_CARD_W / scale);
+  var bottom = top + (GRM_CARD_H / scale);
+  var x = Math.max(0, left);
+  var y = Math.max(0, top);
+  right = Math.min(W, right);
+  bottom = Math.min(H, bottom);
+  var w = right - x;
+  var h = bottom - y;
   return {
     photo_id: parseInt(card.dataset.photoId, 10),
     x: x,
@@ -4368,7 +4370,7 @@ async function grmCalculateBoxSharpness() {
     (data.results || []).forEach(function(r) { byPhoto[r.photo_id] = r; });
     grmState.items.forEach(function(photo) {
       var r = byPhoto[photo.id];
-      if (r && r.sharpness != null) photo.box_sharpness = r.sharpness;
+      photo.box_sharpness = (r && r.sharpness != null) ? r.sharpness : null;
     });
     renderGroupModal();
     grmRefreshSelectedLoupe();

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3776,11 +3776,6 @@ function grmSelect(photoId, mode) {
     if (!grmState.selectionAnchor) grmState.selectionAnchor = grmState.selected || photoId;
     _grmSelectRange(grmState.selectionAnchor, photoId);
     grmState.selected = photoId;
-  } else if (mode === 'force') {
-    selectedIds.clear();
-    selectedIds.add(photoId);
-    grmState.selected = photoId;
-    grmState.selectionAnchor = photoId;
   } else {
     if (grmState.selected === photoId && selectedIds.size === 1 && selectedIds.has(photoId)) {
       selectedIds.clear();
@@ -3816,6 +3811,35 @@ function grmSelect(photoId, mode) {
   } else {
     loupeImg.removeAttribute('src');
     loupeInfo.textContent = 'Select a photo to preview. Hover to compare sharpness across all frames.';
+    detailEl.innerHTML = '';
+    grmLoupeReset();
+  }
+}
+
+function grmRefreshSelectedLoupe() {
+  var loupeImg = document.getElementById('grmLoupePhoto');
+  var loupeInfo = document.getElementById('grmLoupeInfo');
+  var detailEl = document.getElementById('grmLoupeDetail');
+  if (!loupeImg || !loupeInfo || !detailEl) return;
+
+  if (grmState.selected) {
+    loupeImg.src = grmPhotoUrl(grmState.selected);
+    grmApplyLoupeZoom();
+    var photo = grmState.items.find(function(p) { return p.id === grmState.selected; });
+    if (photo) {
+      var sharp = photo.subject_tenengrad != null ? Math.round(photo.subject_tenengrad) : '?';
+      var boxSharp = photo.box_sharpness != null ? ' - box sharpness: ' + Math.round(photo.box_sharpness) : '';
+      loupeInfo.textContent = PIPELINE_EYE_COMPARE
+        ? (photo.filename || '') + ' - sharpness: ' + sharp + boxSharp + ' - click/drag to set eye target'
+        : (photo.filename || '') + ' - sharpness: ' + sharp + boxSharp + ' - move cursor to compare';
+      detailEl.innerHTML = buildPipelineMetadataHtml(photo);
+    }
+    grmUpdateResLabel();
+  } else {
+    loupeImg.removeAttribute('src');
+    loupeInfo.textContent = PIPELINE_EYE_COMPARE
+      ? 'Select a reference photo. Click the large photo to place the eye target.'
+      : 'Select a photo to preview. Hover to compare sharpness across all frames.';
     detailEl.innerHTML = '';
     grmLoupeReset();
   }
@@ -4347,7 +4371,7 @@ async function grmCalculateBoxSharpness() {
       if (r && r.sharpness != null) photo.box_sharpness = r.sharpness;
     });
     renderGroupModal();
-    if (grmState.selected) grmSelect(grmState.selected, 'force');
+    grmRefreshSelectedLoupe();
   } catch(e) {
     console.error('Box sharpness failed:', e);
   } finally {

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -480,6 +480,25 @@
     flex-shrink: 0;
   }
   .grm-footer .grm-hint { font-size: 11px; color: var(--text-ghost, #555); flex: 1; }
+  .grm-res-control,
+  .grm-loupe-zoom-control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+  .grm-res-control input[type="range"],
+  .grm-loupe-zoom-control input[type="range"] {
+    width: 100px;
+    accent-color: var(--accent, #24E5CA);
+  }
+  .grm-res-control label,
+  .grm-res-control span,
+  .grm-loupe-zoom-control label,
+  .grm-loupe-zoom-control span {
+    font-size: 12px;
+    color: var(--text-muted, #888);
+  }
   .grm-thumb-control {
     display: flex;
     align-items: center;
@@ -529,6 +548,7 @@
     height: 100%;
     object-fit: contain;
     display: block;
+    transform-origin: 50% 50%;
   }
   .grm-loupe-info {
     padding: 8px 12px;
@@ -565,6 +585,22 @@
   .grm-loupe-preds-empty {
     color: var(--text-ghost, #555);
     font-style: italic;
+  }
+  .grm-region-sharpness-btn {
+    margin: 6px 12px 0;
+    background: var(--bg-tertiary, #14374E);
+    color: var(--text-muted, #888);
+    border: none;
+    border-radius: 4px;
+    padding: 4px 10px;
+    font-size: 11px;
+    cursor: pointer;
+    align-self: center;
+  }
+  .grm-region-sharpness-btn:hover { color: var(--text-primary, #E0F0F0); }
+  .grm-region-sharpness-btn:disabled {
+    opacity: 0.55;
+    cursor: wait;
   }
   .grm-loupe-crosshair {
     position: absolute;
@@ -1412,8 +1448,8 @@ function buildBurstGroupContextMenu(photoId, filename) {
     { label: 'Copy Path',               onClick: function() { copyReviewPhotoPath(photoId); } },
     { separator: true },
     // Send-elsewhere actions: get the photo into another tool without losing
-    // burst-review state. "Show in Browse" opens in a new tab so the modal
-    // and current pick/reject decisions stay intact.
+    // burst-review state. Browse opens in a new tab so the modal and current
+    // pick/reject decisions stay intact.
     { label: 'Send to iNaturalist',
       onClick: function() {
         if (typeof window.submitToInat === 'function') window.submitToInat(photoId);
@@ -1427,7 +1463,7 @@ function buildBurstGroupContextMenu(photoId, filename) {
       onClick: function() {
         if (typeof window.developPhotos === 'function') window.developPhotos([photoId]);
       } },
-    { label: 'Show in Browse tab',
+    { label: 'Open in Browse Mode',
       onClick: function() { window.open('/browse?photo_id=' + photoId, '_blank'); } },
     { separator: true },
     { label: 'Remove from Group',       onClick: function() { grmRemoveFromGroup(); } },
@@ -1476,6 +1512,7 @@ function openGroupReview(groupId, model) {
   // the natural-size layout, _grmZoomLevel is now a multiplier above
   // cover-fit (1 = no zoom).
   _grmZoomLevel = 1;
+  _grmLoupeZoomLevel = 1;
   _grmOffsets = {};
   _grmDragging = null;
   _grmSuppressNextClick = false;
@@ -1486,6 +1523,10 @@ function openGroupReview(groupId, model) {
   grmRefreshResetAllVisibility();
   document.getElementById('grmOverlay').classList.add('open');
   grmSetThumbSize(GRM_CARD_W, false);
+  var resSlider = document.getElementById('grmResSlider');
+  if (resSlider) resSlider.value = grmResolutionIdx;
+  grmSetLoupeZoom(100, false);
+  grmUpdateResLabel();
   loadGroupData(groupId);
 }
 
@@ -1545,15 +1586,14 @@ function renderGroupModal() {
     var cls = 'grm-card' + (isSelected ? ' selected' : '') + (isBest ? ' ai-best' : '');
     var qScore = it.quality_score != null ? Math.round(it.quality_score * 100) : '-';
     var sharp = it.subject_sharpness != null ? Math.round(it.subject_sharpness) : (it.sharpness != null ? Math.round(it.sharpness) : '-');
+    var boxSharp = it.box_sharpness != null ? Math.round(it.box_sharpness) : null;
     var confPct = Math.round((it.confidence || 0) * 100);
 
-    // Once the user has zoomed, serve full-resolution originals so pixel-peeping
-    // and 1:1 inspection actually show sensor detail instead of an upscaled 400px thumbnail.
-    var src = grmState.upgraded
-      ? '/photos/' + it.photo_id + '/original'
-      : '/thumbnails/' + it.photo_id + '.jpg';
-    var nat = _grmReviewNaturalDims(it, grmState.upgraded);
+    var src = grmPhotoUrl(it.photo_id);
+    var nat = grmNaturalDims(it);
     var imgStyle = 'width:' + nat.w + 'px;height:' + nat.h + 'px;';
+    var scoresHtml = 'Q: <span class="score-val">' + qScore + '</span> S: <span class="score-val">' + sharp + '</span>';
+    if (boxSharp != null) scoresHtml += ' Box: <span class="score-val">' + boxSharp + '</span>';
     return '<div class="' + cls + '" data-photo-id="' + it.photo_id + '" data-pred-id="' + it.id + '"' +
       ' data-nat-w="' + nat.w + '" data-nat-h="' + nat.h + '"' +
       ' onmousedown="grmCardMouseDown(event)"' +
@@ -1565,7 +1605,7 @@ function renderGroupModal() {
       '</div>' +
       '<div class="grm-card-info">' +
         '<div class="grm-card-species">' + escapeHtml(it.species || '') + ' <span style="font-weight:400;color:var(--text-dim,#888);">' + confPct + '%</span></div>' +
-        '<div class="grm-card-scores">Q: <span class="score-val">' + qScore + '</span> S: <span class="score-val">' + sharp + '</span></div>' +
+        '<div class="grm-card-scores">' + scoresHtml + '</div>' +
         (isBest ? '<div class="grm-card-ai">AI BEST</div>' : '') +
       '</div>' +
     '</div>';
@@ -1661,6 +1701,11 @@ function grmSelect(photoId, mode) {
     if (!grmState.selectionAnchor) grmState.selectionAnchor = grmState.selected || photoId;
     _grmSelectRange(grmState.selectionAnchor, photoId);
     grmState.selected = photoId;
+  } else if (mode === 'force') {
+    selectedIds.clear();
+    selectedIds.add(photoId);
+    grmState.selected = photoId;
+    grmState.selectionAnchor = photoId;
   } else {
     if (grmState.selected === photoId && selectedIds.size === 1 && selectedIds.has(photoId)) {
       selectedIds.clear();
@@ -1680,13 +1725,16 @@ function grmSelect(photoId, mode) {
   var loupeInfo = document.getElementById('grmLoupeInfo');
   var loupePreds = document.getElementById('grmLoupePreds');
   if (grmState.selected) {
-    loupeImg.src = '/photos/' + grmState.selected + '/full';
+    loupeImg.src = grmLoupePhotoUrl(grmState.selected);
+    grmApplyLoupeZoom();
     var item = grmState.items.find(function(it) { return it.photo_id === grmState.selected; });
     if (item) {
       var sharp = item.subject_sharpness != null ? Math.round(item.subject_sharpness) : (item.sharpness != null ? Math.round(item.sharpness) : '?');
-      loupeInfo.textContent = (item.filename || '') + ' — sharpness: ' + sharp + ' — move cursor to compare';
+      var boxSharp = item.box_sharpness != null ? ' — box sharpness: ' + Math.round(item.box_sharpness) : '';
+      loupeInfo.textContent = (item.filename || '') + ' — sharpness: ' + sharp + boxSharp + ' — move cursor to compare';
       loupePreds.innerHTML = renderLoupePreds(item);
     }
+    grmUpdateResLabel();
   } else {
     loupeImg.src = '';
     loupeInfo.textContent = 'Select a photo to preview. Hover to compare sharpness across all frames.';
@@ -1748,6 +1796,14 @@ var _grmLoupeHovering = false;
 // actually paints.
 var _grmPendingSnap = false;
 var GRM_THUMB_STORAGE_KEY = 'vireo.burstReviewThumbSize';
+var GRM_RES_STOPS = [
+  { size: 400,  label: '400',      kind: 'thumb' },
+  { size: 1024, label: '1024',     kind: 'preview' },
+  { size: 1920, label: '1920',     kind: 'preview' },
+  { size: 0,    label: 'Original', kind: 'original' }
+];
+var grmResolutionIdx = 1;
+var _grmLoupeZoomLevel = 1;
 
 function _grmInitialThumbSize() {
   try {
@@ -1781,26 +1837,93 @@ function grmSetThumbSize(value, persist) {
 GRM_CARD_W = _grmInitialThumbSize();
 GRM_CARD_H = Math.round(GRM_CARD_W * 2 / 3);
 
-// Natural-size dims for one card. When the strip is still on the 400px
-// thumbnail, we use a 400px-fit; once upgraded to /original we use the
-// stored width/height.
-function _grmReviewNaturalDims(item, upgraded) {
-  if (upgraded) {
-    var W = (item && item.width) ? item.width : 1800;
-    var H = (item && item.height) ? item.height : 1200;
+function grmPhotoUrl(photoId) {
+  var stop = GRM_RES_STOPS[grmResolutionIdx] || GRM_RES_STOPS[1];
+  if (stop.kind === 'thumb') return '/thumbnails/' + photoId + '.jpg';
+  if (stop.kind === 'original') return '/photos/' + photoId + '/original';
+  return '/photos/' + photoId + '/preview?size=' + stop.size;
+}
+
+function grmLoupePhotoUrl(photoId) {
+  var stop = GRM_RES_STOPS[grmResolutionIdx] || GRM_RES_STOPS[1];
+  if (stop.kind === 'thumb') return '/photos/' + photoId + '/full';
+  return grmPhotoUrl(photoId);
+}
+
+function grmNaturalDims(item) {
+  var stop = GRM_RES_STOPS[grmResolutionIdx] || GRM_RES_STOPS[1];
+  var W = (item && item.width) ? item.width : 1800;
+  var H = (item && item.height) ? item.height : 1200;
+  if (stop.kind === 'original') {
     return { w: W, h: H };
   }
-  // 400px thumbnail: longest side fits to 400 while preserving aspect ratio.
-  // Falls back to a 3:2 box when dims are unknown so the card still looks right.
-  var W2 = (item && item.width) ? item.width : 600;
-  var H2 = (item && item.height) ? item.height : 400;
-  var longest = Math.max(W2, H2);
-  if (longest > 400) {
-    var r = 400 / longest;
-    W2 = Math.round(W2 * r);
-    H2 = Math.round(H2 * r);
+  var maxSide = stop.size || 400;
+  var longest = Math.max(W, H);
+  if (longest > maxSide) {
+    var r = maxSide / longest;
+    W = Math.round(W * r);
+    H = Math.round(H * r);
   }
-  return { w: W2, h: H2 };
+  return { w: W, h: H };
+}
+
+function grmUpdateResLabel() {
+  var el = document.getElementById('grmResLabel');
+  if (!el) return;
+  var stop = GRM_RES_STOPS[grmResolutionIdx] || GRM_RES_STOPS[1];
+  var item = grmState && grmState.selected
+    ? grmState.items.find(function(it) { return it.photo_id === grmState.selected; })
+    : (grmState && grmState.items[0]);
+  var label = stop.label;
+  if (item && item.width && item.height) {
+    var dims = grmNaturalDims(item);
+    label = dims.w + '×' + dims.h;
+  }
+  el.textContent = label + ' · ' + stop.kind;
+}
+
+function grmSetResolution(idx) {
+  grmResolutionIdx = parseInt(idx, 10) || 0;
+  grmState.upgraded = (GRM_RES_STOPS[grmResolutionIdx] || {}).kind === 'original';
+  var slider = document.getElementById('grmResSlider');
+  if (slider) slider.value = grmResolutionIdx;
+  document.querySelectorAll('.grm-card').forEach(function(card) {
+    var pid = parseInt(card.dataset.photoId, 10);
+    var img = card.querySelector('img');
+    if (!pid || !img) return;
+    var item = grmState.items.find(function(it) { return it.photo_id === pid; });
+    var nat = grmNaturalDims(item);
+    card.dataset.natW = nat.w;
+    card.dataset.natH = nat.h;
+    img.style.width = nat.w + 'px';
+    img.style.height = nat.h + 'px';
+    img.src = grmPhotoUrl(pid);
+  });
+  if (grmState && grmState.selected) {
+    var loupe = document.getElementById('grmLoupePhoto');
+    if (loupe) loupe.src = grmLoupePhotoUrl(grmState.selected);
+  }
+  _grmApplyAllCardTransforms(_grmLoupeLastX, _grmLoupeLastY);
+  grmUpdateResLabel();
+}
+
+function grmSetLoupeZoom(value, persist) {
+  var pct = parseInt(value, 10);
+  if (!pct) pct = 100;
+  pct = Math.max(100, Math.min(500, pct));
+  _grmLoupeZoomLevel = pct / 100;
+  var slider = document.getElementById('grmLoupeZoomSlider');
+  if (slider) slider.value = pct;
+  var label = document.getElementById('grmLoupeZoomVal');
+  if (label) label.textContent = _grmLoupeZoomLevel.toFixed(_grmLoupeZoomLevel >= 2 ? 1 : 2).replace(/\.0$/, '') + '×';
+  grmApplyLoupeZoom();
+}
+
+function grmApplyLoupeZoom() {
+  var img = document.getElementById('grmLoupePhoto');
+  if (!img) return;
+  img.style.transformOrigin = _grmLoupeLastX + '% ' + _grmLoupeLastY + '%';
+  img.style.transform = 'scale(' + _grmLoupeZoomLevel + ')';
 }
 
 function _grmUpgradeStripToOriginal() {
@@ -1809,21 +1932,29 @@ function _grmUpgradeStripToOriginal() {
   // Also relayout each <img> at the original's natural pixel size so the
   // browser rasterizes the layer at full resolution instead of bilinearly
   // upsampling the 400px thumbnail bitmap (the WKWebView quality bug).
-  if (grmState.upgraded) return;
+  if ((GRM_RES_STOPS[grmResolutionIdx] || {}).kind === 'original') return;
+  grmResolutionIdx = GRM_RES_STOPS.length - 1;
   grmState.upgraded = true;
+  var slider = document.getElementById('grmResSlider');
+  if (slider) slider.value = grmResolutionIdx;
   document.querySelectorAll('.grm-card').forEach(function(card) {
     var pid = card.getAttribute('data-photo-id');
     var img = card.querySelector('img');
     if (!pid || !img) return;
     var item = grmState.items.find(function(it) { return String(it.photo_id) === String(pid); });
-    var nat = _grmReviewNaturalDims(item, true);
+    var nat = grmNaturalDims(item);
     card.dataset.natW = nat.w;
     card.dataset.natH = nat.h;
     img.style.width = nat.w + 'px';
     img.style.height = nat.h + 'px';
-    img.src = '/photos/' + pid + '/original';
+    img.src = grmPhotoUrl(pid);
   });
+  if (grmState && grmState.selected) {
+    var loupe = document.getElementById('grmLoupePhoto');
+    if (loupe) loupe.src = grmLoupePhotoUrl(grmState.selected);
+  }
   _grmApplyAllCardTransforms(_grmLoupeLastX, _grmLoupeLastY);
+  grmUpdateResLabel();
 }
 
 function grmCardImgLoaded(img) {
@@ -1903,6 +2034,7 @@ function grmLoupeMove(e) {
   // Update crosshairs
   document.getElementById('grmCrosshairH').style.top = y + '%';
   document.getElementById('grmCrosshairV').style.left = x + '%';
+  grmApplyLoupeZoom();
 
   // No upgrade here: plain hover shouldn't trigger a burst of full-res fetches
   // for every strip card. Upgrade only when the user expresses zoom intent via
@@ -1936,6 +2068,10 @@ function _grmComputeCardTransform(card, hoverX, hoverY, hovering) {
   return {
     transform: 'translate(' + tx + 'px, ' + ty + 'px) scale(' + s + ')',
     scale: s,
+    tx: tx,
+    ty: ty,
+    w: W,
+    h: H,
     zoomed: hovering,
   };
 }
@@ -1980,6 +2116,7 @@ function grmLoupeZoom(e) {
   _grmLoupeLastY = ((e.clientY - rect.top) / rect.height) * 100;
   document.getElementById('grmCrosshairH').style.top = _grmLoupeLastY + '%';
   document.getElementById('grmCrosshairV').style.left = _grmLoupeLastX + '%';
+  grmApplyLoupeZoom();
   _grmApplyAllCardTransforms(_grmLoupeLastX, _grmLoupeLastY);
 }
 
@@ -2134,6 +2271,61 @@ function grmResetAllOffsets() {
     _grmApplyCardTransform(card);
   });
   grmRefreshResetAllVisibility();
+}
+
+function grmVisibleRegionForCard(card) {
+  var t = _grmComputeCardTransform(card, _grmLoupeLastX, _grmLoupeLastY, _grmLoupeHovering || _grmLoupeLocked);
+  var scale = t.scale || 1;
+  var W = t.w || (parseFloat(card.dataset.natW) || GRM_CARD_W);
+  var H = t.h || (parseFloat(card.dataset.natH) || GRM_CARD_H);
+  var x = Math.max(0, -t.tx / scale);
+  var y = Math.max(0, -t.ty / scale);
+  var w = Math.min(W - x, GRM_CARD_W / scale);
+  var h = Math.min(H - y, GRM_CARD_H / scale);
+  return {
+    photo_id: parseInt(card.dataset.photoId, 10),
+    x: x,
+    y: y,
+    w: Math.max(1, w),
+    h: Math.max(1, h),
+    source_w: W,
+    source_h: H,
+  };
+}
+
+async function grmCalculateBoxSharpness() {
+  var cards = Array.from(document.querySelectorAll('#grmOverlay .grm-card[data-photo-id]'));
+  if (!cards.length) return;
+  var btn = document.getElementById('grmBoxSharpnessBtn');
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = 'Scoring...';
+  }
+  try {
+    var payload = { regions: cards.map(grmVisibleRegionForCard) };
+    var data = await safeFetch('/api/photos/sharpness/regions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }, { toast: false });
+    var byPhoto = {};
+    (data.results || []).forEach(function(r) { byPhoto[r.photo_id] = r; });
+    grmState.items.forEach(function(item) {
+      var r = byPhoto[item.photo_id];
+      if (r && r.sharpness != null) item.box_sharpness = r.sharpness;
+    });
+    renderGroupModal();
+    if (grmState.selected) {
+      grmSelect(grmState.selected, 'force');
+    }
+  } catch(e) {
+    console.error('Box sharpness failed:', e);
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = 'Score box sharpness';
+    }
+  }
 }
 
 function _grmUpdateIndicator(card) {
@@ -2329,6 +2521,7 @@ document.addEventListener('keydown', function(e) {
       </div>
       <div class="grm-loupe-info" id="grmLoupeInfo">Select a photo to preview. Hover to compare sharpness across all frames.</div>
       <button type="button" class="grm-reset-offsets-btn" id="grmResetAllOffsets" onclick="grmResetAllOffsets()">Reset pan offsets</button>
+      <button type="button" class="grm-region-sharpness-btn" id="grmBoxSharpnessBtn" onclick="grmCalculateBoxSharpness()">Score box sharpness</button>
       <div class="grm-loupe-preds" id="grmLoupePreds"></div>
     </div>
   </div>
@@ -2340,6 +2533,16 @@ document.addEventListener('keydown', function(e) {
       <label for="grmThumbSizeSlider">Thumbs</label>
       <input type="range" id="grmThumbSizeSlider" min="100" max="320" step="20" value="180" oninput="grmSetThumbSize(this.value)">
       <span id="grmThumbSizeVal">180px</span>
+    </div>
+    <div class="grm-res-control" title="Image source resolution">
+      <label for="grmResSlider">Res</label>
+      <input type="range" id="grmResSlider" min="0" max="3" step="1" value="1" oninput="grmSetResolution(this.value)">
+      <span id="grmResLabel">1024 · preview</span>
+    </div>
+    <div class="grm-loupe-zoom-control" title="Right preview zoom">
+      <label for="grmLoupeZoomSlider">Right</label>
+      <input type="range" id="grmLoupeZoomSlider" min="100" max="500" step="25" value="100" oninput="grmSetLoupeZoom(this.value)">
+      <span id="grmLoupeZoomVal">1×</span>
     </div>
     <span class="grm-hint">↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; 1 = 1:1 zoom &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
     <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;">Apply & Close</button>

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1701,11 +1701,6 @@ function grmSelect(photoId, mode) {
     if (!grmState.selectionAnchor) grmState.selectionAnchor = grmState.selected || photoId;
     _grmSelectRange(grmState.selectionAnchor, photoId);
     grmState.selected = photoId;
-  } else if (mode === 'force') {
-    selectedIds.clear();
-    selectedIds.add(photoId);
-    grmState.selected = photoId;
-    grmState.selectionAnchor = photoId;
   } else {
     if (grmState.selected === photoId && selectedIds.size === 1 && selectedIds.has(photoId)) {
       selectedIds.clear();
@@ -1724,6 +1719,30 @@ function grmSelect(photoId, mode) {
   var loupeImg = document.getElementById('grmLoupePhoto');
   var loupeInfo = document.getElementById('grmLoupeInfo');
   var loupePreds = document.getElementById('grmLoupePreds');
+  if (grmState.selected) {
+    loupeImg.src = grmLoupePhotoUrl(grmState.selected);
+    grmApplyLoupeZoom();
+    var item = grmState.items.find(function(it) { return it.photo_id === grmState.selected; });
+    if (item) {
+      var sharp = item.subject_sharpness != null ? Math.round(item.subject_sharpness) : (item.sharpness != null ? Math.round(item.sharpness) : '?');
+      var boxSharp = item.box_sharpness != null ? ' — box sharpness: ' + Math.round(item.box_sharpness) : '';
+      loupeInfo.textContent = (item.filename || '') + ' — sharpness: ' + sharp + boxSharp + ' — move cursor to compare';
+      loupePreds.innerHTML = renderLoupePreds(item);
+    }
+    grmUpdateResLabel();
+  } else {
+    loupeImg.src = '';
+    loupeInfo.textContent = 'Select a photo to preview. Hover to compare sharpness across all frames.';
+    loupePreds.innerHTML = '';
+    grmLoupeReset();
+  }
+}
+
+function grmRefreshSelectedLoupe() {
+  var loupeImg = document.getElementById('grmLoupePhoto');
+  var loupeInfo = document.getElementById('grmLoupeInfo');
+  var loupePreds = document.getElementById('grmLoupePreds');
+  if (!loupeImg || !loupeInfo || !loupePreds) return;
   if (grmState.selected) {
     loupeImg.src = grmLoupePhotoUrl(grmState.selected);
     grmApplyLoupeZoom();
@@ -1798,8 +1817,8 @@ var _grmPendingSnap = false;
 var GRM_THUMB_STORAGE_KEY = 'vireo.burstReviewThumbSize';
 var GRM_RES_STOPS = [
   { size: 400,  label: '400',      kind: 'thumb' },
-  { size: 1024, label: '1024',     kind: 'preview' },
   { size: 1920, label: '1920',     kind: 'preview' },
+  { size: 3840, label: '4K',       kind: 'preview' },
   { size: 0,    label: 'Original', kind: 'original' }
 ];
 var grmResolutionIdx = 1;
@@ -2315,9 +2334,7 @@ async function grmCalculateBoxSharpness() {
       if (r && r.sharpness != null) item.box_sharpness = r.sharpness;
     });
     renderGroupModal();
-    if (grmState.selected) {
-      grmSelect(grmState.selected, 'force');
-    }
+    grmRefreshSelectedLoupe();
   } catch(e) {
     console.error('Box sharpness failed:', e);
   } finally {
@@ -2537,7 +2554,7 @@ document.addEventListener('keydown', function(e) {
     <div class="grm-res-control" title="Image source resolution">
       <label for="grmResSlider">Res</label>
       <input type="range" id="grmResSlider" min="0" max="3" step="1" value="1" oninput="grmSetResolution(this.value)">
-      <span id="grmResLabel">1024 · preview</span>
+      <span id="grmResLabel">1920 · preview</span>
     </div>
     <div class="grm-loupe-zoom-control" title="Right preview zoom">
       <label for="grmLoupeZoomSlider">Right</label>

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1864,8 +1864,6 @@ function grmPhotoUrl(photoId) {
 }
 
 function grmLoupePhotoUrl(photoId) {
-  var stop = GRM_RES_STOPS[grmResolutionIdx] || GRM_RES_STOPS[1];
-  if (stop.kind === 'thumb') return '/photos/' + photoId + '/full';
   return grmPhotoUrl(photoId);
 }
 
@@ -2297,10 +2295,16 @@ function grmVisibleRegionForCard(card) {
   var scale = t.scale || 1;
   var W = t.w || (parseFloat(card.dataset.natW) || GRM_CARD_W);
   var H = t.h || (parseFloat(card.dataset.natH) || GRM_CARD_H);
-  var x = Math.max(0, -t.tx / scale);
-  var y = Math.max(0, -t.ty / scale);
-  var w = Math.min(W - x, GRM_CARD_W / scale);
-  var h = Math.min(H - y, GRM_CARD_H / scale);
+  var left = -t.tx / scale;
+  var top = -t.ty / scale;
+  var right = left + (GRM_CARD_W / scale);
+  var bottom = top + (GRM_CARD_H / scale);
+  var x = Math.max(0, left);
+  var y = Math.max(0, top);
+  right = Math.min(W, right);
+  bottom = Math.min(H, bottom);
+  var w = right - x;
+  var h = bottom - y;
   return {
     photo_id: parseInt(card.dataset.photoId, 10),
     x: x,
@@ -2331,7 +2335,7 @@ async function grmCalculateBoxSharpness() {
     (data.results || []).forEach(function(r) { byPhoto[r.photo_id] = r; });
     grmState.items.forEach(function(item) {
       var r = byPhoto[item.photo_id];
-      if (r && r.sharpness != null) item.box_sharpness = r.sharpness;
+      item.box_sharpness = (r && r.sharpness != null) ? r.sharpness : null;
     });
     renderGroupModal();
     grmRefreshSelectedLoupe();


### PR DESCRIPTION
Adds burst review controls for source resolution and right-side preview zoom in both classic and pipeline review modals. Adds a region-sharpness API and a Score box sharpness action so users can calculate focus for only the currently visible comparison boxes. Updates burst right-click menus to expose Open in Browse Mode without losing review state. Validated with `python -m pytest tests/e2e/test_burst_group_context_menu.py tests/e2e/test_burst_group_natural_size.py` and `python -m pytest tests/e2e/test_page_loads.py -q`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Box sharpness scoring for burst photos in the review modal.
  * Resolution selection for burst-group images and loupe zoom controls.
  * Context menu label changed to "Open in Browse Mode."
  * New API endpoint to analyze sharpness for multiple image regions.

* **Tests**
  * Added end-to-end tests for burst modal resolution, loupe zoom, and box sharpness scoring.
  * Added tests for batch region sharpness API behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->