### PR TITLE
[codex] Guard shortcuts sheet in fullscreen lightbox

### DIFF
--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -394,7 +394,28 @@ def test_question_mark_does_not_open_hidden_sheet_in_fullscreen_lightbox(live_se
     """)
 
     page.keyboard.press("?")
-    page.wait_for_timeout(100)
+    page.wait_for_function(
+        """() => new Promise((resolve, reject) => {
+            const sheet = document.getElementById('shortcutsCheatSheet');
+            const isOpen = () => sheet.classList.contains('open');
+            if (isOpen()) {
+                reject(new Error('shortcuts sheet opened immediately'));
+                return;
+            }
+            const deadline = performance.now() + 300;
+            function check() {
+                if (isOpen()) {
+                    reject(new Error('shortcuts sheet opened during fullscreen guard window'));
+                } else if (performance.now() >= deadline) {
+                    resolve(true);
+                } else {
+                    requestAnimationFrame(check);
+                }
+            }
+            requestAnimationFrame(check);
+        })""",
+        timeout=1000,
+    )
 
     assert page.evaluate(
         "document.getElementById('shortcutsCheatSheet').classList.contains('open')"

--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -367,6 +367,43 @@ def test_question_mark_opens_shortcuts_sheet_over_lightbox(live_server, page):
     )
 
 
+def test_question_mark_does_not_open_hidden_sheet_in_fullscreen_lightbox(live_server, page):
+    """When the lightbox is the browser fullscreen element, sibling overlays
+    cannot render above it; ? should not open a hidden shortcuts sheet."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse", timeout=15000)
+    page.wait_for_load_state("networkidle")
+
+    page.evaluate("openLightbox(1, 'hawk1.jpg')")
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=2000,
+    )
+    page.evaluate("""
+        () => {
+          const lightbox = document.getElementById('lightboxOverlay');
+          Object.defineProperty(document, 'fullscreenElement', {
+            configurable: true,
+            get: () => lightbox,
+          });
+          Object.defineProperty(document, 'webkitFullscreenElement', {
+            configurable: true,
+            get: () => null,
+          });
+        }
+    """)
+
+    page.keyboard.press("?")
+    page.wait_for_timeout(100)
+
+    assert page.evaluate(
+        "document.getElementById('shortcutsCheatSheet').classList.contains('open')"
+    ) is False
+    assert page.evaluate(
+        "document.getElementById('lightboxOverlay').classList.contains('active')"
+    ) is True
+
+
 def test_two_overlays_unwind_one_esc_each(live_server, page):
     """With lightbox open and cheat sheet stacked on top, each Esc closes one
     overlay (top-of-stack first). Locks in the new one-Esc-per-overlay model

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2681,6 +2681,8 @@ window.NAV_ALL_PAGES = [
   document.addEventListener('keydown', function(e) {
     if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
     if (document.querySelector('.pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open, .help-overlay.active')) return;
+    var lightboxOverlay = document.getElementById('lightboxOverlay');
+    if (lightboxOverlay && (document.fullscreenElement === lightboxOverlay || document.webkitFullscreenElement === lightboxOverlay)) return;
     // When sheet is open, consume non-Esc keys so page handlers don't fire.
     // Esc is handled by the Keymap.pushEsc stack and must reach the dispatcher.
     if (document.getElementById('shortcutsCheatSheet').classList.contains('open')) {

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -1002,8 +1002,8 @@ def test_get_history_excludes_queued_rows(tmp_path):
 
         blocker.set()
         for fid in filler_ids:
-            wait_for_job_via_runner(runner, fid)
-        wait_for_job_via_runner(runner, queued_id)
+            wait_for_job_via_runner(runner, fid, wait_for_history=True)
+        wait_for_job_via_runner(runner, queued_id, wait_for_history=True)
 
         # After completion the live rows DO appear in history.
         history_ids = [j["id"] for j in runner.get_history(db, limit=50)]


### PR DESCRIPTION
Follow-up to #926 for the late fullscreen lightbox review comment. When the lightbox itself is the browser fullscreen element, sibling overlays cannot render above it, so the ? shortcut now avoids opening a hidden shortcuts sheet in that state. Adds an e2e regression test that simulates the fullscreen element and verifies the sheet stays closed while the lightbox remains active. Validated with pytest tests/e2e/test_keymap.py -q.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard shortcut menu opening when lightbox is in fullscreen mode, preventing unintended overlay stacking.

* **Tests**
  * Added test coverage for keyboard shortcut behavior when lightbox is displayed in fullscreen.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->