### PR TITLE
pipeline review: group null-timestamp photos by file order, flag them

### DIFF
--- a/docs/plans/2026-05-29-null-timestamp-grouping-design.md
+++ b/docs/plans/2026-05-29-null-timestamp-grouping-design.md
@@ -27,11 +27,22 @@ shoot stay adjacent even without EXIF.
 ### 2. Don't cut between two null-timestamp photos
 
 In `cut_microsegments`, add a `both_null` branch *before* the time/score cuts:
-when both adjacent photos have null timestamps, keep them in the same segment.
-Rationale: unreadable files have no timestamp AND no embeddings/species/meta
-(the detector never ran on them), so every similarity signal is ~0 and the
-score cut would otherwise split them into singletons. With no reliable basis to
-separate them, group contiguous nulls by file-order adjacency.
+when both adjacent photos have null timestamps **and share a `folder_id`** and
+neither side carries a similarity signal (embeddings or species), keep them in
+the same segment. Rationale: unreadable files have no timestamp AND no
+embeddings/species/meta (the detector never ran on them), so every similarity
+signal is ~0 and the score cut would otherwise split them into singletons. With
+no reliable basis to separate them, group contiguous nulls by file-order
+adjacency.
+
+The folder check matters because the null sort key
+`(1, datetime.min, folder_id, filename)` places the last null of folder A
+adjacent to the first null of folder B — without the guard the both-null
+branch would fuse unrelated unreadable files from separate shoots into one
+encounter. Photos missing `folder_id` entirely fall through to the score cut.
+
+Readable but undated photos (e.g. screenshots that still carry embeddings)
+are NOT force-grouped: they have similarity signal, so the score cut decides.
 
 Asymmetric pairs (one null, one real) are unaffected: `dt = inf > hard_cut_time`
 still fires a clean cut, so the null cluster never contaminates a real encounter.
@@ -58,7 +69,8 @@ page, flagged with the warning.
 ## Tests
 
 - `test_encounters.py`: both-null no cut; asymmetric still cuts; sort order
-  puts nulls last; contiguous nulls form one segment.
+  puts nulls last; contiguous nulls form one segment; nulls from different
+  folders DO cut at the folder boundary; null pairs with no folder_id cut.
 - `test_bursts.py`: sort order parity.
 - `test_pipeline.py`: `missing_timestamp_count` present and correct; zero when
   all timestamped.

--- a/docs/plans/2026-05-29-null-timestamp-grouping-design.md
+++ b/docs/plans/2026-05-29-null-timestamp-grouping-design.md
@@ -1,0 +1,64 @@
+# Null-timestamp grouping + warning
+
+## Problem
+
+Photos with `timestamp IS NULL` (scan I/O errors, unreadable files) each became
+their own singleton encounter, and all sorted to the very top of the pipeline
+review page. Cause:
+
+- `cut_microsegments` / `detect_bursts` sort key falls back to `datetime.min`
+  for null timestamps, piling them at the start of the timeline.
+- `_time_delta_seconds(None, x)` returns `inf`, so the hard-time-cut at
+  `dt > hard_cut_time` fires on every adjacent pair touching a null timestamp →
+  every null-timestamp photo becomes its own encounter.
+
+Result reads as "the whole pipeline failed to group anything" because the
+singleton wall is the first thing the user sees.
+
+## Design
+
+### 1. Sort null timestamps to the end, ordered by file
+
+In `cut_microsegments` (encounters.py) and `detect_bursts` (bursts.py), change
+the sort key so timestamped photos sort first by real time, and null-timestamp
+photos sort last, ordered by `(folder_id, filename)`. Consecutive NEFs from one
+shoot stay adjacent even without EXIF.
+
+### 2. Don't cut between two null-timestamp photos
+
+In `cut_microsegments`, add a `both_null` branch *before* the time/score cuts:
+when both adjacent photos have null timestamps, keep them in the same segment.
+Rationale: unreadable files have no timestamp AND no embeddings/species/meta
+(the detector never ran on them), so every similarity signal is ~0 and the
+score cut would otherwise split them into singletons. With no reliable basis to
+separate them, group contiguous nulls by file-order adjacency.
+
+Asymmetric pairs (one null, one real) are unaffected: `dt = inf > hard_cut_time`
+still fires a clean cut, so the null cluster never contaminates a real encounter.
+
+`_time_delta_seconds` is **not** changed — it's shared with the merge stage
+(`compute_s_seg`, `_merge_microsegments_with_map`) where a `None` return would
+crash. `compute_s_enc` already drops the time signal for nulls
+(`used["time"] = dt != inf`), so no change needed there either.
+
+### 3. Surface a per-encounter warning
+
+`serialize_results` (pipeline.py) adds `missing_timestamp_count` to each
+serialized encounter (count of photos with falsy timestamp). The review page
+renders a ⚠ badge in the encounter header when the count is non-zero, with a
+tooltip explaining the photos lack EXIF timestamps and are grouped by file
+order.
+
+## Effect on real data (ws16)
+
+The 16 hardware-unreadable NEFs in `2026-05-25/` (`DSC_8039`–`8056`) collapse
+from 16 singletons into one "missing metadata" encounter at the bottom of the
+page, flagged with the warning.
+
+## Tests
+
+- `test_encounters.py`: both-null no cut; asymmetric still cuts; sort order
+  puts nulls last; contiguous nulls form one segment.
+- `test_bursts.py`: sort order parity.
+- `test_pipeline.py`: `missing_timestamp_count` present and correct; zero when
+  all timestamped.

--- a/vireo/bursts.py
+++ b/vireo/bursts.py
@@ -94,10 +94,19 @@ def detect_bursts(photos, config=None):
     if len(photos) <= 1:
         return [photos] if photos else []
 
-    # Sort by timestamp (should already be sorted within an encounter, but be safe)
+    # Sort by timestamp (should already be sorted within an encounter, but be
+    # safe). Null-timestamp photos sort AFTER timestamped ones, ordered by
+    # (folder_id, filename) — parity with encounters.cut_microsegments so a
+    # null-timestamp run lands at the end of the timeline rather than at
+    # datetime.min.
+    from datetime import datetime as _dt
     sorted_photos = sorted(
         photos,
-        key=lambda p: _parse_timestamp(p.get("timestamp")) or __import__("datetime").datetime.min,
+        key=lambda p: (
+            (0, _parse_timestamp(p.get("timestamp")), 0, "")
+            if _parse_timestamp(p.get("timestamp")) is not None
+            else (1, _dt.min, p.get("folder_id") or 0, p.get("filename") or "")
+        ),
     )
 
     cuts = set()

