### PR TITLE
Fix Google place linking from autocomplete

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2869,17 +2869,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ):
             return None
 
+        raw_components = raw.get("address_components")
+        if not isinstance(raw_components, list):
+            raw_components = []
         components = []
-        for comp in raw.get("address_components") or []:
+        for comp in raw_components:
             if not isinstance(comp, dict):
                 continue
             name = comp.get("name") or comp.get("long_name") or ""
             if not name:
                 continue
+            types = comp.get("types")
+            if not isinstance(types, list):
+                types = []
             components.append({
                 "name": name,
                 "short_name": comp.get("short_name") or "",
-                "types": list(comp.get("types") or []),
+                "types": types,
             })
 
         return {

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2796,6 +2796,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return ""
         return " · ".join(parts)
 
+    def _extract_place_id(body):
+        candidate = body.get("place_id")
+        if candidate is None and isinstance(body.get("place"), dict):
+            candidate = body["place"].get("place_id")
+        if candidate is None and isinstance(body.get("details"), dict):
+            candidate = body["details"].get("place_id")
+        if candidate is None:
+            return ""
+        if isinstance(candidate, str):
+            return candidate.strip()
+        return str(candidate).strip()
+
     def _normalize_client_place_details(body):
         """Normalize a Google Maps JS Place payload from the request body.
 
@@ -2808,9 +2820,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not isinstance(raw, dict):
             return None
 
-        place_id = str(
-            raw.get("place_id") or body.get("place_id") or ""
-        ).strip()
+        place_id = _extract_place_id(body)
         if not place_id:
             return None
 
@@ -2835,6 +2845,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             lat = float(lat_value)
             lng = float(lng_value)
         except (TypeError, ValueError):
+            return None
+        if (
+            not math.isfinite(lat)
+            or not math.isfinite(lng)
+            or lat < -90
+            or lat > 90
+            or lng < -180
+            or lng > 180
+        ):
             return None
 
         components = []
@@ -2959,12 +2978,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ``type='location'`` link).
         """
         body = request.get_json(silent=True) or {}
-        place_id = (
-            body.get("place_id")
-            or ((body.get("place") or {}).get("place_id") if isinstance(body.get("place"), dict) else "")
-            or ((body.get("details") or {}).get("place_id") if isinstance(body.get("details"), dict) else "")
-            or ""
-        ).strip()
+        place_id = _extract_place_id(body)
         if not place_id:
             return json_error("missing place_id", 400)
 
@@ -3159,12 +3173,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
           underlying RuntimeError for debugging.
         """
         body = request.get_json(silent=True) or {}
-        place_id = (
-            body.get("place_id")
-            or ((body.get("place") or {}).get("place_id") if isinstance(body.get("place"), dict) else "")
-            or ((body.get("details") or {}).get("place_id") if isinstance(body.get("details"), dict) else "")
-            or ""
-        ).strip()
+        place_id = _extract_place_id(body)
         if not place_id:
             return json_error("missing place_id", 400)
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2838,7 +2838,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     return value
             return None
 
-        geometry_location = ((raw.get("geometry") or {}).get("location") or {})
+        geometry = raw.get("geometry")
+        geometry_location = {}
+        if isinstance(geometry, dict):
+            location = geometry.get("location")
+            if isinstance(location, dict):
+                geometry_location = location
         lat_value = first_present(
             raw.get("lat"),
             raw.get("latitude"),

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2796,17 +2796,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return ""
         return " · ".join(parts)
 
+    def _coerce_place_id(candidate):
+        if candidate is None:
+            return ""
+        if isinstance(candidate, str):
+            return candidate.strip()
+        return str(candidate).strip()
+
     def _extract_place_id(body):
         candidate = body.get("place_id")
         if candidate is None and isinstance(body.get("place"), dict):
             candidate = body["place"].get("place_id")
         if candidate is None and isinstance(body.get("details"), dict):
             candidate = body["details"].get("place_id")
-        if candidate is None:
-            return ""
-        if isinstance(candidate, str):
-            return candidate.strip()
-        return str(candidate).strip()
+        return _coerce_place_id(candidate)
 
     def _normalize_client_place_details(body):
         """Normalize a Google Maps JS Place payload from the request body.
@@ -2820,8 +2823,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not isinstance(raw, dict):
             return None
 
-        place_id = _extract_place_id(body)
+        place_id = _coerce_place_id(raw.get("place_id"))
         if not place_id:
+            return None
+        body_place_id = _coerce_place_id(body.get("place_id"))
+        if body_place_id and body_place_id != place_id:
             return None
 
         def first_present(*values):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2797,6 +2797,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         return " · ".join(parts)
 
     def _coerce_place_id(candidate):
+        """Return a stripped string ``place_id`` for any JSON scalar value."""
         if candidate is None:
             return ""
         if isinstance(candidate, str):
@@ -2804,6 +2805,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         return str(candidate).strip()
 
     def _extract_place_id(body):
+        """Extract ``place_id`` from top-level or nested client place payloads."""
         candidate = body.get("place_id")
         if candidate is None and isinstance(body.get("place"), dict):
             candidate = body["place"].get("place_id")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2796,6 +2796,68 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return ""
         return " · ".join(parts)
 
+    def _normalize_client_place_details(body):
+        """Normalize a Google Maps JS Place payload from the request body.
+
+        Browser autocomplete already receives geometry and address components
+        when the Maps JS key is valid. Accepting that payload avoids a second
+        server-side Place Details request, which can fail for correctly
+        referrer-restricted browser keys.
+        """
+        raw = body.get("place") or body.get("details")
+        if not isinstance(raw, dict):
+            return None
+
+        place_id = str(
+            raw.get("place_id") or body.get("place_id") or ""
+        ).strip()
+        if not place_id:
+            return None
+
+        def first_present(*values):
+            for value in values:
+                if value is not None:
+                    return value
+            return None
+
+        geometry_location = ((raw.get("geometry") or {}).get("location") or {})
+        lat_value = first_present(
+            raw.get("lat"),
+            raw.get("latitude"),
+            geometry_location.get("lat") if isinstance(geometry_location, dict) else None,
+        )
+        lng_value = first_present(
+            raw.get("lng"),
+            raw.get("longitude"),
+            geometry_location.get("lng") if isinstance(geometry_location, dict) else None,
+        )
+        try:
+            lat = float(lat_value)
+            lng = float(lng_value)
+        except (TypeError, ValueError):
+            return None
+
+        components = []
+        for comp in raw.get("address_components") or []:
+            if not isinstance(comp, dict):
+                continue
+            name = comp.get("name") or comp.get("long_name") or ""
+            if not name:
+                continue
+            components.append({
+                "name": name,
+                "short_name": comp.get("short_name") or "",
+                "types": list(comp.get("types") or []),
+            })
+
+        return {
+            "place_id": place_id,
+            "name": raw.get("name") or raw.get("formatted_address") or "",
+            "lat": lat,
+            "lng": lng,
+            "address_components": components,
+        }
+
     def _walk_parent_chain(db, leaf_parent_id):
         """Walk ``parent_id`` upward from ``leaf_parent_id`` to the root.
 
@@ -2897,14 +2959,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ``type='location'`` link).
         """
         body = request.get_json(silent=True) or {}
-        place_id = (body.get("place_id") or "").strip()
+        place_id = (
+            body.get("place_id")
+            or ((body.get("place") or {}).get("place_id") if isinstance(body.get("place"), dict) else "")
+            or ((body.get("details") or {}).get("place_id") if isinstance(body.get("details"), dict) else "")
+            or ""
+        ).strip()
         if not place_id:
             return json_error("missing place_id", 400)
-
-        import config as cfg
-        key = cfg.load().get("google_maps_api_key", "")
-        if not key:
-            return json_error("no_api_key", 400)
 
         db = _get_db()
         # Guard against stale clients (e.g. tab open after photo deleted).
@@ -2915,9 +2977,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ).fetchone() is None:
             return json_error("photo_not_found", 404)
 
