### PR TITLE
Add Needs Location default collection

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1124,7 +1124,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     # because the target name already exists, leaving a duplicate.
     init_db.migrate_default_subject_collection()
     init_db.migrate_default_needs_identification_collection()
-    init_db.create_default_collections()
+    init_db.create_default_collections_for_all_workspaces()
 
     # Wildlife backfill timing:
     # - Subsequent boots: marker is set, nothing to do, fast.
@@ -4185,6 +4185,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Activate the new workspace
         db.set_active_workspace(ws_id)
+        db.create_default_collections(workspace_id=ws_id)
         db.update_workspace(ws_id, last_opened_at=datetime.now().isoformat())
 
         # Return the target workspace's saved page path

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9779,6 +9779,11 @@ class Database:
                 )
         self.conn.commit()
 
+    def create_default_collections_for_all_workspaces(self):
+        """Create missing default smart collections in every workspace."""
+        for ws in self.get_workspaces():
+            self.create_default_collections(workspace_id=ws["id"])
+
     def migrate_default_subject_collection(self):
         """Rename legacy 'Needs Classification' (with rule has_species==0)
         to 'Needs Identification' (rule has_subject==0) across ALL workspaces.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9766,6 +9766,10 @@ class Database:
                 "Recent Import",
                 [{"field": "timestamp", "op": "recent_days", "value": 30}],
             ),
+            (
+                "Needs Location",
+                [{"field": "location_keyword_missing", "op": "equals", "value": 1}],
+            ),
         ]
         for name, rules in defaults:
             if name not in existing_names:

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1358,6 +1358,40 @@ def test_default_collections_adds_missing(tmp_path):
     assert len(colls) == 6  # no duplicate Flagged
 
 
+def test_default_collections_for_all_workspaces_adds_missing_defaults(tmp_path):
+    """Startup seeding covers non-active workspaces in upgraded databases."""
+    import json
+
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws1 = db.ensure_default_workspace()
+    ws2 = db.create_workspace("ws-b")
+
+    # Simulate an upgraded multi-workspace database where only one workspace
+    # already had the older default set. The all-workspaces startup pass should
+    # add the new Needs Location default everywhere without duplicating Flagged.
+    db.conn.execute(
+        "INSERT INTO collections (workspace_id, name, rules) VALUES (?, ?, ?)",
+        (
+            ws2,
+            "Flagged",
+            json.dumps([{"field": "flag", "op": "equals", "value": "flagged"}]),
+        ),
+    )
+    db.conn.commit()
+
+    db.set_active_workspace(ws1)
+    db.create_default_collections_for_all_workspaces()
+
+    for ws in (ws1, ws2):
+        rows = db.conn.execute(
+            "SELECT name FROM collections WHERE workspace_id = ?", (ws,),
+        ).fetchall()
+        names = [r["name"] for r in rows]
+        assert "Needs Location" in names
+        assert names.count("Flagged") == 1
+
+
 def test_default_collection_uses_has_subject_for_new_workspaces(tmp_path):
     """A newly-created workspace gets 'Needs Identification' (not 'Needs
     Classification') with the has_subject==0 rule."""

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1320,6 +1320,7 @@ def test_default_collections_created(tmp_path):
     assert 'Untagged' in names
     assert 'Flagged' in names
     assert 'Recent Import' in names
+    assert 'Needs Location' in names
 
 
 def test_default_collections_idempotent(tmp_path):
@@ -1332,7 +1333,7 @@ def test_default_collections_idempotent(tmp_path):
     db.create_default_collections()
 
     colls = db.get_collections()
-    assert len(colls) == 5
+    assert len(colls) == 6
 
 
 def test_default_collections_adds_missing(tmp_path):
@@ -1353,7 +1354,8 @@ def test_default_collections_adds_missing(tmp_path):
     assert 'Needs Identification' in names
     assert 'Untagged' in names
     assert 'Recent Import' in names
-    assert len(colls) == 5  # no duplicate Flagged
+    assert 'Needs Location' in names
+    assert len(colls) == 6  # no duplicate Flagged
 
 
 def test_default_collection_uses_has_subject_for_new_workspaces(tmp_path):
@@ -1491,10 +1493,47 @@ def test_upgrade_path_no_duplicate_collection(tmp_path):
         {"field": "has_subject", "op": "equals", "value": 0},
         {"field": "wildlife_excluded", "op": "equals", "value": 0},
     ]
-    # Sanity: total default-collection count is 5, not 6 (no duplicate).
+    # Sanity: default collections include one Needs Identification, not a
+    # duplicate alongside the legacy Needs Classification.
     default_names = {"All Photos", "Needs Identification", "Untagged",
-                     "Flagged", "Recent Import"}
+                     "Flagged", "Recent Import", "Needs Location"}
     assert default_names.issubset(cols.keys())
+
+
+def test_default_needs_location_collection_matches_gps_without_location_keyword(tmp_path):
+    """The default Needs Location collection surfaces geotagged photos that
+    still need Vireo's structured location keyword."""
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder('/photos', name='photos')
+    needs_location = db.add_photo(
+        folder_id=fid, filename='gps-no-location.jpg',
+        extension='.jpg', file_size=100, file_mtime=1.0,
+    )
+    no_gps = db.add_photo(
+        folder_id=fid, filename='no-gps.jpg',
+        extension='.jpg', file_size=100, file_mtime=1.0,
+    )
+    has_location = db.add_photo(
+        folder_id=fid, filename='gps-with-location.jpg',
+        extension='.jpg', file_size=100, file_mtime=1.0,
+    )
+    db.conn.execute(
+        "UPDATE photos SET latitude = 1.0, longitude = 2.0 WHERE id IN (?, ?)",
+        (needs_location, has_location),
+    )
+    loc_kw = db.add_keyword("Yosemite", kw_type="location")
+    db.tag_photo(has_location, loc_kw)
+
+    db.create_default_collections()
+    cid = next(c["id"] for c in db.get_collections()
+               if c["name"] == "Needs Location")
+
+    pids = {p["id"] for p in db.get_collection_photos(cid, per_page=999)}
+    assert pids == {needs_location}
 
 
 def test_default_genre_keywords_inserted(tmp_path):

--- a/vireo/tests/test_workspaces_api.py
+++ b/vireo/tests/test_workspaces_api.py
@@ -102,7 +102,7 @@ def test_create_workspace_seeds_default_collections(app_and_db):
     ).fetchall()
     names = {r["name"] for r in rows}
     assert {"All Photos", "Needs Identification", "Untagged",
-            "Flagged", "Recent Import"} <= names
+            "Flagged", "Recent Import", "Needs Location"} <= names
 
 
 def test_update_workspace(app_and_db):


### PR DESCRIPTION
## Summary
Adds a default Needs Location smart collection that surfaces photos with EXIF GPS but no Vireo location keyword yet.
Updates default collection seeding expectations for existing startup/workspace creation paths and adds regression coverage for the collection's matching behavior.

## Tests
- python -m pytest vireo/tests/test_db.py -k "default_collections or default_needs_location or upgrade_path_no_duplicate_collection" -q
- python -m pytest vireo/tests/test_workspaces_api.py::test_create_workspace_seeds_default_collections -q
- python -m pytest vireo/tests/test_collections_api.py -q