### PR TITLE
[codex] Defer lightbox 1:1 until high-res source loads

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -378,6 +378,117 @@ def test_browse_lightbox_one_to_one_nav_falls_back_when_original_fails(live_serv
     assert "/full" in page.locator("#lightboxImg").get_attribute("src")
 
 
+def test_browse_lightbox_restored_pending_one_to_one_waits_for_fallback_after_initial_original_fails(
+    live_server, page
+):
+    """A restored pending 1:1 must not snap on /full after initial /original fails."""
+    page.add_init_script(
+        "Object.defineProperty(window, 'devicePixelRatio', { value: 1, configurable: true });"
+    )
+    full_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" '
+        'viewBox="0 0 600 400"><rect width="600" height="400" fill="#274"/></svg>'
+    )
+    fallback_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="2560" height="1600" '
+        'viewBox="0 0 2560 1600"><rect width="2560" height="1600" fill="#642"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=full_svg, content_type="image/svg+xml"),
+    )
+    page.route(
+        "**/api/photos/1",
+        lambda route: route.fulfill(
+            json={
+                "id": 1,
+                "filename": "restored-pending.jpg",
+                "width": 4000,
+                "height": 2500,
+                "flag": "none",
+                "wildlife_excluded": False,
+            }
+        ),
+    )
+    page.route("**/photos/*/original", lambda route: route.abort())
+    held_fallback = {}
+
+    def hold_fallback(route):
+        if "released" in held_fallback:
+            route.fulfill(body=fallback_svg, content_type="image/svg+xml")
+        else:
+            held_fallback["route"] = route
+
+    page.route("**/photos/*/preview?size=2560", hold_fallback)
+    page.route("**/photos/*/preview?size=3840", hold_fallback)
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 900, "height": 700})
+    page.goto(f"{url}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    page.evaluate(
+        """() => {
+            const p = window.photos[0];
+            window._lbViewportByPhotoId[String(p.id)] = {
+                zoom: 1,
+                centerX: 0.5,
+                centerY: 0.5,
+                oneToOne: true,
+                pending1To1: true,
+            };
+            window.openLightbox(p.id, p.filename, window.photos);
+        }"""
+    )
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+
+    deadline = time.time() + 3
+    while "route" not in held_fallback and time.time() < deadline:
+        page.wait_for_timeout(25)
+    assert "route" in held_fallback, page.evaluate(
+        """() => ({
+            pending: window._lbPending1To1,
+            zoom: window._lbZoom,
+            nativeZoom: window._lbNativeZoom,
+            currentSource: window._lbCurrentSrcKey,
+            desiredSource: window._lbDesiredSrcKey,
+            originalUnavailable: window._lbOriginalUnavailable,
+            pendingViewport: window._lbPendingViewportState,
+            imgComplete: document.getElementById('lightboxImg')?.complete,
+            naturalWidth: document.getElementById('lightboxImg')?.naturalWidth,
+        })"""
+    )
+
+    waiting = page.evaluate(
+        """() => ({
+            pending: window._lbPending1To1,
+            zoom: window._lbZoom,
+            currentSource: window._lbCurrentSrcKey,
+            desiredSource: window._lbDesiredSrcKey,
+        })"""
+    )
+    assert waiting["pending"] is True
+    assert abs(waiting["zoom"] - 1) < 0.001
+    assert waiting["currentSource"] == "full"
+    assert waiting["desiredSource"] in ("2560", "3840")
+
+    held_fallback["released"] = True
+    held_fallback.pop("route").fulfill(
+        body=fallback_svg, content_type="image/svg+xml"
+    )
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return (window._lbCurrentSrcKey === '2560' || window._lbCurrentSrcKey === '3840')
+                && window._lbPending1To1 === false
+                && img && img.complete && img.naturalWidth === 2560
+                && window._lbNativeZoom
+                && Math.abs(window._lbZoom - window._lbNativeZoom) < 0.01;
+        }""",
+        timeout=8000,
+    )
+
+
 def test_browse_lightbox_one_to_one_uses_device_pixels_and_natural_layout(live_server, page):
     """1:1 uses natural image coordinates and maps source pixels to device pixels."""
     page.add_init_script(

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -185,22 +185,37 @@ def test_browse_lightbox_one_to_one_uses_device_pixels_and_natural_layout(live_s
 
 
 def test_browse_lightbox_defers_one_to_one_until_original_size_known(live_server, page):
-    """A loaded preview/full tier must not masquerade as true 1:1."""
+    """Metadata resolving before the held /original must not flash a soft 1:1.
+
+    Regression guard for the metadata-before-/original race: learning the true
+    dimensions (and therefore _lbNativeZoom) while /original is still loading
+    must NOT clear the pending 1:1 and snap on the upscaled /full tier. The
+    snap may only happen once the high-resolution source is actually current.
+    """
     page.add_init_script(
         "Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true });"
     )
-    svg = (
+    full_svg = (
         '<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="960" '
         'viewBox="0 0 1920 960"><rect width="1920" height="960" fill="#274"/></svg>'
     )
+    original_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#3a7"/></svg>'
+    )
     page.route(
         "**/photos/*/full",
-        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+        lambda route: route.fulfill(body=full_svg, content_type="image/svg+xml"),
     )
     held_original = {}
 
     def hold_original(route):
-        held_original["route"] = route
+        if "released" in held_original:
+            route.fulfill(body=original_svg, content_type="image/svg+xml")
+        elif "route" not in held_original:
+            held_original["route"] = route
+        else:
+            route.fulfill(body=original_svg, content_type="image/svg+xml")
 
     page.route("**/photos/*/original", hold_original)
 
@@ -220,6 +235,8 @@ def test_browse_lightbox_defers_one_to_one_until_original_size_known(live_server
         }"""
     )
 
