### PR TITLE
Exclude Not Wildlife from Needs Identification

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -936,6 +936,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     # 'Needs Identification' first, then the migration skips renaming
     # because the target name already exists, leaving a duplicate.
     init_db.migrate_default_subject_collection()
+    init_db.migrate_default_needs_identification_collection()
     init_db.create_default_collections()
 
     # Wildlife backfill timing:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -59,6 +59,11 @@ KEYWORD_TYPES = frozenset({"taxonomy", "individual", "location", "genre", "gener
 # membership / classifier skip purposes. Workspaces can override.
 SUBJECT_TYPES_DEFAULT = frozenset({"taxonomy", "individual", "genre"})
 
+NEEDS_IDENTIFICATION_RULES = [
+    {"field": "has_subject", "op": "equals", "value": 0},
+    {"field": "wildlife_excluded", "op": "equals", "value": 0},
+]
+
 ALL_NAV_IDS = frozenset({
     "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
     "misses", "highlights", "browse", "map", "variants",
@@ -9202,6 +9207,12 @@ class Database:
                     return _keyword_not_exists(type_clause, subject_types)
                 if op == "equals" and _truthy(value):
                     return _keyword_exists(type_clause, subject_types)
+            if field == "wildlife_excluded":
+                excluded = "p.wildlife_excluded = 1"
+                if op in ("equals", "is"):
+                    return (excluded if _truthy(value) else f"NOT ({excluded})"), []
+                if op == "is not":
+                    return (f"NOT ({excluded})" if _truthy(value) else excluded), []
             if field == "keyword_count":
                 expr = "(SELECT COUNT(*) FROM photo_keywords pk2 WHERE pk2.photo_id = p.id)"
                 return _numeric_condition(expr, op, value)
@@ -9486,7 +9497,7 @@ class Database:
             ("All Photos", [{"field": "all"}]),
             (
                 "Needs Identification",
-                [{"field": "has_subject", "op": "equals", "value": 0}],
+                NEEDS_IDENTIFICATION_RULES,
             ),
             ("Untagged", [{"field": "keyword_count", "op": "equals", "value": 0}]),
             ("Flagged", [{"field": "flag", "op": "equals", "value": "flagged"}]),
@@ -9531,13 +9542,39 @@ class Database:
                 "UPDATE collections SET name = ?, rules = ? WHERE id = ?",
                 (
                     "Needs Identification",
-                    json.dumps(
-                        [{"field": "has_subject", "op": "equals", "value": 0}]
-                    ),
+                    json.dumps(NEEDS_IDENTIFICATION_RULES),
                     row["id"],
                 ),
             )
         self.conn.commit()
+
+    def migrate_default_needs_identification_collection(self):
+        """Upgrade the default Needs Identification rule to skip Not Wildlife.
+
+        User-customized collections are left alone; only the exact previous
+        default ``has_subject == 0`` rule is rewritten.
+        """
+        old_rule = [{"field": "has_subject", "op": "equals", "value": 0}]
+        rows = self.conn.execute(
+            "SELECT id, rules FROM collections WHERE name = ?",
+            ("Needs Identification",),
+        ).fetchall()
+        updated = 0
+        for row in rows:
+            try:
+                current = json.loads(row["rules"])
+            except (TypeError, ValueError):
+                continue
+            if current != old_rule:
+                continue
+            self.conn.execute(
+                "UPDATE collections SET rules = ? WHERE id = ?",
+                (json.dumps(NEEDS_IDENTIFICATION_RULES), row["id"]),
+            )
+            updated += 1
+        if updated:
+            self.conn.commit()
+        return updated
 
     # ------ iNaturalist submissions ------
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2163,6 +2163,7 @@ var FIELD_OPS = {
   has_mask: ['equals'],
   active_mask_variant: ['is', 'is not', 'contains'],
   has_gps: ['equals'],
+  wildlife_excluded: ['equals'],
   location_keyword_missing: ['equals'],
   inat_submitted: ['equals'],
   is_duplicate: ['equals'],
@@ -2188,6 +2189,7 @@ var FIELD_LABELS = {
   has_mask: 'Has Mask',
   active_mask_variant: 'Mask Variant',
   has_gps: 'Has GPS',
+  wildlife_excluded: 'Not Wildlife',
   location_keyword_missing: 'GPS Without Location Keyword',
   inat_submitted: 'iNaturalist Submitted',
   is_duplicate: 'Duplicate',
@@ -2225,6 +2227,7 @@ function defaultValueForRule(field, op) {
   }
   if (field === 'active_mask_variant') return 'sam2-large';
   if (field === 'prediction_status') return 'pending';
+  if (field === 'wildlife_excluded') return 0;
   if (['has_mask', 'has_gps', 'location_keyword_missing', 'inat_submitted',
        'is_duplicate', 'needs_review'].indexOf(field) !== -1) return 1;
   return '';
@@ -2457,8 +2460,8 @@ function renderRuleValueInput(r, i) {
   if (r.field === 'all') {
     return '<span style="flex:1;color:var(--text-ghost);font-size:12px;">Matches every photo in this workspace</span>';
   }
-  if (['has_mask', 'has_gps', 'location_keyword_missing', 'inat_submitted',
-       'is_duplicate', 'needs_review'].indexOf(r.field) !== -1) {
+  if (['has_mask', 'has_gps', 'wildlife_excluded', 'location_keyword_missing',
+       'inat_submitted', 'is_duplicate', 'needs_review'].indexOf(r.field) !== -1) {
     var boolVal = (r.value === true || r.value === 1 || r.value === '1' || r.value === 'true') ? '1' : '0';
     return '<select onchange="updateRule(\'' + p + '\',\'value\',this.value)" style="flex:1;">' +
         '<option value="1"' + (boolVal==='1'?' selected':'') + '>Yes</option>' +

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -889,6 +889,65 @@ def test_has_subject_rule_matches_photos_without_subject_keywords(tmp_path, monk
     assert pids == {p2}
 
 
+def test_collection_wildlife_excluded_rule(tmp_path):
+    """Collections can filter photos marked Not Wildlife."""
+    import json
+
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='wild.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='pet.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    db.update_photo_wildlife_excluded(p2, True)
+
+    cid = db.add_collection(
+        "Wildlife Only",
+        json.dumps([{"field": "wildlife_excluded", "op": "equals", "value": 0}]),
+    )
+    pids = {p["id"] for p in db.get_collection_photos(cid, per_page=999)}
+    assert pids == {p1}
+
+
+def test_default_needs_identification_excludes_not_wildlife(tmp_path, monkeypatch):
+    """The default Needs Identification collection omits photos explicitly
+    marked Not Wildlife, even when they have no subject keyword."""
+    import json
+
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.create_workspace("ws")
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder('/photos', name='photos')
+    needs_id = db.add_photo(folder_id=fid, filename='needs.jpg',
+                            extension='.jpg', file_size=100, file_mtime=1.0)
+    not_wildlife = db.add_photo(folder_id=fid, filename='pet.jpg',
+                                extension='.jpg', file_size=100, file_mtime=1.0)
+    identified = db.add_photo(folder_id=fid, filename='identified.jpg',
+                              extension='.jpg', file_size=100, file_mtime=1.0)
+    db.update_photo_wildlife_excluded(not_wildlife, True)
+    genre_kid = db.add_keyword("Wildlife", kw_type="genre")
+    db.tag_photo(identified, genre_kid)
+
+    db.create_default_collections()
+    cid = next(c["id"] for c in db.get_collections()
+               if c["name"] == "Needs Identification")
+    rules = json.loads(next(c["rules"] for c in db.get_collections()
+                            if c["id"] == cid))
+
+    pids = {p["id"] for p in db.get_collection_photos(cid, per_page=999)}
+    assert rules == [
+        {"field": "has_subject", "op": "equals", "value": 0},
+        {"field": "wildlife_excluded", "op": "equals", "value": 0},
+    ]
+    assert pids == {needs_id}
+
+
 def test_has_subject_rule_value_one_matches_identified_photos(tmp_path, monkeypatch):
     """has_subject==1 is the inverse — only identified photos match."""
     import json
@@ -1312,7 +1371,8 @@ def test_default_collection_uses_has_subject_for_new_workspaces(tmp_path):
     assert "Needs Identification" in cols
     assert "Needs Classification" not in cols
     assert cols["Needs Identification"] == [
-        {"field": "has_subject", "op": "equals", "value": 0}
+        {"field": "has_subject", "op": "equals", "value": 0},
+        {"field": "wildlife_excluded", "op": "equals", "value": 0},
     ]
 
 
@@ -1337,7 +1397,8 @@ def test_existing_needs_classification_collection_migrated_idempotently(tmp_path
     assert "Needs Identification" in cols
     assert "Needs Classification" not in cols
     assert cols["Needs Identification"] == [
-        {"field": "has_subject", "op": "equals", "value": 0}
+        {"field": "has_subject", "op": "equals", "value": 0},
+        {"field": "wildlife_excluded", "op": "equals", "value": 0},
     ]
 
 
@@ -1357,6 +1418,49 @@ def test_migration_skips_user_customized_collection(tmp_path):
     cols = {c["name"]: json.loads(c["rules"]) for c in db.get_collections()}
     assert "Needs Classification" in cols
     assert cols["Needs Classification"] == custom
+
+
+def test_existing_needs_identification_default_adds_not_wildlife_filter(tmp_path):
+    """Existing default Needs Identification collections skip Not Wildlife
+    photos after migration."""
+    import json
+
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    db.add_collection(
+        "Needs Identification",
+        json.dumps([{"field": "has_subject", "op": "equals", "value": 0}]),
+    )
+
+    updated = db.migrate_default_needs_identification_collection()
+
+    cols = {c["name"]: json.loads(c["rules"]) for c in db.get_collections()}
+    assert updated == 1
+    assert cols["Needs Identification"] == [
+        {"field": "has_subject", "op": "equals", "value": 0},
+        {"field": "wildlife_excluded", "op": "equals", "value": 0},
+    ]
+
+
+def test_needs_identification_not_wildlife_migration_skips_custom_rules(tmp_path):
+    """A user-customized Needs Identification collection should not be
+    overwritten by the default-rule migration."""
+    import json
+
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    custom = [{"field": "rating", "op": ">=", "value": 3}]
+    db.add_collection("Needs Identification", json.dumps(custom))
+
+    updated = db.migrate_default_needs_identification_collection()
+
+    cols = {c["name"]: json.loads(c["rules"]) for c in db.get_collections()}
+    assert updated == 0
+    assert cols["Needs Identification"] == custom
 
 
 def test_upgrade_path_no_duplicate_collection(tmp_path):
@@ -1384,7 +1488,8 @@ def test_upgrade_path_no_duplicate_collection(tmp_path):
     assert "Needs Classification" not in cols
     assert "Needs Identification" in cols
     assert cols["Needs Identification"] == [
-        {"field": "has_subject", "op": "equals", "value": 0}
+        {"field": "has_subject", "op": "equals", "value": 0},
+        {"field": "wildlife_excluded", "op": "equals", "value": 0},
     ]
     # Sanity: total default-collection count is 5, not 6 (no duplicate).
     default_names = {"All Photos", "Needs Identification", "Untagged",
@@ -8608,7 +8713,8 @@ def test_migrate_default_subject_collection_covers_all_workspaces(tmp_path):
             f"workspace {ws} still has legacy 'Needs Classification' name"
         )
         assert json.loads(row["rules"]) == [
-            {"field": "has_subject", "op": "equals", "value": 0}
+            {"field": "has_subject", "op": "equals", "value": 0},
+            {"field": "wildlife_excluded", "op": "equals", "value": 0},
         ]
 
 


### PR DESCRIPTION
This updates the default Needs Identification smart collection so photos marked Not Wildlife no longer remain in that queue.

The root cause was that Not Wildlife set `photos.wildlife_excluded`, but the default collection only checked `has_subject == 0`. This adds a `wildlife_excluded` smart-collection rule field, migrates existing default Needs Identification collections without touching customized rules, and exposes the field in the collection editor.

Validation: `PYTHONPATH=vireo python3 -m pytest vireo/tests/test_db.py -k "default_collection_uses_has_subject or existing_needs_classification_collection_migrated or existing_needs_identification_default_adds_not_wildlife_filter or needs_identification_not_wildlife_migration_skips_custom_rules or upgrade_path_no_duplicate_collection or migration_covers_all_workspaces or collection_wildlife_excluded_rule or default_needs_identification_excludes_not_wildlife or has_subject_rule"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Not Wildlife" filtering option for smart collections, allowing users to exclude wildlife-marked photos from collection results.
  * Updated the default "Needs Identification" collection to automatically exclude wildlife-marked photos during system initialization and migration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->