### PR TITLE
db: content-addressed detection IDs

### DIFF
--- a/docs/plans/2026-05-28-content-addressed-detection-ids-design.md
+++ b/docs/plans/2026-05-28-content-addressed-detection-ids-design.md
@@ -93,10 +93,12 @@ def write_detection_batch(self, photo_id, detector_model, detections):
     for det in detections:
         det_id = detection_id(photo_id, detector_model, det.box, det.category)
         self.conn.execute("""
-            INSERT OR REPLACE INTO detections
+            INSERT INTO detections
               (id, photo_id, detector_model, box_x, box_y, box_w, box_h,
                detector_confidence, category)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+              detector_confidence = excluded.detector_confidence
         """, (det_id, photo_id, detector_model, det.box.x, det.box.y,
               det.box.w, det.box.h, det.confidence, det.category))
         ids.append(det_id)
@@ -105,7 +107,7 @@ def write_detection_batch(self, photo_id, detector_model, detections):
     return ids
 ```
 
-Two pipelines concurrently writing the same (photo, model) now produce identical IDs and the same row content. `INSERT OR REPLACE` is idempotent for matching rows. Stale detections (boxes the model no longer produces) need explicit cleanup — handled by deleting any existing row whose ID is *not* in the new ID set:
+Two pipelines concurrently writing the same (photo, model) now produce identical IDs and the same row content. `INSERT ... ON CONFLICT(id) DO UPDATE` is idempotent for matching rows and crucially does NOT fire `ON DELETE CASCADE` on `predictions.detection_id` the way `INSERT OR REPLACE` would (replace deletes the conflicting row, then inserts). Stale detections (boxes the model no longer produces) need explicit cleanup — handled by deleting any existing row whose ID is *not* in the new ID set:
 
 ```python
 new_ids = set(ids)

