### PR TITLE
[codex] Add offline original cache

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9426,6 +9426,129 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         return jsonify({"job_id": job_id})
 
+    @app.route("/api/jobs/offline-cache", methods=["POST"])
+    def api_job_offline_cache():
+        """Copy selected originals into Vireo's managed offline cache."""
+        body = request.get_json(silent=True) or {}
+        raw_ids = body.get("photo_ids", [])
+        collection_id = _coerce_collection_id(body.get("collection_id"))
+        if collection_id is False:
+            return json_error("collection_id must be an integer")
+        if raw_ids and not isinstance(raw_ids, list):
+            return json_error("photo_ids must be a list of integers")
+
+        db = _get_db()
+        if not raw_ids and collection_id is not None:
+            raw_ids = [
+                p["id"]
+                for p in db.get_collection_photos(collection_id, per_page=999999)
+            ]
+        if not raw_ids:
+            return json_error("photo_ids or collection_id required")
+        try:
+            photo_ids = [int(pid) for pid in raw_ids]
+        except (ValueError, TypeError):
+            return json_error("photo_ids must be integers")
+        if any(isinstance(pid, bool) for pid in raw_ids):
+            return json_error("photo_ids must be integers")
+
+        runner = app._job_runner
+        active_ws = db._active_workspace_id
+
+        placeholders = ",".join("?" for _ in photo_ids)
+        visible = db.conn.execute(
+            f"""SELECT p.id FROM photos p
+                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                WHERE wf.workspace_id = ? AND p.id IN ({placeholders})""",
+            [active_ws] + list(photo_ids),
+        ).fetchall()
+        visible_set = {r["id"] for r in visible}
+        photo_ids = [pid for pid in photo_ids if pid in visible_set]
+        if not photo_ids:
+            return json_error("no cacheable photos in current workspace")
+
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+
+        def work(job):
+            from offline_cache import cache_photo_original
+
+            thread_db = Database(db_path)
+            thread_db.set_active_workspace(active_ws)
+            photos_map = thread_db.get_photos_by_ids(photo_ids)
+            folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
+
+            cached = 0
+            skipped = 0
+            failed = 0
+            copied_bytes = 0
+            total = len(photo_ids)
+            job["_start_time"] = time.time()
+            job["progress"]["total"] = total
+
+            for i, pid in enumerate(photo_ids):
+                photo = photos_map.get(pid)
+                filename = photo["filename"] if photo else ""
+                if not photo:
+                    failed += 1
+                    job["errors"].append(f"Photo {pid}: not found")
+                else:
+                    try:
+                        result = cache_photo_original(
+                            thread_db, photo, vireo_dir, folders
+                        )
+                        if result["status"] == "cached":
+                            cached += 1
+                            copied_bytes += int(result.get("bytes") or 0)
+                        elif result["status"] == "skipped":
+                            skipped += 1
+                        else:
+                            failed += 1
+                            job["errors"].append(
+                                f'{photo["filename"]}: {result["status"]}'
+                            )
+                    except Exception as exc:
+                        failed += 1
+                        job["errors"].append(f'{photo["filename"]}: {exc}')
+                        log.warning("Offline cache failed for %s: %s", filename, exc)
+
+                runner.push_event(
+                    job["id"],
+                    "progress",
+                    {
+                        "current": i + 1,
+                        "total": total,
+                        "current_file": filename,
+                        "rate": round(
+                            (i + 1) / max(time.time() - job["_start_time"], 0.01), 1
+                        ),
+                        "phase": "Caching originals for offline use",
+                    },
+                )
+
+            result = {
+                "cached": cached,
+                "skipped": skipped,
+                "failed": failed,
+                "total": total,
+                "bytes": copied_bytes,
+            }
+            if failed:
+                job["result"] = result
+                first_err = job["errors"][0] if job["errors"] else "offline cache failed"
+                job["_fatal_error"] = (
+                    f"{failed}/{total} photos could not be cached: {first_err}"
+                )
+                raise RuntimeError(first_err)
+            return result
+
+        job_id = runner.start(
+            "offline-cache",
+            work,
+            config={"photo_ids": photo_ids},
+            workspace_id=active_ws,
+        )
+        return jsonify({"job_id": job_id})
+
     @app.route("/api/jobs/move-folder", methods=["POST"])
     def api_job_move_folder():
         """Move an entire folder to a destination."""
@@ -13125,7 +13248,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ).fetchone()
         if not folder:
             return "Not found", 404
-        image_path = os.path.join(folder["path"], photo["filename"])
+        from offline_cache import resolve_original_path
+        image_path, using_offline_cache = resolve_original_path(
+            db,
+            photo,
+            vireo_dir,
+            {photo["folder_id"]: folder["path"]},
+        )
 
         # For browser-native formats without a working copy, serve directly
         ext = os.path.splitext(photo["filename"])[1].lower()
@@ -13146,6 +13275,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         source_for_extraction = image_path
         if photo["companion_path"]:
             companion_abs = os.path.join(folder["path"], photo["companion_path"])
+            if using_offline_cache:
+                offline_row = db.offline_original_get(photo_id)
+                if offline_row and offline_row["companion_path"]:
+                    offline_companion = os.path.join(
+                        vireo_dir, offline_row["companion_path"]
+                    )
+                    if os.path.exists(offline_companion):
+                        companion_abs = offline_companion
             if os.path.exists(companion_abs):
                 orig_w = photo["width"]
                 orig_h = photo["height"]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9471,12 +9471,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ]
         if not raw_ids:
             return json_error("photo_ids or collection_id required")
-        try:
-            photo_ids = [int(pid) for pid in raw_ids]
-        except (ValueError, TypeError):
-            return json_error("photo_ids must be integers")
-        if any(isinstance(pid, bool) for pid in raw_ids):
-            return json_error("photo_ids must be integers")
+        photo_ids = []
+        for pid in raw_ids:
+            # `bool` is a subclass of `int`, and `int(1.9)` silently
+            # truncates to `1` — reject both so the wrong photo can't be
+            # cached without any client-visible error.
+            if isinstance(pid, bool) or isinstance(pid, float):
+                return json_error("photo_ids must be integers")
+            try:
+                photo_ids.append(int(pid))
+            except (ValueError, TypeError):
+                return json_error("photo_ids must be integers")
 
         runner = app._job_runner
         active_ws = db._active_workspace_id

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9455,14 +9455,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         runner = app._job_runner
         active_ws = db._active_workspace_id
 
