### PR TITLE
[codex] Fix test failures

### DIFF
--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -60,13 +60,14 @@ def find_darktable(configured_path):
 
 def find_dng_converter(configured_path):
     """Find Adobe DNG Converter or another compatible DNG converter binary."""
-    if configured_path and os.path.isfile(configured_path):
-        return os.path.realpath(configured_path)
+    if configured_path:
+        if os.path.isfile(configured_path):
+            return os.path.realpath(configured_path)
+        return None
 
     candidates = [
         shutil.which("Adobe DNG Converter"),
         shutil.which("Adobe DNG Converter.exe"),
-        "/Applications/Adobe DNG Converter.app/Contents/MacOS/Adobe DNG Converter",
     ]
 
     # Adobe DNG Converter on Windows has shipped under a few layouts: the
@@ -88,6 +89,8 @@ def find_dng_converter(configured_path):
                 "Adobe DNG Converter.exe",
             )
         )
+
+    candidates.append("/Applications/Adobe DNG Converter.app/Contents/MacOS/Adobe DNG Converter")
 
     for candidate in candidates:
         if candidate and os.path.isfile(candidate):

--- a/vireo/testing/userfirst/seeds.py
+++ b/vireo/testing/userfirst/seeds.py
@@ -177,6 +177,7 @@ def misses_seed(db_path, thumb_dir, photos_root):
             [{"box": {"x": 0.35, "y": 0.35, "w": 0.2, "h": 0.2},
               "confidence": 0.10 if _cat == "no_subject" else 0.85,
               "category": "animal"}],
+            detector_model="megadetector-v6",
         )
     db.conn.commit()
 


### PR DESCRIPTION
Fixes environment-sensitive DNG converter lookup by making explicit configured paths authoritative and checking Windows install roots before the macOS app fallback. Updates the user-first misses seed to pass the required detector model when writing detections. This addresses the Python test failures caused by local Adobe DNG Converter auto-detection and the updated `Database.save_detections` signature.

Validation: `python -m pytest tests/ vireo/tests/ -n auto -v --tb=short --cov=vireo --cov-report=term-missing --cov-fail-under=40`, `ruff check vireo/ tests/`, and `cargo test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DNG Converter detection now treats user-configured paths as authoritative and returns no result if the path is invalid, eliminating unnecessary fallback searches.

* **New Features**
  * Added native support for discovering Adobe DNG Converter on macOS systems through standard application paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->