### PR TITLE
Review modals: compact keyboard hints into a keycap bar + mouse popover

### DIFF
--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1019,7 +1019,74 @@ input[type="range"]::-moz-range-thumb {
   background: var(--bg-secondary);
   flex-shrink: 0;
 }
-.grm-footer .grm-hint { font-size: 11px; color: var(--text-ghost); flex: 1; }
+.grm-keys-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  padding: 7px 20px;
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border-primary);
+  font-size: 11px;
+  color: var(--text-ghost);
+  flex-shrink: 0;
+}
+.grm-keys-bar .grm-key { display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; }
+.grm-keys-bar kbd {
+  display: inline-block;
+  min-width: 14px;
+  padding: 1px 6px;
+  text-align: center;
+  border-radius: 4px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-secondary);
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 10px;
+  line-height: 1.7;
+}
+.grm-mouse-help {
+  position: relative;
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  cursor: help;
+  color: var(--text-dim);
+}
+.grm-mouse-help .grm-mouse-help-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  border: 1px solid var(--border-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+.grm-mouse-pop {
+  display: none;
+  position: absolute;
+  bottom: calc(100% + 8px);
+  right: 0;
+  width: max-content;
+  max-width: 280px;
+  padding: 8px 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.35);
+  color: var(--text-secondary);
+  line-height: 1.8;
+  text-align: left;
+  z-index: 10;
+}
+.grm-mouse-pop strong { display: block; color: var(--text-primary); margin-bottom: 4px; font-size: 11px; }
+.grm-mouse-help:hover .grm-mouse-pop,
+.grm-mouse-help:focus .grm-mouse-pop,
+.grm-mouse-help:focus-within .grm-mouse-pop { display: block; }
 .grm-commit-toggle { display:flex; align-items:center; gap:6px; font-size:12px;
   color: var(--text-muted); cursor:pointer; user-select:none; }
 .grm-commit-toggle input { cursor:pointer; }
