### PR TITLE
[codex] Add cull encounter arrow navigation

### DIFF
--- a/tests/e2e/test_cull_keyboard.py
+++ b/tests/e2e/test_cull_keyboard.py
@@ -73,3 +73,19 @@ def test_cull_arrow_keys_ignore_form_controls(live_server, page):
     page.keyboard.press("ArrowRight")
 
     expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")
+
+
+def test_cull_arrow_keys_ignore_modified_browser_shortcuts(live_server, page):
+    page.route(
+        "**/api/pipeline/page-init",
+        lambda route: route.fulfill(json={"results": _pipeline_results_for_cull_keyboard()}),
+    )
+
+    page.goto(f"{live_server['url']}/cull")
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")
+
+    page.keyboard.press("Alt+ArrowRight")
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")
+
+    page.keyboard.press("Meta+ArrowRight")
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")

--- a/tests/e2e/test_cull_keyboard.py
+++ b/tests/e2e/test_cull_keyboard.py
@@ -1,0 +1,75 @@
+from playwright.sync_api import expect
+
+
+def _pipeline_results_for_cull_keyboard():
+    return {
+        "photos": [
+            {"id": 1, "filename": "enc1-a.jpg", "label": "KEEP", "quality_composite": 0.91},
+            {"id": 2, "filename": "enc1-b.jpg", "label": "REVIEW", "quality_composite": 0.67},
+            {"id": 3, "filename": "enc2-a.jpg", "label": "KEEP", "quality_composite": 0.88},
+            {"id": 4, "filename": "enc3-a.jpg", "label": "REJECT", "quality_composite": 0.32},
+        ],
+        "encounters": [
+            {
+                "photo_ids": [1, 2],
+                "photo_count": 2,
+                "burst_count": 1,
+                "species": ["Test bird"],
+                "bursts": [{"photo_ids": [1, 2]}],
+                "time_range": ["2024-03-10T08:00:00", "2024-03-10T08:01:00"],
+            },
+            {
+                "photo_ids": [3],
+                "photo_count": 1,
+                "burst_count": 1,
+                "species": ["Test bird"],
+                "bursts": [{"photo_ids": [3]}],
+                "time_range": ["2024-03-10T08:05:00", "2024-03-10T08:05:00"],
+            },
+            {
+                "photo_ids": [4],
+                "photo_count": 1,
+                "burst_count": 1,
+                "species": ["Test bird"],
+                "bursts": [{"photo_ids": [4]}],
+                "time_range": ["2024-03-10T08:09:00", "2024-03-10T08:09:00"],
+            },
+        ],
+        "summary": {"keep_count": 2, "review_count": 1, "reject_count": 1},
+    }
+
+
+def test_cull_arrow_keys_move_between_encounters(live_server, page):
+    page.route(
+        "**/api/pipeline/page-init",
+        lambda route: route.fulfill(json={"results": _pipeline_results_for_cull_keyboard()}),
+    )
+
+    page.goto(f"{live_server['url']}/cull")
+
+    expect(page.locator(".pose-group")).to_have_count(3)
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")
+
+    page.keyboard.press("ArrowRight")
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 2")
+
+    page.keyboard.press("ArrowRight")
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 3")
+
+    page.keyboard.press("ArrowLeft")
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 2")
+
+
+def test_cull_arrow_keys_ignore_form_controls(live_server, page):
+    page.route(
+        "**/api/pipeline/page-init",
+        lambda route: route.fulfill(json={"results": _pipeline_results_for_cull_keyboard()}),
+    )
+
+    page.goto(f"{live_server['url']}/cull")
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")
+
+    page.locator("#cullCollection").focus()
+    page.keyboard.press("ArrowRight")
+
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")

--- a/tests/e2e/test_cull_keyboard.py
+++ b/tests/e2e/test_cull_keyboard.py
@@ -89,3 +89,45 @@ def test_cull_arrow_keys_ignore_modified_browser_shortcuts(live_server, page):
 
     page.keyboard.press("Meta+ArrowRight")
     expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")
