### PR TITLE
Stop pipeline review from claiming missing eye keypoints after a full run

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3871,6 +3871,84 @@ class Database:
         ).fetchone()
         return row["n"] or 0
 
+    def count_eye_keypoint_attemptable(self, min_species_conf, photo_ids=None):
+        """Count photos whose top-routable prediction would actually be
+        attempted by the eye-keypoint stage under the current config.
+
+        Tighter than ``count_eye_keypoint_eligible``: that one matches the
+        loose mask+detection+prediction join, which includes photos whose
+        top prediction will be skipped at Gate 1 (classifier confidence
+        below ``min_species_conf``) or fail taxonomy routing (anything
+        outside the keys of ``pipeline._EYE_KEYPOINT_MODEL_FOR_CLASS``).
+        Those photos never get an ``eye_kp_fingerprint`` stamped — by
+        design, so a future config change can retry them — so they would
+        permanently inflate ``eye_target`` and trip the "computed without
+        eye keypoints" banner on every run.
+
+        Match ``list_photos_for_eye_keypoint_stage``'s "best routable row
+        per photo" selection so a taxonomy-bearing prediction wins over a
+        taxonomy-less one. Predictions that route only via the scientific
+        name → taxa-table fallback are *not* counted here (the SQL filter
+        is taxonomy_class-only); those photos will still be attempted by
+        the stage but will be undercounted in the target, which keeps
+        ``attempts >= target`` and means the banner won't lie — at worst
+        it stays quiet when it could have surfaced.
+        """
+        import config as cfg
+        ws = self._ws_id()
+        min_conf = self.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2,
+        )
+        scope_sql, scope_params = self._scope_clause(photo_ids)
+        # Window function pins the same per-photo prediction the stage
+        # would pick (taxonomy-present first, then detector_conf desc,
+        # then species_conf desc) so the attemptable filter is applied to
+        # the *winner*, not to any prediction the photo happens to carry.
+        # The labels_fingerprint subquery mirrors
+        # list_photos_for_eye_keypoint_stage so re-classified detections
+        # only contribute their latest prediction set.
+        row = self.conn.execute(
+            f"""WITH ranked AS (
+                    SELECT p.id AS photo_id,
+                           pr.confidence AS species_conf,
+                           pr.taxonomy_class,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY p.id
+                               ORDER BY
+                                 CASE
+                                     WHEN pr.taxonomy_class IS NOT NULL
+                                       OR pr.scientific_name IS NOT NULL
+                                     THEN 0 ELSE 1
+                                 END,
+                                 d.detector_confidence DESC,
+                                 pr.confidence DESC
+                           ) AS rn
+                    FROM photos p
+                    JOIN workspace_folders wf
+                      ON wf.folder_id = p.folder_id
+                     AND wf.workspace_id = ?
+                    JOIN detections d
+                      ON d.photo_id = p.id
+                     AND d.detector_model != 'full-image'
+                     AND d.detector_confidence >= ?
+                    JOIN predictions pr ON pr.detection_id = d.id
+                    WHERE p.mask_path IS NOT NULL
+                      AND pr.labels_fingerprint = (
+                          SELECT pr2.labels_fingerprint FROM predictions pr2
+                          WHERE pr2.detection_id = pr.detection_id
+                            AND pr2.classifier_model = pr.classifier_model
+                          ORDER BY pr2.created_at DESC, pr2.id DESC
+                          LIMIT 1
+                      ){scope_sql}
+                )
+                SELECT COUNT(*) AS n FROM ranked
+                WHERE rn = 1
+                  AND taxonomy_class IN ('Aves', 'Mammalia')
+                  AND species_conf >= ?""",
+            (ws, min_conf, *scope_params, min_species_conf),
+        ).fetchone()
+        return row["n"] or 0
+
     def get_dashboard_stats(self):
         """Return aggregate statistics for the dashboard."""
         ws = self._ws_id()

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -1159,6 +1159,8 @@ def compute_review_readiness(db, mask_threshold=0.25, dinov2_variant=None):
             "enhancing_missing": list[str],  # stages that would improve quality
         }
     """
+    import config as cfg
+
     cov = db.get_coverage_stats()
     total = cov["total"]
     targets = _count_stage_targets(db) if total else {
@@ -1174,7 +1176,20 @@ def compute_review_readiness(db, mask_threshold=0.25, dinov2_variant=None):
     usable_embeddings = _count_usable_embeddings(
         db, dinov2_variant, detected_only=embedding_detected_only,
     )
-    eye_target = db.count_eye_keypoint_eligible() if total else 0
+    # Use the *attemptable* count, not the loose mask+detection+prediction
+    # eligible count: photos the stage skips at a pre-model gate
+    # (out-of-scope taxonomy, classifier confidence below
+    # eye_classifier_conf_gate) intentionally don't get an
+    # eye_kp_fingerprint stamped, so they would otherwise sit in the gap
+    # between target and attempts forever and trip the "computed without
+    # eye keypoints" banner after every run. Mirrors the variant-aware
+    # treatment of usable_embeddings above.
+    eye_conf_gate = db.get_effective_config(cfg.load()).get(
+        "eye_classifier_conf_gate", 0.5,
+    )
+    eye_target = (
+        db.count_eye_keypoint_attemptable(eye_conf_gate) if total else 0
+    )
     eye_attempts = _count_eye_keypoint_attempts(db) if eye_target else 0
     out = {
         "state": "empty",

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -1184,9 +1184,17 @@ def compute_review_readiness(db, mask_threshold=0.25, dinov2_variant=None):
     # between target and attempts forever and trip the "computed without
     # eye keypoints" banner after every run. Mirrors the variant-aware
     # treatment of usable_embeddings above.
+    # eye_classifier_conf_gate lives under the nested "pipeline" sub-dict
+    # of the config (see config.DEFAULTS and the settings API round-trip
+    # test), so reading it off the top level always returns the default
+    # 0.5 even when the user has explicitly raised or lowered it in
+    # settings — a silent bug that would re-introduce the same banner
+    # lying this PR set out to fix. Mirrors how pipeline_job.py:3064-3066
+    # reads the same key off the pipeline sub-dict before invoking the
+    # eye stage.
     eye_conf_gate = db.get_effective_config(cfg.load()).get(
-        "eye_classifier_conf_gate", 0.5,
-    )
+        "pipeline", {}
+    ).get("eye_classifier_conf_gate", 0.5)
     eye_target = (
         db.count_eye_keypoint_attemptable(eye_conf_gate) if total else 0
     )

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -1192,6 +1192,43 @@ def test_compute_review_readiness_eye_target_follows_gate_changes(tmp_path):
     assert "eye_keypoints" in out_loose["enhancing_missing"]
 
 
+def test_compute_review_readiness_eye_target_honors_workspace_pipeline_override(tmp_path):
+    """A workspace-level ``pipeline.eye_classifier_conf_gate`` override
+    must reshape the eye-keypoint target.
+
+    Codex's PR #900 review called out *workspace* settings alongside
+    global ones. The earlier commit verified the nested read against
+    global config; this pins the workspace-overrides path explicitly so
+    a future refactor of ``get_effective_config`` (e.g. forgetting to
+    deep-merge nested dicts) can't silently sever the gate at the
+    workspace level while leaving the global path working.
+    """
+    import config as cfg
+    from db import Database
+    from pipeline import compute_review_readiness
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    # Global default gate stays at 0.5; only the active workspace lowers
+    # it, mirroring a user with a per-workspace looser threshold.
+    cfg.save({"pipeline": {"eye_classifier_conf_gate": 0.5}})
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.create_workspace(
+        "loose-gate",
+        config_overrides={"pipeline": {"eye_classifier_conf_gate": 0.2}},
+    )
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder(str(tmp_path), name="photos")
+    # Species confidence 0.3 sits between the global gate (0.5) and the
+    # workspace override (0.2): excluded if the workspace override is
+    # ignored, included if it's honored.
+    _add_eligible_photo(db, fid, "shy.jpg", 0.3, taxonomy_class="Aves")
+
+    out = compute_review_readiness(db)
+    assert out["eye_keypoint_target_photos"] == 1
+    assert "eye_keypoints" in out["enhancing_missing"]
+
+
 def test_save_results_preserves_miss_computed_at_across_reflow(tmp_path):
     """save_results must preserve an existing miss_computed_at marker
     when the caller's results dict doesn't carry one. reflow and

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -83,11 +83,16 @@ def _setup_db_with_photos(tmp_path, n_encounters=2, photos_per_encounter=3):
                 {"box": {"x": 0.2, "y": 0.2, "w": 0.4, "h": 0.4}, "confidence": 0.9},
             ], detector_model="megadetector")
 
