### PR TITLE
[codex] Add capture time adjustment workflow

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2233,7 +2233,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         from capture_time import build_capture_time_preview
 
         db = _get_db()
-        body = request.get_json(silent=True) or {}
+        body = request.get_json(silent=True)
+        if body is None:
+            body = {}
+        elif not isinstance(body, dict):
+            return json_error("request body must be a JSON object", 400)
         raw_ids = body.get("photo_ids", [])
         if not isinstance(raw_ids, list):
             return json_error("photo_ids must be a list", 400)
@@ -10214,7 +10218,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/jobs/capture-time", methods=["POST"])
     def api_job_capture_time():
         """Adjust capture timestamps and timezone offsets for selected photos."""
-        body = request.get_json(silent=True) or {}
+        body = request.get_json(silent=True)
+        if body is None:
+            body = {}
+        elif not isinstance(body, dict):
+            return json_error("request body must be a JSON object", 400)
         raw_ids = body.get("photo_ids", [])
         if not isinstance(raw_ids, list):
             return json_error("photo_ids must be a list", 400)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2227,6 +2227,52 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         _attach_detections(db, photos)
         return jsonify({"photos": photos})
 
+    @app.route("/api/capture-time/preview", methods=["POST"])
+    def api_capture_time_preview():
+        """Preview a capture-time correction for selected photos."""
+        from capture_time import build_capture_time_preview
+
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        raw_ids = body.get("photo_ids", [])
+        if not isinstance(raw_ids, list):
+            return json_error("photo_ids must be a list", 400)
+        if not raw_ids:
+            return json_error("photo_ids required", 400)
+        if len(raw_ids) > 500:
+            return json_error("too many photo_ids", 400)
+
+        photo_ids = []
+        seen = set()
+        for raw in raw_ids:
+            if isinstance(raw, bool) or not isinstance(raw, int):
+                return json_error("photo_ids must be integers", 400)
+            if raw in seen:
+                continue
+            seen.add(raw)
+            photo_ids.append(raw)
+
+        photos = []
+        for pid in photo_ids[:20]:
+            photo = db.get_photo(pid, verify_workspace=True)
+            if photo:
+                photos.append(photo)
+        if not photos:
+            return json_error("no photos found", 404)
+
+        try:
+            preview = build_capture_time_preview(
+                photos,
+                mode=body.get("mode", "preserve_instant"),
+                target_offset=body.get("target_offset"),
+                shift_minutes=body.get("shift_minutes"),
+                limit=5,
+            )
+        except ValueError as exc:
+            return json_error(str(exc), 400)
+        preview["count"] = len(photo_ids)
+        return jsonify(preview)
+
     @app.route("/api/pipeline/selection-results", methods=["POST"])
     def api_pipeline_selection_results():
         """Return a temporary Pipeline Review result for selected photo IDs."""
@@ -10163,6 +10209,86 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return sync_to_xmp(thread_db, progress_callback=progress_cb)
 
         job_id = runner.start("sync", work, workspace_id=active_ws)
+        return jsonify({"job_id": job_id})
+
+    @app.route("/api/jobs/capture-time", methods=["POST"])
+    def api_job_capture_time():
+        """Adjust capture timestamps and timezone offsets for selected photos."""
+        body = request.get_json(silent=True) or {}
+        raw_ids = body.get("photo_ids", [])
+        if not isinstance(raw_ids, list):
+            return json_error("photo_ids must be a list", 400)
+        if not raw_ids:
+            return json_error("photo_ids required", 400)
+        if len(raw_ids) > 5000:
+            return json_error("too many photo_ids", 400)
+
+        photo_ids = []
+        seen = set()
+        for raw in raw_ids:
+            if isinstance(raw, bool) or not isinstance(raw, int):
+                return json_error("photo_ids must be integers", 400)
+            if raw in seen:
+                continue
+            seen.add(raw)
+            photo_ids.append(raw)
+
+        mode = body.get("mode", "preserve_instant")
+        target_offset = body.get("target_offset")
+        shift_minutes = body.get("shift_minutes")
+        keep_backups = bool(body.get("keep_backups", True))
+        runner = app._job_runner
+        active_ws = _get_db()._active_workspace_id
+
+        def work(job):
+            from capture_time import adjust_capture_time
+
+            thread_db = Database(db_path)
+            thread_db.set_active_workspace(active_ws)
+            job["_start_time"] = time.time()
+            job["progress"]["total"] = len(photo_ids)
+
+            def progress_cb(current, total, filename):
+                job["progress"]["current"] = current
+                job["progress"]["total"] = total
+                job["progress"]["current_file"] = filename
+                runner.push_event(
+                    job["id"],
+                    "progress",
+                    {
+                        "current": current,
+                        "total": total,
+                        "current_file": filename,
+                        "rate": round(
+                            current / max(time.time() - job["_start_time"], 0.01), 1
+                        ),
+                        "phase": "Adjusting capture time",
+                    },
+                )
+
+            return adjust_capture_time(
+                thread_db,
+                photo_ids,
+                mode=mode,
+                target_offset=target_offset,
+                shift_minutes=shift_minutes,
+                keep_backups=keep_backups,
+                progress_callback=progress_cb,
+                cancel_check=lambda: runner.is_cancelled(job["id"]),
+            )
+
+        job_id = runner.start(
+            "capture-time",
+            work,
+            config={
+                "photo_ids": photo_ids,
+                "mode": mode,
+                "target_offset": target_offset,
+                "shift_minutes": shift_minutes,
+                "keep_backups": keep_backups,
+            },
+            workspace_id=active_ws,
+        )
         return jsonify({"job_id": job_id})
 
     @app.route("/api/jobs/sharpness", methods=["POST"])

