### PR TITLE
Burst group: split species confirm from pick/reject apply

### DIFF
--- a/docs/plans/2026-05-29-burst-group-confirm-split-design.md
+++ b/docs/plans/2026-05-29-burst-group-confirm-split-design.md
@@ -1,0 +1,123 @@
+# Review Burst Group — decouple species confirmation from pick/reject apply
+
+**Date:** 2026-05-29
+**Status:** Design approved, ready for implementation plan
+
+## Problem
+
+Inside the **Review Burst Group** modal (`vireo/templates/pipeline_review.html`),
+there is exactly one commit path: the **"Apply flags/species & Close"** button
+(`grmApply()`). It fuses three independent things into a single atomic action:
+
+1. Pick/reject/candidate **flag** decisions.
+2. **Species** — tags picks with the species keyword *and* marks the burst confirmed.
+3. **Closing** the burst.
+
+So the user cannot independently confirm "yes, this is the species" versus
+"yes, I accept the picks and rejects." The two are forced together.
+
+There is also a **backend divergence**: the grid's species ✓ button goes through
+`/api/encounters/species` (persists `species_confirmed` server-side, tags *all*
+frames, handles species replacement, auto-detaches a burst whose species differs
+from its encounter). The modal's `grmApply()` instead folds species into
+`/api/pipeline/group/apply`, which tags only the **picks** and marks confirmation
+**only in the local pipeline cache** — never server-side. "Confirmed in the modal"
+and "confirmed in the grid" are not the same persisted state.
+
+## Decisions
+
+### B — Two checkboxes + one "Apply and close" button
+
+The single fused button is replaced by:
+
+- Checkbox **"Confirm species"** — when committed, tags *every* frame in the burst
+  with the species and marks the burst confirmed.
+- Checkbox **"Apply picks/rejects"** — when committed, writes the
+  pick/reject/candidate flag decisions.
+- A single **"Apply and close"** button that commits whichever boxes are checked,
+  then closes. If neither is checked it is effectively "Close" (no DB writes).
+
+**Smart defaults (option C):** a box is checked only when there is a *real pending
+change*, recomputed live on every zone move and species-field edit:
+
+- "Apply picks/rejects": checked when `grmComputeDiff()` shows
+  `flagNew + rejectNew + clearNew > 0`.
+- "Confirm species": checked when the species field is non-empty **and** differs
+  from the burst's already-confirmed species (`grmState.initialSpecies`).
+  Re-confirming an unchanged species is a no-op → stays unchecked.
+
+**Inline warning (option B):** if a checkbox is *unchecked* but its diff is
+non-empty (the user overrode a smart-default-checked box), show a small amber
+hint beside it — e.g. "3 flag changes won't be saved" / "species won't be
+confirmed". No dialog. Closing therefore never silently drops work.
+
+**Button label** keeps today's transparency, scoped to checked boxes only:
+"Flag 3 · Reject 2 & Close", "Confirm species & Close", or "No changes & Close".
+
+### C — Backend unification
+
+- **`/api/pipeline/group/apply` becomes flags-only.** The modal stops sending
+  `species`. The keyword-tagging block is removed from the endpoint (param left
+  accepted-but-ignored or removed, decided by test fallout; the modal is its only
+  caller).
+- **Species confirmation routes through `/api/encounters/species`**, the same
+  endpoint the grid uses, called burst-scoped:
+  `{ species, photo_ids: <current burst members>, burst_index: <current idx> }`.
+  This gives, identically to the grid: tag all burst frames, persist
+  `species_confirmed` / `species_override.confirmed` server-side, species
+  replacement (untag old + queue sidecar remove), auto-detach on species mismatch,
+  and an authoritative `encounters` + `summary` response that the modal adopts
+  into `pipelineResults` (mirroring `confirmSpecies()`).
+
+Net effect: modal and grid confirmation become one persisted state, one code path.
+
+## Data flow / ordering in `grmApply()`
+
+Two restructuring operations can fire in one apply — the modal's existing
+"removed photos → detach into single-frame bursts" logic, and species confirm's
+auto-detach. `/api/encounters/species` reloads the cache from disk and validates
+`photo_ids ⊆ bursts[burst_index]`, so order matters.
+
+1. Read checkbox state → `applyFlags`, `confirmSpecies`.
+2. If `applyFlags`: `POST /api/pipeline/group/apply` (flags only) → update local
+   `pipelineResults.photos` labels + flags. Abort on failure (return early, do not
+   close) so DB and cache cannot drift.
+3. Local structural mutations as today (browse-selection handling, removed→detach
+   splicing). Recompute the current burst index + remaining member ids.
+4. `save-cache(pipelineResults)` → persists flags-as-labels + post-removal
+   structure to disk so the next step reads a consistent cache.
+5. If `confirmSpecies` (and burst still has ≥1 frame): `POST /api/encounters/species`
+   with the **remaining** burst member ids (removed photos excluded, so they are
+   not tagged) + current `burst_index`. Adopt returned `encounters` + `summary`
+   into `pipelineResults` (the endpoint already re-saved the cache).
+6. Close, clear the species field, `renderResults()`, `updateSummaryBar()`.
+
+Rationale: flags are per-photo and structure-independent → first. The modal's own
+structural edits are persisted before the species call so the endpoint validates
+against the structure the user sees. Species confirm runs last; its response is
+authoritative, exactly how the grid treats it.
+
+## Edge cases
+
+- **Empty burst after removal:** skip the species call (nothing to confirm); the
+  existing "all removed → fall back to normal review" path is preserved.
+- **Browse-selection source:** temporary in-memory bursts may not map to a
+  persisted encounter `/api/encounters/species` can find. **Verify live** before
+  committing; if unmapped, either keyword-tag-only fallback or gate species-confirm
+  off for that source. Do not assume.
+- **Species replacement in-modal:** changing an already-confirmed burst's species
+  now untags the old one via the unified endpoint (previously impossible cleanly).
+- **Unchecked-but-dirty close:** amber hint shows; changes silently discarded on
+  close (no dialog).
+- **Seed guard:** the existing `grmState.seeded` check stays — Apply is a no-op
+  until group state has loaded.
+
+## Testing
+
+- **E2E (Playwright, user-first):** smart-default checkbox states on open; unchecking
+  a dirty box shows the amber hint; species-only apply leaves flags untouched + tags
+  all frames + marks confirmed; flags-only apply leaves species unconfirmed; both
+  checked lands both; species replacement untags the old keyword.
+- **Backend:** `group/apply` no longer tags species; the modal species path produces
+  the same DB state as a grid `/api/encounters/species` call; auto-detach still fires.
+- **Regression:** the CLAUDE.md test bundle.

--- a/docs/plans/2026-05-29-burst-group-confirm-split.md
+++ b/docs/plans/2026-05-29-burst-group-confirm-split.md
@@ -116,6 +116,88 @@ git commit -m "pipeline: make /group/apply flags-only; species moves to dedicate
 
 ---
 
+## Task 1b: Fix rapid-review species path (caller of the gutted endpoint)
+
+**Why (added after Task 1 code review):** `vireo/templates/pipeline_rapid_review.html`
+is a *second* caller of `/api/pipeline/group/apply`. Its `applyCurrent()` sends
+`species`, then sets `enc.confirmed_species`/`enc.species_confirmed = true` and
+propagates the species across sibling bursts — relying on the endpoint to tag the
+keyword. After Task 1 it would mark the encounter confirmed while persisting **no**
+species keyword (a "No black boxes" / UI-truthfulness regression). Rapid review has
+no checkboxes — species + flags are intentionally one fast "Apply" action — so the
+fix is just to persist species through the unified path, not to add a UI split.
+
+**Files:**
+- Modify: `vireo/templates/pipeline_rapid_review.html:1690-1761` (`applyCurrent`)
+- Modify: `tests/e2e/test_pipeline_rapid_review.py` (it mocks `/group/apply` and
+  asserts the old species-tagging apply-label text — update to the new contract)
+
+**Step 1: Stop sending `species` to `/group/apply`**
+
+In `applyCurrent` remove the `species: species` field from the `/group/apply`
+body (line ~1714). The `resp.photos[pid].has_species_keyword` branch (line ~1735)
+is now always False — it can stay (dead but harmless) or be simplified; the local
+`if (species && pickSet.has(p.id)) p.confirmed_species = species;` (line ~1727)
+stays for the optimistic UI.
+
+**Step 2: Persist species via the unified endpoint**
+
+After the `/group/apply` call and the local label/flag updates, before the
+encounter-confirm block, add a burst-scoped species confirmation when `species` is
+set. Tag **all** current-burst photos (matching the pipeline decision):
+
+```js
+    if (species) {
+      var spResp = await safeFetch('/api/encounters/species', {
+        method: 'POST', headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          species: species,
+          photo_ids: items.map(function(p) { return p.id; }),
+          burst_index: session.burstIdx,
+        }),
+      });
+      // Adopt authoritative structure (it may auto-detach on species mismatch),
+      // so the save-cache below doesn't clobber the endpoint's restructure.
+      if (spResp && spResp.encounters) {
+        rapid.results.encounters = spResp.encounters;
+        if (spResp.summary) rapid.results.summary = spResp.summary;
+      }
+    }
+```
+
+Keep the existing `enc.confirmed_species`/`species_confirmed` + sibling-burst
+species-hint propagation (lines ~1739-1755) — but note `enc` is read from
+`rapid.results.encounters[session.encIdx]`, which the adopt step above may have
+replaced; re-read `enc` after adoption so it points at the fresh object. The
+`save-cache` (line ~1757) then persists the merged `rapid.results`.
+
+**Step 3: Update the rapid-review e2e expectations**
+
+`tests/e2e/test_pipeline_rapid_review.py` stubs `/api/pipeline/group/apply` via
+`page.route(...)` and asserts an apply-label like
+`'... add species keyword "Test bird" to 1 pick.'`. Update the mock/assertions to
+the new flow: `/group/apply` no longer tags species; species now goes through
+`/api/encounters/species` (which the test must also stub). If the apply-label text
+is generated client-side from the picks/species, adjust the expected string to
+match the new wording; if it was derived from the mocked response, re-point it.
+Read the test first and adapt to its actual structure — do not assume.
+
+**Step 4: Verify**
+
+Run: `python -m pytest tests/e2e/test_pipeline_rapid_review.py -v`
+Expected: PASS. Then manually: rapid-review a burst, type a species, Apply Next →
+the species keyword is actually on the burst photos in the DB and the encounter
+shows confirmed (grid agrees).
+
+**Step 5: Commit**
+
+```bash
+git add vireo/templates/pipeline_rapid_review.html tests/e2e/test_pipeline_rapid_review.py
+git commit -m "pipeline rapid review: persist species via unified endpoint after /group/apply went flags-only"
+```
+
+---
+
 ## Task 2: Footer markup — two checkboxes + "Apply and close"
 
 Replace the single fused button with two checkboxes and one apply button, plus

