### PR TITLE
[codex] Add Highlights prediction feedback

### DIFF
--- a/docs/plans/2026-05-29-highlights-prediction-edit-design.md
+++ b/docs/plans/2026-05-29-highlights-prediction-edit-design.md
@@ -1,0 +1,143 @@
+# Highlights: confirm & change predictions
+
+**Date:** 2026-05-29
+**Branch:** `highlights-page-prediction-edit`
+
+## Problem
+
+The Highlights page groups photos into species "buckets" — an accepted species
+keyword wins, otherwise the top prediction above the confidence slider, with an
+"Unidentified" section for the rest. The page is **read-only**: if Vireo predicts
+"Bald Eagle" but the bird is a House Sparrow, there is no way to tell Vireo it's
+wrong, or to confirm a prediction that's right. Confirm/change machinery exists
+elsewhere (rapid-review, the predictions flow, `/api/predictions/<id>/accept|reject|replace-keywords`,
+`/api/encounters/species`) but Highlights surfaces none of it.
+
+## Goals
+
+- Confirm or change a prediction directly from Highlights.
+- Operate at the **row level** (the whole bucket, when it's right or uniformly
+  wrong) and at the **per-photo level** (the lightbox, for mixed rows).
+- Write the **real species keyword** so changes propagate everywhere (Browse,
+  Keywords, export) — same machinery as the rest of the app. This satisfies
+  `CORE_PHILOSOPHY.md` "No black boxes": a "Confirmed" badge means the keyword
+  is actually written.
+
+## Decisions (from brainstorming)
+
+1. **Scope:** both — row-level by default, per-photo drill-down for mixed rows.
+2. **Change input:** text field with autocomplete from known species; typing a
+   brand-new name is allowed.
+3. **Behavior:** identical to accepting/correcting a prediction elsewhere — it
+   writes the accepted keyword; a changed photo gets the new keyword and the
+   wrong prediction is rejected.
+4. **Confirm scope:** confirming a row applies to **every** photo in the row,
+   visible or not (not just the thumbnails currently shown).
+5. **Per-photo surface:** the **lightbox**, not inline card controls — keeps the
+   grid scannable and is where pixel-peeping already happens.
+
+## UX surfaces
+
+### Row-level (bucket header)
+
+- **Predicted rows** (grey "Predicted" badge): **Confirm** + **Change**.
+  - *Confirm* accepts the prediction for all photos in the row.
+  - *Change* opens a species autocomplete; submitting relabels every photo in
+    the row to the new species and rejects the wrong prediction.
+- **Confirmed rows**: no Confirm (no-op); still offer **Change** to fix an
+  earlier wrong confirmation.
+- **Unidentified section**: **Set species** (a relabel with nothing to reject).
+
+### Per-photo (lightbox)
+
+Opening a Highlights thumbnail shows the photo's current species — either
+"Predicted: Bald Eagle (87%)" or "Confirmed: House Sparrow" — with **Confirm**
+(only for an unconfirmed prediction) and **Change** (autocomplete) controls.
+This is the mixed-row fix path: zoom in, confirm it's a sparrow, relabel that one.
+
+After any action the page reloads `/api/highlights` for the current scope so
+buckets and badges reflect the new truth immediately.
+
+## Data flow & endpoints
+
+### `/api/highlights` gains prediction IDs
+
+`get_highlights_candidates` already resolves each photo's top non-rejected
+prediction. Surface that prediction's `id` so each photo object in the API
+response carries `prediction_id` (nullable) and `predicted_confidence`. The
+frontend uses these for the lightbox display and to know what's confirmable.
+
+### `POST /api/highlights/confirm`
+
+Body: `{ "photo_ids": [...] }`.
+
+For each photo, **re-resolve its top non-rejected prediction server-side** (same
+query as the candidates resolver, so a stale client can't confirm the wrong
+thing) and run the existing `db.accept_prediction(pred_id)`. That already marks
+the prediction accepted, rejects siblings, adds the species keyword, queues
+sidecar sync, and records an edit.
+
+- Dedup by prediction/group so a shared grouped prediction is processed once.
+- Photos with no pending prediction are skipped (no-op success).
+
+Returns a per-photo summary.
+
+### `POST /api/highlights/relabel`
+
+Body: `{ "photo_ids": [...], "species": "House Sparrow" }`.
+
+In **one transaction**, for each photo:
+
+1. Reject its current top prediction if any (`update_prediction_status(..., 'rejected')`)
+   so it won't resurface.
+2. Strip existing species keywords (`untag_photo` + `_queue_keyword_remove`).
+3. `add_keyword(species, is_species=True)` + `tag_photo` + `_queue_keyword_add`.
+
+Record one `species_replace` edit. This is the exact write path
+`/api/encounters/species` uses, minus the pipeline-cache bookkeeping (Highlights
+has none). Rollback on any failure so a mid-loop error can't half-retag a row.
+
+### Species autocomplete
+
+Reuse the existing species-keyword suggestion source (the same data rapid-review's
+species input draws from). A brand-new typed name just creates the keyword via
+`add_keyword`.
+
+## Edge cases
+
+- **Unidentified / no prediction:** relabel works with nothing to reject; Confirm
+  is hidden (nothing to confirm).
+- **Grouped predictions:** dedup on confirm; skip already-accepted.
+- **Mixed rows** (same name, some confirmed + some predicted): Confirm accepts
+  only the still-pending predictions; Change relabels all.
+- **No-op changes:** relabel to the current species is an idempotent tag; confirm
+  on an already-accepted photo is skipped.
+- **Validation:** both endpoints validate `photo_ids` exist and belong to the
+  active workspace; `relabel` requires non-empty `species`.
+- **Lightbox safety:** the lightbox is shared across pages. Highlights passes its
+  controls + callbacks via the existing `options` argument to `openLightbox`;
+  other pages pass nothing and see no change.
+
+## Testing
+
+### Backend (pytest, temp DB)
+
+- `/api/highlights` shape: predicted photo carries `prediction_id` +
+  `predicted_confidence`; accepted-only photo carries `prediction_id: null`.
+- Confirm: prediction → `accepted`, keyword added, siblings rejected, edit recorded.
+- Confirm dedup: two photos sharing one grouped prediction → processed once,
+  both tagged, no error.
+- Confirm skips non-predicted: no-op success, no duplicate keyword.
+- Relabel: old keyword stripped, new applied, old prediction rejected,
+  `species_replace` edit recorded, sidecar add/remove queued.
+- Relabel on unidentified: keyword applied, no error.
+- Relabel atomic rollback: injected mid-loop failure leaves no partial retag.
+- Validation: unknown `photo_ids` → error; empty `species` → error.
+- Bucket migration: after confirm, reload shows photo in an `is_accepted: true`
+  bucket; after relabel, under the new species.
+
+### Frontend
+
+Manual verification via the `verify`/`run` skill — drive a real browser
+(user-first testing): confirm a row, change a row, fix one photo in the lightbox,
+watch buckets update.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4406,6 +4406,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     ).fetchall()
                 )
             processed = set()
+            confirmable_photo_ids_by_key = {}
+            for pid in photo_ids:
+                if pid in accepted_photo_ids:
+                    continue
+                pred = top_predictions.get(pid)
+                if pred is None:
+                    continue
+                key = (
+                    "group",
+                    pred["classifier_model"],
+                    pred["group_id"],
+                ) if pred["group_id"] else ("prediction", pred["id"])
+                confirmable_photo_ids_by_key.setdefault(key, []).append(pid)
             affected = []
             skipped = []
             for pid in photo_ids:
@@ -4424,9 +4437,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 if key in processed:
                     continue
                 processed.add(key)
-                result = db.accept_prediction(pred["id"], _commit=False)
+                result = db.accept_prediction(
+                    pred["id"],
+                    photo_ids=confirmable_photo_ids_by_key.get(key, [pid]),
+                    _commit=False,
+                )
                 if result is None:
                     skipped.append({"photo_id": pid, "reason": "prediction_not_found"})
