### PR TITLE
[codex] Honor explicit species confirmations

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11300,13 +11300,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if missing:
             return json_error(f"Unknown photo_ids: {missing}")
 
-        # Drop photos whose only detections are below the workspace's
-        # detector_confidence threshold — those are MegaDetector noise boxes,
-        # not real subjects, and tagging them with a species lets them slip
-        # into highlights / by-species views with the wrong label. Photos
-        # with NO detection rows at all stay eligible: this endpoint also
-        # serves manual species assertions on photos that were never run
-        # through the pipeline. See the "Mountain chickadee" highlights bug.
+        # Surface photos whose only detections are below the workspace's
+        # detector_confidence threshold, but do not drop them. This endpoint
+        # represents an explicit user confirmation, and that assertion should
+        # win over a weak detector box. Fully automatic labeling paths should
+        # do their own filtering before calling lower-level tag helpers.
         import config as cfg
         effective_cfg = db.get_effective_config(cfg.load())
         det_conf_threshold = effective_cfg.get("detector_confidence", 0.2)
@@ -11318,36 +11316,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 GROUP BY photo_id""",
             photo_ids,
         ).fetchall()
-        skipped_photo_ids = [
+        low_confidence_photo_ids = [
             r["photo_id"] for r in det_rows
             if r["n"] > 0 and (r["max_conf"] or 0) < det_conf_threshold
         ]
-        # Load the pipeline cache before the all-skipped early return: the
-        # client's confirmSpecies fallback (templates/pipeline_review.html
-        # ~L2620) treats a successful response without ``encounters`` as a
-        # local-confirmation and sets ``species_confirmed=true`` itself.
-        # Returning the unchanged cache here keeps the encounter's confirmed
-        # state consistent with what actually happened on the server (i.e.,
-        # nothing).
         from pipeline import load_results_raw, save_results_raw
 
         cache_dir = os.path.dirname(db_path)
         cached = load_results_raw(cache_dir, db._active_workspace_id)
-        if skipped_photo_ids:
-            skipped_set = set(skipped_photo_ids)
-            photo_ids = [pid for pid in photo_ids if pid not in skipped_set]
-            if not photo_ids:
-                resp_body = {
-                    "ok": True,
-                    "species": species,
-                    "photo_count": 0,
-                    "skipped_photo_ids": skipped_photo_ids,
-                    "previous_species": None,
-                }
-                if cached:
-                    resp_body["encounters"] = cached.get("encounters", [])
-                    resp_body["summary"] = cached.get("summary", {})
-                return jsonify(resp_body)
         previous_species = None
         target_enc = None
         target_enc_idx = None
@@ -11506,7 +11482,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "keyword_id": kid,
             "photo_count": len(photo_ids),
             "previous_species": replaced,
-            "skipped_photo_ids": skipped_photo_ids,
+            "low_confidence_photo_ids": low_confidence_photo_ids,
+            # Kept for older clients/tests that checked this field; explicit
+            # confirmations no longer skip submitted photos.
+            "skipped_photo_ids": [],
         }
         if cached:
             response["encounters"] = cached.get("encounters", [])

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3040,6 +3040,13 @@ async function confirmSpecies(event, encIdx, burstIdx, speciesName) {
     enc.confirmed_species = speciesName;
     updateSummaryBar(refreshLocalSummaryCounts());
   }
+  if (resp.low_confidence_photo_ids && resp.low_confidence_photo_ids.length) {
+    showToast(
+      'Tagged ' + resp.low_confidence_photo_ids.length + ' low-confidence detector ' +
+      (resp.low_confidence_photo_ids.length === 1 ? 'photo' : 'photos'),
+      'info'
+    );
+  }
   renderResults();
   checkPendingSync();
 }

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -326,21 +326,13 @@ def test_encounter_species_rejects_invalid_photo_ids(app_and_db):
     assert not any(c["value"] == "Robin" for c in pending)
 
 
-def test_encounter_species_skips_sub_threshold_photos(app_and_db):
-    """POST /api/encounters/species must skip photos whose only detections
-    are below the workspace's detector_confidence threshold.
+def test_encounter_species_tags_sub_threshold_photos_with_warning(app_and_db):
+    """Explicit species confirmation must tag every submitted photo.
 
-    Regression for the "Mountain chickadee" highlights bug: when an
-    encounter is bulk-confirmed, photos with only noise-level detections
-    (e.g. confidence ~0.02 from MegaDetector emitting a whole-frame box on
-    a frame with no real subject) were tagged with the species too. Those
-    bad tags then made the photos eligible for highlights and they floated
-    to the top by quality_score because the noise box happened to span the
-    whole frame.
-
-    Photos with NO detections at all stay eligible (this endpoint is also
-    used to label photos that were never run through the pipeline — the
-    user is asserting the species manually).
+    A weak detector row is useful warning context, but it must not silently
+    override a user-confirmed species label. Regression for DSC_3682.NEF:
+    a correct Allen's hummingbird prediction was skipped because its only
+    detector row was below the threshold.
     """
     app, db = app_and_db
     client = app.test_client()