+    # Press 1:1 while the true size is still unknown: it must defer (stay at
+    # fit, pending) and request /original rather than enlarging /full.
     state = page.evaluate(
         """() => {
             window._lbPhotoW = null;
@@ -243,18 +260,50 @@ def test_browse_lightbox_defers_one_to_one_until_original_size_known(live_server
     assert state["zoom"] == 1
     assert state["desiredSource"] == "original"
 
-    upgraded = page.evaluate(
+    # Wait until the deferred swap has actually issued the /original request
+    # and it is being held, so the metadata step below genuinely races a
+    # still-loading high-res source.
+    deadline = time.time() + 2
+    while "route" not in held_original and time.time() < deadline:
+        page.wait_for_timeout(25)
+    assert "route" in held_original
+
+    # Metadata resolves before the held /original finishes. Learning the true
+    # dimensions must NOT clear the pending state or snap on the upscaled /full.
+    still_deferred = page.evaluate(
         """() => {
             window._lbPhotoW = 4000;
             window._lbPhotoH = 2000;
             window._lbRecomputeNativeZoom();
             window._lbApplyPendingOneToOneZoom();
-            return Math.abs(window._lbZoom - window._lbNativeZoom) < 0.01;
+            return {
+                pending: window._lbPending1To1,
+                zoom: window._lbZoom,
+                currentSource: window._lbCurrentSrcKey,
+                nativeZoom: window._lbNativeZoom,
+            };
         }"""
     )
-    assert upgraded is True
-    if "route" in held_original:
-        held_original.pop("route").abort()
+    assert still_deferred["pending"] is True
+    assert abs(still_deferred["zoom"] - 1) < 0.001
+    assert still_deferred["currentSource"] == "full"
+    assert still_deferred["nativeZoom"] > 1
+
+    # Releasing /original lets the deferred 1:1 finally snap against the
+    # high-resolution source.
+    held_original["released"] = True
+    held_original.pop("route").fulfill(
+        body=original_svg, content_type="image/svg+xml"
+    )
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return window._lbCurrentSrcKey === 'original'
+                && window._lbPending1To1 === false
+                && img && img.complete && img.naturalWidth === 4000
+                && Math.abs(window._lbZoom - window._lbNativeZoom) < 0.01;
+        }"""
+    )
 
 
 def test_browse_lightbox_waits_for_original_before_one_to_one_snap(live_server, page):

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -730,3 +730,117 @@ def test_browse_image_hotkeys_preserve_selection_and_shortcut_remaps(live_server
     page.keyboard.press("e")
     expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay")
     page.wait_for_function("photos[0].flag === 'flagged'")
+
+
+def test_browse_lightbox_deferred_one_to_one_survives_original_failure_to_fallback(
+    live_server, page
+):
+    """Codex P2: a deferred 1:1 must not snap on the upscaled /full when
+    /original fails while a higher preview tier is still being fetched.
+
+    When the user presses z before photo dimensions are known and /original
+    then fails, the error path reschedules to the sharpest remaining tier.
+    The inline resolve must stay deferred while that upgrade is queued —
+    otherwise it snaps on the upscaled /full (soft-1:1 flash) and its trailing
+    reschedule retargets the swap back to /full, canceling the upgrade and
+    stranding the user on /full forever.
+
+    Integer-only tier math (600 -> 2560, devicePixelRatio 1) makes
+    _lbPickSourceKey land deterministically so the regression is a hard
+    failure rather than a float-boundary coin flip.
+    """
+    page.add_init_script(
+        "Object.defineProperty(window, 'devicePixelRatio', { value: 1, configurable: true });"
+    )
+    # /full is a small upscaled preview (600px); 1:1 genuinely needs a higher
+    # tier. With dims unknown the lightbox can't tell the photo is large, so on
+    # /original failure _lbPickSourceKey(_lbNativeZoom) reads the 600px /full
+    # decode (== recorded _lbFullLongEdge) and returns 'full' — the boundary
+    # that defeats the tier-rank guard the pre-fix code relied on.
+    full_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" '
+        'viewBox="0 0 600 400"><rect width="600" height="400" fill="#274"/></svg>'
+    )
+    fallback_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="2560" height="1600" '
+        'viewBox="0 0 2560 1600"><rect width="2560" height="1600" fill="#642"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=full_svg, content_type="image/svg+xml"),
+    )
+    page.route("**/photos/*/original", lambda route: route.abort())
+    page.route(
+        "**/photos/*/preview?size=2560",
+        lambda route: route.fulfill(body=fallback_svg, content_type="image/svg+xml"),
+    )
+    page.route(
+        "**/photos/*/preview?size=3840",
+        lambda route: route.fulfill(body=fallback_svg, content_type="image/svg+xml"),
+    )
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 600;
+        }"""
+    )
+
+    # Simulate pressing z while photo dimensions are still unknown: bump
+    # _lbOpenSeq so the in-flight /api/photos dims callback bails (it cannot
+    # repopulate _lbPhotoW), then clear dims and toggle. With nativeZoom
+    # unknown the deferred path schedules a swap to /original.
+    page.evaluate(
+        """() => {
+            window._lbOpenSeq += 1;
+            window._lbPhotoW = null;
+            window._lbPhotoH = null;
+            window._lbNativeZoom = null;
+            window._lbOriginalUnavailable = false;
+            window._lbCurrentSrcKey = 'full';
+            window.toggleLightboxZoom();
+        }"""
+    )
+    page.wait_for_function(
+        "window._lbPending1To1 === true && window._lbDesiredSrcKey === 'original'"
+    )
+    assert abs(page.evaluate("window._lbZoom") - 1) < 0.001
+    assert page.evaluate("window._lbCurrentSrcKey") == "full"
+
+    # /original aborts. The fix must keep the deferral pending and retarget the
+    # swap at the sharpest remaining preview tier (a real upgrade vs. /full).
+    # Pre-fix the inline resolve snapped on /full (pickSourceKey == 'full', so
+    # the tier-rank guard 0 < 0 did not defer) and its trailing reschedule
+    # retargeted the swap back to 'full', so this state is never reached and
+    # the wait fails fast.
+    page.wait_for_function(
+        """() => window._lbOriginalUnavailable === true
+            && window._lbPending1To1 === true
+            && window._lbCurrentSrcKey === 'full'
+            && (window._lbDesiredSrcKey === '2560' || window._lbDesiredSrcKey === '3840')""",
+        timeout=6000,
+    )
+    assert abs(page.evaluate("window._lbZoom") - 1) < 0.001
+
+    # Once the fallback tier becomes the current source the deferred snap
+    # completes at true 1:1 on that tier — never stranded on the upscaled /full.
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return (window._lbCurrentSrcKey === '2560' || window._lbCurrentSrcKey === '3840')
+                && window._lbPending1To1 === false
+                && img && img.complete && img.naturalWidth === 2560
+                && window._lbNativeZoom
+                && Math.abs(window._lbZoom - window._lbNativeZoom) < 0.01;
+        }""",
+        timeout=8000,
+    )

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -386,6 +386,109 @@ def test_browse_lightbox_waits_for_original_before_one_to_one_snap(live_server, 
     )
 
 