+                    continue
+                if not result["affected"]:
+                    skipped.extend(
+                        {"photo_id": confirm_pid, "reason": "prediction_not_found"}
+                        for confirm_pid in confirmable_photo_ids_by_key.get(key, [pid])
+                    )
                     continue
                 items = [
                     {

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4168,63 +4168,70 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if error:
             return json_error(error, status)
 
-        top_predictions = _highlight_top_predictions(db, photo_ids)
-        accepted_photo_ids = set()
-        for i in range(0, len(photo_ids), 800):
-            chunk = photo_ids[i:i + 800]
-            placeholders = ",".join("?" for _ in chunk)
-            accepted_photo_ids.update(
-                row["photo_id"] for row in db.conn.execute(
-                    f"""SELECT DISTINCT pk.photo_id
-                        FROM photo_keywords pk
-                        JOIN keywords k ON k.id = pk.keyword_id
-                        WHERE pk.photo_id IN ({placeholders})
-                          AND k.is_species = 1""",
-                    chunk,
-                ).fetchall()
-            )
-        processed = set()
-        affected = []
-        skipped = []
-        for pid in photo_ids:
-            if pid in accepted_photo_ids:
-                skipped.append({"photo_id": pid, "reason": "already_confirmed"})
-                continue
-            pred = top_predictions.get(pid)
-            if pred is None:
-                skipped.append({"photo_id": pid, "reason": "no_prediction"})
-                continue
-            key = (
-                "group",
-                pred["classifier_model"],
-                pred["group_id"],
-            ) if pred["group_id"] else ("prediction", pred["id"])
-            if key in processed:
-                continue
-            processed.add(key)
-            result = db.accept_prediction(pred["id"])
-            if result is None:
-                skipped.append({"photo_id": pid, "reason": "prediction_not_found"})
-                continue
-            items = [
-                {
-                    "photo_id": a["photo_id"],
-                    "old_value": str(a["prediction_id"]),
-                    "new_value": str(result["keyword_id"]),
-                }
-                for a in result["affected"]
-            ]
-            desc = f'Accepted prediction: added "{result["species"]}"'
-            if len(items) > 1:
-                desc += f" to {len(items)} photos"
-            db.record_edit(
-                "prediction_accept",
-                desc,
-                str(result["keyword_id"]),
-                items,
-                is_batch=len(items) > 1,
-            )
-            affected.extend(items)
+        try:
+            top_predictions = _highlight_top_predictions(db, photo_ids)
+            accepted_photo_ids = set()
+            for i in range(0, len(photo_ids), 800):
+                chunk = photo_ids[i:i + 800]
+                placeholders = ",".join("?" for _ in chunk)
+                accepted_photo_ids.update(
+                    row["photo_id"] for row in db.conn.execute(
+                        f"""SELECT DISTINCT pk.photo_id
+                            FROM photo_keywords pk
+                            JOIN keywords k ON k.id = pk.keyword_id
+                            WHERE pk.photo_id IN ({placeholders})
+                              AND (k.is_species = 1 OR k.type = 'taxonomy')""",
+                        chunk,
+                    ).fetchall()
+                )
+            processed = set()
+            affected = []
+            skipped = []
+            for pid in photo_ids:
+                if pid in accepted_photo_ids:
+                    skipped.append({"photo_id": pid, "reason": "already_confirmed"})
+                    continue
+                pred = top_predictions.get(pid)
+                if pred is None:
+                    skipped.append({"photo_id": pid, "reason": "no_prediction"})
+                    continue
+                key = (
+                    "group",
+                    pred["classifier_model"],
+                    pred["group_id"],
+                ) if pred["group_id"] else ("prediction", pred["id"])
+                if key in processed:
+                    continue
+                processed.add(key)
+                result = db.accept_prediction(pred["id"], _commit=False)
+                if result is None:
+                    skipped.append({"photo_id": pid, "reason": "prediction_not_found"})
+                    continue
+                items = [
+                    {
+                        "photo_id": a["photo_id"],
+                        "old_value": str(a["prediction_id"]),
+                        "new_value": str(result["keyword_id"]),
+                    }
+                    for a in result["affected"]
+                ]
+                desc = f'Accepted prediction: added "{result["species"]}"'
+                if len(items) > 1:
+                    desc += f" to {len(items)} photos"
+                db.record_edit(
+                    "prediction_accept",
+                    desc,
+                    str(result["keyword_id"]),
+                    items,
+                    is_batch=len(items) > 1,
+                    _commit=False,
+                )
+                affected.extend(items)
+            db.conn.commit()
+        except Exception:
+            db.conn.rollback()
+            raise
+        db._prune_edit_history()
         return jsonify({"ok": True, "affected": affected, "skipped": skipped})
 
     @app.route("/api/highlights/relabel", methods=["POST"])
@@ -4277,12 +4284,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 db.tag_photo(pid, kid, _commit=False)
                 _queue_keyword_add(pid, species, workspace_id=ws_id, _commit=False)
                 old_value = str(old_primary["id"]) if old_primary else ""
-                if pred is not None:
-                    old_value = json.dumps({
+                old_keyword_ids = [old["id"] for old in old_rows]
+                if pred is not None or len(old_keyword_ids) > 1:
+                    old_payload = {
                         "keyword_id": old_value,
-                        "prediction_id": pred["id"],
-                        "prediction_status": pred["status"],
-                    }, sort_keys=True)
+                        "keyword_ids": old_keyword_ids,
+                    }
+                    if pred is not None:
+                        old_payload.update({
+                            "prediction_id": pred["id"],
+                            "prediction_status": pred["status"],
+                        })
+                    old_value = json.dumps(old_payload, sort_keys=True)
                 items.append({
                     "photo_id": pid,
                     "old_value": old_value,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4194,9 +4194,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if pred is None:
                 skipped.append({"photo_id": pid, "reason": "no_prediction"})
                 continue
-            if pred["status"] != "pending":
-                skipped.append({"photo_id": pid, "reason": pred["status"]})
-                continue
             key = (
                 "group",
                 pred["classifier_model"],
@@ -4251,6 +4248,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             kid = db.add_keyword(species, is_species=True, _commit=False)
             items = []
             rejected_prediction_ids = []
+            has_old_species = False
             for pid in photo_ids:
                 pred = top_predictions.get(pid)
                 if pred is not None:
@@ -4267,6 +4265,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     (pid,),
                 ).fetchall()
                 old_primary = old_rows[0] if old_rows else None
+                if old_primary is not None:
+                    has_old_species = True
                 for old in old_rows:
                     db.untag_photo(pid, old["id"], _commit=False)
                     if old["name"].strip().lower() != species.lower():
@@ -4276,15 +4276,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
                 db.tag_photo(pid, kid, _commit=False)
                 _queue_keyword_add(pid, species, workspace_id=ws_id, _commit=False)
+                old_value = str(old_primary["id"]) if old_primary else ""
+                if pred is not None:
+                    old_value = json.dumps({
+                        "keyword_id": old_value,
+                        "prediction_id": pred["id"],
+                        "prediction_status": pred["status"],
+                    }, sort_keys=True)
                 items.append({
                     "photo_id": pid,
-                    "old_value": str(old_primary["id"]) if old_primary else "",
+                    "old_value": old_value,
                     "new_value": str(kid),
                 })
 
             action_type = (
                 "species_replace"
-                if any(item["old_value"] for item in items)
+                if has_old_species
                 else "keyword_add"
             )
             if action_type == "species_replace":

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -315,6 +315,11 @@ def _collect_highlight_buckets(candidates, confidence_threshold):
             "predicted_species": r.get("predicted_species"),
             "predicted_confidence": predicted_conf,
             "has_accepted_species": accepted is not None,
+            "is_confirmable_prediction": (
+                accepted is None
+                and species is not None
+                and r.get("prediction_id") is not None
+            ),
         }
 
         if species is None:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3980,6 +3980,86 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     # -- Highlights --
 
+    def _parse_highlight_photo_ids(body):
+        raw_ids = body.get("photo_ids", [])
+        if not isinstance(raw_ids, list) or not raw_ids:
+            return None, "photo_ids required"
+        photo_ids = []
+        seen = set()
+        for raw in raw_ids:
+            if isinstance(raw, bool) or not isinstance(raw, int):
+                return None, "photo_ids must be integers"
+            if raw not in seen:
+                photo_ids.append(raw)
+                seen.add(raw)
+        return photo_ids, None
+
+    def _validate_highlight_photo_ids(db, photo_ids):
+        found_ids = set()
+        batch_size = 800
+        for i in range(0, len(photo_ids), batch_size):
+            chunk = photo_ids[i:i + batch_size]
+            placeholders = ",".join("?" for _ in chunk)
+            found_ids.update(
+                r["id"] for r in db.conn.execute(
+                    f"SELECT id FROM photos WHERE id IN ({placeholders})",
+                    chunk,
+                ).fetchall()
+            )
+        missing = [pid for pid in photo_ids if pid not in found_ids]
+        if missing:
+            return f"Unknown photo_ids: {missing}", 404
+        outside = [pid for pid in photo_ids if not db._photo_in_workspace(pid)]
+        if outside:
+            return (
+                f"Photo IDs do not belong to the active workspace: {outside}",
+                403,
+            )
+        return None, None
+
+    def _highlight_top_predictions(db, photo_ids):
+        if not photo_ids:
+            return {}
+        ws = db._ws_id()
+        results = {}
+        batch_size = 800
+        for i in range(0, len(photo_ids), batch_size):
+            chunk = photo_ids[i:i + batch_size]
+            placeholders = ",".join("?" for _ in chunk)
+            rows = db.conn.execute(
+                f"""SELECT photo_id, id, species, confidence, classifier_model,
+                          group_id, status
+                   FROM (
+                       SELECT d.photo_id, pr.id, pr.species, pr.confidence,
+                              pr.classifier_model,
+                              pr_rev.group_id,
+                              COALESCE(pr_rev.status, 'pending') AS status,
+                              ROW_NUMBER() OVER (
+                                  PARTITION BY d.photo_id
+                                  ORDER BY pr.confidence DESC, pr.id DESC
+                              ) AS rn
+                       FROM detections d
+                       JOIN predictions pr ON pr.detection_id = d.id
+                       LEFT JOIN prediction_review pr_rev
+                         ON pr_rev.prediction_id = pr.id
+                        AND pr_rev.workspace_id = ?
+                       WHERE d.photo_id IN ({placeholders})
+                         AND pr.species IS NOT NULL
+                         AND COALESCE(pr_rev.status, 'pending') != 'rejected'
+                         AND pr.labels_fingerprint = (
+                             SELECT pr2.labels_fingerprint FROM predictions pr2
+                             WHERE pr2.detection_id = pr.detection_id
+                               AND pr2.classifier_model = pr.classifier_model
+                             ORDER BY pr2.created_at DESC, pr2.id DESC
+                             LIMIT 1
+                         )
+                   ) WHERE rn = 1""",
+                (ws, *chunk),
+            ).fetchall()
+            for row in rows:
+                results[row["photo_id"]] = row
+        return results
+
     @app.route("/api/highlights")
     def api_highlights():
         db = _get_db()
@@ -4026,6 +4106,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "filename": r["filename"],
                 "quality_score": r["quality_score"],
                 "has_accepted_species": accepted is not None,
+                "species": accepted,
+                "prediction_id": r.get("prediction_id"),
+                "predicted_species": r.get("predicted_species"),
+                "predicted_confidence": r.get("predicted_confidence"),
             }
 
             if species is None:
@@ -4071,6 +4155,160 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "eligible": len(candidates),
             },
             "scope": "workspace" if folder_id is None else "folder",
+        })
+
+    @app.route("/api/highlights/confirm", methods=["POST"])
+    def api_highlights_confirm():
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        photo_ids, error = _parse_highlight_photo_ids(body)
+        if error:
+            return json_error(error)
+        error, status = _validate_highlight_photo_ids(db, photo_ids)
+        if error:
+            return json_error(error, status)
+
+        top_predictions = _highlight_top_predictions(db, photo_ids)
+        accepted_photo_ids = set()
+        for i in range(0, len(photo_ids), 800):
+            chunk = photo_ids[i:i + 800]
+            placeholders = ",".join("?" for _ in chunk)
+            accepted_photo_ids.update(
+                row["photo_id"] for row in db.conn.execute(
+                    f"""SELECT DISTINCT pk.photo_id
+                        FROM photo_keywords pk
+                        JOIN keywords k ON k.id = pk.keyword_id
+                        WHERE pk.photo_id IN ({placeholders})
+                          AND k.is_species = 1""",
+                    chunk,
+                ).fetchall()
+            )
+        processed = set()
+        affected = []
+        skipped = []
+        for pid in photo_ids:
+            if pid in accepted_photo_ids:
+                skipped.append({"photo_id": pid, "reason": "already_confirmed"})
+                continue
+            pred = top_predictions.get(pid)
+            if pred is None:
+                skipped.append({"photo_id": pid, "reason": "no_prediction"})
+                continue
+            if pred["status"] != "pending":
+                skipped.append({"photo_id": pid, "reason": pred["status"]})
+                continue
+            key = (
+                "group",
+                pred["classifier_model"],
+                pred["group_id"],
+            ) if pred["group_id"] else ("prediction", pred["id"])
+            if key in processed:
+                continue
+            processed.add(key)
+            result = db.accept_prediction(pred["id"])
+            if result is None:
+                skipped.append({"photo_id": pid, "reason": "prediction_not_found"})
+                continue
+            items = [
+                {
+                    "photo_id": a["photo_id"],
+                    "old_value": str(a["prediction_id"]),
+                    "new_value": str(result["keyword_id"]),
+                }
+                for a in result["affected"]
+            ]
+            desc = f'Accepted prediction: added "{result["species"]}"'
+            if len(items) > 1:
+                desc += f" to {len(items)} photos"
+            db.record_edit(
+                "prediction_accept",
+                desc,
+                str(result["keyword_id"]),
+                items,
+                is_batch=len(items) > 1,
+            )
+            affected.extend(items)
+        return jsonify({"ok": True, "affected": affected, "skipped": skipped})
+
+    @app.route("/api/highlights/relabel", methods=["POST"])
+    def api_highlights_relabel():
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        photo_ids, error = _parse_highlight_photo_ids(body)
+        if error:
+            return json_error(error)
+        species = body.get("species", "")
+        species = species.strip() if isinstance(species, str) else ""
+        if not species:
+            return json_error("species required")
+        error, status = _validate_highlight_photo_ids(db, photo_ids)
+        if error:
+            return json_error(error, status)
+
+        top_predictions = _highlight_top_predictions(db, photo_ids)
+        ws_id = db._ws_id()
+        try:
+            kid = db.add_keyword(species, is_species=True, _commit=False)
+            items = []
+            rejected_prediction_ids = []
+            for pid in photo_ids:
+                pred = top_predictions.get(pid)
+                if pred is not None:
+                    db.update_prediction_status(pred["id"], "rejected", _commit=False)
+                    rejected_prediction_ids.append(pred["id"])
+
+                old_rows = db.conn.execute(
+                    """SELECT k.id, k.name, k.is_species, k.type
+                       FROM photo_keywords pk
+                       JOIN keywords k ON k.id = pk.keyword_id
+                       WHERE pk.photo_id = ?
+                         AND (k.is_species = 1 OR k.type = 'taxonomy')
+                       ORDER BY k.is_species DESC, pk.rowid DESC""",
+                    (pid,),
+                ).fetchall()
+                old_primary = old_rows[0] if old_rows else None
+                for old in old_rows:
+                    db.untag_photo(pid, old["id"], _commit=False)
+                    if old["name"].strip().lower() != species.lower():
+                        _queue_keyword_remove(
+                            pid, old["name"], workspace_id=ws_id, _commit=False,
+                        )
+
+                db.tag_photo(pid, kid, _commit=False)
+                _queue_keyword_add(pid, species, workspace_id=ws_id, _commit=False)
+                items.append({
+                    "photo_id": pid,
+                    "old_value": str(old_primary["id"]) if old_primary else "",
+                    "new_value": str(kid),
+                })
+
+            action_type = (
+                "species_replace"
+                if any(item["old_value"] for item in items)
+                else "keyword_add"
+            )
+            if action_type == "species_replace":
+                desc = f'Replaced species with "{species}" on {len(photo_ids)} photos'
+            else:
+                desc = f'Set species "{species}" on {len(photo_ids)} photos'
+            db.record_edit(
+                action_type,
+                desc,
+                str(kid),
+                items,
+                is_batch=len(items) > 1,
+                _commit=False,
+            )
+            db.conn.commit()
+        except Exception:
+            db.conn.rollback()
+            raise
+        db._prune_edit_history()
+        return jsonify({
+            "ok": True,
+            "keyword_id": kid,
+            "affected": items,
+            "rejected_prediction_ids": rejected_prediction_ids,
         })
 
     @app.route("/api/highlights/save", methods=["POST"])

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -6817,9 +6817,10 @@ class Database:
 
         Each row carries:
           * ``species`` — accepted species keyword (NULL if none accepted)
