### PR TITLE
pipeline review: add sort control for encounter order

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -12533,6 +12533,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Remove burst from encounter
         detached = bursts.pop(burst_idx)
         detached_ids = detached["photo_ids"]
+        photos_by_id = {p["id"]: p for p in results.get("photos", [])}
 
         if len(bursts) == 0:
             # Last burst — remove the encounter entirely, detached becomes the encounter
@@ -12542,6 +12543,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             enc["photo_ids"] = [pid for pid in enc["photo_ids"] if pid not in detached_ids]
             enc["photo_count"] = len(enc["photo_ids"])
             enc["burst_count"] = len(bursts)
+            # Photos left, so the remaining range can only shrink; recompute it
+            # (mirrors _auto_detach_burst_for_species) instead of leaving a stale,
+            # too-wide range that would misplace this encounter under time sorts.
+            enc["time_range"] = _compute_time_range(photos_by_id, enc["photo_ids"])
             enc["species_predictions"] = rebuild_species_predictions(results, enc["photo_ids"])
             # Pair indices in trace reference the original photo composition;
             # drop it so the algorithm-trace panel renders an honest "needs
@@ -12562,7 +12567,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "species_confirmed": bool(detached.get("species_override", {}).get("confirmed")) if detached.get("species_override") else False,
             "photo_count": len(detached_ids),
             "burst_count": 1,
