### PR TITLE
[codex] Fix misses unmark shortcut

### DIFF
--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -387,6 +387,37 @@ def test_double_click_opens_lightbox(live_server, page):
     )
 
 
+def test_u_unmarks_miss_from_lightbox(live_server, page):
+    """When inspecting a miss in the lightbox, `u` clears the miss flag."""
+    url = live_server["url"]
+    db = live_server["db"]
+    pid = live_server["data"]["photos"][0]
+    _seed_misses(db, [pid], "oof")
+
+    page.goto(f"{url}/misses")
+    card = page.locator(f"[data-testid='miss-card-oof-{pid}']")
+    card.wait_for(state="visible", timeout=3000)
+
+    card.dblclick()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+
+    page.keyboard.press("u")
+
+    page.wait_for_function(
+        f"!document.querySelector('[data-testid=\"miss-card-oof-{pid}\"]')",
+        timeout=3000,
+    )
+    row = db.conn.execute(
+        "SELECT miss_oof, flag FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert row["miss_oof"] == 0
+    assert row["flag"] in (None, "none")
+
+
 def test_selection_bar_unmarks_selected_misses(live_server, page):
     """The visible toolbar can clear the selected photos' miss flags."""
     url = live_server["url"]
@@ -416,6 +447,33 @@ def test_selection_bar_unmarks_selected_misses(live_server, page):
         (a, b),
     ).fetchall()
     assert {r["id"]: r["miss_no_subject"] for r in rows} == {a: 0, b: 0}
+
+
+def test_u_unmarks_clicked_miss(live_server, page):
+    """Plain-click selection followed by `u` clears the selected miss."""
+    url = live_server["url"]
+    db = live_server["db"]
+    pid = live_server["data"]["photos"][0]
+    _seed_misses(db, [pid], "no_subject")
+
+    page.goto(f"{url}/misses")
+    card = page.locator(f"[data-testid='miss-card-no_subject-{pid}']")
+    card.wait_for(state="visible", timeout=3000)
+
+    card.click()
+    assert page.evaluate("selection.size") == 1
+
+    page.keyboard.press("u")
+
+    page.wait_for_function(
+        f"!document.querySelector('[data-testid=\"miss-card-no_subject-{pid}\"]')",
+        timeout=3000,
+    )
+    row = db.conn.execute(
+        "SELECT miss_no_subject FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert row["miss_no_subject"] == 0
 
 
 def test_selection_bar_deletes_selected_misses_from_vireo(live_server, page):

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -154,7 +154,7 @@ def test_x_with_selection_bulk_rejects(live_server, page):
     assert untouched["flag"] in (None, "none"), f"pids[1] was modified: {untouched['flag']!r}"
 
     # Selection cleared after bulk apply.
-    assert page.evaluate("selection.size") == 0
+    page.wait_for_function("selection.size === 0", timeout=3000)
 
 
 def test_p_with_selection_bulk_flags(live_server, page):
@@ -416,6 +416,41 @@ def test_u_unmarks_miss_from_lightbox(live_server, page):
     ).fetchone()
     assert row["miss_oof"] == 0
     assert row["flag"] in (None, "none")
