### PR TITLE
Fix map tab pinning

### DIFF
--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -259,6 +259,7 @@ def test_map_tab_can_be_pinned_before_leaflet_cdn_finishes(live_server, page):
     page.wait_for_selector(
         ".nav-tab[data-nav-id='map']:not(.is-ephemeral)", timeout=3000
     )
+    assert held_routes, "Expected Leaflet JS to be requested from unpkg.com"
 
     for route in held_routes:
         route.abort()

--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -240,6 +240,30 @@ def test_ephemeral_tab_pin_button_persists_tab(live_server, page):
     )
 
 
+def test_map_tab_can_be_pinned_before_leaflet_cdn_finishes(live_server, page):
+    """The navbar must initialize without waiting for /map's CDN scripts."""
+    url = live_server["url"]
+
+    held_routes = []
+
+    def hold_unpkg(route):
+        if route.request.url.endswith(".css"):
+            route.fulfill(status=200, content_type="text/css", body="")
+            return
+        held_routes.append(route)
+
+    page.route("https://unpkg.com/**", hold_unpkg)
+    page.goto(f"{url}/map", wait_until="commit")
+    page.wait_for_selector(".nav-tab[data-nav-id='map'].is-ephemeral", timeout=3000)
+    page.click("[data-testid='nav-tab-pin-map']")
+    page.wait_for_selector(
+        ".nav-tab[data-nav-id='map']:not(.is-ephemeral)", timeout=3000
+    )
+
+    for route in held_routes:
+        route.abort()
+
+
 def test_rapid_review_ephemeral_tab_pin_button_persists_tab(live_server, page):
     """Rapid Review can be pinned from its ephemeral tab."""
     url = live_server["url"]

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2163,7 +2163,12 @@ window.NAV_ALL_PAGES = [
     },
   };
 
-  if (document.readyState === 'loading') {
+  // The tab strip only needs the navbar DOM above, not the full page. Start it
+  // immediately so pages with slow blocking scripts (notably /map's Leaflet
+  // CDN scripts) still show an ephemeral tab that can be pinned.
+  if (STRIP()) {
+    fetchAndRender();
+  } else if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', fetchAndRender);
   } else {
     fetchAndRender();


### PR DESCRIPTION
Fixes a timing issue where the /map tab could fail to appear as a pinnable ephemeral tab while Leaflet CDN scripts were still loading. The navbar now initializes the tab strip as soon as the navbar DOM exists, instead of waiting for full DOMContentLoaded. Added an E2E regression that holds the Leaflet JS request open and verifies the Map tab can still be pinned. Validated with focused tab API/navigation tests and the full navigation E2E suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved navbar initialization to begin rendering as soon as the tab strip is available, enhancing responsiveness.

* **Tests**
  * Added test to verify map tab pinning functions correctly while external resources load.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->