### PR TITLE
[codex] Add Browse jump for miss photos

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -37,6 +37,7 @@ pub mod ids {
     pub const FILE_EXPORT_SELECTED: &str = "file_export_selected";
 
     pub const PHOTO_OPEN_LIGHTBOX: &str = "photo_open_lightbox";
+    pub const PHOTO_OPEN_BROWSE: &str = "photo_open_browse";
     pub const PHOTO_REVEAL: &str = "photo_reveal";
     pub const PHOTO_OPEN_EDITOR: &str = "photo_open_editor";
     pub const PHOTO_COPY_PATHS: &str = "photo_copy_paths";
@@ -117,6 +118,7 @@ pub fn command_for_id(id: &str) -> Option<&'static str> {
         ids::FILE_IMPORT_FOLDER => Some("import_folder"),
         ids::FILE_EXPORT_SELECTED => Some("export_selected"),
         ids::PHOTO_OPEN_LIGHTBOX => Some("photo_open_lightbox"),
+        ids::PHOTO_OPEN_BROWSE => Some("photo_open_browse"),
         ids::PHOTO_REVEAL => Some("photo_reveal"),
         ids::PHOTO_OPEN_EDITOR => Some("photo_open_editor"),
         ids::PHOTO_COPY_PATHS => Some("photo_copy_paths"),
@@ -363,6 +365,10 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
     let photo_menu = SubmenuBuilder::new(app, "Photo")
         .item(
             &MenuItemBuilder::with_id(ids::PHOTO_OPEN_LIGHTBOX, "Open in Lightbox")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::PHOTO_OPEN_BROWSE, "Open in Browse")
                 .build(app)?,
         )
         .item(

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -6,6 +6,8 @@ selection. Double-click opens the shared lightbox.
 """
 import time
 
+from playwright.sync_api import expect
+
 
 def _seed_misses(db, photo_ids, category="no_subject"):
     """Mark each given photo as a miss in the named category."""
@@ -444,3 +446,65 @@ def test_selection_bar_deletes_selected_misses_from_vireo(live_server, page):
     )
     assert db.get_photo(a) is None
     assert db.get_photo(b) is None
+
+
+def test_selection_bar_opens_selected_miss_in_browse(live_server, page):
+    url = live_server["url"]
+    db = live_server["db"]
+    pid = live_server["data"]["photos"][0]
+    _seed_misses(db, [pid], "no_subject")
+
+    page.goto(f"{url}/misses")
+    card = page.locator(f"[data-testid='miss-card-no_subject-{pid}']")
+    card.wait_for(state="visible", timeout=3000)
+    card.click()
+
+    btn = page.locator("#missesSelectionBrowseBtn")
+    expect(btn).to_be_enabled()
+    btn.click()
+
+    page.wait_for_function(
+        f"location.pathname === '/browse' && new URLSearchParams(location.search).get('photo_id') === '{pid}'",
+        timeout=5000,
+    )
+
+
+def test_misses_b_opens_focused_card_in_browse(live_server, page):
+    url = live_server["url"]
+    db = live_server["db"]
+    pid = live_server["data"]["photos"][0]
+    _seed_misses(db, [pid], "clipped")
+
+    page.goto(f"{url}/misses")
+    page.locator(f"[data-testid='miss-card-clipped-{pid}']").wait_for(
+        state="visible", timeout=3000,
+    )
+
+    page.keyboard.press("j")
+    page.keyboard.press("b")
+
+    page.wait_for_function(
+        f"location.pathname === '/browse' && new URLSearchParams(location.search).get('photo_id') === '{pid}'",
+        timeout=5000,
+    )
+
+
+def test_misses_context_menu_opens_card_in_browse(live_server, page):
+    url = live_server["url"]
+    db = live_server["db"]
+    pid = live_server["data"]["photos"][0]
+    _seed_misses(db, [pid], "oof")
+
+    page.goto(f"{url}/misses")
+    card = page.locator(f"[data-testid='miss-card-oof-{pid}']")
+    card.wait_for(state="visible", timeout=3000)
+    card.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    menu.locator(".vireo-ctx-item", has_text="Open in Browse").click()
+
+    page.wait_for_function(
+        f"location.pathname === '/browse' && new URLSearchParams(location.search).get('photo_id') === '{pid}'",
+        timeout=5000,
+    )

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4177,6 +4177,10 @@ function buildLightboxContextMenu(pid) {
   items.push(toggleItem('Lightbox controls', _lbChromeVisible, toggleLightboxChrome));
   items.push(toggleItem('Wildlife classification', !_lbCurrentWildlifeExcluded, lightboxToggleWildlifeExcluded));
   items.push({ separator: true });
+  items.push({ label: 'Open in Browse',
+    onClick: function() {
+      window.location.href = '/browse?photo_id=' + encodeURIComponent(pid);
+    } });
 
   if (has('findSimilar')) {
     items.push({ label: 'Find Similar',
@@ -5345,6 +5349,16 @@ function nativeMenuOpenLightbox() {
   nativeMenuError('Open in Lightbox is available from photo grids.');
 }
 
+function nativeMenuOpenBrowse() {
+  var ids = nativeMenuRequirePhotos('Open in Browse');
+  if (!ids) return;
+  if (ids.length !== 1) {
+    nativeMenuError('Open in Browse needs one selected photo.');
+    return;
+  }
+  nativeMenuRoute('/browse?photo_id=' + encodeURIComponent(ids[0]));
+}
+
 function nativeMenuPhotoIdsForWrite() {
   var ids = nativeMenuActivePhotoIds();
   if (ids.length) return ids;
@@ -5515,6 +5529,9 @@ window.handleNativeMenuCommand = async function(command) {
         break;
       case 'photo_open_lightbox':
         nativeMenuOpenLightbox();
+        break;
+      case 'photo_open_browse':
+        nativeMenuOpenBrowse();
         break;
       case 'photo_reveal': {
         var revealIds = nativeMenuRequirePhotos('Reveal in Finder');

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -388,6 +388,9 @@
 
   <div class="misses-selection-bar" id="missesSelectionBar">
     <span class="misses-selection-count" id="missesSelectionCount">0 selected</span>
+    <button class="misses-selection-btn" id="missesSelectionBrowseBtn" type="button" onclick="openSelectionInBrowse()">
+      Open in Browse
+    </button>
     <button class="misses-selection-btn" id="missesSelectionUnflagBtn" type="button" onclick="bulkUnflagSelection()">
       Unmark missed
     </button>
@@ -802,6 +805,7 @@ function render() {
       '<kbd>J</kbd>/<kbd>K</kbd> next/prev &middot; ' +
       '<kbd>Shift+J/K</kbd> extend selection &middot; ' +
       '<kbd>U</kbd>/<kbd>P</kbd>/<kbd>X</kbd> unflag/flag/reject (focused or selection) &middot; ' +
+      '<kbd>B</kbd> open focused in Browse &middot; ' +
       '<kbd>Esc</kbd> clear selection &middot; ' +
       'Click to select; Shift-click range; double-click to open lightbox' +
     '</div>';
@@ -924,6 +928,45 @@ function openMiss(cat, idx, e) {
   // true from a prior session would swallow the first click-to-zoom.
   window._lightboxZoomHandled = false;
   openLightbox(p.id, p.filename || '', photoList);
+}
+
+function getFocusedMiss() {
+  if (focusedCategory == null || focusedIndex < 0) return null;
+  return (missesData[focusedCategory] || [])[focusedIndex] || null;
+}
+
+function getActiveSelection() {
+  if (selection.size > 0) return Array.from(selection);
+  var focused = getFocusedMiss();
+  return focused ? [focused.id] : [];
+}
+
+function openPhotoInBrowse(photoId) {
+  photoId = parseInt(photoId, 10);
+  if (isNaN(photoId)) return;
+  window.location.href = '/browse?photo_id=' + encodeURIComponent(photoId);
+}
+
+function openSelectionInBrowse() {
+  var ids = getActiveSelection();
+  if (ids.length !== 1) return;
+  openPhotoInBrowse(ids[0]);
+}
+
+function openFocusedMissInBrowse() {
+  var focused = getFocusedMiss();
+  if (!focused) return;
+  openPhotoInBrowse(focused.id);
+}
+
+function openBrowseShortcutPhoto(fullscreen) {
+  var focused = getFocusedMiss();
+  if (!focused) return false;
+  openMiss(focusedCategory, focusedIndex);
+  if (fullscreen && typeof requestLightboxFullscreen === 'function') {
+    requestLightboxFullscreen();
+  }
+  return true;
 }
 
 /* Drop any selected ids that are no longer rendered in any category. Call
@@ -1137,6 +1180,8 @@ function updateSelectionBar() {
   countEl.textContent = n + ' selected';
   var unflagBtn = document.getElementById('missesSelectionUnflagBtn');
   if (unflagBtn) unflagBtn.disabled = previewActive;
+  var browseBtn = document.getElementById('missesSelectionBrowseBtn');
+  if (browseBtn) browseBtn.disabled = n !== 1;
 }
 
 function selectRangeWithinCategory(cat, fromIdx, toIdx) {
@@ -1186,6 +1231,42 @@ function onCardDoubleClick(cat, idx, e) {
   }
   openMiss(cat, idx, e);
 }
+
+function buildMissContextMenu(photoId, cat, idx) {
+  return [
+    { label: 'Open in Browse',
+      onClick: function() { openPhotoInBrowse(photoId); } },
+    { label: 'Open in Lightbox',
+      onClick: function() { openMiss(cat, idx); } },
+    { separator: true },
+    { label: 'Flag as Pick',
+      onClick: function() { flagFocusedMiss(photoId, 'flagged'); } },
+    { label: 'Reject Photo',
+      onClick: function() { flagFocusedMiss(photoId, 'rejected'); } },
+    { label: 'Unmark Missed', disabled: previewActive,
+      onClick: function() { unflagMiss(cat, photoId); } },
+  ];
+}
+
+document.addEventListener('contextmenu', function(e) {
+  var card = e.target.closest('.miss-card');
+  if (!card || !card.dataset.photoId) return;
+  if (e.target.closest('.vireo-ctx-menu')) return;
+  e.preventDefault();
+  e.stopPropagation();
+  var photoId = parseInt(card.dataset.photoId, 10);
+  var cat = card.dataset.cat;
+  var idx = parseInt(card.dataset.idx, 10);
+  if (isNaN(photoId) || !cat || isNaN(idx)) return;
+  setFocused(cat, idx);
+  if (!selection.has(photoId)) {
+    clearSelection();
+    setSelected(photoId, true);
+  }
+  if (typeof openContextMenu === 'function') {
+    openContextMenu(e, buildMissContextMenu(photoId, cat, idx));
+  }
+});
 
 function removePhotosFromMissesData(ids) {
   var deleted = new Set(ids);
@@ -1324,6 +1405,11 @@ document.addEventListener('keydown', function(e) {
     if (selection.size > 0) {
       e.preventDefault();
       clearSelection();
+    }
+  } else if (k === 'b' || k === 'B') {
+    if (!e.shiftKey && focusedCategory != null && focusedIndex >= 0) {
+      e.preventDefault();
+      openFocusedMissInBrowse();
     }
   } else if (k === 'Enter') {
     if (focusedCategory != null && focusedIndex >= 0) {


### PR DESCRIPTION
Adds ways to open a miss photo directly in Browse mode from the Misses page, the native Photo menu, and the shared lightbox context menu.
The Misses page now supports an Open in Browse selection action, a B shortcut for the focused card, and a right-click menu item that all deep-link to `/browse?photo_id=...`.
This reuses Browse's existing photo deep-link behavior so the target folder loads, scrolls, and highlights the photo.
Validated with `python -m pytest tests/e2e/test_misses_multi_select.py -q`, `python -m pytest tests/e2e/test_lightbox_context_menu.py -q`, and `git diff --check`; `cargo check` was blocked by the missing Tauri sidecar binary `src-tauri/binaries/vireo-server-aarch64-apple-darwin`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Open in Browse" action to misses selection bar and right-click context menu on miss cards
  * Added keyboard shortcut (B) to open focused miss in browse mode
  * Added "Open in Browse" option to photo lightbox context menu

* **Tests**
  * Added end-to-end tests verifying "Open in Browse" functionality across selection toolbar, keyboard shortcut, and context menu interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->