### PR TITLE
[codex] Remember lightbox pan zoom

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -154,6 +154,101 @@ def test_browse_lightbox_restores_and_carries_zoomed_viewport(live_server, page)
     assert abs(restored_view["centerY"] - first_view["centerY"]) < 0.03
 
 
+def test_browse_lightbox_pending_high_zoom_survives_native_zoom_race(live_server, page):
+    """A saved zoom > 4 is not lost when native zoom is unknown at first apply.
+
+    Race: if /api/photos/<id> resolves before the image load event,
+    _lbTryApplyPendingViewportState runs while _lbNativeZoom is null. The
+    fallback max clamps zoom to 4, so the pending state must be kept (not
+    cleared) so a later apply, once native zoom is known, can restore the
+    original high zoom.
+    """
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#274"/>'
+        '<circle cx="1000" cy="1400" r="180" fill="#fff"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+    )
+    page.route(
+        "**/photos/*/original",
+        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+    )
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 4000;
+        }"""
+    )
+
+    # Establish native zoom and pick a target zoom > 4 that is within the
+    # real max (nativeZoom * 4) so it would survive an accurate apply.
+    setup = page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbRecomputeNativeZoom();
+            const native = window._lbNativeZoom;
+            const target = Math.min(native * 2, native * 4 - 0.5);
+            return {native: native, target: target};
+        }"""
+    )
+    assert setup["native"] is not None and setup["native"] > 2.0
+    assert setup["target"] > 4.0
+
+    # Simulate the race: native zoom unknown when the pending high-zoom
+    # state is applied (e.g. API fetch resolved before image load).
+    degraded = page.evaluate(
+        """(target) => {
+            window._lbNativeZoom = null;
+            window._lbPendingViewportState = {
+                zoom: target, centerX: 0.3, centerY: 0.6,
+                oneToOne: false, pending1To1: false,
+            };
+            const applied = window._lbTryApplyPendingViewportState();
+            return {
+                applied: applied,
+                zoom: window._lbZoom,
+                stillPending: window._lbPendingViewportState !== null,
+            };
+        }""",
+        setup["target"],
+    )
+    assert degraded["applied"] is True
+    # Clamped to the fallback max while native zoom was unknown...
+    assert abs(degraded["zoom"] - 4.0) < 0.01
+    # ...but the pending state must survive so it can be retried.
+    assert degraded["stillPending"] is True
+
+    # Native zoom becomes known (image load path): the high zoom is
+    # restored accurately and the pending state is finally cleared.
+    restored = page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbRecomputeNativeZoom();
+            window._lbTryApplyPendingViewportState();
+            return {
+                zoom: window._lbZoom,
+                stillPending: window._lbPendingViewportState !== null,
+            };
+        }"""
+    )
+    assert abs(restored["zoom"] - setup["target"]) < 0.1
+    assert restored["stillPending"] is False
+
+
 def test_browse_lightbox_one_to_one_nav_falls_back_when_original_fails(live_server, page):
     """1:1 arrow navigation falls back to /full when the original is unavailable."""
     image_body = base64.b64decode(_PNG_1X1)

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -81,6 +81,79 @@ def test_browse_lightbox_arrows_preserve_one_to_one_zoom(live_server, page):
     assert page.evaluate("window._lbZoom") > 1.001
 
 
+def test_browse_lightbox_restores_and_carries_zoomed_viewport(live_server, page):
+    """Arrow navigation preserves pan/zoom per photo and carries it to unseen photos."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#274"/>'
+        '<circle cx="1000" cy="1400" r="180" fill="#fff"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+    )
+    page.route(
+        "**/photos/*/original",
+        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+    )
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 4000;
+        }"""
+    )
+
+    first_view = page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbRecomputeNativeZoom();
+            window._lbApplyViewportState({zoom: 2.2, centerX: 0.24, centerY: 0.70});
+            window._lbSaveViewportState(window._lightboxCurrentId);
+            return window._lbViewportStateFromCurrent();
+        }"""
+    )
+
+    page.locator("[title='Next (→)']").click()
+    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    page.wait_for_function("window._lbPendingViewportState === null")
+    carried_view = page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbRecomputeNativeZoom();
+            window._lbTryApplyPendingViewportState();
+            return window._lbViewportStateFromCurrent();
+        }"""
+    )
+    assert abs(carried_view["zoom"] - first_view["zoom"]) < 0.05
+    assert abs(carried_view["centerX"] - first_view["centerX"]) < 0.03
+    assert abs(carried_view["centerY"] - first_view["centerY"]) < 0.03
+
+    page.evaluate(
+        """() => {
+            window._lbApplyViewportState({zoom: 2.2, centerX: 0.78, centerY: 0.30});
+            window._lbSaveViewportState(window._lightboxCurrentId);
+        }"""
+    )
+    page.locator("[title='Previous (←)']").click()
+    expect(page.locator("#lightboxCounter")).to_contain_text("1 /")
+    page.wait_for_function("window._lbPendingViewportState === null")
+    restored_view = page.evaluate("window._lbViewportStateFromCurrent()")
+    assert abs(restored_view["zoom"] - first_view["zoom"]) < 0.05
+    assert abs(restored_view["centerX"] - first_view["centerX"]) < 0.03
+    assert abs(restored_view["centerY"] - first_view["centerY"]) < 0.03
+
+
 def test_browse_lightbox_one_to_one_nav_falls_back_when_original_fails(live_server, page):
     """1:1 arrow navigation falls back to /full when the original is unavailable."""
     image_body = base64.b64decode(_PNG_1X1)

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -249,6 +249,102 @@ def test_browse_lightbox_pending_high_zoom_survives_native_zoom_race(live_server
     assert restored["stillPending"] is False
 
 
+def test_browse_lightbox_manual_zoom_cancels_pending_restore(live_server, page):
+    """A manual wheel zoom cancels a still-armed pending viewport restore.
+
+    Regression: _lbPendingViewportState is intentionally kept until native
+    zoom is known so a high-zoom restore survives the metadata/image-load
+    race (see test above). But that same window let a later
+    _lbTryApplyPendingViewportState() (image-load callback) snap the
+    viewport back after the user had already zoomed the new photo. A
+    user-driven viewport mutation must cancel the pending restore.
+    """
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#274"/>'
+        '<circle cx="1000" cy="1400" r="180" fill="#fff"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+    )
+    page.route(
+        "**/photos/*/original",
+        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+    )
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 4000;
+        }"""
+    )
+
+    # Arm a high-zoom restore while native zoom is unknown — this is the
+    # carried-navigation race where the pending state survives an async
+    # retry (the precondition for the snap-back bug).
+    setup = page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbRecomputeNativeZoom();
+            const native = window._lbNativeZoom;
+            const target = Math.min(native * 2, native * 4 - 0.5);
+            window._lbNativeZoom = null;
+            window._lbPendingViewportState = {
+                zoom: target, centerX: 0.3, centerY: 0.6,
+                oneToOne: false, pending1To1: false,
+            };
+            window._lbTryApplyPendingViewportState();
+            return {
+                native: native,
+                target: target,
+                stillPending: window._lbPendingViewportState !== null,
+            };
+        }"""
+    )
+    assert setup["native"] is not None and setup["native"] > 2.0
+    # Sanity: pending must survive the native-zoom race, else there is no bug.
+    assert setup["stillPending"] is True
+
+    # The user manually zooms out with the wheel over the image.
+    page.locator("#lightboxWrap").hover()
+    page.mouse.wheel(0, 600)
+
+    after_wheel = page.evaluate(
+        """() => ({
+            zoom: window._lbZoom,
+            stillPending: window._lbPendingViewportState !== null,
+        })"""
+    )
+    # The manual wheel zoom must have cancelled the pending restore...
+    assert after_wheel["stillPending"] is False
+    # ...and produced a zoom clearly distinct from the stale pending target.
+    assert abs(after_wheel["zoom"] - setup["target"]) > 0.5
+
+    # A later image-load retry (native zoom now known) must NOT snap the
+    # viewport back to the stale pending state.
+    retried = page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbRecomputeNativeZoom();
+            const applied = window._lbTryApplyPendingViewportState();
+            return {applied: applied, zoom: window._lbZoom};
+        }"""
+    )
+    assert retried["applied"] is False
+    assert abs(retried["zoom"] - after_wheel["zoom"]) < 0.01
+
+
 def test_browse_lightbox_one_to_one_nav_falls_back_when_original_fails(live_server, page):
     """1:1 arrow navigation falls back to /full when the original is unavailable."""
     image_body = base64.b64decode(_PNG_1X1)

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2925,12 +2925,121 @@ var _lbCurrentWildlifeExcluded = false;
 var _lbFlagEditSeq = 0;      // increments for local flag writes so stale metadata fetches cannot overwrite the chip
 var _lbOpenSeq = 0;          // increments for every lightbox open so old metadata fetches cannot reapply after reopen
 var _lbFlagPendingWrites = 0;