@@ -1513,7 +1580,6 @@ input[type="range"]::-moz-range-thumb {
       <input type="range" id="grmLoupeZoomSlider" min="100" max="500" step="25" value="100" oninput="grmSetLoupeZoom(this.value)">
       <span id="grmLoupeZoomVal">1×</span>
     </div>
-    <span class="grm-hint" id="grmHint">P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Z = right 1:1 &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
     <div class="grm-commit-group" style="margin-left:auto;display:flex;align-items:center;gap:14px;">
       <label class="grm-commit-toggle">
         <input type="checkbox" id="grmConfirmSpeciesChk" onchange="grmOnToggleChange('species')">
@@ -1529,6 +1595,24 @@ input[type="range"]::-moz-range-thumb {
         style="padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;background:var(--accent);color:var(--accent-text);"
         title="Commit whichever boxes are checked, then close this burst.">Apply and close</button>
     </div>
+  </div>
+  <div class="grm-keys-bar">
+    <span class="grm-key"><kbd>P</kbd> pick</span>
+    <span class="grm-key"><kbd>X</kbd> reject</span>
+    <span class="grm-key"><kbd>↑↓</kbd> move zone</span>
+    <span class="grm-key" id="grmKeyNav"><kbd>←→</kbd> navigate</span>
+    <span class="grm-key"><kbd>Space</kbd> unsort</span>
+    <span class="grm-key" id="grmKeyRemove"><kbd>Del</kbd> remove</span>
+    <span class="grm-key"><kbd>Z</kbd> right 1:1</span>
+    <span class="grm-mouse-help" tabindex="0" role="button" aria-label="Mouse controls">
+      <span class="grm-mouse-help-icon">?</span> mouse
+      <span class="grm-mouse-pop">
+        <strong>Mouse</strong>
+        Click the preview to lock/unlock zoom<br>
+        Drag a thumbnail to pan it<br>
+        Double-click a thumbnail to reset pan
+      </span>
+    </span>
   </div>
 </div>
 
@@ -3774,12 +3858,13 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
       ? 'Remove this photo from the temporary review set'
       : 'Detach this photo from the burst group on apply';
   }
-  var hint = document.getElementById('grmHint');
-  if (hint) {
-    hint.innerHTML = isSinglePhotoReview && source !== 'browse-selection'
-      ? 'P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; Space = unsort &nbsp; Click preview to lock/unlock zoom &nbsp; Drag thumbnail to pan; double-click to reset'
-      : 'P = pick &nbsp; X = reject &nbsp; ↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset';
-  }
+  // Navigate (←→) only makes sense with more than one frame; remove (Del)
+  // tracks the Remove button's availability. Keep these keycaps honest so the
+  // bar never advertises a shortcut that does nothing in the current context.
+  var navKey = document.getElementById('grmKeyNav');
+  if (navKey) navKey.style.display = (isSinglePhotoReview && source !== 'browse-selection') ? 'none' : '';
+  var removeKey = document.getElementById('grmKeyRemove');
+  if (removeKey) removeKey.style.display = (allowRemove === false) ? 'none' : '';
   grmSetThumbSize(GRM_CARD_W, false);
 
   // Disable Apply while we wait for /group/state — clicking it before

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1604,7 +1604,7 @@ input[type="range"]::-moz-range-thumb {
     <span class="grm-key"><kbd>Space</kbd> unsort</span>
     <span class="grm-key" id="grmKeyRemove"><kbd>Del</kbd> remove</span>
     <span class="grm-key"><kbd>Z</kbd> right 1:1</span>
-    <span class="grm-mouse-help" tabindex="0" role="button" aria-label="Mouse controls">
+    <span class="grm-mouse-help" tabindex="0" aria-label="Mouse controls">
       <span class="grm-mouse-help-icon">?</span> mouse
       <span class="grm-mouse-pop">
         <strong>Mouse</strong>
@@ -5140,6 +5140,10 @@ function grmRemoveFromGroup() {
 document.addEventListener('keydown', function(e) {
   if (!document.getElementById('grmOverlay').classList.contains('open')) return;
   if (e.target.tagName === 'INPUT') return;
+  // The mouse-help control is focusable so keyboard users can read its
+  // popover; don't let keystrokes there (e.g. Space) fall through to the
+  // review shortcuts and mutate the selected photo's state.
+  if (e.target.closest && e.target.closest('.grm-mouse-help')) return;
 
   if (e.key === 'Escape') { closeGroupReview(); e.preventDefault(); return; }
   if (e.key === 'ArrowUp') { grmMoveUp(); e.preventDefault(); return; }

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -479,7 +479,74 @@
     background: var(--bg-secondary, #0E2A3D);
     flex-shrink: 0;
   }
-  .grm-footer .grm-hint { font-size: 11px; color: var(--text-ghost, #555); flex: 1; }
+  .grm-keys-bar {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px 14px;
+    padding: 7px 20px;
+    background: var(--bg-secondary, #0E2A3D);
+    border-top: 1px solid var(--border-primary, #1A4560);
+    font-size: 11px;
+    color: var(--text-ghost, #555);
+    flex-shrink: 0;
+  }
+  .grm-keys-bar .grm-key { display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; }
+  .grm-keys-bar kbd {
+    display: inline-block;
+    min-width: 14px;
+    padding: 1px 6px;
+    text-align: center;
+    border-radius: 4px;
+    background: var(--bg-tertiary, #14374E);
+    border: 1px solid var(--border-secondary, #1A4560);
+    color: var(--text-muted, #888);
+    font-family: inherit;
+    font-size: 10px;
+    line-height: 1.7;
+  }
+  .grm-mouse-help {
+    position: relative;
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    cursor: help;
+    color: var(--text-dim, #6a8a9a);
+  }
+  .grm-mouse-help .grm-mouse-help-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    border: 1px solid var(--border-secondary, #1A4560);
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--text-muted, #888);
+  }
+  .grm-mouse-pop {
+    display: none;
+    position: absolute;
+    bottom: calc(100% + 8px);
+    right: 0;
+    width: max-content;
+    max-width: 280px;
+    padding: 8px 12px;
+    background: var(--bg-tertiary, #14374E);
+    border: 1px solid var(--border-primary, #1A4560);
+    border-radius: 6px;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.35);
+    color: var(--text-secondary, #B0D0D0);
+    line-height: 1.8;
+    text-align: left;
+    z-index: 10;
+  }
+  .grm-mouse-pop strong { display: block; color: var(--text-primary, #E0F0F0); margin-bottom: 4px; font-size: 11px; }
+  .grm-mouse-help:hover .grm-mouse-pop,
+  .grm-mouse-help:focus .grm-mouse-pop,
+  .grm-mouse-help:focus-within .grm-mouse-pop { display: block; }
   .grm-res-control,
   .grm-loupe-zoom-control {
     display: flex;
@@ -2653,8 +2720,24 @@ document.addEventListener('keydown', function(e) {
       <input type="range" id="grmLoupeZoomSlider" min="100" max="500" step="25" value="100" oninput="grmSetLoupeZoom(this.value)">
       <span id="grmLoupeZoomVal">1×</span>
     </div>
-    <span class="grm-hint">↑↓ move zone &nbsp; ←→ navigate &nbsp; Space = unsort &nbsp; Del = remove &nbsp; Z = right 1:1 &nbsp; 1 = strip 1:1 &nbsp; Click preview to lock/unlock zoom &nbsp; Drag a thumbnail to pan it; double-click to reset</span>
     <button id="grmApplyBtn" onclick="grmApply()" class="btn-batch-accept" style="margin-left:auto;padding:8px 20px;border:none;border-radius:4px;font-size:13px;font-weight:600;cursor:pointer;">Apply & Close</button>
+  </div>
+  <div class="grm-keys-bar">
+    <span class="grm-key"><kbd>↑↓</kbd> move zone</span>
+    <span class="grm-key"><kbd>←→</kbd> navigate</span>
+    <span class="grm-key"><kbd>Space</kbd> unsort</span>
+    <span class="grm-key"><kbd>Del</kbd> remove</span>
+    <span class="grm-key"><kbd>Z</kbd> right 1:1</span>
+    <span class="grm-key"><kbd>1</kbd> strip 1:1</span>
+    <span class="grm-mouse-help" tabindex="0" role="button" aria-label="Mouse controls">
+      <span class="grm-mouse-help-icon">?</span> mouse
+      <span class="grm-mouse-pop">
+        <strong>Mouse</strong>
+        Click the preview to lock/unlock zoom<br>
+        Drag a thumbnail to pan it<br>
+        Double-click a thumbnail to reset pan
+      </span>
+    </span>
   </div>
 </div>
 

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -486,7 +486,7 @@
     gap: 6px 14px;
     padding: 7px 20px;
     background: var(--bg-secondary, #0E2A3D);
-    border-top: 1px solid var(--border-primary, #1A4560);
+    border-top: 1px solid var(--border-primary, #14374E);
     font-size: 11px;
     color: var(--text-ghost, #555);
     flex-shrink: 0;
@@ -535,7 +535,7 @@
     max-width: 280px;
     padding: 8px 12px;
     background: var(--bg-tertiary, #14374E);
-    border: 1px solid var(--border-primary, #1A4560);
+    border: 1px solid var(--border-primary, #14374E);
     border-radius: 6px;
     box-shadow: 0 4px 16px rgba(0,0,0,0.35);
     color: var(--text-secondary, #B0D0D0);
@@ -2642,6 +2642,10 @@ async function grmApply() {
 document.addEventListener('keydown', function(e) {
   if (!document.getElementById('grmOverlay').classList.contains('open')) return;
   if (e.target.tagName === 'INPUT') return;
+  // The mouse-help control is focusable so keyboard users can read its
+  // popover; don't let keystrokes there (e.g. Space) fall through to the
+  // review shortcuts and mutate the selected photo's state.
+  if (e.target.closest && e.target.closest('.grm-mouse-help')) return;
 
   if (e.key === 'Escape') { closeGroupReview(); e.preventDefault(); return; }
   if (e.key === 'ArrowUp') { grmMoveUp(); e.preventDefault(); return; }
@@ -2729,7 +2733,7 @@ document.addEventListener('keydown', function(e) {
     <span class="grm-key"><kbd>Del</kbd> remove</span>
     <span class="grm-key"><kbd>Z</kbd> right 1:1</span>
     <span class="grm-key"><kbd>1</kbd> strip 1:1</span>
-    <span class="grm-mouse-help" tabindex="0" role="button" aria-label="Mouse controls">
+    <span class="grm-mouse-help" tabindex="0" aria-label="Mouse controls">
       <span class="grm-mouse-help-icon">?</span> mouse
       <span class="grm-mouse-pop">
         <strong>Mouse</strong>


### PR DESCRIPTION
## What & why

The bottom toolbar's `grm-hint` span had `flex: 1` and fought every other control for space in a single flex row. Wedged between the fixed-width controls (Species, Remove, Thumbs, Res, Right) and the commit group, it only got the narrow middle gap — so the full shortcut sentence wrapped into a ~15-line column that ate vertical space and read terribly (see the original screenshot: a tall stacked block of grey text).

## Change

Replaced the inline hint with a dedicated thin **keys bar** below the controls toolbar:

- **Keyboard shortcuts** render as keycap chips (`<kbd>`) on one always-visible line — they're core to the culling flow, so they stay on screen.
- **Mouse interactions** (click to lock zoom, drag to pan, double-click to reset) fold into a `? mouse` affordance that reveals a popover on hover/focus. Those are discoverable by just trying them and don't need to be persistent.

The controls toolbar is now a single clean row.

Applied to both `pipeline_review.html` and `review.html`.

In `pipeline_review`, the **navigate** (←→) and **remove** (Del) keycaps now hide when they don't apply (single-photo review / remove disabled), matching the existing button-level gating instead of advertising shortcuts that do nothing — consistent with the "no black boxes" UI-transparency rule.

## Verification

- Launched the app against a copy of the real DB (under a separate `HOME` to avoid the single-instance lock), drove Chromium via Playwright, opened both review overlays, and screenshotted the new bar + popover. Toolbar is one clean row; popover renders above the affordance unclipped.
- `python -m pytest vireo/tests/test_app.py -q` → **203 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcuts bar to the review modal showing per-key chips for actions (pick/reject, move-zone, navigation, unsort, remove, etc.).
  * Added a hover/focus mouse-controls help tooltip with a dedicated control and adjusted footer layout so the primary action appears before the keys.

* **Bug Fixes**
  * Shortcut keychips auto-hide in contexts where actions aren’t available (e.g., single-photo or removals-disabled).
  * Keyboard input while interacting with the mouse help no longer triggers modal shortcuts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->