### PR TITLE
Fix UI freeze: coalesce bottom-panel log rendering to one rAF flush

### DIFF
--- a/tests/e2e/test_log_panel_perf.py
+++ b/tests/e2e/test_log_panel_perf.py
@@ -1,0 +1,86 @@
+"""Regression: the bottom-panel log stream must not do O(n) work per line.
+
+Root cause of the "UI frozen while a long job runs" report: every live SSE
+log line ran the full ``lpApplyFilter()`` re-scan (querySelectorAll over all
+~200 line nodes + a style write on each) plus a forced auto-scroll reflow.
+At the pipeline's log rate, sustained for hours, this saturates the renderer
+main thread even though the Flask backend stays fast.
+
+The live (non-bulk) path must coalesce rendering so a burst of N lines does
+NOT trigger N full re-filters. ``addLpLine`` is exercised directly because
+the SSE handler calls it verbatim: ``addLpLine(JSON.parse(e.data))``.
+"""
+
+
+def _drive_log_burst(page, live_server, n):
+    """Load /browse, wrap lpApplyFilter to count, fire N live log lines."""
+    page.goto(f"{live_server['url']}/browse")
+    # Navbar IIFE defines window.addLpLine / window.lpApplyFilter at load.
+    page.wait_for_function("typeof window.addLpLine === 'function'")
+    page.wait_for_function("typeof window.lpApplyFilter === 'function'")
+
+    page.evaluate(
+        """(n) => {
+            // Count full re-filter passes. addLpLine calls the bare
+            // identifier `lpApplyFilter`, which resolves to this global,
+            // so wrapping here intercepts the hot-path invocation.
+            window.__filterCalls = 0;
+            const orig = window.lpApplyFilter;
+            window.lpApplyFilter = function () {
+                window.__filterCalls++;
+                return orig.apply(this, arguments);
+            };
+            const now = Date.now() / 1000;
+            for (let i = 0; i < n; i++) {
+                // Exactly what the SSE 'log' handler passes: single arg,
+                // non-bulk -> the live render path under test.
+                window.addLpLine({
+                    time: now + i * 0.001,
+                    level: 'INFO',
+                    message: 'burst line ' + i,
+                });
+            }
+        }""",
+        n,
+    )
+
+
+def test_live_log_burst_does_not_refilter_per_line(live_server, page):
+    """300 streamed lines must not cause 300 full lpApplyFilter re-scans."""
+    n = 300
+    _drive_log_burst(page, live_server, n)
+
+    # Wait for the coalesced render to settle (DOM/array capped at 200).
+    page.wait_for_function(
+        "document.getElementById('lpCount').textContent === '200'"
+    )
+
+    filter_calls = page.evaluate("window.__filterCalls")
+    line_count = page.evaluate(
+        "document.querySelectorAll('#lpContent .lp-line').length"
+    )
+    count_text = page.evaluate(
+        "document.getElementById('lpCount').textContent"
+    )
+    last_visible = page.evaluate(
+        """() => {
+            const els = document.querySelectorAll('#lpContent .lp-line');
+            const last = els[els.length - 1];
+            return last ? last.textContent : '';
+        }"""
+    )
+
+    # Bound + correctness preserved by the fix.
+    assert line_count == 200, f"DOM not capped at 200: {line_count}"
+    assert count_text == "200", f"lpCount wrong: {count_text!r}"
+    assert "burst line 299" in last_visible, (
+        f"newest line not rendered: {last_visible!r}"
+    )
+
+    # The actual regression assertion: the expensive O(n) re-filter must be
+    # coalesced, not run once per streamed line. A few rAF-batched flushes
+    # are fine; one-per-line (== n) is the bug.
+    assert filter_calls <= 5, (
+        f"lpApplyFilter ran {filter_calls} times for {n} streamed lines "
+        f"— per-line O(n) re-render (renderer-freeze bug) is present"
+    )

--- a/tests/e2e/test_log_panel_perf.py
+++ b/tests/e2e/test_log_panel_perf.py
@@ -50,9 +50,19 @@ def test_live_log_burst_does_not_refilter_per_line(live_server, page):
     n = 300
     _drive_log_burst(page, live_server, n)
 