-            "time_range": [None, None],
+            # Compute from the detached photos' timestamps. A [None, None] range
+            # here would sort to the extremes under the encounter time sorts and
+            # render a blank time label in the encounter header.
+            "time_range": _compute_time_range(photos_by_id, detached_ids),
             "photo_ids": detached_ids,
             "bursts": [detached],
         }

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1648,7 +1648,27 @@ function encounterSortOrder() {
   var encs = (pipelineResults && pipelineResults.encounters) || [];
   var order = encs.map(function(_, i) { return i; });
   if (encounterSort === 'default') return order;
-  function startTime(e) { return (e && e.time_range && e.time_range[0]) ? e.time_range[0] : ''; }
+  var tsByPhoto = null;
+  function photoTimestamps() {
+    if (tsByPhoto) return tsByPhoto;
+    tsByPhoto = {};
+    ((pipelineResults && pipelineResults.photos) || []).forEach(function(p) {
+      if (p && p.timestamp) tsByPhoto[p.id] = p.timestamp;
+    });
+    return tsByPhoto;
+  }
+  function startTime(e) {
+    if (e && e.time_range && e.time_range[0]) return e.time_range[0];
+    // No stored range (e.g. a freshly detached burst): fall back to the
+    // earliest contained photo timestamp so time sorts place it
+    // chronologically instead of dumping it at an extreme.
+    var map = photoTimestamps(), best = '';
+    ((e && e.photo_ids) || []).forEach(function(pid) {
+      var t = map[pid];
+      if (t && (best === '' || t < best)) best = t;
+    });
+    return best;
+  }
   function cmpStr(a, b) { return a < b ? -1 : (a > b ? 1 : 0); }
   order.sort(function(ia, ib) {
     var a = encs[ia], b = encs[ib], d = 0;

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -237,6 +237,25 @@
   min-width: 32px;
   text-align: right;
 }
+.encounter-sort-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.encounter-sort-wrap select {
+  padding: 5px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border-primary);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 12px;
+  outline: none;
+  cursor: pointer;
+}
+.encounter-sort-wrap select:focus { border-color: var(--accent); }
 
 /* Encounter cards */
 .encounter-card {
@@ -1385,6 +1404,17 @@ input[type="range"]::-moz-range-thumb {
         <input type="text" id="speciesFilterInput" placeholder="Filter by species..." oninput="setSpeciesFilter(this.value)">
         <button class="species-filter-clear" id="speciesFilterClear" onclick="clearSpeciesFilter()" title="Clear filter">&times;</button>
       </div>
+      <div class="encounter-sort-wrap" title="Order encounters are listed in">
+        <label for="encounterSortSelect">Sort:</label>
+        <select id="encounterSortSelect" onchange="setEncounterSort(this.value)">
+          <option value="default">Chronological</option>
+          <option value="photos_desc">Most photos</option>
+          <option value="photos_asc">Fewest photos</option>
+          <option value="bursts_desc">Most bursts</option>
+          <option value="time_desc">Newest first</option>
+          <option value="time_asc">Oldest first</option>
+        </select>
+      </div>
       <div class="confidence-slider-wrap" title="Thumbnail size">
         <span>&#9638;</span>
         <input type="range" id="thumbSizeSlider" min="100" max="320" step="20" value="160"
@@ -1503,6 +1533,11 @@ var collapsedEncounters = new Set();
 var PIPELINE_SIDEBAR_STORAGE_KEY = 'vireo.pipelineReview.sidebarCollapsed';
 var PIPELINE_VIEW_STATE_STORAGE_KEY = 'vireo.pipelineReview.viewState';
 var PIPELINE_REVIEW_FILTERS = ['all', 'KEEP', 'REVIEW', 'REJECT'];
+var PIPELINE_ENCOUNTER_SORTS = ['default', 'photos_desc', 'photos_asc', 'bursts_desc', 'time_desc', 'time_asc'];
+// Display order for the encounter list. Does NOT reorder pipelineResults.encounters;
+// renderResults() iterates a sorted list of original indices so every encounter's
+// canonical index (focus, detach, species overrides, GRM) stays valid.
+var encounterSort = 'default';
 
 function setPipelineSidebarCollapsed(collapsed, persist) {
   var layout = document.getElementById('pipelineLayout');
@@ -1540,6 +1575,7 @@ function persistPipelineReviewViewState() {
       activeFilter: activeFilter,
       speciesFilter: speciesInput ? speciesInput.value : speciesFilterText,
       hideConfirmed: !!hideConfirmed,
+      encounterSort: encounterSort,
       thumbSize: document.getElementById('thumbSizeSlider')
         ? document.getElementById('thumbSizeSlider').value
         : null,
@@ -1559,6 +1595,9 @@ function applyPipelineReviewToolbarState() {
   if (input) input.value = speciesFilterText || '';
   var clearBtn = document.getElementById('speciesFilterClear');
   if (clearBtn) clearBtn.style.display = speciesFilter ? 'block' : 'none';
+
+  var sortSel = document.getElementById('encounterSortSelect');
+  if (sortSel) sortSel.value = encounterSort;
 }
 
 function restorePipelineReviewViewState() {
@@ -1578,6 +1617,10 @@ function restorePipelineReviewViewState() {
   speciesFilter = speciesFilterText.toLowerCase();
   hideConfirmed = !!state.hideConfirmed;
 
+  if (PIPELINE_ENCOUNTER_SORTS.indexOf(state.encounterSort) !== -1) {
+    encounterSort = state.encounterSort;
+  }
+
   var thumbSize = parseInt(state.thumbSize, 10);
   if (!isNaN(thumbSize)) {
     thumbSize = Math.max(100, Math.min(320, thumbSize));
@@ -1587,6 +1630,38 @@ function restorePipelineReviewViewState() {
   }
 
   applyPipelineReviewToolbarState();
+}
+
+function setEncounterSort(val) {
+  if (PIPELINE_ENCOUNTER_SORTS.indexOf(val) === -1) return;
+  encounterSort = val;
+  persistPipelineReviewViewState();
+  renderResults();
+}
+
+// Returns the order in which encounters should be displayed, as a list of
+// ORIGINAL indices into pipelineResults.encounters. Never mutates the array,
+// so every encounter's canonical index stays stable. Falls back to natural
+// (chronological) order for 'default'. Ties break on original index so the
+// result is deterministic regardless of Array.sort stability.
+function encounterSortOrder() {
+  var encs = (pipelineResults && pipelineResults.encounters) || [];
+  var order = encs.map(function(_, i) { return i; });
+  if (encounterSort === 'default') return order;
+  function startTime(e) { return (e && e.time_range && e.time_range[0]) ? e.time_range[0] : ''; }
+  function cmpStr(a, b) { return a < b ? -1 : (a > b ? 1 : 0); }
+  order.sort(function(ia, ib) {
+    var a = encs[ia], b = encs[ib], d = 0;
+    switch (encounterSort) {
+      case 'photos_desc': d = (b.photo_count || 0) - (a.photo_count || 0); break;
+      case 'photos_asc':  d = (a.photo_count || 0) - (b.photo_count || 0); break;
+      case 'bursts_desc': d = (b.burst_count || 0) - (a.burst_count || 0); break;
+      case 'time_desc':   d = cmpStr(startTime(b), startTime(a)); break;
+      case 'time_asc':    d = cmpStr(startTime(a), startTime(b)); break;
+    }
+    return d !== 0 ? d : ia - ib;
+  });
+  return order;
 }
 
 function encounterKey(enc) {
@@ -2062,7 +2137,8 @@ function renderResults() {
   // management below can pick a *visible* encounter (not one that was
   // filtered out by species filter, hide-confirmed, or label filter).
   var renderedIndices = [];
-  pipelineResults.encounters.forEach(function(enc, ei) {
+  encounterSortOrder().forEach(function(ei) {
+    var enc = pipelineResults.encounters[ei];
     var timeRange = '';
     if (enc.time_range && enc.time_range[0]) {
       var t0 = enc.time_range[0].split('T')[1] || '';

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1963,6 +1963,58 @@ def test_pipeline_detach_burst(app_and_db):
     assert "Eagle" in new_species
 
 
+def test_pipeline_detach_burst_computes_time_ranges(app_and_db):
+    """detach-burst must compute time_range from photo timestamps for both the
+    new encounter and the shrunken source encounter. A [None, None] range would
+    sort detached encounters to the extremes under the review page's time sorts
+    and render a blank time label in the encounter header."""
+    import json as _json
+    app, db = app_and_db
+    client = app.test_client()
+
+    cache_dir = os.path.dirname(app.config["DB_PATH"])
+    ws_id = db._active_workspace_id
+    results = {
+        "encounters": [
+            {
+                "species": ["Robin", 0.9],
+                "confirmed_species": None,
+                "species_predictions": [],
+                "species_confirmed": False,
+                "photo_count": 3,
+                "burst_count": 2,
+                # Deliberately stale/missing — the handler must recompute it.
+                "time_range": [None, None],
+                "photo_ids": [1, 2, 3],
+                "bursts": [
+                    {"photo_ids": [1, 2], "species_predictions": [], "species_override": None},
+                    {"photo_ids": [3], "species_predictions": [], "species_override": None},
+                ],
+            }
+        ],
+        "photos": [
+            {"id": 1, "label": "KEEP", "filename": "a.jpg", "timestamp": "2024-01-01T10:00:00", "species_top5": []},
+            {"id": 2, "label": "KEEP", "filename": "b.jpg", "timestamp": "2024-01-01T10:00:05", "species_top5": []},
+            {"id": 3, "label": "REVIEW", "filename": "c.jpg", "timestamp": "2024-01-01T10:05:00", "species_top5": []},
+        ],
+        "summary": {"total_photos": 3, "encounter_count": 1, "burst_count": 2,
+                     "keep_count": 2, "review_count": 1, "reject_count": 0, "rarity_protected": 0},
+    }
+    path = os.path.join(cache_dir, f"pipeline_results_ws{ws_id}.json")
+    with open(path, "w") as f:
+        _json.dump(results, f)
+
+    resp = client.post("/api/pipeline/detach-burst",
+                       json={"encounter_index": 0, "burst_index": 1})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Source encounter range recomputed to the surviving photos (1, 2).
+    assert data["encounters"][0]["time_range"] == ["2024-01-01T10:00:00", "2024-01-01T10:00:05"]
+    # New encounter range computed from the detached photo (3), not [None, None].
+    assert data["encounters"][1]["photo_ids"] == [3]
+    assert data["encounters"][1]["time_range"] == ["2024-01-01T10:05:00", "2024-01-01T10:05:00"]
+
+
 def test_pipeline_detach_photo(app_and_db):
     """POST /api/pipeline/detach-photo moves a photo to a new burst."""
     import json as _json


### PR DESCRIPTION
Adds a **Sort** dropdown to the pipeline review filter bar so encounters can be ordered by most/fewest photos, most bursts, or newest/oldest first, in addition to the default chronological order. The selection persists across page loads via the existing `vireo.pipelineReview.viewState` localStorage blob, alongside the other view preferences. To keep every encounter's canonical index valid (focus, detach, species overrides, group-review modal), `renderResults()` iterates a sorted list of *original* indices rather than reordering `pipelineResults.encounters`, with ties broken on original index for determinism. The change is purely client-side JS/CSS in `vireo/templates/pipeline_review.html` (+77 lines). Verified: Jinja template parses cleanly and `vireo/tests/test_app.py` passes (199 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added encounter sort dropdown to the pipeline review filter bar with chronological, photo-count, burst-count, and start-time options; preferences are saved and restored.
* **Bug Fixes**
  * Fixes encounter time ranges after detaching a burst so remaining and new encounters show correct timestamps.
* **Tests**
  * Added test coverage to verify correct time-range computation after burst detach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->