-        placeholders = ",".join("?" for _ in photo_ids)
-        visible = db.conn.execute(
-            f"""SELECT p.id FROM photos p
-                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-                WHERE wf.workspace_id = ? AND p.id IN ({placeholders})""",
-            [active_ws] + list(photo_ids),
-        ).fetchall()
-        visible_set = {r["id"] for r in visible}
+        visible_set = set()
+        for chunk in _chunked(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = db.conn.execute(
+                f"""SELECT p.id FROM photos p
+                    JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                    WHERE wf.workspace_id = ? AND p.id IN ({placeholders})""",
+                [active_ws, *chunk],
+            ).fetchall()
+            visible_set.update(r["id"] for r in rows)
         photo_ids = [pid for pid in photo_ids if pid in visible_set]
         if not photo_ids:
             return json_error("no cacheable photos in current workspace")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -829,6 +829,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         vireo_dir = os.path.dirname(thumb_dir)
         preview_dir = os.path.join(vireo_dir, "previews")
         working_dir = os.path.join(vireo_dir, "working")
+        # Offline-cache layout: offline/{originals,xmp,companions}/{pid}{ext}.
+        # The FK cascade drops the offline_originals row when the photo is
+        # deleted, so we lose the exact stored paths — glob by photo id to
+        # cover any source extension and any sidecar/companion that was
+        # copied alongside it.
+        offline_dirs = [
+            os.path.join(vireo_dir, "offline", "originals"),
+            os.path.join(vireo_dir, "offline", "xmp"),
+            os.path.join(vireo_dir, "offline", "companions"),
+        ]
         for f in files:
             pid = f["photo_id"]
             # {id}.jpg lives in all three dirs (legacy full preview, thumb,
@@ -853,6 +863,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         "delete — will be reclaimed by Clear Cache: %s",
                         variant, e,
                     )
+            for d in offline_dirs:
+                for orphan in _glob.glob(os.path.join(d, f"{pid}.*")):
+                    try:
+                        os.remove(orphan)
+                    except OSError as e:
+                        log.warning(
+                            "Failed to remove offline cache file %s after "
+                            "photo delete — will be reclaimed by Clear "
+                            "Cache: %s",
+                            orphan, e,
+                        )
 
     @app.before_request
     def _enforce_api_v1_token():
@@ -9430,6 +9451,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_job_offline_cache():
         """Copy selected originals into Vireo's managed offline cache."""
         body = request.get_json(silent=True) or {}
+        # Flask returns top-level JSON lists/numbers/strings as-is, so guard
+        # against `body.get(...)` raising AttributeError on non-object payloads
+        # (e.g. a client posting `[]` directly).
+        if not isinstance(body, dict):
+            return json_error("request body must be a JSON object")
         raw_ids = body.get("photo_ids", [])
         collection_id = _coerce_collection_id(body.get("collection_id"))
         if collection_id is False:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9476,7 +9476,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # `bool` is a subclass of `int`, and `int(1.9)` silently
             # truncates to `1` — reject both so the wrong photo can't be
             # cached without any client-visible error.
-            if isinstance(pid, bool) or isinstance(pid, float):
+            if isinstance(pid, (bool, float)):
                 return json_error("photo_ids must be integers")
             try:
                 photo_ids.append(int(pid))

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4999,7 +4999,8 @@ class Database:
         status,
         error=None,
     ):
-        self.conn.execute(
+        execute_with_retry(
+            self.conn,
             """INSERT OR REPLACE INTO offline_originals
                (photo_id, original_path, xmp_path, companion_path, bytes,
                 source_size, source_mtime, cached_at, status, error)
@@ -5017,7 +5018,7 @@ class Database:
                 error,
             ),
         )
-        self.conn.commit()
+        commit_with_retry(self.conn)
 
     def offline_original_get(self, photo_id):
         return self.conn.execute(
@@ -5028,8 +5029,12 @@ class Database:
         ).fetchone()
 
     def offline_original_delete(self, photo_id):
-        self.conn.execute("DELETE FROM offline_originals WHERE photo_id=?", (photo_id,))
-        self.conn.commit()
+        execute_with_retry(
+            self.conn,
+            "DELETE FROM offline_originals WHERE photo_id=?",
+            (photo_id,),
+        )
+        commit_with_retry(self.conn)
 
     def offline_original_total_bytes(self):
         row = self.conn.execute(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -553,6 +553,20 @@ class Database:
                 FOREIGN KEY (photo_id) REFERENCES photos(id) ON DELETE CASCADE
             );
 
+            CREATE TABLE IF NOT EXISTS offline_originals (
+                photo_id INTEGER NOT NULL PRIMARY KEY,
+                original_path TEXT,
+                xmp_path TEXT,
+                companion_path TEXT,
+                bytes INTEGER NOT NULL DEFAULT 0,
+                source_size INTEGER,
+                source_mtime REAL,
+                cached_at REAL NOT NULL,
+                status TEXT NOT NULL,
+                error TEXT,
+                FOREIGN KEY (photo_id) REFERENCES photos(id) ON DELETE CASCADE
+            );
+
             CREATE TABLE IF NOT EXISTS new_image_snapshots (
               id INTEGER PRIMARY KEY AUTOINCREMENT,
               workspace_id INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
@@ -598,6 +612,8 @@ class Database:
                 ON photo_color_labels(workspace_id);
             CREATE INDEX IF NOT EXISTS preview_cache_last_access
                 ON preview_cache(last_access_at);
+            CREATE INDEX IF NOT EXISTS idx_offline_originals_status
+                ON offline_originals(status);
             CREATE INDEX IF NOT EXISTS idx_new_image_snapshots_ws
                 ON new_image_snapshots(workspace_id);
 
@@ -4966,6 +4982,61 @@ class Database:
             "WHERE photo_id=? AND size=?",
             (photo_id, size),
         ).fetchone()
+
+    # ------------------------------------------------------------------
+    # offline original cache
+    # ------------------------------------------------------------------
+    def offline_original_upsert(
+        self,
+        photo_id,
+        original_path,
+        xmp_path,
+        companion_path,
+        bytes_,
+        source_size,
+        source_mtime,
+        cached_at,
+        status,
+        error=None,
+    ):
+        self.conn.execute(
+            """INSERT OR REPLACE INTO offline_originals
+               (photo_id, original_path, xmp_path, companion_path, bytes,
+                source_size, source_mtime, cached_at, status, error)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                photo_id,
+                original_path,
+                xmp_path,
+                companion_path,
+                bytes_,
+                source_size,
+                source_mtime,
+                cached_at,
+                status,
+                error,
+            ),
+        )
+        self.conn.commit()
+
+    def offline_original_get(self, photo_id):
+        return self.conn.execute(
+            """SELECT photo_id, original_path, xmp_path, companion_path, bytes,
+                      source_size, source_mtime, cached_at, status, error
+               FROM offline_originals WHERE photo_id=?""",
+            (photo_id,),
+        ).fetchone()
+
+    def offline_original_delete(self, photo_id):
+        self.conn.execute("DELETE FROM offline_originals WHERE photo_id=?", (photo_id,))
+        self.conn.commit()
+
+    def offline_original_total_bytes(self):
+        row = self.conn.execute(
+            "SELECT COALESCE(SUM(bytes), 0) AS total FROM offline_originals "
+            "WHERE status='cached'"
+        ).fetchone()
+        return row["total"]
 
     def update_photo_sharpness(self, photo_id, sharpness):
         """Set photo sharpness score."""