--- a/vireo/encounters.py
+++ b/vireo/encounters.py
@@ -407,23 +407,26 @@ def cut_microsegments(photos, config=None, emit_trace=False):
         both_null = ts_a is None and ts_b is None
         folder_a = sorted_photos[i].get("folder_id")
         folder_b = sorted_photos[i + 1].get("folder_id")
+        # A folder change between two null-timestamp photos is a hard cut.
+        # The null sort key (1, datetime.min, folder_id, filename) places the
+        # last null of one folder adjacent to the first null of the next, and
+        # folder_id is NOT part of compute_s_enc — so without an explicit
+        # boundary cut, two undated photos from DIFFERENT shoots could merge
+        # whether they're unreadable (score ~0, force-grouped by file order)
+        # or signalful (visually similar embeddings/species sliding under the
+        # score cut). Treat distinct or missing folder_id as a boundary; only
+        # same, non-null folders are "unchanged". (Missing folder_id shouldn't
+        # happen in production scans — cutting there stays on the safe side.)
+        folder_changed = folder_a is None or folder_a != folder_b
         # "Signal-less" = no timestamp AND no usable similarity signal on
         # either side (no embeddings, no species). Unreadable files are
         # signal-less; undated-but-readable photos (e.g. screenshots, which
         # still get embeddings) are NOT — they must be judged on the score
