### PR TITLE
[codex] Open compare photos in lightbox

### DIFF
--- a/tests/e2e/test_compare_page.py
+++ b/tests/e2e/test_compare_page.py
@@ -21,3 +21,17 @@ def test_compare_page_filters_conflicts_without_crashing(live_server, page):
     page.locator("#filterRow button", has_text="Matches").click()
 
     expect(page.locator("#filterRow .active")).to_contain_text("Matches")
+
+
+def test_compare_page_thumbnail_opens_lightbox(live_server, page):
+    page.goto(f"{live_server['url']}/compare")
+
+    page.locator("#filterRow button", has_text="All").click()
+    first_row = page.locator(".compare-table tbody tr").first
+    expect(first_row).to_be_visible()
+    filename = first_row.locator(".photo-name").inner_text()
+
+    first_row.locator(".photo-thumb-button").click()
+
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    expect(page.locator("#lightboxFilename")).to_have_text(filename)

--- a/vireo/templates/compare.html
+++ b/vireo/templates/compare.html
@@ -169,12 +169,26 @@ body { padding-bottom: 36px; }
   gap: 9px;
   min-width: 0;
 }
-.photo-cell img {
+.photo-thumb-button {
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: var(--bg-tertiary);
+  cursor: zoom-in;
+  flex: 0 0 auto;
+  overflow: hidden;
+}
+.photo-thumb-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.photo-thumb-button img {
   width: 44px;
   height: 44px;
   object-fit: cover;
-  border-radius: 4px;
-  flex: 0 0 auto;
+  display: block;
 }
 .photo-name {
   color: var(--text-primary);
@@ -557,11 +571,42 @@ function renderPhotoCell(photo) {
   if (photo.rating) meta.push(photo.rating + ' star' + (photo.rating === 1 ? '' : 's'));
   if (photo.flag && photo.flag !== 'none') meta.push(photo.flag);
   return '<div class="photo-cell">' +
-    '<img src="/thumbnails/' + photo.photo_id + '.jpg" loading="lazy" alt="">' +
+    '<button type="button" class="photo-thumb-button" title="View larger" onclick="openCompareLightbox(' +
+    photo.photo_id + ')"><img src="/thumbnails/' + photo.photo_id + '.jpg" loading="lazy" alt="' +
+    escapeAttr(photo.filename) + '"></button>' +
     '<div><div class="photo-name">' + escapeHtml(photo.filename) + '</div>' +
     '<div class="photo-meta">' + escapeHtml(meta.join(' · ')) + '</div>' +
     '<div class="pred-actions"><a class="inline-btn" href="/browse?photo_id=' +
-    encodeURIComponent(photo.photo_id) + '">Open photo</a></div></div></div>';
+    encodeURIComponent(photo.photo_id) + '">Browse</a></div></div></div>';
+}
+
+function compareLightboxPhotoList() {
+  return filteredRows().map(function(photo) {
+    return {
+      id: photo.photo_id,
+      filename: photo.filename || '',
+      flag: photo.flag || 'none',
+      wildlife_excluded: !!photo.wildlife_excluded,
+    };
+  });
+}
+
+function openCompareLightbox(photoId) {
+  var list = compareLightboxPhotoList();
+  var current = list.find(function(photo) { return photo.id === photoId; });
+  if (!current) {
+    var fallback = (compareData && compareData.photos || []).find(function(photo) {
+      return photo.photo_id === photoId;
+    });
+    current = {
+      id: photoId,
+      filename: fallback ? (fallback.filename || '') : '',
+      flag: fallback ? (fallback.flag || 'none') : 'none',
+      wildlife_excluded: !!(fallback && fallback.wildlife_excluded),
+    };
+    list = [current];
+  }
+  openLightbox(current.id, current.filename, list);
 }
 
 function isSpeciesKeyword(k) {


### PR DESCRIPTION
Compare page thumbnails now open the shared in-app lightbox instead of sending users to Browse just to see a larger image.
The lightbox uses the current filtered compare rows as its navigation list, preserving compare workflow context, while the explicit Browse link remains available.
This fixes the interrupted review flow where "Open photo" took users away from the keyword comparison page.

Validation: `python -m pytest tests/e2e/test_compare_page.py -q`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thumbnails in the compare table are now clickable and open an interactive lightbox overlay for viewing larger photo images. The previous "Open photo" action link has been removed.

* **Tests**
  * Added end-to-end test that verifies clicking a photo thumbnail opens the lightbox with the correct image on the compare page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->