--- a/docs/plans/2026-05-29-burst-group-confirm-split.md
+++ b/docs/plans/2026-05-29-burst-group-confirm-split.md
@@ -1,0 +1,466 @@
+# Review Burst Group — Confirm/Apply Split Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let the user independently commit "confirm this species" and "accept these picks/rejects" inside the Review Burst Group modal, via two smart-defaulted checkboxes and one "Apply and close" button, and unify species confirmation onto the same backend path the grid uses.
+
+**Architecture:** Frontend change concentrated in `vireo/templates/pipeline_review.html` (modal footer markup + the `grmApply()` flow + checkbox state derived from the existing `grmComputeDiff()`). Backend change: `/api/pipeline/group/apply` becomes flags-only; species confirmation routes through the existing `/api/encounters/species` (pipeline bursts) or `/api/batch/keyword` (browse-selection ad-hoc sets).
+
+**Tech Stack:** Flask, Jinja2, vanilla JS (no framework), SQLite, pytest, Playwright (E2E).
+
+**Design doc:** `docs/plans/2026-05-29-burst-group-confirm-split-design.md`
+
+**Decisions baked in:**
+- Smart-default checkboxes (option C); inline amber warning when an unchecked box is dirty (option B).
+- "Confirm species" tags **all** burst frames (matches the grid), not just picks.
+- "Apply picks/rejects" owns flag changes **and** removed-photo detach (`detachNew`).
+- Backend: `group/apply` stops handling species; species goes through
+  `/api/encounters/species` (pipeline) / `/api/batch/keyword` (browse-selection).
+
+---
+
+## Task 1: Make `/api/pipeline/group/apply` flags-only
+
+Remove species keyword tagging from the endpoint. The modal will stop sending
+`species`; species confirmation moves entirely to other endpoints (Task 4).
+
+**Files:**
+- Modify: `vireo/app.py:12707-12820` (`api_pipeline_group_apply`)
+- Test: `vireo/tests/test_pipeline_group_apply.py`
+
+**Step 1: Update the failing test**
+
+Find the existing test(s) in `vireo/tests/test_pipeline_group_apply.py` that pass
+`species` and assert picks get the species keyword. Change the assertion to the
+new contract: posting `species` does **not** tag any photo. Add a focused test:
+
+```python
+def test_group_apply_ignores_species_and_tags_nothing(client, ...):
+    # picks=[p1], rejects=[p2], species provided
+    resp = client.post("/api/pipeline/group/apply", json={
+        "picks": [p1], "rejects": [p2], "candidates": [],
+        "species": "Blue Jay",
+    })
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # flags still applied
+    assert body["photos"][str(p1)]["flag"] == "flagged"
+    assert body["photos"][str(p2)]["flag"] == "rejected"
+    # but NO species keyword was added to the pick
+    assert body["photos"][str(p1)]["has_species_keyword"] is False
+    # and the DB has no species keyword on p1
+    kws = get_db().get_photo_keywords(p1)
+    assert not any(k["name"] == "Blue Jay" for k in kws)
+```
+
+(Use the file's existing fixtures/helpers for `client`, photo creation, and
+`get_db`. Mirror the setup of the current species test in that file.)
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest vireo/tests/test_pipeline_group_apply.py -v`
+Expected: FAIL — current endpoint tags the pick, so `has_species_keyword` is True.
+
+**Step 3: Remove species handling from the endpoint**
+
+In `vireo/app.py` `api_pipeline_group_apply` (lines ~12707-12820):
+
+- Delete the `species` parsing line:
+  `species = (body.get("species") or "").strip()`
+- Delete the species-precompute block (lines ~12743-12750):
+  ```python
+  species_kid = None
+  photos_with_species = set()
+  if species:
+      species_kid = db.add_keyword(species, is_species=True)
+      for pid in picks:
+          ...
+  ```
+- Delete the keyword-tagging block inside the `try:` (lines ~12773-12785):
+  ```python
+  kw_added_pids = []
+  if species and species_kid is not None:
+      for pid in picks:
+          ...
+  ```
+- Delete the `kw_added_pids` edit-history block (lines ~12802-12807).
+- In the response (lines ~12810-12819), replace the `has_species_keyword`
+  computation that referenced `species_kid` with a constant `False`:
+  ```python
+  result_photos[pid] = {
+      "flag": row["flag"] or "none",
+      "has_species_keyword": False,
+  }
+  ```
+  (Kept in the payload so the client cache-sync code in `grmApply` need not
+  change shape; it is now always False because this endpoint no longer tags.)
+- Update the docstring's first paragraph to say it applies flag decisions only.
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest vireo/tests/test_pipeline_group_apply.py -v`
+Expected: PASS.
+
+**Step 5: Run the broader app/pipeline suites for fallout**
+
+Run: `python -m pytest vireo/tests/test_pipeline_group_apply.py vireo/tests/test_app.py -q`
+Expected: PASS (fix any test that asserted the old species-tagging behavior to
+match the new flags-only contract — do not weaken unrelated assertions).
+
+**Step 6: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_pipeline_group_apply.py
+git commit -m "pipeline: make /group/apply flags-only; species moves to dedicated path"
+```
+
+---
+
+## Task 2: Footer markup — two checkboxes + "Apply and close"
+
+Replace the single fused button with two checkboxes and one apply button, plus
+hidden amber-hint spans. Pure markup + CSS; behavior is wired in Task 3.
+
+**Files:**
+- Modify: `vireo/templates/pipeline_review.html:1458-1479` (the `.grm-footer`)
+- Modify: `vireo/templates/pipeline_review.html` CSS block (near the other
+  `.grm-*` styles, e.g. around lines 900-990) — add `.grm-commit-toggle` and
+  `.grm-dirty-hint` styles.
+
+**Step 1: Replace the apply button markup**
+
+In `.grm-footer`, replace the single button (line 1478) with:
+
+```html
+<div class="grm-commit-group" style="margin-left:auto;display:flex;align-items:center;gap:14px;">
+  <label class="grm-commit-toggle">
+    <input type="checkbox" id="grmConfirmSpeciesChk" onchange="grmOnToggleChange()">
+    <span>Confirm species</span>
+    <span class="grm-dirty-hint" id="grmSpeciesDirtyHint" style="display:none;"></span>
+  </label>
+  <label class="grm-commit-toggle">
+    <input type="checkbox" id="grmApplyFlagsChk" onchange="grmOnToggleChange()">
+    <span>Apply picks/rejects</span>
+    <span class="grm-dirty-hint" id="grmFlagsDirtyHint" style="display:none;"></span>
+  </label>
+  <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept"
+    style="padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);"
+    title="Commit whichever boxes are checked, then close this burst.">Apply and close</button>
+</div>
+```
+
+Keep the existing `Species:` input (line 1459-1460), Remove button, thumb/res/zoom
+controls, and `grmHint` exactly as they are — only the trailing button is replaced.
+
+**Step 2: Add CSS**
+
+Near the other `.grm-*` rules:
+
+```css
+.grm-commit-toggle { display:flex; align-items:center; gap:6px; font-size:12px;
+  color: var(--text-muted); cursor:pointer; user-select:none; }
+.grm-commit-toggle input { cursor:pointer; }
+.grm-dirty-hint { font-size:11px; color: var(--warning, #e0a800); }
+```
+
+(If `--warning` is not a defined theme var, use a literal amber `#e0a800`.)
+
+**Step 3: Verify it renders**
+
+Run the app, open a burst group, confirm two checkboxes + "Apply and close" show.
+Run: `python vireo/app.py --db ~/.vireo/vireo.db --port 8080` and load the
+pipeline review page. (No automated test in this task — covered by Task 5 E2E.)
+
+**Step 4: Commit**
+
+```bash
+git add vireo/templates/pipeline_review.html
+git commit -m "pipeline review: split burst-group apply into species/flags checkboxes (markup)"
+```
+
+---
+
+## Task 3: Checkbox state — smart defaults + amber hints
+
+Wire the checkboxes' default/derived state from the existing `grmComputeDiff()`,
+and show amber hints when an unchecked box is dirty. Track whether the user has
+manually overridden each box so smart-default recomputation doesn't fight them.
+
+**Files:**
+- Modify: `vireo/templates/pipeline_review.html` — `grmState` init in
+  `openGroupReview` (lines ~3578-3604); `grmUpdateApplyLabel` (lines ~3879-3897);
+  add new functions near it.
+
+**Step 1: Add override-tracking to `grmState`**
+
+In `openGroupReview`'s `grmState = {...}` (line 3578), add:
+
+```js
+    // null = follow smart default; true/false = user explicitly set it.
+    confirmSpeciesOverride: null,
+    applyFlagsOverride: null,
+```
+
+**Step 2: Add the toggle + sync functions**
+
+Add near `grmUpdateApplyLabel`:
+
+```js
+// User manually toggled a checkbox: record the override, then re-sync labels.
+function grmOnToggleChange() {
+  var spChk = document.getElementById('grmConfirmSpeciesChk');
+  var flChk = document.getElementById('grmApplyFlagsChk');
+  if (spChk) grmState.confirmSpeciesOverride = spChk.checked;
+  if (flChk) grmState.applyFlagsOverride = flChk.checked;
+  grmUpdateApplyLabel();
+}
+
+// Smart default: is there a real pending change for each side?
+function grmSpeciesDirty(diff) { return !!diff.speciesChanged; }
+function grmFlagsDirty(diff) {
+  return (diff.flagNew + diff.rejectNew + diff.clearNew + diff.detachNew) > 0;
+}
+
+// Resolve the effective checked state: user override wins, else smart default.
+function grmResolveChecks(diff) {
+  var sp = grmState.confirmSpeciesOverride;
+  var fl = grmState.applyFlagsOverride;
+  return {
+    species: sp === null ? grmSpeciesDirty(diff) : sp,
+    flags: fl === null ? grmFlagsDirty(diff) : fl,
+  };
+}
+```
+
+**Step 3: Drive checkbox + hint state from `grmUpdateApplyLabel`**
+
+In `grmUpdateApplyLabel`, after `var diff = grmComputeDiff();`, set the checkbox
+checked state and amber hints, and scope the button label to checked boxes:
+
+```js
+  var checks = grmResolveChecks(diff);
+  var spChk = document.getElementById('grmConfirmSpeciesChk');
+  var flChk = document.getElementById('grmApplyFlagsChk');
+  if (spChk) spChk.checked = checks.species;
+  if (flChk) flChk.checked = checks.flags;
+
+  // Amber hint only when a box is unchecked but its side is dirty.
+  var spHint = document.getElementById('grmSpeciesDirtyHint');
+  if (spHint) {
+    var show = !checks.species && grmSpeciesDirty(diff);
+    spHint.style.display = show ? '' : 'none';
+    spHint.textContent = show ? "species won't be confirmed" : '';
+  }
+  var flHint = document.getElementById('grmFlagsDirtyHint');
+  if (flHint) {
+    var n = diff.flagNew + diff.rejectNew + diff.clearNew + diff.detachNew;
+    var showF = !checks.flags && n > 0;
+    flHint.style.display = showF ? '' : 'none';
+    flHint.textContent = showF ? (n + ' cull change' + (n === 1 ? '' : 's') + " won't be saved") : '';
+  }
+```
+
+Then change the existing label-building so `parts` only includes a side when its
+box is checked: guard the species parts (`Set species`, `Tag N`) behind
+`checks.species`, and the flag parts (`Flag/Reject/Clear/Detach`) behind
+`checks.flags`. Keep the `'No DB changes & Close'` fallback, but change the
+suffix to match the new button: when `parts.length` is 0 set
+`btn.textContent = 'Apply and close'`, else `parts.join(' · ') + ' & Close'`.
+
+**Step 4: Verify in the app**
+
+Open a burst: with pending flag moves, "Apply picks/rejects" is pre-checked; type
+a new species → "Confirm species" pre-checks; uncheck one with changes → amber
+hint appears; button label updates to only the checked side.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/templates/pipeline_review.html
+git commit -m "pipeline review: smart-default checkboxes + amber dirty hints"
+```
+
+---
+
+## Task 4: Rewrite `grmApply()` to commit only checked sides
+
+Split the fused apply into flags-only `/group/apply` + dedicated species path,
+in the order the design fixed.
+
+**Files:**
+- Modify: `vireo/templates/pipeline_review.html:4747-4893` (`grmApply`)
+- Add: a helper `grmConfirmSpeciesCall(...)` near `grmApply`.
+
+**Step 1: Read effective checkbox state at the top of `grmApply`**
+
+After the `grmState.seeded` guard (line 4754), add:
+
+```js
+  var diff = grmComputeDiff();
+  var checks = grmResolveChecks(diff);
+  var species = document.getElementById('grmSpecies').value.trim();
+```
+
+(Replace the existing `var species = ...` line 4755.)
+
+**Step 2: Gate the flags `/group/apply` call behind `checks.flags`**
+
+Wrap the existing `/api/pipeline/group/apply` fetch + local label/flag sync
+(lines ~4757-4816) in `if (checks.flags) { ... }`. Stop sending `species` in the
+body (remove the `species: species` line ~4777). On fetch failure, keep the
+existing early `return` (abort before close).
+
+When `checks.flags` is false: skip the call, and also skip the removed-photo
+detach block (Step 4) — removals are part of "cull changes".
+
+**Step 3: Add the species-confirm helper**
+
+```js
+// Confirm species for the burst. Pipeline bursts go through the same endpoint
+// the grid uses (persists confirmation + auto-detach). Browse-selection ad-hoc
+// sets have no encounter, so just tag the keyword on all members.
+async function grmConfirmSpeciesCall(species, memberIds) {
+  if (!species || memberIds.length === 0) return;
+  if (grmState.source === 'browse-selection') {
+    await safeFetch('/api/batch/keyword', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ photo_ids: memberIds, name: species, type: 'taxonomy' }),
+    });
+    return;
+  }
+  var resp = await safeFetch('/api/encounters/species', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ species: species, photo_ids: memberIds, burst_index: grmState.burstIdx }),
+  });
+  // Adopt authoritative structure (mirrors confirmSpecies()).
+  if (resp && resp.encounters) {
+    pipelineResults.encounters = resp.encounters;
+    if (resp.summary) pipelineResults.summary = resp.summary;
+  }
+}
+```
+
+**Step 4: Reorder the body of `grmApply`**
+
+Target sequence (replacing lines ~4818-4892):
+
+1. `if (checks.flags)`: existing browse-selection branch + removed→detach branch
+   run as today (they mutate `pipelineResults`). When flags unchecked, skip both.
+2. Remove the old local `enc.species_confirmed = true` block (lines ~4872-4879) —
+   confirmation is now server-owned via the helper.
+3. `safeFetch('/api/pipeline/save-cache', ...)` with `pipelineResults` (as today),
+   so the cache on disk is consistent before the species call reads it.
+4. `if (checks.species)`: compute the **remaining** burst member ids
+   `memberIds = grmState.items.filter(p => !grmState.removed.has(p.id)).map(p => p.id)`
+   and `await grmConfirmSpeciesCall(species, memberIds);`
+5. `closeGroupReview(); document.getElementById('grmSpecies').value = '';`
+   `renderResults(); updateSummaryBar(refreshLocalSummaryCounts());`
+
+Note the browse-selection branch currently early-returns (lines 4818-4852). Refactor
+so that branch performs its `pipelineResults` mutations + save-cache, then falls
+through to the shared species-confirm + close steps (do **not** early-return before
+species confirm). Preserve its special "all removed → fallbackToNormalPipelineReview"
+case (still early-returns after persisting, since there's no burst left to confirm).
+
+**Step 5: Verify end-to-end in the app**
+
+- Species-only (uncheck flags): flags unchanged in DB; all burst frames tagged;
+  burst shows confirmed (grid badge agrees).
+- Flags-only (uncheck species): flags land; species stays unconfirmed.
+- Both: both land. Species replacement untags the old keyword.
+- Removed photo + flags unchecked: removal is **not** applied (amber hint warned).
+
+**Step 6: Commit**
+
+```bash
+git add vireo/templates/pipeline_review.html
+git commit -m "pipeline review: grmApply commits only checked sides; species via unified path"
+```
+
+---
+
+## Task 5: E2E coverage (Playwright, user-first)
+
+**Files:**
+- Modify/Create: `tests/e2e/test_pipeline_review_species.py` (extend existing
+  species E2E) — or a new `tests/e2e/test_burst_group_confirm_split.py`.
+
+Follow the existing E2E harness conventions in that directory (fixture that builds
+test photos via `scripts/build_test_photos.py`, launches the app, drives a real
+browser). See `tests/e2e/test_pipeline_review_species.py` and
+`tests/e2e/test_pipeline_rapid_review.py` for the setup pattern.
+
+**Step 1: Write the failing E2E tests**
+
+Cases (one test function each):
+
+1. `test_smart_default_flags_checked_when_moves_pending` — move a photo to
+   rejects → "Apply picks/rejects" checkbox is checked, "Confirm species" not.
+2. `test_smart_default_species_checked_on_new_species` — type a species differing
+   from confirmed → "Confirm species" checks.
+3. `test_unchecking_dirty_box_shows_amber_hint` — uncheck a checked, dirty box →
+   the `.grm-dirty-hint` becomes visible with expected text.
+4. `test_species_only_apply_leaves_flags_untouched` — uncheck flags, confirm
+   species, Apply → assert via `/api/pipeline/results` or DB that flags are
+   unchanged and all burst frames carry the species keyword.
+5. `test_flags_only_apply_leaves_species_unconfirmed` — confirm flags only →
+   species not confirmed (no keyword added, burst not confirmed).
+
+**Step 2: Run to verify they fail / drive remaining gaps**
+
+Run: `python -m pytest tests/e2e/test_burst_group_confirm_split.py -v`
+Expected: tests written before/independthat catch regressions fail first, then
+pass against the Task 2-4 implementation.
+
+**Step 3: Make them pass**
+
+Adjust selectors/assertions to the implemented markup; fix any real bug surfaced.
+
+**Step 4: Commit**
+
+```bash
+git add tests/e2e/test_burst_group_confirm_split.py
+git commit -m "test(e2e): burst-group confirm/apply split behaviors"
+```
+
+---
+
+## Task 6: Full regression + PR
+
+**Step 1: Run the CLAUDE.md test bundle**
+
+Run:
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py \
+  vireo/tests/test_app.py vireo/tests/test_photos_api.py \
+  vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py \
+  vireo/tests/test_darktable_api.py vireo/tests/test_config.py \
+  vireo/tests/test_pipeline_group_apply.py -v
+```
+Expected: PASS (ignore the known pre-existing failures noted in memory; confirm
+none are newly introduced by this change).
+
+**Step 2: Create the PR**
+
+```bash
+gh pr create --base main --title "Burst group: split species confirm from pick/reject apply" \
+  --body "<what changed + test results, link design doc>"
+```
+
+**Step 3:** Push review-feedback fixes to the same branch.
+
+---
+
+## Notes / open verifications for the implementer
+
+- **Browse-selection species:** `/api/batch/keyword` with `type:"taxonomy"` is the
+  chosen path (taxonomy reconciles to `is_species` in `db.add_keyword`). Verify a
+  brand-new species name not in any taxon list still lands as a species keyword
+  (it should, via the explicit `taxonomy` type).
+- **`detachNew` under "Apply picks/rejects":** removals are gated by the flags
+  checkbox. If the user wants removals independent of flags, revisit — but the
+  design treats both as "cull edits".
+- **`grmComputeDiff` already excludes species when** `keywordStateSpecies !==
+  species`; that staleness is fine for the checkbox (it only affects the
+  `tagNew` count in the label, not the checked state which keys off
+  `speciesChanged`).

--- a/tests/e2e/test_burst_group_confirm_split.py
+++ b/tests/e2e/test_burst_group_confirm_split.py
@@ -363,6 +363,71 @@ def test_flags_only_apply_preserves_differing_burst_override(live_server, page):
     assert tagged_y == set(), tagged_y
 
 
+def test_detached_burst_preserves_differing_confirmed_override(live_server, page):
+    """Regression: detaching a frame from a burst that is CONFIRMED as override
+    species X (while the encounter label is a different species Y) must carry X
+    onto the new single-photo burst — not drop it to null (which silently
+    reverts that frame to the encounter species Y on a flags-only apply).
+
+    "Remove from group" one frame, leave "Apply picks/rejects" CHECKED (the
+    flags-only detach path runs), Apply → the new single-photo burst in the
+    saved cache must retain species_override = {species: X, confirmed: True},
+    and the shortened source burst must still carry X too.
+    """
+    override_species = "Cooper's Hawk"      # X — what the burst is confirmed as
+    encounter_species = "Northern Harrier"  # Y — the encounter label/prediction
+    photo_ids = live_server["data"]["photos"][0:3]
+    _write_single_burst_cache(
+        live_server,
+        photo_ids,
+        confirmed_species=encounter_species,
+        burst_override_species=override_species,
+        burst_override_confirmed=True,
+    )
+
+    _open_burst_modal(page, live_server)
+
+    # Field reflects the burst override (X); confirm defaults OFF (no change).
+    expect(page.locator("#grmSpecies")).to_have_value(override_species)
+    expect(page.locator("#grmConfirmSpeciesChk")).not_to_be_checked()
+
+    # Remove the second card from the group; keep "Apply picks/rejects" CHECKED
+    # so grmApply runs the flags-only detach path that splits it into its own
+    # single-photo burst.
+    second_pid = int(
+        page.locator("#grmOverlay .grm-card[data-photo-id]").nth(1).get_attribute("data-photo-id")
+    )
+    page.locator(f"#grmOverlay .grm-card[data-photo-id='{second_pid}']").click()
+    page.locator("#grmRemoveBtn").click()
+    expect(page.locator("#grmApplyFlagsChk")).to_be_checked()
+    expect(page.locator("#grmConfirmSpeciesChk")).not_to_be_checked()
+
+    with page.expect_response("**/api/pipeline/group/apply"):
+        page.locator("#grmApplyBtn").click()
+    expect(page.locator("#grmOverlay")).not_to_have_class(re.compile(r"\bopen\b"))
+
+    cache = _read_cache(live_server)
+    bursts = cache["encounters"][0]["bursts"]
+    # The detach produced a second burst (the removed frame on its own).
+    assert len(bursts) == 2, [b["photo_ids"] for b in bursts]
+    detached = next(b for b in bursts if b["photo_ids"] == [second_pid])
+    source = next(b for b in bursts if second_pid not in b["photo_ids"])
+
+    # The detached single-photo burst KEEPS the burst-specific confirmed override
+    # X — it is not null and not the encounter species Y.
+    assert detached["species_override"] is not None, detached
+    assert detached["species_override"]["species"] == override_species, detached["species_override"]
+    assert detached["species_override"]["confirmed"] is True, detached["species_override"]
+
+    # The shortened source burst still carries X for its remaining frames.
+    assert source["species_override"]["species"] == override_species, source["species_override"]
+    assert source["species_override"]["confirmed"] is True
+
+    # No frame was tagged with the encounter species Y by a stray species call.
+    tagged_y = _photos_with_species(live_server, photo_ids, encounter_species)
+    assert tagged_y == set(), tagged_y
+
+
 def test_species_only_with_removed_photo_keeps_member_and_tags_it(live_server, page):
     """Truthfulness guard: mark a photo "Remove from group", leave flags
     UNCHECKED, confirm species → the removal is discarded (photo stays a burst

--- a/tests/e2e/test_burst_group_confirm_split.py
+++ b/tests/e2e/test_burst_group_confirm_split.py
@@ -36,10 +36,25 @@ from playwright.sync_api import expect
 # override intent), so the two tests below now exercise the intended flow.
 
 
-def _write_single_burst_cache(live_server, photo_ids, *, confirmed_species=None):
+def _write_single_burst_cache(
+    live_server,
+    photo_ids,
+    *,
+    confirmed_species=None,
+    burst_override_species=None,
+    burst_override_confirmed=True,
+):
     """Write a pipeline cache with one encounter containing one multi-frame
     burst over `photo_ids`. Optionally pre-confirm the burst's species so we
     can test the "same species → no-op, stays unchecked" smart default.
