### PR TITLE
[codex] Unify browse batch review payload

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2000,6 +2000,49 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         _attach_detections(db, photos)
         return jsonify({"photos": photos})
 
+    @app.route("/api/pipeline/selection-results", methods=["POST"])
+    def api_pipeline_selection_results():
+        """Return a temporary Pipeline Review result for selected photo IDs."""
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        raw_ids = body.get("photo_ids", [])
+        if not isinstance(raw_ids, list):
+            return json_error("photo_ids must be a list", 400)
+        if not raw_ids:
+            return json_error("photo_ids required", 400)
+        if len(raw_ids) > 500:
+            return json_error("too many photo_ids", 400)
+
+        photo_ids = []
+        seen = set()
+        for raw in raw_ids:
+            if isinstance(raw, bool) or not isinstance(raw, int):
+                return json_error("photo_ids must be integers", 400)
+            if raw in seen:
+                continue
+            seen.add(raw)
+            photo_ids.append(raw)
+
+        import config as cfg
+        from pipeline import (
+            load_photo_features,
+            run_selected_batch_review,
+            serialize_results,
+        )
+
+        effective_cfg = db.get_effective_config(cfg.load())
+        loaded = load_photo_features(db, config=effective_cfg, photo_ids=photo_ids)
+        by_id = {p["id"]: p for p in loaded}
+        photos = [by_id[pid] for pid in photo_ids if pid in by_id]
+        if len(photos) < 2:
+            return json_error("at least two selected photos are required", 400)
+
+        results = serialize_results(
+            run_selected_batch_review(photos, config=effective_cfg)
+        )
+        results["source"] = "browse-selection"
+        return jsonify(results)
+
     @app.route("/api/photos/geo")
     def api_photos_geo():
         db = _get_db()

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -146,6 +146,13 @@ def load_photo_features(db, collection_id=None, config=None,
             (ws_id,),
         ).fetchall()
 
+    scope_sql = ""
+    scope_params = ()
+    if scoped_photo_ids is not None:
+        scope_placeholders = ",".join("?" for _ in scoped_photo_ids)
+        scope_sql = f" AND p.id IN ({scope_placeholders})"
+        scope_params = tuple(scoped_photo_ids)
+
     # Resolve the workspace-effective detector_confidence threshold once.
     # The detections table is global (no workspace_id); threshold filtering
     # happens at read time against the active workspace's effective config.
