### PR TITLE
jobs: bulk-cancel queued pipelines

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -42,6 +42,7 @@ from preview_cache import (
 from preview_cache import (
     reconcile_preview_cache,
 )
+from werkzeug.exceptions import BadRequest
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
@@ -10214,8 +10215,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """
         runner = app._job_runner
         db = _get_db()
-        body = request.get_json(silent=True)
-        if body is None:
+        raw_body = request.get_data(cache=True)
+        if request.is_json and raw_body.strip():
+            try:
+                body = request.get_json()
+            except BadRequest:
+                return json_error("Malformed JSON body", 400)
+        elif raw_body.strip():
+            body = request.get_json(silent=True)
+        else:
             body = {}
         if not isinstance(body, dict):
             return json_error("JSON body must be an object", 400)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10172,6 +10172,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("job not found", 404)
         return json_error(f"job is not running (status={job['status']})", 404)
 
+    @app.route("/api/jobs/cancel-queued", methods=["POST"])
+    def api_jobs_cancel_queued():
+        """Bulk-cancel every queued pipeline in a workspace.
+
+        Body (optional): ``{"workspace_id": <id>}``. Default scope is
+        the active workspace — matching what the user sees on the Jobs
+        page. Running pipelines and queued pipelines in OTHER
+        workspaces are untouched.
+
+        Returns ``{"cancelled": [job_ids...]}``.
+        """
+        runner = app._job_runner
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        ws_id = body.get("workspace_id")
+        if ws_id is None:
+            ws_id = db._active_workspace_id
+
+        cancelled = []
+        # Snapshot list first; ``cancel_job`` mutates the runner's
+        # internal state, and ``list_jobs`` would race against it.
+        for job in runner.list_jobs():
+            if job.get("status") != "queued":
+                continue
+            if ws_id is not None and job.get("workspace_id") != ws_id:
+                continue
+            if runner.cancel_job(job["id"]):
+                cancelled.append(job["id"])
+        return jsonify({"cancelled": cancelled})
+
     @app.route("/api/jobs/<job_id>/stream")
     def api_job_stream(job_id):
         """SSE stream of job progress events."""

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10216,7 +10216,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         runner = app._job_runner
         db = _get_db()
         raw_body = request.get_data(cache=True)
-        if request.is_json and raw_body.strip():
+        if request.is_json and raw_body:
             try:
                 body = request.get_json()
             except BadRequest:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10185,21 +10185,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """
         runner = app._job_runner
         db = _get_db()
-        body = request.get_json(silent=True) or {}
-        ws_id = body.get("workspace_id")
-        if ws_id is None:
-            ws_id = db._active_workspace_id
+        body = request.get_json(silent=True)
+        if body is None:
+            body = {}
+        if not isinstance(body, dict):
+            return json_error("JSON body must be an object", 400)
 
-        cancelled = []
-        # Snapshot list first; ``cancel_job`` mutates the runner's
-        # internal state, and ``list_jobs`` would race against it.
-        for job in runner.list_jobs():
-            if job.get("status") != "queued":
-                continue
-            if ws_id is not None and job.get("workspace_id") != ws_id:
-                continue
-            if runner.cancel_job(job["id"]):
-                cancelled.append(job["id"])
+        if "workspace_id" in body:
+            ws_id = body["workspace_id"]
+            if isinstance(ws_id, bool) or not isinstance(ws_id, int):
+                return json_error("workspace_id must be an integer", 400)
+        else:
+            ws_id = db._active_workspace_id
+            if ws_id is None:
+                return json_error("workspace_id is required", 400)
+
+        cancelled = runner.cancel_queued_jobs(workspace_id=ws_id)
         return jsonify({"cancelled": cancelled})
 
     @app.route("/api/jobs/<job_id>/stream")

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -195,7 +195,6 @@ class JobRunner:
             if not candidates:
                 return
             job_id, ctx = candidates[0]
-            self._queued_pipelines.pop(job_id, None)
             self._promoting_pipelines.add(job_id)
 
         promoted = True
@@ -214,19 +213,24 @@ class JobRunner:
                 conn.close()
 
         if not promoted:
+            record_terminal = False
             with self._lock:
                 self._promoting_pipelines.discard(job_id)
-            self._record_terminal_queued_pipeline(job_id, ctx, status="cancelled")
-            self.push_event(
-                job_id,
-                "complete",
-                {
-                    "status": "cancelled",
-                    "result": None,
-                    "duration": 0.0,
-                    "errors": [],
-                },
-            )
+                if job_id not in self._jobs:
+                    ctx = self._queued_pipelines.pop(job_id, ctx)
+                    record_terminal = True
+            if record_terminal:
+                self._record_terminal_queued_pipeline(job_id, ctx, status="cancelled")
+                self.push_event(
+                    job_id,
+                    "complete",
+                    {
+                        "status": "cancelled",
+                        "result": None,
+                        "duration": 0.0,
+                        "errors": [],
+                    },
+                )
             return
 
         job = {
@@ -246,6 +250,7 @@ class JobRunner:
         }
         with self._lock:
             self._promoting_pipelines.discard(job_id)
+            self._queued_pipelines.pop(job_id, None)
             self._prune_finished_jobs()
             self._jobs[job_id] = job
             self._events[job_id] = deque(maxlen=1000)
@@ -788,7 +793,7 @@ class JobRunner:
             if job_id in self._queued_pipelines:
                 if expected_status and expected_status != "queued":
                     return False
-                ctx = self._queued_pipelines.pop(job_id)
+                ctx = self._queued_pipelines[job_id]
             else:
                 return False
 
@@ -812,6 +817,9 @@ class JobRunner:
         if not cancelled:
             return False
 
+        with self._lock:
+            ctx = self._queued_pipelines.pop(job_id, ctx)
+            self._promoting_pipelines.discard(job_id)
         self._record_terminal_queued_pipeline(job_id, ctx, status="cancelled")
         # Emit the terminal SSE event AFTER releasing the lock — clients
         # subscribed to /api/jobs/<id>/stream while the job was queued

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -41,6 +41,7 @@ class JobRunner:
         # job_history without a matching entry here; the startup sweep
         # promotes such rows to 'failed'.
         self._queued_pipelines = {}  # job_id -> dict(work_fn, config, ...)
+        self._promoting_pipelines = set()
         # Monotonic suffix so two enqueues landing in the same
         # millisecond don't collide on the PRIMARY KEY.
         self._enqueue_counter = 0
@@ -184,6 +185,7 @@ class JobRunner:
                 1 for j in self._jobs.values()
                 if j["type"] == "pipeline" and j["status"] == "running"
             )
+            active += len(self._promoting_pipelines)
             if active >= SLOT_CAP:
                 return
             candidates = sorted(
@@ -193,44 +195,57 @@ class JobRunner:
             if not candidates:
                 return
             job_id, ctx = candidates[0]
-            # Atomic queued→running flip. If a concurrent cancel beat us
-            # to it, rowcount is 0 and the row stays in its final
-            # state — we leave self._queued_pipelines untouched so the
-            # caller cleaning up the cancel can remove it.
-            if self._db_path:
-                import sqlite3
-                conn = sqlite3.connect(self._db_path, timeout=30)
-                try:
-                    cur = conn.execute(
-                        "UPDATE job_history SET status='running' "
-                        "WHERE id = ? AND status = 'queued'",
-                        (job_id,),
-                    )
-                    promoted = cur.rowcount == 1
-                    conn.commit()
-                finally:
-                    conn.close()
-                if not promoted:
-                    # The row was modified elsewhere (cancelled).
-                    self._queued_pipelines.pop(job_id, None)
-                    return
-            # Move from queue context into the live jobs dict.
-            del self._queued_pipelines[job_id]
-            job = {
-                "id": job_id,
-                "type": "pipeline",
-                "status": "running",
-                "started_at": ctx["started_at"],
-                "finished_at": None,
-                "progress": {"current": 0, "total": 0, "current_file": ""},
-                "result": None,
-                "errors": [],
-                "config": ctx["config"],
-                "workspace_id": ctx["workspace_id"],
-                "steps": [],
-                "ephemeral": False,
-                "runtime_warning": ctx["runtime_warning"],
-            }
+            self._queued_pipelines.pop(job_id, None)
+            self._promoting_pipelines.add(job_id)
+
+        promoted = True
+        if self._db_path:
+            import sqlite3
+            conn = sqlite3.connect(self._db_path, timeout=30)
+            try:
+                cur = conn.execute(
+                    "UPDATE job_history SET status='running' "
+                    "WHERE id = ? AND status = 'queued'",
+                    (job_id,),
+                )
+                promoted = cur.rowcount == 1
+                conn.commit()
+            finally:
+                conn.close()
+
+        if not promoted:
+            with self._lock:
+                self._promoting_pipelines.discard(job_id)
+            self._record_terminal_queued_pipeline(job_id, ctx, status="cancelled")
+            self.push_event(
+                job_id,
+                "complete",
+                {
+                    "status": "cancelled",
+                    "result": None,
+                    "duration": 0.0,
+                    "errors": [],
+                },
+            )
+            return
+
+        job = {
+            "id": job_id,
+            "type": "pipeline",
+            "status": "running",
+            "started_at": ctx["started_at"],
+            "finished_at": None,
+            "progress": {"current": 0, "total": 0, "current_file": ""},
+            "result": None,
+            "errors": [],
+            "config": ctx["config"],
+            "workspace_id": ctx["workspace_id"],
+            "steps": [],
+            "ephemeral": False,
+            "runtime_warning": ctx["runtime_warning"],
+        }
+        with self._lock:
+            self._promoting_pipelines.discard(job_id)
             self._prune_finished_jobs()
             self._jobs[job_id] = job
             self._events[job_id] = deque(maxlen=1000)
@@ -245,6 +260,32 @@ class JobRunner:
             target=self._run_job, args=(job, work_fn), daemon=True,
         )
         thread.start()