--- a/vireo/offline_cache.py
+++ b/vireo/offline_cache.py
@@ -34,6 +34,24 @@ def _xmp_source_for(folder_path, filename):
     return os.path.join(folder_path, stem + ".xmp")
 
 
+def _same_file_stat(src, dst):
+    if not src or not dst:
+        return False
+    try:
+        src_st = os.stat(src)
+        dst_st = os.stat(dst)
+    except OSError:
+        return False
+    return src_st.st_size == dst_st.st_size and src_st.st_mtime == dst_st.st_mtime
+
+
+def _unlink_cached_rel(vireo_dir, rel_path):
+    if not rel_path:
+        return
+    with contextlib.suppress(OSError):
+        os.unlink(os.path.join(vireo_dir, rel_path))
+
+
 def offline_original_abs(vireo_dir, row):
     if not row or not row["original_path"]:
         return None
@@ -117,6 +135,16 @@ def cache_photo_original(db, photo, vireo_dir, folders):
         companion_src = os.path.join(folder_path, companion)
     companion_src_exists = bool(companion_src) and os.path.isfile(companion_src)
 
+    xmp_rel_expected = (
+        _offline_rel_path("xmp", photo["id"], ".xmp") if xmp_src_exists else None
+    )
+    companion_rel_expected = None
+    if companion_src_exists:
+        companion_ext = os.path.splitext(companion)[1] or ".jpg"
+        companion_rel_expected = _offline_rel_path(
+            "companions", photo["id"], companion_ext.lower()
+        )
+
     existing_xmp_abs = (
         os.path.join(vireo_dir, existing["xmp_path"])
         if existing and existing["xmp_path"]
@@ -128,13 +156,21 @@ def cache_photo_original(db, photo, vireo_dir, folders):
         else None
     )
     xmp_fresh = (
-        (existing_xmp_abs is not None) == xmp_src_exists
-        and (existing_xmp_abs is None or os.path.isfile(existing_xmp_abs))
+        (not xmp_src_exists and existing_xmp_abs is None)
+        or (
+            xmp_src_exists
+            and existing
+            and existing["xmp_path"] == xmp_rel_expected
+            and _same_file_stat(xmp_src, existing_xmp_abs)
+        )
     )
     companion_fresh = (
-        (existing_companion_abs is not None) == companion_src_exists
-        and (
-            existing_companion_abs is None or os.path.isfile(existing_companion_abs)
+        (not companion_src_exists and existing_companion_abs is None)
+        or (
+            companion_src_exists
+            and existing
+            and existing["companion_path"] == companion_rel_expected
+            and _same_file_stat(companion_src, existing_companion_abs)
         )
     )
 
@@ -148,7 +184,11 @@ def cache_photo_original(db, photo, vireo_dir, folders):
         and xmp_fresh
         and companion_fresh
     ):
-        return {"status": "skipped", "bytes": existing["bytes"], "path": existing_path}
+        return {
+            "status": "skipped",
+            "bytes": existing["bytes"],
+            "path": existing_path,
+        }
 
     ext = os.path.splitext(photo["filename"])[1] or photo["extension"] or ".jpg"
     original_rel = _offline_rel_path("originals", photo["id"], ext.lower())
@@ -158,20 +198,25 @@ def cache_photo_original(db, photo, vireo_dir, folders):
     copied_bytes = os.path.getsize(original_abs)
     xmp_rel = None
     if xmp_src_exists:
-        xmp_rel = _offline_rel_path("xmp", photo["id"], ".xmp")
+        xmp_rel = xmp_rel_expected
         xmp_abs = os.path.join(vireo_dir, xmp_rel)
         _copy_atomic(xmp_src, xmp_abs)
         copied_bytes += os.path.getsize(xmp_abs)
+    if existing and existing["xmp_path"] and existing["xmp_path"] != xmp_rel:
+        _unlink_cached_rel(vireo_dir, existing["xmp_path"])
 
     companion_rel = None
     if companion_src_exists:
-        companion_ext = os.path.splitext(companion)[1] or ".jpg"
-        companion_rel = _offline_rel_path(
-            "companions", photo["id"], companion_ext.lower()
-        )
+        companion_rel = companion_rel_expected
         companion_abs = os.path.join(vireo_dir, companion_rel)
         _copy_atomic(companion_src, companion_abs)
         copied_bytes += os.path.getsize(companion_abs)