+var _lbViewportByPhotoId = {};  // per-session lightbox viewport cache keyed by photo id
+var _lbPendingViewportState = null;
 
 function _lbIsOneToOneZoom() {
   if (_lbPending1To1) return true;
   if (!_lbNativeZoom || _lbNativeZoom <= 1.001) return false;
   var tolerance = Math.max(0.01, _lbNativeZoom * 0.01);
   return Math.abs(_lbZoom - _lbNativeZoom) <= tolerance;
+}
+
+function _lbCloneViewportState(state) {
+  if (!state) return null;
+  return {
+    zoom: Number(state.zoom) || 1.0,
+    centerX: Number(state.centerX),
+    centerY: Number(state.centerY),
+    oneToOne: !!state.oneToOne,
+    pending1To1: !!state.pending1To1,
+  };
+}
+
+function _lbViewportStateFromCurrent() {
+  var metrics = _lbUpdateLayoutMetrics();
+  var state = {
+    zoom: _lbZoom || 1.0,
+    centerX: 0.5,
+    centerY: 0.5,
+    oneToOne: _lbIsOneToOneZoom(),
+    pending1To1: !!_lbPending1To1,
+  };
+  var wrap = document.getElementById('lightboxWrap');
+  var t = document.getElementById('lightboxTransform');
+  if (metrics && wrap && t) {
+    var wrapRect = wrap.getBoundingClientRect();
+    var rect = t.getBoundingClientRect();
+    var scale = metrics.scale || 1;
+    if (scale > 0 && metrics.w && metrics.h) {
+      var imgX = (wrapRect.left + wrapRect.width / 2 - rect.left) / scale;
+      var imgY = (wrapRect.top + wrapRect.height / 2 - rect.top) / scale;
+      state.centerX = Math.max(0, Math.min(1, imgX / metrics.w));
+      state.centerY = Math.max(0, Math.min(1, imgY / metrics.h));
+    }
+  }
+  return state;
+}
+
+function _lbSaveViewportState(photoId) {
+  if (photoId == null) return null;
+  var state = _lbViewportStateFromCurrent();
+  _lbViewportByPhotoId[String(photoId)] = state;
+  return _lbCloneViewportState(state);
+}
+
+function _lbViewportStateForOpen(photoId, fallbackState) {
+  var key = String(photoId);
+  if (Object.prototype.hasOwnProperty.call(_lbViewportByPhotoId, key)) {
+    return _lbCloneViewportState(_lbViewportByPhotoId[key]);
+  }
+  return _lbCloneViewportState(fallbackState);
+}
+
+function _lbApplyViewportState(state) {
+  state = _lbCloneViewportState(state);
+  if (!state) return false;
+  var metrics = _lbUpdateLayoutMetrics();
+  if (!metrics) return false;
+  var wrap = document.getElementById('lightboxWrap');
+  if (!wrap) return false;
+
+  var maxZoom = _lbNativeZoom ? _lbNativeZoom * 4 : 4;
+  var targetZoom = state.zoom || 1.0;
+  if (state.oneToOne) {
+    if (_lbNativeZoom) {
+      targetZoom = _lbNativeZoom;
+      _lbPending1To1 = false;
+    } else {
+      _lbPending1To1 = true;
+      targetZoom = Math.max(1.0, targetZoom);
+    }
+  } else {
+    _lbPending1To1 = false;
+  }
+  targetZoom = Math.max(1.0, Math.min(maxZoom, targetZoom));
+  _lbZoom = targetZoom;
+
+  if (_lbZoom <= 1.001) {
+    _lbPanX = 0;
+    _lbPanY = 0;
+  } else {
+    var scale = _lbFitScale * _lbZoom;
+    var centerX = Number.isFinite(state.centerX) ? state.centerX : 0.5;
+    var centerY = Number.isFinite(state.centerY) ? state.centerY : 0.5;
+    centerX = Math.max(0, Math.min(1, centerX));
+    centerY = Math.max(0, Math.min(1, centerY));
+    var baseLeft = (metrics.wrapW - metrics.w * scale) / 2;
+    var baseTop = (metrics.wrapH - metrics.h * scale) / 2;
+    _lbPanX = (metrics.wrapW / 2) - (centerX * metrics.w * scale) - baseLeft;
+    _lbPanY = (metrics.wrapH / 2) - (centerY * metrics.h * scale) - baseTop;
+    _lbClampPan();
+  }
+
+  wrap.classList.toggle('zoomed', _lbZoom > 1.001);
+  _lbApplyTransform();
+  _lbScheduleSourceSwap();
+  return true;
+}
+
+function _lbTryApplyPendingViewportState() {
+  if (!_lbPendingViewportState) return false;
+  var state = _lbPendingViewportState;
+  if (!_lbApplyViewportState(state)) return false;
+  if (!state.oneToOne || _lbNativeZoom) {
+    _lbPendingViewportState = null;
+  }
+  return true;
 }
 
 function _lbApplyPendingOneToOneZoom() {
@@ -3392,15 +3501,29 @@ function _lbLoadMaskVariants(photoId) {
 
 function openLightbox(photoId, filename, photoList, options) {
   var alreadyOpen = !!window._lbEscToken;
+  options = options || {};
+  var fallbackViewportState = options.fallbackViewportState || null;
+  if (alreadyOpen && _lightboxCurrentId != null) {
+    _lbSaveViewportState(_lightboxCurrentId);
+  }
   if (alreadyOpen) Keymap.popEsc(window._lbEscToken);
   window._lbEscToken = Keymap.pushEsc(function() { closeLightbox(); });
   if (!alreadyOpen) Keymap.lockBodyScroll();
   _lbOpenSeq += 1;
   var openSeq = _lbOpenSeq;
-  options = options || {};
   var preserveOneToOne = !!options.preserveOneToOne;
-  var transitionZoom = preserveOneToOne
-    ? Math.max(1.0, _lbZoom || _lbNativeZoom || 1.0)
+  var restoreViewportState = _lbViewportStateForOpen(photoId, fallbackViewportState);
+  if (!restoreViewportState && preserveOneToOne) {
+    restoreViewportState = {
+      zoom: Math.max(1.0, _lbZoom || _lbNativeZoom || 1.0),
+      centerX: 0.5,
+      centerY: 0.5,
+      oneToOne: true,
+      pending1To1: true,
+    };
+  }
+  var transitionZoom = restoreViewportState
+    ? Math.max(1.0, restoreViewportState.zoom || 1.0)
     : 1.0;
 
   _lightboxCurrentId = photoId;
@@ -3437,9 +3560,10 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbNativeZoom = null;
   _lbPhotoW = null;
   _lbPhotoH = null;
-  _lbCurrentSrcKey = preserveOneToOne ? 'original' : 'full';
+  _lbCurrentSrcKey = (restoreViewportState && restoreViewportState.zoom > 1.001) ? 'original' : 'full';
   _lbFullLongEdge = null;
-  _lbPending1To1 = preserveOneToOne;
+  _lbPending1To1 = !!(restoreViewportState && (restoreViewportState.oneToOne || restoreViewportState.pending1To1));
+  _lbPendingViewportState = restoreViewportState;
   _lbOriginalUnavailable = false;
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;
@@ -3457,7 +3581,7 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbApplyWildlifeExcludedButton();
       _lbRecordFetchedFlag(photoId, data.flag, flagFetchSeq);
       _lbRecomputeNativeZoom();
-      _lbApplyPendingOneToOneZoom();
+      if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
       _lbRenderEyeCrosshair(data);
     })
     .catch(function() {});
@@ -3478,7 +3602,7 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbPhotoH = img.naturalHeight;
     }
     _lbRecomputeNativeZoom();
