### PR TITLE
Add Codex PR instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Codex Instructions
+
+## Pull Requests
+
+When creating GitHub pull requests, create them ready for review by default, not as drafts.
+
+- If using `gh pr create`, do not pass `--draft`.
+- If using a GitHub API or connector, set `draft: false`.
+- Only create a draft PR when the user explicitly asks for a draft.


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with Codex-specific pull request guidance.
- Instruct Codex to create ready-for-review PRs by default and only use draft PRs when explicitly requested.

## Testing

- Not run; documentation/configuration-only change.