+    if (
+        existing
+        and existing["companion_path"]
+        and existing["companion_path"] != companion_rel
+    ):
+        _unlink_cached_rel(vireo_dir, existing["companion_path"])
 
     db.offline_original_upsert(
         photo["id"],

--- a/vireo/offline_cache.py
+++ b/vireo/offline_cache.py
@@ -90,8 +90,26 @@ def cache_photo_original(db, photo, vireo_dir, folders):
     """Copy one photo's original and sidecar metadata into the offline cache."""
     folder_id = photo["folder_id"]
     now = time.time()
+    existing = db.offline_original_get(photo["id"])
+    existing_path = offline_original_abs(vireo_dir, existing)
+    # If a prior run cached this photo and the cached file is still on disk,
+    # treat it as the source-of-record for offline access when the live source
+    # is unavailable — don't clobber the DB record (which would also disable
+    # `resolve_original_path`'s fallback to the cached copy).
+    cache_intact = bool(
+        existing
+        and existing["status"] == "cached"
+        and existing_path
+        and os.path.isfile(existing_path)
+    )
 
     if folder_id not in folders:
+        if cache_intact:
+            return {
+                "status": "skipped",
+                "bytes": existing["bytes"],
+                "path": existing_path,
+            }
         db.offline_original_upsert(
             photo["id"],
             original_path=None,
@@ -110,6 +128,12 @@ def cache_photo_original(db, photo, vireo_dir, folders):
     source_path = os.path.join(folder_path, photo["filename"])
 
     if not os.path.isfile(source_path):
+        if cache_intact:
+            return {
+                "status": "skipped",
+                "bytes": existing["bytes"],
+                "path": existing_path,
+            }
         db.offline_original_upsert(
             photo["id"],
             original_path=None,
@@ -125,8 +149,6 @@ def cache_photo_original(db, photo, vireo_dir, folders):
         return {"status": "missing_source", "bytes": 0, "path": source_path}
 
     st = os.stat(source_path)
-    existing = db.offline_original_get(photo["id"])
-    existing_path = offline_original_abs(vireo_dir, existing)
     xmp_src = _xmp_source_for(folder_path, photo["filename"])
     xmp_src_exists = os.path.isfile(xmp_src)
     companion_src = None

--- a/vireo/offline_cache.py
+++ b/vireo/offline_cache.py
@@ -1,16 +1,28 @@
 """Local original-file cache for offline viewing."""
 
+import contextlib
 import os
 import shutil
+import tempfile
 import time
 
 
 def _copy_atomic(src, dst):
-    """Copy ``src`` to ``dst`` via a sibling temp file."""
+    """Copy ``src`` to ``dst`` via a unique sibling temp file."""
     os.makedirs(os.path.dirname(dst), exist_ok=True)
-    tmp = dst + ".tmp"
-    shutil.copy2(src, tmp)
-    os.replace(tmp, dst)
+    fd, tmp = tempfile.mkstemp(
+        dir=os.path.dirname(dst),
+        prefix=os.path.basename(dst) + ".",
+        suffix=".tmp",
+    )
+    os.close(fd)
+    try:
+        shutil.copy2(src, tmp)
+        os.replace(tmp, dst)
+    finally:
+        if os.path.exists(tmp):
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
 
 
 def _offline_rel_path(kind, photo_id, suffix):
@@ -43,10 +55,13 @@ def resolve_original_path(db, photo, vireo_dir, folders):
     The source-of-truth file wins when it is available. The offline copy is a
     fallback for temporarily unavailable volumes.
     """
-    folder_path = folders.get(photo["folder_id"], "")
-    source_path = os.path.join(folder_path, photo["filename"])
-    if os.path.isfile(source_path):
-        return source_path, False
+    folder_id = photo["folder_id"]
+    if folder_id in folders:
+        source_path = os.path.join(folders[folder_id], photo["filename"])
+        if os.path.isfile(source_path):
+            return source_path, False
+    else:
+        source_path = ""
     cached = cached_original_for_photo(db, photo["id"], vireo_dir)
     if cached:
         return cached, True
@@ -55,9 +70,26 @@ def resolve_original_path(db, photo, vireo_dir, folders):
 
 def cache_photo_original(db, photo, vireo_dir, folders):
     """Copy one photo's original and sidecar metadata into the offline cache."""
-    folder_path = folders.get(photo["folder_id"], "")
-    source_path = os.path.join(folder_path, photo["filename"])
+    folder_id = photo["folder_id"]
     now = time.time()
+
+    if folder_id not in folders:
+        db.offline_original_upsert(
+            photo["id"],
+            original_path=None,
+            xmp_path=None,
+            companion_path=None,
+            bytes_=0,
+            source_size=photo["file_size"] or 0,
+            source_mtime=photo["file_mtime"],
+            cached_at=now,
+            status="missing_source",
+            error=f"unknown folder_id {folder_id}",
+        )
+        return {"status": "missing_source", "bytes": 0, "path": ""}
+
+    folder_path = folders[folder_id]
+    source_path = os.path.join(folder_path, photo["filename"])
 
     if not os.path.isfile(source_path):
         db.offline_original_upsert(
@@ -77,6 +109,35 @@ def cache_photo_original(db, photo, vireo_dir, folders):
     st = os.stat(source_path)
     existing = db.offline_original_get(photo["id"])
     existing_path = offline_original_abs(vireo_dir, existing)
+    xmp_src = _xmp_source_for(folder_path, photo["filename"])
+    xmp_src_exists = os.path.isfile(xmp_src)
+    companion_src = None
+    companion = photo["companion_path"]
+    if companion:
+        companion_src = os.path.join(folder_path, companion)
+    companion_src_exists = bool(companion_src) and os.path.isfile(companion_src)
+
+    existing_xmp_abs = (
+        os.path.join(vireo_dir, existing["xmp_path"])
+        if existing and existing["xmp_path"]
+        else None
+    )
+    existing_companion_abs = (
+        os.path.join(vireo_dir, existing["companion_path"])
+        if existing and existing["companion_path"]
+        else None
+    )
+    xmp_fresh = (
+        (existing_xmp_abs is not None) == xmp_src_exists
+        and (existing_xmp_abs is None or os.path.isfile(existing_xmp_abs))
+    )
+    companion_fresh = (
+        (existing_companion_abs is not None) == companion_src_exists
+        and (
+            existing_companion_abs is None or os.path.isfile(existing_companion_abs)
+        )
+    )
+
     if (
         existing
         and existing["status"] == "cached"
@@ -84,6 +145,8 @@ def cache_photo_original(db, photo, vireo_dir, folders):
         and os.path.isfile(existing_path)
         and existing["source_size"] == st.st_size
         and existing["source_mtime"] == st.st_mtime
+        and xmp_fresh
+        and companion_fresh
     ):
         return {"status": "skipped", "bytes": existing["bytes"], "path": existing_path}
 
@@ -94,22 +157,21 @@ def cache_photo_original(db, photo, vireo_dir, folders):
 
     copied_bytes = os.path.getsize(original_abs)
     xmp_rel = None
-    xmp_src = _xmp_source_for(folder_path, photo["filename"])
-    if os.path.isfile(xmp_src):
+    if xmp_src_exists:
         xmp_rel = _offline_rel_path("xmp", photo["id"], ".xmp")
-        _copy_atomic(xmp_src, os.path.join(vireo_dir, xmp_rel))
+        xmp_abs = os.path.join(vireo_dir, xmp_rel)
+        _copy_atomic(xmp_src, xmp_abs)
+        copied_bytes += os.path.getsize(xmp_abs)
 
     companion_rel = None
-    companion = photo["companion_path"]
-    if companion:
-        companion_src = os.path.join(folder_path, companion)
-        if os.path.isfile(companion_src):
-            companion_ext = os.path.splitext(companion)[1] or ".jpg"
-            companion_rel = _offline_rel_path(
-                "companions", photo["id"], companion_ext.lower()
-            )
-            _copy_atomic(companion_src, os.path.join(vireo_dir, companion_rel))
-            copied_bytes += os.path.getsize(os.path.join(vireo_dir, companion_rel))
+    if companion_src_exists:
+        companion_ext = os.path.splitext(companion)[1] or ".jpg"
+        companion_rel = _offline_rel_path(
+            "companions", photo["id"], companion_ext.lower()
+        )
+        companion_abs = os.path.join(vireo_dir, companion_rel)
+        _copy_atomic(companion_src, companion_abs)
+        copied_bytes += os.path.getsize(companion_abs)
 
     db.offline_original_upsert(
         photo["id"],

--- a/vireo/offline_cache.py
+++ b/vireo/offline_cache.py
@@ -1,0 +1,126 @@
+"""Local original-file cache for offline viewing."""
+
+import os
+import shutil
+import time
+
+
+def _copy_atomic(src, dst):
+    """Copy ``src`` to ``dst`` via a sibling temp file."""
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    tmp = dst + ".tmp"
+    shutil.copy2(src, tmp)
+    os.replace(tmp, dst)
+
+
+def _offline_rel_path(kind, photo_id, suffix):
+    return os.path.join("offline", kind, f"{int(photo_id)}{suffix}")
+
+
+def _xmp_source_for(folder_path, filename):
+    stem = os.path.splitext(filename)[0]
+    return os.path.join(folder_path, stem + ".xmp")
+
+
+def offline_original_abs(vireo_dir, row):
+    if not row or not row["original_path"]:
+        return None
+    return os.path.join(vireo_dir, row["original_path"])
+
+
+def cached_original_for_photo(db, photo_id, vireo_dir):
+    """Return the cached original path if present on disk, else None."""
+    row = db.offline_original_get(photo_id)
+    path = offline_original_abs(vireo_dir, row)
+    if path and os.path.isfile(path):
+        return path
+    return None
+
+
+def resolve_original_path(db, photo, vireo_dir, folders):
+    """Return (path, used_offline_cache) for a photo's original.
+
+    The source-of-truth file wins when it is available. The offline copy is a
+    fallback for temporarily unavailable volumes.
+    """
+    folder_path = folders.get(photo["folder_id"], "")
+    source_path = os.path.join(folder_path, photo["filename"])
+    if os.path.isfile(source_path):
+        return source_path, False
+    cached = cached_original_for_photo(db, photo["id"], vireo_dir)
+    if cached:
+        return cached, True
+    return source_path, False
+
+
+def cache_photo_original(db, photo, vireo_dir, folders):
+    """Copy one photo's original and sidecar metadata into the offline cache."""
+    folder_path = folders.get(photo["folder_id"], "")
+    source_path = os.path.join(folder_path, photo["filename"])
+    now = time.time()
+
+    if not os.path.isfile(source_path):
+        db.offline_original_upsert(
+            photo["id"],
+            original_path=None,
+            xmp_path=None,
+            companion_path=None,
+            bytes_=0,
+            source_size=photo["file_size"] or 0,
+            source_mtime=photo["file_mtime"],
+            cached_at=now,
+            status="missing_source",
+            error=f"source file missing: {source_path}",
+        )
+        return {"status": "missing_source", "bytes": 0, "path": source_path}
+
+    st = os.stat(source_path)
+    existing = db.offline_original_get(photo["id"])
+    existing_path = offline_original_abs(vireo_dir, existing)
+    if (
+        existing
+        and existing["status"] == "cached"
+        and existing_path
+        and os.path.isfile(existing_path)
+        and existing["source_size"] == st.st_size
+        and existing["source_mtime"] == st.st_mtime
+    ):
+        return {"status": "skipped", "bytes": existing["bytes"], "path": existing_path}
+
+    ext = os.path.splitext(photo["filename"])[1] or photo["extension"] or ".jpg"
+    original_rel = _offline_rel_path("originals", photo["id"], ext.lower())
+    original_abs = os.path.join(vireo_dir, original_rel)
+    _copy_atomic(source_path, original_abs)
+
+    copied_bytes = os.path.getsize(original_abs)
+    xmp_rel = None
+    xmp_src = _xmp_source_for(folder_path, photo["filename"])
+    if os.path.isfile(xmp_src):
+        xmp_rel = _offline_rel_path("xmp", photo["id"], ".xmp")
+        _copy_atomic(xmp_src, os.path.join(vireo_dir, xmp_rel))
+
+    companion_rel = None
+    companion = photo["companion_path"]
+    if companion:
+        companion_src = os.path.join(folder_path, companion)
+        if os.path.isfile(companion_src):
+            companion_ext = os.path.splitext(companion)[1] or ".jpg"
+            companion_rel = _offline_rel_path(
+                "companions", photo["id"], companion_ext.lower()
+            )
+            _copy_atomic(companion_src, os.path.join(vireo_dir, companion_rel))
+            copied_bytes += os.path.getsize(os.path.join(vireo_dir, companion_rel))
+
+    db.offline_original_upsert(
+        photo["id"],
+        original_path=original_rel,
+        xmp_path=xmp_rel,
+        companion_path=companion_rel,
+        bytes_=copied_bytes,
+        source_size=st.st_size,
+        source_mtime=st.st_mtime,
+        cached_at=now,
+        status="cached",
+        error=None,
+    )
+    return {"status": "cached", "bytes": copied_bytes, "path": original_abs}

--- a/vireo/offline_cache.py
+++ b/vireo/offline_cache.py
@@ -30,8 +30,15 @@ def _offline_rel_path(kind, photo_id, suffix):
 
 
 def _xmp_source_for(folder_path, filename):
+    # Match both cases — other code paths (see app.py sidecar cleanup)
+    # treat `.XMP` as a valid sidecar, so case-sensitive filesystems would
+    # otherwise drop uppercase sidecars from the offline cache.
     stem = os.path.splitext(filename)[0]
-    return os.path.join(folder_path, stem + ".xmp")
+    lower = os.path.join(folder_path, stem + ".xmp")
+    upper = os.path.join(folder_path, stem + ".XMP")
+    if os.path.isfile(upper) and not os.path.isfile(lower):
+        return upper
+    return lower
 
 
 def _same_file_stat(src, dst):

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -5409,7 +5409,7 @@ async function makeAvailableOffline() {
       showToast('Offline cache error: ' + data.error, 'error');
       return;
     }
-    showToast('Caching ' + activeIds.length + ' photo' + (activeIds.length === 1 ? '' : 's') + ' for offline use');
+    showToast('Offline caching started (' + activeIds.length + ' photo' + (activeIds.length === 1 ? '' : 's') + ')');
   } catch(err) {
     showToast('Offline cache failed: ' + err.message, 'error');
   }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1169,6 +1169,7 @@ body {
       <button id="developBtn" onclick="developSelected()" title="Develop selected RAW photos with darktable" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Develop</button>
       <button onclick="openInEditorBatch(event)" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Open in Editor</button>
       <button onclick="batchSubmitInat()" style="background:var(--bg-tertiary);color:#74ac00;border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">iNaturalist</button>
+      <button onclick="makeAvailableOffline()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Make Offline</button>
       <button onclick="openExportModal()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Export</button>
       <button onclick="batchDelete()" style="background:var(--danger);color:white;border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;" title="Delete selected photos">Delete</button>
       <button onclick="clearSelection()" style="background:none;color:var(--text-faint);border:none;padding:4px 8px;font-size:12px;cursor:pointer;margin-left:auto;">Clear</button>
@@ -5392,6 +5393,25 @@ async function startExport() {
   } catch(err) {
     alert('Export failed: ' + err.message);
     btn.disabled = false;
+  }
+}
+
+async function makeAvailableOffline() {
+  var activeIds = getActiveSelection();
+  if (activeIds.length === 0) return;
+  try {
+    var data = await safeFetch('/api/jobs/offline-cache', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: activeIds}),
+    });
+    if (data.error) {
+      showToast('Offline cache error: ' + data.error, 'error');
+      return;
+    }
+    showToast('Caching ' + activeIds.length + ' photo' + (activeIds.length === 1 ? '' : 's') + ' for offline use');
+  } catch(err) {
+    showToast('Offline cache failed: ' + err.message, 'error');
   }
 }
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -245,6 +245,49 @@ def test_original_route_uses_offline_cache_when_source_missing(client_with_photo
     assert offline_resp.data == source_bytes
 
 
+def test_offline_cache_rerun_preserves_cache_when_source_missing(client_with_photo):
+    """Re-running Make Offline with the source unavailable keeps the cached copy."""
+    app, db, pid = client_with_photo
+    client = app.test_client()
+
+    resp = client.post("/api/jobs/offline-cache", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+
+    row = db.offline_original_get(pid)
+    assert row is not None and row["status"] == "cached"
+    cached_original_path = row["original_path"]
+    cached_bytes = row["bytes"]
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    assert os.path.isfile(os.path.join(vireo_dir, cached_original_path))
+
+    photo = db.get_photo(pid)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
+    ).fetchone()
+    source = os.path.join(folder["path"], photo["filename"])
+    os.remove(source)
+    assert not os.path.isfile(source)
+
+    resp = client.post("/api/jobs/offline-cache", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+    assert job["result"]["skipped"] == 1
+    assert job["result"]["failed"] == 0
+
+    row = db.offline_original_get(pid)
+    assert row["status"] == "cached"
+    assert row["original_path"] == cached_original_path
+    assert row["bytes"] == cached_bytes
+    assert os.path.isfile(os.path.join(vireo_dir, cached_original_path))
+
+    offline_resp = client.get(f"/photos/{pid}/original")
+    assert offline_resp.status_code == 200
+    assert len(offline_resp.data) == cached_bytes
+
+
 def test_api_coverage(app_and_db):
     """GET /api/coverage returns workspace-level and per-folder coverage."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -168,12 +168,14 @@ def test_original_route_uses_offline_cache_when_source_missing(client_with_photo
         "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
     ).fetchone()
     source = os.path.join(folder["path"], photo["filename"])
-    cached_bytes = client.get(f"/photos/{pid}/original").data
+    with open(source, "rb") as fh:
+        source_bytes = fh.read()
     os.remove(source)
+    assert not os.path.isfile(source)
 
     offline_resp = client.get(f"/photos/{pid}/original")
     assert offline_resp.status_code == 200
-    assert offline_resp.data == cached_bytes
+    assert offline_resp.data == source_bytes
 
 
 def test_api_coverage(app_and_db):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -332,6 +332,23 @@ def test_offline_cache_rejects_non_object_body(client_with_photo):
     assert resp.get_json()["error"] == "request body must be a JSON object"
 
 
+def test_offline_cache_rejects_non_integer_photo_ids(client_with_photo):
+    """Float and bool photo_ids are rejected instead of silently coerced."""
+    app, _, _ = client_with_photo
+    client = app.test_client()
+    # Floats would otherwise truncate via int() and cache the wrong photo.
+    resp = client.post("/api/jobs/offline-cache", json={"photo_ids": [1.9]})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "photo_ids must be integers"
+    resp = client.post("/api/jobs/offline-cache", json={"photo_ids": [2.0]})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "photo_ids must be integers"
+    # bool is an int subclass; reject it too.
+    resp = client.post("/api/jobs/offline-cache", json={"photo_ids": [True]})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "photo_ids must be integers"
+
+
 def test_offline_cache_files_removed_when_photo_deleted(client_with_photo):
     """Deleting a photo removes its offline cache files from disk."""
     app, db, pid = client_with_photo

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -136,7 +136,8 @@ def test_offline_cache_job_copies_original_and_xmp(client_with_photo):
     folder = db.conn.execute(
         "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
     ).fetchone()
-    xmp_path = os.path.join(folder["path"], "test.xmp")
+    stem, _ = os.path.splitext(photo["filename"])
+    xmp_path = os.path.join(folder["path"], f"{stem}.xmp")
     with open(xmp_path, "w", encoding="utf-8") as fh:
         fh.write("<x:xmpmeta></x:xmpmeta>")
 
@@ -151,6 +152,72 @@ def test_offline_cache_job_copies_original_and_xmp(client_with_photo):
     vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
     assert os.path.isfile(os.path.join(vireo_dir, row["original_path"]))
     assert os.path.isfile(os.path.join(vireo_dir, row["xmp_path"]))
+
+
+def test_offline_cache_refreshes_and_removes_xmp_sidecar(client_with_photo):
+    """Re-caching refreshes changed sidecars and removes stale cached ones."""
+    app, db, pid = client_with_photo
+    client = app.test_client()
+
+    photo = db.get_photo(pid)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
+    ).fetchone()
+    companion_name = "test-companion.jpg"
+    companion_path = os.path.join(folder["path"], companion_name)
+    with open(companion_path, "w", encoding="utf-8") as fh:
+        fh.write("companion 1")
+    db.conn.execute(
+        "UPDATE photos SET companion_path=? WHERE id=?", (companion_name, pid)
+    )
+    db.conn.commit()
+
+    stem, _ = os.path.splitext(photo["filename"])
+    xmp_path = os.path.join(folder["path"], f"{stem}.xmp")
+    with open(xmp_path, "w", encoding="utf-8") as fh:
+        fh.write("version 1")
+
+    resp = client.post("/api/jobs/offline-cache", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+
+    row = db.offline_original_get(pid)
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    cached_xmp = os.path.join(vireo_dir, row["xmp_path"])
+    cached_companion = os.path.join(vireo_dir, row["companion_path"])
+    assert open(cached_xmp, encoding="utf-8").read() == "version 1"
+    assert open(cached_companion, encoding="utf-8").read() == "companion 1"
+
+    with open(xmp_path, "w", encoding="utf-8") as fh:
+        fh.write("version 2")
+    with open(companion_path, "w", encoding="utf-8") as fh:
+        fh.write("companion 2")
+    newer = os.path.getmtime(xmp_path) + 10
+    os.utime(xmp_path, (newer, newer))
+    os.utime(companion_path, (newer, newer))
+
+    resp = client.post("/api/jobs/offline-cache", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+    row = db.offline_original_get(pid)
+    cached_xmp = os.path.join(vireo_dir, row["xmp_path"])
+    cached_companion = os.path.join(vireo_dir, row["companion_path"])
+    assert open(cached_xmp, encoding="utf-8").read() == "version 2"
+    assert open(cached_companion, encoding="utf-8").read() == "companion 2"
+
+    os.remove(xmp_path)
+    os.remove(companion_path)
+    resp = client.post("/api/jobs/offline-cache", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+    row = db.offline_original_get(pid)
+    assert row["xmp_path"] is None
+    assert row["companion_path"] is None
+    assert not os.path.exists(cached_xmp)
+    assert not os.path.exists(cached_companion)
 
 
 def test_original_route_uses_offline_cache_when_source_missing(client_with_photo):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -320,6 +320,52 @@ def test_offline_cache_rerun_preserves_cache_when_source_missing(client_with_pho
     assert len(offline_resp.data) == cached_bytes
 
 
+def test_offline_cache_rejects_non_object_body(client_with_photo):
+    """POST with a top-level non-object JSON body returns 400, not 500."""
+    app, _, _ = client_with_photo
+    client = app.test_client()
+    resp = client.post("/api/jobs/offline-cache", json=[1, 2, 3])
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "request body must be a JSON object"
+    resp = client.post("/api/jobs/offline-cache", json="oops")
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "request body must be a JSON object"
+
+
+def test_offline_cache_files_removed_when_photo_deleted(client_with_photo):
+    """Deleting a photo removes its offline cache files from disk."""
+    app, db, pid = client_with_photo
+    client = app.test_client()
+
+    photo = db.get_photo(pid)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
+    ).fetchone()
+    stem, _ = os.path.splitext(photo["filename"])
+    xmp_path = os.path.join(folder["path"], f"{stem}.xmp")
+    with open(xmp_path, "w", encoding="utf-8") as fh:
+        fh.write("<x:xmpmeta></x:xmpmeta>")
+
+    resp = client.post("/api/jobs/offline-cache", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+
+    row = db.offline_original_get(pid)
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    cached_original = os.path.join(vireo_dir, row["original_path"])
+    cached_xmp = os.path.join(vireo_dir, row["xmp_path"])
+    assert os.path.isfile(cached_original)
+    assert os.path.isfile(cached_xmp)
+
+    resp = client.post("/api/audit/remove-orphans", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+
+    assert db.offline_original_get(pid) is None
+    assert not os.path.exists(cached_original)
+    assert not os.path.exists(cached_xmp)
+
+
 def test_api_coverage(app_and_db):
     """GET /api/coverage returns workspace-level and per-folder coverage."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+from wait import wait_for_job_via_client
+
 
 def test_index_redirects_to_browse(app_and_db, monkeypatch):
     """GET / redirects to /browse when a model is available."""
@@ -123,6 +125,55 @@ def test_api_photos_extensions_scoped_to_active_workspace(app_and_db):
     # .cr2 belongs to "Other" workspace and must not appear here.
     assert '.cr2' not in resp.get_json()
     assert '.jpg' in resp.get_json()
+
+
+def test_offline_cache_job_copies_original_and_xmp(client_with_photo):
+    """Selected photos can be copied into the managed offline cache."""
+    app, db, pid = client_with_photo
+    client = app.test_client()
+
+    photo = db.get_photo(pid)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
+    ).fetchone()
+    xmp_path = os.path.join(folder["path"], "test.xmp")
+    with open(xmp_path, "w", encoding="utf-8") as fh:
+        fh.write("<x:xmpmeta></x:xmpmeta>")
+
+    resp = client.post("/api/jobs/offline-cache", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+
+    row = db.offline_original_get(pid)
+    assert row is not None
+    assert row["status"] == "cached"
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    assert os.path.isfile(os.path.join(vireo_dir, row["original_path"]))
+    assert os.path.isfile(os.path.join(vireo_dir, row["xmp_path"]))
+
+
+def test_original_route_uses_offline_cache_when_source_missing(client_with_photo):
+    """Full-res viewing falls back to the cached original when the source is gone."""
+    app, db, pid = client_with_photo
+    client = app.test_client()
+
+    resp = client.post("/api/jobs/offline-cache", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+
+    photo = db.get_photo(pid)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
+    ).fetchone()
+    source = os.path.join(folder["path"], photo["filename"])
+    cached_bytes = client.get(f"/photos/{pid}/original").data
+    os.remove(source)
+
+    offline_resp = client.get(f"/photos/{pid}/original")
+    assert offline_resp.status_code == 200
+    assert offline_resp.data == cached_bytes
 
 
 def test_api_coverage(app_and_db):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -154,6 +154,33 @@ def test_offline_cache_job_copies_original_and_xmp(client_with_photo):
     assert os.path.isfile(os.path.join(vireo_dir, row["xmp_path"]))
 
 
+def test_offline_cache_picks_up_uppercase_xmp_sidecar(client_with_photo):
+    """Offline cache copies sidecars whose extension is `.XMP` (not just `.xmp`)."""
+    app, db, pid = client_with_photo
+    client = app.test_client()
+
+    photo = db.get_photo(pid)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
+    ).fetchone()
+    stem, _ = os.path.splitext(photo["filename"])
+    xmp_path = os.path.join(folder["path"], f"{stem}.XMP")
+    with open(xmp_path, "w", encoding="utf-8") as fh:
+        fh.write("<x:xmpmeta></x:xmpmeta>")
+
+    resp = client.post("/api/jobs/offline-cache", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+
+    row = db.offline_original_get(pid)
+    assert row is not None
+    assert row["status"] == "cached"
+    assert row["xmp_path"], "expected uppercase .XMP sidecar to be cached"
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    assert os.path.isfile(os.path.join(vireo_dir, row["xmp_path"]))
+
+
 def test_offline_cache_refreshes_and_removes_xmp_sidecar(client_with_photo):
     """Re-caching refreshes changed sidecars and removes stale cached ones."""
     app, db, pid = client_with_photo

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -178,7 +178,12 @@ def test_offline_cache_picks_up_uppercase_xmp_sidecar(client_with_photo):
     assert row["status"] == "cached"
     assert row["xmp_path"], "expected uppercase .XMP sidecar to be cached"
     vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
-    assert os.path.isfile(os.path.join(vireo_dir, row["xmp_path"]))
+    cached_xmp_abs = os.path.join(vireo_dir, row["xmp_path"])
+    assert os.path.isfile(cached_xmp_abs)
+    # Verify the .XMP source content actually made it into the cache so
+    # this can't accidentally pass by caching an empty or wrong file.
+    with open(cached_xmp_abs, encoding="utf-8") as fh:
+        assert fh.read() == "<x:xmpmeta></x:xmpmeta>"
 
 
 def test_offline_cache_refreshes_and_removes_xmp_sidecar(client_with_photo):


### PR DESCRIPTION
## Summary
Adds a managed offline-original cache so selected photos can be copied locally before disconnecting from a NAS.
The Browse batch bar now has a Make Offline action, backed by a background job that stores originals, XMP sidecars, and companion files under Vireo's local data directory.
Full-resolution photo serving now falls back to the cached original when the source file is unavailable, while continuing to prefer the NAS/source file when it exists.

## Checks
- pytest -q vireo/tests/test_app.py
- pytest -q vireo/tests/test_db.py
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Make Offline" batch action/button to queue selected photos or a collection for offline caching via a new job endpoint.
  * Originals, XMP sidecars (including uppercase .XMP) and companion files are copied into managed offline storage and served from cache when sources are missing.
  * Serving favors cached companion files when present.

* **Bug Fixes**
  * Empty, invalid, or non-cacheable requests are rejected with a clear error.

* **Tests**
  * Integration tests for caching, refresh behavior, and serving originals from cache.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->