### PR TITLE
[codex] Add burst review right preview 1:1 zoom

### DIFF
--- a/tests/e2e/test_burst_group_natural_size.py
+++ b/tests/e2e/test_burst_group_natural_size.py
@@ -248,6 +248,59 @@ def test_burst_modal_resolution_and_right_zoom_controls(live_server, page, tmp_p
     assert abs(float(match.group(1)) - 2.0) < 0.01
 
 
+def test_burst_modal_z_toggles_right_preview_one_to_one(live_server, page, tmp_path):
+    """Z should put the right-hand burst preview into device-pixel 1:1."""
+    db = live_server["db"]
+    n = _seed_burst_with_real_photos(db, tmp_path)
+    if n < 1:
+        pytest.skip("could not seed burst group")
+    _ensure_photo_files_on_disk(db, tmp_path)
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    page.keyboard.press("z")
+    page.wait_for_function(
+        """() => {
+          const img = document.getElementById('grmLoupePhoto');
+          return document.getElementById('grmLoupeZoomVal').textContent === '1:1'
+            && img && img.complete && img.naturalWidth > 0;
+        }""",
+        timeout=5000,
+    )
+
+    metrics = page.evaluate(
+        """() => {
+          const img = document.getElementById('grmLoupePhoto');
+          const box = document.getElementById('grmLoupeImg').getBoundingClientRect();
+          const fitScale = Math.min(box.width / img.naturalWidth, box.height / img.naturalHeight);
+          const expected = Math.max(1, 1 / (fitScale * window.devicePixelRatio));
+          const match = /scale\\(([-0-9.]+)\\)/.exec(img.style.transform || '');
+          return {
+            expected,
+            actual: match ? parseFloat(match[1]) : null,
+            src: img.currentSrc || img.src,
+            label: document.getElementById('grmLoupeZoomVal').textContent,
+          };
+        }"""
+    )
+    assert metrics["actual"] is not None
+    assert metrics["label"] == "1:1"
+    assert "/original" in metrics["src"]
+    assert abs(metrics["actual"] - metrics["expected"]) < 0.02
+
+    page.keyboard.press("z")
+    page.wait_for_function(
+        """() => document.getElementById('grmLoupeZoomVal').textContent !== '1:1'"""
+    )
+    reset = page.locator("#grmLoupePhoto").evaluate("el => el.style.transform")
+    match = re.search(r"scale\(([-0-9.]+)\)", reset)
+    assert match, f"scale transform missing from {reset!r}"
+    assert abs(float(match.group(1)) - 1.0) < 0.01
+
+
 def test_burst_modal_scores_visible_box_sharpness(live_server, page, tmp_path):
     """Box sharpness scoring should render results without changing selection."""
     db = live_server["db"]

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1445,7 +1445,7 @@ input[type="range"]::-moz-range-thumb {
     </div>
     <div class="grm-loupe" id="grmLoupe">
       <div class="grm-loupe-img" id="grmLoupeImg" onmousemove="grmLoupeMove(event)" onmouseleave="grmLoupeReset()" onclick="grmLoupeToggleLock(event)" onwheel="grmLoupeZoom(event)">
-        <img id="grmLoupePhoto" alt="">
+        <img id="grmLoupePhoto" alt="" onload="grmLoupeImgLoaded(this)">
         <div class="grm-loupe-crosshair-h" id="grmCrosshairH"></div>
         <div class="grm-loupe-crosshair-v" id="grmCrosshairV"></div>
       </div>
@@ -1474,7 +1474,7 @@ input[type="range"]::-moz-range-thumb {
       <input type="range" id="grmLoupeZoomSlider" min="100" max="500" step="25" value="100" oninput="grmSetLoupeZoom(this.value)">
       <span id="grmLoupeZoomVal">1×</span>
     </div>
-    <span class="grm-hint" id="grmHint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
+    <span class="grm-hint" id="grmHint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Z = right 1:1 &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
     <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);" title="Apply pick/reject flag changes and species keywords, then close this burst.">Apply flags/species & Close</button>
   </div>
 </div>
@@ -1593,6 +1593,8 @@ function grmUpdateResLabel() {
 
 function grmSetResolution(idx) {
   grmResolutionIdx = parseInt(idx, 10) || 0;
+  _grmLoupePendingOneToOne = false;
+  _grmLoupeOneToOne = false;
   // Update card image sources AND natural-size layout in place. Preserving
   // the zoom transforms keeps the loupe locked on the current region while
   // the slider drags. Each card's <img> is laid out at the new served
@@ -1627,7 +1629,9 @@ function grmSetResolution(idx) {
 function grmSetLoupeZoom(value) {
   var pct = parseInt(value, 10);
   if (!pct) pct = 100;
-  pct = Math.max(100, Math.min(500, pct));
+  pct = Math.max(100, Math.min(_grmLoupeSliderMax(), pct));
+  _grmLoupePendingOneToOne = false;
+  _grmLoupeOneToOne = false;
   _grmLoupeZoomLevel = pct / 100;
   var slider = document.getElementById('grmLoupeZoomSlider');
   if (slider) slider.value = pct;
@@ -1643,6 +1647,108 @@ function grmApplyLoupeZoom() {
   var y = _grmLastHoverY == null ? 50 : _grmLastHoverY;
   img.style.transformOrigin = x + '% ' + y + '%';
   img.style.transform = 'scale(' + _grmLoupeZoomLevel + ')';
+}
+
+function _grmAfterLoupeSourceChange() {
+  if (_grmLoupeOneToOne || _grmLoupePendingOneToOne) {
+    _grmLoupeOneToOne = false;
+    _grmLoupePendingOneToOne = true;
+    _grmFinishLoupeOneToOne();
+  } else {
+    grmApplyLoupeZoom();
+  }
+}
+
+function _grmLoupeSliderMax() {
+  var slider = document.getElementById('grmLoupeZoomSlider');
+  var fromDom = slider ? parseInt(slider.max, 10) : 500;
+  return Math.max(500, fromDom || 500);
+}
+
+function _grmLoupeFitScale(img) {
+  var box = document.getElementById('grmLoupeImg');
+  if (!box || !img || !img.naturalWidth || !img.naturalHeight) return null;
+  var rect = box.getBoundingClientRect();
+  if (!rect.width || !rect.height) return null;
+  return Math.min(rect.width / img.naturalWidth, rect.height / img.naturalHeight);
+}
+
+function _grmLoupeNativeZoom(img) {
+  var fitScale = _grmLoupeFitScale(img);
+  if (!fitScale) return null;
+  return Math.max(1, 1 / (fitScale * (window.devicePixelRatio || 1)));
+}
+
+function _grmSetLoupeZoomLevel(zoom, labelText) {
+  _grmLoupeZoomLevel = Math.max(1, zoom || 1);
+  var pct = Math.round(_grmLoupeZoomLevel * 100);
+  var slider = document.getElementById('grmLoupeZoomSlider');
+  if (slider) {
+    slider.max = String(Math.max(500, pct));
+    slider.value = String(pct);
+  }
+  var label = document.getElementById('grmLoupeZoomVal');
+  if (label) {
+    label.textContent = labelText || _grmLoupeZoomLevel.toFixed(_grmLoupeZoomLevel >= 2 ? 1 : 2).replace(/\.0$/, '') + '×';
+  }
+  grmApplyLoupeZoom();
+}
+
+function _grmSetOriginalResolutionForLoupe() {
+  var lastIdx = GRM_RES_STOPS.length - 1;
+  if ((GRM_RES_STOPS[grmResolutionIdx] || {}).kind === 'original') return;
+  grmResolutionIdx = lastIdx;
+  var slider = document.getElementById('grmResSlider');
+  if (slider) slider.value = grmResolutionIdx;
+  document.querySelectorAll('#grmOverlay .grm-card').forEach(function(card) {
+    var pid = parseInt(card.getAttribute('data-photo-id'), 10);
+    if (!pid) return;
+    var img = card.querySelector('img');
+    if (!img) return;
+    var photo = grmState && grmState.items
+      ? grmState.items.find(function(p) { return p.id === pid; })
+      : null;
+    var nat = grmNaturalDims(photo);
+    card.dataset.natW = nat.w;
+    card.dataset.natH = nat.h;
+    img.style.width = nat.w + 'px';
+    img.style.height = nat.h + 'px';
+    img.src = grmPhotoUrl(pid);
+  });
+  if (grmState && grmState.selected) {
+    var loupe = document.getElementById('grmLoupePhoto');
+    if (loupe) loupe.src = grmPhotoUrl(grmState.selected);
+  }
+  grmApplyCardTransforms();
+  grmUpdateResLabel();
+}
+
+function grmLoupeImgLoaded(img) {
+  if (_grmLoupePendingOneToOne) {
+    _grmFinishLoupeOneToOne();
+  }
+}
+
+function grmToggleLoupeOneToOne() {
+  if (_grmLoupeOneToOne || _grmLoupePendingOneToOne) {
+    _grmLoupePendingOneToOne = false;
+    _grmLoupeOneToOne = false;
+    _grmSetLoupeZoomLevel(1);
+    return;
+  }
+  _grmLoupePendingOneToOne = true;
+  _grmSetOriginalResolutionForLoupe();
+  _grmFinishLoupeOneToOne();
+}
+
+function _grmFinishLoupeOneToOne() {
+  var img = document.getElementById('grmLoupePhoto');
+  if (!img || !img.complete || !img.naturalWidth || !img.naturalHeight) return;
+  var zoom = _grmLoupeNativeZoom(img);
+  if (zoom == null) return;
+  _grmLoupePendingOneToOne = false;
+  _grmLoupeOneToOne = true;
+  _grmSetLoupeZoomLevel(zoom, '1:1');
 }
 
 function setSpeciesFilter(val) {
@@ -3469,6 +3575,8 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   _grmLoupeLocked = false;
   _grmZoomMultiplier = 1;
   _grmLoupeZoomLevel = 1;
+  _grmLoupeOneToOne = false;
+  _grmLoupePendingOneToOne = false;
   _grmLastHoverX = null;
   _grmLastHoverY = null;
   _grmOffsets = {};
@@ -3870,7 +3978,7 @@ function grmSelect(photoId, mode) {
 
   if (grmState.selected) {
     loupeImg.src = grmPhotoUrl(grmState.selected);
-    grmApplyLoupeZoom();
+    _grmAfterLoupeSourceChange();
     var photo = grmState.items.find(function(p) { return p.id === grmState.selected; });
     if (photo) {
       var sharp = photo.subject_tenengrad != null ? Math.round(photo.subject_tenengrad) : '?';
@@ -3897,7 +4005,7 @@ function grmRefreshSelectedLoupe() {
 
   if (grmState.selected) {
     loupeImg.src = grmPhotoUrl(grmState.selected);
-    grmApplyLoupeZoom();
+    _grmAfterLoupeSourceChange();
     var photo = grmState.items.find(function(p) { return p.id === grmState.selected; });
     if (photo) {
       var sharp = photo.subject_tenengrad != null ? Math.round(photo.subject_tenengrad) : '?';
@@ -4031,6 +4139,8 @@ var GRM_THUMB_STORAGE_KEY = 'vireo.burstReviewThumbSize';
 
 var _grmZoomMultiplier = 1;   // wheel fine-tune on top of the 1:1 base scale
 var _grmLoupeZoomLevel = 1;
+var _grmLoupeOneToOne = false;
+var _grmLoupePendingOneToOne = false;
 var _grmLoupeLocked = false;
 var _grmLastHoverX = null;    // last cursor x% on the loupe (null = no hover yet)
 var _grmLastHoverY = null;
@@ -4573,6 +4683,7 @@ document.addEventListener('keydown', function(e) {
   }
   if (e.key === 'Delete' || e.key === 'Backspace') { grmRemoveFromGroup(); e.preventDefault(); return; }
   if (e.key === ' ') { grmMoveCandidate(); e.preventDefault(); return; }
+  if (e.key && e.key.toLowerCase() === 'z') { grmToggleLoupeOneToOne(); e.preventDefault(); return; }
   if (pipelineReviewBareKey(e, 'p')) { grmMovePick(); e.preventDefault(); return; }
   if (pipelineReviewBareKey(e, 'x')) { grmMoveReject(); e.preventDefault(); return; }
 });

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1593,8 +1593,14 @@ function grmUpdateResLabel() {
 
 function grmSetResolution(idx) {
   grmResolutionIdx = parseInt(idx, 10) || 0;
+  var wasOneToOne = _grmLoupeOneToOne || _grmLoupePendingOneToOne;
   _grmLoupePendingOneToOne = false;
   _grmLoupeOneToOne = false;
+  if (wasOneToOne) {
+    // Resolution change invalidates the prior 1:1 calculation; mirror the
+    // toggle-off path so the zoom label stops showing "1:1".
+    _grmSetLoupeZoomLevel(1);
+  }
   // Update card image sources AND natural-size layout in place. Preserving
   // the zoom transforms keeps the loupe locked on the current region while
   // the slider drags. Each card's <img> is laid out at the new served

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1520,6 +1520,8 @@ function openGroupReview(groupId, model) {
   _grmLoupeLastY = 50;
   _grmLoupeHovering = false;
   _grmPendingSnap = false;
+  _grmLoupeOneToOne = false;
+  _grmLoupePendingOneToOne = false;
   grmRefreshResetAllVisibility();
   document.getElementById('grmOverlay').classList.add('open');
   grmSetThumbSize(GRM_CARD_W, false);
@@ -1721,7 +1723,7 @@ function grmSelect(photoId, mode) {
   var loupePreds = document.getElementById('grmLoupePreds');
   if (grmState.selected) {
     loupeImg.src = grmLoupePhotoUrl(grmState.selected);
-    grmApplyLoupeZoom();
+    _grmAfterLoupeSourceChange();
     var item = grmState.items.find(function(it) { return it.photo_id === grmState.selected; });
     if (item) {
       var sharp = item.subject_sharpness != null ? Math.round(item.subject_sharpness) : (item.sharpness != null ? Math.round(item.sharpness) : '?');
@@ -1745,7 +1747,7 @@ function grmRefreshSelectedLoupe() {
   if (!loupeImg || !loupeInfo || !loupePreds) return;
   if (grmState.selected) {
     loupeImg.src = grmLoupePhotoUrl(grmState.selected);
-    grmApplyLoupeZoom();
+    _grmAfterLoupeSourceChange();
     var item = grmState.items.find(function(it) { return it.photo_id === grmState.selected; });
     if (item) {
       var sharp = item.subject_sharpness != null ? Math.round(item.subject_sharpness) : (item.sharpness != null ? Math.round(item.sharpness) : '?');
@@ -1823,6 +1825,8 @@ var GRM_RES_STOPS = [
 ];
 var grmResolutionIdx = 1;
 var _grmLoupeZoomLevel = 1;
+var _grmLoupeOneToOne = false;
+var _grmLoupePendingOneToOne = false;
 
 function _grmInitialThumbSize() {
   try {
@@ -1902,6 +1906,8 @@ function grmUpdateResLabel() {
 function grmSetResolution(idx) {
   grmResolutionIdx = parseInt(idx, 10) || 0;
   grmState.upgraded = (GRM_RES_STOPS[grmResolutionIdx] || {}).kind === 'original';
+  _grmLoupePendingOneToOne = false;
+  _grmLoupeOneToOne = false;
   var slider = document.getElementById('grmResSlider');
   if (slider) slider.value = grmResolutionIdx;
   document.querySelectorAll('.grm-card').forEach(function(card) {
@@ -1927,7 +1933,9 @@ function grmSetResolution(idx) {
 function grmSetLoupeZoom(value, persist) {
   var pct = parseInt(value, 10);
   if (!pct) pct = 100;
-  pct = Math.max(100, Math.min(500, pct));
+  pct = Math.max(100, Math.min(_grmLoupeSliderMax(), pct));
+  _grmLoupePendingOneToOne = false;
+  _grmLoupeOneToOne = false;
   _grmLoupeZoomLevel = pct / 100;
   var slider = document.getElementById('grmLoupeZoomSlider');
   if (slider) slider.value = pct;
@@ -1941,6 +1949,79 @@ function grmApplyLoupeZoom() {
   if (!img) return;
   img.style.transformOrigin = _grmLoupeLastX + '% ' + _grmLoupeLastY + '%';
   img.style.transform = 'scale(' + _grmLoupeZoomLevel + ')';
+}
+
+function _grmAfterLoupeSourceChange() {
+  if (_grmLoupeOneToOne || _grmLoupePendingOneToOne) {
+    _grmLoupeOneToOne = false;
+    _grmLoupePendingOneToOne = true;
+    _grmFinishLoupeOneToOne();
+  } else {
+    grmApplyLoupeZoom();
+  }
+}
+
+function _grmLoupeSliderMax() {
+  var slider = document.getElementById('grmLoupeZoomSlider');
+  var fromDom = slider ? parseInt(slider.max, 10) : 500;
+  return Math.max(500, fromDom || 500);
+}
+
+function _grmLoupeFitScale(img) {
+  var box = document.getElementById('grmLoupeImg');
+  if (!box || !img || !img.naturalWidth || !img.naturalHeight) return null;
+  var rect = box.getBoundingClientRect();
+  if (!rect.width || !rect.height) return null;
+  return Math.min(rect.width / img.naturalWidth, rect.height / img.naturalHeight);
+}
+
+function _grmLoupeNativeZoom(img) {
+  var fitScale = _grmLoupeFitScale(img);
+  if (!fitScale) return null;
+  return Math.max(1, 1 / (fitScale * (window.devicePixelRatio || 1)));
+}
+
+function _grmSetLoupeZoomLevel(zoom, labelText) {
+  _grmLoupeZoomLevel = Math.max(1, zoom || 1);
+  var pct = Math.round(_grmLoupeZoomLevel * 100);
+  var slider = document.getElementById('grmLoupeZoomSlider');
+  if (slider) {
+    slider.max = String(Math.max(500, pct));
+    slider.value = String(pct);
+  }
+  var label = document.getElementById('grmLoupeZoomVal');
+  if (label) {
+    label.textContent = labelText || _grmLoupeZoomLevel.toFixed(_grmLoupeZoomLevel >= 2 ? 1 : 2).replace(/\.0$/, '') + '×';
+  }
+  grmApplyLoupeZoom();
+}
+
+function grmLoupeImgLoaded(img) {
+  if (_grmLoupePendingOneToOne) {
+    _grmFinishLoupeOneToOne();
+  }
+}
+
+function grmToggleLoupeOneToOne() {
+  if (_grmLoupeOneToOne || _grmLoupePendingOneToOne) {
+    _grmLoupePendingOneToOne = false;
+    _grmLoupeOneToOne = false;
+    _grmSetLoupeZoomLevel(1);
+    return;
+  }
+  _grmLoupePendingOneToOne = true;
+  _grmUpgradeStripToOriginal();
+  _grmFinishLoupeOneToOne();
+}
+
+function _grmFinishLoupeOneToOne() {
+  var img = document.getElementById('grmLoupePhoto');
+  if (!img || !img.complete || !img.naturalWidth || !img.naturalHeight) return;
+  var zoom = _grmLoupeNativeZoom(img);
+  if (zoom == null) return;
+  _grmLoupePendingOneToOne = false;
+  _grmLoupeOneToOne = true;
+  _grmSetLoupeZoomLevel(zoom, '1:1');
 }
 
 function _grmUpgradeStripToOriginal() {
@@ -2508,6 +2589,7 @@ document.addEventListener('keydown', function(e) {
   if (e.key === 'Delete' || e.key === 'Backspace') { grmRemoveFromGroup(); e.preventDefault(); return; }
   if (e.key === ' ') { grmMoveCandidate(); e.preventDefault(); return; }
   if (e.key === '1') { grmSnapOneToOne(); e.preventDefault(); return; }
+  if (e.key && e.key.toLowerCase() === 'z') { grmToggleLoupeOneToOne(); e.preventDefault(); return; }
 });
 
 </script>
@@ -2536,7 +2618,7 @@ document.addEventListener('keydown', function(e) {
     </div>
     <div class="grm-loupe" id="grmLoupe">
       <div class="grm-loupe-img" id="grmLoupeImg" onmousemove="grmLoupeMove(event)" onmouseleave="grmLoupeReset()" onclick="grmLoupeToggleLock(event)" onwheel="grmLoupeZoom(event)">
-        <img id="grmLoupePhoto" src="" alt="">
+        <img id="grmLoupePhoto" src="" alt="" onload="grmLoupeImgLoaded(this)">
         <div class="grm-loupe-crosshair-h" id="grmCrosshairH"></div>
         <div class="grm-loupe-crosshair-v" id="grmCrosshairV"></div>
       </div>
@@ -2565,7 +2647,7 @@ document.addEventListener('keydown', function(e) {
       <input type="range" id="grmLoupeZoomSlider" min="100" max="500" step="25" value="100" oninput="grmSetLoupeZoom(this.value)">
       <span id="grmLoupeZoomVal">1×</span>
     </div>
-    <span class="grm-hint">↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; 1 = 1:1 zoom &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
+    <span class="grm-hint">↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Z = right 1:1 &nbsp; 1 = strip 1:1 &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
     <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;">Apply & Close</button>
   </div>
 </div>

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1906,8 +1906,14 @@ function grmUpdateResLabel() {
 function grmSetResolution(idx) {
   grmResolutionIdx = parseInt(idx, 10) || 0;
   grmState.upgraded = (GRM_RES_STOPS[grmResolutionIdx] || {}).kind === 'original';
+  var wasOneToOne = _grmLoupeOneToOne || _grmLoupePendingOneToOne;
   _grmLoupePendingOneToOne = false;
   _grmLoupeOneToOne = false;
+  if (wasOneToOne) {
+    // Resolution change invalidates the prior 1:1 calculation; mirror the
+    // toggle-off path so the zoom label stops showing "1:1".
+    _grmSetLoupeZoomLevel(1);
+  }
   var slider = document.getElementById('grmResSlider');
   if (slider) slider.value = grmResolutionIdx;
   document.querySelectorAll('.grm-card').forEach(function(card) {


### PR DESCRIPTION
Adds a `z` shortcut in burst review modals to toggle the right-hand preview between fit and true device-pixel 1:1 zoom. The zoom path upgrades to the original source, waits for the selected preview image to decode, and recomputes when the selected photo changes; both `/review` and pipeline review burst modals show the updated hint. Adds an e2e regression test for the right-preview 1:1 behavior, including source upgrade and reset. Validated with `pytest tests/e2e/test_burst_group_natural_size.py -q` and `pytest tests/e2e/test_pipeline_review_species.py tests/e2e/test_page_loads.py -q`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 1:1 zoom mode for the right loupe in group review (toggle with Z). Uses the original image when active, clamps wheel/slider to allowable max, and defers/finalizes 1:1 via a pending → finished load flow. Mode resets when switching photos or reopening the modal. UI help text updated to include the Z shortcut.

* **Tests**
  * Added end-to-end test validating the 1:1 toggle, image source, and transform scaling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->