### PR TITLE
pipeline: Start/Queue button driven by /api/pipeline/slots

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -35,7 +35,7 @@ from flask import (
     send_from_directory,
 )
 from highlights import select_highlights
-from jobs import JobRunner, LogBroadcaster
+from jobs import SLOT_CAP, JobRunner, LogBroadcaster
 from preview_cache import (
     evict_if_over_quota as evict_preview_cache_if_over_quota,
 )
@@ -1449,6 +1449,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "collections": collection_dicts,
             }
         )
+
+    @app.route("/api/pipeline/slots")
+    def api_pipeline_slots():
+        """Pipeline-slot occupancy for the Start/Queue button.
+
+        The pipeline page polls this to decide whether the next click
+        will start immediately (``active < slot_cap``) or land on the
+        queue (``active >= slot_cap``), and to render the small
+        "N running . M queued" status line near the Start button.
+
+        Counts only ``type == 'pipeline'`` jobs — standalone scan,
+        classify, ingest, etc. don't consume pipeline slots.
+        """
+        runner = app._job_runner
+        active = 0
+        queued = 0
+        for j in runner.list_jobs():
+            if j.get("type") != "pipeline":
+                continue
+            status = j.get("status")
+            if status == "running":
+                active += 1
+            elif status == "queued":
+                queued += 1
+        return jsonify({
+            "active": active,
+            "queued": queued,
+            "slot_cap": SLOT_CAP,
+        })
 
     @app.route("/api/pipeline/page-init")
     def api_pipeline_page_init():

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -173,10 +173,10 @@ class JobRunner:
     def _try_promote_queued(self):
         """Promote the oldest queued pipeline if a slot is open.
 
-        Single-pass: count active pipelines under ``self._lock`` and mark the
-        oldest queued context as promoting, then release the lock before the
-        conditional SQLite UPDATE. If a Cancel lands first, rowcount==0 and
-        promotion quietly gives up.
+        Single-pass: count active and in-flight promotions under
+        ``self._lock`` and mark the oldest queued context as promoting, then
+        release the lock before the conditional SQLite UPDATE. If a Cancel
+        lands first, rowcount==0 and promotion quietly gives up.
         """
         with self._lock:
             active = sum(
@@ -185,7 +185,11 @@ class JobRunner:
             )
             if active >= SLOT_CAP:
                 return
