### PR TITLE
[codex] Use review modal for single-photo pipeline items

### DIFF
--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -754,6 +754,10 @@ def test_classic_pipeline_review_single_photo_opens_review_modal(live_server, pa
     expect(page.locator("#grmLoupeZoomSlider")).to_be_visible()
     expect(page.locator("#grmRemoveBtn")).to_be_hidden()
 
+    page.keyboard.press("Backspace")
+    expect(page.locator("#grmOverlay .grm-card[data-photo-id]")).to_have_count(1)
+    expect(page.locator("#grmCount")).to_have_text("0 picks, 0 rejects, 1 unsorted")
+
     page.keyboard.press("x")
     expect(page.locator("#grmCount")).to_have_text("0 picks, 1 rejects, 0 unsorted")
     expect(page.locator("#grmApplyBtn")).to_have_text("Reject 1 & Close")

--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -697,7 +697,7 @@ def test_classic_pipeline_review_opens_requested_burst_from_url(live_server, pag
     )
 
 
-def test_classic_pipeline_review_inspector_pick_reject_hotkeys(live_server, page):
+def test_classic_pipeline_review_single_photo_opens_review_modal(live_server, page):
     image_body = base64.b64decode(_PNG_1X1)
     results = {
         "photos": [
@@ -721,12 +721,6 @@ def test_classic_pipeline_review_inspector_pick_reject_hotkeys(live_server, page
             "reject_count": 0,
         },
     }
-    flag_payloads = []
-
-    def flag_route(route):
-        flag_payloads.append(route.request.post_data_json)
-        route.fulfill(json={"ok": True})
-
     page.route(
         "**/api/pipeline/page-init",
         lambda route: route.fulfill(
@@ -737,28 +731,39 @@ def test_classic_pipeline_review_inspector_pick_reject_hotkeys(live_server, page
             }
         ),
     )
-    page.route("**/api/photos/1/flag", flag_route)
+    page.route(
+        "**/api/pipeline/group/state",
+        lambda route: route.fulfill(
+            json={
+                "photos": {"1": {"flag": "none", "has_species_keyword": False}},
+                "species_kid": None,
+            }
+        ),
+    )
     page.route("**/thumbnails/*.jpg", lambda route: route.fulfill(body=image_body, content_type="image/png"))
-    page.route("**/masks/*.png", lambda route: route.fulfill(status=404))
+    page.route("**/photos/*/preview?*", lambda route: route.fulfill(body=image_body, content_type="image/png"))
+    page.route("**/photos/*/original", lambda route: route.fulfill(body=image_body, content_type="image/png"))
 
     page.goto(f"{live_server['url']}/pipeline/review")
     page.locator(".photo-card img").click()
-    expect(page.locator("#inspectOverlay")).to_have_class(re.compile(r"\bopen\b"))
+    expect(page.locator("#inspectOverlay")).not_to_have_class(re.compile(r"\bopen\b"))
+    expect(page.locator("#grmOverlay")).to_have_class(re.compile(r"\bopen\b"))
+    expect(page.locator("#grmTitle")).to_have_text("Review Photo")
+    expect(page.locator("#grmOverlay .grm-card[data-photo-id]")).to_have_count(1)
+    expect(page.locator("#grmResSlider")).to_be_visible()
+    expect(page.locator("#grmLoupeZoomSlider")).to_be_visible()
+    expect(page.locator("#grmRemoveBtn")).to_be_hidden()
 
-    with page.expect_response("**/api/photos/1/flag"):
-        page.keyboard.press("x")
-    expect(page.locator("#inspectPanel")).to_contain_text("Rejected (X)")
-    expect(page.locator(".photo-card .flag-rejected")).to_be_visible()
-    assert flag_payloads[-1] == {"flag": "rejected"}
+    page.keyboard.press("x")
+    expect(page.locator("#grmCount")).to_have_text("0 picks, 1 rejects, 0 unsorted")
+    expect(page.locator("#grmApplyBtn")).to_have_text("Reject 1 & Close")
 
-    with page.expect_response("**/api/photos/1/flag"):
-        page.keyboard.press("p")
-    expect(page.locator("#inspectPanel")).to_contain_text("Flagged (P)")
-    expect(page.locator(".photo-card .flag-flagged")).to_be_visible()
-    assert flag_payloads[-1] == {"flag": "flagged"}
+    page.keyboard.press("p")
+    expect(page.locator("#grmCount")).to_have_text("1 picks, 0 rejects, 0 unsorted")
+    expect(page.locator("#grmApplyBtn")).to_have_text("Flag 1 · Tag 1 as Test bird & Close")
 
 
-def test_classic_pipeline_review_group_shortcuts_do_not_flag_stale_inspector_photo(live_server, page):
+def test_classic_pipeline_review_group_shortcuts_do_not_flag_prior_single_photo(live_server, page):
     image_body = base64.b64decode(_PNG_1X1)
     results = {
         "photos": [
@@ -805,6 +810,7 @@ def test_classic_pipeline_review_group_shortcuts_do_not_flag_stale_inspector_pho
         lambda route: route.fulfill(
             json={
                 "photos": {
+                    "1": {"flag": "none", "has_species_keyword": False},
                     "2": {"flag": "none", "has_species_keyword": False},
                     "3": {"flag": "none", "has_species_keyword": False},
                 },
@@ -814,15 +820,22 @@ def test_classic_pipeline_review_group_shortcuts_do_not_flag_stale_inspector_pho
     )
     page.route("**/api/photos/1/flag", stale_flag_route)
     page.route("**/thumbnails/*.jpg", lambda route: route.fulfill(body=image_body, content_type="image/png"))
-    page.route("**/masks/*.png", lambda route: route.fulfill(status=404))
+    page.route("**/photos/*/preview?*", lambda route: route.fulfill(body=image_body, content_type="image/png"))
+    page.route("**/photos/*/original", lambda route: route.fulfill(body=image_body, content_type="image/png"))
 
     page.goto(f"{live_server['url']}/pipeline/review")
     page.locator(".photo-card[data-photo-id='1'] img").click()
-    expect(page.locator("#inspectOverlay")).to_have_class(re.compile(r"\bopen\b"))
-
-    page.locator("#inspectPanel .context-filmstrip img").nth(1).click()
     expect(page.locator("#inspectOverlay")).not_to_have_class(re.compile(r"\bopen\b"))
     expect(page.locator("#grmOverlay")).to_have_class(re.compile(r"\bopen\b"))
+    expect(page.locator("#grmTitle")).to_have_text("Review Photo")
+    expect(page.locator("#grmOverlay .grm-card[data-photo-id]")).to_have_count(1)
+
+    page.locator("#grmOverlay .grm-close").click()
+    expect(page.locator("#grmOverlay")).not_to_have_class(re.compile(r"\bopen\b"))
+    page.locator(".photo-card[data-photo-id='2'] img").click()
+    expect(page.locator("#grmOverlay")).to_have_class(re.compile(r"\bopen\b"))
+    expect(page.locator("#grmTitle")).to_have_text("Review Burst Group")
+    expect(page.locator("#grmOverlay .grm-card[data-photo-id]")).to_have_count(2)
 
     page.keyboard.press("x")
     expect(page.locator("#grmCount")).to_have_text("0 picks, 1 rejects, 1 unsorted")

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3441,6 +3441,8 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   var initialSelectedId = grmSelectablePhotoId(items, selectPhotoId, null) || grmFirstSelectablePhotoId(items, null);
   var initialSelectedIds = new Set();
   if (initialSelectedId) initialSelectedIds.add(initialSelectedId);
+  var isSinglePhotoReview = items.length === 1;
+  var allowRemove = !(isSinglePhotoReview && source !== 'browse-selection');
 
   grmState = {
     encIdx: encIdx,
@@ -3461,6 +3463,7 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
     keywordStateSpecies: initialSpecies,
     initialSpecies: initialSpecies,
     source: source,
+    allowRemove: allowRemove,
     sessionId: sessionId,
     // False until /group/state resolves and grmSeedFromDbState runs. Apply &
     // Close is gated on this so a click during the seed window can't ship
@@ -3479,7 +3482,6 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   grmRefreshResetAllVisibility();
 
   document.getElementById('grmOverlay').classList.add('open');
-  var isSinglePhotoReview = items.length === 1;
   var title = document.getElementById('grmTitle');
   if (title) {
     title.textContent = source === 'browse-selection'
@@ -3488,7 +3490,7 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   }
   var removeBtn = document.getElementById('grmRemoveBtn');
   if (removeBtn) {
-    removeBtn.style.display = isSinglePhotoReview && source !== 'browse-selection' ? 'none' : '';
+    removeBtn.style.display = allowRemove ? '' : 'none';
     removeBtn.textContent = source === 'browse-selection' ? 'Remove from review' : 'Remove from group';
     removeBtn.title = source === 'browse-selection'
       ? 'Remove this photo from the temporary review set'
@@ -4552,6 +4554,7 @@ function grmMoveCandidate() {
 }
 
 function grmRemoveFromGroup() {
+  if (grmState && grmState.allowRemove === false) return;
   if (!grmState.selected) return;
   _grmMarkTouched(grmState.selected);
   grmState.removed.add(grmState.selected);
@@ -4585,7 +4588,10 @@ document.addEventListener('keydown', function(e) {
     if (idx < items.length - 1) grmSelect(items[idx + 1].id);
     e.preventDefault(); return;
   }
-  if (e.key === 'Delete' || e.key === 'Backspace') { grmRemoveFromGroup(); e.preventDefault(); return; }
+  if (e.key === 'Delete' || e.key === 'Backspace') {
+    if (grmState.allowRemove !== false) grmRemoveFromGroup();
+    e.preventDefault(); return;
+  }
   if (e.key === ' ') { grmMoveCandidate(); e.preventDefault(); return; }
   if (pipelineReviewBareKey(e, 'p')) { grmMovePick(); e.preventDefault(); return; }
   if (pipelineReviewBareKey(e, 'x')) { grmMoveReject(); e.preventDefault(); return; }

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2459,9 +2459,11 @@ function openInspect(photoId) {
   var photo = findPhotoInResults(photoId);
   if (!photo) return;
 
-  // Route multi-photo bursts to the GRM
+  // Route burst-backed review units to the GRM. Single-photo bursts need the
+  // same zoom/resolution controls as multi-photo bursts; keep the legacy
+  // inspector only as a fallback for old/flat cache shapes with no burst data.
   var burstInfo = findBurstForPhoto(photoId);
-  if (burstInfo && burstInfo.photoIds.length >= 2) {
+  if (burstInfo && burstInfo.photoIds.length >= 1) {
     closeInspect();
     openGroupReview(burstInfo.encIdx, burstInfo.burstIdx, photoId);
     return;
@@ -3477,14 +3479,26 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   grmRefreshResetAllVisibility();
 
   document.getElementById('grmOverlay').classList.add('open');
+  var isSinglePhotoReview = items.length === 1;
   var title = document.getElementById('grmTitle');
-  if (title) title.textContent = source === 'browse-selection' ? 'Review Selected Photos' : 'Review Burst Group';
+  if (title) {
+    title.textContent = source === 'browse-selection'
+      ? 'Review Selected Photos'
+      : (isSinglePhotoReview ? 'Review Photo' : 'Review Burst Group');
+  }
   var removeBtn = document.getElementById('grmRemoveBtn');
   if (removeBtn) {
+    removeBtn.style.display = isSinglePhotoReview && source !== 'browse-selection' ? 'none' : '';
     removeBtn.textContent = source === 'browse-selection' ? 'Remove from review' : 'Remove from group';
     removeBtn.title = source === 'browse-selection'
       ? 'Remove this photo from the temporary review set'
       : 'Detach this photo from the burst group on apply';
+  }
+  var hint = document.getElementById('grmHint');
+  if (hint) {
+    hint.innerHTML = isSinglePhotoReview && source !== 'browse-selection'
+      ? 'P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; Space = unsort &nbsp; Click preview to lock/unlock zoom &nbsp; Drag thumbnail to pan; double-click to reset'
+      : 'P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset';
   }
   grmSetThumbSize(GRM_CARD_W, false);
 


### PR DESCRIPTION
Single-photo pipeline review items now open the existing review modal instead of the thumbnail-only inspector, giving them the same zoom, pan, and resolution controls as multi-photo bursts.

The modal adjusts its title and hides the detach control for one-photo pipeline review units while keeping Browse selection behavior unchanged. This fixes the inconsistent single-image review experience where users had less inspection control precisely when no comparison frames were available.

Validation: `pytest tests/e2e/test_pipeline_rapid_review.py -q`, `pytest tests/e2e/test_pipeline_review_species.py -q`, and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Single-photo items now open in the review modal and follow the same zoom/resolution workflow as multi-photo bursts.
  * Review modal UI updates titles and keyboard hints to reflect single-photo vs multi-photo contexts.
  * Remove action and keyboard shortcuts are disabled where appropriate for single-photo reviews.

* **Tests**
  * End-to-end coverage added for single-photo review modal and group-shortcut behavior; stale-inspector flow updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->