### PR TITLE
[codex] Persist pipeline review settings

### DIFF
--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -7,8 +7,9 @@ from playwright.sync_api import expect
 
 def _write_predictionless_pipeline_cache(live_server, photo_ids):
     db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
     rows = db.conn.execute(
-        "SELECT id, filename, timestamp FROM photos WHERE id IN (?, ?) ORDER BY id",
+        f"SELECT id, filename, timestamp FROM photos WHERE id IN ({placeholders}) ORDER BY id",
         photo_ids,
     ).fetchall()
     photos = [
@@ -53,6 +54,80 @@ def _write_predictionless_pipeline_cache(live_server, photo_ids):
             "review_count": len(ids),
             "reject_count": 0,
             "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def _write_confirmation_pipeline_cache(live_server, photo_ids):
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, filename, timestamp FROM photos WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    species = ["Red-tailed Hawk", "American Robin"]
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+            "confirmed_species": species[idx] if idx == 0 else None,
+        }
+        for idx, row in enumerate(rows)
+    ]
+    encounters = []
+    for idx, photo in enumerate(photos):
+        confirmed = idx == 0
+        encounters.append(
+            {
+                "photo_ids": [photo["id"]],
+                "photo_count": 1,
+                "burst_count": 1,
+                "time_range": [photo["timestamp"], photo["timestamp"]],
+                "species": [species[idx]],
+                "species_predictions": [
+                    {"species": species[idx], "models": [{"confidence": 0.92}]},
+                ],
+                "species_confirmed": confirmed,
+                "confirmed_species": species[idx] if confirmed else None,
+                "bursts": [
+                    {
+                        "photo_ids": [photo["id"]],
+                        "species_predictions": [
+                            {"species": species[idx], "models": [{"confidence": 0.92}]},
+                        ],
+                        "species_override": (
+                            {"species": species[idx], "confirmed": True}
+                            if confirmed
+                            else None
+                        ),
+                    }
+                ],
+            }
+        )
+    cache = {
+        "photos": photos,
+        "encounters": encounters,
+        "summary": {
+            "total_photos": len(photos),
+            "encounter_count": len(encounters),
+            "burst_count": len(encounters),
+            "keep_count": 0,
+            "review_count": len(photos),
+            "reject_count": 0,
+            "rarity_protected": 0,
+            "confirmed_count": 1,
+            "unconfirmed_count": len(photos) - 1,
         },
     }
     path = os.path.join(
@@ -133,3 +208,30 @@ def test_pipeline_review_sidebar_collapses_and_persists(live_server, page):
     expect(layout).not_to_have_class(re.compile(r"\bsidebar-collapsed\b"))
     expect(content).to_be_visible()
     expect(toggle).to_have_attribute("aria-expanded", "true")
+
+
+def test_pipeline_review_view_settings_persist(live_server, page):
+    photo_ids = live_server["data"]["photos"][1:3]
+    _write_confirmation_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    expect(page.locator(".encounter-card")).to_have_count(2)
+
+    page.locator("#hideConfirmedBtn").click()
+    page.locator('[data-filter="REVIEW"]').click()
+    page.locator("#speciesFilterInput").fill("Robin")
+    page.locator("#thumbSizeSlider").evaluate(
+        """el => {
+            el.value = '220';
+            el.dispatchEvent(new Event('input', { bubbles: true }));
+        }"""
+    )
+
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    page.reload()
+
+    expect(page.locator("#hideConfirmedBtn")).to_have_class(re.compile(r"\bactive\b"))
+    expect(page.locator('[data-filter="REVIEW"]')).to_have_class(re.compile(r"\bactive\b"))
+    expect(page.locator("#speciesFilterInput")).to_have_value("Robin")
+    expect(page.locator("#thumbSizeSlider")).to_have_value("220")
+    expect(page.locator(".encounter-card")).to_have_count(1)

--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -72,8 +72,12 @@ def _write_confirmation_pipeline_cache(live_server, photo_ids):
         photo_ids,
     ).fetchall()
     species = ["Red-tailed Hawk", "American Robin"]
-    photos = [
-        {
+    photos = []
+    photo_species = []
+    for idx, row in enumerate(rows):
+        species_name = species[idx % len(species)]
+        photo_species.append(species_name)
+        photos.append({
             "id": row["id"],
             "filename": row["filename"],
             "timestamp": row["timestamp"],
@@ -81,12 +85,11 @@ def _write_confirmation_pipeline_cache(live_server, photo_ids):
             "quality_composite": 0.5,
             "flag": "none",
             "rating": 0,
-            "confirmed_species": species[idx] if idx == 0 else None,
-        }
-        for idx, row in enumerate(rows)
-    ]
+            "confirmed_species": species_name if idx == 0 else None,
+        })
     encounters = []
     for idx, photo in enumerate(photos):
