### PR TITLE
workspaces: seed default collections on API create

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3919,6 +3919,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("Name is required")
         try:
             ws_id = db.create_workspace(name, config_overrides=body.get("config_overrides"))
+            # Seed the standard smart collections (All Photos, Flagged, etc.).
+            # Startup only seeds the active workspace, so without this a
+            # workspace created via the API never gets defaults until it's
+            # active during a future Vireo restart — which is how a
+            # workspace in the wild ended up with zero defaults and broke
+            # "All Photos" in the pipeline collection picker.
+            db.create_default_collections(workspace_id=ws_id)
             # Link selected folders if provided
             folder_ids = body.get("folder_ids", [])
             for folder_id in folder_ids:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9643,9 +9643,20 @@ class Database:
             self.conn.commit()
         return updated
 
-    def create_default_collections(self):
-        """Create default smart collections, skipping any that already exist by name."""
-        existing_names = {c["name"] for c in self.get_collections()}
+    def create_default_collections(self, workspace_id=None):
+        """Create default smart collections, skipping any that already exist by name.
+
+        Workspace defaults to the active one. Pass ``workspace_id`` to seed a
+        specific workspace without needing it to be active — used by
+        ``api_create_workspace`` so brand-new workspaces get the defaults at
+        creation time instead of relying on a future startup pass.
+        """
+        ws_id = workspace_id if workspace_id is not None else self._ws_id()
+        existing_names = {
+            row["name"] for row in self.conn.execute(
+                "SELECT name FROM collections WHERE workspace_id = ?", (ws_id,),
+            ).fetchall()
+        }
 
         defaults = [
             ("All Photos", [{"field": "all"}]),
@@ -9662,7 +9673,11 @@ class Database:
         ]
         for name, rules in defaults:
             if name not in existing_names:
-                self.add_collection(name, json.dumps(rules))
+                self.conn.execute(
+                    "INSERT INTO collections (name, rules, workspace_id) VALUES (?, ?, ?)",
+                    (name, json.dumps(rules), ws_id),
+                )
+        self.conn.commit()
 
     def migrate_default_subject_collection(self):
         """Rename legacy 'Needs Classification' (with rule has_species==0)

--- a/vireo/tests/test_workspaces_api.py
+++ b/vireo/tests/test_workspaces_api.py
@@ -82,6 +82,29 @@ def test_create_workspace_with_folders(app_and_db):
     assert linked_ids == set(folder_ids)
 
 
+def test_create_workspace_seeds_default_collections(app_and_db):
+    """POST /api/workspaces seeds the standard smart collections into the new workspace.
+
+    Regression guard: without this, a workspace created via the API has no
+    'All Photos' (or other defaults) until it's the active workspace during
+    a future Vireo restart — which broke the pipeline collection picker for
+    workspaces created mid-session.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    resp = client.post("/api/workspaces", json={"name": "Defaults WS"})
+    assert resp.status_code == 200
+    ws_id = resp.get_json()["id"]
+
+    rows = db.conn.execute(
+        "SELECT name FROM collections WHERE workspace_id = ?", (ws_id,),
+    ).fetchall()
+    names = {r["name"] for r in rows}
+    assert {"All Photos", "Needs Identification", "Untagged",
+            "Flagged", "Recent Import"} <= names
+
+
 def test_update_workspace(app_and_db):
     """PUT /api/workspaces/<id> updates the workspace name."""
     app, _db = app_and_db


### PR DESCRIPTION
## Summary
- `POST /api/workspaces` only created the workspace row — it never called `create_default_collections()`, so workspaces created mid-session had no "All Photos" / "Flagged" / "Untagged" / "Needs Identification" / "Recent Import" until they happened to be the active workspace during a future Vireo startup.
- Symptom from a real workspace: the pipeline collection picker showed no default option, blocking a regroup run.
- Fix: `api_create_workspace` now seeds defaults right after `create_workspace`. `create_default_collections` gained an optional `workspace_id` param so it can seed any workspace, not just the active one — existing no-arg callers (startup, tests) are unchanged.

## Test plan
- [x] `python -m pytest vireo/tests/test_workspaces_api.py vireo/tests/test_db.py vireo/tests/test_collections_api.py vireo/tests/test_collection_duplicate_api.py vireo/tests/test_config.py -q` → 521 passed
- [x] Project test bundle from `CLAUDE.md` → 975 passed, 1 pre-existing skip
- [x] New regression test `test_create_workspace_seeds_default_collections` covers the create→defaults path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Default smart collections (All Photos, Needs Identification, Untagged, Flagged, Recent Import) are now automatically created when a new workspace is set up through the API.
  * Workspaces no longer require a restart to display all standard collections after creation.

* **Tests**
  * Added regression test to ensure new workspaces include all expected default collections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->