-          * ``predicted_species`` / ``predicted_confidence`` — top-confidence
-            non-rejected prediction across the photo's detections (NULL if
-            no usable prediction exists)
+          * ``prediction_id`` / ``predicted_species`` /
+            ``predicted_confidence`` — top-confidence non-rejected prediction
+            across the photo's detections (NULL if no usable prediction
+            exists)
 
         Only photos with ``quality_score >= min_quality`` that are not
         user-rejected are returned, ordered by ``quality_score`` DESC.
@@ -6840,6 +6841,7 @@ class Database:
                       p.subject_size, p.sharpness, p.phash_crop,
                       p.dino_subject_embedding, p.dino_global_embedding,
                       bp.species,
+                      tp.prediction_id,
                       tp.predicted_species,
                       tp.predicted_confidence
                FROM photos p
@@ -6859,10 +6861,11 @@ class Database:
                ) bp ON bp.photo_id = p.id
                LEFT JOIN (
                    SELECT photo_id,
+                          id AS prediction_id,
                           species AS predicted_species,
                           confidence AS predicted_confidence
                    FROM (
-                       SELECT d.photo_id, pr.species, pr.confidence,
+                       SELECT d.photo_id, pr.id, pr.species, pr.confidence,
                               ROW_NUMBER() OVER (
                                   PARTITION BY d.photo_id
                                   ORDER BY pr.confidence DESC, pr.id DESC

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7804,7 +7804,7 @@ class Database:
         ).fetchone()
         return bool(row["is_species"]) if row else False
 
-    def accept_prediction(self, prediction_id, replace_species=False):
+    def accept_prediction(self, prediction_id, replace_species=False, _commit=True):
         """Accept a prediction: mark as accepted and add species keyword.
 
         If the prediction belongs to a group, derives the consensus species
@@ -7817,8 +7817,8 @@ class Database:
         list carries the ``old_species`` names that were stripped from that
         photo (empty when ``replace_species`` is False).
 
-        All database changes are performed atomically in a single transaction.
-        On failure, all changes are rolled back.
+        All database changes are performed atomically in a single transaction
+        unless ``_commit`` is False and the caller owns the transaction.
         """
         ws = self._ws_id()
         pred = self.conn.execute(
@@ -7954,7 +7954,8 @@ class Database:
             else:
                 _accept_for_photo(pred["photo_id"], prediction_id)
 
-            self.conn.commit()
+            if _commit:
+                self.conn.commit()
             return {"species": species, "keyword_id": kid, "affected": affected}
         except Exception:
             self.conn.rollback()
@@ -8930,7 +8931,9 @@ class Database:
                 if entry['action_type'] == 'keyword_add':
                     self._restore_edit_prediction_status(old_meta)
                 if entry['action_type'] == 'prediction_accept' and old_val:
-                    pred_id = int(old_val)
+                    pred_id = self._edit_prediction_id(old_meta, old_val)
+                    if pred_id is None:
+                        continue
                     ws = self._ws_id()
                     # Restore predictions to pre-accept state. Scope by
                     # labels_fingerprint too — without it, undoing an accept
@@ -9000,7 +9003,7 @@ class Database:
                 # old one, symmetrically reversing the pending-change queue.
                 old_meta = self._edit_old_value_meta(old_val)
                 new_kid = int(item['new_value']) if item['new_value'] else None
-                old_kid = old_meta.get("keyword_id")
+                old_kids = old_meta.get("keyword_ids") or []
                 if new_kid:
                     self.untag_photo(pid, new_kid)
                     new_kw = self.conn.execute(
@@ -9012,7 +9015,7 @@ class Database:
                         )
                         if cancelled == 0:
                             self.queue_change(pid, 'keyword_remove', new_kw['name'])
-                if old_kid:
+                for old_kid in old_kids:
                     self.tag_photo(pid, old_kid)
                     old_kw = self.conn.execute(
                         "SELECT name FROM keywords WHERE id = ?", (old_kid,)
@@ -9059,7 +9062,9 @@ class Database:
                 if entry['action_type'] == 'keyword_add':
                     self._reject_edit_prediction(old_meta)
                 if entry['action_type'] == 'prediction_accept' and item['old_value']:
-                    pred_id = int(item['old_value'])
+                    pred_id = self._edit_prediction_id(old_meta, item['old_value'])
+                    if pred_id is None:
+                        continue
                     ws = self._ws_id()
                     self.update_prediction_status(pred_id, 'accepted')
                     # Re-reject siblings, scoped to the same labels_fingerprint
@@ -9107,8 +9112,8 @@ class Database:
                 # Re-apply the swap: untag old, retag new, mirror pending queue.
                 old_meta = self._edit_old_value_meta(item['old_value'])
                 new_kid = int(new_val) if new_val else None
-                old_kid = old_meta.get("keyword_id")
-                if old_kid:
+                old_kids = old_meta.get("keyword_ids") or []
+                for old_kid in old_kids:
                     self.untag_photo(pid, old_kid)
                     old_kw = self.conn.execute(
                         "SELECT name FROM keywords WHERE id = ?", (old_kid,)
@@ -9135,22 +9140,40 @@ class Database:
     def _edit_old_value_meta(self, old_value):
         """Parse edit item old_value, including newer JSON metadata payloads."""
         if not old_value:
-            return {"keyword_id": None}
+            return {"keyword_id": None, "keyword_ids": []}
         if isinstance(old_value, str) and old_value.lstrip().startswith("{"):
             try:
                 data = json.loads(old_value)
             except (TypeError, ValueError):
                 return {"keyword_id": None}
             keyword_id = data.get("keyword_id")
+            keyword_ids = data.get("keyword_ids")
             try:
                 data["keyword_id"] = int(keyword_id) if keyword_id else None
             except (TypeError, ValueError):
                 data["keyword_id"] = None
+            if not isinstance(keyword_ids, list):
+                keyword_ids = [data["keyword_id"]] if data["keyword_id"] else []
+            parsed_ids = []
+            for kid in keyword_ids:
+                with contextlib.suppress(TypeError, ValueError):
+                    parsed_ids.append(int(kid))
+            data["keyword_ids"] = parsed_ids
             return data
         try:
-            return {"keyword_id": int(old_value)}
+            keyword_id = int(old_value)
+            return {"keyword_id": keyword_id, "keyword_ids": [keyword_id]}
         except (TypeError, ValueError):
-            return {"keyword_id": None}
+            return {"keyword_id": None, "keyword_ids": []}
+
+    def _edit_prediction_id(self, meta, fallback):
+        raw = meta.get("prediction_id") if meta else None
+        if raw is None:
+            raw = fallback
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return None
 
     def _restore_edit_prediction_status(self, meta):
         pred_id = meta.get("prediction_id")

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -8921,11 +8921,14 @@ class Database:
                 else:
                     self.remove_color_label(pid)
             elif entry['action_type'] in ('keyword_add', 'prediction_accept'):
+                old_meta = self._edit_old_value_meta(old_val)
                 self.untag_photo(pid, int(entry['new_value']))
                 kw = self.conn.execute("SELECT name FROM keywords WHERE id = ?",
                                        (int(entry['new_value']),)).fetchone()
                 if kw:
                     self.remove_pending_changes(pid, 'keyword_add', kw['name'])
+                if entry['action_type'] == 'keyword_add':
+                    self._restore_edit_prediction_status(old_meta)
                 if entry['action_type'] == 'prediction_accept' and old_val:
                     pred_id = int(old_val)
                     ws = self._ws_id()
@@ -8995,8 +8998,9 @@ class Database:
                 # Atomic swap: the edit replaced old_value's species with
                 # new_value's. Undo untags the new species and retags the
                 # old one, symmetrically reversing the pending-change queue.
+                old_meta = self._edit_old_value_meta(old_val)
                 new_kid = int(item['new_value']) if item['new_value'] else None
-                old_kid = int(old_val) if old_val else None
+                old_kid = old_meta.get("keyword_id")
                 if new_kid:
                     self.untag_photo(pid, new_kid)
                     new_kw = self.conn.execute(
@@ -9019,6 +9023,7 @@ class Database:
                         )
                         if cancelled == 0:
                             self.queue_change(pid, 'keyword_add', old_kw['name'])
+                self._restore_edit_prediction_status(old_meta)
 
     def _apply_redo(self, entry, items):
         """Re-apply the effects of an undone edit entry."""
@@ -9045,11 +9050,14 @@ class Database:
                 else:
                     self.remove_color_label(pid)
             elif entry['action_type'] in ('keyword_add', 'prediction_accept'):
+                old_meta = self._edit_old_value_meta(item['old_value'])
                 self.tag_photo(pid, int(entry['new_value']))
                 kw = self.conn.execute("SELECT name FROM keywords WHERE id = ?",
                                        (int(entry['new_value']),)).fetchone()
                 if kw:
                     self.queue_change(pid, 'keyword_add', kw['name'])
+                if entry['action_type'] == 'keyword_add':
+                    self._reject_edit_prediction(old_meta)
                 if entry['action_type'] == 'prediction_accept' and item['old_value']:
                     pred_id = int(item['old_value'])
                     ws = self._ws_id()
@@ -9097,8 +9105,9 @@ class Database:
                     self.queue_change(pid, 'keyword_remove', kw['name'])
             elif entry['action_type'] == 'species_replace':
                 # Re-apply the swap: untag old, retag new, mirror pending queue.
+                old_meta = self._edit_old_value_meta(item['old_value'])
                 new_kid = int(new_val) if new_val else None
-                old_kid = int(item['old_value']) if item['old_value'] else None
+                old_kid = old_meta.get("keyword_id")
                 if old_kid:
                     self.untag_photo(pid, old_kid)
                     old_kw = self.conn.execute(
@@ -9121,6 +9130,40 @@ class Database:
                         )
                         if cancelled == 0:
                             self.queue_change(pid, 'keyword_add', new_kw['name'])
+                self._reject_edit_prediction(old_meta)
+
+    def _edit_old_value_meta(self, old_value):
+        """Parse edit item old_value, including newer JSON metadata payloads."""
+        if not old_value:
+            return {"keyword_id": None}
+        if isinstance(old_value, str) and old_value.lstrip().startswith("{"):
+            try:
+                data = json.loads(old_value)
+            except (TypeError, ValueError):
+                return {"keyword_id": None}
+            keyword_id = data.get("keyword_id")
+            try:
+                data["keyword_id"] = int(keyword_id) if keyword_id else None
+            except (TypeError, ValueError):
+                data["keyword_id"] = None
+            return data
+        try:
+            return {"keyword_id": int(old_value)}
+        except (TypeError, ValueError):
+            return {"keyword_id": None}
+
+    def _restore_edit_prediction_status(self, meta):
+        pred_id = meta.get("prediction_id")
+        if not pred_id:
+            return
+        status = meta.get("prediction_status") or "pending"
+        self.update_prediction_status(int(pred_id), status, _commit=False)
+
+    def _reject_edit_prediction(self, meta):
+        pred_id = meta.get("prediction_id")
+        if not pred_id:
+            return
+        self.update_prediction_status(int(pred_id), "rejected", _commit=False)
 
     def _prune_edit_history(self):
         """Delete oldest entries beyond the configured max (excludes undone entries awaiting redo)."""

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7811,7 +7811,13 @@ class Database:
         ).fetchone()
         return bool(row["is_species"]) if row else False
 
-    def accept_prediction(self, prediction_id, replace_species=False, _commit=True):
+    def accept_prediction(
+        self,
+        prediction_id,
+        replace_species=False,
+        photo_ids=None,
+        _commit=True,
+    ):
         """Accept a prediction: mark as accepted and add species keyword.
 
         If the prediction belongs to a group, derives the consensus species
@@ -7824,10 +7830,17 @@ class Database:
         list carries the ``old_species`` names that were stripped from that
         photo (empty when ``replace_species`` is False).
 
+        When ``photo_ids`` is provided for a grouped prediction, only matching
+        group members are tagged and marked accepted. This lets callers apply a
+        grouped accept to a filtered subset without changing hidden photos.
+
         All database changes are performed atomically in a single transaction
         unless ``_commit`` is False and the caller owns the transaction.
         """
         ws = self._ws_id()
+        limited_photo_ids = None
+        if photo_ids is not None:
+            limited_photo_ids = {int(pid) for pid in photo_ids}
         pred = self.conn.execute(
             """SELECT pr.*,
                       pr.classifier_model AS model,
@@ -7957,8 +7970,20 @@ class Database:
                     (ws, ws, pred["group_id"], pred["model"]),
                 ).fetchall()
                 for gp in group_preds:
+                    if (
+                        limited_photo_ids is not None
+                        and gp["photo_id"] not in limited_photo_ids
+                    ):
+                        continue
                     _accept_for_photo(gp["photo_id"], gp["id"])
             else:
+                if (
+                    limited_photo_ids is not None
+                    and pred["photo_id"] not in limited_photo_ids
+                ):
+                    if _commit:
+                        self.conn.commit()
+                    return {"species": species, "keyword_id": kid, "affected": []}
                 _accept_for_photo(pred["photo_id"], prediction_id)
 
             if _commit:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7990,7 +7990,8 @@ class Database:
                 self.conn.commit()
             return {"species": species, "keyword_id": kid, "affected": affected}
         except Exception:
-            self.conn.rollback()
+            if _commit:
+                self.conn.rollback()
             raise
 
     # -- Detections --

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -290,6 +290,7 @@ async function loadSpeciesSuggestions() {
       list.appendChild(opt);
     });
   } catch (e) {
+    speciesSuggestionsLoaded = false;
     // Free typing still works if suggestions cannot be loaded.
   }
 }
@@ -519,7 +520,10 @@ function updateHighlightsLightboxControls(photoId) {
       if (btn.getAttribute('data-lb-action') === 'confirm') {
         confirmPhotoIds([photo.id], btn);
       } else {
-        showSpeciesModal('Change species', photo.filename || '', [photo.id], photoSpeciesName(photo));
+        var modalTitle = (photo.prediction_id || photo.has_accepted_species)
+          ? 'Change species'
+          : 'Set species';
+        showSpeciesModal(modalTitle, photo.filename || '', [photo.id], photoSpeciesName(photo));
       }
     });
   });

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -18,12 +18,18 @@
   .save-btn:hover { opacity:0.9; }
 
   .bucket { padding:16px 24px; border-bottom:1px solid var(--border-primary); }
-  .bucket-header { display:flex; align-items:baseline; justify-content:space-between; margin-bottom:10px; }
+  .bucket-header { display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:10px; }
+  .bucket-heading { display:flex; align-items:baseline; gap:8px; min-width:0; flex-wrap:wrap; }
   .bucket-title { font-size:16px; color:var(--text-primary); font-weight:600; }
   .bucket-meta { font-size:13px; color:var(--text-secondary); }
   .bucket-badge { display:inline-block; margin-left:8px; font-size:10px; padding:2px 6px; border-radius:8px; background:var(--bg-tertiary); color:var(--text-secondary); text-transform:uppercase; letter-spacing:0.5px; }
   .bucket-badge.predicted { background:var(--bg-tertiary); color:var(--text-secondary); }
   .bucket-badge.accepted { background:var(--accent); color:var(--accent-text); }
+  .bucket-actions { display:flex; align-items:center; gap:8px; flex-wrap:wrap; justify-content:flex-end; }
+  .bucket-action { padding:4px 10px; border-radius:4px; border:1px solid var(--border-secondary); background:var(--bg-secondary); color:var(--text-primary); cursor:pointer; font-size:12px; }
+  .bucket-action.primary { background:var(--accent); color:var(--accent-text); border-color:var(--accent); }
+  .bucket-action:hover { border-color:var(--accent); }
+  .bucket-action:disabled { opacity:0.55; cursor:default; }
   .bucket-strip { display:grid; grid-template-columns:repeat(auto-fill, minmax(180px, 1fr)); gap:10px; }
   .highlights-card { position:relative; border-radius:6px; overflow:hidden; background:var(--bg-secondary); cursor:pointer; border:1px solid var(--border-primary); }
   .highlights-card:hover { border-color:var(--accent); }
@@ -46,6 +52,20 @@
   .save-modal input[type=text] { width:100%; padding:8px; font-size:14px; border:1px solid var(--border-secondary); border-radius:4px; box-sizing:border-box; margin-bottom:12px; background:var(--bg-input); color:var(--text-primary); }
   .save-modal-actions { display:flex; gap:8px; justify-content:flex-end; }
   .save-modal-actions button { padding:6px 16px; border-radius:4px; border:none; cursor:pointer; font-size:13px; }
+
+  .species-modal-overlay { display:none; position:fixed; inset:0; background:rgba(0,0,0,0.55); z-index:700; align-items:center; justify-content:center; }
+  .species-modal-overlay.open { display:flex; }
+  .species-modal { width:min(420px, calc(100vw - 32px)); background:var(--bg-primary); border:1px solid var(--border-primary); border-radius:8px; padding:20px; box-shadow:0 16px 48px rgba(0,0,0,0.35); }
+  .species-modal h3 { margin:0 0 12px; font-size:16px; color:var(--text-primary); }
+  .species-modal p { margin:0 0 12px; color:var(--text-secondary); font-size:13px; }
+  .species-modal input[type=text] { width:100%; padding:8px; font-size:14px; border:1px solid var(--border-secondary); border-radius:4px; box-sizing:border-box; background:var(--bg-input); color:var(--text-primary); }
+  .species-modal-actions { display:flex; gap:8px; justify-content:flex-end; margin-top:14px; }
+  .species-modal-actions button { padding:6px 16px; border-radius:4px; border:1px solid var(--border-secondary); background:var(--bg-secondary); color:var(--text-primary); cursor:pointer; font-size:13px; }
+  .species-modal-actions .primary { background:var(--accent); color:var(--accent-text); border-color:var(--accent); }
+
+  .highlight-lb-panel { display:flex; align-items:center; gap:8px; flex-wrap:wrap; padding:5px 8px; border-radius:4px; background:rgba(0,0,0,0.6); border:1px solid var(--text-faint); color:var(--text-secondary); font-size:12px; }
+  .highlight-lb-panel button { border:1px solid var(--border-secondary); background:rgba(255,255,255,0.08); color:var(--text-primary); border-radius:4px; padding:4px 9px; cursor:pointer; font-size:12px; }
+  .highlight-lb-panel button.primary { border-color:var(--accent); color:var(--accent); }
 </style>
 </head>
 <body>
@@ -107,6 +127,20 @@
   </div>
 </div>
 
+<!-- Species correction modal -->
+<div class="species-modal-overlay" id="speciesModal" onclick="if (event.target === this) closeSpeciesModal();">
+  <div class="species-modal">
+    <h3 id="speciesModalTitle">Set species</h3>
+    <p id="speciesModalSummary"></p>
+    <input type="text" id="speciesModalInput" list="highlightSpeciesList" placeholder="Species name" autocomplete="off">
+    <datalist id="highlightSpeciesList"></datalist>
+    <div class="species-modal-actions">
+      <button onclick="closeSpeciesModal()">Cancel</button>
+      <button class="primary" id="speciesModalSubmit" onclick="submitSpeciesModal()">Apply</button>
+    </div>
+  </div>
+</div>
+
 <script>
 var WORKSPACE_SCOPE = '__workspace__';
 var currentData = null;          // last API response
@@ -115,6 +149,9 @@ var unidentifiedExpanded = false;
 var currentFolderName = '';
 var debounceTimer = null;
 var existingCollections = [];
+var speciesSuggestionsLoaded = false;
+var speciesModalPhotoIds = [];
+var activeLightboxPhotoId = null;
 
 function escapeAttr(s) {
   if (s === null || s === undefined) return '';
@@ -185,10 +222,113 @@ function attachCardClicks(container, photoSet) {
       var pid = parseInt(card.getAttribute('data-photo-id'));
       var photo = photoSet.find(function(p) { return p.id === pid; });
       if (window.openLightbox && photo) {
+        activeLightboxPhotoId = pid;
         openLightbox(pid, photo.filename, photoSet);
       }
     });
   });
+}
+
+function bucketPhotoIds(bucket) {
+  return (bucket.photos || []).map(function(p) { return p.id; });
+}
+
+function unidPhotoIds() {
+  return (currentData && currentData.unidentified && currentData.unidentified.photos || [])
+    .map(function(p) { return p.id; });
+}
+
+function photoCurrentLabel(photo) {
+  if (!photo) return '';
+  if (photo.has_accepted_species && photo.species) {
+    return 'Confirmed: ' + photo.species;
+  }
+  if (photo.predicted_species) {
+    var conf = photo.predicted_confidence != null
+      ? ' (' + Math.round(photo.predicted_confidence * 100) + '%)'
+      : '';
+    return 'Predicted: ' + photo.predicted_species + conf;
+  }
+  return 'Unidentified';
+}
+
+function photoSpeciesName(photo) {
+  if (!photo) return '';
+  if (photo.has_accepted_species && photo.species) return photo.species;
+  if (photo.predicted_species) return photo.predicted_species;
+  return '';
+}
+
+async function confirmPhotoIds(photoIds, button) {
+  if (!photoIds.length) return;
+  if (button) button.disabled = true;
+  try {
+    await safeFetch('/api/highlights/confirm', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ photo_ids: photoIds }),
+    });
+    await loadHighlights();
+    if (typeof showToast === 'function') showToast('Prediction confirmed', 'success');
+  } finally {
+    if (button) button.disabled = false;
+  }
+}
+
+async function loadSpeciesSuggestions() {
+  if (speciesSuggestionsLoaded) return;
+  speciesSuggestionsLoaded = true;
+  try {
+    var keywords = await safeFetch('/api/keywords/all', {}, { toast: false });
+    var list = document.getElementById('highlightSpeciesList');
+    list.innerHTML = '';
+    (keywords || []).filter(function(k) {
+      return k && k.name && (k.type === 'taxonomy' || k.taxon_name || k.taxon_common_name);
+    }).forEach(function(k) {
+      var opt = document.createElement('option');
+      opt.value = k.name;
+      list.appendChild(opt);
+    });
+  } catch (e) {
+    // Free typing still works if suggestions cannot be loaded.
+  }
+}
+
+function showSpeciesModal(title, summary, photoIds, initialSpecies) {
+  speciesModalPhotoIds = photoIds.slice();
+  document.getElementById('speciesModalTitle').textContent = title;
+  document.getElementById('speciesModalSummary').textContent = summary;
+  var input = document.getElementById('speciesModalInput');
+  input.value = initialSpecies || '';
+  document.getElementById('speciesModal').classList.add('open');
+  loadSpeciesSuggestions();
+  setTimeout(function() { input.focus(); input.select(); }, 0);
+}
+
+function closeSpeciesModal() {
+  document.getElementById('speciesModal').classList.remove('open');
+  speciesModalPhotoIds = [];
+}
+
+async function submitSpeciesModal() {
+  var input = document.getElementById('speciesModalInput');
+  var species = input.value.trim();
+  if (!species || !speciesModalPhotoIds.length) return;
+  var submit = document.getElementById('speciesModalSubmit');
+  submit.disabled = true;
+  try {
+    await safeFetch('/api/highlights/relabel', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ photo_ids: speciesModalPhotoIds, species: species }),
+    });
+    closeSpeciesModal();
+    await loadHighlights();
+    updateHighlightsLightboxControls(activeLightboxPhotoId);
+    if (typeof showToast === 'function') showToast('Species updated', 'success');
+  } finally {
+    submit.disabled = false;
+  }
 }
 
 function renderBucket(bucket) {
@@ -208,10 +348,18 @@ function renderBucket(bucket) {
       + (expanded ? 'Show fewer' : '+ ' + remaining + ' more')
       + '</button>';
   }
+  var actions = '<div class="bucket-actions">';
+  if (!bucket.is_accepted) {
+    actions += '<button class="bucket-action primary" data-action="confirm-bucket" data-species="'
+      + escapeAttr(bucket.species) + '">Confirm</button>';
+  }
+  actions += '<button class="bucket-action" data-action="change-bucket" data-species="'
+    + escapeAttr(bucket.species) + '">Change</button></div>';
   return '<section class="bucket">'
     + '<div class="bucket-header">'
-    + '<div class="bucket-title">' + escapeAttr(bucket.species) + badge + '</div>'
-    + '<div class="bucket-meta">' + meta + '</div>'
+    + '<div class="bucket-heading"><div class="bucket-title">' + escapeAttr(bucket.species) + badge + '</div>'
+    + '<div class="bucket-meta">' + meta + '</div></div>'
+    + actions
     + '</div>'
     + '<div class="bucket-strip">' + visible.map(renderCard).join('') + '</div>'
     + expandBtn
@@ -233,8 +381,9 @@ function renderUnidentified() {
   return '<div class="unid-divider">Unidentified — Vireo couldn\'t ID these</div>'
     + '<section class="bucket">'
     + '<div class="bucket-header">'
-    + '<div class="bucket-title">Unidentified</div>'
-    + '<div class="bucket-meta">' + unid.photo_count + ' photos</div>'
+    + '<div class="bucket-heading"><div class="bucket-title">Unidentified</div>'
+    + '<div class="bucket-meta">' + unid.photo_count + ' photos</div></div>'
+    + '<div class="bucket-actions"><button class="bucket-action" data-action="change-unidentified">Set species</button></div>'
     + '</div>'
     + '<div class="bucket-strip">' + visible.map(renderCard).join('') + '</div>'
     + expandBtn
@@ -291,7 +440,104 @@ function render() {
       render();
     });
   });
+
+  content.querySelectorAll('.bucket-action').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var action = btn.getAttribute('data-action');
+      if (action === 'confirm-bucket') {
+        var species = btn.getAttribute('data-species');
+        var bucket = buckets.find(function(b) { return b.species === species; });
+        if (bucket) confirmPhotoIds(bucketPhotoIds(bucket), btn);
+      } else if (action === 'change-bucket') {
+        var changeSpecies = btn.getAttribute('data-species');
+        var changeBucket = buckets.find(function(b) { return b.species === changeSpecies; });
+        if (changeBucket) {
+          showSpeciesModal(
+            'Change species',
+            changeBucket.photo_count + ' photo' + (changeBucket.photo_count === 1 ? '' : 's'),
+            bucketPhotoIds(changeBucket),
+            changeBucket.species
+          );
+        }
+      } else if (action === 'change-unidentified') {
+        var ids = unidPhotoIds();
+        showSpeciesModal(
+          'Set species',
+          ids.length + ' unidentified photo' + (ids.length === 1 ? '' : 's'),
+          ids,
+          ''
+        );
+      }
+    });
+  });
+  updateHighlightsLightboxControls(activeLightboxPhotoId);
 }
+
+function findHighlightPhoto(photoId) {
+  if (!currentData || photoId == null) return null;
+  var buckets = currentData.buckets || [];
+  for (var i = 0; i < buckets.length; i++) {
+    var match = (buckets[i].photos || []).find(function(p) { return p.id === photoId; });
+    if (match) return match;
+  }
+  var unid = currentData.unidentified && currentData.unidentified.photos || [];
+  return unid.find(function(p) { return p.id === photoId; }) || null;
+}
+
+function ensureHighlightsLightboxPanel() {
+  var actions = document.getElementById('lightboxActions');
+  if (!actions) return null;
+  var panel = document.getElementById('highlightLightboxPanel');
+  if (!panel) {
+    panel = document.createElement('div');
+    panel.id = 'highlightLightboxPanel';
+    panel.className = 'highlight-lb-panel';
+    actions.insertBefore(panel, actions.firstChild);
+  }
+  return panel;
+}
+
+function updateHighlightsLightboxControls(photoId) {
+  var panel = ensureHighlightsLightboxPanel();
+  if (!panel) return;
+  var photo = findHighlightPhoto(photoId);
+  if (!photo) {
+    panel.style.display = 'none';
+    panel.innerHTML = '';
+    return;
+  }
+  panel.style.display = '';
+  var html = '<span>' + escapeAttr(photoCurrentLabel(photo)) + '</span>';
+  if (!photo.has_accepted_species && photo.prediction_id) {
+    html += '<button class="primary" data-lb-action="confirm">Confirm</button>';
+  }
+  html += '<button data-lb-action="change">' + (photo.prediction_id || photo.has_accepted_species ? 'Change' : 'Set species') + '</button>';
+  panel.innerHTML = html;
+  panel.querySelectorAll('button').forEach(function(btn) {
+    btn.addEventListener('click', function(event) {
+      event.stopPropagation();
+      if (btn.getAttribute('data-lb-action') === 'confirm') {
+        confirmPhotoIds([photo.id], btn);
+      } else {
+        showSpeciesModal('Change species', photo.filename || '', [photo.id], photoSpeciesName(photo));
+      }
+    });
+  });
+}
+
+document.addEventListener('lightbox:photochanged', function(event) {
+  activeLightboxPhotoId = event.detail ? event.detail.photoId : null;
+  updateHighlightsLightboxControls(activeLightboxPhotoId);
+});
+
+document.getElementById('speciesModalInput').addEventListener('keydown', function(event) {
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    submitSpeciesModal();
+  } else if (event.key === 'Escape') {
+    closeSpeciesModal();
+  }
+});
 
 function debounceLoad() {
   clearTimeout(debounceTimer);

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -267,12 +267,25 @@ function attachCardClicks(container, photoSet) {
   });
 }
 
-function bucketPhotoIds(bucket) {
-  return (bucket.photos || []).map(function(p) { return p.id; });
+async function ensureFullBucketLoaded(species, isUnidentified) {
+  var target = isUnidentified
+    ? (currentData && currentData.unidentified)
+    : (currentData && currentData.buckets || []).find(function(b) { return b.species === species; });
+  if (!target) return [];
+  while (target.has_more) {
+    await loadMoreBucket(species, isUnidentified);
+  }
+  return target.photos || [];
 }
 
-function unidPhotoIds() {
-  return (currentData && currentData.unidentified && currentData.unidentified.photos || [])
+async function bucketPhotoIds(bucket) {
+  var photos = await ensureFullBucketLoaded(bucket.species, false);
+  return photos.map(function(p) { return p.id; });
+}
+
+async function unidPhotoIds() {
+  var photos = await ensureFullBucketLoaded(null, true);
+  return photos
     .map(function(p) { return p.id; });
 }
 
@@ -508,31 +521,37 @@ function render() {
   });
 
   content.querySelectorAll('.bucket-action').forEach(function(btn) {
-    btn.addEventListener('click', function() {
+    btn.addEventListener('click', async function() {
       var action = btn.getAttribute('data-action');
-      if (action === 'confirm-bucket') {
-        var species = btn.getAttribute('data-species');
-        var bucket = buckets.find(function(b) { return b.species === species; });
-        if (bucket) confirmPhotoIds(bucketPhotoIds(bucket), btn);
-      } else if (action === 'change-bucket') {
-        var changeSpecies = btn.getAttribute('data-species');
-        var changeBucket = buckets.find(function(b) { return b.species === changeSpecies; });
-        if (changeBucket) {
+      btn.disabled = true;
+      try {
+        if (action === 'confirm-bucket') {
+          var species = btn.getAttribute('data-species');
+          var bucket = buckets.find(function(b) { return b.species === species; });
+          if (bucket) await confirmPhotoIds(await bucketPhotoIds(bucket), btn);
+        } else if (action === 'change-bucket') {
+          var changeSpecies = btn.getAttribute('data-species');
+          var changeBucket = buckets.find(function(b) { return b.species === changeSpecies; });
+          if (changeBucket) {
+            var changeIds = await bucketPhotoIds(changeBucket);
+            showSpeciesModal(
+              'Change species',
+              changeIds.length + ' photo' + (changeIds.length === 1 ? '' : 's'),
+              changeIds,
+              changeBucket.species
+            );
+          }
+        } else if (action === 'change-unidentified') {
+          var ids = await unidPhotoIds();
           showSpeciesModal(
-            'Change species',
-            changeBucket.photo_count + ' photo' + (changeBucket.photo_count === 1 ? '' : 's'),
-            bucketPhotoIds(changeBucket),
-            changeBucket.species
+            'Set species',
+            ids.length + ' unidentified photo' + (ids.length === 1 ? '' : 's'),
+            ids,
+            ''
           );
         }
-      } else if (action === 'change-unidentified') {
-        var ids = unidPhotoIds();
-        showSpeciesModal(
-          'Set species',
-          ids.length + ' unidentified photo' + (ids.length === 1 ? '' : 's'),
-          ids,
-          ''
-        );
+      } finally {
+        btn.disabled = false;
       }
     });
   });

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -593,10 +593,10 @@ function updateHighlightsLightboxControls(photoId) {
   }
   panel.style.display = '';
   var html = '<span>' + escapeAttr(photoCurrentLabel(photo)) + '</span>';
-  if (!photo.has_accepted_species && photo.prediction_id) {
+  if (photo.is_confirmable_prediction) {
     html += '<button class="primary" data-lb-action="confirm">Confirm</button>';
   }
-  html += '<button data-lb-action="change">' + (photo.prediction_id || photo.has_accepted_species ? 'Change' : 'Set species') + '</button>';
+  html += '<button data-lb-action="change">' + (photo.is_confirmable_prediction || photo.has_accepted_species ? 'Change' : 'Set species') + '</button>';
   panel.innerHTML = html;
   panel.querySelectorAll('button').forEach(function(btn) {
     btn.addEventListener('click', function(event) {
@@ -604,7 +604,7 @@ function updateHighlightsLightboxControls(photoId) {
       if (btn.getAttribute('data-lb-action') === 'confirm') {
         confirmPhotoIds([photo.id], btn);
       } else {
-        var modalTitle = (photo.prediction_id || photo.has_accepted_species)
+        var modalTitle = (photo.is_confirmable_prediction || photo.has_accepted_species)
           ? 'Change species'
           : 'Set species';
         showSpeciesModal(modalTitle, photo.filename || '', [photo.id], photoSpeciesName(photo));

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4403,6 +4403,62 @@ def test_highlights_confirm_skips_taxonomy_keyword_photo(app_and_db):
     assert db.get_review_status(pred["id"], db._ws_id()) == "pending"
 
 
+def test_highlights_confirm_group_limited_to_submitted_photos(app_and_db):
+    """Grouped Highlights confirm does not tag hidden or unsubmitted group photos."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hcg', 'hcg', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    pid1 = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'group-1.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    pid2 = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'group-2.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    existing_kid = db.add_keyword("House Sparrow", is_species=True)
+    db.tag_photo(pid2, existing_kid)
+    det1 = db.save_detections(
+        pid1,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.9}],
+        detector_model="MDV6",
+    )[0]
+    det2 = db.save_detections(
+        pid2,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.9}],
+        detector_model="MDV6",
+    )[0]
+    db.add_prediction(det1, "Bald Eagle", 0.91, "m", group_id="group-1")
+    db.add_prediction(det2, "Bald Eagle", 0.89, "m", group_id="group-1")
+    pred1 = db.conn.execute(
+        "SELECT id FROM predictions WHERE detection_id = ? AND species = ?",
+        (det1, "Bald Eagle"),
+    ).fetchone()
+    pred2 = db.conn.execute(
+        "SELECT id FROM predictions WHERE detection_id = ? AND species = ?",
+        (det2, "Bald Eagle"),
+    ).fetchone()
+
+    resp = client.post("/api/highlights/confirm", json={"photo_ids": [pid1]})
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [item["photo_id"] for item in body["affected"]] == [pid1]
+    assert db.get_review_status(pred1["id"], db._ws_id()) == "accepted"
+    assert db.get_review_status(pred2["id"], db._ws_id()) == "pending"
+    assert "Bald Eagle" in {kw["name"] for kw in db.get_photo_keywords(pid1)}
+    pid2_keywords = {kw["name"] for kw in db.get_photo_keywords(pid2)}
+    assert "House Sparrow" in pid2_keywords
+    assert "Bald Eagle" not in pid2_keywords
+
+
 def test_highlights_relabel_rejects_prediction_and_replaces_species(app_and_db):
     """POST /api/highlights/relabel retags photos and rejects the stale prediction."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4107,6 +4107,10 @@ def test_highlights_predictions_above_threshold_populate_buckets(app_and_db):
     assert len(data["buckets"]) == 1
     assert data["buckets"][0]["species"] == "ʻIʻiwi"
     assert data["buckets"][0]["is_accepted"] is False
+    photo = data["buckets"][0]["photos"][0]
+    assert photo["prediction_id"] is not None
+    assert photo["predicted_species"] == "ʻIʻiwi"
+    assert photo["predicted_confidence"] == 0.82
     assert data["unidentified"]["photo_count"] == 0
 
     # Threshold 0.90 — prediction below threshold, photo falls to Unidentified
@@ -4114,6 +4118,114 @@ def test_highlights_predictions_above_threshold_populate_buckets(app_and_db):
     data = resp.get_json()
     assert data["buckets"] == []
     assert data["unidentified"]["photo_count"] == 1
+
+
+def test_highlights_confirm_accepts_current_prediction(app_and_db):
+    """POST /api/highlights/confirm accepts the server-resolved top prediction."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hc', 'hc', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'confirm.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    det = db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.9}],
+        detector_model="MDV6",
+    )[0]
+    db.add_prediction(det, "Bald Eagle", 0.91, "m")
+    db.add_prediction(det, "House Sparrow", 0.42, "m")
+    pred = db.conn.execute(
+        "SELECT id FROM predictions WHERE species = 'Bald Eagle'"
+    ).fetchone()
+    sibling = db.conn.execute(
+        "SELECT id FROM predictions WHERE species = 'House Sparrow'"
+    ).fetchone()
+
+    resp = client.post("/api/highlights/confirm", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+    assert db.get_review_status(pred["id"], db._ws_id()) == "accepted"
+    assert db.get_review_status(sibling["id"], db._ws_id()) == "rejected"
+    assert "Bald Eagle" in {kw["name"] for kw in db.get_photo_keywords(pid)}
+    history = db.get_edit_history(limit=1)
+    assert history[0]["action_type"] == "prediction_accept"
+
+
+def test_highlights_relabel_rejects_prediction_and_replaces_species(app_and_db):
+    """POST /api/highlights/relabel retags photos and rejects the stale prediction."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hr', 'hr', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    old_kid = db.add_keyword("Bald Eagle", is_species=True)
+    pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'relabel.jpg', 0.8, 'none')",
+        (fid,),
+    ).lastrowid
+    db.tag_photo(pid, old_kid)
+    det = db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.9}],
+        detector_model="MDV6",
+    )[0]
+    db.add_prediction(det, "Bald Eagle", 0.88, "m")
+    pred = db.conn.execute(
+        "SELECT id FROM predictions WHERE species = 'Bald Eagle'"
+    ).fetchone()
+
+    resp = client.post(
+        "/api/highlights/relabel",
+        json={"photo_ids": [pid], "species": "House Sparrow"},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+    assert db.get_review_status(pred["id"], db._ws_id()) == "rejected"
+    keywords = {kw["name"] for kw in db.get_photo_keywords(pid)}
+    assert "House Sparrow" in keywords
+    assert "Bald Eagle" not in keywords
+    history = db.get_edit_history(limit=1)
+    assert history[0]["action_type"] == "species_replace"
+
+
+def test_highlights_relabel_unidentified_sets_species(app_and_db):
+    """Relabel also works for unidentified photos with no prediction to reject."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hu', 'hu', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'unid.jpg', 0.7, 'none')",
+        (fid,),
+    ).lastrowid
+    db.conn.commit()
+
+    resp = client.post(
+        "/api/highlights/relabel",
+        json={"photo_ids": [pid], "species": "Song Sparrow"},
+    )
+    assert resp.status_code == 200
+    assert "Song Sparrow" in {kw["name"] for kw in db.get_photo_keywords(pid)}
 
 
 def test_highlights_accepted_species_wins_over_higher_confidence_prediction(app_and_db):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4160,6 +4160,38 @@ def test_highlights_confirm_accepts_current_prediction(app_and_db):
     assert history[0]["action_type"] == "prediction_accept"
 
 
