### PR TITLE
Browse grid: clarify "Capture date" field shows date & time

### DIFF
--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1760,7 +1760,7 @@ var CARD_FIELD_OPTIONS = [
   { id: 'species', label: 'Species', desc: 'Species identification badges' },
   { id: 'dimensions', label: 'Dimensions', desc: 'Image width \u00d7 height' },
   { id: 'file_size', label: 'File size', desc: 'e.g. "4.2 MB"' },
-  { id: 'capture_date', label: 'Capture date', desc: 'Date photo was taken' },
+  { id: 'capture_date', label: 'Capture date & time', desc: 'Date and time photo was taken (to the minute)' },
   { id: 'extension', label: 'Extension', desc: 'File type (JPG, RAW, etc.)' },
   { id: 'quality_score', label: 'Quality score', desc: 'Pipeline quality score' },
 ];


### PR DESCRIPTION
The browse grid `capture_date` card field already renders date and time to the minute (`YYYY-MM-DD HH:MM`, with the full sub-second timestamp on hover), but its Settings checkbox was labeled "Capture date" with the description "Date photo was taken", making it look date-only. This relabels it to "Capture date & time" and updates the description to match what the card actually shows. The field `id` is unchanged, so existing saved `browse_card_fields` configs are unaffected — purely a UI clarification with no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated "Capture date" field label and description in settings to "Capture date & time," clarifying that the field captures both date and time information to the minute.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->