--- a/docs/plans/2026-05-28-content-addressed-detection-ids-design.md
+++ b/docs/plans/2026-05-28-content-addressed-detection-ids-design.md
@@ -1,0 +1,156 @@
+# Content-addressed detection IDs
+
+**Status:** design
+**Date:** 2026-05-28
+**Motivation:** Fix the detect-write race Codex flagged on PR #907 (SLOT_CAP=2).
+
+## Problem
+
+`detections.id` is `INTEGER PRIMARY KEY` (auto-rowid). `db.write_detection_batch(photo_id, detector_model, detections)` does:
+
+```sql
+DELETE FROM detections WHERE photo_id = ? AND detector_model = ?
+INSERT INTO detections (...) VALUES (...)  -- returns new lastrowid each time
+```
+
+With SLOT_CAP=2, two pipelines can run the same photo concurrently. Pipeline A INSERTs, gets IDs `[101, 102]`, caches them in `detect_state`, and starts classify. Pipeline B then DELETEs (CASCADE removes A's predictions via the FK) and INSERTs `[103, 104]`. A's classify now writes `predictions(detection_id=101)` — but row 101 no longer exists. Either FK insert fails or, worse, B's later DELETE silently CASCADEs away predictions A wrote against rows B never knew about.
+
+We already mitigate one slice of this with `acquire_photo_detect(photo_id)` in `pipeline_locks.py`, but a serialising lock is a workaround, not a fix. The underlying issue: detection rows have no stable identity. Two pipelines producing the same detections produce different IDs.
+
+## Fix: content-addressed IDs
+
+Compute each detection's ID as a hash of its content. Two pipelines that produce the same detection produce the same row. DELETE+INSERT becomes effectively an UPSERT — concurrent writers converge to the same state.
+
+### Why content addressing (vs surrogate ID + UNIQUE constraint)
+
+A detection isn't an entity with independent identity. Photos have identity — a user can rename, tag, edit one, and it's still that photo. A detection is a tuple: "the detector said there's an animal here, at these coordinates, in this photo, when run with this model." Two boxes at the same position, in the same photo, from the same detector, **are the same detection** — not two different detections that happen to share content. The natural key isn't just unique; it's constitutive. That's the signature of something that should be content-addressed.
+
+A surrogate-ID + `UNIQUE (photo_id, detector_model, box_x, box_y, box_w, box_h, category)` constraint would also fix the race, but every code path that touches detection rows would still need to think about the surrogate vs. natural distinction. Content addressing collapses the two — there is only one identity.
+
+## ID formula
+
+```python
+def positive_int_hash(*parts: str) -> int:
+    """52-bit SHA-256 digest, JS-safe-int by construction."""
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return int(digest[:13], 16)  # 13 hex chars = 52 bits
+
+def detection_id(photo_id: int, detector_model: str, box, category: str) -> int:
+    qx, qy, qw, qh = [f"{round(v, 4):.4f}" for v in (box.x, box.y, box.w, box.h)]
+    return positive_int_hash(str(photo_id), detector_model, qx, qy, qw, qh, category)
+```
+
+### Natural key composition
+
+| Field             | In hash? | Reason |
+|-------------------|----------|--------|
+| `photo_id`        | yes      | Different photos = different detections. |
+| `detector_model`  | yes      | Future `megadetector-v7` should coexist with v6 on identical boxes. |
+| `box_x/y/w/h`     | yes      | Quantized to 4 decimals (see below). |
+| `category`        | yes      | Part of model output. If the model flips animal↔person on the same box across runs, those are different rows so DELETE+INSERT retires the stale one. |
+| `detector_confidence` | no   | Float; drifts between runs; not identity. |
+| `created_at`      | no       | Would defeat the point. |
+
+### Bbox quantization: 4 decimal places
+
+Bbox coords are normalized to `[0, 1]`. We quantize before hashing to absorb ONNX float drift between providers (CUDA / CoreML / CPU produce mantissa-bit-level differences on identical inputs).
+
+| Precision | Pixel slop on 4K image | Verdict |
+|-----------|------------------------|---------|
+| 3 decimals | ~4 px | Too coarse — risks collision between adjacent small-bird boxes. |
+| **4 decimals** | **~0.4 px** | **Chosen.** Comfortably above ONNX drift (~1e-6); comfortably below NMS-enforced separation. |
+| 5 decimals | ~0.04 px | Vulnerable to inter-provider float drift. |
+| 6 decimals | sub-pixel | Definitely vulnerable. |
+
+### Bit width: 52 bits
+
+JavaScript `Number.MAX_SAFE_INTEGER` is `2^53 - 1`. A 63-bit integer (SQLite's positive INTEGER range) loses precision the moment it round-trips through `JSON.parse`. Truncating SHA-256 to 52 bits keeps every value exactly representable in JS — no string-serialisation gymnastics, no future foot-gun if some new endpoint sends detection IDs to the frontend.
+
+Collision math: birthday-paradox 50% collision in a 2^52 space requires ~95M items. Vireo's lifetime detection count is in the millions, not billions — collision probability ~10⁻⁹. Effectively zero.
+
+## Schema change
+
+```sql
+-- Before:
+CREATE TABLE detections (
+    id INTEGER PRIMARY KEY,
+    ...
+)
+
+-- After: same DDL. SQLite's INTEGER PRIMARY KEY accepts explicit values;
+-- the AUTOINCREMENT-like auto-rowid behavior only kicks in when the INSERT
+-- omits `id`. We just stop omitting it.
+```
+
+No migration. Old auto-rowid rows (small integers) coexist with new hash rows (large integers) in the same column. The first time `write_detection_batch` runs for a (photo, model) pair after the change, its DELETE wipes the old rows and the INSERT writes new content-addressed ones. Existing CASCADE FKs handle the predictions cleanup — that's identical to today's re-detect semantics.
+
+## write_detection_batch change
+
+```python
+def write_detection_batch(self, photo_id, detector_model, detections):
+    # No more DELETE+INSERT — UPSERT by computed ID.
+    ids = []
+    for det in detections:
+        det_id = detection_id(photo_id, detector_model, det.box, det.category)
+        self.conn.execute("""
+            INSERT OR REPLACE INTO detections
+              (id, photo_id, detector_model, box_x, box_y, box_w, box_h,
+               detector_confidence, category)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """, (det_id, photo_id, detector_model, det.box.x, det.box.y,
+              det.box.w, det.box.h, det.confidence, det.category))
+        ids.append(det_id)
+    # detector_runs ON CONFLICT update stays as-is.
+    ...
+    return ids
+```
+
+Two pipelines concurrently writing the same (photo, model) now produce identical IDs and the same row content. `INSERT OR REPLACE` is idempotent for matching rows. Stale detections (boxes the model no longer produces) need explicit cleanup — handled by deleting any existing row whose ID is *not* in the new ID set:
+
+```python
+new_ids = set(ids)
+existing = self.conn.execute(
+    "SELECT id FROM detections WHERE photo_id = ? AND detector_model = ?",
+    (photo_id, detector_model),
+).fetchall()
+stale = [row["id"] for row in existing if row["id"] not in new_ids]
+if stale:
+    placeholders = ",".join("?" for _ in stale)
+    self.conn.execute(
+        f"DELETE FROM detections WHERE id IN ({placeholders})", stale,
+    )
+```
+
+This DELETE is narrow (only stale-by-content rows), runs *after* the INSERTs, and is safe under concurrent writers: if pipeline A and B compute the same `new_ids`, neither deletes anything the other inserted.
+
+## Lock cleanup
+
+`acquire_photo_detect(photo_id)` in `pipeline_locks.py` and its call site in `pipeline_job.py` become unnecessary — the race is fixed at the data layer, not by serialisation. Remove the lock and its tests (or leave the lock as belt-and-suspenders; lean toward remove to avoid dead infrastructure).
+
+## Test surface
+
+- **New:** unit test for `detection_id()` — same inputs ⇒ same ID; quantization absorbs sub-quarter-pixel drift; different category / different model / different photo ⇒ different ID.
+- **New:** regression test in `vireo/tests/test_db.py` — two threads calling `write_detection_batch(same_photo, same_model, same_detections)` concurrently; assert row count, ID set, and predictions FK validity.
+- **Update:** `vireo/tests/test_classify_job.py` mocks. Lines 194, 511, 214, 254, 530-532, 944, 1837-1839 use hardcoded `[101]`, `[101, 102]`, `999` for detection IDs. Replace with `detection_id(...)` computed from the same inputs the mock receives.
+- **Remove:** `test_pipeline_locks.py::test_photo_detect_lock_*` (3 tests) if we delete the lock.
+
+## Audit summary (from explore agent, 2026-05-28)
+
+| Surface | Status | Notes |
+|---------|--------|-------|
+| `db.write_detection_batch` | rewrite | Only producer. |
+| `classify_job.detect_state` consumer | safe | Stores IDs in dict; no arithmetic. |
+| `predictions.detection_id` FK | safe | Works with any INTEGER value. |
+| `app.py` SQL queries on detections.id | safe | Parameterised; no `MAX(id)`, no `BETWEEN`. |
+| `app.py` JSON returning detection IDs | safe at 52 bits | At 63 bits this would be a JS precision bug. |
+| `vireo/templates/*.html` JS | safe | No arithmetic on detection IDs. |
+| `test_classify_job.py` mock values | update | Hardcoded small IDs need to use `detection_id()`. |
+
+## Out of scope
+
+- Other tables with the same DELETE+INSERT pattern (predictions, keypoints, etc.). Address those if/when concurrency exposes them; don't rewrite the data layer speculatively.
+- Migration of existing auto-rowid rows. Lazy replacement on next re-detect, per the [[project_solo_user_app]] philosophy.
+
+## Sequencing
+
+This PR lands **before** the SLOT_CAP=2 lift (PR #907) so the cap lift becomes safe. After merge, rebase #907 onto main; the `acquire_photo_detect` removal and content-addressed IDs together replace the lock-based mitigation #907 currently relies on.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vireo",
   "private": true,
-  "version": "0.8.52",
+  "version": "0.8.53",
   "scripts": {
     "tauri": "tauri"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vireo"
-version = "0.8.52"
+version = "0.8.53"
 description = "AI-powered wildlife photo organizer"
 requires-python = ">=3.11"
 dependencies = [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2269,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -3764,9 +3764,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4943,7 +4943,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vireo"
-version = "0.8.52"
+version = "0.8.53"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vireo"
-version = "0.8.52"
+version = "0.8.53"
 description = "AI-powered wildlife photo organizer"
 authors = []
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Vireo",
-  "version": "0.8.52",
+  "version": "0.8.53",
   "identifier": "com.vireo.app",
   "build": {
     "frontendDist": "../build",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13566,8 +13566,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             {photo["folder_id"]: folder["path"]},
         )
 
+        from image_loader import RAW_EXTENSIONS
+        resolved_ext = os.path.splitext(image_path)[1].lower()
         if (
-            not using_offline_cache
+            (not using_offline_cache or resolved_ext in RAW_EXTENSIONS)
             and _has_current_working_copy_failure(
                 photo, vireo_dir, trust_existing_working_copy=False,
                 live_source_path=image_path, folder_path=folder["path"],
@@ -13581,7 +13583,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "Could not load image", 500
 
         # For browser-native formats without a working copy, serve directly
-        ext = os.path.splitext(photo["filename"])[1].lower()
+        ext = resolved_ext
         if ext in (".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp") and not photo["working_copy_path"] and os.path.exists(image_path):
             return send_file(image_path)
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 import time
 import webbrowser
-from datetime import UTC
+from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import quote
 
@@ -127,12 +127,154 @@ logging.getLogger("werkzeug").addFilter(_QuietRequestFilter())
 # SQLite versions. Sized below 999 to leave headroom for additional bound
 # parameters in joined statements.
 _SQL_PARAM_CHUNK = 900
+_WORKING_COPY_FAILURE_RETRY_SECONDS = 24 * 60 * 60
 
 
 def _chunked(seq, size=_SQL_PARAM_CHUNK):
     """Yield ``seq`` in successive lists of at most ``size`` items."""
     for i in range(0, len(seq), size):
         yield seq[i:i + size]
+
+
+def _has_current_working_copy_failure(
+    photo, vireo_dir=None, trust_existing_working_copy=True,
+    live_source_path=None, folder_path=None,
+):
+    """Return True when this RAW already failed working-copy extraction.
+
+    Missing thumbnail/preview requests normally self-heal by decoding the
+    source. For RAW rows whose working-copy extraction already failed at the
+    same source mtime, retrying that decode in a request thread can block the
+    UI for minutes and then fail the same way. A present working copy is still
+    authoritative for thumbnail/preview routes, but callers that have already
+    rejected that copy as insufficient can opt into honoring the marker anyway.
+    A stale ``working_copy_path`` whose file was deleted should not bypass a
+    fresh failure marker. If a RAW+JPEG companion pair has a companion-source
+    marker while both the companion and RAW source are currently available, allow
+    request paths to try the RAW: scanner.py prefers companions for working-copy
+    extraction, so that marker may not describe a RAW failure. Match scanner.py's
+    stale-failure contract: a file replacement changes ``file_mtime`` and
+    failures older than 24 hours are allowed to retry.
+    """
+    def _get(key):
+        try:
+            return photo[key]
+        except (KeyError, IndexError, TypeError):
+            return None
+
+    working_copy_path = _get("working_copy_path")
+    if working_copy_path and trust_existing_working_copy:
+        if not vireo_dir:
+            return False
+        wc_abs = (
+            working_copy_path if os.path.isabs(working_copy_path)
+            else os.path.join(vireo_dir, working_copy_path)
+        )
+        if os.path.exists(wc_abs):
+            return False
+
+    filename = _get("filename") or ""
+    try:
+        from image_loader import RAW_EXTENSIONS
+    except Exception:
+        RAW_EXTENSIONS = {
+            ".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf",
+        }
+    if os.path.splitext(filename)[1].lower() not in RAW_EXTENSIONS:
+        return False
+
+    companion_path = _get("companion_path")
+    if companion_path and live_source_path and folder_path:
+        companion_abs = os.path.join(folder_path, companion_path)
+        failed_source = _get("working_copy_failed_source")
+        if (
+            failed_source != "source"
+            and os.path.exists(live_source_path)
+            and os.path.exists(companion_abs)
+        ):
+            return False
+
+    failed_at = _get("working_copy_failed_at")
+    failed_mtime = _get("working_copy_failed_mtime")
+    file_mtime = _get("file_mtime")
+    if not failed_at or failed_mtime is None or file_mtime is None:
+        return False
+    try:
+        if float(failed_mtime) != float(file_mtime):
+            return False
+    except (TypeError, ValueError):
+        return False
+    try:
+        failed_s = str(failed_at).strip()
+        if failed_s.endswith("Z"):
+            failed_s = failed_s[:-1] + "+00:00"
+        failed_dt = datetime.fromisoformat(failed_s)
+        if failed_dt.tzinfo is None:
+            failed_dt = failed_dt.replace(tzinfo=UTC)
+    except (TypeError, ValueError):
+        return False
+    age = (datetime.now(UTC) - failed_dt.astimezone(UTC)).total_seconds()
+    return age < _WORKING_COPY_FAILURE_RETRY_SECONDS
+
+
+def _record_working_copy_failure(db, photo, source_path=None):
+    """Persist a RAW extraction failure marker after a request-time retry.
+
+    When ``_has_current_working_copy_failure`` returns False because the stored
+    marker is older than ``_WORKING_COPY_FAILURE_RETRY_SECONDS``, the request
+    paths are allowed to retry the slow RAW decode. If that retry still fails,
+    we refresh ``working_copy_failed_at``/``working_copy_failed_mtime`` so the
+    next thumbnail/preview/original request fails fast again instead of
+    repeating the expensive decode until the scanner runs. Mirrors the SQL the
+    scanner writes on failure (scanner.py around the working-copy backfill).
+    No-op for non-RAW rows, rows without a recorded ``file_mtime``/``id``,
+    source paths that are currently unavailable/offline, or source paths that
+    aren't the original RAW (e.g. a corrupt working-copy JPEG returned by
+    ``get_canonical_image_path``) — a non-RAW decode failure isn't a RAW
+    extraction failure and must not stamp the RAW marker. Request-time RAW
+    failures are recorded with ``working_copy_failed_source='source'`` so
+    companion-source bypasses do not ignore fresh RAW failures.
+    """
+    def _get(key):
+        try:
+            return photo[key]
+        except (KeyError, IndexError, TypeError):
+            return None
+
+    filename = _get("filename") or ""
+    try:
+        from image_loader import RAW_EXTENSIONS
+    except Exception:
+        RAW_EXTENSIONS = {
+            ".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf",
+        }
+    if os.path.splitext(filename)[1].lower() not in RAW_EXTENSIONS:
+        return
+    if source_path is not None:
+        if os.path.splitext(source_path)[1].lower() not in RAW_EXTENSIONS:
+            return
+        if not os.path.exists(source_path):
+            return
+
+    file_mtime = _get("file_mtime")
+    photo_id = _get("id")
+    if file_mtime is None or photo_id is None:
+        return
+
+    try:
+        db.conn.execute(
+            "UPDATE photos SET working_copy_failed_at=datetime('now'),"
+            " working_copy_failed_mtime=?,"
+            " working_copy_failed_source='source'"
+            " WHERE id=?",
+            (file_mtime, photo_id),
+        )
+        db.conn.commit()
+    except Exception:
+        log.debug(
+            "Could not refresh working_copy_failed marker for photo %s",
+            photo_id, exc_info=True,
+        )
 
 
 def _ensure_volume_trashes_dir(filepath, ensured_volumes):
@@ -10620,6 +10762,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Self-heal path: regenerate on miss (or stale) when the photo
         # still exists.
+        folder_row = db.get_folder(photo["folder_id"])
+        if not folder_row:
+            return "", 404
+        live_source = os.path.join(folder_row["path"], photo["filename"])
+        if _has_current_working_copy_failure(
+            photo, os.path.dirname(thumb_dir),
+            live_source_path=live_source, folder_path=folder_row["path"],
+        ):
+            log.info(
+                "Skipping thumbnail self-heal for photo %s; RAW working-copy "
+                "extraction already failed for current source mtime",
+                photo_id,
+            )
+            return "", 404
 
         # Resolve source via the canonical-path helper so we prefer the
         # JPEG working copy over the original RAW. This makes the
@@ -10639,7 +10795,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Workspace membership is already enforced above via
         # ``get_photo(verify_workspace=True)``, so a direct ``get_folder``
         # lookup here is safe and status-agnostic.
-        folder_row = db.get_folder(photo["folder_id"])
         folders = (
             {folder_row["id"]: folder_row["path"]} if folder_row else {}
         )
@@ -10656,6 +10811,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not result:
             # generate_thumbnail logged the reason (unreadable source,
             # unsupported format, etc.). Nothing else to do here.
+            _record_working_copy_failure(db, photo, source)
             return "", 404
 
         # Peg the regenerated thumbnail's mtime to the source file_mtime
@@ -13248,9 +13404,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "Not found", 404
         folders = {folder_row["id"]: folder_row["path"]}
 
+        live_source = os.path.join(folder_row["path"], photo["filename"])
+        if _has_current_working_copy_failure(
+            photo, vireo_dir,
+            live_source_path=live_source, folder_path=folder_row["path"],
+        ):
+            log.info(
+                "Skipping preview generation for photo %s; RAW working-copy "
+                "extraction already failed for current source mtime",
+                photo_id,
+            )
+            return "Could not load image", 500
+
         canonical = get_canonical_image_path(photo, vireo_dir, folders)
         img = load_image(canonical, max_size=size)
         if img is None:
+            _record_working_copy_failure(db, photo, canonical)
             return "Could not load image", 500
 
         preview_quality = cfg.load().get("preview_quality", 90)
@@ -13397,6 +13566,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             {photo["folder_id"]: folder["path"]},
         )
 
+        if (
+            not using_offline_cache
+            and _has_current_working_copy_failure(
+                photo, vireo_dir, trust_existing_working_copy=False,
+                live_source_path=image_path, folder_path=folder["path"],
+            )
+        ):
+            log.info(
+                "Skipping original-image extraction for photo %s; RAW working-copy "
+                "extraction already failed for current source mtime",
+                photo_id,
+            )
+            return "Could not load image", 500
+
         # For browser-native formats without a working copy, serve directly
         ext = os.path.splitext(photo["filename"])[1].lower()
         if ext in (".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp") and not photo["working_copy_path"] and os.path.exists(image_path):
@@ -13460,6 +13643,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Fallback: serve via load_image
         img = load_image(image_path, max_size=None)
         if img is None:
+            _record_working_copy_failure(db, photo, image_path)
             return "Could not load image", 500
         originals_dir = os.path.join(vireo_dir, "originals")
         cache_path = os.path.join(originals_dir, f"{photo_id}.jpg")

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -420,19 +420,38 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
             if detections:
                 detected += 1
 
-                # Build detection list with database IDs
+                # Build detection list with database IDs. Content-addressed IDs
+                # can collapse near-duplicate detector outputs into one
+                # persisted row, so fall back to the DB rows if the returned ID
+                # count no longer matches the raw detector output count.
                 det_list = []
-                for det, det_id in zip(detections, det_ids, strict=True):
-                    det_list.append({
-                        "id": det_id,
-                        "box_x": det["box"]["x"],
-                        "box_y": det["box"]["y"],
-                        "box_w": det["box"]["w"],
-                        "box_h": det["box"]["h"],
-                        "confidence": det["confidence"],
-                        "category": det.get("category", "animal"),
-                        "detector_model": "megadetector-v6",
-                    })
+                if len(det_ids) == len(detections):
+                    for det, det_id in zip(detections, det_ids, strict=True):
+                        det_list.append({
+                            "id": det_id,
+                            "box_x": det["box"]["x"],
+                            "box_y": det["box"]["y"],
+                            "box_w": det["box"]["w"],
+                            "box_h": det["box"]["h"],
+                            "confidence": det["confidence"],
+                            "category": det.get("category", "animal"),
+                            "detector_model": "megadetector-v6",
+                        })
+                else:
+                    for det in db.get_detections(
+                        photo["id"], min_conf=0,
+                        detector_model="megadetector-v6",
+                    ):
+                        det_list.append({
+                            "id": det["id"],
+                            "box_x": det["box_x"],
+                            "box_y": det["box_y"],
+                            "box_w": det["box_w"],
+                            "box_h": det["box_h"],
+                            "confidence": det["detector_confidence"],
+                            "category": det["category"],
+                            "detector_model": det["detector_model"],
+                        })
                 detection_map[photo["id"]] = det_list
 
                 # Mark as processed immediately after detection rows are committed

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -981,15 +981,9 @@ def _classify_photos(
                     batch = []
         else:
             # No detections — use (or create) a full-image synthetic detection
-            # to carry the classifier output.
-            #
-            # save_detections() does clear-and-reinsert per
-            # (photo_id, detector_model), so calling it on every pass would
-            # generate a new id each time and cascade-delete prior predictions
-            # and classifier_runs tied to the old id. Reuse the existing
-            # full-image detection when one is already cached, and only
-            # create a fresh one if none exists (or if the caller asked for
-            # a reclassify).
+            # to carry the classifier output. save_detections is now idempotent
+            # under content-addressed IDs, but reading the existing row first
+            # avoids an UPSERT + stale-cleanup roundtrip on the common path.
             # min_conf=0 because the synthetic full-image detection is
             # written with confidence=0 — the default threshold filter would
             # hide it.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -8203,7 +8203,14 @@ class Database:
                       detector_confidence, category)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(id) DO UPDATE SET
-                     detector_confidence = excluded.detector_confidence""",
+                     photo_id = excluded.photo_id,
+                     detector_model = excluded.detector_model,
+                     box_x = excluded.box_x,
+                     box_y = excluded.box_y,
+                     box_w = excluded.box_w,
+                     box_h = excluded.box_h,
+                     detector_confidence = excluded.detector_confidence,
+                     category = excluded.category""",
                 (det_id, photo_id, detector_model,
                  box["x"], box["y"], box["w"], box["h"],
                  det["confidence"], category),

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -286,6 +286,7 @@ class Database:
                 working_copy_path        TEXT,
                 working_copy_failed_at   TEXT,
                 working_copy_failed_mtime REAL,
+                working_copy_failed_source TEXT,
                 eye_x                    REAL,
                 eye_y                    REAL,
                 eye_conf                 REAL,
@@ -763,6 +764,12 @@ class Database:
         except sqlite3.OperationalError:
             self.conn.execute(
                 "ALTER TABLE photos ADD COLUMN working_copy_failed_mtime REAL"
+            )
+        try:
+            self.conn.execute("SELECT working_copy_failed_source FROM photos LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute(
+                "ALTER TABLE photos ADD COLUMN working_copy_failed_source TEXT"
             )
         # Migration: add eye_kp_fingerprint column. Set to NULL for new
         # photos; populated when the eye-keypoint stage runs. Phase 1 also
@@ -2766,7 +2773,10 @@ class Database:
     # Columns for single-photo detail queries (includes exif_data JSON +
     # eye-focus fields consumed by the review lightbox's crosshair overlay)
     PHOTO_DETAIL_COLS = (
-        PHOTO_COLS + ", exif_data, eye_x, eye_y, eye_conf, eye_tenengrad"
+        PHOTO_COLS
+        + ", exif_data, eye_x, eye_y, eye_conf, eye_tenengrad,"
+        + " working_copy_failed_at, working_copy_failed_mtime,"
+        + " working_copy_failed_source"
     )
 
     def get_photo(self, photo_id, verify_workspace=False):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -8177,14 +8177,15 @@ class Database:
     def _upsert_detection_rows(self, photo_id, detector_model, detections):
         """Content-addressed UPSERT of detection rows for one (photo, model).
 
-        Returns the list of IDs in caller-supplied order. Does NOT commit —
+        Returns the list of unique IDs in first-seen order. Does NOT commit —
         the caller controls the transaction so the detector_runs row can be
         written in the same commit (see `write_detection_batch`).
         """
         from detection_id import detection_id as _detection_id
 
-        ids = []
-        for det in detections:
+        unique = {}
+        ordered_ids = []
+        for idx, det in enumerate(detections):
             box = det["box"]
             category = det.get("category", "animal")
             det_id = _detection_id(
@@ -8192,6 +8193,24 @@ class Database:
                 (box["x"], box["y"], box["w"], box["h"]),
                 category,
             )
+            if det_id not in unique:
+                ordered_ids.append(det_id)
+                unique[det_id] = (det, category, idx)
+                continue
+            prev_det, _prev_category, prev_idx = unique[det_id]
+            if (
+                det["confidence"] > prev_det["confidence"]
+                or (
+                    det["confidence"] == prev_det["confidence"]
+                    and idx > prev_idx
+                )
+            ):
+                unique[det_id] = (det, category, idx)
+
+        ids = []
+        for det_id in ordered_ids:
+            det, category, _idx = unique[det_id]
+            box = det["box"]
             # INSERT ON CONFLICT DO UPDATE — true UPSERT. Do NOT use
             # `INSERT OR REPLACE`, which DELETEs the conflicting row before
             # re-inserting; that DELETE fires `predictions.detection_id`
@@ -8269,7 +8288,7 @@ class Database:
                    ON CONFLICT(photo_id, detector_model)
                    DO UPDATE SET box_count = excluded.box_count,
                                  run_at = datetime('now')""",
-                (photo_id, detector_model, len(detections)),
+                (photo_id, detector_model, len(ids)),
             )
             commit_with_retry(self.conn)
             return ids

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -8210,11 +8210,17 @@ class Database:
             (photo_id, detector_model),
         ).fetchall()]
         stale = [eid for eid in existing if eid not in new_ids]
-        if stale:
-            placeholders = ",".join("?" for _ in stale)
+        # Chunk to stay under SQLite's compile-time SQLITE_MAX_VARIABLE_NUMBER
+        # (defaults to 999 in older builds, 32766 in newer). A single photo
+        # rarely has >1k detections today, but the chunking is cheap insurance
+        # against future detectors that produce many small boxes.
+        CHUNK = 500
+        for i in range(0, len(stale), CHUNK):
+            chunk = stale[i:i + CHUNK]
+            placeholders = ",".join("?" for _ in chunk)
             self.conn.execute(
                 f"DELETE FROM detections WHERE id IN ({placeholders})",
-                stale,
+                chunk,
             )
         return ids
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -8146,32 +8146,76 @@ class Database:
         (photo, model); any workspace re-running the same (photo, model) is a
         bug — callers should short-circuit via `get_detector_run_photo_ids`.
 
+        IDs are content-addressed (see vireo.detection_id) so two pipelines
+        writing the same (photo, model, detections) produce identical rows
+        — the second writer's UPSERT is a no-op rather than a CASCADE-deleting
+        DELETE+INSERT.
+
         Args:
             photo_id: the photo
             detections: list of dicts {box: {x,y,w,h}, confidence, category}
             detector_model: required, e.g. "megadetector-v6"
         Returns:
-            list of new detection IDs (empty if detections was empty).
+            list of detection IDs (empty if detections was empty).
         """
         if detector_model is None:
             raise ValueError("detector_model is required")
-        self.conn.execute(
-            "DELETE FROM detections WHERE photo_id = ? AND detector_model = ?",
-            (photo_id, detector_model),
-        )
+        ids = self._upsert_detection_rows(photo_id, detector_model, detections)
+        commit_with_retry(self.conn)
+        return ids
+
+    def _upsert_detection_rows(self, photo_id, detector_model, detections):
+        """Content-addressed UPSERT of detection rows for one (photo, model).
+
+        Returns the list of IDs in caller-supplied order. Does NOT commit —
+        the caller controls the transaction so the detector_runs row can be
+        written in the same commit (see `write_detection_batch`).
+        """
+        from detection_id import detection_id as _detection_id
+
         ids = []
         for det in detections:
             box = det["box"]
-            cur = self.conn.execute(
-                """INSERT INTO detections
-                     (photo_id, detector_model, box_x, box_y, box_w, box_h,
-                      detector_confidence, category)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-                (photo_id, detector_model, box["x"], box["y"], box["w"], box["h"],
-                 det["confidence"], det.get("category", "animal")),
+            category = det.get("category", "animal")
+            det_id = _detection_id(
+                photo_id, detector_model,
+                (box["x"], box["y"], box["w"], box["h"]),
+                category,
             )
-            ids.append(cur.lastrowid)
-        commit_with_retry(self.conn)
+            # INSERT ON CONFLICT DO UPDATE — true UPSERT. Do NOT use
+            # `INSERT OR REPLACE`, which DELETEs the conflicting row before
+            # re-inserting; that DELETE fires `predictions.detection_id`
+            # `ON DELETE CASCADE` and silently wipes any predictions another
+            # pipeline has already written for this detection.
+            self.conn.execute(
+                """INSERT INTO detections
+                     (id, photo_id, detector_model, box_x, box_y, box_w, box_h,
+                      detector_confidence, category)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(id) DO UPDATE SET
+                     detector_confidence = excluded.detector_confidence""",
+                (det_id, photo_id, detector_model,
+                 box["x"], box["y"], box["w"], box["h"],
+                 det["confidence"], category),
+            )
+            ids.append(det_id)
+
+        # Retire rows the new run no longer produces. Narrow DELETE: only
+        # rows whose ID is NOT in the new set. Safe under concurrent writers
+        # because two writers with the same detections compute the same
+        # `new_ids` set, so neither deletes the other's rows.
+        new_ids = set(ids)
+        existing = [r["id"] for r in self.conn.execute(
+            "SELECT id FROM detections WHERE photo_id = ? AND detector_model = ?",
+            (photo_id, detector_model),
+        ).fetchall()]
+        stale = [eid for eid in existing if eid not in new_ids]
+        if stale:
+            placeholders = ",".join("?" for _ in stale)
+            self.conn.execute(
+                f"DELETE FROM detections WHERE id IN ({placeholders})",
+                stale,
+            )
         return ids
 
     def write_detection_batch(self, photo_id, detector_model, detections):
@@ -8195,22 +8239,7 @@ class Database:
         if detector_model is None:
             raise ValueError("detector_model is required")
         try:
-            self.conn.execute(
-                "DELETE FROM detections WHERE photo_id = ? AND detector_model = ?",
-                (photo_id, detector_model),
-            )
-            ids = []
-            for det in detections:
-                box = det["box"]
-                cur = self.conn.execute(
-                    """INSERT INTO detections
-                         (photo_id, detector_model, box_x, box_y, box_w, box_h,
-                          detector_confidence, category)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (photo_id, detector_model, box["x"], box["y"], box["w"], box["h"],
-                     det["confidence"], det.get("category", "animal")),
-                )
-                ids.append(cur.lastrowid)
+            ids = self._upsert_detection_rows(photo_id, detector_model, detections)
             self.conn.execute(
                 """INSERT INTO detector_runs (photo_id, detector_model, box_count)
                    VALUES (?, ?, ?)

--- a/vireo/detection_id.py
+++ b/vireo/detection_id.py
@@ -1,0 +1,41 @@
+# vireo/detection_id.py
+"""Content-addressed identifiers for detection rows.
+
+Detection IDs are computed from the detection's natural key so that two
+pipelines concurrently writing the same (photo, model) produce identical
+ids — converting the DELETE+INSERT in ``write_detection_batch`` into an
+idempotent UPSERT.
+
+The hash is truncated to 52 bits so every id is exactly representable as
+a JavaScript Number (``Number.MAX_SAFE_INTEGER == 2**53 - 1``), avoiding
+silent precision loss when ids ride through JSON to the frontend.
+"""
+import hashlib
+
+
+def positive_int_hash(*parts: str) -> int:
+    """Return a 52-bit non-negative int derived from SHA-256 of the parts."""
+    payload = "|".join(parts).encode("utf-8")
+    digest = hashlib.sha256(payload).hexdigest()
+    return int(digest[:13], 16)  # 13 hex chars == 52 bits
+
+
+def detection_id(
+    photo_id: int,
+    detector_model: str,
+    box: tuple[float, float, float, float],
+    category: str,
+) -> int:
+    """Compute the content-addressed id for a detection row.
+
+    ``box`` is ``(x, y, w, h)`` normalized to [0, 1]. Coords are quantized
+    to 4 decimals (~0.4 px on a 4K image) so ONNX float drift between
+    inference providers does not produce divergent ids for the same
+    logical detection.
+    """
+    x, y, w, h = box
+    qbox = (f"{round(x, 4):.4f}", f"{round(y, 4):.4f}",
+            f"{round(w, 4):.4f}", f"{round(h, 4):.4f}")
+    return positive_int_hash(
+        str(photo_id), detector_model, *qbox, category,
+    )

--- a/vireo/detection_id.py
+++ b/vireo/detection_id.py
@@ -14,8 +14,15 @@ import hashlib
 
 
 def positive_int_hash(*parts: str) -> int:
-    """Return a 52-bit non-negative int derived from SHA-256 of the parts."""
-    payload = "|".join(parts).encode("utf-8")
+    """Return a 52-bit non-negative int derived from SHA-256 of the parts.
+
+    Uses length-prefix encoding (``len:value`` per part) so the boundary
+    between parts is unambiguous even if a part itself contains the
+    separator character. Today's callers only feed alphanumeric/dotted
+    strings, but pinning the encoding now means future callers don't
+    have to audit for delimiter collisions.
+    """
+    payload = "".join(f"{len(p)}:{p}" for p in parts).encode("utf-8")
     digest = hashlib.sha256(payload).hexdigest()
     return int(digest[:13], 16)  # 13 hex chars == 52 bits
 

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -340,6 +340,49 @@ def _pair_raw_jpeg_companions(db):
                 "UPDATE OR IGNORE predictions SET detection_id = ? WHERE detection_id = ?",
                 (new_id, det["id"]),
             )
+            # If a companion prediction collided with an existing primary
+            # prediction, its row stayed on the old detection id. Preserve any
+            # workspace review state by moving it onto the surviving prediction
+            # before the old detection delete cascades the duplicate away.
+            db.conn.execute(
+                """INSERT INTO prediction_review
+                     (prediction_id, workspace_id, status, reviewed_at,
+                      individual, group_id, vote_count, total_votes)
+                   SELECT survivor.id, pr.workspace_id, pr.status,
+                          pr.reviewed_at, pr.individual, pr.group_id,
+                          pr.vote_count, pr.total_votes
+                     FROM predictions duplicate
+                     JOIN predictions survivor
+                       ON survivor.detection_id = ?
+                      AND survivor.classifier_model = duplicate.classifier_model
+                      AND survivor.labels_fingerprint = duplicate.labels_fingerprint
+                      AND survivor.species IS duplicate.species
+                     JOIN prediction_review pr
+                       ON pr.prediction_id = duplicate.id
+                    WHERE duplicate.detection_id = ?
+                   ON CONFLICT(prediction_id, workspace_id)
+                   DO UPDATE SET status = excluded.status,
+                                 reviewed_at = excluded.reviewed_at,
+                                 individual = COALESCE(
+                                     excluded.individual,
+                                     prediction_review.individual
+                                 ),
+                                 group_id = COALESCE(
+                                     excluded.group_id,
+                                     prediction_review.group_id
+                                 ),
+                                 vote_count = COALESCE(
+                                     excluded.vote_count,
+                                     prediction_review.vote_count
+                                 ),
+                                 total_votes = COALESCE(
+                                     excluded.total_votes,
+                                     prediction_review.total_votes
+                                 )
+                    WHERE prediction_review.status = 'pending'
+                      AND excluded.status <> 'pending'""",
+                (new_id, det["id"]),
+            )
             # Redirect classifier_runs too — they're the cache key the
             # non-reclassify gate consults. Without this, paired photos with
             # cached predictions would look unclassified to

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -392,7 +392,8 @@ def _invalidate_derived_caches(db, vireo_dir, photo_id, thumb_cache_dir=None):
     db.conn.execute(
         "UPDATE photos SET working_copy_path = NULL,"
         " working_copy_failed_at = NULL,"
-        " working_copy_failed_mtime = NULL"
+        " working_copy_failed_mtime = NULL,"
+        " working_copy_failed_source = NULL"
         " WHERE id = ?",
         (photo_id,),
     )
@@ -694,10 +695,12 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
 
         # Prefer companion JPEG if available
         source = os.path.join(row["folder_path"], row["filename"])
+        failure_source = "source"
         if row["companion_path"]:
             companion = os.path.join(row["folder_path"], row["companion_path"])
             if os.path.isfile(companion):
                 source = companion
+                failure_source = "companion"
 
         # extract_working_copy is slow (RAW decode + JPEG encode); run it
         # before any DB write so no transaction is open while it runs.
@@ -706,7 +709,8 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
             db.conn.execute(
                 "UPDATE photos SET working_copy_path=?,"
                 " working_copy_failed_at=NULL,"
-                " working_copy_failed_mtime=NULL"
+                " working_copy_failed_mtime=NULL,"
+                " working_copy_failed_source=NULL"
                 " WHERE id=?",
                 (wc_rel, row["id"]),
             )
@@ -725,9 +729,10 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
             )
             db.conn.execute(
                 "UPDATE photos SET working_copy_failed_at=datetime('now'),"
-                " working_copy_failed_mtime=?"
+                " working_copy_failed_mtime=?,"
+                " working_copy_failed_source=?"
                 " WHERE id=?",
-                (row["file_mtime"], row["id"]),
+                (row["file_mtime"], failure_source, row["id"]),
             )
         commit_with_retry(db.conn)
 

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -289,11 +289,64 @@ def _pair_raw_jpeg_companions(db):
         )
 
         # Transfer detections (and their cascaded predictions) from companion to primary.
-        # Detections are linked to photos; predictions cascade through detection_id.
-        db.conn.execute(
-            "UPDATE detections SET photo_id = ? WHERE photo_id = ?",
-            (primary["id"], companion["id"]),
-        )
+        # Detection IDs are content-addressed on (photo_id, detector_model, box,
+        # category) — see vireo/detection_id.py. A bare `UPDATE photo_id` would
+        # leave the row's `id` column stale (still hashed against the companion's
+        # photo_id); a later detector run on the primary that produced the same
+        # box would then either collide on the stale id (if SQLite reused the
+        # companion's rowid for a new photo) or, more commonly, never match and
+        # so the stale row would be reaped by the stale-cleanup DELETE in
+        # `_upsert_detection_rows`, cascading away its predictions. Recompute
+        # the id, redirect predictions to the new id, then drop the stale row.
+        from detection_id import detection_id as _detection_id
+
+        moving = db.conn.execute(
+            "SELECT id, detector_model, box_x, box_y, box_w, box_h,"
+            " detector_confidence, category"
+            " FROM detections WHERE photo_id = ?",
+            (companion["id"],),
+        ).fetchall()
+        for det in moving:
+            new_id = _detection_id(
+                primary["id"], det["detector_model"],
+                (det["box_x"], det["box_y"], det["box_w"], det["box_h"]),
+                det["category"],
+            )
+            if new_id == det["id"]:
+                # Cannot happen in practice (photo_id changed) but defensive.
+                db.conn.execute(
+                    "UPDATE detections SET photo_id = ? WHERE id = ?",
+                    (primary["id"], det["id"]),
+                )
+                continue
+            # Insert the row under the new id. If the primary already has a
+            # detection for the same (model, box, category), the UPSERT no-ops
+            # and we just discard the companion's row below.
+            db.conn.execute(
+                "INSERT INTO detections"
+                " (id, photo_id, detector_model, box_x, box_y, box_w, box_h,"
+                "  detector_confidence, category)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                " ON CONFLICT(id) DO NOTHING",
+                (new_id, primary["id"], det["detector_model"],
+                 det["box_x"], det["box_y"], det["box_w"], det["box_h"],
+                 det["detector_confidence"], det["category"]),
+            )
+            # Redirect predictions to the new detection id. ON CONFLICT in
+            # predictions is unlikely (would require the primary already had
+            # a prediction for this species against the same detection) but
+            # IGNORE keeps us defensive.
+            db.conn.execute(
+                "UPDATE OR IGNORE predictions SET detection_id = ? WHERE detection_id = ?",
+                (new_id, det["id"]),
+            )
+            # Drop any predictions that lost the UPDATE race (duplicate-key)
+            # along with the now-orphan companion detection row (CASCADE
+            # cleans up any remaining predictions tied to the old id).
+            db.conn.execute(
+                "DELETE FROM detections WHERE id = ?",
+                (det["id"],),
+            )
 
         # Transfer pending_changes from companion to primary. No dedup needed
         # here (unlike the inat_submissions block below): pending_changes has

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -340,9 +340,21 @@ def _pair_raw_jpeg_companions(db):
                 "UPDATE OR IGNORE predictions SET detection_id = ? WHERE detection_id = ?",
                 (new_id, det["id"]),
             )
-            # Drop any predictions that lost the UPDATE race (duplicate-key)
-            # along with the now-orphan companion detection row (CASCADE
-            # cleans up any remaining predictions tied to the old id).
+            # Redirect classifier_runs too — they're the cache key the
+            # non-reclassify gate consults. Without this, paired photos with
+            # cached predictions would look unclassified to
+            # `get_classifier_run_keys(new_id)` and rerun the classifier
+            # after every pair-up. Same OR IGNORE pattern as predictions:
+            # primary's own run rows win on (detection_id, classifier_model,
+            # labels_fingerprint) conflicts.
+            db.conn.execute(
+                "UPDATE OR IGNORE classifier_runs SET detection_id = ? WHERE detection_id = ?",
+                (new_id, det["id"]),
+            )
+            # Drop any predictions/classifier_runs that lost the UPDATE race
+            # (duplicate-key) along with the now-orphan companion detection
+            # row — CASCADE on both FKs cleans up any remaining rows tied to
+            # the old id.
             db.conn.execute(
                 "DELETE FROM detections WHERE id = ?",
                 (det["id"],),

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -311,7 +311,11 @@ def test_original_route_uses_offline_cache_despite_recent_raw_failure_marker(
     offline_resp = client.get(f"/photos/{pid}/original")
 
     assert offline_resp.status_code == 200
-    assert offline_resp.data[:2] == b"\xff\xd8"
+    row = db.offline_original_get(pid)
+    assert row is not None and row["bytes"] > 0
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    with open(os.path.join(vireo_dir, row["original_path"]), "rb") as f:
+        assert offline_resp.data == f.read()
 
 
 def test_offline_cache_rerun_preserves_cache_when_source_missing(client_with_photo):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -277,6 +277,43 @@ def test_original_route_uses_offline_cache_when_source_missing(client_with_photo
     assert offline_resp.data == source_bytes
 
 
+def test_original_route_uses_offline_cache_despite_recent_raw_failure_marker(
+    client_with_photo,
+):
+    """A RAW failure marker should not block an available offline original."""
+    app, db, pid = client_with_photo
+    client = app.test_client()
+
+    resp = client.post("/api/jobs/offline-cache", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+
+    photo = db.get_photo(pid)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
+    ).fetchone()
+    source = os.path.join(folder["path"], photo["filename"])
+    os.remove(source)
+    assert not os.path.isfile(source)
+
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='missing.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (photo["file_mtime"], pid),
+    )
+    db.conn.commit()
+
+    offline_resp = client.get(f"/photos/{pid}/original")
+
+    assert offline_resp.status_code == 200
+    assert offline_resp.data[:2] == b"\xff\xd8"
+
+
 def test_offline_cache_rerun_preserves_cache_when_source_missing(client_with_photo):
     """Re-running Make Offline with the source unavailable keeps the cached copy."""
     app, db, pid = client_with_photo

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -534,6 +534,75 @@ def test_detect_batch_returns_all_detections(tmp_path):
     mock_db.write_detection_batch.assert_called_once()
 
 
+def test_detect_batch_handles_same_batch_detection_id_collapse(tmp_path):
+    """If DB persistence collapses two detector outputs to one content ID,
+    _detect_batch must classify the persisted row instead of strict-zip failing.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _detect_batch
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    img = Image.new("RGB", (200, 200), color="green")
+    img_path = str(tmp_path / "bird.jpg")
+    img.save(img_path)
+
+    photos = [
+        {"id": 1, "filename": "bird.jpg", "folder_id": 10},
+    ]
+    folders = {10: str(tmp_path)}
+
+    fake_detections = [
+        {"box": {"x": 0.10001, "y": 0.2, "w": 0.3, "h": 0.4},
+         "confidence": 0.80, "category": "animal"},
+        {"box": {"x": 0.10002, "y": 0.2, "w": 0.3, "h": 0.4},
+         "confidence": 0.95, "category": "animal"},
+    ]
+
+    mock_db = MagicMock()
+    mock_db.write_detection_batch.return_value = [101]
+    mock_db.get_detections.return_value = [{
+        "id": 101,
+        "box_x": 0.10002,
+        "box_y": 0.2,
+        "box_w": 0.3,
+        "box_h": 0.4,
+        "detector_confidence": 0.95,
+        "category": "animal",
+        "detector_model": "megadetector-v6",
+    }]
+
+    with patch("classify_job.detect_animals", return_value=fake_detections), \
+         patch("classify_job.get_primary_detection", return_value=fake_detections[1]), \
+         patch("classify_job.compute_sharpness", return_value=50.0):
+        detection_map, detected, _processed = _detect_batch(
+            photos=photos,
+            folders=folders,
+            runner=runner,
+            job=job,
+            reclassify=False,
+            db=mock_db,
+            already_detected_ids=set(),
+        )
+
+    assert detected == 1
+    assert detection_map[1] == [{
+        "id": 101,
+        "box_x": 0.10002,
+        "box_y": 0.2,
+        "box_w": 0.3,
+        "box_h": 0.4,
+        "confidence": 0.95,
+        "category": "animal",
+        "detector_model": "megadetector-v6",
+    }]
+    mock_db.get_detections.assert_called_once_with(
+        1, min_conf=0, detector_model="megadetector-v6",
+    )
+
+
 def test_detect_batch_skips_empty_photo_on_rerun(tmp_path, monkeypatch):
     """A photo with no animals is recorded in detector_runs; rerun skips detection."""
     from db import Database

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1202,12 +1202,12 @@ def test_store_grouped_predictions_persists_group_match_for_cache(tmp_path, monk
     assert result["predictions_stored"] == 0
     assert result["already_labeled"] == 2
     rows = db.conn.execute(
-        "SELECT detection_id, species, category FROM predictions ORDER BY detection_id"
+        "SELECT detection_id, species, category FROM predictions"
     ).fetchall()
-    assert [(r["detection_id"], r["species"], r["category"]) for r in rows] == [
+    assert {(r["detection_id"], r["species"], r["category"]) for r in rows} == {
         (det_ids[0], "Robin", "match"),
         (det_ids[1], "Robin", "match"),
-    ]
+    }
 
 
 def test_group_match_drops_per_frame_alternatives(tmp_path, monkeypatch):
@@ -1296,16 +1296,15 @@ def test_group_match_drops_per_frame_alternatives(tmp_path, monkeypatch):
         "SELECT detection_id, species, category, status "
         "FROM predictions "
         "LEFT JOIN prediction_review "
-        "  ON prediction_review.prediction_id = predictions.id "
-        "ORDER BY detection_id"
+        "  ON prediction_review.prediction_id = predictions.id"
     ).fetchall()
-    assert [
+    assert {
         (r["detection_id"], r["species"], r["category"], r["status"])
         for r in rows
-    ] == [
+    } == {
         (det_ids[0], "Robin", "match", "accepted"),
         (det_ids[1], "Robin", "match", "accepted"),
-    ]
+    }
     # The cached top-1 (confidence-DESC) is the consensus species, not Hawk.
     top = db.get_predictions_for_detection(det_ids[0], min_classifier_conf=0)
     assert top[0]["species"] == "Robin"

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -2949,14 +2949,12 @@ def test_get_geolocated_photos_species_filter_multi_species(tmp_path):
                       file_size=100, file_mtime=1.0)
     db.conn.execute("UPDATE photos SET latitude=37.0, longitude=-122.0 WHERE id=?", (p1,))
     db.conn.commit()
-    det1 = db.save_detections(p1, [
-        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.95, "category": "animal"}
+    det_ids = db.save_detections(p1, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.95, "category": "animal"},
+        {"box": {"x": 0.5, "y": 0.5, "w": 0.3, "h": 0.4}, "confidence": 0.60, "category": "animal"},
     ], detector_model="MDV6")
-    det2 = db.save_detections(p1, [
-        {"box": {"x": 0.5, "y": 0.5, "w": 0.3, "h": 0.4}, "confidence": 0.60, "category": "animal"}
-    ], detector_model="MDV6")
-    db.add_prediction(det1[0], 'Red-tailed Hawk', 0.95, 'bioclip')
-    db.add_prediction(det2[0], "Sparrow", 0.60, 'bioclip')
+    db.add_prediction(det_ids[0], 'Red-tailed Hawk', 0.95, 'bioclip')
+    db.add_prediction(det_ids[1], "Sparrow", 0.60, 'bioclip')
     for pr in db.get_predictions(photo_ids=[p1]):
         db.accept_prediction(pr['id'])
 
@@ -3187,14 +3185,12 @@ def test_get_accepted_species_multiple_species_per_photo(tmp_path):
     db.conn.execute("UPDATE photos SET latitude=37.0, longitude=-122.0 WHERE id=?", (p1,))
     db.conn.commit()
     # Two detections for the same photo, each with different species
-    det_ids1 = db.save_detections(p1, [
-        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.95, "category": "animal"}
+    det_ids = db.save_detections(p1, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.95, "category": "animal"},
+        {"box": {"x": 0.5, "y": 0.5, "w": 0.3, "h": 0.4}, "confidence": 0.60, "category": "animal"},
     ], detector_model="MDV6")
-    det_ids2 = db.save_detections(p1, [
-        {"box": {"x": 0.5, "y": 0.5, "w": 0.3, "h": 0.4}, "confidence": 0.60, "category": "animal"}
-    ], detector_model="MDV6")
-    db.add_prediction(det_ids1[0], 'Red-tailed Hawk', 0.95, 'bioclip')
-    db.add_prediction(det_ids2[0], 'Cooper\'s Hawk', 0.60, 'bioclip')
+    db.add_prediction(det_ids[0], 'Red-tailed Hawk', 0.95, 'bioclip')
+    db.add_prediction(det_ids[1], 'Cooper\'s Hawk', 0.60, 'bioclip')
     preds = db.get_predictions(photo_ids=[p1])
     for pr in preds:
         db.accept_prediction(pr['id'])
@@ -4733,6 +4729,143 @@ def test_write_detection_batch_records_empty_scene(tmp_path):
     assert run is not None
     assert run["box_count"] == 0
     assert photo_id in db.get_detector_run_photo_ids("megadetector-v6")
+
+
+def test_write_detection_batch_ids_are_stable_for_same_content(tmp_path):
+    """IDs are derived from content, not table state. Even after other rows
+    are inserted (so auto-rowid recycling no longer hides the bug), the same
+    (photo, model, detections) must produce the same IDs.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_a = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    photo_b = db.add_photo(
+        folder_id=folder_id, filename="b.jpg", extension=".jpg",
+        file_size=200, file_mtime=2.0,
+    )
+
+    detections = [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+         "confidence": 0.9, "category": "animal"},
+        {"box": {"x": 0.4, "y": 0.4, "w": 0.2, "h": 0.2},
+         "confidence": 0.7, "category": "animal"},
+    ]
+    ids1 = db.write_detection_batch(photo_a, "megadetector-v6", detections)
+    # Insert into a different photo so the table is non-empty when photo_a's
+    # rows are deleted-and-reinserted — defeats auto-rowid's "reset to 1
+    # when table empty" recycling that hides the bug.
+    db.write_detection_batch(photo_b, "megadetector-v6", detections)
+    ids2 = db.write_detection_batch(photo_a, "megadetector-v6", detections)
+    assert ids1 == ids2, (
+        f"same content must produce same IDs across rewrites; got {ids1} vs {ids2}"
+    )
+
+    count = db.conn.execute(
+        "SELECT COUNT(*) AS c FROM detections WHERE photo_id = ? AND detector_model = ?",
+        (photo_a, "megadetector-v6"),
+    ).fetchone()["c"]
+    assert count == len(detections), "second write must not duplicate rows"
+
+
+def test_write_detection_batch_retires_stale_rows(tmp_path):
+    """Detections the new run no longer produces must be deleted, even when
+    other detections from the same (photo, model) are unchanged. Predictions
+    against retired detections CASCADE-delete; predictions against retained
+    detections survive.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+
+    a = {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+         "confidence": 0.9, "category": "animal"}
+    b = {"box": {"x": 0.3, "y": 0.3, "w": 0.2, "h": 0.2},
+         "confidence": 0.9, "category": "animal"}
+    c = {"box": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2},
+         "confidence": 0.9, "category": "animal"}
+    ids_abc = db.write_detection_batch(photo_id, "megadetector-v6", [a, b, c])
+    id_a, id_b, id_c = ids_abc
+
+    ids_ac = db.write_detection_batch(photo_id, "megadetector-v6", [a, c])
+    assert ids_ac == [id_a, id_c], "stable IDs for retained boxes"
+
+    remaining = {r["id"] for r in db.conn.execute(
+        "SELECT id FROM detections WHERE photo_id = ? AND detector_model = ?",
+        (photo_id, "megadetector-v6"),
+    ).fetchall()}
+    assert remaining == {id_a, id_c}, f"stale id {id_b} must be deleted"
+
+
+def test_write_detection_batch_second_writer_does_not_cascade_predictions(tmp_path):
+    """The race: pipeline A writes detections, classify writes predictions
+    against them, pipeline B writes the same detections again. With
+    auto-rowid IDs, B's DELETE CASCADEs A's predictions (data loss). With
+    content-addressed IDs, B's UPSERT matches A's rows so the FK targets
+    survive.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    detections = [
+        {"box": {"x": 0.10, "y": 0.10, "w": 0.20, "h": 0.20},
+         "confidence": 0.9, "category": "animal"},
+    ]
+
+    # Pipeline A: writes detections, then writes a prediction against the
+    # detection it just produced.
+    ids_a = db.write_detection_batch(photo_id, "megadetector-v6", detections)
+    det_id = ids_a[0]
+    db.conn.execute(
+        """INSERT INTO predictions
+             (detection_id, classifier_model, labels_fingerprint, species, confidence, category)
+           VALUES (?, 'classifier-v1', 'legacy', 'cardinal', 0.95, 'animal')""",
+        (det_id,),
+    )
+    db.conn.commit()
+
+    pred_count_before = db.conn.execute(
+        "SELECT COUNT(*) AS c FROM predictions WHERE detection_id = ?",
+        (det_id,),
+    ).fetchone()["c"]
+    assert pred_count_before == 1
+
+    # Pipeline B: writes the same detections. With auto-rowid this would
+    # DELETE A's row and CASCADE-delete A's prediction.
+    ids_b = db.write_detection_batch(photo_id, "megadetector-v6", detections)
+    assert ids_b == ids_a, "concurrent writer must produce same IDs"
+
+    pred_count_after = db.conn.execute(
+        "SELECT COUNT(*) AS c FROM predictions WHERE detection_id = ?",
+        (det_id,),
+    ).fetchone()["c"]
+    assert pred_count_after == 1, (
+        "B's write must not CASCADE-delete A's prediction; "
+        f"got {pred_count_after} predictions remaining"
+    )
 
 
 def test_multiple_predictions_per_detection(tmp_path):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4945,6 +4945,64 @@ def test_pairing_recomputes_detection_ids_so_photo_id_reuse_is_safe(tmp_path):
     assert pred is not None and pred["species"] == "Robin"
 
 
+def test_pairing_redirects_classifier_runs_so_cache_gate_still_hits(tmp_path):
+    """Regression for Codex P2 on PR #912: after pair-up rehashes a
+    detection's id, the classifier_runs row must follow.
+
+    `get_classifier_run_keys(detection_id)` is the gate that decides
+    whether classify_photos can serve cached predictions. If the run-key
+    row stays pointed at the old (companion) id, paired-then-rehashed
+    photos look unclassified to the gate and get re-classified
+    unnecessarily on every subsequent classify pass.
+    """
+    from db import Database
+    from detection_id import detection_id as compute_id
+    from scanner import _pair_raw_jpeg_companions
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, fid)
+    jpeg_id = db.add_photo(folder_id=fid, filename="IMG_1.jpg", extension=".jpg",
+                           file_size=1, file_mtime=1.0)
+    raw_id = db.add_photo(folder_id=fid, filename="IMG_1.cr3", extension=".cr3",
+                          file_size=1, file_mtime=1.0)
+
+    box = {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}
+    det_ids = db.write_detection_batch(jpeg_id, "MDV6", [
+        {"box": box, "confidence": 0.9, "category": "animal"},
+    ])
+    old_det_id = det_ids[0]
+    db.add_prediction(old_det_id, "Robin", 0.95, "bioclip")
+    # Record the classifier_run row that gates non-reclassify reruns.
+    db.conn.execute(
+        """INSERT INTO classifier_runs
+             (detection_id, classifier_model, labels_fingerprint, prediction_count)
+           VALUES (?, 'bioclip', 'fp-x', 1)""",
+        (old_det_id,),
+    )
+    db.conn.commit()
+
+    _pair_raw_jpeg_companions(db)
+
+    expected_new_id = compute_id(
+        raw_id, "MDV6", (box["x"], box["y"], box["w"], box["h"]), "animal",
+    )
+    # The classifier_runs row must now point at the rehashed detection id —
+    # otherwise the non-reclassify gate would treat the paired photo as
+    # unclassified and rerun the classifier needlessly.
+    keys = db.get_classifier_run_keys(expected_new_id)
+    assert ("bioclip", "fp-x") in keys, (
+        f"classifier_runs must follow rehash; new id keys: {keys}"
+    )
+    # And nothing left pointing at the stale old id (CASCADE cleanup).
+    stale = db.conn.execute(
+        "SELECT 1 FROM classifier_runs WHERE detection_id = ?", (old_det_id,),
+    ).fetchone()
+    assert stale is None, "stale classifier_runs row must not survive"
+
+
 def test_multiple_predictions_per_detection(tmp_path):
     """Multiple species predictions can be stored for the same detection."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4939,6 +4939,49 @@ def test_write_detection_batch_conflict_refreshes_box_fields(tmp_path):
     }
 
 
+def test_write_detection_batch_deduplicates_same_batch_ids(tmp_path):
+    """One detector batch can contain two boxes in the same quantized ID bucket.
+    Persist and count the unique detection once, using the strongest row.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+
+    low = {
+        "box": {"x": 0.10001, "y": 0.20001, "w": 0.30001, "h": 0.40001},
+        "confidence": 0.50,
+        "category": "animal",
+    }
+    high = {
+        "box": {"x": 0.10002, "y": 0.20002, "w": 0.30002, "h": 0.40002},
+        "confidence": 0.95,
+        "category": "animal",
+    }
+
+    ids = db.write_detection_batch(photo_id, "megadetector-v6", [low, high])
+    assert len(ids) == 1
+
+    row = db.conn.execute(
+        "SELECT box_x, detector_confidence FROM detections WHERE id = ?",
+        (ids[0],),
+    ).fetchone()
+    assert row["box_x"] == high["box"]["x"]
+    assert row["detector_confidence"] == high["confidence"]
+    run = db.conn.execute(
+        "SELECT box_count FROM detector_runs WHERE photo_id = ? AND detector_model = ?",
+        (photo_id, "megadetector-v6"),
+    ).fetchone()
+    assert run["box_count"] == 1
+
+
 def test_pairing_recomputes_detection_ids_so_photo_id_reuse_is_safe(tmp_path):
     """Regression: when raw+jpeg pairing moves a detection to the primary photo,
     its content-addressed id MUST be recomputed against the primary's photo_id.
@@ -5047,6 +5090,51 @@ def test_pairing_redirects_classifier_runs_so_cache_gate_still_hits(tmp_path):
         "SELECT 1 FROM classifier_runs WHERE detection_id = ?", (old_det_id,),
     ).fetchone()
     assert stale is None, "stale classifier_runs row must not survive"
+
+
+def test_pairing_preserves_review_when_duplicate_prediction_collapses(tmp_path):
+    """When a companion prediction loses the duplicate collapse, its manual
+    review state must move to the surviving primary prediction.
+    """
+    from db import Database
+    from scanner import _pair_raw_jpeg_companions
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, fid)
+    jpeg_id = db.add_photo(folder_id=fid, filename="IMG_1.jpg", extension=".jpg",
+                           file_size=1, file_mtime=1.0)
+    raw_id = db.add_photo(folder_id=fid, filename="IMG_1.cr3", extension=".cr3",
+                          file_size=1, file_mtime=1.0)
+
+    box = {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}
+    jpeg_det = db.write_detection_batch(jpeg_id, "MDV6", [
+        {"box": box, "confidence": 0.9, "category": "animal"},
+    ])[0]
+    raw_det = db.write_detection_batch(raw_id, "MDV6", [
+        {"box": box, "confidence": 0.9, "category": "animal"},
+    ])[0]
+    db.add_prediction(jpeg_det, "Robin", 0.95, "bioclip", status="accepted")
+    db.add_prediction(raw_det, "Robin", 0.90, "bioclip")
+
+    _pair_raw_jpeg_companions(db)
+
+    row = db.conn.execute(
+        """SELECT pr_rev.status
+             FROM predictions pr
+             JOIN prediction_review pr_rev ON pr_rev.prediction_id = pr.id
+            WHERE pr.detection_id IN (
+                  SELECT id FROM detections WHERE photo_id = ?
+            )
+              AND pr.species = 'Robin'
+              AND pr.classifier_model = 'bioclip'
+              AND pr_rev.workspace_id = ?""",
+        (raw_id, ws),
+    ).fetchone()
+    assert row is not None
+    assert row["status"] == "accepted"
 
 
 def test_multiple_predictions_per_detection(tmp_path):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4893,6 +4893,52 @@ def test_write_detection_batch_second_writer_does_not_cascade_predictions(tmp_pa
     )
 
 
