### PR TITLE
[codex] Avoid repeated RAW decode after extraction failure

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13515,8 +13515,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             {photo["folder_id"]: folder["path"]},
         )
 
-        if _has_current_working_copy_failure(
-            photo, vireo_dir, trust_existing_working_copy=False,
+        if (
+            not using_offline_cache
+            and _has_current_working_copy_failure(
+                photo, vireo_dir, trust_existing_working_copy=False,
+            )
         ):
             log.info(
                 "Skipping original-image extraction for photo %s; RAW working-copy "

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -136,6 +136,45 @@ def _chunked(seq, size=_SQL_PARAM_CHUNK):
         yield seq[i:i + size]
 
 
+def _has_current_working_copy_failure(photo):
+    """Return True when this RAW already failed working-copy extraction.
+
+    Missing thumbnail/preview requests normally self-heal by decoding the
+    source. For RAW rows whose working-copy extraction already failed at the
+    same source mtime, retrying that decode in a request thread can block the
+    UI for minutes and then fail the same way. A file replacement changes
+    ``file_mtime`` and naturally clears this gate.
+    """
+    def _get(key):
+        try:
+            return photo[key]
+        except (KeyError, IndexError, TypeError):
+            return None
+
+    if _get("working_copy_path"):
+        return False
+
+    filename = _get("filename") or ""
+    try:
+        from image_loader import RAW_EXTENSIONS
+    except Exception:
+        RAW_EXTENSIONS = {
+            ".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf",
+        }
+    if os.path.splitext(filename)[1].lower() not in RAW_EXTENSIONS:
+        return False
+
+    failed_at = _get("working_copy_failed_at")
+    failed_mtime = _get("working_copy_failed_mtime")
+    file_mtime = _get("file_mtime")
+    if not failed_at or failed_mtime is None or file_mtime is None:
+        return False
+    try:
+        return float(failed_mtime) == float(file_mtime)
+    except (TypeError, ValueError):
+        return False
+
+
 def _ensure_volume_trashes_dir(filepath, ensured_volumes):
     """Make sure ``/Volumes/<X>/.Trashes/<uid>/`` exists when ``filepath`` is on
     an external/network mount. macOS ``send2trash`` legacy mode raises
@@ -10594,6 +10633,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Self-heal path: regenerate on miss (or stale) when the photo
         # still exists.
+        if _has_current_working_copy_failure(photo):
+            log.info(
+                "Skipping thumbnail self-heal for photo %s; RAW working-copy "
+                "extraction already failed for current source mtime",
+                photo_id,
+            )
+            return "", 404
 
         # Resolve source via the canonical-path helper so we prefer the
         # JPEG working copy over the original RAW. This makes the
@@ -13222,6 +13268,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "Not found", 404
         folders = {folder_row["id"]: folder_row["path"]}
 
+        if _has_current_working_copy_failure(photo):
+            log.info(
+                "Skipping preview generation for photo %s; RAW working-copy "
+                "extraction already failed for current source mtime",
+                photo_id,
+            )
+            return "Could not load image", 500
+
         canonical = get_canonical_image_path(photo, vireo_dir, folders)
         img = load_image(canonical, max_size=size)
         if img is None:
@@ -13370,6 +13424,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             vireo_dir,
             {photo["folder_id"]: folder["path"]},
         )
+
+        if _has_current_working_copy_failure(photo):
+            log.info(
+                "Skipping original-image extraction for photo %s; RAW working-copy "
+                "extraction already failed for current source mtime",
+                photo_id,
+            )
+            return "Could not load image", 500
 
         # For browser-native formats without a working copy, serve directly
         ext = os.path.splitext(photo["filename"])[1].lower()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 import time
 import webbrowser
-from datetime import UTC
+from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import quote
 
@@ -128,6 +128,7 @@ logging.getLogger("werkzeug").addFilter(_QuietRequestFilter())
 # SQLite versions. Sized below 999 to leave headroom for additional bound
 # parameters in joined statements.
 _SQL_PARAM_CHUNK = 900
+_WORKING_COPY_FAILURE_RETRY_SECONDS = 24 * 60 * 60
 
 
 def _chunked(seq, size=_SQL_PARAM_CHUNK):
@@ -142,8 +143,9 @@ def _has_current_working_copy_failure(photo):
     Missing thumbnail/preview requests normally self-heal by decoding the
     source. For RAW rows whose working-copy extraction already failed at the
     same source mtime, retrying that decode in a request thread can block the
-    UI for minutes and then fail the same way. A file replacement changes
-    ``file_mtime`` and naturally clears this gate.
+    UI for minutes and then fail the same way. Match scanner.py's stale-failure
+    contract: a file replacement changes ``file_mtime`` and failures older than
+    24 hours are allowed to retry.
     """
     def _get(key):
         try:
@@ -170,9 +172,21 @@ def _has_current_working_copy_failure(photo):
     if not failed_at or failed_mtime is None or file_mtime is None:
         return False
     try:
-        return float(failed_mtime) == float(file_mtime)
+        if float(failed_mtime) != float(file_mtime):
+            return False
     except (TypeError, ValueError):
         return False
+    try:
+        failed_s = str(failed_at).strip()
+        if failed_s.endswith("Z"):
+            failed_s = failed_s[:-1] + "+00:00"
+        failed_dt = datetime.fromisoformat(failed_s)
+        if failed_dt.tzinfo is None:
+            failed_dt = failed_dt.replace(tzinfo=UTC)
+    except (TypeError, ValueError):
+        return False
+    age = (datetime.now(UTC) - failed_dt.astimezone(UTC)).total_seconds()
+    return age < _WORKING_COPY_FAILURE_RETRY_SECONDS
 
 
 def _ensure_volume_trashes_dir(filepath, ensured_volumes):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -189,6 +189,54 @@ def _has_current_working_copy_failure(photo):
     return age < _WORKING_COPY_FAILURE_RETRY_SECONDS
 
 
+def _record_working_copy_failure(db, photo):
+    """Persist a RAW extraction failure marker after a request-time retry.
+
+    When ``_has_current_working_copy_failure`` returns False because the stored
+    marker is older than ``_WORKING_COPY_FAILURE_RETRY_SECONDS``, the request
+    paths are allowed to retry the slow RAW decode. If that retry still fails,
+    we refresh ``working_copy_failed_at``/``working_copy_failed_mtime`` so the
+    next thumbnail/preview/original request fails fast again instead of
+    repeating the expensive decode until the scanner runs. Mirrors the SQL the
+    scanner writes on failure (scanner.py around the working-copy backfill).
+    No-op for non-RAW rows or rows without a recorded ``file_mtime``/``id``.
+    """
+    def _get(key):
+        try:
+            return photo[key]
+        except (KeyError, IndexError, TypeError):
+            return None
+
+    filename = _get("filename") or ""
+    try:
+        from image_loader import RAW_EXTENSIONS
+    except Exception:
+        RAW_EXTENSIONS = {
+            ".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf",
+        }
+    if os.path.splitext(filename)[1].lower() not in RAW_EXTENSIONS:
+        return
+
+    file_mtime = _get("file_mtime")
+    photo_id = _get("id")
+    if file_mtime is None or photo_id is None:
+        return
+
+    try:
+        db.conn.execute(
+            "UPDATE photos SET working_copy_failed_at=datetime('now'),"
+            " working_copy_failed_mtime=?"
+            " WHERE id=?",
+            (file_mtime, photo_id),
+        )
+        db.conn.commit()
+    except Exception:
+        log.debug(
+            "Could not refresh working_copy_failed marker for photo %s",
+            photo_id, exc_info=True,
+        )
+
+
 def _ensure_volume_trashes_dir(filepath, ensured_volumes):
     """Make sure ``/Volumes/<X>/.Trashes/<uid>/`` exists when ``filepath`` is on
     an external/network mount. macOS ``send2trash`` legacy mode raises
@@ -10685,11 +10733,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "Thumbnail self-heal failed for photo %s (source=%s)",
                 photo_id, photo["filename"],
             )
+            _record_working_copy_failure(db, photo)
             return "", 404
 
         if not result:
             # generate_thumbnail logged the reason (unreadable source,
             # unsupported format, etc.). Nothing else to do here.
+            _record_working_copy_failure(db, photo)
             return "", 404
 
         # Peg the regenerated thumbnail's mtime to the source file_mtime
@@ -13293,6 +13343,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         canonical = get_canonical_image_path(photo, vireo_dir, folders)
         img = load_image(canonical, max_size=size)
         if img is None:
+            _record_working_copy_failure(db, photo)
             return "Could not load image", 500
 
         preview_quality = cfg.load().get("preview_quality", 90)
@@ -13510,6 +13561,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Fallback: serve via load_image
         img = load_image(image_path, max_size=None)
         if img is None:
+            _record_working_copy_failure(db, photo)
             return "Could not load image", 500
         originals_dir = os.path.join(vireo_dir, "originals")
         cache_path = os.path.join(originals_dir, f"{photo_id}.jpg")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -137,17 +137,21 @@ def _chunked(seq, size=_SQL_PARAM_CHUNK):
         yield seq[i:i + size]
 
 
-def _has_current_working_copy_failure(photo, vireo_dir=None):
+def _has_current_working_copy_failure(
+    photo, vireo_dir=None, trust_existing_working_copy=True,
+):
     """Return True when this RAW already failed working-copy extraction.
 
     Missing thumbnail/preview requests normally self-heal by decoding the
     source. For RAW rows whose working-copy extraction already failed at the
     same source mtime, retrying that decode in a request thread can block the
     UI for minutes and then fail the same way. A present working copy is still
-    authoritative, but a stale ``working_copy_path`` whose file was deleted
-    should not bypass a fresh failure marker. Match scanner.py's stale-failure
-    contract: a file replacement changes ``file_mtime`` and failures older than
-    24 hours are allowed to retry.
+    authoritative for thumbnail/preview routes, but callers that have already
+    rejected that copy as insufficient can opt into honoring the marker anyway.
+    A stale ``working_copy_path`` whose file was deleted should not bypass a
+    fresh failure marker. Match scanner.py's stale-failure contract: a file
+    replacement changes ``file_mtime`` and failures older than 24 hours are
+    allowed to retry.
     """
     def _get(key):
         try:
@@ -156,7 +160,7 @@ def _has_current_working_copy_failure(photo, vireo_dir=None):
             return None
 
     working_copy_path = _get("working_copy_path")
-    if working_copy_path:
+    if working_copy_path and trust_existing_working_copy:
         if not vireo_dir:
             return False
         wc_abs = (
@@ -13505,7 +13509,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             {photo["folder_id"]: folder["path"]},
         )
 
-        if _has_current_working_copy_failure(photo, vireo_dir):
+        if _has_current_working_copy_failure(
+            photo, vireo_dir, trust_existing_working_copy=False,
+        ):
             log.info(
                 "Skipping original-image extraction for photo %s; RAW working-copy "
                 "extraction already failed for current source mtime",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -213,8 +213,11 @@ def _record_working_copy_failure(db, photo, source_path=None):
     next thumbnail/preview/original request fails fast again instead of
     repeating the expensive decode until the scanner runs. Mirrors the SQL the
     scanner writes on failure (scanner.py around the working-copy backfill).
-    No-op for non-RAW rows, rows without a recorded ``file_mtime``/``id``, or
-    source paths that are currently unavailable/offline.
+    No-op for non-RAW rows, rows without a recorded ``file_mtime``/``id``,
+    source paths that are currently unavailable/offline, or source paths that
+    aren't the original RAW (e.g. a corrupt working-copy JPEG returned by
+    ``get_canonical_image_path``) — a non-RAW decode failure isn't a RAW
+    extraction failure and must not stamp the RAW marker.
     """
     def _get(key):
         try:
@@ -231,8 +234,11 @@ def _record_working_copy_failure(db, photo, source_path=None):
         }
     if os.path.splitext(filename)[1].lower() not in RAW_EXTENSIONS:
         return
-    if source_path is not None and not os.path.exists(source_path):
-        return
+    if source_path is not None:
+        if os.path.splitext(source_path)[1].lower() not in RAW_EXTENSIONS:
+            return
+        if not os.path.exists(source_path):
+            return
 
     file_mtime = _get("file_mtime")
     photo_id = _get("id")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -137,13 +137,15 @@ def _chunked(seq, size=_SQL_PARAM_CHUNK):
         yield seq[i:i + size]
 
 
-def _has_current_working_copy_failure(photo):
+def _has_current_working_copy_failure(photo, vireo_dir=None):
     """Return True when this RAW already failed working-copy extraction.
 
     Missing thumbnail/preview requests normally self-heal by decoding the
     source. For RAW rows whose working-copy extraction already failed at the
     same source mtime, retrying that decode in a request thread can block the
-    UI for minutes and then fail the same way. Match scanner.py's stale-failure
+    UI for minutes and then fail the same way. A present working copy is still
+    authoritative, but a stale ``working_copy_path`` whose file was deleted
+    should not bypass a fresh failure marker. Match scanner.py's stale-failure
     contract: a file replacement changes ``file_mtime`` and failures older than
     24 hours are allowed to retry.
     """
@@ -153,8 +155,16 @@ def _has_current_working_copy_failure(photo):
         except (KeyError, IndexError, TypeError):
             return None
 
-    if _get("working_copy_path"):
-        return False
+    working_copy_path = _get("working_copy_path")
+    if working_copy_path:
+        if not vireo_dir:
+            return False
+        wc_abs = (
+            working_copy_path if os.path.isabs(working_copy_path)
+            else os.path.join(vireo_dir, working_copy_path)
+        )
+        if os.path.exists(wc_abs):
+            return False
 
     filename = _get("filename") or ""
     try:
@@ -10698,7 +10708,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Self-heal path: regenerate on miss (or stale) when the photo
         # still exists.
-        if _has_current_working_copy_failure(photo):
+        if _has_current_working_copy_failure(
+            photo, os.path.dirname(thumb_dir),
+        ):
             log.info(
                 "Skipping thumbnail self-heal for photo %s; RAW working-copy "
                 "extraction already failed for current source mtime",
@@ -13335,7 +13347,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "Not found", 404
         folders = {folder_row["id"]: folder_row["path"]}
 
-        if _has_current_working_copy_failure(photo):
+        if _has_current_working_copy_failure(photo, vireo_dir):
             log.info(
                 "Skipping preview generation for photo %s; RAW working-copy "
                 "extraction already failed for current source mtime",
@@ -13493,7 +13505,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             {photo["folder_id"]: folder["path"]},
         )
 
-        if _has_current_working_copy_failure(photo):
+        if _has_current_working_copy_failure(photo, vireo_dir):
             log.info(
                 "Skipping original-image extraction for photo %s; RAW working-copy "
                 "extraction already failed for current source mtime",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -139,6 +139,7 @@ def _chunked(seq, size=_SQL_PARAM_CHUNK):
 
 def _has_current_working_copy_failure(
     photo, vireo_dir=None, trust_existing_working_copy=True,
+    live_source_path=None, folder_path=None,
 ):
     """Return True when this RAW already failed working-copy extraction.
 
@@ -149,9 +150,13 @@ def _has_current_working_copy_failure(
     authoritative for thumbnail/preview routes, but callers that have already
     rejected that copy as insufficient can opt into honoring the marker anyway.
     A stale ``working_copy_path`` whose file was deleted should not bypass a
-    fresh failure marker. Match scanner.py's stale-failure contract: a file
-    replacement changes ``file_mtime`` and failures older than 24 hours are
-    allowed to retry.
+    fresh failure marker. If a RAW+JPEG companion pair has a marker while both
+    the companion and RAW source are currently available, allow request paths to
+    try the RAW: scanner.py prefers companions for working-copy extraction, so
+    that marker may describe a companion-source failure rather than a RAW
+    failure. Match scanner.py's stale-failure contract: a file replacement
+    changes ``file_mtime`` and failures older than 24 hours are allowed to
+    retry.
     """
     def _get(key):
         try:
@@ -179,6 +184,12 @@ def _has_current_working_copy_failure(
         }
     if os.path.splitext(filename)[1].lower() not in RAW_EXTENSIONS:
         return False
+
+    companion_path = _get("companion_path")
+    if companion_path and live_source_path and folder_path:
+        companion_abs = os.path.join(folder_path, companion_path)
+        if os.path.exists(live_source_path) and os.path.exists(companion_abs):
+            return False
 
     failed_at = _get("working_copy_failed_at")
     failed_mtime = _get("working_copy_failed_mtime")
@@ -10718,8 +10729,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Self-heal path: regenerate on miss (or stale) when the photo
         # still exists.
+        folder_row = db.get_folder(photo["folder_id"])
+        if not folder_row:
+            return "", 404
+        live_source = os.path.join(folder_row["path"], photo["filename"])
         if _has_current_working_copy_failure(
             photo, os.path.dirname(thumb_dir),
+            live_source_path=live_source, folder_path=folder_row["path"],
         ):
             log.info(
                 "Skipping thumbnail self-heal for photo %s; RAW working-copy "
@@ -10746,7 +10762,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Workspace membership is already enforced above via
         # ``get_photo(verify_workspace=True)``, so a direct ``get_folder``
         # lookup here is safe and status-agnostic.
-        folder_row = db.get_folder(photo["folder_id"])
         folders = (
             {folder_row["id"]: folder_row["path"]} if folder_row else {}
         )
@@ -10758,7 +10773,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "Thumbnail self-heal failed for photo %s (source=%s)",
                 photo_id, photo["filename"],
             )
-            _record_working_copy_failure(db, photo, source)
             return "", 404
 
         if not result:
@@ -13357,7 +13371,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "Not found", 404
         folders = {folder_row["id"]: folder_row["path"]}
 
-        if _has_current_working_copy_failure(photo, vireo_dir):
+        live_source = os.path.join(folder_row["path"], photo["filename"])
+        if _has_current_working_copy_failure(
+            photo, vireo_dir,
+            live_source_path=live_source, folder_path=folder_row["path"],
+        ):
             log.info(
                 "Skipping preview generation for photo %s; RAW working-copy "
                 "extraction already failed for current source mtime",
@@ -13519,6 +13537,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             not using_offline_cache
             and _has_current_working_copy_failure(
                 photo, vireo_dir, trust_existing_working_copy=False,
+                live_source_path=image_path, folder_path=folder["path"],
             )
         ):
             log.info(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -189,7 +189,7 @@ def _has_current_working_copy_failure(photo):
     return age < _WORKING_COPY_FAILURE_RETRY_SECONDS
 
 
-def _record_working_copy_failure(db, photo):
+def _record_working_copy_failure(db, photo, source_path=None):
     """Persist a RAW extraction failure marker after a request-time retry.
 
     When ``_has_current_working_copy_failure`` returns False because the stored
@@ -199,7 +199,8 @@ def _record_working_copy_failure(db, photo):
     next thumbnail/preview/original request fails fast again instead of
     repeating the expensive decode until the scanner runs. Mirrors the SQL the
     scanner writes on failure (scanner.py around the working-copy backfill).
-    No-op for non-RAW rows or rows without a recorded ``file_mtime``/``id``.
+    No-op for non-RAW rows, rows without a recorded ``file_mtime``/``id``, or
+    source paths that are currently unavailable/offline.
     """
     def _get(key):
         try:
@@ -215,6 +216,8 @@ def _record_working_copy_failure(db, photo):
             ".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf",
         }
     if os.path.splitext(filename)[1].lower() not in RAW_EXTENSIONS:
+        return
+    if source_path is not None and not os.path.exists(source_path):
         return
 
     file_mtime = _get("file_mtime")
@@ -10733,13 +10736,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "Thumbnail self-heal failed for photo %s (source=%s)",
                 photo_id, photo["filename"],
             )
-            _record_working_copy_failure(db, photo)
+            _record_working_copy_failure(db, photo, source)
             return "", 404
 
         if not result:
             # generate_thumbnail logged the reason (unreadable source,
             # unsupported format, etc.). Nothing else to do here.
-            _record_working_copy_failure(db, photo)
+            _record_working_copy_failure(db, photo, source)
             return "", 404
 
         # Peg the regenerated thumbnail's mtime to the source file_mtime
@@ -13343,7 +13346,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         canonical = get_canonical_image_path(photo, vireo_dir, folders)
         img = load_image(canonical, max_size=size)
         if img is None:
-            _record_working_copy_failure(db, photo)
+            _record_working_copy_failure(db, photo, canonical)
             return "Could not load image", 500
 
         preview_quality = cfg.load().get("preview_quality", 90)
@@ -13561,7 +13564,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Fallback: serve via load_image
         img = load_image(image_path, max_size=None)
         if img is None:
-            _record_working_copy_failure(db, photo)
+            _record_working_copy_failure(db, photo, image_path)
             return "Could not load image", 500
         originals_dir = os.path.join(vireo_dir, "originals")
         cache_path = os.path.join(originals_dir, f"{photo_id}.jpg")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -150,13 +150,12 @@ def _has_current_working_copy_failure(
     authoritative for thumbnail/preview routes, but callers that have already
     rejected that copy as insufficient can opt into honoring the marker anyway.
     A stale ``working_copy_path`` whose file was deleted should not bypass a
-    fresh failure marker. If a RAW+JPEG companion pair has a marker while both
-    the companion and RAW source are currently available, allow request paths to
-    try the RAW: scanner.py prefers companions for working-copy extraction, so
-    that marker may describe a companion-source failure rather than a RAW
-    failure. Match scanner.py's stale-failure contract: a file replacement
-    changes ``file_mtime`` and failures older than 24 hours are allowed to
-    retry.
+    fresh failure marker. If a RAW+JPEG companion pair has a companion-source
+    marker while both the companion and RAW source are currently available, allow
+    request paths to try the RAW: scanner.py prefers companions for working-copy
+    extraction, so that marker may not describe a RAW failure. Match scanner.py's
+    stale-failure contract: a file replacement changes ``file_mtime`` and
+    failures older than 24 hours are allowed to retry.
     """
     def _get(key):
         try:
@@ -188,7 +187,12 @@ def _has_current_working_copy_failure(
     companion_path = _get("companion_path")
     if companion_path and live_source_path and folder_path:
         companion_abs = os.path.join(folder_path, companion_path)
-        if os.path.exists(live_source_path) and os.path.exists(companion_abs):
+        failed_source = _get("working_copy_failed_source")
+        if (
+            failed_source != "source"
+            and os.path.exists(live_source_path)
+            and os.path.exists(companion_abs)
+        ):
             return False
 
     failed_at = _get("working_copy_failed_at")
@@ -228,7 +232,9 @@ def _record_working_copy_failure(db, photo, source_path=None):
     source paths that are currently unavailable/offline, or source paths that
     aren't the original RAW (e.g. a corrupt working-copy JPEG returned by
     ``get_canonical_image_path``) — a non-RAW decode failure isn't a RAW
-    extraction failure and must not stamp the RAW marker.
+    extraction failure and must not stamp the RAW marker. Request-time RAW
+    failures are recorded with ``working_copy_failed_source='source'`` so
+    companion-source bypasses do not ignore fresh RAW failures.
     """
     def _get(key):
         try:
@@ -259,7 +265,8 @@ def _record_working_copy_failure(db, photo, source_path=None):
     try:
         db.conn.execute(
             "UPDATE photos SET working_copy_failed_at=datetime('now'),"
-            " working_copy_failed_mtime=?"
+            " working_copy_failed_mtime=?,"
+            " working_copy_failed_source='source'"
             " WHERE id=?",
             (file_mtime, photo_id),
         )

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -286,6 +286,7 @@ class Database:
                 working_copy_path        TEXT,
                 working_copy_failed_at   TEXT,
                 working_copy_failed_mtime REAL,
+                working_copy_failed_source TEXT,
                 eye_x                    REAL,
                 eye_y                    REAL,
                 eye_conf                 REAL,
@@ -763,6 +764,12 @@ class Database:
         except sqlite3.OperationalError:
             self.conn.execute(
                 "ALTER TABLE photos ADD COLUMN working_copy_failed_mtime REAL"
+            )
+        try:
+            self.conn.execute("SELECT working_copy_failed_source FROM photos LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute(
+                "ALTER TABLE photos ADD COLUMN working_copy_failed_source TEXT"
             )
         # Migration: add eye_kp_fingerprint column. Set to NULL for new
         # photos; populated when the eye-keypoint stage runs. Phase 1 also
@@ -2768,7 +2775,8 @@ class Database:
     PHOTO_DETAIL_COLS = (
         PHOTO_COLS
         + ", exif_data, eye_x, eye_y, eye_conf, eye_tenengrad,"
-        + " working_copy_failed_at, working_copy_failed_mtime"
+        + " working_copy_failed_at, working_copy_failed_mtime,"
+        + " working_copy_failed_source"
     )
 
     def get_photo(self, photo_id, verify_workspace=False):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2766,7 +2766,9 @@ class Database:
     # Columns for single-photo detail queries (includes exif_data JSON +
     # eye-focus fields consumed by the review lightbox's crosshair overlay)
     PHOTO_DETAIL_COLS = (
-        PHOTO_COLS + ", exif_data, eye_x, eye_y, eye_conf, eye_tenengrad"
+        PHOTO_COLS
+        + ", exif_data, eye_x, eye_y, eye_conf, eye_tenengrad,"
+        + " working_copy_failed_at, working_copy_failed_mtime"
     )
 
     def get_photo(self, photo_id, verify_workspace=False):

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -392,7 +392,8 @@ def _invalidate_derived_caches(db, vireo_dir, photo_id, thumb_cache_dir=None):
     db.conn.execute(
         "UPDATE photos SET working_copy_path = NULL,"
         " working_copy_failed_at = NULL,"
-        " working_copy_failed_mtime = NULL"
+        " working_copy_failed_mtime = NULL,"
+        " working_copy_failed_source = NULL"
         " WHERE id = ?",
         (photo_id,),
     )
@@ -694,10 +695,12 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
 
         # Prefer companion JPEG if available
         source = os.path.join(row["folder_path"], row["filename"])
+        failure_source = "source"
         if row["companion_path"]:
             companion = os.path.join(row["folder_path"], row["companion_path"])
             if os.path.isfile(companion):
                 source = companion
+                failure_source = "companion"
 
         # extract_working_copy is slow (RAW decode + JPEG encode); run it
         # before any DB write so no transaction is open while it runs.
@@ -706,7 +709,8 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
             db.conn.execute(
                 "UPDATE photos SET working_copy_path=?,"
                 " working_copy_failed_at=NULL,"
-                " working_copy_failed_mtime=NULL"
+                " working_copy_failed_mtime=NULL,"
+                " working_copy_failed_source=NULL"
                 " WHERE id=?",
                 (wc_rel, row["id"]),
             )
@@ -725,9 +729,10 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
             )
             db.conn.execute(
                 "UPDATE photos SET working_copy_failed_at=datetime('now'),"
-                " working_copy_failed_mtime=?"
+                " working_copy_failed_mtime=?,"
+                " working_copy_failed_source=?"
                 " WHERE id=?",
-                (row["file_mtime"], row["id"]),
+                (row["file_mtime"], failure_source, row["id"]),
             )
         commit_with_retry(db.conn)
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -277,6 +277,43 @@ def test_original_route_uses_offline_cache_when_source_missing(client_with_photo
     assert offline_resp.data == source_bytes
 
 
+def test_original_route_uses_offline_cache_despite_recent_raw_failure_marker(
+    client_with_photo,
+):
+    """A RAW failure marker should not block an available offline original."""
+    app, db, pid = client_with_photo
+    client = app.test_client()
+
+    resp = client.post("/api/jobs/offline-cache", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+
+    photo = db.get_photo(pid)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
+    ).fetchone()
+    source = os.path.join(folder["path"], photo["filename"])
+    os.remove(source)
+    assert not os.path.isfile(source)
+
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='missing.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (photo["file_mtime"], pid),
+    )
+    db.conn.commit()
+
+    offline_resp = client.get(f"/photos/{pid}/original")
+
+    assert offline_resp.status_code == 200
+    assert offline_resp.data[:2] == b"\xff\xd8"
+
+
 def test_offline_cache_rerun_preserves_cache_when_source_missing(client_with_photo):
     """Re-running Make Offline with the source unavailable keeps the cached copy."""
     app, db, pid = client_with_photo

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1398,6 +1398,53 @@ def test_original_skips_recent_failed_raw_working_copy(
     assert called["extract"] is False
 
 
+def test_original_skips_recent_failed_raw_after_rejecting_small_working_copy(
+    client_with_photo, monkeypatch,
+):
+    """If a capped working copy is too small for /original, a fresh RAW failure
+    marker should still suppress another full-res extraction attempt."""
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    Image.new("RGB", (100, 100), (40, 80, 120)).save(
+        os.path.join(working_dir, f"{photo_id}.jpg"), "JPEG",
+    )
+
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=?,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (f"working/{photo_id}.jpg", file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    called = {"extract": False}
+
+    def fail_if_called(*_args, **_kwargs):
+        called["extract"] = True
+        raise AssertionError("original retried RAW after small wc rejection")
+
+    monkeypatch.setattr(image_loader, "extract_working_copy", fail_if_called)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/original")
+
+    assert resp.status_code == 500
+    assert called["extract"] is False
+
+
 def test_original_refreshes_failure_marker_when_stale_retry_fails(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1292,6 +1292,67 @@ def test_preview_retries_raw_when_recent_marker_came_from_companion(
     assert called["path"] == raw_path
 
 
+def test_preview_honors_raw_marker_after_companion_bypass_retry_fails(
+    client_with_photo, monkeypatch,
+):
+    """A RAW failure recorded after companion bypass should suppress repeats."""
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.join(folder["path"], "bad.NEF")
+    companion_path = os.path.join(folder["path"], "bad.jpg")
+    with open(raw_path, "wb") as f:
+        f.write(b"raw bytes")
+    Image.new("RGB", (800, 600), (40, 80, 120)).save(
+        companion_path, "JPEG",
+    )
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               companion_path='bad.jpg',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?,
+               working_copy_failed_source='companion'
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    calls = {"count": 0}
+
+    def fail_raw(_path, *_args, **_kwargs):
+        calls["count"] += 1
+        return None
+
+    monkeypatch.setattr(image_loader, "load_image", fail_raw)
+
+    client = app.test_client()
+    first = client.get(f"/photos/{photo_id}/preview?size=1920")
+    second = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert first.status_code == 500
+    assert second.status_code == 500
+    assert calls["count"] == 1
+    row = db.conn.execute(
+        """SELECT working_copy_failed_mtime, working_copy_failed_source
+           FROM photos WHERE id=?""",
+        (photo_id,),
+    ).fetchone()
+    assert row["working_copy_failed_mtime"] == file_mtime
+    assert row["working_copy_failed_source"] == "source"
+
+
 def test_preview_retries_stale_failed_raw_working_copy(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1246,9 +1246,17 @@ def test_preview_refreshes_failure_marker_when_stale_retry_fails(
     """When the retry window has expired and the request-time decode still
     fails, /preview must refresh ``working_copy_failed_at`` so the next
     request fails fast again instead of repeating the slow decode."""
+    import os
+
     import image_loader
 
     app, db, photo_id = client_with_photo
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    with open(os.path.join(folder["path"], "bad.NEF"), "wb") as f:
+        f.write(b"not a decodable raw")
     file_mtime = db.conn.execute(
         "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
     ).fetchone()["file_mtime"]
@@ -1281,6 +1289,39 @@ def test_preview_refreshes_failure_marker_when_stale_retry_fails(
     ).fetchone()
     assert row["working_copy_failed_mtime"] == file_mtime
     assert row["age_seconds"] is not None and row["age_seconds"] < 60
+
+
+def test_preview_does_not_refresh_failure_marker_when_raw_source_is_missing(
+    client_with_photo,
+):
+    """Missing/offline RAW sources are not decode failures; leave stale
+    extraction markers stale so remounting the source can recover quickly."""
+    app, db, photo_id = client_with_photo
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='missing.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now', '-48 hours'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 500
+    row = db.conn.execute(
+        """SELECT (julianday('now') - julianday(working_copy_failed_at))
+                  * 24 * 60 * 60 AS age_seconds
+           FROM photos WHERE id=?""",
+        (photo_id,),
+    ).fetchone()
+    assert row["age_seconds"] is not None and row["age_seconds"] > 24 * 60 * 60
 
 
 def test_original_skips_recent_failed_raw_working_copy(
@@ -1325,9 +1366,17 @@ def test_original_refreshes_failure_marker_when_stale_retry_fails(
 ):
     """A stale RAW failure may retry once; if original extraction and fallback
     loading still fail, the route should refresh the failure marker."""
+    import os
+
     import image_loader
 
     app, db, photo_id = client_with_photo
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    with open(os.path.join(folder["path"], "bad.NEF"), "wb") as f:
+        f.write(b"not a decodable raw")
     file_mtime = db.conn.execute(
         "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
     ).fetchone()["file_mtime"]

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1241,6 +1241,57 @@ def test_preview_skips_recent_failed_raw_when_working_copy_path_is_stale(
     assert called["load"] is False
 
 
+def test_preview_retries_raw_when_recent_marker_came_from_companion(
+    client_with_photo, monkeypatch,
+):
+    """A companion-source failure marker should not suppress a readable RAW."""
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.join(folder["path"], "bad.NEF")
+    companion_path = os.path.join(folder["path"], "bad.jpg")
+    with open(raw_path, "wb") as f:
+        f.write(b"raw bytes")
+    Image.new("RGB", (800, 600), (40, 80, 120)).save(
+        companion_path, "JPEG",
+    )
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               companion_path='bad.jpg',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    called = {"path": None}
+
+    def load_raw(path, *_args, **_kwargs):
+        called["path"] = path
+        return Image.new("RGB", (800, 600), (40, 80, 120))
+
+    monkeypatch.setattr(image_loader, "load_image", load_raw)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 200
+    assert called["path"] == raw_path
+
+
 def test_preview_retries_stale_failed_raw_working_copy(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1183,19 +1183,61 @@ def test_preview_skips_recent_failed_raw_working_copy(
     )
     db.conn.commit()
 
-    called = {"load": False}
+    called = {"load": False, "extract": False}
 
-    def fail_if_called(*_args, **_kwargs):
+    def fail_load_if_called(*_args, **_kwargs):
         called["load"] = True
         raise AssertionError("preview retried failed RAW decode")
 
-    monkeypatch.setattr(image_loader, "load_image", fail_if_called)
+    def fail_extract_if_called(*_args, **_kwargs):
+        called["extract"] = True
+        raise AssertionError("preview retried failed RAW extraction")
+
+    monkeypatch.setattr(image_loader, "load_image", fail_load_if_called)
+    monkeypatch.setattr(image_loader, "extract_working_copy", fail_extract_if_called)
 
     client = app.test_client()
     resp = client.get(f"/photos/{photo_id}/preview?size=1920")
 
     assert resp.status_code == 500
     assert called["load"] is False
+    assert called["extract"] is False
+
+
+def test_preview_retries_stale_failed_raw_working_copy(
+    client_with_photo, monkeypatch,
+):
+    """A RAW failure older than the retry window should be allowed to retry."""
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now', '-48 hours'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    called = {"load": False}
+
+    def record_retry(*_args, **_kwargs):
+        called["load"] = True
+        return None
+
+    monkeypatch.setattr(image_loader, "load_image", record_retry)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 500
+    assert called["load"] is True
 
 
 def test_original_skips_recent_failed_raw_working_copy(

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1240,6 +1240,49 @@ def test_preview_retries_stale_failed_raw_working_copy(
     assert called["load"] is True
 
 
+def test_preview_refreshes_failure_marker_when_stale_retry_fails(
+    client_with_photo, monkeypatch,
+):
+    """When the retry window has expired and the request-time decode still
+    fails, /preview must refresh ``working_copy_failed_at`` so the next
+    request fails fast again instead of repeating the slow decode."""
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now', '-48 hours'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    monkeypatch.setattr(image_loader, "load_image", lambda *a, **k: None)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+    assert resp.status_code == 500
+
+    # Marker should now be fresh (within a few seconds of "now") and the
+    # mtime should match the file's current mtime so the gate fires again
+    # on the next request.
+    row = db.conn.execute(
+        """SELECT working_copy_failed_mtime,
+                  (julianday('now') - julianday(working_copy_failed_at))
+                  * 24 * 60 * 60 AS age_seconds
+           FROM photos WHERE id=?""",
+        (photo_id,),
+    ).fetchone()
+    assert row["working_copy_failed_mtime"] == file_mtime
+    assert row["age_seconds"] is not None and row["age_seconds"] < 60
+
+
 def test_original_skips_recent_failed_raw_working_copy(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1320,6 +1320,46 @@ def test_original_skips_recent_failed_raw_working_copy(
     assert called["extract"] is False
 
 
+def test_original_refreshes_failure_marker_when_stale_retry_fails(
+    client_with_photo, monkeypatch,
+):
+    """A stale RAW failure may retry once; if original extraction and fallback
+    loading still fail, the route should refresh the failure marker."""
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now', '-48 hours'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    monkeypatch.setattr(image_loader, "extract_working_copy", lambda *a, **k: False)
+    monkeypatch.setattr(image_loader, "load_image", lambda *a, **k: None)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/original")
+
+    assert resp.status_code == 500
+    row = db.conn.execute(
+        """SELECT working_copy_failed_mtime,
+                  (julianday('now') - julianday(working_copy_failed_at))
+                  * 24 * 60 * 60 AS age_seconds
+           FROM photos WHERE id=?""",
+        (photo_id,),
+    ).fetchone()
+    assert row["working_copy_failed_mtime"] == file_mtime
+    assert row["age_seconds"] is not None and row["age_seconds"] < 60
+
+
 def test_eviction_removes_oldest_files_when_over_quota(tmp_path, monkeypatch):
     """When writes push cache over quota, oldest-accessed entries are evicted."""
     import os

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1161,6 +1161,80 @@ def test_full_is_alias_for_preview_at_configured_size(client_with_photo, monkeyp
     assert len(full) > 0
 
 
+def test_preview_skips_recent_failed_raw_working_copy(
+    client_with_photo, monkeypatch,
+):
+    """A RAW whose working-copy extraction already failed at the current mtime
+    should fail fast instead of retrying RAW decode in /preview."""
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    called = {"load": False}
+
+    def fail_if_called(*_args, **_kwargs):
+        called["load"] = True
+        raise AssertionError("preview retried failed RAW decode")
+
+    monkeypatch.setattr(image_loader, "load_image", fail_if_called)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 500
+    assert called["load"] is False
+
+
+def test_original_skips_recent_failed_raw_working_copy(
+    client_with_photo, monkeypatch,
+):
+    """The 1:1 original route should also fail fast for a current RAW
+    extraction failure."""
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    called = {"extract": False}
+
+    def fail_if_called(*_args, **_kwargs):
+        called["extract"] = True
+        raise AssertionError("original route retried failed RAW extraction")
+
+    monkeypatch.setattr(image_loader, "extract_working_copy", fail_if_called)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/original")
+
+    assert resp.status_code == 500
+    assert called["extract"] is False
+
+
 def test_eviction_removes_oldest_files_when_over_quota(tmp_path, monkeypatch):
     """When writes push cache over quota, oldest-accessed entries are evicted."""
     import os

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1361,6 +1361,57 @@ def test_preview_does_not_refresh_failure_marker_when_raw_source_is_missing(
     assert row["age_seconds"] is not None and row["age_seconds"] > 24 * 60 * 60
 
 
+def test_preview_does_not_refresh_failure_marker_when_working_copy_jpeg_is_corrupt(
+    client_with_photo, monkeypatch,
+):
+    """A corrupt/unreadable working-copy JPEG must not stamp the RAW marker.
+
+    ``get_canonical_image_path`` prefers an existing working-copy JPEG over the
+    original RAW. If that JPEG fails to load, the failure is in the JPEG, not
+    in RAW extraction — recording it as a RAW failure would suppress legitimate
+    RAW retries for 24h even though the RAW was never tried.
+    """
+    import os
+
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_rel = f"working/{photo_id}.jpg"
+    with open(os.path.join(vireo_dir, wc_rel), "wb") as f:
+        f.write(b"corrupt jpeg bytes")
+
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=?,
+               working_copy_failed_at=datetime('now', '-48 hours'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (wc_rel, file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    monkeypatch.setattr(image_loader, "load_image", lambda *a, **k: None)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 500
+    row = db.conn.execute(
+        """SELECT (julianday('now') - julianday(working_copy_failed_at))
+                  * 24 * 60 * 60 AS age_seconds
+           FROM photos WHERE id=?""",
+        (photo_id,),
+    ).fetchone()
+    assert row["age_seconds"] is not None and row["age_seconds"] > 24 * 60 * 60
+
+
 def test_original_skips_recent_failed_raw_working_copy(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1204,6 +1204,43 @@ def test_preview_skips_recent_failed_raw_working_copy(
     assert called["extract"] is False
 
 
+def test_preview_skips_recent_failed_raw_when_working_copy_path_is_stale(
+    client_with_photo, monkeypatch,
+):
+    """A stale DB working_copy_path whose file is gone should not bypass a
+    fresh RAW failure marker."""
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path='working/missing.jpg',
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    called = {"load": False}
+
+    def fail_load_if_called(*_args, **_kwargs):
+        called["load"] = True
+        raise AssertionError("preview retried failed RAW with stale wc path")
+
+    monkeypatch.setattr(image_loader, "load_image", fail_load_if_called)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 500
+    assert called["load"] is False
+
+
 def test_preview_retries_stale_failed_raw_working_copy(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -793,6 +793,51 @@ def test_serve_thumbnail_refreshes_failure_marker_when_stale_retry_fails(
     assert row["age_seconds"] is not None and row["age_seconds"] < 60
 
 
+def test_serve_thumbnail_does_not_refresh_raw_marker_on_cache_write_error(
+    tmp_path, monkeypatch,
+):
+    """Thumbnail cache write failures should not be recorded as RAW failures."""
+    import thumbnails
+
+    app, db, pid, _thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (pid,),
+    ).fetchone()
+    with open(os.path.join(folder["path"], "bad.NEF"), "wb") as f:
+        f.write(b"raw bytes")
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now', '-48 hours'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, pid),
+    )
+    db.conn.commit()
+
+    def fail_write(*_args, **_kwargs):
+        raise OSError("thumbnail cache is unwritable")
+
+    monkeypatch.setattr(thumbnails, "generate_thumbnail", fail_write)
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 404
+    row = db.conn.execute(
+        """SELECT (julianday('now') - julianday(working_copy_failed_at))
+                  * 24 * 60 * 60 AS age_seconds
+           FROM photos WHERE id=?""",
+        (pid,),
+    ).fetchone()
+    assert row["age_seconds"] is not None and row["age_seconds"] > 24 * 60 * 60
+
+
 def test_serve_thumbnail_resolves_when_folder_status_is_missing(tmp_path, monkeypatch):
     """The self-heal must use the photo's actual folder path even when
     the folder's status is ``'missing'``. ``get_folder_tree()`` filters

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -702,6 +702,44 @@ def test_serve_thumbnail_404s_when_source_is_unreadable(tmp_path, monkeypatch):
     assert resp.status_code == 404
 
 
+def test_serve_thumbnail_skips_recent_failed_raw_working_copy(
+    tmp_path, monkeypatch,
+):
+    """A RAW row that already failed working-copy extraction at the current
+    mtime must not retry RAW decode in the thumbnail request thread.
+    """
+    import thumbnails
+
+    app, db, pid, _thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, pid),
+    )
+    db.conn.commit()
+
+    called = {"generate": False}
+
+    def fail_if_called(*_args, **_kwargs):
+        called["generate"] = True
+        raise AssertionError("thumbnail request retried failed RAW decode")
+
+    monkeypatch.setattr(thumbnails, "generate_thumbnail", fail_if_called)
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 404
+    assert called["generate"] is False
+
+
 def test_serve_thumbnail_resolves_when_folder_status_is_missing(tmp_path, monkeypatch):
     """The self-heal must use the photo's actual folder path even when
     the folder's status is ``'missing'``. ``get_folder_tree()`` filters

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -711,6 +711,12 @@ def test_serve_thumbnail_skips_recent_failed_raw_working_copy(
     import thumbnails
 
     app, db, pid, _thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (pid,),
+    ).fetchone()
+    with open(os.path.join(folder["path"], "bad.NEF"), "wb") as f:
+        f.write(b"not a decodable raw")
     file_mtime = db.conn.execute(
         "SELECT file_mtime FROM photos WHERE id=?", (pid,)
     ).fetchone()["file_mtime"]
@@ -748,6 +754,12 @@ def test_serve_thumbnail_refreshes_failure_marker_when_stale_retry_fails(
     import thumbnails
 
     app, db, pid, _thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (pid,),
+    ).fetchone()
+    with open(os.path.join(folder["path"], "bad.NEF"), "wb") as f:
+        f.write(b"not a decodable raw")
     file_mtime = db.conn.execute(
         "SELECT file_mtime FROM photos WHERE id=?", (pid,)
     ).fetchone()["file_mtime"]

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -740,6 +740,47 @@ def test_serve_thumbnail_skips_recent_failed_raw_working_copy(
     assert called["generate"] is False
 
 
+def test_serve_thumbnail_refreshes_failure_marker_when_stale_retry_fails(
+    tmp_path, monkeypatch,
+):
+    """A stale RAW failure may retry once; if thumbnail regeneration still
+    fails, the route should refresh the marker so later requests fail fast."""
+    import thumbnails
+
+    app, db, pid, _thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now', '-48 hours'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, pid),
+    )
+    db.conn.commit()
+
+    monkeypatch.setattr(
+        thumbnails, "generate_thumbnail", lambda *args, **kwargs: None,
+    )
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 404
+    row = db.conn.execute(
+        """SELECT working_copy_failed_mtime,
+                  (julianday('now') - julianday(working_copy_failed_at))
+                  * 24 * 60 * 60 AS age_seconds
+           FROM photos WHERE id=?""",
+        (pid,),
+    ).fetchone()
+    assert row["working_copy_failed_mtime"] == file_mtime
+    assert row["age_seconds"] is not None and row["age_seconds"] < 60
+
+
 def test_serve_thumbnail_resolves_when_folder_status_is_missing(tmp_path, monkeypatch):
     """The self-heal must use the photo's actual folder path even when
     the folder's status is ``'missing'``. ``get_folder_tree()`` filters


### PR DESCRIPTION
## Summary

This fixes review/image views getting tied up by RAW files whose working-copy extraction already failed for the current file mtime. Thumbnail, preview, and original-image routes now fail fast for those rows instead of retrying the same slow RAW decode in request threads, while `get_photo()` exposes the failure markers needed for that decision. Added regression tests for thumbnail self-heal, preview generation, and original-image serving.

## Validation

`python -m pytest vireo/tests/test_thumbnails.py vireo/tests/test_photos_api.py::test_preview_cache_miss_creates_row vireo/tests/test_photos_api.py::test_preview_cache_hit_updates_last_access vireo/tests/test_photos_api.py::test_full_is_alias_for_preview_at_configured_size vireo/tests/test_photos_api.py::test_preview_skips_recent_failed_raw_working_copy vireo/tests/test_photos_api.py::test_original_skips_recent_failed_raw_working_copy -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppress repeated retry attempts for recently failed RAW extractions (24‑hour backoff). Thumbnails return 404; preview and original image requests return an immediate error. If a stale retry fails, the failure marker is refreshed to prevent repeated work.

* **Tests**
  * Added regression tests covering fail-fast, retry-window, marker refresh, and missing-source behaviors for thumbnails, previews, and originals.

* **Chores**
  * Photo metadata now includes RAW-failure timestamps used by the backoff logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/908?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->