+
+    def _record_terminal_queued_pipeline(self, job_id, ctx, status="cancelled"):
+        """Keep a cancelled queued pipeline in the normal terminal lifecycle."""
+        finished_at = datetime.now().isoformat()
+        job = {
+            "id": job_id,
+            "type": "pipeline",
+            "status": status,
+            "started_at": ctx["started_at"],
+            "finished_at": finished_at,
+            "progress": {"current": 0, "total": 0, "current_file": ""},
+            "result": None,
+            "errors": [],
+            "config": ctx["config"],
+            "workspace_id": ctx["workspace_id"],
+            "steps": [],
+            "ephemeral": False,
+            "runtime_warning": ctx.get("runtime_warning"),
+            "_ended_at": time.time(),
+            "_persisted": True,
+        }
+        with self._lock:
+            self._prune_finished_jobs()
+            self._jobs[job_id] = job
+            self._events.setdefault(job_id, deque(maxlen=1000))
+            self._subscribers.setdefault(job_id, [])
 
     def start(self, job_type, work_fn, config=None, workspace_id=None,
               ephemeral=False, runtime_warning=None):
@@ -712,7 +753,7 @@ class JobRunner:
                             step[key] = kwargs[key]
                     break
 
-    def cancel_job(self, job_id):
+    def cancel_job(self, job_id, expected_status=None):
         """Request cancellation of a running OR queued job.
 
         For running jobs: the work function should periodically check
@@ -725,58 +766,83 @@ class JobRunner:
         cancel landing between SELECT and UPDATE wins (its rowcount==0
         path leaves the row in the cancelled state and gives up).
 
+        Args:
+            job_id: id to cancel.
+            expected_status: optional status guard. When set, cancellation only
+                proceeds if the latest in-memory state still has this status.
+
         Returns True if the job was found and either marked for
         cancellation (running) or transitioned to cancelled (queued).
         """
-        emit_complete = False
+        ctx = None
         with self._lock:
             job = self._jobs.get(job_id)
             if job is not None and job["status"] == "running":
+                if expected_status and expected_status != "running":
+                    return False
                 self._cancelled.add(job_id)
                 return True
+            if job is not None:
+                return False
             # Queued case: still in _queued_pipelines, not _jobs yet.
             if job_id in self._queued_pipelines:
-                cancelled_at = datetime.now().isoformat()
-                if self._db_path:
-                    import sqlite3
-                    conn = sqlite3.connect(self._db_path, timeout=30)
-                    try:
-                        cur = conn.execute(
-                            "UPDATE job_history "
-                            "SET status='cancelled', finished_at=? "
-                            "WHERE id = ? AND status = 'queued'",
-                            (cancelled_at, job_id),
-                        )
-                        conn.commit()
-                        # rowcount==0 means a concurrent promotion beat
-                        # us — the row is now 'running' and the worker
-                        # will see the cancellation flag below.
-                        if cur.rowcount == 0:
-                            self._cancelled.add(job_id)
-                            return True
-                    finally:
-                        conn.close()
-                self._queued_pipelines.pop(job_id, None)
-                emit_complete = True
+                if expected_status and expected_status != "queued":
+                    return False
+                ctx = self._queued_pipelines.pop(job_id)
             else:
                 return False
+
+        cancelled_at = datetime.now().isoformat()
+        cancelled = True
+        if self._db_path:
+            import sqlite3
+            conn = sqlite3.connect(self._db_path, timeout=30)
+            try:
+                cur = conn.execute(
+                    "UPDATE job_history "
+                    "SET status='cancelled', finished_at=? "
+                    "WHERE id = ? AND status = 'queued'",
+                    (cancelled_at, job_id),
+                )
+                conn.commit()
+                cancelled = cur.rowcount == 1
+            finally:
+                conn.close()
+
+        if not cancelled:
+            return False
+
+        self._record_terminal_queued_pipeline(job_id, ctx, status="cancelled")
         # Emit the terminal SSE event AFTER releasing the lock — clients
         # subscribed to /api/jobs/<id>/stream while the job was queued
         # need a ``complete`` event with status='cancelled' so they
         # close cleanly. Without this they'd see ``get(job_id) is None``
         # on the next keepalive and report the job as ``expired``.
-        if emit_complete:
-            self.push_event(
-                job_id,
-                "complete",
-                {
-                    "status": "cancelled",
-                    "result": None,
-                    "duration": 0.0,
-                    "errors": [],
-                },
-            )
+        self.push_event(
+            job_id,
+            "complete",
+            {
+                "status": "cancelled",
+                "result": None,
+                "duration": 0.0,
+                "errors": [],
+            },
+        )
         return True
+
+    def cancel_queued_jobs(self, workspace_id=None):
+        """Cancel queued pipelines, optionally scoped to one workspace."""
+        with self._lock:
+            job_ids = [
+                job_id
+                for job_id, ctx in self._queued_pipelines.items()
+                if workspace_id is None or ctx.get("workspace_id") == workspace_id
+            ]
+        cancelled = []
+        for job_id in job_ids:
+            if self.cancel_job(job_id, expected_status="queued"):
+                cancelled.append(job_id)
+        return cancelled
 
     def is_cancelled(self, job_id):
         """Check whether a job has been marked for cancellation."""

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -13,6 +13,8 @@ log = logging.getLogger(__name__)
 # How long to keep completed/failed jobs in memory before eviction (seconds)
 _JOB_RETENTION_SECS = 3600  # 1 hour
 
+_PROMOTION_RETRY_DELAY_SECS = 0.1
+
 
 # Maximum number of pipeline jobs allowed to run concurrently. Kept at
 # 1 in this PR; concurrency is enabled in a later PR after the UI and
@@ -44,6 +46,7 @@ class JobRunner:
         # Monotonic suffix so two enqueues landing in the same
         # millisecond don't collide on the PRIMARY KEY.
         self._enqueue_counter = 0
+        self._promotion_retry_scheduled = False
         if db:
             self._db_path = db.conn.execute("PRAGMA database_list").fetchone()[2]
             self._ensure_history_table(db)
@@ -224,6 +227,7 @@ class JobRunner:
             with self._lock:
                 if self._queued_pipelines.get(job_id) is ctx:
                     ctx.pop("_promoting", None)
+                    self._schedule_promotion_retry_locked()
             log.exception("Failed to promote queued pipeline %s", job_id)
             return
 
@@ -289,6 +293,24 @@ class JobRunner:
         thread = threading.Thread(
             target=self._run_job, args=(job, work_fn), daemon=True,
         )