-    # Wait for the coalesced render to settle (DOM/array capped at 200).
+    # Wait for the coalesced render to settle. Checking the cap alone is
+    # racy: the navbar backfills startup logs via the bulk path on load,
+    # so lpCount can already read '200' before the injected burst's rAF
+    # flush runs. Also require the newest injected line to be present —
+    # that can only be true after the burst flushed.
     page.wait_for_function(
-        "document.getElementById('lpCount').textContent === '200'"
+        """() => {
+            const countOk =
+                document.getElementById('lpCount').textContent === '200';
+            const els = document.querySelectorAll('#lpContent .lp-line');
+            const last = els.length ? els[els.length - 1].textContent : '';
+            return countOk && last.includes('burst line 299');
+        }"""
     )
 
     filter_calls = page.evaluate("window.__filterCalls")

--- a/tests/e2e/test_log_panel_perf.py
+++ b/tests/e2e/test_log_panel_perf.py
@@ -84,3 +84,69 @@ def test_live_log_burst_does_not_refilter_per_line(live_server, page):
         f"lpApplyFilter ran {filter_calls} times for {n} streamed lines "
         f"— per-line O(n) re-render (renderer-freeze bug) is present"
     )
+
+
+def test_backgrounded_tab_burst_stays_bounded(live_server, page):
+    """A long job logging into a hidden tab must not blow up.
+
+    requestAnimationFrame is paused while a tab is hidden/minimized, but
+    the EventSource keeps delivering, so addLpLine keeps enqueuing. The
+    pending queue must stay bounded (capped on enqueue) and must schedule
+    exactly one flush no matter how many lines arrive while paused — then
+    resume correctly (DOM capped, newest kept, oldest dropped) when the
+    tab becomes visible again.
+    """
+    page.goto(f"{live_server['url']}/browse")
+    page.wait_for_function("typeof window.addLpLine === 'function'")
+
+    result = page.evaluate(
+        """() => {
+            // Simulate a hidden tab: rAF never auto-fires; capture the
+            // single scheduled callback and count how many were scheduled.
+            const cbs = [];
+            window.__rafScheduled = 0;
+            window.requestAnimationFrame = function (cb) {
+                window.__rafScheduled++;
+                cbs.push(cb);
+                return cbs.length;
+            };
+            const now = Date.now() / 1000;
+            // Far more than the 200 retention cap.
+            for (let i = 0; i < 1000; i++) {
+                window.addLpLine({
+                    time: now + i * 0.001,
+                    level: 'INFO',
+                    message: 'bg line ' + i,
+                });
+            }
+            const scheduledWhilePaused = window.__rafScheduled;
+            // Tab visible again: drain the one captured flush.
+            cbs.forEach((cb) => cb());
+            const els = document.querySelectorAll('#lpContent .lp-line');
+            return {
+                scheduledWhilePaused,
+                lineCount: els.length,
+                countText: document.getElementById('lpCount').textContent,
+                newest: els.length ? els[els.length - 1].textContent : '',
+                oldest: els.length ? els[0].textContent : '',
+            };
+        }"""
+    )
+
+    # One flush scheduled for the whole 1000-line paused burst — not a
+    # per-line rAF storm waiting to stampede on resume.
+    assert result["scheduledWhilePaused"] == 1, (
+        f"expected 1 scheduled flush for the paused burst, got "
+        f"{result['scheduledWhilePaused']}"
+    )
+    # Resume is bounded and correct.
+    assert result["lineCount"] == 200, (
+        f"DOM not capped after resume: {result['lineCount']}"
+    )
+    assert result["countText"] == "200", f"lpCount wrong: {result['countText']!r}"
+    assert "bg line 999" in result["newest"], (
+        f"newest line missing after resume: {result['newest']!r}"
+    )
+    assert "bg line 0" not in result["oldest"], (
+        f"oldest line should have been dropped: {result['oldest']!r}"
+    )

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -6368,14 +6368,25 @@ function formatDuration(seconds) {
   }
 
   /* ---------- Log lines ---------- */
