### PR TITLE
[codex] Fix lightbox flag hotkey rollback

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3167,6 +3167,11 @@ function _lbRememberConfirmedFlag(photoId, flag) {
   _lbConfirmedFlags[String(photoId)] = normalized;
 }
 
+function _lbForgetConfirmedFlag(photoId) {
+  if (photoId == null) return;
+  delete _lbConfirmedFlags[String(photoId)];
+}
+
 function _lbConfirmedFlagFor(photoId) {
   var key = String(photoId);
   if (Object.prototype.hasOwnProperty.call(_lbConfirmedFlags, key)) {
@@ -3608,6 +3613,11 @@ function openLightbox(photoId, filename, photoList, options) {
   var currentFromList = _lightboxPhotoList.find(function(x) { return x.id === photoId; });
   if (currentFromList && Object.prototype.hasOwnProperty.call(currentFromList, 'flag')) {
     _lbRememberConfirmedFlag(photoId, currentFromList.flag);
+  } else {
+    // Flagless opens (e.g. review/misses/cull push only {id, filename}) must
+    // not reuse a flag remembered from an earlier open; rely on the
+    // /api/photos/:id fetch to repopulate the confirmed flag instead.
+    _lbForgetConfirmedFlag(photoId);
   }
   _lbCurrentWildlifeExcluded = !!(currentFromList && currentFromList.wildlife_excluded);
   _lbSetFlagStatus(_lbConfirmedFlagFor(photoId));

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2926,6 +2926,7 @@ var _lbCurrentWildlifeExcluded = false;
 var _lbFlagEditSeq = 0;      // increments for local flag writes so stale metadata fetches cannot overwrite the chip
 var _lbOpenSeq = 0;          // increments for every lightbox open so old metadata fetches cannot reapply after reopen
 var _lbFlagPendingWrites = 0;
+var _lbConfirmedFlags = {};   // last server-confirmed flag per photo, isolated from optimistic page helpers
 var _lbViewportByPhotoId = {};  // per-session lightbox viewport cache keyed by photo id
 var _lbPendingViewportState = null;
 
@@ -3160,11 +3161,26 @@ function _lbFlagFromPhotoList(photoId) {
   return p.flag;
 }
 
+function _lbRememberConfirmedFlag(photoId, flag) {
+  var normalized = _lbNormalizeFlag(flag);
+  if (!normalized || photoId == null) return;
+  _lbConfirmedFlags[String(photoId)] = normalized;
+}
+
+function _lbConfirmedFlagFor(photoId) {
+  var key = String(photoId);
+  if (Object.prototype.hasOwnProperty.call(_lbConfirmedFlags, key)) {
+    return _lbConfirmedFlags[key];
+  }
+  return _lbFlagFromPhotoList(photoId);
+}
+
 function _lbRecordFlag(photoId, flag) {
   var normalized = _lbNormalizeFlag(flag);
   if (!normalized) return;
   var p = _lightboxPhotoList.find(function(x) { return x.id === photoId; });
   if (p) p.flag = normalized;
+  _lbRememberConfirmedFlag(photoId, normalized);
   if (_lightboxCurrentId === photoId) _lbSetFlagStatus(normalized);
 }
 
@@ -3173,6 +3189,7 @@ function _lbCacheFlag(photoId, flag) {
   if (!normalized) return;
   var p = _lightboxPhotoList.find(function(x) { return x.id === photoId; });
   if (p) p.flag = normalized;
+  _lbRememberConfirmedFlag(photoId, normalized);
 }
 
 function _lbRecordFetchedFlag(photoId, flag, flagFetchSeq) {
@@ -3199,7 +3216,7 @@ function _lbApplyFlag(photoId, flag) {
       body: JSON.stringify({flag: normalized}),
     }, { toast: false }).then(function() { return true; }).catch(function() { return false; });
   } else {
-    _lbSetFlagStatus(_lbFlagFromPhotoList(photoId));
+    _lbSetFlagStatus(_lbConfirmedFlagFor(photoId));
     return false;
   }
 
@@ -3207,7 +3224,7 @@ function _lbApplyFlag(photoId, flag) {
     _lbFlagPendingWrites = Math.max(0, _lbFlagPendingWrites - 1);
     if (_lightboxCurrentId !== photoId) return;
     if (ok === false) {
-      if (_lbFlagEditSeq === seq) _lbSetFlagStatus(_lbFlagFromPhotoList(photoId));
+      if (_lbFlagEditSeq === seq) _lbSetFlagStatus(_lbConfirmedFlagFor(photoId));
       return;
     }
     if (_lbFlagEditSeq === seq || _lbFlagPendingWrites === 0) {
@@ -3218,7 +3235,7 @@ function _lbApplyFlag(photoId, flag) {
   }).catch(function() {
     _lbFlagPendingWrites = Math.max(0, _lbFlagPendingWrites - 1);
     if (_lbFlagEditSeq === seq && _lightboxCurrentId === photoId) {
-      _lbSetFlagStatus(_lbFlagFromPhotoList(photoId));
+      _lbSetFlagStatus(_lbConfirmedFlagFor(photoId));
     }
   });
 
@@ -3589,8 +3606,11 @@ function openLightbox(photoId, filename, photoList, options) {
   _lightboxCurrentId = photoId;
   if (photoList) _lightboxPhotoList = photoList;
   var currentFromList = _lightboxPhotoList.find(function(x) { return x.id === photoId; });
+  if (currentFromList && Object.prototype.hasOwnProperty.call(currentFromList, 'flag')) {
+    _lbRememberConfirmedFlag(photoId, currentFromList.flag);
+  }
   _lbCurrentWildlifeExcluded = !!(currentFromList && currentFromList.wildlife_excluded);
-  _lbSetFlagStatus(_lbFlagFromPhotoList(photoId));
+  _lbSetFlagStatus(_lbConfirmedFlagFor(photoId));
 
   var overlay = document.getElementById('lightboxOverlay');
   var img = document.getElementById('lightboxImg');

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4755,6 +4755,8 @@ document.addEventListener('keydown', function(e) {
     return;
   }
 
+  if (document.getElementById('lightboxOverlay').classList.contains('active')) return;
+
   if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
 
   if (e.key === 'Escape') {


### PR DESCRIPTION
Fixes an intermittent lightbox flag hotkey rollback failure by tracking the last server-confirmed flag inside the lightbox instead of relying on page model state. It also prevents browse-page shortcuts from handling flag keys while the shared lightbox is active, avoiding duplicate writes that can bypass the lightbox rollback path. The root cause was stale or separately-mutated page state racing with failed optimistic lightbox writes. Validated with repeated lightbox hotkey E2E runs plus adjacent browse lightbox and keymap tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented keyboard shortcuts from running while the lightbox is open to avoid unintended actions during photo review.
  * Improved lightbox flag state handling so server-confirmed flag status is reliably remembered and restored (including when remote updates fail), keeping displayed pick/reject flags synchronized with server state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->