--- a/vireo/capture_time.py
+++ b/vireo/capture_time.py
@@ -1,0 +1,303 @@
+"""Capture-time and timezone repair helpers."""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from datetime import datetime, timedelta
+
+from metadata import extract_metadata
+
+OFFSET_RE = re.compile(r"^([+-])(\d{2}):(\d{2})$")
+
+
+def parse_offset_minutes(value):
+    """Return UTC offset minutes for '+HH:MM' / '-HH:MM', or None."""
+    if value is None:
+        return None
+    match = OFFSET_RE.match(str(value).strip())
+    if not match:
+        return None
+    sign, hh, mm = match.groups()
+    hours = int(hh)
+    minutes = int(mm)
+    if hours > 14 or minutes > 59:
+        return None
+    total = hours * 60 + minutes
+    return -total if sign == "-" else total
+
+
+def validate_offset(value):
+    if parse_offset_minutes(value) is None:
+        raise ValueError("offset must use +HH:MM or -HH:MM")
+    return str(value).strip()
+
+
+def _has_key(row, key):
+    keys = row.keys() if hasattr(row, "keys") else row
+    return key in keys
+
+
+def _exif_group(photo):
+    raw = photo["exif_data"] if _has_key(photo, "exif_data") else None
+    if not raw:
+        return {}
+    try:
+        metadata = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    if not isinstance(metadata, dict):
+        return {}
+    exif = metadata.get("EXIF")
+    return exif if isinstance(exif, dict) else {}
+
+
+def _capture_datetime(photo):
+    exif = _exif_group(photo)
+    value = exif.get("DateTimeOriginal") or exif.get("CreateDate")
+    if value:
+        try:
+            dt = datetime.strptime(str(value), "%Y:%m:%d %H:%M:%S")
+            subsec = exif.get("SubSecTimeOriginal") or exif.get("SubSecTime")
+            if subsec is not None:
+                digits = "".join(ch for ch in str(subsec).strip() if ch.isdigit())
+                if digits:
+                    dt = dt.replace(microsecond=int(digits[:6].ljust(6, "0")))
+            return dt
+        except (TypeError, ValueError):
+            pass
+
+    value = photo["timestamp"] if _has_key(photo, "timestamp") else None
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _capture_offset(photo):
+    exif = _exif_group(photo)
+    return (
+        exif.get("OffsetTimeOriginal")
+        or exif.get("OffsetTime")
+        or exif.get("OffsetTimeDigitized")
+    )
+
+
+def resolve_shift_minutes(mode, target_offset=None, shift_minutes=None, sample_photos=None):
+    """Resolve user intent into a signed minute shift."""
+    if mode == "manual":
+        try:
+            return int(shift_minutes or 0)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("shift_minutes must be an integer") from exc
+
+    if mode != "preserve_instant":
+        raise ValueError("mode must be preserve_instant or manual")
+
+    target_minutes = parse_offset_minutes(target_offset)
+    if target_minutes is None:
+        raise ValueError("target_offset is required for preserve_instant")
+
+    sample_photos = sample_photos or []
+    for photo in sample_photos:
+        current_minutes = parse_offset_minutes(_capture_offset(photo))
+        if current_minutes is not None:
+            return target_minutes - current_minutes
+
+    raise ValueError("current offset not found; use a manual time shift")
+
+
+def format_preview_timestamp(dt):
+    if dt is None:
+        return None
+    base = dt.strftime("%Y-%m-%d %H:%M:%S")
+    if dt.microsecond:
+        frac = f"{dt.microsecond:06d}".rstrip("0")
+        return f"{base}.{frac}"
+    return base
+
+
+def build_capture_time_preview(photos, *, mode, target_offset=None, shift_minutes=None, limit=5):
+    """Return sample before/after rows for the selected photos."""
+    sample = list(photos)[: max(1, int(limit))]
+    resolved_shift = resolve_shift_minutes(
+        mode,
+        target_offset=target_offset,
+        shift_minutes=shift_minutes,
+        sample_photos=sample,
+    )
+    target_offset = validate_offset(target_offset) if target_offset else None
+
+    rows = []
+    for photo in sample:
+        dt = _capture_datetime(photo)
+        current_offset = _capture_offset(photo)
+        after = dt + timedelta(minutes=resolved_shift) if dt is not None else None
+        rows.append(
+            {
+                "photo_id": photo["id"],
+                "filename": photo["filename"],
+                "before_time": format_preview_timestamp(dt),
+                "before_offset": current_offset,
+                "after_time": format_preview_timestamp(after),
+                "after_offset": target_offset or current_offset,
+            }
+        )
+
+    return {
+        "mode": mode,
+        "shift_minutes": resolved_shift,
+        "target_offset": target_offset,
+        "samples": rows,
+    }
+
+
+def _shift_arg(minutes):
+    op = "+=" if minutes >= 0 else "-="
+    total = abs(int(minutes))
+    hours, mins = divmod(total, 60)
+    return f"-AllDates{op}0:0:0 {hours}:{mins}:0"
+
+
+def _photo_paths(db, photo):
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()
+    if not folder:
+        return []
+    paths = [os.path.join(folder["path"], photo["filename"])]
+    companion = photo["companion_path"] if _has_key(photo, "companion_path") else None
+    if companion:
+        paths.append(os.path.join(folder["path"], companion))
+    return paths
+
+
+def _timestamp_from_exif_group(exif_group):
+    dto = exif_group.get("DateTimeOriginal") or exif_group.get("CreateDate")
+    if not dto:
+        return None
+    try:
+        dt = datetime.strptime(str(dto), "%Y:%m:%d %H:%M:%S")
+        subsec = exif_group.get("SubSecTimeOriginal") or exif_group.get("SubSecTime")
+        if subsec is not None:
+            subsec_str = str(subsec).strip()
+            if subsec_str.isdigit():
+                dt = dt.replace(microsecond=int(subsec_str[:6].ljust(6, "0")))
+        return dt.isoformat()
+    except (TypeError, ValueError):
+        return None
+
+
+def _refresh_photo_metadata(db, photo_id, primary_path):
+    metadata = extract_metadata([primary_path]).get(primary_path)
+    if not metadata:
+        return
+    exif = metadata.get("EXIF", {})
+    timestamp = _timestamp_from_exif_group(exif)
+    file_mtime = os.path.getmtime(primary_path) if os.path.exists(primary_path) else None
+
+    updates = ["exif_data=?"]
+    params = [json.dumps(metadata)]
+    if timestamp is not None:
+        updates.append("timestamp=?")
+        params.append(timestamp)
+    if file_mtime is not None:
+        updates.append("file_mtime=?")
+        params.append(file_mtime)
+    params.append(photo_id)
+    db.conn.execute(f"UPDATE photos SET {', '.join(updates)} WHERE id=?", params)
+
+
+def adjust_capture_time(
+    db,
+    photo_ids,
+    *,
+    mode,
+    target_offset=None,
+    shift_minutes=None,
+    keep_backups=True,
+    progress_callback=None,
+    cancel_check=None,
+):
+    """Apply a capture-time correction to selected photos via ExifTool."""
+    if shutil.which("exiftool") is None:
+        raise RuntimeError("exiftool is not installed")
+
+    photos = []
+    for pid in photo_ids:
+        row = db.get_photo(pid, verify_workspace=True)
+        if row:
+            photos.append(row)
+    if not photos:
+        raise ValueError("no photos found")
+
+    preview = build_capture_time_preview(
+        photos,
+        mode=mode,
+        target_offset=target_offset,
+        shift_minutes=shift_minutes,
+        limit=1,
+    )
+    resolved_shift = preview["shift_minutes"]
+    target_offset = preview["target_offset"]
+
+    written = 0
+    failed = 0
+    failures = []
+    total = len(photos)
+    for index, photo in enumerate(photos, start=1):
+        if cancel_check and cancel_check():
+            break
+        paths = [p for p in _photo_paths(db, photo) if os.path.exists(p)]
+        if not paths:
+            failed += 1
+            failures.append({"photo_id": photo["id"], "error": "source file not found"})
+            if progress_callback:
+                progress_callback(index, total, photo["filename"])
+            continue
+
+        cmd = ["exiftool"]
+        if not keep_backups:
+            cmd.append("-overwrite_original")
+        if resolved_shift:
+            cmd.append(_shift_arg(resolved_shift))
+        if target_offset:
+            cmd.extend(
+                [
+                    f"-OffsetTime={target_offset}",
+                    f"-OffsetTimeOriginal={target_offset}",
+                    f"-OffsetTimeDigitized={target_offset}",
+                ]
+            )
+        cmd.append("--")
+        cmd.extend(paths)
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if result.returncode not in (0, 1):
+                raise RuntimeError((result.stderr or result.stdout or "ExifTool failed").strip())
+            _refresh_photo_metadata(db, photo["id"], paths[0])
+            db.conn.commit()
+            written += 1
+        except Exception as exc:
+            failed += 1
+            failures.append({"photo_id": photo["id"], "filename": photo["filename"], "error": str(exc)})
+        if progress_callback:
+            progress_callback(index, total, photo["filename"])
+
+    return {
+        "updated": written,
+        "failed": failed,
+        "failures": failures[:20],
+        "shift_minutes": resolved_shift,
+        "target_offset": target_offset,
+        "backup_files": bool(keep_backups),
+    }

