### PR TITLE
sync: fix Review Pending Changes lightbox nav and add per-photo panel

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3702,6 +3702,9 @@ function openLightbox(photoId, filename, photoList, options) {
 
   _lightboxCurrentId = photoId;
   if (photoList) _lightboxPhotoList = photoList;
+  try {
+    document.dispatchEvent(new CustomEvent('lightbox:photochanged', { detail: { photoId: photoId } }));
+  } catch(_) {}
   var currentFromList = _lightboxPhotoList.find(function(x) { return x.id === photoId; });
   if (currentFromList && Object.prototype.hasOwnProperty.call(currentFromList, 'flag')) {
     _lbRememberConfirmedFlag(photoId, currentFromList.flag);
@@ -4097,6 +4100,7 @@ function closeLightbox(e) {
   document.getElementById('lightboxImg').src = '';
   document.getElementById('lightboxZoomBadge').style.display = 'none';
   _lightboxCurrentId = null;
+  try { document.dispatchEvent(new CustomEvent('lightbox:closed')); } catch(_) {}
   _lbSetFlagStatus(undefined);
   var detContainer = document.getElementById('lightboxDetections');
   if (detContainer) detContainer.innerHTML = '';

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -33,6 +33,8 @@
 var _syncPreviewData = null;
 var _syncThumbSize = 120;
 var _syncActiveFilters = null;
+var _syncModalOpen = false;
+var _syncLightboxPanelEl = null;
 
 async function checkPendingSync() {
   try {
@@ -92,6 +94,7 @@ function updateSyncThumbSize(val) {
 
 async function openSyncPreview() {
   _syncActiveFilters = null;
+  _syncModalOpen = true;
   var overlay = document.getElementById('syncPreviewOverlay');
   var content = document.getElementById('syncPreviewContent');
   overlay.style.display = 'block';
@@ -191,13 +194,165 @@ function renderSyncPreview() {
 /* Delegate sync preview thumb clicks for lightbox (XSS-safe) */
 document.getElementById('syncPreviewContent').addEventListener('click', function(e) {
   var thumb = e.target.closest('img[data-photo-id]');
-  if (thumb) openLightbox(parseInt(thumb.dataset.photoId, 10), thumb.dataset.filename || '');
+  if (!thumb) return;
+  // Pass the list of currently-visible photos so the lightbox arrows can navigate
+  // between pending-change items. Without this, _lightboxPhotoList stays empty
+  // and lightboxNav() bails out immediately.
+  var photoList = [];
+  if (_syncPreviewData && _syncPreviewData.photos && _syncActiveFilters) {
+    _syncPreviewData.photos.forEach(function(p) {
+      var hasVisible = p.changes.some(function(c) { return _syncActiveFilters.has(c.type); });
+      if (hasVisible) photoList.push({ id: p.photo_id, filename: p.filename });
+    });
+  }
+  openLightbox(parseInt(thumb.dataset.photoId, 10), thumb.dataset.filename || '', photoList);
 });
 
 function closeSyncPreview() {
   document.getElementById('syncPreviewOverlay').style.display = 'none';
+  _syncModalOpen = false;
+  _syncDestroyLightboxPanel();
   checkPendingSync();
 }
+
+function _syncFindPhotoData(photoId) {
+  if (!_syncPreviewData || !_syncPreviewData.photos) return null;
+  return _syncPreviewData.photos.find(function(p) { return p.photo_id === photoId; }) || null;
+}
+
+function _syncVisibleChangesFor(photo) {
+  if (!photo) return [];
+  if (!_syncActiveFilters) return photo.changes.slice();
+  return photo.changes.filter(function(c) { return _syncActiveFilters.has(c.type); });
+}
+
+function _syncEnsureLightboxPanel() {
+  if (_syncLightboxPanelEl && _syncLightboxPanelEl.parentNode) return _syncLightboxPanelEl;
+  var overlay = document.getElementById('lightboxOverlay');
+  if (!overlay) return null;
+  var panel = document.createElement('div');
+  panel.id = 'syncLightboxPanel';
+  panel.style.cssText = 'position:absolute;top:56px;right:16px;max-width:340px;background:rgba(0,0,0,0.7);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:6px;padding:10px 12px;font-size:12px;z-index:10002;box-shadow:0 4px 16px rgba(0,0,0,0.5);';
+  panel.addEventListener('click', function(e) { e.stopPropagation(); });
+  overlay.appendChild(panel);
+  _syncLightboxPanelEl = panel;
+  return panel;
+}
+
+function _syncDestroyLightboxPanel() {
+  if (_syncLightboxPanelEl && _syncLightboxPanelEl.parentNode) {
+    _syncLightboxPanelEl.parentNode.removeChild(_syncLightboxPanelEl);
+  }
+  _syncLightboxPanelEl = null;
+}
+
+function _syncRenderLightboxPanel(photoId) {
+  if (!_syncModalOpen) { _syncDestroyLightboxPanel(); return; }
+  var photo = _syncFindPhotoData(photoId);
+  var visible = _syncVisibleChangesFor(photo);
+  if (!photo || visible.length === 0) {
+    _syncDestroyLightboxPanel();
+    return;
+  }
+  var panel = _syncEnsureLightboxPanel();
+  if (!panel) return;
+  var html = '<div style="font-weight:600;margin-bottom:6px;color:var(--accent);">Pending changes</div>';
+  visible.forEach(function(c) {
+    var icon = c.type === 'keyword_add' ? '+' : c.type === 'keyword_remove' ? '−' : '~';
+    var color = c.type === 'keyword_add' ? 'var(--accent)' : c.type === 'keyword_remove' ? 'var(--danger)' : 'var(--warning)';
+    var typeLabel = c.type.replace(/_/g, ' ');
+    html += '<div style="display:flex;align-items:center;gap:6px;padding:3px 0;">' +
+      '<span style="color:' + color + ';font-weight:700;width:12px;text-align:center;">' + icon + '</span>' +
+      '<span style="flex:1;color:var(--text-primary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escapeHtml(c.value) + '</span>' +
+      '<span style="font-size:10px;color:var(--text-dim);">' + typeLabel + '</span>' +
+      '<button data-sync-discard-change="' + c.id + '" style="background:none;border:none;color:var(--text-ghost);cursor:pointer;padding:0 4px;font-size:16px;line-height:1;" title="Discard this change">&times;</button>' +
+      '</div>';
+  });
+  html += '<div style="display:flex;justify-content:space-between;align-items:center;margin-top:8px;gap:8px;">' +
+    '<span style="font-size:11px;color:var(--text-dim);">Use ← → to navigate</span>' +
+    '<button data-sync-discard-photo="' + photoId + '" style="background:none;border:1px solid var(--danger);color:var(--danger);border-radius:4px;font-size:11px;cursor:pointer;padding:3px 8px;">Discard all</button>' +
+    '</div>';
+  panel.innerHTML = html;
+}
+
+async function _syncDiscardFromLightbox(changeIds, photoId) {
+  if (!changeIds || changeIds.length === 0) return;
+  try {
+    await safeFetch('/api/sync/discard', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ change_ids: changeIds }),
+    });
+  } catch(e) { return; }
+
+  var discardSet = {};
+  changeIds.forEach(function(id) { discardSet[id] = true; });
+  if (_syncPreviewData && _syncPreviewData.photos) {
+    _syncPreviewData.photos.forEach(function(p) {
+      p.changes = p.changes.filter(function(c) { return !discardSet[c.id]; });
+    });
+    _syncPreviewData.photos = _syncPreviewData.photos.filter(function(p) { return p.changes.length > 0; });
+  }
+
+  var photoAfter = _syncFindPhotoData(photoId);
+  var visibleAfter = _syncVisibleChangesFor(photoAfter);
+
+  renderSyncPreview();
+
+  if (visibleAfter.length > 0) {
+    _syncRenderLightboxPanel(photoId);
+    return;
+  }
+
+  // No more visible changes for this photo — advance the lightbox to the next
+  // photo with visible changes, or close if none remain.
+  var newList = [];
+  if (_syncPreviewData && _syncPreviewData.photos) {
+    _syncPreviewData.photos.forEach(function(p) {
+      if (_syncVisibleChangesFor(p).length > 0) {
+        newList.push({ id: p.photo_id, filename: p.filename });
+      }
+    });
+  }
+  var prevList = window._lightboxPhotoList || [];
+  var prevIdx = prevList.findIndex(function(p) { return p.id === photoId; });
+  if (newList.length === 0) {
+    closeLightbox();
+    return;
+  }
+  var nextIdx = prevIdx >= 0 ? Math.min(prevIdx, newList.length - 1) : 0;
+  var next = newList[nextIdx];
+  openLightbox(next.id, next.filename, newList);
+}
+
+document.addEventListener('click', function(e) {
+  var changeBtn = e.target.closest('button[data-sync-discard-change]');
+  if (changeBtn) {
+    e.stopPropagation();
+    var changeId = parseInt(changeBtn.getAttribute('data-sync-discard-change'), 10);
+    if (!isNaN(changeId)) _syncDiscardFromLightbox([changeId], _lightboxCurrentId);
+    return;
+  }
+  var photoBtn = e.target.closest('button[data-sync-discard-photo]');
+  if (photoBtn) {
+    e.stopPropagation();
+    var pid = parseInt(photoBtn.getAttribute('data-sync-discard-photo'), 10);
+    var photo = _syncFindPhotoData(pid);
+    if (photo) {
+      var ids = photo.changes.map(function(c) { return c.id; });
+      _syncDiscardFromLightbox(ids, pid);
+    }
+  }
+});
+
+document.addEventListener('lightbox:photochanged', function(e) {
+  if (!_syncModalOpen) return;
+  _syncRenderLightboxPanel(e.detail && e.detail.photoId);
+});
+
+document.addEventListener('lightbox:closed', function() {
+  _syncDestroyLightboxPanel();
+});
 
 async function discardChange(changeId, rowEl) {
   try {

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -285,14 +285,7 @@ async function _syncDiscardFromLightbox(changeIds, photoId) {
     });
   } catch(e) { return; }
 
-  var discardSet = {};
-  changeIds.forEach(function(id) { discardSet[id] = true; });
-  if (_syncPreviewData && _syncPreviewData.photos) {
-    _syncPreviewData.photos.forEach(function(p) {
-      p.changes = p.changes.filter(function(c) { return !discardSet[c.id]; });
-    });
-    _syncPreviewData.photos = _syncPreviewData.photos.filter(function(p) { return p.changes.length > 0; });
-  }
+  _syncForgetChanges(changeIds);
 
   var photoAfter = _syncFindPhotoData(photoId);
   var visibleAfter = _syncVisibleChangesFor(photoAfter);
@@ -339,7 +332,9 @@ document.addEventListener('click', function(e) {
     var pid = parseInt(photoBtn.getAttribute('data-sync-discard-photo'), 10);
     var photo = _syncFindPhotoData(pid);
     if (photo) {
-      var ids = photo.changes.map(function(c) { return c.id; });
+      // Only discard the changes the user can see — hidden-by-filter
+      // changes must survive a filtered "Discard all".
+      var ids = _syncVisibleChangesFor(photo).map(function(c) { return c.id; });
       _syncDiscardFromLightbox(ids, pid);
     }
   }
@@ -354,6 +349,16 @@ document.addEventListener('lightbox:closed', function() {
   _syncDestroyLightboxPanel();
 });
 
+function _syncForgetChanges(changeIds) {
+  if (!_syncPreviewData || !_syncPreviewData.photos || !changeIds || changeIds.length === 0) return;
+  var drop = {};
+  changeIds.forEach(function(id) { drop[id] = true; });
+  _syncPreviewData.photos.forEach(function(p) {
+    p.changes = p.changes.filter(function(c) { return !drop[c.id]; });
+  });
+  _syncPreviewData.photos = _syncPreviewData.photos.filter(function(p) { return p.changes.length > 0; });
+}
+
 async function discardChange(changeId, rowEl) {
   try {
     await safeFetch('/api/sync/discard', {
@@ -361,6 +366,7 @@ async function discardChange(changeId, rowEl) {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({change_ids: [changeId]}),
     });
+    _syncForgetChanges([changeId]);
     if (rowEl) {
       rowEl.style.opacity = '0.3';
       rowEl.style.textDecoration = 'line-through';
@@ -375,6 +381,7 @@ async function discardPhotoChanges(changeIds, btn) {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({change_ids: changeIds}),
     });
+    _syncForgetChanges(changeIds);
     var row = btn.closest('[style*="border-bottom"]');
     if (row) row.style.display = 'none';
   } catch(e) {}

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -233,7 +233,27 @@ function _syncEnsureLightboxPanel() {
   var panel = document.createElement('div');
   panel.id = 'syncLightboxPanel';
   panel.style.cssText = 'position:absolute;top:56px;right:16px;max-width:340px;background:rgba(0,0,0,0.7);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:6px;padding:10px 12px;font-size:12px;z-index:10002;box-shadow:0 4px 16px rgba(0,0,0,0.5);';
-  panel.addEventListener('click', function(e) { e.stopPropagation(); });
+  // Handle discard clicks on the panel itself: we stopPropagation() so the
+  // lightbox overlay's onclick doesn't close the lightbox out from under the
+  // user, which means a document-level delegate would never see these events.
+  panel.addEventListener('click', function(e) {
+    var changeBtn = e.target.closest('button[data-sync-discard-change]');
+    if (changeBtn) {
+      var changeId = parseInt(changeBtn.getAttribute('data-sync-discard-change'), 10);
+      if (!isNaN(changeId)) _syncDiscardFromLightbox([changeId], _lightboxCurrentId);
+    } else {
+      var photoBtn = e.target.closest('button[data-sync-discard-photo]');
+      if (photoBtn) {
+        var pid = parseInt(photoBtn.getAttribute('data-sync-discard-photo'), 10);
+        var photo = _syncFindPhotoData(pid);
+        if (photo) {
+          var ids = _syncVisibleChangesFor(photo).map(function(c) { return c.id; });
+          _syncDiscardFromLightbox(ids, pid);
+        }
+      }
+    }
+    e.stopPropagation();
+  });
   overlay.appendChild(panel);
   _syncLightboxPanelEl = panel;
   return panel;
@@ -317,28 +337,6 @@ async function _syncDiscardFromLightbox(changeIds, photoId) {
   var next = newList[nextIdx];
   openLightbox(next.id, next.filename, newList);
 }
-
-document.addEventListener('click', function(e) {
-  var changeBtn = e.target.closest('button[data-sync-discard-change]');
-  if (changeBtn) {
-    e.stopPropagation();
-    var changeId = parseInt(changeBtn.getAttribute('data-sync-discard-change'), 10);
-    if (!isNaN(changeId)) _syncDiscardFromLightbox([changeId], _lightboxCurrentId);
-    return;
-  }
-  var photoBtn = e.target.closest('button[data-sync-discard-photo]');
-  if (photoBtn) {
-    e.stopPropagation();
-    var pid = parseInt(photoBtn.getAttribute('data-sync-discard-photo'), 10);
-    var photo = _syncFindPhotoData(pid);
-    if (photo) {
-      // Only discard the changes the user can see — hidden-by-filter
-      // changes must survive a filtered "Discard all".
-      var ids = _syncVisibleChangesFor(photo).map(function(c) { return c.id; });
-      _syncDiscardFromLightbox(ids, pid);
-    }
-  }
-});
 
 document.addEventListener('lightbox:photochanged', function(e) {
   if (!_syncModalOpen) return;


### PR DESCRIPTION
## Summary
- In the **Review Pending Changes** modal, clicking a thumbnail opened the lightbox but the ←/→ arrows did nothing — the thumbnail click didn't pass a photo list to `openLightbox`, so `_lightboxPhotoList` stayed empty and `lightboxNav` bailed at the `length < 2` guard. The click handler now builds and passes the list of currently-visible (post-filter) pending photos.
- The lightbox previously gave no indication of *what* was pending for the photo on screen. Added a top-right panel in the lightbox (only when the sync modal is open) that lists this photo's pending changes with the same `+`/`−`/`~` rows as the modal, a per-change `×`, and a "Discard all" button. Discards call `/api/sync/discard`, refresh the modal in place, and auto-advance the lightbox to the next pending photo (or close if none remain).
- Adds two CustomEvents in `_navbar.html` (`lightbox:photochanged`, `lightbox:closed`) so the sync panel can react to lightbox state without cross-file coupling; other lightbox callers are unaffected because the sync panel only handles events while its modal is open.

## Test plan
- [ ] Open Review Pending Changes with multiple pending photos → click a thumbnail → ←/→ navigates through pending photos.
- [ ] In the lightbox, per-change `×` removes that change; modal updates in place.
- [ ] "Discard all" on the last visible change auto-advances to the next pending photo; closes lightbox when none remain.
- [ ] Opening the lightbox from other pages (browse, review, highlights) shows no pending-changes panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lightbox now emits events when a photo is opened or when the lightbox closes.
  * Sync preview integrates with the lightbox to show a “Pending changes” panel for the current photo.
  * Users can filter and discard pending changes directly from the lightbox.
  * Lightbox navigation now skips photos with no visible pending changes; discards update the preview and advance/close navigation as needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/913?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->