+def test_browse_lightbox_resize_preserves_deferred_one_to_one(live_server, page):
+    """A viewport resize while 'loading 1:1' must not drop the deferred snap."""
+    page.add_init_script(
+        "Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true });"
+    )
+    full_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="960" '
+        'viewBox="0 0 1920 960"><rect width="1920" height="960" fill="#274"/></svg>'
+    )
+    original_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#3a7"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=full_svg, content_type="image/svg+xml"),
+    )
+    held_original = {}
+
+    def hold_first_original(route):
+        if "released" in held_original:
+            route.fulfill(body=original_svg, content_type="image/svg+xml")
+        elif "route" not in held_original:
+            held_original["route"] = route
+        else:
+            route.fulfill(body=original_svg, content_type="image/svg+xml")
+
+    page.route("**/photos/*/original", hold_first_original)
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 1920;
+        }"""
+    )
+    page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbRecomputeNativeZoom();
+        }"""
+    )
+    page.wait_for_function("window._lbNativeZoom > 1")
+
+    page.keyboard.press("z")
+    page.wait_for_function(
+        "window._lbPending1To1 === true && window._lbDesiredSrcKey === 'original'"
+    )
+    assert abs(page.evaluate("window._lbZoom") - 1) < 0.001
+    assert page.evaluate("window._lbCurrentSrcKey") == "full"
+
+    # Wait until the deferred swap has actually issued the held /original
+    # request — i.e. we are genuinely in the "loading 1:1" state Codex flagged.
+    deadline = time.time() + 2
+    while "route" not in held_original and time.time() < deadline:
+        page.wait_for_timeout(25)
+    assert "route" in held_original
+
+    native_zoom_before = page.evaluate("window._lbNativeZoom")
+
+    # Resize while the high-res source is still loading. The image is 4000px
+    # wide so _lbFitScale (hence _lbNativeZoom) is width-constrained; shrinking
+    # the viewport width forces a deterministic _lbNativeZoom change once the
+    # resize handler runs. The handler recomputes _lbNativeZoom unconditionally
+    # (before any pending-state logic), so the change below is a fix-independent
+    # signal that the debounced handler has actually executed — no fixed sleep.
+    page.set_viewport_size({"width": 640, "height": 800})
+    page.wait_for_function(
+        "Math.abs(window._lbNativeZoom - %r) > 0.1" % native_zoom_before
+    )
+
+    # The resize handler has now run while /original is still held. Pre-fix it
+    # cleared _lbPending1To1 and retargeted the swap back to /full, so releasing
+    # /original below no longer snaps to 1:1 — the deferred zoom request was
+    # silently dropped and the snap assertion times out (hard regression).
+    original_route = held_original.pop("route")
+    held_original["released"] = True
+    original_route.fulfill(body=original_svg, content_type="image/svg+xml")
+
+    # Post-fix the deferred intent survives the resize, so the lightbox still
+    # snaps to true 1:1 on /original. Pre-fix this never completes (the snap was
+    # dropped) and the wait times out — making the regression a hard failure.
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return window._lbCurrentSrcKey === 'original'
+                && window._lbPending1To1 === false
+                && img && img.complete && img.naturalWidth === 4000
+                && Math.abs(window._lbZoom - window._lbNativeZoom) < 0.01;
+        }""",
+        timeout=8000,
+    )
+
+
 def test_browse_lightbox_does_not_retry_original_after_unavailable(live_server, page):
     """After /original fails, source selection should stay on preview/full tiers."""
     full_svg = (

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -901,6 +901,34 @@ def test_browse_lightbox_waits_for_fallback_tier_after_original_fails(live_serve
     assert waiting["currentSource"] == "full"
     assert waiting["desiredSource"] == "3840"
 
+    before_resize_transforms = page.evaluate(
+        """() => {
+            window.__lbResizeTransformCount = 0;
+            const originalApplyTransform = window._lbApplyTransform;
+            window._lbApplyTransform = function() {
+                window.__lbResizeTransformCount += 1;
+                return originalApplyTransform.apply(this, arguments);
+            };
+            return window.__lbResizeTransformCount;
+        }"""
+    )
+    page.set_viewport_size({"width": 760, "height": 800})
+    page.wait_for_function(
+        "window.__lbResizeTransformCount > %d" % before_resize_transforms
+    )
+    after_resize = page.evaluate(
+        """() => ({
+            pending: window._lbPending1To1,
+            zoom: window._lbZoom,
+            currentSource: window._lbCurrentSrcKey,
+            desiredSource: window._lbDesiredSrcKey,
+        })"""
+    )
+    assert after_resize["pending"] is True
+    assert abs(after_resize["zoom"] - 1) < 0.001
+    assert after_resize["currentSource"] == "full"
+    assert after_resize["desiredSource"] == "3840"
+
     fallback_route = held_fallback.pop("route")
     held_fallback["released"] = True
     fallback_route.fulfill(body=fallback_svg, content_type="image/svg+xml")

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -316,7 +316,10 @@ def test_browse_lightbox_waits_for_original_before_one_to_one_snap(live_server, 
     )
     assert abs(page.evaluate("window._lbZoom") - 1) < 0.001
     assert page.evaluate("window._lbCurrentSrcKey") == "full"
-    page.wait_for_timeout(250)
+    deadline = time.time() + 2
+    while "route" not in held_original and time.time() < deadline:
+        page.wait_for_timeout(25)
+    assert "route" in held_original
 
     original_route = held_original.pop("route")
     held_original["released"] = True

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -1222,3 +1222,138 @@ def test_browse_lightbox_deferred_one_to_one_survives_original_failure_to_fallba
         }""",
         timeout=8000,
     )
+
+
+def test_browse_lightbox_resize_preserves_post_original_failure_fallback(
+    live_server, page
+):
+    """Codex P2 (Thread 11): a viewport resize while the post-/original-failure
+    fallback tier is still loading must not cancel that upgrade.
+
+    Repro: press z with dims unknown -> /original aborts -> the error path
+    keeps the deferral pending and queues the sharpest remaining preview tier
+    (2560/3840). While that tier is still loading the user resizes. The resize
+    recovery path used to re-derive the swap target from _lbNativeZoom, which —
+    because /original is unavailable and the current source is the upscaled
+    /full — reflects the /full decode, so it re-picked 'full', canceled the
+    in-flight fallback upgrade, and snapped a soft 1:1 on /full. Post-fix the
+    deferred intent (and the higher-tier target) survives the resize.
+    """
+    full_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="960" '
+        'viewBox="0 0 1920 960"><rect width="1920" height="960" fill="#246"/></svg>'
+    )
+    fallback_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="2560" height="1600" '
+        'viewBox="0 0 2560 1600"><rect width="2560" height="1600" fill="#642"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=full_svg, content_type="image/svg+xml"),
+    )
+    page.route("**/photos/*/original", lambda route: route.abort())
+    held_fallback = {}
+
+    def hold_fallback(route):
+        # Hold the most recent fallback-tier request (2560 or 3840) until the
+        # test explicitly releases it. The resize re-arms the swap, so a later
+        # request supersedes the earlier held one — keep only the live route.
+        if "released" in held_fallback:
+            route.fulfill(body=fallback_svg, content_type="image/svg+xml")
+        else:
+            held_fallback["route"] = route
+
+    page.route("**/photos/*/preview?size=2560", hold_fallback)
+    page.route("**/photos/*/preview?size=3840", hold_fallback)
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 1920;
+        }"""
+    )
+
+    page.evaluate(
+        """() => {
+            window._lbPhotoW = null;
+            window._lbPhotoH = null;
+            window._lbOriginalUnavailable = false;
+            window._lbCurrentSrcKey = 'full';
+            window._lbNativeZoom = null;
+            window._lbZoom = 1;
+            window.toggleLightboxZoom();
+        }"""
+    )
+
+    # /original aborts; the deferred 1:1 must now be pending against the
+    # sharpest remaining preview tier (a real upgrade vs. the /full it is on).
+    deadline = time.time() + 3
+    while "route" not in held_fallback and time.time() < deadline:
+        page.wait_for_timeout(25)
+    assert "route" in held_fallback
+    waiting = page.evaluate(
+        """() => ({
+            pending: window._lbPending1To1,
+            zoom: window._lbZoom,
+            currentSource: window._lbCurrentSrcKey,
+            desiredSource: window._lbDesiredSrcKey,
+        })"""
+    )
+    assert waiting["pending"] is True
+    assert abs(waiting["zoom"] - 1) < 0.001
+    assert waiting["currentSource"] == "full"
+    assert waiting["desiredSource"] in ("2560", "3840")
+
+    native_zoom_before = page.evaluate("window._lbNativeZoom")
+
+    # Resize while the fallback tier is still held. _lbRecomputeNativeZoom runs
+    # unconditionally at the top of the resize handler (before any pending-state
+    # logic), so a deterministic change in _lbNativeZoom is a fix-independent
+    # signal that the debounced handler actually executed — no fixed sleep.
+    page.set_viewport_size({"width": 640, "height": 800})
+    page.wait_for_function(
+        "Math.abs(window._lbNativeZoom - %r) > 0.1" % native_zoom_before
+    )
+
+    # The resize handler has now run while the fallback tier is still loading.
+    # Pre-fix it canceled the upgrade and snapped a soft 1:1 on /full; post-fix
+    # the deferred intent and the higher-tier target both survive.
+    survived = page.evaluate(
+        """() => ({
+            pending: window._lbPending1To1,
+            zoom: window._lbZoom,
+            currentSource: window._lbCurrentSrcKey,
+            desiredSource: window._lbDesiredSrcKey,
+        })"""
+    )
+    assert survived["pending"] is True
+    assert abs(survived["zoom"] - 1) < 0.001
+    assert survived["currentSource"] == "full"
+    assert survived["desiredSource"] in ("2560", "3840")
+
+    # Releasing the fallback tier lets the deferred 1:1 finally snap against it
+    # — never stranded on the upscaled /full.
+    held_fallback["released"] = True
+    held_fallback.pop("route").fulfill(
+        body=fallback_svg, content_type="image/svg+xml"
+    )
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return (window._lbCurrentSrcKey === '2560' || window._lbCurrentSrcKey === '3840')
+                && window._lbPending1To1 === false
+                && img && img.complete && img.naturalWidth === 2560
+                && window._lbNativeZoom
+                && Math.abs(window._lbZoom - window._lbNativeZoom) < 0.01;
+        }""",
+        timeout=8000,
+    )

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -681,6 +681,98 @@ def test_browse_lightbox_defers_one_to_one_until_original_size_known(live_server
     )
 
 
