### PR TITLE
Pipeline concurrency: server-side queue (Step 4)

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11605,8 +11605,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 thumb_cache_dir=app.config["THUMB_CACHE_DIR"],
             )
 
-        job_id = runner.start(
-            "pipeline", work,
+        # Enqueue rather than start directly: when SLOT_CAP is 1 and
+        # nothing else is active, ``enqueue_pipeline`` promotes inline
+        # before returning, so this looks identical to the old ``start``
+        # call. When a pipeline is already running, the new run waits in
+        # ``status='queued'`` until the slot opens. Callers receive the
+        # same {"job_id": ...} response either way; clients learn about
+        # the queued state via /api/jobs/<id> polling or the SSE stream.
+        job_id = runner.enqueue_pipeline(
+            work,
             config={
                 "source": source,
                 "sources": sources,

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -436,11 +436,22 @@ class JobRunner:
                 )
                 ws_id = job.get("workspace_id")
                 if ws_id is not None:
+                    # Retention: keep the 100 most-recent TERMINAL rows
+                    # per workspace. Excluding non-terminal rows is
+                    # load-bearing: a queued pipeline waiting behind a
+                    # busy slot can sit in the table for a long time;
+                    # if its row got pruned by an unrelated job
+                    # completing, the next promotion attempt would see
+                    # rowcount==0 on its conditional UPDATE and treat
+                    # that as a cancel, silently dropping the run.
                     conn.execute(
                         """DELETE FROM job_history
-                           WHERE workspace_id = ? AND id NOT IN (
+                           WHERE workspace_id = ?
+                             AND status IN ('completed', 'failed', 'cancelled')
+                             AND id NOT IN (
                                SELECT id FROM job_history
                                WHERE workspace_id = ?
+                                 AND status IN ('completed', 'failed', 'cancelled')
                                ORDER BY started_at DESC LIMIT 100
                            )""",
                         (ws_id, ws_id),

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -487,39 +487,54 @@ class JobRunner:
         )
         return f"{pretty_type} {job['status']}"
 
+    def _synthesize_queued_view(self, job_id, ctx):
+        """Render a queued pipeline's in-memory context as a job-shaped dict.
+
+        Queued pipelines aren't in ``self._jobs`` yet — they live in
+        ``self._queued_pipelines`` until the scheduler promotes them.
+        ``get()`` and ``list_jobs()`` both need to surface them in the
+        same shape as a live job so callers (UI, SSE, the navbar's
+        active-jobs polling) can render and cancel them uniformly.
+        """
+        return {
+            "id": job_id,
+            "type": "pipeline",
+            "status": "queued",
+            "started_at": ctx["started_at"],
+            "finished_at": None,
+            "progress": {"current": 0, "total": 0, "current_file": ""},
+            "result": None,
+            "errors": [],
+            "config": dict(ctx["config"]),
+            "workspace_id": ctx["workspace_id"],
+            "steps": [],
+            "ephemeral": False,
+            "runtime_warning": ctx.get("runtime_warning"),
+        }
+
     def get(self, job_id):
         """Get a job by id. Returns a shallow copy so callers don't mutate shared state."""
         with self._lock:
             job = self._jobs.get(job_id)
             if job is not None:
                 return dict(job)
-            # Queued pipelines aren't in self._jobs yet — they live in
-            # self._queued_pipelines until the scheduler promotes them.
-            # Surface them with a minimal job-shaped dict so callers
-            # polling for status (UI, SSE) see ``queued`` instead of 404.
             ctx = self._queued_pipelines.get(job_id)
             if ctx is None:
                 return None
-            return {
-                "id": job_id,
-                "type": "pipeline",
-                "status": "queued",
-                "started_at": ctx["started_at"],
-                "finished_at": None,
-                "progress": {"current": 0, "total": 0, "current_file": ""},
-                "result": None,
-                "errors": [],
-                "config": dict(ctx["config"]),
-                "workspace_id": ctx["workspace_id"],
-                "steps": [],
-                "ephemeral": False,
-                "runtime_warning": ctx.get("runtime_warning"),
-            }
+            return self._synthesize_queued_view(job_id, ctx)
 
     def list_jobs(self):
-        """List all tracked jobs (active and recently completed)."""
+        """List all tracked jobs (active, queued, and recently completed).
+
+        Includes synthetic queued-pipeline entries so the navbar and
+        /jobs page can render and cancel them; otherwise a queued run
+        disappears from the UI between enqueue and promotion.
+        """
         with self._lock:
-            return list(self._jobs.values())
+            jobs = list(self._jobs.values())
+            for job_id, ctx in self._queued_pipelines.items():
+                jobs.append(self._synthesize_queued_view(job_id, ctx))
+            return jobs
 
     def get_history(self, db, limit=10):
         """Get recent job history from the database.

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -689,6 +689,7 @@ class JobRunner:
         Returns True if the job was found and either marked for
         cancellation (running) or transitioned to cancelled (queued).
         """
+        emit_complete = False
         with self._lock:
             job = self._jobs.get(job_id)
             if job is not None and job["status"] == "running":
@@ -717,8 +718,26 @@ class JobRunner:
                     finally:
                         conn.close()
                 self._queued_pipelines.pop(job_id, None)
-                return True
-            return False
+                emit_complete = True
+            else:
+                return False
+        # Emit the terminal SSE event AFTER releasing the lock — clients
+        # subscribed to /api/jobs/<id>/stream while the job was queued
+        # need a ``complete`` event with status='cancelled' so they
+        # close cleanly. Without this they'd see ``get(job_id) is None``
+        # on the next keepalive and report the job as ``expired``.
+        if emit_complete:
+            self.push_event(
+                job_id,
+                "complete",
+                {
+                    "status": "cancelled",
+                    "result": None,
+                    "duration": 0.0,
+                    "errors": [],
+                },
+            )
+        return True
 
     def is_cancelled(self, job_id):
         """Check whether a job has been marked for cancellation."""

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -539,21 +539,34 @@ class JobRunner:
     def get_history(self, db, limit=10):
         """Get recent job history from the database.
 
+        Only TERMINAL rows (completed/failed/cancelled) are returned —
+        ``queued`` and ``running`` rows represent live state and surface
+        through ``list_jobs()`` / ``get()`` so the UI can render and
+        cancel them. Including them in history would make queued runs
+        show up under "last run" / Jobs-page history with no cancel
+        affordance, which is exactly the wrong UX.
+
         Args:
             db: Database instance (must be from the calling thread)
             limit: max number of rows
         """
         try:
             ws_id = db._active_workspace_id
+            terminal = ("completed", "failed", "cancelled")
+            placeholders = ",".join(["?"] * len(terminal))
             if ws_id is not None:
                 rows = db.conn.execute(
-                    "SELECT * FROM job_history WHERE workspace_id = ? ORDER BY started_at DESC LIMIT ?",
-                    (ws_id, limit),
+                    f"SELECT * FROM job_history "
+                    f"WHERE workspace_id = ? AND status IN ({placeholders}) "
+                    f"ORDER BY started_at DESC LIMIT ?",
+                    (ws_id, *terminal, limit),
                 ).fetchall()
             else:
                 rows = db.conn.execute(
-                    "SELECT * FROM job_history ORDER BY started_at DESC LIMIT ?",
-                    (limit,),
+                    f"SELECT * FROM job_history "
+                    f"WHERE status IN ({placeholders}) "
+                    f"ORDER BY started_at DESC LIMIT ?",
+                    (*terminal, limit),
                 ).fetchall()
             result = []
             for r in rows:

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -14,6 +14,12 @@ log = logging.getLogger(__name__)
 _JOB_RETENTION_SECS = 3600  # 1 hour
 
 
+# Maximum number of pipeline jobs allowed to run concurrently. Kept at
+# 1 in this PR; concurrency is enabled in a later PR after the UI and
+# resource locks land. See docs/plans/2026-05-26-pipeline-concurrency-design.md.
+SLOT_CAP = 1
+
+
 class JobRunner:
     """Runs long operations in background threads with progress tracking.
 
@@ -28,9 +34,20 @@ class JobRunner:
         self._lock = threading.Lock()
         self._cancelled = set()  # job ids that have been cancelled
         self._db_path = None
+        # Pending pipeline work, keyed by job_id. Populated by
+        # ``enqueue_pipeline`` and consumed by ``_try_promote_queued``
+        # when a slot opens. The work_fn closure can't be persisted
+        # cross-process, so a process restart will see queued rows in
+        # job_history without a matching entry here; the startup sweep
+        # promotes such rows to 'failed'.
+        self._queued_pipelines = {}  # job_id -> dict(work_fn, config, ...)
+        # Monotonic suffix so two enqueues landing in the same
+        # millisecond don't collide on the PRIMARY KEY.
+        self._enqueue_counter = 0
         if db:
             self._db_path = db.conn.execute("PRAGMA database_list").fetchone()[2]
             self._ensure_history_table(db)
+            self._startup_sweep(db)
 
     def _ensure_history_table(self, db):
         db.conn.execute(
@@ -69,6 +86,165 @@ class JobRunner:
             db.conn.execute("SELECT summary FROM job_history LIMIT 0")
         except Exception:
             db.conn.execute("ALTER TABLE job_history ADD COLUMN summary TEXT DEFAULT ''")
+
+    def _startup_sweep(self, db):
+        """Reconcile job_history with the fact that we just started.
+
+        On a clean shutdown a job thread either finishes or is cancelled
+        and the row is updated accordingly. On a crash or kill, threads
+        die without persisting — so rows with ``status='running'`` from
+        a prior process are orphans. Mark them ``'failed'``. Queued rows
+        from a prior process likewise lose their in-process work closure;
+        mark them ``'failed'`` too so they don't linger forever waiting
+        for a slot.
+
+        Future PR: rebuild work closures from the ``config`` blob on
+        startup so queued runs survive restart. For this PR we just
+        clear the rot.
+        """
+        now = datetime.now().isoformat()
+        msg = "Interrupted by Vireo restart"
+        for status in ("running", "queued"):
+            rows = db.conn.execute(
+                "SELECT id FROM job_history WHERE status = ?", (status,),
+            ).fetchall()
+            if not rows:
+                continue
+            payload = json.dumps({"error": msg})
+            for row in rows:
+                db.conn.execute(
+                    "UPDATE job_history "
+                    "SET status='failed', finished_at=?, result=?, error_count=1 "
+                    "WHERE id = ?",
+                    (now, payload, row["id"]),
+                )
+        db.conn.commit()
+
+    def enqueue_pipeline(self, work_fn, config=None, workspace_id=None,
+                         runtime_warning=None):
+        """Enqueue a pipeline job. Promotes immediately when a slot is free.
+
+        Unlike ``start`` (which spawns a worker thread synchronously),
+        ``enqueue_pipeline`` persists the job to ``job_history`` with
+        ``status='queued'``, stashes the work closure in-process, and
+        then asks the scheduler to promote it. With ``SLOT_CAP=1`` and
+        no other pipelines active, promotion happens before this method
+        returns and the work thread is already running.
+
+        Returns the job id.
+        """
+        with self._lock:
+            self._enqueue_counter += 1
+            seq = self._enqueue_counter
+        job_id = f"pipeline-{int(time.time() * 1000)}-{seq}"
+        now_iso = datetime.now().isoformat()
+        config_blob = config or {}
+
+        # Persist the queued row using a thread-local connection so we
+        # don't share the caller's DB handle across thread boundaries.
+        if self._db_path:
+            import sqlite3
+            conn = sqlite3.connect(self._db_path, timeout=30)
+            try:
+                conn.execute(
+                    "INSERT INTO job_history "
+                    "(id, type, status, started_at, config, workspace_id, "
+                    " error_count) "
+                    "VALUES (?, 'pipeline', 'queued', ?, ?, ?, 0)",
+                    (job_id, now_iso, json.dumps(config_blob), workspace_id),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        with self._lock:
+            self._queued_pipelines[job_id] = {
+                "work_fn": work_fn,
+                "config": config_blob,
+                "workspace_id": workspace_id,
+                "runtime_warning": runtime_warning,
+                "started_at": now_iso,
+            }
+
+        # Promote eagerly so a free slot is filled before we return.
+        self._try_promote_queued()
+        return job_id
+
+    def _try_promote_queued(self):
+        """Promote the oldest queued pipeline if a slot is open.
+
+        Single-pass: under ``self._lock`` count active pipelines, and if
+        below ``SLOT_CAP`` find the oldest in-memory queued context and
+        attempt to promote it. The conditional UPDATE ensures a Cancel
+        landing between SELECT and UPDATE wins (rowcount==0 → quietly
+        skip and try the next one).
+        """
+        with self._lock:
+            active = sum(
+                1 for j in self._jobs.values()
+                if j["type"] == "pipeline" and j["status"] == "running"
+            )
+            if active >= SLOT_CAP:
+                return
+            candidates = sorted(
+                self._queued_pipelines.items(),
+                key=lambda kv: kv[1]["started_at"],
+            )
+            if not candidates:
+                return
+            job_id, ctx = candidates[0]
+            # Atomic queued→running flip. If a concurrent cancel beat us
+            # to it, rowcount is 0 and the row stays in its final
+            # state — we leave self._queued_pipelines untouched so the
+            # caller cleaning up the cancel can remove it.
+            if self._db_path:
+                import sqlite3
+                conn = sqlite3.connect(self._db_path, timeout=30)
+                try:
+                    cur = conn.execute(
+                        "UPDATE job_history SET status='running' "
+                        "WHERE id = ? AND status = 'queued'",
+                        (job_id,),
+                    )
+                    promoted = cur.rowcount == 1
+                    conn.commit()
+                finally:
+                    conn.close()
+                if not promoted:
+                    # The row was modified elsewhere (cancelled).
+                    self._queued_pipelines.pop(job_id, None)
+                    return
+            # Move from queue context into the live jobs dict.
+            del self._queued_pipelines[job_id]
+            job = {
+                "id": job_id,
+                "type": "pipeline",
+                "status": "running",
+                "started_at": ctx["started_at"],
+                "finished_at": None,
+                "progress": {"current": 0, "total": 0, "current_file": ""},
+                "result": None,
+                "errors": [],
+                "config": ctx["config"],
+                "workspace_id": ctx["workspace_id"],
+                "steps": [],
+                "ephemeral": False,
+                "runtime_warning": ctx["runtime_warning"],
+            }
+            self._prune_finished_jobs()
+            self._jobs[job_id] = job
+            self._events[job_id] = deque(maxlen=1000)
+            # setdefault, NOT assignment: clients can subscribe to the
+            # SSE stream while the pipeline is still queued. Replacing
+            # the list at promotion time would silently drop those
+            # waiters' queues.
+            self._subscribers.setdefault(job_id, [])
+            work_fn = ctx["work_fn"]
+
+        thread = threading.Thread(
+            target=self._run_job, args=(job, work_fn), daemon=True,
+        )
+        thread.start()
 
     def start(self, job_type, work_fn, config=None, workspace_id=None,
               ephemeral=False, runtime_warning=None):
@@ -200,6 +376,12 @@ class JobRunner:
             # can synchronize with `job_history` reads. Ephemeral jobs are
             # also flagged so callers waiting on this don't hang.
             job["_persisted"] = True
+            # A pipeline slot just opened — let any queued pipeline take
+            # its turn. Non-pipeline jobs (scan, thumbnails, etc.) also
+            # call through here but the queue check is cheap and the
+            # method is a no-op when nothing is queued.
+            if job["type"] == "pipeline":
+                self._try_promote_queued()
 
     def _persist_job(self, job, duration):
         """Persist job to history table using a thread-local connection."""
@@ -309,9 +491,30 @@ class JobRunner:
         """Get a job by id. Returns a shallow copy so callers don't mutate shared state."""
         with self._lock:
             job = self._jobs.get(job_id)
-            if job is None:
+            if job is not None:
+                return dict(job)
+            # Queued pipelines aren't in self._jobs yet — they live in
+            # self._queued_pipelines until the scheduler promotes them.
+            # Surface them with a minimal job-shaped dict so callers
+            # polling for status (UI, SSE) see ``queued`` instead of 404.
+            ctx = self._queued_pipelines.get(job_id)
+            if ctx is None:
                 return None
-            return dict(job)
+            return {
+                "id": job_id,
+                "type": "pipeline",
+                "status": "queued",
+                "started_at": ctx["started_at"],
+                "finished_at": None,
+                "progress": {"current": 0, "total": 0, "current_file": ""},
+                "result": None,
+                "errors": [],
+                "config": dict(ctx["config"]),
+                "workspace_id": ctx["workspace_id"],
+                "steps": [],
+                "ephemeral": False,
+                "runtime_warning": ctx.get("runtime_warning"),
+            }
 
     def list_jobs(self):
         """List all tracked jobs (active and recently completed)."""
@@ -471,19 +674,51 @@ class JobRunner:
                     break
 
     def cancel_job(self, job_id):
-        """Request cancellation of a running job.
+        """Request cancellation of a running OR queued job.
 
-        The job's work function should periodically check
-        runner.is_cancelled(job_id) and exit early if True.
+        For running jobs: the work function should periodically check
+        ``runner.is_cancelled(job_id)`` and exit early if True. The
+        terminal status flip happens in ``_run_job``.
 
-        Returns True if the job was found and marked for cancellation.
+        For queued pipelines: atomically transition the persisted row
+        to ``status='cancelled'`` and remove the in-memory context.
+        The conditional UPDATE in ``_try_promote_queued`` ensures a
+        cancel landing between SELECT and UPDATE wins (its rowcount==0
+        path leaves the row in the cancelled state and gives up).
+
+        Returns True if the job was found and either marked for
+        cancellation (running) or transitioned to cancelled (queued).
         """
         with self._lock:
             job = self._jobs.get(job_id)
-            if not job or job["status"] != "running":
-                return False
-            self._cancelled.add(job_id)
-            return True
+            if job is not None and job["status"] == "running":
+                self._cancelled.add(job_id)
+                return True
+            # Queued case: still in _queued_pipelines, not _jobs yet.
+            if job_id in self._queued_pipelines:
+                cancelled_at = datetime.now().isoformat()
+                if self._db_path:
+                    import sqlite3
+                    conn = sqlite3.connect(self._db_path, timeout=30)
+                    try:
+                        cur = conn.execute(
+                            "UPDATE job_history "
+                            "SET status='cancelled', finished_at=? "
+                            "WHERE id = ? AND status = 'queued'",
+                            (cancelled_at, job_id),
+                        )
+                        conn.commit()
+                        # rowcount==0 means a concurrent promotion beat
+                        # us — the row is now 'running' and the worker
+                        # will see the cancellation flag below.
+                        if cur.rowcount == 0:
+                            self._cancelled.add(job_id)
+                            return True
+                    finally:
+                        conn.close()
+                self._queued_pipelines.pop(job_id, None)
+                return True
+            return False
 
     def is_cancelled(self, job_id):
         """Check whether a job has been marked for cancellation."""

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -65,6 +65,7 @@
   width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
 }
 .job-list-item-dot.running { background: var(--accent); animation: pulse-dot 1.5s ease-in-out infinite; }
+.job-list-item-dot.queued { background: var(--text-muted, #888); border: 1px solid var(--accent); }
 .job-list-item-dot.completed { background: var(--success, #4caf50); }
 .job-list-item-dot.failed { background: var(--danger); }
 .job-list-item-dot.cancelled { background: var(--text-ghost); }
@@ -110,6 +111,7 @@
   font-size: 12px; padding: 3px 10px; border-radius: 4px; font-weight: 500;
 }
 .job-detail-status.running { background: var(--accent); color: var(--accent-text); }
+.job-detail-status.queued { background: var(--bg-tertiary); color: var(--text-muted, #888); border: 1px solid var(--border-secondary); }
 .job-detail-status.completed { background: color-mix(in srgb, var(--success, #4caf50) 20%, transparent); color: var(--success, #4caf50); }
 .job-detail-status.failed { background: color-mix(in srgb, var(--danger) 20%, transparent); color: var(--danger); }
 .job-detail-meta {
@@ -313,7 +315,12 @@
 
   function renderJobCard(job, options) {
     options = options || {};
-    var isLive = job.status === 'running';
+    // Queued pipelines are "live" for UI purposes: they have a real
+    // backend identity, they're cancellable (runner.cancel_job handles
+    // the queued case), and dropping them out of the active section
+    // strands them — the user has no way to find or cancel a queued
+    // pipeline until the slot opens.
+    var isLive = job.status === 'running' || job.status === 'queued';
     var elapsed = '';
     if (isLive && job.started_at) {
       elapsed = formatElapsed((Date.now() - new Date(job.started_at).getTime()) / 1000);
@@ -571,7 +578,12 @@
     var statusFilter = document.getElementById('filterStatus').value;
     var html = '';
 
-    var running = activeJobs.filter(function(j) { return j.status === 'running'; });
+    // Active = running OR queued. Queued pipelines waiting behind a busy
+    // slot are findable + cancellable here; without this, opening /jobs
+    // after queuing from another tab would show the queued run nowhere.
+    var running = activeJobs.filter(function(j) {
+      return j.status === 'running' || j.status === 'queued';
+    });
     html += '<div class="jobs-list-divider clickable' + (currentView === 'active' ? ' selected' : '') + '" data-view="active">Active' +
       (running.length > 0 ? ' (' + running.length + ')' : '') + '</div>';
     running.forEach(function(j) { html += renderListItem(j, 'active'); });
@@ -626,7 +638,9 @@
   }
 
   function updateRunningBadge() {
-    var running = activeJobs.filter(function(j) { return j.status === 'running'; });
+    var running = activeJobs.filter(function(j) {
+      return j.status === 'running' || j.status === 'queued';
+    });
     var badge = document.getElementById('runningBadge');
     if (running.length > 0) { badge.textContent = running.length; badge.style.display = ''; }
     else { badge.style.display = 'none'; }
@@ -767,7 +781,9 @@
 
   function renderActiveOverview() {
     var pane = document.getElementById('jobDetailPane');
-    var running = activeJobs.filter(function(j) { return j.status === 'running'; });
+    var running = activeJobs.filter(function(j) {
+      return j.status === 'running' || j.status === 'queued';
+    });
 
     if (running.length === 0) {
       pane.innerHTML = '<div class="jobs-overview-empty">No active jobs.<br><span style="font-size:12px;margin-top:8px;display:inline-block;">Start a pipeline from the Pipeline page, or run individual jobs from Browse.</span></div>';

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -363,6 +363,42 @@ def pytest_fail(msg):
     raise AssertionError(msg)
 
 
+def test_list_jobs_includes_queued_pipelines(tmp_path):
+    """Codex P2 regression: the navbar and /jobs page build their
+    active-jobs list from ``runner.list_jobs()``. Queued pipelines live
+    only in ``_queued_pipelines`` until promotion — if they're not
+    surfaced through ``list_jobs`` they disappear from the app-wide UI
+    and can't be cancelled from /jobs.
+    """
+    runner, _ = _make_runner_with_db(tmp_path)
+    blocker = threading.Event()
+
+    def first_work(job):
+        blocker.wait(timeout=3.0)
+        return {}
+
+    first_id = runner.enqueue_pipeline(first_work, config={}, workspace_id=1)
+    second_id = runner.enqueue_pipeline(
+        lambda job: None, config={"x": 7}, workspace_id=2,
+    )
+
+    all_jobs = runner.list_jobs()
+    ids = {j["id"]: j for j in all_jobs}
+    assert first_id in ids
+    assert second_id in ids, (
+        "queued pipeline must be visible through list_jobs() so the "
+        "navbar/jobs page can render and cancel it"
+    )
+    assert ids[second_id]["status"] == "queued"
+    assert ids[second_id]["type"] == "pipeline"
+    assert ids[second_id]["config"] == {"x": 7}
+    assert ids[second_id]["workspace_id"] == 2
+
+    blocker.set()
+    wait_for_job_via_runner(runner, first_id)
+    wait_for_job_via_runner(runner, second_id)
+
+
 def test_cancelling_queued_pipeline_emits_complete_event_to_sse(tmp_path):
     """Codex P2 regression: when a queued pipeline is cancelled while a
     client is subscribed to its SSE stream, the client must receive a

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -363,6 +363,50 @@ def pytest_fail(msg):
     raise AssertionError(msg)
 
 
+def test_get_history_excludes_queued_rows(tmp_path):
+    """Codex P2 regression: queued pipeline rows live in job_history
+    immediately on enqueue, but they're LIVE state, not history. The
+    /jobs page and bottom-panel render history as completed runs with
+    no cancel affordance — a queued row showing up there is confusing
+    UX. ``get_history`` must filter to terminal statuses.
+    """
+    runner, db = _make_runner_with_db(tmp_path)
+    try:
+        ws = db._active_workspace_id
+
+        blocker = threading.Event()
+        first_id = runner.enqueue_pipeline(
+            work_fn=lambda job: blocker.wait(timeout=3.0),
+            config={}, workspace_id=ws,
+        )
+        queued_id = runner.enqueue_pipeline(
+            work_fn=lambda job: None, config={}, workspace_id=ws,
+        )
+
+        # Sanity: both rows exist with non-terminal status.
+        assert runner.get(queued_id)["status"] == "queued"
+
+        # History must NOT include either live row.
+        history_ids = [j["id"] for j in runner.get_history(db, limit=50)]
+        assert first_id not in history_ids, (
+            "running rows belong to live state, not history"
+        )
+        assert queued_id not in history_ids, (
+            "queued rows belong to live state, not history"
+        )
+
+        blocker.set()
+        wait_for_job_via_runner(runner, first_id)
+        wait_for_job_via_runner(runner, queued_id)
+
+        # After completion both DO appear in history.
+        history_ids = [j["id"] for j in runner.get_history(db, limit=50)]
+        assert first_id in history_ids
+        assert queued_id in history_ids
+    finally:
+        db.close()
+
+
 def test_list_jobs_includes_queued_pipelines(tmp_path):
     """Codex P2 regression: the navbar and /jobs page build their
     active-jobs list from ``runner.list_jobs()``. Queued pipelines live

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -363,6 +363,80 @@ def pytest_fail(msg):
     raise AssertionError(msg)
 
 
+def test_retention_does_not_prune_queued_row_under_load(tmp_path):
+    """Codex P2 regression: ``_persist_job`` retains the 100 most-recent
+    rows per workspace. If a queued pipeline sits behind a busy slot
+    while >100 other jobs complete in the same workspace, the old
+    retention DELETE (which keyed only on started_at) would prune the
+    queued row. The subsequent promotion conditional UPDATE then sees
+    rowcount==0 and silently drops the queued context.
+
+    The fixed retention DELETE filters to terminal statuses so
+    non-terminal rows survive regardless of count.
+    """
+    runner, db = _make_runner_with_db(tmp_path)
+    try:
+        ws = db._active_workspace_id
+        blocker = threading.Event()
+
+        # Long-running first pipeline holds the slot.
+        first_id = runner.enqueue_pipeline(
+            work_fn=lambda job: blocker.wait(timeout=10.0),
+            config={}, workspace_id=ws,
+        )
+        # Queued pipeline.
+        queued_id = runner.enqueue_pipeline(
+            work_fn=lambda job: {"ran": True},
+            config={}, workspace_id=ws,
+        )
+
+        # Simulate 105 unrelated jobs completing in this workspace by
+        # writing terminal rows directly. They share the workspace_id
+        # so they're candidates for the retention DELETE.
+        import sqlite3
+        conn = sqlite3.connect(str(tmp_path / "test.db"))
+        try:
+            now = "2026-05-27T00:00:00"
+            for i in range(105):
+                conn.execute(
+                    "INSERT OR REPLACE INTO job_history "
+                    "(id, type, status, started_at, finished_at, "
+                    " duration, error_count, workspace_id) "
+                    "VALUES (?, 'scan', 'completed', ?, ?, 0.1, 0, ?)",
+                    (f"scan-fill-{i:03d}", now, now, ws),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Trigger _persist_job's retention by completing one more job
+        # via the runner. Use a non-pipeline type so it goes through
+        # runner.start (which persists immediately on finish).
+        fill_id = runner.start(
+            "scan", lambda job: None, workspace_id=ws,
+        )
+        wait_for_job_via_runner(runner, fill_id)
+
+        # The queued row MUST still exist after retention ran.
+        row = db.conn.execute(
+            "SELECT id, status FROM job_history WHERE id = ?", (queued_id,),
+        ).fetchone()
+        assert row is not None, (
+            "queued row was pruned by retention DELETE — promotion would "
+            "now see rowcount==0 and silently drop the run"
+        )
+        assert row["status"] == "queued"
+
+        # And promotion still works when the slot opens.
+        blocker.set()
+        wait_for_job_via_runner(runner, first_id)
+        second_final = wait_for_job_via_runner(runner, queued_id)
+        assert second_final["status"] == "completed"
+        assert second_final["result"] == {"ran": True}
+    finally:
+        db.close()
+
+
 def test_get_history_excludes_queued_rows(tmp_path):
     """Codex P2 regression: queued pipeline rows live in job_history
     immediately on enqueue, but they're LIVE state, not history. The

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -393,17 +393,26 @@ def test_retention_does_not_prune_queued_row_under_load(tmp_path):
         # Simulate 105 unrelated jobs completing in this workspace by
         # writing terminal rows directly. They share the workspace_id
         # so they're candidates for the retention DELETE.
+        #
+        # Timestamps MUST be newer than the queued row's runtime
+        # started_at (set by enqueue_pipeline via datetime.now()).
+        # Otherwise the OLD buggy retention DELETE — which orders by
+        # started_at DESC and keeps the top 100 — would naturally keep
+        # the queued row (newer timestamp wins) and the test would
+        # pass even against the broken code, defeating its purpose.
+        # Use a far-future date so the order is unambiguous regardless
+        # of when the test runs.
         import sqlite3
         conn = sqlite3.connect(str(tmp_path / "test.db"))
         try:
-            now = "2026-05-27T00:00:00"
+            future_ts = "2099-01-01T00:00:00"
             for i in range(105):
                 conn.execute(
                     "INSERT OR REPLACE INTO job_history "
                     "(id, type, status, started_at, finished_at, "
                     " duration, error_count, workspace_id) "
                     "VALUES (?, 'scan', 'completed', ?, ?, 0.1, 0, ?)",
-                    (f"scan-fill-{i:03d}", now, now, ws),
+                    (f"scan-fill-{i:03d}", future_ts, future_ts, ws),
                 )
             conn.commit()
         finally:

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -1,0 +1,373 @@
+# vireo/tests/test_pipeline_queue.py
+"""Tests for the server-side pipeline queue.
+
+The queue persists pending pipeline runs in ``job_history`` with
+``status='queued'`` and promotes them to ``status='running'`` as slot
+capacity opens. ``SLOT_CAP`` is 1 in this PR — the second queued run
+waits for the first to reach a terminal state before promotion.
+"""
+
+import os
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from db import Database
+from wait import wait_for_job_via_runner
+
+
+def _make_runner_with_db(tmp_path):
+    """Build a JobRunner + Database pair for a single test.
+
+    The caller doesn't have to close the Database explicitly: pytest's
+    tmp_path teardown removes the file, and Python's GC eventually
+    finalises the Database object. For tests that open a second
+    Database against the same file (the startup-sweep tests), close
+    explicitly inside the test to avoid SQLite holding shared file
+    locks across handles when GC order is non-deterministic.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    from jobs import JobRunner
+    return JobRunner(db=db), db
+
+
+def test_enqueue_pipeline_returns_pipeline_prefixed_job_id(tmp_path):
+    """enqueue_pipeline must return a job id of the form ``pipeline-<ms>``."""
+    runner, _ = _make_runner_with_db(tmp_path)
+
+    job_id = runner.enqueue_pipeline(
+        work_fn=lambda job: None,
+        config={"sources": []},
+        workspace_id=1,
+    )
+    assert job_id.startswith("pipeline-"), job_id
+
+
+def test_enqueue_pipeline_persists_queued_row(tmp_path):
+    """A row with status='queued' must be inserted into job_history."""
+    runner, db = _make_runner_with_db(tmp_path)
+
+    job_id = runner.enqueue_pipeline(
+        work_fn=lambda job: None,
+        config={"sources": ["/a"]},
+        workspace_id=42,
+    )
+
+    # New connection so we don't see the runner's write through any
+    # transactional cache; this confirms the row is committed.
+    row = db.conn.execute(
+        "SELECT id, type, status, workspace_id, config "
+        "FROM job_history WHERE id = ?",
+        (job_id,),
+    ).fetchone()
+    assert row is not None, "enqueue did not persist a job_history row"
+    assert row["type"] == "pipeline"
+    assert row["status"] in ("queued", "running")  # may have promoted already
+    assert row["workspace_id"] == 42
+
+
+def test_enqueue_pipeline_promotes_immediately_when_slot_free(tmp_path):
+    """With no other pipelines active and SLOT_CAP>=1, an enqueued job
+    promotes and runs to completion without further calls.
+    """
+    runner, _ = _make_runner_with_db(tmp_path)
+    completed = threading.Event()
+
+    def work(job):
+        completed.set()
+        return {"ok": True}
+
+    job_id = runner.enqueue_pipeline(
+        work_fn=work, config={}, workspace_id=1,
+    )
+    assert completed.wait(timeout=2.0), "work_fn was never invoked"
+    job = wait_for_job_via_runner(runner, job_id)
+    assert job["status"] == "completed"
+    assert job["result"] == {"ok": True}
+
+
+def test_second_enqueue_while_first_running_stays_queued(tmp_path):
+    """A second enqueue while the slot is occupied must NOT start
+    running. SLOT_CAP is 1 in this PR; the second waits.
+    """
+    runner, _ = _make_runner_with_db(tmp_path)
+    first_started = threading.Event()
+    let_first_finish = threading.Event()
+    second_started = threading.Event()
+
+    def first_work(job):
+        first_started.set()
+        let_first_finish.wait(timeout=3.0)
+        return {"first": True}
+
+    def second_work(job):
+        second_started.set()
+        return {"second": True}
+
+    first_id = runner.enqueue_pipeline(
+        work_fn=first_work, config={}, workspace_id=1,
+    )
+    assert first_started.wait(timeout=2.0), "first work_fn never started"
+
+    second_id = runner.enqueue_pipeline(
+        work_fn=second_work, config={}, workspace_id=1,
+    )
+    # Second must NOT have started yet — slot is occupied.
+    assert not second_started.wait(timeout=0.2), (
+        "second pipeline started while slot was occupied"
+    )
+    # Verify status via the runner's accessor.
+    second_view = runner.get(second_id)
+    assert second_view is not None
+    assert second_view["status"] == "queued"
+
+    # Release the first; second must now promote and run.
+    let_first_finish.set()
+    wait_for_job_via_runner(runner, first_id)
+    assert second_started.wait(timeout=2.0), (
+        "second pipeline did not promote after first completed"
+    )
+    second_final = wait_for_job_via_runner(runner, second_id)
+    assert second_final["status"] == "completed"
+    assert second_final["result"] == {"second": True}
+
+
+def test_startup_sweep_marks_orphan_running_rows_as_failed(tmp_path):
+    """Rows with status='running' from a prior process have no live
+    thread to finish them. A fresh JobRunner must mark them 'failed'
+    so the user (and /api/jobs/history) doesn't see them as alive forever.
+    """
+    db_path = str(tmp_path / "test.db")
+
+    # First runner: simulate a process that crashed mid-run.
+    first_db = Database(db_path)
+    from jobs import JobRunner
+    JobRunner(db=first_db)  # ensures schema
+    first_db.conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at, error_count) "
+        "VALUES ('scan-old', 'scan', 'running', '2026-05-26T00:00:00', 0)"
+    )
+    first_db.conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at, error_count) "
+        "VALUES ('pipeline-old', 'pipeline', 'queued', '2026-05-26T00:00:00', 0)"
+    )
+    first_db.conn.commit()
+    first_db.close()
+
+    # Second runner: opens the same DB. Startup sweep must clean both up.
+    second_db = Database(db_path)
+    try:
+        JobRunner(db=second_db)
+        rows = {
+            r["id"]: r["status"]
+            for r in second_db.conn.execute(
+                "SELECT id, status FROM job_history "
+                "WHERE id IN ('scan-old', 'pipeline-old')"
+            )
+        }
+        assert rows == {"scan-old": "failed", "pipeline-old": "failed"}, (
+            f"startup sweep should have failed both orphans; got {rows}"
+        )
+    finally:
+        second_db.close()
+
+
+def test_startup_sweep_does_not_touch_terminal_rows(tmp_path):
+    """Rows with status='completed', 'failed', or 'cancelled' from a
+    prior process are already terminal — the sweep must leave them alone.
+    """
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    from jobs import JobRunner
+    JobRunner(db=db)
+    db.conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at, error_count) "
+        "VALUES ('scan-done', 'scan', 'completed', '2026-05-26T00:00:00', 0)"
+    )
+    db.conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at, error_count) "
+        "VALUES ('scan-bad', 'scan', 'failed', '2026-05-26T00:00:00', 1)"
+    )
+    db.conn.commit()
+    db.close()
+
+    db2 = Database(db_path)
+    try:
+        JobRunner(db=db2)
+        rows = {
+            r["id"]: r["status"]
+            for r in db2.conn.execute(
+                "SELECT id, status FROM job_history "
+                "WHERE id IN ('scan-done', 'scan-bad')"
+            )
+        }
+        assert rows == {"scan-done": "completed", "scan-bad": "failed"}
+    finally:
+        db2.close()
+
+
+def test_queued_pipeline_is_visible_via_get(tmp_path):
+    """``runner.get(job_id)`` must return a queued-shaped job dict for
+    pipelines that haven't promoted yet, not None. The UI polls this
+    endpoint to render queue state.
+    """
+    runner, _ = _make_runner_with_db(tmp_path)
+    blocker = threading.Event()
+
+    def blocking_work(job):
+        blocker.wait(timeout=3.0)
+        return {}
+
+    first_id = runner.enqueue_pipeline(
+        work_fn=blocking_work, config={}, workspace_id=1,
+    )
+    second_id = runner.enqueue_pipeline(
+        work_fn=lambda job: {"ok": True}, config={"x": 1}, workspace_id=2,
+    )
+
+    view = runner.get(second_id)
+    assert view is not None
+    assert view["status"] == "queued"
+    assert view["type"] == "pipeline"
+    assert view["config"] == {"x": 1}
+    assert view["workspace_id"] == 2
+
+    blocker.set()
+    wait_for_job_via_runner(runner, first_id)
+    wait_for_job_via_runner(runner, second_id)
+
+
+def test_cancel_queued_pipeline_transitions_row_to_cancelled(tmp_path):
+    """Cancelling a queued pipeline must atomically flip job_history to
+    'cancelled' (without ever running the work_fn) and drop the
+    in-memory context so promotion never picks it up.
+    """
+    runner, db = _make_runner_with_db(tmp_path)
+    blocker = threading.Event()
+    second_started = threading.Event()
+
+    def first_work(job):
+        blocker.wait(timeout=3.0)
+        return {}
+
+    def second_work(job):
+        second_started.set()
+        return {"should-not-run": True}
+
+    first_id = runner.enqueue_pipeline(work_fn=first_work, config={}, workspace_id=1)
+    second_id = runner.enqueue_pipeline(work_fn=second_work, config={}, workspace_id=1)
+    assert runner.get(second_id)["status"] == "queued"
+
+    # Cancel while still queued.
+    ok = runner.cancel_job(second_id)
+    assert ok is True
+    row = db.conn.execute(
+        "SELECT status FROM job_history WHERE id = ?", (second_id,),
+    ).fetchone()
+    assert row["status"] == "cancelled"
+
+    # Releasing the first must NOT promote the cancelled one.
+    blocker.set()
+    wait_for_job_via_runner(runner, first_id)
+    # Give the scheduler a beat — the cancelled row must stay cancelled.
+    time.sleep(0.05)
+    assert not second_started.is_set(), (
+        "cancelled queued job must not be promoted"
+    )
+    final_row = db.conn.execute(
+        "SELECT status FROM job_history WHERE id = ?", (second_id,),
+    ).fetchone()
+    assert final_row["status"] == "cancelled"
+
+
+def test_promotion_loses_race_to_cancel_leaves_row_cancelled(tmp_path):
+    """If a Cancel lands between the scheduler picking a queued job and
+    its conditional UPDATE, the UPDATE matches zero rows and the
+    scheduler bails out. The row stays 'cancelled' in job_history.
+    """
+    runner, db = _make_runner_with_db(tmp_path)
+
+    # Pre-write a queued row directly, mimicking a row whose in-memory
+    # context might race with cancel. We simulate the race by issuing
+    # the cancel UPDATE before calling _try_promote_queued.
+    import sqlite3
+    job_id = "pipeline-1700000000000"
+    conn = sqlite3.connect(str(tmp_path / "test.db"))
+    conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at, error_count) "
+        "VALUES (?, 'pipeline', 'queued', '2026-05-26T00:00:00', 0)",
+        (job_id,),
+    )
+    conn.execute(
+        "UPDATE job_history SET status='cancelled' WHERE id = ?", (job_id,),
+    )
+    conn.commit()
+    conn.close()
+
+    # Inject an in-memory context for this id so _try_promote_queued
+    # finds something to look at.
+    with runner._lock:
+        runner._queued_pipelines[job_id] = {
+            "work_fn": lambda job: pytest_fail("should not have run"),
+            "config": {},
+            "workspace_id": 1,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:00",
+        }
+
+    runner._try_promote_queued()
+
+    final = db.conn.execute(
+        "SELECT status FROM job_history WHERE id = ?", (job_id,),
+    ).fetchone()
+    assert final["status"] == "cancelled", (
+        "conditional UPDATE must not overwrite a cancelled row"
+    )
+    # And the in-memory context is cleaned up.
+    assert job_id not in runner._queued_pipelines
+
+
+def pytest_fail(msg):
+    raise AssertionError(msg)
+
+
+def test_sse_subscribers_attached_while_queued_receive_post_promotion_events(tmp_path):
+    """A client connected to /api/jobs/<id>/stream while the job is
+    queued must keep receiving events once the job is promoted to
+    running. Otherwise the UI sees ``status: queued`` forever even
+    after the pipeline actually starts.
+    """
+    runner, _ = _make_runner_with_db(tmp_path)
+    blocker = threading.Event()
+    let_second_finish = threading.Event()
+
+    def first_work(job):
+        blocker.wait(timeout=3.0)
+        return {}
+
+    def second_work(job):
+        runner.push_event(job["id"], "progress", {"phase": "started"})
+        let_second_finish.wait(timeout=3.0)
+        return {"ok": True}
+
+    first_id = runner.enqueue_pipeline(first_work, config={}, workspace_id=1)
+    second_id = runner.enqueue_pipeline(second_work, config={}, workspace_id=1)
+    assert runner.get(second_id)["status"] == "queued"
+
+    # Subscribe BEFORE promotion.
+    q = runner.subscribe(second_id)
+
+    # Release the first; second is now promoted and emits a progress event.
+    blocker.set()
+    wait_for_job_via_runner(runner, first_id)
+
+    # The event the second's work_fn pushed must reach this subscriber.
+    evt = q.get(timeout=2.0)
+    assert evt["type"] == "progress"
+    assert evt["data"]["phase"] == "started"
+
+    let_second_finish.set()
+    wait_for_job_via_runner(runner, second_id)

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -22,6 +22,12 @@ from wait import wait_for_job_via_runner
 def _make_runner_with_db(tmp_path):
     """Build a JobRunner + Database pair for a single test.
 
+    Also redirects ``config.CONFIG_PATH`` to ``tmp_path / "config.json"``
+    so tests can't write through to ``~/.vireo/config.json`` even if a
+    code path we exercise calls ``config.save()``. The conftest's
+    ``_restore_global_config_paths`` autouse fixture restores it after
+    the test.
+
     The caller doesn't have to close the Database explicitly: pytest's
     tmp_path teardown removes the file, and Python's GC eventually
     finalises the Database object. For tests that open a second
@@ -29,6 +35,8 @@ def _make_runner_with_db(tmp_path):
     explicitly inside the test to avoid SQLite holding shared file
     locks across handles when GC order is non-deterministic.
     """
+    import config as cfg
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
     db = Database(str(tmp_path / "test.db"))
     from jobs import JobRunner
     return JobRunner(db=db), db
@@ -47,26 +55,47 @@ def test_enqueue_pipeline_returns_pipeline_prefixed_job_id(tmp_path):
 
 
 def test_enqueue_pipeline_persists_queued_row(tmp_path):
-    """A row with status='queued' must be inserted into job_history."""
-    runner, db = _make_runner_with_db(tmp_path)
-
+    """A row with status='queued' must be inserted into job_history
+    BEFORE the worker thread runs to completion, and must be visible
+    cross-connection (different sqlite handle).
+    """
+    runner, _ = _make_runner_with_db(tmp_path)
+    # Block the first pipeline so the read below sees a non-terminal
+    # state; without it the trivial lambda runs to completion before
+    # the assertion fires and the status would be 'completed'.
+    blocker = threading.Event()
+    first_id = runner.enqueue_pipeline(
+        work_fn=lambda job: blocker.wait(timeout=3.0),
+        config={}, workspace_id=1,
+    )
     job_id = runner.enqueue_pipeline(
         work_fn=lambda job: None,
         config={"sources": ["/a"]},
         workspace_id=42,
     )
 
-    # New connection so we don't see the runner's write through any
-    # transactional cache; this confirms the row is committed.
-    row = db.conn.execute(
-        "SELECT id, type, status, workspace_id, config "
-        "FROM job_history WHERE id = ?",
-        (job_id,),
-    ).fetchone()
+    # Open a fresh Database against the same file to verify the row is
+    # actually committed and visible cross-connection — the test fixture's
+    # Database isn't the same connection the runner used for the INSERT
+    # (enqueue_pipeline opens its own sqlite3 connection), but using a
+    # genuinely separate Database removes any ambiguity.
+    verify_db = Database(str(tmp_path / "test.db"))
+    try:
+        row = verify_db.conn.execute(
+            "SELECT id, type, status, workspace_id, config "
+            "FROM job_history WHERE id = ?",
+            (job_id,),
+        ).fetchone()
+    finally:
+        verify_db.close()
     assert row is not None, "enqueue did not persist a job_history row"
     assert row["type"] == "pipeline"
-    assert row["status"] in ("queued", "running")  # may have promoted already
+    assert row["status"] == "queued"
     assert row["workspace_id"] == 42
+
+    blocker.set()
+    wait_for_job_via_runner(runner, first_id)
+    wait_for_job_via_runner(runner, job_id)
 
 
 def test_enqueue_pipeline_promotes_immediately_when_slot_free(tmp_path):
@@ -332,6 +361,41 @@ def test_promotion_loses_race_to_cancel_leaves_row_cancelled(tmp_path):
 
 def pytest_fail(msg):
     raise AssertionError(msg)
+
+
+def test_cancelling_queued_pipeline_emits_complete_event_to_sse(tmp_path):
+    """Codex P2 regression: when a queued pipeline is cancelled while a
+    client is subscribed to its SSE stream, the client must receive a
+    terminal 'complete' event with status='cancelled' so it closes the
+    stream cleanly. Without this the runner.get() lookup turns None
+    and the SSE loop reports the job as 'expired'.
+    """
+    runner, _ = _make_runner_with_db(tmp_path)
+    blocker = threading.Event()
+
+    def first_work(job):
+        blocker.wait(timeout=3.0)
+        return {}
+
+    first_id = runner.enqueue_pipeline(first_work, config={}, workspace_id=1)
+    second_id = runner.enqueue_pipeline(
+        lambda job: pytest_fail("cancelled queued must not run"),
+        config={}, workspace_id=1,
+    )
+    assert runner.get(second_id)["status"] == "queued"
+
+    # Subscribe BEFORE cancel — mirrors a UI tab that hit /api/jobs/<id>/stream
+    # while the run was still waiting in the queue.
+    q = runner.subscribe(second_id)
+
+    assert runner.cancel_job(second_id) is True
+
+    evt = q.get(timeout=1.0)
+    assert evt["type"] == "complete"
+    assert evt["data"]["status"] == "cancelled"
+
+    blocker.set()
+    wait_for_job_via_runner(runner, first_id)
 
 
 def test_sse_subscribers_attached_while_queued_receive_post_promotion_events(tmp_path):


### PR DESCRIPTION
## Summary

Step 4 from [docs/plans/2026-05-26-pipeline-concurrency-design.md](docs/plans/2026-05-26-pipeline-concurrency-design.md). Adds a one-slot persistent queue for pipeline runs. **`SLOT_CAP` stays at 1** — the UI still serialises Start, and concurrency itself doesn't turn on until Steps 5 + 6. This PR just lays the queue down.

## What's new

- **`JobRunner.enqueue_pipeline(work_fn, config, workspace_id, ...)`** — inserts a `job_history` row with `status='queued'`, stashes the work closure in-process, then asks the scheduler to promote it.
- **`_try_promote_queued()`** — counts active pipelines, picks oldest queued context, performs a conditional `UPDATE` (queued→running) keyed on the row id. Race-safe: rowcount==0 means a cancel landed first.
- **`_startup_sweep()`** — on construction, marks orphan `running` rows from a prior process as `failed`. Queued rows from a prior process are similarly failed (their in-process closures are gone; rebuilding from `config` is a future PR).
- **`cancel_job` extended for queued jobs** — atomic row update + in-memory cleanup. Handles the cancel-during-promotion race.
- **`JobRunner.get`** returns a queued-shaped job dict so the UI / SSE doesn't see 404 before promotion.
- **Per-runner monotonic counter** on job IDs (`pipeline-<ms>-<seq>`) so same-ms enqueues don't collide on the PRIMARY KEY.
- **SSE preserved across promotion** — `_try_promote_queued` uses `setdefault` on the subscribers list, so a client connected to `/api/jobs/<id>/stream` while the job is queued keeps its queue and receives events once running.
- **`/api/jobs/pipeline`** now calls `enqueue_pipeline` instead of `start`. Response shape unchanged.

## Tests

10 new tests in `vireo/tests/test_pipeline_queue.py`:
- `job_id` format `pipeline-<ms>-<seq>`
- row persisted with `status='queued'` and the config blob
- immediate promotion when a slot is free
- second enqueue while first is running stays queued, then runs after
- startup sweep fails orphan running + queued rows
- startup sweep does NOT touch terminal rows
- `runner.get` returns queued shape (not None) for pre-promotion jobs
- `cancel_job` on a queued job flips row to cancelled, skips promotion
- promotion losing the race to cancel leaves row cancelled
- SSE subscribers attached while queued receive post-promotion events

Sanity check (local): 57 jobs-API + 19 core jobs + 196 app + 139 pipeline_job + 10 new queue tests all pass.

## What's NOT in this PR (intentionally)

- UI changes (button label flip, queue indicator, /jobs page queued rows + Cancel) — Step 5.
- Lift `SLOT_CAP` to 2 — Step 6.
- Cross-process queue survival (rebuilding work closures from persisted `config` on startup) — future PR.

## Test plan

- [ ] CI passes
- [ ] Smoke: start a normal pipeline — same behaviour as before (immediate promotion, runs to completion)
- [ ] Smoke: while a pipeline is running, trigger a second `POST /api/jobs/pipeline` (e.g. via curl). Verify the second `job_id` is queued (`/api/jobs/<id>` returns `status: queued`) and promotes to running once the first finishes
- [ ] Smoke: cancel the queued job via the existing cancel mechanism — verify `job_history` shows it as `cancelled` without ever running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipelines can be queued when concurrency is reached and are promoted FIFO as slots free.
  * Submitting a pipeline returns a job ID immediately whether it starts or is queued; queued jobs are visible, cancellable, and surface state via polling/SSE.

* **Bug Fixes**
  * On startup, interrupted running/queued jobs are reconciled to terminal failed state to avoid stale entries.
  * Job-history pruning now preserves queued/non-terminal rows so promotions and cancellations behave correctly.

* **Tests**
  * Added comprehensive tests covering queuing, promotion, cancellation, startup-sweep, visibility, history, and SSE behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->