+        species_name = photo_species[idx]
         confirmed = idx == 0
         encounters.append(
             {
@@ -94,20 +97,20 @@ def _write_confirmation_pipeline_cache(live_server, photo_ids):
                 "photo_count": 1,
                 "burst_count": 1,
                 "time_range": [photo["timestamp"], photo["timestamp"]],
-                "species": [species[idx]],
+                "species": [species_name],
                 "species_predictions": [
-                    {"species": species[idx], "models": [{"confidence": 0.92}]},
+                    {"species": species_name, "models": [{"confidence": 0.92}]},
                 ],
                 "species_confirmed": confirmed,
-                "confirmed_species": species[idx] if confirmed else None,
+                "confirmed_species": species_name if confirmed else None,
                 "bursts": [
                     {
                         "photo_ids": [photo["id"]],
                         "species_predictions": [
-                            {"species": species[idx], "models": [{"confidence": 0.92}]},
+                            {"species": species_name, "models": [{"confidence": 0.92}]},
                         ],
                         "species_override": (
-                            {"species": species[idx], "confirmed": True}
+                            {"species": species_name, "confirmed": True}
                             if confirmed
                             else None
                         ),
@@ -234,4 +237,12 @@ def test_pipeline_review_view_settings_persist(live_server, page):
     expect(page.locator('[data-filter="REVIEW"]')).to_have_class(re.compile(r"\bactive\b"))
     expect(page.locator("#speciesFilterInput")).to_have_value("Robin")
     expect(page.locator("#thumbSizeSlider")).to_have_value("220")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    page.reload()
+    expect(page.locator("#speciesFilterInput")).to_have_value("Robin")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    page.locator("#speciesFilterClear").click()
+    expect(page.locator("#speciesFilterInput")).to_have_value("")
     expect(page.locator(".encounter-card")).to_have_count(1)

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1484,6 +1484,7 @@ var pipelineResults = null;
 var activeFilter = 'all';
 var minConfidence = 40;
 var speciesFilter = '';
+var speciesFilterText = '';
 var hideConfirmed = false;
 // Captured from /api/pipeline/page-init so computeReviewNow() can apply
 // the same workspace-override logic the happy path uses on page load.
@@ -1500,6 +1501,8 @@ var reviewReadiness = null;
 // share the original first photo_id.
 var collapsedEncounters = new Set();
 var PIPELINE_SIDEBAR_STORAGE_KEY = 'vireo.pipelineReview.sidebarCollapsed';
+var PIPELINE_VIEW_STATE_STORAGE_KEY = 'vireo.pipelineReview.viewState';
+var PIPELINE_REVIEW_FILTERS = ['all', 'KEEP', 'REVIEW', 'REJECT'];
 
 function setPipelineSidebarCollapsed(collapsed, persist) {
   var layout = document.getElementById('pipelineLayout');
@@ -1528,6 +1531,62 @@ function initPipelineSidebarState() {
     collapsed = window.localStorage.getItem(PIPELINE_SIDEBAR_STORAGE_KEY) === '1';
   } catch (e) {}
   setPipelineSidebarCollapsed(collapsed, false);
+}
+
+function persistPipelineReviewViewState() {
+  var speciesInput = document.getElementById('speciesFilterInput');
+  try {
+    window.localStorage.setItem(PIPELINE_VIEW_STATE_STORAGE_KEY, JSON.stringify({
+      activeFilter: activeFilter,
+      speciesFilter: speciesInput ? speciesInput.value : speciesFilterText,
+      hideConfirmed: !!hideConfirmed,
+      thumbSize: document.getElementById('thumbSizeSlider')
+        ? document.getElementById('thumbSizeSlider').value
+        : null,
+    }));
+  } catch (e) {}
+}
+
+function applyPipelineReviewToolbarState() {
+  document.querySelectorAll('.filter-btn[data-filter]').forEach(function(btn) {
+    btn.classList.toggle('active', btn.getAttribute('data-filter') === activeFilter);
+  });
+
+  var hideBtn = document.getElementById('hideConfirmedBtn');
+  if (hideBtn) hideBtn.classList.toggle('active', hideConfirmed);
+
+  var input = document.getElementById('speciesFilterInput');
+  if (input) input.value = speciesFilterText || '';
+  var clearBtn = document.getElementById('speciesFilterClear');
+  if (clearBtn) clearBtn.style.display = speciesFilter ? 'block' : 'none';
+}
+
+function restorePipelineReviewViewState() {
+  var state = null;
+  try {
+    state = JSON.parse(window.localStorage.getItem(PIPELINE_VIEW_STATE_STORAGE_KEY) || 'null');
+  } catch (e) {}
+  if (!state || typeof state !== 'object') {
+    applyPipelineReviewToolbarState();
+    return;
+  }
+
+  if (PIPELINE_REVIEW_FILTERS.indexOf(state.activeFilter) !== -1) {
+    activeFilter = state.activeFilter;
+  }
+  speciesFilterText = typeof state.speciesFilter === 'string' ? state.speciesFilter : '';
+  speciesFilter = speciesFilterText.toLowerCase();
+  hideConfirmed = !!state.hideConfirmed;
+
+  var thumbSize = parseInt(state.thumbSize, 10);
+  if (!isNaN(thumbSize)) {
+    thumbSize = Math.max(100, Math.min(320, thumbSize));
+    var slider = document.getElementById('thumbSizeSlider');
+    if (slider) slider.value = String(thumbSize);
+    updateThumbSize(thumbSize);
+  }
+
+  applyPipelineReviewToolbarState();
 }
 
 function encounterKey(enc) {
@@ -1758,18 +1817,22 @@ function _grmFinishLoupeOneToOne() {
 }
 
 function setSpeciesFilter(val) {
+  speciesFilterText = val;
   speciesFilter = val.toLowerCase();
   var clearBtn = document.getElementById('speciesFilterClear');
   if (clearBtn) clearBtn.style.display = val ? 'block' : 'none';
+  persistPipelineReviewViewState();
   renderResults();
 }
 
 function clearSpeciesFilter() {
   speciesFilter = '';
+  speciesFilterText = '';
   var input = document.getElementById('speciesFilterInput');
   if (input) input.value = '';
   var clearBtn = document.getElementById('speciesFilterClear');
   if (clearBtn) clearBtn.style.display = 'none';
+  persistPipelineReviewViewState();
   renderResults();
 }
 
@@ -2148,9 +2211,8 @@ function toggleEncounter(idx) {
 
 function setFilter(f) {
   activeFilter = f;
-  document.querySelectorAll('.filter-btn[data-filter]').forEach(function(btn) {
-    btn.classList.toggle('active', btn.getAttribute('data-filter') === f);
-  });
+  applyPipelineReviewToolbarState();
+  persistPipelineReviewViewState();
   renderResults();
 }
 
@@ -2162,8 +2224,8 @@ function isBurstConfirmed(enc, burst) {
 
 function toggleHideConfirmed() {
   hideConfirmed = !hideConfirmed;
-  var btn = document.getElementById('hideConfirmedBtn');
-  if (btn) btn.classList.toggle('active', hideConfirmed);
+  applyPipelineReviewToolbarState();
+  persistPipelineReviewViewState();
   renderResults();
 }
 
@@ -2171,6 +2233,7 @@ var _confTimer = null;
 
 function updateThumbSize(val) {
   document.getElementById('encountersContainer').style.setProperty('--photo-card-size', val + 'px');
+  persistPipelineReviewViewState();
 }
 
 function setMinConfidence(val) {
@@ -2821,6 +2884,7 @@ function computeReviewNow() {
     document.getElementById('filterBar').style.display = '';
     document.getElementById('sidebarScoring').style.display = '';
     document.getElementById('sidebarGrouping').style.display = '';
+    restorePipelineReviewViewState();
     renderResults();
     openRequestedGroupReviewFromUrl();
     checkPendingSync();
@@ -2883,6 +2947,7 @@ function loadPipelinePageInit() {
     var fb = document.getElementById('filterBar');
     if (fb) fb.style.display = '';
 
+    restorePipelineReviewViewState();
     renderResults();
     openRequestedGroupReviewFromUrl();
     checkPendingSync();

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1583,7 +1583,7 @@ function restorePipelineReviewViewState() {
     thumbSize = Math.max(100, Math.min(320, thumbSize));
     var slider = document.getElementById('thumbSizeSlider');
     if (slider) slider.value = String(thumbSize);
-    updateThumbSize(thumbSize);
+    updateThumbSize(thumbSize, false);
   }
 
   applyPipelineReviewToolbarState();
@@ -2231,9 +2231,9 @@ function toggleHideConfirmed() {
 
 var _confTimer = null;
 
-function updateThumbSize(val) {
+function updateThumbSize(val, persist) {
   document.getElementById('encountersContainer').style.setProperty('--photo-card-size', val + 'px');
-  persistPipelineReviewViewState();
+  if (persist !== false) persistPipelineReviewViewState();
 }
 
 function setMinConfidence(val) {


### PR DESCRIPTION
## Summary
Persist Pipeline Review toolbar state in localStorage so returning to the page restores the previous label filter, species filter, thumbnail size, and Hide confirmed toggle. This fixes the page resetting Hide confirmed to off after navigation or reload. Added e2e coverage that changes the toolbar settings, reloads Pipeline Review, and verifies the settings and filtered results are restored.

## Validation
- `pytest tests/e2e/test_pipeline_review_species.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View settings in the pipeline review now persist across reloads (toolbar filters, species text search, hide-confirmed toggle, thumbnail size).
  * Pipeline review supports workspace-scoped confirmation cache that represents each photo as its own encounter and reflects per-photo species/confirmation state.

* **Bug Fixes**
  * Encounter summary counts (confirmed/unconfirmed) are computed and displayed correctly when using the confirmation cache.

* **Tests**
  * End-to-end test added to verify persisted view settings and stable encounter counts across reloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->