+def test_browse_lightbox_pending_one_to_one_guard_schedules_sharper_source(
+    live_server, page
+):
+    """If native 1:1 needs a sharper source, the guard must queue that source."""
+    page.add_init_script(
+        "Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true });"
+    )
+    full_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="960" '
+        'viewBox="0 0 1920 960"><rect width="1920" height="960" fill="#274"/></svg>'
+    )
+    original_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#3a7"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=full_svg, content_type="image/svg+xml"),
+    )
+    held_original = {}
+
+    def hold_original(route):
+        if "released" in held_original:
+            route.fulfill(body=original_svg, content_type="image/svg+xml")
+        elif "route" not in held_original:
+            held_original["route"] = route
+        else:
+            route.fulfill(body=original_svg, content_type="image/svg+xml")
+
+    page.route("**/photos/*/original", hold_original)
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+
+    page.locator(".grid-card").first.wait_for(state="visible")
+    page.locator(".grid-card").first.dblclick()
+
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 1920;
+        }"""
+    )
+
+    state = page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbCurrentSrcKey = 'full';
+            window._lbDesiredSrcKey = 'full';
+            window._lbPending1To1 = true;
+            window._lbZoom = 1;
+            window._lbRecomputeNativeZoom();
+            window._lbApplyPendingOneToOneZoom();
+            return {
+                pending: window._lbPending1To1,
+                zoom: window._lbZoom,
+                nativeZoom: window._lbNativeZoom,
+                currentSource: window._lbCurrentSrcKey,
+                desiredSource: window._lbDesiredSrcKey,
+            };
+        }"""
+    )
+    assert state["pending"] is True
+    assert abs(state["zoom"] - 1) < 0.001
+    assert state["nativeZoom"] > 1
+    assert state["currentSource"] == "full"
+    assert state["desiredSource"] == "original"
+
+    deadline = time.time() + 2
+    while "route" not in held_original and time.time() < deadline:
+        page.wait_for_timeout(25)
+    assert "route" in held_original
+
+    held_original["released"] = True
+    held_original.pop("route").fulfill(
+        body=original_svg,
+        content_type="image/svg+xml",
+    )
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return window._lbCurrentSrcKey === 'original'
+                && window._lbPending1To1 === false
+                && img && img.complete && img.naturalWidth === 4000
+                && Math.abs(window._lbZoom - window._lbNativeZoom) < 0.01;
+        }"""
+    )
+
+
 def test_browse_lightbox_waits_for_original_before_one_to_one_snap(live_server, page):
     """Known 1:1 zoom waits for the high-res source instead of enlarging /full."""
     page.add_init_script(

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -233,15 +233,15 @@ def test_browse_lightbox_defers_one_to_one_until_original_size_known(live_server
                 nativeZoom: window._lbNativeZoom,
                 pending: window._lbPending1To1,
                 zoom: window._lbZoom,
-                sourceKey: window._lbPickSourceKey(),
+                desiredSource: window._lbDesiredSrcKey,
             };
         }"""
     )
 
     assert state["nativeZoom"] is None
     assert state["pending"] is True
-    assert state["zoom"] > 1
-    assert state["sourceKey"] == "original"
+    assert state["zoom"] == 1
+    assert state["desiredSource"] == "original"
 
     upgraded = page.evaluate(
         """() => {
@@ -255,6 +255,83 @@ def test_browse_lightbox_defers_one_to_one_until_original_size_known(live_server
     assert upgraded is True
     if "route" in held_original:
         held_original.pop("route").abort()
+
+
+def test_browse_lightbox_waits_for_original_before_one_to_one_snap(live_server, page):
+    """Known 1:1 zoom waits for the high-res source instead of enlarging /full."""
+    page.add_init_script(
+        "Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true });"
+    )
+    full_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="960" '
+        'viewBox="0 0 1920 960"><rect width="1920" height="960" fill="#274"/></svg>'
+    )
+    original_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#3a7"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=full_svg, content_type="image/svg+xml"),
+    )
+    held_original = {}
+
+    def hold_first_original(route):
+        if "released" in held_original:
+            route.fulfill(body=original_svg, content_type="image/svg+xml")
+        elif "route" not in held_original:
+            held_original["route"] = route
+        else:
+            route.fulfill(body=original_svg, content_type="image/svg+xml")
+
+    page.route("**/photos/*/original", hold_first_original)
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 1920;
+        }"""
+    )
+    page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbRecomputeNativeZoom();
+        }"""
+    )
+    page.wait_for_function("window._lbNativeZoom > 1")
+
+    page.keyboard.press("z")
+    page.wait_for_function(
+        "window._lbPending1To1 === true && window._lbDesiredSrcKey === 'original'"
+    )
+    assert abs(page.evaluate("window._lbZoom") - 1) < 0.001
+    assert page.evaluate("window._lbCurrentSrcKey") == "full"
+    page.wait_for_timeout(250)
+
+    original_route = held_original.pop("route")
+    held_original["released"] = True
+    original_route.fulfill(
+        body=original_svg,
+        content_type="image/svg+xml",
+    )
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return window._lbCurrentSrcKey === 'original'
+                && img && img.complete && img.naturalWidth === 4000
+                && Math.abs(window._lbZoom - window._lbNativeZoom) < 0.01;
+        }"""
+    )
 
 
 def test_browse_lightbox_does_not_retry_original_after_unavailable(live_server, page):