-        details = places.place_details(place_id, key)
+        details = _normalize_client_place_details(body)
         if details is None:
-            return json_error("place_not_found", 404)
+            import config as cfg
+            key = cfg.load().get("google_maps_api_key", "")
+            if not key:
+                return json_error("no_api_key", 400)
+            details = places.place_details(place_id, key)
+            if details is None:
+                return json_error("place_not_found", 404)
 
         try:
             leaf_id = db.upsert_place_chain(details)
@@ -3067,7 +3135,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_link_keyword_to_place(keyword_id):
         """Attach Google place data to an existing keyword.
 
-        Body: ``{"place_id": "ChIJ..."}``. Looks up the place via
+        Body: ``{"place_id": "ChIJ..."}``, optionally with a normalized
+        ``place`` object from Google Maps JS autocomplete. When the client
+        does not provide details, looks up the place via
         :func:`places.place_details` and delegates to
         :meth:`Database.link_keyword_to_place`, which UPDATEs the target row
         in-place — or, if another keyword already owns this ``place_id``,
@@ -3089,18 +3159,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
           underlying RuntimeError for debugging.
         """
         body = request.get_json(silent=True) or {}
-        place_id = (body.get("place_id") or "").strip()
+        place_id = (
+            body.get("place_id")
+            or ((body.get("place") or {}).get("place_id") if isinstance(body.get("place"), dict) else "")
+            or ((body.get("details") or {}).get("place_id") if isinstance(body.get("details"), dict) else "")
+            or ""
+        ).strip()
         if not place_id:
             return json_error("missing place_id", 400)
 