+def test_highlights_confirm_accepts_reviewed_prediction(app_and_db):
+    """Highlights Confirm accepts non-rejected predictions it displays."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hcr', 'hcr', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'reviewed.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    det = db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.9}],
+        detector_model="MDV6",
+    )[0]
+    db.add_prediction(det, "Bald Eagle", 0.91, "m", status="reviewed")
+    pred = db.conn.execute(
+        "SELECT id FROM predictions WHERE species = 'Bald Eagle'"
+    ).fetchone()
+
+    resp = client.post("/api/highlights/confirm", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+    assert db.get_review_status(pred["id"], db._ws_id()) == "accepted"
+    assert "Bald Eagle" in {kw["name"] for kw in db.get_photo_keywords(pid)}
+
+
 def test_highlights_relabel_rejects_prediction_and_replaces_species(app_and_db):
     """POST /api/highlights/relabel retags photos and rejects the stale prediction."""
     app, db = app_and_db
@@ -4200,6 +4232,56 @@ def test_highlights_relabel_rejects_prediction_and_replaces_species(app_and_db):
     assert "Bald Eagle" not in keywords
     history = db.get_edit_history(limit=1)
     assert history[0]["action_type"] == "species_replace"
+
+
+def test_highlights_relabel_undo_restores_rejected_prediction(app_and_db):
+    """Undoing a Highlights relabel restores both species tags and prediction status."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hru', 'hru', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    old_kid = db.add_keyword("Bald Eagle", is_species=True)
+    pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'undo-relabel.jpg', 0.8, 'none')",
+        (fid,),
+    ).lastrowid
+    db.tag_photo(pid, old_kid)
+    det = db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.9}],
+        detector_model="MDV6",
+    )[0]
+    db.add_prediction(det, "Bald Eagle", 0.88, "m")
+    pred = db.conn.execute(
+        "SELECT id FROM predictions WHERE species = 'Bald Eagle'"
+    ).fetchone()
+
+    resp = client.post(
+        "/api/highlights/relabel",
+        json={"photo_ids": [pid], "species": "House Sparrow"},
+    )
+    assert resp.status_code == 200
+    assert db.get_review_status(pred["id"], db._ws_id()) == "rejected"
+
+    undone = db.undo_last_edit()
+    assert undone["action_type"] == "species_replace"
+    assert db.get_review_status(pred["id"], db._ws_id()) == "pending"
+    keywords = {kw["name"] for kw in db.get_photo_keywords(pid)}
+    assert "Bald Eagle" in keywords
+    assert "House Sparrow" not in keywords
+
+    redone = db.redo_last_undo()
+    assert redone["action_type"] == "species_replace"
+    assert db.get_review_status(pred["id"], db._ws_id()) == "rejected"
+    keywords = {kw["name"] for kw in db.get_photo_keywords(pid)}
+    assert "House Sparrow" in keywords
+    assert "Bald Eagle" not in keywords
 
 
 def test_highlights_relabel_unidentified_sets_species(app_and_db):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4280,6 +4280,7 @@ def test_highlights_predictions_above_threshold_populate_buckets(app_and_db):
     assert photo["prediction_id"] is not None
     assert photo["predicted_species"] == "ʻIʻiwi"
     assert photo["predicted_confidence"] == 0.82
