### PR TITLE
[codex] Distinguish manual collections

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -523,6 +523,30 @@ def _enforce_preview_cache_quota_at_startup(app):
             pass
 
 
+def _collection_accepts_manual_photos(rules):
+    """Return True when collection rules are static photo-id membership only."""
+    if isinstance(rules, list):
+        return all(_collection_accepts_manual_photos(child) for child in rules)
+
+    if not isinstance(rules, dict):
+        return False
+
+    if rules.get("field") == "photo_ids":
+        return isinstance(rules.get("value", []), list)
+
+    if "rules" in rules and "field" not in rules:
+        return (
+            rules.get("mode", "all") == "all"
+            and isinstance(rules.get("rules"), list)
+            and all(
+                _collection_accepts_manual_photos(child)
+                for child in rules.get("rules")
+            )
+        )
+
+    return False
+
+
 def create_app(db_path, thumb_cache_dir=None, api_token=None):
     """Create the Flask app for the Vireo photo browser.
 
@@ -1382,6 +1406,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         photo_dicts = [dict(p) for p in photos]
         _attach_species(db, photo_dicts)
         _attach_detections(db, photo_dicts)
+        collection_dicts = []
+        for c in collections:
+            d = dict(c)
+            try:
+                d["can_add_photos"] = _collection_accepts_manual_photos(
+                    json.loads(c["rules"])
+                )
+            except (TypeError, ValueError):
+                d["can_add_photos"] = False
+            collection_dicts.append(d)
 
         return jsonify(
             {
@@ -1391,7 +1425,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "per_page": per_page,
                 "folders": [dict(f) for f in folders],
                 "keywords": [dict(k) for k in keywords],
-                "collections": [dict(c) for c in collections],
+                "collections": collection_dicts,
             }
         )
 
@@ -3556,6 +3590,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         for c in collections:
             d = dict(c)
             d["photo_count"] = db.count_collection_photos(c["id"])
+            try:
+                d["can_add_photos"] = _collection_accepts_manual_photos(
+                    json.loads(c["rules"])
+                )
+            except (TypeError, ValueError):
+                d["can_add_photos"] = False
             result.append(d)
         return jsonify(result)
 
@@ -3668,62 +3708,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("photo_ids required")
 
         row = db.conn.execute(
-            "SELECT rules FROM collections WHERE id = ?", (collection_id,)
+            "SELECT rules FROM collections WHERE id = ? AND workspace_id = ?",
+            (collection_id, db._ws_id()),
         ).fetchone()
         if not row:
             return json_error("Collection not found", 404)
 
         rules = json.loads(row["rules"])
-        # Refuse to mutate smart/system collections like "All Photos" — adding
-        # a photo_ids rule would AND-combine with the sentinel and silently
-        # convert the dynamic default into a static subset.
-        def _has_all_rule(node):
-            if isinstance(node, list):
-                return any(_has_all_rule(child) for child in node)
-            if not isinstance(node, dict):
-                return False
-            if node.get("field") == "all":
-                return True
-            return _has_all_rule(node.get("rules"))
-
-        if _has_all_rule(rules):
+        if not _collection_accepts_manual_photos(rules):
             return json_error("Cannot add photos to this collection", 400)
-        def _find_photo_ids_rule(node, group_modes=()):
+
+        def _find_photo_ids_rule(node):
             if isinstance(node, list):
                 for child in node:
-                    found = _find_photo_ids_rule(child, group_modes)
+                    found = _find_photo_ids_rule(child)
                     if found is not None:
                         return found
             elif isinstance(node, dict):
                 if node.get("field") == "photo_ids":
-                    return node, group_modes
+                    return node
                 if "rules" in node:
-                    mode = node.get("mode", "all")
-                    return _find_photo_ids_rule(
-                        node.get("rules"), group_modes + (mode,)
-                    )
+                    return _find_photo_ids_rule(node.get("rules"))
             return None
 
-        def _has_non_all_group(node):
-            if isinstance(node, list):
-                return any(_has_non_all_group(child) for child in node)
-            if not isinstance(node, dict):
-                return False
-            if "rules" in node and node.get("field") is None:
-                if node.get("mode", "all") != "all":
-                    return True
-                return _has_non_all_group(node.get("rules"))
-            return False
-
-        found_ids_rule = _find_photo_ids_rule(rules)
-        if found_ids_rule is not None:
-            ids_rule, group_modes = found_ids_rule
-            if any(mode != "all" for mode in group_modes):
-                return json_error("Cannot add photos to this collection", 400)
-        else:
-            ids_rule = None
-            if _has_non_all_group(rules):
-                return json_error("Cannot add photos to this collection", 400)
+        ids_rule = _find_photo_ids_rule(rules)
 
         if ids_rule is None:
             ids_rule = {"field": "photo_ids", "value": []}
@@ -3741,8 +3749,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ids_rule["value"] = sorted(existing)
 
         db.conn.execute(
-            "UPDATE collections SET rules = ? WHERE id = ?",
-            (json.dumps(rules), collection_id),
+            "UPDATE collections SET rules = ? WHERE id = ? AND workspace_id = ?",
+            (json.dumps(rules), collection_id, db._ws_id()),
         )
         db.conn.commit()
         return jsonify({"ok": True, "total": len(ids_rule["value"])})

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -62,6 +62,32 @@ body {
   color: var(--text-faint);
   font-variant-numeric: tabular-nums;
 }
+.tree-item .collection-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tree-item .collection-kind-badge {
+  margin-left: 6px;
+  padding: 1px 5px;
+  border: 1px solid var(--border-secondary);
+  border-radius: 4px;
+  color: var(--text-faint);
+  font-size: 9px;
+  line-height: 1.3;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+.tree-item .collection-kind-badge.smart {
+  border-color: color-mix(in srgb, var(--info) 50%, var(--border-secondary));
+  color: var(--info);
+}
+.tree-item .collection-kind-badge.manual {
+  border-color: var(--border-primary);
+  color: var(--text-ghost);
+}
 .tree-item .folder-status-partial {
   margin-left: 6px;
   font-size: 10px;
@@ -1875,8 +1901,12 @@ function renderCollectionList(collections) {
   collections.forEach(function(c) {
     collectionsById[c.id] = c;
     var count = c.photo_count != null ? c.photo_count : '';
-    html += '<div class="tree-item" data-collection-id="' + c.id + '" onclick="filterByCollection(' + c.id + ')">' +
-      '<span>' + escapeHtml(c.name) + '</span>' +
+    var canAddPhotos = collectionAcceptsManualPhotos(c);
+    var kind = canAddPhotos ? 'manual' : 'smart';
+    var kindLabel = canAddPhotos ? 'Manual' : 'Smart';
+    html += '<div class="tree-item" data-collection-id="' + c.id + '" data-collection-kind="' + kind + '" onclick="filterByCollection(' + c.id + ')">' +
+      '<span class="collection-name">' + escapeHtml(c.name) + '</span>' +
+      '<span class="collection-kind-badge ' + kind + '">' + kindLabel + '</span>' +
       '<span class="count">' + count + '</span></div>';
   });
   document.getElementById('collectionList').innerHTML = html || '<div style="font-size:12px;color:var(--text-ghost);padding:4px 8px;">No collections</div>';
@@ -3708,6 +3738,35 @@ function batchDelete() {
 var _batchCollections = [];
 var _batchCollectionSelectedId = null;
 
+function collectionAcceptsManualPhotos(collection) {
+  if (typeof collection.can_add_photos === 'boolean') {
+    return collection.can_add_photos;
+  }
+
+  function rulesAcceptManualPhotos(node) {
+    if (Array.isArray(node)) {
+      return node.every(rulesAcceptManualPhotos);
+    }
+    if (!node || typeof node !== 'object') return false;
+    if (node.field === 'photo_ids') {
+      return Array.isArray(node.value || []);
+    }
+    if (!node.field && Array.isArray(node.rules)) {
+      return (node.mode || 'all') === 'all' && node.rules.every(rulesAcceptManualPhotos);
+    }
+    return false;
+  }
+
+  try {
+    var rules = typeof collection.rules === 'string'
+      ? JSON.parse(collection.rules)
+      : collection.rules;
+    return rulesAcceptManualPhotos(rules);
+  } catch(e) {
+    return false;
+  }
+}
+
 async function addToCollection() {
   var activeIds = getActiveSelection();
   if (activeIds.length === 0) {
@@ -3723,6 +3782,7 @@ async function addToCollection() {
     return;
   }
 
+  collections = collections.filter(collectionAcceptsManualPhotos);
   _batchCollections = collections;
   _batchCollectionSelectedId = null;
   document.getElementById('batchCollectionTitle').textContent = 'Add ' + activeIds.length + ' photo(s) to collection';
@@ -3732,7 +3792,7 @@ async function addToCollection() {
     listHtml += '<div class="batch-coll-item" data-id="' + c.id + '" onclick="pickBatchCollection(' + c.id + ')" style="padding:6px 10px;cursor:pointer;border-radius:4px;font-size:13px;color:var(--text-primary);">' + escapeHtml(c.name) + '</div>';
   });
   if (collections.length === 0) {
-    listHtml = '<div style="font-size:12px;color:var(--text-dim);padding:4px 10px;">No collections yet</div>';
+    listHtml = '<div style="font-size:12px;color:var(--text-dim);padding:4px 10px;">No manual collections yet</div>';
   }
   document.getElementById('batchCollectionList').innerHTML = listHtml;
   document.getElementById('batchCollectionNewName').value = '';
@@ -5138,7 +5198,7 @@ document.addEventListener('contextmenu', function(e) {
   e.preventDefault();
   var cid = parseInt(ti.dataset.collectionId, 10);
   if (isNaN(cid)) return;
-  var nameEl = ti.querySelector('span');
+  var nameEl = ti.querySelector('.collection-name');
   var name = nameEl ? nameEl.textContent : '';
   openContextMenu(e, [
     { label: 'Filter by this Collection',

--- a/vireo/tests/test_collections_api.py
+++ b/vireo/tests/test_collections_api.py
@@ -63,6 +63,61 @@ def test_create_and_list_collection(app_and_db):
     assert created_id in ids
 
 
+def test_list_collections_marks_manual_photo_targets(app_and_db):
+    """GET /api/collections reports which collections can accept manual adds."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    client.post(
+        "/api/collections",
+        json={"name": "Manual", "rules": [{"field": "photo_ids", "value": []}]},
+    )
+    client.post(
+        "/api/collections",
+        json={
+            "name": "Smart",
+            "rules": [{"field": "rating", "op": ">=", "value": 4}],
+        },
+    )
+    client.post(
+        "/api/collections",
+        json={"name": "All Photos", "rules": [{"field": "all"}]},
+    )
+
+    resp = client.get("/api/collections")
+    assert resp.status_code == 200
+    by_name = {c["name"]: c for c in resp.get_json()}
+    assert by_name["Manual"]["can_add_photos"] is True
+    assert by_name["Smart"]["can_add_photos"] is False
+    assert by_name["All Photos"]["can_add_photos"] is False
+
+
+def test_browse_init_marks_manual_photo_targets(app_and_db):
+    """Initial Browse payload includes collection type metadata for the sidebar."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    client.post(
+        "/api/collections",
+        json={"name": "Manual", "rules": [{"field": "photo_ids", "value": []}]},
+    )
+    client.post(
+        "/api/collections",
+        json={
+            "name": "Smart",
+            "rules": [{"field": "rating", "op": ">=", "value": 4}],
+        },
+    )
+
+    resp = client.get("/api/browse/init")
+    assert resp.status_code == 200
+    by_name = {c["name"]: c for c in resp.get_json()["collections"]}
+    assert by_name["Manual"]["can_add_photos"] is True
+    assert by_name["Smart"]["can_add_photos"] is False
+
+
 def test_delete_collection(app_and_db):
     """DELETE /api/collections/<id> removes it."""
     app, db = app_and_db
@@ -258,6 +313,32 @@ def test_cannot_add_photos_to_all_photos_default(app_and_db):
         "SELECT rules FROM collections WHERE id = ?", (all_photos["id"],)
     ).fetchone()
     assert json.loads(row["rules"]) == [{"field": "all"}]
+
+
+def test_cannot_add_photos_to_smart_collection(app_and_db):
+    """Manual adds to a smart collection should not convert it into a subset."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    rules = [{"field": "rating", "op": ">=", "value": 4}]
+    resp = client.post(
+        "/api/collections",
+        json={"name": "High Rated", "rules": rules},
+    )
+    cid = resp.get_json()["id"]
+    pid = db.get_photos()[0]["id"]
+
+    resp = client.post(
+        f"/api/collections/{cid}/add-photos",
+        json={"photo_ids": [pid]},
+    )
+    assert resp.status_code == 400
+
+    row = db.conn.execute(
+        "SELECT rules FROM collections WHERE id = ?", (cid,)
+    ).fetchone()
+    assert json.loads(row["rules"]) == rules
 
 
 def test_cannot_add_photos_to_none_grouped_collection(app_and_db):


### PR DESCRIPTION
This distinguishes manual/static collections from smart collections in Browse with explicit Manual and Smart badges. The add-to-collection flow now only lists manual collections, while the API rejects manual photo additions to smart collections so dynamic rules are not accidentally narrowed. The collection APIs expose `can_add_photos` in both the list and Browse init payloads so the UI has a stable signal. Validated with `pytest vireo/tests/test_collections_api.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Collections now display visual badges indicating whether they accept manual photo additions ("Manual") or are automatically curated ("Smart")
  * Photo addition workflow filters to show only collections that accept manual photos
  * System validates collection type before allowing photo additions, preventing invalid operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->