### PR TITLE
Pipeline concurrency: foundation (ModelCache, GPU + regroup locks)

### DIFF
--- a/docs/plans/2026-05-26-pipeline-concurrency-design.md
+++ b/docs/plans/2026-05-26-pipeline-concurrency-design.md
@@ -1,0 +1,156 @@
+# Pipeline concurrency + queue — design
+
+**Date:** 2026-05-26
+**Branch:** pipeline-concurrency-regression
+**Status:** design agreed, awaiting implementation plan
+
+## Goal
+
+Replace today's hard "one pipeline at a time" UI lock with a resource-aware concurrency model: up to two pipelines execute at once, an unbounded FIFO queue holds the rest, and stages of the running pipelines overlap on whichever resources are free. The user can pile up many imports and walk away.
+
+## Motivation
+
+Today: the Start button is disabled with "A pipeline is running…" while another is active (`pipeline.html:2215–2223`). Lock is JS-only, doesn't survive page reload, doesn't see other tabs.
+
+The lock was introduced in commit `03d23a39` (2026-03-28, pipeline page redesign). It exists for real reasons — concurrent GPU sessions OOM, regroup races on workspace state, the UI can't render two pipelines at once. But it overshoots: stages have *different* resource profiles, and one pipeline's classify leaves disk I/O and CPU cores idle. A second pipeline's scan / thumbnails / previews could fill that gap.
+
+The win is bounded — `pipeline_job.py` already overlaps stages internally via queues, so one pipeline already saturates its bottleneck resource. The marginal gain from a second is the overlap of *one pipeline's GPU phase with another pipeline's I/O/CPU phase*, not a 2× speedup. Worth doing for the babysit-the-machine UX win as much as for the throughput.
+
+## Concurrency model
+
+**Two execution slots, unbounded queue.** Up to two pipelines run concurrently; the rest sit in a FIFO queue and start as slots open. Picked over per-resource-only gating because the third pipeline can't do useful work (it'd just queue on the GPU lock), and capping at 2 makes UI and cancellation reasoning much simpler.
+
+**Single GPU semaphore (size 1), released between batches.** Every GPU-using stage (`classify`, `detect`, `eye_keypoints`, `extract_masks`) wraps its per-batch inference call in `with gpu_lock:`. Two GPU stages never run simultaneously; B's scan / thumbnails / previews / regroup run free while A holds the GPU lock for a batch. Lock is released between batches so A's 10-minute classify doesn't completely block B — they alternate at batch granularity.
+
+**Per-workspace regroup lock.** A `workspace_regroup_locks: dict[int, threading.Lock]` acquired by the regroup stage. Two pipelines targeting the same workspace can run every stage concurrently except regroup, which serialises. This is the only stage in the existing code that genuinely races on workspace-scoped state.
+
+**Lock order (write down to prevent deadlocks):**
+1. `_progress_lock` (outermost)
+2. `JobRunner._lock`
+3. `workspace_regroup_locks[ws]`
+4. `gpu_lock` (innermost)
+
+## Shared model cache
+
+Today `loaded_models` lives inside one pipeline job's stack. Two pipelines = two ONNX session loads of the same file = 2× VRAM. Fix: a process-wide `ModelCache` singleton.
+
+**Lifecycle:** refcounted with idle eviction.
+
+- `cache.acquire(model_id, variant)` returns a context-manager handle; refcount++ on enter, refcount-- on exit.
+- When refcount hits 0, a 5-minute `threading.Timer` is armed. If nothing reacquires before it fires, the session is closed and VRAM freed. Subsequent `acquire` cancels the pending timer.
+- Keyed by `(model_id, variant)`. Different models / variants are independent entries.
+
+Independently useful: rapid re-runs (queue 5 imports back-to-back) pay the model load cost once instead of five times.
+
+## Persistence
+
+**Queued pipelines persist in the existing `job_history` table** with `status='queued'`. No new table.
+
+- `job_history.config` (JSON column, already exists per `vireo/jobs.py:47`) holds the full POST body that was sent to `/api/pipeline/start`.
+- Job IDs are generated at *enqueue* time (`f"pipeline-{int(time.time() * 1000)}"`) and carry through to running and terminal states. One ID per logical run.
+- Pruning by `_JOB_RETENTION_SECS` already keys on `finished_at`, so queued rows are not at risk.
+
+**Startup sweep** in `JobRunner.__init__`:
+- Any `status='running'` rows from before this process started → mark `'failed'` with an "interrupted by restart" message (their threads are gone).
+- Any `status='queued'` rows → the scheduler picks them up naturally as slots open.
+
+## Queue at enqueue time
+
+What's frozen per queued entry:
+
+- Full POST body (`sources`, `destination`, `file_types`, `model_ids`, `recursive`, `skip_*` toggles, etc.) snapshotted into `config`.
+- Resolved `workspace_id`. If the user requested `_destWorkspaceMode === 'new'`, the workspace is **created eagerly at enqueue time** (not at execution time). The new workspace's ID is what's stored. Reason: name-collision errors should surface immediately, not 20 minutes later when the slot opens.
+- Models referenced by ID only. Deleted/missing model at execution time → fails fast in the existing `model_loader` stage with the same error as today.
+
+The user can change UI settings freely after enqueueing; the queued run is unaffected.
+
+## Scheduler
+
+Event-driven, with a startup sweep as the fallback path.
+
+- After any pipeline reaches a terminal state (`completed` | `failed` | `cancelled`), the runner checks: if `active_pipeline_count < 2`, attempt to promote the oldest `status='queued'` row.
+- Promotion is a conditional UPDATE: `UPDATE job_history SET status='running' WHERE id=? AND status='queued'`. If `rowcount == 1`, spawn the worker thread with the persisted `config`. If `rowcount == 0` (because Cancel landed first), quietly move to the next candidate.
+- Same event also fires on enqueue when a slot is free (covers the "queue is empty and a new run comes in" path).
+- On startup, the same promotion loop runs once to drain queued rows up to the slot cap.
+
+## `POST /api/pipeline/start` becomes a thin wrapper
+
+Same request/response shape as today, but two paths:
+
+```python
+def api_pipeline_start():
+    params = build_params(request.json)
+    if active_pipeline_count() < SLOT_CAP:
+        job_id = enqueue_and_promote_immediately(params)
+    else:
+        job_id = enqueue_only(params)
+    return jsonify(job_id=job_id, queued=(status_is_queued))
+```
+
+Clients don't have to care which happened — the SSE stream at `/api/jobs/<id>/stream` already emits events whenever the job starts, including from `queued` → `running` transition.
+
+## UI
+
+**Pipeline page** (`pipeline.html`):
+
+- `_pipelineRunning` JS guard is removed. The Start button is no longer disabled because a pipeline is running.
+- Button label flips based on backend state: `"Start Pipeline"` when a slot is free now, `"Queue Pipeline"` when both slots are full.
+- A small status line near the button: `"2 running • 3 queued — see Jobs"` (link to `/jobs`). Hidden when nothing is running and queue is empty.
+- The main pills + progress area shows "this tab's most recently launched run." If this tab hasn't launched one this session, fall back to the most recently started run.
+- Currently-shown run on this tab is tracked by JS variable (`_focusedJobId`). Tab-local; tabs don't fight each other.
+
+**Jobs page** (`/jobs`):
+
+- Add `'queued'` to the status filter and the list renderer (new dot color / label).
+- Each queued row gets a **Cancel** button (action: `UPDATE job_history SET status='cancelled', finished_at=? WHERE id=? AND status='queued'`).
+- New **"Cancel all queued"** button at the top of the list when ≥1 queued row exists. One UPDATE statement, one button.
+- Detail pane for a queued row shows the persisted `config` blob in a readable form (sources, destination, model IDs, toggles).
+
+**No new "queue strip" inline on the pipeline page.** The existing `/jobs` page already has the list/detail layout for this. The pipeline page just shows the count and links over.
+
+## Cancellation
+
+1. **Stop a running pipeline** — same as today. Abort event set, worker drains, run finishes with `status='cancelled'`. **No effect on queued runs.** Independent configurations; cancelling one says nothing about the others.
+
+2. **Cancel a queued pipeline** — atomic `UPDATE` on the row. No thread to interrupt. Row stays in history with empty progress/steps as the tell.
+
+3. **Running pipeline fails** — same: queued runs continue, next one starts as the slot opens. The user gets the existing failure toast. No "pause queue on failure" mode.
+
+4. **Cancel all queued** — bulk UPDATE. Does not affect running pipelines.
+
+5. **Promotion race** — solved by the conditional UPDATE described above. A Cancel click that lands between "scheduler picks this row" and "thread spawns" wins because the UPDATE matches zero rows.
+
+## Edge cases
+
+- **Same source path on both running pipelines.** Both scanners insert by hash; SQLite serialises, dedupe is idempotent. Wasted I/O but no corruption.
+- **Same destination directory.** Two pipelines copying into the same folder template can produce filename collisions. The existing ingest code's collision handling already covers this (rename-on-collision); we don't add new logic. *Risk note:* the user should avoid this on purpose, but we don't block it.
+- **Both pipelines hit `model_loader` at once.** The `ModelCache` handles this — second `acquire` sees the loaded session, refcount goes to 2.
+- **Cap of 2 + many queued + heavy classify.** Queued rows pile up in `job_history` until consumed. The "Cancel all queued" escape hatch covers user regret.
+
+## Non-goals
+
+- Configurable slot cap (it's `SLOT_CAP = 2`, a module constant — bumpable later if measurement supports it).
+- Reordering queued rows. FIFO only.
+- Pausing the queue without cancelling.
+- Cross-workspace prioritisation, fairness, or scheduling beyond FIFO.
+- Touching `/api/jobs/scan`, `/api/jobs/classify`, etc. — standalone non-pipeline jobs remain unchanged.
+
+## Risks / open implementation questions for the plan
+
+- **Hoisting `loaded_models` out of `pipeline_job.py`.** The existing structure deeply assumes per-job-stack model dicts. The cache rewrite is the largest piece of work in this design; everything else is glue.
+- **GPU lock granularity.** "Per-batch" is the right shape but each GPU stage in `pipeline_job.py` has slightly different batch loops. The plan needs to identify the precise wrap points stage-by-stage and verify none of them hold the lock across long Python work.
+- **Workspace switching UX while two pipelines run on different workspaces.** Today the navbar shows the active workspace; the page renders that workspace's state. We're not solving multi-workspace UI in this design — both pipelines may run regardless of which workspace the user is currently viewing, but the pipeline page's "this tab's run" focus may show a run that's against a workspace the user isn't currently in. Probably fine, but worth a smoke test.
+- **Tests.** Concurrency is hard to test deterministically. Plan should include: a unit test of the `ModelCache` lifecycle (acquire, release, idle eviction, race), an integration test of "start two pipelines, cancel one, second completes," and a startup-sweep test (queued rows persisted, run picks them up).
+
+## Order of implementation
+
+The plan should sequence work so each step is independently testable and useful:
+
+1. **`ModelCache`** with refcounted acquire/release and idle eviction. Land standalone; one pipeline at a time still works, just with shared cached models.
+2. **GPU semaphore** wrapped around each GPU stage's per-batch loop. Still one pipeline at a time — no behaviour change, just adds the lock that will gate concurrent pipelines later.
+3. **Per-workspace regroup lock.** Same — added but not yet exercised concurrently.
+4. **Server-side queue.** Status `'queued'`, scheduler, conditional promotion, startup sweep. `POST /api/pipeline/start` becomes wrapper. Slot cap still effectively 1 (UI still disables Start).
+5. **UI changes.** Remove `_pipelineRunning` guard, flip button label, add "N running • M queued" indicator, add Cancel / Cancel-all on `/jobs`, add `'queued'` to status filter.
+6. **Lift SLOT_CAP from 1 to 2.** The actual switch-on. Everything above must be stable first.
+
+Each step lands as its own PR. Steps 1–3 ship in any order before step 4. Steps 5 and 6 can land together or separately.

--- a/vireo/classifier.py
+++ b/vireo/classifier.py
@@ -252,8 +252,16 @@ def _run_text_batched(text_session, text_input_name, tokens, model_dir=None):
     races) are passed through unchanged so a transient runtime error
     can't permanently flag a healthy install for Repair.
     """
+    # Serialise GPU access across concurrent pipelines: when two pipelines
+    # load BioCLIP with different label fingerprints, both factories run
+    # concurrently under the cache's load_lock-per-key, and each one
+    # computes its own label embeddings here. Without this lock, both
+    # text encoders run on the GPU at the same time and can OOM.
+    # Skipped for CPU-only sessions (same rationale as image_session).
+    from pipeline_locks import acquire_gpu_if_session_uses_it
     try:
-        return text_session.run(None, {text_input_name: tokens})[0]
+        with acquire_gpu_if_session_uses_it(text_session):
+            return text_session.run(None, {text_input_name: tokens})[0]
     except Exception as e:
         if not _looks_like_stale_batched_export(e):
             raise
@@ -609,7 +617,7 @@ class Classifier:
             numpy float32 array of shape (1, embedding_dim) -- normalized
         """
         from PIL import Image as PILImage
-        from pipeline_locks import acquire_gpu
+        from pipeline_locks import acquire_gpu_if_session_uses_it
 
         if isinstance(image, (str, os.PathLike)):
             with PILImage.open(image) as img:
@@ -620,8 +628,13 @@ class Classifier:
         # GPU serialisation across concurrent pipelines, scoped tightly to
         # the forward pass. Preprocessing above (load/decode/resize) and the
         # normalisation below run without the lock so concurrent pipelines
-        # can use the GPU while this one does CPU work.
-        with acquire_gpu():
+        # can use the GPU while this one does CPU work. Skipped entirely
+        # for CPU-only sessions — Apple Silicon excludes CoreML when an
+        # external-data ONNX is present, and CPU-only installs likewise
+        # report no GPU provider; taking the semaphore there would block
+        # real GPU stages in other pipelines for work that never touches
+        # the GPU.
+        with acquire_gpu_if_session_uses_it(self._image_session):
             features = self._image_session.run(
                 None, {self._image_input_name: input_arr}
             )[0]

--- a/vireo/classifier.py
+++ b/vireo/classifier.py
@@ -609,6 +609,7 @@ class Classifier:
             numpy float32 array of shape (1, embedding_dim) -- normalized
         """
         from PIL import Image as PILImage
+        from pipeline_locks import acquire_gpu
 
         if isinstance(image, (str, os.PathLike)):
             with PILImage.open(image) as img:
@@ -616,9 +617,14 @@ class Classifier:
         else:
             input_arr = self._preprocess(image)
 
-        features = self._image_session.run(
-            None, {self._image_input_name: input_arr}
-        )[0]
+        # GPU serialisation across concurrent pipelines, scoped tightly to
+        # the forward pass. Preprocessing above (load/decode/resize) and the
+        # normalisation below run without the lock so concurrent pipelines
+        # can use the GPU while this one does CPU work.
+        with acquire_gpu():
+            features = self._image_session.run(
+                None, {self._image_input_name: input_arr}
+            )[0]
         features = features.astype(np.float32)
         return _normalize(features)
 

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -740,31 +740,38 @@ def _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=1):
     """
     from datetime import datetime as dt
 
+    from pipeline_locks import acquire_gpu
+
     images = [entry["img"] for entry in batch]
     failed = 0
 
     try:
