### PR TITLE
[codex] Fix group review shortcut seeding

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3331,6 +3331,69 @@ function findBurstForPhoto(photoId) {
   return null;
 }
 
+function grmNormalizePhotoId(photoId) {
+  var id = parseInt(photoId, 10);
+  return Number.isInteger(id) ? id : null;
+}
+
+function grmSelectablePhotoId(items, photoId, removedSet) {
+  var id = grmNormalizePhotoId(photoId);
+  if (id == null) return null;
+  if (removedSet && removedSet.has(id)) return null;
+  return items.some(function(p) { return p.id === id; }) ? id : null;
+}
+
+function grmFirstSelectablePhotoId(items, removedSet) {
+  for (var i = 0; i < items.length; i++) {
+    if (!removedSet || !removedSet.has(items[i].id)) return items[i].id;
+  }
+  return null;
+}
+
+function grmFallbackSelectionId(items, preferredId) {
+  var removedSet = grmState && grmState.removed ? grmState.removed : null;
+  return grmSelectablePhotoId(items, preferredId, removedSet) || grmFirstSelectablePhotoId(items, removedSet);
+}
+
+function grmCurrentSelectionId(items) {
+  var removedSet = grmState && grmState.removed ? grmState.removed : null;
+  var selected = grmSelectablePhotoId(items, grmState && grmState.selected, removedSet);
+  if (selected != null) return selected;
+  if (grmState && grmState.selectedIds) {
+    var selectedIds = Array.from(grmState.selectedIds);
+    for (var i = 0; i < selectedIds.length; i++) {
+      var id = grmSelectablePhotoId(items, selectedIds[i], removedSet);
+      if (id != null) return id;
+    }
+  }
+  return null;
+}
+
+function grmRenderKeepingCurrentSelection(items, fallbackId) {
+  var currentId = grmCurrentSelectionId(items);
+  if (currentId != null) {
+    if (!grmState.selectedIds) grmState.selectedIds = new Set();
+    if (!grmState.selectedIds.has(currentId)) grmState.selectedIds.add(currentId);
+    grmState.selected = currentId;
+    if (!grmState.selectionAnchor) grmState.selectionAnchor = currentId;
+    renderGroupModal();
+    grmRefreshSelectedLoupe();
+    return;
+  }
+
+  var nextId = grmFallbackSelectionId(items, fallbackId);
+  if (nextId != null) {
+    grmSelect(nextId);
+    return;
+  }
+
+  grmState.selected = null;
+  if (grmState.selectedIds) grmState.selectedIds.clear();
+  grmState.selectionAnchor = null;
+  renderGroupModal();
+  grmRefreshSelectedLoupe();
+}
+
 function openRequestedGroupReviewFromUrl() {
   if (!pipelineResults) return;
   var params = new URLSearchParams(window.location.search || '');
@@ -3366,7 +3429,7 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   // Bump the session id so any in-flight /group/state fetch from a previous
   // openGroupReview call lands as stale and gets ignored when it resolves.
   var sessionId = (grmState.sessionId || 0) + 1;
-  var initialSelectedId = selectPhotoId || (items[0] && items[0].id) || null;
+  var initialSelectedId = grmSelectablePhotoId(items, selectPhotoId, null) || grmFirstSelectablePhotoId(items, null);
   var initialSelectedIds = new Set();
   if (initialSelectedId) initialSelectedIds.add(initialSelectedId);
 
@@ -3469,21 +3532,7 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
 // flags from a degraded snapshot.
 function grmShowSeedError(items, selectPhotoId) {
   grmState.dbState = {};
-  var initSelect = selectPhotoId || (items[0] && items[0].id);
-  if (
-    initSelect &&
-    grmState.selected === initSelect &&
-    grmState.selectedIds &&
-    grmState.selectedIds.size === 1 &&
-    grmState.selectedIds.has(initSelect)
-  ) {
-    renderGroupModal();
-    grmRefreshSelectedLoupe();
-  } else if (initSelect) {
-    grmSelect(initSelect);
-  } else {
-    renderGroupModal();
-  }
+  grmRenderKeepingCurrentSelection(items, selectPhotoId);
   var btn = document.getElementById('grmApplyBtn');
   if (btn) {
     btn.disabled = true;
@@ -3510,13 +3559,17 @@ function grmSeedFromDbState(dbPhotos, items, selectPhotoId) {
     }
   });
 
-  var initSelect = selectPhotoId;
-  if (!initSelect) {
+  var initSelect = grmSelectablePhotoId(items, selectPhotoId, grmState.removed);
+  if (initSelect == null) {
     var firstSelected = null;
     items.forEach(function(p) {
-      if (firstSelected == null && (grmState.picks.has(p.id) || grmState.rejects.has(p.id))) firstSelected = p.id;
+      if (
+        firstSelected == null &&
+        !grmState.removed.has(p.id) &&
+        (grmState.picks.has(p.id) || grmState.rejects.has(p.id))
+      ) firstSelected = p.id;
     });
-    initSelect = firstSelected || (items[0] && items[0].id);
+    initSelect = firstSelected || grmFirstSelectablePhotoId(items, grmState.removed);
   }
   // Mark the modal seeded *before* re-rendering so grmUpdateApplyLabel
   // (called from renderGroupModal) re-enables the button.
@@ -3528,20 +3581,7 @@ function grmSeedFromDbState(dbPhotos, items, selectPhotoId) {
     applyBtn.style.cursor = '';
   }
 
-  if (
-    initSelect &&
-    grmState.selected === initSelect &&
-    grmState.selectedIds &&
-    grmState.selectedIds.size === 1 &&
-    grmState.selectedIds.has(initSelect)
-  ) {
-    renderGroupModal();
-    grmRefreshSelectedLoupe();
-  } else if (initSelect) {
-    grmSelect(initSelect);
-  } else {
-    renderGroupModal();
-  }
+  grmRenderKeepingCurrentSelection(items, initSelect);
   grmUpdateApplyLabel();
 }
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3161,6 +3161,7 @@ var grmState = {
   selected: null,     // photo id
   selectedIds: new Set(),
   selectionAnchor: null,
+  touched: new Set(), // photo ids changed by the user before DB seeding lands
   sessionId: 0        // bumped on each openGroupReview; used to drop stale fetches
 };
 
@@ -3365,6 +3366,10 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   // Bump the session id so any in-flight /group/state fetch from a previous
   // openGroupReview call lands as stale and gets ignored when it resolves.
   var sessionId = (grmState.sessionId || 0) + 1;
+  var initialSelectedId = selectPhotoId || (items[0] && items[0].id) || null;
+  var initialSelectedIds = new Set();
+  if (initialSelectedId) initialSelectedIds.add(initialSelectedId);
+
   grmState = {
     encIdx: encIdx,
     burstIdx: burstIdx,
@@ -3372,9 +3377,10 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
     picks: new Set(),
     rejects: new Set(),
     removed: new Set(),
-    selected: null,
-    selectedIds: new Set(),
-    selectionAnchor: null,
+    selected: initialSelectedId,
+    selectedIds: initialSelectedIds,
+    selectionAnchor: initialSelectedId,
+    touched: new Set(),
     // Filled in by the /group/state fetch below. Keys: photo_id → {flag,
     // has_species_keyword}. This is the live DB snapshot the modal opened
     // with, used to (a) render "from DB" markers and (b) compute the
@@ -3434,6 +3440,7 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   // Render an empty modal first so it appears responsive while we fetch DB
   // state. The seed pass below populates picks/rejects and re-renders.
   renderGroupModal();
+  grmRefreshSelectedLoupe();
 
   safeFetch('/api/pipeline/group/state', {
     method: 'POST',
@@ -3463,7 +3470,16 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
 function grmShowSeedError(items, selectPhotoId) {
   grmState.dbState = {};
   var initSelect = selectPhotoId || (items[0] && items[0].id);
-  if (initSelect) {
+  if (
+    initSelect &&
+    grmState.selected === initSelect &&
+    grmState.selectedIds &&
+    grmState.selectedIds.size === 1 &&
+    grmState.selectedIds.has(initSelect)
+  ) {
+    renderGroupModal();
+    grmRefreshSelectedLoupe();
+  } else if (initSelect) {
     grmSelect(initSelect);
   } else {
     renderGroupModal();
@@ -3484,6 +3500,7 @@ function grmSeedFromDbState(dbPhotos, items, selectPhotoId) {
   grmState.dbState = dbPhotos || {};
 
   items.forEach(function(p) {
+    if (grmState.touched && grmState.touched.has(p.id)) return;
     var st = grmState.dbState[p.id];
     var flag = st ? st.flag : null;
     if (flag === 'flagged') {
@@ -3511,7 +3528,16 @@ function grmSeedFromDbState(dbPhotos, items, selectPhotoId) {
     applyBtn.style.cursor = '';
   }
 
-  if (initSelect) {
+  if (
+    initSelect &&
+    grmState.selected === initSelect &&
+    grmState.selectedIds &&
+    grmState.selectedIds.size === 1 &&
+    grmState.selectedIds.has(initSelect)
+  ) {
+    renderGroupModal();
+    grmRefreshSelectedLoupe();
+  } else if (initSelect) {
     grmSelect(initSelect);
   } else {
     renderGroupModal();
@@ -4411,8 +4437,14 @@ function _grmGetZone(photoId) {
   return 'candidates';
 }
 
+function _grmMarkTouched(photoId) {
+  if (!grmState.touched) grmState.touched = new Set();
+  if (photoId) grmState.touched.add(photoId);
+}
+
 function grmMoveUp() {
   if (!grmState.selected) return;
+  _grmMarkTouched(grmState.selected);
   var zone = _grmGetZone(grmState.selected);
   if (zone === 'rejects') {
     grmState.rejects.delete(grmState.selected);
@@ -4424,6 +4456,7 @@ function grmMoveUp() {
 
 function grmMoveDown() {
   if (!grmState.selected) return;
+  _grmMarkTouched(grmState.selected);
   var zone = _grmGetZone(grmState.selected);
   if (zone === 'picks') {
     grmState.picks.delete(grmState.selected);
@@ -4435,6 +4468,7 @@ function grmMoveDown() {
 
 function grmMovePick() {
   if (!grmState.selected) return;
+  _grmMarkTouched(grmState.selected);
   grmState.rejects.delete(grmState.selected);
   grmState.picks.add(grmState.selected);
   renderGroupModal();
@@ -4442,6 +4476,7 @@ function grmMovePick() {
 
 function grmMoveReject() {
   if (!grmState.selected) return;
+  _grmMarkTouched(grmState.selected);
   grmState.picks.delete(grmState.selected);
   grmState.rejects.add(grmState.selected);
   renderGroupModal();
@@ -4449,6 +4484,7 @@ function grmMoveReject() {
 
 function grmMoveCandidate() {
   if (!grmState.selected) return;
+  _grmMarkTouched(grmState.selected);
   grmState.picks.delete(grmState.selected);
   grmState.rejects.delete(grmState.selected);
   renderGroupModal();
@@ -4456,6 +4492,7 @@ function grmMoveCandidate() {
 
 function grmRemoveFromGroup() {
   if (!grmState.selected) return;
+  _grmMarkTouched(grmState.selected);
   grmState.removed.add(grmState.selected);
   grmState.picks.delete(grmState.selected);
   grmState.rejects.delete(grmState.selected);


### PR DESCRIPTION
Fixes a group review modal race where the selected photo was not available until the live DB state request finished, so immediate `x`/`p` shortcuts could miss the intended burst photo or interact with stale inspector state.

The modal now seeds the initial selection synchronously, refreshes the loupe for that selection, and tracks pre-seed user edits so the later DB snapshot cannot overwrite them.

Validated with `pytest tests/e2e/test_pipeline_rapid_review.py --browser chromium` (`19 passed`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Group Review Modal now preserves the user’s active photo selection and in-modal zone edits across asynchronous seeding and seeding failures.
  * Modal initializes with a sensible photo selection on open, avoiding empty/unstable selection states.
  * User-driven moves and edits are marked and protected so database syncs won’t overwrite recent user changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->