### PR TITLE
pipeline: fix reclassify purge deleting freshly re-detected detections

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2552,11 +2552,33 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         first_model_photo_ids
                         & detect_state["processed_ids"]
                     )
+                    # Delete only pre-run ids the current run did NOT
+                    # re-produce. Detection ids are content-addressed
+                    # (vireo/detection_id.py), so re-detecting the same boxes
+                    # yields the SAME ids as the pre-run snapshot, and
+                    # write_detection_batch UPSERTs them with the freshly
+                    # written predictions now hanging off them. Deleting every
+                    # pre-run id unconditionally would cascade-delete those
+                    # predictions (and the live detection rows) for every photo
+                    # whose boxes didn't change — the common reclassify case.
+                    # Compare against the ids THIS run actually re-detected
+                    # (detect_state["detections"] is the in-memory map
+                    # _detect_batch built); a photo that came back empty has
+                    # no entry, so its pre-run rows are all stale and get
+                    # purged (write_detection_batch([]) already cleared them at
+                    # the data layer — this is the belt-and-suspenders pass and
+                    # cross-model cleanup). A photo re-detected with the same
+                    # boxes has its ids in the fresh set, so they survive.
+                    fresh_by_photo = detect_state["detections"]
                     stale_ids = [
                         det_id
                         for photo_id, id_set in pre_ids.items()
-                        for det_id in id_set
                         if photo_id in purge_ids
+                        for det_id in id_set
+                        if det_id not in {
+                            d["id"]
+                            for d in fresh_by_photo.get(photo_id, [])
+                        }
                     ]
                     if stale_ids:
                         getattr(

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -2752,6 +2752,109 @@ def test_pipeline_reclassify_purges_stale_detection_rows(tmp_path, monkeypatch):
     )
 
 
+def test_pipeline_reclassify_same_boxes_preserves_predictions(
+    tmp_path, monkeypatch,
+):
+    """Reclassify that re-detects the SAME boxes must NOT purge the rows it
+    just rewrote.
+
+    Detection ids are content-addressed, so re-detecting an unchanged box
+    yields the same id as the pre-run snapshot. write_detection_batch UPSERTs
+    that row and classify writes fresh predictions onto it. The reclassify
+    purge used to delete every pre-run id unconditionally — which, with stable
+    ids, meant deleting the live detection and cascading the just-written
+    predictions for every photo whose boxes didn't change (the common case).
+    The purge must subtract the current live set so only genuinely-dropped
+    rows are deleted. (Codex P1 family on PR #907 / latent since the
+    content-addressed-id merge.)
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_id = db.add_photo(folder_id, "test.jpg", ".jpg", 12345, 1_000_000.0)
+    _drop_jpeg(folder_path, "test.jpg")
+
+    box = {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}
+    prior = db.save_detections(
+        photo_id,
+        [{"box": box, "confidence": 0.9, "category": "animal"}],
+        detector_model="megadetector-v6",
+    )
+    prior_id = prior[0]
+
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [photo_id]}]),
+    )
+    model_ids = _setup_two_fake_downloaded_models(tmp_path, monkeypatch)
+
+    # Reclassify re-detects the SAME box → content-addressed id == prior_id.
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        dmap = {}
+        for p in batch:
+            ids = db_.write_detection_batch(
+                p["id"], "megadetector-v6",
+                [{"box": box, "confidence": 0.9, "category": "animal"}],
+            )
+            dmap[p["id"]] = [{
+                "id": ids[0], "box_x": box["x"], "box_y": box["y"],
+                "box_w": box["w"], "box_h": box["h"], "confidence": 0.9,
+                "category": "animal", "detector_model": "megadetector-v6",
+            }]
+        return dmap, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    class FakeClassifier:
+        def __init__(self, *a, **k):
+            pass
+
+        def classify_with_embedding(self, img, threshold=0):
+            import numpy as np
+            return ([{"species": "Robin", "score": 0.9}],
+                    np.zeros(512, dtype=np.float32))
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            z = np.zeros(512, dtype=np.float32)
+            return [([{"species": "Robin", "score": 0.9}], z) for _ in images]
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id, model_ids=model_ids[:1], reclassify=True,
+        skip_extract_masks=True, skip_regroup=True,
+    )
+    run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
+
+    verify = Database(db_path)
+    verify.set_active_workspace(ws_id)
+    assert verify.get_detections(photo_id) != [], (
+        "re-detected detection (same box → same content id) must survive "
+        "reclassify, not be purged as 'stale'"
+    )
+    preds = verify.conn.execute(
+        "SELECT COUNT(*) AS c FROM predictions WHERE detection_id=?",
+        (prior_id,),
+    ).fetchone()["c"]
+    assert preds >= 1, (
+        f"freshly-written predictions must survive the reclassify purge; "
+        f"got {preds}"
+    )
+
+
 def test_detect_batch_skips_empty_photo_on_rerun(tmp_path, monkeypatch):
     """A photo with no animals, recorded in detector_runs, must not be
     re-detected on a subsequent non-reclassify pipeline run.


### PR DESCRIPTION
## Summary

Fixes a **P1 data-loss bug** in the reclassify path, latent on `main` since content-addressed detection IDs (#912) merged.

On reclassify, `detect_stage` snapshots `pre_run_det_ids`, and after the first model classifies, the purge deletes them as "stale." In the old auto-rowid world this was correct — re-detection produced *new* rowids, so the snapshot rows were genuinely orphaned. With content-addressed IDs, **re-detecting the same boxes yields the same IDs as the snapshot**: `write_detection_batch` UPSERTs those rows and classify writes fresh predictions onto them. The unconditional purge then deletes the live detection and cascades away the just-written predictions for every photo whose boxes didn't change — i.e. the common reclassify case.

Verified end-to-end: after a reclassify that re-detects an unchanged box, `get_detections()` returned `[]` and the predictions were gone.

## Fix

Compute stale IDs as `pre_run_det_ids − ids this run actually re-detected` (`detect_state["detections"]`, the in-memory map `_detect_batch` built), instead of deleting every pre-run id:

- Photo re-detected with the **same boxes** → its ids are in the fresh set → rows + predictions survive.
- Photo that came back **empty**, or whose **boxes changed** → its now-absent pre-run rows are still purged.

The existing `finds-nothing → purge stale row` and `partial-batch → purge only completed photos` tests pass **unchanged**: their stubs return an empty detection map, so all pre-run ids are still treated as stale.

## Why separate from #907

This is independent of the SLOT_CAP lift — it's live on `main` at cap=1 right now (any reclassify over unchanged boxes loses predictions). Landing it standalone protects `main` immediately and keeps the concurrency PR (#907) focused. #907 will rebase on top so its reclassify-purge review threads are genuinely resolved.

## Test plan

- [x] New regression: `test_pipeline_reclassify_same_boxes_preserves_predictions` — faithful stub re-writes the same box via `write_detection_batch`, asserts detection + fresh predictions survive. Verified it fails without the fix.
- [x] `test_pipeline_job.py` + `test_pipeline_queue.py` + `test_classify_job.py` + `test_db.py` → **680 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reclassify detection purging logic to more accurately distinguish between stale and valid detection records, ensuring that detections with unchanged results are preserved while removing truly obsolete prior data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->