-        try:
-            if model_type == "timm":
-                batch_preds = clf.classify_batch(images, threshold=0)
-                batch_results = [(preds, None) for preds in batch_preds]
-            else:
-                batch_results = clf.classify_batch_with_embedding(images, threshold=0)
-        except Exception:
-            log.warning("Batch classification failed, falling back to single-image", exc_info=True)
-            batch_results = []
-            for entry in batch:
-                try:
-                    if model_type == "timm":
-                        preds = clf.classify(entry["img"], threshold=0)
-                        batch_results.append((preds, None))
-                    else:
-                        preds, emb = clf.classify_with_embedding(entry["img"], threshold=0)
-                        batch_results.append((preds, emb))
-                except Exception:
-                    log.warning("Classification failed for %s", entry["photo"]["filename"], exc_info=True)
-                    batch_results.append(None)
-                    failed += 1
+        # Serialise GPU inference across concurrent pipelines. Scoped to the
+        # forward passes only — the DB upserts and result-building below run
+        # without the lock so another pipeline can use the GPU while this
+        # one persists predictions/embeddings.
+        with acquire_gpu():
+            try:
+                if model_type == "timm":
+                    batch_preds = clf.classify_batch(images, threshold=0)
+                    batch_results = [(preds, None) for preds in batch_preds]
+                else:
+                    batch_results = clf.classify_batch_with_embedding(images, threshold=0)
+            except Exception:
+                log.warning("Batch classification failed, falling back to single-image", exc_info=True)
+                batch_results = []
+                for entry in batch:
+                    try:
+                        if model_type == "timm":
+                            preds = clf.classify(entry["img"], threshold=0)
+                            batch_results.append((preds, None))
+                        else:
+                            preds, emb = clf.classify_with_embedding(entry["img"], threshold=0)
+                            batch_results.append((preds, emb))
+                    except Exception:
+                        log.warning("Classification failed for %s", entry["photo"]["filename"], exc_info=True)
+                        batch_results.append(None)
+                        failed += 1
 
         for entry, result in zip(batch, batch_results, strict=True):
             if result is None:

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -740,38 +740,36 @@ def _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=1):
     """
     from datetime import datetime as dt
 
-    from pipeline_locks import acquire_gpu
-
     images = [entry["img"] for entry in batch]
     failed = 0
 
     try:
-        # Serialise GPU inference across concurrent pipelines. Scoped to the
-        # forward passes only — the DB upserts and result-building below run
-        # without the lock so another pipeline can use the GPU while this
-        # one persists predictions/embeddings.
-        with acquire_gpu():
-            try:
-                if model_type == "timm":
-                    batch_preds = clf.classify_batch(images, threshold=0)
-                    batch_results = [(preds, None) for preds in batch_preds]
-                else:
-                    batch_results = clf.classify_batch_with_embedding(images, threshold=0)
-            except Exception:
-                log.warning("Batch classification failed, falling back to single-image", exc_info=True)
-                batch_results = []
-                for entry in batch:
-                    try:
-                        if model_type == "timm":
-                            preds = clf.classify(entry["img"], threshold=0)
-                            batch_results.append((preds, None))
-                        else:
-                            preds, emb = clf.classify_with_embedding(entry["img"], threshold=0)
-                            batch_results.append((preds, emb))
-                    except Exception:
-                        log.warning("Classification failed for %s", entry["photo"]["filename"], exc_info=True)
-                        batch_results.append(None)
-                        failed += 1
+        # GPU serialisation across concurrent pipelines lives inside the
+        # classifier helpers (around the ``session.run`` calls), so this
+        # path holds no process-wide lock around preprocessing, DB upserts,
+        # or result-building. See ``Classifier._get_image_embedding`` and
+        # ``TimmClassifier.classify[_batch]``.
+        try:
+            if model_type == "timm":
+                batch_preds = clf.classify_batch(images, threshold=0)
+                batch_results = [(preds, None) for preds in batch_preds]
+            else:
+                batch_results = clf.classify_batch_with_embedding(images, threshold=0)
+        except Exception:
+            log.warning("Batch classification failed, falling back to single-image", exc_info=True)
+            batch_results = []
+            for entry in batch:
+                try:
+                    if model_type == "timm":
+                        preds = clf.classify(entry["img"], threshold=0)
+                        batch_results.append((preds, None))
+                    else:
+                        preds, emb = clf.classify_with_embedding(entry["img"], threshold=0)
+                        batch_results.append((preds, emb))
+                except Exception:
+                    log.warning("Classification failed for %s", entry["photo"]["filename"], exc_info=True)
+                    batch_results.append(None)
+                    failed += 1
 
         for entry, result in zip(batch, batch_results, strict=True):
             if result is None:

--- a/vireo/detector.py
+++ b/vireo/detector.py
@@ -336,7 +336,12 @@ def detect_animals(image_path):
         input_tensor, preprocess_info = _preprocess(img_array)
 
         input_name = session.get_inputs()[0].name
-        outputs = session.run(None, {input_name: input_tensor})
+        # Hold the GPU semaphore for the inference call only, not for image
+        # I/O, decoding, or postprocessing. Holding it wider would block
+        # other pipelines' GPU stages on this pipeline's CPU/disk work.
+        from pipeline_locks import acquire_gpu
+        with acquire_gpu():
+            outputs = session.run(None, {input_name: input_tensor})
 
         return _postprocess(outputs, preprocess_info, RAW_CONF_FLOOR)
     except Exception:

--- a/vireo/detector.py
+++ b/vireo/detector.py
@@ -339,8 +339,12 @@ def detect_animals(image_path):
         # Hold the GPU semaphore for the inference call only, not for image
         # I/O, decoding, or postprocessing. Holding it wider would block
         # other pipelines' GPU stages on this pipeline's CPU/disk work.
-        from pipeline_locks import acquire_gpu
-        with acquire_gpu():
+        # Skipped entirely for CPU-only sessions — on Apple Silicon the
+        # MegaDetector external-data ONNX excludes CoreML and runs on the
+        # CPU; SAM2/DINO may still be on CoreML in the same process, and
+        # blocking them on detector CPU work would defeat concurrency.
+        from pipeline_locks import acquire_gpu_if_session_uses_it
+        with acquire_gpu_if_session_uses_it(session):
             outputs = session.run(None, {input_name: input_tensor})
 
         return _postprocess(outputs, preprocess_info, RAW_CONF_FLOOR)

--- a/vireo/dino_embed.py
+++ b/vireo/dino_embed.py
@@ -357,12 +357,42 @@ def embed_batch(images, variant="vit-b14"):
     # the forward pass. Preprocessing above (resize/normalize per image)
     # runs without the lock so concurrent pipelines aren't blocked on
     # CPU work.
-    from pipeline_locks import acquire_gpu
+    #
+    # Skip the GPU semaphore when the session is CPU-only — on Apple
+    # Silicon with external-data models (CoreML excluded — see
+    # ``onnx_runtime.create_session``) and on CPU-only installs, DINO
+    # runs on the CPU. Taking the process-wide GPU lock there would
+    # needlessly block concurrent detector/classifier/SAM batches that
+    # *do* use the GPU, defeating the concurrency this design enables.
     input_name = session.get_inputs()[0].name
-    with acquire_gpu():
+    if _session_uses_gpu(session):
+        from pipeline_locks import acquire_gpu
+        with acquire_gpu():
+            outputs = session.run(None, {input_name: batch})
+    else:
         outputs = session.run(None, {input_name: batch})
 
     return outputs[0].astype(np.float32)
+
+
+_GPU_PROVIDERS = ("CUDAExecutionProvider", "CoreMLExecutionProvider")
+
+
+def _session_uses_gpu(session):
+    """Return True if ``session`` is actually executing on a GPU provider.
+
+    ``InferenceSession.get_providers()`` returns the providers ONNX
+    Runtime decided to use after construction, so this reflects reality
+    even when CoreML was requested but excluded (e.g. for external-data
+    models). Falls back to ``True`` if the session doesn't expose
+    ``get_providers`` — the conservative default that matches prior
+    behavior.
+    """
+    try:
+        providers = session.get_providers()
+    except Exception:
+        return True
+    return any(p in _GPU_PROVIDERS for p in providers)
 
 
 def embed_subject(crop_image, variant="vit-b14"):

--- a/vireo/dino_embed.py
+++ b/vireo/dino_embed.py
@@ -41,6 +41,14 @@ _session = None
 _variant_loaded = None
 
 _dinov2_download_lock = threading.Lock()
+# Serialises first-load and variant-swap in _get_dinov2_session. Without
+# this, two concurrent pipelines reaching their first DINO inference at
+# the same time can both pass the `_session is None` check, both call
+# onnx_runtime.create_session(), and overwrite each other in the module
+# globals — leaving a duplicate ONNX session pinning VRAM and defeating
+# the shared-session guarantee that ModelCache + acquire_gpu provide for
+# the inference path itself.
+_dinov2_session_lock = threading.Lock()
 
 
 def _dinov2_model_path(variant):
@@ -266,26 +274,34 @@ def _get_dinov2_session(variant="vit-b14"):
             f"Choose from: {list(DINOV2_VARIANTS.keys())}"
         )
 
-    model_dir = os.path.join(
-        os.path.expanduser("~"), ".vireo", "models", f"dinov2-{variant}"
-    )
-    model_path = os.path.join(model_dir, "model.onnx")
+    # Double-checked locking: the fast path above avoids taking the lock
+    # on the steady-state cache hit. The slow path here serialises first
+    # load and variant-swap so two concurrent acquirers don't both create
+    # an ONNX session and leak the loser into VRAM.
+    with _dinov2_session_lock:
+        if _session is not None and _variant_loaded == variant:
+            return _session
 
-    if not os.path.isfile(model_path):
-        raise FileNotFoundError(
-            f"DINOv2 ONNX model not found at {model_path}. "
-            f"Download it first via the models page."
+        model_dir = os.path.join(
+            os.path.expanduser("~"), ".vireo", "models", f"dinov2-{variant}"
         )
+        model_path = os.path.join(model_dir, "model.onnx")
 
-    log.info("Loading DINOv2 ONNX (%s)...", variant)
-    sess = onnx_runtime.create_session(model_path)
+        if not os.path.isfile(model_path):
+            raise FileNotFoundError(
+                f"DINOv2 ONNX model not found at {model_path}. "
+                f"Download it first via the models page."
+            )
 
-    _session = sess
-    _variant_loaded = variant
-    log.info(
-        "DINOv2 ONNX loaded (%s, %d-dim)", variant, DINOV2_VARIANTS[variant]
-    )
-    return sess
+        log.info("Loading DINOv2 ONNX (%s)...", variant)
+        sess = onnx_runtime.create_session(model_path)
+
+        _session = sess
+        _variant_loaded = variant
+        log.info(
+            "DINOv2 ONNX loaded (%s, %d-dim)", variant, DINOV2_VARIANTS[variant]
+        )
+        return sess
 
 
 def embed(image, variant="vit-b14"):

--- a/vireo/dino_embed.py
+++ b/vireo/dino_embed.py
@@ -337,8 +337,14 @@ def embed_batch(images, variant="vit-b14"):
     ]
     batch = np.concatenate(tensors, axis=0)
 
+    # GPU serialisation across concurrent pipelines, scoped tightly to
+    # the forward pass. Preprocessing above (resize/normalize per image)
+    # runs without the lock so concurrent pipelines aren't blocked on
+    # CPU work.
+    from pipeline_locks import acquire_gpu
     input_name = session.get_inputs()[0].name
-    outputs = session.run(None, {input_name: batch})
+    with acquire_gpu():
+        outputs = session.run(None, {input_name: batch})
 
     return outputs[0].astype(np.float32)
 

--- a/vireo/keypoints.py
+++ b/vireo/keypoints.py
@@ -268,7 +268,13 @@ def detect_keypoints(image, bbox, model_name):
     arr = arr[np.newaxis, :, :, :]
 
     session = _load_session(model_name)
-    outputs = session.run(None, {"pixel_values": arr})
+    # Serialise GPU access across concurrent pipelines. Per-photo
+    # granularity (one inference call per detect_keypoints invocation) is
+    # the right size — release between calls lets another pipeline
+    # interleave its own GPU work.
+    from pipeline_locks import acquire_gpu
+    with acquire_gpu():
+        outputs = session.run(None, {"pixel_values": arr})
 
     output_type = cfg.get("output_type", "heatmap")
     if output_type == "simcc":

--- a/vireo/keypoints.py
+++ b/vireo/keypoints.py
@@ -268,13 +268,11 @@ def detect_keypoints(image, bbox, model_name):
     arr = arr[np.newaxis, :, :, :]
 
     session = _load_session(model_name)
-    # Serialise GPU access across concurrent pipelines. Per-photo
-    # granularity (one inference call per detect_keypoints invocation) is
-    # the right size — release between calls lets another pipeline
-    # interleave its own GPU work.
-    from pipeline_locks import acquire_gpu
-    with acquire_gpu():
-        outputs = session.run(None, {"pixel_values": arr})
+    # NOTE: no acquire_gpu() here. The keypoints session is hardcoded
+    # to CPUExecutionProvider (see _load_session). Wrapping the call in
+    # the GPU semaphore would needlessly block real GPU stages in
+    # concurrent pipelines for work that doesn't touch the GPU.
+    outputs = session.run(None, {"pixel_values": arr})
 
     output_type = cfg.get("output_type", "heatmap")
     if output_type == "simcc":

--- a/vireo/masking.py
+++ b/vireo/masking.py
@@ -259,8 +259,14 @@ def generate_mask(image, detection_box, variant="sam2-small"):
             std=_IMAGENET_STD,
         )
 
+        # GPU serialisation across concurrent pipelines, scoped tightly
+        # to the encoder forward pass — preprocessing above and
+        # postprocessing/decoder setup below run without holding the
+        # semaphore so another pipeline's GPU op can interleave.
+        from pipeline_locks import acquire_gpu
         enc_input_name = encoder_session.get_inputs()[0].name
-        enc_outputs = encoder_session.run(None, {enc_input_name: input_tensor})
+        with acquire_gpu():
+            enc_outputs = encoder_session.run(None, {enc_input_name: input_tensor})
         image_embeddings = enc_outputs[0]  # (1, C, H', W')
         # Encoder also outputs high-res FPN features for the mask decoder
         high_res_feat_0 = enc_outputs[1] if len(enc_outputs) > 1 else None
@@ -310,7 +316,8 @@ def generate_mask(image, detection_box, variant="sam2-small"):
             if name in input_map:
                 decoder_inputs[name] = input_map[name]
 
-        dec_outputs = decoder_session.run(None, decoder_inputs)
+        with acquire_gpu():
+            dec_outputs = decoder_session.run(None, decoder_inputs)
         # Outputs: masks (1, N, H, W) and scores (1, N)
         masks = dec_outputs[0]  # (1, N, H, W)
         scores = dec_outputs[1]  # (1, N)

--- a/vireo/model_cache.py
+++ b/vireo/model_cache.py
@@ -25,11 +25,17 @@ log = logging.getLogger(__name__)
 
 class _Entry:
     __slots__ = (
-        "load_lock", "value", "refcount", "idle_timer", "evict_token",
+        "key", "load_lock", "value", "refcount", "idle_timer", "evict_token",
         "load_error",
     )
 
-    def __init__(self):
+    def __init__(self, key):
+        # Current cache key. Updated by ModelCache._rekey when the factory
+        # mutates on-disk state in ways that change a fingerprint baked
+        # into the key (e.g. classifier self-heal redownload replacing
+        # corrupt weights). _release looks the entry up by this so a
+        # rekeyed entry still gets correctly identity-matched.
+        self.key = key
         # Held while a factory is running so concurrent acquirers wait for the
         # first load to complete instead of all loading in parallel.
         self.load_lock = threading.Lock()
@@ -51,9 +57,8 @@ class _Handle:
     decrements the refcount exactly once, even if called multiple times.
     """
 
-    def __init__(self, cache, key, entry, value):
+    def __init__(self, cache, entry, value):
         self._cache = cache
-        self._key = key
         self._entry = entry
         self._value = value
         self._released = False
@@ -68,7 +73,7 @@ class _Handle:
         if self._released:
             return
         self._released = True
-        self._cache._release(self._key, self._entry)
+        self._cache._release_entry(self._entry)
 
 
 class ModelCache:
@@ -85,17 +90,25 @@ class ModelCache:
         self._entries = {}
         self._idle_secs = idle_secs
 
-    def acquire(self, key, factory):
+    def acquire(self, key, factory, post_load_key=None):
         """Acquire a refcounted handle to the value for ``key``.
 
         On cache miss, ``factory()`` is called to produce the value. On a
         concurrent acquire of the same missing key, only one thread calls
         the factory; the rest wait and receive the same value.
+
+        ``post_load_key`` is an optional callable ``(value) -> key`` invoked
+        once after the factory returns. If the returned key differs from
+        the original, the entry is atomically rekeyed so the next acquirer
+        looks it up under the corrected key. Use this when the factory
+        mutates on-disk state in ways that change a fingerprint baked into
+        the key (e.g. ONNX self-heal redownload replaces corrupt weights
+        and the post-load file stats no longer match the pre-load ones).
         """
         with self._global_lock:
             entry = self._entries.get(key)
             if entry is None:
-                entry = _Entry()
+                entry = _Entry(key)
                 self._entries[key] = entry
             entry.refcount += 1
             if entry.idle_timer is not None:
@@ -116,31 +129,43 @@ class ModelCache:
                     self._abandon(key, entry)
                     raise
                 entry.value = value
+                if post_load_key is not None:
+                    try:
+                        actual_key = post_load_key(value)
+                    except Exception:
+                        log.exception(
+                            "ModelCache: post_load_key callback raised; "
+                            "leaving entry keyed by the pre-load key"
+                        )
+                        actual_key = key
+                    if actual_key != key:
+                        self._rekey(key, actual_key, entry)
             elif entry.load_error is not None:
                 # A prior acquirer's factory raised; this acquirer should
                 # also see the failure and not get a phantom value. Release
-                # the original entry by identity — between abandon and now,
-                # another acquirer may have created a fresh entry under the
-                # same key, and decrementing it here would corrupt its
-                # refcount and cause spurious eviction of a model still in
-                # use.
-                self._release(key, entry)
+                # by entry identity — between abandon and now, another
+                # acquirer may have created a fresh entry under the same
+                # key, and decrementing it here would corrupt its refcount
+                # and cause spurious eviction of a model still in use.
+                self._release_entry(entry)
                 raise entry.load_error
-            return _Handle(self, key, entry, entry.value)
+            return _Handle(self, entry, entry.value)
 
-    def _release(self, key, entry):
+    def _release_entry(self, entry):
         """Decrement refcount on the specific entry the caller acquired.
 
-        Identity-checked: if the entry under ``key`` has been replaced
-        (e.g. the original was abandoned after a failed load, and a later
-        acquirer installed a fresh entry), this is a no-op. The orphan
-        entry's refcount is meaningless because nothing can find it
-        anymore, and the new entry must not be touched by a caller that
-        never incremented it.
+        Identity-checked: if the entry currently under ``entry.key`` is no
+        longer this entry (e.g. abandoned after a failed load, then
+        replaced by a later acquirer), this is a no-op. The orphan entry's
+        refcount is meaningless because nothing can find it anymore, and a
+        new entry under the same key must not be touched by a caller that
+        never incremented it. Uses ``entry.key`` so a rekeyed entry is
+        still correctly located.
         """
         timer = None
         with self._global_lock:
-            current = self._entries.get(key)
+            lookup_key = entry.key
+            current = self._entries.get(lookup_key)
             if current is not entry:
                 return
             if entry.refcount > 0:
@@ -154,16 +179,17 @@ class ModelCache:
                 token = object()
                 entry.evict_token = token
                 timer = threading.Timer(
-                    self._idle_secs, self._evict, args=(key, entry, token),
+                    self._idle_secs, self._evict, args=(entry, token),
                 )
                 timer.daemon = True
                 entry.idle_timer = timer
         if timer is not None:
             timer.start()
 
-    def _evict(self, key, entry, token):
+    def _evict(self, entry, token):
         with self._global_lock:
-            current = self._entries.get(key)
+            lookup_key = entry.key
+            current = self._entries.get(lookup_key)
             if current is not entry:
                 return
             if entry.refcount > 0:
@@ -177,8 +203,8 @@ class ModelCache:
                 return
             # Drop the entry; entry.value will be garbage-collected (and any
             # __del__ on the model object — ONNX session close — runs then).
-            del self._entries[key]
-            log.debug("ModelCache: evicted %r after idle window", key)
+            del self._entries[lookup_key]
+            log.debug("ModelCache: evicted %r after idle window", lookup_key)
 
     def _abandon(self, key, entry):
         """Remove a failed-load entry. Called with no locks held."""
@@ -187,6 +213,35 @@ class ModelCache:
             if current is entry:
                 # Only remove if no later acquire replaced this entry.
                 del self._entries[key]
+
+    def _rekey(self, old_key, new_key, entry):
+        """Move ``entry`` from ``old_key`` to ``new_key`` atomically.
+
+        Called from inside ``acquire`` while still holding ``entry.load_lock``
+        so concurrent acquirers on ``old_key`` join this entry (they
+        already incremented its refcount and are blocked on load_lock).
+        Best-effort: if a separate entry has already been created under
+        ``new_key`` (a racing acquirer computed the post-load key first),
+        keep this entry where it is. The duplicate will idle-evict; we
+        accept a brief VRAM doubling over corrupting a sibling entry's
+        refcount.
+        """
+        with self._global_lock:
+            current = self._entries.get(old_key)
+            if current is not entry:
+                # Already moved or abandoned.
+                return
+            if new_key in self._entries:
+                log.warning(
+                    "ModelCache: cannot rekey %r -> %r (target exists); "
+                    "leaving entry under original key. Next acquire on the "
+                    "post-load key will use the existing target entry.",
+                    old_key, new_key,
+                )
+                return
+            del self._entries[old_key]
+            self._entries[new_key] = entry
+            entry.key = new_key
 
     # Test hook: exposed deliberately so tests can assert eviction without
     # snooping on _entries directly. Not part of the public API.

--- a/vireo/model_cache.py
+++ b/vireo/model_cache.py
@@ -24,7 +24,10 @@ log = logging.getLogger(__name__)
 
 
 class _Entry:
-    __slots__ = ("load_lock", "value", "refcount", "idle_timer", "load_error")
+    __slots__ = (
+        "load_lock", "value", "refcount", "idle_timer", "evict_token",
+        "load_error",
+    )
 
     def __init__(self):
         # Held while a factory is running so concurrent acquirers wait for the
@@ -33,6 +36,11 @@ class _Entry:
         self.value = None
         self.refcount = 0
         self.idle_timer = None
+        # Fresh sentinel installed each time _release arms an idle timer.
+        # _evict compares the token it was scheduled with against the
+        # entry's current token; a stale timer whose callback fires after
+        # acquire+release cycled a new timer in finds a mismatch and bails.
+        self.evict_token = None
         self.load_error = None
 
 
@@ -93,6 +101,9 @@ class ModelCache:
             if entry.idle_timer is not None:
                 entry.idle_timer.cancel()
                 entry.idle_timer = None
+            # Invalidate any in-flight stale callback whose cancel() lost
+            # the race with the timer thread firing.
+            entry.evict_token = None
 
         with entry.load_lock:
             if entry.value is None and entry.load_error is None:
@@ -136,20 +147,33 @@ class ModelCache:
                 entry.refcount -= 1
             if entry.refcount == 0 and entry.value is not None:
                 # Arm idle eviction. Use a daemon Timer so process exit isn't
-                # blocked by a pending eviction window.
-                timer = threading.Timer(self._idle_secs, self._evict, args=(key,))
+                # blocked by a pending eviction window. The fresh token lets
+                # _evict tell a stale timer (whose callback raced past
+                # cancel()) apart from a live one — only the live timer's
+                # token will still match entry.evict_token when _evict runs.
+                token = object()
+                entry.evict_token = token
+                timer = threading.Timer(
+                    self._idle_secs, self._evict, args=(key, entry, token),
+                )
                 timer.daemon = True
                 entry.idle_timer = timer
         if timer is not None:
             timer.start()
 
-    def _evict(self, key):
+    def _evict(self, key, entry, token):
         with self._global_lock:
-            entry = self._entries.get(key)
-            if entry is None:
+            current = self._entries.get(key)
+            if current is not entry:
                 return
             if entry.refcount > 0:
                 # Re-acquired in the gap between timer fire and lock; abort.
+                return
+            if entry.evict_token is not token:
+                # Stale timer: an acquire+release cycle replaced our token
+                # with a fresh one while our callback was queued. The new
+                # timer (or none, if still acquired) owns the eviction
+                # decision now.
                 return
             # Drop the entry; entry.value will be garbage-collected (and any
             # __del__ on the model object — ONNX session close — runs then).