@@ -170,7 +177,7 @@ def load_photo_features(db, collection_id=None, config=None,
     # old label set don't leak into the top-k.
     if labels_fingerprint is not None:
         pred_rows = db.conn.execute(
-            """SELECT d.photo_id, pr.species, pr.confidence,
+            f"""SELECT d.photo_id, pr.species, pr.confidence,
                       pr.classifier_model AS model
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
@@ -179,12 +186,13 @@ def load_photo_features(db, collection_id=None, config=None,
                WHERE wf.workspace_id = ?
                  AND d.detector_confidence >= ?
                  AND pr.labels_fingerprint = ?
+                 {scope_sql}
                ORDER BY d.photo_id, pr.confidence DESC""",
-            (ws_id, min_conf, labels_fingerprint),
+            (ws_id, min_conf, labels_fingerprint, *scope_params),
         ).fetchall()
     else:
         pred_rows = db.conn.execute(
-            """SELECT d.photo_id, pr.species, pr.confidence,
+            f"""SELECT d.photo_id, pr.species, pr.confidence,
                       pr.classifier_model AS model
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
@@ -192,6 +200,7 @@ def load_photo_features(db, collection_id=None, config=None,
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                WHERE wf.workspace_id = ?
                  AND d.detector_confidence >= ?
+                 {scope_sql}
                  AND pr.labels_fingerprint = (
                      SELECT pr2.labels_fingerprint FROM predictions pr2
                      WHERE pr2.detection_id = pr.detection_id
@@ -200,7 +209,7 @@ def load_photo_features(db, collection_id=None, config=None,
                      LIMIT 1
                  )
                ORDER BY d.photo_id, pr.confidence DESC""",
-            (ws_id, min_conf),
+            (ws_id, min_conf, *scope_params),
         ).fetchall()
 
     # Group predictions by photo_id, keep top K
@@ -257,11 +266,14 @@ def load_photo_features(db, collection_id=None, config=None,
     # Load user-confirmed species keywords (alphabetically first wins
     # for photos with multiple species tags — rare but deterministic)
     species_kw_rows = db.conn.execute(
-        """SELECT pk.photo_id, k.name
+        f"""SELECT pk.photo_id, k.name
            FROM photo_keywords pk
+           JOIN photos p ON p.id = pk.photo_id
            JOIN keywords k ON k.id = pk.keyword_id
            WHERE k.is_species = 1
-           ORDER BY k.name"""
+             {scope_sql}
+           ORDER BY k.name""",
+        scope_params,
     ).fetchall()
     confirmed_by_photo = {}
     for row in species_kw_rows:

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -78,7 +78,7 @@ def _resolve_collection_photo_ids(db, collection_id):
 
 
 def load_photo_features(db, collection_id=None, config=None,
-                        labels_fingerprint=None):
+                        labels_fingerprint=None, photo_ids=None):
     """Load all pipeline-relevant features for workspace photos from the database.
 
     Returns a list of photo dicts ready for the pipeline stages, with:
@@ -96,28 +96,45 @@ def load_photo_features(db, collection_id=None, config=None,
             recent fingerprint only — otherwise a photo with cached
             predictions from multiple label sets would leak stale species
             into the top-k.
+        photo_ids: optional iterable of photo IDs to scope results. When used
+            with collection_id, the returned rows are the intersection.
 
     Returns:
         list of photo dicts
     """
     ws_id = db._ws_id()
 
-    # Resolve collection to photo IDs if scoping is requested
-    collection_photo_ids = None
+    # Resolve optional scopes to a single ID set.
+    scoped_photo_ids = None
     if collection_id is not None:
-        collection_photo_ids = _resolve_collection_photo_ids(db, collection_id)
-        if not collection_photo_ids:
+        scoped_photo_ids = _resolve_collection_photo_ids(db, collection_id)
+        if not scoped_photo_ids:
+            return []
+    if photo_ids is not None:
+        requested_ids = {
+            int(pid)
+            for pid in photo_ids
+            if isinstance(pid, int) and not isinstance(pid, bool)
+        }
+        if not requested_ids:
+            return []
+        scoped_photo_ids = (
+            requested_ids if scoped_photo_ids is None
+            else scoped_photo_ids & requested_ids
+        )
+        if not scoped_photo_ids:
             return []
 
-    if collection_photo_ids is not None:
-        placeholders = ",".join("?" for _ in collection_photo_ids)
+    if scoped_photo_ids is not None:
+        scoped_photo_ids = sorted(scoped_photo_ids)
+        placeholders = ",".join("?" for _ in scoped_photo_ids)
         rows = db.conn.execute(
             f"""SELECT {_PIPELINE_PHOTO_COLS}
                 FROM photos p
                 JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                 WHERE wf.workspace_id = ? AND p.id IN ({placeholders})
                 ORDER BY p.timestamp, p.filename ASC, p.id ASC""",
-            (ws_id, *collection_photo_ids),
+            (ws_id, *scoped_photo_ids),
         ).fetchall()
     else:
         rows = db.conn.execute(
@@ -429,6 +446,47 @@ def run_full_pipeline(photos, config=None, emit_trace=False):
         summary["reject_count"],
     )
 
+    return {
+        "encounters": encounters,
+        "photos": all_photos,
+        "summary": summary,
+    }
+
+
+def run_selected_batch_review(photos, config=None):
+    """Build normal pipeline-review results for one temporary photo batch.
+
+    Browse's "Review Burst" handoff uses this to keep selected-photo review on
+    the same serialized result contract as the regular Pipeline Review page,
+    without writing an ad-hoc cache or reimplementing review data in JavaScript.
+    """
+    from encounters import encounter_species_label
+    from scoring import score_encounter
+
+    photos = list(photos or [])
+    if photos:
+        timestamps = [p.get("timestamp") for p in photos if p.get("timestamp")]
+        time_range = [min(timestamps), max(timestamps)] if timestamps else [None, None]
+    else:
+        time_range = [None, None]
+
+    species = encounter_species_label(photos)
+    encounter = {
+        "photos": photos,
+        "bursts": [photos],
+        "photo_count": len(photos),
+        "burst_count": 1 if photos else 0,
+        "time_range": time_range,
+        "species": species,
+    }
+
+    if photos:
+        score_encounter(encounter, config=config)
+        encounters, all_photos = run_triage([encounter], config=config)
+    else:
+        encounters, all_photos = [], []
+
+    summary = _make_summary(encounters, all_photos)
     return {
         "encounters": encounters,
         "photos": all_photos,

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3228,6 +3228,21 @@ function openBrowseBurstReviewFromStorage() {
       return;
     }
 
+    var target = null;
+    data.encounters.some(function(enc, encIdx) {
+      var bursts = Array.isArray(enc.bursts) ? enc.bursts : [];
+      return bursts.some(function(burst, burstIdx) {
+        var firstIds = burst && (burst.photo_ids || burst);
+        if (!firstIds || !firstIds.length) return false;
+        target = { encIdx: encIdx, burstIdx: burstIdx, photoId: firstIds[0] };
+        return true;
+      });
+    });
+    if (!target) {
+      fallbackToNormalPipelineReview('Could not find a burst to review — showing the latest pipeline review instead.');
+      return;
+    }
+
     pipelineResults = data;
     pipelineResults.source = 'browse-selection';
 
@@ -3239,10 +3254,7 @@ function openBrowseBurstReviewFromStorage() {
     // closing the modal via Esc/× or hitting the /group/state retry path stays
     // recoverable across a plain reload. clearBrowseBurstHandoff() runs only
     // once the user applies (workflow complete) or we fall back to normal review.
-    var firstEnc = pipelineResults.encounters[0];
-    var firstBurst = firstEnc && firstEnc.bursts && firstEnc.bursts[0];
-    var firstIds = firstBurst ? (firstBurst.photo_ids || firstBurst) : (firstEnc ? firstEnc.photo_ids : []);
-    openGroupReview(0, 0, firstIds && firstIds.length ? firstIds[0] : null);
+    openGroupReview(target.encIdx, target.burstIdx, target.photoId);
   }).catch(function() {
     fallbackToNormalPipelineReview('Could not open burst review — showing the latest pipeline review instead.');
   });

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1836,24 +1836,6 @@ function renderResults() {
   if (!pipelineResults) return;
   var container = document.getElementById('encountersContainer');
   if (!container) return;
-  if (pipelineResults.source === 'browse-selection') {
-    var summary = refreshLocalSummaryCounts() || pipelineResults.summary || {};
-    var total = Number(summary.total_photos || 0);
-    var ce = document.getElementById('countAll'); if (ce) ce.textContent = ' (' + total + ')';
-    ce = document.getElementById('countKeep'); if (ce) ce.textContent = ' (' + Number(summary.keep_count || 0) + ')';
-    ce = document.getElementById('countReview'); if (ce) ce.textContent = ' (' + Number(summary.review_count || 0) + ')';
-    ce = document.getElementById('countReject'); if (ce) ce.textContent = ' (' + Number(summary.reject_count || 0) + ')';
-    container.innerHTML = '<div class="empty-state" style="display:block;">'
-      + '<p>Temporary Browse selection. Use the burst review modal to pick, reject, or tag these photos.</p>'
-      + '<button type="button" onclick="reopenBrowseBurstReview()" '
-      + 'style="margin-top:12px;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);" '
-      + 'title="Reopen the burst review modal for this Browse selection.">Reopen burst review</button>'
-      + '</div>';
-    _focusedEncounterIdx = null;
-    renderAlgorithmTrace();
-    return;
-  }
-
   // Build photo lookup
   var photoMap = {};
   pipelineResults.photos.forEach(function(p) { photoMap[p.id] = p; });
@@ -3194,22 +3176,6 @@ function browseBurstStoredIds() {
   }
 }
 
-function browseBurstTimeRange(photos) {
-  var stamps = photos.map(function(p) { return p.timestamp; }).filter(Boolean).sort();
-  if (!stamps.length) return [null, null];
-  return [stamps[0], stamps[stamps.length - 1]];
-}
-
-function normalizeBrowseBurstPhoto(p) {
-  var copy = Object.assign({}, p);
-  copy.label = copy.flag === 'flagged' ? 'KEEP' : copy.flag === 'rejected' ? 'REJECT' : 'REVIEW';
-  copy.quality_composite = copy.quality_composite != null ? copy.quality_composite : copy.quality_score;
-  copy.subject_tenengrad = copy.subject_tenengrad != null
-    ? copy.subject_tenengrad
-    : (copy.subject_sharpness != null ? copy.subject_sharpness : copy.sharpness);
-  return copy;
-}
-
 function renderBrowseBurstReviewShell() {
   var empty = document.getElementById('emptyState');
   if (empty) empty.style.display = 'none';
@@ -3252,55 +3218,31 @@ function openBrowseBurstReviewFromStorage() {
     return;
   }
 
-  safeFetch('/api/photos/by-ids', {
+  safeFetch('/api/pipeline/selection-results', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({photo_ids: ids}),
   }).then(function(data) {
-    var byId = {};
-    (data.photos || []).forEach(function(p) { byId[p.id] = normalizeBrowseBurstPhoto(p); });
-    var photos = ids.map(function(id) { return byId[id]; }).filter(Boolean);
-    if (photos.length < 2) {
+    if (!data || !data.photos || data.photos.length < 2 || !data.encounters || data.encounters.length === 0) {
       fallbackToNormalPipelineReview('Could not load the selected photos for burst review — showing the latest pipeline review instead.');
       return;
     }
 
-    var loadedIds = photos.map(function(p) { return p.id; });
-    pipelineResults = {
-      source: 'browse-selection',
-      photos: photos,
-      encounters: [{
-        photo_ids: loadedIds,
-        photo_count: loadedIds.length,
-        burst_count: 1,
-        bursts: [{photo_ids: loadedIds, species_predictions: [], species_override: null}],
-        species: [],
-        species_predictions: [],
-        confirmed_species: '',
-        species_confirmed: false,
-        time_range: browseBurstTimeRange(photos),
-      }],
-      summary: {
-        total_photos: loadedIds.length,
-        keep_count: photos.filter(function(p) { return p.label === 'KEEP'; }).length,
-        review_count: photos.filter(function(p) { return p.label === 'REVIEW'; }).length,
-        reject_count: photos.filter(function(p) { return p.label === 'REJECT'; }).length,
-        encounter_count: 1,
-        burst_count: 1,
-      },
-    };
+    pipelineResults = data;
+    pipelineResults.source = 'browse-selection';
 
     collapsedEncounters = new Set();
     renderBrowseBurstReviewShell();
     updateSummaryBar(pipelineResults.summary);
     renderResults();
-    // Keep the handoff state (session storage + ?browse_burst=1) in place.
-    // The body is just a placeholder in browse-selection mode, so closing
-    // the modal via Esc/× or hitting the /group/state "reopen to retry"
-    // path must remain recoverable — both via the in-page Reopen button and
-    // via a plain reload. clearBrowseBurstHandoff() runs only once the user
-    // applies (workflow complete) or we fall back to normal review.
-    openGroupReview(0, 0, loadedIds[0]);
+    // Keep the handoff state (session storage + ?browse_burst=1) in place so
+    // closing the modal via Esc/× or hitting the /group/state retry path stays
+    // recoverable across a plain reload. clearBrowseBurstHandoff() runs only
+    // once the user applies (workflow complete) or we fall back to normal review.
+    var firstEnc = pipelineResults.encounters[0];
+    var firstBurst = firstEnc && firstEnc.bursts && firstEnc.bursts[0];
+    var firstIds = firstBurst ? (firstBurst.photo_ids || firstBurst) : (firstEnc ? firstEnc.photo_ids : []);
+    openGroupReview(0, 0, firstIds && firstIds.length ? firstIds[0] : null);
   }).catch(function() {
     fallbackToNormalPipelineReview('Could not open burst review — showing the latest pipeline review instead.');
   });
@@ -3915,23 +3857,6 @@ function grmRefreshSelectedLoupe() {
 }
 
 function buildPipelineMetadataHtml(photo) {
-  if (grmState && grmState.source === 'browse-selection') {
-    var flag = photo.flag || 'none';
-    var dims = (photo.width && photo.height) ? (photo.width + '×' + photo.height) : '—';
-    var rating = photo.rating != null ? photo.rating : 0;
-    var sharpBrowse = photo.subject_tenengrad != null ? Math.round(photo.subject_tenengrad) : '—';
-    var htmlBrowse = '<span class="triage-badge review">BROWSE SELECTION</span>';
-    htmlBrowse += '<table class="feature-table">';
-    htmlBrowse += '<tr><td>Filename</td><td>' + escapeHtml(photo.filename || '') + '</td></tr>';
-    htmlBrowse += '<tr><td>Flag</td><td>' + escapeHtml(flag) + '</td></tr>';
-    htmlBrowse += '<tr><td>Rating</td><td>' + rating + '</td></tr>';
-    htmlBrowse += '<tr><td>Dimensions</td><td>' + dims + '</td></tr>';
-    htmlBrowse += '<tr><td>Timestamp</td><td>' + escapeHtml(photo.timestamp || '—') + '</td></tr>';
-    htmlBrowse += '<tr><td>Sharpness</td><td>' + sharpBrowse + '</td></tr>';
-    htmlBrowse += '</table>';
-    return htmlBrowse;
-  }
-
   var enc = pipelineResults.encounters[grmState.encIdx];
   var label = (photo.label || '').toLowerCase();
   var q = photo.quality_composite || 0;

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -263,6 +263,59 @@ def test_api_photos_by_ids_validates_payload(app_and_db):
     assert resp.status_code == 400
 
 
+def test_pipeline_selection_results_uses_full_review_payload(app_and_db):
+    """Browse-selected review should return the same rich result shape as Pipeline Review."""
+    app, db = app_and_db
+    photos = db.get_photos(sort="name")
+    by_name = {p["filename"]: p["id"] for p in photos}
+    ordered_ids = [by_name["bird3.jpg"], by_name["bird1.jpg"]]
+
+    for idx, pid in enumerate(ordered_ids):
+        db.update_photo_pipeline_features(
+            pid,
+            mask_path=f"/masks/{pid}.png",
+            subject_tenengrad=250 + idx * 25,
+            bg_tenengrad=30,
+            crop_complete=0.9,
+            bg_separation=40.0,
+            subject_clip_high=0.01,
+            subject_clip_low=0.01,
+            subject_y_median=120.0,
+            phash_crop=f"{pid:016x}",
+        )
+        db.update_photo_quality(pid, subject_size=0.1)
+        det_id = db.save_detections(
+            pid,
+            [{"box": {"x": 0.2, "y": 0.2, "w": 0.4, "h": 0.4}, "confidence": 0.9}],
+            detector_model="megadetector-v6",
+        )[0]
+        db.add_prediction(
+            det_id,
+            "Cedar Waxwing" if idx == 0 else "American Robin",
+            0.92 - idx * 0.05,
+            "bioclip",
+        )
+
+    client = app.test_client()
+    resp = client.post("/api/pipeline/selection-results", json={"photo_ids": ordered_ids})
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["source"] == "browse-selection"
+    assert [p["id"] for p in data["photos"]] == ordered_ids
+    assert data["summary"]["total_photos"] == 2
+    assert len(data["encounters"]) == 1
+    enc = data["encounters"][0]
+    assert enc["photo_ids"] == ordered_ids
+    assert enc["bursts"][0]["photo_ids"] == ordered_ids
+    assert {p["species"] for p in enc["species_predictions"]} == {
+        "Cedar Waxwing",
+        "American Robin",
+    }
+    assert enc["bursts"][0]["species_predictions"] == enc["species_predictions"]
+    assert all("quality_composite" in p for p in data["photos"])
+
+
 def test_api_photos_calendar(app_and_db):
     """GET /api/photos/calendar returns daily photo counts for a year."""
     app, _ = app_and_db


### PR DESCRIPTION
## Summary
This changes Browse Mode's selected-photo Review Burst handoff to fetch a normal Pipeline Review result payload instead of building a reduced JavaScript-only placeholder. The selected batch now reuses pipeline feature loading, scoring, triage, species prediction aggregation, and the existing Pipeline Review renderer, so future changes to the review view apply to this path too. The fix addresses the missing detected-species information by returning encounter and burst species predictions for Browse-selected reviews.

## Validation
Ran `python -m py_compile vireo/pipeline.py vireo/app.py`, `pytest vireo/tests/test_photos_api.py`, focused pipeline tests, and `pytest tests/e2e/test_browse_context_menu.py::test_browse_selection_opens_burst_review`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add server endpoint to run a temporary pipeline review for a selected set of photos.

* **Improvements**
  * Browse→burst review now uses server-side review generation and renders selected batches with the standard pipeline review UI.
  * Selection validation and original photo ordering are preserved in responses.

* **Tests**
  * Added test coverage ensuring full review payload includes encounters, species predictions, and quality metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->