+
+
+def test_cull_arrow_keys_ignore_active_overlays(live_server, page):
+    page.route(
+        "**/api/pipeline/page-init",
+        lambda route: route.fulfill(json={"results": _pipeline_results_for_cull_keyboard()}),
+    )
+
+    page.goto(f"{live_server['url']}/cull")
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")
+
+    # Simulate the pipeline inspector overlay being open (e.g. opened from the
+    # cull lightbox). Arrow keys should defer to the overlay rather than moving
+    # the underlying cull focus.
+    page.evaluate(
+        "() => { const o = document.getElementById('pipelineOverlay');"
+        " if (o) o.classList.add('active'); }"
+    )
+    page.keyboard.press("ArrowRight")
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")
+
+    page.evaluate(
+        "() => { const o = document.getElementById('pipelineOverlay');"
+        " if (o) o.classList.remove('active'); }"
+    )
+
+    # Same expectation for the Similar Photos overlay.
+    page.evaluate(
+        "() => { const o = document.getElementById('similarOverlay');"
+        " if (o) o.classList.add('active'); }"
+    )
+    page.keyboard.press("ArrowRight")
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")
+
+    page.evaluate(
+        "() => { const o = document.getElementById('similarOverlay');"
+        " if (o) o.classList.remove('active'); }"
+    )
+
+    # With overlays closed, arrow keys resume cull navigation.
+    page.keyboard.press("ArrowRight")
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 2")

--- a/tests/e2e/test_cull_keyboard.py
+++ b/tests/e2e/test_cull_keyboard.py
@@ -49,10 +49,14 @@ def test_cull_arrow_keys_move_between_encounters(live_server, page):
 
     expect(page.locator(".pose-group")).to_have_count(3)
     expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")
+    page.keyboard.press("ArrowLeft")
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")
 
     page.keyboard.press("ArrowRight")
     expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 2")
 
+    page.keyboard.press("ArrowRight")
+    expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 3")
     page.keyboard.press("ArrowRight")
     expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 3")
 

--- a/tests/e2e/test_cull_keyboard.py
+++ b/tests/e2e/test_cull_keyboard.py
@@ -49,7 +49,13 @@ def test_cull_arrow_keys_move_between_encounters(live_server, page):
 
     expect(page.locator(".pose-group")).to_have_count(3)
     expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")
-    page.keyboard.press("ArrowLeft")
+    prevented = page.evaluate(
+        """() => {
+            const ev = new KeyboardEvent('keydown', {key: 'ArrowLeft', bubbles: true, cancelable: true});
+            return !document.dispatchEvent(ev);
+        }"""
+    )
+    assert prevented is False
     expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 1")
 
     page.keyboard.press("ArrowRight")
@@ -57,7 +63,13 @@ def test_cull_arrow_keys_move_between_encounters(live_server, page):
 
     page.keyboard.press("ArrowRight")
     expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 3")
-    page.keyboard.press("ArrowRight")
+    prevented = page.evaluate(
+        """() => {
+            const ev = new KeyboardEvent('keydown', {key: 'ArrowRight', bubbles: true, cancelable: true});
+            return !document.dispatchEvent(ev);
+        }"""
+    )
+    assert prevented is False
     expect(page.locator(".pose-group.focused .pose-label")).to_contain_text("Encounter 3")
 
     page.keyboard.press("ArrowLeft")