+
+
+def test_u_unmarks_only_active_miss_category_from_lightbox(live_server, page):
+    """A lightbox `u` clears the miss category that opened the lightbox."""
+    url = live_server["url"]
+    db = live_server["db"]
+    pid = live_server["data"]["photos"][0]
+    _seed_misses(db, [pid], "clipped")
+    _seed_misses(db, [pid], "oof")
+
+    page.goto(f"{url}/misses")
+    clipped_card = page.locator(f"[data-testid='miss-card-clipped-{pid}']")
+    oof_card = page.locator(f"[data-testid='miss-card-oof-{pid}']")
+    clipped_card.wait_for(state="visible", timeout=3000)
+    oof_card.wait_for(state="visible", timeout=3000)
+
+    clipped_card.dblclick()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+
+    page.keyboard.press("u")
+
+    page.wait_for_function(
+        f"!document.querySelector('[data-testid=\"miss-card-clipped-{pid}\"]')"
+        f" && document.querySelector('[data-testid=\"miss-card-oof-{pid}\"]')",
+        timeout=3000,
+    )
+    row = db.conn.execute(
+        "SELECT miss_clipped, miss_oof FROM photos WHERE id=?",
+        (pid,),
+    ).fetchone()
+    assert row["miss_clipped"] == 0
+    assert row["miss_oof"] == 1
 
 
 def test_selection_bar_unmarks_selected_misses(live_server, page):

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4599,6 +4599,14 @@ document.addEventListener('keydown', function(e) {
     else if (matchesShortcut(e, unflagKey)) lbFlag = 'none';
     if (lbFlag !== null && _lightboxCurrentId != null) {
       var pid = _lightboxCurrentId;
+      if (
+        typeof window.handleMissesLightboxFlagShortcut === 'function' &&
+        window.handleMissesLightboxFlagShortcut(pid, lbFlag) === true
+      ) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        return;
+      }
       _lbApplyFlag(pid, lbFlag);
       e.preventDefault();
       e.stopImmediatePropagation();

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -1157,37 +1157,29 @@ async function unflagMiss(cat, photoId, e) {
   render();
 }
 
-async function unflagMissEverywhere(photoId) {
+async function unflagLightboxMiss(photoId) {
   if (previewActive) {
     if (typeof showToast === 'function') {
       showToast('Save or reset the preview before unmarking misses', 'error');
     }
     return;
   }
-  var cats = CATEGORY_ORDER.filter(function(cat) {
-    return (missesData[cat] || []).some(function(p) { return p.id === photoId; });
-  });
-  if (cats.length === 0 && missLightboxCurrent && missLightboxCurrent.photoId === photoId) {
-    cats = [missLightboxCurrent.category];
-  }
-  if (cats.length === 0) return;
+  if (!missLightboxCurrent || missLightboxCurrent.photoId !== photoId) return;
+  var cat = missLightboxCurrent.category;
+  if (!cat) return;
 
   var failures = 0;
-  await Promise.all(cats.map(function(cat) {
-    return fetch('/api/misses/' + photoId + '/unflag', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ category: cat }),
-    }).then(function(r) { if (!r.ok) failures++; }).catch(function() { failures++; });
-  }));
+  await fetch('/api/misses/' + photoId + '/unflag', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ category: cat }),
+  }).then(function(r) { if (!r.ok) failures++; }).catch(function() { failures++; });
   if (failures > 0) {
     if (typeof showToast === 'function') showToast('Unflag failed', 'error');
     return;
   }