@@ -445,7 +522,7 @@ def test_browse_e_f_g_keyboard_modes(live_server, page):
     )
     page.keyboard.press("f")
     assert page.evaluate("window.__fullscreenRequested") is False
-    assert page.evaluate("window._lbZoom") > 1
+    assert page.evaluate("window._lbZoom > 1 || window._lbPending1To1") is True
 
     page.evaluate(
         """() => {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3086,6 +3086,24 @@ function _lbApplyPendingOneToOneZoom() {
   );
 }
 
+function _lbDeferPendingOneToOneUntilSourceReady(targetZoom) {
+  if (!_lbPending1To1) return false;
+  _lbPendingViewportState = null;
+  _lbApplyTransform();
+  _lbScheduleSourceSwap(targetZoom);
+  if (_lbDesiredSrcKey === _lbCurrentSrcKey) {
+    _lbApplyPendingOneToOneZoom();
+  }
+  return true;
+}
+
+function _lbDeferPendingOneToOneToPreviewFallback() {
+  // /original is unavailable but the user still wants true 1:1. Keep the
+  // deferral pending and aim at the sharpest remaining preview tier instead of
+  // snapping on an upscaled /full.
+  return _lbDeferPendingOneToOneUntilSourceReady(4);
+}
+
 function _lbNormalizeFlag(flag) {
   if (flag === 'flagged' || flag === 'rejected' || flag === 'none') return flag;
   if (flag == null || flag === '') return 'none';
@@ -3604,7 +3622,7 @@ function openLightbox(photoId, filename, photoList, options) {
   );
   _lbCurrentSrcKey = (
     restoreViewportState &&
-    (restoreViewportState.zoom > 1.001 || restoreWantsOneToOne)
+    restoreViewportState.zoom > 1.001
   ) ? 'original' : 'full';
   _lbFullLongEdge = null;
   _lbPending1To1 = restoreWantsOneToOne;
@@ -3652,7 +3670,19 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbPhotoH = img.naturalHeight;
     }
     _lbRecomputeNativeZoom();
-    if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
+    if (
+      _lbCurrentSrcKey === 'full' &&
+      _lbPending1To1 &&
+      (
+        _lbOriginalUnavailable
+          ? _lbDeferPendingOneToOneToPreviewFallback()
+          : _lbDeferPendingOneToOneUntilSourceReady(_lbNativeZoom || 4)
+      )
+    ) {
+      // The helper keeps 1:1 pending until the required source tier is current.
+    } else if (!_lbTryApplyPendingViewportState()) {
+      _lbApplyPendingOneToOneZoom();
+    }
     _lbApplyTransform();
   }
   function handleInitialImageError() {
@@ -4796,34 +4826,7 @@ function _lbScheduleSourceSwap(targetZoom) {
         _lbOriginalUnavailable = true;
         _lbRecomputeNativeZoom();
         if (had1To1Pending) {
-          // /original is gone but the user still wants true 1:1. Keep the
-          // deferral pending and aim the reschedule at the sharpest remaining
-          // preview tier instead of snapping now on an upscaled /full (the
-          // soft-1:1 flash). A large target zoom forces _lbPickSourceKey past
-          // the /full threshold even when true dimensions — and therefore
-          // _lbNativeZoom — are still unknown at failure time; rescheduling
-          // with the post-clear state would otherwise keep us pinned to /full.
-          // The pending snap then completes in onSwapLoad once the higher tier
-          // is the current source (gated by the tier-rank guard).
-          _lbApplyTransform();
-          _lbScheduleSourceSwap(4);
-          // Only resolve the deferred 1:1 inline when the reschedule did NOT
-          // queue a higher tier (small viewport, or the current source is
-          // already the best remaining tier). _lbScheduleSourceSwap sets
-          // _lbDesiredSrcKey and only arms a swap when it differs from
-          // _lbCurrentSrcKey, so equality here means no upgrade is coming and
-          // onSwapLoad would never fire — without this the badge would stay
-          // stuck on "loading 1:1" at fit zoom forever. When an upgrade IS
-          // queued we must NOT snap now: _lbNativeZoom was just recomputed from
-          // the /full decode, so _lbPickSourceKey(_lbNativeZoom) reads 'full'
-          // and the tier-rank guard inside _lbApplyPendingOneToOneZoom fails to
-          // defer — it would snap on the upscaled /full (soft-1:1 flash) and
-          // its trailing _lbScheduleSourceSwap() would retarget back to /full,
-          // canceling the 2560/3840 upgrade. In that case onSwapLoad applies
-          // the deferred snap once the higher tier becomes the current source.
-          if (_lbDesiredSrcKey === _lbCurrentSrcKey) {
-            _lbApplyPendingOneToOneZoom();
-          }
+          _lbDeferPendingOneToOneToPreviewFallback();
         } else {
           _lbApplyPendingOneToOneZoom();
           _lbApplyTransform();

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3602,7 +3602,10 @@ function toggleLightboxZoom(e) {
     _lbRecomputeNativeZoom();
   }
 
-  var isZoomed = _lbZoom > 1.001;
+  // A deferred 1:1 leaves _lbZoom at 1 while the high-res source loads, so treat
+  // a pending 1:1 as "zoomed" too — otherwise a second toggle re-enters the
+  // zoom-in path and the image still snaps to 1:1 once it finishes loading.
+  var isZoomed = _lbZoom > 1.001 || _lbPending1To1;
   if (isZoomed) {
     _lbSetZoom(1.0, null, null);
     _lbPending1To1 = false;
@@ -4579,11 +4582,22 @@ function _lbScheduleSourceSwap(targetZoom) {
       if (_lightboxCurrentId !== photoId) return;
       if (_lbOpenSeq !== swapOpenSeq) return;
       if (key === 'original') {
+        // Capture the pending-1:1 target before recompute/clear so the fallback
+        // tier is sized for the resolution true 1:1 needs (2560/3840) instead
+        // of the post-clear state, which would keep us on /full or snap early.
+        var pendingTargetZoom = _lbPending1To1 && _lbNativeZoom ? _lbNativeZoom : null;
         _lbOriginalUnavailable = true;
         _lbRecomputeNativeZoom();
-        _lbApplyPendingOneToOneZoom();
+        // With a deferred 1:1 still pending, leave it set so the snap happens
+        // once the fallback tier loads (onSwapLoad). Otherwise apply the
+        // (no-op) pending state now.
+        if (pendingTargetZoom == null) {
+          _lbApplyPendingOneToOneZoom();
+        }
         _lbApplyTransform();
-        _lbScheduleSourceSwap(_lbPending1To1 && _lbNativeZoom ? _lbNativeZoom : null);
+        // Always reschedule: /original is gone, so re-pick the best remaining
+        // tier (3840) rather than staying stuck on the lower current source.
+        _lbScheduleSourceSwap(pendingTargetZoom);
       }
       // Keep current source on failure
     };

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4633,14 +4633,23 @@ function _lbScheduleSourceSwap(targetZoom) {
           // is the current source (gated by the tier-rank guard).
           _lbApplyTransform();
           _lbScheduleSourceSwap(4);
-          // If no higher tier is actually available (small viewport, or the
-          // current source is already the best remaining tier) the reschedule
-          // is a no-op and onSwapLoad never fires — without this the badge
-          // would stay stuck on "loading 1:1" at fit zoom forever. The
-          // tier-rank guard inside _lbApplyPendingOneToOneZoom keeps the snap
-          // deferred when a real upgrade IS still queued, so this only resolves
-          // the genuine no-swap-needed case.
-          _lbApplyPendingOneToOneZoom();
+          // Only resolve the deferred 1:1 inline when the reschedule did NOT
+          // queue a higher tier (small viewport, or the current source is
+          // already the best remaining tier). _lbScheduleSourceSwap sets
+          // _lbDesiredSrcKey and only arms a swap when it differs from
+          // _lbCurrentSrcKey, so equality here means no upgrade is coming and
+          // onSwapLoad would never fire — without this the badge would stay
+          // stuck on "loading 1:1" at fit zoom forever. When an upgrade IS
+          // queued we must NOT snap now: _lbNativeZoom was just recomputed from
+          // the /full decode, so _lbPickSourceKey(_lbNativeZoom) reads 'full'
+          // and the tier-rank guard inside _lbApplyPendingOneToOneZoom fails to
+          // defer — it would snap on the upscaled /full (soft-1:1 flash) and
+          // its trailing _lbScheduleSourceSwap() would retarget back to /full,
+          // canceling the 2560/3840 upgrade. In that case onSwapLoad applies
+          // the deferred snap once the higher tier becomes the current source.
+          if (_lbDesiredSrcKey === _lbCurrentSrcKey) {
+            _lbApplyPendingOneToOneZoom();
+          }
         } else {
           _lbApplyPendingOneToOneZoom();
           _lbApplyTransform();

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3075,7 +3075,11 @@ function _lbApplyPendingOneToOneZoom() {
   // source that is already sharper than required — e.g. /original kept during
   // 1:1-preserving navigation — still applies immediately instead of waiting
   // forever for a downgrade that never comes.
-  if (_lbSrcRank(_lbCurrentSrcKey) < _lbSrcRank(_lbPickSourceKey(_lbNativeZoom))) return;
+  var requiredSource = _lbPickSourceKey(_lbNativeZoom);
+  if (_lbSrcRank(_lbCurrentSrcKey) < _lbSrcRank(requiredSource)) {
+    _lbScheduleSourceSwap(_lbNativeZoom);
+    return;
+  }
   _lbPending1To1 = false;
   var anchor = _lbPending1To1Anchor;
   _lbPending1To1Anchor = null;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3691,8 +3691,22 @@ function toggleLightboxZoom(e) {
     resizeTimer = setTimeout(function() {
       resizeTimer = null;
       _lbRecomputeNativeZoom();
+      // A deferred 1:1 keeps _lbZoom at fit while the high-res source loads.
+      // _lbSetZoom clears _lbPending1To1 (and its trailing reschedule retargets
+      // the source swap back to /full), so a resize during "loading 1:1" would
+      // silently drop the user's zoom request. Capture the deferred intent,
+      // re-clamp the actual zoom, then restore it and re-arm the source swap so
+      // the snap still completes once the high-res tier is current.
+      var pending = _lbPending1To1;
+      var pendingAnchor = _lbPending1To1Anchor;
       // Current zoom may now violate clamps; re-run through _lbSetZoom to re-clamp & re-apply.
       _lbSetZoom(_lbZoom, null, null);
+      if (pending) {
+        _lbPending1To1 = true;
+        _lbPending1To1Anchor = pendingAnchor;
+        _lbScheduleSourceSwap(_lbNativeZoom || 4);
+        _lbApplyPendingOneToOneZoom();
+      }
     }, 100);
   });
 })();

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3447,6 +3447,11 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbCurrentSrcKey = preserveOneToOne ? 'original' : 'full';
   _lbFullLongEdge = null;
   _lbPending1To1 = preserveOneToOne;
+  // The deferred-1:1 anchor is a client-space click coordinate scoped to the
+  // PREVIOUS photo. Clear it on every open so a 1:1-preserving navigation (or a
+  // swap still in flight from the prior photo) snaps centered instead of reusing
+  // a stale edge anchor on the new image — consistent with the pan reset above.
+  _lbPending1To1Anchor = null;
   _lbOriginalUnavailable = false;
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2934,8 +2934,25 @@ function _lbIsOneToOneZoom() {
   return Math.abs(_lbZoom - _lbNativeZoom) <= tolerance;
 }
 
+function _lbSrcRank(key) {
+  // Tier ordering by available source resolution (higher = sharper).
+  if (key === 'original') return 3;
+  if (key === '3840') return 2;
+  if (key === '2560') return 1;
+  return 0; // 'full' or unknown
+}
+
 function _lbApplyPendingOneToOneZoom() {
   if (!_lbPending1To1 || !_lbNativeZoom) return;
+  // Don't snap to true 1:1 until the displayed source is at least the tier
+  // that 1:1 needs. Otherwise the /api/photos/<id> metadata fetch resolving
+  // before the held /original load would learn _lbNativeZoom, clear the
+  // pending state, and snap on the upscaled lower tier — the soft-1:1 flash
+  // this deferral exists to prevent. Compare by tier rank (not equality) so a
+  // source that is already sharper than required — e.g. /original kept during
+  // 1:1-preserving navigation — still applies immediately instead of waiting
+  // forever for a downgrade that never comes.
+  if (_lbSrcRank(_lbCurrentSrcKey) < _lbSrcRank(_lbPickSourceKey(_lbNativeZoom))) return;
   _lbPending1To1 = false;
   var anchor = _lbPending1To1Anchor;
   _lbPending1To1Anchor = null;
@@ -4587,22 +4604,28 @@ function _lbScheduleSourceSwap(targetZoom) {
       if (_lightboxCurrentId !== photoId) return;
       if (_lbOpenSeq !== swapOpenSeq) return;
       if (key === 'original') {
-        // Capture the pending-1:1 target before recompute/clear so the fallback
-        // tier is sized for the resolution true 1:1 needs (2560/3840) instead
-        // of the post-clear state, which would keep us on /full or snap early.
-        var pendingTargetZoom = _lbPending1To1 && _lbNativeZoom ? _lbNativeZoom : null;
+        var had1To1Pending = _lbPending1To1;
         _lbOriginalUnavailable = true;
         _lbRecomputeNativeZoom();
-        // With a deferred 1:1 still pending, leave it set so the snap happens
-        // once the fallback tier loads (onSwapLoad). Otherwise apply the
-        // (no-op) pending state now.
-        if (pendingTargetZoom == null) {
+        if (had1To1Pending) {
+          // /original is gone but the user still wants true 1:1. Keep the
+          // deferral pending and aim the reschedule at the sharpest remaining
+          // preview tier instead of snapping now on an upscaled /full (the
+          // soft-1:1 flash). A large target zoom forces _lbPickSourceKey past
+          // the /full threshold even when true dimensions — and therefore
+          // _lbNativeZoom — are still unknown at failure time; rescheduling
+          // with the post-clear state would otherwise keep us pinned to /full.
+          // The pending snap then completes in onSwapLoad once the higher tier
+          // is the current source (gated by the tier-rank guard).
+          _lbApplyTransform();
+          _lbScheduleSourceSwap(4);
+        } else {
           _lbApplyPendingOneToOneZoom();
+          _lbApplyTransform();
+          // /original is gone, so re-pick the best remaining tier rather than
+          // staying stuck on the lower current source.
+          _lbScheduleSourceSwap();
         }
-        _lbApplyTransform();
-        // Always reschedule: /original is gone, so re-pick the best remaining
-        // tier (3840) rather than staying stuck on the lower current source.
-        _lbScheduleSourceSwap(pendingTargetZoom);
       }
       // Keep current source on failure
     };

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2920,6 +2920,7 @@ var _lbCurrentSrcKey = null; // 'full' | '2560' | '3840' | 'original'
 var _lbFullLongEdge = null;  // actual long edge of /full for current photo (may be < 1920 if preview_max_size is configured low)
 var _lbSessionFullLongEdge = null;  // last learned /full size across photos; better fallback than hardcoded 1920 for custom preview_max_size
 var _lbPending1To1 = false;  // true when z/click was pressed with unknown nativeZoom; upgrade to true 1:1 once learned
+var _lbPending1To1Anchor = null; // optional client-space anchor for a deferred 1:1 snap
 var _lbOriginalUnavailable = false;  // true after /original fails; fall back to current decoded source dimensions
 var _lbCurrentWildlifeExcluded = false;
 var _lbFlagEditSeq = 0;      // increments for local flag writes so stale metadata fetches cannot overwrite the chip
@@ -2936,7 +2937,13 @@ function _lbIsOneToOneZoom() {
 function _lbApplyPendingOneToOneZoom() {
   if (!_lbPending1To1 || !_lbNativeZoom) return;
   _lbPending1To1 = false;
-  _lbSetZoom(_lbNativeZoom, null, null);
+  var anchor = _lbPending1To1Anchor;
+  _lbPending1To1Anchor = null;
+  _lbSetZoom(
+    _lbNativeZoom,
+    anchor ? anchor.x : null,
+    anchor ? anchor.y : null
+  );
 }
 
 function _lbNormalizeFlag(flag) {
@@ -3599,20 +3606,32 @@ function toggleLightboxZoom(e) {
   if (isZoomed) {
     _lbSetZoom(1.0, null, null);
     _lbPending1To1 = false;
+    _lbPending1To1Anchor = null;
   } else {
     // Anchor zoom on click position (or center if no event)
     var rect = img.getBoundingClientRect();
     var anchorX = e && e.clientX ? e.clientX : rect.left + rect.width / 2;
     var anchorY = e && e.clientY ? e.clientY : rect.top + rect.height / 2;
     if (_lbNativeZoom) {
-      _lbSetZoom(_lbNativeZoom, anchorX, anchorY);
-      _lbPending1To1 = false;
+      var desiredSource = _lbPickSourceKey(_lbNativeZoom);
+      if (desiredSource !== _lbCurrentSrcKey) {
+        _lbPending1To1 = true;
+        _lbPending1To1Anchor = { x: anchorX, y: anchorY };
+        _lbScheduleSourceSwap(_lbNativeZoom);
+        _lbApplyTransform();
+      } else {
+        _lbSetZoom(_lbNativeZoom, anchorX, anchorY);
+        _lbPending1To1 = false;
+        _lbPending1To1Anchor = null;
+      }
     } else {
-      // Dimensions unknown — fall back to the max zoom (clamps to 4) and flag
-      // the request so we can upgrade to true 1:1 once /original loads and
-      // nativeZoom is learned.
-      _lbSetZoom(4, anchorX, anchorY);
+      // Dimensions unknown. Load the high-resolution source first, then apply
+      // 1:1 after the browser has decoded it; otherwise the user sees an
+      // enlarged preview and reads that as a soft 1:1 view.
       _lbPending1To1 = true;
+      _lbPending1To1Anchor = { x: anchorX, y: anchorY };
+      _lbScheduleSourceSwap(4);
+      _lbApplyTransform();
     }
   }
 }
@@ -4292,7 +4311,10 @@ function _lbApplyTransform() {
   t.style.transform = 'translate(' + tx + 'px, ' + ty + 'px) scale(' + metrics.scale + ')';
   var badge = document.getElementById('lightboxZoomBadge');
   if (!badge) return;
-  if (_lbZoom <= 1.001) {
+  if (_lbPending1To1) {
+    badge.style.display = '';
+    badge.textContent = 'loading 1:1';
+  } else if (_lbZoom <= 1.001) {
     badge.style.display = 'none';
   } else if (_lbNativeZoom) {
     badge.style.display = '';
@@ -4381,6 +4403,7 @@ function _lbSetZoom(newZoom, anchorClientX, anchorClientY) {
   // Callers that still want it (toggleLightboxZoom's fallback path) re-set the flag
   // after calling us.
   _lbPending1To1 = false;
+  _lbPending1To1Anchor = null;
   // Clamp to valid range. Max is 4x native (or 4x fit if no nativeZoom).
   var maxZoom = _lbNativeZoom ? _lbNativeZoom * 4 : 4;
   newZoom = Math.max(1.0, Math.min(maxZoom, newZoom));
@@ -4469,18 +4492,19 @@ function _lbClampPan() {
 var _lbSwapTimer = null;
 var _lbDesiredSrcKey = null;
 
-function _lbPickSourceKey() {
+function _lbPickSourceKey(targetZoom) {
   // Returns 'full' | '2560' | '3840' | 'original' based on current display needs.
   // Fall back to /full at fit and /original when zoomed whenever we can't compute
   // a proper displayed-long-edge (photo dims missing, or nativeZoom not yet
   // established — the latter happens briefly when API dims arrive before the
   // initial image load completes).
   var dims = _lbLayoutDims();
+  var zoom = targetZoom != null ? targetZoom : _lbZoom;
   if (!dims || !_lbNativeZoom) {
-    return (_lbZoom > 1.001 && !_lbOriginalUnavailable) ? 'original' : 'full';
+    return (zoom > 1.001 && !_lbOriginalUnavailable) ? 'original' : 'full';
   }
   var longEdge = Math.max(dims.w, dims.h);
-  var displayedLong = longEdge * _lbFitScale * _lbZoom;
+  var displayedLong = longEdge * _lbFitScale * zoom;
   // DPR consideration: high-DPI screens need more pixels for a crisp display.
   var dpr = window.devicePixelRatio || 1;
   var needed = displayedLong * dpr;
@@ -4500,9 +4524,9 @@ function _lbSrcUrl(photoId, key) {
   return '/photos/' + photoId + '/preview?size=' + key;
 }
 
-function _lbScheduleSourceSwap() {
+function _lbScheduleSourceSwap(targetZoom) {
   if (!_lightboxCurrentId) return;
-  var desired = _lbPickSourceKey();
+  var desired = _lbPickSourceKey(targetZoom);
   _lbDesiredSrcKey = desired;
   if (desired === _lbCurrentSrcKey) return;
 
@@ -4557,8 +4581,9 @@ function _lbScheduleSourceSwap() {
       if (key === 'original') {
         _lbOriginalUnavailable = true;
         _lbRecomputeNativeZoom();
+        _lbApplyPendingOneToOneZoom();
         _lbApplyTransform();
-        _lbScheduleSourceSwap();
+        _lbScheduleSourceSwap(_lbPending1To1 && _lbNativeZoom ? _lbNativeZoom : null);
       }
       // Keep current source on failure
     };

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3850,14 +3850,24 @@ function toggleLightboxZoom(e) {
       // the snap still completes once the high-res tier is current.
       var pending = _lbPending1To1;
       var pendingAnchor = _lbPending1To1Anchor;
-      // Current zoom may now violate clamps; re-run through _lbSetZoom to re-clamp & re-apply.
-      _lbSetZoom(_lbZoom, null, null);
+      var pendingDesiredSource = _lbDesiredSrcKey;
       if (pending) {
         _lbPending1To1 = true;
         _lbPending1To1Anchor = pendingAnchor;
-        _lbScheduleSourceSwap(_lbNativeZoom || 4);
-        _lbApplyPendingOneToOneZoom();
+        _lbClampPan();
+        _lbApplyTransform();
+        if (!pendingDesiredSource || pendingDesiredSource === _lbCurrentSrcKey) {
+          _lbScheduleSourceSwap(_lbNativeZoom || 4);
+        } else {
+          _lbDesiredSrcKey = pendingDesiredSource;
+        }
+        if (_lbDesiredSrcKey === _lbCurrentSrcKey) {
+          _lbApplyPendingOneToOneZoom();
+        }
+        return;
       }
+      // Current zoom may now violate clamps; re-run through _lbSetZoom to re-clamp & re-apply.
+      _lbSetZoom(_lbZoom, null, null);
     }, 100);
   });
 })();

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3598,9 +3598,16 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbNativeZoom = null;
   _lbPhotoW = null;
   _lbPhotoH = null;
-  _lbCurrentSrcKey = (restoreViewportState && restoreViewportState.zoom > 1.001) ? 'original' : 'full';
+  var restoreWantsOneToOne = !!(
+    restoreViewportState &&
+    (restoreViewportState.oneToOne || restoreViewportState.pending1To1)
+  );
+  _lbCurrentSrcKey = (
+    restoreViewportState &&
+    (restoreViewportState.zoom > 1.001 || restoreWantsOneToOne)
+  ) ? 'original' : 'full';
   _lbFullLongEdge = null;
-  _lbPending1To1 = !!(restoreViewportState && (restoreViewportState.oneToOne || restoreViewportState.pending1To1));
+  _lbPending1To1 = restoreWantsOneToOne;
   // The deferred-1:1 anchor is a client-space click coordinate scoped to the
   // PREVIOUS photo. Clear it on every open so a 1:1-preserving navigation (or a
   // swap still in flight from the prior photo) snaps centered instead of reusing

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4565,11 +4565,11 @@ function _lbScheduleSourceSwap(targetZoom) {
           _lbPhotoH = img.naturalHeight;
         }
         _lbRecomputeNativeZoom();
-        // If the user pressed z/toggle when nativeZoom was unknown, upgrade to true 1:1 now.
-        if (_lbPending1To1 && _lbNativeZoom) {
-          _lbPending1To1 = false;
-          _lbSetZoom(_lbNativeZoom, null, null);
-        }
+        // If the user pressed z/click when nativeZoom was unknown, upgrade to
+        // true 1:1 now. Route through the shared helper so the stored anchor is
+        // honored — completing with a recentered zoom would make a deferred 1:1
+        // jump away from the point the user clicked.
+        _lbApplyPendingOneToOneZoom();
         _lbApplyTransform();
       });
       img.src = url;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4633,6 +4633,14 @@ function _lbScheduleSourceSwap(targetZoom) {
           // is the current source (gated by the tier-rank guard).
           _lbApplyTransform();
           _lbScheduleSourceSwap(4);
+          // If no higher tier is actually available (small viewport, or the
+          // current source is already the best remaining tier) the reschedule
+          // is a no-op and onSwapLoad never fires — without this the badge
+          // would stay stuck on "loading 1:1" at fit zoom forever. The
+          // tier-rank guard inside _lbApplyPendingOneToOneZoom keeps the snap
+          // deferred when a real upgrade IS still queued, so this only resolves
+          // the genuine no-swap-needed case.
+          _lbApplyPendingOneToOneZoom();
         } else {
           _lbApplyPendingOneToOneZoom();
           _lbApplyTransform();


### PR DESCRIPTION
## Summary

- Defer Browse lightbox 1:1 zoom until the source tier needed for that zoom has loaded.
- Preserve the click/key zoom anchor across the deferred snap.
- Show a `loading 1:1` badge while the high-resolution source is loading.
- Add E2E coverage for both unknown-size and known-size 1:1 requests so `/full` is not enlarged as a temporary soft 1:1 view.

## Root Cause

The previous device-pixel 1:1 fix corrected the final math, but the lightbox still applied the 1:1 transform immediately and only then swapped from `/full` to `/original`. For large photos or RAW-backed originals, that meant users could spend visible time looking at an upscaled preview and conclude the zoom was still soft.

## Validation

- `python -m pytest tests/e2e/test_browse_lightbox.py tests/e2e/test_lightbox_context_menu.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added e2e coverage verifying the lightbox waits for the high-resolution original before snapping to native 1:1; added a test that holds the original response to confirm deferred behavior and broadened keyboard-mode assertions to accept either immediate zoom or a pending 1:1 transition.

* **Bug Fixes**
  * Preserve the user’s click/center anchor during deferred 1:1 upgrades and clear stale anchors on open.
  * Show a “loading 1:1” indicator while high-res assets load.
  * Improve source-tier selection, swap and retry behavior for more reliable high-resolution handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->