-  window.addLpLine = function(record, bulk) {
-    if (lpLines.length >= lpMaxLines) {
-      lpLines.shift();
-      var first = document.getElementById('lpContent').firstChild;
-      if (first) first.remove();
-    }
-    lpLines.push(record);
-    var container = document.getElementById('lpContent');
+  // Live log lines arrive over SSE at the job's log rate (can be many per
+  // second for hours). Doing per-line DOM work — appending, a forced
+  // auto-scroll reflow, and a full lpApplyFilter() re-scan over every
+  // retained node — saturates the renderer main thread and freezes the UI
+  // even while the backend stays responsive. So the live (non-bulk) path
+  // only enqueues; a single requestAnimationFrame flush coalesces a whole
+  // frame's worth of lines into one append + one scroll + one count write,
+  // with the level filter read once and applied inline per new node (no
+  // O(n) re-scan). lpApplyFilter() stays for the filter <select> onchange,
+  // where a full re-scan of existing lines is genuinely required.
+  var _lpPending = [];
+  var _lpFlushScheduled = false;
+
+  function _lpMinOrder() {
+    var sel = document.getElementById('lpLevelFilter');
+    return LEVEL_ORDER[sel ? sel.value : 'DEBUG'] || 0;
+  }
+
+  function _lpMakeLineEl(record, minOrder) {
     var time = new Date(record.time * 1000);
     var timeStr = time.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
     var div = document.createElement('div');
@@ -6384,16 +6395,68 @@ function formatDuration(seconds) {
     div.innerHTML = '<span class="lp-time">' + timeStr + '</span>' +
       '<span class="lp-level">' + record.level + '</span>' +
       bpEscape(record.message || '');
-    container.appendChild(div);
-    if (!bulk) {
-      var autoScroll = document.getElementById('lpAutoScroll');
-      if (autoScroll && autoScroll.checked) {
-        container.scrollTop = container.scrollHeight;
-      }
-      lpApplyFilter();
+    // Apply the active level filter to just this node — cheap, and avoids
+    // re-scanning every existing line on each new line.
+    if ((LEVEL_ORDER[record.level] || 0) < minOrder) div.style.display = 'none';
+    return div;
+  }
+
+  function _lpFlush() {
+    _lpFlushScheduled = false;
+    if (_lpPending.length === 0) return;
+    var batch = _lpPending;
+    _lpPending = [];
+    var container = document.getElementById('lpContent');
+    if (!container) return;
+    var minOrder = _lpMinOrder();
+
+    for (var i = 0; i < batch.length; i++) lpLines.push(batch[i]);
+    var overflow = lpLines.length - lpMaxLines;
+    if (overflow > 0) lpLines.splice(0, overflow);
+
+    // Only build nodes we'll actually keep — a single burst larger than
+    // the cap would otherwise create (and immediately discard) thousands.
+    var keepFrom = Math.max(0, batch.length - lpMaxLines);
+    var frag = document.createDocumentFragment();
+    for (var j = keepFrom; j < batch.length; j++) {
+      frag.appendChild(_lpMakeLineEl(batch[j], minOrder));
+    }
+    container.appendChild(frag);
+    while (container.childNodes.length > lpMaxLines && container.firstChild) {
+      container.firstChild.remove();
+    }
+
+    var autoScroll = document.getElementById('lpAutoScroll');
+    if (autoScroll && autoScroll.checked) {
+      container.scrollTop = container.scrollHeight;
     }
     document.getElementById('lpCount').textContent = lpLines.length;
     document.getElementById('logsBadge').textContent = lpLines.length;
+  }
+
+  window.addLpLine = function(record, bulk) {
+    if (bulk) {
+      // Restore/backfill path: synchronous so callers that immediately
+      // run lpApplyFilter() afterwards see the final DOM. Still bounded,
+      // still no per-line scroll.
+      if (lpLines.length >= lpMaxLines) {
+        lpLines.shift();
+        var firstB = document.getElementById('lpContent').firstChild;
+        if (firstB) firstB.remove();
+      }
+      lpLines.push(record);
+      document.getElementById('lpContent').appendChild(
+        _lpMakeLineEl(record, _lpMinOrder())
+      );
+      document.getElementById('lpCount').textContent = lpLines.length;
+      document.getElementById('logsBadge').textContent = lpLines.length;
+      return;
+    }
+    _lpPending.push(record);
+    if (!_lpFlushScheduled) {
+      _lpFlushScheduled = true;
+      requestAnimationFrame(_lpFlush);
+    }
   };
 
   window.lpApplyFilter = function() {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -6453,6 +6453,16 @@ function formatDuration(seconds) {
       return;
     }
     _lpPending.push(record);
+    // Bound the queue independent of rAF. A hidden/minimized tab pauses
+    // requestAnimationFrame while the EventSource keeps delivering, so
+    // without this the pending array would grow unbounded for the entire
+    // life of a long job and then process one giant batch on resume.
+    // Only the last lpMaxLines can ever be shown (the DOM cap in
+    // _lpFlush), so dropping older pending records here is lossless and
+    // mirrors the lpLines cap.
+    if (_lpPending.length > lpMaxLines) {
+      _lpPending.splice(0, _lpPending.length - lpMaxLines);
+    }
     if (!_lpFlushScheduled) {
       _lpFlushScheduled = true;
       requestAnimationFrame(_lpFlush);


### PR DESCRIPTION
## Symptom

The Vireo UI became **completely unresponsive / frozen** while a long background pipeline ran, even though the job kept making progress.

## Root cause (investigated, not guessed)

The backend was fine — measured live: `/browse` (481 KB) served in **13 ms**, 10 parallel loads in **51 ms**, no Flask thread/GIL exhaustion. The freeze was the **front-end renderer**: Vireo's WebKit content process was pegged at **100% CPU for ~13 h** (exactly the app's uptime).

Cause: in `vireo/templates/_navbar.html`, `addLpLine()` did O(n) work for **every live SSE log line**:

- `lpApplyFilter()` — `querySelectorAll('#lpContent .lp-line')` over all ~200 retained nodes + a `style.display` write on each, **per line**, and
- a forced `scrollTop = scrollHeight` auto-scroll reflow, **per line**.

At a background job's log rate, sustained for hours, this saturates the renderer main thread → no paint, no input → "frozen," while the backend stays responsive. (The 200-line cap was already fine; the bug is the per-line full re-filter + forced reflow, not unbounded growth.) Matches the `CLAUDE.md` note: the bottom-panel SSE log stream only runs when the panel is open.

## Fix

Live (non-bulk) lines now enqueue and flush **once per `requestAnimationFrame`**: one `DocumentFragment` append, one scroll write, one count update; the level filter is read once per flush and applied inline to each new node (no O(n) re-scan). `lpApplyFilter()` is retained for the filter `<select>` `onchange`, where re-scanning existing lines is genuinely required. The bulk restore path stays synchronous so its callers' follow-up `lpApplyFilter()`/reads are unaffected. Line/DOM caps unchanged (200).

## Test (TDD)

New `tests/e2e/test_log_panel_perf.py` drives 300 streamed lines through the exact SSE call path (`addLpLine(record)`):

- **RED (before):** `lpApplyFilter ran 300 times for 300 streamed lines`.
- **GREEN (after):** coalesced to a handful of rAF flushes; DOM still capped at 200; newest line still rendered.

## Verification

- New test: **passes** (failed before the fix).
- Full `tests/e2e/` suite: **288 passed, 6 skipped**.
- CLAUDE.md backend regression suite: **967 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live log display now batches high-volume incoming lines, enforces the visible-line cap, and preserves newest entries while trimming oldest.

* **Bug Fixes**
  * Prevented per-line re-filtering and UI stalls during large bursts; backgrounded/minimized tabs coalesce bursts so rendering work stays bounded.

* **Tests**
  * Added end-to-end tests validating burst handling, DOM cap enforcement, and bounded re-filter behavior in foreground and background.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->