+    assert photo["is_confirmable_prediction"] is True
     assert data["unidentified"]["photo_count"] == 0
 
     # Threshold 0.90 — prediction below threshold, photo falls to Unidentified
@@ -4287,6 +4288,10 @@ def test_highlights_predictions_above_threshold_populate_buckets(app_and_db):
     data = resp.get_json()
     assert data["buckets"] == []
     assert data["unidentified"]["photo_count"] == 1
+    photo = data["unidentified"]["photos"][0]
+    assert photo["prediction_id"] is not None
+    assert photo["predicted_species"] == "ʻIʻiwi"
+    assert photo["is_confirmable_prediction"] is False
 
 
 def test_highlights_confirm_accepts_current_prediction(app_and_db):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4144,10 +4144,12 @@ def test_highlights_confirm_accepts_current_prediction(app_and_db):
     db.add_prediction(det, "Bald Eagle", 0.91, "m")
     db.add_prediction(det, "House Sparrow", 0.42, "m")
     pred = db.conn.execute(
-        "SELECT id FROM predictions WHERE species = 'Bald Eagle'"
+        "SELECT id FROM predictions WHERE detection_id = ? AND species = ?",
+        (det, "Bald Eagle"),
     ).fetchone()
     sibling = db.conn.execute(
-        "SELECT id FROM predictions WHERE species = 'House Sparrow'"
+        "SELECT id FROM predictions WHERE detection_id = ? AND species = ?",
+        (det, "House Sparrow"),
     ).fetchone()
 
     resp = client.post("/api/highlights/confirm", json={"photo_ids": [pid]})
