### PR TITLE
[codex] Allow shortcuts sheet over lightbox

### DIFF
--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -301,6 +301,29 @@ def test_shortcuts_sheet_lists_misses_and_shared_hotkeys(live_server, page):
     assert {"key": "Alt+U", "label": "Clear pick/reject flag"} in groups["Lightbox"]
 
 
+def test_question_mark_opens_shortcuts_sheet_over_lightbox(live_server, page):
+    """The global ? shortcut should still work while the lightbox owns focus."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=15000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("openLightbox(1, 'hawk1.jpg')")
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=2000,
+    )
+
+    page.keyboard.press("?")
+    page.wait_for_function(
+        "document.getElementById('shortcutsCheatSheet').classList.contains('open')",
+        timeout=2000,
+    )
+
+    assert page.evaluate(
+        "document.getElementById('lightboxOverlay').classList.contains('active')"
+    ) is True
+
+
 def test_two_overlays_unwind_one_esc_each(live_server, page):
     """With lightbox open and cheat sheet stacked on top, each Esc closes one
     overlay (top-of-stack first). Locks in the new one-Esc-per-overlay model

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -320,6 +320,12 @@ def test_question_mark_opens_shortcuts_sheet_over_lightbox(live_server, page):
         timeout=2000,
     )
 
+    assert page.evaluate("""
+        () => {
+          const el = document.elementFromPoint(window.innerWidth / 2, window.innerHeight / 2);
+          return !!(el && el.closest('#shortcutsCheatSheet'));
+        }
+    """) is True
     assert page.evaluate(
         "document.getElementById('lightboxOverlay').classList.contains('active')"
     ) is True

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -302,7 +302,8 @@ def test_shortcuts_sheet_lists_misses_and_shared_hotkeys(live_server, page):
 
 
 def test_question_mark_opens_shortcuts_sheet_over_lightbox(live_server, page):
-    """The global ? shortcut should still work while the lightbox owns focus."""
+    """The global ? shortcut should still work while the lightbox owns focus,
+    and the sheet must render visibly above the lightbox (not behind it)."""
     url = live_server["url"]
     page.goto(f"{url}/browse", timeout=15000)
     page.wait_for_load_state("networkidle")
@@ -322,6 +323,42 @@ def test_question_mark_opens_shortcuts_sheet_over_lightbox(live_server, page):
     assert page.evaluate(
         "document.getElementById('lightboxOverlay').classList.contains('active')"
     ) is True
+
+    # Verify the sheet is visually above the lightbox, not hidden behind it.
+    # A class of `open` alone is insufficient when z-index puts the sheet below
+    # the lightbox overlay — see Codex review on PR #926.
+    z_indexes = page.evaluate(
+        """() => {
+            const sheet = document.getElementById('shortcutsCheatSheet');
+            const lb = document.getElementById('lightboxOverlay');
+            return {
+                sheet: parseInt(getComputedStyle(sheet).zIndex, 10),
+                lightbox: parseInt(getComputedStyle(lb).zIndex, 10),
+            };
+        }"""
+    )
+    assert z_indexes["sheet"] > z_indexes["lightbox"], (
+        f"shortcuts sheet z-index ({z_indexes['sheet']}) must exceed "
+        f"lightbox z-index ({z_indexes['lightbox']}) so the sheet renders on top"
+    )
+
+    # The topmost element at the sheet's center must belong to the sheet's
+    # subtree, not the lightbox — proves the stacking actually works in render.
+    topmost_belongs_to_sheet = page.evaluate(
+        """() => {
+            const sheet = document.getElementById('shortcutsCheatSheet');
+            const r = sheet.getBoundingClientRect();
+            const el = document.elementFromPoint(
+                r.left + r.width / 2,
+                r.top + r.height / 2,
+            );
+            return el !== null && sheet.contains(el);
+        }"""
+    )
+    assert topmost_belongs_to_sheet, (
+        "topmost element at the sheet's center should be inside the sheet, "
+        "not the lightbox behind it"
+    )
 
 
 def test_two_overlays_unwind_one_esc_each(live_server, page):

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -863,12 +863,14 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 .modal-error { color: var(--danger); font-size: 13px; margin-top: 8px; display: none; }
 
 /* ---------- Shortcuts Cheat Sheet ---------- */
+/* z-index sits above the lightbox stack (overlay 9999, close 10000, nav 10001)
+   so the sheet remains visible when stacked over an active lightbox. */
 .shortcuts-overlay {
   display: none;
   position: fixed;
   top: 0; left: 0; right: 0; bottom: 0;
   background: rgba(0,0,0,0.7);
-  z-index: 500;
+  z-index: 10002;
   justify-content: center;
   align-items: center;
 }

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2678,7 +2678,7 @@ window.NAV_ALL_PAGES = [
   // open so page handlers (rating, navigation, etc.) don't also fire.
   document.addEventListener('keydown', function(e) {
     if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
-    if (document.querySelector('.lightbox-overlay.active, .pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open, .help-overlay.active')) return;
+    if (document.querySelector('.pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open, .help-overlay.active')) return;
     // When sheet is open, consume non-Esc keys so page handlers don't fire.
     // Esc is handled by the Keymap.pushEsc stack and must reach the dispatcher.
     if (document.getElementById('shortcutsCheatSheet').classList.contains('open')) {


### PR DESCRIPTION
Fixes the global ? shortcut so the keyboard shortcuts sheet can open while a photo is zoomed in/lightbox is active. The root cause was the shortcuts-sheet keydown guard treating the lightbox like a blocking modal, even though the sheet is designed to stack over it. Adds an e2e regression test that opens the lightbox, presses ?, and verifies the sheet opens without closing the photo. Validated with pytest tests/e2e/test_keymap.py -q.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The Shortcuts Cheat Sheet (triggered by `?`) now reliably opens while the lightbox is active and displays above it, preserving the lightbox beneath.

* **Tests**
  * Added end-to-end test coverage that verifies the cheat sheet opens over the lightbox, remains visible on top, and confirms the lightbox stays active underneath.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->