### PR TITLE
[codex] Improve browse grid infinite scroll

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1790,6 +1790,69 @@ function renderCardInfo(p) {
   return infoHtml;
 }
 
+function renderPhotoCard(p, idx) {
+  var selectedClass = (p.id === selectedPhotoId || selectedPhotos.has(p.id)) ? ' selected' : '';
+
+  // Detection box overlays — render one per detection in the photo
+  var boxHtml = '';
+  if (showDetectionBoxes && Array.isArray(p.detections)) {
+    p.detections.forEach(function(d) {
+      if (d == null || d.x == null) return;
+      var conf = (d.confidence != null) ? Math.round(d.confidence * 100) + '%' : '';
+      var cat = (d.category && d.category !== 'animal') ? escapeHtml(d.category) + ' ' : '';
+      boxHtml += '<div class="det-box" style="left:' + (d.x * 100) + '%;top:' + (d.y * 100) + '%;width:' + (d.w * 100) + '%;height:' + (d.h * 100) + '%;">' +
+        ((cat || conf) ? '<span class="det-box-label">' + cat + conf + '</span>' : '') +
+      '</div>';
+    });
+  }
+
+  var clipBadge = '';
+  if (p._similarity !== undefined) {
+    clipBadge = '<span class="clip-score-badge">' + Math.round(p._similarity * 100) + '%</span>';
+  }
+  var inatBadge = inatSubmitted[String(p.id)] ? '<span class="inat-badge">iNat</span>' : '';
+  var wildlifeBadge = p.wildlife_excluded ? '<span class="no-wildlife-badge">No Wildlife</span>' : '';
+
+  // Species badges on image overlay (only when NOT in cardFields — if in cardFields, rendered below)
+  var speciesBadgeHtml = '';
+  if (cardFields.indexOf('species') === -1 && p.species && p.species.length > 0) {
+    var maxShow = 3;
+    var shown = p.species.slice(0, maxShow);
+    speciesBadgeHtml = '<div class="species-badges">';
+    shown.forEach(function(s) {
+      speciesBadgeHtml += '<span class="species-badge">' + escapeHtml(s) + '</span>';
+    });
+    if (p.species.length > maxShow) {
+      speciesBadgeHtml += '<span class="species-badge-overflow">+' + (p.species.length - maxShow) + ' more</span>';
+    }
+    speciesBadgeHtml += '</div>';
+  }
+
+  return '<div class="grid-card' + selectedClass + '" data-id="' + p.id + '" data-idx="' + idx + '" data-filename="' + escapeAttr(p.filename) + '" onclick="selectPhoto(event,' + p.id + ',' + idx + ')">' +
+    '<div class="grid-card-img-wrap">' +
+      '<img src="/thumbnails/' + p.id + '.jpg" loading="lazy" alt="' + escapeAttr(p.filename) + '">' +
+      clipBadge +
+      boxHtml +
+      inatBadge +
+      wildlifeBadge +
+      speciesBadgeHtml +
+    '</div>' +
+    '<div class="grid-card-info">' +
+      renderCardInfo(p) +
+    '</div>' +
+  '</div>';
+}
+
+function appendGridPhotos(newPhotos, startIdx) {
+  if (!newPhotos.length) return;
+  var grid = document.getElementById('grid');
+  var html = '';
+  newPhotos.forEach(function(p, offset) {
+    html += renderPhotoCard(p, startIdx + offset);
+  });
+  grid.insertAdjacentHTML('beforeend', html);
+}
+
 function refreshGridCards(photoIds) {
   photoIds.forEach(function(id) {
     var p = photos.find(function(x) { return x.id === id; });
@@ -2758,6 +2821,7 @@ async function loadPhotos() {
     var data = await safeFetch(url);
     if (epoch !== loadEpoch) return;  // grid was reset mid-flight; drop stale response
     totalPhotos = data.total;
+    var firstNewIdx = photos.length;
 
     if (data.photos.length === 0) {
       allLoaded = true;
@@ -2770,7 +2834,8 @@ async function loadPhotos() {
       if (photos.length >= totalPhotos) allLoaded = true;
     }
 
-    renderGrid();
+    if (firstNewIdx === 0) renderGrid();
+    else appendGridPhotos(data.photos, firstNewIdx);
     updateFilterSummary();
   } catch(e) {
     if (epoch !== loadEpoch) return;
@@ -3151,56 +3216,7 @@ function renderGrid() {
 
   var html = '';
   photos.forEach(function(p, idx) {
-    var selectedClass = (p.id === selectedPhotoId || selectedPhotos.has(p.id)) ? ' selected' : '';
-
-    // Detection box overlays — render one per detection in the photo
-    var boxHtml = '';
-    if (showDetectionBoxes && Array.isArray(p.detections)) {
-      p.detections.forEach(function(d) {
-        if (d == null || d.x == null) return;
-        var conf = (d.confidence != null) ? Math.round(d.confidence * 100) + '%' : '';
-        var cat = (d.category && d.category !== 'animal') ? escapeHtml(d.category) + ' ' : '';
-        boxHtml += '<div class="det-box" style="left:' + (d.x * 100) + '%;top:' + (d.y * 100) + '%;width:' + (d.w * 100) + '%;height:' + (d.h * 100) + '%;">' +
-          ((cat || conf) ? '<span class="det-box-label">' + cat + conf + '</span>' : '') +
-        '</div>';
-      });
-    }
-
-    var clipBadge = '';
-    if (p._similarity !== undefined) {
-      clipBadge = '<span class="clip-score-badge">' + Math.round(p._similarity * 100) + '%</span>';
-    }
-    var inatBadge = inatSubmitted[String(p.id)] ? '<span class="inat-badge">iNat</span>' : '';
-    var wildlifeBadge = p.wildlife_excluded ? '<span class="no-wildlife-badge">No Wildlife</span>' : '';
-
-    // Species badges on image overlay (only when NOT in cardFields — if in cardFields, rendered below)
-    var speciesBadgeHtml = '';
-    if (cardFields.indexOf('species') === -1 && p.species && p.species.length > 0) {
-      var maxShow = 3;
-      var shown = p.species.slice(0, maxShow);
-      speciesBadgeHtml = '<div class="species-badges">';
-      shown.forEach(function(s) {
-        speciesBadgeHtml += '<span class="species-badge">' + escapeHtml(s) + '</span>';
-      });
-      if (p.species.length > maxShow) {
-        speciesBadgeHtml += '<span class="species-badge-overflow">+' + (p.species.length - maxShow) + ' more</span>';
-      }
-      speciesBadgeHtml += '</div>';
-    }
-
-    html += '<div class="grid-card' + selectedClass + '" data-id="' + p.id + '" data-idx="' + idx + '" data-filename="' + escapeAttr(p.filename) + '" onclick="selectPhoto(event,' + p.id + ',' + idx + ')">' +
-      '<div class="grid-card-img-wrap">' +
-        '<img src="/thumbnails/' + p.id + '.jpg" loading="lazy" alt="' + escapeAttr(p.filename) + '">' +
-        clipBadge +
-        boxHtml +
-        inatBadge +
-        wildlifeBadge +
-        speciesBadgeHtml +
-      '</div>' +
-      '<div class="grid-card-info">' +
-        renderCardInfo(p) +
-      '</div>' +
-    '</div>';
+    html += renderPhotoCard(p, idx);
   });
   grid.innerHTML = html;
 }
@@ -3253,14 +3269,15 @@ function browseKeyMatchesConfiguredShortcut(e) {
 }
 
 /* ---------- Infinite Scroll ---------- */
+var gridContainer = document.getElementById('gridContainer');
 var observer = new IntersectionObserver(function(entries) {
   if (entries[0].isIntersecting) loadPhotos();
-}, { rootMargin: '200px' });
+}, { root: gridContainer, rootMargin: '1200px 0px' });
 observer.observe(document.getElementById('scrollSentinel'));
 
 /* ---------- Scroll Position Tracking ---------- */
 var scrollTimer = null;
-document.getElementById('gridContainer').addEventListener('scroll', function() {
+gridContainer.addEventListener('scroll', function() {
   if (scrollTimer) clearTimeout(scrollTimer);
   scrollTimer = setTimeout(updateScrollPosition, 50);
 });

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1861,6 +1861,18 @@ function refreshGridCards(photoIds) {
     if (!card) return;
     var info = card.querySelector('.grid-card-info');
     if (info) info.innerHTML = renderCardInfo(p);
+    // iNat badge lives in img-wrap (not grid-card-info), so sync it explicitly
+    // when async metadata arrives after the card was appended.
+    var wrap = card.querySelector('.grid-card-img-wrap');
+    if (wrap) {
+      var existing = wrap.querySelector('.inat-badge');
+      var shouldShow = !!inatSubmitted[String(id)];
+      if (shouldShow && !existing) {
+        wrap.insertAdjacentHTML('beforeend', '<span class="inat-badge">iNat</span>');
+      } else if (!shouldShow && existing) {
+        existing.remove();
+      }
+    }
   });
 }
 
@@ -2827,9 +2839,6 @@ async function loadPhotos() {
       allLoaded = true;
     } else {
       photos = photos.concat(data.photos);
-      var newIds = data.photos.map(function(p) { return p.id; });
-      loadInatStatus(newIds);
-      fetchColorLabels(newIds);
       currentPage++;
       if (photos.length >= totalPhotos) allLoaded = true;
     }
@@ -2837,6 +2846,15 @@ async function loadPhotos() {
     if (firstNewIdx === 0) renderGrid();
     else appendGridPhotos(data.photos, firstNewIdx);
     updateFilterSummary();
+
+    // Refresh appended cards once async metadata resolves — appendGridPhotos
+    // only renders each page once, so badges/labels would otherwise stay
+    // missing until an unrelated full grid render.
+    if (data.photos.length > 0) {
+      var refreshIds = data.photos.map(function(p) { return p.id; });
+      loadInatStatus(refreshIds).then(function() { refreshGridCards(refreshIds); });
+      fetchColorLabels(refreshIds).then(function() { refreshGridCards(refreshIds); });
+    }
   } catch(e) {
     if (epoch !== loadEpoch) return;
     document.getElementById('loadingState').textContent = 'Error loading photos.';
@@ -2844,6 +2862,20 @@ async function loadPhotos() {
     if (epoch === loadEpoch) {
       loading = false;
       document.getElementById('loadingState').style.display = 'none';
+      // Re-arm the infinite-scroll observer. With the 1200px root margin
+      // the sentinel often remains intersecting after a load completes (e.g.
+      // bootstrap returned a short page on a tall viewport), and the
+      // observer was originally registered while loading=true so its single
+      // initial callback was a no-op. Re-observing fires a fresh callback
+      // with the current state so the next page is requested without
+      // requiring the user to scroll.
+      if (!allLoaded && typeof observer !== 'undefined') {
+        var sentinel = document.getElementById('scrollSentinel');
+        if (sentinel) {
+          observer.unobserve(sentinel);
+          observer.observe(sentinel);
+        }
+      }
     }
   }
 }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2800,6 +2800,7 @@ async function loadPhotos() {
   if (loading || allLoaded) return;
   loading = true;
   var epoch = loadEpoch;
+  var loadSucceeded = false;
   document.getElementById('loadingState').style.display = 'block';
 
   var url;
@@ -2862,6 +2863,7 @@ async function loadPhotos() {
         if (epoch === loadEpoch) refreshGridCards(refreshIds);
       });
     }
+    loadSucceeded = true;
   } catch(e) {
     if (epoch !== loadEpoch) return;
     document.getElementById('loadingState').textContent = 'Error loading photos.';
@@ -2869,7 +2871,7 @@ async function loadPhotos() {
     if (epoch === loadEpoch) {
       loading = false;
       document.getElementById('loadingState').style.display = 'none';
-      rearmInfiniteScrollObserver();
+      if (loadSucceeded) rearmInfiniteScrollObserver();
     }
   }
 }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -5284,6 +5284,7 @@ document.addEventListener('contextmenu', function(e) {
 
   // Prevent the IntersectionObserver from triggering loadPhotos() while deep-link is loading
   loading = true;
+  var deepLinkLoaded = false;
   try {
     applyBrowseConfig(await _cfgPromise);
     var photo = await safeFetch('/api/photos/' + photoId, {}, { toast: false });
@@ -5318,6 +5319,7 @@ document.addEventListener('contextmenu', function(e) {
       if (photos.length >= totalPhotos) allLoaded = true;
       renderGrid();
       document.getElementById('loadingState').style.display = 'none';
+      deepLinkLoaded = true;
     }
 
     // Keep loading pages until we find the photo or run out
@@ -5344,6 +5346,7 @@ document.addEventListener('contextmenu', function(e) {
     }
   } catch(e) { /* ignore deep-link errors silently */ }
   loading = false;
+  if (deepLinkLoaded) rearmInfiniteScrollObserver();
 })();
 
 /* ---------- Export Modal ---------- */

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1943,6 +1943,7 @@ async function bootstrapBrowse() {
   if (new URLSearchParams(window.location.search).get('photo_id')) return;
   // Prevent the IntersectionObserver from triggering loadPhotos() while bootstrap is in flight
   loading = true;
+  var bootstrapSucceeded = false;
   try {
     applyBrowseConfig(await _cfgPromise);
     var data = await safeFetch('/api/browse/init?per_page=' + perPage + '&sort=' + document.getElementById('sortSelect').value);
@@ -1965,10 +1966,12 @@ async function bootstrapBrowse() {
     document.getElementById('loadingState').style.display = 'none';
     // Lazy-load collection photo counts to avoid N+1 on init
     loadCollectionCounts();
+    bootstrapSucceeded = true;
   } catch(e) {
     document.getElementById('loadingState').textContent = 'Error loading.';
   }
   loading = false;
+  if (bootstrapSucceeded) rearmInfiniteScrollObserver();
 }
 
 function renderCollectionList(collections) {
@@ -2852,8 +2855,12 @@ async function loadPhotos() {
     // missing until an unrelated full grid render.
     if (data.photos.length > 0) {
       var refreshIds = data.photos.map(function(p) { return p.id; });
-      loadInatStatus(refreshIds).then(function() { refreshGridCards(refreshIds); });
-      fetchColorLabels(refreshIds).then(function() { refreshGridCards(refreshIds); });
+      loadInatStatus(refreshIds).then(function() {
+        if (epoch === loadEpoch) refreshGridCards(refreshIds);
+      });
+      fetchColorLabels(refreshIds).then(function() {
+        if (epoch === loadEpoch) refreshGridCards(refreshIds);
+      });
     }
   } catch(e) {
     if (epoch !== loadEpoch) return;
@@ -2862,20 +2869,7 @@ async function loadPhotos() {
     if (epoch === loadEpoch) {
       loading = false;
       document.getElementById('loadingState').style.display = 'none';
-      // Re-arm the infinite-scroll observer. With the 1200px root margin
-      // the sentinel often remains intersecting after a load completes (e.g.
-      // bootstrap returned a short page on a tall viewport), and the
-      // observer was originally registered while loading=true so its single
-      // initial callback was a no-op. Re-observing fires a fresh callback
-      // with the current state so the next page is requested without
-      // requiring the user to scroll.
-      if (!allLoaded && typeof observer !== 'undefined') {
-        var sentinel = document.getElementById('scrollSentinel');
-        if (sentinel) {
-          observer.unobserve(sentinel);
-          observer.observe(sentinel);
-        }
-      }
+      rearmInfiniteScrollObserver();
     }
   }
 }
@@ -3306,6 +3300,18 @@ var observer = new IntersectionObserver(function(entries) {
   if (entries[0].isIntersecting) loadPhotos();
 }, { root: gridContainer, rootMargin: '1200px 0px' });
 observer.observe(document.getElementById('scrollSentinel'));
+
+function rearmInfiniteScrollObserver() {
+  // With the 1200px root margin, the sentinel can remain intersecting after
+  // bootstrap or page loads. Re-observing asks IntersectionObserver to deliver
+  // a fresh callback for the current layout instead of waiting for a scroll
+  // transition that may never occur.
+  if (allLoaded || typeof observer === 'undefined') return;
+  var sentinel = document.getElementById('scrollSentinel');
+  if (!sentinel) return;
+  observer.unobserve(sentinel);
+  observer.observe(sentinel);
+}
 
 /* ---------- Scroll Position Tracking ---------- */
 var scrollTimer = null;


### PR DESCRIPTION
This PR reduces the pause at the end of Browse grid scrolling by appending newly fetched photo cards instead of rebuilding every loaded card on each page load.
It also scopes the infinite-scroll observer to the grid container and starts prefetching earlier, so the next page is usually ready before the user reaches the bottom.
The root cause was growing DOM replacement work on every infinite-scroll page combined with a late sentinel trigger.
Validated with `node --check .context/browse-scripts-check.js` and `pytest tests/e2e/test_page_loads.py -q`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized per-photo card rendering for cleaner markup and easier maintenance.
* **New Features**
  * Incremental appending of newly loaded photos; full grid render only on initial load.
* **Bug Fixes**
  * Overlays and badges (submission status, similarity, species) now reliably sync for newly appended photos.
* **Performance**
  * Improved infinite-scroll handling with re-arming tied to successful load and deep-link completion for smoother browsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->