@@ -4183,13 +4185,53 @@ def test_highlights_confirm_accepts_reviewed_prediction(app_and_db):
     )[0]
     db.add_prediction(det, "Bald Eagle", 0.91, "m", status="reviewed")
     pred = db.conn.execute(
-        "SELECT id FROM predictions WHERE species = 'Bald Eagle'"
+        "SELECT id FROM predictions WHERE detection_id = ? AND species = ?",
+        (det, "Bald Eagle"),
     ).fetchone()
 
     resp = client.post("/api/highlights/confirm", json={"photo_ids": [pid]})
     assert resp.status_code == 200
     assert db.get_review_status(pred["id"], db._ws_id()) == "accepted"
     assert "Bald Eagle" in {kw["name"] for kw in db.get_photo_keywords(pid)}
+
+
+def test_highlights_confirm_skips_taxonomy_keyword_photo(app_and_db):
+    """Taxonomy keywords already count as confirmed for Highlights confirm."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hct', 'hct', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    taxonomy_kid = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES ('Bald Eagle', 'taxonomy', 0)"
+    ).lastrowid
+    pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'taxonomy.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    db.tag_photo(pid, taxonomy_kid)
+    det = db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.9}],
+        detector_model="MDV6",
+    )[0]
+    db.add_prediction(det, "Bald Eagle", 0.91, "m")
+    pred = db.conn.execute(
+        "SELECT id FROM predictions WHERE detection_id = ? AND species = ?",
+        (det, "Bald Eagle"),
+    ).fetchone()
+
+    resp = client.post("/api/highlights/confirm", json={"photo_ids": [pid]})
+    assert resp.status_code == 200
+    assert resp.get_json()["skipped"] == [
+        {"photo_id": pid, "reason": "already_confirmed"}
+    ]
+    assert db.get_review_status(pred["id"], db._ws_id()) == "pending"
 
 
 def test_highlights_relabel_rejects_prediction_and_replaces_species(app_and_db):
@@ -4217,7 +4259,8 @@ def test_highlights_relabel_rejects_prediction_and_replaces_species(app_and_db):
     )[0]
     db.add_prediction(det, "Bald Eagle", 0.88, "m")
     pred = db.conn.execute(
-        "SELECT id FROM predictions WHERE species = 'Bald Eagle'"
+        "SELECT id FROM predictions WHERE detection_id = ? AND species = ?",
+        (det, "Bald Eagle"),
     ).fetchone()
 
     resp = client.post(
@@ -4246,12 +4289,14 @@ def test_highlights_relabel_undo_restores_rejected_prediction(app_and_db):
         (db._ws_id(), fid),
     )
     old_kid = db.add_keyword("Bald Eagle", is_species=True)
+    old_taxonomy_kid = db.add_keyword("Haliaeetus", kw_type="taxonomy")
     pid = db.conn.execute(
         "INSERT INTO photos (folder_id, filename, quality_score, flag) "
         "VALUES (?, 'undo-relabel.jpg', 0.8, 'none')",
         (fid,),
     ).lastrowid
     db.tag_photo(pid, old_kid)
+    db.tag_photo(pid, old_taxonomy_kid)
     det = db.save_detections(
         pid,
         [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.9}],
@@ -4259,7 +4304,8 @@ def test_highlights_relabel_undo_restores_rejected_prediction(app_and_db):
     )[0]
     db.add_prediction(det, "Bald Eagle", 0.88, "m")
     pred = db.conn.execute(
-        "SELECT id FROM predictions WHERE species = 'Bald Eagle'"
+        "SELECT id FROM predictions WHERE detection_id = ? AND species = ?",
+        (det, "Bald Eagle"),
     ).fetchone()
 
     resp = client.post(
@@ -4274,6 +4320,7 @@ def test_highlights_relabel_undo_restores_rejected_prediction(app_and_db):
     assert db.get_review_status(pred["id"], db._ws_id()) == "pending"
     keywords = {kw["name"] for kw in db.get_photo_keywords(pid)}
     assert "Bald Eagle" in keywords
+    assert "Haliaeetus" in keywords
     assert "House Sparrow" not in keywords
 
     redone = db.redo_last_undo()
@@ -4282,6 +4329,48 @@ def test_highlights_relabel_undo_restores_rejected_prediction(app_and_db):
     keywords = {kw["name"] for kw in db.get_photo_keywords(pid)}
     assert "House Sparrow" in keywords
     assert "Bald Eagle" not in keywords
+    assert "Haliaeetus" not in keywords
+
+
+def test_highlights_relabel_prediction_only_undo_restores_prediction(app_and_db):
+    """Undoing relabel on a prediction-only photo restores the predicted bucket."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hrup', 'hrup', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'undo-predicted.jpg', 0.8, 'none')",
+        (fid,),
+    ).lastrowid
+    det = db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.9}],
+        detector_model="MDV6",
+    )[0]
+    db.add_prediction(det, "Bald Eagle", 0.88, "m")
+    pred = db.conn.execute(
+        "SELECT id FROM predictions WHERE detection_id = ? AND species = ?",
+        (det, "Bald Eagle"),
+    ).fetchone()
+
+    resp = client.post(
+        "/api/highlights/relabel",
+        json={"photo_ids": [pid], "species": "House Sparrow"},
+    )
+    assert resp.status_code == 200
+    assert db.get_review_status(pred["id"], db._ws_id()) == "rejected"
+    assert db.get_edit_history(limit=1)[0]["action_type"] == "keyword_add"
+
+    undone = db.undo_last_edit()
+    assert undone["action_type"] == "keyword_add"
+    assert db.get_review_status(pred["id"], db._ws_id()) == "pending"
+    assert "House Sparrow" not in {kw["name"] for kw in db.get_photo_keywords(pid)}
 
 
 def test_highlights_relabel_unidentified_sets_species(app_and_db):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4531,6 +4531,44 @@ def test_accept_prediction_tags_photo(tmp_path):
     assert any(k["name"] == "Elk" for k in kws)
 
 