+def test_write_detection_batch_conflict_refreshes_box_fields(tmp_path):
+    """If a replacement box falls in the same quantized ID bucket, the row's
+    exact stored coordinates must still update to the latest detector output.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+
+    first = {
+        "box": {"x": 0.10001, "y": 0.20001, "w": 0.30001, "h": 0.40001},
+        "confidence": 0.70,
+        "category": "animal",
+    }
+    second = {
+        "box": {"x": 0.10002, "y": 0.20002, "w": 0.30002, "h": 0.40002},
+        "confidence": 0.91,
+        "category": "animal",
+    }
+
+    ids1 = db.write_detection_batch(photo_id, "megadetector-v6", [first])
+    ids2 = db.write_detection_batch(photo_id, "megadetector-v6", [second])
+    assert ids2 == ids1, "sub-quantization box drift should keep the same id"
+
+    row = db.conn.execute(
+        "SELECT box_x, box_y, box_w, box_h, detector_confidence, category"
+        " FROM detections WHERE id = ?",
+        (ids1[0],),
+    ).fetchone()
+    assert dict(row) == {
+        "box_x": second["box"]["x"],
+        "box_y": second["box"]["y"],
+        "box_w": second["box"]["w"],
+        "box_h": second["box"]["h"],
+        "detector_confidence": second["confidence"],
+        "category": "animal",
+    }
+
+
 def test_pairing_recomputes_detection_ids_so_photo_id_reuse_is_safe(tmp_path):
     """Regression: when raw+jpeg pairing moves a detection to the primary photo,
     its content-addressed id MUST be recomputed against the primary's photo_id.

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4170,12 +4170,12 @@ def test_save_detections(tmp_path):
     ids = db.save_detections(pid, detections, detector_model="MDV6-yolov9-c")
     assert len(ids) == 2
     rows = db.conn.execute(
-        "SELECT * FROM detections WHERE photo_id = ? ORDER BY id",
+        "SELECT * FROM detections WHERE photo_id = ?",
         (pid,),
     ).fetchall()
     assert len(rows) == 2