--- a/vireo/capture_time.py
+++ b/vireo/capture_time.py
@@ -103,21 +103,27 @@ def _normalize_subsec(subsec):
 
 
 def _normalize_inputs(mode, target_offset, shift_minutes):
-    """Validate user inputs and return (target_minutes, manual_shift, target_offset_str)."""
+    """Validate user inputs and return (target_minutes, manual_shift, target_offset_str).
+
+    In ``manual`` mode ``target_offset`` is intentionally ignored so a stale
+    or prefilled value can't silently overwrite ``OffsetTime*`` tags when the
+    user only asked for a minute shift.
+    """
     if mode == "manual":
         try:
             manual_shift = int(shift_minutes or 0)
         except (TypeError, ValueError) as exc:
             raise ValueError("shift_minutes must be an integer") from exc
         target_minutes = None
+        target_offset_str = None
     elif mode == "preserve_instant":
         target_minutes = parse_offset_minutes(target_offset)
         if target_minutes is None:
             raise ValueError("target_offset is required for preserve_instant")
         manual_shift = None
+        target_offset_str = validate_offset(target_offset)
     else:
         raise ValueError("mode must be preserve_instant or manual")
-    target_offset_str = validate_offset(target_offset) if target_offset else None
     return target_minutes, manual_shift, target_offset_str
 
 

--- a/vireo/capture_time.py
+++ b/vireo/capture_time.py
@@ -1,6 +1,7 @@
 """Capture-time and timezone repair helpers."""
 
 import json
+import logging
 import os
 import re
 import shutil
@@ -8,6 +9,8 @@ import subprocess
 from datetime import datetime, timedelta
 
 from metadata import extract_metadata
+
+log = logging.getLogger(__name__)
 
 OFFSET_RE = re.compile(r"^([+-])(\d{2}):(\d{2})$")
 
@@ -22,7 +25,11 @@ def parse_offset_minutes(value):
     sign, hh, mm = match.groups()
     hours = int(hh)
     minutes = int(mm)
-    if hours > 14 or minutes > 59:
+    if minutes > 59:
+        return None
+    if sign == "+" and (hours > 14 or (hours == 14 and minutes > 0)):
+        return None
+    if sign == "-" and (hours > 12 or (hours == 12 and minutes > 0)):
         return None
     total = hours * 60 + minutes
     return -total if sign == "-" else total
@@ -84,6 +91,15 @@ def _capture_offset(photo):
         or exif.get("OffsetTime")
         or exif.get("OffsetTimeDigitized")
     )
+
+
+def _normalize_subsec(subsec):
+    if subsec is None:
+        return None
+    digits = "".join(ch for ch in str(subsec).strip() if ch.isdigit())
+    if not digits:
+        return None
+    return int(digits[:6].ljust(6, "0"))
 
 
 def _normalize_inputs(mode, target_offset, shift_minutes):
@@ -207,10 +223,9 @@ def _timestamp_from_exif_group(exif_group):
     try:
         dt = datetime.strptime(str(dto), "%Y:%m:%d %H:%M:%S")
         subsec = exif_group.get("SubSecTimeOriginal") or exif_group.get("SubSecTime")
-        if subsec is not None:
-            subsec_str = str(subsec).strip()
-            if subsec_str.isdigit():
-                dt = dt.replace(microsecond=int(subsec_str[:6].ljust(6, "0")))
+        microsecond = _normalize_subsec(subsec)
+        if microsecond is not None:
+            dt = dt.replace(microsecond=microsecond)
         return dt.isoformat()
     except (TypeError, ValueError):
         return None
@@ -233,7 +248,8 @@ def _refresh_photo_metadata(db, photo_id, primary_path):
         updates.append("file_mtime=?")
         params.append(file_mtime)
     params.append(photo_id)