+def test_accept_prediction_commit_false_preserves_caller_transaction_on_error(
+    tmp_path, monkeypatch,
+):
+    """accept_prediction(_commit=False) leaves rollback to the caller."""
+    import pytest
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos")
+    pid = db.add_photo(
+        folder_id=fid,
+        filename="elk.jpg",
+        extension=".jpg",
+        file_size=100,
+        file_mtime=1.0,
+    )
+    det_ids = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4}, "confidence": 0.9},
+    ], detector_model="MDV6")
+    db.add_prediction(det_ids[0], species="Elk", confidence=0.9, model="bioclip")
+    pred = db.get_predictions()[0]
+
+    db.conn.execute(
+        "INSERT INTO keywords (name, is_species) VALUES ('Outer Marker', 0)"
+    )
+
+    def fail_add_keyword(*args, **kwargs):
+        raise RuntimeError("simulated accept failure")
+
+    monkeypatch.setattr(db, "add_keyword", fail_add_keyword)
+    with pytest.raises(RuntimeError, match="simulated accept failure"):
+        db.accept_prediction(pred["id"], _commit=False)
+
+    assert db.conn.execute(
+        "SELECT 1 FROM keywords WHERE name = 'Outer Marker'"
+    ).fetchone() is not None
+    db.conn.rollback()
+
+
 def test_get_existing_detection_photo_ids(tmp_path):
     """get_existing_detection_photo_ids shim returns photo IDs where the default
     detector model has run (delegates to get_detector_run_photo_ids)."""


### PR DESCRIPTION
Adds the Highlights prediction feedback design doc and implements row-level and lightbox controls to confirm or change predicted species. The API now exposes prediction IDs in Highlights, adds confirm/relabel endpoints that reuse existing keyword, prediction review, sidecar, and edit-history paths, and supports unidentified species assignment. Backend tests cover the new response shape, prediction confirmation, relabeling wrong predictions, and setting species on unidentified photos.

Validation: `python3 -m pytest vireo/tests/test_app.py -k 'highlights'`, `python3 -m pytest vireo/tests/test_db.py -k 'get_highlights_candidates'`, and `node --check` on the Highlights page script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confirm or correct predicted species directly from Highlights (per-photo, per-bucket, and in the lightbox)
  * Predictions now show confidence and identifiers in Highlights
  * Interactive species correction modal with autocomplete and “Set species” for unidentified photos
  * Batch confirm/change respects grouped items and only affects selected photos

* **Bug Fixes / Reliability**
  * Corrections applied atomically and recorded in edit history (supports undo/redo); already-confirmed photos are skipped

* **Tests**
  * Expanded tests covering confirm/relabel flows, undo/redo, grouped behavior, and prediction metadata in Highlights

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->