### PR TITLE
Fix collection anchor scan pagination

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3387,9 +3387,21 @@ function browseKeyMatchesConfiguredShortcut(e) {
 
 /* ---------- Infinite Scroll ---------- */
 var gridContainer = document.getElementById('gridContainer');
+var infiniteScrollObserverDisconnected = false;
 var observer = new IntersectionObserver(function(entries) {
   if (entries[0].isIntersecting) loadPhotos();
 }, { root: gridContainer, rootMargin: '1200px 0px' });
+
+var _observerObserve = observer.observe.bind(observer);
+var _observerDisconnect = observer.disconnect.bind(observer);
+observer.observe = function(target) {
+  infiniteScrollObserverDisconnected = false;
+  return _observerObserve(target);
+};
+observer.disconnect = function() {
+  infiniteScrollObserverDisconnected = true;
+  return _observerDisconnect();
+};
 observer.observe(document.getElementById('scrollSentinel'));
 
 function rearmInfiniteScrollObserver() {
@@ -3397,6 +3409,7 @@ function rearmInfiniteScrollObserver() {
   // bootstrap or page loads. Re-observing asks IntersectionObserver to deliver
   // a fresh callback for the current layout instead of waiting for a scroll
   // transition that may never occur.
+  if (infiniteScrollObserverDisconnected) return;
   if (allLoaded || typeof observer === 'undefined') return;
   var sentinel = document.getElementById('scrollSentinel');
   if (!sentinel) return;


### PR DESCRIPTION
Fixes collection anchor restore tests by preserving explicit infinite-scroll observer disconnects. The observer rearm helper now skips automatic re-observation after a disconnect, so delayed collection anchor scans do not trigger extra pagination after selection or collection state changes. Validated with the collection context-menu E2E suite and targeted browse collection reset tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed infinite scroll from unexpectedly re-activating during page transitions and load events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/vireo/pull/938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->