+        thread.start()
+
+    def _schedule_promotion_retry_locked(self):
+        """Retry queue promotion after a transient DB failure.
+
+        Must be called with self._lock held.
+        """
+        if self._promotion_retry_scheduled:
+            return
+        self._promotion_retry_scheduled = True
+
+        def retry():
+            time.sleep(_PROMOTION_RETRY_DELAY_SECS)
+            with self._lock:
+                self._promotion_retry_scheduled = False
+            self._try_promote_queued()
+
+        thread = threading.Thread(target=retry, daemon=True)
         thread.start()
 
     def _record_terminal_queued_pipeline(self, job_id, ctx, status="cancelled"):

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -200,8 +200,9 @@ class JobRunner:
         promoted = True
         if self._db_path:
             import sqlite3
-            conn = sqlite3.connect(self._db_path, timeout=30)
+            conn = None
             try:
+                conn = sqlite3.connect(self._db_path, timeout=30)
                 cur = conn.execute(
                     "UPDATE job_history SET status='running' "
                     "WHERE id = ? AND status = 'queued'",
@@ -209,8 +210,14 @@ class JobRunner:
                 )
                 promoted = cur.rowcount == 1
                 conn.commit()
+            except Exception:
+                with self._lock:
+                    self._promoting_pipelines.discard(job_id)
+                log.exception("Failed to promote queued pipeline %s", job_id)
+                return
             finally:
-                conn.close()
+                if conn is not None:
+                    conn.close()
 
         if not promoted:
             record_terminal = False

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -805,7 +805,7 @@ class JobRunner:
                             step[key] = kwargs[key]
                     break
 
-    def cancel_job(self, job_id, expected_status=None):
+    def cancel_job(self, job_id, expected_status=None, promote_after_cancel=True):
         """Request cancellation of a running OR queued job.
 
         For running jobs: the work function should periodically check
@@ -822,6 +822,10 @@ class JobRunner:
             job_id: id to cancel.
             expected_status: optional status guard. When set, cancellation only
                 proceeds if the latest in-memory state still has this status.
+            promote_after_cancel: if True, immediately re-check the queue after
+                removing a queued job. Bulk queued cancellation sets this False
+                so the whole snapshot can be cancelled before another queued job
+                is promoted.
 
         Returns True if the job was found and either marked for
         cancellation (running) or transitioned to cancelled (queued).
@@ -903,7 +907,7 @@ class JobRunner:
                     "errors": [],
                 },
             )
-        if retry_promotion:
+        if retry_promotion and promote_after_cancel:
             self._try_promote_queued()
         return True
 
@@ -917,8 +921,14 @@ class JobRunner:
             ]
         cancelled = []
         for job_id in job_ids:
-            if self.cancel_job(job_id, expected_status="queued"):
+            if self.cancel_job(
+                job_id,
+                expected_status="queued",
+                promote_after_cancel=False,
+            ):
                 cancelled.append(job_id)
+        if cancelled:
+            self._try_promote_queued()
         return cancelled
 
     def is_cancelled(self, job_id):

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -260,6 +260,9 @@ class JobRunner:
             # waiters' queues.
             self._subscribers.setdefault(job_id, [])
             work_fn = ctx["work_fn"]
+            if job_id in self._cancelled:
+                def work_fn(job):
+                    return None
 
         thread = threading.Thread(
             target=self._run_job, args=(job, work_fn), daemon=True,
@@ -767,9 +770,9 @@ class JobRunner:
 
         For queued pipelines: atomically transition the persisted row
         to ``status='cancelled'`` and remove the in-memory context.
-        The conditional UPDATE in ``_try_promote_queued`` ensures a
-        cancel landing between SELECT and UPDATE wins (its rowcount==0
-        path leaves the row in the cancelled state and gives up).
+        If promotion already flipped the row to ``running`` but has not
+        installed the job in ``_jobs`` yet, preserve the cancellation
+        request so the promoted worker exits as cancelled.
 
         Args:
             job_id: id to cancel.
@@ -815,6 +818,13 @@ class JobRunner:
                 conn.close()
 
         if not cancelled:
+            with self._lock:
+                if (
+                    job_id in self._promoting_pipelines
+                    and job_id in self._queued_pipelines
+                ):
+                    self._cancelled.add(job_id)
+                    return True
             return False
 
         with self._lock:

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -827,6 +827,7 @@ class JobRunner:
         cancellation (running) or transitioned to cancelled (queued).
         """
         emit_complete = False
+        retry_promotion = False
         queued_cancel = None
         with self._lock:
             job = self._jobs.get(job_id)
@@ -880,6 +881,7 @@ class JobRunner:
                 return False
             if self._queued_pipelines.get(job_id) is queued_cancel:
                 self._queued_pipelines.pop(job_id, None)
+                retry_promotion = True
             emit_complete = True
         if emit_complete:
             self._record_terminal_queued_pipeline(
@@ -901,6 +903,8 @@ class JobRunner:
                     "errors": [],
                 },
             )
+        if retry_promotion:
+            self._try_promote_queued()
         return True
 
     def cancel_queued_jobs(self, workspace_id=None):

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -923,7 +923,6 @@ class JobRunner:
         for job_id in job_ids:
             if self.cancel_job(
                 job_id,
-                expected_status="queued",
                 promote_after_cancel=False,
             ):
                 cancelled.append(job_id)

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -844,8 +844,18 @@ class JobRunner:
             # rowcount==0 means a concurrent promotion beat us — the row is
             # now 'running' and the worker will see the cancellation flag.
             if not cancelled:
-                self._cancelled.add(job_id)
-                return True
+                job = self._jobs.get(job_id)
+                if (
+                    job is not None
+                    and job["status"] == "running"
+                    and (expected_status is None or expected_status == "running")
+                ):
+                    self._cancelled.add(job_id)
+                    return True
+                if self._queued_pipelines.get(job_id) is queued_cancel:
+                    self._cancelled.add(job_id)
+                    return True
+                return False
             if self._queued_pipelines.get(job_id) is queued_cancel:
                 self._queued_pipelines.pop(job_id, None)
             emit_complete = True

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -594,13 +594,12 @@
     });
     html += '<div class="jobs-list-divider clickable' + (currentView === 'active' ? ' selected' : '') + '" data-view="active">Active' +
       (running.length > 0 ? ' (' + running.length + ')' : '') + '</div>';
-    // "Cancel all queued" — only show when at least one queued job
-    // exists. Defaults to the active workspace on the server; the user
-    // doesn't have to think about scope here.
-    var anyQueued = running.some(function(j) { return j.status === 'queued'; });
-    if (anyQueued) {
+    var queuedInActiveWs = running.filter(function(j) {
+      return j.status === 'queued' && j.workspace_id === activeWsId;
+    });
+    if (queuedInActiveWs.length > 0) {
       html += '<div class="jobs-bulk-actions">';
-      html += '<button class="btn-cancel" id="btnCancelAllQueued">Cancel all queued</button>';
+      html += '<button class="btn-cancel" id="btnCancelAllQueued">Cancel queued in active workspace</button>';
       html += '</div>';
     }
     running.forEach(function(j) { html += renderListItem(j, 'active'); });
@@ -676,7 +675,7 @@
       fetch('/api/jobs/cancel-queued', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: '{}',
+        body: JSON.stringify({ workspace_id: activeWsId }),
       })
         .then(function(r) {
           if (r.ok) {
@@ -704,14 +703,14 @@
             if (typeof showToast === 'function') showToast(msg, 'error');
             // Restore the button — caller may want to retry.
             bulkBtn.disabled = false;
-            bulkBtn.textContent = 'Cancel all queued';
+            bulkBtn.textContent = 'Cancel queued in active workspace';
             bulkBtn.classList.remove('cancelling');
           });
         })
         .catch(function() {
           if (typeof showToast === 'function') showToast('Unable to cancel queued jobs', 'error');
           bulkBtn.disabled = false;
-          bulkBtn.textContent = 'Cancel all queued';
+          bulkBtn.textContent = 'Cancel queued in active workspace';
           bulkBtn.classList.remove('cancelling');
         });
       return;

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -539,6 +539,10 @@
         updateList();
         updateRunningBadge();
         if (currentView === 'active') renderActiveOverview();
+        else if (selectedSource === 'active' && selectedJobId) {
+          var selected = activeJobs.find(function(j) { return j.id === selectedJobId; });
+          if (selected) renderDetail(selected);
+        }
       })
       .catch(function() {});
   }

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -526,7 +526,7 @@
       .then(function(r) { return r.json(); })
       .then(function(data) {
         activeJobs = data.active || [];
-        setHistoryJobs(data.history || historyJobs);
+        mergeHistoryJobs(data.history || []);
         activeWsId = data.active_workspace_id || null;
         workspaceNames = data.workspace_names || {};
         // Drop optimistic-cancel state for jobs that have left the active
@@ -566,6 +566,20 @@
         try { j.result = JSON.parse(j.result); } catch(e) { j.result = null; }
       }
     });