--- a/vireo/model_cache.py
+++ b/vireo/model_cache.py
@@ -1,0 +1,176 @@
+"""Process-wide refcounted cache for loaded model objects.
+
+Used to share a single loaded Classifier / TimmClassifier / ONNX session
+across concurrent pipeline runs so two pipelines using the same model
+don't double up on VRAM. When the last user releases an entry, an idle
+timer arms; if no one re-acquires within ``idle_secs`` seconds the
+cached value is dropped and (for GPU sessions) VRAM is freed.
+
+Typical use:
+
+    cache = get_default_cache()
+    with cache.acquire(("model-id", labels_fp), lambda: load_classifier(...)) as clf:
+        ... run inference ...
+
+The factory is invoked at most once per (key, load-window) — concurrent
+acquirers of the same key block until the first load returns and then
+all receive the same object.
+"""
+
+import logging
+import threading
+
+log = logging.getLogger(__name__)
+
+
+class _Entry:
+    __slots__ = ("load_lock", "value", "refcount", "idle_timer", "load_error")
+
+    def __init__(self):
+        # Held while a factory is running so concurrent acquirers wait for the
+        # first load to complete instead of all loading in parallel.
+        self.load_lock = threading.Lock()
+        self.value = None
+        self.refcount = 0
+        self.idle_timer = None
+        self.load_error = None
+
+
+class _Handle:
+    """Context manager returned by ModelCache.acquire().
+
+    ``__enter__`` returns the loaded value; ``__exit__`` (or ``release()``)
+    decrements the refcount exactly once, even if called multiple times.
+    """
+
+    def __init__(self, cache, key, value):
+        self._cache = cache
+        self._key = key
+        self._value = value
+        self._released = False
+
+    def __enter__(self):
+        return self._value
+
+    def __exit__(self, exc_type, exc, tb):
+        self.release()
+
+    def release(self):
+        if self._released:
+            return
+        self._released = True
+        self._cache._release(self._key)
+
+
+class ModelCache:
+    """Refcounted cache with idle-timer eviction.
+
+    Thread-safe. The internal ``_global_lock`` is held only for short
+    bookkeeping operations (entry creation, refcount mutation, timer
+    management). Slow factory loads run under a per-entry ``load_lock``
+    so other cache keys aren't blocked.
+    """
+
+    def __init__(self, idle_secs=300.0):
+        self._global_lock = threading.Lock()
+        self._entries = {}
+        self._idle_secs = idle_secs
+
+    def acquire(self, key, factory):
+        """Acquire a refcounted handle to the value for ``key``.
+
+        On cache miss, ``factory()`` is called to produce the value. On a
+        concurrent acquire of the same missing key, only one thread calls
+        the factory; the rest wait and receive the same value.
+        """
+        with self._global_lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                entry = _Entry()
+                self._entries[key] = entry
+            entry.refcount += 1
+            if entry.idle_timer is not None:
+                entry.idle_timer.cancel()
+                entry.idle_timer = None
+
+        with entry.load_lock:
+            if entry.value is None and entry.load_error is None:
+                try:
+                    value = factory()
+                except BaseException as e:
+                    # Surface to this caller and any waiters under the
+                    # load_lock; remove the entry so future acquires retry.
+                    entry.load_error = e
+                    self._abandon(key, entry)
+                    raise
+                entry.value = value
+            elif entry.load_error is not None:
+                # A prior acquirer's factory raised; this acquirer should
+                # also see the failure and not get a phantom value.
+                self._release(key)
+                raise entry.load_error
+            return _Handle(self, key, entry.value)
+
+    def _release(self, key):
+        timer = None
+        with self._global_lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return
+            if entry.refcount > 0:
+                entry.refcount -= 1
+            if entry.refcount == 0 and entry.value is not None:
+                # Arm idle eviction. Use a daemon Timer so process exit isn't
+                # blocked by a pending eviction window.
+                timer = threading.Timer(self._idle_secs, self._evict, args=(key,))
+                timer.daemon = True
+                entry.idle_timer = timer
+        if timer is not None:
+            timer.start()
+
+    def _evict(self, key):
+        with self._global_lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return
+            if entry.refcount > 0:
+                # Re-acquired in the gap between timer fire and lock; abort.
+                return
+            # Drop the entry; entry.value will be garbage-collected (and any
+            # __del__ on the model object — ONNX session close — runs then).
+            del self._entries[key]
+            log.debug("ModelCache: evicted %r after idle window", key)
+
+    def _abandon(self, key, entry):
+        """Remove a failed-load entry. Called with no locks held."""
+        with self._global_lock:
+            current = self._entries.get(key)
+            if current is entry:
+                # Only remove if no later acquire replaced this entry.
+                del self._entries[key]
+
+    # Test hook: exposed deliberately so tests can assert eviction without
+    # snooping on _entries directly. Not part of the public API.
+    def _has_entry(self, key):
+        with self._global_lock:
+            return key in self._entries
+
+
+_default = None
+_default_lock = threading.Lock()
+
+
+def get_default_cache(idle_secs=300.0):
+    """Return the process-wide default ModelCache, creating it on first call."""
+    global _default
+    with _default_lock:
+        if _default is None:
+            _default = ModelCache(idle_secs=idle_secs)
+        return _default
+
+
+def reset_default_cache_for_tests():
+    """Drop the default cache. Tests use this to isolate from prior runs."""
+    global _default
+    with _default_lock:
+        _default = None

--- a/vireo/model_cache.py
+++ b/vireo/model_cache.py
@@ -43,9 +43,10 @@ class _Handle:
     decrements the refcount exactly once, even if called multiple times.
     """
 
-    def __init__(self, cache, key, value):
+    def __init__(self, cache, key, entry, value):
         self._cache = cache
         self._key = key
+        self._entry = entry
         self._value = value
         self._released = False
 
@@ -59,7 +60,7 @@ class _Handle:
         if self._released:
             return
         self._released = True
-        self._cache._release(self._key)
+        self._cache._release(self._key, self._entry)
 
 
 class ModelCache:
@@ -106,16 +107,30 @@ class ModelCache:
                 entry.value = value
             elif entry.load_error is not None:
                 # A prior acquirer's factory raised; this acquirer should
-                # also see the failure and not get a phantom value.
-                self._release(key)
+                # also see the failure and not get a phantom value. Release
+                # the original entry by identity — between abandon and now,
+                # another acquirer may have created a fresh entry under the
+                # same key, and decrementing it here would corrupt its
+                # refcount and cause spurious eviction of a model still in
+                # use.
+                self._release(key, entry)
                 raise entry.load_error
-            return _Handle(self, key, entry.value)
+            return _Handle(self, key, entry, entry.value)
 
-    def _release(self, key):
+    def _release(self, key, entry):
+        """Decrement refcount on the specific entry the caller acquired.
+
+        Identity-checked: if the entry under ``key`` has been replaced
+        (e.g. the original was abandoned after a failed load, and a later
+        acquirer installed a fresh entry), this is a no-op. The orphan
+        entry's refcount is meaningless because nothing can find it
+        anymore, and the new entry must not be touched by a caller that
+        never incremented it.
+        """
         timer = None
         with self._global_lock:
-            entry = self._entries.get(key)
-            if entry is None:
+            current = self._entries.get(key)
+            if current is not entry:
                 return
             if entry.refcount > 0:
                 entry.refcount -= 1

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 
 import numpy as np
 from db import Database, commit_with_retry
+from model_cache import get_default_cache
 
 log = logging.getLogger(__name__)
 
@@ -83,6 +84,25 @@ def _looks_like_missing_external_data(err):
 
 
 _RAW_EXTENSIONS = (".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf")
+
+
+def _release_classifier_cache_handle(loaded_models):
+    """Decrement the cache refcount for the currently-held classifier bundle.
+
+    Pulled out of ``classify_stage`` so the spec-swap path and the stage's
+    finally block share one place that knows about the ``_cache_handle``
+    key. Idempotent: if no handle is present (e.g. classify was skipped
+    before any model loaded) this is a no-op.
+    """
+    handle = loaded_models.pop("_cache_handle", None)
+    if handle is None:
+        return
+    try:
+        handle.release()
+    except Exception:
+        # Releasing a cache handle must never break pipeline cleanup.
+        # The cache's idle timer will reclaim leaked entries eventually.
+        log.exception("ModelCache: handle release raised; leak will be reclaimed by idle timer")
 
 
 def _find_broken_metadata_folders(db, photo_ids):
@@ -1427,17 +1447,36 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     active_model["id"], verify_err,
                 )
 
-        try:
+        def _construct_classifier():
             if model_type == "timm":
                 from timm_classifier import TimmClassifier
-                clf = TimmClassifier(model_str, taxonomy=tax)
-            else:
-                from classifier import Classifier
-                clf = Classifier(
-                    labels=None if use_tol else labels,
-                    model_str=model_str,
-                    pretrained_str=weights_path,
-                )
+                return TimmClassifier(model_str, taxonomy=tax)
+            from classifier import Classifier
+            return Classifier(
+                labels=None if use_tol else labels,
+                model_str=model_str,
+                pretrained_str=weights_path,
+            )
+
+        # Cache key includes the labels fingerprint when use_tol=False because
+        # the Classifier pre-computes text embeddings for the provided labels
+        # at construction time. Two pipelines with the same model but
+        # different labels must NOT share a session. Tree-of-Life mode
+        # (use_tol=True) reads precomputed embeddings from disk and is
+        # label-independent, so the key collapses to a constant.
+        cache_key = (
+            "timm" if model_type == "timm" else "bioclip",
+            active_model["id"],
+            model_str,
+            weights_path,
+            "__tol__" if use_tol else fp,
+        )
+        cache_handle = None
+        try:
+            cache_handle = get_default_cache().acquire(
+                cache_key, _construct_classifier
+            )
+            clf = cache_handle.__enter__()
         except Exception as load_err:
             # ONNXRuntime signals missing external-data with a
             # "model_path must not be empty" / "Initializer" error. Treat
@@ -1502,6 +1541,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
         return {
             "clf": clf,
+            "_cache_handle": cache_handle,
             "model_type": model_type,
             "model_name": model_name,
             "model_str": model_str,
@@ -1865,6 +1905,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         status=row_status, summary=row_summary,
                         error=loader_err if loader_failed else None,
                     )
+            # model_loader may have already loaded the first classifier
+            # before this early-return path was hit (e.g. abort.is_set()).
+            # Release its cache handle so a same-key reload can be a hit
+            # and idle eviction can reclaim VRAM.
+            _release_classifier_cache_handle(loaded_models)
             _update_stages(runner, job["id"], stages)
             return
 
@@ -1965,6 +2010,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     # large collections can hit transient OOMs.
                     with contextlib.suppress(NameError, UnboundLocalError):
                         raw_results.clear()  # noqa: F821 — bound in prior iter
+                    # Release the previous spec's cache handle so its
+                    # refcount drops and a same-cache-key reload below (or
+                    # in another pipeline) can be a hit. Must happen
+                    # BEFORE popping ``clf`` so we don't lose the only
+                    # reference to the bundle that owns the handle.
+                    _release_classifier_cache_handle(loaded_models)
                     for k in ("clf", "model_type", "model_name", "model_str",
                               "labels", "use_tol", "active_model"):
                         loaded_models.pop(k, None)
@@ -2464,6 +2515,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     job["id"], sid,
                     status="failed", error=str(e),
                 )
+        finally:
+            # Release the held classifier so subsequent pipelines can reuse
+            # the cached session (or the idle timer can reclaim VRAM). Runs
+            # whether classify completed cleanly, errored mid-loop, or hit
+            # the fatal-exception path above.
+            _release_classifier_cache_handle(loaded_models)
 
         _update_stages(runner, job["id"], stages)
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -93,6 +93,27 @@ _CLASSIFIER_BUNDLE_FIELDS = (
 )
 
 
+def _taxonomy_fingerprint(tax):
+    """Stable key component representing the taxonomy backing a classifier.
+
+    Used in the timm classifier cache key so a pipeline that loads the
+    classifier with no taxonomy (or a stale one) does not get reused after
+    a taxonomy download or refresh updates the on-disk file. ``None`` is
+    a valid input — pipelines run without taxonomy still hit the cache
+    consistently among themselves.
+    """
+    if tax is None:
+        return ("no-tax",)
+    path = getattr(tax, "_path", None)
+    if not path:
+        return ("inline", id(tax))
+    try:
+        st = os.stat(path)
+        return (path, int(st.st_mtime_ns), st.st_size)
+    except OSError:
+        return (path, None, None)
+
+
 def _release_classifier_cache_handle(loaded_models):
     """Release the cache handle AND drop the bundle's strong refs.
 
@@ -1479,12 +1500,22 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         # different labels must NOT share a session. Tree-of-Life mode
         # (use_tol=True) reads precomputed embeddings from disk and is
         # label-independent, so the key collapses to a constant.
+        #
+        # The timm key also varies by taxonomy fingerprint: TimmClassifier
+        # captures the taxonomy at construction and resolves common names /
+        # hierarchy from it on every prediction. Reusing a classifier loaded
+        # against a stale taxonomy (or no taxonomy) after a later run
+        # downloads or refreshes one would silently emit predictions
+        # missing the enrichment, so a change in taxonomy must miss the
+        # cache and rebuild.
+        tax_fp = _taxonomy_fingerprint(tax) if model_type == "timm" else None
         cache_key = (
             "timm" if model_type == "timm" else "bioclip",
             active_model["id"],
             model_str,
             weights_path,
             "__tol__" if use_tol else fp,
+            tax_fp,
         )
         cache_handle = None
         try:
@@ -1823,17 +1854,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     progress={"current": batch_idx, "total": total},
                 )
 
-                # Serialise the GPU op for this detection batch. Released
-                # between batches so a concurrent pipeline can interleave
-                # its own GPU work without waiting for the entire detect
-                # stage to finish.
-                with acquire_gpu():
-                    det_map, det_count, det_processed = _detect_batch(
-                        batch, folders, runner, job,
-                        params.reclassify, thread_db,
-                        already_detected_ids=already_detected,
-                        cached_detections=None,
-                    )
+                # GPU serialisation lives inside detector.detect_animals()
+                # — wrapping the whole batch here would hold the semaphore
+                # across DB writes and CPU sharpness/quality work, blocking
+                # a concurrent pipeline's GPU stages on this pipeline's
+                # non-GPU work.
+                det_map, det_count, det_processed = _detect_batch(
+                    batch, folders, runner, job,
+                    params.reclassify, thread_db,
+                    already_detected_ids=already_detected,
+                    cached_detections=None,
+                )
                 total_detected += det_count
                 already_detected.update(det_processed)
                 for pid, dets in det_map.items():

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 import numpy as np
 from db import Database, commit_with_retry
 from model_cache import get_default_cache
+from pipeline_locks import acquire_gpu, acquire_workspace_regroup
 
 log = logging.getLogger(__name__)
 
@@ -1808,12 +1809,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     progress={"current": batch_idx, "total": total},
                 )
 
-                det_map, det_count, det_processed = _detect_batch(
-                    batch, folders, runner, job,
-                    params.reclassify, thread_db,
-                    already_detected_ids=already_detected,
-                    cached_detections=None,
-                )
+                # Serialise the GPU op for this detection batch. Released
+                # between batches so a concurrent pipeline can interleave
+                # its own GPU work without waiting for the entire detect
+                # stage to finish.
+                with acquire_gpu():
+                    det_map, det_count, det_processed = _detect_batch(
+                        batch, folders, runner, job,
+                        params.reclassify, thread_db,
+                        already_detected_ids=already_detected,
+                        cached_detections=None,
+                    )
                 total_detected += det_count
                 already_detected.update(det_processed)
                 for pid, dets in det_map.items():
@@ -2141,10 +2147,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     inference_batch.clear()
                     has_flushed_in_spec = True
                     pre_len = len(raw_results)