-    _lbApplyPendingOneToOneZoom();
+    if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
     _lbApplyTransform();
   }
   function handleInitialImageError() {
@@ -3544,8 +3668,10 @@ function lightboxNav(delta) {
   if (idx === -1) return;
   var newIdx = idx + delta;
   if (newIdx < 0 || newIdx >= _lightboxPhotoList.length) return;
+  var currentViewportState = _lbSaveViewportState(_lightboxCurrentId);
   var next = _lightboxPhotoList[newIdx];
   openLightbox(next.id, next.filename, _lightboxPhotoList, {
+    fallbackViewportState: currentViewportState,
     preserveOneToOne: _lbIsOneToOneZoom()
   });
 }
@@ -3694,12 +3820,15 @@ function toggleLightboxZoom(e) {
       // Single click without dragging = zoom out to fit
       _lbSetZoom(1.0, null, null);
       window._lightboxZoomHandled = true;
+    } else if (didDrag) {
+      _lbSaveViewportState(_lightboxCurrentId);
     }
   });
 })();
 
 function closeLightbox(e) {
   if (e && e.target && e.target.tagName === 'IMG') return;
+  if (_lightboxCurrentId != null) _lbSaveViewportState(_lightboxCurrentId);
   var wasOpen = !!window._lbEscToken;
   if (wasOpen) { Keymap.popEsc(window._lbEscToken); window._lbEscToken = null; }
   var wrap = document.getElementById('lightboxWrap');
@@ -3707,6 +3836,7 @@ function closeLightbox(e) {
   _lbZoom = 1.0;
   _lbPanX = 0;
   _lbPanY = 0;
+  _lbPendingViewportState = null;
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;
   _lbApplyTransform();
@@ -4398,6 +4528,7 @@ function _lbSetZoom(newZoom, anchorClientX, anchorClientY) {
     wrap.classList.toggle('zoomed', _lbZoom > 1.001);
     _lbApplyTransform();
     _lbScheduleSourceSwap();
+    _lbSaveViewportState(_lightboxCurrentId);
     return;
   }
   // Cursor at clientX has image-local coord (clientX - rect.left) / scale.
@@ -4433,6 +4564,7 @@ function _lbSetZoom(newZoom, anchorClientX, anchorClientY) {
   wrap.classList.toggle('zoomed', _lbZoom > 1.001);
   _lbApplyTransform();
   _lbScheduleSourceSwap();
+  _lbSaveViewportState(_lightboxCurrentId);
 }
 
 function _lbClampPan() {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3032,6 +3032,16 @@ function _lbApplyViewportState(state) {
   return true;
 }
 
+function _lbClearPendingViewportRestore() {
+  // Called from user-driven viewport mutations (wheel/keyboard/click zoom,
+  // drag pan) so a still-armed restore carried over by arrow navigation
+  // cannot be reapplied by a later async metadata/image-load callback and
+  // stomp the user's manual zoom/pan. Programmatic restore paths
+  // (_lbTryApplyPendingViewportState) own clearing their own state and must
+  // not route through here.
+  _lbPendingViewportState = null;
+}
+
 function _lbTryApplyPendingViewportState() {
   if (!_lbPendingViewportState) return false;
   var state = _lbPendingViewportState;
@@ -3718,6 +3728,9 @@ function toggleLightboxZoom(e) {
   var wrap = document.getElementById('lightboxWrap');
   var img = document.getElementById('lightboxImg');
   if (!img) return;
+  // Explicit user zoom toggle ('z' shortcut or click-to-zoom) supersedes any
+  // restore carried over by arrow navigation.
+  _lbClearPendingViewportRestore();
 
   // If we don't know native zoom yet (e.g. dimensions fetch still pending),
   // fall back to old two-tier behavior: load original, no continuous control.
@@ -3762,6 +3775,7 @@ function toggleLightboxZoom(e) {
     var scale = e.ctrlKey ? 0.02 : 0.0015;
     var zoomFactor = Math.exp(-e.deltaY * scale);
     var newZoom = _lbZoom * zoomFactor;
+    _lbClearPendingViewportRestore();
     _lbSetZoom(newZoom, e.clientX, e.clientY);
   }, { passive: false });
 })();
@@ -3808,8 +3822,11 @@ function toggleLightboxZoom(e) {
     if (!dragging) return;
     var dx = e.clientX - startX;
     var dy = e.clientY - startY;
-    if (Math.abs(dx) > DRAG_THRESHOLD || Math.abs(dy) > DRAG_THRESHOLD) {
+    if (!didDrag && (Math.abs(dx) > DRAG_THRESHOLD || Math.abs(dy) > DRAG_THRESHOLD)) {
       didDrag = true;
+      // First real pan movement cancels a pending restore so an async
+      // image-load retry cannot snap the viewport back mid-drag.
+      _lbClearPendingViewportRestore();
     }
     _lbPanX = panStartX + dx;
     _lbPanY = panStartY + dy;
@@ -3822,6 +3839,7 @@ function toggleLightboxZoom(e) {
     dragging = false;
     if (!didDrag && _lbZoom > 1.001) {
       // Single click without dragging = zoom out to fit
+      _lbClearPendingViewportRestore();
       _lbSetZoom(1.0, null, null);
       window._lightboxZoomHandled = true;
     } else if (didDrag) {
@@ -3840,7 +3858,7 @@ function closeLightbox(e) {
   _lbZoom = 1.0;
   _lbPanX = 0;
   _lbPanY = 0;
-  _lbPendingViewportState = null;
+  _lbClearPendingViewportRestore();
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;
   _lbApplyTransform();
@@ -4353,14 +4371,17 @@ document.addEventListener('keydown', function(e) {
   // would also fire rate_0 and silently clear the photo's rating.
   if (!editable && !e.ctrlKey && !e.metaKey && !e.altKey) {
     if (e.key === '+' || e.key === '=') {
+      _lbClearPendingViewportRestore();
       _lbSetZoom(_lbZoom * 1.25, null, null);
       e.preventDefault();
       e.stopImmediatePropagation();
     } else if (e.key === '-' || e.key === '_') {
+      _lbClearPendingViewportRestore();
       _lbSetZoom(_lbZoom * 0.8, null, null);
       e.preventDefault();
       e.stopImmediatePropagation();
     } else if (e.key === '0') {
+      _lbClearPendingViewportRestore();
       _lbSetZoom(1.0, null, null);
       e.preventDefault();
       e.stopImmediatePropagation();

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3036,7 +3036,11 @@ function _lbTryApplyPendingViewportState() {
   if (!_lbPendingViewportState) return false;
   var state = _lbPendingViewportState;
   if (!_lbApplyViewportState(state)) return false;
-  if (!state.oneToOne || _lbNativeZoom) {
+  // Keep the pending state until native zoom is known. Until then
+  // _lbApplyViewportState clamps with a fallback max of 4, so a saved
+  // zoom > 4 would be permanently degraded if cleared here and never
+  // retried once the image load event establishes _lbNativeZoom.
+  if (_lbNativeZoom) {
     _lbPendingViewportState = null;
   }
   return true;


### PR DESCRIPTION
This updates the shared lightbox so zoom and pan state is cached per photo during browse navigation. When moving to a photo without saved lightbox state, it carries the current normalized viewport instead of snapping back to center, while revisiting a photo restores its own saved viewport. The fix preserves existing 1:1 source-swap behavior and keeps direct lightbox opens from inheriting unrelated viewport state. Validated with `python -m pytest tests/e2e/test_browse_lightbox.py -q`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lightbox now preserves per-photo zoom and pan: navigating Next/Previous carries the current viewport to the next photo, restores the exact zoom/center when returning, and avoids snapping when users manually interact; pending restores are cleared on explicit user actions.

* **Tests**
  * Added an end-to-end test that verifies viewport preservation and restoration across lightbox navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->