--- a/vireo/templates/cull.html
+++ b/vireo/templates/cull.html
@@ -872,7 +872,7 @@ document.addEventListener('keydown', function(e) {
   if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
   if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
   if (cullKeyTargetIsEditable(e.target)) return;
-  if (document.querySelector('.lightbox-overlay.active, .modal-overlay.open, .help-overlay.active, .report-overlay.active')) return;
+  if (document.querySelector('.lightbox-overlay.active, .pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open, .shortcuts-overlay.open, .help-overlay.active, .report-overlay.active')) return;
   if (moveFocusedCullGroup(e.key === 'ArrowRight' ? 1 : -1)) {
     e.preventDefault();
   }

--- a/vireo/templates/cull.html
+++ b/vireo/templates/cull.html
@@ -858,6 +858,7 @@ function moveFocusedCullGroup(delta) {
   var current = refs.findIndex(cullGroupMatches);
   if (current < 0) current = 0;
   var next = Math.max(0, Math.min(refs.length - 1, current + delta));
+  if (next === current) return false;
   return focusCullGroup(refs[next], true);
 }
 

--- a/vireo/templates/cull.html
+++ b/vireo/templates/cull.html
@@ -49,7 +49,14 @@ body { padding-bottom: 36px; }
 .pose-group {
   padding: 12px 16px;
   border-top: 1px solid var(--border-subtle);
+  scroll-margin: 64px;
 }
+.pose-group.focused {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  background: var(--accent-dim);
+}
+.pose-group.focused .pose-label { color: var(--accent); }
 .pose-label {
   font-size: 11px;
   color: var(--text-dim);
@@ -397,6 +404,7 @@ var cullData = null;
 var pipelineResults = null;
 var selectedCollectionId = null;
 var expandedSpecies = {};
+var focusedCullGroup = { speciesIdx: null, groupIdx: null };
 var _reflowTimer = null;
 var _regroupTimer = null;
 
@@ -790,17 +798,98 @@ function pipelineToCullData(results) {
   };
 }
 
+function cullGroupsForSpecies(speciesGroup) {
+  return (speciesGroup && (speciesGroup.scene_groups || speciesGroup.pose_groups)) || [];
+}
+
+function cullGroupRefs() {
+  var refs = [];
+  if (!cullData || !cullData.species_groups) return refs;
+  cullData.species_groups.forEach(function(sg, si) {
+    cullGroupsForSpecies(sg).forEach(function(_group, gi) {
+      refs.push({ speciesIdx: si, groupIdx: gi });
+    });
+  });
+  return refs;
+}
+
+function cullGroupMatches(ref) {
+  return focusedCullGroup.speciesIdx === ref.speciesIdx &&
+    focusedCullGroup.groupIdx === ref.groupIdx;
+}
+
+function cullGroupSelector(ref) {
+  return '.pose-group[data-species-index="' + ref.speciesIdx + '"][data-group-index="' + ref.groupIdx + '"]';
+}
+
+function normalizeFocusedCullGroup(refs) {
+  refs = refs || cullGroupRefs();
+  if (!refs.length) {
+    focusedCullGroup = { speciesIdx: null, groupIdx: null };
+    return refs;
+  }
+  var exists = refs.some(cullGroupMatches);
+  if (!exists) {
+    focusedCullGroup = { speciesIdx: refs[0].speciesIdx, groupIdx: refs[0].groupIdx };
+  }
+  return refs;
+}
+
+function scrollFocusedCullGroup() {
+  if (focusedCullGroup.speciesIdx == null || focusedCullGroup.groupIdx == null) return;
+  var el = document.querySelector(cullGroupSelector(focusedCullGroup));
+  if (el) el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+}
+
+function focusCullGroup(ref, shouldScroll) {
+  if (!ref) return false;
+  focusedCullGroup = { speciesIdx: ref.speciesIdx, groupIdx: ref.groupIdx };
+  expandedSpecies[ref.speciesIdx] = true;
+  renderCulling();
+  if (shouldScroll !== false) {
+    window.requestAnimationFrame(scrollFocusedCullGroup);
+  }
+  return true;
+}
+
+function moveFocusedCullGroup(delta) {
+  var refs = normalizeFocusedCullGroup();
+  if (!refs.length) return false;
+  var current = refs.findIndex(cullGroupMatches);
+  if (current < 0) current = 0;
+  var next = Math.max(0, Math.min(refs.length - 1, current + delta));
+  return focusCullGroup(refs[next], true);
+}
+
+function cullKeyTargetIsEditable(target) {
+  if (!target) return false;
+  if (target.closest && target.closest('input, textarea, select, button')) return true;
+  return !!target.isContentEditable;
+}
+
+document.addEventListener('keydown', function(e) {
+  if (e.defaultPrevented) return;
+  if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+  if (cullKeyTargetIsEditable(e.target)) return;
+  if (document.querySelector('.lightbox-overlay.active, .modal-overlay.open, .help-overlay.active, .report-overlay.active')) return;
+  if (moveFocusedCullGroup(e.key === 'ArrowRight' ? 1 : -1)) {
+    e.preventDefault();
+  }
+});
+
 function renderCulling() {
   if (!cullData || !cullData.species_groups || cullData.species_groups.length === 0) {
     document.getElementById('cullSummary').style.display = 'none';
     document.getElementById('applyBtn').style.display = 'none';
     document.getElementById('cullContent').innerHTML =
       '<div style="text-align:center;padding:40px;color:var(--text-dim);">No pipeline results for this view. Run Analyze for Culling after extracting pipeline features.</div>';
+    focusedCullGroup = { speciesIdx: null, groupIdx: null };
     return;
   }
   if (Object.keys(expandedSpecies).length === 0 && cullData.species_groups.length > 0) {
     expandedSpecies[0] = true;
   }
+  normalizeFocusedCullGroup();
 
   // Summary bar
   var summaryHtml = '<div class="summary-bar">' +
@@ -833,9 +922,10 @@ function renderCulling() {
     var isExpanded = expandedSpecies[si];
     html += '<div class="species-body" id="speciesBody' + si + '" style="display:' + (isExpanded ? '' : 'none') + ';">';
 
-    var groups = sg.scene_groups || sg.pose_groups || [];
+    var groups = cullGroupsForSpecies(sg);
     groups.forEach(function(pg, pi) {
-      html += '<div class="pose-group">';
+      var groupFocused = focusedCullGroup.speciesIdx === si && focusedCullGroup.groupIdx === pi;
+      html += '<div class="pose-group' + (groupFocused ? ' focused' : '') + '" data-species-index="' + si + '" data-group-index="' + pi + '">';
       if (groups.length > 1) {
         var groupLabel = pg.label || ('Scene ' + (pi + 1) + ' (' + pg.photos.length + ' photos)');
         html += '<div class="pose-label">' + escapeHtml(groupLabel) + '</div>';

--- a/vireo/templates/cull.html
+++ b/vireo/templates/cull.html
@@ -870,6 +870,7 @@ function cullKeyTargetIsEditable(target) {
 document.addEventListener('keydown', function(e) {
   if (e.defaultPrevented) return;
   if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+  if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
   if (cullKeyTargetIsEditable(e.target)) return;
   if (document.querySelector('.lightbox-overlay.active, .modal-overlay.open, .help-overlay.active, .report-overlay.active')) return;
   if (moveFocusedCullGroup(e.key === 'ArrowRight' ? 1 : -1)) {


### PR DESCRIPTION
Adds keyboard focus state to the Cull page so Left and Right move between encounter groups in the visible culling results. The focused encounter is highlighted, expanded as needed, and scrolled into view while form controls and overlays keep their existing arrow-key behavior. This fixes the mismatch where culling is organized by encounters but arrow navigation did not follow those encounter groups. Validated with new Cull keyboard E2E coverage plus focused Cull page-load and app template tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Left/Right arrow navigation moves focus between encounter pose groups with a visible focused state and auto-scroll.
  * Navigation is ignored while typing, when modifier keys are used, or when overlays/modals are active.

* **Tests**
  * New end-to-end tests cover arrow-key navigation, ignoring form controls, modified shortcuts, and active-overlay behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->