-            # Add a species prediction (references detection, not photo)
+            # Add a species prediction (references detection, not photo).
+            # Stamp taxonomy_class so the prediction routes through the
+            # eye-keypoint stage's primary path — without it, attemptable
+            # photo counts collapse to zero and readiness assertions about
+            # the eye_keypoints enhancing gap stop firing.
             species = "robin" if enc_idx == 0 else "eagle"
             db.add_prediction(
                 det_ids[0], species, 0.9 - i * 0.05, "bioclip",
                 category="match",
+                taxonomy={"class": "Aves"},
             )
 
             enc_ids.append(pid)
@@ -1044,7 +1049,10 @@ def test_compute_review_readiness_eye_attempts_clear_eye_gap(tmp_path):
     det_ids = db.write_detection_batch(pid, "megadetector-v6", [
         {"box": {"x": 0.2, "y": 0.2, "w": 0.4, "h": 0.4}, "confidence": 0.9},
     ])
-    db.add_prediction(det_ids[0], "robin", 0.9, "bioclip", category="match")
+    db.add_prediction(
+        det_ids[0], "robin", 0.9, "bioclip", category="match",
+        taxonomy={"class": "Aves"},
+    )
     emb = np.ones(768, dtype=np.float32)
     emb = emb / np.linalg.norm(emb)
     db.update_photo_pipeline_features(
@@ -1066,6 +1074,122 @@ def test_compute_review_readiness_eye_attempts_clear_eye_gap(tmp_path):
     assert out["with_eye_keypoint_attempts"] == 1
     assert out["eye_keypoint_target_photos"] == 1
     assert "eye_keypoints" not in out["enhancing_missing"]
+
+
+def _add_eligible_photo(db, fid, filename, species_conf, *, taxonomy_class):
+    """Insert one photo+detection+prediction that the eye stage would route
+    on if ``taxonomy_class`` is Aves/Mammalia and ``species_conf`` clears
+    the classifier confidence gate. Returns the photo id."""
+    pid = db.add_photo(
+        fid, filename, ".jpg", 1000, 1.0,
+        timestamp=datetime(2026, 3, 20, 10, 0, 0).isoformat(),
+        width=4000, height=3000,
+    )
+    det_ids = db.write_detection_batch(pid, "megadetector-v6", [
+        {"box": {"x": 0.2, "y": 0.2, "w": 0.4, "h": 0.4}, "confidence": 0.9},
+    ])
+    db.add_prediction(
+        det_ids[0], "subject", species_conf, "bioclip", category="match",
+        taxonomy={"class": taxonomy_class} if taxonomy_class else None,
+    )
+    db.update_photo_pipeline_features(pid, mask_path=f"/masks/{pid}.png")
+    return pid
+
+
+def test_compute_review_readiness_eye_target_excludes_out_of_scope_taxonomy(tmp_path):
+    """A photo whose top prediction routes to no keypoint model (taxonomy
+    outside Aves/Mammalia) must not inflate ``eye_keypoint_target_photos``.
+
+    Pre-fix: the loose mask+detection+prediction eligibility join counted
+    these photos, so ``eye_attempts < eye_target`` stayed true forever and
+    the "results were computed without eye keypoints" banner showed after
+    every full run for any workspace that contained, say, an insect.
+    """
+    from db import Database
+    from pipeline import compute_review_readiness
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+    # Out-of-scope species: dragonflies aren't birds or mammals, so the
+    # stage's _resolve_keypoint_model returns None and the photo is skipped
+    # without stamping a fingerprint. It must not appear in the target.
+    _add_eligible_photo(db, fid, "bug.jpg", 0.9, taxonomy_class="Insecta")
+
+    out = compute_review_readiness(db)
+    assert out["eye_keypoint_target_photos"] == 0
+    assert "eye_keypoints" not in out["enhancing_missing"]
+
+
+def test_compute_review_readiness_eye_target_excludes_low_confidence(tmp_path):
+    """A routable photo whose top prediction sits below the eye-stage
+    classifier confidence gate must not inflate the target.
+
+    Pre-fix: the loose count included this photo, so the banner appeared
+    after every run even though the stage will keep skipping it at Gate 1.
+    """
+    import config as cfg
+    from db import Database
+    from pipeline import compute_review_readiness
+
+    # The stage gate defaults to 0.5; pin the test to a known threshold
+    # so a future default tweak doesn't quietly break the assertion.
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    cfg.save({"eye_classifier_conf_gate": 0.5})
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+    _add_eligible_photo(db, fid, "shy.jpg", 0.3, taxonomy_class="Aves")
+
+    out = compute_review_readiness(db)
+    assert out["eye_keypoint_target_photos"] == 0
+    assert "eye_keypoints" not in out["enhancing_missing"]
+
+
+def test_compute_review_readiness_eye_target_includes_routable_above_gate(tmp_path):
+    """A routable photo above the confidence gate must still appear in the
+    target so a missing eye-keypoint attempt continues to surface."""
+    import config as cfg
+    from db import Database
+    from pipeline import compute_review_readiness
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    cfg.save({"eye_classifier_conf_gate": 0.5})
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+    _add_eligible_photo(db, fid, "bird.jpg", 0.9, taxonomy_class="Aves")
+
+    out = compute_review_readiness(db)
+    assert out["eye_keypoint_target_photos"] == 1
+    assert "eye_keypoints" in out["enhancing_missing"]
+
+
+def test_compute_review_readiness_eye_target_follows_gate_changes(tmp_path):
+    """Lowering ``eye_classifier_conf_gate`` must expand the target, the
+    same way switching DINOv2 variants reshapes ``with_embeddings``.
+
+    This pins the principle that the readiness counter reflects the
+    *current* config — re-running the stage with a lower gate would now
+    legitimately produce new attempts, and the banner should reappear.
+    """
+    import config as cfg
+    from db import Database
+    from pipeline import compute_review_readiness
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    cfg.save({"eye_classifier_conf_gate": 0.5})
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+    _add_eligible_photo(db, fid, "shy.jpg", 0.3, taxonomy_class="Aves")
+
+    out_strict = compute_review_readiness(db)
+    assert out_strict["eye_keypoint_target_photos"] == 0
+
+    cfg.save({"eye_classifier_conf_gate": 0.2})
+    out_loose = compute_review_readiness(db)
+    assert out_loose["eye_keypoint_target_photos"] == 1
+    assert "eye_keypoints" in out_loose["enhancing_missing"]
 
 
 def test_save_results_preserves_miss_computed_at_across_reflow(tmp_path):

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -1134,7 +1134,7 @@ def test_compute_review_readiness_eye_target_excludes_low_confidence(tmp_path):
     # The stage gate defaults to 0.5; pin the test to a known threshold
     # so a future default tweak doesn't quietly break the assertion.
     cfg.CONFIG_PATH = str(tmp_path / "config.json")
-    cfg.save({"eye_classifier_conf_gate": 0.5})
+    cfg.save({"pipeline": {"eye_classifier_conf_gate": 0.5}})
 
     db = Database(str(tmp_path / "test.db"))
     fid = db.add_folder(str(tmp_path), name="photos")
@@ -1153,7 +1153,7 @@ def test_compute_review_readiness_eye_target_includes_routable_above_gate(tmp_pa
     from pipeline import compute_review_readiness
 
     cfg.CONFIG_PATH = str(tmp_path / "config.json")
-    cfg.save({"eye_classifier_conf_gate": 0.5})
+    cfg.save({"pipeline": {"eye_classifier_conf_gate": 0.5}})
 
     db = Database(str(tmp_path / "test.db"))
     fid = db.add_folder(str(tmp_path), name="photos")
@@ -1177,7 +1177,7 @@ def test_compute_review_readiness_eye_target_follows_gate_changes(tmp_path):
     from pipeline import compute_review_readiness
 
     cfg.CONFIG_PATH = str(tmp_path / "config.json")
-    cfg.save({"eye_classifier_conf_gate": 0.5})
+    cfg.save({"pipeline": {"eye_classifier_conf_gate": 0.5}})
 
     db = Database(str(tmp_path / "test.db"))
     fid = db.add_folder(str(tmp_path), name="photos")
@@ -1186,7 +1186,7 @@ def test_compute_review_readiness_eye_target_follows_gate_changes(tmp_path):
     out_strict = compute_review_readiness(db)
     assert out_strict["eye_keypoint_target_photos"] == 0
 
-    cfg.save({"eye_classifier_conf_gate": 0.2})
+    cfg.save({"pipeline": {"eye_classifier_conf_gate": 0.2}})
     out_loose = compute_review_readiness(db)
     assert out_loose["eye_keypoint_target_photos"] == 1
     assert "eye_keypoints" in out_loose["enhancing_missing"]


### PR DESCRIPTION
## Summary

- `compute_review_readiness` was comparing `eye_target` (loose mask+detection+prediction join) against `eye_attempts` (photos with a current `eye_kp_fingerprint`). The eye stage *deliberately* doesn't stamp a fingerprint when a pre-model gate trips — low classifier confidence (`eye_classifier_conf_gate`, default 0.5) or out-of-scope taxonomy — so the user can change config later and have those photos retried. Net effect: any workspace containing e.g. one low-confidence prediction or one insect/fish photo permanently sat with `attempts < target`, and the pipeline review page kept showing **"These results were computed without eye keypoints. Re-run those stages to improve quality."** after every full run, even though re-running would just skip the same photos again.
- New `Database.count_eye_keypoint_attemptable(min_species_conf)` mirrors `list_photos_for_eye_keypoint_stage`'s best-routable row-per-photo selection (window function on the same ORDER BY: taxonomy-present first, then detector_conf desc, then species_conf desc) and filters the winner on `taxonomy_class IN ('Aves','Mammalia') AND species_conf >= gate`. `compute_review_readiness` now uses this for `eye_target`, the same way `with_embeddings` already reshapes when the DINOv2 variant changes — readiness reflects the *current* config, not a static lower bound.
- Scope note: predictions that would route only via the scientific-name → taxa-table fallback in `_resolve_keypoint_model` aren't counted in the new target. That's the safe direction (`attempts >= target` keeps the banner quiet rather than lying). The plan-page summary (`compute_eye_keypoint_plan` in `pipeline_plan.py`) has a related but separate "X eligible" wording issue — left for a follow-up so this PR stays narrowly focused on the banner.

## Why this matters (CORE_PHILOSOPHY)

This is the "no black boxes" rule from `CORE_PHILOSOPHY.md`: a status pill must answer the question users read it as. "Re-run those stages to improve quality" implied a re-run would help; under the old counter it never would for these photos. Now the banner only fires when a re-run would genuinely add attempts.

## Test plan

- [x] New tests in `vireo/tests/test_pipeline.py`:
  - `test_compute_review_readiness_eye_target_excludes_out_of_scope_taxonomy` — an Insecta photo no longer inflates `eye_target`
  - `test_compute_review_readiness_eye_target_excludes_low_confidence` — a below-gate Aves photo doesn't inflate the target
  - `test_compute_review_readiness_eye_target_includes_routable_above_gate` — a routable above-gate photo still surfaces the gap when not yet attempted
  - `test_compute_review_readiness_eye_target_follows_gate_changes` — lowering `eye_classifier_conf_gate` re-expands the target (pins the variant-aware-counter principle)
- [x] Existing `_setup_db_with_photos` and `test_compute_review_readiness_eye_attempts_clear_eye_gap` updated to stamp `taxonomy_class='Aves'` so their intent (eye_keypoints in / not-in `enhancing_missing`) continues firing under the tighter count.
- [x] Full CLAUDE.md test set: `test_workspaces.py`, `test_db.py`, `test_app.py`, `test_photos_api.py`, `test_edits_api.py`, `test_jobs_api.py`, `test_darktable_api.py`, `test_config.py`, plus all `test_pipeline*.py` — **1341 passed, 1 skipped in 5:00**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Eye-keypoint readiness now counts only photos that would actually attempt routing, using workspace-effective configuration and a species-confidence gate; candidates are limited to supported taxonomies (Aves, Mammalia) and valid mask/prediction quality.
  * Workspace-level pipeline overrides for the classifier confidence gate are honored when computing targets.

* **Tests**
  * Expanded test coverage and helpers to validate routing, taxonomy filtering, confidence-gate behavior, and workspace override effects for eye-keypoint targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->