### PR TITLE
Pipeline concurrency: lift SLOT_CAP from 1 to 2 (Step 6)

### DIFF
--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -16,10 +16,15 @@ _JOB_RETENTION_SECS = 3600  # 1 hour
 _PROMOTION_RETRY_DELAY_SECS = 0.1
 
 
-# Maximum number of pipeline jobs allowed to run concurrently. Kept at
-# 1 in this PR; concurrency is enabled in a later PR after the UI and
-# resource locks land. See docs/plans/2026-05-26-pipeline-concurrency-design.md.
-SLOT_CAP = 1
+# Maximum number of pipeline jobs allowed to run concurrently. Bumped
+# to 2 in Step 6 of the concurrency rollout (Steps 1-3 added the
+# ModelCache + GPU/regroup locks that make this safe; Steps 4-5 added
+# the queue + UI). The cap is intentionally low: the gains from
+# overlapping two pipelines come from one's GPU phase running while
+# another's I/O / CPU phases progress. A third pipeline would mostly
+# queue at the GPU lock without adding throughput.
+# See docs/plans/2026-05-26-pipeline-concurrency-design.md.
+SLOT_CAP = 2
 
 
 class JobRunner:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2964,22 +2964,32 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 image_path = os.path.join(folder_path, photo["filename"])
 
                 try:
-                    # Per-(photo, variant) serialisation: two pipelines
-                    # whose collections overlap can both reach this
-                    # photo+variant. Without this lock, both pass the
-                    # get_photo_mask cache miss, both call generate_mask,
-                    # both write the deterministic
-                    # masks/{photo_id}.{variant}.png path, and the file
-                    # on disk can end up describing a different mask than
-                    # the photo_masks row points at (or identical runs
-                    # can truncate each other's PNG mid-write).
+                    # Per-photo serialisation. Two pipelines whose
+                    # collections overlap can both reach this photo.
+                    # Without this lock:
                     #
-                    # Locking by (photo_id, variant) — not (workspace,
-                    # photo) — because the same photo can legitimately
-                    # appear in multiple workspaces (photos are global
-                    # in Vireo); the conflict is keyed on the shared
-                    # filesystem path, not the workspace.
-                    with acquire_photo_mask(photo_id, sam2_variant):
+                    #   - Same variant: both write the same
+                    #     ``masks/{photo_id}.{variant}.png`` file and
+                    #     can corrupt each other's bytes mid-write.
+                    #   - Different variants (e.g. two workspaces
+                    #     sharing folders but configured with sam2-small
+                    #     vs sam2-large): the per-variant mask files
+                    #     don't collide, BUT both runs denormalise into
+                    #     the same ``photos`` row via
+                    #     ``set_active_mask_variant`` and
+                    #     ``update_photo_embeddings``. Their writes can
+                    #     interleave, leaving photos.active_mask_variant
+                    #     pointing at one variant while photos.dino_*
+                    #     embeddings were cropped from the other's mask.
+                    #     regroup reads these denormalised columns, so
+                    #     the corruption would silently flow into
+                    #     grouping.
+                    #
+                    # Keyed by photo_id alone — not (photo_id, variant) —
+                    # so the cross-variant collision in (2) is covered.
+                    # Workspace isn't part of the key because photos are
+                    # global in Vireo.
+                    with acquire_photo_mask(photo_id):
                         # Cache hit: a row already exists for (photo, variant)
                         # AND its stored prompt + detector still match the
                         # current primary detection AND the file is on disk.

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 import numpy as np
 from db import Database, commit_with_retry
 from model_cache import get_default_cache
-from pipeline_locks import acquire_workspace_regroup
+from pipeline_locks import acquire_photo_mask, acquire_workspace_regroup
 
 log = logging.getLogger(__name__)
 
@@ -2964,135 +2964,151 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 image_path = os.path.join(folder_path, photo["filename"])
 
                 try:
-                    # Cache hit: a row already exists for (photo, variant)
-                    # AND its stored prompt + detector still match the
-                    # current primary detection AND the file is on disk.
-                    # In that case the SAM result is unchanged, so we
-                    # only re-activate the mask (cheap denormalize) and
-                    # skip the heavy SAM + DINOv2 work.
-                    existing = thread_db.get_photo_mask(
-                        photo_id, sam2_variant,
-                    )
-                    if existing is not None:
-                        cached_prompt = (
-                            existing["prompt_x"], existing["prompt_y"],
-                            existing["prompt_w"], existing["prompt_h"],
+                    # Per-(photo, variant) serialisation: two pipelines
+                    # whose collections overlap can both reach this
+                    # photo+variant. Without this lock, both pass the
+                    # get_photo_mask cache miss, both call generate_mask,
+                    # both write the deterministic
+                    # masks/{photo_id}.{variant}.png path, and the file
+                    # on disk can end up describing a different mask than
+                    # the photo_masks row points at (or identical runs
+                    # can truncate each other's PNG mid-write).
+                    #
+                    # Locking by (photo_id, variant) — not (workspace,
+                    # photo) — because the same photo can legitimately
+                    # appear in multiple workspaces (photos are global
+                    # in Vireo); the conflict is keyed on the shared
+                    # filesystem path, not the workspace.
+                    with acquire_photo_mask(photo_id, sam2_variant):
+                        # Cache hit: a row already exists for (photo, variant)
+                        # AND its stored prompt + detector still match the
+                        # current primary detection AND the file is on disk.
+                        # In that case the SAM result is unchanged, so we
+                        # only re-activate the mask (cheap denormalize) and
+                        # skip the heavy SAM + DINOv2 work.
+                        existing = thread_db.get_photo_mask(
+                            photo_id, sam2_variant,
                         )
-                        if (existing["detector_model"]
-                                == entry["detector_model"]
-                                and cached_prompt == entry["prompt"]
-                                and existing["path"]
-                                and os.path.isfile(existing["path"])):
-                            thread_db.set_active_mask_variant(
-                                photo_id, sam2_variant,
+                        if existing is not None:
+                            cached_prompt = (
+                                existing["prompt_x"], existing["prompt_y"],
+                                existing["prompt_w"], existing["prompt_h"],
                             )
-                            masked += 1
+                            if (existing["detector_model"]
+                                    == entry["detector_model"]
+                                    and cached_prompt == entry["prompt"]
+                                    and existing["path"]
+                                    and os.path.isfile(existing["path"])):
+                                thread_db.set_active_mask_variant(
+                                    photo_id, sam2_variant,
+                                )
+                                masked += 1
+                                processed = i + 1
+                                continue
+
+                        # First true cache miss: ensure SAM2 + DINOv2 weights
+                        # are present before render_proxy/generate_mask runs.
+                        # No-op on subsequent iterations.
+                        _ensure_weights()
+
+                        proxy = render_proxy(image_path, longest_edge=proxy_longest_edge)
+                        if proxy is None:
+                            skipped += 1
                             processed = i + 1
                             continue
+                        if _should_abort(abort):
+                            break
 
-                    # First true cache miss: ensure SAM2 + DINOv2 weights
-                    # are present before render_proxy/generate_mask runs.
-                    # No-op on subsequent iterations.
-                    _ensure_weights()
+                        # GPU serialisation lives inside masking.generate_mask
+                        # (around the encoder/decoder session.run calls). The
+                        # wider wrap previously here held the semaphore through
+                        # SAM weight load + image preprocessing + prompt-coord
+                        # math, blocking other pipelines' GPU work for CPU-only
+                        # phases.
+                        mask = generate_mask(proxy, det_box, variant=sam2_variant)
+                        if mask is None:
+                            skipped += 1
+                            processed = i + 1
+                            continue
+                        if _should_abort(abort):
+                            break
 
-                    proxy = render_proxy(image_path, longest_edge=proxy_longest_edge)
-                    if proxy is None:
-                        skipped += 1
-                        processed = i + 1
-                        continue
-                    if _should_abort(abort):
-                        break
-
-                    # GPU serialisation lives inside masking.generate_mask
-                    # (around the encoder/decoder session.run calls). The
-                    # wider wrap previously here held the semaphore through
-                    # SAM weight load + image preprocessing + prompt-coord
-                    # math, blocking other pipelines' GPU work for CPU-only
-                    # phases.
-                    mask = generate_mask(proxy, det_box, variant=sam2_variant)
-                    if mask is None:
-                        skipped += 1
-                        processed = i + 1
-                        continue
-                    if _should_abort(abort):
-                        break
-
-                    mask_path = save_mask(
-                        mask, masks_dir, photo_id, sam2_variant,
-                    )
-                    completeness = crop_completeness(mask)
-                    features = compute_all_quality_features(proxy, mask)
-                    if _should_abort(abort):
-                        break
-
-                    # Per-mask features (move from photos row into
-                    # photo_masks; set_active_mask_variant denormalizes
-                    # them back into photos for downstream readers).
-                    mask_subject_tenengrad = features.pop(
-                        "subject_tenengrad", None,
-                    )
-                    mask_bg_tenengrad = features.pop("bg_tenengrad", None)
-                    # Mask-derived subject_size: fraction of frame
-                    # covered by the boolean mask. Replaces the
-                    # detection-bbox approximation classify uses.
-                    total_pixels = float(mask.size)
-                    if total_pixels > 0:
-                        mask_subject_size = float(
-                            np.count_nonzero(mask) / total_pixels
+                        mask_path = save_mask(
+                            mask, masks_dir, photo_id, sam2_variant,
                         )
-                    else:
-                        mask_subject_size = None
+                        completeness = crop_completeness(mask)
+                        features = compute_all_quality_features(proxy, mask)
+                        if _should_abort(abort):
+                            break
 
-                    # GPU serialisation lives inside dino_embed.embed /
-                    # embed_batch (around the session.run call). The wider
-                    # wrap previously here held the semaphore through
-                    # per-image resize/normalize preprocessing.
-                    subject_crop = crop_subject(proxy, mask, margin=0.15)
-                    if subject_crop is not None:
-                        embs = embed_batch(
-                            [subject_crop, proxy], variant=dinov2_variant,
+                        # Per-mask features (move from photos row into
+                        # photo_masks; set_active_mask_variant denormalizes
+                        # them back into photos for downstream readers).
+                        mask_subject_tenengrad = features.pop(
+                            "subject_tenengrad", None,
                         )
-                        subj_emb_blob = embedding_to_blob(embs[0])
-                        global_emb_blob = embedding_to_blob(embs[1])
-                    else:
-                        subj_emb_blob = None
-                        global_emb_blob = embedding_to_blob(
-                            embed(proxy, variant=dinov2_variant),
-                        )
+                        mask_bg_tenengrad = features.pop("bg_tenengrad", None)
+                        # Mask-derived subject_size: fraction of frame
+                        # covered by the boolean mask. Replaces the
+                        # detection-bbox approximation classify uses.
+                        total_pixels = float(mask.size)
+                        if total_pixels > 0:
+                            mask_subject_size = float(
+                                np.count_nonzero(mask) / total_pixels
+                            )
+                        else:
+                            mask_subject_size = None
 
-                    thread_db.upsert_photo_mask(
-                        photo_id=photo_id,
-                        variant=sam2_variant,
-                        path=mask_path,
-                        detector_model=entry["detector_model"],
-                        prompt_x=entry["prompt"][0],
-                        prompt_y=entry["prompt"][1],
-                        prompt_w=entry["prompt"][2],
-                        prompt_h=entry["prompt"][3],
-                        subject_size=mask_subject_size,
-                        subject_tenengrad=mask_subject_tenengrad,
-                        bg_tenengrad=mask_bg_tenengrad,
-                        crop_complete=completeness,
-                    )
-                    thread_db.set_active_mask_variant(
-                        photo_id, sam2_variant,
-                    )
-                    # Remaining (non-mask) per-photo features still land
-                    # on the photos row.  mask_path / crop_complete /
-                    # subject_tenengrad / bg_tenengrad now flow via
-                    # set_active_mask_variant above, so they are
-                    # intentionally NOT passed here.
-                    if features:
-                        thread_db.update_photo_pipeline_features(
-                            photo_id, **features,
+                        # GPU serialisation lives inside dino_embed.embed /
+                        # embed_batch (around the session.run call). The wider
+                        # wrap previously here held the semaphore through
+                        # per-image resize/normalize preprocessing.
+                        subject_crop = crop_subject(proxy, mask, margin=0.15)
+                        if subject_crop is not None:
+                            embs = embed_batch(
+                                [subject_crop, proxy], variant=dinov2_variant,
+                            )
+                            subj_emb_blob = embedding_to_blob(embs[0])
+                            global_emb_blob = embedding_to_blob(embs[1])
+                        else:
+                            subj_emb_blob = None
+                            global_emb_blob = embedding_to_blob(
+                                embed(proxy, variant=dinov2_variant),
+                            )
+
+                        thread_db.upsert_photo_mask(
+                            photo_id=photo_id,
+                            variant=sam2_variant,
+                            path=mask_path,
+                            detector_model=entry["detector_model"],
+                            prompt_x=entry["prompt"][0],
+                            prompt_y=entry["prompt"][1],
+                            prompt_w=entry["prompt"][2],
+                            prompt_h=entry["prompt"][3],
+                            subject_size=mask_subject_size,
+                            subject_tenengrad=mask_subject_tenengrad,
+                            bg_tenengrad=mask_bg_tenengrad,
+                            crop_complete=completeness,
                         )
-                    thread_db.update_photo_embeddings(
-                        photo_id,
-                        dino_subject_embedding=subj_emb_blob,
-                        dino_global_embedding=global_emb_blob,
-                        variant=dinov2_variant,
-                    )
-                    masked += 1
+                        thread_db.set_active_mask_variant(
+                            photo_id, sam2_variant,
+                        )
+                        # Remaining (non-mask) per-photo features still land
+                        # on the photos row.  mask_path / crop_complete /
+                        # subject_tenengrad / bg_tenengrad now flow via
+                        # set_active_mask_variant above, so they are
+                        # intentionally NOT passed here.
+                        if features:
+                            thread_db.update_photo_pipeline_features(
+                                photo_id, **features,
+                            )
+                        thread_db.update_photo_embeddings(
+                            photo_id,
+                            dino_subject_embedding=subj_emb_blob,
+                            dino_global_embedding=global_emb_blob,
+                            variant=dinov2_variant,
+                        )
+                        masked += 1
                 except Exception:
                     em_failed += 1
                     log.warning("Mask extraction failed for photo %s", photo_id, exc_info=True)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -3009,12 +3009,40 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     and cached_prompt == entry["prompt"]
                                     and existing["path"]
                                     and os.path.isfile(existing["path"])):
-                                thread_db.set_active_mask_variant(
-                                    photo_id, sam2_variant,
-                                )
-                                masked += 1
-                                processed = i + 1
-                                continue
+                                # The cheap skip (re-activate only) is correct
+                                # ONLY when the photos row is already fully
+                                # consistent for this variant. set_active_mask_
+                                # variant denormalises this variant's mask
+                                # features, but it does NOT touch the
+                                # dino_* embeddings — those still describe
+                                # whatever mask was active when they were last
+                                # computed. If the row is currently active on a
+                                # different SAM variant (e.g. two workspaces
+                                # share a folder but use sam2-small vs -large),
+                                # re-activating would leave the denormalised
+                                # mask features describing this variant while
+                                # the subject embedding was cropped from the
+                                # other variant's mask. regroup reads both off
+                                # the photos row, so it would mix them. Only
+                                # skip when active_mask_variant AND
+                                # dino_embedding_variant already match; else
+                                # fall through to the full recompute, which
+                                # writes set_active_mask_variant +
+                                # update_photo_embeddings together.
+                                state = thread_db.conn.execute(
+                                    "SELECT active_mask_variant, "
+                                    "dino_embedding_variant FROM photos "
+                                    "WHERE id = ?",
+                                    (photo_id,),
+                                ).fetchone()
+                                if (state is not None
+                                        and state["active_mask_variant"]
+                                        == sam2_variant
+                                        and state["dino_embedding_variant"]
+                                        == dinov2_variant):
+                                    masked += 1
+                                    processed = i + 1
+                                    continue
 
                         # First true cache miss: ensure SAM2 + DINOv2 weights
                         # are present before render_proxy/generate_mask runs.

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -14,6 +14,7 @@ import logging
 import math
 import os
 import queue
+import tempfile
 import threading
 import time
 from dataclasses import dataclass
@@ -1387,7 +1388,26 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     canonical = get_canonical_image_path(photo, base_dir, folders)
                     img = load_image(canonical, max_size=max_size)
                     if img:
-                        img.save(cache_path, format="JPEG", quality=preview_quality)
+                        # Atomic write: with SLOT_CAP > 1 two pipelines
+                        # processing the same photo can both miss the
+                        # os.path.exists() check above and race here on the
+                        # deterministic {id}_{max_size}.jpg path. A direct
+                        # img.save(cache_path) would interleave/truncate the
+                        # JPEG bytes; tempfile + os.replace makes the visible
+                        # file flip atomically (same pattern as
+                        # thumbnails.generate_thumbnail).
+                        fd, tmp_path = tempfile.mkstemp(
+                            prefix=f'.{photo["id"]}.', suffix=".jpg.tmp",
+                            dir=preview_dir,
+                        )
+                        os.close(fd)
+                        try:
+                            img.save(tmp_path, format="JPEG", quality=preview_quality)
+                            os.replace(tmp_path, cache_path)
+                        except Exception:
+                            with contextlib.suppress(OSError):
+                                os.unlink(tmp_path)
+                            raise
                         with contextlib.suppress(Exception):
                             thread_db.preview_cache_insert(
                                 photo["id"], max_size, os.path.getsize(cache_path),

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -3402,109 +3402,106 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         runner.update_step(job["id"], "regroup", status="running")
         _update_stages(runner, job["id"], stages)
 
-        # Two pipelines targeting the same workspace must not regroup
-        # concurrently — save_results + set_workspace_group_state would
-        # race and leave inconsistent grouping state. Per-workspace lock
-        # serialises only this stage; pipelines on different workspaces
-        # don't interact.
-        #
-        # runner.update_step takes JobRunner._lock; per the documented
-        # lock order in pipeline_locks.py, JobRunner._lock is outer to
-        # workspace_regroup. So we capture the intended update inside the
-        # `with` block and apply it after releasing the lock.
-        deferred_step_update = None  # dict of kwargs for runner.update_step
+        # The per-workspace regroup lock is now acquired by the
+        # orchestrator (see run_pipeline_job body) so it spans BOTH
+        # regroup_stage and miss_stage atomically — the inner lock
+        # that used to live here would deadlock against the outer one
+        # (Python locks aren't reentrant). The deferred-update pattern
+        # likewise goes away: runner.update_step is fine to call here
+        # because nothing under JobRunner._lock acquires the workspace
+        # regroup lock, so there's no cycle to invert.
         try:
-            with acquire_workspace_regroup(workspace_id):
-                import config as cfg
-                from pipeline import load_photo_features, run_full_pipeline, save_results
+            import config as cfg
+            from pipeline import load_photo_features, run_full_pipeline, save_results
 
-                thread_db = Database(db_path)
-                thread_db.set_active_workspace(workspace_id)
+            thread_db = Database(db_path)
+            thread_db.set_active_workspace(workspace_id)
 
-                effective_cfg = thread_db.get_effective_config(cfg.load())
-                pipeline_cfg = effective_cfg.get("pipeline", {})
+            effective_cfg = thread_db.get_effective_config(cfg.load())
+            pipeline_cfg = effective_cfg.get("pipeline", {})
 
-                photos = load_photo_features(thread_db, collection_id=collection_id, config=effective_cfg)
-                if params.exclude_photo_ids:
-                    photos = [p for p in photos if p["id"] not in params.exclude_photo_ids]
-                if not photos:
-                    result["stages"]["regroup"] = {"error": "No photos with pipeline features found."}
-                    stages["regroup"]["status"] = "completed"
-                    deferred_step_update = {
-                        "status": "completed", "summary": "No photos to group",
-                    }
+            photos = load_photo_features(thread_db, collection_id=collection_id, config=effective_cfg)
+            if params.exclude_photo_ids:
+                photos = [p for p in photos if p["id"] not in params.exclude_photo_ids]
+            if not photos:
+                result["stages"]["regroup"] = {"error": "No photos with pipeline features found."}
+                stages["regroup"]["status"] = "completed"
+                runner.update_step(
+                    job["id"], "regroup",
+                    status="completed", summary="No photos to group",
+                )
+            else:
+                results = run_full_pipeline(photos, config=pipeline_cfg, emit_trace=True)
+                cache_dir = os.path.dirname(db_path)
+                save_results(results, cache_dir, workspace_id)
+
+                # Stamp the grouping fingerprint + timestamp BEFORE marking
+                # the step completed, so a partial regroup that crashes
+                # between here and update_step doesn't end up labeled "fresh"
+                # with a stale fp.
+                #
+                # Only stamp when the regroup actually covered the whole
+                # workspace — if it ran on a filtered subset (a
+                # sub-collection, or with exclude_photo_ids set) some
+                # workspace photos were intentionally not regrouped, so
+                # claiming workspace-level freshness would let the pipeline
+                # page hide a real stale state.
+                from pipeline import (
+                    _resolve_collection_photo_ids,
+                    compute_group_fingerprint,
+                )
+                collection_photo_ids = _resolve_collection_photo_ids(
+                    thread_db, collection_id,
+                )
+                ws_photo_ids = {
+                    r["id"] for r in thread_db.conn.execute(
+                        """SELECT p.id
+                             FROM photos p
+                             JOIN workspace_folders wf
+                               ON wf.folder_id = p.folder_id
+                            WHERE wf.workspace_id = ?""",
+                        (workspace_id,),
+                    ).fetchall()
+                }
+                covered_full_workspace = (
+                    not params.exclude_photo_ids
+                    and ws_photo_ids.issubset(collection_photo_ids)
+                )
+                if covered_full_workspace:
+                    thread_db.set_workspace_group_state(
+                        workspace_id=workspace_id,
+                        fingerprint=compute_group_fingerprint(effective_cfg),
+                        when_ts=int(time.time()),
+                    )
                 else:
-                    results = run_full_pipeline(photos, config=pipeline_cfg, emit_trace=True)
-                    cache_dir = os.path.dirname(db_path)
-                    save_results(results, cache_dir, workspace_id)
+                    # Partial run — save_results just clobbered
+                    # pipeline_results_ws*.json with subset output, so any
+                    # pre-existing fingerprint now points at a cache that
+                    # no longer reflects the full workspace. Invalidate so
+                    # the pipeline page surfaces the staleness as will-run
+                    # instead of falsely reporting done-prior.
+                    thread_db.set_workspace_group_state(
+                        workspace_id=workspace_id,
+                        fingerprint=None,
+                        when_ts=None,
+                    )
 
-                    # Stamp the grouping fingerprint + timestamp BEFORE marking
-                    # the step completed, so a partial regroup that crashes
-                    # between here and update_step doesn't end up labeled "fresh"
-                    # with a stale fp.
-                    #
-                    # Only stamp when the regroup actually covered the whole
-                    # workspace — if it ran on a filtered subset (a
-                    # sub-collection, or with exclude_photo_ids set) some
-                    # workspace photos were intentionally not regrouped, so
-                    # claiming workspace-level freshness would let the pipeline
-                    # page hide a real stale state.
-                    from pipeline import (
-                        _resolve_collection_photo_ids,
-                        compute_group_fingerprint,
-                    )
-                    collection_photo_ids = _resolve_collection_photo_ids(
-                        thread_db, collection_id,
-                    )
-                    ws_photo_ids = {
-                        r["id"] for r in thread_db.conn.execute(
-                            """SELECT p.id
-                                 FROM photos p
-                                 JOIN workspace_folders wf
-                                   ON wf.folder_id = p.folder_id
-                                WHERE wf.workspace_id = ?""",
-                            (workspace_id,),
-                        ).fetchall()
-                    }
-                    covered_full_workspace = (
-                        not params.exclude_photo_ids
-                        and ws_photo_ids.issubset(collection_photo_ids)
-                    )
-                    if covered_full_workspace:
-                        thread_db.set_workspace_group_state(
-                            workspace_id=workspace_id,
-                            fingerprint=compute_group_fingerprint(effective_cfg),
-                            when_ts=int(time.time()),
-                        )
-                    else:
-                        # Partial run — save_results just clobbered
-                        # pipeline_results_ws*.json with subset output, so any
-                        # pre-existing fingerprint now points at a cache that
-                        # no longer reflects the full workspace. Invalidate so
-                        # the pipeline page surfaces the staleness as will-run
-                        # instead of falsely reporting done-prior.
-                        thread_db.set_workspace_group_state(
-                            workspace_id=workspace_id,
-                            fingerprint=None,
-                            when_ts=None,
-                        )
-
-                    stages["regroup"]["status"] = "completed"
-                    summary_info = results.get("summary", {})
-                    groups = summary_info.get("groups", "")
-                    deferred_step_update = {
-                        "status": "completed",
-                        "summary": f"{groups} groups" if groups else "Done",
-                    }
-                    result["stages"]["regroup"] = summary_info
+                stages["regroup"]["status"] = "completed"
+                summary_info = results.get("summary", {})
+                groups = summary_info.get("groups", "")
+                runner.update_step(
+                    job["id"], "regroup",
+                    status="completed",
+                    summary=f"{groups} groups" if groups else "Done",
+                )
+                result["stages"]["regroup"] = summary_info
         except Exception as e:
             errors.append(f"[regroup] Fatal: {e}")
             log.exception("Pipeline regroup stage failed")
             stages["regroup"]["status"] = "failed"
-            deferred_step_update = {"status": "failed", "error": str(e)}
-
-        if deferred_step_update is not None:
-            runner.update_step(job["id"], "regroup", **deferred_step_update)
+            runner.update_step(
+                job["id"], "regroup", status="failed", error=str(e),
+            )
         _update_stages(runner, job["id"], stages)
 
     def miss_stage():
@@ -3634,19 +3631,29 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
     if not abort.is_set():
         eye_keypoints_stage()
 
-    # Phase 4: regroup (needs extract-masks + eye-keypoints output)
+    # Phases 4 + 5: regroup and miss detection. Held under the
+    # per-workspace regroup lock TOGETHER so a concurrent same-workspace
+    # pipeline can't slip a regroup_stage in between this run's
+    # regroup_stage and its miss_stage — that would leave the persisted
+    # miss flags + ``miss_computed_at`` paired with a grouping
+    # (burst_id / pipeline_results_ws*.json) the miss computation never
+    # saw. Pipelines targeting different workspaces share neither
+    # stage's state and don't contend here.
     if not abort.is_set():
-        regroup_stage()
-
-    # Phase 5: miss detection (pure derivation from per-photo features +
-    # burst_id written by regroup). Cheap; no model inference.
-    # Skip when regroup failed: miss classification depends on regroup's
-    # burst_id output, so running here after a regroup failure would
-    # overwrite miss_* flags with stale context during an already-failing
-    # job. regroup_stage marks itself "failed" without setting abort, so
-    # check the stage status explicitly.
-    if not abort.is_set() and stages["regroup"].get("status") != "failed":
-        miss_stage()
+        with acquire_workspace_regroup(workspace_id):
+            regroup_stage()
+            # Skip miss when regroup failed: miss classification depends
+            # on regroup's burst_id output, so running here after a
+            # regroup failure would overwrite miss_* flags with stale
+            # context during an already-failing job. regroup_stage marks
+            # itself "failed" without setting abort, so check the stage
+            # status explicitly. abort.is_set() is re-checked too — a
+            # user cancel between regroup and miss should skip miss.
+            if (
+                not abort.is_set()
+                and stages["regroup"].get("status") != "failed"
+            ):
+                miss_stage()
 
     cancel_watcher_stop.set()
 

--- a/vireo/pipeline_locks.py
+++ b/vireo/pipeline_locks.py
@@ -8,14 +8,20 @@ Two primitives:
   classify doesn't completely starve a second pipeline that just wants
   one quick GPU op.
 
-* ``acquire_workspace_regroup(workspace_id)`` — a per-workspace lock so
-  two pipelines targeting the same workspace serialise on regroup but
-  not on earlier stages.
+* ``acquire_workspace_regroup(workspace_id)`` — a per-workspace lock
+  held across BOTH ``regroup_stage`` and ``miss_stage`` so two pipelines
+  targeting the same workspace can't interleave on the workspace-scoped
+  grouping state (``burst_id`` writes, ``pipeline_results_ws*.json``,
+  and the ``miss_computed_at`` timestamp paired with that grouping).
+  Pipelines on different workspaces never contend.
 
 Lock order (acquire outermost first): ``_progress_lock`` →
-``JobRunner._lock`` → ``acquire_workspace_regroup`` → ``acquire_gpu``.
-Never invert. The GPU lock is the innermost; nothing else may be acquired
-while it is held.
+``acquire_workspace_regroup`` → ``JobRunner._lock`` → ``acquire_gpu``.
+``JobRunner._lock`` is a brief leaf lock taken by ``runner.update_step``
+inside the workspace critical section; this is safe because no code
+path under ``JobRunner._lock`` acquires ``acquire_workspace_regroup``,
+so there is no cycle. ``acquire_gpu`` is the innermost: nothing else
+may be acquired while it is held.
 """
 
 import threading

--- a/vireo/pipeline_locks.py
+++ b/vireo/pipeline_locks.py
@@ -136,35 +136,52 @@ def _workspace_regroup_lock_for_tests(workspace_id):
     return acquire_workspace_regroup(workspace_id)
 
 
-# Per-(photo_id, variant) locks for mask extraction. Two concurrent
-# pipelines whose collections overlap can both reach extract_masks_stage
-# with the same photo and the same sam2_variant; without serialization
-# they'd both pass the get_photo_mask cache miss, both call generate_mask,
-# both write the deterministic ``masks/{photo_id}.{variant}.png`` path,
-# and the file on disk could end up describing a different mask than the
-# photo_masks row points at. The key includes variant so two pipelines
-# touching the same photo with DIFFERENT mask variants don't contend.
+# Per-photo locks for mask extraction. Two concurrent pipelines whose
+# collections overlap can both reach extract_masks_stage with the same
+# photo. The conflict has two distinct sources, and the lock has to
+# cover BOTH:
+#
+#   1. The deterministic ``masks/{photo_id}.{variant}.png`` file path
+#      (per-variant collision). Two pipelines with the SAME variant
+#      would corrupt each other's PNG bytes.
+#
+#   2. The denormalised writes to the ``photos`` row —
+#      ``set_active_mask_variant`` (mask_path, crop_complete,
+#      subject_tenengrad, bg_tenengrad) and ``update_photo_embeddings``
+#      (dino_subject_embedding, dino_global_embedding) — happen
+#      regardless of variant. Two pipelines processing the same photo
+#      with DIFFERENT variants can still interleave these writes,
+#      leaving photos.active_mask_variant pointing at one variant
+#      while photos.dino_subject_embedding was cropped from the
+#      other's mask.
+#
+# Because (2) crosses variants, the key is ``photo_id`` only.
+# Concurrency loss: two pipelines on the same photo with different
+# SAM variants now serialise on the whole extract-masks body. This is
+# rare in practice (it requires two workspaces sharing folders AND
+# configured with different SAM variants), and the alternative —
+# splitting into a per-variant lock for the mask file + a per-photo
+# lock for the row writes — would invert the lock order (a worker
+# holding the inner lock then trying to take the outer would deadlock).
 _PHOTO_MASK_LOCKS: dict = {}
 _PHOTO_MASK_LOCKS_GUARD = threading.Lock()
 
 
-def acquire_photo_mask(photo_id, variant):
-    """Context manager for the per-(photo_id, variant) mask-write lock.
+def acquire_photo_mask(photo_id):
+    """Context manager for the per-photo mask-write lock.
 
     Held across the get_photo_mask → generate_mask → save_mask →
-    upsert_photo_mask sequence in ``extract_masks_stage`` so two
-    pipelines hitting the same photo+variant serialise on that
-    sequence. Pipelines on different photos (or different variants of
-    the same photo) don't contend.
+    upsert_photo_mask → set_active_mask_variant → update_photo_embeddings
+    sequence in ``extract_masks_stage`` so two pipelines hitting the
+    same photo serialise. Pipelines on different photos don't contend.
     """
-    key = (photo_id, variant)
     with _PHOTO_MASK_LOCKS_GUARD:
-        lock = _PHOTO_MASK_LOCKS.get(key)
+        lock = _PHOTO_MASK_LOCKS.get(photo_id)
         if lock is None:
             lock = threading.Lock()
-            _PHOTO_MASK_LOCKS[key] = lock
+            _PHOTO_MASK_LOCKS[photo_id] = lock
     return lock
 
 
-def _photo_mask_lock_for_tests(photo_id, variant):
-    return acquire_photo_mask(photo_id, variant)
+def _photo_mask_lock_for_tests(photo_id):
+    return acquire_photo_mask(photo_id)

--- a/vireo/pipeline_locks.py
+++ b/vireo/pipeline_locks.py
@@ -134,3 +134,37 @@ def acquire_workspace_regroup(workspace_id):
 # the module-private dict directly.
 def _workspace_regroup_lock_for_tests(workspace_id):
     return acquire_workspace_regroup(workspace_id)
+
+
+# Per-(photo_id, variant) locks for mask extraction. Two concurrent
+# pipelines whose collections overlap can both reach extract_masks_stage
+# with the same photo and the same sam2_variant; without serialization
+# they'd both pass the get_photo_mask cache miss, both call generate_mask,
+# both write the deterministic ``masks/{photo_id}.{variant}.png`` path,
+# and the file on disk could end up describing a different mask than the
+# photo_masks row points at. The key includes variant so two pipelines
+# touching the same photo with DIFFERENT mask variants don't contend.
+_PHOTO_MASK_LOCKS: dict = {}
+_PHOTO_MASK_LOCKS_GUARD = threading.Lock()
+
+
+def acquire_photo_mask(photo_id, variant):
+    """Context manager for the per-(photo_id, variant) mask-write lock.
+
+    Held across the get_photo_mask → generate_mask → save_mask →
+    upsert_photo_mask sequence in ``extract_masks_stage`` so two
+    pipelines hitting the same photo+variant serialise on that
+    sequence. Pipelines on different photos (or different variants of
+    the same photo) don't contend.
+    """
+    key = (photo_id, variant)
+    with _PHOTO_MASK_LOCKS_GUARD:
+        lock = _PHOTO_MASK_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _PHOTO_MASK_LOCKS[key] = lock
+    return lock
+
+
+def _photo_mask_lock_for_tests(photo_id, variant):
+    return acquire_photo_mask(photo_id, variant)

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -1789,32 +1789,51 @@ def _block_pipeline_until(event, result=None):
     return work
 
 
+def _fill_pipeline_slots(runner, workspace_id):
+    """Enqueue ``SLOT_CAP`` blocking pipelines + wait for them all to
+    start, so the next enqueue lands in the queued state.
+
+    Returns ``(occupant_ids, release_event)``. Call ``release_event.set()``
+    to let them finish.
+    """
+    import threading
+
+    from jobs import SLOT_CAP
+    release = threading.Event()
+    started = [threading.Event() for _ in range(SLOT_CAP)]
+    ids = []
+    for i in range(SLOT_CAP):
+        evt = started[i]
+        def work(job, _evt=evt, _release=release):
+            _evt.set()
+            _release.wait(timeout=5.0)
+            return {}
+        ids.append(runner.enqueue_pipeline(
+            work_fn=work, config={}, workspace_id=workspace_id,
+        ))
+    for i, evt in enumerate(started):
+        assert evt.wait(timeout=2.0), f"slot-filler {i} never started"
+    return ids, release
+
+
 def test_cancel_queued_endpoint_cancels_all_queued_in_active_workspace(app_and_db):
     """POST /api/jobs/cancel-queued (no body) cancels every queued
     pipeline in the active workspace. The currently-running pipeline
     is left alone.
     """
-    import threading
     app, db = app_and_db
     runner = app._job_runner
     client = app.test_client()
     ws_id = db._active_workspace_id
 
-    # Pin slot 1 with a running pipeline so the next two stay queued.
-    release = threading.Event()
-    running_id = runner.enqueue_pipeline(
-        work_fn=_block_pipeline_until(release),
-        config={}, workspace_id=ws_id,
-    )
-    # Two queued pipelines behind it.
+    # Fill every slot so the next two enqueues stay queued.
+    occupant_ids, release = _fill_pipeline_slots(runner, ws_id)
     queued_a = runner.enqueue_pipeline(
         work_fn=lambda job: None, config={}, workspace_id=ws_id,
     )
     queued_b = runner.enqueue_pipeline(
         work_fn=lambda job: None, config={}, workspace_id=ws_id,
     )
-    # Sanity: both are queued, the first is running.
-    assert runner.get(running_id)["status"] == "running"
     assert runner.get(queued_a)["status"] == "queued"
     assert runner.get(queued_b)["status"] == "queued"
 
@@ -1834,12 +1853,14 @@ def test_cancel_queued_endpoint_cancels_all_queued_in_active_workspace(app_and_d
                 f"queued job {jid} should be cancelled, was {row['status']}"
             )
 
-        # Running pipeline is untouched.
-        assert runner.get(running_id)["status"] == "running"
+        # Slot-filler pipelines (still running) are untouched.
+        for jid in occupant_ids:
+            assert runner.get(jid)["status"] == "running"
     finally:
         release.set()
         from wait import wait_for_job_via_runner
-        wait_for_job_via_runner(runner, running_id)
+        for jid in occupant_ids:
+            wait_for_job_via_runner(runner, jid)
 
 
 def test_cancel_queued_endpoint_rejects_invalid_body(app_and_db):
@@ -1854,22 +1875,16 @@ def test_cancel_queued_endpoint_rejects_invalid_body(app_and_db):
 
 def test_cancel_queued_endpoint_rejects_malformed_json_without_cancel(app_and_db):
     """Malformed JSON must not fall back to the destructive default scope."""
-    import threading
 
     app, db = app_and_db
     runner = app._job_runner
     client = app.test_client()
     ws_id = db._active_workspace_id
 
-    release = threading.Event()
-    running_id = runner.enqueue_pipeline(
-        work_fn=_block_pipeline_until(release),
-        config={}, workspace_id=ws_id,
-    )
+    occupant_ids, release = _fill_pipeline_slots(runner, ws_id)
     queued_id = runner.enqueue_pipeline(
         work_fn=lambda job: None, config={}, workspace_id=ws_id,
     )
-    assert runner.get(running_id)["status"] == "running"
     assert runner.get(queued_id)["status"] == "queued"
 
     try:
@@ -1884,7 +1899,8 @@ def test_cancel_queued_endpoint_rejects_malformed_json_without_cancel(app_and_db
     finally:
         release.set()
         from wait import wait_for_job_via_runner
-        wait_for_job_via_runner(runner, running_id)
+        for jid in occupant_ids:
+            wait_for_job_via_runner(runner, jid)
         wait_for_job_via_runner(runner, queued_id)
 
 
@@ -1905,7 +1921,6 @@ def test_cancel_queued_endpoint_leaves_other_workspaces_alone(app_and_db):
     pipelines in that workspace are cancelled. Queued pipelines in
     other workspaces stay queued.
     """
-    import threading
     app, db = app_and_db
     runner = app._job_runner
     client = app.test_client()
@@ -1913,13 +1928,9 @@ def test_cancel_queued_endpoint_leaves_other_workspaces_alone(app_and_db):
     # Create a second workspace so we have a meaningful "other" id.
     ws_b = db.create_workspace("scoped-other")
 
-    # Pin the single slot so EVERY enqueued pipeline below stays queued
-    # regardless of workspace. (SLOT_CAP=1 in this PR.)
-    release = threading.Event()
-    pin_id = runner.enqueue_pipeline(
-        work_fn=_block_pipeline_until(release),
-        config={}, workspace_id=ws_a,
-    )
+    # Fill every slot in ws_a so subsequent enqueues (in either
+    # workspace) stay queued. Slot capacity is global, not per-workspace.
+    occupant_ids, release = _fill_pipeline_slots(runner, ws_a)
     queued_a = runner.enqueue_pipeline(
         work_fn=lambda job: None, config={}, workspace_id=ws_a,
     )
@@ -1951,7 +1962,8 @@ def test_cancel_queued_endpoint_leaves_other_workspaces_alone(app_and_db):
     finally:
         release.set()
         from wait import wait_for_job_via_runner
-        wait_for_job_via_runner(runner, pin_id)
+        for jid in occupant_ids:
+            wait_for_job_via_runner(runner, jid)
         # Cancel the surviving queued job so the test fixture's
         # teardown isn't waiting on a pipeline that will never run.
         runner.cancel_job(queued_b)

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6295,6 +6295,127 @@ def test_pipeline_miss_stage_skipped_when_regroup_fails(tmp_path, monkeypatch):
         )
 
 
+def test_workspace_regroup_lock_spans_regroup_and_miss(tmp_path, monkeypatch):
+    """The workspace_regroup lock must wrap BOTH regroup_stage and
+    miss_stage. Without a single lock spanning both, pipeline B could
+    sneak in between A's regroup release and A's miss acquire and
+    rewrite burst_id / pipeline_results_ws*.json — leaving the
+    persisted miss flags inconsistent with the cached grouping the
+    review UI reads for "Review misses".
+
+    Trace acquire/release vs. regroup-work and miss-step events and
+    verify release happens AFTER the miss step, not between them."""
+    import config as cfg
+    import pipeline as pipeline_mod
+    import pipeline_job as pj
+    import pipeline_locks
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    Image.new("RGB", (16, 16), "black").save(str(photo_dir / "a.jpg"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    events = []
+
+    real_acquire = pipeline_locks.acquire_workspace_regroup
+
+    class TrackingLock:
+        def __init__(self, inner, ws):
+            self._inner = inner
+            self._ws = ws
+
+        def __enter__(self):
+            events.append(("acquire", self._ws))
+            self._inner.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            events.append(("release", self._ws))
+            return self._inner.__exit__(*args)
+
+    monkeypatch.setattr(
+        pj, "acquire_workspace_regroup",
+        lambda ws: TrackingLock(real_acquire(ws), ws),
+    )
+
+    def _ok_run(photos, config=None, emit_trace=False):
+        events.append(("regroup_work", ws_id))
+        return {"summary": {"groups": 1}, "photos": photos}
+
+    monkeypatch.setattr(pipeline_mod, "run_full_pipeline", _ok_run)
+    monkeypatch.setattr(pipeline_mod, "save_results", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        pipeline_mod, "load_photo_features",
+        lambda thread_db, collection_id=None, config=None: [{"id": 1}],
+    )
+
+    class TrackingRunner(FakeRunner):
+        def update_step(self, job_id, step_id, **kwargs):
+            if step_id == "misses":
+                events.append(("miss_step", kwargs.get("status")))
+            super().update_step(job_id, step_id, **kwargs)
+
+    # skip_classify=True keeps the test from needing real model files;
+    # miss_stage takes its early-skip path but still calls update_step
+    # on the "misses" step — which must happen INSIDE the lock.
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+    )
+    runner = TrackingRunner()
+    job = _make_job()
+
+    with contextlib.suppress(Exception):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # Strip events from earlier stages that don't touch the regroup lock.
+    interesting = [
+        e for e in events
+        if e[0] in ("acquire", "release", "regroup_work", "miss_step")
+    ]
+    assert ("acquire", ws_id) in interesting, (
+        f"workspace_regroup lock was never acquired; events: {interesting}"
+    )
+    assert ("release", ws_id) in interesting, (
+        f"workspace_regroup lock was never released; events: {interesting}"
+    )
+
+    acquire_idx = interesting.index(("acquire", ws_id))
+    release_idx = interesting.index(("release", ws_id))
+    regroup_idx = next(
+        (i for i, e in enumerate(interesting) if e[0] == "regroup_work"),
+        None,
+    )
+    miss_idx = next(
+        (i for i, e in enumerate(interesting) if e[0] == "miss_step"),
+        None,
+    )
+
+    assert regroup_idx is not None, (
+        f"regroup work never ran; events: {interesting}"
+    )
+    assert miss_idx is not None, (
+        f"miss step never ran; events: {interesting}"
+    )
+    assert acquire_idx < regroup_idx < release_idx, (
+        f"regroup work must run inside the lock; events: {interesting}"
+    )
+    assert acquire_idx < miss_idx < release_idx, (
+        "miss step must run inside the same lock as regroup — otherwise "
+        "a second same-workspace pipeline could sneak in and rewrite "
+        f"grouping state between them. events: {interesting}"
+    )
+
+
 def test_pipeline_regroup_stamps_workspace_group_fingerprint(tmp_path, monkeypatch):
     """When regroup_stage completes successfully, last_grouped_at and
     last_group_fingerprint must be written on the active workspace so the

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -7142,6 +7142,124 @@ def _run_extract_masks_for_test(
     return db, runner, generate_mask_calls, photo_ids
 
 
+def _apply_extract_masks_stubs(monkeypatch, generate_mask_calls):
+    """(Re)install the SAM2/DINOv2 stubs for a follow-up extract_masks run on
+    an existing DB. generate_mask appends (variant, det_box) to the passed
+    list so the caller can assert whether SAM ran.
+    """
+    import dino_embed
+    import masking
+    import numpy as np
+    import quality
+
+    monkeypatch.setattr(
+        masking, "render_proxy",
+        lambda *a, **k: np.zeros((4, 4, 3), dtype=np.uint8),
+    )
+
+    def fake_generate_mask(proxy, det_box, variant=None):
+        generate_mask_calls.append((variant, tuple(sorted(det_box.items()))))
+        return np.ones((4, 4), dtype=bool)
+
+    monkeypatch.setattr(masking, "generate_mask", fake_generate_mask)
+    monkeypatch.setattr(masking, "crop_completeness", lambda m: 0.9)
+    monkeypatch.setattr(masking, "crop_subject", lambda p, m, margin=0.15: None)
+    monkeypatch.setattr(masking, "ensure_sam2_weights", lambda **k: None)
+    monkeypatch.setattr(
+        quality, "compute_all_quality_features",
+        lambda p, m: {
+            "subject_tenengrad": 1.5, "bg_tenengrad": 0.3,
+            "subject_clip_high": 0.01, "subject_clip_low": 0.01,
+            "subject_y_median": 100.0, "bg_separation": 50.0,
+            "phash_crop": "deadbeef", "noise_estimate": 5.0,
+        },
+    )
+    monkeypatch.setattr(
+        dino_embed, "embed",
+        lambda p, variant=None: np.zeros(384, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        dino_embed, "embed_batch",
+        lambda imgs, variant=None: np.zeros((len(imgs), 384), dtype=np.float32),
+    )
+    monkeypatch.setattr(dino_embed, "embedding_to_blob", lambda e: b"")
+    monkeypatch.setattr(dino_embed, "ensure_dinov2_weights", lambda **k: None)
+
+
+def test_extract_masks_recomputes_when_active_variant_differs(
+    tmp_path, monkeypatch,
+):
+    """Cross-variant cache-hit consistency (Codex P2 on PR #907).
+
+    A cached mask exists for the *requested* SAM variant, but the photos
+    row is currently active on a DIFFERENT variant (e.g. two workspaces
+    share a folder, one configured sam2-small and one sam2-large, both on
+    dinov2 vit-b14). The cheap "re-activate only" fast path would call
+    set_active_mask_variant — denormalising the requested variant's mask
+    features — WITHOUT update_photo_embeddings, leaving photos.dino_*
+    describing the previously-active variant's mask. regroup reads both off
+    the photos row, so it would mix one variant's mask features with
+    another's embedding. The fix forces a recompute when the active variant
+    (or dino embedding variant) doesn't already match, so generate_mask runs
+    and the photos row ends internally consistent.
+    """
+    import config as cfg
+
+    spec = {"filename": "a.jpg", "box": (10, 20, 100, 200),
+            "model": "MegaDetector"}
+
+    # Run 1: variant small → photo_masks[small], photos.active=small.
+    db, _, _, photo_ids = _run_extract_masks_for_test(
+        tmp_path, monkeypatch, "sam2-small", [spec],
+    )
+    pid = photo_ids[0]
+    db_path = str(tmp_path / "test.db")
+    ws_id = db._active_workspace_id
+    col_id = db.conn.execute(
+        "SELECT id FROM collections ORDER BY id LIMIT 1"
+    ).fetchone()[0]
+
+    def rerun(variant):
+        calls = []
+        _apply_extract_masks_stubs(monkeypatch, calls)
+        cfg.save({"pipeline": {"sam2_variant": variant,
+                               "dinov2_variant": "vit-b14"}})
+        run_pipeline_job(
+            _make_job(), FakeRunner(), db_path, ws_id,
+            PipelineParams(collection_id=col_id, skip_classify=True,
+                           skip_extract_masks=False, skip_regroup=True),
+        )
+        return calls
+
+    # Run 2: variant large → adds photo_masks[large], photos.active=large.
+    calls_large = rerun("sam2-large")
+    assert calls_large, "switching to a new variant must run SAM"
+    state = db.conn.execute(
+        "SELECT active_mask_variant FROM photos WHERE id=?", (pid,),
+    ).fetchone()
+    assert state["active_mask_variant"] == "sam2-large"
+    # Both variant rows now cached on disk.
+    variants = {r["variant"] for r in db.list_masks_for_photo(pid)}
+    assert variants == {"sam2-small", "sam2-large"}
+
+    # Run 3: back to small. The small row is cached (prompt+detector match,
+    # file on disk) so the OLD code would cheap-skip via set_active_mask_
+    # variant and never touch embeddings. With the fix, because the photos
+    # row is active on large, the stage recomputes: generate_mask runs for
+    # small and the row ends active+consistent on small.
+    calls_small = rerun("sam2-small")
+    assert calls_small, (
+        "cached mask but stale active variant must recompute, not cheap-skip; "
+        f"generate_mask was not called: {calls_small}"
+    )
+    final = db.conn.execute(
+        "SELECT active_mask_variant, dino_embedding_variant FROM photos "
+        "WHERE id=?", (pid,),
+    ).fetchone()
+    assert final["active_mask_variant"] == "sam2-small"
+    assert final["dino_embedding_variant"] == "vit-b14"
+
+
 def test_extract_masks_skips_sam_when_cached_with_same_prompt(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -620,6 +620,87 @@ def test_pipeline_previews_stage_runs(tmp_path, monkeypatch):
         "Expected 'previews' stage in progress events"
 
 
+def test_pipeline_previews_stage_writes_atomically(tmp_path, monkeypatch):
+    """previews_stage must write to a sibling temp file then os.replace into
+    the deterministic ``previews/{id}_{max_size}.jpg`` path.
+
+    With SLOT_CAP > 1, two pipelines processing the same photo can both miss
+    the os.path.exists() cache check and race on the same deterministic path.
+    A direct img.save(cache_path) would interleave/truncate bytes, leaving a
+    corrupt JPEG that preview_cache claims is valid. Regression for Codex
+    P2 review on PR #907.
+    """
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    Image.new("RGB", (100, 100), "red").save(str(photo_dir / "a.jpg"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # Capture every path Image.save() is invoked with so we can prove the
+    # final cache_path was never the direct target — only the os.replace
+    # destination is.
+    saved_paths = []
+    real_save = Image.Image.save
+
+    def tracking_save(self, fp, *args, **kwargs):
+        saved_paths.append(fp)
+        return real_save(self, fp, *args, **kwargs)
+
+    monkeypatch.setattr(Image.Image, "save", tracking_save)
+
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+        preview_max_size=1920,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    preview_dir = os.path.join(os.path.dirname(db_path), "previews")
+    db2 = Database(db_path)
+    db2.set_active_workspace(ws_id)
+    photo_id = db2.get_photos(per_page=1)[0]["id"]
+    final_path = os.path.join(preview_dir, f"{photo_id}_1920.jpg")
+
+    # The final preview must exist and be a complete, openable JPEG (proves
+    # os.replace ran).
+    assert os.path.isfile(final_path)
+    with Image.open(final_path) as img:
+        img.verify()
+
+    # No Image.save call targeted the final deterministic path directly —
+    # every write went through a sibling temp file. Thumbnails go through
+    # generate_thumbnail (also atomic) so those saves also won't target the
+    # preview path; restrict the check to saves inside preview_dir.
+    preview_dir_saves = [
+        p for p in saved_paths
+        if isinstance(p, (str, bytes)) and str(p).startswith(preview_dir)
+    ]
+    assert preview_dir_saves, "previews_stage should have written at least one file"
+    for p in preview_dir_saves:
+        assert str(p) != final_path, (
+            f"previews_stage wrote directly to {final_path}; expected a "
+            "temp sibling + os.replace to make the swap atomic under "
+            "concurrent same-photo pipelines"
+        )
+        assert str(p).endswith(".jpg.tmp"), (
+            f"expected .jpg.tmp temp file, got {p}"
+        )
+
+
 def test_pipeline_params_sources_used_over_source():
     """When sources is provided, it should take precedence over source."""
     params = PipelineParams(source="/single", sources=["/a", "/b"])

--- a/vireo/tests/test_pipeline_locks.py
+++ b/vireo/tests/test_pipeline_locks.py
@@ -11,6 +11,7 @@ from pipeline_locks import (
     _GPU_SEMAPHORE,
     acquire_gpu,
     acquire_gpu_if_session_uses_it,
+    acquire_photo_mask,
     acquire_workspace_regroup,
 )
 
@@ -188,3 +189,96 @@ def test_workspace_regroup_lock_reentrant_keys_share_one_lock():
     lock1 = _workspace_regroup_lock_for_tests(7)
     lock2 = _workspace_regroup_lock_for_tests(7)
     assert lock1 is lock2
+
+
+def test_photo_mask_lock_serialises_same_photo_and_variant():
+    """Two threads writing the same (photo, variant) take turns."""
+    held = []
+
+    def first():
+        with acquire_photo_mask(42, "sam2-small"):
+            held.append("first-in")
+            time.sleep(0.05)
+            held.append("first-out")
+
+    def second():
+        with acquire_photo_mask(42, "sam2-small"):
+            held.append("second-in")
+
+    t1 = threading.Thread(target=first)
+    t2 = threading.Thread(target=second)
+    t1.start()
+    _wait_until(lambda: "first-in" in held)
+    t2.start()
+    t1.join(timeout=3.0)
+    t2.join(timeout=3.0)
+    assert not t1.is_alive() and not t2.is_alive()
+    assert held == ["first-in", "first-out", "second-in"], held
+
+
+def test_photo_mask_lock_does_not_block_different_photo():
+    """Same variant, different photo IDs don't contend."""
+    held = []
+    first_holding = threading.Event()
+    let_first_go = threading.Event()
+
+    def first():
+        with acquire_photo_mask(1, "sam2-small"):
+            held.append("first-in")
+            first_holding.set()
+            let_first_go.wait(timeout=2.0)
+
+    def second():
+        with acquire_photo_mask(2, "sam2-small"):
+            held.append("second-in")
+
+    t1 = threading.Thread(target=first)
+    t2 = threading.Thread(target=second)
+    t1.start()
+    assert first_holding.wait(timeout=1.0)
+    t2.start()
+    t2.join(timeout=1.0)
+    assert not t2.is_alive(), "different photo must not be blocked"
+    assert "second-in" in held
+    let_first_go.set()
+    t1.join(timeout=2.0)
+
+
+def test_photo_mask_lock_does_not_block_different_variant():
+    """Same photo, different variants don't contend — each variant has
+    its own deterministic mask path, so they don't conflict.
+    """
+    held = []
+    first_holding = threading.Event()
+    let_first_go = threading.Event()
+
+    def first():
+        with acquire_photo_mask(42, "sam2-small"):
+            held.append("first-in")
+            first_holding.set()
+            let_first_go.wait(timeout=2.0)
+
+    def second():
+        with acquire_photo_mask(42, "sam2-large"):
+            held.append("second-in")
+
+    t1 = threading.Thread(target=first)
+    t2 = threading.Thread(target=second)
+    t1.start()
+    assert first_holding.wait(timeout=1.0)
+    t2.start()
+    t2.join(timeout=1.0)
+    assert not t2.is_alive(), "different variant must not be blocked"
+    assert "second-in" in held
+    let_first_go.set()
+    t1.join(timeout=2.0)
+
+
+def test_photo_mask_lock_reentrant_keys_share_one_lock():
+    """The lock object for a given (photo_id, variant) is stable."""
+    from pipeline_locks import _photo_mask_lock_for_tests
+    lock1 = _photo_mask_lock_for_tests(7, "sam2-small")
+    lock2 = _photo_mask_lock_for_tests(7, "sam2-small")
+    lock3 = _photo_mask_lock_for_tests(7, "sam2-large")
+    assert lock1 is lock2
+    assert lock1 is not lock3

--- a/vireo/tests/test_pipeline_locks.py
+++ b/vireo/tests/test_pipeline_locks.py
@@ -191,18 +191,18 @@ def test_workspace_regroup_lock_reentrant_keys_share_one_lock():
     assert lock1 is lock2
 
 
-def test_photo_mask_lock_serialises_same_photo_and_variant():
-    """Two threads writing the same (photo, variant) take turns."""
+def test_photo_mask_lock_serialises_same_photo():
+    """Two threads writing the same photo's mask take turns."""
     held = []
 
     def first():
-        with acquire_photo_mask(42, "sam2-small"):
+        with acquire_photo_mask(42):
             held.append("first-in")
             time.sleep(0.05)
             held.append("first-out")
 
     def second():
-        with acquire_photo_mask(42, "sam2-small"):
+        with acquire_photo_mask(42):
             held.append("second-in")
 
     t1 = threading.Thread(target=first)
@@ -217,19 +217,19 @@ def test_photo_mask_lock_serialises_same_photo_and_variant():
 
 
 def test_photo_mask_lock_does_not_block_different_photo():
-    """Same variant, different photo IDs don't contend."""
+    """Different photo IDs don't contend — common case."""
     held = []
     first_holding = threading.Event()
     let_first_go = threading.Event()
 
     def first():
-        with acquire_photo_mask(1, "sam2-small"):
+        with acquire_photo_mask(1):
             held.append("first-in")
             first_holding.set()
             let_first_go.wait(timeout=2.0)
 
     def second():
-        with acquire_photo_mask(2, "sam2-small"):
+        with acquire_photo_mask(2):
             held.append("second-in")
 
     t1 = threading.Thread(target=first)
@@ -244,22 +244,34 @@ def test_photo_mask_lock_does_not_block_different_photo():
     t1.join(timeout=2.0)
 
 
-def test_photo_mask_lock_does_not_block_different_variant():
-    """Same photo, different variants don't contend — each variant has
-    its own deterministic mask path, so they don't conflict.
+def test_photo_mask_lock_serialises_same_photo_across_variants():
+    """Same photo, DIFFERENT SAM variants still take turns.
+
+    Cross-variant serialisation is load-bearing: ``set_active_mask_variant``
+    and ``update_photo_embeddings`` denormalise into the same ``photos``
+    row regardless of variant, so interleaved writes between two
+    pipelines on the same photo with different variants would corrupt
+    the row (e.g. active_mask_variant=large but dino embedding cropped
+    from small's mask). The lock keys on photo_id only — variant is
+    intentionally NOT part of the key.
+
+    The pipeline_job call site passes only photo_id; this test exercises
+    the lock primitive directly to lock in the cross-variant guarantee.
     """
     held = []
     first_holding = threading.Event()
     let_first_go = threading.Event()
 
     def first():
-        with acquire_photo_mask(42, "sam2-small"):
+        # Caller treats lock as photo-scoped — variant is irrelevant.
+        with acquire_photo_mask(42):
             held.append("first-in")
             first_holding.set()
             let_first_go.wait(timeout=2.0)
+            held.append("first-out")
 
     def second():
-        with acquire_photo_mask(42, "sam2-large"):
+        with acquire_photo_mask(42):
             held.append("second-in")
 
     t1 = threading.Thread(target=first)
@@ -267,18 +279,20 @@ def test_photo_mask_lock_does_not_block_different_variant():
     t1.start()
     assert first_holding.wait(timeout=1.0)
     t2.start()
-    t2.join(timeout=1.0)
-    assert not t2.is_alive(), "different variant must not be blocked"
-    assert "second-in" in held
+    # Second must block until first releases — even though semantically
+    # the two pipelines might be working different variants.
+    assert not held.count("second-in"), (
+        "second thread ran while first held the photo lock"
+    )
     let_first_go.set()
     t1.join(timeout=2.0)
+    t2.join(timeout=2.0)
+    assert held == ["first-in", "first-out", "second-in"], held
 
 
 def test_photo_mask_lock_reentrant_keys_share_one_lock():
-    """The lock object for a given (photo_id, variant) is stable."""
+    """The lock object for a given photo_id is stable across calls."""
     from pipeline_locks import _photo_mask_lock_for_tests
-    lock1 = _photo_mask_lock_for_tests(7, "sam2-small")
-    lock2 = _photo_mask_lock_for_tests(7, "sam2-small")
-    lock3 = _photo_mask_lock_for_tests(7, "sam2-large")
+    lock1 = _photo_mask_lock_for_tests(7)
+    lock2 = _photo_mask_lock_for_tests(7)
     assert lock1 is lock2
-    assert lock1 is not lock3

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -3,8 +3,9 @@
 
 The queue persists pending pipeline runs in ``job_history`` with
 ``status='queued'`` and promotes them to ``status='running'`` as slot
-capacity opens. ``SLOT_CAP`` is 1 in this PR — the second queued run
-waits for the first to reach a terminal state before promotion.
+capacity opens. Tests that need a "queued" precondition use
+``_fill_slots()`` to occupy every slot with blocking pipelines first,
+so they stay meaningful regardless of the current ``SLOT_CAP`` value.
 """
 
 import threading
@@ -15,6 +16,30 @@ from wait import wait_for_job_via_runner
 
 def _wait_for_event(event, label, timeout=2.0):
     assert event.wait(timeout=timeout), f"{label} did not happen"
+
+
+def _fill_slots(runner, workspace_id=1):
+    """Enqueue ``SLOT_CAP`` blocking pipelines and wait for them all to
+    start. Returns ``(ids, release_event)``; call ``release_event.set()``
+    to let them finish. Used by tests that need the next enqueue to
+    land in the ``queued`` state.
+    """
+    from jobs import SLOT_CAP
+    release = threading.Event()
+    started_events = [threading.Event() for _ in range(SLOT_CAP)]
+    ids = []
+    for i in range(SLOT_CAP):
+        evt = started_events[i]
+        def work(job, _evt=evt, _release=release):
+            _evt.set()
+            _release.wait(timeout=5.0)
+            return {}
+        ids.append(runner.enqueue_pipeline(
+            work_fn=work, config={}, workspace_id=workspace_id,
+        ))
+    for i, evt in enumerate(started_events):
+        assert evt.wait(timeout=2.0), f"slot-filler {i} never started"
+    return ids, release
 
 
 def _make_runner_with_db(tmp_path):
@@ -59,22 +84,11 @@ def test_enqueue_pipeline_persists_queued_row(tmp_path):
     cross-connection (different sqlite handle).
     """
     runner, _ = _make_runner_with_db(tmp_path)
-    # Block the first pipeline so the read below sees a non-terminal
-    # state; without it the trivial lambda runs to completion before
-    # the assertion fires and the status would be 'completed'.
-    first_started = threading.Event()
-    blocker = threading.Event()
-
-    def first_work(job):
-        first_started.set()
-        blocker.wait(timeout=3.0)
-        return {}
-
-    first_id = runner.enqueue_pipeline(
-        work_fn=first_work,
-        config={}, workspace_id=1,
-    )
-    _wait_for_event(first_started, "first pipeline start")
+    # Fill every slot with blocking pipelines so the next enqueue
+    # lands in 'queued'. Without this the trivial lambda would run
+    # to completion before the assertion fires and the status would
+    # be 'completed'.
+    filler_ids, blocker = _fill_slots(runner)
     job_id = runner.enqueue_pipeline(
         work_fn=lambda job: None,
         config={"sources": ["/a"]},
@@ -101,7 +115,8 @@ def test_enqueue_pipeline_persists_queued_row(tmp_path):
     assert row["workspace_id"] == 42
 
     blocker.set()
-    wait_for_job_via_runner(runner, first_id)
+    for fid in filler_ids:
+        wait_for_job_via_runner(runner, fid)
     wait_for_job_via_runner(runner, job_id)
 
 
@@ -125,50 +140,107 @@ def test_enqueue_pipeline_promotes_immediately_when_slot_free(tmp_path):
     assert job["result"] == {"ok": True}
 
 
-def test_second_enqueue_while_first_running_stays_queued(tmp_path):
-    """A second enqueue while the slot is occupied must NOT start
-    running. SLOT_CAP is 1 in this PR; the second waits.
+def test_enqueue_beyond_slot_cap_stays_queued(tmp_path):
+    """Enqueueing one more than ``SLOT_CAP`` pipelines while the slots
+    are full must leave the extra one ``queued``. The cap is the
+    concurrency contract — phrased against the module constant so this
+    test stays meaningful regardless of whether the cap is 1, 2, or
+    bumped later.
     """
+    from jobs import SLOT_CAP
+    runner, _ = _make_runner_with_db(tmp_path)
+    blocker = threading.Event()
+    started_events = [threading.Event() for _ in range(SLOT_CAP)]
+    extra_started = threading.Event()
+
+    def make_blocking_work(started_event):
+        def work(job):
+            started_event.set()
+            blocker.wait(timeout=3.0)
+            return {}
+        return work
+
+    # Fill every slot with a blocking pipeline.
+    occupant_ids = []
+    for i in range(SLOT_CAP):
+        jid = runner.enqueue_pipeline(
+            work_fn=make_blocking_work(started_events[i]),
+            config={}, workspace_id=1,
+        )
+        occupant_ids.append(jid)
+    for i, evt in enumerate(started_events):
+        assert evt.wait(timeout=2.0), f"occupant {i} never started"
+
+    # One more — must stay queued, NOT run.
+    def extra_work(job):
+        extra_started.set()
+        return {"extra": True}
+
+    extra_id = runner.enqueue_pipeline(
+        work_fn=extra_work, config={}, workspace_id=1,
+    )
+    assert not extra_started.wait(timeout=0.2), (
+        f"extra pipeline started while all {SLOT_CAP} slots occupied"
+    )
+    extra_view = runner.get(extra_id)
+    assert extra_view is not None
+    assert extra_view["status"] == "queued"
+
+    # Release the occupants; the extra must now promote.
+    blocker.set()
+    for jid in occupant_ids:
+        wait_for_job_via_runner(runner, jid)
+    assert extra_started.wait(timeout=2.0), (
+        "extra pipeline did not promote after slots cleared"
+    )
+    wait_for_job_via_runner(runner, extra_id)
+
+
+def test_two_pipelines_run_concurrently_when_slot_cap_at_least_two(tmp_path):
+    """Two enqueued pipelines must both reach the running state at the
+    same time when ``SLOT_CAP >= 2``. This is the real concurrency
+    contract Step 6 enables; the test is skipped on installs that
+    deliberately keep ``SLOT_CAP=1`` so reviewers can flip the cap
+    back temporarily without false test failures.
+    """
+    from jobs import SLOT_CAP
+    if SLOT_CAP < 2:
+        import pytest
+        pytest.skip(f"SLOT_CAP={SLOT_CAP}; concurrency test requires >=2")
+
     runner, _ = _make_runner_with_db(tmp_path)
     first_started = threading.Event()
-    let_first_finish = threading.Event()
     second_started = threading.Event()
+    blocker = threading.Event()
 
     def first_work(job):
         first_started.set()
-        let_first_finish.wait(timeout=3.0)
+        blocker.wait(timeout=3.0)
         return {"first": True}
 
     def second_work(job):
         second_started.set()
+        blocker.wait(timeout=3.0)
         return {"second": True}
 
     first_id = runner.enqueue_pipeline(
         work_fn=first_work, config={}, workspace_id=1,
     )
-    assert first_started.wait(timeout=2.0), "first work_fn never started"
-
     second_id = runner.enqueue_pipeline(
         work_fn=second_work, config={}, workspace_id=1,
     )
-    # Second must NOT have started yet — slot is occupied.
-    assert not second_started.wait(timeout=0.2), (
-        "second pipeline started while slot was occupied"
-    )
-    # Verify status via the runner's accessor.
-    second_view = runner.get(second_id)
-    assert second_view is not None
-    assert second_view["status"] == "queued"
 
-    # Release the first; second must now promote and run.
-    let_first_finish.set()
-    wait_for_job_via_runner(runner, first_id)
+    # Both work_fns must be invoked WITHOUT either one finishing —
+    # the second must NOT have waited for the first to terminate.
+    assert first_started.wait(timeout=2.0), "first pipeline did not start"
     assert second_started.wait(timeout=2.0), (
-        "second pipeline did not promote after first completed"
+        "second pipeline did not start concurrently with first — "
+        "SLOT_CAP appears to still be 1 or the scheduler is serialising"
     )
-    second_final = wait_for_job_via_runner(runner, second_id)
-    assert second_final["status"] == "completed"
-    assert second_final["result"] == {"second": True}
+
+    blocker.set()
+    wait_for_job_via_runner(runner, first_id)
+    wait_for_job_via_runner(runner, second_id)
 
 
 def test_startup_sweep_marks_orphan_running_rows_as_failed(tmp_path):
@@ -251,18 +323,7 @@ def test_queued_pipeline_is_visible_via_get(tmp_path):
     endpoint to render queue state.
     """
     runner, _ = _make_runner_with_db(tmp_path)
-    first_started = threading.Event()
-    blocker = threading.Event()
-
-    def blocking_work(job):
-        first_started.set()
-        blocker.wait(timeout=3.0)
-        return {}
-
-    first_id = runner.enqueue_pipeline(
-        work_fn=blocking_work, config={}, workspace_id=1,
-    )
-    _wait_for_event(first_started, "first pipeline start")
+    filler_ids, blocker = _fill_slots(runner)
     second_id = runner.enqueue_pipeline(
         work_fn=lambda job: {"ok": True}, config={"x": 1}, workspace_id=2,
     )
@@ -275,7 +336,8 @@ def test_queued_pipeline_is_visible_via_get(tmp_path):
     assert view["workspace_id"] == 2
 
     blocker.set()
-    wait_for_job_via_runner(runner, first_id)
+    for fid in filler_ids:
+        wait_for_job_via_runner(runner, fid)
     wait_for_job_via_runner(runner, second_id)
 
 
@@ -285,21 +347,13 @@ def test_cancel_queued_pipeline_transitions_row_to_cancelled(tmp_path):
     in-memory context so promotion never picks it up.
     """
     runner, db = _make_runner_with_db(tmp_path)
-    blocker = threading.Event()
-    first_started = threading.Event()
     second_started = threading.Event()
-
-    def first_work(job):
-        first_started.set()
-        blocker.wait(timeout=3.0)
-        return {}
 
     def second_work(job):
         second_started.set()
         return {"should-not-run": True}
 
-    first_id = runner.enqueue_pipeline(work_fn=first_work, config={}, workspace_id=1)
-    _wait_for_event(first_started, "first pipeline start")
+    filler_ids, blocker = _fill_slots(runner)
     second_id = runner.enqueue_pipeline(work_fn=second_work, config={}, workspace_id=1)
     assert runner.get(second_id)["status"] == "queued"
 
@@ -318,9 +372,10 @@ def test_cancel_queued_pipeline_transitions_row_to_cancelled(tmp_path):
     ).fetchone()
     assert row["status"] == "cancelled"
 
-    # Releasing the first must NOT promote the cancelled one.
+    # Releasing the slot-fillers must NOT promote the cancelled one.
     blocker.set()
-    wait_for_job_via_runner(runner, first_id)
+    for fid in filler_ids:
+        wait_for_job_via_runner(runner, fid)
     # Wait briefly; the cancelled row must never be promoted.
     assert not second_started.wait(timeout=0.3), (
         "cancelled queued job must not be promoted"
@@ -849,20 +904,10 @@ def test_retention_does_not_prune_queued_row_under_load(tmp_path):
     runner, db = _make_runner_with_db(tmp_path)
     try:
         ws = db._active_workspace_id
-        first_started = threading.Event()
-        blocker = threading.Event()
 
-        def first_work(job):
-            first_started.set()
-            blocker.wait(timeout=10.0)
-            return {}
-
-        # Long-running first pipeline holds the slot.
-        first_id = runner.enqueue_pipeline(
-            work_fn=first_work,
-            config={}, workspace_id=ws,
-        )
-        _wait_for_event(first_started, "first pipeline start")
+        # Long-running pipelines fill every slot so the next enqueue
+        # lands in 'queued'.
+        filler_ids, blocker = _fill_slots(runner, workspace_id=ws)
         # Queued pipeline.
         queued_id = runner.enqueue_pipeline(
             work_fn=lambda job: {"ran": True},
@@ -915,9 +960,10 @@ def test_retention_does_not_prune_queued_row_under_load(tmp_path):
         )
         assert row["status"] == "queued"
 
-        # And promotion still works when the slot opens.
+        # And promotion still works when the slots open.
         blocker.set()
-        wait_for_job_via_runner(runner, first_id)
+        for fid in filler_ids:
+            wait_for_job_via_runner(runner, fid)
         second_final = wait_for_job_via_runner(runner, queued_id)
         assert second_final["status"] == "completed"
         assert second_final["result"] == {"ran": True}
@@ -936,42 +982,33 @@ def test_get_history_excludes_queued_rows(tmp_path):
     try:
         ws = db._active_workspace_id
 
-        first_started = threading.Event()
-        blocker = threading.Event()
-
-        def first_work(job):
-            first_started.set()
-            blocker.wait(timeout=3.0)
-            return {}
-
-        first_id = runner.enqueue_pipeline(
-            work_fn=first_work,
-            config={}, workspace_id=ws,
-        )
-        _wait_for_event(first_started, "first pipeline start")
+        filler_ids, blocker = _fill_slots(runner, workspace_id=ws)
         queued_id = runner.enqueue_pipeline(
             work_fn=lambda job: None, config={}, workspace_id=ws,
         )
 
-        # Sanity: both rows exist with non-terminal status.
+        # Sanity: queued row is non-terminal.
         assert runner.get(queued_id)["status"] == "queued"
 
-        # History must NOT include either live row.
+        # History must NOT include any live row.
         history_ids = [j["id"] for j in runner.get_history(db, limit=50)]
-        assert first_id not in history_ids, (
-            "running rows belong to live state, not history"
-        )
+        for fid in filler_ids:
+            assert fid not in history_ids, (
+                "running rows belong to live state, not history"
+            )
         assert queued_id not in history_ids, (
             "queued rows belong to live state, not history"
         )
 
         blocker.set()
-        wait_for_job_via_runner(runner, first_id)
+        for fid in filler_ids:
+            wait_for_job_via_runner(runner, fid)
         wait_for_job_via_runner(runner, queued_id)
 
-        # After completion both DO appear in history.
+        # After completion the live rows DO appear in history.
         history_ids = [j["id"] for j in runner.get_history(db, limit=50)]
-        assert first_id in history_ids
+        for fid in filler_ids:
+            assert fid in history_ids
         assert queued_id in history_ids
     finally:
         db.close()
@@ -985,23 +1022,15 @@ def test_list_jobs_includes_queued_pipelines(tmp_path):
     and can't be cancelled from /jobs.
     """
     runner, _ = _make_runner_with_db(tmp_path)
-    first_started = threading.Event()
-    blocker = threading.Event()
-
-    def first_work(job):
-        first_started.set()
-        blocker.wait(timeout=3.0)
-        return {}
-
-    first_id = runner.enqueue_pipeline(first_work, config={}, workspace_id=1)
-    _wait_for_event(first_started, "first pipeline start")
+    filler_ids, blocker = _fill_slots(runner)
     second_id = runner.enqueue_pipeline(
         lambda job: None, config={"x": 7}, workspace_id=2,
     )
 
     all_jobs = runner.list_jobs()
     ids = {j["id"]: j for j in all_jobs}
-    assert first_id in ids
+    for fid in filler_ids:
+        assert fid in ids
     assert second_id in ids, (
         "queued pipeline must be visible through list_jobs() so the "
         "navbar/jobs page can render and cancel it"
@@ -1012,7 +1041,8 @@ def test_list_jobs_includes_queued_pipelines(tmp_path):
     assert ids[second_id]["workspace_id"] == 2
 
     blocker.set()
-    wait_for_job_via_runner(runner, first_id)
+    for fid in filler_ids:
+        wait_for_job_via_runner(runner, fid)
     wait_for_job_via_runner(runner, second_id)
 
 
@@ -1024,16 +1054,7 @@ def test_cancelling_queued_pipeline_emits_complete_event_to_sse(tmp_path):
     and the SSE loop reports the job as 'expired'.
     """
     runner, _ = _make_runner_with_db(tmp_path)
-    first_started = threading.Event()
-    blocker = threading.Event()
-
-    def first_work(job):
-        first_started.set()
-        blocker.wait(timeout=3.0)
-        return {}
-
-    first_id = runner.enqueue_pipeline(first_work, config={}, workspace_id=1)
-    _wait_for_event(first_started, "first pipeline start")
+    filler_ids, blocker = _fill_slots(runner)
     second_id = runner.enqueue_pipeline(
         lambda job: pytest_fail("cancelled queued must not run"),
         config={}, workspace_id=1,
@@ -1051,7 +1072,8 @@ def test_cancelling_queued_pipeline_emits_complete_event_to_sse(tmp_path):
     assert evt["data"]["status"] == "cancelled"
 
     blocker.set()
-    wait_for_job_via_runner(runner, first_id)
+    for fid in filler_ids:
+        wait_for_job_via_runner(runner, fid)
 
 
 def test_sse_subscribers_attached_while_queued_receive_post_promotion_events(tmp_path):
@@ -1061,31 +1083,24 @@ def test_sse_subscribers_attached_while_queued_receive_post_promotion_events(tmp
     after the pipeline actually starts.
     """
     runner, _ = _make_runner_with_db(tmp_path)
-    first_started = threading.Event()
-    blocker = threading.Event()
     let_second_finish = threading.Event()
-
-    def first_work(job):
-        first_started.set()
-        blocker.wait(timeout=3.0)
-        return {}
 
     def second_work(job):
         runner.push_event(job["id"], "progress", {"phase": "started"})
         let_second_finish.wait(timeout=3.0)
         return {"ok": True}
 
-    first_id = runner.enqueue_pipeline(first_work, config={}, workspace_id=1)
-    _wait_for_event(first_started, "first pipeline start")
+    filler_ids, blocker = _fill_slots(runner)
     second_id = runner.enqueue_pipeline(second_work, config={}, workspace_id=1)
     assert runner.get(second_id)["status"] == "queued"
 
     # Subscribe BEFORE promotion.
     q = runner.subscribe(second_id)
 
-    # Release the first; second is now promoted and emits a progress event.
+    # Release the slot-fillers; second is now promoted and emits a progress event.
     blocker.set()
-    wait_for_job_via_runner(runner, first_id)
+    for fid in filler_ids:
+        wait_for_job_via_runner(runner, fid)
 
     # The event the second's work_fn pushed must reach this subscriber.
     evt = q.get(timeout=2.0)


### PR DESCRIPTION
## Pipeline concurrency: lift SLOT_CAP from 1 to 2 (Step 6)

Final step of the pipeline-concurrency rollout — allows two pipelines to run at once.

### Rebuilt on top of #912

This branch was **rebuilt on current `main`** after #912 (content-addressed detection IDs) merged. #912 fixes the detection-write race at the data layer — `write_detection_batch` is now an idempotent UPSERT keyed by a content hash, so two pipelines writing the same `(photo, model)` converge instead of clobbering each other.

That makes the **entire interim detection-serialization subsystem this branch used to carry unnecessary**, so it has been **removed**:

- ❌ `acquire_photo_detect` lock
- ❌ the `claim_photo_detect` / `photo_detect_claimed_by_others` / `release_all_photo_detect_claims` claim-and-adopt mechanism and its `detect_claim_token` plumbing through `classify_job` / `pipeline_job`

Several P1 review comments on the old branch were flagging bugs *inside* that adoption machinery (the reclassify purge cascading away adopted detections). Removing it makes those moot — the data layer now guarantees correctness.

### What remains (genuinely needed for cap=2)

These guard hazards that are **independent of detection identity**:

- **`SLOT_CAP = 2`** (`jobs.py`)
- **`acquire_photo_mask(photo_id)`** — serialises per-photo mask writes. Keyed by `photo_id` alone (not variant) because `set_active_mask_variant` / `update_photo_embeddings` denormalise into the same `photos` row regardless of variant.
- **Workspace regroup lock spanning regroup + miss** — `miss_stage` now runs under the same `acquire_workspace_regroup` as `regroup_stage`, so a peer can't rewrite `burst_id` / grouping cache while miss flags are being stamped.
- **Mask cache-hit consistency fix** (new): the extract-masks fast path now recomputes embeddings when a cache hit would switch the photos row's active SAM variant, instead of re-activating without refreshing `dino_*` (which left mask features and embeddings describing different variants — Codex P2).

### Review threads

- *Serialize detection writes / synthetic full-image / reclassify ID stability / adopted-detection purge* → **superseded by #912** (UPSERT, no DELETE+INSERT) or **moot** (adoption code removed).
- *Same-workspace miss serialization* → addressed (regroup+miss lock span).
- *Serialize per-photo mask writes (incl. cross-variant)* → addressed (`acquire_photo_mask` keyed by photo_id).
- *Require active mask to match before reusing embeddings* → fixed (new recompute gate + regression test).

### Tests

Full pipeline + db + classify + scanner + workspace sweep green. New regression: `test_extract_masks_recomputes_when_active_variant_differs` (verified it fails without the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