-        import config as cfg
-        key = cfg.load().get("google_maps_api_key", "")
-        if not key:
-            return json_error("no_api_key", 400)
-
-        details = places.place_details(place_id, key)
+        details = _normalize_client_place_details(body)
         if details is None:
-            return json_error("place_not_found", 404)
+            import config as cfg
+            key = cfg.load().get("google_maps_api_key", "")
+            if not key:
+                return json_error("no_api_key", 400)
+            details = places.place_details(place_id, key)
+            if details is None:
+                return json_error("place_not_found", 404)
 
         db = _get_db()
         try:

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4454,7 +4454,13 @@ async function bindLocationAutocomplete() {
     if (!google || !google.maps || !google.maps.places) return;
     _locationAutocomplete = new google.maps.places.Autocomplete(input, {
       types: ['geocode', 'establishment'],
-      fields: ['place_id', 'name', 'formatted_address'],
+      fields: [
+        'place_id',
+        'name',
+        'formatted_address',
+        'geometry',
+        'address_components'
+      ],
     });
     _locationAutocomplete.addListener('place_changed', function() {
       var place = _locationAutocomplete.getPlace();
@@ -4467,7 +4473,7 @@ async function bindLocationAutocomplete() {
         clearTimeout(_locationPendingTextSubmit);
         _locationPendingTextSubmit = null;
       }
-      _submitLocationPlace(place.place_id);
+      _submitLocationPlace(place.place_id, normalizeGooglePlaceForSubmit(place));
     });
   }).catch(function(err) {
     console.warn('Google Maps load failed:', err);
@@ -4475,15 +4481,42 @@ async function bindLocationAutocomplete() {
   });
 }
 
-async function _submitLocationPlace(placeId) {
+function normalizeGooglePlaceForSubmit(place) {
+  if (!place || !place.place_id) return null;
+  var loc = place.geometry && place.geometry.location;
+  var lat = null;
+  var lng = null;
+  if (loc) {
+    lat = (typeof loc.lat === 'function') ? loc.lat() : loc.lat;
+    lng = (typeof loc.lng === 'function') ? loc.lng() : loc.lng;
+  }
+  if (lat == null || lng == null) return null;
+  return {
+    place_id: place.place_id,
+    name: place.name || place.formatted_address || '',
+    lat: lat,
+    lng: lng,
+    address_components: (place.address_components || []).map(function(c) {
+      return {
+        name: c.long_name || c.name || '',
+        short_name: c.short_name || '',
+        types: c.types || [],
+      };
+    }),
+  };
+}
+
+async function _submitLocationPlace(placeId, placeDetails) {
   var photoId = window._detailPhotoId;
   if (!photoId) return;
   _hideLocationError();
+  var body = { place_id: placeId };
+  if (placeDetails) body.place = placeDetails;
   try {
     var resp = await safeFetch('/api/photos/' + photoId + '/location', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ place_id: placeId }),
+      body: JSON.stringify(body),
     });
     if (resp && resp.location) {
       renderLocationFilled(resp.location);

--- a/vireo/templates/keywords.html
+++ b/vireo/templates/keywords.html
@@ -741,12 +741,22 @@
       // `input`; binding twice triggers two `place_changed` events).
       _activeLinkAutocomplete = new google.maps.places.Autocomplete(input, {
         types: ['geocode', 'establishment'],
-        fields: ['place_id', 'name', 'formatted_address'],
+        fields: [
+          'place_id',
+          'name',
+          'formatted_address',
+          'geometry',
+          'address_components'
+        ],
       });
       _activeLinkAutocomplete.addListener('place_changed', function() {
         const place = _activeLinkAutocomplete.getPlace();
         if (place && place.place_id && _activeLinkKeywordId) {
-          submitLinkPlace(_activeLinkKeywordId, place.place_id);
+          submitLinkPlace(
+            _activeLinkKeywordId,
+            place.place_id,
+            normalizeGooglePlaceForSubmit(place)
+          );
         }
       });
     } catch(err) {
@@ -762,14 +772,41 @@
     _hideLinkError();
   }
 