-            if any(ctx.get("_promoting") for ctx in self._queued_pipelines.values()):
+            promoting = sum(
+                1 for ctx in self._queued_pipelines.values()
+                if ctx.get("_promoting")
+            )
+            if active + promoting >= SLOT_CAP:
                 return
             candidates = sorted(
                 (

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -173,11 +173,10 @@ class JobRunner:
     def _try_promote_queued(self):
         """Promote the oldest queued pipeline if a slot is open.
 
-        Single-pass: under ``self._lock`` count active pipelines, and if
-        below ``SLOT_CAP`` find the oldest in-memory queued context and
-        attempt to promote it. The conditional UPDATE ensures a Cancel
-        landing between SELECT and UPDATE wins (rowcount==0 → quietly
-        skip and try the next one).
+        Single-pass: count active pipelines under ``self._lock`` and mark the
+        oldest queued context as promoting, then release the lock before the
+        conditional SQLite UPDATE. If a Cancel lands first, rowcount==0 and
+        promotion quietly gives up.
         """
         with self._lock:
             active = sum(
@@ -186,17 +185,24 @@ class JobRunner:
             )
             if active >= SLOT_CAP:
                 return
+            if any(ctx.get("_promoting") for ctx in self._queued_pipelines.values()):
+                return
             candidates = sorted(
-                self._queued_pipelines.items(),
+                (
+                    item for item in self._queued_pipelines.items()
+                    if not item[1].get("_promoting")
+                ),
                 key=lambda kv: kv[1]["started_at"],
             )
             if not candidates:
                 return
             job_id, ctx = candidates[0]
-            # Atomic queued→running flip. If a concurrent cancel beat us
-            # to it, rowcount is 0 and the row stays in its final
-            # state — we leave self._queued_pipelines untouched so the
-            # caller cleaning up the cancel can remove it.
+            ctx["_promoting"] = True
+
+        promoted = True
+        try:
+            # Atomic queued->running flip. If a concurrent cancel beat us
+            # to it, rowcount is 0 and the row stays in its final state.
             if self._db_path:
                 import sqlite3
                 conn = sqlite3.connect(self._db_path, timeout=30)
@@ -210,10 +216,20 @@ class JobRunner:
                     conn.commit()
                 finally:
                     conn.close()
-                if not promoted:
-                    # The row was modified elsewhere (cancelled).
-                    self._queued_pipelines.pop(job_id, None)
-                    return
+        except Exception:
+            with self._lock:
+                if self._queued_pipelines.get(job_id) is ctx:
+                    ctx.pop("_promoting", None)
+            raise
+
+        with self._lock:
+            if self._queued_pipelines.get(job_id) is not ctx:
+                return
+            ctx.pop("_promoting", None)
+            if not promoted:
+                # The row was modified elsewhere (cancelled).
+                self._queued_pipelines.pop(job_id, None)
+                return
             # Move from queue context into the live jobs dict.
             del self._queued_pipelines[job_id]
             job = {
@@ -729,6 +745,7 @@ class JobRunner:
         cancellation (running) or transitioned to cancelled (queued).
         """
         emit_complete = False
+        queued_cancel = None
         with self._lock:
             job = self._jobs.get(job_id)
             if job is not None and job["status"] == "running":
@@ -737,29 +754,35 @@ class JobRunner:
             # Queued case: still in _queued_pipelines, not _jobs yet.
             if job_id in self._queued_pipelines:
                 cancelled_at = datetime.now().isoformat()
-                if self._db_path:
-                    import sqlite3
-                    conn = sqlite3.connect(self._db_path, timeout=30)
-                    try:
-                        cur = conn.execute(
-                            "UPDATE job_history "
-                            "SET status='cancelled', finished_at=? "
-                            "WHERE id = ? AND status = 'queued'",
-                            (cancelled_at, job_id),
-                        )
-                        conn.commit()
-                        # rowcount==0 means a concurrent promotion beat
-                        # us — the row is now 'running' and the worker
-                        # will see the cancellation flag below.
-                        if cur.rowcount == 0:
-                            self._cancelled.add(job_id)
-                            return True
-                    finally:
-                        conn.close()
-                self._queued_pipelines.pop(job_id, None)
-                emit_complete = True
+                queued_cancel = self._queued_pipelines[job_id]
             else:
                 return False
+
+        cancelled = True
+        if self._db_path:
+            import sqlite3
+            conn = sqlite3.connect(self._db_path, timeout=30)
+            try:
+                cur = conn.execute(
+                    "UPDATE job_history "
+                    "SET status='cancelled', finished_at=? "
+                    "WHERE id = ? AND status = 'queued'",
+                    (cancelled_at, job_id),
+                )
+                conn.commit()
+                cancelled = cur.rowcount == 1
+            finally:
+                conn.close()
+
+        with self._lock:
+            # rowcount==0 means a concurrent promotion beat us — the row is
+            # now 'running' and the worker will see the cancellation flag.
+            if not cancelled:
+                self._cancelled.add(job_id)
+                return True
+            if self._queued_pipelines.get(job_id) is queued_cancel:
+                self._queued_pipelines.pop(job_id, None)
+            emit_complete = True
         # Emit the terminal SSE event AFTER releasing the lock — clients
         # subscribed to /api/jobs/<id>/stream while the job was queued
         # need a ``complete`` event with status='cancelled' so they

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -226,40 +226,47 @@ class JobRunner:
                     ctx.pop("_promoting", None)
             raise
 
+        retry_promotion = False
         with self._lock:
             if self._queued_pipelines.get(job_id) is not ctx:
-                return
-            ctx.pop("_promoting", None)
-            if not promoted:
-                # The row was modified elsewhere (cancelled).
-                self._queued_pipelines.pop(job_id, None)
-                return
-            # Move from queue context into the live jobs dict.
-            del self._queued_pipelines[job_id]
-            job = {
-                "id": job_id,
-                "type": "pipeline",
-                "status": "running",
-                "started_at": ctx["started_at"],
-                "finished_at": None,
-                "progress": {"current": 0, "total": 0, "current_file": ""},
-                "result": None,
-                "errors": [],
-                "config": ctx["config"],
-                "workspace_id": ctx["workspace_id"],
-                "steps": [],
-                "ephemeral": False,
-                "runtime_warning": ctx["runtime_warning"],
-            }
-            self._prune_finished_jobs()
-            self._jobs[job_id] = job
-            self._events[job_id] = deque(maxlen=1000)
-            # setdefault, NOT assignment: clients can subscribe to the
-            # SSE stream while the pipeline is still queued. Replacing
-            # the list at promotion time would silently drop those
-            # waiters' queues.
-            self._subscribers.setdefault(job_id, [])
-            work_fn = ctx["work_fn"]
+                retry_promotion = True
+            else:
+                ctx.pop("_promoting", None)
+                if not promoted:
+                    # The row was modified elsewhere (cancelled).
+                    self._queued_pipelines.pop(job_id, None)
+                    retry_promotion = True
+                else:
+                    # Move from queue context into the live jobs dict.
+                    del self._queued_pipelines[job_id]
+                    job = {
+                        "id": job_id,
+                        "type": "pipeline",
+                        "status": "running",
+                        "started_at": ctx["started_at"],
+                        "finished_at": None,
+                        "progress": {"current": 0, "total": 0, "current_file": ""},
+                        "result": None,
+                        "errors": [],
+                        "config": ctx["config"],
+                        "workspace_id": ctx["workspace_id"],
+                        "steps": [],
+                        "ephemeral": False,
+                        "runtime_warning": ctx["runtime_warning"],
+                    }
+                    self._prune_finished_jobs()
+                    self._jobs[job_id] = job
+                    self._events[job_id] = deque(maxlen=1000)
+                    # setdefault, NOT assignment: clients can subscribe to the
+                    # SSE stream while the pipeline is still queued. Replacing
+                    # the list at promotion time would silently drop those
+                    # waiters' queues.
+                    self._subscribers.setdefault(job_id, [])
+                    work_fn = ctx["work_fn"]
+
+        if retry_promotion:
+            self._try_promote_queued()
+            return
 
         thread = threading.Thread(
             target=self._run_job, args=(job, work_fn), daemon=True,

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -530,7 +530,14 @@
         });
         updateList();
         updateRunningBadge();
-        if (currentView === 'active') renderActiveOverview();
+        if (selectedSource === 'active' && selectedJobId) {
+          var selected = activeJobs.find(function(j) { return j.id === selectedJobId; });
+          if (selected) {
+            renderDetail(selected);
+          }
+        } else if (currentView === 'active') {
+          renderActiveOverview();
+        }
       })
       .catch(function() {});
   }

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -534,6 +534,14 @@
           var selected = activeJobs.find(function(j) { return j.id === selectedJobId; });
           if (selected) {
             renderDetail(selected);
+          } else {
+            var historical = historyJobs.find(function(j) { return j.id === selectedJobId; });
+            if (historical) {
+              selectedSource = 'history';
+              renderHistoryDetail(historical);
+            } else {
+              fetchHistory(true);
+            }
           }
         } else if (currentView === 'active') {
           renderActiveOverview();
@@ -542,7 +550,7 @@
       .catch(function() {});
   }
 
-  function fetchHistory() {
+  function fetchHistory(refreshMissingSelection) {
     fetch('/api/jobs/history?limit=100')
       .then(function(r) { return r.json(); })
       .then(function(data) {
@@ -557,6 +565,20 @@
         });
         updateList();
         populateTypeFilter();
+        if (refreshMissingSelection && selectedSource === 'active' && selectedJobId) {
+          var historical = historyJobs.find(function(j) { return j.id === selectedJobId; });
+          if (historical) {
+            selectedSource = 'history';
+            renderHistoryDetail(historical);
+          } else {
+            currentView = 'active';
+            selectedJobId = null;
+            selectedSource = null;
+            renderActiveOverview();
+            updateList();
+          }
+          return;
+        }
         if (currentView === 'history') renderHistoryOverview();
       })
       .catch(function() {});

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1101,6 +1101,11 @@ body { padding-bottom: 36px; }
     </button>
   </div>
   <div id="pipelineActionStatus" class="status-msg" style="margin-top:8px;"></div>
+  <div id="pipelineSlotStatus" class="status-msg" style="margin-top:6px;font-size:13px;color:var(--text-secondary);display:none;" data-testid="pipeline-slot-status">
+    <span id="pipelineSlotCounts"></span>
+    <span style="margin:0 6px;">&middot;</span>
+    <a href="/jobs">see Jobs</a>
+  </div>
   <div id="modelWarningBanner" style="display:none;background:var(--warning,#f0c040);color:#000;padding:8px 14px;border-radius:6px;margin:8px 0;font-size:13px;">
     <span id="modelWarningText"></span>
     <button onclick="this.parentElement.style.display='none'" style="float:right;background:none;border:none;cursor:pointer;font-size:16px;line-height:1;padding:0 4px;">&times;</button>
@@ -2212,11 +2217,22 @@ function getIngestFileTypes() {
 function updateStartButton() {
   var btn = document.getElementById('btnStartPipeline');
   var actionStatus = document.getElementById('pipelineActionStatus');
+  // While *this tab* owns a live pipeline run, the same button has
+  // been repurposed as "Stop Pipeline" (see startPipeline). Don't
+  // clobber its label/handler; just gate the disabled state on the
+  // cancel-in-flight flag.
+  //
+  // Step 5 of the pipeline-concurrency rollout removed the broader
+  // "_pipelineRunning disables Start" guard: a click while *any*
+  // pipeline (this tab's or another's) is running now enqueues a new
+  // run instead of being blocked. The label flips between
+  // "Start Pipeline" and "Queue Pipeline" based on slot occupancy
+  // polled from /api/pipeline/slots (see refreshSlotInfo).
   if (_pipelineRunning) {
     if (actionStatus) {
       actionStatus.textContent = _pipelineCancelling
-        ? 'Cancelling the running pipeline. Start will be available after the job stops.'
-        : 'A pipeline is running. Stop it or wait for it to finish before starting another.';
+        ? 'Cancelling the running pipeline.'
+        : '';
       actionStatus.className = 'status-msg';
     }
     btn.disabled = !!_pipelineCancelling;
@@ -2322,6 +2338,73 @@ function onStageToggle(stage) {
   refreshPipelineUI();
   schedulePlanRefresh();
 }
+
+// -- Pipeline slot poller --
+// Server-side queue (Step 4 of pipeline-concurrency) lets a click
+// while another run is active land on the queue instead of failing.
+// We poll /api/pipeline/slots to (1) flip the Start button label to
+// "Queue Pipeline" when no slot is free, and (2) show a small
+// "N running . M queued" status line linking to /jobs.
+var _slotInfo = { active: 0, queued: 0, slot_cap: 1 };
+var _slotPollTimer = null;
+var _SLOT_POLL_MS = 2000;
+
+function _applySlotInfo(info) {
+  _slotInfo = info || _slotInfo;
+  // Label flip — only when *this tab* isn't itself running a pipeline,
+  // because while it is, the same button is the Stop button.
+  if (!_pipelineRunning) {
+    var btn = document.getElementById('btnStartPipeline');
+    if (btn) {
+      var queueing = _slotInfo.active >= _slotInfo.slot_cap;
+      btn.textContent = queueing ? 'Queue Pipeline' : 'Start Pipeline';
+    }
+  }
+  // Status line: hidden when there's nothing to report.
+  var line = document.getElementById('pipelineSlotStatus');
+  var counts = document.getElementById('pipelineSlotCounts');
+  if (!line || !counts) return;
+  if (_slotInfo.active === 0 && _slotInfo.queued === 0) {
+    line.style.display = 'none';
+    return;
+  }
+  counts.textContent = _slotInfo.active + ' running • ' + _slotInfo.queued + ' queued';
+  line.style.display = '';
+}
+
+async function refreshSlotInfo() {
+  try {
+    var data = await safeFetch('/api/pipeline/slots', {}, { toast: false });
+    if (data) _applySlotInfo(data);
+  } catch(e) {
+    // Network blip — keep last known state; don't toast.
+  }
+}
+
+function _startSlotPolling() {
+  if (_slotPollTimer !== null) return;
+  refreshSlotInfo();
+  _slotPollTimer = setInterval(refreshSlotInfo, _SLOT_POLL_MS);
+}
+
+function _stopSlotPolling() {
+  if (_slotPollTimer !== null) {
+    clearInterval(_slotPollTimer);
+    _slotPollTimer = null;
+  }
+}
+
+document.addEventListener('visibilitychange', function() {
+  if (document.hidden) {
+    _stopSlotPolling();
+  } else {
+    _startSlotPolling();
+  }
+});
+
+// Kick off polling once the DOM is ready (this script lives at the
+// bottom of pipeline.html, so the DOM is already parsed by now).
+_startSlotPolling();
 
 // -- Pipeline orchestration --
 var _pipelineRunning = false;
@@ -2543,6 +2626,10 @@ async function startPipeline() {
     btn.textContent = 'Start Pipeline';
     btn.onclick = startPipeline;
     updateStartButton();
+    // Resync the Start/Queue label and "N running . M queued" line
+    // right away — the run we just finished freed a slot, but other
+    // tabs/processes may still be running pipelines.
+    refreshSlotInfo();
     // The pipeline just wrote new detections, masks, keypoints, etc. —
     // refresh the plan so the next run's pills reflect the new state of
     // the world (e.g. "Already done" for stages that just completed).

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2402,9 +2402,10 @@ document.addEventListener('visibilitychange', function() {
   }
 });
 
-// Kick off polling once the DOM is ready (this script lives at the
-// bottom of pipeline.html, so the DOM is already parsed by now).
-_startSlotPolling();
+// Kick off polling only when visible; hidden tabs should stay paused.
+if (!document.hidden) {
+  _startSlotPolling();
+}
 
 // -- Pipeline orchestration --
 var _pipelineRunning = false;

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -148,6 +148,109 @@ def test_job_detail_endpoint_returns_full_result(app_and_db):
     assert detail["result"] == big_result
 
 
+def test_pipeline_slots_empty(app_and_db):
+    """GET /api/pipeline/slots reports zero active and zero queued when
+    the runner has no pipeline jobs, and surfaces the module's slot cap."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    from jobs import SLOT_CAP
+
+    resp = client.get('/api/pipeline/slots')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {"active": 0, "queued": 0, "slot_cap": SLOT_CAP}
+
+
+def test_pipeline_slots_counts_only_pipeline_jobs(app_and_db):
+    """``active`` and ``queued`` must count only pipeline-type jobs.
+    A running scan or duplicate-scan job must not be counted as a
+    pipeline slot occupant."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    runner = app._job_runner
+
+    running_pipeline = {
+        "id": "pipe-running-1",
+        "type": "pipeline",
+        "status": "running",
+        "started_at": "2026-05-27T10:00:00",
+        "finished_at": None,
+        "progress": {"current": 1, "total": 10},
+        "errors": [],
+        "config": {},
+        "result": None,
+    }
+    finished_pipeline = {
+        "id": "pipe-done-1",
+        "type": "pipeline",
+        "status": "completed",
+        "started_at": "2026-05-27T09:00:00",
+        "finished_at": "2026-05-27T09:30:00",
+        "progress": {"current": 10, "total": 10},
+        "errors": [],
+        "config": {},
+        "result": {"ok": True},
+    }
+    running_scan = {
+        "id": "scan-running-1",
+        "type": "scan",
+        "status": "running",
+        "started_at": "2026-05-27T10:05:00",
+        "finished_at": None,
+        "progress": {"current": 0, "total": 0},
+        "errors": [],
+        "config": {},
+        "result": None,
+    }
+    with runner._lock:
+        runner._jobs["pipe-running-1"] = running_pipeline
+        runner._jobs["pipe-done-1"] = finished_pipeline
+        runner._jobs["scan-running-1"] = running_scan
+
+    data = client.get('/api/pipeline/slots').get_json()
+    assert data["active"] == 1, \
+        "only running pipelines count toward active slots"
+    assert data["queued"] == 0
+
+
+def test_pipeline_slots_counts_queued(app_and_db):
+    """Queued pipelines (surfaced via ``list_jobs()`` from
+    ``_queued_pipelines``) must appear in ``queued`` but not in
+    ``active``."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    runner = app._job_runner
+
+    # Synthesize a queued pipeline the same way ``enqueue_pipeline``
+    # would — by registering an entry in ``_queued_pipelines``. We do
+    # this directly so the test doesn't need the full pipeline plumbing.
+    with runner._lock:
+        runner._queued_pipelines["pipe-queued-1"] = {
+            "started_at": "2026-05-27T10:10:00",
+            "config": {"sources": []},
+            "workspace_id": None,
+            "work_fn": lambda *a, **kw: None,
+        }
+        runner._jobs["pipe-running-2"] = {
+            "id": "pipe-running-2",
+            "type": "pipeline",
+            "status": "running",
+            "started_at": "2026-05-27T10:00:00",
+            "finished_at": None,
+            "progress": {"current": 1, "total": 10},
+            "errors": [],
+            "config": {},
+            "result": None,
+        }
+
+    data = client.get('/api/pipeline/slots').get_json()
+    assert data["active"] == 1
+    assert data["queued"] == 1
+
+
 def test_scan_status_includes_extended_stats(app_and_db):
     """GET /api/scan/status includes keyword count, db_size, etc."""
     app, _ = app_and_db

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -209,10 +209,14 @@ def test_pipeline_slots_counts_only_pipeline_jobs(app_and_db):
         runner._jobs["pipe-done-1"] = finished_pipeline
         runner._jobs["scan-running-1"] = running_scan
 
-    data = client.get('/api/pipeline/slots').get_json()
+    from jobs import SLOT_CAP
+    resp = client.get('/api/pipeline/slots')
+    assert resp.status_code == 200
+    data = resp.get_json()
     assert data["active"] == 1, \
         "only running pipelines count toward active slots"
     assert data["queued"] == 0
+    assert data["slot_cap"] == SLOT_CAP
 
 
 def test_pipeline_slots_counts_queued(app_and_db):
@@ -246,9 +250,13 @@ def test_pipeline_slots_counts_queued(app_and_db):
             "result": None,
         }
 
-    data = client.get('/api/pipeline/slots').get_json()
+    from jobs import SLOT_CAP
+    resp = client.get('/api/pipeline/slots')
+    assert resp.status_code == 200
+    data = resp.get_json()
     assert data["active"] == 1
     assert data["queued"] == 1
+    assert data["slot_cap"] == SLOT_CAP
 
 
 def test_scan_status_includes_extended_stats(app_and_db):

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -409,6 +409,53 @@ def test_in_flight_promotion_counts_against_slot_cap_not_global_guard(tmp_path, 
         assert runner._queued_pipelines[first_id]["_promoting"] is True
 
 
+def test_cancelled_promotion_candidate_retries_next_queued_pipeline(tmp_path):
+    """A cancelled front-of-queue row should not stall later queued work."""
+    import sqlite3
+
+    runner, db = _make_runner_with_db(tmp_path)
+    cancelled_id = "pipeline-1700000000003"
+    next_id = "pipeline-1700000000004"
+    conn = sqlite3.connect(str(tmp_path / "test.db"))
+    conn.executemany(
+        "INSERT INTO job_history (id, type, status, started_at, error_count) "
+        "VALUES (?, 'pipeline', ?, ?, 0)",
+        [
+            (cancelled_id, "cancelled", "2026-05-26T00:00:00"),
+            (next_id, "queued", "2026-05-26T00:00:01"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    with runner._lock:
+        runner._queued_pipelines[cancelled_id] = {
+            "work_fn": lambda job: pytest_fail("cancelled job must not run"),
+            "config": {},
+            "workspace_id": 1,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:00",
+        }
+        runner._queued_pipelines[next_id] = {
+            "work_fn": lambda job: None,
+            "config": {},
+            "workspace_id": 1,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:01",
+        }
+
+    runner._try_promote_queued()
+    promoted = wait_for_job_via_runner(runner, next_id, wait_for_history=True)
+
+    assert promoted["status"] == "completed"
+    with runner._lock:
+        assert cancelled_id not in runner._queued_pipelines
+    row = db.conn.execute(
+        "SELECT status FROM job_history WHERE id = ?", (next_id,),
+    ).fetchone()
+    assert row["status"] == "completed"
+
+
 def pytest_fail(msg):
     raise AssertionError(msg)
 

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -7,13 +7,7 @@ capacity opens. ``SLOT_CAP`` is 1 in this PR — the second queued run
 waits for the first to reach a terminal state before promotion.
 """
 
-import os
-import sys
 import threading
-import time
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, os.path.dirname(__file__))
 
 from db import Database
 from wait import wait_for_job_via_runner
@@ -302,9 +296,8 @@ def test_cancel_queued_pipeline_transitions_row_to_cancelled(tmp_path):
     # Releasing the first must NOT promote the cancelled one.
     blocker.set()
     wait_for_job_via_runner(runner, first_id)
-    # Give the scheduler a beat — the cancelled row must stay cancelled.
-    time.sleep(0.05)
-    assert not second_started.is_set(), (
+    # Wait briefly; the cancelled row must never be promoted.
+    assert not second_started.wait(timeout=0.3), (
         "cancelled queued job must not be promoted"
     )
     final_row = db.conn.execute(

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -353,6 +353,62 @@ def test_promotion_loses_race_to_cancel_leaves_row_cancelled(tmp_path):
     assert job_id not in runner._queued_pipelines
 
 
+def test_in_flight_promotion_counts_against_slot_cap_not_global_guard(tmp_path, monkeypatch):
+    """A promotion in progress should consume one slot, not block all slots.
+
+    This protects the planned ``SLOT_CAP > 1`` case: if one queued context is
+    already between the in-memory pick and SQLite UPDATE, another queued
+    context should still promote when capacity remains.
+    """
+    import sqlite3
+
+    import jobs as jobs_module
+
+    monkeypatch.setattr(jobs_module, "SLOT_CAP", 2)
+    runner, db = _make_runner_with_db(tmp_path)
+    first_id = "pipeline-1700000000001"
+    second_id = "pipeline-1700000000002"
+    conn = sqlite3.connect(str(tmp_path / "test.db"))
+    conn.executemany(
+        "INSERT INTO job_history (id, type, status, started_at, error_count) "
+        "VALUES (?, 'pipeline', 'queued', ?, 0)",
+        [
+            (first_id, "2026-05-26T00:00:00"),
+            (second_id, "2026-05-26T00:00:01"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    with runner._lock:
+        runner._queued_pipelines[first_id] = {
+            "work_fn": lambda job: None,
+            "config": {},
+            "workspace_id": 1,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:00",
+            "_promoting": True,
+        }
+        runner._queued_pipelines[second_id] = {
+            "work_fn": lambda job: None,
+            "config": {},
+            "workspace_id": 1,
+            "runtime_warning": None,
+            "started_at": "2026-05-26T00:00:01",
+        }
+
+    runner._try_promote_queued()
+    promoted = wait_for_job_via_runner(runner, second_id, wait_for_history=True)
+
+    assert promoted["status"] == "completed"
+    row = db.conn.execute(
+        "SELECT status FROM job_history WHERE id = ?", (second_id,),
+    ).fetchone()
+    assert row["status"] == "completed"
+    with runner._lock:
+        assert runner._queued_pipelines[first_id]["_promoting"] is True
+
+
 def pytest_fail(msg):
     raise AssertionError(msg)
 


### PR DESCRIPTION
## Summary

Step 5a of the pipeline-concurrency rollout (design: `docs/plans/2026-05-26-pipeline-concurrency-design.md`).

- Adds `GET /api/pipeline/slots` returning `{active, queued, slot_cap}` — counts only `type == "pipeline"` jobs in `runner.list_jobs()`. `SLOT_CAP` is imported from `jobs`.
- Removes the `_pipelineRunning`-as-guard behavior on the Start button. With the server-side queue (PR #901), a click while another pipeline is active should enqueue, not be blocked.
- Pipeline page polls `/api/pipeline/slots` every 2s while visible (paused on `document.hidden` via `visibilitychange`) and flips the button label between **Start Pipeline** (slot free) and **Queue Pipeline** (`active >= slot_cap`).
- Adds a small status line near the button: `"N running . M queued"` plus a "see Jobs" link to `/jobs`. Hidden when both counts are zero.

## Deferred to later PRs

- The `_focusedJobId` "this tab's run" focus logic from the design — separate refinement PR.
- Lifting `SLOT_CAP` from 1 to 2 — Step 6, the actual concurrency switch-on.
- `/jobs` page polish (cancel-all-queued, queued status filter) — another agent's slice.

## Tests

- 3 new endpoint tests in `vireo/tests/test_jobs_api.py` (TDD: RED before GREEN):
  - empty state returns zeros and the module's `slot_cap`
  - only `type == "pipeline"` running jobs count toward `active` (a running scan does not)
  - queued pipelines synthesized through `_queued_pipelines` show up in `queued` but not `active`
- Project test sweep: `tests/test_workspaces.py`, `vireo/tests/test_db.py`, `vireo/tests/test_app.py`, `vireo/tests/test_photos_api.py`, `vireo/tests/test_edits_api.py`, `vireo/tests/test_jobs_api.py`, `vireo/tests/test_darktable_api.py`, `vireo/tests/test_config.py` — 978 passed, 1 skipped.
- `vireo/tests/test_pipeline_queue.py` (Step 4's plumbing) — 14 passed.

## Base

Branch was developed off `origin/pipeline-queue-server` (Step 4), but the PR targets `main` and will rebase cleanly once #901 lands.

## Test plan

- [ ] Open the pipeline page with no pipelines running: button says "Start Pipeline", slot status line is hidden.
- [ ] Start a pipeline in one tab; in a second tab the button label flips to "Queue Pipeline" (since `SLOT_CAP=1`) and the status line shows "1 running . 0 queued -- see Jobs".
- [ ] Click "Queue Pipeline" in the second tab; status line updates to "1 running . 1 queued".
- [ ] Switch the second tab to a background window; verify the 2s poll stops (network tab in DevTools) and resumes on focus.
- [ ] Cancel the queued run from `/jobs`; second tab's status line updates within ~2s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pipeline job queuing with concurrency limiting to control concurrent pipeline execution.
  * Live pipeline slot occupancy indicator now displays running and queued job counts on the Pipeline page.
  * Queued pipeline jobs are now visible in the active jobs view with full cancellation support.
  * New API endpoint provides real-time slot status information.

* **Tests**
  * Added tests for pipeline slot status reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->