-  cats.forEach(function(cat) {
-    missesData[cat] = (missesData[cat] || []).filter(function(p) {
-      return p.id !== photoId;
-    });
+  missesData[cat] = (missesData[cat] || []).filter(function(p) {
+    return p.id !== photoId;
   });
   pruneSelectionToVisible();
   render();
@@ -1196,7 +1188,7 @@ async function unflagMissEverywhere(photoId) {
 window.handleMissesLightboxFlagShortcut = function(photoId, flag) {
   if (flag !== 'none') return false;
   if (!missLightboxCurrent || missLightboxCurrent.photoId !== photoId) return false;
-  unflagMissEverywhere(photoId);
+  unflagLightboxMiss(photoId);
   return true;
 };
 

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -489,6 +489,8 @@ var previewRequestId = 0;
 var missConfigLoaded = false;
 var focusedCategory = null;
 var focusedIndex = -1;
+var missLightboxCategoryById = {};
+var missLightboxCurrent = null;
 // Multi-select state. Spans categories — ctrl-click on cards in different
 // sections accumulates them all. The focused card doubles as the anchor for
 // shift-click range selection (range stays within the clicked category).
@@ -920,7 +922,12 @@ function openMiss(cat, idx, e) {
   if (!photos || !photos[idx]) return;
   var p = photos[idx];
   setFocused(cat, idx);
-  var photoList = photos.map(function(q) { return { id: q.id, filename: q.filename }; });
+  missLightboxCategoryById = {};
+  var photoList = photos.map(function(q) {
+    missLightboxCategoryById[q.id] = cat;
+    return { id: q.id, filename: q.filename, missCategory: cat };
+  });
+  missLightboxCurrent = { photoId: p.id, category: cat };
 
   if (typeof openLightbox !== 'function') return;
   // The wrap onclick handler in _navbar.html guards on !window._lightboxZoomHandled,
@@ -929,6 +936,16 @@ function openMiss(cat, idx, e) {
   window._lightboxZoomHandled = false;
   openLightbox(p.id, p.filename || '', photoList);
 }
+
+document.addEventListener('lightbox:photochanged', function(e) {
+  var photoId = e && e.detail ? e.detail.photoId : null;
+  var cat = photoId != null ? missLightboxCategoryById[photoId] : null;
+  missLightboxCurrent = cat ? { photoId: photoId, category: cat } : null;
+});
+
+document.addEventListener('lightbox:closed', function() {
+  missLightboxCurrent = null;
+});
 
 function getFocusedMiss() {
   if (focusedCategory == null || focusedIndex < 0) return null;
@@ -1139,6 +1156,49 @@ async function unflagMiss(cat, photoId, e) {
   pruneSelectionToVisible();
   render();
 }
+
+async function unflagMissEverywhere(photoId) {
+  if (previewActive) {
+    if (typeof showToast === 'function') {
+      showToast('Save or reset the preview before unmarking misses', 'error');
+    }
+    return;
+  }
+  var cats = CATEGORY_ORDER.filter(function(cat) {
+    return (missesData[cat] || []).some(function(p) { return p.id === photoId; });
+  });
+  if (cats.length === 0 && missLightboxCurrent && missLightboxCurrent.photoId === photoId) {
+    cats = [missLightboxCurrent.category];
+  }
+  if (cats.length === 0) return;
+
+  var failures = 0;
+  await Promise.all(cats.map(function(cat) {
+    return fetch('/api/misses/' + photoId + '/unflag', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category: cat }),
+    }).then(function(r) { if (!r.ok) failures++; }).catch(function() { failures++; });
+  }));
+  if (failures > 0) {
+    if (typeof showToast === 'function') showToast('Unflag failed', 'error');
+    return;
+  }
+  cats.forEach(function(cat) {
+    missesData[cat] = (missesData[cat] || []).filter(function(p) {
+      return p.id !== photoId;
+    });
+  });
+  pruneSelectionToVisible();
+  render();
+}
+
+window.handleMissesLightboxFlagShortcut = function(photoId, flag) {
+  if (flag !== 'none') return false;
+  if (!missLightboxCurrent || missLightboxCurrent.photoId !== photoId) return false;
+  unflagMissEverywhere(photoId);
+  return true;
+};
 
 /* ---------- Selection ----------
  * Plain click selects exactly one photo. Ctrl/Cmd-click toggles additional


### PR DESCRIPTION
## Summary
Fixes the Misses lightbox path so pressing `u` unmarks the current photo as missed instead of only clearing its normal pick/reject flag.

The Misses page now tracks which miss category opened the shared lightbox and lets the shared lightbox shortcut delegate unmark handling back to Misses when appropriate.

Added e2e coverage for both click-then-`u` and lightbox-then-`u` miss unmark flows.

## Checks
`python -m pytest tests/e2e/test_misses_multi_select.py tests/e2e/test_misses_flag_hotkeys.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled keyboard shortcut ('u') to unflag misses from the lightbox and multi-select views.

* **Tests**
  * Added end-to-end tests for unflagging misses via keyboard shortcut in lightbox and clicked-selection contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/929?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->