### PR TITLE
[codex] Default sidecar deletion for missing photos

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1768,7 +1768,7 @@ function sendReport() {
       <label><input type="checkbox" id="missingPhotosSelectAll" onchange="toggleAllMissingPhotos(this.checked)"> Select all</label>
       <span id="missingPhotosSelectedCount">0 selected</span>
       <span class="spacer"></span>
-      <label title="Also delete the .xmp sidecar files left behind on disk."><input type="checkbox" id="missingPhotosDeleteSidecars"> Also delete leftover XMP sidecars</label>
+      <label title="Also delete the .xmp sidecar files left behind on disk."><input type="checkbox" id="missingPhotosDeleteSidecars" checked> Also delete leftover XMP sidecars</label>
     </div>
     <div id="missingPhotosList" style="flex:1;overflow-y:auto;"></div>
     <div class="modal-actions">
@@ -6888,6 +6888,7 @@ async function startRemoveFolder(folderId, path, photoCount) {
 let _missingPhotosSelected = new Set();
 
 function openMissingPhotosModal() {
+  document.getElementById('missingPhotosDeleteSidecars').checked = true;
   document.getElementById('missingPhotosModal').classList.add('open');
   loadMissingPhotos();
 }


### PR DESCRIPTION
## Summary

Make the Missing Originals cleanup flow default to deleting leftover XMP sidecar files when removing missing photos from Vireo.

The checkbox is now checked in the modal markup and reset to checked whenever the modal opens, so a previous manual opt-out does not silently carry into the next cleanup session. Users can still uncheck it before confirming if they want to preserve sidecars.

## Validation

- `python -m pytest vireo/tests/test_app.py::test_api_photos_missing_delete_sidecars`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Missing Originals" modal to ensure the "Also delete leftover XMP sidecars" checkbox is checked by default when the modal opens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->