+  }
+
+  function mergeHistoryJobs(rows) {
+    if (!rows || !rows.length) return;
+    var seen = {};
+    var merged = [];
+    rows.forEach(function(j) {
+      seen[j.id] = true;
+      merged.push(j);
+    });
+    historyJobs.forEach(function(j) {
+      if (!seen[j.id]) merged.push(j);
+    });
+    setHistoryJobs(merged);
   }
 
   function fetchHistory() {

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -570,13 +570,22 @@
 
   function mergeHistoryJobs(rows) {
     if (!rows || !rows.length) return;
+    var incomingById = {};
+    rows.forEach(function(j) {
+      incomingById[j.id] = j;
+    });
     var seen = {};
     var merged = [];
-    rows.forEach(function(j) {
-      seen[j.id] = true;
-      merged.push(j);
-    });
     historyJobs.forEach(function(j) {
+      var incoming = incomingById[j.id];
+      if (incoming) {
+        merged.push(Object.assign({}, j, incoming));
+      } else {
+        merged.push(j);
+      }
+      seen[j.id] = true;
+    });
+    rows.forEach(function(j) {
       if (!seen[j.id]) merged.push(j);
     });
     setHistoryJobs(merged);

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -526,6 +526,7 @@
       .then(function(r) { return r.json(); })
       .then(function(data) {
         activeJobs = data.active || [];
+        setHistoryJobs(data.history || historyJobs);
         activeWsId = data.active_workspace_id || null;
         workspaceNames = data.workspace_names || {};
         // Drop optimistic-cancel state for jobs that have left the active
@@ -541,28 +542,44 @@
         if (currentView === 'active') renderActiveOverview();
         else if (selectedSource === 'active' && selectedJobId) {
           var selected = activeJobs.find(function(j) { return j.id === selectedJobId; });
-          if (selected) renderDetail(selected);
+          if (selected) {
+            renderDetail(selected);
+          } else {
+            var histSelected = historyJobs.find(function(j) { return j.id === selectedJobId; });
+            if (histSelected) {
+              selectedSource = 'history';
+              renderHistoryDetail(histSelected);
+            }
+          }
         }
       })
       .catch(function() {});
+  }
+
+  function setHistoryJobs(rows) {
+    historyJobs = rows || [];
+    historyJobs.forEach(function(j) {
+      if (typeof j.tree === 'string') {
+        try { j.tree = JSON.parse(j.tree); } catch(e) { j.tree = []; }
+      }
+      if (typeof j.result === 'string') {
+        try { j.result = JSON.parse(j.result); } catch(e) { j.result = null; }
+      }
+    });
   }
 
   function fetchHistory() {
     fetch('/api/jobs/history?limit=100')
       .then(function(r) { return r.json(); })
       .then(function(data) {
-        historyJobs = data || [];
-        historyJobs.forEach(function(j) {
-          if (typeof j.tree === 'string') {
-            try { j.tree = JSON.parse(j.tree); } catch(e) { j.tree = []; }
-          }
-          if (typeof j.result === 'string') {
-            try { j.result = JSON.parse(j.result); } catch(e) { j.result = null; }
-          }
-        });
+        setHistoryJobs(data);
         updateList();
         populateTypeFilter();
         if (currentView === 'history') renderHistoryOverview();
+        else if (selectedSource === 'history' && selectedJobId) {
+          var selected = historyJobs.find(function(j) { return j.id === selectedJobId; });
+          if (selected) renderHistoryDetail(selected);
+        }
       })
       .catch(function() {});
   }

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -127,6 +127,13 @@
 .btn-cancel:disabled {
   background: var(--text-muted); cursor: progress; opacity: 0.7;
 }
+.jobs-bulk-actions {
+  padding: 8px 16px; border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-tertiary);
+}
+.jobs-bulk-actions .btn-cancel {
+  font-size: 11px; padding: 3px 10px;
+}
 .btn-retry {
   font-size: 11px; padding: 2px 8px; border-radius: 3px; cursor: pointer;
   background: var(--accent); color: var(--accent-text); border: none;
@@ -244,6 +251,7 @@
       </select>
       <select id="filterStatus" onchange="applyFilters()">
         <option value="">All status</option>
+        <option value="queued">Queued</option>
         <option value="completed">Completed</option>
         <option value="failed">Failed</option>
       </select>
@@ -586,6 +594,15 @@
     });
     html += '<div class="jobs-list-divider clickable' + (currentView === 'active' ? ' selected' : '') + '" data-view="active">Active' +
       (running.length > 0 ? ' (' + running.length + ')' : '') + '</div>';
+    // "Cancel all queued" — only show when at least one queued job
+    // exists. Defaults to the active workspace on the server; the user
+    // doesn't have to think about scope here.
+    var anyQueued = running.some(function(j) { return j.status === 'queued'; });
+    if (anyQueued) {
+      html += '<div class="jobs-bulk-actions">';
+      html += '<button class="btn-cancel" id="btnCancelAllQueued">Cancel all queued</button>';
+      html += '</div>';
+    }
     running.forEach(function(j) { html += renderListItem(j, 'active'); });
 
     var filtered = historyJobs;