-  async function submitLinkPlace(keywordId, placeId) {
+  function normalizeGooglePlaceForSubmit(place) {
+    if (!place || !place.place_id) return null;
+    const loc = place.geometry && place.geometry.location;
+    let lat = null;
+    let lng = null;
+    if (loc) {
+      lat = (typeof loc.lat === 'function') ? loc.lat() : loc.lat;
+      lng = (typeof loc.lng === 'function') ? loc.lng() : loc.lng;
+    }
+    if (lat == null || lng == null) return null;
+    return {
+      place_id: place.place_id,
+      name: place.name || place.formatted_address || '',
+      lat: lat,
+      lng: lng,
+      address_components: (place.address_components || []).map(function(c) {
+        return {
+          name: c.long_name || c.name || '',
+          short_name: c.short_name || '',
+          types: c.types || [],
+        };
+      }),
+    };
+  }
+
+  async function submitLinkPlace(keywordId, placeId, placeDetails) {
     _hideLinkError();
+    const body = {place_id: placeId};
+    if (placeDetails) body.place = placeDetails;
     let resp;
     try {
       resp = await fetch('/api/keywords/' + keywordId + '/link-place', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({place_id: placeId}),
+        body: JSON.stringify(body),
       });
     } catch(err) {
       _showLinkError('Network error: ' + (err && err.message || err));

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2775,6 +2775,29 @@ def test_post_photo_location_accepts_client_place_details_without_server_lookup(
     ]
 
 
+def test_post_photo_location_normalizes_non_string_client_place_id(app_and_db):
+    """Nested client place_id values are string-normalized before use."""
+    import config as cfg
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": ""})
+
+    place = _central_park_client_place()
+    place["place_id"] = 12345
+
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/location",
+        json={"place": place},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    loc = resp.get_json()["location"]
+    assert loc["place_id"] == "12345"
+
+
 def test_post_photo_location_returns_400_on_missing_place_id(app_and_db):
     """Empty body / missing place_id is a 400 — never reaches Google."""
     app, db = app_and_db
@@ -3509,6 +3532,37 @@ def test_post_keyword_link_place_accepts_client_place_details_without_server_loo
     assert [p["name"] for p in kw["parent_chain"]] == [
         "United States", "New York", "New York County", "New York",
     ]
+
+
+def test_post_keyword_link_place_rejects_non_finite_client_coords(app_and_db):
+    """Client-supplied coordinates must be finite and in valid lat/lng bounds."""
+    import config as cfg
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": ""})
+    kw_id = db.get_or_create_text_location("Central Park")
+
+    place = _central_park_client_place()
+    place["geometry"]["location"]["lat"] = "NaN"
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/keywords/{kw_id}/link-place",
+        json={
+            "place_id": "ChIJ4zGFAZpYwokRGUGph3Mf37k",
+            "place": place,
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "no_api_key"
+
+    row = db.conn.execute(
+        "SELECT place_id, latitude, longitude FROM keywords WHERE id = ?",
+        (kw_id,),
+    ).fetchone()
+    assert row["place_id"] is None
+    assert row["latitude"] is None
+    assert row["longitude"] is None
 
 
 def test_post_keyword_link_place_merges_when_place_id_already_taken(

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2663,6 +2663,22 @@ def _central_park_details():
     }
 
 
+def _central_park_client_place():
+    """Canned Google Maps JS Place payload sent by the browser."""
+    return {
+        "place_id": "ChIJ4zGFAZpYwokRGUGph3Mf37k",
+        "name": "Central Park",
+        "geometry": {"location": {"lat": 40.7828, "lng": -73.9654}},
+        "address_components": [
+            {"long_name": "New York", "short_name": "New York", "types": ["locality"]},
+            {"long_name": "New York County", "short_name": "New York County",
+             "types": ["administrative_area_level_2"]},
+            {"long_name": "New York", "short_name": "NY", "types": ["administrative_area_level_1"]},
+            {"long_name": "United States", "short_name": "US", "types": ["country"]},
+        ],
+    }
+
+
 def test_post_photo_location_with_valid_place_id(app_and_db, monkeypatch):
     """Valid pick: route stores leaf + parents and returns the serialized location."""
     import config as cfg
@@ -2717,6 +2733,46 @@ def test_post_photo_location_with_valid_place_id(app_and_db, monkeypatch):
     assert len(rows) == 1
     assert rows[0]["place_id"] == "ChIJ4zGFAZpYwokRGUGph3Mf37k"
     assert rows[0]["name"] == "Central Park"
+
+
+def test_post_photo_location_accepts_client_place_details_without_server_lookup(
+    app_and_db, monkeypatch,
+):
+    """Autocomplete may succeed with a referrer-restricted browser key even
+    when a server-side Place Details request would be denied. If the browser
+    sends full details, the route should store them directly.
+    """
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": ""})
+
+    def fail_place_details(place_id, key):
+        raise AssertionError("server-side Place Details should not be called")
+
+    monkeypatch.setattr(places, "place_details", fail_place_details)
+
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/location",
+        json={
+            "place_id": "ChIJ4zGFAZpYwokRGUGph3Mf37k",
+            "place": _central_park_client_place(),
+        },
+    )
+    assert resp.status_code == 200, resp.get_json()
+    loc = resp.get_json()["location"]
+    assert loc["name"] == "Central Park"
+    assert loc["place_id"] == "ChIJ4zGFAZpYwokRGUGph3Mf37k"
+    assert loc["latitude"] == 40.7828
+    assert loc["longitude"] == -73.9654
+    assert [p["name"] for p in loc["parent_chain"]] == [
+        "United States", "New York", "New York County", "New York",
+    ]
 
 
 def test_post_photo_location_returns_400_on_missing_place_id(app_and_db):
@@ -3411,6 +3467,48 @@ def test_post_keyword_link_place_attaches_metadata(app_and_db, monkeypatch):
     ).fetchall()
     assert len(rows) == 1
     assert rows[0]["id"] == kw_id
+
+
+def test_post_keyword_link_place_accepts_client_place_details_without_server_lookup(
+    app_and_db, monkeypatch,
+):
+    """Keyword linking can use the autocomplete payload directly instead of
+    requiring a second backend Place Details request.
+    """
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": ""})
+
+    def fail_place_details(place_id, key):
+        raise AssertionError("server-side Place Details should not be called")
+
+    monkeypatch.setattr(places, "place_details", fail_place_details)
+
+    kw_id = db.get_or_create_text_location("Central Park")
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/keywords/{kw_id}/link-place",
+        json={
+            "place_id": "ChIJ4zGFAZpYwokRGUGph3Mf37k",
+            "place": _central_park_client_place(),
+        },
+    )
+    assert resp.status_code == 200, resp.get_json()
+    data = resp.get_json()
+
+    assert data["merged"] is False
+    kw = data["keyword"]
+    assert kw["keyword_id"] == kw_id
+    assert kw["name"] == "Central Park"
+    assert kw["place_id"] == "ChIJ4zGFAZpYwokRGUGph3Mf37k"
+    assert kw["latitude"] == 40.7828
+    assert kw["longitude"] == -73.9654
+    assert [p["name"] for p in kw["parent_chain"]] == [
+        "United States", "New York", "New York County", "New York",
+    ]
 
 
 def test_post_keyword_link_place_merges_when_place_id_already_taken(

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3565,6 +3565,34 @@ def test_post_keyword_link_place_rejects_non_finite_client_coords(app_and_db):
     assert row["longitude"] is None
 
 
+def test_post_keyword_link_place_rejects_mismatched_client_place_id(app_and_db):
+    """A client place payload must not bind one place_id to another place's geometry."""
+    import config as cfg
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": ""})
+    kw_id = db.get_or_create_text_location("Central Park")
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/keywords/{kw_id}/link-place",
+        json={
+            "place_id": "ChIJDifferentPlace",
+            "place": _central_park_client_place(),
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "no_api_key"
+
+    row = db.conn.execute(
+        "SELECT place_id, latitude, longitude FROM keywords WHERE id = ?",
+        (kw_id,),
+    ).fetchone()
+    assert row["place_id"] is None
+    assert row["latitude"] is None
+    assert row["longitude"] is None
+
+
 def test_post_keyword_link_place_merges_when_place_id_already_taken(
     app_and_db, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3565,6 +3565,44 @@ def test_post_keyword_link_place_rejects_non_finite_client_coords(app_and_db):
     assert row["longitude"] is None
 
 
+def test_post_keyword_link_place_falls_back_on_malformed_client_geometry(
+    app_and_db, monkeypatch,
+):
+    """Malformed client geometry should not turn a valid request into a 500."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+    captured = {}
+
+    def fake_place_details(place_id, key):
+        captured["place_id"] = place_id
+        captured["key"] = key
+        return _central_park_details()
+
+    monkeypatch.setattr(places, "place_details", fake_place_details)
+    kw_id = db.get_or_create_text_location("Central Park")
+    place = _central_park_client_place()
+    place["geometry"] = "bad"
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/keywords/{kw_id}/link-place",
+        json={
+            "place_id": "ChIJ4zGFAZpYwokRGUGph3Mf37k",
+            "place": place,
+        },
+    )
+
+    assert resp.status_code == 200, resp.get_json()
+    assert captured == {
+        "place_id": "ChIJ4zGFAZpYwokRGUGph3Mf37k",
+        "key": "FAKE-KEY",
+    }
+    assert resp.get_json()["keyword"]["place_id"] == "ChIJ4zGFAZpYwokRGUGph3Mf37k"
+
+
 def test_post_keyword_link_place_rejects_mismatched_client_place_id(app_and_db):
     """A client place payload must not bind one place_id to another place's geometry."""
     import config as cfg

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3603,6 +3603,37 @@ def test_post_keyword_link_place_falls_back_on_malformed_client_geometry(
     assert resp.get_json()["keyword"]["place_id"] == "ChIJ4zGFAZpYwokRGUGph3Mf37k"
 
 
+def test_post_keyword_link_place_ignores_malformed_component_types(
+    app_and_db, monkeypatch,
+):
+    """Malformed component metadata should not reject otherwise valid details."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": ""})
+
+    def fail_place_details(place_id, key):
+        raise AssertionError("server-side Place Details should not be called")
+
+    monkeypatch.setattr(places, "place_details", fail_place_details)
+    kw_id = db.get_or_create_text_location("Central Park")
+    place = _central_park_client_place()
+    place["address_components"][0]["types"] = 42
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/keywords/{kw_id}/link-place",
+        json={
+            "place_id": "ChIJ4zGFAZpYwokRGUGph3Mf37k",
+            "place": place,
+        },
+    )
+
+    assert resp.status_code == 200, resp.get_json()
+    assert resp.get_json()["keyword"]["place_id"] == "ChIJ4zGFAZpYwokRGUGph3Mf37k"
+
+
 def test_post_keyword_link_place_rejects_mismatched_client_place_id(app_and_db):
     """A client place payload must not bind one place_id to another place's geometry."""
     import config as cfg

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -769,10 +769,6 @@ def test_promotion_db_error_retries_queued_pipeline(tmp_path, monkeypatch):
     monkeypatch.setattr(sqlite3, "connect", fail_connect)
     runner._try_promote_queued()
 
-    with runner._lock:
-        if job_id in runner._queued_pipelines:
-            assert not runner._queued_pipelines[job_id].get("_promoting")
-
     _wait_for_event(work_started, "promotion retry")
     final = wait_for_job_via_runner(runner, job_id, wait_for_history=True)
     assert final["status"] == "completed"


### PR DESCRIPTION
## Summary
Fixes Google place linking when autocomplete succeeds but the backend Place Details lookup fails due to API key restrictions.
The browser now sends the selected place geometry and address components for both keyword linking and photo location assignment, while the backend keeps its server-side lookup as a fallback.
Added regression coverage for client-provided place details without a server lookup.

## Checks
- pytest vireo/tests/test_photos_api.py -k "location or keyword_link_place"
- python -m pytest vireo/tests/test_places.py vireo/tests/test_photos_api.py -k "place_details or reverse_geocode or location or keyword_link_place"
- python -m ruff check vireo/app.py vireo/tests/test_photos_api.py
- pytest tests/e2e/test_keywords_link.py::test_link_attaches_place_id_via_test_hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now requests and submits richer place details (place_id, name/address, coordinates, address components) when saving photo locations or linking keywords.

* **Bug Fixes / Validation**
  * Client-submitted place IDs normalized to strings; non-finite coordinates and mismatched place/geometry are rejected with 400 responses.

* **Behavior Change**
  * Server prefers validated client-provided place details and skips external place lookups; falls back to server lookup, returning 400/404 when lookup or keys are missing.

* **Tests**
  * Added tests covering client place-detail submission, normalization, and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->