### PR TITLE
Fix grid up/down keyboard navigation

### DIFF
--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -3,6 +3,17 @@ import json
 from playwright.sync_api import expect
 
 
+def disable_infinite_scroll(page):
+    page.add_init_script("""
+      class NoopIntersectionObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+      window.IntersectionObserver = NoopIntersectionObserver;
+    """)
+
+
 def test_single_click_reveals_batch_bar(live_server, page):
     """Normal-click on one photo reveals the batch bar so Develop/Export/Delete
     are reachable with a single photo selected.
@@ -365,6 +376,7 @@ def test_singleton_set_keyboard_shortcut_applies(live_server, page):
 def test_arrow_navigation_loads_next_page_at_loaded_boundary(live_server, page):
     """Keyboard navigation should continue past the currently loaded page."""
     url = live_server["url"]
+    disable_infinite_scroll(page)
     page.route(
         "**/api/config",
         lambda route: route.fulfill(
@@ -386,11 +398,33 @@ def test_arrow_navigation_loads_next_page_at_loaded_boundary(live_server, page):
     assert page.evaluate("selectedPhotoId === photos[2].id")
 
 
+def test_vertical_arrow_navigation_moves_by_rendered_grid_columns(live_server, page):
+    """Up/down should move spatially by one visible grid row, not by one photo."""
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1400, "height": 900})
+    page.goto(f"{url}/browse")
+
+    page.locator(".grid-card").first.wait_for(state="visible")
+    page.locator(".grid-card").first.click()
+    columns = page.evaluate("getBrowseGridColumnCount()")
+    assert columns >= 2
+    page.wait_for_function("cols => photos.length > cols", arg=columns)
+
+    page.keyboard.press("ArrowDown")
+    page.wait_for_function("cols => selectedIndex === cols", arg=columns)
+    assert page.evaluate("selectedPhotoId === photos[selectedIndex].id")
+
+    page.keyboard.press("ArrowUp")
+    page.wait_for_function("selectedIndex === 0")
+    assert page.evaluate("selectedPhotoId === photos[0].id")
+
+
 def test_shift_arrow_navigation_preserves_range_selection_at_loaded_boundary(
     live_server, page
 ):
     """Loading another page for keyboard navigation must preserve modifiers."""
     url = live_server["url"]
+    disable_infinite_scroll(page)
     page.route(
         "**/api/config",
         lambda route: route.fulfill(

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -419,6 +419,19 @@ def test_vertical_arrow_navigation_moves_by_rendered_grid_columns(live_server, p
     assert page.evaluate("selectedPhotoId === photos[0].id")
 
 
+def test_arrow_down_without_selection_starts_at_first_photo(live_server, page):
+    """Starting keyboard navigation with Down should focus the first card."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    page.locator(".grid-card").first.wait_for(state="visible")
+    assert page.evaluate("selectedIndex") == -1
+
+    page.keyboard.press("ArrowDown")
+    page.wait_for_function("selectedIndex === 0")
+    assert page.evaluate("selectedPhotoId === photos[0].id")
+
+
 def test_shift_arrow_navigation_preserves_range_selection_at_loaded_boundary(
     live_server, page
 ):

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -5146,13 +5146,21 @@ document.addEventListener('keydown', function(e) {
   }
 
   // Arrow keys: navigate grid (not configurable)
-  if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+  if (e.key === 'ArrowRight') {
     e.preventDefault();
     moveBrowseSelection(1, e);
     return;
-  } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+  } else if (e.key === 'ArrowLeft') {
     e.preventDefault();
     moveBrowseSelection(-1, e);
+    return;
+  } else if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    moveBrowseSelection(getBrowseGridColumnCount(), e);
+    return;
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    moveBrowseSelection(-getBrowseGridColumnCount(), e);
     return;
   }
 
@@ -5216,10 +5224,26 @@ document.addEventListener('keydown', function(e) {
   }
 });
 
+function getBrowseGridColumnCount() {
+  var grid = document.getElementById('grid');
+  var cards = grid ? grid.querySelectorAll('.grid-card') : document.querySelectorAll('.grid-card');
+  if (!cards.length) return 1;
+
+  var firstTop = cards[0].offsetTop;
+  var count = 0;
+  for (var i = 0; i < cards.length; i++) {
+    if (Math.abs(cards[i].offsetTop - firstTop) > 2) break;
+    count++;
+  }
+  return Math.max(1, count);
+}
+
 async function moveBrowseSelection(delta, e) {
   var nextIndex = selectedIndex + delta;
-  if (delta > 0 && nextIndex >= photos.length && !allLoaded) {
+  while (delta > 0 && nextIndex >= photos.length && !allLoaded) {
+    var beforeLength = photos.length;
     await loadPhotos();
+    if (photos.length === beforeLength) break;
     nextIndex = selectedIndex + delta;
   }
   if (nextIndex < 0 || nextIndex >= photos.length || !photos[nextIndex]) return;

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -5226,6 +5226,12 @@ document.addEventListener('keydown', function(e) {
 
 function getBrowseGridColumnCount() {
   var grid = document.getElementById('grid');
+  if (grid) {
+    var template = window.getComputedStyle(grid).gridTemplateColumns || '';
+    var tracks = template.trim().split(/\s+/).filter(Boolean);
+    if (tracks.length && template !== 'none') return tracks.length;
+  }
+
   var cards = grid ? grid.querySelectorAll('.grid-card') : document.querySelectorAll('.grid-card');
   if (!cards.length) return 1;
 
@@ -5239,12 +5245,12 @@ function getBrowseGridColumnCount() {
 }
 
 async function moveBrowseSelection(delta, e) {
-  var nextIndex = selectedIndex + delta;
+  var nextIndex = selectedIndex < 0 && delta > 0 ? 0 : selectedIndex + delta;
   while (delta > 0 && nextIndex >= photos.length && !allLoaded) {
     var beforeLength = photos.length;
     await loadPhotos();
     if (photos.length === beforeLength) break;
-    nextIndex = selectedIndex + delta;
+    nextIndex = selectedIndex < 0 ? 0 : selectedIndex + delta;
   }
   if (nextIndex < 0 || nextIndex >= photos.length || !photos[nextIndex]) return;
   var selectionEvent = {


### PR DESCRIPTION
Updates Browse grid arrow-key navigation so Up and Down move by the rendered grid column count instead of acting like previous/next aliases. This makes keyboard movement match the visual grid while keeping Left and Right as single-photo navigation and preserving shift-range selection. The page-boundary load path now handles larger vertical jumps. Validated with `pytest tests/e2e/test_browse_single_select.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Arrow Up/Down now move selection by grid row (based on visible column count) for more natural gallery navigation.
  * Navigating forward beyond loaded items now triggers continued loading so selection can advance into newly fetched photos.

* **Tests**
  * Added end-to-end tests covering grid-based arrow navigation, starting navigation with Arrow Down, and boundary loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->