@@ -648,6 +665,57 @@
 
   // Event delegation for job list clicks
   document.getElementById('jobListContent').addEventListener('click', function(e) {
+    var bulkBtn = e.target.closest('#btnCancelAllQueued');
+    if (bulkBtn) {
+      // Optimistic UI: disable the button immediately. The next
+      // fetchJobs poll will re-render the list without queued rows
+      // (and without this button) once the server-side cancels land.
+      bulkBtn.disabled = true;
+      bulkBtn.textContent = 'Cancelling…';
+      bulkBtn.classList.add('cancelling');
+      fetch('/api/jobs/cancel-queued', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      })
+        .then(function(r) {
+          if (r.ok) {
+            return r.json().then(function(data) {
+              var n = (data && data.cancelled && data.cancelled.length) || 0;
+              if (typeof showToast === 'function') {
+                showToast(
+                  n === 0
+                    ? 'No queued jobs to cancel'
+                    : 'Cancelled ' + n + ' queued job' + (n === 1 ? '' : 's'),
+                  'info',
+                );
+              }
+              // Mark each cancelled id as cancelling so any per-row
+              // Cancel button that renders before the next poll lands
+              // also shows the optimistic state.
+              if (data && data.cancelled) {
+                data.cancelled.forEach(function(id) { cancellingJobIds[id] = true; });
+              }
+              fetchJobs();
+            });
+          }
+          return r.json().then(function(data) {
+            var msg = (data && data.error) || 'Unable to cancel queued jobs';
+            if (typeof showToast === 'function') showToast(msg, 'error');
+            // Restore the button — caller may want to retry.
+            bulkBtn.disabled = false;
+            bulkBtn.textContent = 'Cancel all queued';
+            bulkBtn.classList.remove('cancelling');
+          });
+        })
+        .catch(function() {
+          if (typeof showToast === 'function') showToast('Unable to cancel queued jobs', 'error');
+          bulkBtn.disabled = false;
+          bulkBtn.textContent = 'Cancel all queued';
+          bulkBtn.classList.remove('cancelling');
+        });
+      return;
+    }
     var viewItem = e.target.closest('[data-view]');
     if (viewItem) {
       currentView = viewItem.getAttribute('data-view');

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -1873,13 +1873,14 @@ def test_cancel_queued_endpoint_rejects_malformed_json_without_cancel(app_and_db
     assert runner.get(queued_id)["status"] == "queued"
 
     try:
-        resp = client.post(
-            "/api/jobs/cancel-queued",
-            data='{"workspace_id":',
-            content_type="application/json",
-        )
-        assert resp.status_code == 400
-        assert runner.get(queued_id)["status"] == "queued"
+        for body in ('{"workspace_id":', "   \n\t"):
+            resp = client.post(
+                "/api/jobs/cancel-queued",
+                data=body,
+                content_type="application/json",
+            )
+            assert resp.status_code == 400
+            assert runner.get(queued_id)["status"] == "queued"
     finally:
         release.set()
         from wait import wait_for_job_via_runner

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -1649,3 +1649,140 @@ def test_extract_masks_route_workspace_branch_respects_detector_confidence(
         "SELECT active_mask_variant FROM photos WHERE id=?", (pid_low,),
     ).fetchone()
     assert low_active["active_mask_variant"] is None
+
+
+# --- POST /api/jobs/cancel-queued (bulk queued-pipeline cancel) ---------
+#
+# These tests cover the bulk cancel endpoint used by the "Cancel all
+# queued" button on the /jobs page. The endpoint must:
+#   - cancel every queued pipeline (default: scoped to the active
+#     workspace, explicit: scoped to ``workspace_id`` in the body),
+#   - never touch running pipelines,
+#   - never touch queued pipelines belonging to a different workspace
+#     when a workspace is named.
+#
+# Tests below construct queued+running pipelines by reaching directly
+# into ``runner.enqueue_pipeline`` so we don't depend on the full
+# pipeline_job stack to build the fixture.
+
+
+def _block_pipeline_until(event, result=None):
+    """Build a work_fn that waits on ``event`` before returning.
+
+    Used to keep a 'running' pipeline pinned to its slot so that
+    subsequent ``enqueue_pipeline`` calls land in the queued state.
+    """
+    def work(job):
+        event.wait(timeout=5.0)
+        return result or {}
+    return work
+
+
+def test_cancel_queued_endpoint_cancels_all_queued_in_active_workspace(app_and_db):
+    """POST /api/jobs/cancel-queued (no body) cancels every queued
+    pipeline in the active workspace. The currently-running pipeline
+    is left alone.
+    """
+    import threading
+    app, db = app_and_db
+    runner = app._job_runner
+    client = app.test_client()
+    ws_id = db._active_workspace_id
+
+    # Pin slot 1 with a running pipeline so the next two stay queued.
+    release = threading.Event()
+    running_id = runner.enqueue_pipeline(
+        work_fn=_block_pipeline_until(release),
+        config={}, workspace_id=ws_id,
+    )
+    # Two queued pipelines behind it.
+    queued_a = runner.enqueue_pipeline(
+        work_fn=lambda job: None, config={}, workspace_id=ws_id,
+    )
+    queued_b = runner.enqueue_pipeline(
+        work_fn=lambda job: None, config={}, workspace_id=ws_id,
+    )
+    # Sanity: both are queued, the first is running.
+    assert runner.get(running_id)["status"] == "running"
+    assert runner.get(queued_a)["status"] == "queued"
+    assert runner.get(queued_b)["status"] == "queued"
+
+    try:
+        resp = client.post("/api/jobs/cancel-queued", json={})
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        data = resp.get_json()
+        assert set(data["cancelled"]) == {queued_a, queued_b}
+
+        # Queued rows are now cancelled.
+        for jid in (queued_a, queued_b):
+            row = db.conn.execute(
+                "SELECT status FROM job_history WHERE id = ?", (jid,),
+            ).fetchone()
+            assert row is not None
+            assert row["status"] == "cancelled", (
+                f"queued job {jid} should be cancelled, was {row['status']}"
+            )
+
+        # Running pipeline is untouched.
+        assert runner.get(running_id)["status"] == "running"
+    finally:
+        release.set()
+        from wait import wait_for_job_via_runner
+        wait_for_job_via_runner(runner, running_id)
+
+
+def test_cancel_queued_endpoint_leaves_other_workspaces_alone(app_and_db):
+    """When ``workspace_id`` is given in the body, only queued
+    pipelines in that workspace are cancelled. Queued pipelines in
+    other workspaces stay queued.
+    """
+    import threading
+    app, db = app_and_db
+    runner = app._job_runner
+    client = app.test_client()
+    ws_a = db._active_workspace_id
+    # Create a second workspace so we have a meaningful "other" id.
+    ws_b = db.create_workspace("scoped-other")
+
+    # Pin the single slot so EVERY enqueued pipeline below stays queued
+    # regardless of workspace. (SLOT_CAP=1 in this PR.)
+    release = threading.Event()
+    pin_id = runner.enqueue_pipeline(
+        work_fn=_block_pipeline_until(release),
+        config={}, workspace_id=ws_a,
+    )
+    queued_a = runner.enqueue_pipeline(
+        work_fn=lambda job: None, config={}, workspace_id=ws_a,
+    )
+    queued_b = runner.enqueue_pipeline(
+        work_fn=lambda job: None, config={}, workspace_id=ws_b,
+    )
+    assert runner.get(queued_a)["status"] == "queued"
+    assert runner.get(queued_b)["status"] == "queued"
+
+    try:
+        # Scope explicitly to workspace A.
+        resp = client.post(
+            "/api/jobs/cancel-queued", json={"workspace_id": ws_a},
+        )
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        data = resp.get_json()
+        assert data["cancelled"] == [queued_a], data
+
+        # Workspace A's queued row is cancelled.
+        row_a = db.conn.execute(
+            "SELECT status FROM job_history WHERE id = ?", (queued_a,),
+        ).fetchone()
+        assert row_a["status"] == "cancelled"
+
+        # Workspace B's queued row is still queued — the bulk cancel
+        # must not cross workspace boundaries when a workspace is named.
+        assert runner.get(queued_b) is not None
+        assert runner.get(queued_b)["status"] == "queued"
+    finally:
+        release.set()
+        from wait import wait_for_job_via_runner
+        wait_for_job_via_runner(runner, pin_id)
+        # Cancel the surviving queued job so the test fixture's
+        # teardown isn't waiting on a pipeline that will never run.
+        runner.cancel_job(queued_b)

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -1731,6 +1731,28 @@ def test_cancel_queued_endpoint_cancels_all_queued_in_active_workspace(app_and_d
         wait_for_job_via_runner(runner, running_id)
 
 
+def test_cancel_queued_endpoint_rejects_invalid_body(app_and_db):
+    """Bulk queued cancel requires an object body when JSON is supplied."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    for payload in (True, [], "workspace"):
+        resp = client.post("/api/jobs/cancel-queued", json=payload)
+        assert resp.status_code == 400
+
+
+def test_cancel_queued_endpoint_rejects_invalid_workspace_id(app_and_db):
+    """``workspace_id`` must be an integer id, not bool or another type."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    for workspace_id in (True, False, "1", 1.5):
+        resp = client.post(
+            "/api/jobs/cancel-queued", json={"workspace_id": workspace_id},
+        )
+        assert resp.status_code == 400
+
+
 def test_cancel_queued_endpoint_leaves_other_workspaces_alone(app_and_db):
     """When ``workspace_id`` is given in the body, only queued
     pipelines in that workspace are cancelled. Queued pipelines in

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -1852,6 +1852,41 @@ def test_cancel_queued_endpoint_rejects_invalid_body(app_and_db):
         assert resp.status_code == 400
 
 
+def test_cancel_queued_endpoint_rejects_malformed_json_without_cancel(app_and_db):
+    """Malformed JSON must not fall back to the destructive default scope."""
+    import threading
+
+    app, db = app_and_db
+    runner = app._job_runner
+    client = app.test_client()
+    ws_id = db._active_workspace_id
+
+    release = threading.Event()
+    running_id = runner.enqueue_pipeline(
+        work_fn=_block_pipeline_until(release),
+        config={}, workspace_id=ws_id,
+    )
+    queued_id = runner.enqueue_pipeline(
+        work_fn=lambda job: None, config={}, workspace_id=ws_id,
+    )
+    assert runner.get(running_id)["status"] == "running"
+    assert runner.get(queued_id)["status"] == "queued"
+
+    try:
+        resp = client.post(
+            "/api/jobs/cancel-queued",
+            data='{"workspace_id":',
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert runner.get(queued_id)["status"] == "queued"
+    finally:
+        release.set()
+        from wait import wait_for_job_via_runner
+        wait_for_job_via_runner(runner, running_id)
+        wait_for_job_via_runner(runner, queued_id)
+
+
 def test_cancel_queued_endpoint_rejects_invalid_workspace_id(app_and_db):
     """``workspace_id`` must be an integer id, not bool or another type."""
     app, _ = app_and_db

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -19,6 +19,10 @@ from db import Database
 from wait import wait_for_job_via_runner
 
 
+def _wait_for_event(event, label, timeout=2.0):
+    assert event.wait(timeout=timeout), f"{label} did not happen"
+
+
 def _make_runner_with_db(tmp_path):
     """Build a JobRunner + Database pair for a single test.
 
@@ -64,11 +68,19 @@ def test_enqueue_pipeline_persists_queued_row(tmp_path):
     # Block the first pipeline so the read below sees a non-terminal
     # state; without it the trivial lambda runs to completion before
     # the assertion fires and the status would be 'completed'.
+    first_started = threading.Event()
     blocker = threading.Event()
+
+    def first_work(job):
+        first_started.set()
+        blocker.wait(timeout=3.0)
+        return {}
+
     first_id = runner.enqueue_pipeline(
-        work_fn=lambda job: blocker.wait(timeout=3.0),
+        work_fn=first_work,
         config={}, workspace_id=1,
     )
+    _wait_for_event(first_started, "first pipeline start")
     job_id = runner.enqueue_pipeline(
         work_fn=lambda job: None,
         config={"sources": ["/a"]},
@@ -245,15 +257,18 @@ def test_queued_pipeline_is_visible_via_get(tmp_path):
     endpoint to render queue state.
     """
     runner, _ = _make_runner_with_db(tmp_path)
+    first_started = threading.Event()
     blocker = threading.Event()
 
     def blocking_work(job):
+        first_started.set()
         blocker.wait(timeout=3.0)
         return {}
 
     first_id = runner.enqueue_pipeline(
         work_fn=blocking_work, config={}, workspace_id=1,
     )
+    _wait_for_event(first_started, "first pipeline start")
     second_id = runner.enqueue_pipeline(
         work_fn=lambda job: {"ok": True}, config={"x": 1}, workspace_id=2,
     )
@@ -277,9 +292,11 @@ def test_cancel_queued_pipeline_transitions_row_to_cancelled(tmp_path):
     """
     runner, db = _make_runner_with_db(tmp_path)
     blocker = threading.Event()
+    first_started = threading.Event()
     second_started = threading.Event()
 
     def first_work(job):
+        first_started.set()
         blocker.wait(timeout=3.0)
         return {}
 
@@ -288,12 +305,20 @@ def test_cancel_queued_pipeline_transitions_row_to_cancelled(tmp_path):
         return {"should-not-run": True}
 
     first_id = runner.enqueue_pipeline(work_fn=first_work, config={}, workspace_id=1)
+    _wait_for_event(first_started, "first pipeline start")
     second_id = runner.enqueue_pipeline(work_fn=second_work, config={}, workspace_id=1)
     assert runner.get(second_id)["status"] == "queued"
 
     # Cancel while still queued.
     ok = runner.cancel_job(second_id)
     assert ok is True
+    cancelled_view = runner.get(second_id)
+    assert cancelled_view is not None
+    assert cancelled_view["status"] == "cancelled"
+    events = runner.get_events(second_id)
+    assert events
+    assert events[-1]["type"] == "complete"
+    assert events[-1]["data"]["status"] == "cancelled"
     row = db.conn.execute(
         "SELECT status FROM job_history WHERE id = ?", (second_id,),
     ).fetchone()
@@ -358,6 +383,13 @@ def test_promotion_loses_race_to_cancel_leaves_row_cancelled(tmp_path):
     )
     # And the in-memory context is cleaned up.
     assert job_id not in runner._queued_pipelines
+    view = runner.get(job_id)
+    assert view is not None
+    assert view["status"] == "cancelled"
+    events = runner.get_events(job_id)
+    assert events
+    assert events[-1]["type"] == "complete"
+    assert events[-1]["data"]["status"] == "cancelled"
 
 
 def pytest_fail(msg):
@@ -378,13 +410,20 @@ def test_retention_does_not_prune_queued_row_under_load(tmp_path):
     runner, db = _make_runner_with_db(tmp_path)
     try:
         ws = db._active_workspace_id
+        first_started = threading.Event()
         blocker = threading.Event()
+
+        def first_work(job):
+            first_started.set()
+            blocker.wait(timeout=10.0)
+            return {}
 
         # Long-running first pipeline holds the slot.
         first_id = runner.enqueue_pipeline(
-            work_fn=lambda job: blocker.wait(timeout=10.0),
+            work_fn=first_work,
             config={}, workspace_id=ws,
         )
+        _wait_for_event(first_started, "first pipeline start")
         # Queued pipeline.
         queued_id = runner.enqueue_pipeline(
             work_fn=lambda job: {"ran": True},
@@ -458,11 +497,19 @@ def test_get_history_excludes_queued_rows(tmp_path):
     try:
         ws = db._active_workspace_id
 
+        first_started = threading.Event()
         blocker = threading.Event()
+
+        def first_work(job):
+            first_started.set()
+            blocker.wait(timeout=3.0)
+            return {}
+
         first_id = runner.enqueue_pipeline(
-            work_fn=lambda job: blocker.wait(timeout=3.0),
+            work_fn=first_work,
             config={}, workspace_id=ws,
         )
+        _wait_for_event(first_started, "first pipeline start")
         queued_id = runner.enqueue_pipeline(
             work_fn=lambda job: None, config={}, workspace_id=ws,
         )
@@ -499,13 +546,16 @@ def test_list_jobs_includes_queued_pipelines(tmp_path):
     and can't be cancelled from /jobs.
     """
     runner, _ = _make_runner_with_db(tmp_path)
+    first_started = threading.Event()
     blocker = threading.Event()
 
     def first_work(job):
+        first_started.set()
         blocker.wait(timeout=3.0)
         return {}
 
     first_id = runner.enqueue_pipeline(first_work, config={}, workspace_id=1)
+    _wait_for_event(first_started, "first pipeline start")
     second_id = runner.enqueue_pipeline(
         lambda job: None, config={"x": 7}, workspace_id=2,
     )
@@ -535,13 +585,16 @@ def test_cancelling_queued_pipeline_emits_complete_event_to_sse(tmp_path):
     and the SSE loop reports the job as 'expired'.
     """
     runner, _ = _make_runner_with_db(tmp_path)
+    first_started = threading.Event()
     blocker = threading.Event()
 
     def first_work(job):
+        first_started.set()
         blocker.wait(timeout=3.0)
         return {}
 
     first_id = runner.enqueue_pipeline(first_work, config={}, workspace_id=1)
+    _wait_for_event(first_started, "first pipeline start")
     second_id = runner.enqueue_pipeline(
         lambda job: pytest_fail("cancelled queued must not run"),
         config={}, workspace_id=1,
@@ -569,10 +622,12 @@ def test_sse_subscribers_attached_while_queued_receive_post_promotion_events(tmp
     after the pipeline actually starts.
     """
     runner, _ = _make_runner_with_db(tmp_path)
+    first_started = threading.Event()
     blocker = threading.Event()
     let_second_finish = threading.Event()
 
     def first_work(job):
+        first_started.set()
         blocker.wait(timeout=3.0)
         return {}
 
@@ -582,6 +637,7 @@ def test_sse_subscribers_attached_while_queued_receive_post_promotion_events(tmp
         return {"ok": True}
 
     first_id = runner.enqueue_pipeline(first_work, config={}, workspace_id=1)
+    _wait_for_event(first_started, "first pipeline start")
     second_id = runner.enqueue_pipeline(second_work, config={}, workspace_id=1)
     assert runner.get(second_id)["status"] == "queued"
 

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -423,6 +423,60 @@ def test_promoting_pipeline_remains_visible_and_cancellable(tmp_path):
     assert final["status"] == "cancelled"
 
 
+def test_cancel_promoting_pipeline_after_db_running_preserves_request(tmp_path):
+    """Cancelling during the DB-running promotion window must still win."""
+    runner, db = _make_runner_with_db(tmp_path)
+    job_id = "pipeline-1700000000001"
+    db.conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at, error_count) "
+        "VALUES (?, 'pipeline', 'running', '2026-05-26T00:00:00', 0)",
+        (job_id,),
+    )
+    db.conn.commit()
+    with runner._lock:
+        runner._queued_pipelines[job_id] = {
+            "work_fn": lambda job: pytest_fail("should not have run"),
+            "config": {"x": 1},
+            "workspace_id": 1,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:00",
+        }
+        runner._promoting_pipelines.add(job_id)
+
+    assert runner.cancel_job(job_id, expected_status="queued") is True
+    assert runner.is_cancelled(job_id)
+    with runner._lock:
+        assert job_id in runner._queued_pipelines
+        assert job_id in runner._promoting_pipelines
+
+
+def test_promoted_pipeline_with_pending_cancel_skips_work_fn(tmp_path):
+    """A queued cancel recorded during promotion suppresses pipeline work."""
+    runner, db = _make_runner_with_db(tmp_path)
+    job_id = "pipeline-1700000000001"
+    work_called = threading.Event()
+    db.conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at, error_count) "
+        "VALUES (?, 'pipeline', 'queued', '2026-05-26T00:00:00', 0)",
+        (job_id,),
+    )
+    db.conn.commit()
+    with runner._lock:
+        runner._queued_pipelines[job_id] = {
+            "work_fn": lambda job: work_called.set(),
+            "config": {"x": 1},
+            "workspace_id": 1,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:00",
+        }
+        runner._cancelled.add(job_id)
+
+    runner._try_promote_queued()
+    final = wait_for_job_via_runner(runner, job_id)
+    assert final["status"] == "cancelled"
+    assert not work_called.is_set()
+
+
 def pytest_fail(msg):
     raise AssertionError(msg)
 

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -416,6 +416,55 @@ def test_promoting_pipeline_remains_visible_and_cancellable(tmp_path):
     assert final["status"] == "cancelled"
 
 
+def test_cancel_promoting_queued_pipeline_retries_next_candidate(tmp_path):
+    """Cancelling a promoting queued job must not strand later queued work."""
+    runner, db = _make_runner_with_db(tmp_path)
+    cancelled_id = "pipeline-1700000000001"
+    next_id = "pipeline-1700000000002"
+    next_started = threading.Event()
+    db.conn.executemany(
+        "INSERT INTO job_history (id, type, status, started_at, workspace_id, "
+        "error_count) VALUES (?, 'pipeline', 'queued', ?, ?, 0)",
+        [
+            (cancelled_id, "2026-05-26T00:00:00", 1),
+            (next_id, "2026-05-26T00:00:01", 2),
+        ],
+    )
+    db.conn.commit()
+    with runner._lock:
+        runner._queued_pipelines[cancelled_id] = {
+            "work_fn": lambda job: pytest_fail("cancelled job must not run"),
+            "config": {},
+            "workspace_id": 1,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:00",
+            "_promoting": True,
+        }
+        runner._queued_pipelines[next_id] = {
+            "work_fn": lambda job: next_started.set(),
+            "config": {},
+            "workspace_id": 2,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:01",
+        }
+
+    assert runner.cancel_queued_jobs(workspace_id=1) == [cancelled_id]
+
+    _wait_for_event(next_started, "next queued promotion")
+    next_final = wait_for_job_via_runner(
+        runner, next_id, wait_for_history=True,
+    )
+    assert next_final["status"] == "completed"
+    rows = {
+        r["id"]: r["status"]
+        for r in db.conn.execute(
+            "SELECT id, status FROM job_history WHERE id IN (?, ?)",
+            (cancelled_id, next_id),
+        )
+    }
+    assert rows == {cancelled_id: "cancelled", next_id: "completed"}
+
+
 def test_cancel_promoting_pipeline_after_db_running_preserves_request(tmp_path):
     """Cancelling during the DB-running promotion window must still win."""
     runner, db = _make_runner_with_db(tmp_path)

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -529,12 +529,13 @@ def test_promoted_pipeline_with_pending_cancel_skips_work_fn(tmp_path):
     assert not work_called.is_set()
 
 
-def test_promotion_db_error_clears_promoting_marker(tmp_path, monkeypatch):
-    """A SQLite promotion failure must not permanently consume SLOT_CAP."""
+def test_promotion_db_error_retries_queued_pipeline(tmp_path, monkeypatch):
+    """A transient SQLite promotion failure must not strand queued work."""
     import sqlite3
 
     runner, db = _make_runner_with_db(tmp_path)
     job_id = "pipeline-1700000000001"
+    work_started = threading.Event()
     db.conn.execute(
         "INSERT INTO job_history (id, type, status, started_at, error_count) "
         "VALUES (?, 'pipeline', 'queued', '2026-05-26T00:00:00', 0)",
@@ -543,22 +544,37 @@ def test_promotion_db_error_clears_promoting_marker(tmp_path, monkeypatch):
     db.conn.commit()
     with runner._lock:
         runner._queued_pipelines[job_id] = {
-            "work_fn": lambda job: pytest_fail("should not have run"),
+            "work_fn": lambda job: work_started.set(),
             "config": {"x": 1},
             "workspace_id": 1,
             "runtime_warning": None,
             "started_at": "2026-05-26T00:00:00",
         }
 
+    original_connect = sqlite3.connect
+    calls = {"count": 0}
+
     def fail_connect(*args, **kwargs):
-        raise sqlite3.OperationalError("database is locked")
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise sqlite3.OperationalError("database is locked")
+        return original_connect(*args, **kwargs)
 
     monkeypatch.setattr(sqlite3, "connect", fail_connect)
     runner._try_promote_queued()
 
     with runner._lock:
-        assert not runner._queued_pipelines[job_id].get("_promoting")
-        assert job_id in runner._queued_pipelines
+        if job_id in runner._queued_pipelines:
+            assert not runner._queued_pipelines[job_id].get("_promoting")
+
+    _wait_for_event(work_started, "promotion retry")
+    final = wait_for_job_via_runner(runner, job_id, wait_for_history=True)
+    assert final["status"] == "completed"
+    assert calls["count"] >= 2
+    row = db.conn.execute(
+        "SELECT status FROM job_history WHERE id = ?", (job_id,),
+    ).fetchone()
+    assert row["status"] == "completed"
 
 
 def test_in_flight_promotion_counts_against_slot_cap_not_global_guard(tmp_path, monkeypatch):

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -443,6 +443,65 @@ def test_cancel_promoting_pipeline_after_db_running_preserves_request(tmp_path):
         assert runner._queued_pipelines[job_id]["_promoting"] is True
 
 
+def test_cancel_queued_pipeline_after_promotion_finishes_marks_running(tmp_path, monkeypatch):
+    """A per-job queued cancel still wins if promotion finishes mid-cancel."""
+    import sqlite3
+
+    runner, db = _make_runner_with_db(tmp_path)
+    job_id = "pipeline-1700000000001"
+    db.conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at, error_count) "
+        "VALUES (?, 'pipeline', 'running', '2026-05-26T00:00:00', 0)",
+        (job_id,),
+    )
+    db.conn.commit()
+    with runner._lock:
+        runner._queued_pipelines[job_id] = {
+            "work_fn": lambda job: pytest_fail("should not have run"),
+            "config": {"x": 1},
+            "workspace_id": 1,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:00",
+            "_promoting": True,
+        }
+
+    class FakeCursor:
+        rowcount = 0
+
+    class FakeConnection:
+        def execute(self, *args, **kwargs):
+            with runner._lock:
+                ctx = runner._queued_pipelines.pop(job_id)
+                ctx.pop("_promoting", None)
+                runner._jobs[job_id] = {
+                    "id": job_id,
+                    "type": "pipeline",
+                    "status": "running",
+                    "started_at": ctx["started_at"],
+                    "finished_at": None,
+                    "progress": {"current": 0, "total": 0, "current_file": ""},
+                    "result": None,
+                    "errors": [],
+                    "config": ctx["config"],
+                    "workspace_id": ctx["workspace_id"],
+                    "steps": [],
+                    "ephemeral": False,
+                    "runtime_warning": ctx["runtime_warning"],
+                }
+            return FakeCursor()
+
+        def commit(self):
+            return None
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(sqlite3, "connect", lambda *args, **kwargs: FakeConnection())
+
+    assert runner.cancel_job(job_id) is True
+    assert runner.is_cancelled(job_id)
+
+
 def test_promoted_pipeline_with_pending_cancel_skips_work_fn(tmp_path):
     """A queued cancel recorded during promotion suppresses pipeline work."""
     runner, db = _make_runner_with_db(tmp_path)

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -392,6 +392,37 @@ def test_promotion_loses_race_to_cancel_leaves_row_cancelled(tmp_path):
     assert events[-1]["data"]["status"] == "cancelled"
 
 
+def test_promoting_pipeline_remains_visible_and_cancellable(tmp_path):
+    """A queued job in the promotion DB window must not disappear from APIs."""
+    runner, db = _make_runner_with_db(tmp_path)
+    job_id = "pipeline-1700000000001"
+    db.conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at, error_count) "
+        "VALUES (?, 'pipeline', 'queued', '2026-05-26T00:00:00', 0)",
+        (job_id,),
+    )
+    db.conn.commit()
+    with runner._lock:
+        runner._queued_pipelines[job_id] = {
+            "work_fn": lambda job: pytest_fail("should not have run"),
+            "config": {"x": 1},
+            "workspace_id": 1,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:00",
+        }
+        runner._promoting_pipelines.add(job_id)
+
+    view = runner.get(job_id)
+    assert view is not None
+    assert view["status"] == "queued"
+    assert any(j["id"] == job_id for j in runner.list_jobs())
+
+    assert runner.cancel_job(job_id, expected_status="queued") is True
+    final = runner.get(job_id)
+    assert final is not None
+    assert final["status"] == "cancelled"
+
+
 def pytest_fail(msg):
     raise AssertionError(msg)
 

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -477,6 +477,38 @@ def test_promoted_pipeline_with_pending_cancel_skips_work_fn(tmp_path):
     assert not work_called.is_set()
 
 
+def test_promotion_db_error_clears_promoting_marker(tmp_path, monkeypatch):
+    """A SQLite promotion failure must not permanently consume SLOT_CAP."""
+    import sqlite3
+
+    runner, db = _make_runner_with_db(tmp_path)
+    job_id = "pipeline-1700000000001"
+    db.conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at, error_count) "
+        "VALUES (?, 'pipeline', 'queued', '2026-05-26T00:00:00', 0)",
+        (job_id,),
+    )
+    db.conn.commit()
+    with runner._lock:
+        runner._queued_pipelines[job_id] = {
+            "work_fn": lambda job: pytest_fail("should not have run"),
+            "config": {"x": 1},
+            "workspace_id": 1,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:00",
+        }
+
+    def fail_connect(*args, **kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(sqlite3, "connect", fail_connect)
+    runner._try_promote_queued()
+
+    with runner._lock:
+        assert job_id not in runner._promoting_pipelines
+        assert job_id in runner._queued_pipelines
+
+
 def pytest_fail(msg):
     raise AssertionError(msg)
 

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -465,6 +465,51 @@ def test_cancel_promoting_queued_pipeline_retries_next_candidate(tmp_path):
     assert rows == {cancelled_id: "cancelled", next_id: "completed"}
 
 
+def test_cancel_queued_jobs_defers_promotion_until_snapshot_cancelled(tmp_path):
+    """Bulk cancel must cancel all queued snapshot entries before promotion."""
+    runner, db = _make_runner_with_db(tmp_path)
+    first_id = "pipeline-1700000000001"
+    second_id = "pipeline-1700000000002"
+    second_started = threading.Event()
+    db.conn.executemany(
+        "INSERT INTO job_history (id, type, status, started_at, workspace_id, "
+        "error_count) VALUES (?, 'pipeline', 'queued', ?, 1, 0)",
+        [
+            (first_id, "2026-05-26T00:00:00"),
+            (second_id, "2026-05-26T00:00:01"),
+        ],
+    )
+    db.conn.commit()
+    with runner._lock:
+        runner._queued_pipelines[first_id] = {
+            "work_fn": lambda job: pytest_fail("first job must not run"),
+            "config": {},
+            "workspace_id": 1,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:00",
+            "_promoting": True,
+        }
+        runner._queued_pipelines[second_id] = {
+            "work_fn": lambda job: second_started.set(),
+            "config": {},
+            "workspace_id": 1,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:01",
+        }
+
+    assert runner.cancel_queued_jobs(workspace_id=1) == [first_id, second_id]
+
+    assert not second_started.wait(timeout=0.3)
+    rows = {
+        r["id"]: r["status"]
+        for r in db.conn.execute(
+            "SELECT id, status FROM job_history WHERE id IN (?, ?)",
+            (first_id, second_id),
+        )
+    }
+    assert rows == {first_id: "cancelled", second_id: "cancelled"}
+
+
 def test_cancel_promoting_pipeline_after_db_running_preserves_request(tmp_path):
     """Cancelling during the DB-running promotion window must still win."""
     runner, db = _make_runner_with_db(tmp_path)

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -510,6 +510,63 @@ def test_cancel_queued_jobs_defers_promotion_until_snapshot_cancelled(tmp_path):
     assert rows == {first_id: "cancelled", second_id: "cancelled"}
 
 
+def test_cancel_queued_jobs_preserves_snapshot_cancel_after_promotion(
+    tmp_path, monkeypatch,
+):
+    """Bulk cancel should still cancel a snapshot member promoted mid-loop."""
+    runner, db = _make_runner_with_db(tmp_path)
+    job_id = "pipeline-1700000000001"
+    db.conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at, workspace_id, "
+        "error_count) VALUES (?, 'pipeline', 'queued', ?, 1, 0)",
+        (job_id, "2026-05-26T00:00:00"),
+    )
+    db.conn.commit()
+    with runner._lock:
+        runner._queued_pipelines[job_id] = {
+            "work_fn": lambda job: pytest_fail("job must not run"),
+            "config": {},
+            "workspace_id": 1,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:00",
+            "_promoting": True,
+        }
+
+    original_cancel_job = runner.cancel_job
+
+    def promote_before_cancel(cancel_id, *args, **kwargs):
+        if cancel_id == job_id:
+            with runner._lock:
+                ctx = runner._queued_pipelines.pop(job_id)
+                ctx.pop("_promoting", None)
+                runner._jobs[job_id] = {
+                    "id": job_id,
+                    "type": "pipeline",
+                    "status": "running",
+                    "started_at": ctx["started_at"],
+                    "finished_at": None,
+                    "progress": {"current": 0, "total": 0, "current_file": ""},
+                    "result": None,
+                    "errors": [],
+                    "config": ctx["config"],
+                    "workspace_id": ctx["workspace_id"],
+                    "steps": [],
+                    "ephemeral": False,
+                    "runtime_warning": ctx["runtime_warning"],
+                }
+            db.conn.execute(
+                "UPDATE job_history SET status='running' WHERE id = ?",
+                (job_id,),
+            )
+            db.conn.commit()
+        return original_cancel_job(cancel_id, *args, **kwargs)
+
+    monkeypatch.setattr(runner, "cancel_job", promote_before_cancel)
+
+    assert runner.cancel_queued_jobs(workspace_id=1) == [job_id]
+    assert runner.is_cancelled(job_id)
+
+
 def test_cancel_promoting_pipeline_after_db_running_preserves_request(tmp_path):
     """Cancelling during the DB-running promotion window must still win."""
     runner, db = _make_runner_with_db(tmp_path)


### PR DESCRIPTION
## Summary

- Adds `POST /api/jobs/cancel-queued` (default scope = active workspace, optional `{"workspace_id": N}` body). Iterates queued pipelines from `runner.list_jobs()` and calls `runner.cancel_job` on each. Running pipelines and queued pipelines in other workspaces are untouched.
- Adds a "Cancel all queued" button at the top of the Active list on `/jobs` — only visible when at least one queued pipeline exists. Click → POST to the new endpoint → re-fetch.
- Adds `Queued` to the Jobs page status filter so the dropdown matches the Active list's queued rows.

Part of Step 5 of the pipeline-concurrency rollout (design doc: `docs/plans/2026-05-26-pipeline-concurrency-design.md`). Depends on Step 4 (#901, `pipeline-queue-server`); will rebase cleanly onto `main` once that lands.

## Test plan
- [x] `python -m pytest vireo/tests/test_jobs_api.py vireo/tests/test_pipeline_queue.py --timeout=30 -q` (73 passed)
- [x] New endpoint tests cover: bulk-cancel of two queued jobs in active workspace, running job left alone, queued jobs in other workspaces untouched when `workspace_id` is set

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipeline submissions now enter a queue when capacity is full instead of starting immediately.
  * Added workspace-level bulk "Cancel queued" action (POST /api/jobs/cancel-queued) returning cancelled job IDs.

* **UI**
  * Queued jobs appear in Active Jobs with live status, cancel controls, SSE updates, and a bulk cancel panel with optimistic feedback.

* **Bug Fixes**
  * Cancelling queued jobs emits terminal completion events and handles promotion/cancel races so promoted pipelines remain cancellable.

* **Tests**
  * New and refactored tests for queuing, promotion, visibility, and bulk cancellation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->