+
+    By default the per-burst `species_override` mirrors `confirmed_species`
+    (encounter and burst agree). Pass `burst_override_species` to give the
+    burst an override species that DIFFERS from the encounter
+    `confirmed_species` — this models a burst confirmed/overridden as X while
+    the encounter label is Y, the case the confirm/apply split must not clobber
+    when applying flags only. `burst_override_confirmed` toggles whether that
+    override is confirmed (defaults True).
     """
     db = live_server["db"]
     placeholders = ",".join("?" for _ in photo_ids)
@@ -61,14 +76,19 @@ def _write_single_burst_cache(live_server, photo_ids, *, confirmed_species=None)
         for row in rows
     ]
     ids = [p["id"] for p in photos]
+    if burst_override_species is not None:
+        override = {
+            "species": burst_override_species,
+            "confirmed": burst_override_confirmed,
+        }
+    elif confirmed_species:
+        override = {"species": confirmed_species, "confirmed": True}
+    else:
+        override = None
     burst = {
         "photo_ids": ids,
         "species_predictions": [],
-        "species_override": (
-            {"species": confirmed_species, "confirmed": True}
-            if confirmed_species
-            else None
-        ),
+        "species_override": override,
     }
     cache = {
         "photos": photos,
@@ -285,6 +305,62 @@ def test_flags_only_apply_leaves_species_unconfirmed(live_server, page):
     cache = _read_cache(live_server)
     burst = cache["encounters"][0]["bursts"][0]
     assert not (burst.get("species_override") or {}).get("confirmed")
+
+
+def test_flags_only_apply_preserves_differing_burst_override(live_server, page):
+    """Regression: a burst CONFIRMED as override species X while the encounter
+    label is a different species Y must NOT have X replaced by Y when the user
+    applies pick/reject edits only.
+
+    On open the species field must reflect the burst's actual override (X), not
+    the encounter label (Y), so "Confirm species" stays UNchecked. Moving a
+    frame to rejects and clicking Apply then runs the flags-only path and leaves
+    the override species untouched — it does not silently post Y to
+    /api/encounters/species (which would untag X, tag Y).
+    """
+    # Pick species that the conftest fixture does NOT pre-tag onto these frames
+    # (it only tags photo[0]="Red-tailed Hawk", photo[3]="American Robin"), so a
+    # post-apply keyword check cleanly reflects what THIS apply did.
+    override_species = "Cooper's Hawk"      # X — what the burst is confirmed as
+    encounter_species = "Northern Harrier"  # Y — the encounter label/prediction
+    photo_ids = live_server["data"]["photos"][0:3]
+    _write_single_burst_cache(
+        live_server,
+        photo_ids,
+        confirmed_species=encounter_species,
+        burst_override_species=override_species,
+        burst_override_confirmed=True,
+    )
+
+    _open_burst_modal(page, live_server)
+
+    # Field reflects the BURST override (X), not the encounter label (Y), and
+    # "Confirm species" defaults OFF because field == already-confirmed species.
+    expect(page.locator("#grmSpecies")).to_have_value(override_species)
+    expect(page.locator("#grmConfirmSpeciesChk")).not_to_be_checked()
+
+    # Reject the selected frame; flags auto-checks. Apply runs flags-only.
+    page.keyboard.press("x")
+    expect(page.locator("#grmApplyFlagsChk")).to_be_checked()
+    expect(page.locator("#grmConfirmSpeciesChk")).not_to_be_checked()
+
+    with page.expect_response("**/api/pipeline/group/apply"):
+        page.locator("#grmApplyBtn").click()
+    expect(page.locator("#grmOverlay")).not_to_have_class(re.compile(r"\bopen\b"))
+
+    # The reject persisted.
+    flags = _photo_flags(live_server, photo_ids)
+    assert sorted(flags.values()) == ["none", "none", "rejected"], flags
+
+    # The burst's override species is STILL X (not replaced by Y).
+    cache = _read_cache(live_server)
+    burst = cache["encounters"][0]["bursts"][0]
+    assert burst["species_override"]["species"] == override_species, burst["species_override"]
+    assert burst["species_override"]["confirmed"] is True
+
+    # No frame was tagged with the encounter species Y by a stray species call.
+    tagged_y = _photos_with_species(live_server, photo_ids, encounter_species)
+    assert tagged_y == set(), tagged_y
 
 
 def test_species_only_with_removed_photo_keeps_member_and_tags_it(live_server, page):

--- a/tests/e2e/test_burst_group_confirm_split.py
+++ b/tests/e2e/test_burst_group_confirm_split.py
@@ -1,0 +1,350 @@
+"""E2E coverage for the Review Burst Group confirm/apply split.
+
+The burst-group modal footer (in `pipeline_review.html`) carries two
+checkboxes — "Confirm species" (#grmConfirmSpeciesChk) and "Apply
+picks/rejects" (#grmApplyFlagsChk) — and a single "Apply and close" button
+(#grmApplyBtn). These tests drive a real browser against a real Flask server
+with a real on-disk pipeline cache, so the apply paths exercise the live
+`/api/pipeline/group/apply` (flags-only) and `/api/encounters/species`
+endpoints and the assertions read genuinely persisted state (the photos.flag
+column, the photo_keywords table, and the pipeline cache file on disk).
+
+We reuse the predictionless-cache helper shape from
+`test_pipeline_review_species.py` but build a SINGLE multi-frame burst so we
+can move/remove individual frames and confirm that species tagging covers
+every frame (not just picks).
+
+Why a new file rather than extending test_pipeline_review_species.py: that
+file's helpers seed separate single-photo encounters for the species-widget
+flow; these tests need one multi-frame burst opened through the burst-group
+modal (grmApply), a distinct setup and surface area. They share the same
+live_server/page fixtures and the same real-cache + real-DB assertion style.
+"""
+import json
+import os
+import re
+
+import pytest
+from playwright.sync_api import expect
+
+# Known product bug (NOT a test defect): grmOnToggleChange() pins BOTH
+# overrides (confirmSpeciesOverride AND applyFlagsOverride) to their current
+# DOM state on EVERY checkbox toggle, instead of recording an override only
+# for the box the user actually clicked. So the realistic species-only flow —
+# uncheck "Apply picks/rejects" first, THEN type a new species — leaves
+# "Confirm species" stuck unchecked even though a real, pending species change
+# exists. That contradicts the design's per-box override intent ("track
+# whether the user has manually overridden EACH box") and the UI-truthfulness
+# rule (a real pending change must surface). The underlying apply logic is
+# correct (verified: with flags unchecked + species checked, no flag persists,
+# every frame is tagged, the burst is confirmed) — only the checkbox state
+# derivation is wrong. These two tests assert the INTENDED user flow; they are
+# strict-xfail so they flip to a hard failure (XPASS) the moment the bug is
+# fixed, forcing the marker's removal.
+_TOGGLE_PINS_BOTH_OVERRIDES = pytest.mark.xfail(
+    strict=True,
+    reason="grmOnToggleChange pins both overrides on any toggle; unchecking "
+    "flags then typing a species fails to auto-check Confirm species",
+)
+
+
+def _write_single_burst_cache(live_server, photo_ids, *, confirmed_species=None):
+    """Write a pipeline cache with one encounter containing one multi-frame
+    burst over `photo_ids`. Optionally pre-confirm the burst's species so we
+    can test the "same species → no-op, stays unchecked" smart default.
+    """
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, filename, timestamp FROM photos WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+            "confirmed_species": confirmed_species,
+        }
+        for row in rows
+    ]
+    ids = [p["id"] for p in photos]
+    burst = {
+        "photo_ids": ids,
+        "species_predictions": [],
+        "species_override": (
+            {"species": confirmed_species, "confirmed": True}
+            if confirmed_species
+            else None
+        ),
+    }
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": ids,
+                "photo_count": len(ids),
+                "burst_count": 1,
+                "time_range": [photos[0]["timestamp"], photos[-1]["timestamp"]],
+                "species": [confirmed_species] if confirmed_species else [],
+                "species_predictions": [],
+                "species_confirmed": bool(confirmed_species),
+                "confirmed_species": confirmed_species,
+                "bursts": [burst],
+            }
+        ],
+        "summary": {
+            "total_photos": len(ids),
+            "encounter_count": 1,
+            "burst_count": 1,
+            "keep_count": 0,
+            "review_count": len(ids),
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = _cache_path(live_server)
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def _cache_path(live_server):
+    db = live_server["db"]
+    return os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+
+
+def _read_cache(live_server):
+    with open(_cache_path(live_server)) as f:
+        return json.load(f)
+
+
+def _open_burst_modal(page, live_server):
+    """Navigate to the pipeline review page and open the burst-group modal by
+    clicking the first photo card (routes through openInspect → openGroupReview).
+    Waits for the modal to seed so Apply is enabled.
+    """
+    # The burst modal is a full-screen overlay built for large pixel-peeping
+    # displays; its footer (species field + sliders + the two commit
+    # checkboxes + Apply button) is wider than the default 1280px test
+    # viewport, which pushes Apply off-screen. Use a realistically wide
+    # viewport so every footer control is clickable.
+    page.set_viewport_size({"width": 1600, "height": 900})
+    page.goto(f"{live_server['url']}/pipeline/review")
+    page.locator(".photo-card img").first.click()
+    expect(page.locator("#grmOverlay")).to_have_class(re.compile(r"\bopen\b"))
+    # Seed completes when Apply leaves the "Loading…" state and re-enables.
+    expect(page.locator("#grmApplyBtn")).to_be_enabled()
+
+
+def _photo_flags(live_server, photo_ids):
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, flag FROM photos WHERE id IN ({placeholders})", photo_ids
+    ).fetchall()
+    return {r["id"]: (r["flag"] or "none") for r in rows}
+
+
+def _photos_with_species(live_server, photo_ids, species):
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"""
+        SELECT p.id
+        FROM photos p
+        JOIN photo_keywords pk ON pk.photo_id = p.id
+        JOIN keywords k ON k.id = pk.keyword_id
+        WHERE p.id IN ({placeholders}) AND k.name = ? AND k.is_species = 1
+        """,
+        (*photo_ids, species),
+    ).fetchall()
+    return {r["id"] for r in rows}
+
+
+def test_smart_default_flags_checked_when_moves_pending(live_server, page):
+    """Moving a frame to rejects pre-checks "Apply picks/rejects" via the smart
+    default; "Confirm species" stays unchecked because the species field is
+    empty (no pending species change)."""
+    photo_ids = live_server["data"]["photos"][0:3]  # hawk1/2/3, one burst
+    _write_single_burst_cache(live_server, photo_ids)
+
+    _open_burst_modal(page, live_server)
+
+    # Reject the currently-selected frame.
+    page.keyboard.press("x")
+    expect(page.locator("#grmCount")).to_contain_text("1 rejects")
+
+    expect(page.locator("#grmApplyFlagsChk")).to_be_checked()
+    expect(page.locator("#grmConfirmSpeciesChk")).not_to_be_checked()
+
+
+def test_smart_default_species_checked_on_new_species(live_server, page):
+    """Typing a species that differs from the burst's confirmed species
+    pre-checks "Confirm species"."""
+    photo_ids = live_server["data"]["photos"][0:3]
+    _write_single_burst_cache(live_server, photo_ids, confirmed_species="Red-tailed Hawk")
+
+    _open_burst_modal(page, live_server)
+
+    # Field opens pre-filled with the confirmed species → no change → unchecked.
+    expect(page.locator("#grmSpecies")).to_have_value("Red-tailed Hawk")
+    expect(page.locator("#grmConfirmSpeciesChk")).not_to_be_checked()
+
+    page.locator("#grmSpecies").fill("Cooper's Hawk")
+    expect(page.locator("#grmConfirmSpeciesChk")).to_be_checked()
+    # No flag moves → flags box stays unchecked.
+    expect(page.locator("#grmApplyFlagsChk")).not_to_be_checked()
+
+
+def test_unchecking_dirty_box_shows_amber_hint(live_server, page):
+    """Unchecking a checked+dirty box reveals its amber .grm-dirty-hint with
+    non-empty text."""
+    photo_ids = live_server["data"]["photos"][0:3]
+    _write_single_burst_cache(live_server, photo_ids)
+
+    _open_burst_modal(page, live_server)
+
+    page.keyboard.press("x")  # one pending reject → flags box auto-checks
+    expect(page.locator("#grmApplyFlagsChk")).to_be_checked()
+    expect(page.locator("#grmFlagsDirtyHint")).to_be_hidden()
+
+    # Uncheck it (real click on the checkbox fires grmOnToggleChange).
+    page.locator("#grmApplyFlagsChk").uncheck()
+
+    hint = page.locator("#grmFlagsDirtyHint")
+    expect(hint).to_be_visible()
+    assert hint.inner_text().strip(), "amber hint text should be non-empty"
+    expect(hint).to_contain_text("won't be saved")
+
+
+@_TOGGLE_PINS_BOTH_OVERRIDES
+def test_species_only_apply_leaves_flags_untouched_and_tags_all_frames(live_server, page):
+    """Species-only apply (flags unchecked): no photo's flag changes, EVERY
+    burst frame gets the species keyword, and the burst is marked confirmed.
+
+    Intended flow: stage a flag move, uncheck "Apply picks/rejects", THEN type
+    a new species so "Confirm species" auto-checks. Currently xfail — see
+    _TOGGLE_PINS_BOTH_OVERRIDES."""
+    photo_ids = live_server["data"]["photos"][0:3]
+    _write_single_burst_cache(live_server, photo_ids)
+
+    _open_burst_modal(page, live_server)
+
+    # Stage a flag move so flags would be dirty — then uncheck flags to prove
+    # the move is NOT persisted while species is.
+    page.keyboard.press("x")
+    expect(page.locator("#grmApplyFlagsChk")).to_be_checked()
+    page.locator("#grmApplyFlagsChk").uncheck()
+
+    page.locator("#grmSpecies").fill("Northern Goshawk")
+    expect(page.locator("#grmConfirmSpeciesChk")).to_be_checked()
+
+    with page.expect_response("**/api/encounters/species"):
+        page.locator("#grmApplyBtn").click()
+    expect(page.locator("#grmOverlay")).not_to_have_class(re.compile(r"\bopen\b"))
+
+    # No flag changed: the staged reject was discarded with the unchecked box.
+    flags = _photo_flags(live_server, photo_ids)
+    assert flags == {pid: "none" for pid in photo_ids}, flags
+
+    # Every frame carries the species keyword — not just a pick.
+    tagged = _photos_with_species(live_server, photo_ids, "Northern Goshawk")
+    assert tagged == set(photo_ids), tagged
+
+    # Burst is marked confirmed in the persisted cache.
+    cache = _read_cache(live_server)
+    burst = cache["encounters"][0]["bursts"][0]
+    assert burst.get("species_override", {}).get("confirmed") is True
+    assert burst["species_override"]["species"] == "Northern Goshawk"
+
+
+def test_flags_only_apply_leaves_species_unconfirmed(live_server, page):
+    """Flags-only apply (species unchecked): flags persist, but no species
+    keyword is added and the burst is not marked confirmed."""
+    photo_ids = live_server["data"]["photos"][0:3]
+    _write_single_burst_cache(live_server, photo_ids)
+
+    _open_burst_modal(page, live_server)
+
+    # Reject the selected frame → flags auto-checks.
+    page.keyboard.press("x")
+    expect(page.locator("#grmApplyFlagsChk")).to_be_checked()
+
+    # Type a species but explicitly leave it unconfirmed.
+    page.locator("#grmSpecies").fill("Sharp-shinned Hawk")
+    expect(page.locator("#grmConfirmSpeciesChk")).to_be_checked()
+    page.locator("#grmConfirmSpeciesChk").uncheck()
+    expect(page.locator("#grmSpeciesDirtyHint")).to_be_visible()
+
+    with page.expect_response("**/api/pipeline/group/apply"):
+        page.locator("#grmApplyBtn").click()
+    expect(page.locator("#grmOverlay")).not_to_have_class(re.compile(r"\bopen\b"))
+
+    # Exactly one frame was rejected; the rest untouched.
+    flags = _photo_flags(live_server, photo_ids)
+    assert sorted(flags.values()) == ["none", "none", "rejected"], flags
+
+    # No species keyword added anywhere.
+    tagged = _photos_with_species(live_server, photo_ids, "Sharp-shinned Hawk")
+    assert tagged == set(), tagged
+
+    # Burst NOT marked confirmed.
+    cache = _read_cache(live_server)
+    burst = cache["encounters"][0]["bursts"][0]
+    assert not (burst.get("species_override") or {}).get("confirmed")
+
+
+@_TOGGLE_PINS_BOTH_OVERRIDES
+def test_species_only_with_removed_photo_keeps_member_and_tags_it(live_server, page):
+    """Truthfulness guard: mark a photo "Remove from group", leave flags
+    UNCHECKED, confirm species → the removal is discarded (photo stays a burst
+    member) AND it still receives the species keyword.
+
+    If grmApply detached the removed photo while flags were unchecked, the
+    photo would no longer be a burst member and the burst-scoped
+    /api/encounters/species call (validated against the on-disk burst) would
+    either omit it or fail — so this asserts both the cache structure and the
+    keyword landing on the removed frame.
+    """
+    photo_ids = live_server["data"]["photos"][0:3]
+    _write_single_burst_cache(live_server, photo_ids)
+
+    _open_burst_modal(page, live_server)
+
+    # Select the second card explicitly, then remove it from the group.
+    second_pid = int(
+        page.locator("#grmOverlay .grm-card[data-photo-id]").nth(1).get_attribute("data-photo-id")
+    )
+    page.locator(f"#grmOverlay .grm-card[data-photo-id='{second_pid}']").click()
+    page.locator("#grmRemoveBtn").click()
+
+    # Removal makes flags dirty (detachNew>0) so the box auto-checks; uncheck it
+    # to discard the removal, mirroring a user who only wants to confirm species.
+    expect(page.locator("#grmApplyFlagsChk")).to_be_checked()
+    page.locator("#grmApplyFlagsChk").uncheck()
+    expect(page.locator("#grmFlagsDirtyHint")).to_be_visible()
+
+    page.locator("#grmSpecies").fill("Broad-winged Hawk")
+    expect(page.locator("#grmConfirmSpeciesChk")).to_be_checked()
+
+    with page.expect_response("**/api/encounters/species"):
+        page.locator("#grmApplyBtn").click()
+    expect(page.locator("#grmOverlay")).not_to_have_class(re.compile(r"\bopen\b"))
+
+    # Removal discarded: the burst still holds all three frames.
+    cache = _read_cache(live_server)
+    burst = cache["encounters"][0]["bursts"][0]
+    assert sorted(burst["photo_ids"]) == sorted(photo_ids), burst["photo_ids"]
+    assert len(cache["encounters"][0]["bursts"]) == 1, "no detach should have happened"
+
+    # The "removed" photo still got tagged because it remained a member.
+    tagged = _photos_with_species(live_server, photo_ids, "Broad-winged Hawk")
+    assert tagged == set(photo_ids), tagged
+    assert second_pid in tagged

--- a/tests/e2e/test_burst_group_confirm_split.py
+++ b/tests/e2e/test_burst_group_confirm_split.py
@@ -176,6 +176,16 @@ def _photos_with_species(live_server, photo_ids, species):
     return {r["id"] for r in rows}
 
 
+def _tag_all(live_server, photo_ids, species):
+    """Tag every photo with `species` as a species keyword directly in the DB,
+    so /group/state reports has_species_keyword=True for the whole burst."""
+    db = live_server["db"]
+    kid = db.add_keyword(species, is_species=True)
+    for pid in photo_ids:
+        db.tag_photo(pid, kid)
+    return kid
+
+
 def test_smart_default_flags_checked_when_moves_pending(live_server, page):
     """Moving a frame to rejects pre-checks "Apply picks/rejects" via the smart
     default; "Confirm species" stays unchecked because the species field is
@@ -198,6 +208,10 @@ def test_smart_default_species_checked_on_new_species(live_server, page):
     pre-checks "Confirm species"."""
     photo_ids = live_server["data"]["photos"][0:3]
     _write_single_burst_cache(live_server, photo_ids, confirmed_species="Red-tailed Hawk")
+    # Tag every frame with the confirmed species so there is no outstanding
+    # keyword work — this isolates the "species text unchanged → unchecked"
+    # smart default from the missing-keyword gate (covered separately).
+    _tag_all(live_server, photo_ids, "Red-tailed Hawk")
 
     _open_burst_modal(page, live_server)
 
@@ -271,6 +285,46 @@ def test_species_only_apply_leaves_flags_untouched_and_tags_all_frames(live_serv
     assert burst["species_override"]["species"] == "Northern Goshawk"
 
 
+def test_smart_default_species_checked_when_frame_missing_keyword(live_server, page):
+    """Burst already confirmed as the current species, but one frame still
+    lacks that species keyword (e.g. legacy data that only tagged picks). The
+    species field is unchanged, so speciesChanged is false — but outstanding
+    tag work must still flip the "Confirm species" smart default ON, and Apply
+    must POST /api/encounters/species so the missing keyword gets written.
+
+    Regression for the classic burst-group modal analogue of the rapid-review
+    missing-keyword gate: /api/pipeline/group/apply is flags-only, so without
+    this gate the unwritten keyword would be silently dropped.
+    """
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][0:3]
+    species = "Red-tailed Hawk"
+
+    # Confirm the burst as the species in the cache, but only tag TWO of the
+    # three frames in the DB — the third is missing the keyword.
+    _write_single_burst_cache(live_server, photo_ids, confirmed_species=species)
+    kid = db.add_keyword(species, is_species=True)
+    db.tag_photo(photo_ids[0], kid)
+    db.tag_photo(photo_ids[1], kid)
+    # photo_ids[2] intentionally left untagged.
+
+    _open_burst_modal(page, live_server)
+
+    # Species field reflects the confirmed species; do NOT change it.
+    expect(page.locator("#grmSpecies")).to_have_value(species)
+    # Smart default flips ON because a frame still needs the keyword, even
+    # though the confirmed species itself is unchanged.
+    expect(page.locator("#grmConfirmSpeciesChk")).to_be_checked()
+
+    with page.expect_response("**/api/encounters/species"):
+        page.locator("#grmApplyBtn").click()
+    expect(page.locator("#grmOverlay")).not_to_have_class(re.compile(r"\bopen\b"))
+
+    # All three frames now carry the species keyword — the missing one got it.
+    tagged = _photos_with_species(live_server, photo_ids, species)
+    assert tagged == set(photo_ids), tagged
+
+
 def test_flags_only_apply_leaves_species_unconfirmed(live_server, page):
     """Flags-only apply (species unchecked): flags persist, but no species
     keyword is added and the burst is not marked confirmed."""
@@ -331,6 +385,10 @@ def test_flags_only_apply_preserves_differing_burst_override(live_server, page):
         burst_override_species=override_species,
         burst_override_confirmed=True,
     )
+    # Tag every frame with the override species X so there is no outstanding
+    # keyword work — this keeps "Confirm species" OFF by the smart default,
+    # isolating the override-preservation behavior from the missing-keyword gate.
+    _tag_all(live_server, photo_ids, override_species)
 
     _open_burst_modal(page, live_server)
 
@@ -384,6 +442,10 @@ def test_detached_burst_preserves_differing_confirmed_override(live_server, page
         burst_override_species=override_species,
         burst_override_confirmed=True,
     )
+    # Tag every frame with the override species X so the burst has no
+    # outstanding keyword work — confirm stays OFF, isolating the detach-path
+    # override-preservation from the missing-keyword gate.
+    _tag_all(live_server, photo_ids, override_species)
 
     _open_burst_modal(page, live_server)
 

--- a/tests/e2e/test_burst_group_confirm_split.py
+++ b/tests/e2e/test_burst_group_confirm_split.py
@@ -24,28 +24,16 @@ import json
 import os
 import re
 
-import pytest
 from playwright.sync_api import expect
 
-# Known product bug (NOT a test defect): grmOnToggleChange() pins BOTH
-# overrides (confirmSpeciesOverride AND applyFlagsOverride) to their current
-# DOM state on EVERY checkbox toggle, instead of recording an override only
-# for the box the user actually clicked. So the realistic species-only flow —
-# uncheck "Apply picks/rejects" first, THEN type a new species — leaves
+# Regression guard for a fixed product bug: grmOnToggleChange() used to pin
+# BOTH overrides (confirmSpeciesOverride AND applyFlagsOverride) to their
+# current DOM state on EVERY checkbox toggle, instead of recording an override
+# only for the box the user actually clicked. So the realistic species-only
+# flow — uncheck "Apply picks/rejects" first, THEN type a new species — left
 # "Confirm species" stuck unchecked even though a real, pending species change
-# exists. That contradicts the design's per-box override intent ("track
-# whether the user has manually overridden EACH box") and the UI-truthfulness
-# rule (a real pending change must surface). The underlying apply logic is
-# correct (verified: with flags unchecked + species checked, no flag persists,
-# every frame is tagged, the burst is confirmed) — only the checkbox state
-# derivation is wrong. These two tests assert the INTENDED user flow; they are
-# strict-xfail so they flip to a hard failure (XPASS) the moment the bug is
-# fixed, forcing the marker's removal.
-_TOGGLE_PINS_BOTH_OVERRIDES = pytest.mark.xfail(
-    strict=True,
-    reason="grmOnToggleChange pins both overrides on any toggle; unchecking "
-    "flags then typing a species fails to auto-check Confirm species",
-)
+# existed. The fix records an override only for the box that fired (per-box
+# override intent), so the two tests below now exercise the intended flow.
 
 
 def _write_single_burst_cache(live_server, photo_ids, *, confirmed_species=None):
@@ -224,14 +212,12 @@ def test_unchecking_dirty_box_shows_amber_hint(live_server, page):
     expect(hint).to_contain_text("won't be saved")
 
 
-@_TOGGLE_PINS_BOTH_OVERRIDES
 def test_species_only_apply_leaves_flags_untouched_and_tags_all_frames(live_server, page):
     """Species-only apply (flags unchecked): no photo's flag changes, EVERY
     burst frame gets the species keyword, and the burst is marked confirmed.
 
     Intended flow: stage a flag move, uncheck "Apply picks/rejects", THEN type
-    a new species so "Confirm species" auto-checks. Currently xfail — see
-    _TOGGLE_PINS_BOTH_OVERRIDES."""
+    a new species so "Confirm species" auto-checks."""
     photo_ids = live_server["data"]["photos"][0:3]
     _write_single_burst_cache(live_server, photo_ids)
 
@@ -301,7 +287,6 @@ def test_flags_only_apply_leaves_species_unconfirmed(live_server, page):
     assert not (burst.get("species_override") or {}).get("confirmed")
 
 
-@_TOGGLE_PINS_BOTH_OVERRIDES
 def test_species_only_with_removed_photo_keeps_member_and_tags_it(live_server, page):
     """Truthfulness guard: mark a photo "Remove from group", leave flags
     UNCHECKED, confirm species → the removal is discarded (photo stays a burst

--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -935,6 +935,163 @@ def test_rapid_review_apply_tags_all_burst_frames_via_encounters_species(live_se
     assert sorted(body["photo_ids"]) == [1, 2, 3]
 
 
+def test_rapid_review_cull_only_on_confirmed_burst_skips_species_post(live_server, page):
+    # A burst ALREADY confirmed as "Test bird" (encounter species_confirmed +
+    # burst override confirmed, photos carrying the keyword). Applying ONLY a
+    # cull change (reject a frame) with the species field still = "Test bird"
+    # must NOT post to /api/encounters/species: re-posting an unchanged species
+    # would record a no-op keyword_add edit per frame whose undo strips the
+    # existing species keywords. Flags must still apply + save.
+    species_payloads = []
+    save_payloads = []
+    results = {
+        "photos": [
+            {"id": 1, "filename": "a.jpg", "label": "KEEP", "flag": "flagged", "confirmed_species": "Test bird"},
+            {"id": 2, "filename": "b.jpg", "label": "REVIEW", "flag": "none", "confirmed_species": "Test bird"},
+            {"id": 3, "filename": "c.jpg", "label": "REVIEW", "flag": "none", "confirmed_species": "Test bird"},
+        ],
+        "encounters": [
+            {
+                "photo_ids": [1, 2, 3],
+                "photo_count": 3,
+                "burst_count": 1,
+                "species": ["Test bird"],
+                "species_confirmed": True,
+                "confirmed_species": "Test bird",
+                "bursts": [
+                    {
+                        "photo_ids": [1, 2, 3],
+                        "species_override": {"species": "Test bird", "confirmed": True},
+                    }
+                ],
+            }
+        ],
+        "summary": {"keep_count": 1, "review_count": 2, "reject_count": 0},
+    }
+    _mock_pipeline_rapid_review(
+        page,
+        results=results,
+        apply_photos={
+            "1": {"flag": "flagged", "has_species_keyword": True},
+            "2": {"flag": "rejected", "has_species_keyword": True},
+            "3": {"flag": "none", "has_species_keyword": True},
+        },
+        state_photos={
+            "1": {"flag": "flagged", "has_species_keyword": True},
+            "2": {"flag": "none", "has_species_keyword": True},
+            "3": {"flag": "none", "has_species_keyword": True},
+        },
+        species_payloads=species_payloads,
+        save_payloads=save_payloads,
+    )
+
+    # Deep-link forces the "all" queue so a fully-confirmed burst is reviewable.
+    page.goto(f"{live_server['url']}/pipeline/rapid-review?enc=0&burst=0")
+    expect(page.locator("#applyBtn")).to_be_enabled()
+    expect(page.locator("#filename")).to_have_text("a.jpg")
+    # Species field already reflects the confirmed species; do NOT change it.
+    expect(page.locator("#speciesInput")).to_have_value("Test bird")
+    # Reject the current frame — a cull-only change.
+    page.keyboard.press("x")
+    expect(page.locator("#rejectCount")).to_have_text("1")
+
+    with (
+        page.expect_request("**/api/pipeline/group/apply") as apply_req,
+        page.expect_response("**/api/pipeline/save-cache"),
+    ):
+        page.locator("#applyBtn").click()
+
+    # No species post: re-confirming the unchanged species would be a destructive
+    # no-op keyword_add.
+    assert species_payloads == [], "cull-only on a confirmed burst must not re-post species"
+    # Flags still applied via /group/apply (a reject was submitted) and persisted.
+    apply_body = apply_req.value.post_data_json
+    assert apply_body["rejects"], "expected a reject to be submitted to /group/apply"
+    assert save_payloads, "expected save-cache to fire"
+
+
+def test_rapid_review_first_confirmation_and_replacement_post_species(live_server, page):
+    # Converse sanity: an UNCONFIRMED burst (no species_confirmed / no override)
+    # with the species field set posts on first confirmation; changing to a
+    # DIFFERENT species from the confirmed one also posts (replacement).
+    species_payloads = []
+    results = {
+        "photos": [
+            {"id": 1, "filename": "a.jpg", "label": "REVIEW", "flag": "none"},
+            {"id": 2, "filename": "b.jpg", "label": "REVIEW", "flag": "none"},
+        ],
+        "encounters": [
+            {
+                "photo_ids": [1, 2],
+                "photo_count": 2,
+                "burst_count": 1,
+                "species": ["Test bird"],
+                "bursts": [{"photo_ids": [1, 2]}],
+            }
+        ],
+        "summary": {"keep_count": 0, "review_count": 2, "reject_count": 0},
+    }
+    _mock_pipeline_rapid_review(page, results=results, species_payloads=species_payloads)
+
+    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    expect(page.locator("#applyBtn")).to_be_enabled()
+    # "Test bird" is an unconfirmed prediction (no species_confirmed), so the
+    # field pre-fills with it and applying is a first-time confirmation → posts.
+    expect(page.locator("#speciesInput")).to_have_value("Test bird")
+
+    with page.expect_response("**/api/encounters/species"):
+        page.locator("#applyBtn").click()
+
+    assert species_payloads, "first confirmation of an unconfirmed burst must post"
+    assert species_payloads[-1]["species"] == "Test bird"
+
+
+def test_rapid_review_species_replacement_on_confirmed_burst_posts(live_server, page):
+    # A burst confirmed as "Test bird"; changing the field to a DIFFERENT species
+    # must post (replacement), unlike the unchanged-species cull-only case.
+    species_payloads = []
+    results = {
+        "photos": [
+            {"id": 1, "filename": "a.jpg", "label": "KEEP", "flag": "flagged", "confirmed_species": "Test bird"},
+            {"id": 2, "filename": "b.jpg", "label": "REVIEW", "flag": "none", "confirmed_species": "Test bird"},
+        ],
+        "encounters": [
+            {
+                "photo_ids": [1, 2],
+                "photo_count": 2,
+                "burst_count": 1,
+                "species": ["Test bird"],
+                "species_confirmed": True,
+                "confirmed_species": "Test bird",
+                "bursts": [
+                    {"photo_ids": [1, 2], "species_override": {"species": "Test bird", "confirmed": True}}
+                ],
+            }
+        ],
+        "summary": {"keep_count": 1, "review_count": 1, "reject_count": 0},
+    }
+    _mock_pipeline_rapid_review(
+        page,
+        results=results,
+        state_photos={
+            "1": {"flag": "flagged", "has_species_keyword": True},
+            "2": {"flag": "none", "has_species_keyword": True},
+        },
+        species_payloads=species_payloads,
+    )
+
+    page.goto(f"{live_server['url']}/pipeline/rapid-review?enc=0&burst=0")
+    expect(page.locator("#applyBtn")).to_be_enabled()
+    expect(page.locator("#speciesInput")).to_have_value("Test bird")
+    page.locator("#speciesInput").fill("Different bird")
+
+    with page.expect_response("**/api/encounters/species"):
+        page.locator("#applyBtn").click()
+
+    assert species_payloads, "species replacement must post"
+    assert species_payloads[-1]["species"] == "Different bird"
+
+
 def test_rapid_review_adopts_detach_restructure_without_clobbering_cache(live_server, page):
     # Simulate the server auto-detaching the burst on a species mismatch: the
     # /api/encounters/species response returns a RESTRUCTURED encounters payload

--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -22,6 +22,8 @@ def _mock_pipeline_rapid_review(
     original_content_type="image/png",
     shortcut_config=None,
     state_photos=None,
+    species_payloads=None,
+    species_response=None,
 ):
     image_body = base64.b64decode(_PNG_1X1)
     if shortcut_config is None:
@@ -102,19 +104,23 @@ def _mock_pipeline_rapid_review(
         route.fulfill(json={"ok": True})
 
     page.route("**/api/pipeline/save-cache", save_cache)
+
     # /group/apply is flags-only now; species confirmation routes through the
-    # unified /api/encounters/species endpoint. Echo back the current structure
-    # so the client's adopt step is a no-op (preserves the mocked encounters).
-    page.route(
-        "**/api/encounters/species",
-        lambda route: route.fulfill(
-            json={
-                "ok": True,
-                "encounters": results["encounters"],
-                "summary": results["summary"],
-            }
-        ),
-    )
+    # unified /api/encounters/species endpoint. By default echo back the current
+    # structure (no-op adopt). Tests can capture request bodies via
+    # species_payloads and override the adopted structure via species_response
+    # (e.g. to simulate the server's auto-detach restructure).
+    def encounters_species(route):
+        if species_payloads is not None:
+            species_payloads.append(route.request.post_data_json)
+        body = species_response if species_response is not None else {
+            "ok": True,
+            "encounters": results["encounters"],
+            "summary": results["summary"],
+        }
+        route.fulfill(json=body)
+
+    page.route("**/api/encounters/species", encounters_species)
     page.route(
         "**/thumbnails/*.jpg",
         lambda route: route.fulfill(body=image_body, content_type="image/png"),
@@ -229,16 +235,19 @@ def test_rapid_review_apply_button_summarizes_pending_writes(live_server, page):
 
     page.goto(f"{live_server['url']}/pipeline/rapid-review")
 
-    expect(page.locator("#applyBtn")).to_have_text("Apply: no DB changes")
+    # Species tagging now covers EVERY frame in the burst (not just picks), so
+    # with a pre-filled species and no frames yet carrying the keyword, Apply
+    # would tag all 3 — the label must say so before any pick.
+    expect(page.locator("#applyBtn")).to_have_text("Apply: Tag 3")
 
     page.keyboard.press("p")
-    expect(page.locator("#applyBtn")).to_have_text("Apply: Flag 1 · Tag 1")
+    expect(page.locator("#applyBtn")).to_have_text("Apply: Flag 1 · Tag 3")
 
     page.keyboard.press("x")
-    expect(page.locator("#applyBtn")).to_have_text("Apply: Flag 1 · Reject 1 · Tag 1")
+    expect(page.locator("#applyBtn")).to_have_text("Apply: Flag 1 · Reject 1 · Tag 3")
     expect(page.locator("#applyBtn")).to_have_attribute(
         "title",
-        'Apply will flag 1 photo as a pick, reject 1 photo, add species keyword "Test bird" to 1 pick.',
+        'Apply will flag 1 photo as a pick, reject 1 photo, add species keyword "Test bird" to 3 burst frames.',
     )
 
 
@@ -858,3 +867,132 @@ def test_classic_pipeline_review_group_shortcuts_do_not_flag_prior_single_photo(
     expect(page.locator("#grmCount")).to_have_text("0 picks, 1 rejects, 1 unsorted")
     page.wait_for_timeout(200)
     assert stale_flag_payloads == []
+
+
+def test_rapid_review_apply_tags_all_burst_frames_via_encounters_species(live_server, page):
+    # A multi-frame burst where only ONE frame is a pick. Species tagging must
+    # cover EVERY frame (matching the pipeline decision / the grid), so the
+    # /api/encounters/species request body must carry all burst photo_ids — not
+    # just the pick — plus the burst's index.
+    species_payloads = []
+    results = {
+        "photos": [
+            {"id": 1, "filename": "a.jpg", "label": "REVIEW", "flag": "none"},
+            {"id": 2, "filename": "b.jpg", "label": "REVIEW", "flag": "none"},
+            {"id": 3, "filename": "c.jpg", "label": "REVIEW", "flag": "none"},
+        ],
+        "encounters": [
+            {
+                "photo_ids": [1, 2, 3],
+                "photo_count": 3,
+                "burst_count": 1,
+                "species": ["Test bird"],
+                "bursts": [{"photo_ids": [1, 2, 3]}],
+            }
+        ],
+        "summary": {"keep_count": 0, "review_count": 3, "reject_count": 0},
+    }
+    _mock_pipeline_rapid_review(
+        page,
+        results=results,
+        apply_photos={
+            "1": {"flag": "flagged", "has_species_keyword": False},
+            "2": {"flag": "none", "has_species_keyword": False},
+            "3": {"flag": "none", "has_species_keyword": False},
+        },
+        species_payloads=species_payloads,
+    )
+
+    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    expect(page.locator("#applyBtn")).to_be_enabled()
+    # Pick only the first frame; the other two stay unsorted.
+    page.keyboard.press("p")
+
+    with page.expect_response("**/api/encounters/species"):
+        page.locator("#applyBtn").click()
+
+    assert species_payloads, "expected /api/encounters/species to fire"
+    body = species_payloads[-1]
+    assert body["species"] == "Test bird"
+    assert body["burst_index"] == 0
+    # ALL burst frames, not just the single pick.
+    assert sorted(body["photo_ids"]) == [1, 2, 3]
+
+
+def test_rapid_review_adopts_detach_restructure_without_clobbering_cache(live_server, page):
+    # Simulate the server auto-detaching the burst on a species mismatch: the
+    # /api/encounters/species response returns a RESTRUCTURED encounters payload
+    # (one extra encounter, indices shifted). The client must adopt that exact
+    # structure and the subsequent save-cache must persist it — proving there is
+    # no stale-index local write that corrupts the encounter the user confirmed.
+    save_payloads = []
+    results = {
+        "photos": [
+            {"id": 1, "filename": "a.jpg", "label": "REVIEW", "flag": "none"},
+            {"id": 2, "filename": "b.jpg", "label": "REVIEW", "flag": "none"},
+        ],
+        "encounters": [
+            {
+                "photo_ids": [1, 2],
+                "photo_count": 2,
+                "burst_count": 2,
+                "species": ["Original bird"],
+                "bursts": [{"photo_ids": [1]}, {"photo_ids": [2]}],
+            }
+        ],
+        "summary": {"keep_count": 0, "review_count": 2, "reject_count": 0},
+    }
+    # The detached burst (photo 1, the confirmed-divergent species) becomes its
+    # own new encounter; the original encounter keeps the remaining sibling.
+    restructured = {
+        "ok": True,
+        "encounters": [
+            {
+                "photo_ids": [2],
+                "photo_count": 1,
+                "burst_count": 1,
+                "species": ["Original bird"],
+                "bursts": [{"photo_ids": [2]}],
+            },
+            {
+                "photo_ids": [1],
+                "photo_count": 1,
+                "burst_count": 1,
+                "species": ["Divergent bird"],
+                "species_confirmed": True,
+                "confirmed_species": "Divergent bird",
+                "bursts": [{"photo_ids": [1], "species_override": {"species": "Divergent bird", "confirmed": True}}],
+            },
+        ],
+        "summary": {"keep_count": 0, "review_count": 2, "reject_count": 0},
+    }
+    _mock_pipeline_rapid_review(
+        page,
+        results=results,
+        apply_photos={"1": {"flag": "none", "has_species_keyword": False}},
+        save_payloads=save_payloads,
+        species_response=restructured,
+    )
+
+    page.goto(f"{live_server['url']}/pipeline/rapid-review?enc=0&burst=0")
+    expect(page.locator("#applyBtn")).to_be_enabled()
+    expect(page.locator("#filename")).to_have_text("a.jpg")
+    # Confirm a species that diverges from the encounter's, triggering detach.
+    page.locator("#speciesInput").fill("Divergent bird")
+
+    with page.expect_response("**/api/pipeline/save-cache"):
+        page.locator("#applyBtn").click()
+
+    assert save_payloads, "expected save-cache to fire"
+    saved = save_payloads[-1]
+    # The client adopted the server's restructured encounters verbatim — the
+    # save-cache body must match it exactly (no clobber, no stale-index write).
+    assert saved["encounters"] == restructured["encounters"]
+    # The detached encounter still carries its server-set confirmation; nothing
+    # locally overwrote the (now index-shifted) encounter the user confirmed.
+    detached = next(e for e in saved["encounters"] if e["photo_ids"] == [1])
+    assert detached["species_confirmed"] is True
+    assert detached["confirmed_species"] == "Divergent bird"
+    # The sibling that kept the original species was NOT given the divergent one.
+    sibling = next(e for e in saved["encounters"] if e["photo_ids"] == [2])
+    assert sibling["species"] == ["Original bird"]

--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -712,10 +712,17 @@ def test_classic_pipeline_review_opens_requested_burst_from_url(live_server, pag
 
     page.keyboard.press("p")
     expect(page.locator("#grmCount")).to_have_text("1 picks, 0 rejects, 2 unsorted")
-    expect(page.locator("#grmApplyBtn")).to_have_text("Flag 1 · Tag 1 as Test bird & Close")
+    # The burst's species ("Test bird") is an unconfirmed prediction, so picking
+    # a frame pre-checks "Confirm species" (smart default keys off confirmed
+    # species, not the prediction fallback). The species is therefore set and
+    # all 3 post-apply burst members are tagged.
+    expect(page.locator("#grmConfirmSpeciesChk")).to_be_checked()
+    expect(page.locator("#grmApplyFlagsChk")).to_be_checked()
+    expect(page.locator("#grmApplyBtn")).to_have_text("Flag 1 · Set species · Tag 3 as Test bird & Close")
     expect(page.locator("#grmApplyBtn")).to_have_attribute(
         "title",
-        'Apply will flag 1 photo as a pick, add species keyword "Test bird" to 1 pick, then close this burst.',
+        'Apply will flag 1 photo as a pick, set confirmed species to "Test bird", '
+        'add species keyword "Test bird" to 3 burst frames, then close this burst.',
     )
 
 
@@ -782,11 +789,20 @@ def test_classic_pipeline_review_single_photo_opens_review_modal(live_server, pa
 
     page.keyboard.press("x")
     expect(page.locator("#grmCount")).to_have_text("0 picks, 1 rejects, 0 unsorted")
-    expect(page.locator("#grmApplyBtn")).to_have_text("Reject 1 & Close")
+    # "Test bird" is an unconfirmed prediction here, so "Confirm species" is
+    # pre-checked regardless of the cull state — the species gets set and the
+    # frame tagged.
+    expect(page.locator("#grmConfirmSpeciesChk")).to_be_checked()
+    expect(page.locator("#grmApplyBtn")).to_have_text("Reject 1 · Set species · Tag 1 as Test bird & Close")
 
     page.keyboard.press("p")
     expect(page.locator("#grmCount")).to_have_text("1 picks, 0 rejects, 0 unsorted")
-    expect(page.locator("#grmApplyBtn")).to_have_text("Flag 1 · Tag 1 as Test bird & Close")
+    # Picking the photo pre-checks both "Confirm species" (unconfirmed
+    # prediction) and "Apply flags" (a pending pick), so the species is
+    # confirmed/tagged on apply — the regression this guards against.
+    expect(page.locator("#grmConfirmSpeciesChk")).to_be_checked()
+    expect(page.locator("#grmApplyFlagsChk")).to_be_checked()
+    expect(page.locator("#grmApplyBtn")).to_have_text("Flag 1 · Set species · Tag 1 as Test bird & Close")
 
 
 def test_classic_pipeline_review_group_shortcuts_do_not_flag_prior_single_photo(live_server, page):

--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -1010,6 +1010,80 @@ def test_rapid_review_cull_only_on_confirmed_burst_skips_species_post(live_serve
     assert save_payloads, "expected save-cache to fire"
 
 
+def test_rapid_review_confirmed_burst_with_untagged_frame_posts_species(live_server, page):
+    # A burst confirmed as "Test bird" but where /group/state reports one frame
+    # STILL MISSING the species keyword (e.g. legacy data that only tagged
+    # picks). The species field is unchanged ("Test bird"), so the confirmed
+    # species does NOT change — but rapidComputeApplyDiff advertises "Tag N", and
+    # /api/pipeline/group/apply is flags-only, so the missing keyword would never
+    # be written unless we still POST /api/encounters/species. The gate must fire
+    # on outstanding tag work, not only on a confirmed-species change. (Regression
+    # for the no-tag-on-already-confirmed-but-untagged-frame gap.)
+    species_payloads = []
+    save_payloads = []
+    results = {
+        "photos": [
+            {"id": 1, "filename": "a.jpg", "label": "KEEP", "flag": "flagged", "confirmed_species": "Test bird"},
+            {"id": 2, "filename": "b.jpg", "label": "REVIEW", "flag": "none", "confirmed_species": "Test bird"},
+            {"id": 3, "filename": "c.jpg", "label": "REVIEW", "flag": "none", "confirmed_species": "Test bird"},
+        ],
+        "encounters": [
+            {
+                "photo_ids": [1, 2, 3],
+                "photo_count": 3,
+                "burst_count": 1,
+                "species": ["Test bird"],
+                "species_confirmed": True,
+                "confirmed_species": "Test bird",
+                "bursts": [
+                    {
+                        "photo_ids": [1, 2, 3],
+                        "species_override": {"species": "Test bird", "confirmed": True},
+                    }
+                ],
+            }
+        ],
+        "summary": {"keep_count": 1, "review_count": 2, "reject_count": 0},
+    }
+    _mock_pipeline_rapid_review(
+        page,
+        results=results,
+        apply_photos={
+            "1": {"flag": "flagged", "has_species_keyword": True},
+            "2": {"flag": "none", "has_species_keyword": True},
+            "3": {"flag": "none", "has_species_keyword": True},
+        },
+        # Frame 3 lacks the species keyword despite the burst being confirmed.
+        state_photos={
+            "1": {"flag": "flagged", "has_species_keyword": True},
+            "2": {"flag": "none", "has_species_keyword": True},
+            "3": {"flag": "none", "has_species_keyword": False},
+        },
+        species_payloads=species_payloads,
+        save_payloads=save_payloads,
+    )
+
+    # Deep-link the "all" queue so a confirmed burst is reviewable.
+    page.goto(f"{live_server['url']}/pipeline/rapid-review?enc=0&burst=0")
+    expect(page.locator("#applyBtn")).to_be_enabled()
+    # Species field already reflects the confirmed species; leave it unchanged.
+    expect(page.locator("#speciesInput")).to_have_value("Test bird")
+    # The Apply button must advertise the outstanding tag work (truthfulness).
+    expect(page.locator("#applyBtn")).to_contain_text("Tag 1")
+
+    # Apply with NO flag or species change — only the missing keyword to write.
+    with page.expect_response("**/api/encounters/species"):
+        page.locator("#applyBtn").click()
+
+    # The species post fired despite the species being unchanged, so the missing
+    # keyword is written to all burst frames.
+    assert species_payloads, "expected /api/encounters/species to fire for outstanding tag work"
+    body = species_payloads[-1]
+    assert body["species"] == "Test bird"
+    assert sorted(body["photo_ids"]) == [1, 2, 3]
+    assert body["burst_index"] == 0
+
+
 def test_rapid_review_first_confirmation_and_replacement_post_species(live_server, page):
     # Converse sanity: an UNCONFIRMED burst (no species_confirmed / no override)
     # with the species field set posts on first confirmation; changing to a

--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -972,8 +972,8 @@ def test_rapid_review_cull_only_on_confirmed_burst_skips_species_post(live_serve
         page,
         results=results,
         apply_photos={
-            "1": {"flag": "flagged", "has_species_keyword": True},
-            "2": {"flag": "rejected", "has_species_keyword": True},
+            "1": {"flag": "rejected", "has_species_keyword": True},
+            "2": {"flag": "none", "has_species_keyword": True},
             "3": {"flag": "none", "has_species_keyword": True},
         },
         state_photos={

--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -102,6 +102,19 @@ def _mock_pipeline_rapid_review(
         route.fulfill(json={"ok": True})
 
     page.route("**/api/pipeline/save-cache", save_cache)
+    # /group/apply is flags-only now; species confirmation routes through the
+    # unified /api/encounters/species endpoint. Echo back the current structure
+    # so the client's adopt step is a no-op (preserves the mocked encounters).
+    page.route(
+        "**/api/encounters/species",
+        lambda route: route.fulfill(
+            json={
+                "ok": True,
+                "encounters": results["encounters"],
+                "summary": results["summary"],
+            }
+        ),
+    )
     page.route(
         "**/thumbnails/*.jpg",
         lambda route: route.fulfill(body=image_body, content_type="image/png"),

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -12015,46 +12015,90 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # (SQLite lock, disk error, etc.) can't leave half the photos retagged
         # while the other half still carry the old species.
         try:
+            # Resolve the target species keyword id up front so we can precheck
+            # which photos already carry it. add_keyword is idempotent and
+            # returns the existing id when the species already exists.
+            kid = db.add_keyword(species, is_species=True, _commit=False)
+
+            # Precheck which submitted photos already carry the new species
+            # keyword. Only photos that get a *new* tag should generate
+            # edit-history items and sidecar adds — otherwise confirming an
+            # already-tagged photo would push a no-op onto the undo stack, and
+            # undoing it would destructively remove the pre-existing keyword.
+            # Mirrors the precheck pattern in api_batch_keyword.
+            placeholders_ids = ",".join("?" for _ in photo_ids)
+            already_has_new = {
+                row["photo_id"]
+                for row in db.conn.execute(
+                    f"""SELECT photo_id FROM photo_keywords
+                        WHERE keyword_id = ? AND photo_id IN ({placeholders_ids})""",
+                    [kid] + list(photo_ids),
+                ).fetchall()
+            }
+            newly_tagged = [pid for pid in photo_ids if pid not in already_has_new]
+
+            # For a replacement, only photos that actually carry the old
+            # species keyword should be untagged / generate a remove.
+            had_old = set()
             if is_replacement and old_kid is not None:
+                had_old = {
+                    row["photo_id"]
+                    for row in db.conn.execute(
+                        f"""SELECT photo_id FROM photo_keywords
+                            WHERE keyword_id = ? AND photo_id IN ({placeholders_ids})""",
+                        [old_kid] + list(photo_ids),
+                    ).fetchall()
+                }
                 for pid in photo_ids:
+                    if pid not in had_old:
+                        continue
                     db.untag_photo(pid, old_kid, _commit=False)
                     _queue_keyword_remove(
                         pid, previous_species,
                         workspace_id=ws_id, _commit=False,
                     )
 
-            kid = db.add_keyword(species, is_species=True, _commit=False)
-
-            for pid in photo_ids:
+            for pid in newly_tagged:
                 db.tag_photo(pid, kid, _commit=False)
                 _queue_keyword_add(
                     pid, species, workspace_id=ws_id, _commit=False,
                 )
 
-            if is_replacement and old_kid is not None:
+            if is_replacement and old_kid is not None and had_old:
+                # Photos that actually changed: had the old keyword (so the
+                # remove side fired) and/or newly gained the new one. Use the
+                # union so undo restores the exact state we mutated.
+                newly_set = set(newly_tagged)
+                changed = [
+                    pid for pid in photo_ids if pid in had_old or pid in newly_set
+                ]
                 items = [
-                    {"photo_id": pid, "old_value": str(old_kid), "new_value": str(kid)}
-                    for pid in photo_ids
+                    {
+                        "photo_id": pid,
+                        "old_value": str(old_kid) if pid in had_old else "",
+                        "new_value": str(kid) if pid in newly_set else "",
+                    }
+                    for pid in changed
                 ]
                 db.record_edit(
                     "species_replace",
-                    f'Replaced species "{previous_species}" with "{species}" on {len(photo_ids)} photos',
+                    f'Replaced species "{previous_species}" with "{species}" on {len(changed)} photos',
                     str(kid),
                     items,
-                    is_batch=len(photo_ids) > 1,
+                    is_batch=len(changed) > 1,
                     _commit=False,
                 )
-            else:
+            elif newly_tagged:
                 items = [
                     {"photo_id": pid, "old_value": "", "new_value": str(kid)}
-                    for pid in photo_ids
+                    for pid in newly_tagged
                 ]
                 db.record_edit(
                     "keyword_add",
-                    f'Confirmed species "{species}" on {len(photo_ids)} photos',
+                    f'Confirmed species "{species}" on {len(newly_tagged)} photos',
                     str(kid),
                     items,
-                    is_batch=len(photo_ids) > 1,
+                    is_batch=len(newly_tagged) > 1,
                     _commit=False,
                 )
             db.conn.commit()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -12706,20 +12706,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/api/pipeline/group/apply", methods=["POST"])
     def api_pipeline_group_apply():
-        """Apply pick/reject decisions and species to a pipeline burst group.
+        """Apply pick/reject/candidate flag decisions to a pipeline burst group.
 
-        Diff-based: only writes flag changes for photos whose flag actually
-        changes, only adds the species keyword when it isn't already on the
-        photo, and clears flags on photos moved to candidates that were
-        previously flagged/rejected. Returns per-photo new flag/keyword state
-        so the client can update its rendered cards without reloading.
+        Flags-only: species confirmation now routes through a dedicated path
+        (`/api/encounters/species`), so this endpoint no longer tags any species
+        keyword. Diff-based: only writes flag changes for photos whose flag
+        actually changes, and clears flags on photos moved to candidates that
+        were previously flagged/rejected. Returns per-photo new flag state so
+        the client can update its rendered cards without reloading.
         """
         db = _get_db()
         body = request.get_json(silent=True) or {}
         picks = list(body.get("picks", []) or [])
         rejects = list(body.get("rejects", []) or [])
         candidates = list(body.get("candidates", []) or [])
-        species = (body.get("species") or "").strip()
 
         # The same photo can't be in two zones. Reject conflicting input.
         seen = set()
@@ -12739,15 +12739,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             row = db.get_photo(pid)
             if row:
                 old_flags[pid] = row["flag"] or "none"
-
-        species_kid = None
-        photos_with_species = set()
-        if species:
-            species_kid = db.add_keyword(species, is_species=True)
-            for pid in picks:
-                kws = db.get_photo_keywords(pid)
-                if any(k["id"] == species_kid for k in kws):
-                    photos_with_species.add(pid)
 
         try:
             # Apply target flags. We rely on update_photo_flag's own write
@@ -12769,20 +12760,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 if old in ("flagged", "rejected"):
                     db.update_photo_flag(pid, "none")
                     flag_items.append({"photo_id": pid, "old_value": old, "new_value": "none"})
-
-            kw_added_pids = []
-            if species and species_kid is not None:
-                for pid in picks:
-                    if pid in photos_with_species:
-                        continue
-                    db.tag_photo(pid, species_kid)
-                    # Use the shared helper so a pending `keyword_remove` for
-                    # the same species cancels out instead of co-existing with
-                    # a new `keyword_add`. sync_to_xmp applies removals after
-                    # adds, so a leftover remove would strip the keyword from
-                    # XMP even though the DB still has the tag.
-                    _queue_keyword_add(pid, species)
-                    kw_added_pids.append(pid)
         except ValueError as e:
             return json_error(str(e), 403)
 
@@ -12799,23 +12776,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             db.record_edit("flag", desc, "pipeline_group_apply", flag_items,
                            is_batch=len(flag_items) > 1)
 
-        if kw_added_pids and species_kid is not None:
-            kw_items = [{"photo_id": pid, "old_value": "", "new_value": str(species_kid)}
-                        for pid in kw_added_pids]
-            db.record_edit("keyword_add",
-                           f'Added "{species}" to {len(kw_added_pids)} photos (pipeline burst group)',
-                           str(species_kid), kw_items, is_batch=len(kw_added_pids) > 1)
-
         # Return new per-photo state so the client can update without a reload.
+        # `has_species_keyword` is kept in the payload (now always False) so the
+        # client cache-sync code need not change shape; this endpoint no longer
+        # tags species.
         result_photos = {}
         for pid in picks + rejects + candidates:
             row = db.get_photo(pid)
             if not row:
                 continue
-            kws = db.get_photo_keywords(pid)
             result_photos[pid] = {
                 "flag": row["flag"] or "none",
-                "has_species_keyword": species_kid is not None and any(k["id"] == species_kid for k in kws),
+                "has_species_keyword": False,
             }
         return jsonify({"ok": True, "photos": result_photos})
 

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -1705,6 +1705,35 @@ async function applyCurrent(openNext) {
   var items = rapid.items.slice();
   var pickSet = new Set(picks);
   var rejectSet = new Set(rejects);
+  // Capture the species THIS burst is ALREADY confirmed as, BEFORE any
+  // optimistic local mutation below. Mirrors the burst-group modal's
+  // initialConfirmedSpecies (pipeline_review.html openGroupReview): prefer a
+  // confirmed burst override, else the encounter's confirmed species, else ''
+  // (unconfirmed). The species POST is gated on an ACTUAL change against this
+  // baseline — applying cull-only changes to a burst already tagged as X must
+  // NOT re-post X, because /api/encounters/species records a keyword_add
+  // edit-history entry per submitted frame even when tag_photo is an
+  // INSERT-OR-IGNORE no-op, and undoing that no-op add would strip the
+  // existing species keywords. Snapshot off rapid.results (not live rapid.*)
+  // since openSession() can run during the awaits below.
+  var alreadyConfirmedSpecies = '';
+  var snapEnc = (rapid.results.encounters || [])[session.encIdx];
+  if (snapEnc) {
+    var snapBursts = (snapEnc.bursts && snapEnc.bursts.length) ? snapEnc.bursts : null;
+    var snapBurst = snapBursts ? snapBursts[session.burstIdx] : null;
+    if (snapBurst && snapBurst.species_override && snapBurst.species_override.confirmed === true && snapBurst.species_override.species) {
+      alreadyConfirmedSpecies = snapBurst.species_override.species;
+    } else if (snapEnc.species_confirmed && snapEnc.confirmed_species) {
+      alreadyConfirmedSpecies = snapEnc.confirmed_species;
+    }
+  }
+  // NOTE: this gates on the burst-level confirmed-species change only. A frame
+  // that is part of a "confirmed as X" burst but happens to lack the X keyword
+  // would not be re-tagged by skipping the post. Rapid review has no reliable
+  // per-photo keyword state client-side here, so we deliberately do not invent
+  // that signal; the gate fixes the reported destructive no-op-add bug while
+  // first confirmations and species replacements still post (see below).
+  var speciesChanged = !!(species && species !== alreadyConfirmedSpecies);
 
   try {
     var resp = await safeFetch('/api/pipeline/group/apply', {
@@ -1750,7 +1779,7 @@ async function applyCurrent(openNext) {
     // locally — after an auto-detach the encounter indices shift, so the cached
     // session.encIdx may point at a different (or out-of-bounds) encounter, and
     // a local write would corrupt it and then be persisted by save-cache below.
-    if (species) {
+    if (speciesChanged) {
       var spResp = await safeFetch('/api/encounters/species', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -1734,6 +1734,10 @@ async function applyCurrent(openNext) {
         var p = rapid.photoMap[pid];
         if (p) {
           p.flag = resp.photos[pidStr].flag;
+          // /group/apply is flags-only, so has_species_keyword is always
+          // false here in production; confirmed species comes from the
+          // adopted /api/encounters/species response below. Kept only because
+          // some rapid-review tests still mock the old response shape.
           if (species && resp.photos[pidStr].has_species_keyword) p.confirmed_species = species;
         }
       });

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -1726,12 +1726,6 @@ async function applyCurrent(openNext) {
       if (pickSet.has(p.id)) p.flag = 'flagged';
       else if (rejectSet.has(p.id)) p.flag = 'rejected';
       else p.flag = 'none';
-      // The /api/encounters/species call below tags EVERY frame in `items`
-      // (picks and non-picks alike), so mirror that locally for all of them.
-      // Marking only picks would leave non-pick frames in the "Needs species"
-      // queue / without a confirmed-species chip until a reload, even though
-      // the server has already tagged them.
-      if (species) p.confirmed_species = species;
     });
     if (resp && resp.photos) {
       Object.keys(resp.photos).forEach(function(pidStr) {
@@ -1787,6 +1781,15 @@ async function applyCurrent(openNext) {
         //     navigate server truth instead of stale indices.
         rapid.allSessions = buildSessions(rapid.results);
       }
+      // Only now that the species call has SUCCEEDED do we mirror the
+      // confirmation onto the local photos. The endpoint tags EVERY frame in
+      // `items` (picks and non-picks alike), so mark them all — marking only
+      // picks would leave non-pick frames in the "Needs species" queue / without
+      // a confirmed-species chip until a reload. Doing this before the call
+      // (or in the label loop above) would leave the cache claiming confirmation
+      // even when /api/encounters/species fails, hiding the burst from "Needs
+      // species" locally until reload (the catch path doesn't roll it back).
+      items.forEach(function(p) { p.confirmed_species = species; });
     }
     updateSummaryFromPhotos();
     await safeFetch('/api/pipeline/save-cache', {

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -1726,7 +1726,12 @@ async function applyCurrent(openNext) {
       if (pickSet.has(p.id)) p.flag = 'flagged';
       else if (rejectSet.has(p.id)) p.flag = 'rejected';
       else p.flag = 'none';
-      if (species && pickSet.has(p.id)) p.confirmed_species = species;
+      // The /api/encounters/species call below tags EVERY frame in `items`
+      // (picks and non-picks alike), so mirror that locally for all of them.
+      // Marking only picks would leave non-pick frames in the "Needs species"
+      // queue / without a confirmed-species chip until a reload, even though
+      // the server has already tagged them.
+      if (species) p.confirmed_species = species;
     });
     if (resp && resp.photos) {
       Object.keys(resp.photos).forEach(function(pidStr) {
@@ -1751,9 +1756,7 @@ async function applyCurrent(openNext) {
     // locally — after an auto-detach the encounter indices shift, so the cached
     // session.encIdx may point at a different (or out-of-bounds) encounter, and
     // a local write would corrupt it and then be persisted by save-cache below.
-    var restructured = false;
     if (species) {
-      var encCountBefore = (rapid.results.encounters || []).length;
       var spResp = await safeFetch('/api/encounters/species', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
@@ -1768,29 +1771,22 @@ async function applyCurrent(openNext) {
       if (spResp && spResp.encounters) {
         rapid.results.encounters = spResp.encounters;
         if (spResp.summary) rapid.results.summary = spResp.summary;
-        // A change in encounter count is the signal an auto-detach restructured
-        // the queue. When that happens the cached session.encIdx no longer maps
-        // to the same encounter, so we must NOT propagate this (divergent)
-        // species onto the original encounter's sibling bursts: those siblings
-        // kept their original species — that divergence is exactly why the
-        // burst detached.
-        restructured = (rapid.results.encounters.length !== encCountBefore);
+        // Rebuild the sidebar sessions from the server's authoritative
+        // encounters rather than trying to patch the old layout in place.
+        // buildSessions() derives each session's encIdx/burstIdx, species
+        // (via burstSpecies, which reads enc.confirmed_species /
+        // burst.species_override) and hasBurstOverride straight from the
+        // adopted payload, so this single rebuild covers BOTH cases the old
+        // count heuristic tried to distinguish:
+        //   - no detach: the server set confirmed_species on the encounter, so
+        //     sibling bursts pick up the just-confirmed species (the Apply-Next
+        //     pre-fill hint) for free.
+        //   - auto-detach (count-changing OR count-equal merge into an adjacent
+        //     same-species encounter): the shifted encIdx/burstIdx and divergent
+        //     species are reflected exactly, so the sidebar and openClassic()
+        //     navigate server truth instead of stale indices.
+        rapid.allSessions = buildSessions(rapid.results);
       }
-    }
-    // Propagate the confirmed species onto sibling bursts' cached hints only
-    // when no restructure happened. sessions[].species is cached at page load,
-    // so updating every burst in this encounter keeps Apply Next tagging picks
-    // with the confirmed species without the user retyping it per burst.
-    // Iterate allSessions, not the filtered rapid.sessions: a queue
-    // filter/toggle can hide sibling bursts, and they must still get the
-    // confirmed species so they aren't stale when they re-enter the queue.
-    if (species && !restructured) {
-      rapid.allSessions.forEach(function(s) {
-        if (s.encIdx === session.encIdx && !s.hasBurstOverride) {
-          s.species = species;
-          s.subtitle = s.ids.length + ' photos - ' + species;
-        }
-      });
     }
     updateSummaryFromPhotos();
     await safeFetch('/api/pipeline/save-cache', {

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -1727,13 +1727,29 @@ async function applyCurrent(openNext) {
       alreadyConfirmedSpecies = snapEnc.confirmed_species;
     }
   }
-  // NOTE: this gates on the burst-level confirmed-species change only. A frame
-  // that is part of a "confirmed as X" burst but happens to lack the X keyword
-  // would not be re-tagged by skipping the post. Rapid review has no reliable
-  // per-photo keyword state client-side here, so we deliberately do not invent
-  // that signal; the gate fixes the reported destructive no-op-add bug while
-  // first confirmations and species replacements still post (see below).
+  // Gate the species POST on ACTUAL species/tag work, mirroring
+  // rapidComputeApplyDiff(): post when the confirmed species changes
+  // (speciesChanged) OR when one or more current-burst frames are missing the
+  // species keyword (tagNeeded). The latter covers a burst already confirmed as
+  // X that still has untagged frames (e.g. legacy data that only tagged picks):
+  // the Apply button advertises "Tag N", so the POST must run to write those
+  // keywords — /api/pipeline/group/apply above is flags-only and never tags.
+  // Skipping the POST when there is NO species change AND nothing left to tag
+  // avoids the destructive no-op keyword_add (an undoable add that, when undone,
+  // strips the existing species keywords). Per-photo keyword state is reliably
+  // seeded client-side (rapid.initialSpeciesKeywords / keywordStateSpecies; see
+  // openSession + the keyword-state refresh), so the tagNeeded signal is real,
+  // not invented.
   var speciesChanged = !!(species && species !== alreadyConfirmedSpecies);
+  var tagNeeded = false;
+  if (species) {
+    for (var ti = 0; ti < items.length; ti++) {
+      var hasKw = rapid.keywordStateSpecies === species &&
+        !!rapid.initialSpeciesKeywords[items[ti].id];
+      if (!hasKw) { tagNeeded = true; break; }
+    }
+  }
+  var speciesPostNeeded = speciesChanged || tagNeeded;
 
   try {
     var resp = await safeFetch('/api/pipeline/group/apply', {
@@ -1779,7 +1795,7 @@ async function applyCurrent(openNext) {
     // locally — after an auto-detach the encounter indices shift, so the cached
     // session.encIdx may point at a different (or out-of-bounds) encounter, and
     // a local write would corrupt it and then be persisted by save-cache below.
-    if (speciesChanged) {
+    if (speciesPostNeeded) {
       var spResp = await safeFetch('/api/encounters/species', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -1711,7 +1711,6 @@ async function applyCurrent(openNext) {
         picks: picks,
         rejects: rejects,
         candidates: candidates,
-        species: species,
       }),
     });
     items.forEach(function(p) {
@@ -1736,6 +1735,27 @@ async function applyCurrent(openNext) {
         }
       });
     }
+    // /group/apply is flags-only now; persist the species through the same
+    // unified endpoint the grid uses so confirmation actually lands server-side
+    // (tags all burst frames, handles species replacement + auto-detach).
+    if (species) {
+      var spResp = await safeFetch('/api/encounters/species', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          species: species,
+          photo_ids: items.map(function(p) { return p.id; }),
+          burst_index: session.burstIdx,
+        }),
+      });
+      // Adopt the authoritative structure (the endpoint may auto-detach on a
+      // species mismatch), so the save-cache below doesn't clobber its restructure.
+      if (spResp && spResp.encounters) {
+        rapid.results.encounters = spResp.encounters;
+        if (spResp.summary) rapid.results.summary = spResp.summary;
+      }
+    }
+    // Re-read after the adopt step above may have replaced encounters[].
     var enc = rapid.results.encounters[session.encIdx];
     if (species && enc) {
       enc.confirmed_species = species;

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -1619,7 +1619,10 @@ function rapidComputeApplyDiff() {
     var hasSpeciesKeyword = species &&
       rapid.keywordStateSpecies === species &&
       !!rapid.initialSpeciesKeywords[p.id];
-    if (species && newFlag === 'flagged' && !hasSpeciesKeyword) diff.tagNew++;
+    // Apply tags EVERY frame in the burst with the species keyword (matching
+    // the grid / the persisted pipeline decision), not just picks. Count all
+    // current-burst members that don't already carry it.
+    if (species && !hasSpeciesKeyword) diff.tagNew++;
   });
   return diff;
 }
@@ -1641,7 +1644,7 @@ function rapidApplyTitle(diff, openNext) {
   if (diff.clearNew > 0) actions.push('clear flags on ' + diff.clearNew + ' ' + rapidPlural(diff.clearNew, 'photo'));
   if (diff.speciesChanged) actions.push('set confirmed species to "' + diff.species + '"');
   if (diff.tagNew > 0) {
-    actions.push('add species keyword "' + diff.species + '" to ' + diff.tagNew + ' ' + rapidPlural(diff.tagNew, 'pick'));
+    actions.push('add species keyword "' + diff.species + '" to ' + diff.tagNew + ' ' + rapidPlural(diff.tagNew, 'burst frame'));
   }
   var text = actions.length ? ('Apply will ' + actions.join(', ') + '.') : 'Apply will make no database changes for this burst.';
   if (openNext) text += ' Then open the next burst.';
@@ -1738,7 +1741,15 @@ async function applyCurrent(openNext) {
     // /group/apply is flags-only now; persist the species through the same
     // unified endpoint the grid uses so confirmation actually lands server-side
     // (tags all burst frames, handles species replacement + auto-detach).
+    // The server now OWNS confirmation: it sets species_confirmed on the
+    // correct encounter and returns the authoritative structure via
+    // spResp.encounters. We do not write enc.confirmed_species/species_confirmed
+    // locally — after an auto-detach the encounter indices shift, so the cached
+    // session.encIdx may point at a different (or out-of-bounds) encounter, and
+    // a local write would corrupt it and then be persisted by save-cache below.
+    var restructured = false;
     if (species) {
+      var encCountBefore = (rapid.results.encounters || []).length;
       var spResp = await safeFetch('/api/encounters/species', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
@@ -1753,19 +1764,23 @@ async function applyCurrent(openNext) {
       if (spResp && spResp.encounters) {
         rapid.results.encounters = spResp.encounters;
         if (spResp.summary) rapid.results.summary = spResp.summary;
+        // A change in encounter count is the signal an auto-detach restructured
+        // the queue. When that happens the cached session.encIdx no longer maps
+        // to the same encounter, so we must NOT propagate this (divergent)
+        // species onto the original encounter's sibling bursts: those siblings
+        // kept their original species — that divergence is exactly why the
+        // burst detached.
+        restructured = (rapid.results.encounters.length !== encCountBefore);
       }
     }
-    // Re-read after the adopt step above may have replaced encounters[].
-    var enc = rapid.results.encounters[session.encIdx];
-    if (species && enc) {
-      enc.confirmed_species = species;
-      enc.species_confirmed = true;
-      // sessions[].species is cached at page load, so update every burst in
-      // this encounter — otherwise Apply Next stops tagging picks with the
-      // confirmed species until the user retypes it for each burst. Iterate
-      // allSessions, not the filtered rapid.sessions: a queue filter/toggle
-      // can hide sibling bursts, and they must still get the confirmed
-      // species so they aren't stale when they re-enter the queue.
+    // Propagate the confirmed species onto sibling bursts' cached hints only
+    // when no restructure happened. sessions[].species is cached at page load,
+    // so updating every burst in this encounter keeps Apply Next tagging picks
+    // with the confirmed species without the user retyping it per burst.
+    // Iterate allSessions, not the filtered rapid.sessions: a queue
+    // filter/toggle can hide sibling bursts, and they must still get the
+    // confirmed species so they aren't stale when they re-enter the queue.
+    if (species && !restructured) {
       rapid.allSessions.forEach(function(s) {
         if (s.encIdx === session.encIdx && !s.hasBurstOverride) {
           s.species = species;

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3618,7 +3618,10 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
     // Close is gated on this so a click during the seed window can't ship
     // an empty picks/rejects payload (which would clear pre-existing flags
     // by treating every photo as a candidate).
-    seeded: false
+    seeded: false,
+    // null = follow smart default; true/false = user explicitly set it.
+    confirmSpeciesOverride: null,
+    applyFlagsOverride: null
   };
   _grmLoupeLocked = false;
   _grmZoomMultiplier = 1;
@@ -3890,6 +3893,31 @@ function grmRefreshSpeciesKeywordState() {
   });
 }
 
+// User manually toggled a checkbox: record the override, then re-sync labels.
+function grmOnToggleChange() {
+  var spChk = document.getElementById('grmConfirmSpeciesChk');
+  var flChk = document.getElementById('grmApplyFlagsChk');
+  if (spChk) grmState.confirmSpeciesOverride = spChk.checked;
+  if (flChk) grmState.applyFlagsOverride = flChk.checked;
+  grmUpdateApplyLabel();
+}
+
+// Smart default: is there a real pending change for each side?
+function grmSpeciesDirty(diff) { return !!diff.speciesChanged; }
+function grmFlagsDirty(diff) {
+  return (diff.flagNew + diff.rejectNew + diff.clearNew + diff.detachNew) > 0;
+}
+
+// Resolve the effective checked state: user override wins, else smart default.
+function grmResolveChecks(diff) {
+  var sp = grmState.confirmSpeciesOverride;
+  var fl = grmState.applyFlagsOverride;
+  return {
+    species: sp === null ? grmSpeciesDirty(diff) : sp,
+    flags: fl === null ? grmFlagsDirty(diff) : fl,
+  };
+}
+
 // Update the Apply button label to reflect the *new* DB writes that will
 // happen — not the totals in each zone — so the user can see at a glance
 // what they're committing to. A photo already flagged in the DB and still
@@ -3903,14 +3931,36 @@ function grmUpdateApplyLabel() {
   // misreport pending writes and clobber the error/loading message.
   if (!grmState || !grmState.seeded) return;
   var diff = grmComputeDiff();
+
+  var checks = grmResolveChecks(diff);
+  var spChk = document.getElementById('grmConfirmSpeciesChk');
+  var flChk = document.getElementById('grmApplyFlagsChk');
+  if (spChk) spChk.checked = checks.species;
+  if (flChk) flChk.checked = checks.flags;
+
+  // Amber hint only when a box is unchecked but its side is dirty.
+  var spHint = document.getElementById('grmSpeciesDirtyHint');
+  if (spHint) {
+    var show = !checks.species && grmSpeciesDirty(diff);
+    spHint.style.display = show ? '' : 'none';
+    spHint.textContent = show ? "species won't be confirmed" : '';
+  }
+  var flHint = document.getElementById('grmFlagsDirtyHint');
+  if (flHint) {
+    var n = diff.flagNew + diff.rejectNew + diff.clearNew + diff.detachNew;
+    var showF = !checks.flags && n > 0;
+    flHint.style.display = showF ? '' : 'none';
+    flHint.textContent = showF ? (n + ' cull change' + (n === 1 ? '' : 's') + " won't be saved") : '';
+  }
+
   var parts = [];
-  if (diff.flagNew > 0) parts.push('Flag ' + diff.flagNew);
-  if (diff.rejectNew > 0) parts.push('Reject ' + diff.rejectNew);
-  if (diff.clearNew > 0) parts.push('Clear ' + diff.clearNew);
-  if (diff.speciesChanged) parts.push('Set species');
-  if (diff.tagNew > 0) parts.push('Tag ' + diff.tagNew + (diff.species ? ' as ' + diff.species : ''));
-  if (diff.detachNew > 0) parts.push('Detach ' + diff.detachNew);
-  btn.textContent = parts.length ? parts.join(' · ') + ' & Close' : 'No DB changes & Close';
+  if (checks.flags && diff.flagNew > 0) parts.push('Flag ' + diff.flagNew);
+  if (checks.flags && diff.rejectNew > 0) parts.push('Reject ' + diff.rejectNew);
+  if (checks.flags && diff.clearNew > 0) parts.push('Clear ' + diff.clearNew);
+  if (checks.species && diff.speciesChanged) parts.push('Set species');
+  if (checks.species && diff.tagNew > 0) parts.push('Tag ' + diff.tagNew + (diff.species ? ' as ' + diff.species : ''));
+  if (checks.flags && diff.detachNew > 0) parts.push('Detach ' + diff.detachNew);
+  btn.textContent = parts.length ? parts.join(' · ') + ' & Close' : 'Apply and close';
   btn.title = grmApplyTitle(diff);
 }
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -4032,18 +4032,30 @@ function grmOnToggleChange(which) {
 }
 
 // Smart default: is there a real pending change for each side?
-function grmSpeciesDirty(diff) { return !!diff.speciesChanged; }
 function grmFlagsDirty(diff) {
   return (diff.flagNew + diff.rejectNew + diff.clearNew + diff.detachNew) > 0;
+}
+// The species side is dirty when the confirmed species changes OR when the
+// burst is already confirmed as the current species but some post-apply frame
+// still lacks that species keyword (e.g. legacy data that only tagged picks).
+// /api/pipeline/group/apply is flags-only, so those missing keywords would
+// never be written unless the species side commits — mirror the rapid-review
+// gate (speciesChanged || outstanding tag work). The tag count depends on the
+// resolved flags state (a removed photo only drops out when its removal
+// actually commits), so callers pass the already-resolved `flags` value.
+function grmSpeciesDirty(diff, flagsResolved) {
+  if (diff.speciesChanged) return true;
+  return grmSpeciesTagCount({ flags: flagsResolved }, diff.species) > 0;
 }
 
 // Resolve the effective checked state: user override wins, else smart default.
 function grmResolveChecks(diff) {
   var sp = grmState.confirmSpeciesOverride;
   var fl = grmState.applyFlagsOverride;
+  var flags = fl === null ? grmFlagsDirty(diff) : fl;
   return {
-    species: sp === null ? grmSpeciesDirty(diff) : sp,
-    flags: fl === null ? grmFlagsDirty(diff) : fl,
+    species: sp === null ? grmSpeciesDirty(diff, flags) : sp,
+    flags: flags,
   };
 }
 
@@ -4070,7 +4082,7 @@ function grmUpdateApplyLabel() {
   // Amber hint only when a box is unchecked but its side is dirty.
   var spHint = document.getElementById('grmSpeciesDirtyHint');
   if (spHint) {
-    var show = !checks.species && grmSpeciesDirty(diff);
+    var show = !checks.species && grmSpeciesDirty(diff, checks.flags);
     spHint.style.display = show ? '' : 'none';
     spHint.textContent = show ? "species won't be confirmed" : '';
   }

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1481,12 +1481,12 @@ input[type="range"]::-moz-range-thumb {
     <span class="grm-hint" id="grmHint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Z = right 1:1 &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
     <div class="grm-commit-group" style="margin-left:auto;display:flex;align-items:center;gap:14px;">
       <label class="grm-commit-toggle">
-        <input type="checkbox" id="grmConfirmSpeciesChk" onchange="grmOnToggleChange()">
+        <input type="checkbox" id="grmConfirmSpeciesChk" onchange="grmOnToggleChange('species')">
         <span>Confirm species</span>
         <span class="grm-dirty-hint" id="grmSpeciesDirtyHint" style="display:none;"></span>
       </label>
       <label class="grm-commit-toggle">
-        <input type="checkbox" id="grmApplyFlagsChk" onchange="grmOnToggleChange()">
+        <input type="checkbox" id="grmApplyFlagsChk" onchange="grmOnToggleChange('flags')">
         <span>Apply picks/rejects</span>
         <span class="grm-dirty-hint" id="grmFlagsDirtyHint" style="display:none;"></span>
       </label>
@@ -3893,12 +3893,17 @@ function grmRefreshSpeciesKeywordState() {
   });
 }
 
-// User manually toggled a checkbox: record the override, then re-sync labels.
-function grmOnToggleChange() {
-  var spChk = document.getElementById('grmConfirmSpeciesChk');
-  var flChk = document.getElementById('grmApplyFlagsChk');
-  if (spChk) grmState.confirmSpeciesOverride = spChk.checked;
-  if (flChk) grmState.applyFlagsOverride = flChk.checked;
+// User manually toggled a checkbox: record the override for ONLY the box that
+// fired, then re-sync labels. Recording both would pin the untouched box's
+// override and break its smart default (null = follow the dirty heuristic).
+function grmOnToggleChange(which) {
+  if (which === 'species') {
+    var spChk = document.getElementById('grmConfirmSpeciesChk');
+    if (spChk) grmState.confirmSpeciesOverride = spChk.checked;
+  } else if (which === 'flags') {
+    var flChk = document.getElementById('grmApplyFlagsChk');
+    if (flChk) grmState.applyFlagsOverride = flChk.checked;
+  }
   grmUpdateApplyLabel();
 }
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -4856,6 +4856,10 @@ document.addEventListener('contextmenu', function(e) {
 async function grmConfirmSpeciesCall(species, memberIds) {
   if (!species || memberIds.length === 0) return;
   if (grmState.source === 'browse-selection') {
+    // Browse selections are ad-hoc and have no persisted encounter/burst to
+    // confirm, so "Confirm species" here means "tag these frames with the
+    // species keyword" — it does not set species_confirmed (there's nothing
+    // to mark). Pipeline bursts below get full server-owned confirmation.
     await safeFetch('/api/batch/keyword', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ photo_ids: memberIds, name: species, type: 'taxonomy' }),

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -5245,10 +5245,17 @@ async function grmApply() {
         // doesn't inherit the source burst's predictions for photos it no longer
         // contains (the loupe and the saved cache both trust burst.species_predictions).
         var photo = findPhotoInResults(pid);
+        // Preserve a burst-specific confirmed species: if the source burst had
+        // a species_override differing from the encounter default, the detached
+        // single-photo burst must keep it (shallow clone so it doesn't alias the
+        // source), or a flags-only apply would silently revert this photo to the
+        // encounter species and drop the burst-specific confirmation.
         enc.bursts.push({
           photo_ids: [pid],
           species_predictions: buildBurstConsensus(photo ? [photo] : []),
-          species_override: null,
+          species_override: burst && burst.species_override
+            ? Object.assign({}, burst.species_override)
+            : null,
         });
       });
       // Recompute the shortened source burst's consensus from its remaining

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3953,15 +3953,19 @@ function grmUpdateApplyLabel() {
     flHint.textContent = showF ? (n + ' cull change' + (n === 1 ? '' : 's') + " won't be saved") : '';
   }
 
+  // True number of frames the species call will newly tag = all post-apply
+  // burst members (parameterized by checks.flags), not just picks.
+  var tagCount = grmSpeciesTagCount(checks, diff.species);
+
   var parts = [];
   if (checks.flags && diff.flagNew > 0) parts.push('Flag ' + diff.flagNew);
   if (checks.flags && diff.rejectNew > 0) parts.push('Reject ' + diff.rejectNew);
   if (checks.flags && diff.clearNew > 0) parts.push('Clear ' + diff.clearNew);
   if (checks.species && diff.speciesChanged) parts.push('Set species');
-  if (checks.species && diff.tagNew > 0) parts.push('Tag ' + diff.tagNew + (diff.species ? ' as ' + diff.species : ''));
+  if (checks.species && tagCount > 0) parts.push('Tag ' + tagCount + (diff.species ? ' as ' + diff.species : ''));
   if (checks.flags && diff.detachNew > 0) parts.push('Detach ' + diff.detachNew);
   btn.textContent = parts.length ? parts.join(' · ') + ' & Close' : 'Apply and close';
-  btn.title = grmApplyTitle(diff);
+  btn.title = grmApplyTitle(diff, checks.species ? tagCount : 0);
 }
 
 // Diff the current modal zones against the DB snapshot we opened with.
@@ -3974,7 +3978,6 @@ function grmComputeDiff() {
     flagNew: 0,
     rejectNew: 0,
     clearNew: 0,
-    tagNew: 0,
     detachNew: 0,
     speciesChanged: !!(species && grmState && species !== (grmState.initialSpecies || '')),
     species: species
@@ -3988,9 +3991,6 @@ function grmComputeDiff() {
     }
     var st = (grmState.dbState && grmState.dbState[p.id]) || {};
     var oldFlag = st.flag || 'none';
-    var hasKw = species &&
-      grmState.keywordStateSpecies === species &&
-      !!st.has_species_keyword;
     var newFlag;
     if (grmState.picks.has(p.id)) newFlag = 'flagged';
     else if (grmState.rejects.has(p.id)) newFlag = 'rejected';
@@ -4001,7 +4001,6 @@ function grmComputeDiff() {
       else if (newFlag === 'rejected') diff.rejectNew++;
       else diff.clearNew++;
     }
-    if (species && newFlag === 'flagged' && !hasKw) diff.tagNew++;
   });
   return diff;
 }
@@ -4010,13 +4009,33 @@ function grmPlural(n, one, many) {
   return n === 1 ? one : (many || one + 's');
 }
 
-function grmApplyTitle(diff) {
+// Photos that will carry the confirmed species = the burst's post-apply
+// members. A removed photo is excluded only if its removal actually
+// commits (checks.flags); when flags are unchecked the removal is
+// discarded, so the photo stays a member and is tagged.
+function grmSpeciesMemberItems(checks) {
+  return grmState.items.filter(function(p) {
+    return checks.flags ? !grmState.removed.has(p.id) : true;
+  });
+}
+// Count of those members that don't already carry the species keyword
+// (i.e. the number /api/encounters/species will newly tag).
+function grmSpeciesTagCount(checks, species) {
+  if (!species) return 0;
+  return grmSpeciesMemberItems(checks).filter(function(p) {
+    var st = (grmState.dbState && grmState.dbState[p.id]) || {};
+    var hasKw = grmState.keywordStateSpecies === species && !!st.has_species_keyword;
+    return !hasKw;
+  }).length;
+}
+
+function grmApplyTitle(diff, tagCount) {
   var actions = [];
   if (diff.flagNew > 0) actions.push('flag ' + diff.flagNew + ' ' + grmPlural(diff.flagNew, 'photo') + ' as ' + grmPlural(diff.flagNew, 'a pick', 'picks'));
   if (diff.rejectNew > 0) actions.push('reject ' + diff.rejectNew + ' ' + grmPlural(diff.rejectNew, 'photo'));
   if (diff.clearNew > 0) actions.push('clear flags on ' + diff.clearNew + ' ' + grmPlural(diff.clearNew, 'photo'));
   if (diff.speciesChanged) actions.push('set confirmed species to "' + diff.species + '"');
-  if (diff.tagNew > 0) actions.push('add species keyword "' + diff.species + '" to ' + diff.tagNew + ' ' + grmPlural(diff.tagNew, 'pick'));
+  if (tagCount > 0) actions.push('add species keyword "' + diff.species + '" to ' + tagCount + ' ' + grmPlural(tagCount, 'burst frame'));
   if (diff.detachNew > 0) actions.push('detach ' + diff.detachNew + ' ' + grmPlural(diff.detachNew, 'photo') + ' from this burst');
   return actions.length
     ? 'Apply will ' + actions.join(', ') + ', then close this burst.'
@@ -4969,7 +4988,15 @@ async function grmApply() {
   // selection set, not the real pipeline run, and save_results_raw would
   // clobber the actual per-workspace cache. Its species path uses
   // /api/batch/keyword (no cache read), so there is no ordering dependency.
-  if (grmState.source !== 'browse-selection') {
+  //
+  // Also skip when flags weren't committed: the only local mutations to
+  // pipelineResults (label/flag sync + removed→detach) live under the
+  // checks.flags block above, so with flags unchecked there is nothing new to
+  // persist. The species-only path relies on the SERVER to save the cache —
+  // /api/encounters/species loads the on-disk cache and re-saves it itself
+  // (we adopt resp.encounters after) — so a local save-cache here would be a
+  // no-op write on the wire.
+  if (grmState.source !== 'browse-selection' && checks.flags) {
     await safeFetch('/api/pipeline/save-cache', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -4988,9 +5015,16 @@ async function grmApply() {
        pipelineResults.encounters[grmState.encIdx].bursts &&
        pipelineResults.encounters[grmState.encIdx].bursts[grmState.burstIdx]);
     if (burstExists) {
-      var memberIds = grmState.items
-        .filter(function(p) { return !grmState.removed.has(p.id); })
-        .map(function(p) { return p.id; });
+      // Post-apply burst members carry the species. Uses the same rule as the
+      // label/tooltip (grmSpeciesMemberItems): a removed photo is excluded only
+      // when its removal actually committed (checks.flags); otherwise it stays a
+      // member and gets tagged.
+      var memberIds = grmSpeciesMemberItems(checks).map(function(p) { return p.id; });
+      // A species-call failure intentionally throws out of grmApply *before*
+      // close, leaving the modal open so the user can retry. Any flags were
+      // already committed idempotently above, so a retry re-runs only the
+      // species side. No try/catch — propagating the throw is the desired
+      // "keep modal open" behavior.
       await grmConfirmSpeciesCall(species, memberIds);
     }
   }

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -4812,6 +4812,29 @@ document.addEventListener('contextmenu', function(e) {
 
 /* --- Apply & Close --- */
 
+// Confirm species for the burst. Pipeline bursts go through the same endpoint
+// the grid uses (persists confirmation + auto-detach). Browse-selection ad-hoc
+// sets have no encounter, so just tag the keyword on all members.
+async function grmConfirmSpeciesCall(species, memberIds) {
+  if (!species || memberIds.length === 0) return;
+  if (grmState.source === 'browse-selection') {
+    await safeFetch('/api/batch/keyword', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ photo_ids: memberIds, name: species, type: 'taxonomy' }),
+    });
+    return;
+  }
+  var resp = await safeFetch('/api/encounters/species', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ species: species, photo_ids: memberIds, burst_index: grmState.burstIdx }),
+  });
+  // Adopt authoritative structure (mirrors confirmSpecies()).
+  if (resp && resp.encounters) {
+    pipelineResults.encounters = resp.encounters;
+    if (resp.summary) pipelineResults.summary = resp.summary;
+  }
+}
+
 async function grmApply() {
   // Belt-and-suspenders: the button is disabled until seed completes, but
   // a stuck-open modal whose /group/state never resolved (offline, server
@@ -4820,138 +4843,165 @@ async function grmApply() {
     console.warn('grmApply called before /group/state seed completed; ignoring.');
     return;
   }
+  var diff = grmComputeDiff();
+  var checks = grmResolveChecks(diff);
   var species = document.getElementById('grmSpecies').value.trim();
 
-  var picksArr = Array.from(grmState.picks);
-  var rejectsArr = Array.from(grmState.rejects);
-  var candidatesArr = grmState.items
-    .filter(function(p) {
-      return !grmState.picks.has(p.id) && !grmState.rejects.has(p.id) && !grmState.removed.has(p.id);
-    })
-    .map(function(p) { return p.id; });
+  // --- Flags side (picks/rejects/candidates + removed→detach) ---
+  // Only committed when the "Apply picks/rejects" box is checked. Removals are
+  // part of "cull changes", so the removed→detach block is gated here too.
+  if (checks.flags) {
+    var picksArr = Array.from(grmState.picks);
+    var rejectsArr = Array.from(grmState.rejects);
+    var candidatesArr = grmState.items
+      .filter(function(p) {
+        return !grmState.picks.has(p.id) && !grmState.rejects.has(p.id) && !grmState.removed.has(p.id);
+      })
+      .map(function(p) { return p.id; });
 
-  // Persist to the database first. If this fails we abort so the local
-  // pipeline cache and the DB can't drift apart — the prior fire-and-forget
-  // save-cache + no-DB-write was the bug behind this whole change.
-  var applyResp;
-  try {
-    applyResp = await safeFetch('/api/pipeline/group/apply', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        picks: picksArr,
-        rejects: rejectsArr,
-        candidates: candidatesArr,
-        species: species,
-      }),
-    });
-  } catch (e) {
-    console.error('Pipeline group apply failed:', e);
-    return;
-  }
-
-  // Update local pipelineResults with pick/reject/candidate decisions
-  var photoMap = {};
-  pipelineResults.photos.forEach(function(p) { photoMap[p.id] = p; });
-
-  grmState.picks.forEach(function(pid) {
-    var p = photoMap[pid];
-    if (p) p.label = 'KEEP';
-  });
-
-  grmState.rejects.forEach(function(pid) {
-    var p = photoMap[pid];
-    if (p) p.label = 'REJECT';
-  });
-
-  // Candidates (not picked, not rejected, not removed) → REVIEW
-  grmState.items.forEach(function(item) {
-    if (!grmState.picks.has(item.id) && !grmState.rejects.has(item.id) && !grmState.removed.has(item.id)) {
-      var p = photoMap[item.id];
-      if (p) p.label = 'REVIEW';
+    // Persist flags to the database first. If this fails we abort so the local
+    // pipeline cache and the DB can't drift apart — the prior fire-and-forget
+    // save-cache + no-DB-write was the bug behind this whole change.
+    var applyResp;
+    try {
+      applyResp = await safeFetch('/api/pipeline/group/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          picks: picksArr,
+          rejects: rejectsArr,
+          candidates: candidatesArr,
+        }),
+      });
+    } catch (e) {
+      console.error('Pipeline group apply failed:', e);
+      return;
     }
-  });
 
-  // Sync the in-memory pipeline cache's per-photo `flag` with what the
-  // server just wrote, so the badges in the main grid (which read p.flag)
-  // refresh without a full reload.
-  if (applyResp && applyResp.photos) {
-    Object.keys(applyResp.photos).forEach(function(pidStr) {
-      var pid = parseInt(pidStr, 10);
+    // Update local pipelineResults with pick/reject/candidate decisions
+    var photoMap = {};
+    pipelineResults.photos.forEach(function(p) { photoMap[p.id] = p; });
+
+    grmState.picks.forEach(function(pid) {
       var p = photoMap[pid];
-      if (p) p.flag = applyResp.photos[pidStr].flag;
+      if (p) p.label = 'KEEP';
     });
-  }
 
-  if (grmState.source === 'browse-selection') {
-    if (grmState.removed.size > 0) {
-      var encBrowse = pipelineResults.encounters[grmState.encIdx];
-      var keepIds = encBrowse.photo_ids.filter(function(pid) { return !grmState.removed.has(pid); });
-      if (keepIds.length === 0) {
-        // Every photo was removed from the temporary Browse burst. Any
-        // flag/species edits were already persisted by /group/apply above,
-        // so there is nothing left to review. Drop the handoff and degrade
-        // to normal pipeline review instead of stranding the page on an
-        // empty browse-selection encounter (0 photos but still 1 encounter/
-        // 1 burst, with a Reopen flow that can no longer reopen).
-        document.getElementById('grmSpecies').value = '';
-        closeGroupReview();
-        fallbackToNormalPipelineReview();
-        return;
+    grmState.rejects.forEach(function(pid) {
+      var p = photoMap[pid];
+      if (p) p.label = 'REJECT';
+    });
+
+    // Candidates (not picked, not rejected, not removed) → REVIEW
+    grmState.items.forEach(function(item) {
+      if (!grmState.picks.has(item.id) && !grmState.rejects.has(item.id) && !grmState.removed.has(item.id)) {
+        var p = photoMap[item.id];
+        if (p) p.label = 'REVIEW';
       }
-      encBrowse.photo_ids = keepIds;
-      encBrowse.photo_count = keepIds.length;
-      if (encBrowse.bursts && encBrowse.bursts[grmState.burstIdx]) {
-        encBrowse.bursts[grmState.burstIdx].photo_ids = keepIds.slice();
-      }
-      pipelineResults.photos = pipelineResults.photos.filter(function(p) {
-        return !grmState.removed.has(p.id);
+    });
+
+    // Sync the in-memory pipeline cache's per-photo `flag` with what the
+    // server just wrote, so the badges in the main grid (which read p.flag)
+    // refresh without a full reload.
+    if (applyResp && applyResp.photos) {
+      Object.keys(applyResp.photos).forEach(function(pidStr) {
+        var pid = parseInt(pidStr, 10);
+        var p = photoMap[pid];
+        if (p) p.flag = applyResp.photos[pidStr].flag;
       });
     }
-    // Flags/species are now persisted to the DB — the one-shot handoff has
-    // served its purpose, so drop it. A later reload degrades to normal
-    // review; the in-memory group stays reopenable via the Reopen button.
-    clearBrowseBurstHandoff();
-    closeGroupReview();
-    document.getElementById('grmSpecies').value = '';
-    renderResults();
-    updateSummaryBar(refreshLocalSummaryCounts());
-    return;
+
+    if (grmState.source === 'browse-selection') {
+      if (grmState.removed.size > 0) {
+        var encBrowse = pipelineResults.encounters[grmState.encIdx];
+        var keepIds = encBrowse.photo_ids.filter(function(pid) { return !grmState.removed.has(pid); });
+        if (keepIds.length === 0) {
+          // Every photo was removed from the temporary Browse burst. Any
+          // flag edits were already persisted by /group/apply above, so there
+          // is nothing left to review (and no burst left to confirm a species
+          // on). Drop the handoff and degrade to normal pipeline review
+          // instead of stranding the page on an empty browse-selection
+          // encounter (0 photos but still 1 encounter/1 burst, with a Reopen
+          // flow that can no longer reopen).
+          document.getElementById('grmSpecies').value = '';
+          closeGroupReview();
+          fallbackToNormalPipelineReview();
+          return;
+        }
+        encBrowse.photo_ids = keepIds;
+        encBrowse.photo_count = keepIds.length;
+        if (encBrowse.bursts && encBrowse.bursts[grmState.burstIdx]) {
+          encBrowse.bursts[grmState.burstIdx].photo_ids = keepIds.slice();
+        }
+        pipelineResults.photos = pipelineResults.photos.filter(function(p) {
+          return !grmState.removed.has(p.id);
+        });
+      }
+      // Flags are now persisted to the DB — the one-shot handoff has served
+      // its purpose, so drop it. A later reload degrades to normal review;
+      // the in-memory group stays reopenable via the Reopen button.
+      clearBrowseBurstHandoff();
+    } else if (grmState.removed.size > 0) {
+      // Detach removed photos from the burst into new single-photo bursts.
+      var enc = pipelineResults.encounters[grmState.encIdx];
+      var burst = enc.bursts[grmState.burstIdx];
+      var burstIds = burst.photo_ids || burst;
+      grmState.removed.forEach(function(pid) {
+        var idx = burstIds.indexOf(pid);
+        if (idx >= 0) burstIds.splice(idx, 1);
+        // Add as a new single-photo burst in the same encounter
+        enc.bursts.push({ photo_ids: [pid], species_predictions: burst.species_predictions || [], species_override: null });
+      });
+      // Clean up empty burst
+      if (burstIds.length === 0) {
+        enc.bursts.splice(grmState.burstIdx, 1);
+      }
+      enc.burst_count = enc.bursts.length;
+    }
   }
 
-  // Detach removed photos from the burst into new single-photo bursts
-  if (grmState.removed.size > 0) {
-    var enc = pipelineResults.encounters[grmState.encIdx];
-    var burst = enc.bursts[grmState.burstIdx];
-    var burstIds = burst.photo_ids || burst;
-    grmState.removed.forEach(function(pid) {
-      var idx = burstIds.indexOf(pid);
-      if (idx >= 0) burstIds.splice(idx, 1);
-      // Add as a new single-photo burst in the same encounter
-      enc.bursts.push({ photo_ids: [pid], species_predictions: burst.species_predictions || [], species_override: null });
+  // Save the updated pipeline cache (label + flag changes + detached bursts)
+  // BEFORE confirming species: /api/encounters/species reloads the cache from
+  // disk and validates photo_ids ⊆ bursts[burst_index], so the structure the
+  // user sees must be persisted first.
+  //
+  // Skip for browse-selection: pipelineResults there is a *temporary* ad-hoc
+  // selection set, not the real pipeline run, and save_results_raw would
+  // clobber the actual per-workspace cache. Its species path uses
+  // /api/batch/keyword (no cache read), so there is no ordering dependency.
+  if (grmState.source !== 'browse-selection') {
+    await safeFetch('/api/pipeline/save-cache', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(pipelineResults),
     });
-    // Clean up empty burst
-    if (burstIds.length === 0) {
-      enc.bursts.splice(grmState.burstIdx, 1);
-    }
-    enc.burst_count = enc.bursts.length;
   }
 
-  // Update species if changed
-  if (species) {
-    var enc = pipelineResults.encounters[grmState.encIdx];
-    if (enc) {
-      enc.confirmed_species = species;
-      enc.species_confirmed = true;
+  // --- Species side ---
+  // Server-owned now: tag all remaining (non-removed) burst frames + mark the
+  // burst confirmed via the unified endpoint. Removed photos are excluded so
+  // they aren't tagged. Skip when the burst no longer exists (emptied by the
+  // detach above) or has no members left.
+  if (checks.species) {
+    var burstExists = grmState.source === 'browse-selection' ||
+      (pipelineResults.encounters[grmState.encIdx] &&
+       pipelineResults.encounters[grmState.encIdx].bursts &&
+       pipelineResults.encounters[grmState.encIdx].bursts[grmState.burstIdx]);
+    if (burstExists) {
+      var memberIds = grmState.items
+        .filter(function(p) { return !grmState.removed.has(p.id); })
+        .map(function(p) { return p.id; });
+      await grmConfirmSpeciesCall(species, memberIds);
     }
   }
 
-  // Save the updated pipeline cache (label + flag changes + detached bursts).
-  safeFetch('/api/pipeline/save-cache', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(pipelineResults),
-  });
+  // Browse-selection is a one-shot handoff: drop it on close regardless of
+  // which side was committed, so a reload degrades to normal review instead
+  // of reopening a burst whose edits already landed. (Idempotent with the
+  // call inside the flags block above.)
+  if (grmState.source === 'browse-selection') {
+    clearBrowseBurstHandoff();
+  }
 
   closeGroupReview();
   // Clear the species input for next use

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3579,17 +3579,24 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
 
   var items = photoIds.map(function(pid) { return photoMap[pid]; }).filter(Boolean);
 
-  // Reset the species input to this encounter's value so a stale value from a
+  // Reset the species input to this burst's value so a stale value from a
   // previously-reviewed group doesn't leak in when the prior modal was closed
-  // via × or Escape (only Apply & Close clears it).
-  var initialSpecies = enc.confirmed_species || (enc.species ? enc.species[0] : '') || '';
+  // via × or Escape (only Apply & Close clears it). A per-burst override wins
+  // over the encounter label/prediction so the field reflects what THIS burst
+  // is actually tagged/confirmed as — otherwise applying flags-only would post
+  // the encounter species and silently replace the burst's existing override
+  // (untag X, tag Y). Matches renderSpeciesWidget's burst-override precedence.
+  var burstOvr = burst && burst.species_override;
+  var initialSpecies = (burstOvr && burstOvr.species)
+    || enc.confirmed_species
+    || (enc.species ? enc.species[0] : '')
+    || '';
 
   // The species this burst is ACTUALLY confirmed as (vs initialSpecies, which
   // falls back to the unconfirmed top prediction so the input pre-fills). The
   // "Confirm species" checkbox smart-default keys off THIS: if the field value
   // differs from what's already confirmed, confirming is a meaningful action
   // (including confirming a so-far-unconfirmed prediction). '' = unconfirmed.
-  var burstOvr = burst && burst.species_override;
   var initialConfirmedSpecies = '';
   if (burstOvr && burstOvr.confirmed === true && burstOvr.species) {
     initialConfirmedSpecies = burstOvr.species;

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -996,6 +996,10 @@ input[type="range"]::-moz-range-thumb {
   flex-shrink: 0;
 }
 .grm-footer .grm-hint { font-size: 11px; color: var(--text-ghost); flex: 1; }
+.grm-commit-toggle { display:flex; align-items:center; gap:6px; font-size:12px;
+  color: var(--text-muted); cursor:pointer; user-select:none; }
+.grm-commit-toggle input { cursor:pointer; }
+.grm-dirty-hint { font-size:11px; color: var(--warning, #e0a800); }
 .grm-res-control,
 .grm-loupe-zoom-control {
   display: flex;
@@ -1475,7 +1479,21 @@ input[type="range"]::-moz-range-thumb {
       <span id="grmLoupeZoomVal">1×</span>
     </div>
     <span class="grm-hint" id="grmHint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Z = right 1:1 &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
-    <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);" title="Apply pick/reject flag changes and species keywords, then close this burst.">Apply flags/species & Close</button>
+    <div class="grm-commit-group" style="margin-left:auto;display:flex;align-items:center;gap:14px;">
+      <label class="grm-commit-toggle">
+        <input type="checkbox" id="grmConfirmSpeciesChk" onchange="grmOnToggleChange()">
+        <span>Confirm species</span>
+        <span class="grm-dirty-hint" id="grmSpeciesDirtyHint" style="display:none;"></span>
+      </label>
+      <label class="grm-commit-toggle">
+        <input type="checkbox" id="grmApplyFlagsChk" onchange="grmOnToggleChange()">
+        <span>Apply picks/rejects</span>
+        <span class="grm-dirty-hint" id="grmFlagsDirtyHint" style="display:none;"></span>
+      </label>
+      <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept"
+        style="padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);"
+        title="Commit whichever boxes are checked, then close this burst.">Apply and close</button>
+    </div>
   </div>
 </div>
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3984,7 +3984,7 @@ function grmUpdateApplyLabel() {
   if (checks.species && tagCount > 0) parts.push('Tag ' + tagCount + (diff.species ? ' as ' + diff.species : ''));
   if (checks.flags && diff.detachNew > 0) parts.push('Detach ' + diff.detachNew);
   btn.textContent = parts.length ? parts.join(' · ') + ' & Close' : 'Apply and close';
-  btn.title = grmApplyTitle(diff, checks.species ? tagCount : 0);
+  btn.title = grmApplyTitle(diff, checks, checks.species ? tagCount : 0);
 }
 
 // Diff the current modal zones against the DB snapshot we opened with.
@@ -4048,14 +4048,18 @@ function grmSpeciesTagCount(checks, species) {
   }).length;
 }
 
-function grmApplyTitle(diff, tagCount) {
+function grmApplyTitle(diff, checks, tagCount) {
+  // Gate each action by the same checkbox that actually commits it, so the
+  // tooltip never promises a write that the current selection won't perform.
+  // "Apply picks/rejects" owns flag changes AND removed-photo detach; the
+  // species checkbox owns the confirmed-species + keyword-tag writes.
   var actions = [];
-  if (diff.flagNew > 0) actions.push('flag ' + diff.flagNew + ' ' + grmPlural(diff.flagNew, 'photo') + ' as ' + grmPlural(diff.flagNew, 'a pick', 'picks'));
-  if (diff.rejectNew > 0) actions.push('reject ' + diff.rejectNew + ' ' + grmPlural(diff.rejectNew, 'photo'));
-  if (diff.clearNew > 0) actions.push('clear flags on ' + diff.clearNew + ' ' + grmPlural(diff.clearNew, 'photo'));
-  if (diff.speciesChanged) actions.push('set confirmed species to "' + diff.species + '"');
-  if (tagCount > 0) actions.push('add species keyword "' + diff.species + '" to ' + tagCount + ' ' + grmPlural(tagCount, 'burst frame'));
-  if (diff.detachNew > 0) actions.push('detach ' + diff.detachNew + ' ' + grmPlural(diff.detachNew, 'photo') + ' from this burst');
+  if (checks.flags && diff.flagNew > 0) actions.push('flag ' + diff.flagNew + ' ' + grmPlural(diff.flagNew, 'photo') + ' as ' + grmPlural(diff.flagNew, 'a pick', 'picks'));
+  if (checks.flags && diff.rejectNew > 0) actions.push('reject ' + diff.rejectNew + ' ' + grmPlural(diff.rejectNew, 'photo'));
+  if (checks.flags && diff.clearNew > 0) actions.push('clear flags on ' + diff.clearNew + ' ' + grmPlural(diff.clearNew, 'photo'));
+  if (checks.species && diff.speciesChanged) actions.push('set confirmed species to "' + diff.species + '"');
+  if (checks.species && tagCount > 0) actions.push('add species keyword "' + diff.species + '" to ' + tagCount + ' ' + grmPlural(tagCount, 'burst frame'));
+  if (checks.flags && diff.detachNew > 0) actions.push('detach ' + diff.detachNew + ' ' + grmPlural(diff.detachNew, 'photo') + ' from this burst');
   return actions.length
     ? 'Apply will ' + actions.join(', ') + ', then close this burst.'
     : 'Apply will make no database changes, then close this burst.';

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3584,6 +3584,19 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   // via × or Escape (only Apply & Close clears it).
   var initialSpecies = enc.confirmed_species || (enc.species ? enc.species[0] : '') || '';
 
+  // The species this burst is ACTUALLY confirmed as (vs initialSpecies, which
+  // falls back to the unconfirmed top prediction so the input pre-fills). The
+  // "Confirm species" checkbox smart-default keys off THIS: if the field value
+  // differs from what's already confirmed, confirming is a meaningful action
+  // (including confirming a so-far-unconfirmed prediction). '' = unconfirmed.
+  var burstOvr = burst && burst.species_override;
+  var initialConfirmedSpecies = '';
+  if (burstOvr && burstOvr.confirmed === true && burstOvr.species) {
+    initialConfirmedSpecies = burstOvr.species;
+  } else if (enc.species_confirmed && enc.confirmed_species) {
+    initialConfirmedSpecies = enc.confirmed_species;
+  }
+
   // Bump the session id so any in-flight /group/state fetch from a previous
   // openGroupReview call lands as stale and gets ignored when it resolves.
   var sessionId = (grmState.sessionId || 0) + 1;
@@ -3611,6 +3624,7 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
     dbState: {},
     keywordStateSpecies: initialSpecies,
     initialSpecies: initialSpecies,
+    initialConfirmedSpecies: initialConfirmedSpecies,
     source: source,
     allowRemove: allowRemove,
     sessionId: sessionId,
@@ -3984,7 +3998,7 @@ function grmComputeDiff() {
     rejectNew: 0,
     clearNew: 0,
     detachNew: 0,
-    speciesChanged: !!(species && grmState && species !== (grmState.initialSpecies || '')),
+    speciesChanged: !!(species && grmState && species !== (grmState.initialConfirmedSpecies || '')),
     species: species
   };
   if (!grmState || !grmState.items) return diff;

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -832,7 +832,22 @@ def test_encounter_species_change_cancels_pending_add(app_and_db):
     """Changing the confirmed species before sync cancels the stale add."""
     app, db = app_and_db
     client = app.test_client()
-    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+    # The conftest fixture pre-tags one photo with "Sparrow" via a direct
+    # db.tag_photo (no pending add). Restrict this test to photos that do NOT
+    # already carry Sparrow so the first confirm genuinely queues a pending
+    # add for every photo — that pending add is what the replacement should
+    # cancel (rather than queueing a keyword_remove for a never-synced tag).
+    sparrow_pre = db.conn.execute(
+        """SELECT pk.photo_id FROM photo_keywords pk
+           JOIN keywords k ON k.id = pk.keyword_id
+           WHERE k.name = 'Sparrow'"""
+    ).fetchall()
+    pre_tagged = {r["photo_id"] for r in sparrow_pre}
+    photo_ids = [
+        p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()
+        if p["id"] not in pre_tagged
+    ]
+    assert photo_ids, "expected at least one photo not pre-tagged with Sparrow"
 
     _seed_encounter_cache(app, db, photo_ids)
 
@@ -1066,6 +1081,108 @@ def test_encounter_species_replacement_redo_reapplies(app_and_db):
         names = {k["name"] for k in db.get_photo_keywords(pid)}
         assert "Blue Jay" in names
         assert "Sparrow" not in names
+
+
+def test_encounter_species_no_op_when_all_already_tagged(app_and_db):
+    """Confirming a species every submitted photo already carries records NO
+    new keyword_add edit, so there's nothing on the undo stack to later
+    destructively remove the pre-existing keyword.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+
+    _seed_encounter_cache(app, db, photo_ids)
+    # First confirm tags every photo and records one keyword_add.
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Blue Jay", "photo_ids": photo_ids})
+    assert resp.status_code == 200
+    assert len(db.get_edit_history()) == 1
+
+    # Re-confirm the SAME species on the SAME photos: all already tagged.
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Blue Jay", "photo_ids": photo_ids})
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+
+    # No new edit-history entry: the redundant confirm was a no-op.
+    assert len(db.get_edit_history()) == 1
+
+    # The pre-existing keyword survives — undoing leaves it intact (there's
+    # nothing the redundant confirm could have queued to remove).
+    for pid in photo_ids:
+        names = {k["name"] for k in db.get_photo_keywords(pid)}
+        assert "Blue Jay" in names
+
+
+def test_encounter_species_records_only_newly_tagged(app_and_db):
+    """A mixed set (some already carry the species, some don't) records edit
+    items ONLY for the newly-tagged photos.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+    assert len(photo_ids) >= 2
+
+    # Pre-tag the first photo with the species keyword directly.
+    kid = db.add_keyword("Blue Jay", is_species=True)
+    db.tag_photo(photo_ids[0], kid)
+
+    _seed_encounter_cache(app, db, photo_ids)
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Blue Jay", "photo_ids": photo_ids})
+    assert resp.status_code == 200
+
+    history = db.get_edit_history()
+    assert len(history) == 1
+    assert history[0]["action_type"] == "keyword_add"
+    # Only the (len - 1) newly-tagged photos are in the edit items.
+    assert history[0]["item_count"] == len(photo_ids) - 1
+
+    # Undoing removes the species only from the photos that were newly tagged;
+    # the pre-tagged photo keeps it.
+    db.undo_last_edit()
+    assert "Blue Jay" in {k["name"] for k in db.get_photo_keywords(photo_ids[0])}
+    for pid in photo_ids[1:]:
+        assert "Blue Jay" not in {k["name"] for k in db.get_photo_keywords(pid)}
+
+
+def test_encounter_species_replacement_only_for_changed_photos(app_and_db):
+    """Replacement records the replace only for photos that actually had the
+    old species, and the add side only for photos that actually gained the new
+    one.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+    photo_ids = [p["id"] for p in db.conn.execute("SELECT id FROM photos").fetchall()]
+    assert len(photo_ids) >= 2
+
+    _seed_encounter_cache(app, db, photo_ids)
+    # Confirm Sparrow on ALL photos.
+    client.post("/api/encounters/species",
+                json={"species": "Sparrow", "photo_ids": photo_ids})
+    # Then untag the last photo's Sparrow so it no longer carries the old
+    # species (simulates a partially-tagged burst on re-confirm).
+    sparrow_id = db.conn.execute(
+        "SELECT id FROM keywords WHERE name='Sparrow' AND is_species=1"
+    ).fetchone()["id"]
+    db.untag_photo(photo_ids[-1], sparrow_id)
+    db.conn.execute("DELETE FROM edit_history")
+    db.conn.commit()
+
+    # Replace Sparrow -> Blue Jay across all photos.
+    resp = client.post("/api/encounters/species",
+                       json={"species": "Blue Jay", "photo_ids": photo_ids})
+    assert resp.status_code == 200
+
+    history = db.get_edit_history()
+    assert len(history) == 1
+    assert history[0]["action_type"] == "species_replace"
+    # All photos gained Blue Jay (none had it), so all are recorded.
+    assert history[0]["item_count"] == len(photo_ids)
+    for pid in photo_ids:
+        assert "Blue Jay" in {k["name"] for k in db.get_photo_keywords(pid)}
+        assert "Sparrow" not in {k["name"] for k in db.get_photo_keywords(pid)}
 
 
 def test_encounter_species_rejects_photo_ids_not_in_burst(app_and_db):

--- a/vireo/tests/test_pipeline_group_apply.py
+++ b/vireo/tests/test_pipeline_group_apply.py
@@ -11,7 +11,9 @@ def _photo_ids(db):
     return [p['id'] for p in db.get_photos()]
 
 
-def test_apply_flags_picks_rejects_and_adds_keyword(app_and_db):
+def test_apply_flags_picks_rejects_and_ignores_species(app_and_db):
+    """Flags-only contract: apply writes pick/reject flags but the endpoint
+    no longer tags species (species confirmation moves to a dedicated path)."""
     app, db = app_and_db
     pids = _photo_ids(db)
     pick_id, reject_id = pids[0], pids[1]
@@ -30,18 +32,45 @@ def test_apply_flags_picks_rejects_and_adds_keyword(app_and_db):
     assert db.get_photo(pick_id)['flag'] == 'flagged'
     assert db.get_photo(reject_id)['flag'] == 'rejected'
 
+    # No species keyword is tagged on the pick.
     pick_kws = {k['name'] for k in db.get_photo_keywords(pick_id)}
-    assert 'Coyote' in pick_kws
+    assert 'Coyote' not in pick_kws
 
-    # Reject should NOT get the species keyword.
+    # Reject also has no species keyword.
     reject_kws = {k['name'] for k in db.get_photo_keywords(reject_id)}
     assert 'Coyote' not in reject_kws
 
     # Returned per-photo state matches what we just wrote.
     photos = data['photos']
     assert photos[str(pick_id)]['flag'] == 'flagged'
-    assert photos[str(pick_id)]['has_species_keyword'] is True
+    assert photos[str(pick_id)]['has_species_keyword'] is False
     assert photos[str(reject_id)]['flag'] == 'rejected'
+    assert photos[str(reject_id)]['has_species_keyword'] is False
+
+
+def test_group_apply_ignores_species_and_tags_nothing(app_and_db):
+    """Posting `species` applies flags but tags NO species keyword."""
+    app, db = app_and_db
+    pids = _photo_ids(db)
+    p1, p2 = pids[0], pids[1]
+    client = app.test_client()
+
+    resp = client.post('/api/pipeline/group/apply', json={
+        'picks': [p1],
+        'rejects': [p2],
+        'candidates': [],
+        'species': 'Blue Jay',
+    })
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # Flags still applied.
+    assert body['photos'][str(p1)]['flag'] == 'flagged'
+    assert body['photos'][str(p2)]['flag'] == 'rejected'
+    # But NO species keyword was added to the pick.
+    assert body['photos'][str(p1)]['has_species_keyword'] is False
+    # And the DB has no species keyword on p1.
+    kws = db.get_photo_keywords(p1)
+    assert not any(k['name'] == 'Blue Jay' for k in kws)
 
 
 def test_apply_clears_flag_when_photo_moved_to_candidates(app_and_db):
@@ -126,12 +155,10 @@ def test_apply_skips_keyword_when_already_applied(app_and_db):
     assert pending == 0
 
 
-def test_apply_cancels_pending_keyword_remove(app_and_db):
-    """If a `keyword_remove` for the same species is already pending sync,
-    a pick that adds that species must cancel the remove rather than queue a
-    contradictory `keyword_add` alongside it. sync_to_xmp applies removes
-    after adds, so a leftover remove would strip the tag from XMP even
-    though the DB has it."""
+def test_apply_does_not_touch_keyword_pending_changes(app_and_db):
+    """Flags-only contract: the endpoint no longer tags species, so it must not
+    queue, cancel, or otherwise modify keyword pending changes. A pre-existing
+    `keyword_remove` is left untouched, and no `keyword_add` is queued."""
     app, db = app_and_db
     pids = _photo_ids(db)
     pid = pids[0]
@@ -153,14 +180,15 @@ def test_apply_cancels_pending_keyword_remove(app_and_db):
         (pid, db._active_workspace_id),
     ).fetchall()
     types = {row['change_type'] for row in pending}
-    # The remove must be cancelled and no add queued in its place.
-    assert 'keyword_remove' not in types
+    # The remove is left untouched and no add is queued in its place.
+    assert 'keyword_remove' in types
     assert 'keyword_add' not in types
 
 
 def test_apply_records_edit_history_for_undo(app_and_db):
-    """Flag and keyword changes must be recorded in edit_history so undo
-    works the same way it does on the regular review page."""
+    """Flag changes must be recorded in edit_history so undo works the same way
+    it does on the regular review page. Flags-only: no `keyword_add` history is
+    recorded by this endpoint anymore (species moves to a dedicated path)."""
     app, db = app_and_db
     pids = _photo_ids(db)
     pid = pids[0]
@@ -180,7 +208,7 @@ def test_apply_records_edit_history_for_undo(app_and_db):
     ).fetchall()
     actions = [r['action_type'] for r in rows]
     assert 'flag' in actions
-    assert 'keyword_add' in actions
+    assert 'keyword_add' not in actions
 
 
 def test_apply_rejects_conflicting_zones(app_and_db):


### PR DESCRIPTION
## Summary

In the Review Burst Group modal you couldn't independently confirm "yes, this is the species" and "yes, I accept the picks/rejects" — the single **"Apply flags/species & Close"** button fused both (and closing) into one action. This splits them.

- **Two smart-defaulted checkboxes + one "Apply and close" button.** "Confirm species" auto-checks when there's a real species confirmation to make (including accepting an as-yet-unconfirmed prediction); "Apply picks/rejects" auto-checks when there are pending flag/removal changes. Unchecking a box that has pending changes surfaces an amber "won't be saved" hint, so closing never silently drops work (No black boxes).
- **Backend unified.** `/api/pipeline/group/apply` is now **flags-only**. Species confirmation routes through the same `/api/encounters/species` endpoint the grid's ✓ already uses — so "confirmed in the modal" and "confirmed in the grid" are finally the **same persisted state**: tags every frame in the burst, server-owned `species_confirmed`, species replacement (untag old), and auto-detach on species mismatch. Previously the modal only set a cache-only confirmation flag and tagged just the picks.
- **Rapid review migrated too.** `pipeline_rapid_review.html` was a second caller of the gutted endpoint; it now persists species via the unified path (it had been marking encounters confirmed while writing no keyword).

### Label/hint truthfulness
The button label and amber hints are scoped to the checked sides and report the **actual** writes — e.g. the species tag count reflects all burst frames that will be tagged (not just picks), worded "burst frames".

## Design / plan
- `docs/plans/2026-05-29-burst-group-confirm-split-design.md`
- `docs/plans/2026-05-29-burst-group-confirm-split.md`

## Test results
- Regression bundle (workspaces, db, app, photos/edits/jobs/darktable/config APIs, pipeline group apply): **1022 passed, 1 skipped**.
- E2E (Playwright, real DB/cache assertions): `test_burst_group_confirm_split.py`, `test_pipeline_review_species.py`, `test_pipeline_rapid_review.py` — **31 passed**.

New E2E coverage asserts real persisted state for: smart-default checkbox states, amber hint on unchecked-dirty, species-only apply (flags untouched, all frames tagged, burst confirmed), flags-only apply (species unconfirmed), and species-only-with-removed-photo (removal discarded, photo stays a member and still gets tagged).

## Known follow-ups (out of scope)
- The modal footer overflows below ~1280px viewport (pre-existing; the modal targets large pixel-peeping displays). A `flex-wrap` would fix it for all widths.
- After a real auto-detach during rapid review, the queue sidebar can show stale entries until reload (cache itself is correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review Burst Group modal now separates “Confirm species” and “Apply picks/rejects” with smart-defaults, amber “won’t be saved” hints, and a single “Apply and close” that commits only checked actions. Apply/tooltip wording now reflects burst-wide tagging and precise actions.

* **Documentation**
  * Added implementation plan detailing the decoupled workflow, checkbox logic, and UX behaviors.

* **Tests**
  * Added/updated E2E tests covering smart defaults, dirty hints, species-only, flags-only, detach/regression cases, and rapid-review flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/920?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->