@@ -377,10 +369,9 @@ def test_encounter_species_skips_sub_threshold_photos(app_and_db):
     assert "Mountain Chickadee" in real_tags, (
         "photo with high-confidence detection must still be tagged"
     )
-    assert "Mountain Chickadee" not in noise_tags, (
-        "photo whose only detection is below threshold must NOT be tagged — "
-        "those are noise photos and the tag is what makes them appear in "
-        "highlights with the wrong species"
+    assert "Mountain Chickadee" in noise_tags, (
+        "explicit user confirmation must tag the submitted photo even when "
+        "the detector confidence is below threshold"
     )
     assert "Mountain Chickadee" in undetected_tags, (
         "photo with no detections at all is a manual-tagging case (user "
@@ -388,27 +379,19 @@ def test_encounter_species_skips_sub_threshold_photos(app_and_db):
         "this must continue to work"
     )
 
-    # Response should reflect what actually happened so the UI can warn
-    # about skipped photos (otherwise the user thinks all 48 were tagged
-    # but really only 47 were).
-    assert data["photo_count"] == 2, (
-        f"photo_count should reflect actually-tagged photos (2), got {data['photo_count']}"
+    assert data["photo_count"] == 3, (
+        f"photo_count should reflect all explicitly-tagged photos, got {data['photo_count']}"
     )
-    skipped = data.get("skipped_photo_ids") or []
-    assert p_noise in skipped, (
-        f"skipped_photo_ids should list the noise photo so the UI can warn; "
-        f"got {skipped!r}"
+    assert data.get("skipped_photo_ids") == []
+    low_conf = data.get("low_confidence_photo_ids") or []
+    assert p_noise in low_conf, (
+        f"low_confidence_photo_ids should list the weak detector photo so "
+        f"the UI can warn; got {low_conf!r}"
     )
 
 
-def test_encounter_species_all_skipped_returns_cached_encounters(app_and_db):
-    """When every submitted photo is sub-threshold, the response must still
-    include ``encounters`` from the cached pipeline results. Without that,
-    the client's confirmSpecies fallback (templates/pipeline_review.html)
-    interprets the successful response as a local-confirmation and sets
-    ``species_confirmed=true`` on the encounter — even though the server
-    did nothing.
-    """
+def test_encounter_species_all_sub_threshold_still_confirms_cache(app_and_db):
+    """Even all-low-confidence submissions are explicit confirmations."""
     import json as _json
     app, db = app_and_db
     client = app.test_client()
@@ -450,19 +433,18 @@ def test_encounter_species_all_skipped_returns_cached_encounters(app_and_db):
     )
     assert resp.status_code == 200
     data = resp.get_json()
-    assert data["photo_count"] == 0
-    assert data["skipped_photo_ids"] == [p_noise]
-    # The cached encounters/summary must be echoed so the client doesn't
-    # locally mark the encounter confirmed.
+    assert data["photo_count"] == 1
+    assert data["skipped_photo_ids"] == []
+    assert data["low_confidence_photo_ids"] == [p_noise]
+    assert "Mountain Chickadee" in {k["name"] for k in db.get_photo_keywords(p_noise)}
+
     assert "encounters" in data, (
-        "all-skipped response must include encounters so the client doesn't "
-        "fall through to the local-confirm branch"
+        "response should include server-updated encounters when a cache exists"
     )
-    assert data["encounters"][0]["species_confirmed"] is False, (
-        "encounter must remain unconfirmed in the response — nothing was "
-        "actually tagged"
-    )
-    assert data["summary"] == sentinel_summary
+    assert data["encounters"][0]["species_confirmed"] is True
+    assert data["encounters"][0]["confirmed_species"] == "Mountain Chickadee"
+    assert data["summary"]["confirmed_count"] == 1
+    assert data["summary"]["unconfirmed_count"] == 0
 
 
 def test_encounter_species_updates_pipeline_cache(app_and_db):


### PR DESCRIPTION
Explicit encounter species confirmations now tag every submitted photo instead of silently dropping photos whose detector confidence is below threshold. Low-confidence detections are still reported in the response as warning context, and the pipeline review UI surfaces that warning after tagging. This fixes the DSC_3682.NEF case where a user-confirmed Allen's hummingbird label was skipped because the detector emitted only a weak box. Validation: `PYTHONPATH=vireo pytest vireo/tests/test_app.py -k 'encounter_species'` and `PYTHONPATH=vireo pytest vireo/tests/test_app.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Species confirmation now includes all submitted photos in the tagging process, including those with only low-confidence detections, instead of excluding them
  * A notification now informs users how many photos were tagged with low-confidence detections when species confirmation is successful

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->