### PR TITLE
Pipeline review: per-photo species predictions + honest group-mean label

### DIFF
--- a/docs/plans/2026-05-29-per-photo-species-predictions-design.md
+++ b/docs/plans/2026-05-29-per-photo-species-predictions-design.md
@@ -1,0 +1,64 @@
+# Per-photo species predictions in review panels
+
+## Problem
+
+In the pipeline review burst-group UI, the "Species Predictions" panel shows the
+same values regardless of which photo is selected. It is an **encounter-level
+aggregate** (mean confidence per species/model across all photos in the
+encounter), built by `_build_species_predictions()` in `vireo/pipeline.py:653`.
+Because the panel sits beside a single selected photo and is titled plainly
+"Species Predictions", it reads as if it were *this photo's* predictions — a
+black-box / mislabel issue under `CORE_PHILOSOPHY.md` ("No black boxes").
+
+Two render sites have the bug, both passed a single `photo` but rendering
+`enc.species_predictions`:
+
+- `buildPipelineMetadataHtml(photo)` — group review modal loupe detail
+  (`vireo/templates/pipeline_review.html:4066`)
+- `openInspect(photoId)` — standalone inspect panel (same file, `:2615`)
+
+## What we have already
+
+Each per-photo object delivered to the client carries `species_top5`: a list of
+`[species, confidence, model]` rows (`pipeline.py:360`, preserved through
+`serialize_results` / `_clean_photo`). It is currently unused in the template.
+**No backend change is required.**
+
+## Design
+
+Add a per-photo block above the aggregate, and relabel the aggregate so it is
+honestly described as a group mean. Order: per-photo first (it is what changes
+on click and what you are looking at), group consensus second.
+
+- **"Species Predictions (this photo)"** — built from `photo.species_top5`,
+  grouped by species, each species listing its models' confidences inline
+  (mirrors the aggregate row layout). Sorted by best confidence descending.
+- **"Group consensus — mean across N photos"** — the existing
+  `enc.species_predictions`, unchanged data, only relabeled. `N` is
+  `enc.photo_count`.
+
+Shared helper `buildSpeciesPredictionsHtml(photo, enc, threshold)` produces both
+blocks so the two call sites stay consistent. `threshold` lets `openInspect`
+keep its existing confidence-threshold filter (`minConfidence/100`); the group
+review modal passes `0` (no filter, matching its current behavior).
+
+Reuse existing CSS (`.inspect-species-predictions`, `.inspect-species-row`,
+`.inspect-species-name`, `.inspect-species-conf`) — no new styles.
+
+Empty cases: if a photo has no `species_top5`, the per-photo block is omitted
+(no empty header); the group block still renders. If both are empty, nothing
+renders (current behavior).
+
+## Out of scope
+
+- No change to aggregation math or backend endpoints.
+- No per-burst vs per-encounter scope change for the aggregate (stays
+  encounter-scoped, just labeled honestly).
+
+## Verification
+
+No JS test harness exists for this inline-template JS. Verify by driving the
+running app in a browser (per the project's user-first testing approach):
+open a burst group, click between photos, confirm the "(this photo)" block
+changes while "Group consensus" stays fixed. Run the Python suite as a
+regression sanity check (it does not cover this JS).

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -4052,7 +4052,10 @@ function renderSpeciesBlock(title, rows) {
   html += '<div style="font-size:13px;font-weight:600;margin-bottom:6px;">' + escapeHtml(title) + '</div>';
   rows.forEach(function(sp) {
     var modelParts = (sp.models || []).map(function(m) {
-      return escapeHtml(m.model) + ' ' + (m.confidence * 100).toFixed(0) + '%';
+      var pct = (m.confidence * 100).toFixed(0) + '%';
+      // Some aggregate rows are confidence-only (no model name); show just the
+      // percentage rather than an empty label with a leading space.
+      return m.model ? escapeHtml(m.model) + ' ' + pct : pct;
     });
     html += '<div class="inspect-species-row">';
     html += '<span class="inspect-species-name">' + escapeHtml(sp.species) + '</span>';

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -4212,9 +4212,11 @@ function buildPipelineMetadataHtml(photo) {
   // local detach (single-photo bursts inherit the parent's predictions) or a
   // reclassification (per-photo species_top5 updates without rebuilding burst
   // aggregates). Fresh aggregation keeps "Burst consensus" consistent with the
-  // per-photo blocks and the photos actually in this burst. grmState.items is
-  // exactly this burst's photo objects.
-  var consRows = buildBurstConsensus(grmState.items);
+  // per-photo blocks and the photos actually in this burst. Use the same
+  // non-removed item set as the visible cards (_grmVisibleItems) so a photo the
+  // reviewer has marked for removal (but not yet applied) doesn't keep
+  // influencing the consensus.
+  var consRows = buildBurstConsensus(_grmVisibleItems());
   html += buildSpeciesPredictionsHtml(photo, consRows, 'Burst consensus', 0);
 
   // Score waterfall

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2670,8 +2670,14 @@ function openInspect(photoId) {
   }
 
   // Species predictions (filtered by confidence threshold): this photo, then
-  // the encounter-level group mean.
-  html += buildSpeciesPredictionsHtml(photo, enc, minConfidence / 100);
+  // the encounter consensus. This legacy panel only runs for flat caches with
+  // no burst data (burst-backed photos route to the GRM above), so encounter
+  // scope is the only meaningful group here.
+  var encPhotos = (enc && enc.photo_ids)
+    ? enc.photo_ids.map(function(pid) { return findPhotoInResults(pid); })
+    : [];
+  var encRows = enc ? (enc.species_predictions || []) : [];
+  html += buildSpeciesPredictionsHtml(photo, encRows, consensusTitle('Encounter', encPhotos), minConfidence / 100);
 
   // Score waterfall
   html += '<div class="score-waterfall">';
@@ -4098,18 +4104,38 @@ function filterAggSpeciesRows(rows, threshold) {
   }).filter(function(sp) { return sp.models.length > 0; });
 }
 
-// Build the per-photo + group-consensus species prediction blocks. The
-// per-photo block changes as you select different photos; the group block is
-// the encounter-level mean and is labeled as such (see CORE_PHILOSOPHY "No
-// black boxes"). `threshold` (0..1) filters by confidence; pass 0 for none.
-function buildSpeciesPredictionsHtml(photo, enc, threshold) {
+// Count frames in `photos` that carry at least one species prediction. The
+// consensus mean is computed only over these frames, so the label must not
+// claim a denominator that includes prediction-less frames (CORE_PHILOSOPHY
+// "No black boxes": a "mean across 14 photos" when only 4 had predictions
+// overstates the consensus).
+function framesWithPredictions(photos) {
+  return (photos || []).filter(function(p) {
+    return p && p.species_top5 && p.species_top5.length > 0;
+  }).length;
+}
+
+// Honest consensus title, e.g. "Burst consensus — mean of 4 frames with
+// predictions". `scopeWord` is "Burst" (group review modal, scoped to the
+// reviewed burst) or "Encounter" (legacy flat-cache inspect fallback).
+function consensusTitle(scopeWord, photos) {
+  var n = framesWithPredictions(photos);
+  return scopeWord + ' consensus — mean of ' + n + ' frame' + (n === 1 ? '' : 's') + ' with predictions';
+}
+
+// Build the per-photo + consensus species prediction blocks. The per-photo
+// block changes as you select different photos; the consensus block is the
+// mean over the scope's frames and is labeled with its scope + honest frame
+// count (see CORE_PHILOSOPHY "No black boxes"). Callers pass the scope's own
+// predictions (`consensusRows`) and title so the block matches what's on
+// screen — burst for the GRM, encounter for the flat-cache fallback.
+// `threshold` (0..1) filters by confidence; pass 0 for none.
+function buildSpeciesPredictionsHtml(photo, consensusRows, consensusTitleText, threshold) {
   threshold = threshold || 0;
   var html = '';
   html += renderSpeciesBlock('Species Predictions (this photo)', buildPerPhotoSpeciesRows(photo, threshold));
-  if (enc && enc.species_predictions && enc.species_predictions.length > 0) {
-    var aggRows = filterAggSpeciesRows(enc.species_predictions, threshold);
-    var n = enc.photo_count || (enc.photo_ids ? enc.photo_ids.length : 0);
-    html += renderSpeciesBlock('Group consensus — mean across ' + n + ' photo' + (n === 1 ? '' : 's'), aggRows);
+  if (consensusRows && consensusRows.length > 0) {
+    html += renderSpeciesBlock(consensusTitleText, filterAggSpeciesRows(consensusRows, threshold));
   }
   return html;
 }
@@ -4136,8 +4162,15 @@ function buildPipelineMetadataHtml(photo) {
     html += '</div>';
   }
 
-  // Species predictions: this photo, then the encounter-level group mean.
-  html += buildSpeciesPredictionsHtml(photo, enc, 0);
+  // Species predictions: this photo, then the consensus for the burst being
+  // reviewed (the GRM is scoped to a single burst — see openGroupReview). Using
+  // burst-level predictions keeps sibling bursts in the same encounter out of
+  // the consensus. grmState.items is exactly this burst's photos, so it gives
+  // the honest "frames with predictions" denominator.
+  var burst = enc.bursts && enc.bursts[grmState.burstIdx];
+  var consRows = burst ? (burst.species_predictions || []) : (enc.species_predictions || []);
+  var consTitle = consensusTitle(burst ? 'Burst' : 'Encounter', grmState.items);
+  html += buildSpeciesPredictionsHtml(photo, consRows, consTitle, 0);
 
   // Score waterfall
   var scores = [

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -4165,11 +4165,23 @@ function buildPipelineMetadataHtml(photo) {
   // Species predictions: this photo, then the consensus for the burst being
   // reviewed (the GRM is scoped to a single burst — see openGroupReview). Using
   // burst-level predictions keeps sibling bursts in the same encounter out of
-  // the consensus. grmState.items is exactly this burst's photos, so it gives
-  // the honest "frames with predictions" denominator.
+  // the consensus, and grmState.items (this burst's photos) gives the honest
+  // "frames with predictions" denominator. Legacy caches store bursts as raw
+  // photo-id arrays with no species_predictions field; detect that with
+  // Array.isArray and fall back to encounter scope so the consensus block isn't
+  // dropped. An empty burst array stays burst-scoped (the block is simply
+  // omitted) rather than re-leaking sibling-burst predictions.
   var burst = enc.bursts && enc.bursts[grmState.burstIdx];
-  var consRows = burst ? (burst.species_predictions || []) : (enc.species_predictions || []);
-  var consTitle = consensusTitle(burst ? 'Burst' : 'Encounter', grmState.items);
+  var hasBurstPreds = burst && Array.isArray(burst.species_predictions);
+  var consRows, consTitle;
+  if (hasBurstPreds) {
+    consRows = burst.species_predictions;
+    consTitle = consensusTitle('Burst', grmState.items);
+  } else {
+    consRows = enc.species_predictions || [];
+    var encPhotos = (enc.photo_ids || []).map(function(pid) { return findPhotoInResults(pid); });
+    consTitle = consensusTitle('Encounter', encPhotos);
+  }
   html += buildSpeciesPredictionsHtml(photo, consRows, consTitle, 0);
 
   // Score waterfall

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2673,8 +2673,10 @@ function openInspect(photoId) {
   // the encounter consensus. This legacy panel only runs for flat caches with
   // no burst data (burst-backed photos route to the GRM above), so encounter
   // scope is the only meaningful group here.
-  var encRows = enc ? (enc.species_predictions || []) : [];
-  html += buildSpeciesPredictionsHtml(photo, encRows, 'Encounter consensus', minConfidence / 100);
+  var encPhotos = (enc && enc.photo_ids)
+    ? enc.photo_ids.map(function(pid) { return findPhotoInResults(pid); }).filter(Boolean)
+    : [];
+  html += buildSpeciesPredictionsHtml(photo, buildBurstConsensus(encPhotos), 'Encounter consensus', minConfidence / 100);
 
   // Score waterfall
   html += '<div class="score-waterfall">';
@@ -4110,6 +4112,50 @@ function filterAggSpeciesRows(rows, threshold) {
   }).filter(function(sp) { return sp.models.length > 0; });
 }
 
+// Client-side mirror of _build_species_predictions (vireo/pipeline.py): aggregate
+// a list of photo objects' species_top5 into consensus rows
+// ({species, count, avg_confidence, models:[{model, confidence, photo_count}]},
+// sorted by total count desc, models sorted by name). Used to rebuild a burst's
+// predictions after a local detach so the cached/displayed "Burst consensus"
+// reflects only the photos still in that burst — not the ones split off.
+function buildBurstConsensus(photos) {
+  var modelData = {};   // species -> model -> {confs:[], count:0}
+  var order = [];       // species insertion order (stable tiebreak, matches server)
+  (photos || []).forEach(function(p) {
+    ((p && p.species_top5) || []).forEach(function(entry) {
+      var sp = entry[0];
+      var conf = entry[1];
+      var model = entry[2] || 'unknown';
+      if (!modelData[sp]) { modelData[sp] = {}; order.push(sp); }
+      if (!modelData[sp][model]) modelData[sp][model] = { confs: [], count: 0 };
+      modelData[sp][model].confs.push(conf);
+      modelData[sp][model].count += 1;
+    });
+  });
+  var round4 = function(x) { return Math.round(x * 1e4) / 1e4; };
+  var rows = order.map(function(sp) {
+    var models = [];
+    var totalCount = 0, totalConfSum = 0, totalConfCount = 0;
+    Object.keys(modelData[sp]).sort().forEach(function(model) {
+      var data = modelData[sp][model];
+      var sum = data.confs.reduce(function(a, b) { return a + b; }, 0);
+      models.push({ model: model, confidence: round4(sum / data.confs.length), photo_count: data.count });
+      totalCount += data.count;
+      totalConfSum += sum;
+      totalConfCount += data.confs.length;
+    });
+    return {
+      species: sp,
+      count: totalCount,
+      avg_confidence: totalConfCount ? round4(totalConfSum / totalConfCount) : 0,
+      models: models,
+    };
+  });
+  // Stable sort by total count desc (insertion order breaks ties, like the server).
+  rows.sort(function(a, b) { return b.count - a.count; });
+  return rows;
+}
+
 // Build the per-photo + consensus species prediction blocks. The per-photo
 // block changes as you select different photos; the consensus block is the
 // per-species mean over the scope's frames. The title names only the scope
@@ -4161,11 +4207,15 @@ function buildPipelineMetadataHtml(photo) {
   // Array.isArray and fall back to encounter scope so the consensus block isn't
   // dropped. An empty burst array stays burst-scoped (the block is simply
   // omitted) rather than re-leaking sibling-burst predictions.
-  var burst = enc.bursts && enc.bursts[grmState.burstIdx];
-  var hasBurstPreds = burst && Array.isArray(burst.species_predictions);
-  var consRows = hasBurstPreds ? burst.species_predictions : (enc.species_predictions || []);
-  var consTitle = hasBurstPreds ? 'Burst consensus' : 'Encounter consensus';
-  html += buildSpeciesPredictionsHtml(photo, consRows, consTitle, 0);
+  // Compute the consensus fresh from this burst's current photos rather than
+  // trusting the cached burst.species_predictions, which can go stale after a
+  // local detach (single-photo bursts inherit the parent's predictions) or a
+  // reclassification (per-photo species_top5 updates without rebuilding burst
+  // aggregates). Fresh aggregation keeps "Burst consensus" consistent with the
+  // per-photo blocks and the photos actually in this burst. grmState.items is
+  // exactly this burst's photo objects.
+  var consRows = buildBurstConsensus(grmState.items);
+  html += buildSpeciesPredictionsHtml(photo, consRows, 'Burst consensus', 0);
 
   // Score waterfall
   var scores = [
@@ -4922,12 +4972,30 @@ async function grmApply() {
     var enc = pipelineResults.encounters[grmState.encIdx];
     var burst = enc.bursts[grmState.burstIdx];
     var burstIds = burst.photo_ids || burst;
+    // Whether the source burst is the modern object shape (carries its own
+    // predictions) vs a legacy raw photo-id array (no predictions field).
+    var srcHasPreds = burst && Array.isArray(burst.species_predictions);
     grmState.removed.forEach(function(pid) {
       var idx = burstIds.indexOf(pid);
       if (idx >= 0) burstIds.splice(idx, 1);
-      // Add as a new single-photo burst in the same encounter
-      enc.bursts.push({ photo_ids: [pid], species_predictions: burst.species_predictions || [], species_override: null });
+      // New single-photo burst: rebuild its consensus from just this photo so it
+      // doesn't inherit the source burst's predictions for photos it no longer
+      // contains (the loupe and the saved cache both trust burst.species_predictions).
+      var photo = findPhotoInResults(pid);
+      enc.bursts.push({
+        photo_ids: [pid],
+        species_predictions: buildBurstConsensus(photo ? [photo] : []),
+        species_override: null,
+      });
     });
+    // Recompute the shortened source burst's consensus from its remaining
+    // photos, so it no longer reflects the detached ones. Skip legacy array
+    // bursts (no predictions field to maintain).
+    if (srcHasPreds) {
+      burst.species_predictions = buildBurstConsensus(
+        burstIds.map(function(id) { return findPhotoInResults(id); }).filter(Boolean)
+      );
+    }
     // Clean up empty burst
     if (burstIds.length === 0) {
       enc.bursts.splice(grmState.burstIdx, 1);

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2673,11 +2673,8 @@ function openInspect(photoId) {
   // the encounter consensus. This legacy panel only runs for flat caches with
   // no burst data (burst-backed photos route to the GRM above), so encounter
   // scope is the only meaningful group here.
-  var encPhotos = (enc && enc.photo_ids)
-    ? enc.photo_ids.map(function(pid) { return findPhotoInResults(pid); })
-    : [];
   var encRows = enc ? (enc.species_predictions || []) : [];
-  html += buildSpeciesPredictionsHtml(photo, encRows, consensusTitle('Encounter', encPhotos), minConfidence / 100);
+  html += buildSpeciesPredictionsHtml(photo, encRows, 'Encounter consensus', minConfidence / 100);
 
   // Score waterfall
   html += '<div class="score-waterfall">';
@@ -4061,7 +4058,16 @@ function renderSpeciesBlock(title, rows) {
       var pct = (m.confidence * 100).toFixed(0) + '%';
       // Some aggregate rows are confidence-only (no model name); show just the
       // percentage rather than an empty label with a leading space.
-      return m.model ? escapeHtml(m.model) + ' ' + pct : pct;
+      var part = m.model ? escapeHtml(m.model) + ' ' + pct : pct;
+      // Consensus rows carry photo_count — the number of frames where this
+      // model predicted this species. Surface it so a minority species
+      // predicted on a single frame isn't read as a broad consensus
+      // (CORE_PHILOSOPHY "No black boxes"). Per-photo rows have no photo_count
+      // (each is one frame) and stay count-free.
+      if (typeof m.photo_count === 'number') {
+        part += ' (' + m.photo_count + ' frame' + (m.photo_count === 1 ? '' : 's') + ')';
+      }
+      return part;
     });
     html += '<div class="inspect-species-row">';
     html += '<span class="inspect-species-name">' + escapeHtml(sp.species) + '</span>';
@@ -4104,32 +4110,16 @@ function filterAggSpeciesRows(rows, threshold) {
   }).filter(function(sp) { return sp.models.length > 0; });
 }
 
-// Count frames in `photos` that carry at least one species prediction. The
-// consensus mean is computed only over these frames, so the label must not
-// claim a denominator that includes prediction-less frames (CORE_PHILOSOPHY
-// "No black boxes": a "mean across 14 photos" when only 4 had predictions
-// overstates the consensus).
-function framesWithPredictions(photos) {
-  return (photos || []).filter(function(p) {
-    return p && p.species_top5 && p.species_top5.length > 0;
-  }).length;
-}
-
-// Honest consensus title, e.g. "Burst consensus — mean of 4 frames with
-// predictions". `scopeWord` is "Burst" (group review modal, scoped to the
-// reviewed burst) or "Encounter" (legacy flat-cache inspect fallback).
-function consensusTitle(scopeWord, photos) {
-  var n = framesWithPredictions(photos);
-  return scopeWord + ' consensus — mean of ' + n + ' frame' + (n === 1 ? '' : 's') + ' with predictions';
-}
-
 // Build the per-photo + consensus species prediction blocks. The per-photo
 // block changes as you select different photos; the consensus block is the
-// mean over the scope's frames and is labeled with its scope + honest frame
-// count (see CORE_PHILOSOPHY "No black boxes"). Callers pass the scope's own
-// predictions (`consensusRows`) and title so the block matches what's on
-// screen — burst for the GRM, encounter for the flat-cache fallback.
-// `threshold` (0..1) filters by confidence; pass 0 for none.
+// per-species mean over the scope's frames. The title names only the scope
+// ("Burst consensus" / "Encounter consensus") — it deliberately does NOT claim
+// a global frame denominator, because each row is averaged only over the frames
+// where that species appears (surfaced as per-model frame counts in
+// renderSpeciesBlock). Callers pass the scope's own predictions
+// (`consensusRows`) and title so the block matches what's on screen — burst for
+// the GRM, encounter for the flat-cache fallback. `threshold` (0..1) filters by
+// confidence; pass 0 for none.
 function buildSpeciesPredictionsHtml(photo, consensusRows, consensusTitleText, threshold) {
   threshold = threshold || 0;
   var html = '';
@@ -4173,15 +4163,8 @@ function buildPipelineMetadataHtml(photo) {
   // omitted) rather than re-leaking sibling-burst predictions.
   var burst = enc.bursts && enc.bursts[grmState.burstIdx];
   var hasBurstPreds = burst && Array.isArray(burst.species_predictions);
-  var consRows, consTitle;
-  if (hasBurstPreds) {
-    consRows = burst.species_predictions;
-    consTitle = consensusTitle('Burst', grmState.items);
-  } else {
-    consRows = enc.species_predictions || [];
-    var encPhotos = (enc.photo_ids || []).map(function(pid) { return findPhotoInResults(pid); });
-    consTitle = consensusTitle('Encounter', encPhotos);
-  }
+  var consRows = hasBurstPreds ? burst.species_predictions : (enc.species_predictions || []);
+  var consTitle = hasBurstPreds ? 'Burst consensus' : 'Encounter consensus';
   html += buildSpeciesPredictionsHtml(photo, consRows, consTitle, 0);
 
   // Score waterfall

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2669,29 +2669,9 @@ function openInspect(photoId) {
     html += '</div>';
   }
 
-  // Species predictions (filtered by confidence threshold)
-  if (enc && enc.species_predictions && enc.species_predictions.length > 0) {
-    var threshold = minConfidence / 100;
-    var filtered = enc.species_predictions.filter(function(sp) {
-      return (sp.models || []).some(function(m) { return m.confidence >= threshold; });
-    });
-    if (filtered.length > 0) {
-      html += '<div class="inspect-species-predictions">';
-      html += '<div style="font-size:13px;font-weight:600;margin-bottom:6px;">Species Predictions</div>';
-      filtered.forEach(function(sp) {
-        var modelParts = (sp.models || []).filter(function(m) {
-          return m.confidence >= threshold;
-        }).map(function(m) {
-          return escapeHtml(m.model) + ' ' + (m.confidence * 100).toFixed(0) + '%';
-        });
-        html += '<div class="inspect-species-row">';
-        html += '<span class="inspect-species-name">' + escapeHtml(sp.species) + '</span>';
-        html += '<span class="inspect-species-conf">' + modelParts.join(', ') + '</span>';
-        html += '</div>';
-      });
-      html += '</div>';
-    }
-  }
+  // Species predictions (filtered by confidence threshold): this photo, then
+  // the encounter-level group mean.
+  html += buildSpeciesPredictionsHtml(photo, enc, minConfidence / 100);
 
   // Score waterfall
   html += '<div class="score-waterfall">';
@@ -4063,6 +4043,74 @@ function grmRefreshSelectedLoupe() {
   }
 }
 
+// Render a single species-prediction block (title + rows). Each row in `rows`
+// is {species, models: [{model, confidence}]}. Returns '' when there are no
+// rows so we never emit an empty header.
+function renderSpeciesBlock(title, rows) {
+  if (!rows || rows.length === 0) return '';
+  var html = '<div class="inspect-species-predictions">';
+  html += '<div style="font-size:13px;font-weight:600;margin-bottom:6px;">' + escapeHtml(title) + '</div>';
+  rows.forEach(function(sp) {
+    var modelParts = (sp.models || []).map(function(m) {
+      return escapeHtml(m.model) + ' ' + (m.confidence * 100).toFixed(0) + '%';
+    });
+    html += '<div class="inspect-species-row">';
+    html += '<span class="inspect-species-name">' + escapeHtml(sp.species) + '</span>';
+    html += '<span class="inspect-species-conf">' + modelParts.join(', ') + '</span>';
+    html += '</div>';
+  });
+  html += '</div>';
+  return html;
+}
+
+// Group a single photo's raw species_top5 ([species, confidence, model] rows)
+// into the same {species, models} shape the aggregate uses, dropping models
+// below `threshold` and sorting by confidence descending.
+function buildPerPhotoSpeciesRows(photo, threshold) {
+  var top5 = (photo && photo.species_top5) || [];
+  if (top5.length === 0) return [];
+  var bySpecies = {};
+  var order = [];
+  top5.forEach(function(entry) {
+    var sp = entry[0];
+    var conf = entry[1];
+    var model = entry[2] || 'unknown';
+    if (conf < threshold) return;
+    if (!bySpecies[sp]) { bySpecies[sp] = []; order.push(sp); }
+    bySpecies[sp].push({ model: model, confidence: conf });
+  });
+  var rows = order.map(function(sp) {
+    var models = bySpecies[sp].slice().sort(function(a, b) { return b.confidence - a.confidence; });
+    return { species: sp, models: models };
+  });
+  rows.sort(function(a, b) { return b.models[0].confidence - a.models[0].confidence; });
+  return rows;
+}
+
+// Drop aggregate rows (and their models) below `threshold`.
+function filterAggSpeciesRows(rows, threshold) {
+  if (!threshold) return rows || [];
+  return (rows || []).map(function(sp) {
+    return { species: sp.species, models: (sp.models || []).filter(function(m) { return m.confidence >= threshold; }) };
+  }).filter(function(sp) { return sp.models.length > 0; });
+}
+
+// Build the per-photo + group-consensus species prediction blocks. The
+// per-photo block changes as you select different photos; the group block is
+// the encounter-level mean and is labeled as such (see CORE_PHILOSOPHY "No
+// black boxes"). `threshold` (0..1) filters by confidence; pass 0 for none.
+function buildSpeciesPredictionsHtml(photo, enc, threshold) {
+  threshold = threshold || 0;
+  var html = '';
+  html += renderSpeciesBlock('Species Predictions (this photo)', buildPerPhotoSpeciesRows(photo, threshold));
+  if (enc && enc.species_predictions && enc.species_predictions.length > 0) {
+    var aggRows = filterAggSpeciesRows(enc.species_predictions, threshold);
+    var n = enc.photo_count || (enc.photo_ids ? enc.photo_ids.length : 0);
+    html += renderSpeciesBlock('Group consensus — mean across ' + n + ' photo' + (n === 1 ? '' : 's'), aggRows);
+  }
+  return html;
+}
+
 function buildPipelineMetadataHtml(photo) {
   var enc = pipelineResults.encounters[grmState.encIdx];
   var label = (photo.label || '').toLowerCase();
@@ -4085,21 +4133,8 @@ function buildPipelineMetadataHtml(photo) {
     html += '</div>';
   }
 
-  // Species predictions
-  if (enc && enc.species_predictions && enc.species_predictions.length > 0) {
-    html += '<div class="inspect-species-predictions">';
-    html += '<div style="font-size:13px;font-weight:600;margin-bottom:6px;">Species Predictions</div>';
-    enc.species_predictions.forEach(function(sp) {
-      var modelParts = (sp.models || []).map(function(m) {
-        return escapeHtml(m.model) + ' ' + (m.confidence * 100).toFixed(0) + '%';
-      });
-      html += '<div class="inspect-species-row">';
-      html += '<span class="inspect-species-name">' + escapeHtml(sp.species) + '</span>';
-      html += '<span class="inspect-species-conf">' + modelParts.join(', ') + '</span>';
-      html += '</div>';
-    });
-    html += '</div>';
-  }
+  // Species predictions: this photo, then the encounter-level group mean.
+  html += buildSpeciesPredictionsHtml(photo, enc, 0);
 
   // Score waterfall
   var scores = [


### PR DESCRIPTION
## What & why

In the burst-group review (and the standalone inspect panel), the **Species Predictions** panel showed the *encounter-level aggregate* while sitting next to a single selected photo. It read as "this photo's predictions" but never changed when you clicked a different photo — a black-box mislabel under `CORE_PHILOSOPHY.md` ("No black boxes"). It's actually the **mean** confidence per species/model across all photos in the encounter (`_build_species_predictions`, `pipeline.py:653`).

## Change

Two blocks now, per-photo first (it's what changes on click), group second:

- **"Species Predictions (this photo)"** — built from each photo's `species_top5`, grouped by species with model confidences inline, sorted by confidence. Omitted when a photo has no prediction.
- **"Group consensus — mean across N photos"** — the existing aggregate, unchanged data, just labeled honestly.

A shared `buildSpeciesPredictionsHtml(photo, enc, threshold)` helper drives both render sites (`buildPipelineMetadataHtml` group-review modal, and `openInspect`) so they stay consistent. `openInspect` keeps its confidence-threshold filter; the group-review modal passes none.

**Pure frontend** — `species_top5` was already delivered per-photo (`pipeline.py:360`, preserved through `serialize_results`) and previously unused in the template. No backend or aggregation changes.

## Testing

- `python -m pytest vireo/tests/test_app.py -q` → **199 passed**.
- `node --check` on the extracted JS → clean.
- Ran the actual extracted JS against the live app's real `/api/pipeline/page-init` data (7,053 photos / 198 encounters): the per-photo block renders and **varies correctly** per photo (e.g. photo 48978 → "Warbling White-eye: BioCLIP-2.5 100%, iNat21 94%" vs 48979 → "Warbling White-eye 83% | Yellow-fronted Canary 48%"), and the group block reads "mean across 25 photos".

### Note on coverage
Per-photo predictions only exist for photos that got a species classification (~4,900 of 7,053). In a sample 25-photo encounter, 8 photos had per-photo predictions; for the rest the "(this photo)" block is correctly omitted and only the group consensus shows. This is honest behavior, but means the new block won't appear on every frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Species predictions now render two sections: "Species Predictions (this photo)" for the selected photo and a relabeled aggregate "Group consensus — mean across N photos" with N shown. Per-photo section is omitted when empty; the inspection overlay applies the confidence threshold while the metadata panel shows the consensus unfiltered.

* **Documentation**
  * Added a design spec describing the updated display and verification steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->