### PR TITLE
[codex] Add Misses threshold tuning

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4952,6 +4952,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         import config as cfg
         from misses import miss_config_from_effective
 
+        if not isinstance(body, dict):
+            raise ValueError("request body must be a JSON object")
+
         effective = db.get_effective_config(cfg.load())
         base_pipeline = effective.get("pipeline", {})
         if not isinstance(base_pipeline, dict):
@@ -4984,21 +4987,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         pipeline["miss_enabled"] = values["miss_enabled"]
         pipeline["miss_det_confidence"] = values["miss_det_confidence"]
-        pipeline["miss_det_confidence_burst"] = round(
-            values["miss_det_confidence"] * 0.60, 4
-        )
+        if "miss_det_confidence" in body:
+            values["miss_det_confidence_burst"] = round(
+                values["miss_det_confidence"] * 0.60, 4
+            )
+        pipeline["miss_det_confidence_burst"] = values["miss_det_confidence_burst"]
         pipeline["miss_classifier_override_conf"] = values[
             "miss_classifier_override_conf"
         ]
         pipeline["miss_bbox_area_min"] = values["miss_bbox_area_min"]
-        pipeline["miss_bbox_area_min_singleton"] = round(
-            values["miss_bbox_area_min"] * 0.40, 5
-        )
-        pipeline["miss_oof_ratio"] = values["miss_oof_ratio"]
-        values["miss_det_confidence_burst"] = pipeline["miss_det_confidence_burst"]
-        values["miss_bbox_area_min_singleton"] = pipeline[
+        if "miss_bbox_area_min" in body:
+            values["miss_bbox_area_min_singleton"] = round(
+                values["miss_bbox_area_min"] * 0.40, 5
+            )
+        pipeline["miss_bbox_area_min_singleton"] = values[
             "miss_bbox_area_min_singleton"
         ]
+        pipeline["miss_oof_ratio"] = values["miss_oof_ratio"]
         return values, pipeline, values["detector_confidence"]
 
     def _save_miss_threshold_overrides(db, values, pipeline):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4947,6 +4947,100 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         dets = db.get_detections(photo_id)
         return jsonify([dict(d) for d in dets])
 
+    def _miss_threshold_config_from_body(db, body):
+        """Merge Misses-page threshold overrides into effective config."""
+        import config as cfg
+        from misses import miss_config_from_effective
+
+        effective = db.get_effective_config(cfg.load())
+        base_pipeline = effective.get("pipeline", {})
+        if not isinstance(base_pipeline, dict):
+            base_pipeline = {}
+        pipeline = dict(base_pipeline)
+        values = miss_config_from_effective(effective)
+
+        specs = {
+            "detector_confidence": (0.0, 1.0),
+            "miss_det_confidence": (0.0, 1.0),
+            "miss_classifier_override_conf": (0.0, 1.01),
+            "miss_bbox_area_min": (0.0, 0.2),
+            "miss_oof_ratio": (0.0, 2.0),
+        }
+        for key, (lo, hi) in specs.items():
+            if key not in body:
+                continue
+            try:
+                value = float(body[key])
+            except (TypeError, ValueError) as err:
+                raise ValueError(f"{key} must be numeric") from err
+            if not math.isfinite(value) or value < lo or value > hi:
+                raise ValueError(f"{key} must be between {lo:g} and {hi:g}")
+            values[key] = value
+
+        if "miss_enabled" in body:
+            if not isinstance(body["miss_enabled"], bool):
+                raise ValueError("miss_enabled must be boolean")
+            values["miss_enabled"] = body["miss_enabled"]
+
+        pipeline["miss_enabled"] = values["miss_enabled"]
+        pipeline["miss_det_confidence"] = values["miss_det_confidence"]
+        pipeline["miss_det_confidence_burst"] = round(
+            values["miss_det_confidence"] * 0.60, 4
+        )
+        pipeline["miss_classifier_override_conf"] = values[
+            "miss_classifier_override_conf"
+        ]
+        pipeline["miss_bbox_area_min"] = values["miss_bbox_area_min"]
+        pipeline["miss_bbox_area_min_singleton"] = round(
+            values["miss_bbox_area_min"] * 0.40, 5
+        )
+        pipeline["miss_oof_ratio"] = values["miss_oof_ratio"]
+        values["miss_det_confidence_burst"] = pipeline["miss_det_confidence_burst"]
+        values["miss_bbox_area_min_singleton"] = pipeline[
+            "miss_bbox_area_min_singleton"
+        ]
+        return values, pipeline, values["detector_confidence"]
+
+    def _save_miss_threshold_overrides(db, values, pipeline):
+        with _settings_write_lock:
+            ws = db.get_workspace(db._active_workspace_id)
+            overrides = {}
+            if ws and ws["config_overrides"]:
+                try:
+                    overrides = (
+                        json.loads(ws["config_overrides"])
+                        if isinstance(ws["config_overrides"], str)
+                        else ws["config_overrides"]
+                    )
+                except (json.JSONDecodeError, TypeError):
+                    overrides = {}
+            if not isinstance(overrides, dict):
+                overrides = {}
+            existing_pipeline = overrides.get("pipeline", {})
+            if not isinstance(existing_pipeline, dict):
+                existing_pipeline = {}
+            for key in (
+                "miss_enabled",
+                "miss_det_confidence",
+                "miss_det_confidence_burst",
+                "miss_classifier_override_conf",
+                "miss_bbox_area_min",
+                "miss_bbox_area_min_singleton",
+                "miss_oof_ratio",
+            ):
+                existing_pipeline[key] = pipeline[key]
+            overrides["pipeline"] = existing_pipeline
+            overrides["detector_confidence"] = values["detector_confidence"]
+            db.update_workspace(db._active_workspace_id, config_overrides=overrides)
+
+    @app.route("/api/misses/config")
+    def api_misses_config():
+        import config as cfg
+        from misses import miss_config_from_effective
+
+        db = _get_db()
+        return jsonify(miss_config_from_effective(db.get_effective_config(cfg.load())))
+
     @app.route("/api/misses")
     def api_misses():
         """Return photos flagged as misses.
@@ -4969,6 +5063,56 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "clipped":    db.list_misses(category="clipped", since=since),
             "oof":        db.list_misses(category="oof", since=since),
         })
+
+    @app.route("/api/misses/preview", methods=["POST"])
+    def api_misses_preview():
+        """Return Misses-page categories using unsaved threshold overrides."""
+        from misses import preview_misses_for_workspace
+
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        try:
+            values, pipeline, detector_confidence = (
+                _miss_threshold_config_from_body(db, body)
+            )
+        except ValueError as e:
+            return json_error(str(e))
+        grouped = preview_misses_for_workspace(
+            db, pipeline, detector_confidence=detector_confidence,
+            since=body.get("since") or None,
+        )
+        grouped["config"] = values
+        grouped["preview"] = True
+        return jsonify(grouped)
+
+    @app.route("/api/misses/recompute", methods=["POST"])
+    def api_misses_recompute():
+        """Recompute persisted miss flags with Misses-page thresholds."""
+        from misses import compute_misses_for_workspace, preview_misses_for_workspace
+
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        try:
+            values, pipeline, detector_confidence = (
+                _miss_threshold_config_from_body(db, body)
+            )
+        except ValueError as e:
+            return json_error(str(e))
+
+        if body.get("save_defaults") is True:
+            _save_miss_threshold_overrides(db, values, pipeline)
+
+        since = body.get("since") or None
+        updated = compute_misses_for_workspace(
+            db, pipeline, detector_confidence=detector_confidence, since=since,
+        )
+        grouped = preview_misses_for_workspace(
+            db, pipeline, detector_confidence=detector_confidence, since=since,
+        )
+        grouped["config"] = values
+        grouped["updated"] = updated
+        grouped["saved_defaults"] = body.get("save_defaults") is True
+        return jsonify(grouped)
 
     @app.route("/api/misses/reject", methods=["POST"])
     def api_misses_reject():

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -13,6 +13,7 @@ no_subject is exclusive — when it's true, clipped/oof can't be evaluated
 and both return False.
 """
 
+import json
 import logging
 from collections import defaultdict
 from datetime import UTC, datetime
@@ -21,6 +22,16 @@ import config as _cfg
 from db import commit_with_retry
 
 log = logging.getLogger(__name__)
+
+MISS_CONFIG_KEYS = {
+    "miss_enabled",
+    "miss_det_confidence",
+    "miss_det_confidence_burst",
+    "miss_bbox_area_min",
+    "miss_bbox_area_min_singleton",
+    "miss_oof_ratio",
+    "miss_classifier_override_conf",
+}
 
 
 def _miss_threshold(config, key):
@@ -111,8 +122,233 @@ def classify_miss(row, siblings, config):
     return {"no_subject": False, "clipped": clipped, "oof": oof}
 
 
+def miss_config_from_effective(effective_config):
+    """Return the miss-related config values from an effective config dict."""
+    pipeline = effective_config.get("pipeline", {})
+    if not isinstance(pipeline, dict):
+        pipeline = {}
+    values = {
+        key: _miss_threshold(pipeline, key)
+        for key in MISS_CONFIG_KEYS
+        if key != "miss_enabled"
+    }
+    values["miss_enabled"] = pipeline.get(
+        "miss_enabled", _cfg.DEFAULTS["pipeline"]["miss_enabled"]
+    )
+    values["detector_confidence"] = effective_config.get(
+        "detector_confidence", _cfg.DEFAULTS["detector_confidence"]
+    )
+    return values
+
+
+def _fetch_workspace_miss_rows(db, detector_confidence=None):
+    """Fetch all active-workspace photo rows needed to derive miss flags."""
+    import config as cfg
+
+    if detector_confidence is None:
+        detector_confidence = db.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
+    ws_id = db._ws_id()
+    rows = db.conn.execute(
+        "SELECT p.id, p.folder_id, p.filename, p.companion_path, "
+        "       p.timestamp, p.burst_id, "
+        "       p.subject_size, p.crop_complete, "
+        "       p.subject_tenengrad, p.bg_tenengrad, "
+        "       p.miss_no_subject, p.miss_clipped, p.miss_oof, "
+        "       p.miss_computed_at, p.flag, "
+        "       (SELECT MAX(d.detector_confidence) FROM detections d "
+        "        WHERE d.photo_id = p.id "
+        "          AND d.detector_confidence >= ?) "
+        "         AS detection_conf, "
+        "       (SELECT MAX(pr.confidence) FROM predictions pr "
+        "        JOIN detections d2 ON d2.id = pr.detection_id "
+        "        WHERE d2.photo_id = p.id) "
+        "         AS max_prediction_conf "
+        "FROM photos p "
+        "JOIN workspace_folders wf ON wf.folder_id = p.folder_id "
+        "WHERE wf.workspace_id = ?",
+        (detector_confidence, ws_id),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _target_ids_from_scope(rows, collection_id=None, db=None, since=None):
+    target_ids = None
+    if collection_id is not None:
+        target_ids = db.collection_photo_ids(collection_id)
+    if since is not None:
+        since_ids = {
+            r["id"] for r in rows
+            if r.get("miss_computed_at") is not None
+            and r.get("miss_computed_at") >= since
+        }
+        target_ids = since_ids if target_ids is None else target_ids & since_ids
+    return target_ids
+
+
+def _derive_miss_updates(rows, pipeline_config, target_ids=None,
+                         exclude_photo_ids=None, now=None):
+    """Classify rows and return update tuples plus flags by photo id."""
+    excluded = set(exclude_photo_ids) if exclude_photo_ids else set()
+    override_conf = _miss_threshold(
+        pipeline_config, "miss_classifier_override_conf"
+    )
+
+    by_burst = defaultdict(list)
+    singletons = []
+    for row in rows:
+        if row["burst_id"]:
+            by_burst[row["burst_id"]].append(row)
+        else:
+            singletons.append(row)
+
+    if now is None:
+        now = datetime.now(UTC).isoformat(timespec="microseconds")
+    updates = []
+    flags_by_id = {}
+
+    def _apply_classifier_override(row, flags):
+        if not flags["no_subject"]:
+            return flags
+        max_pred = row.get("max_prediction_conf")
+        if max_pred is not None and max_pred >= override_conf:
+            return {**flags, "no_subject": False}
+        return flags
+
+    def _should_update(row):
+        if target_ids is not None and row["id"] not in target_ids:
+            return False
+        return row["id"] not in excluded
+
+    def _classify(row, siblings):
+        flags = classify_miss(row, siblings, pipeline_config)
+        return _apply_classifier_override(row, flags)
+
+    for burst_rows in by_burst.values():
+        for row in burst_rows:
+            if not _should_update(row):
+                continue
+            siblings = [s for s in burst_rows if s["id"] != row["id"]]
+            flags = _classify(row, siblings)
+            flags_by_id[row["id"]] = flags
+            updates.append((
+                int(flags["no_subject"]),
+                int(flags["clipped"]),
+                int(flags["oof"]),
+                now,
+                row["id"],
+            ))
+
+    for row in singletons:
+        if not _should_update(row):
+            continue
+        flags = _classify(row, siblings=[])
+        flags_by_id[row["id"]] = flags
+        updates.append((
+            int(flags["no_subject"]),
+            int(flags["clipped"]),
+            int(flags["oof"]),
+            now,
+            row["id"],
+        ))
+
+    return updates, flags_by_id
+
+
+def _attach_primary_detections(db, photos, detector_confidence):
+    if not photos:
+        return
+    photo_ids = [p["id"] for p in photos]
+    primary = {}
+    CHUNK = 500
+    for i in range(0, len(photo_ids), CHUNK):
+        chunk = photo_ids[i:i + CHUNK]
+        placeholders = ",".join("?" * len(chunk))
+        det_rows = db.conn.execute(
+            f"SELECT photo_id, box_x, box_y, box_w, box_h, "
+            f"       detector_confidence "
+            f"FROM detections "
+            f"WHERE detector_confidence >= ? AND photo_id IN ({placeholders}) "
+            f"ORDER BY photo_id, detector_confidence DESC",
+            [detector_confidence, *chunk],
+        ).fetchall()
+        for d in det_rows:
+            primary.setdefault(d["photo_id"], d)
+    for p in photos:
+        d = primary.get(p["id"])
+        if d is None:
+            p["detection_box"] = None
+            p["detection_conf"] = None
+        else:
+            p["detection_box"] = json.dumps({
+                "x": d["box_x"], "y": d["box_y"],
+                "w": d["box_w"], "h": d["box_h"],
+            })
+            p["detection_conf"] = d["detector_confidence"]
+
+
+def preview_misses_for_workspace(db, pipeline_config, detector_confidence=None,
+                                 since=None):
+    """Return dynamically derived misses without writing DB flags."""
+    if not pipeline_config.get("miss_enabled", True):
+        return {"no_subject": [], "clipped": [], "oof": []}
+    if detector_confidence is None:
+        import config as cfg
+        detector_confidence = db.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
+    rows = _fetch_workspace_miss_rows(
+        db, detector_confidence=detector_confidence
+    )
+    target_ids = _target_ids_from_scope(rows, since=since)
+    _, flags_by_id = _derive_miss_updates(
+        rows, pipeline_config, target_ids=target_ids
+    )
+    grouped = {"no_subject": [], "clipped": [], "oof": []}
+    for row in rows:
+        if row["id"] not in flags_by_id:
+            continue
+        if row.get("flag") == "rejected":
+            continue
+        flags = flags_by_id[row["id"]]
+        photo = {
+            key: row.get(key)
+            for key in (
+                "id", "folder_id", "filename", "companion_path",
+                "timestamp", "burst_id", "subject_size", "crop_complete",
+                "subject_tenengrad", "bg_tenengrad", "miss_computed_at",
+                "flag",
+            )
+        }
+        photo["miss_no_subject"] = int(flags["no_subject"])
+        photo["miss_clipped"] = int(flags["clipped"])
+        photo["miss_oof"] = int(flags["oof"])
+        if flags["no_subject"]:
+            grouped["no_subject"].append(dict(photo))
+        if flags["clipped"]:
+            grouped["clipped"].append(dict(photo))
+        if flags["oof"]:
+            grouped["oof"].append(dict(photo))
+
+    for photos in grouped.values():
+        photos.sort(
+            key=lambda p: (
+                p.get("timestamp") or "",
+                p.get("filename") or "",
+                p.get("id") or 0,
+            ),
+            reverse=True,
+        )
+        _attach_primary_detections(
+            db, photos, detector_confidence,
+        )
+    return grouped
+
+
 def compute_misses_for_workspace(
     db, pipeline_config, collection_id=None, exclude_photo_ids=None, now=None,
+    detector_confidence=None, since=None,
 ):
     """Compute and persist miss flags for photos in the active workspace.
 
@@ -146,18 +382,16 @@ def compute_misses_for_workspace(
         log.info("Miss detection disabled via miss_enabled=false")
         return 0
 
-    excluded = set(exclude_photo_ids) if exclude_photo_ids else set()
-
-    ws_id = db._ws_id()
     # Detections are global now; scope *photos* to the workspace via
     # workspace_folders and filter detections at read time by the
     # workspace-effective detector_confidence threshold. Photos whose
     # highest-confidence box is below threshold are legitimate no_subject
     # candidates.
     import config as cfg
-    min_conf = db.get_effective_config(cfg.load()).get(
-        "detector_confidence", 0.2
-    )
+    if detector_confidence is None:
+        detector_confidence = db.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
     # max_prediction_conf is the highest classifier confidence across all
     # detections of the photo, ignoring the workspace detector_confidence
     # cutoff. A classifier prediction at or above
@@ -165,39 +399,12 @@ def compute_misses_for_workspace(
     # canonical case is a hummingbird where megadetector returned a
     # below-threshold box but BioCLIP identified the species with high
     # confidence on that same box.
-    rows = db.conn.execute(
-        "SELECT p.id, p.burst_id, "
-        "       (SELECT MAX(d.detector_confidence) FROM detections d "
-        "        WHERE d.photo_id = p.id "
-        "          AND d.detector_confidence >= ?) "
-        "         AS detection_conf, "
-        "       (SELECT MAX(pr.confidence) FROM predictions pr "
-        "        JOIN detections d2 ON d2.id = pr.detection_id "
-        "        WHERE d2.photo_id = p.id) "
-        "         AS max_prediction_conf, "
-        "       p.subject_size, p.crop_complete, "
-        "       p.subject_tenengrad, p.bg_tenengrad "
-        "FROM photos p "
-        "JOIN workspace_folders wf ON wf.folder_id = p.folder_id "
-        "WHERE wf.workspace_id = ?",
-        (min_conf, ws_id),
-    ).fetchall()
-    override_conf = _miss_threshold(
-        pipeline_config, "miss_classifier_override_conf"
+    rows = _fetch_workspace_miss_rows(
+        db, detector_confidence=detector_confidence
     )
-
-    target_ids = None
-    if collection_id is not None:
-        target_ids = db.collection_photo_ids(collection_id)
-
-    by_burst = defaultdict(list)
-    singletons = []
-    for r in rows:
-        d = dict(r)
-        if d["burst_id"]:
-            by_burst[d["burst_id"]].append(d)
-        else:
-            singletons.append(d)
+    target_ids = _target_ids_from_scope(
+        rows, collection_id=collection_id, db=db, since=since
+    )
 
     # Microsecond precision: the /misses?since=... review window uses
     # the earliest miss_computed_at from a run as a lower bound, and
@@ -209,47 +416,10 @@ def compute_misses_for_workspace(
     # at seconds precision.
     if now is None:
         now = datetime.now(UTC).isoformat(timespec="microseconds")
-    updates = []
-
-    def _apply_classifier_override(row, flags):
-        if not flags["no_subject"]:
-            return flags
-        max_pred = row.get("max_prediction_conf")
-        if max_pred is not None and max_pred >= override_conf:
-            return {**flags, "no_subject": False}
-        return flags
-
-    for burst_rows in by_burst.values():
-        for row in burst_rows:
-            if target_ids is not None and row["id"] not in target_ids:
-                continue
-            if row["id"] in excluded:
-                continue
-            siblings = [s for s in burst_rows if s["id"] != row["id"]]
-            flags = classify_miss(row, siblings, pipeline_config)
-            flags = _apply_classifier_override(row, flags)
-            updates.append((
-                int(flags["no_subject"]),
-                int(flags["clipped"]),
-                int(flags["oof"]),
-                now,
-                row["id"],
-            ))
-
-    for row in singletons:
-        if target_ids is not None and row["id"] not in target_ids:
-            continue
-        if row["id"] in excluded:
-            continue
-        flags = classify_miss(row, siblings=[], config=pipeline_config)
-        flags = _apply_classifier_override(row, flags)
-        updates.append((
-            int(flags["no_subject"]),
-            int(flags["clipped"]),
-            int(flags["oof"]),
-            now,
-            row["id"],
-        ))
+    updates, _ = _derive_miss_updates(
+        rows, pipeline_config, target_ids=target_ids,
+        exclude_photo_ids=exclude_photo_ids, now=now,
+    )
 
     db.conn.executemany(
         "UPDATE photos SET miss_no_subject=?, miss_clipped=?, miss_oof=?, "

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -141,14 +141,19 @@ def miss_config_from_effective(effective_config):
     return values
 
 
-def _fetch_workspace_miss_rows(db, detector_confidence=None):
-    """Fetch all active-workspace photo rows needed to derive miss flags."""
+def _effective_detector_confidence(db):
+    """Read the active workspace detector floor via the shared miss config."""
     import config as cfg
 
+    return miss_config_from_effective(
+        db.get_effective_config(cfg.load())
+    )["detector_confidence"]
+
+
+def _fetch_workspace_miss_rows(db, detector_confidence=None):
+    """Fetch all active-workspace photo rows needed to derive miss flags."""
     if detector_confidence is None:
-        detector_confidence = db.get_effective_config(cfg.load()).get(
-            "detector_confidence", 0.2
-        )
+        detector_confidence = _effective_detector_confidence(db)
     ws_id = db._ws_id()
     rows = db.conn.execute(
         "SELECT p.id, p.folder_id, p.filename, p.companion_path, "
@@ -256,7 +261,7 @@ def _derive_miss_updates(rows, pipeline_config, target_ids=None,
     return updates, flags_by_id
 
 
-def _attach_primary_detections(db, photos, detector_confidence):
+def _attach_primary_detections(db, photos):
     if not photos:
         return
     photo_ids = [p["id"] for p in photos]
@@ -269,9 +274,9 @@ def _attach_primary_detections(db, photos, detector_confidence):
             f"SELECT photo_id, box_x, box_y, box_w, box_h, "
             f"       detector_confidence "
             f"FROM detections "
-            f"WHERE detector_confidence >= ? AND photo_id IN ({placeholders}) "
+            f"WHERE photo_id IN ({placeholders}) "
             f"ORDER BY photo_id, detector_confidence DESC",
-            [detector_confidence, *chunk],
+            chunk,
         ).fetchall()
         for d in det_rows:
             primary.setdefault(d["photo_id"], d)
@@ -294,10 +299,7 @@ def preview_misses_for_workspace(db, pipeline_config, detector_confidence=None,
     if not pipeline_config.get("miss_enabled", True):
         return {"no_subject": [], "clipped": [], "oof": []}
     if detector_confidence is None:
-        import config as cfg
-        detector_confidence = db.get_effective_config(cfg.load()).get(
-            "detector_confidence", 0.2
-        )
+        detector_confidence = _effective_detector_confidence(db)
     rows = _fetch_workspace_miss_rows(
         db, detector_confidence=detector_confidence
     )
@@ -340,9 +342,7 @@ def preview_misses_for_workspace(db, pipeline_config, detector_confidence=None,
             ),
             reverse=True,
         )
-        _attach_primary_detections(
-            db, photos, detector_confidence,
-        )
+        _attach_primary_detections(db, photos)
     return grouped
 
 
@@ -387,11 +387,8 @@ def compute_misses_for_workspace(
     # workspace-effective detector_confidence threshold. Photos whose
     # highest-confidence box is below threshold are legitimate no_subject
     # candidates.
-    import config as cfg
     if detector_confidence is None:
-        detector_confidence = db.get_effective_config(cfg.load()).get(
-            "detector_confidence", 0.2
-        )
+        detector_confidence = _effective_detector_confidence(db)
     # max_prediction_conf is the highest classifier confidence across all
     # detections of the photo, ignoring the workspace detector_confidence
     # cutoff. A classifier prediction at or above

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -388,7 +388,7 @@
 
   <div class="misses-selection-bar" id="missesSelectionBar">
     <span class="misses-selection-count" id="missesSelectionCount">0 selected</span>
-    <button class="misses-selection-btn" type="button" onclick="bulkUnflagSelection()">
+    <button class="misses-selection-btn" id="missesSelectionUnflagBtn" type="button" onclick="bulkUnflagSelection()">
       Unmark missed
     </button>
     <button class="misses-selection-btn danger" type="button" onclick="deleteSelectedMisses()">
@@ -417,46 +417,46 @@
           <span>Detection floor</span>
           <output id="missCfgDetectorFloorVal">--</output>
         </label>
-        <input id="missCfgDetectorFloor" type="range" min="0" max="100" step="1" value="20">
+        <input id="missCfgDetectorFloor" type="range" min="0" max="100" step="1" value="20" disabled>
       </div>
       <div class="misses-tuning-control">
         <label for="missCfgNoSubject">
           <span>No-subject threshold</span>
           <output id="missCfgNoSubjectVal">--</output>
         </label>
-        <input id="missCfgNoSubject" type="range" min="0" max="100" step="1" value="25">
+        <input id="missCfgNoSubject" type="range" min="0" max="100" step="1" value="25" disabled>
       </div>
       <div class="misses-tuning-control">
         <label for="missCfgClassifierRescue">
           <span>Classifier rescue</span>
           <output id="missCfgClassifierRescueVal">--</output>
         </label>
-        <input id="missCfgClassifierRescue" type="range" min="0" max="101" step="1" value="80">
+        <input id="missCfgClassifierRescue" type="range" min="0" max="101" step="1" value="80" disabled>
       </div>
       <div class="misses-tuning-control">
         <label for="missCfgBboxMin">
           <span>Minimum bbox size</span>
           <output id="missCfgBboxMinVal">--</output>
         </label>
-        <input id="missCfgBboxMin" type="range" min="0" max="20" step="1" value="5">
+        <input id="missCfgBboxMin" type="range" min="0" max="20" step="1" value="5" disabled>
       </div>
       <div class="misses-tuning-control">
         <label for="missCfgOofRatio">
           <span>OOF ratio</span>
           <output id="missCfgOofRatioVal">--</output>
         </label>
-        <input id="missCfgOofRatio" type="range" min="0" max="100" step="1" value="50">
+        <input id="missCfgOofRatio" type="range" min="0" max="100" step="1" value="50" disabled>
       </div>
     </div>
     <div class="misses-tuning-actions">
-      <button class="misses-tuning-btn primary" id="missRecomputeBtn" type="button" onclick="recomputeMisses()">
+      <button class="misses-tuning-btn primary" id="missRecomputeBtn" type="button" onclick="recomputeMisses()" disabled>
         Recompute misses
       </button>
-      <button class="misses-tuning-btn" type="button" onclick="resetMissThresholds()">
+      <button class="misses-tuning-btn" id="missResetPreviewBtn" type="button" onclick="resetMissThresholds()" disabled>
         Reset preview
       </button>
       <label class="misses-tuning-check">
-        <input id="missSaveDefaults" type="checkbox" checked>
+        <input id="missSaveDefaults" type="checkbox" checked disabled>
         <span>Save as workspace defaults</span>
       </label>
     </div>
@@ -481,12 +481,25 @@ var missConfig = null;
 var originalMissConfig = null;
 var previewTimer = null;
 var previewActive = false;
+var previewPayload = null;
+var previewRequestId = 0;
+var missConfigLoaded = false;
 var focusedCategory = null;
 var focusedIndex = -1;
 // Multi-select state. Spans categories — ctrl-click on cards in different
 // sections accumulates them all. The focused card doubles as the anchor for
 // shift-click range selection (range stays within the clicked category).
 var selection = new Set();
+var MISS_TUNING_CONTROL_IDS = [
+  'missCfgDetectorFloor',
+  'missCfgNoSubject',
+  'missCfgClassifierRescue',
+  'missCfgBboxMin',
+  'missCfgOofRatio',
+  'missSaveDefaults',
+  'missRecomputeBtn',
+  'missResetPreviewBtn',
+];
 
 function escapeHtml(s) {
   if (s == null) return '';
@@ -540,19 +553,44 @@ function setMissTuningStatus(text) {
   if (el) el.textContent = text || '';
 }
 
+function setMissTuningDisabled(disabled) {
+  MISS_TUNING_CONTROL_IDS.forEach(function(id) {
+    var el = document.getElementById(id);
+    if (el) el.disabled = !!disabled;
+  });
+}
+
+function invalidateMissPreview() {
+  previewRequestId++;
+  if (previewTimer) {
+    clearTimeout(previewTimer);
+    previewTimer = null;
+  }
+}
+
 function percentValue(id) {
   return parseInt(document.getElementById(id).value, 10) / 100;
 }
 
+function addChangedSliderValue(body, key, id, scale) {
+  var raw = parseInt(document.getElementById(id).value, 10);
+  var baseline = null;
+  if (missConfig && missConfig[key] != null) {
+    baseline = Math.round(Number(missConfig[key]) * scale);
+  }
+  if (baseline == null || raw !== baseline) {
+    body[key] = raw / scale;
+  }
+}
+
 function collectMissThresholds() {
-  return {
-    detector_confidence: percentValue('missCfgDetectorFloor'),
-    miss_det_confidence: percentValue('missCfgNoSubject'),
-    miss_classifier_override_conf: percentValue('missCfgClassifierRescue'),
-    miss_bbox_area_min: parseInt(document.getElementById('missCfgBboxMin').value, 10) / 1000,
-    miss_oof_ratio: percentValue('missCfgOofRatio'),
-    miss_enabled: true,
-  };
+  var body = { miss_enabled: true };
+  addChangedSliderValue(body, 'detector_confidence', 'missCfgDetectorFloor', 100);
+  addChangedSliderValue(body, 'miss_det_confidence', 'missCfgNoSubject', 100);
+  addChangedSliderValue(body, 'miss_classifier_override_conf', 'missCfgClassifierRescue', 100);
+  addChangedSliderValue(body, 'miss_bbox_area_min', 'missCfgBboxMin', 1000);
+  addChangedSliderValue(body, 'miss_oof_ratio', 'missCfgOofRatio', 100);
+  return body;
 }
 
 function updateMissSliderLabels() {
@@ -595,12 +633,16 @@ function installMissSliderHandlers() {
 }
 
 async function loadMissConfig() {
+  missConfigLoaded = false;
+  setMissTuningDisabled(true);
   try {
     var r = await fetch('/api/misses/config');
     if (!r.ok) throw new Error('http ' + r.status);
     missConfig = await r.json();
     originalMissConfig = Object.assign({}, missConfig);
     setMissSliders(missConfig);
+    missConfigLoaded = true;
+    setMissTuningDisabled(false);
     setMissTuningStatus('Preview uses current sliders');
   } catch (e) {
     setMissTuningStatus('Thresholds unavailable');
@@ -608,11 +650,18 @@ async function loadMissConfig() {
 }
 
 function scheduleMissPreview() {
+  if (!missConfigLoaded) return;
   if (previewTimer) clearTimeout(previewTimer);
   previewTimer = setTimeout(previewMisses, 250);
 }
 
 async function previewMisses() {
+  if (!missConfigLoaded) return;
+  if (previewTimer) {
+    clearTimeout(previewTimer);
+    previewTimer = null;
+  }
+  var requestId = ++previewRequestId;
   var body = collectMissThresholds();
   var since = getSinceParam();
   if (since) body.since = since;
@@ -625,21 +674,28 @@ async function previewMisses() {
     });
     if (!r.ok) throw new Error('http ' + r.status);
     var data = await r.json();
+    if (requestId !== previewRequestId) return;
     previewActive = true;
+    previewPayload = data;
     applyMissesPayload(data);
     setMissTuningStatus('Preview only');
   } catch (e) {
+    if (requestId !== previewRequestId) return;
     setMissTuningStatus('Preview failed');
   }
 }
 
 async function recomputeMisses() {
+  if (!missConfigLoaded) return;
+  invalidateMissPreview();
   var btn = document.getElementById('missRecomputeBtn');
   var body = collectMissThresholds();
   var since = getSinceParam();
   if (since) body.since = since;
   body.save_defaults = !!document.getElementById('missSaveDefaults').checked;
   if (btn) btn.disabled = true;
+  previewActive = false;
+  previewPayload = null;
   setMissTuningStatus('Recomputing...');
   try {
     var r = await fetch('/api/misses/recompute', {
@@ -650,10 +706,11 @@ async function recomputeMisses() {
     if (!r.ok) throw new Error('http ' + r.status);
     var data = await r.json();
     previewActive = false;
+    previewPayload = null;
     applyMissesPayload(data);
-    if (data.config) {
+    if (data.config && data.saved_defaults) {
       missConfig = data.config;
-      if (data.saved_defaults) originalMissConfig = Object.assign({}, data.config);
+      originalMissConfig = Object.assign({}, data.config);
     }
     setMissTuningStatus('Updated ' + (data.updated || 0) + ' photos');
     if (typeof showToast === 'function') showToast('Recomputed misses', 'success');
@@ -661,14 +718,16 @@ async function recomputeMisses() {
     setMissTuningStatus('Recompute failed');
     if (typeof showToast === 'function') showToast('Recompute failed', 'error');
   } finally {
-    if (btn) btn.disabled = false;
+    if (btn && missConfigLoaded) btn.disabled = false;
   }
 }
 
 function resetMissThresholds() {
-  if (!originalMissConfig) return;
+  if (!missConfigLoaded || !originalMissConfig) return;
+  invalidateMissPreview();
   setMissSliders(originalMissConfig);
   previewActive = false;
+  previewPayload = null;
   setMissTuningStatus('Preview reset');
   loadMisses();
 }
@@ -695,6 +754,10 @@ async function loadMisses() {
   if (since) {
     var b = document.getElementById('scopeBanner');
     if (b) b.style.display = '';
+  }
+  if (previewActive && previewPayload) {
+    applyMissesPayload(previewPayload);
+    return;
   }
   var url = '/api/misses' + (since ? '?since=' + encodeURIComponent(since) : '');
   var r = await fetch(url);
@@ -765,7 +828,7 @@ function renderSection(cat, photos) {
           '<button class="misses-reject-btn" ' +
             'data-testid="miss-reject-' + cat + '" ' +
             'onclick="bulkReject(\'' + cat + '\', event)" ' +
-            (count === 0 ? 'disabled' : '') + '>' +
+            ((count === 0 || previewActive) ? 'disabled' : '') + '>' +
             'Reject all in ' + escapeHtml(label) +
           '</button>' +
         '</div>' +
@@ -822,6 +885,7 @@ function renderCard(cat, p, idx) {
         '<button class="miss-card-unflag" ' +
           'title="Unflag as miss (U)" ' +
           'data-testid="miss-unflag-' + cat + '-' + p.id + '" ' +
+          (previewActive ? 'disabled ' : '') +
           'onclick="unflagMiss(\'' + cat + '\', ' + p.id + ', event)">&times;</button>' +
       '</div>' +
       '<div class="miss-card-info">' +
@@ -874,6 +938,12 @@ function pruneSelectionToVisible() {
 /* ---------- Bulk reject ---------- */
 async function bulkReject(cat, e) {
   if (e) e.stopPropagation();
+  if (previewActive) {
+    if (typeof showToast === 'function') {
+      showToast('Save or reset the preview before bulk rejecting', 'error');
+    }
+    return;
+  }
   var label = CATEGORY_LABELS[cat];
   var n = (missesData[cat] || []).length;
   if (n === 0) return;
@@ -962,6 +1032,12 @@ async function bulkFlagSelection(flag) {
  * linger if loadMisses takes a moment. */
 async function bulkUnflagSelection() {
   if (selection.size === 0) return;
+  if (previewActive) {
+    if (typeof showToast === 'function') {
+      showToast('Save or reset the preview before unmarking misses', 'error');
+    }
+    return;
+  }
   var ids = Array.from(selection);
   // Build the (id, category) work list from the current in-memory data so
   // we don't need an extra round-trip to discover which categories each
@@ -991,6 +1067,12 @@ async function bulkUnflagSelection() {
 /* ---------- Per-card unflag ---------- */
 async function unflagMiss(cat, photoId, e) {
   if (e) e.stopPropagation();
+  if (previewActive) {
+    if (typeof showToast === 'function') {
+      showToast('Save or reset the preview before unmarking misses', 'error');
+    }
+    return;
+  }
   var r = await fetch('/api/misses/' + photoId + '/unflag', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -1047,6 +1129,8 @@ function updateSelectionBar() {
   var n = selection.size;
   bar.classList.toggle('active', n > 0);
   countEl.textContent = n + ' selected';
+  var unflagBtn = document.getElementById('missesSelectionUnflagBtn');
+  if (unflagBtn) unflagBtn.disabled = previewActive;
 }
 
 function selectRangeWithinCategory(cat, fromIdx, toIdx) {

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -289,6 +289,89 @@
     font-size: 10px;
     color: var(--text-secondary);
   }
+
+  .misses-tuning {
+    margin: 0 0 12px;
+    padding: 12px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+  }
+  .misses-tuning-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 10px;
+  }
+  .misses-tuning-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .misses-tuning-status {
+    margin-left: auto;
+    font-size: 11px;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+  .misses-tuning-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+    gap: 10px 14px;
+  }
+  .misses-tuning-control {
+    display: grid;
+    gap: 5px;
+    min-width: 0;
+  }
+  .misses-tuning-control label {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-secondary);
+  }
+  .misses-tuning-control output {
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+  }
+  .misses-tuning-control input[type="range"] {
+    width: 100%;
+    accent-color: var(--accent);
+  }
+  .misses-tuning-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 12px;
+    flex-wrap: wrap;
+  }
+  .misses-tuning-check {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--text-secondary);
+  }
+  .misses-tuning-check input { accent-color: var(--accent); }
+  .misses-tuning-btn {
+    border: 1px solid var(--border-secondary);
+    border-radius: 4px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    padding: 6px 10px;
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .misses-tuning-btn.primary {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+  }
+  .misses-tuning-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 </style>
 </head>
 <body>
@@ -323,6 +406,62 @@
     <a href="/misses" style="color:var(--accent);margin-left:8px;">Show all</a>
   </div>
 
+  <div class="misses-tuning" id="missesTuning">
+    <div class="misses-tuning-head">
+      <span class="misses-tuning-title">Miss thresholds</span>
+      <span class="misses-tuning-status" id="missTuningStatus">Loading thresholds...</span>
+    </div>
+    <div class="misses-tuning-grid">
+      <div class="misses-tuning-control">
+        <label for="missCfgDetectorFloor">
+          <span>Detection floor</span>
+          <output id="missCfgDetectorFloorVal">--</output>
+        </label>
+        <input id="missCfgDetectorFloor" type="range" min="0" max="100" step="1" value="20">
+      </div>
+      <div class="misses-tuning-control">
+        <label for="missCfgNoSubject">
+          <span>No-subject threshold</span>
+          <output id="missCfgNoSubjectVal">--</output>
+        </label>
+        <input id="missCfgNoSubject" type="range" min="0" max="100" step="1" value="25">
+      </div>
+      <div class="misses-tuning-control">
+        <label for="missCfgClassifierRescue">
+          <span>Classifier rescue</span>
+          <output id="missCfgClassifierRescueVal">--</output>
+        </label>
+        <input id="missCfgClassifierRescue" type="range" min="0" max="101" step="1" value="80">
+      </div>
+      <div class="misses-tuning-control">
+        <label for="missCfgBboxMin">
+          <span>Minimum bbox size</span>
+          <output id="missCfgBboxMinVal">--</output>
+        </label>
+        <input id="missCfgBboxMin" type="range" min="0" max="20" step="1" value="5">
+      </div>
+      <div class="misses-tuning-control">
+        <label for="missCfgOofRatio">
+          <span>OOF ratio</span>
+          <output id="missCfgOofRatioVal">--</output>
+        </label>
+        <input id="missCfgOofRatio" type="range" min="0" max="100" step="1" value="50">
+      </div>
+    </div>
+    <div class="misses-tuning-actions">
+      <button class="misses-tuning-btn primary" id="missRecomputeBtn" type="button" onclick="recomputeMisses()">
+        Recompute misses
+      </button>
+      <button class="misses-tuning-btn" type="button" onclick="resetMissThresholds()">
+        Reset preview
+      </button>
+      <label class="misses-tuning-check">
+        <input id="missSaveDefaults" type="checkbox" checked>
+        <span>Save as workspace defaults</span>
+      </label>
+    </div>
+  </div>
+
   <div id="missesRoot">
     <!-- Sections rendered here -->
     <div class="misses-empty-page" id="loadingState">Loading...</div>
@@ -338,6 +477,10 @@ var CATEGORY_LABELS = {
   oof:        'Out of focus',
 };
 var missesData = { no_subject: [], clipped: [], oof: [] };
+var missConfig = null;
+var originalMissConfig = null;
+var previewTimer = null;
+var previewActive = false;
 var focusedCategory = null;
 var focusedIndex = -1;
 // Multi-select state. Spans categories — ctrl-click on cards in different
@@ -392,6 +535,160 @@ function getSinceParam() {
   } catch (e) { return null; }
 }
 
+function setMissTuningStatus(text) {
+  var el = document.getElementById('missTuningStatus');
+  if (el) el.textContent = text || '';
+}
+
+function percentValue(id) {
+  return parseInt(document.getElementById(id).value, 10) / 100;
+}
+
+function collectMissThresholds() {
+  return {
+    detector_confidence: percentValue('missCfgDetectorFloor'),
+    miss_det_confidence: percentValue('missCfgNoSubject'),
+    miss_classifier_override_conf: percentValue('missCfgClassifierRescue'),
+    miss_bbox_area_min: parseInt(document.getElementById('missCfgBboxMin').value, 10) / 1000,
+    miss_oof_ratio: percentValue('missCfgOofRatio'),
+    miss_enabled: true,
+  };
+}
+
+function updateMissSliderLabels() {
+  var det = parseInt(document.getElementById('missCfgDetectorFloor').value, 10);
+  var ns = parseInt(document.getElementById('missCfgNoSubject').value, 10);
+  var rescue = parseInt(document.getElementById('missCfgClassifierRescue').value, 10);
+  var bbox = parseInt(document.getElementById('missCfgBboxMin').value, 10);
+  var oof = parseInt(document.getElementById('missCfgOofRatio').value, 10);
+  document.getElementById('missCfgDetectorFloorVal').textContent = det + '%';
+  document.getElementById('missCfgNoSubjectVal').textContent = ns + '%';
+  document.getElementById('missCfgClassifierRescueVal').textContent = rescue > 100 ? 'off' : rescue + '%';
+  document.getElementById('missCfgBboxMinVal').textContent = (bbox / 1000).toFixed(3);
+  document.getElementById('missCfgOofRatioVal').textContent = (oof / 100).toFixed(2);
+}
+
+function setMissSliders(config) {
+  document.getElementById('missCfgDetectorFloor').value = Math.round((config.detector_confidence || 0) * 100);
+  document.getElementById('missCfgNoSubject').value = Math.round((config.miss_det_confidence || 0) * 100);
+  document.getElementById('missCfgClassifierRescue').value = Math.round((config.miss_classifier_override_conf || 0) * 100);
+  document.getElementById('missCfgBboxMin').value = Math.round((config.miss_bbox_area_min || 0) * 1000);
+  document.getElementById('missCfgOofRatio').value = Math.round((config.miss_oof_ratio || 0) * 100);
+  updateMissSliderLabels();
+}
+
+function installMissSliderHandlers() {
+  [
+    'missCfgDetectorFloor',
+    'missCfgNoSubject',
+    'missCfgClassifierRescue',
+    'missCfgBboxMin',
+    'missCfgOofRatio',
+  ].forEach(function(id) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    el.addEventListener('input', function() {
+      updateMissSliderLabels();
+      scheduleMissPreview();
+    });
+  });
+}
+
+async function loadMissConfig() {
+  try {
+    var r = await fetch('/api/misses/config');
+    if (!r.ok) throw new Error('http ' + r.status);
+    missConfig = await r.json();
+    originalMissConfig = Object.assign({}, missConfig);
+    setMissSliders(missConfig);
+    setMissTuningStatus('Preview uses current sliders');
+  } catch (e) {
+    setMissTuningStatus('Thresholds unavailable');
+  }
+}
+
+function scheduleMissPreview() {
+  if (previewTimer) clearTimeout(previewTimer);
+  previewTimer = setTimeout(previewMisses, 250);
+}
+
+async function previewMisses() {
+  var body = collectMissThresholds();
+  var since = getSinceParam();
+  if (since) body.since = since;
+  setMissTuningStatus('Previewing...');
+  try {
+    var r = await fetch('/api/misses/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!r.ok) throw new Error('http ' + r.status);
+    var data = await r.json();
+    previewActive = true;
+    applyMissesPayload(data);
+    setMissTuningStatus('Preview only');
+  } catch (e) {
+    setMissTuningStatus('Preview failed');
+  }
+}
+
+async function recomputeMisses() {
+  var btn = document.getElementById('missRecomputeBtn');
+  var body = collectMissThresholds();
+  var since = getSinceParam();
+  if (since) body.since = since;
+  body.save_defaults = !!document.getElementById('missSaveDefaults').checked;
+  if (btn) btn.disabled = true;
+  setMissTuningStatus('Recomputing...');
+  try {
+    var r = await fetch('/api/misses/recompute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!r.ok) throw new Error('http ' + r.status);
+    var data = await r.json();
+    previewActive = false;
+    applyMissesPayload(data);
+    if (data.config) {
+      missConfig = data.config;
+      if (data.saved_defaults) originalMissConfig = Object.assign({}, data.config);
+    }
+    setMissTuningStatus('Updated ' + (data.updated || 0) + ' photos');
+    if (typeof showToast === 'function') showToast('Recomputed misses', 'success');
+  } catch (e) {
+    setMissTuningStatus('Recompute failed');
+    if (typeof showToast === 'function') showToast('Recompute failed', 'error');
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
+function resetMissThresholds() {
+  if (!originalMissConfig) return;
+  setMissSliders(originalMissConfig);
+  previewActive = false;
+  setMissTuningStatus('Preview reset');
+  loadMisses();
+}
+
+function applyMissesPayload(data) {
+  missesData = {
+    no_subject: sortPhotos(data.no_subject || []),
+    clipped:    sortPhotos(data.clipped || []),
+    oof:        sortPhotos(data.oof || []),
+  };
+  var present = new Set();
+  CATEGORY_ORDER.forEach(function(cat) {
+    (missesData[cat] || []).forEach(function(p) { present.add(p.id); });
+  });
+  selection.forEach(function(id) {
+    if (!present.has(id)) selection.delete(id);
+  });
+  render();
+}
+
 /* ---------- Fetch + render ---------- */
 async function loadMisses() {
   var since = getSinceParam();
@@ -407,22 +704,7 @@ async function loadMisses() {
     return;
   }
   var data = await r.json();
-  missesData = {
-    no_subject: sortPhotos(data.no_subject || []),
-    clipped:    sortPhotos(data.clipped || []),
-    oof:        sortPhotos(data.oof || []),
-  };
-  // Drop any selected ids that no longer appear (rejected photos disappear
-  // from /api/misses on the next refetch). Without this, a stale id could
-  // sit in the set and be acted on by Esc-only-clear logic.
-  var present = new Set();
-  CATEGORY_ORDER.forEach(function(cat) {
-    (missesData[cat] || []).forEach(function(p) { present.add(p.id); });
-  });
-  selection.forEach(function(id) {
-    if (!present.has(id)) selection.delete(id);
-  });
-  render();
+  applyMissesPayload(data);
 }
 
 function render() {
@@ -498,13 +780,12 @@ function renderSection(cat, photos) {
 function renderCard(cat, p, idx) {
   var bbox = parseDetectionBox(p.detection_box);
   var bboxHtml = '';
-  if (cat === 'no_subject') {
-    // No bbox available — show dashed placeholder frame.
-    bboxHtml = '<div class="no-subject-frame">No subject detected</div>';
-  } else if (bbox) {
+  if (bbox) {
     bboxHtml =
       '<div class="miss-bbox" style="left:' + (bbox.x * 100) + '%;top:' + (bbox.y * 100) + '%;' +
       'width:' + (bbox.w * 100) + '%;height:' + (bbox.h * 100) + '%;"></div>';
+  } else if (cat === 'no_subject') {
+    bboxHtml = '<div class="no-subject-frame">No subject detected</div>';
   }
 
   var meta = '';
@@ -980,7 +1261,8 @@ function extendSelectionByFocus(delta) {
 }
 
 /* ---------- Boot ---------- */
-loadMisses();
+installMissSliderHandlers();
+loadMissConfig().then(loadMisses);
 </script>
 
 </body>

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -584,7 +584,10 @@ function addChangedSliderValue(body, key, id, scale) {
 }
 
 function collectMissThresholds() {
-  var body = { miss_enabled: true };
+  // No miss_enabled toggle on this page: omit it so preview/recompute (and
+  // save_defaults) preserve a workspace's effective value instead of silently
+  // re-enabling miss detection for workspaces that disabled it.
+  var body = {};
   addChangedSliderValue(body, 'detector_confidence', 'missCfgDetectorFloor', 100);
   addChangedSliderValue(body, 'miss_det_confidence', 'missCfgNoSubject', 100);
   addChangedSliderValue(body, 'miss_classifier_override_conf', 'missCfgClassifierRescue', 100);

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -438,14 +438,14 @@
           <span>Minimum bbox size</span>
           <output id="missCfgBboxMinVal">--</output>
         </label>
-        <input id="missCfgBboxMin" type="range" min="0" max="20" step="1" value="5" disabled>
+        <input id="missCfgBboxMin" type="range" min="0" max="200" step="1" value="5" disabled>
       </div>
       <div class="misses-tuning-control">
         <label for="missCfgOofRatio">
           <span>OOF ratio</span>
           <output id="missCfgOofRatioVal">--</output>
         </label>
-        <input id="missCfgOofRatio" type="range" min="0" max="100" step="1" value="50" disabled>
+        <input id="missCfgOofRatio" type="range" min="0" max="200" step="1" value="50" disabled>
       </div>
     </div>
     <div class="misses-tuning-actions">
@@ -758,8 +758,11 @@ async function loadMisses() {
     var b = document.getElementById('scopeBanner');
     if (b) b.style.display = '';
   }
-  if (previewActive && previewPayload) {
-    applyMissesPayload(previewPayload);
+  if (previewActive) {
+    // Re-derive from the preview endpoint with the live slider values
+    // instead of replaying a cached payload that a mutating action may
+    // have made stale.
+    await previewMisses();
     return;
   }
   var url = '/api/misses' + (since ? '?since=' + encodeURIComponent(since) : '');

--- a/vireo/tests/test_misses_api.py
+++ b/vireo/tests/test_misses_api.py
@@ -153,6 +153,14 @@ def test_api_misses_config_returns_thresholds(client, db_with_misses):
     assert data["miss_classifier_override_conf"] == pytest.approx(0.8)
 
 
+@pytest.mark.parametrize("path", ["/api/misses/preview", "/api/misses/recompute"])
+def test_api_misses_threshold_endpoints_reject_non_object_json(client, path):
+    r = client.post(path, data=json.dumps(["not", "an", "object"]),
+                    content_type="application/json")
+    assert r.status_code == 400
+    assert "JSON object" in r.get_json()["error"]
+
+
 def test_api_misses_preview_uses_classifier_rescue_override(tmp_path, monkeypatch):
     """Preview should recalculate categories without persisting DB flags."""
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -193,7 +201,12 @@ def test_api_misses_preview_uses_classifier_rescue_override(tmp_path, monkeypatc
         content_type="application/json",
     )
     assert default_r.status_code == 200
-    assert [p["id"] for p in default_r.get_json()["no_subject"]] == [pid]
+    default_payload = default_r.get_json()
+    assert [p["id"] for p in default_payload["no_subject"]] == [pid]
+    assert default_payload["no_subject"][0]["detection_conf"] == pytest.approx(0.04)
+    assert json.loads(default_payload["no_subject"][0]["detection_box"]) == {
+        "x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4,
+    }
 
     rescued_r = client.post(
         "/api/misses/preview",
@@ -264,6 +277,40 @@ def test_api_misses_recompute_can_save_workspace_defaults(tmp_path, monkeypatch)
     effective = db.get_effective_config(cfg.load())
     assert effective["detector_confidence"] == pytest.approx(0.05)
     assert effective["pipeline"]["miss_classifier_override_conf"] == pytest.approx(0.65)
+
+
+def test_api_misses_recompute_preserves_custom_derived_thresholds(
+    client, db_with_misses,
+):
+    """Derived burst/singleton thresholds should change only with their slider."""
+    import config as cfg
+
+    _, db, _ = db_with_misses
+    db.update_workspace(db._active_workspace_id, config_overrides={
+        "pipeline": {
+            "miss_det_confidence": 0.4,
+            "miss_det_confidence_burst": 0.05,
+            "miss_bbox_area_min": 0.01,
+            "miss_bbox_area_min_singleton": 0.001,
+        }
+    })
+
+    r = client.post(
+        "/api/misses/recompute",
+        data=json.dumps({"miss_oof_ratio": 0.42, "save_defaults": True}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["config"]["miss_det_confidence_burst"] == pytest.approx(0.05)
+    assert data["config"]["miss_bbox_area_min_singleton"] == pytest.approx(0.001)
+
+    effective = db.get_effective_config(cfg.load())
+    assert effective["pipeline"]["miss_det_confidence_burst"] == pytest.approx(0.05)
+    assert effective["pipeline"]["miss_bbox_area_min_singleton"] == pytest.approx(
+        0.001
+    )
+    assert effective["pipeline"]["miss_oof_ratio"] == pytest.approx(0.42)
 
 
 def test_api_bulk_reject_records_edit_history(client, db_with_misses):

--- a/vireo/tests/test_misses_api.py
+++ b/vireo/tests/test_misses_api.py
@@ -144,6 +144,128 @@ def test_api_misses_rejects_invalid_category_on_unflag(client, db_with_misses, c
     assert r.status_code == 400
 
 
+def test_api_misses_config_returns_thresholds(client, db_with_misses):
+    r = client.get("/api/misses/config")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["detector_confidence"] == pytest.approx(0.2)
+    assert data["miss_det_confidence"] == pytest.approx(0.25)
+    assert data["miss_classifier_override_conf"] == pytest.approx(0.8)
+
+
+def test_api_misses_preview_uses_classifier_rescue_override(tmp_path, monkeypatch):
+    """Preview should recalculate categories without persisting DB flags."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    from app import create_app
+    from db import Database
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder("/photos/birds", name="birds")
+    pid = db.add_photo(
+        fid, "weak-bird.jpg", extension=".jpg", file_size=100,
+        file_mtime=1.0, timestamp="2026-04-22T10:00:00",
+    )
+    det_id = db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},
+          "confidence": 0.04, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )[0]
+    db.add_prediction(
+        det_id, species="Likely Bird", confidence=0.70,
+        model="BioCLIP-2.5",
+    )
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir)
+    client = app.test_client()
+
+    default_r = client.post(
+        "/api/misses/preview",
+        data=json.dumps({}),
+        content_type="application/json",
+    )
+    assert default_r.status_code == 200
+    assert [p["id"] for p in default_r.get_json()["no_subject"]] == [pid]
+
+    rescued_r = client.post(
+        "/api/misses/preview",
+        data=json.dumps({"miss_classifier_override_conf": 0.65}),
+        content_type="application/json",
+    )
+    assert rescued_r.status_code == 200
+    assert rescued_r.get_json()["no_subject"] == []
+    row = db.conn.execute(
+        "SELECT miss_no_subject, miss_computed_at FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert row["miss_no_subject"] is None
+    assert row["miss_computed_at"] is None
+
+
+def test_api_misses_recompute_can_save_workspace_defaults(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    from app import create_app
+    from db import Database
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder("/photos/birds", name="birds")
+    pid = db.add_photo(
+        fid, "weak-bird.jpg", extension=".jpg", file_size=100,
+        file_mtime=1.0, timestamp="2026-04-22T10:00:00",
+    )
+    det_id = db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},
+          "confidence": 0.04, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )[0]
+    db.add_prediction(
+        det_id, species="Likely Bird", confidence=0.70,
+        model="BioCLIP-2.5",
+    )
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir)
+    client = app.test_client()
+    r = client.post(
+        "/api/misses/recompute",
+        data=json.dumps({
+            "miss_classifier_override_conf": 0.65,
+            "detector_confidence": 0.05,
+            "save_defaults": True,
+        }),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["updated"] == 1
+    assert data["saved_defaults"] is True
+
+    row = db.conn.execute(
+        "SELECT miss_no_subject FROM photos WHERE id=?", (pid,),
+    ).fetchone()
+    assert row["miss_no_subject"] == 0
+
+    effective = db.get_effective_config(cfg.load())
+    assert effective["detector_confidence"] == pytest.approx(0.05)
+    assert effective["pipeline"]["miss_classifier_override_conf"] == pytest.approx(0.65)
+
+
 def test_api_bulk_reject_records_edit_history(client, db_with_misses):
     """Bulk reject must write a batch `flag` edit_history entry so the change
     is undoable and shows up in the audit log, matching /api/batch/flag."""


### PR DESCRIPTION
Adds Misses-page threshold controls with live preview and a recompute action that can save workspace defaults. Refactors miss classification so preview and persisted recompute use the same path, while preserving run-scoped `?since=` behavior. This gives users a way to tune detector confidence, no-subject cutoff, classifier rescue, bbox size, and OOF ratio for false-negative bird cases. Validated with `pytest vireo/tests/test_misses_api.py vireo/tests/test_misses.py`, `python -m py_compile vireo/app.py vireo/misses.py`, and a smoke test of `/misses`, `/api/misses/config`, and `/api/misses/preview`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Miss threshold tuning UI with sliders, live preview, guarded preview mode (disables mutating actions), and ability to save workspace defaults
  * Preview endpoint returning grouped results (no_subject, clipped, oof) with primary detection info
  * Recompute endpoint to update persisted miss flags using custom thresholds and optionally save defaults
  * Endpoint to fetch current effective miss threshold configuration

* **Tests**
  * Added API tests covering config, preview, recompute, validation, and save-defaults behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->