-        # cut, not force-grouped by file order.
-        #
-        # Also require the same folder. The null sort key
-        # (1, datetime.min, folder_id, filename) places the last null of
-        # one folder adjacent to the first null of the next, so without
-        # this guard the both-null branch would fuse unrelated unreadable
-        # files from separate shoots into a single encounter. Photos
-        # missing folder_id (shouldn't happen in production scans) fall
-        # through to the score cut to stay on the safe side.
+        # cut, not force-grouped by file order. Requires the same folder so
+        # contiguous nulls only group within a single shoot.
         signal_less = (
             both_null
-            and folder_a is not None
-            and folder_a == folder_b
+            and not folder_changed
             and not (
                 _has_similarity_signal(sorted_photos[i])
                 or _has_similarity_signal(sorted_photos[i + 1])
@@ -442,12 +445,21 @@ def cut_microsegments(photos, config=None, emit_trace=False):
             # contiguous nulls together by file order.
             decision = "kept_no_timestamp"
             recent_scores = []
+        elif both_null and folder_changed:
+            # Both null but across a folder boundary — hard cut, regardless of
+            # similarity signal. dt is inf for both-null pairs, so the time cut
+            # below never fires for them; folder_id isn't in compute_s_enc
+            # either, so a signalful pair would otherwise slide under the score
+            # cut and merge two separate shoots. Cut here to keep them apart.
+            cuts.add(i)
+            recent_scores = []
+            decision = "cut_folder"
         elif not both_null and dt > cfg["hard_cut_time"]:
             # Time cut only applies when at least one side has a timestamp.
             # Asymmetric pairs (one null, one real) give dt=inf and cut here,
             # so the null cluster never absorbs a real photo. Both-null pairs
-            # that reached this point DO have a similarity signal and fall
-            # through to the score cut below.
+            # in the SAME folder that reached this point DO have a similarity
+            # signal and fall through to the score cut below.
             cuts.add(i)
             recent_scores = []
             decision = "cut_time"

--- a/vireo/encounters.py
+++ b/vireo/encounters.py
@@ -122,15 +122,29 @@ def _has_similarity_signal(photo):
     A detector verdict counts too: subject_absent/subject_present means
     detection ran. compute_s_enc turns an absent-vs-present pair into an
     active dissimilarity (score cut), so we must NOT force-group such a pair
-    by file order. Only rows where detection genuinely never ran (no
-    embeddings, no species, no detector verdict) are signal-less.
+    by file order.
+
+    Metadata counts too: sim_meta always contributes to compute_s_enc, so a
+    usable focal length (> 0) or a GPS fix (both latitude and longitude) lets
+    the score cut distinguish two timestamp-less photos (e.g. imported images
+    with stripped capture dates but retained lens/GPS data). Force-grouping
+    those by file order would discard the signal sim_meta would have produced.
+
+    Only rows where detection genuinely never ran (no embeddings, no species,
+    no detector verdict) AND that carry no usable metadata (no focal length,
+    no GPS) are signal-less.
     """
+    fl = photo.get("focal_length")
+    has_focal = fl is not None and fl > 0
+    has_gps = photo.get("latitude") is not None and photo.get("longitude") is not None
     return (
         photo.get("dino_subject_embedding") is not None
         or photo.get("dino_global_embedding") is not None
         or bool(photo.get("species_top5"))
         or bool(photo.get("subject_absent"))
         or bool(photo.get("subject_present"))
+        or has_focal
+        or has_gps
     )
 
 

--- a/vireo/encounters.py
+++ b/vireo/encounters.py
@@ -111,6 +111,21 @@ def sim_embedding(emb_a, emb_b):
     return _cosine_sim(emb_a, emb_b)
 
 
+def _has_similarity_signal(photo):
+    """True if a photo carries any signal the score cut can act on.
+
+    Used to decide whether a pair of timestamp-less photos can be judged by
+    similarity (screenshots/exports with embeddings) or is genuinely
+    signal-less (unreadable files — no detection ran, so no embeddings or
+    species) and must instead be grouped by file order.
+    """
+    return (
+        photo.get("dino_subject_embedding") is not None
+        or photo.get("dino_global_embedding") is not None
+        or bool(photo.get("species_top5"))
+    )
+
+
 def sim_species(species_a, species_b):
     """Species similarity via Bhattacharyya coefficient on shared top-5 species.
 
@@ -368,24 +383,34 @@ def cut_microsegments(photos, config=None, emit_trace=False):
         decision = None
 
         both_null = ts_a is None and ts_b is None
+        # "Signal-less" = no timestamp AND no usable similarity signal on
+        # either side (no embeddings, no species). Unreadable files are
+        # signal-less; undated-but-readable photos (e.g. screenshots, which
+        # still get embeddings) are NOT — they must be judged on the score
+        # cut, not force-grouped by file order.
+        signal_less = both_null and not (
+            _has_similarity_signal(sorted_photos[i])
+            or _has_similarity_signal(sorted_photos[i + 1])
+        )
 
         if bid_a is not None and bid_b is not None and bid_a == bid_b:
             decision = "burst_id_kept"
             recent_scores.append(score)
             if len(recent_scores) > 3:
                 recent_scores.pop(0)
-        elif both_null:
-            # Neither photo has a timestamp, so there's no time signal AND
-            # (for unreadable files) usually no embedding/species either —
-            # every similarity score is ~0. Cutting on score would split the
-            # whole null run into singletons. With no reliable basis to
-            # separate them, keep contiguous nulls together by file order.
-            # Asymmetric pairs (one null, one real) skip this branch and hit
-            # the inf time-cut below, so the null cluster never absorbs a real
-            # photo.
+        elif signal_less:
+            # No time signal and no embeddings/species — every similarity
+            # score is ~0, so the score cut would split the whole null run
+            # into singletons. With no reliable basis to separate them, keep
+            # contiguous nulls together by file order.
             decision = "kept_no_timestamp"
             recent_scores = []
-        elif dt > cfg["hard_cut_time"]:
+        elif not both_null and dt > cfg["hard_cut_time"]:
+            # Time cut only applies when at least one side has a timestamp.
+            # Asymmetric pairs (one null, one real) give dt=inf and cut here,
+            # so the null cluster never absorbs a real photo. Both-null pairs
+            # that reached this point DO have a similarity signal and fall
+            # through to the score cut below.
             cuts.add(i)
             recent_scores = []
             decision = "cut_time"

--- a/vireo/encounters.py
+++ b/vireo/encounters.py
@@ -331,10 +331,19 @@ def cut_microsegments(photos, config=None, emit_trace=False):
             return ([photos] if photos else []), []
         return [photos] if photos else []
 
-    # Sort by timestamp
+    # Sort by timestamp. Null-timestamp photos (scan I/O errors, unreadable
+    # files) sort AFTER all timestamped photos — never datetime.min, which
+    # would pile them at the top of the review timeline and read as "the whole
+    # pipeline failed to group." Within the null group, order by
+    # (folder_id, filename) so consecutive frames from one shoot stay adjacent
+    # even without EXIF, letting the both-null branch below keep them together.
     sorted_photos = sorted(
         photos,
-        key=lambda p: _parse_timestamp(p.get("timestamp")) or datetime.min,
+        key=lambda p: (
+            (0, _parse_timestamp(p.get("timestamp")), 0, "")
+            if _parse_timestamp(p.get("timestamp")) is not None
+            else (1, datetime.min, p.get("folder_id") or 0, p.get("filename") or "")
+        ),
     )
 
     cuts = set()
@@ -358,11 +367,24 @@ def cut_microsegments(photos, config=None, emit_trace=False):
         bid_b = sorted_photos[i + 1].get("burst_id")
         decision = None
 
+        both_null = ts_a is None and ts_b is None
+
         if bid_a is not None and bid_b is not None and bid_a == bid_b:
             decision = "burst_id_kept"
             recent_scores.append(score)
             if len(recent_scores) > 3:
                 recent_scores.pop(0)
+        elif both_null:
+            # Neither photo has a timestamp, so there's no time signal AND
+            # (for unreadable files) usually no embedding/species either —
+            # every similarity score is ~0. Cutting on score would split the
+            # whole null run into singletons. With no reliable basis to
+            # separate them, keep contiguous nulls together by file order.
+            # Asymmetric pairs (one null, one real) skip this branch and hit
+            # the inf time-cut below, so the null cluster never absorbs a real
+            # photo.
+            decision = "kept_no_timestamp"
+            recent_scores = []
         elif dt > cfg["hard_cut_time"]:
             cuts.add(i)
             recent_scores = []

--- a/vireo/encounters.py
+++ b/vireo/encounters.py
@@ -383,14 +383,29 @@ def cut_microsegments(photos, config=None, emit_trace=False):
         decision = None
 
         both_null = ts_a is None and ts_b is None
+        folder_a = sorted_photos[i].get("folder_id")
+        folder_b = sorted_photos[i + 1].get("folder_id")
         # "Signal-less" = no timestamp AND no usable similarity signal on
         # either side (no embeddings, no species). Unreadable files are
         # signal-less; undated-but-readable photos (e.g. screenshots, which
         # still get embeddings) are NOT — they must be judged on the score
         # cut, not force-grouped by file order.
-        signal_less = both_null and not (
-            _has_similarity_signal(sorted_photos[i])
-            or _has_similarity_signal(sorted_photos[i + 1])
+        #
+        # Also require the same folder. The null sort key
+        # (1, datetime.min, folder_id, filename) places the last null of
+        # one folder adjacent to the first null of the next, so without
+        # this guard the both-null branch would fuse unrelated unreadable
+        # files from separate shoots into a single encounter. Photos
+        # missing folder_id (shouldn't happen in production scans) fall
+        # through to the score cut to stay on the safe side.
+        signal_less = (
+            both_null
+            and folder_a is not None
+            and folder_a == folder_b
+            and not (
+                _has_similarity_signal(sorted_photos[i])
+                or _has_similarity_signal(sorted_photos[i + 1])
+            )
         )
 
         if bid_a is not None and bid_b is not None and bid_a == bid_b:

--- a/vireo/encounters.py
+++ b/vireo/encounters.py
@@ -118,11 +118,19 @@ def _has_similarity_signal(photo):
     similarity (screenshots/exports with embeddings) or is genuinely
     signal-less (unreadable files — no detection ran, so no embeddings or
     species) and must instead be grouped by file order.
+
+    A detector verdict counts too: subject_absent/subject_present means
+    detection ran. compute_s_enc turns an absent-vs-present pair into an
+    active dissimilarity (score cut), so we must NOT force-group such a pair
+    by file order. Only rows where detection genuinely never ran (no
+    embeddings, no species, no detector verdict) are signal-less.
     """
     return (
         photo.get("dino_subject_embedding") is not None
         or photo.get("dino_global_embedding") is not None
         or bool(photo.get("species_top5"))
+        or bool(photo.get("subject_absent"))
+        or bool(photo.get("subject_present"))
     )
 
 

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -951,6 +951,11 @@ def prune_results(cache_dir, workspace_id, deleted_ids):
 
     data["photos"] = [p for p in data.get("photos", []) if p.get("id") not in deleted]
 
+    # Timestamp lookup over survivors, so missing_timestamp_count can be
+    # recomputed per encounter after deletions (the ⚠ badge would otherwise
+    # show the pre-deletion count).
+    timestamp_by_id = {p.get("id"): p.get("timestamp") for p in data["photos"]}
+
     pruned_encounters = []
     for enc in data.get("encounters", []):
         enc["photo_ids"] = [pid for pid in enc.get("photo_ids", []) if pid not in deleted]
@@ -967,6 +972,12 @@ def prune_results(cache_dir, workspace_id, deleted_ids):
         if not enc["photo_ids"]:
             continue
         enc["photo_count"] = len(enc["photo_ids"])
+        # Only recompute when the field is present, so pruning a cache written
+        # before this field existed doesn't synthesize one.
+        if "missing_timestamp_count" in enc:
+            enc["missing_timestamp_count"] = sum(
+                1 for pid in enc["photo_ids"] if not timestamp_by_id.get(pid)
+            )
         pruned_encounters.append(enc)
     data["encounters"] = pruned_encounters
 

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -765,6 +765,12 @@ def serialize_results(results):
             "burst_count": enc.get("burst_count"),
             "time_range": enc.get("time_range"),
             "photo_ids": [p["id"] for p in photos_list],
+            # Count photos with no EXIF timestamp (scan I/O errors / unreadable
+            # files). The review page badges encounters where this is non-zero
+            # so the user knows the group was assembled by file order, not time.
+            "missing_timestamp_count": sum(
+                1 for p in photos_list if not p.get("timestamp")
+            ),
         }
         # Surface per-cut-point trace when run_full_pipeline was invoked with
         # emit_trace=True (e.g. from /api/pipeline/regroup-live so the

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -271,6 +271,11 @@
   display: flex;
   gap: 12px;
 }
+.enc-warning {
+  color: var(--warning);
+  font-weight: 600;
+  cursor: help;
+}
 .encounter-body { padding: 12px 16px; }
 .encounter-footer {
   margin: 8px -16px -12px;
@@ -2007,6 +2012,21 @@ function renderAlgorithmTrace() {
   panel.innerHTML = html;
 }
 
+function missingTimestampBadge(enc) {
+  // Warn when an encounter contains photos with no EXIF timestamp (scan I/O
+  // errors / unreadable files). Those photos can't be placed on the timeline,
+  // so the group was assembled by file order — say so rather than letting it
+  // look like a normal time-clustered encounter.
+  var n = enc.missing_timestamp_count || 0;
+  if (!n) return '';
+  var title = n + ' photo' + (n === 1 ? '' : 's') +
+    ' in this group ha' + (n === 1 ? 's' : 've') +
+    ' no EXIF timestamp (unreadable file or scan error). ' +
+    'Grouped by file order, not capture time.';
+  return '<span class="enc-warning" title="' + escapeAttr(title) + '">⚠ ' +
+    n + ' missing timestamp' + (n === 1 ? '' : 's') + '</span>';
+}
+
 function renderResults() {
   if (!pipelineResults) return;
   var container = document.getElementById('encountersContainer');
@@ -2104,6 +2124,7 @@ function renderResults() {
     html += '<span>' + enc.photo_count + ' photos</span>';
     if (enc.burst_count) html += '<span>' + enc.burst_count + ' bursts</span>';
     if (timeRange) html += '<span>' + timeRange + '</span>';
+    html += missingTimestampBadge(enc);
     html += '</span></div>';
     html += '<div class="encounter-body" id="encBody' + ei + '"' + (isCollapsed ? ' style="display:none;"' : '') + '>';
 
@@ -2151,6 +2172,7 @@ function renderResults() {
     html += '<span>' + enc.photo_count + ' photos</span>';
     if (enc.burst_count) html += '<span>' + enc.burst_count + ' bursts</span>';
     if (timeRange) html += '<span>' + timeRange + '</span>';
+    html += missingTimestampBadge(enc);
     html += '</span></div>';
 
     html += '</div></div>';

--- a/vireo/tests/test_bursts.py
+++ b/vireo/tests/test_bursts.py
@@ -245,3 +245,31 @@ def test_segment_bursts_for_encounters():
     assert len(result[0]["bursts"]) == 2
     assert len(result[0]["bursts"][0]) == 2
     assert len(result[0]["bursts"][1]) == 2
+
+
+# -- null-timestamp ordering (2026-05-29) --
+
+
+def test_detect_bursts_sorts_null_timestamps_last_by_file():
+    """Null-timestamp photos sort after timestamped ones, ordered by filename.
+
+    Parity with encounters.cut_microsegments so a null-timestamp run lands at
+    the end of the timeline (not datetime.min at the top).
+    """
+    from bursts import detect_bursts
+
+    emb = np.ones(768, dtype=np.float32)
+
+    def _null(photo_id, folder_id, filename):
+        return {"id": photo_id, "timestamp": None, "folder_id": folder_id,
+                "filename": filename, "dino_subject_embedding": emb}
+
+    photos = [
+        _null(99, 10, "DSC_8042.NEF"),
+        _make_photo(0.0, subj_emb=emb, photo_id=1),
+        _null(98, 10, "DSC_8041.NEF"),
+        _make_photo(0.5, subj_emb=emb, photo_id=2),
+    ]
+    bursts = detect_bursts(photos)
+    flat = [p["id"] for b in bursts for p in b]
+    assert flat == [1, 2, 98, 99]

--- a/vireo/tests/test_encounters.py
+++ b/vireo/tests/test_encounters.py
@@ -1150,6 +1150,78 @@ def test_cut_both_null_no_detector_run_still_groups():
     assert len(segments[0]) == 2
 
 
+def test_cut_both_null_focal_length_metadata_cuts():
+    """Two undated photos with no embeddings/species/detector verdict but
+    differing focal lengths must be judged by the score cut, not force-grouped.
+
+    compute_s_enc always folds sim_meta into the score, so a focal-length
+    mismatch (e.g. imports with stripped capture dates but retained lens data)
+    is real dissimilarity signal. _has_similarity_signal must recognise focal
+    length so the pair falls through to the score cut instead of the
+    signal-less keep-together branch.
+    """
+    from encounters import cut_microsegments
+
+    photos = [
+        {"id": 1, "timestamp": None, "folder_id": 10, "filename": "a.jpg",
+         "dino_subject_embedding": None, "dino_global_embedding": None,
+         "species_top5": None, "focal_length": 24.0},
+        {"id": 2, "timestamp": None, "folder_id": 10, "filename": "b.jpg",
+         "dino_subject_embedding": None, "dino_global_embedding": None,
+         "species_top5": None, "focal_length": 400.0},
+    ]
+    segments = cut_microsegments(photos)
+    assert len(segments) == 2, (
+        f"Expected the focal-length mismatch to cut, got "
+        f"{[[p['id'] for p in seg] for seg in segments]}"
+    )
+
+
+def test_cut_both_null_gps_metadata_cuts():
+    """Undated photos with no embeddings/species/detector verdict but distant
+    GPS fixes must cut on the score, not force-group by file order."""
+    from encounters import cut_microsegments
+
+    photos = [
+        {"id": 1, "timestamp": None, "folder_id": 10, "filename": "a.jpg",
+         "dino_subject_embedding": None, "dino_global_embedding": None,
+         "species_top5": None, "latitude": 47.6, "longitude": -122.3},
+        {"id": 2, "timestamp": None, "folder_id": 10, "filename": "b.jpg",
+         "dino_subject_embedding": None, "dino_global_embedding": None,
+         "species_top5": None, "latitude": 40.7, "longitude": -74.0},
+    ]
+    segments = cut_microsegments(photos)
+    assert len(segments) == 2, (
+        f"Expected the GPS mismatch to cut, got "
+        f"{[[p['id'] for p in seg] for seg in segments]}"
+    )
+
+
+def test_cut_both_null_no_metadata_still_groups():
+    """Truly signal-less nulls — no embeddings/species/detector verdict AND no
+    focal length or GPS — still group by file order.
+
+    Guards against over-tightening: a focal_length of 0 / None and absent GPS
+    must NOT count as signal, keeping unreadable files in the keep-together
+    branch.
+    """
+    from encounters import cut_microsegments
+
+    photos = [
+        {"id": 1, "timestamp": None, "folder_id": 10, "filename": "a.NEF",
+         "dino_subject_embedding": None, "dino_global_embedding": None,
+         "species_top5": None, "focal_length": 0, "latitude": None,
+         "longitude": None},
+        {"id": 2, "timestamp": None, "folder_id": 10, "filename": "b.NEF",
+         "dino_subject_embedding": None, "dino_global_embedding": None,
+         "species_top5": None, "focal_length": None, "latitude": None,
+         "longitude": None},
+    ]
+    segments = cut_microsegments(photos)
+    assert len(segments) == 1
+    assert len(segments[0]) == 2
+
+
 def test_cut_null_timestamps_cut_at_folder_boundary():
     """Signal-less nulls from different folders must NOT fuse into one encounter.
 

--- a/vireo/tests/test_encounters.py
+++ b/vireo/tests/test_encounters.py
@@ -1053,3 +1053,46 @@ def test_cut_asymmetric_null_still_cuts():
     assert len(segments) == 2
     assert {p["id"] for p in segments[0]} == {1, 2}
     assert {p["id"] for p in segments[1]} == {50, 51}
+
+
+def test_cut_both_null_with_signal_still_cuts_on_score():
+    """Two undated photos that DO have embeddings (e.g. screenshots) are judged
+    on visual similarity, not force-grouped by file order.
+
+    The both-null keep-together rule is only for signal-less rows (unreadable
+    files). When real similarity signal exists, dissimilar undated images must
+    still split.
+    """
+    from encounters import cut_microsegments
+
+    emb_a = np.array([1, 0, 0] * 256, dtype=np.float32)
+    emb_b = np.array([0, 1, 0] * 256, dtype=np.float32)
+    photos = [
+        {"id": 1, "timestamp": None, "folder_id": 10, "filename": "shot_a.png",
+         "dino_subject_embedding": emb_a, "dino_global_embedding": emb_a,
+         "species_top5": [("robin", 0.9)]},
+        {"id": 2, "timestamp": None, "folder_id": 10, "filename": "shot_b.png",
+         "dino_subject_embedding": emb_b, "dino_global_embedding": emb_b,
+         "species_top5": [("eagle", 0.9)]},
+    ]
+    segments = cut_microsegments(photos)
+    assert len(segments) == 2
+
+
+def test_cut_both_null_with_similar_signal_groups():
+    """Undated photos with matching embeddings/species still group (score keeps)."""
+    from encounters import cut_microsegments
+
+    emb = np.ones(768, dtype=np.float32)
+    species = [("robin", 0.9)]
+    photos = [
+        {"id": 1, "timestamp": None, "folder_id": 10, "filename": "shot_a.png",
+         "dino_subject_embedding": emb, "dino_global_embedding": emb,
+         "species_top5": species},
+        {"id": 2, "timestamp": None, "folder_id": 10, "filename": "shot_b.png",
+         "dino_subject_embedding": emb, "dino_global_embedding": emb,
+         "species_top5": species},
+    ]
+    segments = cut_microsegments(photos)
+    assert len(segments) == 1
+    assert len(segments[0]) == 2

--- a/vireo/tests/test_encounters.py
+++ b/vireo/tests/test_encounters.py
@@ -1098,6 +1098,58 @@ def test_cut_both_null_with_similar_signal_groups():
     assert len(segments[0]) == 2
 
 
+def test_cut_both_null_detector_conflict_cuts():
+    """Two undated photos with no embeddings/species but conflicting detector
+    verdicts (one subject_absent, one subject_present) must split, not
+    force-group.
+
+    The detector already ran and disagrees about whether a subject is present.
+    compute_s_enc treats absent-vs-present as active dissimilarity (score ~0),
+    so this pair must fall through to the score cut rather than the
+    signal-less keep-together branch — otherwise an undated empty frame would
+    be collapsed into an undated animal frame whenever embeddings happen to be
+    missing or failed.
+    """
+    from encounters import cut_microsegments
+
+    photos = [
+        {"id": 1, "timestamp": None, "folder_id": 10, "filename": "a.NEF",
+         "dino_subject_embedding": None, "dino_global_embedding": None,
+         "species_top5": None, "subject_absent": True, "subject_present": False},
+        {"id": 2, "timestamp": None, "folder_id": 10, "filename": "b.NEF",
+         "dino_subject_embedding": None, "dino_global_embedding": None,
+         "species_top5": None, "subject_absent": False, "subject_present": True},
+    ]
+    segments = cut_microsegments(photos)
+    assert len(segments) == 2, (
+        f"Expected the detector conflict to cut, got "
+        f"{[[p['id'] for p in seg] for seg in segments]}"
+    )
+
+
+def test_cut_both_null_no_detector_run_still_groups():
+    """Genuinely signal-less nulls (detector never ran) still group by file
+    order even when subject_absent/subject_present are both False.
+
+    Guards against over-tightening _has_similarity_signal: an unreadable file
+    has no embeddings, no species, AND no detector verdict, so it must remain
+    in the keep-together branch.
+    """
+    from encounters import cut_microsegments
+
+    photos = [
+        {"id": 1, "timestamp": None, "folder_id": 10, "filename": "a.NEF",
+         "dino_subject_embedding": None, "dino_global_embedding": None,
+         "species_top5": None, "subject_absent": False, "subject_present": False},
+        {"id": 2, "timestamp": None, "folder_id": 10, "filename": "b.NEF",
+         "dino_subject_embedding": None, "dino_global_embedding": None,
+         "species_top5": None, "subject_absent": False, "subject_present": False},
+    ]
+    segments = cut_microsegments(photos)
+    assert len(segments) == 1
+    assert len(segments[0]) == 2
+
+
 def test_cut_null_timestamps_cut_at_folder_boundary():
     """Signal-less nulls from different folders must NOT fuse into one encounter.
 

--- a/vireo/tests/test_encounters.py
+++ b/vireo/tests/test_encounters.py
@@ -1247,6 +1247,59 @@ def test_cut_null_timestamps_cut_at_folder_boundary():
     assert {p["id"] for p in segments[1]} == {3, 4}
 
 
+def test_cut_both_null_signalful_cuts_at_folder_boundary():
+    """Two undated photos with MATCHING embeddings but in DIFFERENT folders must
+    cut at the folder boundary.
+
+    folder_id is not part of compute_s_enc, so without an explicit boundary cut
+    these visually identical undated frames would slide under the score cut and
+    merge two separate shoots into one encounter. The folder change is a hard
+    cut for ALL both-null pairs, not just signal-less ones.
+    """
+    from encounters import cut_microsegments
+
+    emb = np.ones(768, dtype=np.float32)
+    species = [("robin", 0.9)]
+    photos = [
+        {"id": 1, "timestamp": None, "folder_id": 10, "filename": "shot_a.png",
+         "dino_subject_embedding": emb, "dino_global_embedding": emb,
+         "species_top5": species},
+        {"id": 2, "timestamp": None, "folder_id": 20, "filename": "shot_b.png",
+         "dino_subject_embedding": emb, "dino_global_embedding": emb,
+         "species_top5": species},
+    ]
+    segments = cut_microsegments(photos)
+    assert len(segments) == 2, (
+        f"Expected the folder boundary to cut despite matching signal, got "
+        f"{[[p['id'] for p in seg] for seg in segments]}"
+    )
+    assert {p["id"] for p in segments[0]} == {1}
+    assert {p["id"] for p in segments[1]} == {2}
+
+
+def test_cut_both_null_signalful_same_folder_groups():
+    """Counterpart to the cross-folder cut: two undated photos with MATCHING
+    embeddings in the SAME folder are still judged by the score and group.
+
+    The folder-boundary cut must not over-fire within a single shoot.
+    """
+    from encounters import cut_microsegments
+
+    emb = np.ones(768, dtype=np.float32)
+    species = [("robin", 0.9)]
+    photos = [
+        {"id": 1, "timestamp": None, "folder_id": 10, "filename": "shot_a.png",
+         "dino_subject_embedding": emb, "dino_global_embedding": emb,
+         "species_top5": species},
+        {"id": 2, "timestamp": None, "folder_id": 10, "filename": "shot_b.png",
+         "dino_subject_embedding": emb, "dino_global_embedding": emb,
+         "species_top5": species},
+    ]
+    segments = cut_microsegments(photos)
+    assert len(segments) == 1
+    assert len(segments[0]) == 2
+
+
 def test_cut_null_timestamps_missing_folder_id_still_cuts():
     """Defensive: nulls with no folder_id at all fall through to the score cut.
 

--- a/vireo/tests/test_encounters.py
+++ b/vireo/tests/test_encounters.py
@@ -961,3 +961,95 @@ def test_segment_encounters_cuts_at_subject_absent_asymmetry():
     )
     # The first encounter should not absorb the subjectless frames.
     assert encounters[0]["photo_count"] == 6
+
+
+# -- null-timestamp grouping (2026-05-29) --
+
+
+def _null_ts_photo(photo_id, folder_id, filename, subj_emb=None,
+                   global_emb=None, species=None, focal_length=None):
+    """A photo with no timestamp (scan I/O error / unreadable file)."""
+    return {
+        "id": photo_id,
+        "timestamp": None,
+        "folder_id": folder_id,
+        "filename": filename,
+        "dino_subject_embedding": subj_emb,
+        "dino_global_embedding": global_emb,
+        "species_top5": species,
+        "focal_length": focal_length,
+    }
+
+
+def test_time_delta_both_none_still_inf():
+    """_time_delta_seconds keeps its inf contract for None inputs.
+
+    It's shared with the merge stage, which divides by / compares against the
+    result; returning None there would crash. The both-null special case lives
+    in cut_microsegments, not here.
+    """
+    from encounters import _time_delta_seconds
+
+    assert _time_delta_seconds(None, None) == float("inf")
+    assert _time_delta_seconds(None, datetime(2026, 5, 25, 10, 0, 0)) == float("inf")
+    assert _time_delta_seconds(datetime(2026, 5, 25, 10, 0, 0), None) == float("inf")
+
+
+def test_cut_keeps_contiguous_null_timestamps_together():
+    """Signal-less null-timestamp photos group into one segment by file order.
+
+    Unreadable files have no timestamp AND no embeddings/species, so every
+    similarity signal is ~0. Without the both-null guard the score cut would
+    split them into singletons.
+    """
+    from encounters import cut_microsegments
+
+    photos = [
+        _null_ts_photo(1, 10, "DSC_8039.NEF"),
+        _null_ts_photo(2, 10, "DSC_8041.NEF"),
+        _null_ts_photo(3, 10, "DSC_8042.NEF"),
+        _null_ts_photo(4, 10, "DSC_8043.NEF"),
+    ]
+    segments = cut_microsegments(photos)
+    assert len(segments) == 1
+    assert len(segments[0]) == 4
+
+
+def test_cut_null_timestamps_sort_last_by_file():
+    """Null-timestamp photos sort after all timestamped photos, by (folder, filename)."""
+    from encounters import cut_microsegments
+
+    emb = np.ones(768, dtype=np.float32)
+    species = [("robin", 0.9)]
+    photos = [
+        _null_ts_photo(99, 10, "DSC_8042.NEF"),
+        _make_photo(0, subj_emb=emb, global_emb=emb, species=species, photo_id=1),
+        _null_ts_photo(98, 10, "DSC_8041.NEF"),
+        _make_photo(5, subj_emb=emb, global_emb=emb, species=species, photo_id=2),
+    ]
+    segments = cut_microsegments(photos)
+    flat = [p["id"] for seg in segments for p in seg]
+    # Real-timestamp photos (1, 2) first in time order, then nulls by filename.
+    assert flat == [1, 2, 98, 99]
+
+
+def test_cut_asymmetric_null_still_cuts():
+    """A null-timestamp photo adjacent to a real one cuts cleanly.
+
+    The null cluster must never contaminate a real encounter.
+    """
+    from encounters import cut_microsegments
+
+    emb = np.ones(768, dtype=np.float32)
+    species = [("robin", 0.9)]
+    photos = [
+        _make_photo(0, subj_emb=emb, global_emb=emb, species=species, photo_id=1),
+        _make_photo(5, subj_emb=emb, global_emb=emb, species=species, photo_id=2),
+        _null_ts_photo(50, 10, "DSC_8039.NEF"),
+        _null_ts_photo(51, 10, "DSC_8041.NEF"),
+    ]
+    segments = cut_microsegments(photos)
+    # One real-timestamp segment, one null-timestamp segment — never merged.
+    assert len(segments) == 2
+    assert {p["id"] for p in segments[0]} == {1, 2}
+    assert {p["id"] for p in segments[1]} == {50, 51}

--- a/vireo/tests/test_encounters.py
+++ b/vireo/tests/test_encounters.py
@@ -1096,3 +1096,48 @@ def test_cut_both_null_with_similar_signal_groups():
     segments = cut_microsegments(photos)
     assert len(segments) == 1
     assert len(segments[0]) == 2
+
+
+def test_cut_null_timestamps_cut_at_folder_boundary():
+    """Signal-less nulls from different folders must NOT fuse into one encounter.
+
+    The null sort key (1, datetime.min, folder_id, filename) places the last
+    null of folder A adjacent to the first null of folder B. Without a folder
+    boundary check the both-null branch would force-group unrelated unreadable
+    files from separate shoots.
+    """
+    from encounters import cut_microsegments
+
+    photos = [
+        _null_ts_photo(1, 10, "DSC_8039.NEF"),
+        _null_ts_photo(2, 10, "DSC_8041.NEF"),
+        _null_ts_photo(3, 20, "DSC_9001.NEF"),
+        _null_ts_photo(4, 20, "DSC_9002.NEF"),
+    ]
+    segments = cut_microsegments(photos)
+    assert len(segments) == 2, (
+        f"Expected one segment per folder, got "
+        f"{[[p['id'] for p in seg] for seg in segments]}"
+    )
+    assert {p["id"] for p in segments[0]} == {1, 2}
+    assert {p["id"] for p in segments[1]} == {3, 4}
+
+
+def test_cut_null_timestamps_missing_folder_id_still_cuts():
+    """Defensive: nulls with no folder_id at all fall through to the score cut.
+
+    Production scans always populate folder_id, but if it's somehow None the
+    safe behaviour is to cut rather than collapse unrelated rows.
+    """
+    from encounters import cut_microsegments
+
+    photos = [
+        {"id": 1, "timestamp": None, "folder_id": None, "filename": "a.NEF",
+         "dino_subject_embedding": None, "dino_global_embedding": None,
+         "species_top5": None},
+        {"id": 2, "timestamp": None, "folder_id": None, "filename": "b.NEF",
+         "dino_subject_embedding": None, "dino_global_embedding": None,
+         "species_top5": None},
+    ]
+    segments = cut_microsegments(photos)
+    assert len(segments) == 2

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -2612,3 +2612,43 @@ def test_serialize_results_counts_missing_timestamps():
     assert encs[0]["missing_timestamp_count"] == 2
     # Zero (not absent) so the JS `if (enc.missing_timestamp_count)` is clean.
     assert encs[1]["missing_timestamp_count"] == 0
+
+
+def test_prune_results_recomputes_missing_timestamp_count(tmp_path):
+    """Deleting a null-timestamp photo updates the encounter's missing count.
+
+    Otherwise the ⚠ badge keeps showing the pre-deletion count.
+    """
+    from pipeline import load_results, prune_results
+
+    cache = {
+        "encounters": [
+            {
+                "species": None, "confirmed_species": None,
+                "species_predictions": [], "species_confirmed": False,
+                "photo_count": 3, "burst_count": 1,
+                "time_range": [None, None],
+                "photo_ids": [1, 2, 3],
+                "missing_timestamp_count": 2,
+                "bursts": [
+                    {"photo_ids": [1, 2, 3], "species_predictions": [],
+                     "species_override": None},
+                ],
+            },
+        ],
+        "photos": [
+            {"id": 1, "label": "REVIEW", "timestamp": "2026-05-25T10:00:00"},
+            {"id": 2, "label": "REVIEW", "timestamp": None},
+            {"id": 3, "label": "REVIEW", "timestamp": None},
+        ],
+        "summary": {},
+    }
+    _write_cache(str(tmp_path), 1, cache)
+
+    # Delete one of the two null-timestamp photos.
+    prune_results(str(tmp_path), 1, [3])
+
+    loaded = load_results(str(tmp_path), 1)
+    enc = loaded["encounters"][0]
+    assert enc["photo_count"] == 2
+    assert enc["missing_timestamp_count"] == 1

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -2567,3 +2567,48 @@ def test_compute_group_fingerprint_ignores_unrelated_pipeline_keys():
         {"pipeline": {"classifier_model": "x", "detector_confidence": 0.9}},
     )
     assert unrelated == base
+
+
+def test_serialize_results_counts_missing_timestamps():
+    """Each serialized encounter reports how many of its photos lack a timestamp."""
+    from pipeline import serialize_results
+
+    results = {
+        "encounters": [
+            {  # 2 of 3 photos missing timestamps
+                "species": None,
+                "photos": [
+                    {"id": 1, "timestamp": "2026-05-25T10:00:00", "confirmed_species": None},
+                    {"id": 2, "timestamp": None, "confirmed_species": None},
+                    {"id": 3, "timestamp": None, "confirmed_species": None},
+                ],
+                "photo_count": 3,
+                "burst_count": 1,
+                "time_range": [None, None],
+            },
+            {  # all timestamped
+                "species": None,
+                "photos": [
+                    {"id": 4, "timestamp": "2026-05-25T11:00:00", "confirmed_species": None},
+                    {"id": 5, "timestamp": "2026-05-25T11:00:05", "confirmed_species": None},
+                ],
+                "photo_count": 2,
+                "burst_count": 1,
+                "time_range": ["2026-05-25T11:00:00", "2026-05-25T11:00:05"],
+            },
+        ],
+        "photos": [
+            {"id": 1, "timestamp": "2026-05-25T10:00:00", "label": "REVIEW"},
+            {"id": 2, "timestamp": None, "label": "REVIEW"},
+            {"id": 3, "timestamp": None, "label": "REVIEW"},
+            {"id": 4, "timestamp": "2026-05-25T11:00:00", "label": "KEEP"},
+            {"id": 5, "timestamp": "2026-05-25T11:00:05", "label": "REVIEW"},
+        ],
+        "summary": {},
+    }
+
+    serialized = serialize_results(results)
+    encs = serialized["encounters"]
+    assert encs[0]["missing_timestamp_count"] == 2
+    # Zero (not absent) so the JS `if (enc.missing_timestamp_count)` is clean.
+    assert encs[1]["missing_timestamp_count"] == 0


### PR DESCRIPTION
## Problem

Photos with no EXIF timestamp (scan I/O errors, unreadable files) each became their own singleton encounter, **all sorted to the very top** of the pipeline review page — which reads as "the whole pipeline failed to group anything."

This surfaced during a real debugging session: a workspace had 300 photos with `timestamp IS NULL` (two overlapping pipelines raced on the same photo rows + a range of unreadable files on a failing external drive). The singleton wall at the top hid all the real multi-photo bursts below it.

Two causes:
- `cut_microsegments` / `detect_bursts` sorted null timestamps to `datetime.min`, piling them at the start of the timeline.
- `_time_delta_seconds(None, x)` returns `inf`, so the hard-time-cut fired on every adjacent pair touching a null timestamp → one encounter per photo.

## Changes

- **Sort nulls last, by file order.** Null-timestamp photos sort after all timestamped photos, ordered by `(folder_id, filename)`, in both `cut_microsegments` and `detect_bursts`. A null-timestamp run lands at the end of the timeline in shooting order.
- **Don't cut between two nulls.** New both-null branch in `cut_microsegments` before the time/score cuts: when neither adjacent photo has a timestamp, keep them in the same segment. Unreadable files have no timestamp AND no embeddings/species (the detector never ran on them), so every similarity score is ~0 and the score cut would otherwise re-split them into singletons. Asymmetric pairs (one null, one real) skip the branch and hit the `inf` time-cut, so the null cluster never contaminates a real encounter.
- **No change to `_time_delta_seconds`** — it's shared with the merge stage, where a `None` return would crash. `compute_s_enc` already drops the time signal for nulls (`used["time"] = dt != inf`), so no change needed there.
- **Warning surface.** `serialize_results` adds `missing_timestamp_count` per encounter; the review page renders a ⚠ badge (header + footer) with a tooltip explaining the group was assembled by file order, not capture time.

## Effect

Contiguous null-timestamp photos collapse from N singletons into one "missing metadata" encounter at the bottom of the page, flagged with the warning.

## Test plan
- [x] `test_encounters.py`: both-null grouping, asymmetric still cuts, null sort order, `_time_delta_seconds` inf contract preserved
- [x] `test_bursts.py`: null sort-order parity
- [x] `test_pipeline.py`: `missing_timestamp_count` present + zero-when-all-timestamped
- [x] Grouping suite: 170 passed
- [x] CLAUDE.md project bundle: 1009 passed, 1 pre-existing skip

Design doc: `docs/plans/2026-05-29-null-timestamp-grouping-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Photos missing EXIF timestamps are now placed after dated photos and ordered deterministically to avoid singleton segments; adjacent undated photos lacking similarity signals are kept together when from the same folder, while folder boundaries and signalful differences still cause cuts.

* **New Features**
  * Encounter serialization includes a missing-timestamp count and encounter cards display a warning badge with tooltip when nonzero.

* **Documentation**
  * Added design notes describing null-timestamp sorting, cut rules, and UI badge behavior.

* **Tests**
  * Expanded tests for sorting, segmentation rules, serialization, and pruning around missing timestamps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->