-    assert rows[0]["box_x"] == 0.1
-    assert rows[1]["box_x"] == 0.5
+    # Content-addressed IDs aren't insertion-ordered, so compare as a set.
+    assert {round(r["box_x"], 4) for r in rows} == {0.1, 0.5}
 
 
 def test_save_detections_replaces_existing(tmp_path):
@@ -4802,6 +4802,21 @@ def test_write_detection_batch_retires_stale_rows(tmp_path):
     ids_abc = db.write_detection_batch(photo_id, "megadetector-v6", [a, b, c])
     id_a, id_b, id_c = ids_abc
 
+    # Plant a prediction against every detection. The retained ones
+    # (id_a, id_c) must survive the second write; only the retired one
+    # (id_b) should cascade-disappear. This pins the cascade contract:
+    # a bad implementation that DELETEs all rows and reinserts the kept
+    # ones would still produce the same `remaining` set below, but it
+    # would wipe id_a and id_c's predictions too.
+    for det_id, species in [(id_a, "A"), (id_b, "B"), (id_c, "C")]:
+        db.conn.execute(
+            """INSERT INTO predictions
+                 (detection_id, classifier_model, labels_fingerprint, species, confidence)
+               VALUES (?, 'classifier-v1', 'legacy', ?, 0.95)""",
+            (det_id, species),
+        )
+    db.conn.commit()
+
     ids_ac = db.write_detection_batch(photo_id, "megadetector-v6", [a, c])
     assert ids_ac == [id_a, id_c], "stable IDs for retained boxes"
 