-    db.conn.execute(f"UPDATE photos SET {', '.join(updates)} WHERE id=?", params)
+    update_clause = ", ".join(updates)
+    db.conn.execute("UPDATE photos SET " + update_clause + " WHERE id=?", params)
 
 
 def adjust_capture_time(
@@ -263,6 +279,7 @@ def adjust_capture_time(
     if not photos:
         raise ValueError("no photos found")
 
+    log.info("Starting capture-time adjustment for %d photo(s)", len(photos))
     written = 0
     failed = 0
     failures = []
@@ -307,6 +324,12 @@ def adjust_capture_time(
         cmd.extend(paths)
 
         try:
+            log.info(
+                "Running ExifTool capture-time adjustment for photo %s on %d file(s)",
+                photo["id"],
+                len(paths),
+            )
+            log.debug("ExifTool command: %s", cmd)
             result = subprocess.run(
                 cmd,
                 capture_output=True,
@@ -317,9 +340,17 @@ def adjust_capture_time(
                 raise RuntimeError((result.stderr or result.stdout or "ExifTool failed").strip())
             _refresh_photo_metadata(db, photo["id"], paths[0])
             db.conn.commit()
+            log.debug("ExifTool stdout: %s", result.stdout.strip())
+            if result.stderr:
+                log.debug("ExifTool stderr: %s", result.stderr.strip())
             written += 1
             shifts_used.append(photo_shift)
+        except (subprocess.TimeoutExpired, RuntimeError, OSError) as exc:
+            log.warning("Capture-time adjustment failed for photo %s: %s", photo["id"], exc)
+            failed += 1
+            failures.append({"photo_id": photo["id"], "filename": photo["filename"], "error": str(exc)})
         except Exception as exc:
+            log.exception("Unexpected capture-time adjustment error for photo %s", photo["id"])
             failed += 1
             failures.append({"photo_id": photo["id"], "filename": photo["filename"], "error": str(exc)})
         if progress_callback:
@@ -327,6 +358,7 @@ def adjust_capture_time(
 
     unanimous = bool(shifts_used) and all(s == shifts_used[0] for s in shifts_used)
     summary_shift = shifts_used[0] if unanimous else None
+    log.info("Capture-time adjustment finished: %d updated, %d failed", written, failed)
 
     return {
         "updated": written,

--- a/vireo/capture_time.py
+++ b/vireo/capture_time.py
@@ -86,28 +86,33 @@ def _capture_offset(photo):
     )
 
 
-def resolve_shift_minutes(mode, target_offset=None, shift_minutes=None, sample_photos=None):
-    """Resolve user intent into a signed minute shift."""
+def _normalize_inputs(mode, target_offset, shift_minutes):
+    """Validate user inputs and return (target_minutes, manual_shift, target_offset_str)."""
     if mode == "manual":
         try:
-            return int(shift_minutes or 0)
+            manual_shift = int(shift_minutes or 0)
         except (TypeError, ValueError) as exc:
             raise ValueError("shift_minutes must be an integer") from exc
-
-    if mode != "preserve_instant":
+        target_minutes = None
+    elif mode == "preserve_instant":
+        target_minutes = parse_offset_minutes(target_offset)
+        if target_minutes is None:
+            raise ValueError("target_offset is required for preserve_instant")
+        manual_shift = None
+    else:
         raise ValueError("mode must be preserve_instant or manual")
+    target_offset_str = validate_offset(target_offset) if target_offset else None
+    return target_minutes, manual_shift, target_offset_str
 
-    target_minutes = parse_offset_minutes(target_offset)
-    if target_minutes is None:
-        raise ValueError("target_offset is required for preserve_instant")
 
-    sample_photos = sample_photos or []
-    for photo in sample_photos:
-        current_minutes = parse_offset_minutes(_capture_offset(photo))
-        if current_minutes is not None:
-            return target_minutes - current_minutes
-
-    raise ValueError("current offset not found; use a manual time shift")
+def _photo_shift_minutes(mode, target_minutes, manual_shift, photo):
+    """Return the signed minute shift for a single photo, or raise ValueError."""
+    if mode == "manual":
+        return manual_shift
+    current_minutes = parse_offset_minutes(_capture_offset(photo))
+    if current_minutes is None:
+        raise ValueError("current offset not found; use a manual time shift")
+    return target_minutes - current_minutes
 
 
 def format_preview_timestamp(dt):
@@ -121,21 +126,33 @@ def format_preview_timestamp(dt):
 
 
 def build_capture_time_preview(photos, *, mode, target_offset=None, shift_minutes=None, limit=5):
-    """Return sample before/after rows for the selected photos."""
+    """Return sample before/after rows for the selected photos.
+
+    For ``preserve_instant`` each sampled photo gets its own shift based on its
+    own current offset, so a selection with mixed offsets is shown accurately
+    instead of being collapsed onto a single shift derived from the first photo.
+    """
     sample = list(photos)[: max(1, int(limit))]
-    resolved_shift = resolve_shift_minutes(
-        mode,
-        target_offset=target_offset,
-        shift_minutes=shift_minutes,
-        sample_photos=sample,
+    target_minutes, manual_shift, target_offset_str = _normalize_inputs(
+        mode, target_offset, shift_minutes
     )
-    target_offset = validate_offset(target_offset) if target_offset else None
 
     rows = []
+    shifts_seen = []
     for photo in sample:
         dt = _capture_datetime(photo)
         current_offset = _capture_offset(photo)
-        after = dt + timedelta(minutes=resolved_shift) if dt is not None else None
+        try:
+            shift = _photo_shift_minutes(mode, target_minutes, manual_shift, photo)
+        except ValueError:
+            shift = None
+        after = (
+            dt + timedelta(minutes=shift)
+            if (dt is not None and shift is not None)
+            else None
+        )
+        if shift is not None:
+            shifts_seen.append(shift)
         rows.append(
             {
                 "photo_id": photo["id"],
@@ -143,14 +160,22 @@ def build_capture_time_preview(photos, *, mode, target_offset=None, shift_minute
                 "before_time": format_preview_timestamp(dt),
                 "before_offset": current_offset,
                 "after_time": format_preview_timestamp(after),
-                "after_offset": target_offset or current_offset,
+                "after_offset": target_offset_str or current_offset,
+                "shift_minutes": shift,
             }
         )
 
+    if mode == "preserve_instant" and not shifts_seen:
+        raise ValueError("current offset not found; use a manual time shift")
+
+    unanimous = bool(shifts_seen) and all(s == shifts_seen[0] for s in shifts_seen)
+    summary_shift = shifts_seen[0] if unanimous else None
+
     return {
         "mode": mode,
-        "shift_minutes": resolved_shift,
-        "target_offset": target_offset,
+        "shift_minutes": summary_shift,
+        "shifts_vary": not unanimous and len(shifts_seen) > 1,
+        "target_offset": target_offset_str,
         "samples": rows,
     }
 
@@ -226,6 +251,10 @@ def adjust_capture_time(
     if shutil.which("exiftool") is None:
         raise RuntimeError("exiftool is not installed")
 
+    target_minutes, manual_shift, target_offset_str = _normalize_inputs(
+        mode, target_offset, shift_minutes
+    )
+
     photos = []
     for pid in photo_ids:
         row = db.get_photo(pid, verify_workspace=True)
@@ -234,20 +263,11 @@ def adjust_capture_time(
     if not photos:
         raise ValueError("no photos found")
 
-    preview = build_capture_time_preview(
-        photos,
-        mode=mode,
-        target_offset=target_offset,
-        shift_minutes=shift_minutes,
-        limit=1,
-    )
-    resolved_shift = preview["shift_minutes"]
-    target_offset = preview["target_offset"]
-
     written = 0
     failed = 0
     failures = []
     total = len(photos)
+    shifts_used = []
     for index, photo in enumerate(photos, start=1):
         if cancel_check and cancel_check():
             break
@@ -259,17 +279,28 @@ def adjust_capture_time(
                 progress_callback(index, total, photo["filename"])
             continue
 
+        try:
+            photo_shift = _photo_shift_minutes(mode, target_minutes, manual_shift, photo)
+        except ValueError as exc:
+            failed += 1
+            failures.append(
+                {"photo_id": photo["id"], "filename": photo["filename"], "error": str(exc)}
+            )
+            if progress_callback:
+                progress_callback(index, total, photo["filename"])
+            continue
+
         cmd = ["exiftool"]
         if not keep_backups:
             cmd.append("-overwrite_original")
-        if resolved_shift:
-            cmd.append(_shift_arg(resolved_shift))
-        if target_offset:
+        if photo_shift:
+            cmd.append(_shift_arg(photo_shift))
+        if target_offset_str:
             cmd.extend(
                 [
-                    f"-OffsetTime={target_offset}",
-                    f"-OffsetTimeOriginal={target_offset}",
-                    f"-OffsetTimeDigitized={target_offset}",
+                    f"-OffsetTime={target_offset_str}",
+                    f"-OffsetTimeOriginal={target_offset_str}",
+                    f"-OffsetTimeDigitized={target_offset_str}",
                 ]
             )
         cmd.append("--")
@@ -287,17 +318,22 @@ def adjust_capture_time(
             _refresh_photo_metadata(db, photo["id"], paths[0])
             db.conn.commit()
             written += 1
+            shifts_used.append(photo_shift)
         except Exception as exc:
             failed += 1
             failures.append({"photo_id": photo["id"], "filename": photo["filename"], "error": str(exc)})
         if progress_callback:
             progress_callback(index, total, photo["filename"])
 
+    unanimous = bool(shifts_used) and all(s == shifts_used[0] for s in shifts_used)
+    summary_shift = shifts_used[0] if unanimous else None
+
     return {
         "updated": written,
         "failed": failed,
         "failures": failures[:20],
-        "shift_minutes": resolved_shift,
-        "target_offset": target_offset,
+        "shift_minutes": summary_shift,
+        "shifts_vary": not unanimous and len(shifts_used) > 1,
+        "target_offset": target_offset_str,
         "backup_files": bool(keep_backups),
     }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3968,24 +3968,40 @@ function buildCaptureTimePayload() {
   };
 }
 
+function formatShiftMinutes(mins) {
+  var sign = mins >= 0 ? '+' : '';
+  var hours = mins / 60;
+  var hoursPart = Number.isInteger(hours) ? ' (' + (hours >= 0 ? '+' : '') + hours + ' hours)' : '';
+  return sign + mins + ' minutes' + hoursPart;
+}
+
 function renderCaptureTimePreview(data) {
   var rows = data.samples || [];
+  var shiftsVary = !!data.shifts_vary;
   var html = '<div class="capture-time-row header">' +
     '<div>File</div><div>Current</div><div>After</div></div>';
   rows.forEach(function(row) {
     var before = (row.before_time || 'No capture time') + (row.before_offset ? ' ' + row.before_offset : '');
     var after = (row.after_time || 'No capture time') + (row.after_offset ? ' ' + row.after_offset : '');
+    var perRowShift = '';
+    if (shiftsVary && typeof row.shift_minutes === 'number') {
+      perRowShift = ' <span style="color:var(--text-muted);font-size:11px;">(' + formatShiftMinutes(row.shift_minutes) + ')</span>';
+    }
     html += '<div class="capture-time-row">' +
       '<div class="capture-time-filename" title="' + escapeHtml(row.filename || '') + '">' + escapeHtml(row.filename || '') + '</div>' +
       '<div class="capture-time-before">' + escapeHtml(before) + '</div>' +
-      '<div class="capture-time-after">' + escapeHtml(after) + '</div>' +
+      '<div class="capture-time-after">' + escapeHtml(after) + perRowShift + '</div>' +
     '</div>';
   });
-  var hours = data.shift_minutes / 60;
-  html += '<div class="capture-time-hint" style="padding:0 10px 10px;margin:0;">' +
-    'Resolved shift: ' + (data.shift_minutes >= 0 ? '+' : '') + data.shift_minutes + ' minutes' +
-    (Number.isInteger(hours) ? ' (' + (hours >= 0 ? '+' : '') + hours + ' hours)' : '') +
-    '</div>';
+  var summary;
+  if (shiftsVary) {
+    summary = 'Shift varies per photo (each photo is shifted to land on the target offset).';
+  } else if (typeof data.shift_minutes === 'number') {
+    summary = 'Resolved shift: ' + formatShiftMinutes(data.shift_minutes);
+  } else {
+    summary = 'No shift will be applied.';
+  }
+  html += '<div class="capture-time-hint" style="padding:0 10px 10px;margin:0;">' + escapeHtml(summary) + '</div>';
   document.getElementById('captureTimePreview').innerHTML = html;
 }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3988,7 +3988,7 @@ function renderCaptureTimePreview(data) {
       perRowShift = ' <span style="color:var(--text-muted);font-size:11px;">(' + formatShiftMinutes(row.shift_minutes) + ')</span>';
     }
     html += '<div class="capture-time-row">' +
-      '<div class="capture-time-filename" title="' + escapeHtml(row.filename || '') + '">' + escapeHtml(row.filename || '') + '</div>' +
+      '<div class="capture-time-filename" title="' + escapeAttr(row.filename || '') + '">' + escapeHtml(row.filename || '') + '</div>' +
       '<div class="capture-time-before">' + escapeHtml(before) + '</div>' +
       '<div class="capture-time-after">' + escapeHtml(after) + perRowShift + '</div>' +
     '</div>';

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1475,11 +1475,11 @@ body {
       </div>
     </div>
     <label class="capture-time-option">
-      <input type="radio" name="captureTimeMode" value="preserve_instant" checked onchange="updateCaptureTimePreview()">
+      <input type="radio" name="captureTimeMode" value="preserve_instant" checked onchange="syncCaptureTimeFieldState(); updateCaptureTimePreview()">
       Set offset and preserve actual instant
     </label>
     <label class="capture-time-option">
-      <input type="radio" name="captureTimeMode" value="manual" onchange="updateCaptureTimePreview()">
+      <input type="radio" name="captureTimeMode" value="manual" onchange="syncCaptureTimeFieldState(); updateCaptureTimePreview()">
       Use manual time shift
     </label>
     <label class="capture-time-option">
@@ -3955,17 +3955,36 @@ function getCaptureTimeMode() {
 
 function buildCaptureTimePayload() {
   var ids = getActiveSelection();
+  var mode = getCaptureTimeMode();
   var targetOffset = document.getElementById('captureTimeTargetOffset').value.trim();
   var shiftRaw = document.getElementById('captureTimeManualShift').value;
   var shiftMinutes = parseInt(shiftRaw, 10);
   if (isNaN(shiftMinutes)) shiftMinutes = 0;
   return {
     photo_ids: ids,
-    mode: getCaptureTimeMode(),
-    target_offset: targetOffset || null,
+    mode: mode,
+    target_offset: mode === 'manual' ? null : (targetOffset || null),
     shift_minutes: shiftMinutes,
     keep_backups: document.getElementById('captureTimeKeepBackups').checked,
   };
+}
+
+function syncCaptureTimeFieldState() {
+  var mode = getCaptureTimeMode();
+  var targetInput = document.getElementById('captureTimeTargetOffset');
+  var shiftInput = document.getElementById('captureTimeManualShift');
+  if (!targetInput || !shiftInput) return;
+  if (mode === 'manual') {
+    targetInput.disabled = true;
+    targetInput.title = 'Not used in manual shift mode';
+    shiftInput.disabled = false;
+    shiftInput.title = '';
+  } else {
+    targetInput.disabled = false;
+    targetInput.title = '';
+    shiftInput.disabled = true;
+    shiftInput.title = 'Not used in preserve-instant mode';
+  }
 }
 
 function formatShiftMinutes(mins) {
@@ -4043,6 +4062,7 @@ function openCaptureTimeModal() {
   document.getElementById('captureTimeApplyBtn').textContent = 'Apply';
   document.getElementById('captureTimeApplyBtn').disabled = true;
   document.getElementById('captureTimeModal').classList.add('open');
+  syncCaptureTimeFieldState();
   updateCaptureTimePreview();
 }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -365,6 +365,57 @@ body {
   font-size: 12px;
   line-height: 1.4;
 }
+.capture-time-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.capture-time-field label,
+.capture-time-option {
+  display: block;
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+.capture-time-hint {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 8px 0 12px;
+}
+.capture-time-preview {
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  max-height: 220px;
+  overflow: auto;
+  margin: 10px 0 12px;
+}
+.capture-time-row {
+  display: grid;
+  grid-template-columns: minmax(110px, 1fr) minmax(145px, 1fr) minmax(145px, 1fr);
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-primary);
+  font-size: 12px;
+  align-items: center;
+}
+.capture-time-row:last-child { border-bottom: none; }
+.capture-time-row.header {
+  color: var(--text-ghost);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--bg-secondary);
+}
+.capture-time-filename {
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.capture-time-before { color: var(--text-muted); }
+.capture-time-after { color: var(--accent); }
 .detail-close {
   float: right;
   background: none;
@@ -1164,6 +1215,7 @@ body {
       <button onclick="batchSetFlag('rejected')" style="background:var(--bg-tertiary);color:var(--danger);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Reject</button>
       <button onclick="batchAddKeyword()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">+ Keyword</button>
       <button onclick="addToCollection()" style="background:var(--bg-tertiary);color:var(--info);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">+ Collection</button>
+      <button onclick="openCaptureTimeModal()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Adjust Time</button>
       <button id="compareBtn" onclick="openBrowseCompare()" title="Compare two selected photos side by side" style="display:none;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Compare</button>
       <button id="burstReviewBtn" onclick="openSelectedInBurstReview()" title="Open selected photos in burst review" style="display:none;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Review Burst</button>
       <button id="developBtn" onclick="developSelected()" title="Develop selected RAW photos with darktable" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Develop</button>
@@ -1401,6 +1453,43 @@ body {
     <div class="modal-actions">
       <button class="modal-btn modal-btn-primary" onclick="confirmBatchCollection()">Add</button>
       <button class="modal-btn modal-btn-cancel" onclick="hideBatchCollectionModal()">Cancel</button>
+    </div>
+  </div>
+</div>
+
+<!-- Capture Time Modal -->
+<div class="modal-overlay" id="captureTimeModal">
+  <div class="modal" style="width:720px;max-width:calc(100vw - 32px);">
+    <h3 id="captureTimeTitle">Adjust Capture Time</h3>
+    <div class="capture-time-hint">
+      Use this when a camera was left in the wrong timezone. Preserving the instant shifts the wall-clock time by the offset difference.
+    </div>
+    <div class="capture-time-grid">
+      <div class="capture-time-field">
+        <label for="captureTimeTargetOffset">Target offset</label>
+        <input class="modal-input" id="captureTimeTargetOffset" value="-10:00" placeholder="-10:00" oninput="updateCaptureTimePreview()">
+      </div>
+      <div class="capture-time-field">
+        <label for="captureTimeManualShift">Manual shift, minutes</label>
+        <input class="modal-input" id="captureTimeManualShift" type="number" value="0" step="1" oninput="updateCaptureTimePreview()">
+      </div>
+    </div>
+    <label class="capture-time-option">
+      <input type="radio" name="captureTimeMode" value="preserve_instant" checked onchange="updateCaptureTimePreview()">
+      Set offset and preserve actual instant
+    </label>
+    <label class="capture-time-option">
+      <input type="radio" name="captureTimeMode" value="manual" onchange="updateCaptureTimePreview()">
+      Use manual time shift
+    </label>
+    <label class="capture-time-option">
+      <input type="checkbox" id="captureTimeKeepBackups" checked>
+      Keep ExifTool backup files
+    </label>
+    <div id="captureTimePreview" class="capture-time-preview"></div>
+    <div class="modal-actions">
+      <button class="modal-btn modal-btn-primary" id="captureTimeApplyBtn" onclick="startCaptureTimeJob()">Apply</button>
+      <button class="modal-btn modal-btn-cancel" onclick="hideCaptureTimeModal()">Cancel</button>
     </div>
   </div>
 </div>
@@ -3857,6 +3946,132 @@ async function confirmBatchCollection() {
   clearSelection();
 }
 
+var captureTimePreviewSeq = 0;
+
+function getCaptureTimeMode() {
+  var selected = document.querySelector('input[name="captureTimeMode"]:checked');
+  return selected ? selected.value : 'preserve_instant';
+}
+
+function buildCaptureTimePayload() {
+  var ids = getActiveSelection();
+  var targetOffset = document.getElementById('captureTimeTargetOffset').value.trim();
+  var shiftRaw = document.getElementById('captureTimeManualShift').value;
+  var shiftMinutes = parseInt(shiftRaw, 10);
+  if (isNaN(shiftMinutes)) shiftMinutes = 0;
+  return {
+    photo_ids: ids,
+    mode: getCaptureTimeMode(),
+    target_offset: targetOffset || null,
+    shift_minutes: shiftMinutes,
+    keep_backups: document.getElementById('captureTimeKeepBackups').checked,
+  };
+}
+
+function renderCaptureTimePreview(data) {
+  var rows = data.samples || [];
+  var html = '<div class="capture-time-row header">' +
+    '<div>File</div><div>Current</div><div>After</div></div>';
+  rows.forEach(function(row) {
+    var before = (row.before_time || 'No capture time') + (row.before_offset ? ' ' + row.before_offset : '');
+    var after = (row.after_time || 'No capture time') + (row.after_offset ? ' ' + row.after_offset : '');
+    html += '<div class="capture-time-row">' +
+      '<div class="capture-time-filename" title="' + escapeHtml(row.filename || '') + '">' + escapeHtml(row.filename || '') + '</div>' +
+      '<div class="capture-time-before">' + escapeHtml(before) + '</div>' +
+      '<div class="capture-time-after">' + escapeHtml(after) + '</div>' +
+    '</div>';
+  });
+  var hours = data.shift_minutes / 60;
+  html += '<div class="capture-time-hint" style="padding:0 10px 10px;margin:0;">' +
+    'Resolved shift: ' + (data.shift_minutes >= 0 ? '+' : '') + data.shift_minutes + ' minutes' +
+    (Number.isInteger(hours) ? ' (' + (hours >= 0 ? '+' : '') + hours + ' hours)' : '') +
+    '</div>';
+  document.getElementById('captureTimePreview').innerHTML = html;
+}
+
+async function updateCaptureTimePreview() {
+  var modal = document.getElementById('captureTimeModal');
+  if (!modal.classList.contains('open')) return;
+  var payload = buildCaptureTimePayload();
+  var previewEl = document.getElementById('captureTimePreview');
+  var applyBtn = document.getElementById('captureTimeApplyBtn');
+  if (!payload.photo_ids.length) {
+    previewEl.innerHTML = '<div class="capture-time-hint" style="padding:10px;margin:0;">No photos selected.</div>';
+    applyBtn.disabled = true;
+    return;
+  }
+  var seq = ++captureTimePreviewSeq;
+  applyBtn.disabled = true;
+  previewEl.innerHTML = '<div class="capture-time-hint" style="padding:10px;margin:0;">Loading preview...</div>';
+  try {
+    var data = await safeFetch('/api/capture-time/preview', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(payload),
+    }, { toast: false });
+    if (seq !== captureTimePreviewSeq) return;
+    renderCaptureTimePreview(data);
+    applyBtn.disabled = false;
+    applyBtn.textContent = 'Apply to ' + payload.photo_ids.length + ' photo' + (payload.photo_ids.length === 1 ? '' : 's');
+  } catch(e) {
+    if (seq !== captureTimePreviewSeq) return;
+    previewEl.innerHTML = '<div class="capture-time-hint" style="padding:10px;margin:0;color:var(--danger);">' + escapeHtml(e.message || 'Could not build preview') + '</div>';
+    applyBtn.disabled = true;
+  }
+}
+
+function openCaptureTimeModal() {
+  var ids = getActiveSelection();
+  if (!ids.length) return;
+  document.getElementById('captureTimeTitle').textContent = 'Adjust Capture Time for ' + ids.length + ' photo' + (ids.length === 1 ? '' : 's');
+  document.getElementById('captureTimeApplyBtn').textContent = 'Apply';
+  document.getElementById('captureTimeApplyBtn').disabled = true;
+  document.getElementById('captureTimeModal').classList.add('open');
+  updateCaptureTimePreview();
+}
+
+function hideCaptureTimeModal() {
+  document.getElementById('captureTimeModal').classList.remove('open');
+  window._vireoNativeMenuPhotoIdsOverride = null;
+}
+
+async function startCaptureTimeJob() {
+  var payload = buildCaptureTimePayload();
+  if (!payload.photo_ids.length) return;
+  var applyBtn = document.getElementById('captureTimeApplyBtn');
+  applyBtn.disabled = true;
+  try {
+    var data = await safeFetch('/api/jobs/capture-time', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(payload),
+    });
+    hideCaptureTimeModal();
+    showToast('Adjusting capture time for ' + payload.photo_ids.length + ' photo' + (payload.photo_ids.length === 1 ? '' : 's') + '...');
+    safeEventSource('/api/jobs/' + data.job_id + '/stream', {
+      onProgress: function(prog) {
+        showToast('Adjusting capture time: ' + prog.current + '/' + prog.total + ' — ' + (prog.current_file || ''));
+      },
+      onComplete: function(done) {
+        if (done.status && done.status !== 'completed') {
+          var errors = done.errors || [];
+          showToast('Capture time failed: ' + (errors[0] || done.status), 'error');
+          return;
+        }
+        var result = done.result || {};
+        showToast('Capture time updated: ' + (result.updated || 0) + ' updated, ' + (result.failed || 0) + ' failed', result.failed ? 'error' : 'success');
+        resetAndLoad();
+        loadSummary();
+      },
+      onError: function() {
+        applyBtn.disabled = false;
+      },
+    });
+  } catch(e) {
+    applyBtn.disabled = false;
+  }
+}
+
 function clearSelection() {
   anchorRestoreEpoch++;
   // Clear both tracks that feed getActiveSelection(), otherwise the batch bar
@@ -5054,6 +5269,7 @@ function buildPhotoContextMenu(photoIds) {
     { separator: true },
     { label: 'Add Keyword\u2026', onClick: function() { batchAddKeyword(); } },
     { label: 'Add to Collection\u2026', onClick: function() { addToCollection(); } },
+    { label: 'Adjust Capture Time\u2026', onClick: function() { openCaptureTimeModal(); } },
     { separator: true },
     { label: 'Delete', onClick: function() { batchDelete(); } },
   ]);

--- a/vireo/tests/test_capture_time_api.py
+++ b/vireo/tests/test_capture_time_api.py
@@ -1,0 +1,124 @@
+import json
+import os
+from types import SimpleNamespace
+
+from wait import wait_for_job_via_client
+
+
+def test_capture_time_preview_preserves_instant_from_current_offset(app_and_db):
+    app, db = app_and_db
+    photo = db.get_photos()[0]
+    db.conn.execute(
+        "UPDATE photos SET exif_data = ? WHERE id = ?",
+        (
+            json.dumps(
+                {
+                    "EXIF": {
+                        "DateTimeOriginal": "2026:05:22 20:07:23",
+                        "SubSecTimeOriginal": "56",
+                        "OffsetTimeOriginal": "-07:00",
+                    }
+                }
+            ),
+            photo["id"],
+        ),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/capture-time/preview",
+        json={
+            "photo_ids": [photo["id"]],
+            "mode": "preserve_instant",
+            "target_offset": "-10:00",
+        },
+    )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["shift_minutes"] == -180
+    assert data["samples"][0]["before_time"] == "2026-05-22 20:07:23.56"
+    assert data["samples"][0]["before_offset"] == "-07:00"
+    assert data["samples"][0]["after_time"] == "2026-05-22 17:07:23.56"
+    assert data["samples"][0]["after_offset"] == "-10:00"
+
+
+def test_capture_time_job_writes_exiftool_and_refreshes_cache(client_with_photo, monkeypatch):
+    import capture_time
+
+    app, db, photo_id = client_with_photo
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()
+    path = os.path.join(folder["path"], photo["filename"])
+    db.conn.execute(
+        "UPDATE photos SET timestamp = ?, exif_data = ? WHERE id = ?",
+        (
+            "2026-05-22T20:07:23.560000",
+            json.dumps(
+                {
+                    "EXIF": {
+                        "DateTimeOriginal": "2026:05:22 20:07:23",
+                        "SubSecTimeOriginal": "56",
+                        "OffsetTimeOriginal": "-07:00",
+                    }
+                }
+            ),
+            photo_id,
+        ),
+    )
+    db.conn.commit()
+
+    commands = []
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def fake_extract(paths):
+        assert paths == [path]
+        return {
+            path: {
+                "EXIF": {
+                    "DateTimeOriginal": "2026:05:22 17:07:23",
+                    "SubSecTimeOriginal": "56",
+                    "OffsetTimeOriginal": "-10:00",
+                    "OffsetTime": "-10:00",
+                    "OffsetTimeDigitized": "-10:00",
+                }
+            }
+        }
+
+    monkeypatch.setattr(capture_time.shutil, "which", lambda name: "/usr/bin/exiftool")
+    monkeypatch.setattr(capture_time.subprocess, "run", fake_run)
+    monkeypatch.setattr(capture_time, "extract_metadata", fake_extract)
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/jobs/capture-time",
+        json={
+            "photo_ids": [photo_id],
+            "mode": "preserve_instant",
+            "target_offset": "-10:00",
+            "keep_backups": False,
+        },
+    )
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+    assert job["result"]["updated"] == 1
+    assert job["result"]["shift_minutes"] == -180
+
+    assert commands
+    cmd = commands[0]
+    assert "-overwrite_original" in cmd
+    assert "-AllDates-=0:0:0 3:0:0" in cmd
+    assert "-OffsetTimeOriginal=-10:00" in cmd
+    assert path in cmd
+
+    refreshed = db.get_photo(photo_id)
+    assert refreshed["timestamp"] == "2026-05-22T17:07:23.560000"
+    metadata = json.loads(refreshed["exif_data"])
+    assert metadata["EXIF"]["OffsetTimeOriginal"] == "-10:00"

--- a/vireo/tests/test_capture_time_api.py
+++ b/vireo/tests/test_capture_time_api.py
@@ -5,6 +5,16 @@ from types import SimpleNamespace
 from wait import wait_for_job_via_client
 
 
+def test_capture_time_offset_validation_rejects_invalid_extremes():
+    from capture_time import parse_offset_minutes
+
+    assert parse_offset_minutes("+14:00") == 14 * 60
+    assert parse_offset_minutes("-12:00") == -12 * 60
+    assert parse_offset_minutes("+14:30") is None
+    assert parse_offset_minutes("-12:30") is None
+    assert parse_offset_minutes("-13:00") is None
+
+
 def test_capture_time_preview_preserves_instant_from_current_offset(app_and_db):
     app, db = app_and_db
     photo = db.get_photos()[0]
@@ -42,6 +52,25 @@ def test_capture_time_preview_preserves_instant_from_current_offset(app_and_db):
     assert data["samples"][0]["before_offset"] == "-07:00"
     assert data["samples"][0]["after_time"] == "2026-05-22 17:07:23.56"
     assert data["samples"][0]["after_offset"] == "-10:00"
+
+
+def test_capture_time_routes_reject_non_object_json(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+
+    preview = client.post(
+        "/api/capture-time/preview",
+        data='["not", "an", "object"]',
+        content_type="application/json",
+    )
+    job = client.post(
+        "/api/jobs/capture-time",
+        data='"not an object"',
+        content_type="application/json",
+    )
+
+    assert preview.status_code == 400
+    assert job.status_code == 400
 
 
 def test_capture_time_job_writes_exiftool_and_refreshes_cache(client_with_photo, monkeypatch):

--- a/vireo/tests/test_capture_time_api.py
+++ b/vireo/tests/test_capture_time_api.py
@@ -122,3 +122,158 @@ def test_capture_time_job_writes_exiftool_and_refreshes_cache(client_with_photo,
     assert refreshed["timestamp"] == "2026-05-22T17:07:23.560000"
     metadata = json.loads(refreshed["exif_data"])
     assert metadata["EXIF"]["OffsetTimeOriginal"] == "-10:00"
+
+
+def test_capture_time_preview_preserves_instant_uses_per_photo_shifts(app_and_db):
+    """preserve_instant must shift each photo by *its own* current offset.
+
+    Regression test for the bug where a single shift was computed from the
+    first sampled photo and reused for every photo, silently breaking the
+    capture instant for any selection whose photos had differing offsets.
+    """
+    app, db = app_and_db
+    photos = db.get_photos()
+    assert len(photos) >= 2
+    p1, p2 = photos[0], photos[1]
+    db.conn.execute(
+        "UPDATE photos SET exif_data = ? WHERE id = ?",
+        (
+            json.dumps(
+                {
+                    "EXIF": {
+                        "DateTimeOriginal": "2026:05:22 20:00:00",
+                        "OffsetTimeOriginal": "-07:00",
+                    }
+                }
+            ),
+            p1["id"],
+        ),
+    )
+    db.conn.execute(
+        "UPDATE photos SET exif_data = ? WHERE id = ?",
+        (
+            json.dumps(
+                {
+                    "EXIF": {
+                        "DateTimeOriginal": "2026:05:22 20:00:00",
+                        "OffsetTimeOriginal": "-08:00",
+                    }
+                }
+            ),
+            p2["id"],
+        ),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/capture-time/preview",
+        json={
+            "photo_ids": [p1["id"], p2["id"]],
+            "mode": "preserve_instant",
+            "target_offset": "-10:00",
+        },
+    )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    samples_by_id = {row["photo_id"]: row for row in data["samples"]}
+    assert samples_by_id[p1["id"]]["shift_minutes"] == -180
+    assert samples_by_id[p1["id"]]["after_time"] == "2026-05-22 17:00:00"
+    assert samples_by_id[p2["id"]]["shift_minutes"] == -120
+    assert samples_by_id[p2["id"]]["after_time"] == "2026-05-22 18:00:00"
+    assert data["shifts_vary"] is True
+    assert data["shift_minutes"] is None
+
+
+def test_capture_time_job_applies_per_photo_shifts(client_with_photo, monkeypatch):
+    """Each ExifTool invocation must use that photo's own derived shift."""
+    import capture_time
+
+    app, db, p1 = client_with_photo
+    photo = db.get_photo(p1)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()
+    photos_dir = folder["path"]
+
+    from PIL import Image as _Image
+
+    second_path = os.path.join(photos_dir, "second.jpg")
+    _Image.new("RGB", (800, 600), (40, 90, 180)).save(second_path, "JPEG", quality=85)
+    p2 = db.add_photo(
+        folder_id=photo["folder_id"],
+        filename="second.jpg",
+        extension=".jpg",
+        file_size=os.path.getsize(second_path),
+        file_mtime=os.path.getmtime(second_path),
+        width=800, height=600,
+    )
+
+    db.conn.execute(
+        "UPDATE photos SET exif_data = ? WHERE id = ?",
+        (
+            json.dumps(
+                {
+                    "EXIF": {
+                        "DateTimeOriginal": "2026:05:22 20:00:00",
+                        "OffsetTimeOriginal": "-07:00",
+                    }
+                }
+            ),
+            p1,
+        ),
+    )
+    db.conn.execute(
+        "UPDATE photos SET exif_data = ? WHERE id = ?",
+        (
+            json.dumps(
+                {
+                    "EXIF": {
+                        "DateTimeOriginal": "2026:05:22 20:00:00",
+                        "OffsetTimeOriginal": "-08:00",
+                    }
+                }
+            ),
+            p2,
+        ),
+    )
+    db.conn.commit()
+
+    commands = []
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(list(cmd))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def fake_extract(paths):
+        return {paths[0]: {"EXIF": {"OffsetTimeOriginal": "-10:00"}}}
+
+    monkeypatch.setattr(capture_time.shutil, "which", lambda name: "/usr/bin/exiftool")
+    monkeypatch.setattr(capture_time.subprocess, "run", fake_run)
+    monkeypatch.setattr(capture_time, "extract_metadata", fake_extract)
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/jobs/capture-time",
+        json={
+            "photo_ids": [p1, p2],
+            "mode": "preserve_instant",
+            "target_offset": "-10:00",
+            "keep_backups": False,
+        },
+    )
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+    assert job["result"]["updated"] == 2
+    assert job["result"]["shifts_vary"] is True
+    assert job["result"]["shift_minutes"] is None
+
+    by_file = {}
+    for cmd in commands:
+        target = cmd[-1]
+        shift_args = [a for a in cmd if a.startswith("-AllDates")]
+        by_file[os.path.basename(target)] = shift_args[0] if shift_args else None
+    assert by_file["test.jpg"] == "-AllDates-=0:0:0 3:0:0"
+    assert by_file["second.jpg"] == "-AllDates-=0:0:0 2:0:0"

--- a/vireo/tests/test_capture_time_api.py
+++ b/vireo/tests/test_capture_time_api.py
@@ -215,6 +215,105 @@ def test_capture_time_preview_preserves_instant_uses_per_photo_shifts(app_and_db
     assert data["shift_minutes"] is None
 
 
+def test_capture_time_manual_mode_ignores_target_offset(client_with_photo, monkeypatch):
+    """Manual shifts must not rewrite OffsetTime* tags, even if target_offset is sent."""
+    import capture_time
+
+    app, db, photo_id = client_with_photo
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()
+    path = os.path.join(folder["path"], photo["filename"])
+    db.conn.execute(
+        "UPDATE photos SET exif_data = ? WHERE id = ?",
+        (
+            json.dumps(
+                {
+                    "EXIF": {
+                        "DateTimeOriginal": "2026:05:22 20:00:00",
+                        "OffsetTimeOriginal": "-07:00",
+                    }
+                }
+            ),
+            photo_id,
+        ),
+    )
+    db.conn.commit()
+
+    commands = []
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(list(cmd))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def fake_extract(paths):
+        return {paths[0]: {"EXIF": {"OffsetTimeOriginal": "-07:00"}}}
+
+    monkeypatch.setattr(capture_time.shutil, "which", lambda name: "/usr/bin/exiftool")
+    monkeypatch.setattr(capture_time.subprocess, "run", fake_run)
+    monkeypatch.setattr(capture_time, "extract_metadata", fake_extract)
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/jobs/capture-time",
+        json={
+            "photo_ids": [photo_id],
+            "mode": "manual",
+            "target_offset": "-10:00",
+            "shift_minutes": 30,
+            "keep_backups": False,
+        },
+    )
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+    assert job["result"]["updated"] == 1
+    assert job["result"]["target_offset"] is None
+
+    assert commands
+    cmd = commands[0]
+    assert "-AllDates+=0:0:0 0:30:0" in cmd
+    assert not any(arg.startswith("-OffsetTime") for arg in cmd), cmd
+
+
+def test_capture_time_preview_manual_mode_ignores_target_offset(app_and_db):
+    """Manual preview must not present target_offset as the after-offset."""
+    app, db = app_and_db
+    photo = db.get_photos()[0]
+    db.conn.execute(
+        "UPDATE photos SET exif_data = ? WHERE id = ?",
+        (
+            json.dumps(
+                {
+                    "EXIF": {
+                        "DateTimeOriginal": "2026:05:22 20:00:00",
+                        "OffsetTimeOriginal": "-07:00",
+                    }
+                }
+            ),
+            photo["id"],
+        ),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/capture-time/preview",
+        json={
+            "photo_ids": [photo["id"]],
+            "mode": "manual",
+            "target_offset": "-10:00",
+            "shift_minutes": 30,
+        },
+    )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["target_offset"] is None
+    assert data["samples"][0]["after_offset"] == "-07:00"
+
+
 def test_capture_time_job_applies_per_photo_shifts(client_with_photo, monkeypatch):
     """Each ExifTool invocation must use that photo's own derived shift."""
     import capture_time


### PR DESCRIPTION
Adds a guided Browse workflow for adjusting selected photos' capture timestamps and timezone offsets, including before/after previews and optional ExifTool backup files.

Adds backend preview and background job endpoints backed by a new capture-time helper that writes via ExifTool and refreshes Vireo's cached metadata afterward.

This helps fix trips where a camera was left in the wrong timezone without exposing a broad metadata editor surface.

Validated with `pytest -q vireo/tests/test_capture_time_api.py vireo/tests/test_photos_api.py::test_api_photos_by_ids_preserves_selection_order`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch capture-time adjustment with live before/after preview and streaming progress.
  * Two modes: preserve original instant (per-photo) or manual minute shift.
  * Option to keep or discard ExifTool backup files.
  * Quick access via “Adjust Time” action and context-menu item.

* **Bug Fixes**
  * Improved input validation and clearer error responses for invalid requests.

* **Tests**
  * Added coverage for preview, job execution, and offset edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->