-                    n_batch_failed = _flush_batch(
-                        pending, clf, model_type, model_name,
-                        thread_db, raw_results,
-                    )
+                    # Serialise the GPU op across all concurrent pipelines.
+                    # Acquired per batch, not for the whole spec, so another
+                    # pipeline waiting on GPU can interleave between our
+                    # batches instead of starving for the full classify run.
+                    with acquire_gpu():
+                        n_batch_failed = _flush_batch(
+                            pending, clf, model_type, model_name,
+                            thread_db, raw_results,
+                        )
                     failed += n_batch_failed
 
                     successful_det_ids = {
@@ -2854,7 +2865,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     if _should_abort(abort):
                         break
 
-                    mask = generate_mask(proxy, det_box, variant=sam2_variant)
+                    with acquire_gpu():
+                        mask = generate_mask(proxy, det_box, variant=sam2_variant)
                     if mask is None:
                         skipped += 1
                         processed = i + 1
@@ -2890,16 +2902,18 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
                     subject_crop = crop_subject(proxy, mask, margin=0.15)
                     if subject_crop is not None:
-                        embs = embed_batch(
-                            [subject_crop, proxy], variant=dinov2_variant,
-                        )
+                        with acquire_gpu():
+                            embs = embed_batch(
+                                [subject_crop, proxy], variant=dinov2_variant,
+                            )
                         subj_emb_blob = embedding_to_blob(embs[0])
                         global_emb_blob = embedding_to_blob(embs[1])
                     else:
                         subj_emb_blob = None
-                        global_emb_blob = embedding_to_blob(
-                            embed(proxy, variant=dinov2_variant),
-                        )
+                        with acquire_gpu():
+                            global_emb_blob = embedding_to_blob(
+                                embed(proxy, variant=dinov2_variant),
+                            )
 
                     thread_db.upsert_photo_mask(
                         photo_id=photo_id,
@@ -3243,90 +3257,96 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         runner.update_step(job["id"], "regroup", status="running")
         _update_stages(runner, job["id"], stages)
 
-        try:
-            import config as cfg
-            from pipeline import load_photo_features, run_full_pipeline, save_results
+        # Two pipelines targeting the same workspace must not regroup
+        # concurrently — save_results + set_workspace_group_state would
+        # race and leave inconsistent grouping state. Per-workspace lock
+        # serialises only this stage; pipelines on different workspaces
+        # don't interact.
+        with acquire_workspace_regroup(workspace_id):
+            try:
+                import config as cfg
+                from pipeline import load_photo_features, run_full_pipeline, save_results
 
-            thread_db = Database(db_path)
-            thread_db.set_active_workspace(workspace_id)
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(workspace_id)
 
-            effective_cfg = thread_db.get_effective_config(cfg.load())
-            pipeline_cfg = effective_cfg.get("pipeline", {})
+                effective_cfg = thread_db.get_effective_config(cfg.load())
+                pipeline_cfg = effective_cfg.get("pipeline", {})
 
-            photos = load_photo_features(thread_db, collection_id=collection_id, config=effective_cfg)
-            if params.exclude_photo_ids:
-                photos = [p for p in photos if p["id"] not in params.exclude_photo_ids]
-            if not photos:
-                result["stages"]["regroup"] = {"error": "No photos with pipeline features found."}
+                photos = load_photo_features(thread_db, collection_id=collection_id, config=effective_cfg)
+                if params.exclude_photo_ids:
+                    photos = [p for p in photos if p["id"] not in params.exclude_photo_ids]
+                if not photos:
+                    result["stages"]["regroup"] = {"error": "No photos with pipeline features found."}
+                    stages["regroup"]["status"] = "completed"
+                    runner.update_step(job["id"], "regroup", status="completed",
+                                       summary="No photos to group")
+                    return
+
+                results = run_full_pipeline(photos, config=pipeline_cfg, emit_trace=True)
+                cache_dir = os.path.dirname(db_path)
+                save_results(results, cache_dir, workspace_id)
+
+                # Stamp the grouping fingerprint + timestamp BEFORE marking the
+                # step completed, so a partial regroup that crashes between here
+                # and update_step doesn't end up labeled "fresh" with a stale fp.
+                #
+                # Only stamp when the regroup actually covered the whole
+                # workspace — if it ran on a filtered subset (a sub-collection,
+                # or with exclude_photo_ids set) some workspace photos were
+                # intentionally not regrouped, so claiming workspace-level
+                # freshness would let the pipeline page hide a real stale state.
+                from pipeline import (
+                    _resolve_collection_photo_ids,
+                    compute_group_fingerprint,
+                )
+                collection_photo_ids = _resolve_collection_photo_ids(
+                    thread_db, collection_id,
+                )
+                ws_photo_ids = {
+                    r["id"] for r in thread_db.conn.execute(
+                        """SELECT p.id
+                             FROM photos p
+                             JOIN workspace_folders wf
+                               ON wf.folder_id = p.folder_id
+                            WHERE wf.workspace_id = ?""",
+                        (workspace_id,),
+                    ).fetchall()
+                }
+                covered_full_workspace = (
+                    not params.exclude_photo_ids
+                    and ws_photo_ids.issubset(collection_photo_ids)
+                )
+                if covered_full_workspace:
+                    thread_db.set_workspace_group_state(
+                        workspace_id=workspace_id,
+                        fingerprint=compute_group_fingerprint(effective_cfg),
+                        when_ts=int(time.time()),
+                    )
+                else:
+                    # Partial run — save_results just clobbered
+                    # pipeline_results_ws*.json with subset output, so any
+                    # pre-existing fingerprint now points at a cache that no
+                    # longer reflects the full workspace. Invalidate so the
+                    # pipeline page surfaces the staleness as will-run instead
+                    # of falsely reporting done-prior.
+                    thread_db.set_workspace_group_state(
+                        workspace_id=workspace_id,
+                        fingerprint=None,
+                        when_ts=None,
+                    )
+
                 stages["regroup"]["status"] = "completed"
+                summary_info = results.get("summary", {})
+                groups = summary_info.get("groups", "")
                 runner.update_step(job["id"], "regroup", status="completed",
-                                   summary="No photos to group")
-                return
-
-            results = run_full_pipeline(photos, config=pipeline_cfg, emit_trace=True)
-            cache_dir = os.path.dirname(db_path)
-            save_results(results, cache_dir, workspace_id)
-
-            # Stamp the grouping fingerprint + timestamp BEFORE marking the
-            # step completed, so a partial regroup that crashes between here
-            # and update_step doesn't end up labeled "fresh" with a stale fp.
-            #
-            # Only stamp when the regroup actually covered the whole
-            # workspace — if it ran on a filtered subset (a sub-collection,
-            # or with exclude_photo_ids set) some workspace photos were
-            # intentionally not regrouped, so claiming workspace-level
-            # freshness would let the pipeline page hide a real stale state.
-            from pipeline import (
-                _resolve_collection_photo_ids,
-                compute_group_fingerprint,
-            )
-            collection_photo_ids = _resolve_collection_photo_ids(
-                thread_db, collection_id,
-            )
-            ws_photo_ids = {
-                r["id"] for r in thread_db.conn.execute(
-                    """SELECT p.id
-                         FROM photos p
-                         JOIN workspace_folders wf
-                           ON wf.folder_id = p.folder_id
-                        WHERE wf.workspace_id = ?""",
-                    (workspace_id,),
-                ).fetchall()
-            }
-            covered_full_workspace = (
-                not params.exclude_photo_ids
-                and ws_photo_ids.issubset(collection_photo_ids)
-            )
-            if covered_full_workspace:
-                thread_db.set_workspace_group_state(
-                    workspace_id=workspace_id,
-                    fingerprint=compute_group_fingerprint(effective_cfg),
-                    when_ts=int(time.time()),
-                )
-            else:
-                # Partial run — save_results just clobbered
-                # pipeline_results_ws*.json with subset output, so any
-                # pre-existing fingerprint now points at a cache that no
-                # longer reflects the full workspace. Invalidate so the
-                # pipeline page surfaces the staleness as will-run instead
-                # of falsely reporting done-prior.
-                thread_db.set_workspace_group_state(
-                    workspace_id=workspace_id,
-                    fingerprint=None,
-                    when_ts=None,
-                )
-
-            stages["regroup"]["status"] = "completed"
-            summary_info = results.get("summary", {})
-            groups = summary_info.get("groups", "")
-            runner.update_step(job["id"], "regroup", status="completed",
-                               summary=f"{groups} groups" if groups else "Done")
-            result["stages"]["regroup"] = summary_info
-        except Exception as e:
-            errors.append(f"[regroup] Fatal: {e}")
-            log.exception("Pipeline regroup stage failed")
-            stages["regroup"]["status"] = "failed"
-            runner.update_step(job["id"], "regroup", status="failed", error=str(e))
+                                   summary=f"{groups} groups" if groups else "Done")
+                result["stages"]["regroup"] = summary_info
+            except Exception as e:
+                errors.append(f"[regroup] Fatal: {e}")
+                log.exception("Pipeline regroup stage failed")
+                stages["regroup"]["status"] = "failed"
+                runner.update_step(job["id"], "regroup", status="failed", error=str(e))
 
         _update_stages(runner, job["id"], stages)
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1563,20 +1563,37 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         # before the old session's idle timer fires would reuse the
         # stale ONNX session on the new bytes.
         tax_fp = _taxonomy_fingerprint(tax) if model_type == "timm" else None
-        weights_fp = _weights_fingerprint(weights_path, active_model.get("files"))
-        cache_key = (
-            "timm" if model_type == "timm" else "bioclip",
-            active_model["id"],
-            model_str,
-            weights_path,
-            "__tol__" if use_tol else fp,
-            tax_fp,
-            weights_fp,
-        )
+        files = active_model.get("files")
+
+        def _build_cache_key(weights_fp):
+            return (
+                "timm" if model_type == "timm" else "bioclip",
+                active_model["id"],
+                model_str,
+                weights_path,
+                "__tol__" if use_tol else fp,
+                tax_fp,
+                weights_fp,
+            )
+
+        cache_key = _build_cache_key(_weights_fingerprint(weights_path, files))
+
+        # _construct_classifier may trigger the ONNX self-heal path
+        # (create_session_with_self_heal) which deletes corrupt weights
+        # and redownloads them inside the factory. That bumps the file
+        # mtime/size, so the pre-load fingerprint baked into ``cache_key``
+        # no longer matches what the *next* pipeline will compute. Rekey
+        # to the post-load fingerprint so the second pipeline hits this
+        # entry instead of loading a duplicate session against the freshly
+        # written bytes.
+        def _post_load_key(_value):
+            return _build_cache_key(_weights_fingerprint(weights_path, files))
+
         cache_handle = None
         try:
             cache_handle = get_default_cache().acquire(
-                cache_key, _construct_classifier
+                cache_key, _construct_classifier,
+                post_load_key=_post_load_key,
             )
             clf = cache_handle.__enter__()
         except Exception as load_err:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -87,15 +87,29 @@ def _looks_like_missing_external_data(err):
 _RAW_EXTENSIONS = (".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf")
 
 
-def _release_classifier_cache_handle(loaded_models):
-    """Decrement the cache refcount for the currently-held classifier bundle.
+_CLASSIFIER_BUNDLE_FIELDS = (
+    "clf", "model_type", "model_name", "model_str",
+    "labels", "use_tol", "active_model", "labels_fingerprint",
+)
 
-    Pulled out of ``classify_stage`` so the spec-swap path and the stage's
-    finally block share one place that knows about the ``_cache_handle``
-    key. Idempotent: if no handle is present (e.g. classify was skipped
-    before any model loaded) this is a no-op.
+
+def _release_classifier_cache_handle(loaded_models):
+    """Release the cache handle AND drop the bundle's strong refs.
+
+    Releasing the handle alone isn't enough: ``loaded_models`` still
+    holds ``clf`` (the live Classifier/ONNX session) so the GC can't
+    reclaim it. After idle eviction removes the cache entry, a second
+    pipeline that loads the same model gets a fresh session — doubling
+    VRAM — while this pipeline's stale ``clf`` is still pinned. Dropping
+    the bundle fields here lets idle eviction actually free VRAM and
+    lets same-model reloads hit the cache.
+
+    Idempotent: no-op if no handle present (classify skipped before any
+    model loaded).
     """
     handle = loaded_models.pop("_cache_handle", None)
+    for k in _CLASSIFIER_BUNDLE_FIELDS:
+        loaded_models.pop(k, None)
     if handle is None:
         return
     try:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -114,6 +114,31 @@ def _taxonomy_fingerprint(tax):
         return (path, None, None)
 
 
+def _weights_fingerprint(weights_path, files):
+    """Stable key component reflecting the on-disk state of the weights.
+
+    A cached ONNX session is keyed by ``weights_path`` plus this
+    fingerprint. Without it, a Repair (download in place) or a custom-
+    model re-registration overwrites the file at the same path but the
+    classifier cache reuses the previously-loaded session built from the
+    old bytes — silently classifying with stale or corrupt weights.
+    Stat-only (size + mtime_ns) so the lookup stays cheap; in-place
+    replacement reliably bumps mtime even for byte-identical files.
+    Missing files map to a sentinel so a partial repair still misses.
+    """
+    if not weights_path or not files:
+        return None
+    parts = []
+    for rel in files:
+        path = os.path.join(weights_path, rel)
+        try:
+            st = os.stat(path)
+            parts.append((rel, st.st_size, int(st.st_mtime_ns)))
+        except OSError:
+            parts.append((rel, None, None))
+    return tuple(parts)
+
+
 def _release_classifier_cache_handle(loaded_models):
     """Release the cache handle AND drop the bundle's strong refs.
 
@@ -1508,7 +1533,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         # downloads or refreshes one would silently emit predictions
         # missing the enrichment, so a change in taxonomy must miss the
         # cache and rebuild.
+        #
+        # The weights fingerprint catches in-place model replacement
+        # (Repair, custom re-register). Without it, a pipeline started
+        # before the old session's idle timer fires would reuse the
+        # stale ONNX session on the new bytes.
         tax_fp = _taxonomy_fingerprint(tax) if model_type == "timm" else None
+        weights_fp = _weights_fingerprint(weights_path, active_model.get("files"))
         cache_key = (
             "timm" if model_type == "timm" else "bioclip",
             active_model["id"],
@@ -1516,6 +1547,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             weights_path,
             "__tol__" if use_tol else fp,
             tax_fp,
+            weights_fp,
         )
         cache_handle = None
         try:
@@ -2192,15 +2224,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     inference_batch.clear()
                     has_flushed_in_spec = True
                     pre_len = len(raw_results)
-                    # Serialise the GPU op across all concurrent pipelines.
-                    # Acquired per batch, not for the whole spec, so another
-                    # pipeline waiting on GPU can interleave between our
-                    # batches instead of starving for the full classify run.
-                    with acquire_gpu():
-                        n_batch_failed = _flush_batch(
-                            pending, clf, model_type, model_name,
-                            thread_db, raw_results,
-                        )
+                    # GPU serialisation lives inside _flush_batch around the
+                    # inference call so the DB upserts/result-building afterward
+                    # don't hold the semaphore while the GPU is idle.
+                    n_batch_failed = _flush_batch(
+                        pending, clf, model_type, model_name,
+                        thread_db, raw_results,
+                    )
                     failed += n_batch_failed
 
                     successful_det_ids = {

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 import numpy as np
 from db import Database, commit_with_retry
 from model_cache import get_default_cache
-from pipeline_locks import acquire_gpu, acquire_workspace_regroup
+from pipeline_locks import acquire_workspace_regroup
 
 log = logging.getLogger(__name__)
 
@@ -2981,8 +2981,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     if _should_abort(abort):
                         break
 
-                    with acquire_gpu():
-                        mask = generate_mask(proxy, det_box, variant=sam2_variant)
+                    # GPU serialisation lives inside masking.generate_mask
+                    # (around the encoder/decoder session.run calls). The
+                    # wider wrap previously here held the semaphore through
+                    # SAM weight load + image preprocessing + prompt-coord
+                    # math, blocking other pipelines' GPU work for CPU-only
+                    # phases.
+                    mask = generate_mask(proxy, det_box, variant=sam2_variant)
                     if mask is None:
                         skipped += 1
                         processed = i + 1
@@ -3016,20 +3021,22 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     else:
                         mask_subject_size = None
 
+                    # GPU serialisation lives inside dino_embed.embed /
+                    # embed_batch (around the session.run call). The wider
+                    # wrap previously here held the semaphore through
+                    # per-image resize/normalize preprocessing.
                     subject_crop = crop_subject(proxy, mask, margin=0.15)
                     if subject_crop is not None:
-                        with acquire_gpu():
-                            embs = embed_batch(
-                                [subject_crop, proxy], variant=dinov2_variant,
-                            )
+                        embs = embed_batch(
+                            [subject_crop, proxy], variant=dinov2_variant,
+                        )
                         subj_emb_blob = embedding_to_blob(embs[0])
                         global_emb_blob = embedding_to_blob(embs[1])
                     else:
                         subj_emb_blob = None
-                        with acquire_gpu():
-                            global_emb_blob = embedding_to_blob(
-                                embed(proxy, variant=dinov2_variant),
-                            )
+                        global_emb_blob = embedding_to_blob(
+                            embed(proxy, variant=dinov2_variant),
+                        )
 
                     thread_db.upsert_photo_mask(
                         photo_id=photo_id,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -125,18 +125,42 @@ def _weights_fingerprint(weights_path, files):
     Stat-only (size + mtime_ns) so the lookup stays cheap; in-place
     replacement reliably bumps mtime even for byte-identical files.
     Missing files map to a sentinel so a partial repair still misses.
+
+    Custom models have no declared ``files`` list, so fall back to
+    listing the directory (or stat'ing the single file if
+    ``weights_path`` points at one). Without this fallback a user who
+    re-registers a custom model at the same path would reuse the stale
+    session until the idle window expires.
     """
-    if not weights_path or not files:
+    if not weights_path:
         return None
-    parts = []
-    for rel in files:
-        path = os.path.join(weights_path, rel)
-        try:
-            st = os.stat(path)
-            parts.append((rel, st.st_size, int(st.st_mtime_ns)))
-        except OSError:
-            parts.append((rel, None, None))
-    return tuple(parts)
+    if files:
+        parts = []
+        for rel in files:
+            path = os.path.join(weights_path, rel)
+            try:
+                st = os.stat(path)
+                parts.append((rel, st.st_size, int(st.st_mtime_ns)))
+            except OSError:
+                parts.append((rel, None, None))
+        return tuple(parts)
+    try:
+        if os.path.isdir(weights_path):
+            parts = []
+            for name in sorted(os.listdir(weights_path)):
+                path = os.path.join(weights_path, name)
+                try:
+                    st = os.stat(path)
+                    parts.append((name, st.st_size, int(st.st_mtime_ns)))
+                except OSError:
+                    parts.append((name, None, None))
+            return tuple(parts)
+        if os.path.isfile(weights_path):
+            st = os.stat(weights_path)
+            return (("__file__", st.st_size, int(st.st_mtime_ns)),)
+    except OSError:
+        pass
+    return None
 
 
 def _release_classifier_cache_handle(loaded_models):

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -3276,8 +3276,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         # race and leave inconsistent grouping state. Per-workspace lock
         # serialises only this stage; pipelines on different workspaces
         # don't interact.
-        with acquire_workspace_regroup(workspace_id):
-            try:
+        #
+        # runner.update_step takes JobRunner._lock; per the documented
+        # lock order in pipeline_locks.py, JobRunner._lock is outer to
+        # workspace_regroup. So we capture the intended update inside the
+        # `with` block and apply it after releasing the lock.
+        deferred_step_update = None  # dict of kwargs for runner.update_step
+        try:
+            with acquire_workspace_regroup(workspace_id):
                 import config as cfg
                 from pipeline import load_photo_features, run_full_pipeline, save_results
 
@@ -3293,75 +3299,81 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 if not photos:
                     result["stages"]["regroup"] = {"error": "No photos with pipeline features found."}
                     stages["regroup"]["status"] = "completed"
-                    runner.update_step(job["id"], "regroup", status="completed",
-                                       summary="No photos to group")
-                    return
-
-                results = run_full_pipeline(photos, config=pipeline_cfg, emit_trace=True)
-                cache_dir = os.path.dirname(db_path)
-                save_results(results, cache_dir, workspace_id)
-
-                # Stamp the grouping fingerprint + timestamp BEFORE marking the
-                # step completed, so a partial regroup that crashes between here
-                # and update_step doesn't end up labeled "fresh" with a stale fp.
-                #
-                # Only stamp when the regroup actually covered the whole
-                # workspace — if it ran on a filtered subset (a sub-collection,
-                # or with exclude_photo_ids set) some workspace photos were
-                # intentionally not regrouped, so claiming workspace-level
-                # freshness would let the pipeline page hide a real stale state.
-                from pipeline import (
-                    _resolve_collection_photo_ids,
-                    compute_group_fingerprint,
-                )
-                collection_photo_ids = _resolve_collection_photo_ids(
-                    thread_db, collection_id,
-                )
-                ws_photo_ids = {
-                    r["id"] for r in thread_db.conn.execute(
-                        """SELECT p.id
-                             FROM photos p
-                             JOIN workspace_folders wf
-                               ON wf.folder_id = p.folder_id
-                            WHERE wf.workspace_id = ?""",
-                        (workspace_id,),
-                    ).fetchall()
-                }
-                covered_full_workspace = (
-                    not params.exclude_photo_ids
-                    and ws_photo_ids.issubset(collection_photo_ids)
-                )
-                if covered_full_workspace:
-                    thread_db.set_workspace_group_state(
-                        workspace_id=workspace_id,
-                        fingerprint=compute_group_fingerprint(effective_cfg),
-                        when_ts=int(time.time()),
-                    )
+                    deferred_step_update = {
+                        "status": "completed", "summary": "No photos to group",
+                    }
                 else:
-                    # Partial run — save_results just clobbered
-                    # pipeline_results_ws*.json with subset output, so any
-                    # pre-existing fingerprint now points at a cache that no
-                    # longer reflects the full workspace. Invalidate so the
-                    # pipeline page surfaces the staleness as will-run instead
-                    # of falsely reporting done-prior.
-                    thread_db.set_workspace_group_state(
-                        workspace_id=workspace_id,
-                        fingerprint=None,
-                        when_ts=None,
+                    results = run_full_pipeline(photos, config=pipeline_cfg, emit_trace=True)
+                    cache_dir = os.path.dirname(db_path)
+                    save_results(results, cache_dir, workspace_id)
+
+                    # Stamp the grouping fingerprint + timestamp BEFORE marking
+                    # the step completed, so a partial regroup that crashes
+                    # between here and update_step doesn't end up labeled "fresh"
+                    # with a stale fp.
+                    #
+                    # Only stamp when the regroup actually covered the whole
+                    # workspace — if it ran on a filtered subset (a
+                    # sub-collection, or with exclude_photo_ids set) some
+                    # workspace photos were intentionally not regrouped, so
+                    # claiming workspace-level freshness would let the pipeline
+                    # page hide a real stale state.
+                    from pipeline import (
+                        _resolve_collection_photo_ids,
+                        compute_group_fingerprint,
                     )
+                    collection_photo_ids = _resolve_collection_photo_ids(
+                        thread_db, collection_id,
+                    )
+                    ws_photo_ids = {
+                        r["id"] for r in thread_db.conn.execute(
+                            """SELECT p.id
+                                 FROM photos p
+                                 JOIN workspace_folders wf
+                                   ON wf.folder_id = p.folder_id
+                                WHERE wf.workspace_id = ?""",
+                            (workspace_id,),
+                        ).fetchall()
+                    }
+                    covered_full_workspace = (
+                        not params.exclude_photo_ids
+                        and ws_photo_ids.issubset(collection_photo_ids)
+                    )
+                    if covered_full_workspace:
+                        thread_db.set_workspace_group_state(
+                            workspace_id=workspace_id,
+                            fingerprint=compute_group_fingerprint(effective_cfg),
+                            when_ts=int(time.time()),
+                        )
+                    else:
+                        # Partial run — save_results just clobbered
+                        # pipeline_results_ws*.json with subset output, so any
+                        # pre-existing fingerprint now points at a cache that
+                        # no longer reflects the full workspace. Invalidate so
+                        # the pipeline page surfaces the staleness as will-run
+                        # instead of falsely reporting done-prior.
+                        thread_db.set_workspace_group_state(
+                            workspace_id=workspace_id,
+                            fingerprint=None,
+                            when_ts=None,
+                        )
 
-                stages["regroup"]["status"] = "completed"
-                summary_info = results.get("summary", {})
-                groups = summary_info.get("groups", "")
-                runner.update_step(job["id"], "regroup", status="completed",
-                                   summary=f"{groups} groups" if groups else "Done")
-                result["stages"]["regroup"] = summary_info
-            except Exception as e:
-                errors.append(f"[regroup] Fatal: {e}")
-                log.exception("Pipeline regroup stage failed")
-                stages["regroup"]["status"] = "failed"
-                runner.update_step(job["id"], "regroup", status="failed", error=str(e))
+                    stages["regroup"]["status"] = "completed"
+                    summary_info = results.get("summary", {})
+                    groups = summary_info.get("groups", "")
+                    deferred_step_update = {
+                        "status": "completed",
+                        "summary": f"{groups} groups" if groups else "Done",
+                    }
+                    result["stages"]["regroup"] = summary_info
+        except Exception as e:
+            errors.append(f"[regroup] Fatal: {e}")
+            log.exception("Pipeline regroup stage failed")
+            stages["regroup"]["status"] = "failed"
+            deferred_step_update = {"status": "failed", "error": str(e)}
 
+        if deferred_step_update is not None:
+            runner.update_step(job["id"], "regroup", **deferred_step_update)
         _update_stages(runner, job["id"], stages)
 
     def miss_stage():

--- a/vireo/pipeline_locks.py
+++ b/vireo/pipeline_locks.py
@@ -48,6 +48,55 @@ class _GpuLockContext:
         _GPU_SEMAPHORE.release()
 
 
+# Providers that actually run on a GPU device. ONNXRuntime's other
+# providers (CPUExecutionProvider, and anything not listed) execute on
+# the CPU, so taking the GPU semaphore for them would needlessly block
+# other pipelines' real GPU work.
+_GPU_PROVIDERS = ("CUDAExecutionProvider", "CoreMLExecutionProvider")
+
+
+def _session_uses_gpu(session):
+    """Return True if ``session`` is actually executing on a GPU provider.
+
+    ``InferenceSession.get_providers()`` returns the providers ONNX
+    Runtime decided to use after construction, so this reflects reality
+    even when CoreML was requested but excluded (e.g. for external-data
+    models). Falls back to ``True`` if the session doesn't expose
+    ``get_providers`` — conservative default that matches the unconditional-
+    lock behavior we had before this check existed.
+    """
+    try:
+        providers = session.get_providers()
+    except Exception:
+        return True
+    return any(p in _GPU_PROVIDERS for p in providers)
+
+
+def acquire_gpu_if_session_uses_it(session):
+    """Context manager: take the GPU semaphore only for GPU-running sessions.
+
+    CPU-only ONNX sessions (Apple Silicon with external-data models,
+    CPU-only installs) skip the lock so they don't block concurrent
+    pipelines' real GPU work. GPU-running sessions still serialise.
+
+    Usage::
+
+        with acquire_gpu_if_session_uses_it(session):
+            outputs = session.run(None, feeds)
+    """
+    if _session_uses_gpu(session):
+        return _GpuLockContext()
+    return _NoOpContext()
+
+
+class _NoOpContext:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
 # Per-workspace regroup locks. Created lazily on first request. Entries
 # are never removed — workspace IDs are stable integers and the lock
 # objects are tiny, so accumulating one per workspace the user has ever

--- a/vireo/pipeline_locks.py
+++ b/vireo/pipeline_locks.py
@@ -1,0 +1,81 @@
+"""Process-wide locks coordinating concurrent pipeline runs.
+
+Two primitives:
+
+* ``acquire_gpu()`` — a single-holder semaphore that every GPU-using stage
+  (classify, detect, extract_masks, eye_keypoints) wraps around its
+  per-batch inference call. Must be released between batches so a long
+  classify doesn't completely starve a second pipeline that just wants
+  one quick GPU op.
+
+* ``acquire_workspace_regroup(workspace_id)`` — a per-workspace lock so
+  two pipelines targeting the same workspace serialise on regroup but
+  not on earlier stages.
+
+Lock order (acquire outermost first): ``_progress_lock`` →
+``JobRunner._lock`` → ``acquire_workspace_regroup`` → ``acquire_gpu``.
+Never invert. The GPU lock is the innermost; nothing else may be acquired
+while it is held.
+"""
+
+import threading
+
+# Single GPU operation at a time across the whole process. Size 1 by
+# design — see docs/plans/2026-05-26-pipeline-concurrency-design.md
+# "Concurrency model" for the rationale.
+_GPU_SEMAPHORE = threading.Semaphore(1)
+
+
+def acquire_gpu():
+    """Context manager for the process-wide GPU semaphore.
+
+    Use around a single batch of inference, not a whole stage::
+
+        for batch in batches:
+            with acquire_gpu():
+                results = model.run(batch)
+            process(results)
+    """
+    return _GpuLockContext()
+
+
+class _GpuLockContext:
+    def __enter__(self):
+        _GPU_SEMAPHORE.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        _GPU_SEMAPHORE.release()
+
+
+# Per-workspace regroup locks. Created lazily on first request. Entries
+# are never removed — workspace IDs are stable integers and the lock
+# objects are tiny, so accumulating one per workspace the user has ever
+# regrouped against is harmless.
+_REGROUP_LOCKS: dict = {}
+_REGROUP_LOCKS_GUARD = threading.Lock()
+
+
+def acquire_workspace_regroup(workspace_id):
+    """Context manager for the regroup lock keyed by ``workspace_id``.
+
+    Two pipelines targeting the same workspace serialise here; pipelines
+    targeting different workspaces don't interact.
+    """
+    if workspace_id is None:
+        # Treat unspecified workspace as a single shared lock. In practice
+        # callers always pass a real id; this branch only protects against
+        # latent bugs that would silently make the lock global.
+        workspace_id = "__unspecified__"
+    with _REGROUP_LOCKS_GUARD:
+        lock = _REGROUP_LOCKS.get(workspace_id)
+        if lock is None:
+            lock = threading.Lock()
+            _REGROUP_LOCKS[workspace_id] = lock
+    return lock
+
+
+# Test hook so unit tests can assert lock identity without snooping on
+# the module-private dict directly.
+def _workspace_regroup_lock_for_tests(workspace_id):
+    return acquire_workspace_regroup(workspace_id)

--- a/vireo/tests/conftest.py
+++ b/vireo/tests/conftest.py
@@ -12,6 +12,21 @@ from PIL import Image
 
 
 @pytest.fixture(autouse=True)
+def _reset_model_cache():
+    """Drop the process-wide ModelCache between tests.
+
+    The cache is keyed by (model_id, fingerprint, ...) so a monkeypatched
+    ``Classifier`` stub from one test would otherwise be served to the
+    next test that reuses the same model id. Reset is cheap and only
+    affects tests; production keeps the singleton for the process lifetime.
+    """
+    from model_cache import reset_default_cache_for_tests
+    reset_default_cache_for_tests()
+    yield
+    reset_default_cache_for_tests()
+
+
+@pytest.fixture(autouse=True)
 def _restore_global_config_paths():
     """Snapshot/restore ``config.CONFIG_PATH`` (and ``models``' equivalents)
     around every test so a leak from a fixture that direct-assigns these

--- a/vireo/tests/test_classifier.py
+++ b/vireo/tests/test_classifier.py
@@ -646,6 +646,12 @@ class TestGpuLockScope:
         import pipeline_locks
 
         clf = _make_custom_classifier(tmp_path)
+        # Declare a GPU provider so the conditional lock engages — this
+        # is the on-GPU path; the CPU-only skip is covered in its own
+        # test below.
+        clf._image_session.get_providers.return_value = [
+            "CUDAExecutionProvider", "CPUExecutionProvider",
+        ]
 
         snapshots = {}
         original_run = clf._image_session.run
@@ -675,6 +681,9 @@ class TestGpuLockScope:
         import pipeline_locks
 
         clf = _make_custom_classifier(tmp_path)
+        clf._image_session.get_providers.return_value = [
+            "CUDAExecutionProvider", "CPUExecutionProvider",
+        ]
 
         snapshots = {"in_run": [], "post_run_in_loop": []}
         original_run = clf._image_session.run
@@ -695,4 +704,32 @@ class TestGpuLockScope:
         )
         assert snapshots["in_run"] == [baseline - 1] * 3, (
             "GPU lock must be held during every per-image session.run call"
+        )
+
+    def test_get_image_embedding_skips_gpu_lock_for_cpu_only_session(self, tmp_path):
+        """When BioCLIP runs on a CPU-only provider (Apple Silicon
+        excludes CoreML for external-data ONNX models; CPU-only installs
+        likewise), the image encoder must not take the process-wide GPU
+        semaphore. Codex P2 on PR #899.
+        """
+        import pipeline_locks
+
+        clf = _make_custom_classifier(tmp_path)
+        clf._image_session.get_providers.return_value = ["CPUExecutionProvider"]
+
+        snapshots = {}
+        original_run = clf._image_session.run
+
+        def record_during_run(output_names, input_dict):
+            snapshots["during_run"] = pipeline_locks._GPU_SEMAPHORE._value
+            return original_run(output_names, input_dict)
+
+        clf._image_session.run = record_during_run
+
+        baseline = pipeline_locks._GPU_SEMAPHORE._value
+        img = Image.new("RGB", (224, 224), color="red")
+        clf._get_image_embedding(img)
+
+        assert snapshots["during_run"] == baseline, (
+            "CPU-only image session must not take the GPU semaphore"
         )

--- a/vireo/tests/test_classifier.py
+++ b/vireo/tests/test_classifier.py
@@ -632,3 +632,67 @@ class TestEmbeddingCache:
         p1 = _embedding_cache_path(["bird", "cat"], "ViT-B-16")
         p2 = _embedding_cache_path(["bird", "dog"], "ViT-B-16")
         assert p1 != p2
+
+
+class TestGpuLockScope:
+    """Regression: the GPU semaphore must wrap only the image-encoder
+    ``session.run`` call inside ``_get_image_embedding`` — not the
+    preprocessing or normalisation around it. Codex P2 on PR #899.
+    """
+
+    def test_get_image_embedding_holds_gpu_lock_around_session_run(self, tmp_path):
+        """``_image_session.run`` must execute with the GPU lock held;
+        preprocessing/normalisation must not."""
+        import pipeline_locks
+
+        clf = _make_custom_classifier(tmp_path)
+
+        snapshots = {}
+        original_run = clf._image_session.run
+
+        def record_during_run(output_names, input_dict):
+            snapshots["during_run"] = pipeline_locks._GPU_SEMAPHORE._value
+            return original_run(output_names, input_dict)
+
+        clf._image_session.run = record_during_run
+
+        baseline = pipeline_locks._GPU_SEMAPHORE._value
+        img = Image.new("RGB", (224, 224), color="red")
+        clf._get_image_embedding(img)
+
+        assert pipeline_locks._GPU_SEMAPHORE._value == baseline, (
+            "semaphore must be released on the way out"
+        )
+        assert snapshots["during_run"] == baseline - 1, (
+            "GPU lock must be held during _image_session.run"
+        )
+
+    def test_classify_batch_with_embedding_holds_lock_only_at_session_run(self, tmp_path):
+        """In the batch path, each per-image ``session.run`` holds the
+        lock; the surrounding loop body (preprocessing, softmax,
+        result-building) must not.
+        """
+        import pipeline_locks
+
+        clf = _make_custom_classifier(tmp_path)
+
+        snapshots = {"in_run": [], "post_run_in_loop": []}
+        original_run = clf._image_session.run
+
+        def record_during_run(output_names, input_dict):
+            snapshots["in_run"].append(pipeline_locks._GPU_SEMAPHORE._value)
+            return original_run(output_names, input_dict)
+
+        clf._image_session.run = record_during_run
+
+        baseline = pipeline_locks._GPU_SEMAPHORE._value
+        images = [Image.new("RGB", (224, 224), color="red") for _ in range(3)]
+        results = clf.classify_batch_with_embedding(images)
+
+        assert len(results) == 3
+        assert pipeline_locks._GPU_SEMAPHORE._value == baseline, (
+            "semaphore must be released on the way out"
+        )
+        assert snapshots["in_run"] == [baseline - 1] * 3, (
+            "GPU lock must be held during every per-image session.run call"
+        )

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -2067,16 +2067,19 @@ def test_flush_batch_default_top_k_is_one():
 # ── GPU lock scope ────────────────────────────────────────────────────────
 
 
-def test_flush_batch_releases_gpu_lock_before_db_writes():
-    """``_flush_batch`` must release the GPU semaphore before the DB
-    upserts and result-building loop.
+def test_flush_batch_does_not_hold_gpu_lock_around_helper_or_db():
+    """``_flush_batch`` must not hold the GPU semaphore around the
+    classifier helper call or the DB writes.
 
-    Regression for the Codex P2 on PR #899: holding the process-wide GPU
-    lock through ``db.upsert_photo_embedding()`` blocked concurrent
-    pipelines' detector/SAM/DINO GPU batches while the GPU itself was
-    idle. We assert by snapshotting the semaphore's slot count at two
-    points — inside ``clf.classify_batch_with_embedding`` (lock held)
-    and inside ``db.upsert_photo_embedding`` (must be released).
+    Regression for the Codex P2 on PR #899: the process-wide GPU lock
+    has been pushed down into the classifier implementations (around
+    ``session.run`` only). At the ``_flush_batch`` level, neither the
+    classifier helper invocation nor ``db.upsert_photo_embedding`` should
+    see the lock held, so concurrent pipelines' detector/SAM/DINO GPU
+    batches aren't blocked while this one does CPU preprocessing or DB
+    work. The lock-held-during-``session.run`` half of this guarantee is
+    asserted in ``test_classifier.py`` /
+    ``test_timm_classifier.py``.
     """
     from unittest.mock import MagicMock
 
@@ -2085,8 +2088,8 @@ def test_flush_batch_releases_gpu_lock_before_db_writes():
 
     snapshots = {}
 
-    def record_inside_inference(images, threshold=0):
-        snapshots["during_inference"] = pipeline_locks._GPU_SEMAPHORE._value
+    def record_inside_helper(images, threshold=0):
+        snapshots["during_helper"] = pipeline_locks._GPU_SEMAPHORE._value
         return [
             (
                 [{"species": "Robin", "score": 0.7, "taxonomy": None}],
@@ -2099,7 +2102,7 @@ def test_flush_batch_releases_gpu_lock_before_db_writes():
         snapshots["during_db_write"] = pipeline_locks._GPU_SEMAPHORE._value
 
     clf = MagicMock()
-    clf.classify_batch_with_embedding.side_effect = record_inside_inference
+    clf.classify_batch_with_embedding.side_effect = record_inside_helper
 
     db = MagicMock()
     db.upsert_photo_embedding.side_effect = record_inside_db
@@ -2118,15 +2121,13 @@ def test_flush_batch_releases_gpu_lock_before_db_writes():
     assert pipeline_locks._GPU_SEMAPHORE._value == baseline, (
         "semaphore must be released on the way out"
     )
-
-    # _value is decremented while the lock is held. With a 1-slot
-    # semaphore, baseline=1 → 0 during inference, back to 1 by the time
-    # the DB write runs.
-    assert snapshots["during_inference"] == baseline - 1, (
-        "GPU lock must be held during clf.classify_batch_with_embedding"
+    assert snapshots["during_helper"] == baseline, (
+        "GPU lock must NOT be held around clf.classify_batch_with_embedding "
+        "at the _flush_batch level — the lock now lives inside the classifier "
+        "helpers, wrapping only ``session.run``"
     )
     assert snapshots["during_db_write"] == baseline, (
-        "GPU lock must be released before db.upsert_photo_embedding so "
+        "GPU lock must NOT be held during db.upsert_photo_embedding so "
         "concurrent pipelines can do GPU work while this one persists"
     )
 

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -2064,6 +2064,80 @@ def test_flush_batch_default_top_k_is_one():
     assert raw_results[0]["alternatives"] == []
 
 
+# ── GPU lock scope ────────────────────────────────────────────────────────
+
+
+def test_flush_batch_releases_gpu_lock_before_db_writes():
+    """``_flush_batch`` must release the GPU semaphore before the DB
+    upserts and result-building loop.
+
+    Regression for the Codex P2 on PR #899: holding the process-wide GPU
+    lock through ``db.upsert_photo_embedding()`` blocked concurrent
+    pipelines' detector/SAM/DINO GPU batches while the GPU itself was
+    idle. We assert by snapshotting the semaphore's slot count at two
+    points — inside ``clf.classify_batch_with_embedding`` (lock held)
+    and inside ``db.upsert_photo_embedding`` (must be released).
+    """
+    from unittest.mock import MagicMock
+
+    import pipeline_locks
+    from classify_job import _flush_batch
+
+    snapshots = {}
+
+    def record_inside_inference(images, threshold=0):
+        snapshots["during_inference"] = pipeline_locks._GPU_SEMAPHORE._value
+        return [
+            (
+                [{"species": "Robin", "score": 0.7, "taxonomy": None}],
+                _FakeEmbedding(),
+            )
+            for _ in images
+        ]
+
+    def record_inside_db(photo_id, model_name, embedding_bytes):
+        snapshots["during_db_write"] = pipeline_locks._GPU_SEMAPHORE._value
+
+    clf = MagicMock()
+    clf.classify_batch_with_embedding.side_effect = record_inside_inference
+
+    db = MagicMock()
+    db.upsert_photo_embedding.side_effect = record_inside_db
+
+    raw_results = []
+    batch = [{
+        "photo": {"id": 1, "filename": "bird.jpg", "timestamp": None},
+        "detection_id": 10,
+        "folder_path": "/photos",
+        "image_path": "/photos/bird.jpg",
+        "img": MagicMock(),
+    }]
+
+    baseline = pipeline_locks._GPU_SEMAPHORE._value
+    _flush_batch(batch, clf, "bioclip", "test-model", db, raw_results)
+    assert pipeline_locks._GPU_SEMAPHORE._value == baseline, (
+        "semaphore must be released on the way out"
+    )
+
+    # _value is decremented while the lock is held. With a 1-slot
+    # semaphore, baseline=1 → 0 during inference, back to 1 by the time
+    # the DB write runs.
+    assert snapshots["during_inference"] == baseline - 1, (
+        "GPU lock must be held during clf.classify_batch_with_embedding"
+    )
+    assert snapshots["during_db_write"] == baseline, (
+        "GPU lock must be released before db.upsert_photo_embedding so "
+        "concurrent pipelines can do GPU work while this one persists"
+    )
+
+
+class _FakeEmbedding:
+    """Stand-in for a numpy array that implements only ``.tobytes()``."""
+
+    def tobytes(self):
+        return b"\x00" * 16
+
+
 # ── Top-N: _store_grouped_predictions alternatives tests ─────────────────────
 
 

--- a/vireo/tests/test_detector.py
+++ b/vireo/tests/test_detector.py
@@ -432,3 +432,86 @@ def test_megadetector_onnx_model_file_valid():
     # Check file is non-trivially sized (ONNX models are at least a few MB)
     size = os.path.getsize(detector.MEGADETECTOR_ONNX_PATH)
     assert size > 1_000_000, f"Model file too small ({size} bytes), may be corrupted"
+
+
+def test_detect_animals_holds_gpu_lock_for_gpu_session(monkeypatch, tmp_path):
+    """``detect_animals`` must take the process-wide GPU semaphore around
+    ``session.run`` when the session reports a GPU provider.
+    """
+    from unittest.mock import MagicMock
+
+    import detector
+    import pipeline_locks
+
+    fake_session = MagicMock()
+    fake_input = MagicMock()
+    fake_input.name = "images"
+    fake_session.get_inputs.return_value = [fake_input]
+    fake_session.get_providers.return_value = [
+        "CUDAExecutionProvider", "CPUExecutionProvider",
+    ]
+
+    snapshots = {}
+
+    def fake_run(output_names, feed_dict):
+        snapshots["during_run"] = pipeline_locks._GPU_SEMAPHORE._value
+        # Return a degenerate empty output that _postprocess can swallow.
+        import numpy as np
+        return [np.zeros((1, 0, 8), dtype=np.float32)]
+
+    fake_session.run = fake_run
+    monkeypatch.setattr(detector, "_get_session", lambda: fake_session)
+
+    # Fake a loadable image so _preprocess succeeds.
+    img_path = tmp_path / "stub.jpg"
+    from PIL import Image
+    Image.new("RGB", (640, 480), color="black").save(img_path)
+
+    baseline = pipeline_locks._GPU_SEMAPHORE._value
+    detector.detect_animals(str(img_path))
+
+    assert snapshots["during_run"] == baseline - 1, (
+        "GPU lock must be held during session.run for GPU sessions"
+    )
+    assert pipeline_locks._GPU_SEMAPHORE._value == baseline, (
+        "semaphore must be released after detection"
+    )
+
+
+def test_detect_animals_skips_gpu_lock_for_cpu_only_session(monkeypatch, tmp_path):
+    """When MegaDetector falls back to CPU (Apple Silicon excludes CoreML
+    for external-data ONNX, or CPU-only installs), ``detect_animals``
+    must not take the process-wide GPU semaphore — concurrent SAM/DINO
+    on the GPU would otherwise stall on detector's CPU work.
+    """
+    from unittest.mock import MagicMock
+
+    import detector
+    import pipeline_locks
+
+    fake_session = MagicMock()
+    fake_input = MagicMock()
+    fake_input.name = "images"
+    fake_session.get_inputs.return_value = [fake_input]
+    fake_session.get_providers.return_value = ["CPUExecutionProvider"]
+
+    snapshots = {}
+
+    def fake_run(output_names, feed_dict):
+        snapshots["during_run"] = pipeline_locks._GPU_SEMAPHORE._value
+        import numpy as np
+        return [np.zeros((1, 0, 8), dtype=np.float32)]
+
+    fake_session.run = fake_run
+    monkeypatch.setattr(detector, "_get_session", lambda: fake_session)
+
+    img_path = tmp_path / "stub.jpg"
+    from PIL import Image
+    Image.new("RGB", (640, 480), color="black").save(img_path)
+
+    baseline = pipeline_locks._GPU_SEMAPHORE._value
+    detector.detect_animals(str(img_path))
+
+    assert snapshots["during_run"] == baseline, (
+        "CPU-only detector session must not take the GPU semaphore"
+    )

--- a/vireo/tests/test_dinov2.py
+++ b/vireo/tests/test_dinov2.py
@@ -230,6 +230,52 @@ def test_embed_batch_rejects_empty_input():
         dino_embed.embed_batch([], variant="vit-b14")
 
 
+def test_embed_batch_releases_gpu_lock_outside_inference():
+    """``embed_batch`` must hold the GPU semaphore only across the
+    ``session.run`` call — not across session loading or image
+    preprocessing.
+
+    Regression for the Codex P2 on PR #899: holding the process-wide GPU
+    lock across DINO's resize/normalize loop blocked concurrent pipelines'
+    GPU stages on CPU preprocessing.
+    """
+    import dino_embed
+    import pipeline_locks
+
+    snapshots = {"during": None}
+
+    def record_inside_run(_outputs, _inputs):
+        snapshots["during"] = pipeline_locks._GPU_SEMAPHORE._value
+        return [np.zeros((1, 768), dtype=np.float32)]
+
+    mock_session = MagicMock()
+    mock_session.get_inputs.return_value = [MagicMock(name="input")]
+    mock_session.run.side_effect = record_inside_run
+
+    dino_embed._session = mock_session
+    dino_embed._variant_loaded = "vit-b14"
+
+    from PIL import Image
+
+    img = Image.new("RGB", (100, 100))
+
+    baseline = pipeline_locks._GPU_SEMAPHORE._value
+    try:
+        dino_embed.embed_batch([img], variant="vit-b14")
+    finally:
+        dino_embed._session = None
+        dino_embed._variant_loaded = None
+
+    # Semaphore's _value is decremented while held. With a 1-slot
+    # semaphore, baseline=1 → 0 during session.run, back to 1 after.
+    assert pipeline_locks._GPU_SEMAPHORE._value == baseline, (
+        "semaphore must be released on the way out"
+    )
+    assert snapshots["during"] == baseline - 1, (
+        "GPU lock must be held during session.run"
+    )
+
+
 def test_embed_subject_delegates_to_embed():
     """embed_subject calls embed with the same arguments."""
     import dino_embed

--- a/vireo/tests/test_dinov2.py
+++ b/vireo/tests/test_dinov2.py
@@ -125,6 +125,73 @@ def test_singleton_reloads_for_different_variant(tmp_path):
     dino_embed._variant_loaded = None
 
 
+def test_concurrent_first_load_creates_only_one_session(tmp_path):
+    """Regression: two threads racing into _get_dinov2_session on first
+    load must share a single ONNX session, not each create their own and
+    overwrite the module global. Without the load lock, both threads pass
+    the ``_session is None`` check and ``onnx_runtime.create_session`` is
+    called twice — leaking the loser into VRAM and defeating the
+    shared-session guarantee that the rest of the concurrency design
+    relies on.
+    """
+    import threading
+    import time
+
+    import dino_embed
+
+    dino_embed._session = None
+    dino_embed._variant_loaded = None
+
+    model_dir = tmp_path / ".vireo" / "models" / "dinov2-vit-b14"
+    model_dir.mkdir(parents=True)
+    model_path = model_dir / "model.onnx"
+    model_path.write_bytes(b"fake")
+
+    create_calls = []
+    start_gate = threading.Event()
+
+    def slow_create(*_args, **_kwargs):
+        create_calls.append(1)
+        # Hold the lock long enough that, without the load lock, the
+        # second thread would also pass the ``_session is None`` check
+        # and call create_session. With the lock, the second thread
+        # blocks here and observes the cached session on re-check.
+        time.sleep(0.05)
+        return MagicMock()
+
+    results = []
+
+    def worker():
+        start_gate.wait(timeout=2.0)
+        with patch("os.path.expanduser", return_value=str(tmp_path)):
+            with patch(
+                "dino_embed.onnx_runtime.create_session",
+                side_effect=slow_create,
+            ):
+                results.append(dino_embed._get_dinov2_session("vit-b14"))
+
+    t1 = threading.Thread(target=worker)
+    t2 = threading.Thread(target=worker)
+    t1.start()
+    t2.start()
+    start_gate.set()
+    t1.join(timeout=3.0)
+    t2.join(timeout=3.0)
+
+    assert not t1.is_alive(), "first thread did not finish"
+    assert not t2.is_alive(), "second thread did not finish"
+    assert len(create_calls) == 1, (
+        "onnx_runtime.create_session must be called exactly once across "
+        f"concurrent first-load attempts; got {len(create_calls)} calls"
+    )
+    assert len(results) == 2
+    assert results[0] is results[1], "both threads must observe the same session"
+    assert dino_embed._session is results[0]
+
+    dino_embed._session = None
+    dino_embed._variant_loaded = None
+
+
 # -- Preprocessing --
 
 

--- a/vireo/tests/test_dinov2.py
+++ b/vireo/tests/test_dinov2.py
@@ -322,6 +322,11 @@ def test_embed_batch_releases_gpu_lock_outside_inference():
 
     mock_session = MagicMock()
     mock_session.get_inputs.return_value = [MagicMock(name="input")]
+    # Report a GPU provider so the conditional lock engages and the
+    # original "lock is held during inference" coverage still holds.
+    mock_session.get_providers.return_value = [
+        "CUDAExecutionProvider", "CPUExecutionProvider",
+    ]
     mock_session.run.side_effect = record_inside_run
 
     dino_embed._session = mock_session
@@ -346,6 +351,52 @@ def test_embed_batch_releases_gpu_lock_outside_inference():
     assert snapshots["during"] == baseline - 1, (
         "GPU lock must be held during session.run"
     )
+
+
+def test_embed_batch_skips_gpu_lock_for_cpu_only_session():
+    """When the DINO session falls back to CPU (Apple Silicon with
+    external-data models, or CPU-only installs), ``embed_batch`` must NOT
+    take the process-wide GPU semaphore — taking it would block unrelated
+    detector/classifier/SAM batches for work that never touches the GPU.
+
+    Regression for the Codex P2 on PR #899
+    (https://github.com/jss367/vireo/pull/899#discussion_r3308852536).
+    """
+    import dino_embed
+    import pipeline_locks
+
+    snapshots = {"during": None}
+
+    def record_inside_run(_outputs, _inputs):
+        snapshots["during"] = pipeline_locks._GPU_SEMAPHORE._value
+        return [np.zeros((1, 768), dtype=np.float32)]
+
+    mock_session = MagicMock()
+    mock_session.get_inputs.return_value = [MagicMock(name="input")]
+    # CPU-only execution — no GPU provider in the list.
+    mock_session.get_providers.return_value = ["CPUExecutionProvider"]
+    mock_session.run.side_effect = record_inside_run
+
+    dino_embed._session = mock_session
+    dino_embed._variant_loaded = "vit-b14"
+
+    from PIL import Image
+
+    img = Image.new("RGB", (100, 100))
+
+    baseline = pipeline_locks._GPU_SEMAPHORE._value
+    try:
+        dino_embed.embed_batch([img], variant="vit-b14")
+    finally:
+        dino_embed._session = None
+        dino_embed._variant_loaded = None
+
+    # Semaphore must remain free across the run — CPU-only sessions
+    # don't take the GPU lock.
+    assert snapshots["during"] == baseline, (
+        "GPU lock must NOT be held during CPU-only session.run"
+    )
+    assert pipeline_locks._GPU_SEMAPHORE._value == baseline
 
 
 def test_embed_subject_delegates_to_embed():

--- a/vireo/tests/test_dinov2.py
+++ b/vireo/tests/test_dinov2.py
@@ -163,20 +163,25 @@ def test_concurrent_first_load_creates_only_one_session(tmp_path):
 
     def worker():
         start_gate.wait(timeout=2.0)
-        with patch("os.path.expanduser", return_value=str(tmp_path)):
-            with patch(
-                "dino_embed.onnx_runtime.create_session",
-                side_effect=slow_create,
-            ):
-                results.append(dino_embed._get_dinov2_session("vit-b14"))
+        results.append(dino_embed._get_dinov2_session("vit-b14"))
 
-    t1 = threading.Thread(target=worker)
-    t2 = threading.Thread(target=worker)
-    t1.start()
-    t2.start()
-    start_gate.set()
-    t1.join(timeout=3.0)
-    t2.join(timeout=3.0)
+    # Apply patches once on the main thread, not from inside each worker.
+    # ``mock.patch`` mutates a module global; two threads independently
+    # entering/exiting a patch on the same target can race the restore
+    # and leak the patched function past the test boundary — flaking
+    # unrelated tests on the same xdist worker that call
+    # ``os.path.expanduser`` (e.g. ``test_runtime.py``).
+    with patch("os.path.expanduser", return_value=str(tmp_path)), patch(
+        "dino_embed.onnx_runtime.create_session",
+        side_effect=slow_create,
+    ):
+        t1 = threading.Thread(target=worker)
+        t2 = threading.Thread(target=worker)
+        t1.start()
+        t2.start()
+        start_gate.set()
+        t1.join(timeout=3.0)
+        t2.join(timeout=3.0)
 
     assert not t1.is_alive(), "first thread did not finish"
     assert not t2.is_alive(), "second thread did not finish"

--- a/vireo/tests/test_masking.py
+++ b/vireo/tests/test_masking.py
@@ -482,6 +482,94 @@ def test_generate_mask_with_mock():
     masking._sam2_variant_loaded = None
 
 
+def test_generate_mask_releases_gpu_lock_outside_inference():
+    """``generate_mask`` must hold the GPU semaphore only across the
+    encoder and decoder ``session.run`` calls — not across preprocessing,
+    prompt encoding, or mask postprocessing.
+
+    Regression for the Codex P2 on PR #899: holding the process-wide GPU
+    lock through SAM preprocessing/session-loading blocked concurrent
+    pipelines' classify/detect/DINO GPU stages even though the GPU was
+    idle. We assert by snapshotting the semaphore's slot count inside the
+    mocked session.run vs after generate_mask returns.
+    """
+    from unittest.mock import MagicMock
+
+    import masking
+    import pipeline_locks
+
+    snapshots = {"enc_during": None, "dec_during": None}
+
+    mock_enc = MagicMock()
+    mock_dec = MagicMock()
+
+    mock_enc.get_inputs.return_value = [MagicMock(name="image")]
+
+    def enc_run(_outputs, _inputs):
+        snapshots["enc_during"] = pipeline_locks._GPU_SEMAPHORE._value
+        return [np.zeros((1, 256, 64, 64), dtype=np.float32)]
+
+    mock_enc.run.side_effect = enc_run
+
+    mock_dec_input_1 = MagicMock()
+    mock_dec_input_1.name = "image_embeddings"
+    mock_dec_input_2 = MagicMock()
+    mock_dec_input_2.name = "point_coords"
+    mock_dec_input_3 = MagicMock()
+    mock_dec_input_3.name = "point_labels"
+    mock_dec_input_4 = MagicMock()
+    mock_dec_input_4.name = "mask_input"
+    mock_dec_input_5 = MagicMock()
+    mock_dec_input_5.name = "has_mask_input"
+    mock_dec_input_6 = MagicMock()
+    mock_dec_input_6.name = "orig_im_size"
+    mock_dec.get_inputs.return_value = [
+        mock_dec_input_1, mock_dec_input_2, mock_dec_input_3,
+        mock_dec_input_4, mock_dec_input_5, mock_dec_input_6,
+    ]
+
+    masks = np.zeros((1, 1, 100, 150), dtype=np.float32)
+    masks[0, 0, 20:60, 30:90] = 1.0
+    scores = np.array([[0.9]], dtype=np.float32)
+
+    def dec_run(_outputs, _inputs):
+        snapshots["dec_during"] = pipeline_locks._GPU_SEMAPHORE._value
+        return [masks, scores]
+
+    mock_dec.run.side_effect = dec_run
+
+    masking._encoder_session = mock_enc
+    masking._decoder_session = mock_dec
+    masking._sam2_variant_loaded = "sam2-small"
+
+    img = Image.new("RGB", (150, 100))
+    detection_box = {"x": 0.2, "y": 0.2, "w": 0.4, "h": 0.4}
+
+    baseline = pipeline_locks._GPU_SEMAPHORE._value
+    try:
+        result = masking.generate_mask(
+            img, detection_box, variant="sam2-small",
+        )
+    finally:
+        masking._encoder_session = None
+        masking._decoder_session = None
+        masking._sam2_variant_loaded = None
+
+    assert result is not None
+    # Semaphore's _value is decremented while the lock is held. With a
+    # 1-slot semaphore, baseline=1 → 0 during each session.run, back to 1
+    # after generate_mask returns.
+    assert pipeline_locks._GPU_SEMAPHORE._value == baseline, (
+        "semaphore must be released on the way out"
+    )
+    assert snapshots["enc_during"] == baseline - 1, (
+        "GPU lock must be held during encoder session.run"
+    )
+    assert snapshots["dec_during"] == baseline - 1, (
+        "GPU lock must be held during decoder session.run"
+    )
+
+
 # -- ensure_sam2_weights (auto-download on first pipeline run) --
 
 

--- a/vireo/tests/test_model_cache.py
+++ b/vireo/tests/test_model_cache.py
@@ -1,0 +1,182 @@
+# vireo/tests/test_model_cache.py
+import os
+import sys
+import threading
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from model_cache import ModelCache
+
+
+def test_acquire_calls_factory_once_per_miss():
+    cache = ModelCache(idle_secs=60)
+    calls = []
+
+    def factory():
+        calls.append(1)
+        return object()
+
+    with cache.acquire("k", factory) as v1:
+        assert v1 is not None
+    assert len(calls) == 1
+
+
+def test_concurrent_acquire_reuses_loaded_value():
+    cache = ModelCache(idle_secs=60)
+    calls = []
+    obj = object()
+
+    def factory():
+        calls.append(1)
+        return obj
+
+    # Two sequential acquires while previous is still held -> factory runs once
+    h1 = cache.acquire("k", factory)
+    v1 = h1.__enter__()
+    h2 = cache.acquire("k", factory)
+    v2 = h2.__enter__()
+    assert v1 is obj
+    assert v2 is obj
+    assert len(calls) == 1
+    h1.__exit__(None, None, None)
+    h2.__exit__(None, None, None)
+
+
+def test_release_arms_idle_timer_and_evicts():
+    cache = ModelCache(idle_secs=0.1)
+    loads = []
+
+    def factory():
+        loads.append(1)
+        return object()
+
+    with cache.acquire("k", factory):
+        pass
+    # Timer should fire shortly; wait for eviction.
+    deadline = time.time() + 2.0
+    while time.time() < deadline:
+        if not cache._has_entry("k"):
+            break
+        time.sleep(0.02)
+    assert not cache._has_entry("k"), "entry should be evicted after idle window"
+
+    # Re-acquire after eviction triggers a fresh load.
+    with cache.acquire("k", factory):
+        pass
+    assert len(loads) == 2
+
+
+def test_reacquire_before_idle_cancels_eviction():
+    cache = ModelCache(idle_secs=1.0)
+    loads = []
+
+    def factory():
+        loads.append(1)
+        return object()
+
+    with cache.acquire("k", factory):
+        pass
+    # Immediately re-acquire; idle timer should be cancelled.
+    with cache.acquire("k", factory):
+        pass
+    # Wait past where the first timer would have fired.
+    time.sleep(0.2)
+    # The factory must NOT have been re-invoked because the second acquire
+    # cancelled the pending eviction.
+    assert len(loads) == 1
+
+
+def test_active_refs_prevent_eviction():
+    cache = ModelCache(idle_secs=0.05)
+
+    def factory():
+        return object()
+
+    h_outer = cache.acquire("k", factory)
+    h_outer.__enter__()
+    with cache.acquire("k", factory):
+        pass  # release inner; refcount still 1
+    time.sleep(0.15)
+    assert cache._has_entry("k"), "entry must survive while refcount > 0"
+    h_outer.__exit__(None, None, None)
+
+
+def test_factory_exception_does_not_corrupt_cache():
+    cache = ModelCache(idle_secs=60)
+
+    def bad_factory():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with cache.acquire("k", bad_factory):
+            pass
+    # Failure must not leave a phantom entry or leaked refcount.
+    assert not cache._has_entry("k")
+
+    # A second acquire on the same key, with a working factory, must succeed.
+    def good_factory():
+        return "ok"
+
+    with cache.acquire("k", good_factory) as v:
+        assert v == "ok"
+
+
+def test_independent_keys_do_not_interfere():
+    cache = ModelCache(idle_secs=60)
+    calls_a = []
+    calls_b = []
+
+    with cache.acquire("a", lambda: (calls_a.append(1), "A")[1]):
+        with cache.acquire("b", lambda: (calls_b.append(1), "B")[1]) as vb:
+            assert vb == "B"
+    assert len(calls_a) == 1
+    assert len(calls_b) == 1
+
+
+def test_concurrent_acquire_from_multiple_threads_only_loads_once():
+    cache = ModelCache(idle_secs=60)
+    load_calls = []
+    load_started = threading.Event()
+    release_load = threading.Event()
+
+    def slow_factory():
+        load_calls.append(1)
+        load_started.set()
+        release_load.wait(timeout=2.0)
+        return "loaded"
+
+    values = []
+
+    def worker():
+        with cache.acquire("k", slow_factory) as v:
+            values.append(v)
+
+    t1 = threading.Thread(target=worker)
+    t2 = threading.Thread(target=worker)
+    t1.start()
+    assert load_started.wait(timeout=1.0)
+    # Second worker should now be queued waiting for the first load to finish.
+    t2.start()
+    time.sleep(0.05)
+    release_load.set()
+    t1.join(timeout=2.0)
+    t2.join(timeout=2.0)
+    assert load_calls == [1], "factory must run exactly once across threads"
+    assert values == ["loaded", "loaded"]
+
+
+def test_handle_release_is_idempotent():
+    cache = ModelCache(idle_secs=60)
+    h = cache.acquire("k", lambda: "v")
+    h.__enter__()
+    h.__exit__(None, None, None)
+    # Second exit must be a no-op, not a double-decrement.
+    h.__exit__(None, None, None)
+    # Acquire again — refcount must be 0, not negative.
+    with cache.acquire("k", lambda: "v2") as v:
+        assert v in ("v", "v2")  # cached or re-loaded — either is fine,
+        # what matters is no exception

--- a/vireo/tests/test_model_cache.py
+++ b/vireo/tests/test_model_cache.py
@@ -269,6 +269,62 @@ def test_failed_load_waiter_does_not_evict_recreated_entry():
     good_handle.__exit__(None, None, None)
 
 
+def test_stale_idle_timer_does_not_evict_renewed_entry():
+    """Regression: when an idle timer's callback races past cancel() and an
+    acquire+release cycle arms a fresh timer before the stale callback gets
+    the lock, the stale callback must not evict the entry that the fresh
+    timer is supposed to own. Without the evict_token guard, the stale
+    callback sees refcount==0 and deletes immediately, throwing away a
+    model whose true idle window has barely started."""
+    cache = ModelCache(idle_secs=60)
+
+    # Load and release so an entry + idle timer exist.
+    h1 = cache.acquire("k", lambda: "loaded-once")
+    h1.__enter__()
+    h1.__exit__(None, None, None)
+    entry = cache._entries["k"]
+    assert entry.refcount == 0
+    first_token = entry.evict_token
+    first_timer = entry.idle_timer
+    assert first_token is not None
+    assert first_timer is not None
+
+    # Simulate a timer callback that has already started running (so cancel
+    # below cannot stop it): grab the args the real callback would receive.
+    stale_args = ("k", entry, first_token)
+
+    # An acquire happens after the stale callback fired but before it took
+    # the lock. This cancels the (already-firing) timer, bumps refcount,
+    # and invalidates the token.
+    h2 = cache.acquire("k", lambda: "must-not-rerun")
+    h2.__enter__()
+    assert cache._entries["k"] is entry, "acquire must reuse the existing entry"
+    assert entry.refcount == 1
+    assert entry.evict_token is None, "acquire must invalidate the in-flight token"
+
+    # Release. This arms a fresh timer with a NEW token.
+    h2.__exit__(None, None, None)
+    fresh_token = entry.evict_token
+    fresh_timer = entry.idle_timer
+    assert fresh_token is not None and fresh_token is not first_token
+    assert fresh_timer is not None and fresh_timer is not first_timer
+
+    # Now the stale callback finally grabs the lock and runs. With the
+    # guard it sees its old token mismatched against entry.evict_token and
+    # bails. Without the guard it deletes the entry — wiping out a model
+    # whose real idle window has hardly begun.
+    cache._evict(*stale_args)
+
+    assert cache._has_entry("k"), (
+        "stale timer evicted entry that a fresh release re-armed"
+    )
+    assert cache._entries["k"] is entry
+    assert entry.evict_token is fresh_token
+
+    # Cancel the fresh timer so it doesn't outlive the test.
+    fresh_timer.cancel()
+
+
 def test_handle_release_is_idempotent():
     cache = ModelCache(idle_secs=60)
     h = cache.acquire("k", lambda: "v")

--- a/vireo/tests/test_model_cache.py
+++ b/vireo/tests/test_model_cache.py
@@ -171,6 +171,104 @@ def test_concurrent_acquire_from_multiple_threads_only_loads_once():
     assert values == ["loaded", "loaded"]
 
 
+def test_failed_load_waiter_does_not_evict_recreated_entry():
+    """Regression: when factory fails while another thread is queued on the
+    same key, the waiter must not decrement the refcount of a fresh entry
+    created later by a third acquirer. Without identity-checked release,
+    the waiter's _release decrements the wrong entry and arms a spurious
+    idle timer on a model still in use."""
+    cache = ModelCache(idle_secs=60)
+
+    # Gate B's _release until thread C has installed a fresh entry under
+    # the same key, so the race is deterministic rather than timing-luck.
+    c_installed = threading.Event()
+    original_release = cache._release
+    release_count = [0]
+
+    def gated_release(*args, **kwargs):
+        release_count[0] += 1
+        if release_count[0] == 1:
+            # First _release is B's failed-load release. Wait for C.
+            assert c_installed.wait(timeout=2.0), "C never installed entry"
+        return original_release(*args, **kwargs)
+
+    cache._release = gated_release
+
+    bad_started = threading.Event()
+    release_bad = threading.Event()
+
+    def bad_factory():
+        bad_started.set()
+        release_bad.wait(timeout=2.0)
+        raise RuntimeError("boom")
+
+    a_exc = []
+
+    def thread_a():
+        try:
+            with cache.acquire("k", bad_factory):
+                pass
+        except RuntimeError as e:
+            a_exc.append(e)
+
+    b_exc = []
+    b_started = threading.Event()
+
+    def b_factory():
+        b_started.set()
+        return "should-not-be-called"
+
+    def thread_b():
+        try:
+            with cache.acquire("k", b_factory):
+                pass
+        except RuntimeError as e:
+            b_exc.append(e)
+
+    ta = threading.Thread(target=thread_a)
+    ta.start()
+    assert bad_started.wait(timeout=1.0)
+
+    tb = threading.Thread(target=thread_b)
+    tb.start()
+    # Give B time to enter the global lock, increment refcount on the
+    # original entry, and queue on load_lock.
+    time.sleep(0.05)
+
+    # Let A's factory raise and abandon the entry.
+    release_bad.set()
+    ta.join(timeout=2.0)
+    assert not ta.is_alive()
+    assert len(a_exc) == 1
+
+    # B has now woken from load_lock and is parked inside gated_release.
+    # Install C's fresh entry under the same key.
+    good_handle = cache.acquire("k", lambda: "good")
+    good_handle.__enter__()
+    new_entry = cache._entries["k"]
+    assert new_entry.refcount == 1
+
+    # Release B; with the bug it decrements new_entry.refcount; with the
+    # fix it's a no-op because new_entry is not the entry B acquired.
+    c_installed.set()
+    tb.join(timeout=2.0)
+    assert not tb.is_alive()
+    assert len(b_exc) == 1
+    assert not b_started.is_set()
+
+    # Critical assertion: C's entry must be untouched.
+    assert cache._entries["k"] is new_entry
+    assert new_entry.refcount == 1, (
+        f"waiter's release corrupted recreated entry's refcount "
+        f"(got {new_entry.refcount}, want 1)"
+    )
+    assert new_entry.idle_timer is None, (
+        "waiter's release armed idle eviction on a model still in use"
+    )
+
+    good_handle.__exit__(None, None, None)
+
+
 def test_handle_release_is_idempotent():
     cache = ModelCache(idle_secs=60)
     h = cache.acquire("k", lambda: "v")

--- a/vireo/tests/test_model_cache.py
+++ b/vireo/tests/test_model_cache.py
@@ -1,4 +1,5 @@
 # vireo/tests/test_model_cache.py
+import logging
 import os
 import sys
 import threading
@@ -179,20 +180,21 @@ def test_failed_load_waiter_does_not_evict_recreated_entry():
     idle timer on a model still in use."""
     cache = ModelCache(idle_secs=60)
 
-    # Gate B's _release until thread C has installed a fresh entry under
-    # the same key, so the race is deterministic rather than timing-luck.
+    # Gate B's _release_entry until thread C has installed a fresh entry
+    # under the same key, so the race is deterministic rather than
+    # timing-luck.
     c_installed = threading.Event()
-    original_release = cache._release
+    original_release = cache._release_entry
     release_count = [0]
 
     def gated_release(*args, **kwargs):
         release_count[0] += 1
         if release_count[0] == 1:
-            # First _release is B's failed-load release. Wait for C.
+            # First release is B's failed-load release. Wait for C.
             assert c_installed.wait(timeout=2.0), "C never installed entry"
         return original_release(*args, **kwargs)
 
-    cache._release = gated_release
+    cache._release_entry = gated_release
 
     bad_started = threading.Event()
     release_bad = threading.Event()
@@ -291,7 +293,7 @@ def test_stale_idle_timer_does_not_evict_renewed_entry():
 
     # Simulate a timer callback that has already started running (so cancel
     # below cannot stop it): grab the args the real callback would receive.
-    stale_args = ("k", entry, first_token)
+    stale_args = (entry, first_token)
 
     # An acquire happens after the stale callback fired but before it took
     # the lock. This cancels the (already-firing) timer, bumps refcount,
@@ -336,3 +338,109 @@ def test_handle_release_is_idempotent():
     with cache.acquire("k", lambda: "v2") as v:
         assert v in ("v", "v2")  # cached or re-loaded — either is fine,
         # what matters is no exception
+
+
+def test_post_load_key_rekeys_when_factory_mutates_fingerprint():
+    """Regression for the self-heal redownload case: the factory replaces
+    on-disk weights, so the fingerprint baked into the original cache key
+    is stale by the time the value is stored. A second pipeline computing
+    the post-load fingerprint must hit the existing entry instead of
+    loading a duplicate model."""
+    cache = ModelCache(idle_secs=60)
+
+    # The factory bumps the fingerprint (simulating self-heal rewriting
+    # the on-disk weights, which changes mtime/size).
+    fp = ["pre"]
+
+    def healing_factory():
+        # The on-disk state mutates here.
+        fp[0] = "post"
+        return "session"
+
+    def post_load_key(_value):
+        return ("model", fp[0])
+
+    h1 = cache.acquire(("model", "pre"), healing_factory,
+                       post_load_key=post_load_key)
+    v1 = h1.__enter__()
+    assert v1 == "session"
+    # Entry must now live under the post-load key, not the pre-load one.
+    assert cache._has_entry(("model", "post"))
+    assert not cache._has_entry(("model", "pre"))
+
+    # A second pipeline computes its key from the post-self-heal files
+    # and looks up directly — must hit the existing entry, not reload.
+    factory_calls = [0]
+
+    def fresh_factory():
+        factory_calls[0] += 1
+        return "another-session"
+
+    h2 = cache.acquire(("model", "post"), fresh_factory,
+                       post_load_key=lambda _v: ("model", "post"))
+    v2 = h2.__enter__()
+    assert v2 == "session", "second acquire must reuse the healed session"
+    assert factory_calls == [0], "factory must not run a second time"
+
+    # Release both — the entry should still be the single one we created.
+    h1.__exit__(None, None, None)
+    h2.__exit__(None, None, None)
+
+
+def test_post_load_key_unchanged_does_not_rekey():
+    """When the factory does not mutate on-disk state, the post-load key
+    matches the pre-load key and the entry stays under its original key."""
+    cache = ModelCache(idle_secs=60)
+
+    h = cache.acquire("k", lambda: "v", post_load_key=lambda _v: "k")
+    h.__enter__()
+    assert cache._has_entry("k")
+    h.__exit__(None, None, None)
+    assert cache._has_entry("k")
+
+
+def test_post_load_key_collision_leaves_entry_under_original_key(caplog):
+    """If a concurrent acquirer has already installed an entry under the
+    post-load key, rekey is a no-op rather than overwriting the sibling
+    entry. The freshly loaded session lives out its life under the
+    pre-load key and idles out (brief duplicate VRAM, no corruption)."""
+    cache = ModelCache(idle_secs=60)
+
+    # Pre-populate "post" with an unrelated entry.
+    h_existing = cache.acquire("post", lambda: "other-session")
+    h_existing.__enter__()
+
+    with caplog.at_level(logging.WARNING, logger="model_cache"):
+        h = cache.acquire("pre", lambda: "healed",
+                          post_load_key=lambda _v: "post")
+        h.__enter__()
+
+    # Rekey was refused; original entry stays at "pre", and the sibling
+    # at "post" is untouched.
+    assert cache._has_entry("pre")
+    assert cache._has_entry("post")
+    assert cache._entries["pre"].value == "healed"
+    assert cache._entries["post"].value == "other-session"
+    assert any("cannot rekey" in r.message for r in caplog.records)
+
+    h.__exit__(None, None, None)
+    h_existing.__exit__(None, None, None)
+
+
+def test_post_load_key_exception_keeps_entry_under_original_key(caplog):
+    """If the post_load_key callback itself raises, the entry stays under
+    its original key and the load result is still returned. The exception
+    is logged rather than propagated — a rekey failure is a degraded
+    cache-hit rate, not a load failure."""
+    cache = ModelCache(idle_secs=60)
+
+    def bad_post_load(_v):
+        raise RuntimeError("fingerprint failed")
+
+    with caplog.at_level(logging.ERROR, logger="model_cache"):
+        with cache.acquire("k", lambda: "v",
+                           post_load_key=bad_post_load) as v:
+            assert v == "v"
+    assert cache._has_entry("k")
+    assert any("post_load_key callback raised" in r.message
+               for r in caplog.records)

--- a/vireo/tests/test_model_cache.py
+++ b/vireo/tests/test_model_cache.py
@@ -165,6 +165,8 @@ def test_concurrent_acquire_from_multiple_threads_only_loads_once():
     release_load.set()
     t1.join(timeout=2.0)
     t2.join(timeout=2.0)
+    assert not t1.is_alive(), "t1 did not terminate after join"
+    assert not t2.is_alive(), "t2 did not terminate after join"
     assert load_calls == [1], "factory must run exactly once across threads"
     assert values == ["loaded", "loaded"]
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -8539,14 +8539,62 @@ def test_weights_fingerprint_changes_on_in_place_replacement(tmp_path):
 
 
 def test_weights_fingerprint_handles_missing_path_and_files():
-    """``None``/empty inputs must collapse to ``None`` so the cache key
-    stays well-formed when ``files`` isn't listed on the model spec.
+    """``None``/missing inputs must collapse to ``None`` so the cache key
+    stays well-formed when nothing can be stat'd.
     """
     from pipeline_job import _weights_fingerprint
 
     assert _weights_fingerprint(None, ["a.onnx"]) is None
-    assert _weights_fingerprint("/nonexistent", None) is None
-    assert _weights_fingerprint("/nonexistent", []) is None
+    assert _weights_fingerprint(None, None) is None
+    assert _weights_fingerprint("/nonexistent/path/that/does/not/exist", None) is None
+    assert _weights_fingerprint("/nonexistent/path/that/does/not/exist", []) is None
+
+
+def test_weights_fingerprint_custom_model_directory(tmp_path):
+    """Custom models have no declared ``files`` list, so the fingerprint
+    must fall back to listing the directory. Without this, a user who
+    re-registers a custom model at the same path within the idle window
+    keeps hitting the cached session built from the old weights.
+    """
+    from pipeline_job import _weights_fingerprint
+
+    (tmp_path / "model.onnx").write_bytes(b"v1")
+    (tmp_path / "config.json").write_bytes(b"{}")
+    fp1 = _weights_fingerprint(str(tmp_path), None)
+    assert fp1 is not None
+    assert any(part[0] == "model.onnx" for part in fp1)
+
+    # Re-register: overwrite the .onnx with new bytes.
+    import os
+    import time
+
+    time.sleep(0.01)
+    (tmp_path / "model.onnx").write_bytes(b"v2-much-larger-payload")
+    os.utime(tmp_path / "model.onnx", None)
+    fp2 = _weights_fingerprint(str(tmp_path), None)
+    assert fp2 != fp1
+
+
+def test_weights_fingerprint_custom_model_single_file(tmp_path):
+    """Custom models can be registered as a path to a single .onnx file
+    rather than a directory; that case must still produce a fingerprint
+    so in-place replacement is detected.
+    """
+    from pipeline_job import _weights_fingerprint
+
+    onnx = tmp_path / "model.onnx"
+    onnx.write_bytes(b"v1")
+    fp1 = _weights_fingerprint(str(onnx), None)
+    assert fp1 is not None
+
+    import os
+    import time
+
+    time.sleep(0.01)
+    onnx.write_bytes(b"v2-much-larger-payload")
+    os.utime(onnx, None)
+    fp2 = _weights_fingerprint(str(onnx), None)
+    assert fp2 != fp1
 
 
 def test_weights_fingerprint_missing_file_distinguishes_from_present(tmp_path):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -8408,3 +8408,89 @@ def test_pipeline_scan_surfaces_permission_denied(tmp_path, monkeypatch):
         assert isinstance(result, dict)
     finally:
         os.chmod(str(locked_dir), 0o755)
+
+
+def test_release_classifier_cache_handle_clears_bundle_fields():
+    """After release, ``loaded_models`` must not keep the classifier alive.
+
+    Regression for the Codex P2 on PR #899: a late-stage release that
+    only popped ``_cache_handle`` left ``clf``/``labels``/``active_model``
+    in ``loaded_models``. The cache refcount could then drop to 0 and the
+    5-minute idle timer fire while the bundle was still strongly
+    referenced — evicting the cache entry without freeing VRAM, and
+    forcing a duplicate session on the next same-key acquire.
+    """
+    import gc
+    import time
+    import weakref
+
+    from model_cache import ModelCache
+    from pipeline_job import _release_classifier_cache_handle
+
+    # Short idle window so the test exercises the actual eviction path
+    # the bug occurs on (timer fires, entry drops, VRAM frees) rather
+    # than just inspecting dict keys.
+    cache = ModelCache(idle_secs=0.05)
+
+    class FakeClassifier:
+        pass
+
+    box = [FakeClassifier()]
+    clf_ref = weakref.ref(box[0])
+    key = ("bioclip", "m1", "model_str", "/path", "fp")
+
+    handle = cache.acquire(key, lambda: box[0])
+    handle.__enter__()
+    loaded_models = {
+        "_cache_handle": handle,
+        "clf": box[0],
+        "model_type": "bioclip",
+        "model_name": "M1",
+        "model_str": "model_str",
+        "labels": ["a", "b"],
+        "use_tol": False,
+        "active_model": {"id": "m1"},
+        "labels_fingerprint": "fp",
+        # Non-bundle keys must be preserved: pipeline-scoped, not per-model.
+        "tax": object(),
+        "resolved_specs": [{"id": "m1"}],
+    }
+    box[0] = None  # drop the test's own strong ref to the classifier
+
+    _release_classifier_cache_handle(loaded_models)
+
+    for k in ("_cache_handle", "clf", "model_type", "model_name",
+              "model_str", "labels", "use_tol", "active_model",
+              "labels_fingerprint"):
+        assert k not in loaded_models, (
+            f"{k!r} must be cleared so idle eviction can reclaim VRAM"
+        )
+    for k in ("tax", "resolved_specs"):
+        assert k in loaded_models, (
+            f"{k!r} is pipeline-scoped and must survive release"
+        )
+
+    # Drop the local handle ref so only the cache could plausibly pin the
+    # classifier. Wait for the idle timer to evict the entry, then GC. With
+    # bundle fields cleared (the fix) the weakref must collapse — meaning
+    # VRAM would actually be freed. Without the fix, ``loaded_models["clf"]``
+    # would survive and the weakref stays alive.
+    del handle
+    deadline = time.time() + 2.0
+    while time.time() < deadline and cache._has_entry(key):
+        time.sleep(0.01)
+    gc.collect()
+    assert clf_ref() is None, (
+        "classifier must be collectable after release+eviction; "
+        "if this fails, something in loaded_models is still pinning it"
+    )
+
+
+def test_release_classifier_cache_handle_idempotent_when_no_bundle():
+    """Calling release on an empty dict (classify skipped pre-load) is a no-op."""
+    from pipeline_job import _release_classifier_cache_handle
+
+    loaded_models = {"tax": object(), "resolved_specs": []}
+    _release_classifier_cache_handle(loaded_models)
+    assert "tax" in loaded_models
+    assert "resolved_specs" in loaded_models

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -8494,3 +8494,77 @@ def test_release_classifier_cache_handle_idempotent_when_no_bundle():
     _release_classifier_cache_handle(loaded_models)
     assert "tax" in loaded_models
     assert "resolved_specs" in loaded_models
+
+
+def test_weights_fingerprint_changes_on_in_place_replacement(tmp_path):
+    """A Repair / re-register that overwrites weights at the same path must
+    produce a different cache-key component.
+
+    Regression for the Codex P2 on PR #899: the classifier cache key
+    only contained ``weights_path`` (a stable directory string), so a
+    pipeline reusing the in-process cache after a Repair would silently
+    classify with stale or corrupt session bytes until the 5-minute idle
+    timer fired.
+    """
+    import os
+    import time
+
+    from pipeline_job import _weights_fingerprint
+
+    files = ["image_encoder.onnx", "config.json"]
+    for rel in files:
+        (tmp_path / rel).write_bytes(b"v1")
+
+    fp1 = _weights_fingerprint(str(tmp_path), files)
+    assert fp1 is not None
+
+    # Identical disk state — fingerprint must be byte-identical so cache
+    # hits across pipeline runs work.
+    assert _weights_fingerprint(str(tmp_path), files) == fp1
+
+    # Bump mtime in a way the OS can resolve (st_mtime_ns is OS-dependent;
+    # 10 ms covers every filesystem we care about). The size also changes
+    # here, but mtime alone would be enough — in-place overwrites bump it.
+    time.sleep(0.01)
+    (tmp_path / "image_encoder.onnx").write_bytes(b"v2-longer")
+    # Force mtime forward in case the filesystem coalesces same-second writes.
+    new_mtime = os.stat(tmp_path / "image_encoder.onnx").st_mtime + 1
+    os.utime(tmp_path / "image_encoder.onnx", (new_mtime, new_mtime))
+
+    fp2 = _weights_fingerprint(str(tmp_path), files)
+    assert fp2 != fp1, (
+        "weights fingerprint must change after in-place file replacement "
+        "so the classifier cache misses on the new bytes"
+    )
+
+
+def test_weights_fingerprint_handles_missing_path_and_files():
+    """``None``/empty inputs must collapse to ``None`` so the cache key
+    stays well-formed when ``files`` isn't listed on the model spec.
+    """
+    from pipeline_job import _weights_fingerprint
+
+    assert _weights_fingerprint(None, ["a.onnx"]) is None
+    assert _weights_fingerprint("/nonexistent", None) is None
+    assert _weights_fingerprint("/nonexistent", []) is None
+
+
+def test_weights_fingerprint_missing_file_distinguishes_from_present(tmp_path):
+    """A partial-Repair state (file deleted but path still listed) must
+    fingerprint differently from the complete state, so the cache misses
+    and the load attempt either succeeds with fresh files or raises a
+    clear "incomplete" error instead of reusing a stale session.
+    """
+    from pipeline_job import _weights_fingerprint
+
+    files = ["a.onnx", "b.onnx"]
+    (tmp_path / "a.onnx").write_bytes(b"x")
+    (tmp_path / "b.onnx").write_bytes(b"y")
+    full_fp = _weights_fingerprint(str(tmp_path), files)
+
+    (tmp_path / "b.onnx").unlink()
+    partial_fp = _weights_fingerprint(str(tmp_path), files)
+
+    assert partial_fp != full_fp
+    # Missing entries collapse to a sentinel so the key still hashes.
+    assert any(part[1] is None for part in partial_fp)

--- a/vireo/tests/test_pipeline_locks.py
+++ b/vireo/tests/test_pipeline_locks.py
@@ -1,0 +1,124 @@
+# vireo/tests/test_pipeline_locks.py
+import os
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from pipeline_locks import (
+    acquire_gpu,
+    acquire_workspace_regroup,
+)
+
+
+def test_gpu_lock_serialises_two_threads():
+    """Only one thread holds the GPU lock at a time."""
+    held = []
+    release_first = threading.Event()
+    second_started = threading.Event()
+
+    def first():
+        with acquire_gpu():
+            held.append("first-in")
+            second_started.wait(timeout=2.0)
+            time.sleep(0.05)  # ensure second is blocked, not racing
+            held.append("first-out")
+        # released
+        time.sleep(0.05)
+
+    def second():
+        second_started.set()
+        with acquire_gpu():
+            held.append("second-in")
+
+    t1 = threading.Thread(target=first)
+    t2 = threading.Thread(target=second)
+    t1.start()
+    # wait for first to actually grab the lock
+    while "first-in" not in held:
+        time.sleep(0.005)
+    t2.start()
+    t1.join(timeout=3.0)
+    t2.join(timeout=3.0)
+
+    assert held == ["first-in", "first-out", "second-in"], (
+        f"second must wait for first to release; got {held}"
+    )
+
+
+def test_gpu_lock_released_after_with_block():
+    """Sequential `with acquire_gpu()` calls don't deadlock — release works."""
+    for _ in range(3):
+        with acquire_gpu():
+            pass
+    # If release was broken, the second iteration would deadlock and the
+    # test timeout would fire. Reaching here is the assertion.
+
+
+def test_workspace_regroup_lock_serialises_same_workspace():
+    """Two threads regrouping the same workspace take turns."""
+    held = []
+    second_started = threading.Event()
+
+    def first():
+        with acquire_workspace_regroup(42):
+            held.append("first-in")
+            second_started.wait(timeout=2.0)
+            time.sleep(0.05)
+            held.append("first-out")
+
+    def second():
+        second_started.set()
+        with acquire_workspace_regroup(42):
+            held.append("second-in")
+
+    t1 = threading.Thread(target=first)
+    t2 = threading.Thread(target=second)
+    t1.start()
+    while "first-in" not in held:
+        time.sleep(0.005)
+    t2.start()
+    t1.join(timeout=3.0)
+    t2.join(timeout=3.0)
+
+    assert held == ["first-in", "first-out", "second-in"], (
+        f"second on same workspace must wait; got {held}"
+    )
+
+
+def test_workspace_regroup_lock_does_not_block_other_workspaces():
+    """Different workspace IDs use independent locks; second runs immediately."""
+    held = []
+    first_holding = threading.Event()
+    let_first_go = threading.Event()
+
+    def first():
+        with acquire_workspace_regroup(1):
+            held.append("first-in")
+            first_holding.set()
+            let_first_go.wait(timeout=2.0)
+            held.append("first-out")
+
+    def second():
+        with acquire_workspace_regroup(2):
+            held.append("second-in")
+
+    t1 = threading.Thread(target=first)
+    t2 = threading.Thread(target=second)
+    t1.start()
+    assert first_holding.wait(timeout=1.0)
+    t2.start()
+    t2.join(timeout=1.0)
+    assert "second-in" in held, "different workspace must not be blocked"
+    let_first_go.set()
+    t1.join(timeout=2.0)
+
+
+def test_workspace_regroup_lock_reentrant_keys_share_one_lock():
+    """The lock object for a given workspace_id is stable across calls."""
+    from pipeline_locks import _workspace_regroup_lock_for_tests
+    lock1 = _workspace_regroup_lock_for_tests(7)
+    lock2 = _workspace_regroup_lock_for_tests(7)
+    assert lock1 is lock2

--- a/vireo/tests/test_pipeline_locks.py
+++ b/vireo/tests/test_pipeline_locks.py
@@ -8,9 +8,58 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, os.path.dirname(__file__))
 
 from pipeline_locks import (
+    _GPU_SEMAPHORE,
     acquire_gpu,
+    acquire_gpu_if_session_uses_it,
     acquire_workspace_regroup,
 )
+
+
+class _FakeSession:
+    def __init__(self, providers):
+        self._providers = list(providers)
+
+    def get_providers(self):
+        return list(self._providers)
+
+
+def test_acquire_gpu_if_session_uses_it_takes_lock_for_cuda_session():
+    sess = _FakeSession(["CUDAExecutionProvider", "CPUExecutionProvider"])
+    before = _GPU_SEMAPHORE._value
+    with acquire_gpu_if_session_uses_it(sess):
+        held = _GPU_SEMAPHORE._value
+    after = _GPU_SEMAPHORE._value
+    assert before == 1
+    assert held == 0, "semaphore should be acquired for GPU sessions"
+    assert after == 1
+
+
+def test_acquire_gpu_if_session_uses_it_takes_lock_for_coreml_session():
+    sess = _FakeSession(["CoreMLExecutionProvider", "CPUExecutionProvider"])
+    with acquire_gpu_if_session_uses_it(sess):
+        assert _GPU_SEMAPHORE._value == 0
+
+
+def test_acquire_gpu_if_session_uses_it_skips_lock_for_cpu_only_session():
+    sess = _FakeSession(["CPUExecutionProvider"])
+    before = _GPU_SEMAPHORE._value
+    with acquire_gpu_if_session_uses_it(sess):
+        held = _GPU_SEMAPHORE._value
+    after = _GPU_SEMAPHORE._value
+    assert before == 1
+    assert held == 1, "CPU-only session must not take the GPU semaphore"
+    assert after == 1
+
+
+def test_acquire_gpu_if_session_uses_it_defaults_to_lock_when_providers_missing():
+    """A session that doesn't expose get_providers (or raises) must
+    conservatively take the lock — same behavior as before this check existed.
+    """
+    class _NoProviders:
+        pass
+
+    with acquire_gpu_if_session_uses_it(_NoProviders()):
+        assert _GPU_SEMAPHORE._value == 0
 
 
 def _wait_until(predicate, timeout=1.0, interval=0.005):

--- a/vireo/tests/test_pipeline_locks.py
+++ b/vireo/tests/test_pipeline_locks.py
@@ -13,6 +13,20 @@ from pipeline_locks import (
 )
 
 
+def _wait_until(predicate, timeout=1.0, interval=0.005):
+    """Poll ``predicate`` until true or timeout; assert on timeout.
+
+    Replaces unbounded ``while not <cond>: time.sleep(...)`` loops that
+    would otherwise hang the suite if a thread stalls.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+    raise AssertionError(f"condition not met within {timeout}s")
+
+
 def test_gpu_lock_serialises_two_threads():
     """Only one thread holds the GPU lock at a time."""
     held = []
@@ -36,12 +50,12 @@ def test_gpu_lock_serialises_two_threads():
     t1 = threading.Thread(target=first)
     t2 = threading.Thread(target=second)
     t1.start()
-    # wait for first to actually grab the lock
-    while "first-in" not in held:
-        time.sleep(0.005)
+    _wait_until(lambda: "first-in" in held)
     t2.start()
     t1.join(timeout=3.0)
     t2.join(timeout=3.0)
+    assert not t1.is_alive(), "first thread did not finish"
+    assert not t2.is_alive(), "second thread did not finish"
 
     assert held == ["first-in", "first-out", "second-in"], (
         f"second must wait for first to release; got {held}"
@@ -77,11 +91,12 @@ def test_workspace_regroup_lock_serialises_same_workspace():
     t1 = threading.Thread(target=first)
     t2 = threading.Thread(target=second)
     t1.start()
-    while "first-in" not in held:
-        time.sleep(0.005)
+    _wait_until(lambda: "first-in" in held)
     t2.start()
     t1.join(timeout=3.0)
     t2.join(timeout=3.0)
+    assert not t1.is_alive(), "first thread did not finish"
+    assert not t2.is_alive(), "second thread did not finish"
 
     assert held == ["first-in", "first-out", "second-in"], (
         f"second on same workspace must wait; got {held}"
@@ -111,9 +126,11 @@ def test_workspace_regroup_lock_does_not_block_other_workspaces():
     assert first_holding.wait(timeout=1.0)
     t2.start()
     t2.join(timeout=1.0)
+    assert not t2.is_alive(), "second thread should not be blocked by a different workspace"
     assert "second-in" in held, "different workspace must not be blocked"
     let_first_go.set()
     t1.join(timeout=2.0)
+    assert not t1.is_alive(), "first thread did not finish"
 
 
 def test_workspace_regroup_lock_reentrant_keys_share_one_lock():

--- a/vireo/tests/test_timm_classifier.py
+++ b/vireo/tests/test_timm_classifier.py
@@ -330,6 +330,12 @@ def test_classify_holds_gpu_lock_around_session_run_only(tmp_path):
     import pipeline_locks
 
     clf = _make_fake_classifier(tmp_path)
+    # Declare a GPU provider so the conditional lock engages — this is
+    # the on-GPU code path; the CPU-only skip is covered in its own test
+    # below.
+    clf._session.get_providers.return_value = [
+        "CUDAExecutionProvider", "CPUExecutionProvider",
+    ]
 
     snapshots = {}
     original_run = clf._session.run.side_effect  # underlying fake_run
@@ -360,6 +366,9 @@ def test_classify_batch_holds_gpu_lock_around_session_run_only(tmp_path):
     import pipeline_locks
 
     clf = _make_fake_classifier(tmp_path)
+    clf._session.get_providers.return_value = [
+        "CUDAExecutionProvider", "CPUExecutionProvider",
+    ]
 
     snapshots = {}
     original_run = clf._session.run.side_effect
@@ -380,4 +389,59 @@ def test_classify_batch_holds_gpu_lock_around_session_run_only(tmp_path):
     )
     assert snapshots["during_run"] == baseline - 1, (
         "GPU lock must be held during _session.run"
+    )
+
+
+def test_classify_skips_gpu_lock_for_cpu_only_session(tmp_path):
+    """When the timm session runs on CPU (Apple Silicon excludes CoreML
+    for external-data models; CPU-only installs likewise), classify()
+    must not take the process-wide GPU semaphore. Codex P2 on PR #899:
+    blocking real GPU stages in other pipelines for CPU-only work
+    defeats the concurrency this design enables.
+    """
+    import pipeline_locks
+
+    clf = _make_fake_classifier(tmp_path)
+    clf._session.get_providers.return_value = ["CPUExecutionProvider"]
+
+    snapshots = {}
+    original_run = clf._session.run.side_effect
+
+    def record_during_run(output_names, input_dict):
+        snapshots["during_run"] = pipeline_locks._GPU_SEMAPHORE._value
+        return original_run(output_names, input_dict)
+
+    clf._session.run.side_effect = record_during_run
+
+    baseline = pipeline_locks._GPU_SEMAPHORE._value
+    img = Image.new("RGB", (500, 400), color="green")
+    clf.classify(img)
+
+    assert snapshots["during_run"] == baseline, (
+        "CPU-only session must not take the GPU semaphore"
+    )
+
+
+def test_classify_batch_skips_gpu_lock_for_cpu_only_session(tmp_path):
+    """Same CPU-only skip as classify(), but for the batched path."""
+    import pipeline_locks
+
+    clf = _make_fake_classifier(tmp_path)
+    clf._session.get_providers.return_value = ["CPUExecutionProvider"]
+
+    snapshots = {}
+    original_run = clf._session.run.side_effect
+
+    def record_during_run(output_names, input_dict):
+        snapshots["during_run"] = pipeline_locks._GPU_SEMAPHORE._value
+        return original_run(output_names, input_dict)
+
+    clf._session.run.side_effect = record_during_run
+
+    baseline = pipeline_locks._GPU_SEMAPHORE._value
+    images = [Image.new("RGB", (500, 400), color="green") for _ in range(3)]
+    clf.classify_batch(images)
+
+    assert snapshots["during_run"] == baseline, (
+        "CPU-only session must not take the GPU semaphore in the batched path"
     )

--- a/vireo/tests/test_timm_classifier.py
+++ b/vireo/tests/test_timm_classifier.py
@@ -314,3 +314,70 @@ def test_get_models_includes_model_type():
     models = get_models()
     for m in models:
         assert "model_type" in m, f"Model {m['id']} missing model_type from get_models()"
+
+
+# ── GPU lock scope ────────────────────────────────────────────────────────
+
+
+def test_classify_holds_gpu_lock_around_session_run_only(tmp_path):
+    """``TimmClassifier.classify`` must hold the GPU lock around
+    ``session.run`` only — not around preprocessing or softmax.
+
+    Regression for Codex P2 on PR #899: the lock has been pushed down
+    out of ``classify_job._flush_batch`` and into the classifier
+    implementations so concurrent pipelines aren't blocked on CPU work.
+    """
+    import pipeline_locks
+
+    clf = _make_fake_classifier(tmp_path)
+
+    snapshots = {}
+    original_run = clf._session.run.side_effect  # underlying fake_run
+
+    def record_during_run(output_names, input_dict):
+        snapshots["during_run"] = pipeline_locks._GPU_SEMAPHORE._value
+        return original_run(output_names, input_dict)
+
+    clf._session.run.side_effect = record_during_run
+
+    baseline = pipeline_locks._GPU_SEMAPHORE._value
+    img = Image.new("RGB", (500, 400), color="green")
+    clf.classify(img)
+
+    assert pipeline_locks._GPU_SEMAPHORE._value == baseline, (
+        "semaphore must be released on the way out"
+    )
+    assert snapshots["during_run"] == baseline - 1, (
+        "GPU lock must be held during _session.run"
+    )
+
+
+def test_classify_batch_holds_gpu_lock_around_session_run_only(tmp_path):
+    """``TimmClassifier.classify_batch`` must hold the GPU lock around
+    the single batched ``session.run`` call — not around per-image
+    preprocessing or the result-building loop.
+    """
+    import pipeline_locks
+
+    clf = _make_fake_classifier(tmp_path)
+
+    snapshots = {}
+    original_run = clf._session.run.side_effect
+
+    def record_during_run(output_names, input_dict):
+        snapshots["during_run"] = pipeline_locks._GPU_SEMAPHORE._value
+        return original_run(output_names, input_dict)
+
+    clf._session.run.side_effect = record_during_run
+
+    baseline = pipeline_locks._GPU_SEMAPHORE._value
+    images = [Image.new("RGB", (500, 400), color="green") for _ in range(4)]
+    results = clf.classify_batch(images)
+
+    assert len(results) == 4
+    assert pipeline_locks._GPU_SEMAPHORE._value == baseline, (
+        "semaphore must be released on the way out"
+    )
+    assert snapshots["during_run"] == baseline - 1, (
+        "GPU lock must be held during _session.run"
+    )

--- a/vireo/timm_classifier.py
+++ b/vireo/timm_classifier.py
@@ -186,6 +186,7 @@ class TimmClassifier:
             list of dicts with species, score, auto_tag, confidence_tag, taxonomy
         """
         from PIL import Image as PILImage
+        from pipeline_locks import acquire_gpu
 
         if isinstance(image, (str, os.PathLike)):
             with PILImage.open(image) as img:
@@ -193,7 +194,11 @@ class TimmClassifier:
         else:
             input_arr = self._preprocess(image)
 
-        output = self._session.run(None, {self._input_name: input_arr})
+        # GPU serialisation across concurrent pipelines, scoped tightly to
+        # the forward pass. Preprocessing above runs without the lock so
+        # concurrent pipelines aren't blocked on CPU work.
+        with acquire_gpu():
+            output = self._session.run(None, {self._input_name: input_arr})
         logits = output[0]  # shape: (1, num_classes)
         probs = onnx_runtime.softmax(logits, axis=-1).flatten()
 
@@ -212,11 +217,18 @@ class TimmClassifier:
         if not images:
             return []
 
+        from pipeline_locks import acquire_gpu
+
         input_arr = np.concatenate(
             [self._preprocess(img) for img in images],
             axis=0,
         )
-        output = self._session.run(None, {self._input_name: input_arr})
+        # GPU serialisation across concurrent pipelines, scoped tightly to
+        # the forward pass. Preprocessing above (per-image resize/normalise)
+        # and the softmax/result-building below run without the lock so
+        # concurrent pipelines can use the GPU while this one does CPU work.
+        with acquire_gpu():
+            output = self._session.run(None, {self._input_name: input_arr})
         logits = output[0]
         probs_batch = onnx_runtime.softmax(logits, axis=-1)
 

--- a/vireo/timm_classifier.py
+++ b/vireo/timm_classifier.py
@@ -186,7 +186,7 @@ class TimmClassifier:
             list of dicts with species, score, auto_tag, confidence_tag, taxonomy
         """
         from PIL import Image as PILImage
-        from pipeline_locks import acquire_gpu
+        from pipeline_locks import acquire_gpu_if_session_uses_it
 
         if isinstance(image, (str, os.PathLike)):
             with PILImage.open(image) as img:
@@ -196,8 +196,11 @@ class TimmClassifier:
 
         # GPU serialisation across concurrent pipelines, scoped tightly to
         # the forward pass. Preprocessing above runs without the lock so
-        # concurrent pipelines aren't blocked on CPU work.
-        with acquire_gpu():
+        # concurrent pipelines aren't blocked on CPU work. Skipped for
+        # CPU-only sessions — Apple Silicon's external-data timm export
+        # excludes CoreML and runs on the CPU; taking the GPU semaphore
+        # there would block real GPU work in other pipelines for nothing.
+        with acquire_gpu_if_session_uses_it(self._session):
             output = self._session.run(None, {self._input_name: input_arr})
         logits = output[0]  # shape: (1, num_classes)
         probs = onnx_runtime.softmax(logits, axis=-1).flatten()
@@ -217,7 +220,7 @@ class TimmClassifier:
         if not images:
             return []
 
-        from pipeline_locks import acquire_gpu
+        from pipeline_locks import acquire_gpu_if_session_uses_it
 
         input_arr = np.concatenate(
             [self._preprocess(img) for img in images],
@@ -227,7 +230,8 @@ class TimmClassifier:
         # the forward pass. Preprocessing above (per-image resize/normalise)
         # and the softmax/result-building below run without the lock so
         # concurrent pipelines can use the GPU while this one does CPU work.
-        with acquire_gpu():
+        # Skipped for CPU-only sessions (same rationale as classify()).
+        with acquire_gpu_if_session_uses_it(self._session):
             output = self._session.run(None, {self._input_name: input_arr})
         logits = output[0]
         probs_batch = onnx_runtime.softmax(logits, axis=-1)


### PR DESCRIPTION
## Summary

First three steps of the pipeline concurrency design ([docs/plans/2026-05-26-pipeline-concurrency-design.md](docs/plans/2026-05-26-pipeline-concurrency-design.md)). Lays the foundation for concurrent pipeline runs without yet enabling concurrency — `SLOT_CAP` is still 1 and the UI lock still disables Start. Subsequent PRs will add the server-side queue, UI changes, and bump the cap to 2.

### What changed

- **`vireo/model_cache.py`** — Process-wide refcounted `ModelCache` with 5-minute idle-timer eviction. Replaces the per-pipeline `loaded_models["clf"]` so two pipelines using the same model+labels share one ONNX session instead of doubling VRAM. Keyed by `(model_type, model_id, model_str, weights_path, labels_fingerprint_or_tol)`.
- **`vireo/pipeline_locks.py`** — Two concurrency primitives:
  - `acquire_gpu()` — single-holder semaphore wrapping per-batch inference in classify (`_flush_batch`), detect (`_detect_batch`), extract_masks (`generate_mask`, `embed_batch`, `embed`), and eye_keypoints (`session.run` inside `keypoints.detect_keypoints`). Released between batches so a long classify doesn't starve a queued pipeline.
  - `acquire_workspace_regroup(workspace_id)` — per-workspace lock keyed by id. Wraps the regroup stage body. Two pipelines on different workspaces never contend; same-workspace pipelines serialise only at regroup.
- **`vireo/pipeline_job.py`** — Integration: cache acquire in `_load_model_bundle`, handle stored in bundle and released at spec swap / early return / end-of-stage finally; GPU and regroup locks at the wrap points described above.
- **`vireo/keypoints.py`** — One added GPU lock around the `session.run` inside `detect_keypoints` (eye_keypoints stage is too opaque to wrap from pipeline_job).
- **`vireo/tests/conftest.py`** — Autouse fixture resets the process-wide ModelCache between tests so monkeypatched `Classifier` stubs don't leak.

### Documented lock order

`_progress_lock` → `JobRunner._lock` → `acquire_workspace_regroup` → `acquire_gpu`. Never invert. Recorded in `pipeline_locks.py` module docstring.

### Tests

- 9 new unit tests for `ModelCache` (acquire/release/eviction/concurrent-load/failure handling).
- 5 new unit tests for `pipeline_locks` (GPU serialisation, regroup per-workspace isolation, key identity).
- All 132 existing `pipeline_job` tests pass unchanged (the locks are invisible when not contended).
- All 51 tests in `test_keypoints.py`, `test_detector.py`, `test_masking.py` pass.

### What's NOT in this PR (intentionally)

- The server-side queue (status='queued' in `job_history`, scheduler, conditional promotion, startup sweep) — step 4 of the design.
- UI changes on pipeline page + jobs page — step 5.
- `SLOT_CAP = 2` flip — step 6.

These follow in separate PRs per the design's rollout order so each piece lands testable.

## Test plan

- [ ] CI passes
- [ ] Run pipeline normally on one workspace — no behavior change visible to user (cache + locks are transparent in the single-pipeline case)
- [ ] Run a multi-model classify — verify the spec-swap path still releases handles correctly (no warning logs about cache leaks)
- [ ] Manual smoke: `python -m pytest vireo/tests/test_model_cache.py vireo/tests/test_pipeline_locks.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a design spec for a resource-aware pipeline concurrency model.

* **New Features**
  * Allow up to two concurrent pipeline runs with FIFO queuing, startup recovery, and stable job IDs.
  * Persistent queue across restarts; enqueue/promote API behavior updated.
  * UI: show running/queued counts, expose queued run details, add cancel and cancel-all queued actions.
  * Shared in-process model caching with idle eviction; GPU serialization and per-workspace regroup locks.

* **Tests**
  * Added tests covering model-cache behavior and concurrency locks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/899?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->