@@ -4810,6 +4825,16 @@ def test_write_detection_batch_retires_stale_rows(tmp_path):
         (photo_id, "megadetector-v6"),
     ).fetchall()}
     assert remaining == {id_a, id_c}, f"stale id {id_b} must be deleted"
+
+    remaining_predictions = {
+        (r["detection_id"], r["species"]) for r in db.conn.execute(
+            "SELECT detection_id, species FROM predictions"
+        ).fetchall()
+    }
+    assert remaining_predictions == {(id_a, "A"), (id_c, "C")}, (
+        "predictions on retained detections must survive; only id_b's "
+        f"prediction should have cascaded away, got {remaining_predictions}"
+    )
 
 
 def test_write_detection_batch_second_writer_does_not_cascade_predictions(tmp_path):
@@ -4866,6 +4891,58 @@ def test_write_detection_batch_second_writer_does_not_cascade_predictions(tmp_pa
         "B's write must not CASCADE-delete A's prediction; "
         f"got {pred_count_after} predictions remaining"
     )
+
+
+def test_pairing_recomputes_detection_ids_so_photo_id_reuse_is_safe(tmp_path):
+    """Regression: when raw+jpeg pairing moves a detection to the primary photo,
+    its content-addressed id MUST be recomputed against the primary's photo_id.
+
+    Otherwise a later photo that reuses the companion's freed rowid (SQLite
+    INTEGER PRIMARY KEY without AUTOINCREMENT recycles ids) could produce a
+    detection whose computed id collides with the stale-moved row, and the
+    UPSERT would silently update the wrong photo's detection.
+    """
+    from db import Database
+    from detection_id import detection_id as compute_id
+    from scanner import _pair_raw_jpeg_companions
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, fid)
+    jpeg_id = db.add_photo(folder_id=fid, filename="IMG_1.jpg", extension=".jpg",
+                           file_size=1, file_mtime=1.0)
+    raw_id = db.add_photo(folder_id=fid, filename="IMG_1.cr3", extension=".cr3",
+                          file_size=1, file_mtime=1.0)
+
+    box = {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}
+    det_ids = db.write_detection_batch(jpeg_id, "MDV6", [
+        {"box": box, "confidence": 0.9, "category": "animal"},
+    ])
+    db.add_prediction(det_ids[0], "Robin", 0.95, "bioclip")
+
+    _pair_raw_jpeg_companions(db)
+
+    # After pairing: the surviving detection's id is computed against the
+    # primary (raw) photo's id, not the companion's.
+    expected_new_id = compute_id(
+        raw_id, "MDV6", (box["x"], box["y"], box["w"], box["h"]), "animal",
+    )
+    rows = db.conn.execute(
+        "SELECT id, photo_id FROM detections WHERE photo_id = ?", (raw_id,),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["id"] == expected_new_id, (
+        "moved detection's id must be recomputed against the new photo_id"
+    )
+
+    # Prediction followed the rehash.
+    pred = db.conn.execute(
+        "SELECT species FROM predictions WHERE detection_id = ?",
+        (expected_new_id,),
+    ).fetchone()
+    assert pred is not None and pred["species"] == "Robin"
 
 
 def test_multiple_predictions_per_detection(tmp_path):

--- a/vireo/tests/test_detection_id.py
+++ b/vireo/tests/test_detection_id.py
@@ -1,0 +1,97 @@
+# vireo/tests/test_detection_id.py
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from detection_id import detection_id, positive_int_hash
+
+
+def test_positive_int_hash_is_deterministic():
+    """Same inputs → same hash, every time."""
+    a = positive_int_hash("foo", "bar", "baz")
+    b = positive_int_hash("foo", "bar", "baz")
+    assert a == b
+
+
+def test_positive_int_hash_differs_for_different_inputs():
+    assert positive_int_hash("foo") != positive_int_hash("bar")
+    assert positive_int_hash("a", "b") != positive_int_hash("ab")  # separator matters
+    assert positive_int_hash("a", "b") != positive_int_hash("b", "a")
+
+
+def test_positive_int_hash_fits_in_js_safe_integer():
+    """52-bit width: every value must be ≤ Number.MAX_SAFE_INTEGER (2^53 - 1).
+
+    Detection IDs ride through JSON to the frontend; values above the JS
+    safe integer would silently lose precision on JSON.parse round-trip.
+    """
+    JS_MAX_SAFE = (1 << 53) - 1  # 9007199254740991
+    for parts in [
+        ("photo:1", "megadetector-v6", "0.1234", "0.5678", "0.0100", "0.0200", "animal"),
+        ("photo:99999999", "x" * 200, "0.9999", "0.9999", "0.9999", "0.9999", "person"),
+        ("", "", "", "", "", "", ""),
+    ]:
+        h = positive_int_hash(*parts)
+        assert 0 <= h <= JS_MAX_SAFE, f"{h} exceeds JS safe integer"
+        # 52-bit cap: high bit (2^52) and above must be zero.
+        assert h < (1 << 52), f"{h} exceeds 52 bits"
+
+
+def test_detection_id_stable_for_same_box():
+    """Same photo, model, box, category → same id."""
+    box = (0.1, 0.2, 0.3, 0.4)
+    a = detection_id(42, "megadetector-v6", box, "animal")
+    b = detection_id(42, "megadetector-v6", box, "animal")
+    assert a == b
+
+
+def test_detection_id_absorbs_sub_quarter_pixel_drift():
+    """ONNX float drift between providers is well below 1e-4.
+
+    Two runs producing boxes that differ in the 5th decimal place should
+    collapse to the same detection id. Without quantization, identical
+    detections from two pipelines would hash to different rows and the
+    UPSERT property breaks.
+    """
+    a = detection_id(42, "megadetector-v6", (0.10001, 0.20001, 0.30001, 0.40001), "animal")
+    b = detection_id(42, "megadetector-v6", (0.10002, 0.20002, 0.30002, 0.40002), "animal")
+    assert a == b
+
+
+def test_detection_id_distinguishes_4th_decimal_changes():
+    """4th-decimal differences (~0.4 px on 4K image) are real, distinct boxes."""
+    a = detection_id(42, "megadetector-v6", (0.1000, 0.2000, 0.3000, 0.4000), "animal")
+    b = detection_id(42, "megadetector-v6", (0.1001, 0.2000, 0.3000, 0.4000), "animal")
+    assert a != b
+
+
+def test_detection_id_distinguishes_photo():
+    box = (0.1, 0.2, 0.3, 0.4)
+    assert detection_id(1, "megadetector-v6", box, "animal") != \
+           detection_id(2, "megadetector-v6", box, "animal")
+
+
+def test_detection_id_distinguishes_detector_model():
+    box = (0.1, 0.2, 0.3, 0.4)
+    assert detection_id(42, "megadetector-v6", box, "animal") != \
+           detection_id(42, "megadetector-v7", box, "animal")
+
+
+def test_detection_id_distinguishes_category():
+    """category is part of model output — different categories on the same
+    box are different detections, so DELETE+INSERT retires the stale one.
+    """
+    box = (0.1, 0.2, 0.3, 0.4)
+    assert detection_id(42, "megadetector-v6", box, "animal") != \
+           detection_id(42, "megadetector-v6", box, "person")
+
+
+def test_detection_id_ignores_confidence_drift():
+    """confidence is NOT part of the natural key — it drifts between runs."""
+    # detection_id signature takes only (photo_id, model, box, category)
+    # so confidence isn't even an argument; this test pins the contract.
+    import inspect
+    sig = inspect.signature(detection_id)
+    assert "confidence" not in sig.parameters
+    assert "detector_confidence" not in sig.parameters

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1161,6 +1161,501 @@ def test_full_is_alias_for_preview_at_configured_size(client_with_photo, monkeyp
     assert len(full) > 0
 
 
+def test_preview_skips_recent_failed_raw_working_copy(
+    client_with_photo, monkeypatch,
+):
+    """A RAW whose working-copy extraction already failed at the current mtime
+    should fail fast instead of retrying RAW decode in /preview."""
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    called = {"load": False, "extract": False}
+
+    def fail_load_if_called(*_args, **_kwargs):
+        called["load"] = True
+        raise AssertionError("preview retried failed RAW decode")
+
+    def fail_extract_if_called(*_args, **_kwargs):
+        called["extract"] = True
+        raise AssertionError("preview retried failed RAW extraction")
+
+    monkeypatch.setattr(image_loader, "load_image", fail_load_if_called)
+    monkeypatch.setattr(image_loader, "extract_working_copy", fail_extract_if_called)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 500
+    assert called["load"] is False
+    assert called["extract"] is False
+
+
+def test_preview_skips_recent_failed_raw_when_working_copy_path_is_stale(
+    client_with_photo, monkeypatch,
+):
+    """A stale DB working_copy_path whose file is gone should not bypass a
+    fresh RAW failure marker."""
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path='working/missing.jpg',
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    called = {"load": False}
+
+    def fail_load_if_called(*_args, **_kwargs):
+        called["load"] = True
+        raise AssertionError("preview retried failed RAW with stale wc path")
+
+    monkeypatch.setattr(image_loader, "load_image", fail_load_if_called)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 500
+    assert called["load"] is False
+
+
+def test_preview_retries_raw_when_recent_marker_came_from_companion(
+    client_with_photo, monkeypatch,
+):
+    """A companion-source failure marker should not suppress a readable RAW."""
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.join(folder["path"], "bad.NEF")
+    companion_path = os.path.join(folder["path"], "bad.jpg")
+    with open(raw_path, "wb") as f:
+        f.write(b"raw bytes")
+    Image.new("RGB", (800, 600), (40, 80, 120)).save(
+        companion_path, "JPEG",
+    )
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               companion_path='bad.jpg',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    called = {"path": None}
+
+    def load_raw(path, *_args, **_kwargs):
+        called["path"] = path
+        return Image.new("RGB", (800, 600), (40, 80, 120))
+
+    monkeypatch.setattr(image_loader, "load_image", load_raw)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 200
+    assert called["path"] == raw_path
+
+
+def test_preview_honors_raw_marker_after_companion_bypass_retry_fails(
+    client_with_photo, monkeypatch,
+):
+    """A RAW failure recorded after companion bypass should suppress repeats."""
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.join(folder["path"], "bad.NEF")
+    companion_path = os.path.join(folder["path"], "bad.jpg")
+    with open(raw_path, "wb") as f:
+        f.write(b"raw bytes")
+    Image.new("RGB", (800, 600), (40, 80, 120)).save(
+        companion_path, "JPEG",
+    )
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               companion_path='bad.jpg',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?,
+               working_copy_failed_source='companion'
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    calls = {"count": 0}
+
+    def fail_raw(_path, *_args, **_kwargs):
+        calls["count"] += 1
+        return None
+
+    monkeypatch.setattr(image_loader, "load_image", fail_raw)
+
+    client = app.test_client()
+    first = client.get(f"/photos/{photo_id}/preview?size=1920")
+    second = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert first.status_code == 500
+    assert second.status_code == 500
+    assert calls["count"] == 1
+    row = db.conn.execute(
+        """SELECT working_copy_failed_mtime, working_copy_failed_source
+           FROM photos WHERE id=?""",
+        (photo_id,),
+    ).fetchone()
+    assert row["working_copy_failed_mtime"] == file_mtime
+    assert row["working_copy_failed_source"] == "source"
+
+
+def test_preview_retries_stale_failed_raw_working_copy(
+    client_with_photo, monkeypatch,
+):
+    """A RAW failure older than the retry window should be allowed to retry."""
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now', '-48 hours'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    called = {"load": False}
+
+    def record_retry(*_args, **_kwargs):
+        called["load"] = True
+        return None
+
+    monkeypatch.setattr(image_loader, "load_image", record_retry)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 500
+    assert called["load"] is True
+
+
+def test_preview_refreshes_failure_marker_when_stale_retry_fails(
+    client_with_photo, monkeypatch,
+):
+    """When the retry window has expired and the request-time decode still
+    fails, /preview must refresh ``working_copy_failed_at`` so the next
+    request fails fast again instead of repeating the slow decode."""
+    import os
+
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    with open(os.path.join(folder["path"], "bad.NEF"), "wb") as f:
+        f.write(b"not a decodable raw")
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now', '-48 hours'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    monkeypatch.setattr(image_loader, "load_image", lambda *a, **k: None)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+    assert resp.status_code == 500
+
+    # Marker should now be fresh (within a few seconds of "now") and the
+    # mtime should match the file's current mtime so the gate fires again
+    # on the next request.
+    row = db.conn.execute(
+        """SELECT working_copy_failed_mtime,
+                  (julianday('now') - julianday(working_copy_failed_at))
+                  * 24 * 60 * 60 AS age_seconds
+           FROM photos WHERE id=?""",
+        (photo_id,),
+    ).fetchone()
+    assert row["working_copy_failed_mtime"] == file_mtime
+    assert row["age_seconds"] is not None and row["age_seconds"] < 60
+
+
+def test_preview_does_not_refresh_failure_marker_when_raw_source_is_missing(
+    client_with_photo,
+):
+    """Missing/offline RAW sources are not decode failures; leave stale
+    extraction markers stale so remounting the source can recover quickly."""
+    app, db, photo_id = client_with_photo
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='missing.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now', '-48 hours'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 500
+    row = db.conn.execute(
+        """SELECT (julianday('now') - julianday(working_copy_failed_at))
+                  * 24 * 60 * 60 AS age_seconds
+           FROM photos WHERE id=?""",
+        (photo_id,),
+    ).fetchone()
+    assert row["age_seconds"] is not None and row["age_seconds"] > 24 * 60 * 60
+
+
+def test_preview_does_not_refresh_failure_marker_when_working_copy_jpeg_is_corrupt(
+    client_with_photo, monkeypatch,
+):
+    """A corrupt/unreadable working-copy JPEG must not stamp the RAW marker.
+
+    ``get_canonical_image_path`` prefers an existing working-copy JPEG over the
+    original RAW. If that JPEG fails to load, the failure is in the JPEG, not
+    in RAW extraction — recording it as a RAW failure would suppress legitimate
+    RAW retries for 24h even though the RAW was never tried.
+    """
+    import os
+
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_rel = f"working/{photo_id}.jpg"
+    with open(os.path.join(vireo_dir, wc_rel), "wb") as f:
+        f.write(b"corrupt jpeg bytes")
+
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=?,
+               working_copy_failed_at=datetime('now', '-48 hours'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (wc_rel, file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    monkeypatch.setattr(image_loader, "load_image", lambda *a, **k: None)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 500
+    row = db.conn.execute(
+        """SELECT (julianday('now') - julianday(working_copy_failed_at))
+                  * 24 * 60 * 60 AS age_seconds
+           FROM photos WHERE id=?""",
+        (photo_id,),
+    ).fetchone()
+    assert row["age_seconds"] is not None and row["age_seconds"] > 24 * 60 * 60
+
+
+def test_original_skips_recent_failed_raw_working_copy(
+    client_with_photo, monkeypatch,
+):
+    """The 1:1 original route should also fail fast for a current RAW
+    extraction failure."""
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    called = {"extract": False}
+
+    def fail_if_called(*_args, **_kwargs):
+        called["extract"] = True
+        raise AssertionError("original route retried failed RAW extraction")
+
+    monkeypatch.setattr(image_loader, "extract_working_copy", fail_if_called)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/original")
+
+    assert resp.status_code == 500
+    assert called["extract"] is False
+
+
+def test_original_skips_recent_failed_raw_after_rejecting_small_working_copy(
+    client_with_photo, monkeypatch,
+):
+    """If a capped working copy is too small for /original, a fresh RAW failure
+    marker should still suppress another full-res extraction attempt."""
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    Image.new("RGB", (100, 100), (40, 80, 120)).save(
+        os.path.join(working_dir, f"{photo_id}.jpg"), "JPEG",
+    )
+
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=?,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (f"working/{photo_id}.jpg", file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    called = {"extract": False}
+
+    def fail_if_called(*_args, **_kwargs):
+        called["extract"] = True
+        raise AssertionError("original retried RAW after small wc rejection")
+
+    monkeypatch.setattr(image_loader, "extract_working_copy", fail_if_called)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/original")
+
+    assert resp.status_code == 500
+    assert called["extract"] is False
+
+
+def test_original_refreshes_failure_marker_when_stale_retry_fails(
+    client_with_photo, monkeypatch,
+):
+    """A stale RAW failure may retry once; if original extraction and fallback
+    loading still fail, the route should refresh the failure marker."""
+    import os
+
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    with open(os.path.join(folder["path"], "bad.NEF"), "wb") as f:
+        f.write(b"not a decodable raw")
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now', '-48 hours'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    monkeypatch.setattr(image_loader, "extract_working_copy", lambda *a, **k: False)
+    monkeypatch.setattr(image_loader, "load_image", lambda *a, **k: None)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/original")
+
+    assert resp.status_code == 500
+    row = db.conn.execute(
+        """SELECT working_copy_failed_mtime,
+                  (julianday('now') - julianday(working_copy_failed_at))
+                  * 24 * 60 * 60 AS age_seconds
+           FROM photos WHERE id=?""",
+        (photo_id,),
+    ).fetchone()
+    assert row["working_copy_failed_mtime"] == file_mtime
+    assert row["age_seconds"] is not None and row["age_seconds"] < 60
+
+
 def test_eviction_removes_oldest_files_when_over_quota(tmp_path, monkeypatch):
     """When writes push cache over quota, oldest-accessed entries are evicted."""
     import os

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1271,7 +1271,8 @@ def test_preview_retries_raw_when_recent_marker_came_from_companion(
                companion_path='bad.jpg',
                working_copy_path=NULL,
                working_copy_failed_at=datetime('now'),
-               working_copy_failed_mtime=?
+               working_copy_failed_mtime=?,
+               working_copy_failed_source='companion'
            WHERE id=?""",
         (file_mtime, photo_id),
     )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -510,8 +510,18 @@ def test_pairing_merges_predictions_without_unique_violation(tmp_path):
     assert preds[0]["species"] == "Robin"
 
 
-def test_pairing_merges_duplicate_predictions_keeps_higher_confidence(tmp_path):
-    """When both raw and JPEG have predictions, both detections transfer to primary."""
+def test_pairing_collapses_duplicate_detections_across_raw_jpeg(tmp_path):
+    """When raw and JPEG already have identical detections (same model + box +
+    category) from prior detector runs, pairing collapses them into one row.
+
+    With content-addressed detection IDs, an identical (model, box, category)
+    on the *same* primary photo collapses to one detection — the companion's
+    moved detection re-hashes to the primary's existing id, the UPSERT
+    no-ops, and the duplicate prediction is dropped by the UNIQUE
+    (detection_id, classifier_model) constraint. This is the correct
+    semantics: RAW + JPEG of the same scene with the same detector output
+    is logically one detection, not two.
+    """
     from db import Database
 
     img_dir = tmp_path / "photos"
@@ -523,10 +533,6 @@ def test_pairing_merges_duplicate_predictions_keeps_higher_confidence(tmp_path):
         f.write(b"\x00" * 200)
 
     db = Database(str(tmp_path / "test.db"))
-    # Scan — this creates both records, then pairs them. But we need BOTH to have
-    # predictions before pairing. So: scan once (creates paired result), undo pairing
-    # manually to set up the scenario, then re-pair.
-    # Instead: create photos manually, add predictions, then run pairing.
     from scanner import _pair_raw_jpeg_companions
 
     fid = db.add_folder(str(img_dir), name="photos")
@@ -535,7 +541,7 @@ def test_pairing_merges_duplicate_predictions_keeps_higher_confidence(tmp_path):
     raw_id = db.add_photo(folder_id=fid, filename="IMG_001.cr3", extension=".cr3",
                           file_size=2000, file_mtime=1.0)
 
-    # Both classified with same model — JPEG has higher confidence
+    # Both classified with same model + same box + same category.
     jpeg_det = db.save_detections(jpeg_id, [
         {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4}, "confidence": 0.9, "category": "animal"}
     ], detector_model="MDV6")
@@ -552,17 +558,24 @@ def test_pairing_merges_duplicate_predictions_keeps_higher_confidence(tmp_path):
     assert len(photos) == 1
     assert photos[0]["filename"] == "IMG_001.cr3"
 
+    # Detections collapse to one: same primary, same (model, box, category)
+    # hashes to a single id.
+    dets = db.conn.execute(
+        "SELECT id FROM detections WHERE photo_id = ?", (photos[0]["id"],),
+    ).fetchall()
+    assert len(dets) == 1, "duplicate detections must collapse to one row"
+
     preds = db.conn.execute(
         """SELECT pr.species, pr.confidence FROM predictions pr
            JOIN detections d ON d.id = pr.detection_id
            WHERE d.photo_id = ?""",
         (photos[0]["id"],),
     ).fetchall()
-    # Both detections (and their predictions) transfer to the primary photo.
-    # UNIQUE(detection_id, model) doesn't conflict since detection IDs differ.
-    assert len(preds) == 2
-    confidences = sorted(p["confidence"] for p in preds)
-    assert confidences == [0.70, 0.95]
+    # UNIQUE(detection_id, classifier_model) means only one Robin@bioclip
+    # prediction can survive on the collapsed detection. We don't pin which
+    # confidence wins — UPDATE OR IGNORE keeps the primary's existing row.
+    assert len(preds) == 1
+    assert preds[0]["species"] == "Robin"
 
 
 def test_pairing_transfers_inat_submissions(tmp_path):

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -702,6 +702,142 @@ def test_serve_thumbnail_404s_when_source_is_unreadable(tmp_path, monkeypatch):
     assert resp.status_code == 404
 
 
+def test_serve_thumbnail_skips_recent_failed_raw_working_copy(
+    tmp_path, monkeypatch,
+):
+    """A RAW row that already failed working-copy extraction at the current
+    mtime must not retry RAW decode in the thumbnail request thread.
+    """
+    import thumbnails
+
+    app, db, pid, _thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (pid,),
+    ).fetchone()
+    with open(os.path.join(folder["path"], "bad.NEF"), "wb") as f:
+        f.write(b"not a decodable raw")
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, pid),
+    )
+    db.conn.commit()
+
+    called = {"generate": False}
+
+    def fail_if_called(*_args, **_kwargs):
+        called["generate"] = True
+        raise AssertionError("thumbnail request retried failed RAW decode")
+
+    monkeypatch.setattr(thumbnails, "generate_thumbnail", fail_if_called)
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 404
+    assert called["generate"] is False
+
+
+def test_serve_thumbnail_refreshes_failure_marker_when_stale_retry_fails(
+    tmp_path, monkeypatch,
+):
+    """A stale RAW failure may retry once; if thumbnail regeneration still
+    fails, the route should refresh the marker so later requests fail fast."""
+    import thumbnails
+
+    app, db, pid, _thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (pid,),
+    ).fetchone()
+    with open(os.path.join(folder["path"], "bad.NEF"), "wb") as f:
+        f.write(b"not a decodable raw")
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now', '-48 hours'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, pid),
+    )
+    db.conn.commit()
+
+    monkeypatch.setattr(
+        thumbnails, "generate_thumbnail", lambda *args, **kwargs: None,
+    )
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 404
+    row = db.conn.execute(
+        """SELECT working_copy_failed_mtime,
+                  (julianday('now') - julianday(working_copy_failed_at))
+                  * 24 * 60 * 60 AS age_seconds
+           FROM photos WHERE id=?""",
+        (pid,),
+    ).fetchone()
+    assert row["working_copy_failed_mtime"] == file_mtime
+    assert row["age_seconds"] is not None and row["age_seconds"] < 60
+
+
+def test_serve_thumbnail_does_not_refresh_raw_marker_on_cache_write_error(
+    tmp_path, monkeypatch,
+):
+    """Thumbnail cache write failures should not be recorded as RAW failures."""
+    import thumbnails
+
+    app, db, pid, _thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (pid,),
+    ).fetchone()
+    with open(os.path.join(folder["path"], "bad.NEF"), "wb") as f:
+        f.write(b"raw bytes")
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now', '-48 hours'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, pid),
+    )
+    db.conn.commit()
+
+    def fail_write(*_args, **_kwargs):
+        raise OSError("thumbnail cache is unwritable")
+
+    monkeypatch.setattr(thumbnails, "generate_thumbnail", fail_write)
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 404
+    row = db.conn.execute(
+        """SELECT (julianday('now') - julianday(working_copy_failed_at))
+                  * 24 * 60 * 60 AS age_seconds
+           FROM photos WHERE id=?""",
+        (pid,),
+    ).fetchone()
+    assert row["age_seconds"] is not None and row["age_seconds"] > 24 * 60 * 60
+
+
 def test_serve_thumbnail_resolves_when_folder_status_is_missing(tmp_path, monkeypatch):
     """The self-heal must use the photo's actual folder path even when
     the folder's status is ``'missing'``. ``get_folder_tree()`` filters

--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -6,9 +6,9 @@ const base = import.meta.env.BASE_URL;
 const releaseUrl = (v: string) => `https://github.com/jss367/vireo/releases/download/v${v}`;
 
 // Per-platform versions — updated independently by CI when each platform builds
-const macosArm64Version = '0.8.52';
-const windowsVersion = '0.8.52';
-const linuxVersion = '0.8.52';
+const macosArm64Version = '0.8.53';
+const windowsVersion = '0.8.53';
+const linuxVersion = '0.8.53';
 ---
 
 <Base title="Download — Vireo" description="Download Vireo for macOS, Windows, or Linux. Free, open source, no account required.">


### PR DESCRIPTION
## Summary

Fixes the detect-write race Codex flagged on #907 (SLOT_CAP=2) at the data layer rather than with serialising locks. `detections.id` becomes a 52-bit SHA-256 hash of `(photo_id, detector_model, quantized_bbox, category)` instead of auto-rowid, so two pipelines writing the same `(photo, model)` compute identical IDs and the second writer's UPSERT is a no-op rather than a CASCADE-deleting DELETE+INSERT.

### Design highlights

- **Why content addressing over surrogate + UNIQUE constraint:** a detection isn't an entity with independent identity. Two boxes at the same position in the same photo from the same detector *are the same detection* — the natural key is constitutive, not merely unique. Full design in `docs/plans/2026-05-28-content-addressed-detection-ids-design.md`.
- **`INSERT ON CONFLICT(id) DO UPDATE`** rather than `INSERT OR REPLACE`. The latter fires a DELETE before re-INSERT, which CASCADEs through `predictions.detection_id` and silently wipes another pipeline's predictions. The dedicated test `test_write_detection_batch_second_writer_does_not_cascade_predictions` pins this.
- **52-bit width** so every detection ID is within `Number.MAX_SAFE_INTEGER` — IDs ride through JSON unharmed. Collision probability at Vireo's scale is ~10⁻⁹.
- **4-decimal bbox quantization** absorbs sub-quarter-pixel ONNX drift between inference providers (CUDA / CoreML / CPU).
- **Stale rows** (boxes the new run no longer produces) are removed by an explicit narrow DELETE keyed on `id NOT IN new_ids`, safe under concurrent writers because both compute the same `new_ids`.
- **No migration.** Old auto-rowid rows coexist in the same column; the first re-detect after the change retires them via the standard semantics.

### Latent test bugs surfaced

Two tests in `test_db.py` called `save_detections` twice for the same `(photo, model)` expecting the calls to accumulate. The old behavior silently wiped the first call's row while reusing rowid 1, so the stale ID coincidentally matched the new one and the FK didn't fail. With content-addressed IDs the stale ID has no surviving row. Combined into single calls.

### Sequencing with #907

This is intended to land **before** #907 (SLOT_CAP=2 lift). #907's `acquire_photo_detect` lock becomes unnecessary once this lands — the race is fixed at the data layer. After merge, #907 rebases on top and drops the lock + its tests.

## Test plan

- [x] New unit tests in `vireo/tests/test_detection_id.py` (determinism, 52-bit ceiling, quantization, key composition) — 10/10 pass
- [x] New regression tests in `vireo/tests/test_db.py`:
  - `test_write_detection_batch_ids_are_stable_for_same_content` — defeats rowid recycling by inserting into a second photo first
  - `test_write_detection_batch_retires_stale_rows` — demonstrates the narrow stale-cleanup DELETE
  - `test_write_detection_batch_second_writer_does_not_cascade_predictions` — the actual race that motivates the change
- [x] Full local sweep: `python -m pytest tests/ vireo/tests/ --ignore=tests/e2e` → **3091 passed, 5 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed races in concurrent detection writes so predictions no longer reference deleted/stale detection records.
  * Prevent repeated expensive RAW extraction retries by honoring a recent failure marker.

* **Behavior Change**
  * Detections are now deterministically identified; RAW+JPEG pairing collapses duplicate detections to a single canonical detection while preserving predictions and cache gates.
  * Thumbnail/preview/original endpoints fast-fail when a recent RAW failure marker applies.

* **Documentation**
  * Added design doc describing the deterministic detection-ID approach and rollout guidance.

* **Tests**
  * Added/updated tests for detection IDs, concurrent writes, pairing, working-copy failure handling, and related regressions.

* **Chores**
  * Version bumped to 0.8.53.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->