### PR TITLE
[codex] Improve highlights ranking

### DIFF
--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -9,6 +9,10 @@ single-folder. This test locks in the fix by asserting that on first render,
 the photos shown reflect workspace scope (blending every folder with quality
 data) and the dropdown selection matches.
 """
+import json
+from urllib.parse import quote
+from urllib.request import urlopen
+
 from playwright.sync_api import expect
 
 
@@ -83,3 +87,123 @@ def test_initial_load_matches_default_workspace_scope(live_server, page):
         f"got bucket titles {species_text!r}. This likely means the first "
         f"fetch used folder scope and the UI/data are out of sync."
     )
+
+
+def test_highlights_ranks_species_by_rich_subject_score(live_server, page):
+    """Best image should use persisted subject quality, not only legacy score.
+
+    The first hawk has a low legacy ``quality_score`` but strong subject
+    metrics; the second has a high legacy score but soft/clipped/incomplete
+    subject metrics. Highlights should put the real photographic keeper first.
+    """
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    hawk_good, hawk_bad = data["photos"][0], data["photos"][1]
+    db.conn.execute(
+        """UPDATE photos
+           SET quality_score = 0.20,
+               subject_tenengrad = 900,
+               bg_tenengrad = 20,
+               crop_complete = 0.98,
+               bg_separation = 10,
+               subject_clip_high = 0.0,
+               subject_clip_low = 0.0,
+               subject_y_median = 115,
+               noise_estimate = 4,
+               subject_size = 0.10
+           WHERE id = ?""",
+        (hawk_good,),
+    )
+    db.conn.execute(
+        """UPDATE photos
+           SET quality_score = 0.95,
+               subject_tenengrad = 20,
+               bg_tenengrad = 400,
+               crop_complete = 0.35,
+               bg_separation = 200,
+               subject_clip_high = 0.65,
+               subject_clip_low = 0.0,
+               subject_y_median = 245,
+               noise_estimate = 90,
+               subject_size = 0.01
+           WHERE id = ?""",
+        (hawk_bad,),
+    )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/highlights", timeout=5000)
+    hawk_section = page.locator("section.bucket").filter(has_text="Red-tailed Hawk")
+    expect(hawk_section.locator(".highlights-card").first).to_be_visible(timeout=5000)
+    expect(hawk_section.locator(".highlights-card img").first).to_have_attribute(
+        "alt", "hawk1.jpg"
+    )
+
+
+def test_highlights_species_search_filters_buckets(live_server, page):
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    page.goto(f"{live_server['url']}/highlights", timeout=5000)
+    expect(page.locator(".highlights-card").first).to_be_visible(timeout=5000)
+
+    with page.expect_response(
+        lambda r: "/api/highlights?" in r.url and "species=robin" in r.url.lower()
+    ):
+        page.locator("#speciesSearch").fill("robin")
+    expect(page.locator(".bucket-title")).to_have_count(1)
+    expect(page.locator(".bucket-title").first).to_contain_text("American Robin")
+    assert not any(
+        "Red-tailed Hawk" in title
+        for title in page.locator(".bucket-title").all_inner_texts()
+    )
+
+
+def test_highlights_api_limits_initial_bucket_and_loads_more(live_server):
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    hawk_kid = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = ?", ("Red-tailed Hawk",)
+    ).fetchone()["id"]
+    folder_id = data["folders"][0]
+    for i in range(25):
+        pid = db.add_photo(
+            folder_id=folder_id,
+            filename=f"extra-hawk-{i}.jpg",
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=1.0,
+            timestamp=f"2024-03-11T08:{i:02d}:00",
+        )
+        db.conn.execute(
+            "UPDATE photos SET quality_score = ? WHERE id = ?",
+            (0.7 - i * 0.001, pid),
+        )
+        db.conn.execute(
+            "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+            (pid, hawk_kid),
+        )
+    db.conn.commit()
+
+    base = live_server["url"]
+    with urlopen(f"{base}/api/highlights?scope=workspace&limit_per_bucket=5") as resp:
+        payload = json.load(resp)
+    hawk = next(b for b in payload["buckets"] if b["species"] == "Red-tailed Hawk")
+    assert hawk["photo_count"] == 28
+    assert hawk["loaded_count"] == 5
+    assert hawk["has_more"] is True
+    assert len(hawk["photos"]) == 5
+
+    species = quote("Red-tailed Hawk")
+    with urlopen(
+        f"{base}/api/highlights/bucket?scope=workspace&species={species}&offset=5&limit=10"
+    ) as resp:
+        chunk = json.load(resp)
+    assert chunk["photo_count"] == 28
+    assert chunk["loaded_count"] == 15
+    assert chunk["has_more"] is True
+    assert len(chunk["photos"]) == 10

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -119,6 +119,249 @@ class _QuietRequestFilter(logging.Filter):
 logging.getLogger("werkzeug").addFilter(_QuietRequestFilter())
 
 
+def _rank01(value, values):
+    valid = [v for v in values if v is not None]
+    if value is None:
+        return 0.0
+    if len(valid) <= 1:
+        return 0.5 if valid else 0.0
+    below = sum(1 for v in valid if v < value)
+    equal = sum(1 for v in valid if v == value)
+    return (below + 0.5 * equal) / len(valid)
+
+
+def _highlight_exposure_score(photo):
+    clip_high = photo.get("subject_clip_high") or 0.0
+    clip_low = photo.get("subject_clip_low") or 0.0
+    y_median = photo.get("subject_y_median")
+    if y_median is None:
+        return 0.5
+    clip_penalty = math.exp(-6.0 * clip_high - 3.0 * clip_low)
+    lum_penalty = math.exp(-abs((y_median / 255.0) - 0.45) / 0.30)
+    return max(0.0, min(1.0, clip_penalty * lum_penalty))
+
+
+def _highlight_area_score(subject_size):
+    if subject_size is None or subject_size <= 0:
+        return 0.0
+    return min(1.0, math.sqrt(subject_size) * 2.0)
+
+
+def _highlight_score_bucket(photos):
+    """Attach highlight scores and compact reason labels to one species bucket."""
+    subject_values = [p.get("subject_tenengrad") for p in photos]
+    eye_values = [p.get("eye_tenengrad") for p in photos if p.get("eye_tenengrad") is not None]
+    bg_values = [p.get("bg_tenengrad") for p in photos]
+    bg_sep_values = [p.get("bg_separation") for p in photos if p.get("bg_separation") is not None]
+    noise_values = [p.get("noise_estimate") for p in photos if p.get("noise_estimate") is not None]
+    max_bg_sep = max(bg_sep_values) if bg_sep_values else None
+
+    for p in photos:
+        if p.get("eye_tenengrad") is not None and eye_values:
+            focus = _rank01(p.get("eye_tenengrad"), eye_values)
+            focus_label = "eye focus"
+        else:
+            subject_t = p.get("subject_tenengrad")
+            rank = _rank01(subject_t, subject_values)
+            if subject_t is not None and p.get("bg_tenengrad") is not None:
+                ratio = math.log((subject_t + 1e-8) / (p.get("bg_tenengrad") + 1e-8))
+                bg_term = 1.0 / (1.0 + math.exp(-ratio))
+                focus = 0.70 * rank + 0.30 * bg_term
+            elif subject_t is not None:
+                focus = rank
+            else:
+                focus = p.get("quality_score") if p.get("quality_score") is not None else 0.0
+            focus_label = "focus"
+
+        exposure = _highlight_exposure_score(p)
+        crop = p.get("crop_complete")
+        crop_score = crop if crop is not None else 0.5
+        if max_bg_sep and p.get("bg_separation") is not None:
+            bg_sep = 1.0 - min(1.0, p.get("bg_separation") / max_bg_sep)
+        else:
+            bg_sep = 0.5
+        composition = 0.55 * crop_score + 0.45 * bg_sep
+        area = _highlight_area_score(p.get("subject_size"))
+        if p.get("noise_estimate") is not None and noise_values:
+            noise = 1.0 - _rank01(p.get("noise_estimate"), noise_values)
+        else:
+            noise = 1.0 - _rank01(p.get("bg_tenengrad"), bg_values) if bg_values else 0.5
+
+        rich_available = any(
+            p.get(k) is not None
+            for k in (
+                "subject_tenengrad", "eye_tenengrad", "crop_complete",
+                "subject_clip_high", "subject_y_median", "noise_estimate",
+            )
+        )
+        if rich_available:
+            score = (
+                0.42 * focus
+                + 0.18 * exposure
+                + 0.16 * composition
+                + 0.10 * area
+                + 0.08 * noise
+                + 0.06 * (p.get("quality_score") or 0.0)
+            )
+        else:
+            score = p.get("quality_score") if p.get("quality_score") is not None else 0.0
+
+        rating = p.get("rating") or 0
+        if p.get("flag") == "flagged":
+            score += 0.08
+        if rating >= 4:
+            score += 0.04 + 0.02 * (rating - 4)
+        elif rating == 3:
+            score += 0.015
+
+        reasons = []
+        if p.get("flag") == "flagged":
+            reasons.append("picked")
+        if rating:
+            reasons.append(f"{rating} star")
+        if focus >= 0.72:
+            reasons.append(f"strong {focus_label}")
+        elif focus < 0.35 and rich_available:
+            reasons.append("soft subject")
+        if exposure >= 0.70:
+            reasons.append("good exposure")
+        elif p.get("subject_clip_high") is not None and p.get("subject_clip_high") > 0.30:
+            reasons.append("highlight clipping")
+        if crop is not None:
+            if crop >= 0.90:
+                reasons.append("clean crop")
+            elif crop < 0.60:
+                reasons.append("clipped subject")
+        if area >= 0.50:
+            reasons.append("large subject")
+        if not reasons:
+            reasons.append("legacy quality")
+
+        p["highlight_score"] = round(max(0.0, min(1.0, score)), 4)
+        p["score_parts"] = {
+            "focus": round(focus, 3),
+            "exposure": round(exposure, 3),
+            "composition": round(composition, 3),
+            "subject": round(area, 3),
+            "noise": round(noise, 3),
+        }
+        p["reasons"] = reasons[:3]
+
+    photos.sort(
+        key=lambda p: (
+            p.get("highlight_score") or 0,
+            p.get("predicted_confidence") or 0,
+            p.get("quality_score") or 0,
+            p.get("rating") or 0,
+            -p.get("id", 0),
+        ),
+        reverse=True,
+    )
+
+
+def _highlight_confidence_label(confidence, is_accepted):
+    if is_accepted:
+        return "confirmed"
+    if confidence is None:
+        return "unknown"
+    if confidence >= 0.85:
+        return "likely"
+    return "candidate"
+
+
+def _collect_highlight_buckets(candidates, confidence_threshold):
+    bucket_map = {}
+    unidentified_photos = []
+
+    for row in candidates:
+        r = dict(row)
+        accepted = r.get("species")
+        predicted_conf = r.get("predicted_confidence")
+        if accepted:
+            species = accepted
+            is_accepted = True
+        elif (
+            r.get("predicted_species")
+            and predicted_conf is not None
+            and predicted_conf >= confidence_threshold
+        ):
+            species = r["predicted_species"]
+            is_accepted = False
+        else:
+            species = None
+            is_accepted = False
+
+        photo = {
+            "id": r["id"],
+            "filename": r["filename"],
+            "rating": r.get("rating") or 0,
+            "flag": r.get("flag") or "none",
+            "quality_score": r.get("quality_score"),
+            "subject_sharpness": r.get("subject_sharpness"),
+            "subject_size": r.get("subject_size"),
+            "sharpness": r.get("sharpness"),
+            "mask_path": r.get("mask_path"),
+            "subject_tenengrad": r.get("subject_tenengrad"),
+            "bg_tenengrad": r.get("bg_tenengrad"),
+            "crop_complete": r.get("crop_complete"),
+            "bg_separation": r.get("bg_separation"),
+            "subject_clip_high": r.get("subject_clip_high"),
+            "subject_clip_low": r.get("subject_clip_low"),
+            "subject_y_median": r.get("subject_y_median"),
+            "noise_estimate": r.get("noise_estimate"),
+            "eye_tenengrad": r.get("eye_tenengrad"),
+            "predicted_confidence": predicted_conf,
+            "has_accepted_species": accepted is not None,
+        }
+
+        if species is None:
+            unidentified_photos.append(photo)
+        else:
+            entry = bucket_map.setdefault(
+                species, {"is_accepted": True, "photos": []}
+            )
+            entry["is_accepted"] = entry["is_accepted"] and is_accepted
+            entry["photos"].append(photo)
+
+    buckets = []
+    for species, entry in bucket_map.items():
+        photos = entry["photos"]
+        _highlight_score_bucket(photos)
+        confidences = [
+            p["predicted_confidence"]
+            for p in photos
+            if p.get("predicted_confidence") is not None
+        ]
+        avg_confidence = (
+            round(sum(confidences) / len(confidences), 4)
+            if confidences else None
+        )
+        best = photos[0] if photos else {}
+        buckets.append({
+            "species": species,
+            "is_accepted": entry["is_accepted"],
+            "certainty": _highlight_confidence_label(
+                avg_confidence, entry["is_accepted"]
+            ),
+            "avg_confidence": avg_confidence,
+            "photo_count": len(photos),
+            "best_quality": best.get("quality_score"),
+            "best_score": best.get("highlight_score"),
+            "photos": photos,
+        })
+
+    _highlight_score_bucket(unidentified_photos)
+    buckets.sort(
+        key=lambda b: (
+            b.get("best_score") or 0,
+            b.get("avg_confidence") or 0,
+            b.get("photo_count") or 0,
+        ),
+        reverse=True,
+    )
+    return buckets, unidentified_photos
+
+
 # Maximum number of bound parameters per SQL statement. SQLite's
 # ``SQLITE_MAX_VARIABLE_NUMBER`` defaults to 32766 on builds since 3.32 but
 # remains 999 on older builds (and on some packagers' default builds). Bulk
@@ -3997,70 +4240,43 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         confidence_threshold = request.args.get(
             "confidence_threshold", 0.70, type=float
         )
+        limit_per_bucket = max(
+            1, min(request.args.get("limit_per_bucket", 20, type=int), 100)
+        )
+        species_filter = (request.args.get("species") or "").strip().lower()
 
         candidates = db.get_highlights_candidates(folder_id, min_quality=min_quality)
         total_in_scope = db.count_filtered_photos(folder_id=folder_id)
 
-        # Resolve effective species: accepted wins, then prediction above
-        # threshold, otherwise Unidentified.
-        bucket_map = {}  # species name -> {is_accepted: bool, photos: list}
-        unidentified_photos = []
+        buckets, unidentified_photos = _collect_highlight_buckets(
+            candidates, confidence_threshold
+        )
+        if species_filter:
+            buckets = [
+                b for b in buckets if species_filter in b["species"].lower()
+            ]
+            if "unidentified".find(species_filter) < 0:
+                unidentified_photos = []
 
-        for row in candidates:
-            r = dict(row)
-            accepted = r.get("species")
-            if accepted:
-                species = accepted
-                is_accepted = True
-            elif (r.get("predicted_species")
-                  and r.get("predicted_confidence") is not None
-                  and r["predicted_confidence"] >= confidence_threshold):
-                species = r["predicted_species"]
-                is_accepted = False
-            else:
-                species = None
-                is_accepted = False
-
-            photo = {
-                "id": r["id"],
-                "filename": r["filename"],
-                "quality_score": r["quality_score"],
-                "has_accepted_species": accepted is not None,
+        def limited_bucket(bucket):
+            photos = bucket["photos"]
+            limited = photos[:limit_per_bucket]
+            return {
+                **bucket,
+                "photos": limited,
+                "loaded_count": len(limited),
+                "has_more": len(photos) > len(limited),
             }
 
-            if species is None:
-                unidentified_photos.append(photo)
-            else:
-                entry = bucket_map.setdefault(
-                    species, {"is_accepted": True, "photos": []}
-                )
-                # is_accepted is True if EVERY photo in this bucket has an
-                # accepted species tag — used by UI to render a "Confirmed"
-                # badge that means the entire row is confirmed, not just some
-                # of it. Initialize to True (the unit element of AND) so the
-                # AND-fold below produces the right answer.
-                entry["is_accepted"] = entry["is_accepted"] and is_accepted
-                entry["photos"].append(photo)
-
-        # candidates is already ordered by quality_score desc, so per-bucket
-        # photos inherit that order without resorting.
-
-        buckets = []
-        for species, entry in bucket_map.items():
-            photos = entry["photos"]
-            buckets.append({
-                "species": species,
-                "is_accepted": entry["is_accepted"],
-                "photo_count": len(photos),
-                "best_quality": photos[0]["quality_score"] if photos else None,
-                "photos": photos,
-            })
+        unidentified_limited = unidentified_photos[:limit_per_bucket]
 
         return jsonify({
-            "buckets": buckets,
+            "buckets": [limited_bucket(b) for b in buckets],
             "unidentified": {
                 "photo_count": len(unidentified_photos),
-                "photos": unidentified_photos,
+                "photos": unidentified_limited,
+                "loaded_count": len(unidentified_limited),
+                "has_more": len(unidentified_photos) > len(unidentified_limited),
             },
             "folders": [
                 {"id": f["id"], "name": f["name"], "photo_count": f["photo_count"]}
@@ -4069,8 +4285,53 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "meta": {
                 "total_in_scope": total_in_scope,
                 "eligible": len(candidates),
+                "limit_per_bucket": limit_per_bucket,
             },
             "scope": "workspace" if folder_id is None else "folder",
+        })
+
+    @app.route("/api/highlights/bucket")
+    def api_highlights_bucket():
+        db = _get_db()
+        folders = db.get_folders_with_quality_data()
+        scope = request.args.get("scope", "folder")
+        folder_id = request.args.get("folder_id", type=int)
+        if scope == "workspace":
+            folder_id = None
+        elif folder_id is None and folders:
+            folder_id = folders[0]["id"]
+
+        min_quality = request.args.get("min_quality", 0.0, type=float)
+        confidence_threshold = request.args.get(
+            "confidence_threshold", 0.70, type=float
+        )
+        species = (request.args.get("species") or "").strip()
+        offset = max(0, request.args.get("offset", 0, type=int))
+        limit = max(1, min(request.args.get("limit", 100, type=int), 500))
+        if not species:
+            return json_error("species required")
+
+        candidates = db.get_highlights_candidates(folder_id, min_quality=min_quality)
+        buckets, unidentified_photos = _collect_highlight_buckets(
+            candidates, confidence_threshold
+        )
+        if species == "__unidentified__":
+            photos = unidentified_photos
+            label = "Unidentified"
+        else:
+            bucket = next((b for b in buckets if b["species"] == species), None)
+            if bucket is None:
+                return json_error("species not found", 404)
+            photos = bucket["photos"]
+            label = bucket["species"]
+
+        chunk = photos[offset: offset + limit]
+        return jsonify({
+            "species": label,
+            "photos": chunk,
+            "photo_count": len(photos),
+            "loaded_count": min(len(photos), offset + len(chunk)),
+            "has_more": offset + len(chunk) < len(photos),
         })
 
     @app.route("/api/highlights/save", methods=["POST"])

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -6822,7 +6822,9 @@ class Database:
             no usable prediction exists)
 
         Only photos with ``quality_score >= min_quality`` that are not
-        user-rejected are returned, ordered by ``quality_score`` DESC.
+        user-rejected are returned. The API layer applies the final
+        highlights ranking because it combines these persisted quality fields
+        with prediction confidence and user ratings.
         """
         ws = self._ws_id()
         if folder_id is None:
@@ -6838,6 +6840,11 @@ class Database:
                       p.timestamp, p.width, p.height, p.rating, p.flag,
                       p.thumb_path, p.quality_score, p.subject_sharpness,
                       p.subject_size, p.sharpness, p.phash_crop,
+                      p.mask_path, p.subject_tenengrad, p.bg_tenengrad,
+                      p.crop_complete, p.bg_separation,
+                      p.subject_clip_high, p.subject_clip_low,
+                      p.subject_y_median, p.noise_estimate,
+                      p.eye_tenengrad,
                       p.dino_subject_embedding, p.dino_global_embedding,
                       bp.species,
                       tp.predicted_species,
@@ -6854,7 +6861,7 @@ class Database:
                               ) AS rn
                        FROM photo_keywords pk
                        JOIN keywords k ON k.id = pk.keyword_id
-                       WHERE k.is_species = 1
+                       WHERE k.is_species = 1 OR k.type = 'taxonomy'
                    ) WHERE rn = 1
                ) bp ON bp.photo_id = p.id
                LEFT JOIN (

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -12,7 +12,8 @@
   .control-group { display:flex; align-items:center; gap:8px; }
   .control-group label { font-size:13px; color:var(--text-secondary); white-space:nowrap; }
   .control-group input[type=range] { width:120px; }
-  .control-group select { font-size:13px; padding:4px 8px; background:var(--bg-input); color:var(--text-primary); border:1px solid var(--border-secondary); border-radius:4px; }
+  .control-group input[type=search], .control-group select { font-size:13px; padding:4px 8px; background:var(--bg-input); color:var(--text-primary); border:1px solid var(--border-secondary); border-radius:4px; }
+  .control-group input[type=search] { width:180px; }
   .control-value { font-size:13px; color:var(--text-primary); min-width:36px; }
   .save-btn { margin-left:auto; padding:6px 16px; background:var(--accent); color:var(--accent-text); border:none; border-radius:4px; cursor:pointer; font-size:13px; }
   .save-btn:hover { opacity:0.9; }
@@ -23,12 +24,20 @@
   .bucket-meta { font-size:13px; color:var(--text-secondary); }
   .bucket-badge { display:inline-block; margin-left:8px; font-size:10px; padding:2px 6px; border-radius:8px; background:var(--bg-tertiary); color:var(--text-secondary); text-transform:uppercase; letter-spacing:0.5px; }
   .bucket-badge.predicted { background:var(--bg-tertiary); color:var(--text-secondary); }
+  .bucket-badge.likely { background:rgba(34,139,34,0.16); color:var(--success); }
+  .bucket-badge.candidate { background:rgba(229,194,51,0.18); color:var(--warning); }
   .bucket-badge.accepted { background:var(--accent); color:var(--accent-text); }
   .bucket-strip { display:grid; grid-template-columns:repeat(auto-fill, minmax(180px, 1fr)); gap:10px; }
   .highlights-card { position:relative; border-radius:6px; overflow:hidden; background:var(--bg-secondary); cursor:pointer; border:1px solid var(--border-primary); }
   .highlights-card:hover { border-color:var(--accent); }
+  .highlights-card.best-card { border-color:var(--accent); }
+  .best-ribbon { position:absolute; top:6px; left:6px; padding:2px 6px; border-radius:999px; background:var(--accent); color:var(--accent-text); font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:0.5px; }
   .highlights-card img { width:100%; aspect-ratio:3/2; object-fit:cover; display:block; background:var(--bg-tertiary); }
-  .card-info { padding:4px 8px; font-size:11px; color:var(--text-secondary); text-align:right; }
+  .card-info { padding:6px 8px; font-size:11px; color:var(--text-secondary); display:flex; flex-wrap:wrap; align-items:center; justify-content:flex-end; gap:4px; min-height:28px; }
+  .card-chip { padding:1px 5px; border-radius:999px; background:var(--bg-tertiary); white-space:nowrap; }
+  .card-chip.score { color:var(--text-primary); font-weight:600; }
+  .card-chip.conf { color:var(--text-secondary); }
+  .card-chip.reason { color:var(--text-secondary); max-width:100%; overflow:hidden; text-overflow:ellipsis; }
   .bucket-expand { margin-top:8px; font-size:13px; color:var(--accent); cursor:pointer; background:none; border:none; padding:0; }
   .bucket-expand:hover { text-decoration:underline; }
 
@@ -57,6 +66,10 @@
     <select id="folderSelect"></select>
   </div>
   <div class="control-group">
+    <label for="speciesSearch">Species</label>
+    <input type="search" id="speciesSearch" placeholder="Cardinal">
+  </div>
+  <div class="control-group">
     <label for="qualitySlider">Min quality</label>
     <input type="range" id="qualitySlider" min="0" max="100" value="0" step="5">
     <span class="control-value" id="qualityValue">0.00</span>
@@ -74,9 +87,9 @@
   <div class="control-group">
     <label for="sortSelect">Sort</label>
     <select id="sortSelect">
+      <option value="best">Best photo first</option>
       <option value="fewest">Fewest photos</option>
       <option value="most">Most photos</option>
-      <option value="best">Best photo first</option>
       <option value="worst">Worst photo first</option>
     </select>
   </div>
@@ -121,7 +134,15 @@ function escapeAttr(s) {
   return String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
-async function loadHighlights() {
+function formatScore(v) {
+  return v == null ? '—' : Number(v).toFixed(2);
+}
+
+function formatPercent(v) {
+  return v == null ? '' : Math.round(Number(v) * 100) + '%';
+}
+
+function requestScopeParams() {
   var params = new URLSearchParams();
   var folderSelect = document.getElementById('folderSelect');
   var firstLoad = folderSelect.options.length === 0;
@@ -132,6 +153,15 @@ async function loadHighlights() {
   }
   params.set('min_quality', (parseInt(document.getElementById('qualitySlider').value) / 100).toFixed(2));
   params.set('confidence_threshold', (parseInt(document.getElementById('confidenceSlider').value) / 100).toFixed(2));
+  return params;
+}
+
+async function loadHighlights() {
+  var params = requestScopeParams();
+  var folderSelect = document.getElementById('folderSelect');
+  var speciesSearch = document.getElementById('speciesSearch').value.trim();
+  params.set('limit_per_bucket', Math.max(20, parseInt(document.getElementById('perRowSlider').value)));
+  if (speciesSearch) params.set('species', speciesSearch);
 
   var data = await safeFetch('/api/highlights?' + params);
   currentData = data;
@@ -161,18 +191,26 @@ function sortedBuckets() {
   var buckets = (currentData.buckets || []).slice();
   buckets.sort(function(a, b) {
     if (sort === 'most') return b.photo_count - a.photo_count;
-    if (sort === 'best') return b.best_quality - a.best_quality;
-    if (sort === 'worst') return a.best_quality - b.best_quality;
+    if (sort === 'best') return (b.best_score || 0) - (a.best_score || 0);
+    if (sort === 'worst') return (a.best_score || 0) - (b.best_score || 0);
     return a.photo_count - b.photo_count; // 'fewest' default
   });
   return buckets;
 }
 
-function renderCard(p) {
+function renderCard(p, idx) {
   var thumbSrc = '/thumbnails/' + p.id + '.jpg';
-  return '<div class="highlights-card" data-photo-id="' + p.id + '">'
+  var conf = p.has_accepted_species
+    ? '<span class="card-chip conf">Tagged</span>'
+    : (p.predicted_confidence != null ? '<span class="card-chip conf">ID ' + formatPercent(p.predicted_confidence) + '</span>' : '');
+  var reasons = (p.reasons || []).slice(0, 2).map(function(r) {
+    return '<span class="card-chip reason">' + escapeAttr(r) + '</span>';
+  }).join('');
+  var title = (p.reasons || []).join(', ');
+  return '<div class="highlights-card' + (idx === 0 ? ' best-card' : '') + '" data-photo-id="' + p.id + '" title="' + escapeAttr(title) + '">'
+    + (idx === 0 ? '<div class="best-ribbon">Best</div>' : '')
     + '<img src="' + thumbSrc + '" alt="' + escapeAttr(p.filename) + '" loading="lazy">'
-    + '<div class="card-info">' + (p.quality_score != null ? p.quality_score.toFixed(2) : '—') + '</div>'
+    + '<div class="card-info"><span class="card-chip score">' + formatScore(p.highlight_score) + '</span>' + conf + reasons + '</div>'
     + '</div>';
 }
 
@@ -195,17 +233,20 @@ function renderBucket(bucket) {
   var perRow = parseInt(document.getElementById('perRowSlider').value);
   var expanded = expandedBuckets.has(bucket.species);
   var visible = expanded ? bucket.photos : bucket.photos.slice(0, perRow);
-  var remaining = bucket.photos.length - visible.length;
+  var remaining = bucket.photo_count - visible.length;
+  var badgeClass = bucket.is_accepted ? 'accepted' : (bucket.certainty === 'likely' ? 'likely' : 'candidate');
+  var badgeText = bucket.is_accepted ? 'Confirmed' : (bucket.certainty === 'likely' ? 'Likely ID' : 'Top candidates');
   var badge = bucket.is_accepted
     ? '<span class="bucket-badge accepted">Confirmed</span>'
-    : '<span class="bucket-badge predicted">Predicted</span>';
+    : '<span class="bucket-badge ' + badgeClass + '">' + badgeText + '</span>';
   var meta = bucket.photo_count + ' photo' + (bucket.photo_count === 1 ? '' : 's')
-    + ' · best ' + bucket.best_quality.toFixed(2);
+    + ' · best ' + formatScore(bucket.best_score);
+  if (!bucket.is_accepted && bucket.avg_confidence != null) meta += ' · ID ' + formatPercent(bucket.avg_confidence);
   var expandBtn = '';
-  if (bucket.photos.length > perRow) {
+  if (bucket.photo_count > perRow) {
     expandBtn = '<button class="bucket-expand" data-species="'
       + escapeAttr(bucket.species) + '">'
-      + (expanded ? 'Show fewer' : '+ ' + remaining + ' more')
+      + (expanded ? (bucket.has_more ? 'Load more' : 'Show fewer') : '+ ' + remaining + ' more')
       + '</button>';
   }
   return '<section class="bucket">'
@@ -227,7 +268,7 @@ function renderUnidentified() {
   var expandBtn = '';
   if (unid.photo_count > perRow) {
     expandBtn = '<button class="bucket-expand" data-unid="1">'
-      + (unidentifiedExpanded ? 'Show fewer' : '+ ' + remaining + ' more')
+      + (unidentifiedExpanded ? (unid.has_more ? 'Load more' : 'Show fewer') : '+ ' + remaining + ' more')
       + '</button>';
   }
   return '<div class="unid-divider">Unidentified — Vireo couldn\'t ID these</div>'
@@ -239,6 +280,19 @@ function renderUnidentified() {
     + '<div class="bucket-strip">' + visible.map(renderCard).join('') + '</div>'
     + expandBtn
     + '</section>';
+}
+
+async function loadMoreBucket(species, isUnidentified) {
+  var params = requestScopeParams();
+  var target = isUnidentified ? currentData.unidentified : (currentData.buckets || []).find(function(b) { return b.species === species; });
+  if (!target || !target.has_more) return;
+  params.set('species', isUnidentified ? '__unidentified__' : species);
+  params.set('offset', target.photos.length);
+  params.set('limit', 500);
+  var data = await safeFetch('/api/highlights/bucket?' + params);
+  target.photos = target.photos.concat(data.photos || []);
+  target.loaded_count = data.loaded_count;
+  target.has_more = data.has_more;
 }
 
 function render() {
@@ -258,7 +312,8 @@ function render() {
   controls.style.display = '';
 
   var buckets = sortedBuckets();
-  meta.textContent = buckets.length + ' species · '
+  var speciesSearch = document.getElementById('speciesSearch').value.trim();
+  meta.textContent = buckets.length + (speciesSearch ? ' matching' : '') + ' species · '
     + currentData.meta.eligible + ' of '
     + currentData.meta.total_in_scope + ' photos scored';
 
@@ -280,13 +335,23 @@ function render() {
 
   // Expand buttons
   content.querySelectorAll('.bucket-expand').forEach(function(btn) {
-    btn.addEventListener('click', function() {
+    btn.addEventListener('click', async function() {
       if (btn.hasAttribute('data-unid')) {
-        unidentifiedExpanded = !unidentifiedExpanded;
+        if (!unidentifiedExpanded || currentData.unidentified.has_more) {
+          unidentifiedExpanded = true;
+          await loadMoreBucket(null, true);
+        } else {
+          unidentifiedExpanded = false;
+        }
       } else {
         var sp = btn.getAttribute('data-species');
-        if (expandedBuckets.has(sp)) expandedBuckets.delete(sp);
-        else expandedBuckets.add(sp);
+        var bucket = (currentData.buckets || []).find(function(b) { return b.species === sp; });
+        if (!expandedBuckets.has(sp) || (bucket && bucket.has_more)) {
+          expandedBuckets.add(sp);
+          await loadMoreBucket(sp, false);
+        } else {
+          expandedBuckets.delete(sp);
+        }
       }
       render();
     });
@@ -304,6 +369,9 @@ document.getElementById('qualitySlider').addEventListener('input', function() {
 });
 document.getElementById('confidenceSlider').addEventListener('input', function() {
   document.getElementById('confidenceValue').textContent = (this.value / 100).toFixed(2);
+  debounceLoad();
+});
+document.getElementById('speciesSearch').addEventListener('input', function() {
   debounceLoad();
 });
 document.getElementById('perRowSlider').addEventListener('input', function() {


### PR DESCRIPTION
Adds a richer highlights ranking that scores each species bucket using persisted focus, eye focus, exposure, crop, subject size, noise, ratings, and pick flags while keeping legacy quality as a fallback. The highlights page now supports species search, clearer confirmed/likely/candidate labels, reason chips on cards, best-first sorting, and lazy bucket expansion for large libraries. The candidate query now includes richer quality fields and treats taxonomy keywords as confirmed species. Validated with `python -m py_compile vireo/app.py vireo/db.py` and `python -m pytest tests/e2e/test_page_loads.py tests/e2e/test_highlights_initial_scope.py -q`.